### PR TITLE
Running code-format for dqm

### DIFF
--- a/DQM/EcalPreshowerMonitorClient/interface/ESClient.h
+++ b/DQM/EcalPreshowerMonitorClient/interface/ESClient.h
@@ -7,11 +7,10 @@
 #include "DQMServices/Core/interface/MonitorElement.h"
 
 namespace edm {
-class ParameterSet;
+  class ParameterSet;
 }
 
 class ESClient {
-
 public:
   ESClient(edm::ParameterSet const &);
   virtual ~ESClient() {}
@@ -35,8 +34,7 @@ protected:
 };
 
 template <typename T>
-T *ESClient::getHisto(MonitorElement *_me, bool _clone /* = false*/,
-                      T *_current /* = 0*/) const {
+T *ESClient::getHisto(MonitorElement *_me, bool _clone /* = false*/, T *_current /* = 0*/) const {
   if (!_me) {
     if (_clone)
       return _current;
@@ -59,4 +57,4 @@ T *ESClient::getHisto(MonitorElement *_me, bool _clone /* = false*/,
     return dynamic_cast<T *>(obj);
 }
 
-#endif // ESClient_H
+#endif  // ESClient_H

--- a/DQM/EcalPreshowerMonitorClient/interface/ESPedestalClient.h
+++ b/DQM/EcalPreshowerMonitorClient/interface/ESPedestalClient.h
@@ -33,4 +33,4 @@ private:
   std::vector<int> senY_;
 };
 
-#endif // ESPedestalClient_H
+#endif  // ESPedestalClient_H

--- a/DQM/EcalPreshowerMonitorClient/interface/ESSummaryClient.h
+++ b/DQM/EcalPreshowerMonitorClient/interface/ESSummaryClient.h
@@ -4,7 +4,6 @@
 #include "DQM/EcalPreshowerMonitorClient/interface/ESClient.h"
 
 class ESSummaryClient : public ESClient {
-
 public:
   /// Constructor
   ESSummaryClient(const edm::ParameterSet &ps);

--- a/DQM/EcalPreshowerMonitorClient/interface/EcalPreshowerMonitorClient.h
+++ b/DQM/EcalPreshowerMonitorClient/interface/EcalPreshowerMonitorClient.h
@@ -6,7 +6,6 @@
 class ESClient;
 
 class EcalPreshowerMonitorClient : public DQMEDHarvester {
-
 public:
   EcalPreshowerMonitorClient(const edm::ParameterSet &);
   ~EcalPreshowerMonitorClient() override;
@@ -14,7 +13,8 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions &);
 
 private:
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &,
+  void dqmEndLuminosityBlock(DQMStore::IBooker &,
+                             DQMStore::IGetter &,
                              const edm::LuminosityBlock &,
                              const edm::EventSetup &) override;
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;

--- a/DQM/EcalPreshowerMonitorClient/src/ESIntegrityClient.cc
+++ b/DQM/EcalPreshowerMonitorClient/src/ESIntegrityClient.cc
@@ -11,10 +11,18 @@
 using namespace std;
 
 ESIntegrityClient::ESIntegrityClient(const edm::ParameterSet &ps)
-    : ESClient(ps), hFED_(nullptr), hFiberOff_(nullptr),
-      hFiberBadStatus_(nullptr), hKF1_(nullptr), hKF2_(nullptr), hKBC_(nullptr),
-      hKEC_(nullptr), hL1ADiff_(nullptr), hBXDiff_(nullptr),
-      hOrbitNumberDiff_(nullptr), hSLinkCRCErr_(nullptr) {
+    : ESClient(ps),
+      hFED_(nullptr),
+      hFiberOff_(nullptr),
+      hFiberBadStatus_(nullptr),
+      hKF1_(nullptr),
+      hKF2_(nullptr),
+      hKBC_(nullptr),
+      hKEC_(nullptr),
+      hL1ADiff_(nullptr),
+      hBXDiff_(nullptr),
+      hOrbitNumberDiff_(nullptr),
+      hSLinkCRCErr_(nullptr) {
   // read in look-up table
   for (int i = 0; i < 2; ++i)
     for (int j = 0; j < 2; ++j)
@@ -39,19 +47,16 @@ ESIntegrityClient::ESIntegrityClient(const edm::ParameterSet &ps)
       meKCHIP_[i][j] = nullptr;
     }
 
-  std::string lutPath(
-      ps.getUntrackedParameter<edm::FileInPath>("LookupTable").fullPath());
+  std::string lutPath(ps.getUntrackedParameter<edm::FileInPath>("LookupTable").fullPath());
 
   int nLines, z, iz, ip, ix, iy, fed, kchip, pace, bundle, fiber, optorx;
   ifstream file(lutPath);
 
   if (file.is_open()) {
-
     file >> nLines;
 
     for (int i = 0; i < nLines; ++i) {
-      file >> iz >> ip >> ix >> iy >> fed >> kchip >> pace >> bundle >> fiber >>
-          optorx;
+      file >> iz >> ip >> ix >> iy >> fed >> kchip >> pace >> bundle >> fiber >> optorx;
 
       z = (iz == -1) ? 2 : iz;
       fed_[z - 1][ip - 1][ix - 1][iy - 1] = fed;
@@ -61,15 +66,13 @@ ESIntegrityClient::ESIntegrityClient(const edm::ParameterSet &ps)
 
     file.close();
   } else {
-    cout << "ESIntegrityClient : Look up table file can not be found in "
-         << lutPath << endl;
+    cout << "ESIntegrityClient : Look up table file can not be found in " << lutPath << endl;
   }
 }
 
 ESIntegrityClient::~ESIntegrityClient() {}
 
 void ESIntegrityClient::book(DQMStore::IBooker &_ibooker) {
-
   char histo[200];
 
   _ibooker.setCurrentFolder(prefixME_ + "/ESIntegrityClient");
@@ -78,29 +81,25 @@ void ESIntegrityClient::book(DQMStore::IBooker &_ibooker) {
     for (int j = 0; j < 2; ++j) {
       int iz = (i == 0) ? 1 : -1;
       snprintf(histo, 200, "ES Integrity Summary 1 Z %d P %d", iz, j + 1);
-      meFED_[i][j] =
-          _ibooker.book2D(histo, histo, 40, 0.5, 40.5, 40, 0.5, 40.5);
+      meFED_[i][j] = _ibooker.book2D(histo, histo, 40, 0.5, 40.5, 40, 0.5, 40.5);
       meFED_[i][j]->setAxisTitle("Si X", 1);
       meFED_[i][j]->setAxisTitle("Si Y", 2);
 
       snprintf(histo, 200, "ES Integrity Summary 2 Z %d P %d", iz, j + 1);
-      meKCHIP_[i][j] =
-          _ibooker.book2D(histo, histo, 40, 0.5, 40.5, 40, 0.5, 40.5);
+      meKCHIP_[i][j] = _ibooker.book2D(histo, histo, 40, 0.5, 40.5, 40, 0.5, 40.5);
       meKCHIP_[i][j]->setAxisTitle("Si X", 1);
       meKCHIP_[i][j]->setAxisTitle("Si Y", 2);
     }
 }
 
 void ESIntegrityClient::endLumiAnalyze(DQMStore::IGetter &_igetter) {
-
   double nDI_FedErr[56];
   for (int i = 0; i < 56; ++i)
     nDI_FedErr[i] = 0;
 
   MonitorElement *me = nullptr;
 
-  me =
-      _igetter.get(prefixME_ + "/ESIntegrityTask/ES FEDs used for data taking");
+  me = _igetter.get(prefixME_ + "/ESIntegrityTask/ES FEDs used for data taking");
   hFED_ = getHisto(me, cloneME_, hFED_);
 
   me = _igetter.get(prefixME_ + "/ESIntegrityTask/ES Fiber Off");
@@ -133,13 +132,13 @@ void ESIntegrityClient::endLumiAnalyze(DQMStore::IGetter &_igetter) {
     for (int j = 0; j < 36; ++j) {
       if (hFiberBadStatus_) {
         if (hFiberBadStatus_->GetBinContent(i, j + 1) > 0)
-          fiberStatus_[i - 1][j] = 2; // bad
+          fiberStatus_[i - 1][j] = 2;  // bad
         else
-          fiberStatus_[i - 1][j] = 1; // good
+          fiberStatus_[i - 1][j] = 1;  // good
       }
       if (hFiberOff_)
         if (hFiberOff_->GetBinContent(i, j + 1) > 0) {
-          fiberStatus_[i - 1][j] = 0; // off
+          fiberStatus_[i - 1][j] = 0;  // off
         }
     }
   }
@@ -174,17 +173,14 @@ void ESIntegrityClient::endLumiAnalyze(DQMStore::IGetter &_igetter) {
   me = _igetter.get(prefixME_ + "/ESIntegrityTask/ES KChip Flag 2 Error codes");
   hKF2_ = getHisto(me, cloneME_, hKF2_);
 
-  me = _igetter.get(prefixME_ +
-                    "/ESIntegrityTask/ES KChip BC mismatch with OptoRX");
+  me = _igetter.get(prefixME_ + "/ESIntegrityTask/ES KChip BC mismatch with OptoRX");
   hKBC_ = getHisto(me, cloneME_, hKBC_);
 
-  me = _igetter.get(prefixME_ +
-                    "/ESIntegrityTask/ES KChip EC mismatch with OptoRX");
+  me = _igetter.get(prefixME_ + "/ESIntegrityTask/ES KChip EC mismatch with OptoRX");
   hKEC_ = getHisto(me, cloneME_, hKEC_);
 
   Int_t kchip_xval[1550];
   for (int i = 0; i < 1550; ++i) {
-
     xval = 3;
     Int_t kErr = 0;
     for (int j = 1; j < 16; ++j) {
@@ -226,12 +222,10 @@ void ESIntegrityClient::endLumiAnalyze(DQMStore::IGetter &_igetter) {
           if (fed_[iz][ip][ix][iy] == -1)
             continue;
           if (fedStatus_[fed_[iz][ip][ix][iy] - 520] == -1 ||
-              fiberStatus_[fed_[iz][ip][ix][iy] - 520]
-                          [fiber_[iz][ip][ix][iy]] == 0)
+              fiberStatus_[fed_[iz][ip][ix][iy] - 520][fiber_[iz][ip][ix][iy]] == 0)
             kchip_xval[kchip_[iz][ip][ix][iy] - 1] = 0;
           if ((kchip_[iz][ip][ix][iy] - 2) >= 0)
-            meKCHIP_[iz][ip]->setBinContent(
-                ix + 1, iy + 1, kchip_xval[kchip_[iz][ip][ix][iy] - 2]);
+            meKCHIP_[iz][ip]->setBinContent(ix + 1, iy + 1, kchip_xval[kchip_[iz][ip][ix][iy] - 2]);
         }
 
   // FED, Fiber, KCHIP summary (i.e. summary 1)
@@ -240,35 +234,29 @@ void ESIntegrityClient::endLumiAnalyze(DQMStore::IGetter &_igetter) {
     for (int ip = 0; ip < 2; ++ip)
       for (int ix = 0; ix < 40; ++ix)
         for (int iy = 0; iy < 40; ++iy) {
-
           if (fed_[iz][ip][ix][iy] == -1)
             continue;
           nErr = 0;
 
           if (fedStatus_[fed_[iz][ip][ix][iy] - 520] == 1) {
-
             if (hFED_) {
-              if (hFED_->GetBinContent(fed_[iz][ip][ix][iy] - 520 + 1) ==
-                  nevFEDs)
+              if (hFED_->GetBinContent(fed_[iz][ip][ix][iy] - 520 + 1) == nevFEDs)
                 xval = 3;
               else {
-                xval = 4; // FED problem
+                xval = 4;  // FED problem
                 nErr++;
               }
             }
 
-            if (fiberStatus_[fed_[iz][ip][ix][iy] - 520]
-                            [fiber_[iz][ip][ix][iy]] == 2) {
-              xval = 2; // fiber problem
+            if (fiberStatus_[fed_[iz][ip][ix][iy] - 520][fiber_[iz][ip][ix][iy]] == 2) {
+              xval = 2;  // fiber problem
               nErr++;
             }
-            if (fiberStatus_[fed_[iz][ip][ix][iy] - 520]
-                            [fiber_[iz][ip][ix][iy]] == 0) {
-              xval = 0; // fiber off
+            if (fiberStatus_[fed_[iz][ip][ix][iy] - 520][fiber_[iz][ip][ix][iy]] == 0) {
+              xval = 0;  // fiber off
             }
-            if (kchip_xval[kchip_[iz][ip][ix][iy] - 1] != 3 &&
-                kchip_xval[kchip_[iz][ip][ix][iy] - 1] != 0) {
-              xval = 5; // kchip problem
+            if (kchip_xval[kchip_[iz][ip][ix][iy] - 1] != 3 && kchip_xval[kchip_[iz][ip][ix][iy] - 1] != 0) {
+              xval = 5;  // kchip problem
               nErr++;
             }
             if (syncStatus_[fed_[iz][ip][ix][iy] - 520] == 1) {

--- a/DQM/EcalPreshowerMonitorClient/src/ESPedestalClient.cc
+++ b/DQM/EcalPreshowerMonitorClient/src/ESPedestalClient.cc
@@ -11,8 +11,13 @@
 using namespace std;
 
 ESPedestalClient::ESPedestalClient(const edm::ParameterSet &ps)
-    : ESClient(ps), fitPedestal_(ps.getUntrackedParameter<bool>("fitPedestal")),
-      fg_(new TF1("fg", "gaus")), senZ_(), senP_(), senX_(), senY_() {
+    : ESClient(ps),
+      fitPedestal_(ps.getUntrackedParameter<bool>("fitPedestal")),
+      fg_(new TF1("fg", "gaus")),
+      senZ_(),
+      senP_(),
+      senX_(),
+      senY_() {
   for (int i = 0; i < 2; i++)
     for (int j = 0; j < 2; j++)
       for (int k = 0; k < 40; k++)
@@ -21,20 +26,17 @@ ESPedestalClient::ESPedestalClient(const edm::ParameterSet &ps)
           hTotN_[i][j][k][m] = nullptr;
         }
 
-  std::string lutPath(
-      ps.getUntrackedParameter<edm::FileInPath>("LookupTable").fullPath());
+  std::string lutPath(ps.getUntrackedParameter<edm::FileInPath>("LookupTable").fullPath());
 
   // read in look-up table
   int nLines, iz, ip, ix, iy, fed, kchip, pace, bundle, fiber, optorx;
   ifstream file(lutPath);
 
   if (file.is_open()) {
-
     file >> nLines;
 
     for (int i = 0; i < nLines; ++i) {
-      file >> iz >> ip >> ix >> iy >> fed >> kchip >> pace >> bundle >> fiber >>
-          optorx;
+      file >> iz >> ip >> ix >> iy >> fed >> kchip >> pace >> bundle >> fiber >> optorx;
 
       senZ_.push_back(iz);
       senP_.push_back(ip);
@@ -44,15 +46,13 @@ ESPedestalClient::ESPedestalClient(const edm::ParameterSet &ps)
 
     file.close();
   } else {
-    cout << "ESPedestalClient : Look up table file can not be found in "
-         << lutPath << endl;
+    cout << "ESPedestalClient : Look up table file can not be found in " << lutPath << endl;
   }
 }
 
 ESPedestalClient::~ESPedestalClient() { delete fg_; }
 
 void ESPedestalClient::endJobAnalyze(DQMStore::IGetter &_igetter) {
-
   if (debug_)
     cout << "ESPedestalClient: endJob" << endl;
 
@@ -60,19 +60,15 @@ void ESPedestalClient::endJobAnalyze(DQMStore::IGetter &_igetter) {
   char hname[300];
   int iz = 0;
   if (fitPedestal_) {
-
     if (verbose_)
       cout << "ESPedestalClient: Fit Pedestal" << endl;
 
     for (unsigned i = 0; i < senZ_.size(); ++i) {
-
       iz = (senZ_[i] == 1) ? 0 : 1;
 
       for (int is = 0; is < 32; ++is) {
-
         string dirname = prefixME_ + "/ESPedestalTask/";
-        sprintf(hname, "ADC Z %d P %d X %d Y %d Str %d", senZ_[i], senP_[i],
-                senX_[i], senY_[i], is + 1);
+        sprintf(hname, "ADC Z %d P %d X %d Y %d Str %d", senZ_[i], senP_[i], senX_[i], senY_[i], is + 1);
         MonitorElement *meFit = _igetter.get(dirname + hname);
 
         if (meFit == nullptr)
@@ -80,63 +76,51 @@ void ESPedestalClient::endJobAnalyze(DQMStore::IGetter &_igetter) {
         TH1F *rootHisto = meFit->getTH1F();
 
         rootHisto->Fit(fg_, "Q", "", 500, 1800);
-        rootHisto->Fit(fg_, "RQ", "",
+        rootHisto->Fit(fg_,
+                       "RQ",
+                       "",
                        fg_->GetParameter(1) - 2. * fg_->GetParameter(2),
                        fg_->GetParameter(1) + 2. * fg_->GetParameter(2));
-        hPed_[iz][senP_[i] - 1][senX_[i] - 1][senY_[i] - 1]->setBinContent(
-            is + 1, (int)(fg_->GetParameter(1) + 0.5));
-        hTotN_[iz][senP_[i] - 1][senX_[i] - 1][senY_[i] - 1]->setBinContent(
-            is + 1, fg_->GetParameter(2));
+        hPed_[iz][senP_[i] - 1][senX_[i] - 1][senY_[i] - 1]->setBinContent(is + 1, (int)(fg_->GetParameter(1) + 0.5));
+        hTotN_[iz][senP_[i] - 1][senX_[i] - 1][senY_[i] - 1]->setBinContent(is + 1, fg_->GetParameter(2));
       }
     }
 
   } else {
-
     if (verbose_)
       cout << "ESPedestalClient: Use Histogram Mean" << endl;
 
     for (unsigned i = 0; i < senZ_.size(); ++i) {
-
       iz = (senZ_[i] == 1) ? 0 : 1;
 
       for (int is = 0; is < 32; ++is) {
-
         string dirname = prefixME_ + "/ESPedestalTask/";
-        sprintf(hname, "ADC Z %d P %d X %d Y %d Str %d", senZ_[i], senP_[i],
-                senX_[i], senY_[i], is + 1);
+        sprintf(hname, "ADC Z %d P %d X %d Y %d Str %d", senZ_[i], senP_[i], senX_[i], senY_[i], is + 1);
         MonitorElement *meMean = _igetter.get(dirname + hname);
 
         if (meMean == nullptr)
           continue;
         TH1F *rootHisto = meMean->getTH1F();
 
-        hPed_[iz][senP_[i] - 1][senX_[i] - 1][senY_[i] - 1]->setBinContent(
-            is + 1, (int)(rootHisto->GetMean() + 0.5));
-        hTotN_[iz][senP_[i] - 1][senX_[i] - 1][senY_[i] - 1]->setBinContent(
-            is + 1, rootHisto->GetRMS());
+        hPed_[iz][senP_[i] - 1][senX_[i] - 1][senY_[i] - 1]->setBinContent(is + 1, (int)(rootHisto->GetMean() + 0.5));
+        hTotN_[iz][senP_[i] - 1][senX_[i] - 1][senY_[i] - 1]->setBinContent(is + 1, rootHisto->GetRMS());
       }
     }
   }
 }
 
 void ESPedestalClient::book(DQMStore::IBooker &_ibooker) {
-
   // define histograms
   _ibooker.setCurrentFolder(prefixME_ + "/ESPedestalClient");
 
   char hname[300];
   for (unsigned i = 0; i < senZ_.size(); ++i) {
-
     int iz = (senZ_[i] == 1) ? 0 : 1;
 
-    sprintf(hname, "Ped Z %d P %d X %d Y %d", senZ_[i], senP_[i], senX_[i],
-            senY_[i]);
-    hPed_[iz][senP_[i] - 1][senX_[i] - 1][senY_[i] - 1] =
-        _ibooker.book1D(hname, hname, 32, 0, 32);
+    sprintf(hname, "Ped Z %d P %d X %d Y %d", senZ_[i], senP_[i], senX_[i], senY_[i]);
+    hPed_[iz][senP_[i] - 1][senX_[i] - 1][senY_[i] - 1] = _ibooker.book1D(hname, hname, 32, 0, 32);
 
-    sprintf(hname, "Total Noise Z %d P %d X %d Y %d", senZ_[i], senP_[i],
-            senX_[i], senY_[i]);
-    hTotN_[iz][senP_[i] - 1][senX_[i] - 1][senY_[i] - 1] =
-        _ibooker.book1D(hname, hname, 32, 0, 32);
+    sprintf(hname, "Total Noise Z %d P %d X %d Y %d", senZ_[i], senP_[i], senX_[i], senY_[i]);
+    hTotN_[iz][senP_[i] - 1][senX_[i] - 1][senY_[i] - 1] = _ibooker.book1D(hname, hname, 32, 0, 32);
   }
 }

--- a/DQM/EcalPreshowerMonitorClient/src/ESSummaryClient.cc
+++ b/DQM/EcalPreshowerMonitorClient/src/ESSummaryClient.cc
@@ -17,7 +17,6 @@ ESSummaryClient::ESSummaryClient(const edm::ParameterSet &ps)
 ESSummaryClient::~ESSummaryClient() {}
 
 void ESSummaryClient::book(DQMStore::IBooker &_ibooker) {
-
   if (debug_)
     cout << "ESSummaryClient: setup" << endl;
 
@@ -39,8 +38,7 @@ void ESSummaryClient::book(DQMStore::IBooker &_ibooker) {
 
   _ibooker.setCurrentFolder(prefixME_ + "/EventInfo");
 
-  meReportSummaryMap_ = _ibooker.book2D("reportSummaryMap", "reportSummaryMap",
-                                        80, 0.5, 80.5, 80, 0.5, 80.5);
+  meReportSummaryMap_ = _ibooker.book2D("reportSummaryMap", "reportSummaryMap", 80, 0.5, 80.5, 80, 0.5, 80.5);
   meReportSummaryMap_->setAxisTitle("Si X", 1);
   meReportSummaryMap_->setAxisTitle("Si Y", 2);
 }
@@ -68,7 +66,6 @@ void ESSummaryClient::fillReportSummary(DQMStore::IGetter &_igetter) {
 
   for (int i = 0; i < 2; ++i) {
     for (int j = 0; j < 2; ++j) {
-
       int iz = (i == 0) ? 1 : -1;
 
       sprintf(histo, "ES Integrity Errors Z %d P %d", iz, j + 1);
@@ -76,8 +73,7 @@ void ESSummaryClient::fillReportSummary(DQMStore::IGetter &_igetter) {
       if (me)
         for (int x = 0; x < 40; ++x)
           for (int y = 0; y < 40; ++y)
-            nDI_FedErr[i * 40 + x][(1 - j) * 40 + y] =
-                me->getBinContent(x + 1, y + 1);
+            nDI_FedErr[i * 40 + x][(1 - j) * 40 + y] = me->getBinContent(x + 1, y + 1);
 
       sprintf(histo, "ES Integrity Summary 1 Z %d P %d", iz, j + 1);
       me = _igetter.get(prefixME_ + "/ESIntegrityClient/" + histo);
@@ -106,9 +102,8 @@ void ESSummaryClient::fillReportSummary(DQMStore::IGetter &_igetter) {
 
   for (int x = 0; x < 80; ++x) {
     if (eCount < 1)
-      break; // Fill reportSummaryMap after have 1 event
+      break;  // Fill reportSummaryMap after have 1 event
     for (int y = 0; y < 80; ++y) {
-
       int z = (x < 40) ? 0 : 1;
       int p = (y >= 40) ? 0 : 1;
 
@@ -116,8 +111,7 @@ void ESSummaryClient::fillReportSummary(DQMStore::IGetter &_igetter) {
         meReportSummaryMap_->setBinContent(x + 1, y + 1, -1.);
       } else {
         if (nDI_FedErr[x][y] >= 0) {
-          meReportSummaryMap_->setBinContent(x + 1, y + 1,
-                                             1 - (nDI_FedErr[x][y] / eCount));
+          meReportSummaryMap_->setBinContent(x + 1, y + 1, 1 - (nDI_FedErr[x][y] / eCount));
 
           nValidChannels++;
           nGlobalErrors += nDI_FedErr[x][y] / eCount;
@@ -135,8 +129,7 @@ void ESSummaryClient::fillReportSummary(DQMStore::IGetter &_igetter) {
     for (unsigned iD(0); iD != 2; ++iD) {
       float reportSummaryES(-1.);
       if (nValidChannelsES[iZ][iD] != 0)
-        reportSummaryES =
-            1. - nGlobalErrorsES[iZ][iD] / nValidChannelsES[iZ][iD];
+        reportSummaryES = 1. - nGlobalErrorsES[iZ][iD] / nValidChannelsES[iZ][iD];
 
       meReportSummaryContents_[iZ][iD]->Fill(reportSummaryES);
     }
@@ -150,15 +143,13 @@ void ESSummaryClient::fillReportSummary(DQMStore::IGetter &_igetter) {
 }
 
 void ESSummaryClient::endLumiAnalyze(DQMStore::IGetter &_igetter) {
-
   fillReportSummary(_igetter);
 
   // The following overwrites the report summary if LS-based Good Channel
   // Fraction histogram is available The source is turned off by default in
   // ESIntegrityTask
 
-  MonitorElement *source(
-      _igetter.get(prefixME_ + "/ESIntegrityTask/ES Good Channel Fraction"));
+  MonitorElement *source(_igetter.get(prefixME_ + "/ESIntegrityTask/ES Good Channel Fraction"));
   if (!source)
     return;
 
@@ -174,6 +165,4 @@ void ESSummaryClient::endLumiAnalyze(DQMStore::IGetter &_igetter) {
   meReportSummary_->Fill(source->getBinContent(3, 3));
 }
 
-void ESSummaryClient::endJobAnalyze(DQMStore::IGetter &_igetter) {
-  fillReportSummary(_igetter);
-}
+void ESSummaryClient::endJobAnalyze(DQMStore::IGetter &_igetter) { fillReportSummary(_igetter); }

--- a/DQM/EcalPreshowerMonitorClient/src/EcalPreshowerMonitorClient.cc
+++ b/DQM/EcalPreshowerMonitorClient/src/EcalPreshowerMonitorClient.cc
@@ -16,12 +16,9 @@
 #include <string>
 #include <vector>
 
-EcalPreshowerMonitorClient::EcalPreshowerMonitorClient(
-    const edm::ParameterSet &ps)
-    : debug_(ps.getUntrackedParameter<bool>("debug")),
-      verbose_(ps.getUntrackedParameter<bool>("verbose")), clients_() {
-  std::vector<std::string> enabledClients(
-      ps.getUntrackedParameter<std::vector<std::string>>("enabledClients"));
+EcalPreshowerMonitorClient::EcalPreshowerMonitorClient(const edm::ParameterSet &ps)
+    : debug_(ps.getUntrackedParameter<bool>("debug")), verbose_(ps.getUntrackedParameter<bool>("verbose")), clients_() {
+  std::vector<std::string> enabledClients(ps.getUntrackedParameter<std::vector<std::string>>("enabledClients"));
 
   if (verbose_) {
     std::cout << " Enabled Clients:";
@@ -32,24 +29,20 @@ EcalPreshowerMonitorClient::EcalPreshowerMonitorClient(
   }
 
   // Setup Clients
-  if (find(enabledClients.begin(), enabledClients.end(), "Integrity") !=
-      enabledClients.end()) {
+  if (find(enabledClients.begin(), enabledClients.end(), "Integrity") != enabledClients.end()) {
     clients_.push_back(new ESIntegrityClient(ps));
   }
 
-  if (find(enabledClients.begin(), enabledClients.end(), "Pedestal") !=
-      enabledClients.end()) {
+  if (find(enabledClients.begin(), enabledClients.end(), "Pedestal") != enabledClients.end()) {
     clients_.push_back(new ESPedestalClient(ps));
   }
 
-  if (find(enabledClients.begin(), enabledClients.end(), "Summary") !=
-      enabledClients.end()) {
+  if (find(enabledClients.begin(), enabledClients.end(), "Summary") != enabledClients.end()) {
     clients_.push_back(new ESSummaryClient(ps));
   }
 }
 
 EcalPreshowerMonitorClient::~EcalPreshowerMonitorClient() {
-
   if (verbose_)
     std::cout << "Finish EcalPreshowerMonitorClient" << std::endl;
 
@@ -59,8 +52,7 @@ EcalPreshowerMonitorClient::~EcalPreshowerMonitorClient() {
 }
 
 /*static*/
-void EcalPreshowerMonitorClient::fillDescriptions(
-    edm::ConfigurationDescriptions &_descs) {
+void EcalPreshowerMonitorClient::fillDescriptions(edm::ConfigurationDescriptions &_descs) {
   edm::ParameterSetDescription desc;
 
   std::vector<std::string> clientsDefault;
@@ -78,9 +70,7 @@ void EcalPreshowerMonitorClient::fillDescriptions(
   _descs.addDefault(desc);
 }
 
-void EcalPreshowerMonitorClient::dqmEndJob(DQMStore::IBooker &_ibooker,
-                                           DQMStore::IGetter &_igetter) {
-
+void EcalPreshowerMonitorClient::dqmEndJob(DQMStore::IBooker &_ibooker, DQMStore::IGetter &_igetter) {
   if (debug_) {
     std::cout << "EcalPreshowerMonitorClient: endJob" << std::endl;
   }
@@ -91,10 +81,10 @@ void EcalPreshowerMonitorClient::dqmEndJob(DQMStore::IBooker &_ibooker,
   }
 }
 
-void EcalPreshowerMonitorClient::dqmEndLuminosityBlock(
-    DQMStore::IBooker &_ibooker, DQMStore::IGetter &_igetter,
-    const edm::LuminosityBlock &, const edm::EventSetup &) {
-
+void EcalPreshowerMonitorClient::dqmEndLuminosityBlock(DQMStore::IBooker &_ibooker,
+                                                       DQMStore::IGetter &_igetter,
+                                                       const edm::LuminosityBlock &,
+                                                       const edm::EventSetup &) {
   for (unsigned int i = 0; i < clients_.size(); i++) {
     clients_[i]->setup(_ibooker);
     clients_[i]->endLumiAnalyze(_igetter);

--- a/DQM/HLXMonitor/interface/HLXMonitor.h
+++ b/DQM/HLXMonitor/interface/HLXMonitor.h
@@ -29,10 +29,10 @@ Implementation:
 #include <sys/time.h>
 
 // user include files
-#include "FWCore/Framework/interface/Frameworkfwd.h" // Not included in example
+#include "FWCore/Framework/interface/Frameworkfwd.h"  // Not included in example
 
-#include "FWCore/Framework/interface/Event.h"       // Not included in example
-#include "FWCore/Framework/interface/MakerMacros.h" // Not included in example
+#include "FWCore/Framework/interface/Event.h"        // Not included in example
+#include "FWCore/Framework/interface/MakerMacros.h"  // Not included in example
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -53,8 +53,7 @@ public:
   ~HLXMonitor() override;
 
 private:
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
   void connectHLXTCP();
@@ -171,7 +170,7 @@ private:
   ///   by the module
   //////////////////////////////////////////////////////////////////
   MonitorElement *runId_;
-  MonitorElement *runStartTimeStamp_; /// UTC time of the run start
+  MonitorElement *runStartTimeStamp_;  /// UTC time of the run start
   MonitorElement *eventId_;
   MonitorElement *lumisecId_;
   MonitorElement *eventTimeStamp_;
@@ -179,23 +178,21 @@ private:
   //////////////////////////////////////////////////////////////////
   /// These MEs are either static or updated upon each analyze() call
   //////////////////////////////////////////////////////////////////
-  MonitorElement *nUpdates_;  /// Number of collector updates (TBD)
-  MonitorElement *processId_; /// The PID associated with this job
-  MonitorElement
-      *processStartTimeStamp_; /// The UTC time of the first event processed
-  MonitorElement *processTimeStamp_; /// The UTC time of the last event
-  MonitorElement *processLatency_;   /// Time elapsed since the last event
-  MonitorElement *processEventRate_; /// Avg # of events in programmable window
-                                     /// (default: 5 min)
-  MonitorElement *processEvents_;    ///# of event processed so far
-  MonitorElement *hostName_;         /// Hostname of the local machine
-  MonitorElement *processName_;      /// DQM "name" of the job (eg, Hcal or DT)
-  MonitorElement *workingDir_;       /// Current working directory of the job
-  MonitorElement *cmsswVer_;         /// CMSSW version run for this job
-  MonitorElement *dqmPatch_;         /// DQM patch version for this job
-  MonitorElement *errSummary_; /// Subdetector-specific error summary (float)
-  MonitorElement
-      *errSummaryEtaPhi_; /// Subdetector-specific etaPhi summary (float)
+  MonitorElement *nUpdates_;               /// Number of collector updates (TBD)
+  MonitorElement *processId_;              /// The PID associated with this job
+  MonitorElement *processStartTimeStamp_;  /// The UTC time of the first event processed
+  MonitorElement *processTimeStamp_;       /// The UTC time of the last event
+  MonitorElement *processLatency_;         /// Time elapsed since the last event
+  MonitorElement *processEventRate_;       /// Avg # of events in programmable window
+                                           /// (default: 5 min)
+  MonitorElement *processEvents_;          ///# of event processed so far
+  MonitorElement *hostName_;               /// Hostname of the local machine
+  MonitorElement *processName_;            /// DQM "name" of the job (eg, Hcal or DT)
+  MonitorElement *workingDir_;             /// Current working directory of the job
+  MonitorElement *cmsswVer_;               /// CMSSW version run for this job
+  MonitorElement *dqmPatch_;               /// DQM patch version for this job
+  MonitorElement *errSummary_;             /// Subdetector-specific error summary (float)
+  MonitorElement *errSummaryEtaPhi_;       /// Subdetector-specific etaPhi summary (float)
   MonitorElement *errSummarySegment_[10];
 
   // Report Summary
@@ -216,7 +213,7 @@ private:
   bool Accumulate;
   std::string OutputFilePrefix;
   std::string OutputDir;
-  std::string Style; // BX, History, Distribution
+  std::string Style;  // BX, History, Distribution
   int SavePeriod;
   unsigned int NUM_HLX;
   unsigned int NUM_BUNCHES;

--- a/DQM/HLXMonitor/src/HLXMonitor.cc
+++ b/DQM/HLXMonitor/src/HLXMonitor.cc
@@ -19,34 +19,26 @@ HLXMonitor::HLXMonitor(const edm::ParameterSet &iConfig) {
   NUM_BUNCHES = iConfig.getUntrackedParameter<unsigned int>("numBunches", 3564);
   MAX_LS = iConfig.getUntrackedParameter<unsigned int>("maximumNumLS", 480);
   listenPort = iConfig.getUntrackedParameter<unsigned int>("SourcePort", 51001);
-  OutputFilePrefix =
-      iConfig.getUntrackedParameter<std::string>("outputFile", "lumi");
+  OutputFilePrefix = iConfig.getUntrackedParameter<std::string>("outputFile", "lumi");
   OutputDir = iConfig.getUntrackedParameter<std::string>("outputDir", "  data");
   SavePeriod = iConfig.getUntrackedParameter<unsigned int>("SavePeriod", 10);
   NBINS = iConfig.getUntrackedParameter<unsigned int>("NBINS",
-                                                      297); // 12 BX per bin
+                                                      297);  // 12 BX per bin
   XMIN = iConfig.getUntrackedParameter<double>("XMIN", 0);
   XMAX = iConfig.getUntrackedParameter<double>("XMAX", 3564);
   Style = iConfig.getUntrackedParameter<std::string>("Style", "BX");
   AquireMode = iConfig.getUntrackedParameter<unsigned int>("AquireMode", 0);
-  Accumulate = iConfig.getUntrackedParameter<bool>("Accumulate", true); // all
+  Accumulate = iConfig.getUntrackedParameter<bool>("Accumulate", true);  // all
   TriggerBX = iConfig.getUntrackedParameter<unsigned int>("TriggerBX", 50);
-  MinLSBeforeSave =
-      iConfig.getUntrackedParameter<unsigned int>("MinLSBeforeSave", 1);
-  reconnTime =
-      iConfig.getUntrackedParameter<unsigned int>("ReconnectionTime", 5);
-  DistribIP1 = iConfig.getUntrackedParameter<std::string>("PrimaryHLXDAQIP",
-                                                          "vmepcs2f17-18");
-  DistribIP2 = iConfig.getUntrackedParameter<std::string>("SecondaryHLXDAQIP",
-                                                          "vmepcs2f17-19");
+  MinLSBeforeSave = iConfig.getUntrackedParameter<unsigned int>("MinLSBeforeSave", 1);
+  reconnTime = iConfig.getUntrackedParameter<unsigned int>("ReconnectionTime", 5);
+  DistribIP1 = iConfig.getUntrackedParameter<std::string>("PrimaryHLXDAQIP", "vmepcs2f17-18");
+  DistribIP2 = iConfig.getUntrackedParameter<std::string>("SecondaryHLXDAQIP", "vmepcs2f17-19");
   ResetAtNewRun = iConfig.getUntrackedParameter<bool>("NewRun_Reset", true);
 
-  eventInfoFolderHLX_ = iConfig.getUntrackedParameter<std::string>(
-      "eventInfoFolderHLX", "EventInfoHLX");
-  eventInfoFolder_ = iConfig.getUntrackedParameter<std::string>(
-      "eventInfoFolder", "EventInfo");
-  subSystemName_ =
-      iConfig.getUntrackedParameter<std::string>("subSystemName", "HLX");
+  eventInfoFolderHLX_ = iConfig.getUntrackedParameter<std::string>("eventInfoFolderHLX", "EventInfoHLX");
+  eventInfoFolder_ = iConfig.getUntrackedParameter<std::string>("eventInfoFolder", "EventInfo");
+  subSystemName_ = iConfig.getUntrackedParameter<std::string>("subSystemName", "HLX");
 
   // Set the lumi section counter
   lsBinOld = 0;
@@ -87,18 +79,17 @@ HLXMonitor::HLXMonitor(const edm::ParameterSet &iConfig) {
     NBINS = (unsigned int)(XMAX - XMIN);
   }
 
-  monitorName_ =
-      iConfig.getUntrackedParameter<std::string>("monitorName", "HLX");
+  monitorName_ = iConfig.getUntrackedParameter<std::string>("monitorName", "HLX");
   // cout << "Monitor name = " << monitorName_ << endl;
   prescaleEvt_ = iConfig.getUntrackedParameter<int>("prescaleEvt", -1);
   // cout << "===>DQM event prescale = " << prescaleEvt_ << " events "<< endl;
 
-  unsigned int HLXHFMapTemp[] = {31, 32, 33, 34, 35, 18, // s2f07 hf-
-                                 13, 14, 15, 16, 17, 0,  // s2f07 hf+
-                                 25, 26, 27, 28, 29, 30, // s2f05 hf-
-                                 7,  8,  9,  10, 11, 12, // s2f05 hf+
-                                 19, 20, 21, 22, 23, 24, // s2f02 hf-
-                                 1,  2,  3,  4,  5,  6}; // s2f02 hf+
+  unsigned int HLXHFMapTemp[] = {31, 32, 33, 34, 35, 18,  // s2f07 hf-
+                                 13, 14, 15, 16, 17, 0,   // s2f07 hf+
+                                 25, 26, 27, 28, 29, 30,  // s2f05 hf-
+                                 7,  8,  9,  10, 11, 12,  // s2f05 hf+
+                                 19, 20, 21, 22, 23, 24,  // s2f02 hf-
+                                 1,  2,  3,  4,  5,  6};  // s2f02 hf+
 
   currentRunEnded_ = true;
   runNumber_ = 0;
@@ -112,7 +103,7 @@ HLXMonitor::HLXMonitor(const edm::ParameterSet &iConfig) {
 
   num4NibblePerLS_ = 16.0;
 
-  connectHLXTCP(); // this was originally done in beginJob()
+  connectHLXTCP();  // this was originally done in beginJob()
 }
 
 HLXMonitor::~HLXMonitor() {
@@ -148,8 +139,7 @@ void HLXMonitor::connectHLXTCP() {
 }
 
 // ------------ Setup the monitoring elements ---------------
-void HLXMonitor::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const &,
-                                edm::EventSetup const &) {
+void HLXMonitor::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const &, edm::EventSetup const &) {
   SetupHists(iBooker);
   SetupEventInfo(iBooker);
 }
@@ -159,45 +149,28 @@ void HLXMonitor::SetupHists(DQMStore::IBooker &iBooker) {
 
   for (unsigned int iWedge = 0; iWedge < 18 && iWedge < NUM_HLX; ++iWedge) {
     std::ostringstream tempStreamer;
-    tempStreamer << std::dec << std::setw(2) << std::setfill('0')
-                 << (iWedge + 1);
+    tempStreamer << std::dec << std::setw(2) << std::setfill('0') << (iWedge + 1);
 
     std::ostringstream wedgeNum;
     wedgeNum << std::dec << (iWedge % 18) + 1;
 
-    iBooker.setCurrentFolder(monitorName_ + "/HFPlus/Wedge" +
-                             tempStreamer.str());
+    iBooker.setCurrentFolder(monitorName_ + "/HFPlus/Wedge" + tempStreamer.str());
 
-    Set1Below[iWedge] = iBooker.book1D("Set1_Below",
-                                       "HF+ Wedge " + wedgeNum.str() +
-                                           ": Below Threshold 1 - Set 1",
-                                       NBINS, XMIN, XMAX);
+    Set1Below[iWedge] =
+        iBooker.book1D("Set1_Below", "HF+ Wedge " + wedgeNum.str() + ": Below Threshold 1 - Set 1", NBINS, XMIN, XMAX);
     Set1Between[iWedge] = iBooker.book1D(
-        "Set1_Between",
-        "HF+ Wedge " + wedgeNum.str() + ": Between Threshold 1 & 2 - Set 1",
-        NBINS, XMIN, XMAX);
-    Set1Above[iWedge] = iBooker.book1D("Set1_Above",
-                                       "HF+ Wedge " + wedgeNum.str() +
-                                           ": Above Threshold 2 - Set 1",
-                                       NBINS, XMIN, XMAX);
-    Set2Below[iWedge] = iBooker.book1D("Set2_Below",
-                                       "HF+ Wedge " + wedgeNum.str() +
-                                           ": Below Threshold 1 - Set 2",
-                                       NBINS, XMIN, XMAX);
+        "Set1_Between", "HF+ Wedge " + wedgeNum.str() + ": Between Threshold 1 & 2 - Set 1", NBINS, XMIN, XMAX);
+    Set1Above[iWedge] =
+        iBooker.book1D("Set1_Above", "HF+ Wedge " + wedgeNum.str() + ": Above Threshold 2 - Set 1", NBINS, XMIN, XMAX);
+    Set2Below[iWedge] =
+        iBooker.book1D("Set2_Below", "HF+ Wedge " + wedgeNum.str() + ": Below Threshold 1 - Set 2", NBINS, XMIN, XMAX);
     Set2Between[iWedge] = iBooker.book1D(
-        "Set2_Between",
-        "HF+ Wedge " + wedgeNum.str() + ": Between Threshold 1 & 2 - Set 2",
-        NBINS, XMIN, XMAX);
-    Set2Above[iWedge] = iBooker.book1D("Set2_Above",
-                                       "HF+ Wedge " + wedgeNum.str() +
-                                           ": Above Threshold 2 - Set 2",
-                                       NBINS, XMIN, XMAX);
-    ETSum[iWedge] = iBooker.book1D(
-        "ETSum", "HF+ Wedge " + wedgeNum.str() + ": Transverse Energy", NBINS,
-        XMIN, XMAX);
+        "Set2_Between", "HF+ Wedge " + wedgeNum.str() + ": Between Threshold 1 & 2 - Set 2", NBINS, XMIN, XMAX);
+    Set2Above[iWedge] =
+        iBooker.book1D("Set2_Above", "HF+ Wedge " + wedgeNum.str() + ": Above Threshold 2 - Set 2", NBINS, XMIN, XMAX);
+    ETSum[iWedge] = iBooker.book1D("ETSum", "HF+ Wedge " + wedgeNum.str() + ": Transverse Energy", NBINS, XMIN, XMAX);
 
-    iBooker.tagContents(monitorName_ + "/HFPlus/Wedge" + tempStreamer.str(),
-                        iWedge + 1);
+    iBooker.tagContents(monitorName_ + "/HFPlus/Wedge" + tempStreamer.str(), iWedge + 1);
   }
 
   if (NUM_HLX > 17) {
@@ -205,44 +178,27 @@ void HLXMonitor::SetupHists(DQMStore::IBooker &iBooker) {
 
     for (unsigned int iWedge = 18; iWedge < NUM_HLX; ++iWedge) {
       std::ostringstream tempStreamer;
-      tempStreamer << std::dec << std::setw(2) << std::setfill('0')
-                   << (iWedge + 1);
+      tempStreamer << std::dec << std::setw(2) << std::setfill('0') << (iWedge + 1);
 
       std::ostringstream wedgeNum;
       wedgeNum << std::dec << (iWedge % 18) + 1;
 
-      iBooker.setCurrentFolder(monitorName_ + "/HFMinus/Wedge" +
-                               tempStreamer.str());
-      Set1Below[iWedge] = iBooker.book1D("Set1_Below",
-                                         "HF- Wedge " + wedgeNum.str() +
-                                             ": Below Threshold 1 - Set 1",
-                                         NBINS, XMIN, XMAX);
+      iBooker.setCurrentFolder(monitorName_ + "/HFMinus/Wedge" + tempStreamer.str());
+      Set1Below[iWedge] = iBooker.book1D(
+          "Set1_Below", "HF- Wedge " + wedgeNum.str() + ": Below Threshold 1 - Set 1", NBINS, XMIN, XMAX);
       Set1Between[iWedge] = iBooker.book1D(
-          "Set1_Between",
-          "HF- Wedge " + wedgeNum.str() + ": Between Threshold 1 & 2 - Set 1",
-          NBINS, XMIN, XMAX);
-      Set1Above[iWedge] = iBooker.book1D("Set1_Above",
-                                         "HF- Wedge " + wedgeNum.str() +
-                                             ": Above Threshold 2 - Set 1",
-                                         NBINS, XMIN, XMAX);
-      Set2Below[iWedge] = iBooker.book1D("Set2_Below",
-                                         "HF- Wedge " + wedgeNum.str() +
-                                             ": Below Threshold 1 - Set 2",
-                                         NBINS, XMIN, XMAX);
+          "Set1_Between", "HF- Wedge " + wedgeNum.str() + ": Between Threshold 1 & 2 - Set 1", NBINS, XMIN, XMAX);
+      Set1Above[iWedge] = iBooker.book1D(
+          "Set1_Above", "HF- Wedge " + wedgeNum.str() + ": Above Threshold 2 - Set 1", NBINS, XMIN, XMAX);
+      Set2Below[iWedge] = iBooker.book1D(
+          "Set2_Below", "HF- Wedge " + wedgeNum.str() + ": Below Threshold 1 - Set 2", NBINS, XMIN, XMAX);
       Set2Between[iWedge] = iBooker.book1D(
-          "Set2_Between",
-          "HF- Wedge " + wedgeNum.str() + ": Between Threshold 1 & 2 - Set 2",
-          NBINS, XMIN, XMAX);
-      Set2Above[iWedge] = iBooker.book1D("Set2_Above",
-                                         "HF- Wedge " + wedgeNum.str() +
-                                             ": Above Threshold 2 - Set 2",
-                                         NBINS, XMIN, XMAX);
-      ETSum[iWedge] = iBooker.book1D(
-          "ETSum", "HF- Wedge " + wedgeNum.str() + ": Transverse Energy", NBINS,
-          XMIN, XMAX);
+          "Set2_Between", "HF- Wedge " + wedgeNum.str() + ": Between Threshold 1 & 2 - Set 2", NBINS, XMIN, XMAX);
+      Set2Above[iWedge] = iBooker.book1D(
+          "Set2_Above", "HF- Wedge " + wedgeNum.str() + ": Above Threshold 2 - Set 2", NBINS, XMIN, XMAX);
+      ETSum[iWedge] = iBooker.book1D("ETSum", "HF- Wedge " + wedgeNum.str() + ": Transverse Energy", NBINS, XMIN, XMAX);
 
-      iBooker.tagContents(monitorName_ + "/HFMinus/Wedge" + tempStreamer.str(),
-                          iWedge + 1);
+      iBooker.tagContents(monitorName_ + "/HFMinus/Wedge" + tempStreamer.str(), iWedge + 1);
     }
   }
 
@@ -295,44 +251,37 @@ void HLXMonitor::SetupHists(DQMStore::IBooker &iBooker) {
   std::string CompEtSumYTitle = "E_{T} Sum per active tower";
   std::string CompOccYTitle = "Occupancy per active tower";
 
-  HFCompareEtSum =
-      iBooker.book1D("HFCompareEtSum", "E_{T} Sum", NUM_HLX, 0, NUM_HLX);
+  HFCompareEtSum = iBooker.book1D("HFCompareEtSum", "E_{T} Sum", NUM_HLX, 0, NUM_HLX);
   HFCompareEtSum->setAxisTitle(CompXTitle, 1);
   HFCompareEtSum->setAxisTitle(CompEtSumYTitle, 2);
 
-  HFCompareOccBelowSet1 = iBooker.book1D("HFCompareOccBelowSet1",
-                                         "Occupancy Below Threshold 1 - Set 1",
-                                         NUM_HLX, 0, NUM_HLX);
+  HFCompareOccBelowSet1 =
+      iBooker.book1D("HFCompareOccBelowSet1", "Occupancy Below Threshold 1 - Set 1", NUM_HLX, 0, NUM_HLX);
   HFCompareOccBelowSet1->setAxisTitle(CompXTitle, 1);
   HFCompareOccBelowSet1->setAxisTitle(CompOccYTitle, 2);
 
-  HFCompareOccBetweenSet1 = iBooker.book1D(
-      "HFCompareOccBetweenSet1", "Occupancy Between Threshold 1 & 2 - Set 1",
-      NUM_HLX, 0, NUM_HLX);
+  HFCompareOccBetweenSet1 =
+      iBooker.book1D("HFCompareOccBetweenSet1", "Occupancy Between Threshold 1 & 2 - Set 1", NUM_HLX, 0, NUM_HLX);
   HFCompareOccBetweenSet1->setAxisTitle(CompXTitle, 1);
   HFCompareOccBetweenSet1->setAxisTitle(CompOccYTitle, 2);
 
-  HFCompareOccAboveSet1 = iBooker.book1D("HFCompareOccAboveSet1",
-                                         "Occupancy Above Threshold 2 - Set 1",
-                                         NUM_HLX, 0, NUM_HLX);
+  HFCompareOccAboveSet1 =
+      iBooker.book1D("HFCompareOccAboveSet1", "Occupancy Above Threshold 2 - Set 1", NUM_HLX, 0, NUM_HLX);
   HFCompareOccAboveSet1->setAxisTitle(CompXTitle, 1);
   HFCompareOccAboveSet1->setAxisTitle(CompOccYTitle, 2);
 
-  HFCompareOccBelowSet2 = iBooker.book1D("HFCompareOccBelowSet2",
-                                         "Occupancy Below Threshold 1 - Set 2",
-                                         NUM_HLX, 0, NUM_HLX);
+  HFCompareOccBelowSet2 =
+      iBooker.book1D("HFCompareOccBelowSet2", "Occupancy Below Threshold 1 - Set 2", NUM_HLX, 0, NUM_HLX);
   HFCompareOccBelowSet2->setAxisTitle(CompXTitle, 1);
   HFCompareOccBelowSet2->setAxisTitle(CompOccYTitle, 2);
 
-  HFCompareOccBetweenSet2 = iBooker.book1D(
-      "HFCompareOccBetweenSet2", "Occupancy Between Threshold 1 & 2 - Set 2",
-      NUM_HLX, 0, NUM_HLX);
+  HFCompareOccBetweenSet2 =
+      iBooker.book1D("HFCompareOccBetweenSet2", "Occupancy Between Threshold 1 & 2 - Set 2", NUM_HLX, 0, NUM_HLX);
   HFCompareOccBetweenSet2->setAxisTitle(CompXTitle, 1);
   HFCompareOccBetweenSet2->setAxisTitle(CompOccYTitle, 2);
 
-  HFCompareOccAboveSet2 = iBooker.book1D("HFCompareOccAboveSet2",
-                                         "Occupancy Above Threshold 2 - Set 2",
-                                         NUM_HLX, 0, NUM_HLX);
+  HFCompareOccAboveSet2 =
+      iBooker.book1D("HFCompareOccAboveSet2", "Occupancy Above Threshold 2 - Set 2", NUM_HLX, 0, NUM_HLX);
   HFCompareOccAboveSet2->setAxisTitle(CompXTitle, 1);
   HFCompareOccAboveSet2->setAxisTitle(CompOccYTitle, 2);
 
@@ -340,15 +289,14 @@ void HLXMonitor::SetupHists(DQMStore::IBooker &iBooker) {
 
   iBooker.setCurrentFolder(monitorName_ + "/Average");
 
-  int OccBins = 10000; // This does absolutely nothing.
+  int OccBins = 10000;  // This does absolutely nothing.
   double OccMin = 0;
-  double OccMax = 0; // If min and max are zero, no bounds on the data are set.
+  double OccMax = 0;  // If min and max are zero, no bounds on the data are set.
 
-  int EtSumBins = 10000; // This does absolutely nothing.  The Variable is not
-                         // used in the function.
+  int EtSumBins = 10000;  // This does absolutely nothing.  The Variable is not
+                          // used in the function.
   double EtSumMin = 0;
-  double EtSumMax =
-      0; // If min and max are zero, no bounds on the data are set.
+  double EtSumMax = 0;  // If min and max are zero, no bounds on the data are set.
 
   std::string errorOpt = "i";
 
@@ -356,44 +304,79 @@ void HLXMonitor::SetupHists(DQMStore::IBooker &iBooker) {
   std::string AvgEtSumYTitle = "Average E_{T} Sum";
   std::string AvgOccYTitle = "Average Tower Occupancy";
 
-  AvgEtSum = iBooker.bookProfile("AvgEtSum", "Average E_{T} Sum", NUM_HLX, 0,
-                                 NUM_HLX, EtSumBins, EtSumMin, EtSumMax);
+  AvgEtSum = iBooker.bookProfile("AvgEtSum", "Average E_{T} Sum", NUM_HLX, 0, NUM_HLX, EtSumBins, EtSumMin, EtSumMax);
   AvgEtSum->setAxisTitle(AvgXTitle, 1);
   AvgEtSum->setAxisTitle(AvgEtSumYTitle, 2);
 
-  AvgOccBelowSet1 = iBooker.bookProfile(
-      "AvgOccBelowSet1", "Average Occupancy Below Threshold 1 - Set1", NUM_HLX,
-      0, NUM_HLX, OccBins, OccMin, OccMax, errorOpt.c_str());
+  AvgOccBelowSet1 = iBooker.bookProfile("AvgOccBelowSet1",
+                                        "Average Occupancy Below Threshold 1 - Set1",
+                                        NUM_HLX,
+                                        0,
+                                        NUM_HLX,
+                                        OccBins,
+                                        OccMin,
+                                        OccMax,
+                                        errorOpt.c_str());
   AvgOccBelowSet1->setAxisTitle(AvgXTitle, 1);
   AvgOccBelowSet1->setAxisTitle(AvgOccYTitle, 2);
 
-  AvgOccBetweenSet1 = iBooker.bookProfile(
-      "AvgOccBetweenSet1", "Average Occupancy Between Threhold 1 & 2 - Set1",
-      NUM_HLX, 0, NUM_HLX, OccBins, OccMin, OccMax, errorOpt.c_str());
+  AvgOccBetweenSet1 = iBooker.bookProfile("AvgOccBetweenSet1",
+                                          "Average Occupancy Between Threhold 1 & 2 - Set1",
+                                          NUM_HLX,
+                                          0,
+                                          NUM_HLX,
+                                          OccBins,
+                                          OccMin,
+                                          OccMax,
+                                          errorOpt.c_str());
   AvgOccBetweenSet1->setAxisTitle(AvgXTitle, 1);
   AvgOccBetweenSet1->setAxisTitle(AvgOccYTitle, 2);
 
-  AvgOccAboveSet1 = iBooker.bookProfile(
-      "AvgOccAboveSet1", "Average Occupancy Above Threshold 2 - Set1", NUM_HLX,
-      0, NUM_HLX, OccBins, OccMin, OccMax, errorOpt.c_str());
+  AvgOccAboveSet1 = iBooker.bookProfile("AvgOccAboveSet1",
+                                        "Average Occupancy Above Threshold 2 - Set1",
+                                        NUM_HLX,
+                                        0,
+                                        NUM_HLX,
+                                        OccBins,
+                                        OccMin,
+                                        OccMax,
+                                        errorOpt.c_str());
   AvgOccAboveSet1->setAxisTitle(AvgXTitle, 1);
   AvgOccAboveSet1->setAxisTitle(AvgOccYTitle, 2);
 
-  AvgOccBelowSet2 = iBooker.bookProfile(
-      "AvgOccBelowSet2", "Average Occupancy Below Threshold 1 - Set2", NUM_HLX,
-      0, NUM_HLX, OccBins, OccMin, OccMax, errorOpt.c_str());
+  AvgOccBelowSet2 = iBooker.bookProfile("AvgOccBelowSet2",
+                                        "Average Occupancy Below Threshold 1 - Set2",
+                                        NUM_HLX,
+                                        0,
+                                        NUM_HLX,
+                                        OccBins,
+                                        OccMin,
+                                        OccMax,
+                                        errorOpt.c_str());
   AvgOccBelowSet2->setAxisTitle(AvgXTitle, 1);
   AvgOccBelowSet2->setAxisTitle(AvgOccYTitle, 2);
 
-  AvgOccBetweenSet2 = iBooker.bookProfile(
-      "AvgOccBetweenSet2", "Average Occupancy Between Threshold 1 & 2 - Set2",
-      NUM_HLX, 0, NUM_HLX, OccBins, OccMin, OccMax, errorOpt.c_str());
+  AvgOccBetweenSet2 = iBooker.bookProfile("AvgOccBetweenSet2",
+                                          "Average Occupancy Between Threshold 1 & 2 - Set2",
+                                          NUM_HLX,
+                                          0,
+                                          NUM_HLX,
+                                          OccBins,
+                                          OccMin,
+                                          OccMax,
+                                          errorOpt.c_str());
   AvgOccBetweenSet2->setAxisTitle(AvgXTitle, 1);
   AvgOccBetweenSet2->setAxisTitle(AvgOccYTitle, 2);
 
-  AvgOccAboveSet2 = iBooker.bookProfile(
-      "AvgOccAboveSet2", "Average Occupancy Above Threshold 2 - Set2", NUM_HLX,
-      0, NUM_HLX, OccBins, OccMin, OccMax, errorOpt.c_str());
+  AvgOccAboveSet2 = iBooker.bookProfile("AvgOccAboveSet2",
+                                        "Average Occupancy Above Threshold 2 - Set2",
+                                        NUM_HLX,
+                                        0,
+                                        NUM_HLX,
+                                        OccBins,
+                                        OccMin,
+                                        OccMax,
+                                        errorOpt.c_str());
   AvgOccAboveSet2->setAxisTitle(AvgXTitle, 1);
   AvgOccAboveSet2->setAxisTitle(AvgOccYTitle, 2);
 
@@ -404,57 +387,46 @@ void HLXMonitor::SetupHists(DQMStore::IBooker &iBooker) {
   std::string LumiEtSumYTitle = "Luminosity: E_{T} Sum";
   std::string LumiOccYTitle = "Luminosity: Occupancy";
 
-  LumiAvgEtSum = iBooker.bookProfile("LumiAvgEtSum", "Average Luminosity ",
-                                     int(XMAX - XMIN), XMIN, XMAX, EtSumBins,
-                                     EtSumMin, EtSumMax);
+  LumiAvgEtSum = iBooker.bookProfile(
+      "LumiAvgEtSum", "Average Luminosity ", int(XMAX - XMIN), XMIN, XMAX, EtSumBins, EtSumMin, EtSumMax);
   LumiAvgEtSum->setAxisTitle(LumiXTitle, 1);
   LumiAvgEtSum->setAxisTitle(LumiEtSumYTitle, 2);
 
   LumiAvgOccSet1 = iBooker.bookProfile(
-      "LumiAvgOccSet1", "Average Luminosity - Set 1", int(XMAX - XMIN), XMIN,
-      XMAX, OccBins, OccMax, OccMin);
+      "LumiAvgOccSet1", "Average Luminosity - Set 1", int(XMAX - XMIN), XMIN, XMAX, OccBins, OccMax, OccMin);
   LumiAvgOccSet1->setAxisTitle(LumiXTitle, 1);
   LumiAvgOccSet1->setAxisTitle(LumiOccYTitle, 2);
 
   LumiAvgOccSet2 = iBooker.bookProfile(
-      "LumiAvgOccSet2", "Average Luminosity - Set 2", int(XMAX - XMIN), XMIN,
-      XMAX, OccBins, OccMax, OccMin);
+      "LumiAvgOccSet2", "Average Luminosity - Set 2", int(XMAX - XMIN), XMIN, XMAX, OccBins, OccMax, OccMin);
   LumiAvgOccSet2->setAxisTitle(LumiXTitle, 1);
   LumiAvgOccSet2->setAxisTitle(LumiOccYTitle, 2);
 
-  LumiInstantEtSum =
-      iBooker.book1D("LumiInstantEtSum", "Instantaneous Luminosity ",
-                     int(XMAX - XMIN), XMIN, XMAX);
+  LumiInstantEtSum = iBooker.book1D("LumiInstantEtSum", "Instantaneous Luminosity ", int(XMAX - XMIN), XMIN, XMAX);
   LumiInstantEtSum->setAxisTitle(LumiXTitle, 1);
   LumiInstantEtSum->setAxisTitle(LumiEtSumYTitle, 2);
 
   LumiInstantOccSet1 =
-      iBooker.book1D("LumiInstantOccSet1", "Instantaneous Luminosity - Set 1",
-                     int(XMAX - XMIN), XMIN, XMAX);
+      iBooker.book1D("LumiInstantOccSet1", "Instantaneous Luminosity - Set 1", int(XMAX - XMIN), XMIN, XMAX);
   LumiInstantOccSet1->setAxisTitle(LumiXTitle, 1);
   LumiInstantOccSet1->setAxisTitle(LumiOccYTitle, 2);
 
   LumiInstantOccSet2 =
-      iBooker.book1D("LumiInstantOccSet2", "Instantaneous Luminosity - Set 2",
-                     int(XMAX - XMIN), XMIN, XMAX);
+      iBooker.book1D("LumiInstantOccSet2", "Instantaneous Luminosity - Set 2", int(XMAX - XMIN), XMIN, XMAX);
   LumiInstantOccSet2->setAxisTitle(LumiXTitle, 1);
   LumiInstantOccSet2->setAxisTitle(LumiOccYTitle, 2);
 
-  LumiIntegratedEtSum =
-      iBooker.book1D("LumiIntegratedEtSum", "Integrated Luminosity ",
-                     int(XMAX - XMIN), XMIN, XMAX);
+  LumiIntegratedEtSum = iBooker.book1D("LumiIntegratedEtSum", "Integrated Luminosity ", int(XMAX - XMIN), XMIN, XMAX);
   LumiIntegratedEtSum->setAxisTitle(LumiXTitle, 1);
   LumiIntegratedEtSum->setAxisTitle(LumiEtSumYTitle, 2);
 
   LumiIntegratedOccSet1 =
-      iBooker.book1D("LumiIntegratedOccSet1", "Integrated Luminosity - Set 1",
-                     int(XMAX - XMIN), XMIN, XMAX);
+      iBooker.book1D("LumiIntegratedOccSet1", "Integrated Luminosity - Set 1", int(XMAX - XMIN), XMIN, XMAX);
   LumiIntegratedOccSet1->setAxisTitle(LumiXTitle, 1);
   LumiIntegratedOccSet1->setAxisTitle(LumiOccYTitle, 2);
 
   LumiIntegratedOccSet2 =
-      iBooker.book1D("LumiIntegratedOccSet2", "Integrated Luminosity - Set 2",
-                     int(XMAX - XMIN), XMIN, XMAX);
+      iBooker.book1D("LumiIntegratedOccSet2", "Integrated Luminosity - Set 2", int(XMAX - XMIN), XMIN, XMAX);
   LumiIntegratedOccSet2->setAxisTitle(LumiXTitle, 1);
   LumiIntegratedOccSet2->setAxisTitle(LumiOccYTitle, 2);
 
@@ -465,60 +437,45 @@ void HLXMonitor::SetupHists(DQMStore::IBooker &iBooker) {
   std::string sumYTitle = "Occupancy Sum (Below+Above+Between)";
 
   SumAllOccSet1 =
-      iBooker.bookProfile("SumAllOccSet1", "Occupancy Check - Set 1", NUM_HLX,
-                          0, NUM_HLX, OccBins, OccMax, OccMin);
+      iBooker.bookProfile("SumAllOccSet1", "Occupancy Check - Set 1", NUM_HLX, 0, NUM_HLX, OccBins, OccMax, OccMin);
   SumAllOccSet1->setAxisTitle(sumXTitle, 1);
   SumAllOccSet1->setAxisTitle(sumYTitle, 2);
 
   SumAllOccSet2 =
-      iBooker.bookProfile("SumAllOccSet2", "Occupancy Check - Set 2", NUM_HLX,
-                          0, NUM_HLX, OccBins, OccMax, OccMin);
+      iBooker.bookProfile("SumAllOccSet2", "Occupancy Check - Set 2", NUM_HLX, 0, NUM_HLX, OccBins, OccMax, OccMin);
   SumAllOccSet2->setAxisTitle(sumXTitle, 1);
   SumAllOccSet2->setAxisTitle(sumYTitle, 2);
 
-  MissingDQMDataCheck =
-      iBooker.book1D("MissingDQMDataCheck", "Missing Data Count", 1, 0, 1);
+  MissingDQMDataCheck = iBooker.book1D("MissingDQMDataCheck", "Missing Data Count", 1, 0, 1);
   MissingDQMDataCheck->setAxisTitle("", 1);
   MissingDQMDataCheck->setAxisTitle("Number Missing Nibbles", 2);
 
   // Signal & Background monitoring histograms
   iBooker.setCurrentFolder(monitorName_ + "/SigBkgLevels");
 
-  MaxInstLumiBX1 =
-      iBooker.book1D("MaxInstLumiBX1", "Max Instantaneous Luminosity BX: 1st",
-                     10000, -1e-5, 0.01);
+  MaxInstLumiBX1 = iBooker.book1D("MaxInstLumiBX1", "Max Instantaneous Luminosity BX: 1st", 10000, -1e-5, 0.01);
   MaxInstLumiBX1->setAxisTitle("Max Inst. L (10^{30}cm^{-2}s^{-1})", 1);
   MaxInstLumiBX1->setAxisTitle("Entries", 2);
-  MaxInstLumiBX2 =
-      iBooker.book1D("MaxInstLumiBX2", "Max Instantaneous Luminosity BX: 2nd",
-                     10000, -1e-5, 0.01);
+  MaxInstLumiBX2 = iBooker.book1D("MaxInstLumiBX2", "Max Instantaneous Luminosity BX: 2nd", 10000, -1e-5, 0.01);
   MaxInstLumiBX2->setAxisTitle("Max Inst. L (10^{30}cm^{-2}s^{-1})", 1);
   MaxInstLumiBX2->setAxisTitle("Entries", 2);
-  MaxInstLumiBX3 =
-      iBooker.book1D("MaxInstLumiBX3", "Max Instantaneous Luminosity BX: 3rd",
-                     10000, -1e-5, 0.01);
+  MaxInstLumiBX3 = iBooker.book1D("MaxInstLumiBX3", "Max Instantaneous Luminosity BX: 3rd", 10000, -1e-5, 0.01);
   MaxInstLumiBX3->setAxisTitle("Max Inst. L (10^{30}cm^{-2}s^{-1})", 1);
   MaxInstLumiBX3->setAxisTitle("Entries", 2);
-  MaxInstLumiBX4 =
-      iBooker.book1D("MaxInstLumiBX4", "Max Instantaneous Luminosity BX: 4th",
-                     10000, -1e-5, 0.01);
+  MaxInstLumiBX4 = iBooker.book1D("MaxInstLumiBX4", "Max Instantaneous Luminosity BX: 4th", 10000, -1e-5, 0.01);
   MaxInstLumiBX4->setAxisTitle("Max Inst. L (10^{30}cm^{-2}s^{-1})", 1);
   MaxInstLumiBX4->setAxisTitle("Entries", 2);
 
-  MaxInstLumiBXNum1 = iBooker.book1D("MaxInstLumiBXNum1",
-                                     "BX Number of Max: 1st", 3564, 0, 3564);
+  MaxInstLumiBXNum1 = iBooker.book1D("MaxInstLumiBXNum1", "BX Number of Max: 1st", 3564, 0, 3564);
   MaxInstLumiBXNum1->setAxisTitle("BX", 1);
   MaxInstLumiBXNum1->setAxisTitle("Num Time Max", 2);
-  MaxInstLumiBXNum2 = iBooker.book1D("MaxInstLumiBXNum2",
-                                     "BX Number of Max: 2nd", 3564, 0, 3564);
+  MaxInstLumiBXNum2 = iBooker.book1D("MaxInstLumiBXNum2", "BX Number of Max: 2nd", 3564, 0, 3564);
   MaxInstLumiBXNum2->setAxisTitle("BX", 1);
   MaxInstLumiBXNum2->setAxisTitle("Num Time Max", 2);
-  MaxInstLumiBXNum3 = iBooker.book1D("MaxInstLumiBXNum3",
-                                     "BX Number of Max: 3rd", 3564, 0, 3564);
+  MaxInstLumiBXNum3 = iBooker.book1D("MaxInstLumiBXNum3", "BX Number of Max: 3rd", 3564, 0, 3564);
   MaxInstLumiBXNum3->setAxisTitle("BX", 1);
   MaxInstLumiBXNum3->setAxisTitle("Num Time Max", 2);
-  MaxInstLumiBXNum4 = iBooker.book1D("MaxInstLumiBXNum4",
-                                     "BX Number of Max: 4th", 3564, 0, 3564);
+  MaxInstLumiBXNum4 = iBooker.book1D("MaxInstLumiBXNum4", "BX Number of Max: 4th", 3564, 0, 3564);
   MaxInstLumiBXNum4->setAxisTitle("BX", 1);
   MaxInstLumiBXNum4->setAxisTitle("Num Time Max", 2);
 
@@ -535,176 +492,250 @@ void HLXMonitor::SetupHists(DQMStore::IBooker &iBooker) {
   std::string BXvsTimeYTitle = "BX";
 
   // Et Sum histories
-  HistAvgEtSumHFP =
-      iBooker.bookProfile("HistAvgEtSumHFP", "Average Et Sum: HF+", MAX_LS, 0.5,
-                          (double)MAX_LS + 0.5, EtSumBins, EtSumMin, EtSumMax);
+  HistAvgEtSumHFP = iBooker.bookProfile(
+      "HistAvgEtSumHFP", "Average Et Sum: HF+", MAX_LS, 0.5, (double)MAX_LS + 0.5, EtSumBins, EtSumMin, EtSumMax);
   HistAvgEtSumHFP->setAxisTitle(HistXTitle, 1);
   HistAvgEtSumHFP->setAxisTitle(HistEtSumYTitle, 2);
 
-  HistAvgEtSumHFM =
-      iBooker.bookProfile("HistAvgEtSumHFM", "Average Et Sum: HF-", MAX_LS, 0.5,
-                          (double)MAX_LS + 0.5, EtSumBins, EtSumMin, EtSumMax);
+  HistAvgEtSumHFM = iBooker.bookProfile(
+      "HistAvgEtSumHFM", "Average Et Sum: HF-", MAX_LS, 0.5, (double)MAX_LS + 0.5, EtSumBins, EtSumMin, EtSumMax);
   HistAvgEtSumHFM->setAxisTitle(HistXTitle, 1);
   HistAvgEtSumHFM->setAxisTitle(HistEtSumYTitle, 2);
 
   // Tower Occupancy Histories
-  HistAvgOccBelowSet1HFP = iBooker.bookProfile(
-      "HistAvgOccBelowSet1HFP", "Average Occ Set1Below: HF+", MAX_LS, 0.5,
-      (double)MAX_LS + 0.5, OccBins, OccMin, OccMax);
+  HistAvgOccBelowSet1HFP = iBooker.bookProfile("HistAvgOccBelowSet1HFP",
+                                               "Average Occ Set1Below: HF+",
+                                               MAX_LS,
+                                               0.5,
+                                               (double)MAX_LS + 0.5,
+                                               OccBins,
+                                               OccMin,
+                                               OccMax);
   HistAvgOccBelowSet1HFP->setAxisTitle(HistXTitle, 1);
   HistAvgOccBelowSet1HFP->setAxisTitle(HistOccYTitle, 2);
 
-  HistAvgOccBelowSet1HFM = iBooker.bookProfile(
-      "HistAvgOccBelowSet1HFM", "Average Occ Set1Below: HF-", MAX_LS, 0.5,
-      (double)MAX_LS + 0.5, OccBins, OccMin, OccMax);
+  HistAvgOccBelowSet1HFM = iBooker.bookProfile("HistAvgOccBelowSet1HFM",
+                                               "Average Occ Set1Below: HF-",
+                                               MAX_LS,
+                                               0.5,
+                                               (double)MAX_LS + 0.5,
+                                               OccBins,
+                                               OccMin,
+                                               OccMax);
   HistAvgOccBelowSet1HFM->setAxisTitle(HistXTitle, 1);
   HistAvgOccBelowSet1HFM->setAxisTitle(HistOccYTitle, 2);
 
-  HistAvgOccBetweenSet1HFP = iBooker.bookProfile(
-      "HistAvgOccBetweenSet1HFP", "Average Occ Set1Between: HF+", MAX_LS, 0.5,
-      (double)MAX_LS + 0.5, OccBins, OccMin, OccMax);
+  HistAvgOccBetweenSet1HFP = iBooker.bookProfile("HistAvgOccBetweenSet1HFP",
+                                                 "Average Occ Set1Between: HF+",
+                                                 MAX_LS,
+                                                 0.5,
+                                                 (double)MAX_LS + 0.5,
+                                                 OccBins,
+                                                 OccMin,
+                                                 OccMax);
   HistAvgOccBetweenSet1HFP->setAxisTitle(HistXTitle, 1);
   HistAvgOccBetweenSet1HFP->setAxisTitle(HistOccYTitle, 2);
 
-  HistAvgOccBetweenSet1HFM = iBooker.bookProfile(
-      "HistAvgOccBetweenSet1HFM", "Average Occ Set1Between: HF-", MAX_LS, 0.5,
-      (double)MAX_LS + 0.5, OccBins, OccMin, OccMax);
+  HistAvgOccBetweenSet1HFM = iBooker.bookProfile("HistAvgOccBetweenSet1HFM",
+                                                 "Average Occ Set1Between: HF-",
+                                                 MAX_LS,
+                                                 0.5,
+                                                 (double)MAX_LS + 0.5,
+                                                 OccBins,
+                                                 OccMin,
+                                                 OccMax);
   HistAvgOccBetweenSet1HFM->setAxisTitle(HistXTitle, 1);
   HistAvgOccBetweenSet1HFM->setAxisTitle(HistOccYTitle, 2);
 
-  HistAvgOccAboveSet1HFP = iBooker.bookProfile(
-      "HistAvgOccAboveSet1HFP", "Average Occ Set1Above: HF+", MAX_LS, 0.5,
-      (double)MAX_LS + 0.5, OccBins, OccMin, OccMax);
+  HistAvgOccAboveSet1HFP = iBooker.bookProfile("HistAvgOccAboveSet1HFP",
+                                               "Average Occ Set1Above: HF+",
+                                               MAX_LS,
+                                               0.5,
+                                               (double)MAX_LS + 0.5,
+                                               OccBins,
+                                               OccMin,
+                                               OccMax);
   HistAvgOccAboveSet1HFP->setAxisTitle(HistXTitle, 1);
   HistAvgOccAboveSet1HFP->setAxisTitle(HistOccYTitle, 2);
 
-  HistAvgOccAboveSet1HFM = iBooker.bookProfile(
-      "HistAvgOccAboveSet1HFM", "Average Occ Set1Above: HF-", MAX_LS, 0.5,
-      (double)MAX_LS + 0.5, OccBins, OccMin, OccMax);
+  HistAvgOccAboveSet1HFM = iBooker.bookProfile("HistAvgOccAboveSet1HFM",
+                                               "Average Occ Set1Above: HF-",
+                                               MAX_LS,
+                                               0.5,
+                                               (double)MAX_LS + 0.5,
+                                               OccBins,
+                                               OccMin,
+                                               OccMax);
   HistAvgOccAboveSet1HFM->setAxisTitle(HistXTitle, 1);
   HistAvgOccAboveSet1HFM->setAxisTitle(HistOccYTitle, 2);
 
-  HistAvgOccBelowSet2HFP = iBooker.bookProfile(
-      "HistAvgOccBelowSet2HFP", "Average Occ Set2Below: HF+", MAX_LS, 0.5,
-      (double)MAX_LS + 0.5, OccBins, OccMin, OccMax);
+  HistAvgOccBelowSet2HFP = iBooker.bookProfile("HistAvgOccBelowSet2HFP",
+                                               "Average Occ Set2Below: HF+",
+                                               MAX_LS,
+                                               0.5,
+                                               (double)MAX_LS + 0.5,
+                                               OccBins,
+                                               OccMin,
+                                               OccMax);
   HistAvgOccBelowSet2HFP->setAxisTitle(HistXTitle, 1);
   HistAvgOccBelowSet2HFP->setAxisTitle(HistOccYTitle, 2);
 
-  HistAvgOccBelowSet2HFM = iBooker.bookProfile(
-      "HistAvgOccBelowSet2HFM", "Average Occ Set2Below: HF-", MAX_LS, 0.5,
-      (double)MAX_LS + 0.5, OccBins, OccMin, OccMax);
+  HistAvgOccBelowSet2HFM = iBooker.bookProfile("HistAvgOccBelowSet2HFM",
+                                               "Average Occ Set2Below: HF-",
+                                               MAX_LS,
+                                               0.5,
+                                               (double)MAX_LS + 0.5,
+                                               OccBins,
+                                               OccMin,
+                                               OccMax);
   HistAvgOccBelowSet2HFM->setAxisTitle(HistXTitle, 1);
   HistAvgOccBelowSet2HFM->setAxisTitle(HistOccYTitle, 2);
 
-  HistAvgOccBetweenSet2HFP = iBooker.bookProfile(
-      "HistAvgOccBetweenSet2HFP", "Average Occ Set2Between: HF+", MAX_LS, 0.5,
-      (double)MAX_LS + 0.5, OccBins, OccMin, OccMax);
+  HistAvgOccBetweenSet2HFP = iBooker.bookProfile("HistAvgOccBetweenSet2HFP",
+                                                 "Average Occ Set2Between: HF+",
+                                                 MAX_LS,
+                                                 0.5,
+                                                 (double)MAX_LS + 0.5,
+                                                 OccBins,
+                                                 OccMin,
+                                                 OccMax);
   HistAvgOccBetweenSet2HFP->setAxisTitle(HistXTitle, 1);
   HistAvgOccBetweenSet2HFP->setAxisTitle(HistOccYTitle, 2);
 
-  HistAvgOccBetweenSet2HFM = iBooker.bookProfile(
-      "HistAvgOccBetweenSet2HFM", "Average Occ Set2Between: HF-", MAX_LS, 0.5,
-      (double)MAX_LS + 0.5, OccBins, OccMin, OccMax);
+  HistAvgOccBetweenSet2HFM = iBooker.bookProfile("HistAvgOccBetweenSet2HFM",
+                                                 "Average Occ Set2Between: HF-",
+                                                 MAX_LS,
+                                                 0.5,
+                                                 (double)MAX_LS + 0.5,
+                                                 OccBins,
+                                                 OccMin,
+                                                 OccMax);
   HistAvgOccBetweenSet2HFM->setAxisTitle(HistXTitle, 1);
   HistAvgOccBetweenSet2HFM->setAxisTitle(HistOccYTitle, 2);
 
-  HistAvgOccAboveSet2HFP = iBooker.bookProfile(
-      "HistAvgOccAboveSet2HFP", "Average Occ Set2Above: HF+", MAX_LS, 0.5,
-      (double)MAX_LS + 0.5, OccBins, OccMin, OccMax);
+  HistAvgOccAboveSet2HFP = iBooker.bookProfile("HistAvgOccAboveSet2HFP",
+                                               "Average Occ Set2Above: HF+",
+                                               MAX_LS,
+                                               0.5,
+                                               (double)MAX_LS + 0.5,
+                                               OccBins,
+                                               OccMin,
+                                               OccMax);
   HistAvgOccAboveSet2HFP->setAxisTitle(HistXTitle, 1);
   HistAvgOccAboveSet2HFP->setAxisTitle(HistOccYTitle, 2);
 
-  HistAvgOccAboveSet2HFM = iBooker.bookProfile(
-      "HistAvgOccAboveSet2HFM", "Average Occ Set2Above: HF-", MAX_LS, 0.5,
-      (double)MAX_LS + 0.5, OccBins, OccMin, OccMax);
+  HistAvgOccAboveSet2HFM = iBooker.bookProfile("HistAvgOccAboveSet2HFM",
+                                               "Average Occ Set2Above: HF-",
+                                               MAX_LS,
+                                               0.5,
+                                               (double)MAX_LS + 0.5,
+                                               OccBins,
+                                               OccMin,
+                                               OccMax);
   HistAvgOccAboveSet2HFM->setAxisTitle(HistXTitle, 1);
   HistAvgOccAboveSet2HFM->setAxisTitle(HistOccYTitle, 2);
 
   // Et Sum histories
-  BXvsTimeAvgEtSumHFP =
-      iBooker.book2D("BXvsTimeAvgEtSumHFP", "Average Et Sum: HF+", MAX_LS, 0.5,
-                     (double)MAX_LS + 0.5, NBINS, (double)XMIN, (double)XMAX);
+  BXvsTimeAvgEtSumHFP = iBooker.book2D("BXvsTimeAvgEtSumHFP",
+                                       "Average Et Sum: HF+",
+                                       MAX_LS,
+                                       0.5,
+                                       (double)MAX_LS + 0.5,
+                                       NBINS,
+                                       (double)XMIN,
+                                       (double)XMAX);
   BXvsTimeAvgEtSumHFP->setAxisTitle(BXvsTimeXTitle, 1);
   BXvsTimeAvgEtSumHFP->setAxisTitle(BXvsTimeYTitle, 2);
 
-  BXvsTimeAvgEtSumHFM =
-      iBooker.book2D("BXvsTimeAvgEtSumHFM", "Average Et Sum: HF-", MAX_LS, 0.5,
-                     (double)MAX_LS + 0.5, NBINS, (double)XMIN, (double)XMAX);
+  BXvsTimeAvgEtSumHFM = iBooker.book2D("BXvsTimeAvgEtSumHFM",
+                                       "Average Et Sum: HF-",
+                                       MAX_LS,
+                                       0.5,
+                                       (double)MAX_LS + 0.5,
+                                       NBINS,
+                                       (double)XMIN,
+                                       (double)XMAX);
   BXvsTimeAvgEtSumHFM->setAxisTitle(BXvsTimeXTitle, 1);
   BXvsTimeAvgEtSumHFM->setAxisTitle(BXvsTimeYTitle, 2);
 
   iBooker.setCurrentFolder(monitorName_ + "/HistoryLumi");
 
   // Lumi Histories
-  HistAvgLumiEtSum = iBooker.bookProfile(
-      "HistAvgLumiEtSum", "Average Instant Luminosity: Et Sum", MAX_LS, 0.5,
-      (double)MAX_LS + 0.5, EtSumBins, EtSumMin, EtSumMax);
+  HistAvgLumiEtSum = iBooker.bookProfile("HistAvgLumiEtSum",
+                                         "Average Instant Luminosity: Et Sum",
+                                         MAX_LS,
+                                         0.5,
+                                         (double)MAX_LS + 0.5,
+                                         EtSumBins,
+                                         EtSumMin,
+                                         EtSumMax);
   HistAvgLumiEtSum->setAxisTitle(HistXTitle, 1);
   HistAvgLumiEtSum->setAxisTitle(HistLumiYTitle, 2);
 
-  HistAvgLumiOccSet1 = iBooker.bookProfile(
-      "HistAvgLumiOccSet1", "Average Instant Luminosity: Occ Set1", MAX_LS, 0.5,
-      (double)MAX_LS + 0.5, OccBins, OccMin, OccMax);
+  HistAvgLumiOccSet1 = iBooker.bookProfile("HistAvgLumiOccSet1",
+                                           "Average Instant Luminosity: Occ Set1",
+                                           MAX_LS,
+                                           0.5,
+                                           (double)MAX_LS + 0.5,
+                                           OccBins,
+                                           OccMin,
+                                           OccMax);
   HistAvgLumiOccSet1->setAxisTitle(HistXTitle, 1);
   HistAvgLumiOccSet1->setAxisTitle(HistLumiYTitle, 2);
 
-  HistAvgLumiOccSet2 = iBooker.bookProfile(
-      "HistAvgLumiOccSet2", "Average Instant Luminosity: Occ Set2", MAX_LS, 0.5,
-      (double)MAX_LS + 0.5, OccBins, OccMin, OccMax);
+  HistAvgLumiOccSet2 = iBooker.bookProfile("HistAvgLumiOccSet2",
+                                           "Average Instant Luminosity: Occ Set2",
+                                           MAX_LS,
+                                           0.5,
+                                           (double)MAX_LS + 0.5,
+                                           OccBins,
+                                           OccMin,
+                                           OccMax);
   HistAvgLumiOccSet2->setAxisTitle(HistXTitle, 1);
   HistAvgLumiOccSet2->setAxisTitle(HistLumiYTitle, 2);
 
   HistInstantLumiEtSum =
-      iBooker.book1D("HistInstantLumiEtSum", "Instant Luminosity: Et Sum",
-                     MAX_LS, 0.5, (double)MAX_LS + 0.5);
+      iBooker.book1D("HistInstantLumiEtSum", "Instant Luminosity: Et Sum", MAX_LS, 0.5, (double)MAX_LS + 0.5);
   HistInstantLumiEtSum->setAxisTitle(HistXTitle, 1);
   HistInstantLumiEtSum->setAxisTitle(HistLumiYTitle, 2);
 
   HistInstantLumiOccSet1 =
-      iBooker.book1D("HistInstantLumiOccSet1", "Instant Luminosity: Occ Set1",
-                     MAX_LS, 0.5, (double)MAX_LS + 0.5);
+      iBooker.book1D("HistInstantLumiOccSet1", "Instant Luminosity: Occ Set1", MAX_LS, 0.5, (double)MAX_LS + 0.5);
   HistInstantLumiOccSet1->setAxisTitle(HistXTitle, 1);
   HistInstantLumiOccSet1->setAxisTitle(HistLumiYTitle, 2);
 
   HistInstantLumiOccSet2 =
-      iBooker.book1D("HistInstantLumiOccSet2", "Instant Luminosity: Occ Set2",
-                     MAX_LS, 0.5, (double)MAX_LS + 0.5);
+      iBooker.book1D("HistInstantLumiOccSet2", "Instant Luminosity: Occ Set2", MAX_LS, 0.5, (double)MAX_LS + 0.5);
   HistInstantLumiOccSet2->setAxisTitle(HistXTitle, 1);
   HistInstantLumiOccSet2->setAxisTitle(HistLumiYTitle, 2);
 
   HistInstantLumiEtSumError =
-      iBooker.book1D("HistInstantLumiEtSumError", "Luminosity Error: Et Sum",
-                     MAX_LS, 0.5, (double)MAX_LS + 0.5);
+      iBooker.book1D("HistInstantLumiEtSumError", "Luminosity Error: Et Sum", MAX_LS, 0.5, (double)MAX_LS + 0.5);
   HistInstantLumiEtSumError->setAxisTitle(HistXTitle, 1);
   HistInstantLumiEtSumError->setAxisTitle(HistLumiErrorYTitle, 2);
 
-  HistInstantLumiOccSet1Error = iBooker.book1D(
-      "HistInstantLumiOccSet1Error", "Luminosity Error: Occ Set1", MAX_LS, 0.5,
-      (double)MAX_LS + 0.5);
+  HistInstantLumiOccSet1Error =
+      iBooker.book1D("HistInstantLumiOccSet1Error", "Luminosity Error: Occ Set1", MAX_LS, 0.5, (double)MAX_LS + 0.5);
   HistInstantLumiOccSet1Error->setAxisTitle(HistXTitle, 1);
   HistInstantLumiOccSet1Error->setAxisTitle(HistLumiErrorYTitle, 2);
 
-  HistInstantLumiOccSet2Error = iBooker.book1D(
-      "HistInstantLumiOccSet2Error", "Luminosity Error: Occ Set2", MAX_LS, 0.5,
-      (double)MAX_LS + 0.5);
+  HistInstantLumiOccSet2Error =
+      iBooker.book1D("HistInstantLumiOccSet2Error", "Luminosity Error: Occ Set2", MAX_LS, 0.5, (double)MAX_LS + 0.5);
   HistInstantLumiOccSet2Error->setAxisTitle(HistXTitle, 1);
   HistInstantLumiOccSet2Error->setAxisTitle(HistLumiErrorYTitle, 2);
 
   HistIntegratedLumiEtSum =
-      iBooker.book1D("HistIntegratedLumiEtSum", "Integrated Luminosity: Et Sum",
-                     MAX_LS, 0.5, (double)MAX_LS + 0.5);
+      iBooker.book1D("HistIntegratedLumiEtSum", "Integrated Luminosity: Et Sum", MAX_LS, 0.5, (double)MAX_LS + 0.5);
   HistIntegratedLumiEtSum->setAxisTitle(HistXTitle, 1);
   HistIntegratedLumiEtSum->setAxisTitle(HistLumiYTitle, 2);
 
-  HistIntegratedLumiOccSet1 = iBooker.book1D("HistIntegratedLumiOccSet1",
-                                             "Integrated Luminosity: Occ Set1",
-                                             MAX_LS, 0.5, (double)MAX_LS + 0.5);
+  HistIntegratedLumiOccSet1 =
+      iBooker.book1D("HistIntegratedLumiOccSet1", "Integrated Luminosity: Occ Set1", MAX_LS, 0.5, (double)MAX_LS + 0.5);
   HistIntegratedLumiOccSet1->setAxisTitle(HistXTitle, 1);
   HistIntegratedLumiOccSet1->setAxisTitle(HistLumiYTitle, 2);
 
-  HistIntegratedLumiOccSet2 = iBooker.book1D("HistIntegratedLumiOccSet2",
-                                             "Integrated Luminosity: Occ Set2",
-                                             MAX_LS, 0.5, (double)MAX_LS + 0.5);
+  HistIntegratedLumiOccSet2 =
+      iBooker.book1D("HistIntegratedLumiOccSet2", "Integrated Luminosity: Occ Set2", MAX_LS, 0.5, (double)MAX_LS + 0.5);
   HistIntegratedLumiOccSet2->setAxisTitle(HistXTitle, 1);
   HistIntegratedLumiOccSet2->setAxisTitle(HistLumiYTitle, 2);
 
@@ -712,38 +743,32 @@ void HLXMonitor::SetupHists(DQMStore::IBooker &iBooker) {
 
   // Lumi Recent Histories (past 128 short sections)
   RecentInstantLumiEtSum =
-      iBooker.book1D("RecentInstantLumiEtSum", "Instant Luminosity: Et Sum",
-                     128, 0.5, (double)128 + 0.5);
+      iBooker.book1D("RecentInstantLumiEtSum", "Instant Luminosity: Et Sum", 128, 0.5, (double)128 + 0.5);
   RecentInstantLumiEtSum->setAxisTitle(RecentHistXTitle, 1);
   RecentInstantLumiEtSum->setAxisTitle(HistLumiYTitle, 2);
 
   RecentInstantLumiOccSet1 =
-      iBooker.book1D("RecentInstantLumiOccSet1", "Instant Luminosity: Occ Set1",
-                     128, 0.5, (double)128 + 0.5);
+      iBooker.book1D("RecentInstantLumiOccSet1", "Instant Luminosity: Occ Set1", 128, 0.5, (double)128 + 0.5);
   RecentInstantLumiOccSet1->setAxisTitle(RecentHistXTitle, 1);
   RecentInstantLumiOccSet1->setAxisTitle(HistLumiYTitle, 2);
 
   RecentInstantLumiOccSet2 =
-      iBooker.book1D("RecentInstantLumiOccSet2", "Instant Luminosity: Occ Set2",
-                     128, 0.5, (double)128 + 0.5);
+      iBooker.book1D("RecentInstantLumiOccSet2", "Instant Luminosity: Occ Set2", 128, 0.5, (double)128 + 0.5);
   RecentInstantLumiOccSet2->setAxisTitle(RecentHistXTitle, 1);
   RecentInstantLumiOccSet2->setAxisTitle(HistLumiYTitle, 2);
 
-  RecentIntegratedLumiEtSum = iBooker.book1D("RecentIntegratedLumiEtSum",
-                                             "Integrated Luminosity: Et Sum",
-                                             128, 0.5, (double)128 + 0.5);
+  RecentIntegratedLumiEtSum =
+      iBooker.book1D("RecentIntegratedLumiEtSum", "Integrated Luminosity: Et Sum", 128, 0.5, (double)128 + 0.5);
   RecentIntegratedLumiEtSum->setAxisTitle(RecentHistXTitle, 1);
   RecentIntegratedLumiEtSum->setAxisTitle(HistLumiYTitle, 2);
 
-  RecentIntegratedLumiOccSet1 = iBooker.book1D(
-      "RecentIntegratedLumiOccSet1", "Integrated Luminosity: Occ Set1", 128,
-      0.5, (double)128 + 0.5);
+  RecentIntegratedLumiOccSet1 =
+      iBooker.book1D("RecentIntegratedLumiOccSet1", "Integrated Luminosity: Occ Set1", 128, 0.5, (double)128 + 0.5);
   RecentIntegratedLumiOccSet1->setAxisTitle(RecentHistXTitle, 1);
   RecentIntegratedLumiOccSet1->setAxisTitle(HistLumiYTitle, 2);
 
-  RecentIntegratedLumiOccSet2 = iBooker.book1D(
-      "RecentIntegratedLumiOccSet2", "Integrated Luminosity: Occ Set2", 128,
-      0.5, (double)128 + 0.5);
+  RecentIntegratedLumiOccSet2 =
+      iBooker.book1D("RecentIntegratedLumiOccSet2", "Integrated Luminosity: Occ Set2", 128, 0.5, (double)128 + 0.5);
   RecentIntegratedLumiOccSet2->setAxisTitle(RecentHistXTitle, 1);
   RecentIntegratedLumiOccSet2->setAxisTitle(HistLumiYTitle, 2);
 }
@@ -800,8 +825,7 @@ void HLXMonitor::SetupEventInfo(DQMStore::IBooker &iBooker) {
   iBooker.setCurrentFolder(currentfolder);
 
   reportSummary_ = iBooker.bookFloat("reportSummary");
-  reportSummaryMap_ = iBooker.book2D("reportSummaryMap", "reportSummaryMap", 18,
-                                     0., 18., 2, -1.5, 1.5);
+  reportSummaryMap_ = iBooker.book2D("reportSummaryMap", "reportSummaryMap", 18, 0., 18., 2, -1.5, 1.5);
 
   currentfolder = subSystemName_ + "/" + eventInfoFolderHLX_;
   iBooker.setCurrentFolder(currentfolder);
@@ -827,8 +851,7 @@ void HLXMonitor::SetupEventInfo(DQMStore::IBooker &iBooker) {
 }
 
 // ------------ method called to for each event  ------------
-void HLXMonitor::analyze(const edm::Event &iEvent,
-                         const edm::EventSetup &iSetup) {
+void HLXMonitor::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
 
   while (HLXTCP.IsConnected() == false) {
@@ -869,8 +892,7 @@ void HLXMonitor::analyze(const edm::Event &iEvent,
     FillEventInfo(lumiSection, iEvent);
     FillReportSummary();
 
-    cout << "Run: " << lumiSection.hdr.runNumber
-         << " Section: " << lumiSection.hdr.sectionNumber
+    cout << "Run: " << lumiSection.hdr.runNumber << " Section: " << lumiSection.hdr.sectionNumber
          << " Orbit: " << lumiSection.hdr.startOrbit << endl;
     cout << "Et Lumi: " << lumiSection.lumiSummary.InstantETLumi << endl;
     cout << "Occ Lumi 1: " << lumiSection.lumiSummary.InstantOccLumi[0] << endl;
@@ -926,76 +948,56 @@ void HLXMonitor::FillHistograms(const LUMI_SECTION &section) {
     // If we are already more than 2 LS's in, move everything back by one bin
     // and fill the last bin with the new value.
     for (int iBin = 1; iBin < 128; ++iBin) {
-      RecentInstantLumiEtSum->setBinContent(
-          iBin, RecentInstantLumiEtSum->getBinContent(iBin + 1));
-      RecentInstantLumiOccSet1->setBinContent(
-          iBin, RecentInstantLumiOccSet1->getBinContent(iBin + 1));
-      RecentInstantLumiOccSet2->setBinContent(
-          iBin, RecentInstantLumiOccSet2->getBinContent(iBin + 1));
-      RecentIntegratedLumiEtSum->setBinContent(
-          iBin, RecentIntegratedLumiEtSum->getBinContent(iBin + 1));
-      RecentIntegratedLumiOccSet1->setBinContent(
-          iBin, RecentIntegratedLumiOccSet1->getBinContent(iBin + 1));
-      RecentIntegratedLumiOccSet2->setBinContent(
-          iBin, RecentIntegratedLumiOccSet2->getBinContent(iBin + 1));
+      RecentInstantLumiEtSum->setBinContent(iBin, RecentInstantLumiEtSum->getBinContent(iBin + 1));
+      RecentInstantLumiOccSet1->setBinContent(iBin, RecentInstantLumiOccSet1->getBinContent(iBin + 1));
+      RecentInstantLumiOccSet2->setBinContent(iBin, RecentInstantLumiOccSet2->getBinContent(iBin + 1));
+      RecentIntegratedLumiEtSum->setBinContent(iBin, RecentIntegratedLumiEtSum->getBinContent(iBin + 1));
+      RecentIntegratedLumiOccSet1->setBinContent(iBin, RecentIntegratedLumiOccSet1->getBinContent(iBin + 1));
+      RecentIntegratedLumiOccSet2->setBinContent(iBin, RecentIntegratedLumiOccSet2->getBinContent(iBin + 1));
     }
     fillBin = 128;
   }
 
-  RecentInstantLumiEtSum->setBinContent(fillBin,
-                                        section.lumiSummary.InstantETLumi);
-  RecentInstantLumiEtSum->setBinError(fillBin,
-                                      section.lumiSummary.InstantETLumiErr);
-  RecentInstantLumiOccSet1->setBinContent(
-      fillBin, section.lumiSummary.InstantOccLumi[0]);
-  RecentInstantLumiOccSet1->setBinError(
-      fillBin, section.lumiSummary.InstantOccLumiErr[0]);
-  RecentInstantLumiOccSet2->setBinContent(
-      fillBin, section.lumiSummary.InstantOccLumi[1]);
-  RecentInstantLumiOccSet2->setBinError(
-      fillBin, section.lumiSummary.InstantOccLumiErr[1]);
+  RecentInstantLumiEtSum->setBinContent(fillBin, section.lumiSummary.InstantETLumi);
+  RecentInstantLumiEtSum->setBinError(fillBin, section.lumiSummary.InstantETLumiErr);
+  RecentInstantLumiOccSet1->setBinContent(fillBin, section.lumiSummary.InstantOccLumi[0]);
+  RecentInstantLumiOccSet1->setBinError(fillBin, section.lumiSummary.InstantOccLumiErr[0]);
+  RecentInstantLumiOccSet2->setBinContent(fillBin, section.lumiSummary.InstantOccLumi[1]);
+  RecentInstantLumiOccSet2->setBinError(fillBin, section.lumiSummary.InstantOccLumiErr[1]);
 
-  double recentOldBinContent =
-      RecentIntegratedLumiEtSum->getBinContent(fillBin - 1);
+  double recentOldBinContent = RecentIntegratedLumiEtSum->getBinContent(fillBin - 1);
   if (fillBin == 1)
     recentOldBinContent = 0;
-  double recentNewBinContent =
-      recentOldBinContent + section.lumiSummary.InstantETLumi;
+  double recentNewBinContent = recentOldBinContent + section.lumiSummary.InstantETLumi;
   RecentIntegratedLumiEtSum->setBinContent(fillBin, recentNewBinContent);
   recentOldBinContent = RecentIntegratedLumiOccSet1->getBinContent(fillBin - 1);
   if (fillBin == 1)
     recentOldBinContent = 0;
-  recentNewBinContent =
-      recentOldBinContent + section.lumiSummary.InstantOccLumi[0];
+  recentNewBinContent = recentOldBinContent + section.lumiSummary.InstantOccLumi[0];
   RecentIntegratedLumiOccSet1->setBinContent(fillBin, recentNewBinContent);
   recentOldBinContent = RecentIntegratedLumiOccSet2->getBinContent(fillBin - 1);
   if (fillBin == 1)
     recentOldBinContent = 0;
-  recentNewBinContent =
-      recentOldBinContent + section.lumiSummary.InstantOccLumi[0];
+  recentNewBinContent = recentOldBinContent + section.lumiSummary.InstantOccLumi[0];
   RecentIntegratedLumiOccSet2->setBinContent(fillBin, recentNewBinContent);
 
-  double recentOldBinError =
-      RecentIntegratedLumiEtSum->getBinError(fillBin - 1);
+  double recentOldBinError = RecentIntegratedLumiEtSum->getBinError(fillBin - 1);
   if (fillBin == 1)
     recentOldBinError = 0;
   double recentNewBinError = sqrt(recentOldBinError * recentOldBinError +
-                                  section.lumiSummary.InstantETLumiErr *
-                                      section.lumiSummary.InstantETLumiErr);
+                                  section.lumiSummary.InstantETLumiErr * section.lumiSummary.InstantETLumiErr);
   RecentIntegratedLumiEtSum->setBinError(fillBin, recentNewBinError);
   recentOldBinError = RecentIntegratedLumiOccSet1->getBinError(fillBin - 1);
   if (fillBin == 1)
     recentOldBinError = 0;
   recentNewBinError = sqrt(recentOldBinError * recentOldBinError +
-                           section.lumiSummary.InstantOccLumiErr[0] *
-                               section.lumiSummary.InstantOccLumiErr[0]);
+                           section.lumiSummary.InstantOccLumiErr[0] * section.lumiSummary.InstantOccLumiErr[0]);
   RecentIntegratedLumiOccSet1->setBinError(fillBin, recentNewBinError);
   recentOldBinError = RecentIntegratedLumiOccSet2->getBinError(fillBin - 1);
   if (fillBin == 1)
     recentOldBinError = 0;
   recentNewBinError = sqrt(recentOldBinError * recentOldBinError +
-                           section.lumiSummary.InstantOccLumiErr[1] *
-                               section.lumiSummary.InstantOccLumiErr[1]);
+                           section.lumiSummary.InstantOccLumiErr[1] * section.lumiSummary.InstantOccLumiErr[1]);
   RecentIntegratedLumiOccSet2->setBinError(fillBin, recentNewBinError);
 
   if (lsBinOld != lsBin) {
@@ -1041,20 +1043,17 @@ void HLXMonitor::FillHistograms(const LUMI_SECTION &section) {
     double histOldBinError = HistIntegratedLumiEtSum->getBinError(lsBinOld);
     if (lsBinOld == 0)
       histOldBinError = 0;
-    double histNewBinError =
-        sqrt(histOldBinError * histOldBinError + sectionInstantErrSumEt);
+    double histNewBinError = sqrt(histOldBinError * histOldBinError + sectionInstantErrSumEt);
     HistIntegratedLumiEtSum->setBinError(lsBin, histNewBinError);
     histOldBinError = HistIntegratedLumiOccSet1->getBinError(lsBinOld);
     if (lsBinOld == 0)
       histOldBinError = 0;
-    histNewBinError =
-        sqrt(histOldBinError * histOldBinError + sectionInstantErrSumOcc1);
+    histNewBinError = sqrt(histOldBinError * histOldBinError + sectionInstantErrSumOcc1);
     HistIntegratedLumiOccSet1->setBinError(lsBin, histNewBinError);
     histOldBinError = HistIntegratedLumiOccSet2->getBinError(lsBinOld);
     if (lsBinOld == 0)
       histOldBinError = 0;
-    histNewBinError =
-        sqrt(histOldBinError * histOldBinError + sectionInstantErrSumOcc2);
+    histNewBinError = sqrt(histOldBinError * histOldBinError + sectionInstantErrSumOcc2);
     HistIntegratedLumiOccSet2->setBinError(lsBin, histNewBinError);
 
     sectionInstantSumEt = 0;
@@ -1068,14 +1067,11 @@ void HLXMonitor::FillHistograms(const LUMI_SECTION &section) {
   }
 
   sectionInstantSumEt += section.lumiSummary.InstantETLumi;
-  sectionInstantErrSumEt += section.lumiSummary.InstantETLumiErr *
-                            section.lumiSummary.InstantETLumiErr;
+  sectionInstantErrSumEt += section.lumiSummary.InstantETLumiErr * section.lumiSummary.InstantETLumiErr;
   sectionInstantSumOcc1 += section.lumiSummary.InstantOccLumi[0];
-  sectionInstantErrSumOcc1 += section.lumiSummary.InstantOccLumiErr[0] *
-                              section.lumiSummary.InstantOccLumiErr[0];
+  sectionInstantErrSumOcc1 += section.lumiSummary.InstantOccLumiErr[0] * section.lumiSummary.InstantOccLumiErr[0];
   sectionInstantSumOcc2 += section.lumiSummary.InstantOccLumi[1];
-  sectionInstantErrSumOcc2 += section.lumiSummary.InstantOccLumiErr[1] *
-                              section.lumiSummary.InstantOccLumiErr[1];
+  sectionInstantErrSumOcc2 += section.lumiSummary.InstantOccLumiErr[1] * section.lumiSummary.InstantOccLumiErr[1];
   ++sectionInstantNorm;
 
   LumiInstantEtSum->softReset();
@@ -1102,26 +1098,13 @@ void HLXMonitor::FillHistograms(const LUMI_SECTION &section) {
         if (norm[1] == 0)
           norm[1] = 1;
 
-        double normEt =
-            section.etSum[iHLX].data[iBX] / (double)(norm[0] + norm[1]);
-        double normOccSet1Below =
-            (double)section.occupancy[iHLX].data[set1BelowIndex][iBX] /
-            (double)norm[0];
-        double normOccSet1Between =
-            (double)section.occupancy[iHLX].data[set1BetweenIndex][iBX] /
-            (double)norm[0];
-        double normOccSet1Above =
-            (double)section.occupancy[iHLX].data[set1AboveIndex][iBX] /
-            (double)norm[0];
-        double normOccSet2Below =
-            (double)section.occupancy[iHLX].data[set2BelowIndex][iBX] /
-            (double)norm[1];
-        double normOccSet2Between =
-            (double)section.occupancy[iHLX].data[set2BetweenIndex][iBX] /
-            (double)norm[1];
-        double normOccSet2Above =
-            (double)section.occupancy[iHLX].data[set2AboveIndex][iBX] /
-            (double)norm[1];
+        double normEt = section.etSum[iHLX].data[iBX] / (double)(norm[0] + norm[1]);
+        double normOccSet1Below = (double)section.occupancy[iHLX].data[set1BelowIndex][iBX] / (double)norm[0];
+        double normOccSet1Between = (double)section.occupancy[iHLX].data[set1BetweenIndex][iBX] / (double)norm[0];
+        double normOccSet1Above = (double)section.occupancy[iHLX].data[set1AboveIndex][iBX] / (double)norm[0];
+        double normOccSet2Below = (double)section.occupancy[iHLX].data[set2BelowIndex][iBX] / (double)norm[1];
+        double normOccSet2Between = (double)section.occupancy[iHLX].data[set2BetweenIndex][iBX] / (double)norm[1];
+        double normOccSet2Above = (double)section.occupancy[iHLX].data[set2AboveIndex][iBX] / (double)norm[1];
 
         // Averages & check sum
         if (iBX < NUM_BUNCHES - 100) {
@@ -1145,8 +1128,7 @@ void HLXMonitor::FillHistograms(const LUMI_SECTION &section) {
             HistAvgOccAboveSet2HFP->Fill(lsBin, normOccSet2Above);
 
             if (iBX >= (XMIN - 1) && iBX <= (XMAX - 1))
-              BXvsTimeAvgEtSumHFP->Fill(
-                  lsBinBX, iBX, normEt / (num4NibblePerLS_ * 18.0 * 12.0));
+              BXvsTimeAvgEtSumHFP->Fill(lsBinBX, iBX, normEt / (num4NibblePerLS_ * 18.0 * 12.0));
           } else {
             HistAvgEtSumHFM->Fill(lsBin, normEt);
             HistAvgOccBelowSet1HFM->Fill(lsBin, normOccSet1Below);
@@ -1157,8 +1139,7 @@ void HLXMonitor::FillHistograms(const LUMI_SECTION &section) {
             HistAvgOccAboveSet2HFM->Fill(lsBin, normOccSet2Above);
 
             if (iBX >= (XMIN - 1) && iBX <= (XMAX - 1))
-              BXvsTimeAvgEtSumHFM->Fill(
-                  lsBinBX, iBX, normEt / (num4NibblePerLS_ * 18.0 * 12.0));
+              BXvsTimeAvgEtSumHFM->Fill(lsBinBX, iBX, normEt / (num4NibblePerLS_ * 18.0 * 12.0));
           }
 
           utotal1 += section.occupancy[iHLX].data[set1BelowIndex][iBX];
@@ -1178,41 +1159,28 @@ void HLXMonitor::FillHistograms(const LUMI_SECTION &section) {
           // Adjust the old bin content to make the new, unnormalize and
           // renormalize
           if (lumiSectionCount > 0) {
-            double oldNormOccSet1Below =
-                (Set1Below[iWedge]->getBinContent(iBin)) *
-                (double)(lumiSectionCount);
+            double oldNormOccSet1Below = (Set1Below[iWedge]->getBinContent(iBin)) * (double)(lumiSectionCount);
             normOccSet1Below += oldNormOccSet1Below;
             normOccSet1Below /= (double)(lumiSectionCount + 1);
-            double oldNormOccSet2Below =
-                (Set2Below[iWedge]->getBinContent(iBin)) *
-                (double)(lumiSectionCount);
+            double oldNormOccSet2Below = (Set2Below[iWedge]->getBinContent(iBin)) * (double)(lumiSectionCount);
             normOccSet2Below += oldNormOccSet2Below;
             normOccSet2Below /= (double)(lumiSectionCount + 1);
 
-            double oldNormOccSet1Between =
-                (Set1Between[iWedge]->getBinContent(iBin)) *
-                (double)(lumiSectionCount);
+            double oldNormOccSet1Between = (Set1Between[iWedge]->getBinContent(iBin)) * (double)(lumiSectionCount);
             normOccSet1Between += oldNormOccSet1Between;
             normOccSet1Between /= (double)(lumiSectionCount + 1);
-            double oldNormOccSet2Between =
-                (Set2Between[iWedge]->getBinContent(iBin)) *
-                (double)(lumiSectionCount);
+            double oldNormOccSet2Between = (Set2Between[iWedge]->getBinContent(iBin)) * (double)(lumiSectionCount);
             normOccSet2Between += oldNormOccSet2Between;
             normOccSet2Between /= (double)(lumiSectionCount + 1);
 
-            double oldNormOccSet1Above =
-                (Set1Above[iWedge]->getBinContent(iBin)) *
-                (double)(lumiSectionCount);
+            double oldNormOccSet1Above = (Set1Above[iWedge]->getBinContent(iBin)) * (double)(lumiSectionCount);
             normOccSet1Above += oldNormOccSet1Above;
             normOccSet1Above /= (double)(lumiSectionCount + 1);
-            double oldNormOccSet2Above =
-                (Set2Above[iWedge]->getBinContent(iBin)) *
-                (double)(lumiSectionCount);
+            double oldNormOccSet2Above = (Set2Above[iWedge]->getBinContent(iBin)) * (double)(lumiSectionCount);
             normOccSet2Above += oldNormOccSet2Above;
             normOccSet2Above /= (double)(lumiSectionCount + 1);
 
-            double oldNormEt =
-                ETSum[iWedge]->getBinContent(iBin) * (double)(lumiSectionCount);
+            double oldNormEt = ETSum[iWedge]->getBinContent(iBin) * (double)(lumiSectionCount);
             normEt += oldNormEt;
             normEt /= (double)(lumiSectionCount + 1);
           }
@@ -1287,15 +1255,11 @@ void HLXMonitor::FillHistograms(const LUMI_SECTION &section) {
     int iBin = iBX - (int)XMIN + 1;
     if (iBin <= int(XMAX - XMIN) && iBin >= 1) {
       LumiInstantEtSum->setBinContent(iBin, section.lumiDetail.ETLumi[iBX]);
-      LumiInstantOccSet1->setBinContent(iBin,
-                                        section.lumiDetail.OccLumi[0][iBX]);
-      LumiInstantOccSet2->setBinContent(iBin,
-                                        section.lumiDetail.OccLumi[1][iBX]);
+      LumiInstantOccSet1->setBinContent(iBin, section.lumiDetail.OccLumi[0][iBX]);
+      LumiInstantOccSet2->setBinContent(iBin, section.lumiDetail.OccLumi[1][iBX]);
       LumiInstantEtSum->setBinError(iBin, section.lumiDetail.ETLumiErr[iBX]);
-      LumiInstantOccSet1->setBinError(iBin,
-                                      section.lumiDetail.OccLumiErr[0][iBX]);
-      LumiInstantOccSet2->setBinError(iBin,
-                                      section.lumiDetail.OccLumiErr[1][iBX]);
+      LumiInstantOccSet1->setBinError(iBin, section.lumiDetail.OccLumiErr[0][iBX]);
+      LumiInstantOccSet2->setBinError(iBin, section.lumiDetail.OccLumiErr[1][iBX]);
 
       double oldBinContent = LumiIntegratedEtSum->getBinContent(iBin);
       if (lumiSectionCount == 0)
@@ -1316,23 +1280,20 @@ void HLXMonitor::FillHistograms(const LUMI_SECTION &section) {
       double oldBinError = LumiIntegratedEtSum->getBinError(iBin);
       if (lumiSectionCount == 0)
         oldBinError = 0;
-      double newBinError = sqrt(oldBinError * oldBinError +
-                                section.lumiDetail.ETLumiErr[iBX] *
-                                    section.lumiDetail.ETLumiErr[iBX]);
+      double newBinError =
+          sqrt(oldBinError * oldBinError + section.lumiDetail.ETLumiErr[iBX] * section.lumiDetail.ETLumiErr[iBX]);
       LumiIntegratedEtSum->setBinError(iBin, newBinError);
       oldBinError = LumiIntegratedOccSet1->getBinError(iBin);
       if (lumiSectionCount == 0)
         oldBinError = 0;
       newBinError = sqrt(oldBinError * oldBinError +
-                         section.lumiDetail.OccLumiErr[0][iBX] *
-                             section.lumiDetail.OccLumiErr[0][iBX]);
+                         section.lumiDetail.OccLumiErr[0][iBX] * section.lumiDetail.OccLumiErr[0][iBX]);
       LumiIntegratedOccSet1->setBinError(iBin, newBinError);
       oldBinError = LumiIntegratedOccSet1->getBinError(iBin);
       if (lumiSectionCount == 0)
         oldBinError = 0;
       newBinError = sqrt(oldBinError * oldBinError +
-                         section.lumiDetail.OccLumiErr[1][iBX] *
-                             section.lumiDetail.OccLumiErr[1][iBX]);
+                         section.lumiDetail.OccLumiErr[1][iBX] * section.lumiDetail.OccLumiErr[1][iBX]);
       LumiIntegratedOccSet2->setBinError(iBin, newBinError);
     }
   }
@@ -1403,15 +1364,13 @@ void HLXMonitor::FillHistoHFCompare(const LUMI_SECTION &section) {
     unsigned int iWedge = HLXHFMap[iHLX];
 
     if (section.occupancy[iHLX].hdr.numNibbles != 0) {
-      float nActvTwrsSet1 =
-          section.occupancy[iHLX].data[set1AboveIndex][TriggerBX] +
-          section.occupancy[iHLX].data[set1BetweenIndex][TriggerBX] +
-          section.occupancy[iHLX].data[set1BelowIndex][TriggerBX];
+      float nActvTwrsSet1 = section.occupancy[iHLX].data[set1AboveIndex][TriggerBX] +
+                            section.occupancy[iHLX].data[set1BetweenIndex][TriggerBX] +
+                            section.occupancy[iHLX].data[set1BelowIndex][TriggerBX];
 
-      float nActvTwrsSet2 =
-          section.occupancy[iHLX].data[set2AboveIndex][TriggerBX] +
-          section.occupancy[iHLX].data[set2BetweenIndex][TriggerBX] +
-          section.occupancy[iHLX].data[set2BelowIndex][TriggerBX];
+      float nActvTwrsSet2 = section.occupancy[iHLX].data[set2AboveIndex][TriggerBX] +
+                            section.occupancy[iHLX].data[set2BetweenIndex][TriggerBX] +
+                            section.occupancy[iHLX].data[set2BelowIndex][TriggerBX];
 
       float total = nActvTwrsSet1 + nActvTwrsSet2;
 
@@ -1422,44 +1381,31 @@ void HLXMonitor::FillHistoHFCompare(const LUMI_SECTION &section) {
       }
 
       if (nActvTwrsSet1 > 0) {
-        float tempData =
-            (float)section.occupancy[iHLX].data[set1BelowIndex][TriggerBX] /
-            nActvTwrsSet1;
+        float tempData = (float)section.occupancy[iHLX].data[set1BelowIndex][TriggerBX] / nActvTwrsSet1;
         HFCompareOccBelowSet1->Fill(iWedge, tempData);
 
-        tempData =
-            (float)section.occupancy[iHLX].data[set1BetweenIndex][TriggerBX] /
-            nActvTwrsSet1;
+        tempData = (float)section.occupancy[iHLX].data[set1BetweenIndex][TriggerBX] / nActvTwrsSet1;
         HFCompareOccBetweenSet1->Fill(iWedge, tempData);
 
-        tempData =
-            (float)section.occupancy[iHLX].data[set1AboveIndex][TriggerBX] /
-            nActvTwrsSet1;
+        tempData = (float)section.occupancy[iHLX].data[set1AboveIndex][TriggerBX] / nActvTwrsSet1;
         HFCompareOccAboveSet1->Fill(iWedge, tempData);
       }
 
       if (nActvTwrsSet2 > 0) {
-        float tempData =
-            (float)section.occupancy[iHLX].data[set2BelowIndex][TriggerBX] /
-            nActvTwrsSet2;
+        float tempData = (float)section.occupancy[iHLX].data[set2BelowIndex][TriggerBX] / nActvTwrsSet2;
         HFCompareOccBelowSet2->Fill(iWedge, tempData);
 
-        tempData =
-            (float)section.occupancy[iHLX].data[set2BetweenIndex][TriggerBX] /
-            nActvTwrsSet2;
+        tempData = (float)section.occupancy[iHLX].data[set2BetweenIndex][TriggerBX] / nActvTwrsSet2;
         HFCompareOccBetweenSet2->Fill(iWedge, tempData);
 
-        tempData =
-            (float)section.occupancy[iHLX].data[set2AboveIndex][TriggerBX] /
-            nActvTwrsSet2;
+        tempData = (float)section.occupancy[iHLX].data[set2AboveIndex][TriggerBX] / nActvTwrsSet2;
         HFCompareOccAboveSet2->Fill(iWedge, tempData);
       }
     }
   }
 }
 
-void HLXMonitor::FillEventInfo(const LUMI_SECTION &section,
-                               const edm::Event &e) {
+void HLXMonitor::FillEventInfo(const LUMI_SECTION &section, const edm::Event &e) {
   // New run .. set the run number and fill run summaries ...
   // std::cout << "Run number " << runNumber_ << " Section hdr run number "
   //	     << section.hdr.runNumber << std::endl;

--- a/DQM/PhysicsObjectsMonitoring/interface/PhysicsObjectsMonitor.h
+++ b/DQM/PhysicsObjectsMonitoring/interface/PhysicsObjectsMonitor.h
@@ -19,10 +19,10 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 
 namespace edm {
-class ParameterSet;
-class Event;
-class EventSetup;
-} // namespace edm
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
 class TFile;
 class TH1F;
@@ -35,10 +35,8 @@ public:
   /// Destructor
   ~PhysicsObjectsMonitor() override;
   // Operations
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
-  void analyze(const edm::Event &event,
-               const edm::EventSetup &eventSetup) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void analyze(const edm::Event &event, const edm::EventSetup &eventSetup) override;
 
 private:
   std::string theSTAMuonLabel;

--- a/DQM/PhysicsObjectsMonitoring/src/PhysicsObjectsMonitor.cc
+++ b/DQM/PhysicsObjectsMonitoring/src/PhysicsObjectsMonitor.cc
@@ -30,31 +30,26 @@ using namespace edm;
 
 /// Constructor
 PhysicsObjectsMonitor::PhysicsObjectsMonitor(const ParameterSet &pset) {
-  theSTAMuonLabel =
-      pset.getUntrackedParameter<string>("StandAloneTrackCollectionLabel");
-  theSeedCollectionLabel =
-      pset.getUntrackedParameter<string>("MuonSeedCollectionLabel");
+  theSTAMuonLabel = pset.getUntrackedParameter<string>("StandAloneTrackCollectionLabel");
+  theSeedCollectionLabel = pset.getUntrackedParameter<string>("MuonSeedCollectionLabel");
   theDataType = pset.getUntrackedParameter<string>("DataType");
 
   if (theDataType != "RealData" && theDataType != "SimData")
     edm::LogInfo("PhysicsObjectsMonitor") << "Error in Data Type!!" << endl;
 
   if (theDataType == "SimData") {
-    edm::LogInfo("PhysicsObjectsMonitor")
-        << "Sorry! Running this package on simulation is no longer supported! ";
+    edm::LogInfo("PhysicsObjectsMonitor") << "Sorry! Running this package on simulation is no longer supported! ";
   }
 
   // set Token(-s)
-  theSTAMuonToken_ = consumes<reco::TrackCollection>(
-      pset.getUntrackedParameter<string>("StandAloneTrackCollectionLabel"));
+  theSTAMuonToken_ =
+      consumes<reco::TrackCollection>(pset.getUntrackedParameter<string>("StandAloneTrackCollectionLabel"));
 }
 
 /// Destructor
 PhysicsObjectsMonitor::~PhysicsObjectsMonitor() {}
 
-void PhysicsObjectsMonitor::bookHistograms(DQMStore::IBooker &iBooker,
-                                           edm::Run const &,
-                                           edm::EventSetup const &) {
+void PhysicsObjectsMonitor::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const &, edm::EventSetup const &) {
   iBooker.setCurrentFolder("PhysicsObjects/MuonReconstruction");
 
   hPres = iBooker.book1D("pTRes", "pT Resolution", 100, -2, 2);
@@ -67,26 +62,19 @@ void PhysicsObjectsMonitor::bookHistograms(DQMStore::IBooker &iBooker,
   py = iBooker.book1D("py", "track py", 100, -50, 50);
   pz = iBooker.book1D("pz", "track pz", 100, -50, 50);
   Nmuon = iBooker.book1D("Nmuon", "Number of muon tracks", 11, -.5, 10.5);
-  Nrechits = iBooker.book1D("Nrechits", "Number of RecHits/Segments on track",
-                            21, -.5, 21.5);
-  NDThits = iBooker.book1D("NDThits", "Number of DT Hits/Segments on track", 31,
-                           -.5, 31.5);
-  NCSChits = iBooker.book1D("NCSChits", "Number of CSC Hits/Segments on track",
-                            31, -.5, 31.5);
-  NRPChits =
-      iBooker.book1D("NRPChits", "Number of RPC hits on track", 11, -.5, 11.5);
+  Nrechits = iBooker.book1D("Nrechits", "Number of RecHits/Segments on track", 21, -.5, 21.5);
+  NDThits = iBooker.book1D("NDThits", "Number of DT Hits/Segments on track", 31, -.5, 31.5);
+  NCSChits = iBooker.book1D("NCSChits", "Number of CSC Hits/Segments on track", 31, -.5, 31.5);
+  NRPChits = iBooker.book1D("NRPChits", "Number of RPC hits on track", 11, -.5, 11.5);
 
-  DTvsCSC = iBooker.book2D("DTvsCSC", "Number of DT vs CSC hits on track", 29,
-                           -.5, 28.5, 29, -.5, 28.5);
+  DTvsCSC = iBooker.book2D("DTvsCSC", "Number of DT vs CSC hits on track", 29, -.5, 28.5, 29, -.5, 28.5);
   TH2F *root_ob = DTvsCSC->getTH2F();
   root_ob->SetXTitle("Number of DT hits");
   root_ob->SetYTitle("Number of CSC hits");
 }
 
-void PhysicsObjectsMonitor::analyze(const Event &event,
-                                    const EventSetup &eventSetup) {
-  edm::LogInfo("PhysicsObjectsMonitor")
-      << "Run: " << event.id().run() << " Event: " << event.id().event();
+void PhysicsObjectsMonitor::analyze(const Event &event, const EventSetup &eventSetup) {
+  edm::LogInfo("PhysicsObjectsMonitor") << "Run: " << event.id().run() << " Event: " << event.id().event();
   MuonPatternRecoDumper debug;
 
   // Get the RecTrack collection from the event
@@ -101,11 +89,9 @@ void PhysicsObjectsMonitor::analyze(const Event &event,
 
   reco::TrackCollection::const_iterator staTrack;
 
-  edm::LogInfo("PhysicsObjectsMonitor")
-      << "Reconstructed tracks: " << staTracks->size() << endl;
+  edm::LogInfo("PhysicsObjectsMonitor") << "Reconstructed tracks: " << staTracks->size() << endl;
   Nmuon->Fill(staTracks->size());
-  for (staTrack = staTracks->begin(); staTrack != staTracks->end();
-       ++staTrack) {
+  for (staTrack = staTracks->begin(); staTrack != staTracks->end(); ++staTrack) {
     reco::TransientTrack track(*staTrack, &*theMGField);
 
     int nrechits = 0;
@@ -113,11 +99,9 @@ void PhysicsObjectsMonitor::analyze(const Event &event,
     int nCSChits = 0;
     int nRPChits = 0;
 
-    for (trackingRecHit_iterator it = track.recHitsBegin();
-         it != track.recHitsEnd(); it++) {
+    for (trackingRecHit_iterator it = track.recHitsBegin(); it != track.recHitsEnd(); it++) {
       if ((*it)->isValid()) {
-        edm::LogInfo("PhysicsObjectsMonitor")
-            << "Analyzer:  Aha this looks like a Rechit!" << std::endl;
+        edm::LogInfo("PhysicsObjectsMonitor") << "Analyzer:  Aha this looks like a Rechit!" << std::endl;
         if ((*it)->geographicalId().subdetId() == MuonSubdetId::DT) {
           nDThits++;
         } else if ((*it)->geographicalId().subdetId() == MuonSubdetId::CSC) {
@@ -125,8 +109,7 @@ void PhysicsObjectsMonitor::analyze(const Event &event,
         } else if ((*it)->geographicalId().subdetId() == MuonSubdetId::RPC) {
           nRPChits++;
         } else {
-          edm::LogInfo("PhysicsObjectsMonitor")
-              << "This is an UNKNOWN hit !! " << std::endl;
+          edm::LogInfo("PhysicsObjectsMonitor") << "This is an UNKNOWN hit !! " << std::endl;
         }
         nrechits++;
       }
@@ -142,8 +125,7 @@ void PhysicsObjectsMonitor::analyze(const Event &event,
 
     recPt = track.impactPointTSCP().momentum().perp();
     edm::LogInfo("PhysicsObjectsMonitor")
-        << " p: " << track.impactPointTSCP().momentum().mag()
-        << " pT: " << recPt << endl;
+        << " p: " << track.impactPointTSCP().momentum().mag() << " pT: " << recPt << endl;
     pt->Fill(recPt);
     ptot->Fill(track.impactPointTSCP().momentum().mag());
     charge->Fill(track.impactPointTSCP().charge());

--- a/DQM/RCTMonitor/interface/RCTMonitor.h
+++ b/DQM/RCTMonitor/interface/RCTMonitor.h
@@ -75,8 +75,7 @@ class RCTMonitor : public DQMEDAnalyzer {
 public:
   explicit RCTMonitor(const edm::ParameterSet &);
   ~RCTMonitor() override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void FillRCT(const edm::Event &, const edm::EventSetup &);
 
@@ -153,4 +152,4 @@ private:
   edm::EDGetTokenT<L1CaloEmCollection> m_rctSourceToken_;
 };
 
-#endif // RCTMonitor_RCTMonitor_H
+#endif  // RCTMonitor_RCTMonitor_H

--- a/DQM/RCTMonitor/src/RCTMonitor.cc
+++ b/DQM/RCTMonitor/src/RCTMonitor.cc
@@ -5,83 +5,58 @@
 
 RCTMonitor::RCTMonitor(const edm::ParameterSet &iConfig) {
   // set Token(-s)
-  m_rctSourceToken_ = consumes<L1CaloEmCollection>(
-      iConfig.getUntrackedParameter<edm::InputTag>("rctSource"));
+  m_rctSourceToken_ = consumes<L1CaloEmCollection>(iConfig.getUntrackedParameter<edm::InputTag>("rctSource"));
 }
 
 RCTMonitor::~RCTMonitor() {}
 
-void RCTMonitor::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const &,
-                                edm::EventSetup const &) {
+void RCTMonitor::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const &, edm::EventSetup const &) {
   // Book RCT histograms
   iBooker.setCurrentFolder("RCT");
 
   m_rctIsoEmRankEtaPhi1 =
-      iBooker.book2D("RctIsoEmRankEtaPhi", "ISO EM RANK", PHIBINS, PHIMIN,
-                     PHIMAX, ETABINS, ETAMIN, ETAMAX);
+      iBooker.book2D("RctIsoEmRankEtaPhi", "ISO EM RANK", PHIBINS, PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
   m_rctIsoEmOccEtaPhi1 =
-      iBooker.book2D("RctIsoEmOccEtaPhi", "ISO EM OCCUPANCY", PHIBINS, PHIMIN,
-                     PHIMAX, ETABINS, ETAMIN, ETAMAX);
-  m_rctIsoEmRank1 =
-      iBooker.book1D("RctIsoEmRank", "ISO EM RANK", R6BINS, R6MIN, R6MAX);
+      iBooker.book2D("RctIsoEmOccEtaPhi", "ISO EM OCCUPANCY", PHIBINS, PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
+  m_rctIsoEmRank1 = iBooker.book1D("RctIsoEmRank", "ISO EM RANK", R6BINS, R6MIN, R6MAX);
   m_rctIsoEmRankEtaPhi10 =
-      iBooker.book2D("RctIsoEmRankEtaPhi10", "ISO EM RANK", PHIBINS, PHIMIN,
-                     PHIMAX, ETABINS, ETAMIN, ETAMAX);
+      iBooker.book2D("RctIsoEmRankEtaPhi10", "ISO EM RANK", PHIBINS, PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
   m_rctIsoEmOccEtaPhi10 =
-      iBooker.book2D("RctIsoEmOccEtaPhi10", "ISO EM OCCUPANCY", PHIBINS, PHIMIN,
-                     PHIMAX, ETABINS, ETAMIN, ETAMAX);
-  m_rctIsoEmRank10 =
-      iBooker.book1D("RctIsoEmRank10", "ISO EM RANK", R6BINS, R6MIN, R6MAX);
+      iBooker.book2D("RctIsoEmOccEtaPhi10", "ISO EM OCCUPANCY", PHIBINS, PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
+  m_rctIsoEmRank10 = iBooker.book1D("RctIsoEmRank10", "ISO EM RANK", R6BINS, R6MIN, R6MAX);
 
   m_rctNonIsoEmRankEtaPhi1 =
-      iBooker.book2D("RctNonIsoEmRankEtaPhi", "NON-ISO EM RANK", PHIBINS,
-                     PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
+      iBooker.book2D("RctNonIsoEmRankEtaPhi", "NON-ISO EM RANK", PHIBINS, PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
   m_rctNonIsoEmOccEtaPhi1 =
-      iBooker.book2D("RctNonIsoEmOccEtaPhi", "NON-ISO EM OCCUPANCY", PHIBINS,
-                     PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
-  m_rctNonIsoEmRank1 = iBooker.book1D("RctNonIsoEmRank", "NON-ISO EM RANK",
-                                      R6BINS, R6MIN, R6MAX);
+      iBooker.book2D("RctNonIsoEmOccEtaPhi", "NON-ISO EM OCCUPANCY", PHIBINS, PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
+  m_rctNonIsoEmRank1 = iBooker.book1D("RctNonIsoEmRank", "NON-ISO EM RANK", R6BINS, R6MIN, R6MAX);
   m_rctNonIsoEmRankEtaPhi10 =
-      iBooker.book2D("RctNonIsoEmRankEtaPhi10", "NON-ISO EM RANK", PHIBINS,
-                     PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
-  m_rctNonIsoEmOccEtaPhi10 =
-      iBooker.book2D("RctNonIsoEmOccEtaPhi10", "NON-ISO EM OCCUPANCY", PHIBINS,
-                     PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
-  m_rctNonIsoEmRank10 = iBooker.book1D("RctNonIsoEmRank10", "NON-ISO EM RANK",
-                                       R6BINS, R6MIN, R6MAX);
+      iBooker.book2D("RctNonIsoEmRankEtaPhi10", "NON-ISO EM RANK", PHIBINS, PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
+  m_rctNonIsoEmOccEtaPhi10 = iBooker.book2D(
+      "RctNonIsoEmOccEtaPhi10", "NON-ISO EM OCCUPANCY", PHIBINS, PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
+  m_rctNonIsoEmRank10 = iBooker.book1D("RctNonIsoEmRank10", "NON-ISO EM RANK", R6BINS, R6MIN, R6MAX);
 
   m_rctRelaxedEmRankEtaPhi1 =
-      iBooker.book2D("RctRelaxedEmRankEtaPhi", "RELAXED EM RANK", PHIBINS,
-                     PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
+      iBooker.book2D("RctRelaxedEmRankEtaPhi", "RELAXED EM RANK", PHIBINS, PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
   m_rctRelaxedEmOccEtaPhi1 =
-      iBooker.book2D("RctRelaxedEmOccEtaPhi", "RELAXED EM OCCUPANCY", PHIBINS,
-                     PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
-  m_rctRelaxedEmRank1 = iBooker.book1D("RctRelaxedEmRank", "RELAXED EM RANK",
-                                       R6BINS, R6MIN, R6MAX);
+      iBooker.book2D("RctRelaxedEmOccEtaPhi", "RELAXED EM OCCUPANCY", PHIBINS, PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
+  m_rctRelaxedEmRank1 = iBooker.book1D("RctRelaxedEmRank", "RELAXED EM RANK", R6BINS, R6MIN, R6MAX);
   m_rctRelaxedEmRankEtaPhi10 =
-      iBooker.book2D("RctRelaxedEmRankEtaPhi", "RELAXED EM RANK", PHIBINS,
-                     PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
-  m_rctRelaxedEmOccEtaPhi10 =
-      iBooker.book2D("RctRelaxedEmOccEtaPhi10", "RELAXED EM OCCUPANCY", PHIBINS,
-                     PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
-  m_rctRelaxedEmRank10 = iBooker.book1D("RctRelaxedEmRank", "RELAXED EM RANK",
-                                        R6BINS, R6MIN, R6MAX);
+      iBooker.book2D("RctRelaxedEmRankEtaPhi", "RELAXED EM RANK", PHIBINS, PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
+  m_rctRelaxedEmOccEtaPhi10 = iBooker.book2D(
+      "RctRelaxedEmOccEtaPhi10", "RELAXED EM OCCUPANCY", PHIBINS, PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
+  m_rctRelaxedEmRank10 = iBooker.book1D("RctRelaxedEmRank", "RELAXED EM RANK", R6BINS, R6MIN, R6MAX);
 
   m_rctRegionsEtEtaPhi =
-      iBooker.book2D("RctRegionsEtEtaPhi", "REGION E_{T}", PHIBINS, PHIMIN,
-                     PHIMAX, ETABINS, ETAMIN, ETAMAX);
+      iBooker.book2D("RctRegionsEtEtaPhi", "REGION E_{T}", PHIBINS, PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
   m_rctRegionsOccEtaPhi =
-      iBooker.book2D("RctRegionsOccEtaPhi", "REGION OCCUPANCY", PHIBINS, PHIMIN,
-                     PHIMAX, ETABINS, ETAMIN, ETAMAX);
+      iBooker.book2D("RctRegionsOccEtaPhi", "REGION OCCUPANCY", PHIBINS, PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
   m_rctTauVetoEtaPhi =
-      iBooker.book2D("RctTauVetoEtaPhi", "TAU VETO OCCUPANCY", PHIBINS, PHIMIN,
-                     PHIMAX, ETABINS, ETAMIN, ETAMAX);
-  m_rctRegionEt =
-      iBooker.book1D("RctRegionEt", "REGION E_{T}", R10BINS, R10MIN, R10MAX);
+      iBooker.book2D("RctTauVetoEtaPhi", "TAU VETO OCCUPANCY", PHIBINS, PHIMIN, PHIMAX, ETABINS, ETAMIN, ETAMAX);
+  m_rctRegionEt = iBooker.book1D("RctRegionEt", "REGION E_{T}", R10BINS, R10MIN, R10MAX);
 }
 
-void RCTMonitor::analyze(const edm::Event &iEvent,
-                         const edm::EventSetup &iSetup) {
+void RCTMonitor::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // Fill histograms
   FillRCT(iEvent, iSetup);
 }
@@ -100,62 +75,48 @@ float DynamicScale(int EtaStamp) {
   }
 }
 
-void RCTMonitor::FillRCT(const edm::Event &iEvent,
-                         const edm::EventSetup &iSetup) {
+void RCTMonitor::FillRCT(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // Get the RCT digis
   edm::Handle<L1CaloEmCollection> em;
 
   iEvent.getByToken(m_rctSourceToken_, em);
 
   // Isolated and non-isolated EM with cut at >1 GeV
-  for (L1CaloEmCollection::const_iterator iem = em->begin(); iem != em->end();
-       iem++) {
-    if (iem->rank() > 1.) {  // applies the 1 GeV cut
-      if (iem->isolated()) { // looks for isolated EM candidates only
+  for (L1CaloEmCollection::const_iterator iem = em->begin(); iem != em->end(); iem++) {
+    if (iem->rank() > 1.) {   // applies the 1 GeV cut
+      if (iem->isolated()) {  // looks for isolated EM candidates only
         m_rctIsoEmRank1->Fill(iem->rank());
         // std::cout << "Just to show what is there " << iem->rank() <<
         // std::endl ;
-        m_rctIsoEmRankEtaPhi1->Fill(iem->regionId().iphi(),
-                                    iem->regionId().ieta(), iem->rank());
-        m_rctIsoEmOccEtaPhi1->Fill(iem->regionId().iphi(),
-                                   iem->regionId().ieta(),
-                                   DynamicScale(iem->regionId().ieta()));
-        m_rctRelaxedEmRankEtaPhi1->Fill(iem->regionId().iphi(),
-                                        iem->regionId().ieta(), iem->rank());
-        m_rctRelaxedEmOccEtaPhi1->Fill(iem->regionId().iphi(),
-                                       iem->regionId().ieta(),
-                                       DynamicScale(iem->regionId().ieta()));
+        m_rctIsoEmRankEtaPhi1->Fill(iem->regionId().iphi(), iem->regionId().ieta(), iem->rank());
+        m_rctIsoEmOccEtaPhi1->Fill(
+            iem->regionId().iphi(), iem->regionId().ieta(), DynamicScale(iem->regionId().ieta()));
+        m_rctRelaxedEmRankEtaPhi1->Fill(iem->regionId().iphi(), iem->regionId().ieta(), iem->rank());
+        m_rctRelaxedEmOccEtaPhi1->Fill(
+            iem->regionId().iphi(), iem->regionId().ieta(), DynamicScale(iem->regionId().ieta()));
         m_rctRelaxedEmRank1->Fill(iem->rank());
-      } else { // instructions for Non-isolated EM candidates
+      } else {  // instructions for Non-isolated EM candidates
         m_rctNonIsoEmRank1->Fill(iem->rank());
-        m_rctNonIsoEmRankEtaPhi1->Fill(iem->regionId().iphi(),
-                                       iem->regionId().ieta(), iem->rank());
-        m_rctNonIsoEmOccEtaPhi1->Fill(iem->regionId().iphi(),
-                                      iem->regionId().ieta(),
-                                      DynamicScale(iem->regionId().ieta()));
-        m_rctRelaxedEmRankEtaPhi1->Fill(iem->regionId().iphi(),
-                                        iem->regionId().ieta(), iem->rank());
-        m_rctRelaxedEmOccEtaPhi1->Fill(iem->regionId().iphi(),
-                                       iem->regionId().ieta(),
-                                       DynamicScale(iem->regionId().ieta()));
+        m_rctNonIsoEmRankEtaPhi1->Fill(iem->regionId().iphi(), iem->regionId().ieta(), iem->rank());
+        m_rctNonIsoEmOccEtaPhi1->Fill(
+            iem->regionId().iphi(), iem->regionId().ieta(), DynamicScale(iem->regionId().ieta()));
+        m_rctRelaxedEmRankEtaPhi1->Fill(iem->regionId().iphi(), iem->regionId().ieta(), iem->rank());
+        m_rctRelaxedEmOccEtaPhi1->Fill(
+            iem->regionId().iphi(), iem->regionId().ieta(), DynamicScale(iem->regionId().ieta()));
         m_rctRelaxedEmRank1->Fill(iem->rank());
       }
     }
-    if (iem->rank() > 10.) { // applies the 10 GeV cut
-      if (iem->isolated()) { // looks for isolated EM candidates only
-        m_rctIsoEmOccEtaPhi10->Fill(iem->regionId().iphi(),
-                                    iem->regionId().ieta(),
-                                    DynamicScale(iem->regionId().ieta()));
-        m_rctRelaxedEmOccEtaPhi10->Fill(iem->regionId().iphi(),
-                                        iem->regionId().ieta(),
-                                        DynamicScale(iem->regionId().ieta()));
-      } else { // instructions for Non-isolated EM candidates
-        m_rctNonIsoEmOccEtaPhi10->Fill(iem->regionId().iphi(),
-                                       iem->regionId().ieta(),
-                                       DynamicScale(iem->regionId().ieta()));
-        m_rctRelaxedEmOccEtaPhi10->Fill(iem->regionId().iphi(),
-                                        iem->regionId().ieta(),
-                                        DynamicScale(iem->regionId().ieta()));
+    if (iem->rank() > 10.) {  // applies the 10 GeV cut
+      if (iem->isolated()) {  // looks for isolated EM candidates only
+        m_rctIsoEmOccEtaPhi10->Fill(
+            iem->regionId().iphi(), iem->regionId().ieta(), DynamicScale(iem->regionId().ieta()));
+        m_rctRelaxedEmOccEtaPhi10->Fill(
+            iem->regionId().iphi(), iem->regionId().ieta(), DynamicScale(iem->regionId().ieta()));
+      } else {  // instructions for Non-isolated EM candidates
+        m_rctNonIsoEmOccEtaPhi10->Fill(
+            iem->regionId().iphi(), iem->regionId().ieta(), DynamicScale(iem->regionId().ieta()));
+        m_rctRelaxedEmOccEtaPhi10->Fill(
+            iem->regionId().iphi(), iem->regionId().ieta(), DynamicScale(iem->regionId().ieta()));
       }
     }
   }

--- a/DQM/SiOuterTracker/interface/OuterTrackerMonitorTTCluster.h
+++ b/DQM/SiOuterTracker/interface/OuterTrackerMonitorTTCluster.h
@@ -18,29 +18,23 @@
 class DQMStore;
 
 class OuterTrackerMonitorTTCluster : public DQMEDAnalyzer {
-
 public:
   explicit OuterTrackerMonitorTTCluster(const edm::ParameterSet &);
   ~OuterTrackerMonitorTTCluster() override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
   // TTCluster stacks
   MonitorElement *Cluster_IMem_Barrel = nullptr;
   MonitorElement *Cluster_IMem_Endcap_Disc = nullptr;
   MonitorElement *Cluster_IMem_Endcap_Ring = nullptr;
-  MonitorElement *Cluster_IMem_Endcap_Ring_Fw[5] = {nullptr, nullptr, nullptr,
-                                                    nullptr, nullptr};
-  MonitorElement *Cluster_IMem_Endcap_Ring_Bw[5] = {nullptr, nullptr, nullptr,
-                                                    nullptr, nullptr};
+  MonitorElement *Cluster_IMem_Endcap_Ring_Fw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
+  MonitorElement *Cluster_IMem_Endcap_Ring_Bw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
   MonitorElement *Cluster_OMem_Barrel = nullptr;
   MonitorElement *Cluster_OMem_Endcap_Disc = nullptr;
   MonitorElement *Cluster_OMem_Endcap_Ring = nullptr;
-  MonitorElement *Cluster_OMem_Endcap_Ring_Fw[5] = {nullptr, nullptr, nullptr,
-                                                    nullptr, nullptr};
-  MonitorElement *Cluster_OMem_Endcap_Ring_Bw[5] = {nullptr, nullptr, nullptr,
-                                                    nullptr, nullptr};
+  MonitorElement *Cluster_OMem_Endcap_Ring_Fw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
+  MonitorElement *Cluster_OMem_Endcap_Ring_Bw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
   MonitorElement *Cluster_W = nullptr;
   MonitorElement *Cluster_Phi = nullptr;
   MonitorElement *Cluster_R = nullptr;
@@ -53,8 +47,7 @@ public:
 
 private:
   edm::ParameterSet conf_;
-  edm::EDGetTokenT<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>>
-      tagTTClustersToken_;
+  edm::EDGetTokenT<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>> tagTTClustersToken_;
   std::string topFolderName_;
 };
 #endif

--- a/DQM/SiOuterTracker/interface/OuterTrackerMonitorTTStub.h
+++ b/DQM/SiOuterTracker/interface/OuterTrackerMonitorTTStub.h
@@ -18,62 +18,50 @@
 class DQMStore;
 
 class OuterTrackerMonitorTTStub : public DQMEDAnalyzer {
-
 public:
   explicit OuterTrackerMonitorTTStub(const edm::ParameterSet &);
   ~OuterTrackerMonitorTTStub() override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
   // TTStub stacks
   // Global position of the stubs
-  MonitorElement *Stub_Barrel_XY = nullptr;    // TTStub barrel y vs x
-  MonitorElement *Stub_Endcap_Fw_XY = nullptr; // TTStub Forward Endcap y vs. x
-  MonitorElement *Stub_Endcap_Bw_XY = nullptr; // TTStub Backward Endcap y vs. x
-  MonitorElement *Stub_RZ = nullptr;           // TTStub #rho vs. z
+  MonitorElement *Stub_Barrel_XY = nullptr;     // TTStub barrel y vs x
+  MonitorElement *Stub_Endcap_Fw_XY = nullptr;  // TTStub Forward Endcap y vs. x
+  MonitorElement *Stub_Endcap_Bw_XY = nullptr;  // TTStub Backward Endcap y vs. x
+  MonitorElement *Stub_RZ = nullptr;            // TTStub #rho vs. z
 
   // Number of stubs
-  MonitorElement *Stub_Barrel = nullptr;         // TTStub per layer
-  MonitorElement *Stub_Endcap_Disc = nullptr;    // TTStubs per disc
-  MonitorElement *Stub_Endcap_Disc_Fw = nullptr; // TTStub per disc
-  MonitorElement *Stub_Endcap_Disc_Bw = nullptr; // TTStub per disc
-  MonitorElement *Stub_Endcap_Ring = nullptr;    // TTStubs per ring
-  MonitorElement *Stub_Endcap_Ring_Fw[5] = {nullptr, nullptr, nullptr, nullptr,
-                                            nullptr}; // TTStubs per EC ring
-  MonitorElement *Stub_Endcap_Ring_Bw[5] = {nullptr, nullptr, nullptr, nullptr,
-                                            nullptr}; // TTStub per EC ring
+  MonitorElement *Stub_Barrel = nullptr;                                                   // TTStub per layer
+  MonitorElement *Stub_Endcap_Disc = nullptr;                                              // TTStubs per disc
+  MonitorElement *Stub_Endcap_Disc_Fw = nullptr;                                           // TTStub per disc
+  MonitorElement *Stub_Endcap_Disc_Bw = nullptr;                                           // TTStub per disc
+  MonitorElement *Stub_Endcap_Ring = nullptr;                                              // TTStubs per ring
+  MonitorElement *Stub_Endcap_Ring_Fw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};  // TTStubs per EC ring
+  MonitorElement *Stub_Endcap_Ring_Bw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};  // TTStub per EC ring
 
   // Stub distribution
-  MonitorElement *Stub_Eta = nullptr; // TTstub eta distribution
-  MonitorElement *Stub_Phi = nullptr; // TTstub phi distribution
-  MonitorElement *Stub_R = nullptr;   // TTstub r distribution
+  MonitorElement *Stub_Eta = nullptr;  // TTstub eta distribution
+  MonitorElement *Stub_Phi = nullptr;  // TTstub phi distribution
+  MonitorElement *Stub_R = nullptr;    // TTstub r distribution
 
   // STUB Displacement - offset
-  MonitorElement *Stub_Barrel_W =
-      nullptr; // TTstub Pos-Corr Displacement (layer)
-  MonitorElement *Stub_Barrel_O = nullptr; // TTStub Offset (layer)
-  MonitorElement *Stub_Endcap_Disc_W =
-      nullptr; // TTstub Pos-Corr Displacement (disc)
-  MonitorElement *Stub_Endcap_Disc_O = nullptr; // TTStub Offset (disc)
-  MonitorElement *Stub_Endcap_Ring_W =
-      nullptr; // TTstub Pos-Corr Displacement (EC ring)
-  MonitorElement *Stub_Endcap_Ring_O = nullptr; // TTStub Offset (EC ring)
+  MonitorElement *Stub_Barrel_W = nullptr;       // TTstub Pos-Corr Displacement (layer)
+  MonitorElement *Stub_Barrel_O = nullptr;       // TTStub Offset (layer)
+  MonitorElement *Stub_Endcap_Disc_W = nullptr;  // TTstub Pos-Corr Displacement (disc)
+  MonitorElement *Stub_Endcap_Disc_O = nullptr;  // TTStub Offset (disc)
+  MonitorElement *Stub_Endcap_Ring_W = nullptr;  // TTstub Pos-Corr Displacement (EC ring)
+  MonitorElement *Stub_Endcap_Ring_O = nullptr;  // TTStub Offset (EC ring)
   MonitorElement *Stub_Endcap_Ring_W_Fw[5] = {
-      nullptr, nullptr, nullptr, nullptr,
-      nullptr}; // TTstub Pos-Corr Displacement (EC ring)
-  MonitorElement *Stub_Endcap_Ring_O_Fw[5] = {
-      nullptr, nullptr, nullptr, nullptr, nullptr}; // TTStub Offset (EC ring)
+      nullptr, nullptr, nullptr, nullptr, nullptr};  // TTstub Pos-Corr Displacement (EC ring)
+  MonitorElement *Stub_Endcap_Ring_O_Fw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};  // TTStub Offset (EC ring)
   MonitorElement *Stub_Endcap_Ring_W_Bw[5] = {
-      nullptr, nullptr, nullptr, nullptr,
-      nullptr}; // TTstub Pos-Corr Displacement (EC ring)
-  MonitorElement *Stub_Endcap_Ring_O_Bw[5] = {
-      nullptr, nullptr, nullptr, nullptr, nullptr}; // TTStub Offset (EC ring)
+      nullptr, nullptr, nullptr, nullptr, nullptr};  // TTstub Pos-Corr Displacement (EC ring)
+  MonitorElement *Stub_Endcap_Ring_O_Bw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};  // TTStub Offset (EC ring)
 
 private:
   edm::ParameterSet conf_;
-  edm::EDGetTokenT<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>
-      tagTTStubsToken_;
+  edm::EDGetTokenT<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>> tagTTStubsToken_;
   std::string topFolderName_;
 };
 #endif

--- a/DQM/SiOuterTracker/interface/OuterTrackerMonitorTTTrack.h
+++ b/DQM/SiOuterTracker/interface/OuterTrackerMonitorTTTrack.h
@@ -19,54 +19,46 @@
 class DQMStore;
 
 class OuterTrackerMonitorTTTrack : public DQMEDAnalyzer {
-
 public:
   explicit OuterTrackerMonitorTTTrack(const edm::ParameterSet &);
   ~OuterTrackerMonitorTTTrack() override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
   // Distributions of all tracks
-  MonitorElement *Track_NStubs = nullptr;     // Number of stubs per track
-  MonitorElement *Track_Eta_NStubs = nullptr; // Number of stubs per track vs
-                                              // eta
+  MonitorElement *Track_NStubs = nullptr;      // Number of stubs per track
+  MonitorElement *Track_Eta_NStubs = nullptr;  // Number of stubs per track vs
+                                               // eta
 
   /// Low-quality TTTracks (All tracks)
-  MonitorElement *Track_LQ_N = nullptr;       // Number of tracks per event
-  MonitorElement *Track_LQ_Pt = nullptr;      // pT distrubtion for tracks
-  MonitorElement *Track_LQ_Eta = nullptr;     // eta distrubtion for tracks
-  MonitorElement *Track_LQ_Phi = nullptr;     // phi distrubtion for tracks
-  MonitorElement *Track_LQ_D0 = nullptr;      // d0 distrubtion for tracks
-  MonitorElement *Track_LQ_VtxZ = nullptr;    // z0 distrubtion for tracks
-  MonitorElement *Track_LQ_Chi2 = nullptr;    // chi2 distrubtion for tracks
-  MonitorElement *Track_LQ_Chi2Red = nullptr; // chi2/dof distrubtion for tracks
-  MonitorElement *Track_LQ_Chi2Red_NStubs =
-      nullptr;                                    // chi2/dof vs number of stubs
-  MonitorElement *Track_LQ_Chi2Red_Eta = nullptr; // chi2/dof vs eta of track
-  MonitorElement *Track_LQ_Eta_BarrelStubs =
-      nullptr; // eta vs number of stubs in barrel
-  MonitorElement *Track_LQ_Eta_ECStubs =
-      nullptr; // eta vs number of stubs in end caps
-  MonitorElement *Track_LQ_Chi2_Probability = nullptr; // chi2 probability
+  MonitorElement *Track_LQ_N = nullptr;                 // Number of tracks per event
+  MonitorElement *Track_LQ_Pt = nullptr;                // pT distrubtion for tracks
+  MonitorElement *Track_LQ_Eta = nullptr;               // eta distrubtion for tracks
+  MonitorElement *Track_LQ_Phi = nullptr;               // phi distrubtion for tracks
+  MonitorElement *Track_LQ_D0 = nullptr;                // d0 distrubtion for tracks
+  MonitorElement *Track_LQ_VtxZ = nullptr;              // z0 distrubtion for tracks
+  MonitorElement *Track_LQ_Chi2 = nullptr;              // chi2 distrubtion for tracks
+  MonitorElement *Track_LQ_Chi2Red = nullptr;           // chi2/dof distrubtion for tracks
+  MonitorElement *Track_LQ_Chi2Red_NStubs = nullptr;    // chi2/dof vs number of stubs
+  MonitorElement *Track_LQ_Chi2Red_Eta = nullptr;       // chi2/dof vs eta of track
+  MonitorElement *Track_LQ_Eta_BarrelStubs = nullptr;   // eta vs number of stubs in barrel
+  MonitorElement *Track_LQ_Eta_ECStubs = nullptr;       // eta vs number of stubs in end caps
+  MonitorElement *Track_LQ_Chi2_Probability = nullptr;  // chi2 probability
 
   /// High-quality TTTracks (NStubs >=5, chi2/dof<10)
-  MonitorElement *Track_HQ_N = nullptr;       // Number of tracks per event
-  MonitorElement *Track_HQ_Pt = nullptr;      // pT distrubtion for tracks
-  MonitorElement *Track_HQ_Eta = nullptr;     // eta distrubtion for tracks
-  MonitorElement *Track_HQ_Phi = nullptr;     // phi distrubtion for tracks
-  MonitorElement *Track_HQ_D0 = nullptr;      // d0 distrubtion for tracks
-  MonitorElement *Track_HQ_VtxZ = nullptr;    // z0 distrubtion for tracks
-  MonitorElement *Track_HQ_Chi2 = nullptr;    // chi2 distrubtion for tracks
-  MonitorElement *Track_HQ_Chi2Red = nullptr; // chi2/dof distrubtion for tracks
-  MonitorElement *Track_HQ_Chi2Red_NStubs =
-      nullptr;                                    // chi2/dof vs number of stubs
-  MonitorElement *Track_HQ_Chi2Red_Eta = nullptr; // chi2/dof vs eta of track
-  MonitorElement *Track_HQ_Eta_BarrelStubs =
-      nullptr; // eta vs number of stubs in barrel
-  MonitorElement *Track_HQ_Eta_ECStubs =
-      nullptr; // eta vs number of stubs in end caps
-  MonitorElement *Track_HQ_Chi2_Probability = nullptr; // chi2 probability
+  MonitorElement *Track_HQ_N = nullptr;                 // Number of tracks per event
+  MonitorElement *Track_HQ_Pt = nullptr;                // pT distrubtion for tracks
+  MonitorElement *Track_HQ_Eta = nullptr;               // eta distrubtion for tracks
+  MonitorElement *Track_HQ_Phi = nullptr;               // phi distrubtion for tracks
+  MonitorElement *Track_HQ_D0 = nullptr;                // d0 distrubtion for tracks
+  MonitorElement *Track_HQ_VtxZ = nullptr;              // z0 distrubtion for tracks
+  MonitorElement *Track_HQ_Chi2 = nullptr;              // chi2 distrubtion for tracks
+  MonitorElement *Track_HQ_Chi2Red = nullptr;           // chi2/dof distrubtion for tracks
+  MonitorElement *Track_HQ_Chi2Red_NStubs = nullptr;    // chi2/dof vs number of stubs
+  MonitorElement *Track_HQ_Chi2Red_Eta = nullptr;       // chi2/dof vs eta of track
+  MonitorElement *Track_HQ_Eta_BarrelStubs = nullptr;   // eta vs number of stubs in barrel
+  MonitorElement *Track_HQ_Eta_ECStubs = nullptr;       // eta vs number of stubs in end caps
+  MonitorElement *Track_HQ_Chi2_Probability = nullptr;  // chi2 probability
 
 private:
   edm::ParameterSet conf_;

--- a/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTCluster.cc
+++ b/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTCluster.cc
@@ -39,13 +39,10 @@
 //
 // constructors and destructor
 //
-OuterTrackerMonitorTTCluster::OuterTrackerMonitorTTCluster(
-    const edm::ParameterSet &iConfig)
-    : conf_(iConfig) {
+OuterTrackerMonitorTTCluster::OuterTrackerMonitorTTCluster(const edm::ParameterSet &iConfig) : conf_(iConfig) {
   topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
-  tagTTClustersToken_ =
-      consumes<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>>(
-          conf_.getParameter<edm::InputTag>("TTClusters"));
+  tagTTClustersToken_ = consumes<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>>(
+      conf_.getParameter<edm::InputTag>("TTClusters"));
 }
 
 OuterTrackerMonitorTTCluster::~OuterTrackerMonitorTTCluster() {
@@ -58,11 +55,9 @@ OuterTrackerMonitorTTCluster::~OuterTrackerMonitorTTCluster() {
 //
 
 // ------------ method called for each event  ------------
-void OuterTrackerMonitorTTCluster::analyze(const edm::Event &iEvent,
-                                           const edm::EventSetup &iSetup) {
+void OuterTrackerMonitorTTCluster::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   /// Track Trigger Clusters
-  edm::Handle<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>>
-      Phase2TrackerDigiTTClusterHandle;
+  edm::Handle<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>> Phase2TrackerDigiTTClusterHandle;
   iEvent.getByToken(tagTTClustersToken_, Phase2TrackerDigiTTClusterHandle);
 
   /// Geometry
@@ -77,34 +72,27 @@ void OuterTrackerMonitorTTCluster::analyze(const edm::Event &iEvent,
   theTrackerGeometry = tGeometryHandle.product();
 
   /// Loop over the input Clusters
-  typename edmNew::DetSetVector<
-      TTCluster<Ref_Phase2TrackerDigi_>>::const_iterator inputIter;
-  typename edmNew::DetSet<TTCluster<Ref_Phase2TrackerDigi_>>::const_iterator
-      contentIter;
+  typename edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>::const_iterator inputIter;
+  typename edmNew::DetSet<TTCluster<Ref_Phase2TrackerDigi_>>::const_iterator contentIter;
 
   // Adding protection
   if (!Phase2TrackerDigiTTClusterHandle.isValid())
     return;
 
-  for (inputIter = Phase2TrackerDigiTTClusterHandle->begin();
-       inputIter != Phase2TrackerDigiTTClusterHandle->end(); ++inputIter) {
-    for (contentIter = inputIter->begin(); contentIter != inputIter->end();
-         ++contentIter) {
+  for (inputIter = Phase2TrackerDigiTTClusterHandle->begin(); inputIter != Phase2TrackerDigiTTClusterHandle->end();
+       ++inputIter) {
+    for (contentIter = inputIter->begin(); contentIter != inputIter->end(); ++contentIter) {
       // Make reference cluster
-      edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>,
-               TTCluster<Ref_Phase2TrackerDigi_>>
-          tempCluRef =
-              edmNew::makeRefTo(Phase2TrackerDigiTTClusterHandle, contentIter);
+      edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>, TTCluster<Ref_Phase2TrackerDigi_>> tempCluRef =
+          edmNew::makeRefTo(Phase2TrackerDigiTTClusterHandle, contentIter);
 
-      DetId detIdClu =
-          theTrackerGeometry->idToDet(tempCluRef->getDetId())->geographicalId();
+      DetId detIdClu = theTrackerGeometry->idToDet(tempCluRef->getDetId())->geographicalId();
       unsigned int memberClu = tempCluRef->getStackMember();
       unsigned int widClu = tempCluRef->findWidth();
 
       MeasurementPoint mp = tempCluRef->findAverageLocalCoordinates();
       const GeomDet *theGeomDet = theTrackerGeometry->idToDet(detIdClu);
-      Global3DPoint posClu = theGeomDet->surface().toGlobal(
-          theGeomDet->topology().localPosition(mp));
+      Global3DPoint posClu = theGeomDet->surface().toGlobal(theGeomDet->topology().localPosition(mp));
 
       double r = posClu.perp();
       double z = posClu.z();
@@ -115,11 +103,8 @@ void OuterTrackerMonitorTTCluster::analyze(const edm::Event &iEvent,
       Cluster_R->Fill(r);
       Cluster_RZ->Fill(z, r);
 
-      if (detIdClu.subdetId() ==
-          static_cast<int>(
-              StripSubdetector::TOB)) // Phase 2 Outer Tracker Barrel
+      if (detIdClu.subdetId() == static_cast<int>(StripSubdetector::TOB))  // Phase 2 Outer Tracker Barrel
       {
-
         if (memberClu == 0)
           Cluster_IMem_Barrel->Fill(tTopo->layer(detIdClu));
         else
@@ -127,44 +112,35 @@ void OuterTrackerMonitorTTCluster::analyze(const edm::Event &iEvent,
 
         Cluster_Barrel_XY->Fill(posClu.x(), posClu.y());
 
-      } // end if isBarrel
-      else if (detIdClu.subdetId() ==
-               static_cast<int>(
-                   StripSubdetector::TID)) // Phase 2 Outer Tracker Endcap
+      }                                                                         // end if isBarrel
+      else if (detIdClu.subdetId() == static_cast<int>(StripSubdetector::TID))  // Phase 2 Outer Tracker Endcap
       {
-
         if (memberClu == 0) {
-          Cluster_IMem_Endcap_Disc->Fill(
-              tTopo->layer(detIdClu)); // returns wheel
+          Cluster_IMem_Endcap_Disc->Fill(tTopo->layer(detIdClu));  // returns wheel
           Cluster_IMem_Endcap_Ring->Fill(tTopo->tidRing(detIdClu));
         } else {
-          Cluster_OMem_Endcap_Disc->Fill(
-              tTopo->layer(detIdClu)); // returns wheel
+          Cluster_OMem_Endcap_Disc->Fill(tTopo->layer(detIdClu));  // returns wheel
           Cluster_OMem_Endcap_Ring->Fill(tTopo->tidRing(detIdClu));
         }
 
         if (posClu.z() > 0) {
           Cluster_Endcap_Fw_XY->Fill(posClu.x(), posClu.y());
           if (memberClu == 0)
-            Cluster_IMem_Endcap_Ring_Fw[tTopo->layer(detIdClu) - 1]->Fill(
-                tTopo->tidRing(detIdClu));
+            Cluster_IMem_Endcap_Ring_Fw[tTopo->layer(detIdClu) - 1]->Fill(tTopo->tidRing(detIdClu));
           else
-            Cluster_OMem_Endcap_Ring_Fw[tTopo->layer(detIdClu) - 1]->Fill(
-                tTopo->tidRing(detIdClu));
+            Cluster_OMem_Endcap_Ring_Fw[tTopo->layer(detIdClu) - 1]->Fill(tTopo->tidRing(detIdClu));
         } else {
           Cluster_Endcap_Bw_XY->Fill(posClu.x(), posClu.y());
           if (memberClu == 0)
-            Cluster_IMem_Endcap_Ring_Bw[tTopo->layer(detIdClu) - 1]->Fill(
-                tTopo->tidRing(detIdClu));
+            Cluster_IMem_Endcap_Ring_Bw[tTopo->layer(detIdClu) - 1]->Fill(tTopo->tidRing(detIdClu));
           else
-            Cluster_OMem_Endcap_Ring_Bw[tTopo->layer(detIdClu) - 1]->Fill(
-                tTopo->tidRing(detIdClu));
+            Cluster_OMem_Endcap_Ring_Bw[tTopo->layer(detIdClu) - 1]->Fill(tTopo->tidRing(detIdClu));
         }
 
-      } // end if isEndcap
-    }   // end loop contentIter
-  }     // end loop inputIter
-} // end of method
+      }  // end if isEndcap
+    }    // end loop contentIter
+  }      // end loop inputIter
+}  // end of method
 
 // ------------ method called once each job just before starting event loop
 // ------------
@@ -177,100 +153,103 @@ void OuterTrackerMonitorTTCluster::bookHistograms(DQMStore::IBooker &iBooker,
   iBooker.setCurrentFolder(topFolderName_ + "/Clusters/NClusters");
 
   // NClusters
-  edm::ParameterSet psTTCluster_Barrel =
-      conf_.getParameter<edm::ParameterSet>("TH1TTCluster_Barrel");
+  edm::ParameterSet psTTCluster_Barrel = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_Barrel");
   HistoName = "NClusters_IMem_Barrel";
-  Cluster_IMem_Barrel = iBooker.book1D(
-      HistoName, HistoName, psTTCluster_Barrel.getParameter<int32_t>("Nbinsx"),
-      psTTCluster_Barrel.getParameter<double>("xmin"),
-      psTTCluster_Barrel.getParameter<double>("xmax"));
+  Cluster_IMem_Barrel = iBooker.book1D(HistoName,
+                                       HistoName,
+                                       psTTCluster_Barrel.getParameter<int32_t>("Nbinsx"),
+                                       psTTCluster_Barrel.getParameter<double>("xmin"),
+                                       psTTCluster_Barrel.getParameter<double>("xmax"));
   Cluster_IMem_Barrel->setAxisTitle("Barrel Layer", 1);
   Cluster_IMem_Barrel->setAxisTitle("# L1 Clusters", 2);
 
   HistoName = "NClusters_OMem_Barrel";
-  Cluster_OMem_Barrel = iBooker.book1D(
-      HistoName, HistoName, psTTCluster_Barrel.getParameter<int32_t>("Nbinsx"),
-      psTTCluster_Barrel.getParameter<double>("xmin"),
-      psTTCluster_Barrel.getParameter<double>("xmax"));
+  Cluster_OMem_Barrel = iBooker.book1D(HistoName,
+                                       HistoName,
+                                       psTTCluster_Barrel.getParameter<int32_t>("Nbinsx"),
+                                       psTTCluster_Barrel.getParameter<double>("xmin"),
+                                       psTTCluster_Barrel.getParameter<double>("xmax"));
   Cluster_OMem_Barrel->setAxisTitle("Barrel Layer", 1);
   Cluster_OMem_Barrel->setAxisTitle("# L1 Clusters", 2);
 
-  edm::ParameterSet psTTCluster_ECDisc =
-      conf_.getParameter<edm::ParameterSet>("TH1TTCluster_ECDiscs");
+  edm::ParameterSet psTTCluster_ECDisc = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_ECDiscs");
   HistoName = "NClusters_IMem_Endcap_Disc";
-  Cluster_IMem_Endcap_Disc = iBooker.book1D(
-      HistoName, HistoName, psTTCluster_ECDisc.getParameter<int32_t>("Nbinsx"),
-      psTTCluster_ECDisc.getParameter<double>("xmin"),
-      psTTCluster_ECDisc.getParameter<double>("xmax"));
+  Cluster_IMem_Endcap_Disc = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psTTCluster_ECDisc.getParameter<int32_t>("Nbinsx"),
+                                            psTTCluster_ECDisc.getParameter<double>("xmin"),
+                                            psTTCluster_ECDisc.getParameter<double>("xmax"));
   Cluster_IMem_Endcap_Disc->setAxisTitle("Endcap Disc", 1);
   Cluster_IMem_Endcap_Disc->setAxisTitle("# L1 Clusters", 2);
 
   HistoName = "NClusters_OMem_Endcap_Disc";
-  Cluster_OMem_Endcap_Disc = iBooker.book1D(
-      HistoName, HistoName, psTTCluster_ECDisc.getParameter<int32_t>("Nbinsx"),
-      psTTCluster_ECDisc.getParameter<double>("xmin"),
-      psTTCluster_ECDisc.getParameter<double>("xmax"));
+  Cluster_OMem_Endcap_Disc = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psTTCluster_ECDisc.getParameter<int32_t>("Nbinsx"),
+                                            psTTCluster_ECDisc.getParameter<double>("xmin"),
+                                            psTTCluster_ECDisc.getParameter<double>("xmax"));
   Cluster_OMem_Endcap_Disc->setAxisTitle("Endcap Disc", 1);
   Cluster_OMem_Endcap_Disc->setAxisTitle("# L1 Clusters", 2);
 
-  edm::ParameterSet psTTCluster_ECRing =
-      conf_.getParameter<edm::ParameterSet>("TH1TTCluster_ECRings");
+  edm::ParameterSet psTTCluster_ECRing = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_ECRings");
   HistoName = "NClusters_IMem_Endcap_Ring";
-  Cluster_IMem_Endcap_Ring = iBooker.book1D(
-      HistoName, HistoName, psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
-      psTTCluster_ECRing.getParameter<double>("xmin"),
-      psTTCluster_ECRing.getParameter<double>("xmax"));
+  Cluster_IMem_Endcap_Ring = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
+                                            psTTCluster_ECRing.getParameter<double>("xmin"),
+                                            psTTCluster_ECRing.getParameter<double>("xmax"));
   Cluster_IMem_Endcap_Ring->setAxisTitle("Endcap Ring", 1);
   Cluster_IMem_Endcap_Ring->setAxisTitle("# L1 Clusters", 2);
 
   HistoName = "NClusters_OMem_Endcap_Ring";
-  Cluster_OMem_Endcap_Ring = iBooker.book1D(
-      HistoName, HistoName, psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
-      psTTCluster_ECRing.getParameter<double>("xmin"),
-      psTTCluster_ECRing.getParameter<double>("xmax"));
+  Cluster_OMem_Endcap_Ring = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
+                                            psTTCluster_ECRing.getParameter<double>("xmin"),
+                                            psTTCluster_ECRing.getParameter<double>("xmax"));
   Cluster_OMem_Endcap_Ring->setAxisTitle("Endcap Ring", 1);
   Cluster_OMem_Endcap_Ring->setAxisTitle("# L1 Clusters", 2);
 
   for (int i = 0; i < numDiscs; i++) {
     HistoName = "NClusters_IMem_Disc+" + std::to_string(i + 1);
-    Cluster_IMem_Endcap_Ring_Fw[i] =
-        iBooker.book1D(HistoName, HistoName,
-                       psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
-                       psTTCluster_ECRing.getParameter<double>("xmin"),
-                       psTTCluster_ECRing.getParameter<double>("xmax"));
+    Cluster_IMem_Endcap_Ring_Fw[i] = iBooker.book1D(HistoName,
+                                                    HistoName,
+                                                    psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
+                                                    psTTCluster_ECRing.getParameter<double>("xmin"),
+                                                    psTTCluster_ECRing.getParameter<double>("xmax"));
     Cluster_IMem_Endcap_Ring_Fw[i]->setAxisTitle("Endcap Ring", 1);
     Cluster_IMem_Endcap_Ring_Fw[i]->setAxisTitle("# L1 Clusters ", 2);
   }
 
   for (int i = 0; i < numDiscs; i++) {
     HistoName = "NClusters_IMem_Disc-" + std::to_string(i + 1);
-    Cluster_IMem_Endcap_Ring_Bw[i] =
-        iBooker.book1D(HistoName, HistoName,
-                       psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
-                       psTTCluster_ECRing.getParameter<double>("xmin"),
-                       psTTCluster_ECRing.getParameter<double>("xmax"));
+    Cluster_IMem_Endcap_Ring_Bw[i] = iBooker.book1D(HistoName,
+                                                    HistoName,
+                                                    psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
+                                                    psTTCluster_ECRing.getParameter<double>("xmin"),
+                                                    psTTCluster_ECRing.getParameter<double>("xmax"));
     Cluster_IMem_Endcap_Ring_Bw[i]->setAxisTitle("Endcap Ring", 1);
     Cluster_IMem_Endcap_Ring_Bw[i]->setAxisTitle("# L1 Clusters ", 2);
   }
 
   for (int i = 0; i < numDiscs; i++) {
     HistoName = "NClusters_OMem_Disc+" + std::to_string(i + 1);
-    Cluster_OMem_Endcap_Ring_Fw[i] =
-        iBooker.book1D(HistoName, HistoName,
-                       psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
-                       psTTCluster_ECRing.getParameter<double>("xmin"),
-                       psTTCluster_ECRing.getParameter<double>("xmax"));
+    Cluster_OMem_Endcap_Ring_Fw[i] = iBooker.book1D(HistoName,
+                                                    HistoName,
+                                                    psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
+                                                    psTTCluster_ECRing.getParameter<double>("xmin"),
+                                                    psTTCluster_ECRing.getParameter<double>("xmax"));
     Cluster_OMem_Endcap_Ring_Fw[i]->setAxisTitle("Endcap Ring", 1);
     Cluster_OMem_Endcap_Ring_Fw[i]->setAxisTitle("# L1 Clusters ", 2);
   }
 
   for (int i = 0; i < numDiscs; i++) {
     HistoName = "NClusters_OMem_Disc-" + std::to_string(i + 1);
-    Cluster_OMem_Endcap_Ring_Bw[i] =
-        iBooker.book1D(HistoName, HistoName,
-                       psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
-                       psTTCluster_ECRing.getParameter<double>("xmin"),
-                       psTTCluster_ECRing.getParameter<double>("xmax"));
+    Cluster_OMem_Endcap_Ring_Bw[i] = iBooker.book1D(HistoName,
+                                                    HistoName,
+                                                    psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
+                                                    psTTCluster_ECRing.getParameter<double>("xmin"),
+                                                    psTTCluster_ECRing.getParameter<double>("xmax"));
     Cluster_OMem_Endcap_Ring_Bw[i]->setAxisTitle("Endcap Ring", 1);
     Cluster_OMem_Endcap_Ring_Bw[i]->setAxisTitle("# L1 Clusters ", 2);
   }
@@ -278,10 +257,10 @@ void OuterTrackerMonitorTTCluster::bookHistograms(DQMStore::IBooker &iBooker,
   iBooker.setCurrentFolder(topFolderName_ + "/Clusters");
 
   // Cluster Width
-  edm::ParameterSet psTTClusterWidth =
-      conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Width");
+  edm::ParameterSet psTTClusterWidth = conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Width");
   HistoName = "Cluster_W";
-  Cluster_W = iBooker.book2D(HistoName, HistoName,
+  Cluster_W = iBooker.book2D(HistoName,
+                             HistoName,
                              psTTClusterWidth.getParameter<int32_t>("Nbinsx"),
                              psTTClusterWidth.getParameter<double>("xmin"),
                              psTTClusterWidth.getParameter<double>("xmax"),
@@ -292,10 +271,10 @@ void OuterTrackerMonitorTTCluster::bookHistograms(DQMStore::IBooker &iBooker,
   Cluster_W->setAxisTitle("Stack Member", 2);
 
   // Cluster eta distribution
-  edm::ParameterSet psTTClusterEta =
-      conf_.getParameter<edm::ParameterSet>("TH1TTCluster_Eta");
+  edm::ParameterSet psTTClusterEta = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_Eta");
   HistoName = "Cluster_Eta";
-  Cluster_Eta = iBooker.book1D(HistoName, HistoName,
+  Cluster_Eta = iBooker.book1D(HistoName,
+                               HistoName,
                                psTTClusterEta.getParameter<int32_t>("Nbinsx"),
                                psTTClusterEta.getParameter<double>("xmin"),
                                psTTClusterEta.getParameter<double>("xmax"));
@@ -303,10 +282,10 @@ void OuterTrackerMonitorTTCluster::bookHistograms(DQMStore::IBooker &iBooker,
   Cluster_Eta->setAxisTitle("# L1 Clusters ", 2);
 
   // Cluster phi distribution
-  edm::ParameterSet psTTClusterPhi =
-      conf_.getParameter<edm::ParameterSet>("TH1TTCluster_Phi");
+  edm::ParameterSet psTTClusterPhi = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_Phi");
   HistoName = "Cluster_Phi";
-  Cluster_Phi = iBooker.book1D(HistoName, HistoName,
+  Cluster_Phi = iBooker.book1D(HistoName,
+                               HistoName,
                                psTTClusterPhi.getParameter<int32_t>("Nbinsx"),
                                psTTClusterPhi.getParameter<double>("xmin"),
                                psTTClusterPhi.getParameter<double>("xmax"));
@@ -314,10 +293,10 @@ void OuterTrackerMonitorTTCluster::bookHistograms(DQMStore::IBooker &iBooker,
   Cluster_Phi->setAxisTitle("# L1 Clusters", 2);
 
   // Cluster R distribution
-  edm::ParameterSet psTTClusterR =
-      conf_.getParameter<edm::ParameterSet>("TH1TTCluster_R");
+  edm::ParameterSet psTTClusterR = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_R");
   HistoName = "Cluster_R";
-  Cluster_R = iBooker.book1D(HistoName, HistoName,
+  Cluster_R = iBooker.book1D(HistoName,
+                             HistoName,
                              psTTClusterR.getParameter<int32_t>("Nbinsx"),
                              psTTClusterR.getParameter<double>("xmin"),
                              psTTClusterR.getParameter<double>("xmax"));
@@ -327,57 +306,50 @@ void OuterTrackerMonitorTTCluster::bookHistograms(DQMStore::IBooker &iBooker,
   iBooker.setCurrentFolder(topFolderName_ + "/Clusters/Position");
 
   // Position plots
-  edm::ParameterSet psTTCluster_Barrel_XY =
-      conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Position");
+  edm::ParameterSet psTTCluster_Barrel_XY = conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Position");
   HistoName = "Cluster_Barrel_XY";
-  Cluster_Barrel_XY =
-      iBooker.book2D(HistoName, HistoName,
-                     psTTCluster_Barrel_XY.getParameter<int32_t>("Nbinsx"),
-                     psTTCluster_Barrel_XY.getParameter<double>("xmin"),
-                     psTTCluster_Barrel_XY.getParameter<double>("xmax"),
-                     psTTCluster_Barrel_XY.getParameter<int32_t>("Nbinsy"),
-                     psTTCluster_Barrel_XY.getParameter<double>("ymin"),
-                     psTTCluster_Barrel_XY.getParameter<double>("ymax"));
+  Cluster_Barrel_XY = iBooker.book2D(HistoName,
+                                     HistoName,
+                                     psTTCluster_Barrel_XY.getParameter<int32_t>("Nbinsx"),
+                                     psTTCluster_Barrel_XY.getParameter<double>("xmin"),
+                                     psTTCluster_Barrel_XY.getParameter<double>("xmax"),
+                                     psTTCluster_Barrel_XY.getParameter<int32_t>("Nbinsy"),
+                                     psTTCluster_Barrel_XY.getParameter<double>("ymin"),
+                                     psTTCluster_Barrel_XY.getParameter<double>("ymax"));
   Cluster_Barrel_XY->setAxisTitle("L1 Cluster Barrel position x [cm]", 1);
   Cluster_Barrel_XY->setAxisTitle("L1 Cluster Barrel position y [cm]", 2);
 
-  edm::ParameterSet psTTCluster_Endcap_Fw_XY =
-      conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Position");
+  edm::ParameterSet psTTCluster_Endcap_Fw_XY = conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Position");
   HistoName = "Cluster_Endcap_Fw_XY";
-  Cluster_Endcap_Fw_XY =
-      iBooker.book2D(HistoName, HistoName,
-                     psTTCluster_Endcap_Fw_XY.getParameter<int32_t>("Nbinsx"),
-                     psTTCluster_Endcap_Fw_XY.getParameter<double>("xmin"),
-                     psTTCluster_Endcap_Fw_XY.getParameter<double>("xmax"),
-                     psTTCluster_Endcap_Fw_XY.getParameter<int32_t>("Nbinsy"),
-                     psTTCluster_Endcap_Fw_XY.getParameter<double>("ymin"),
-                     psTTCluster_Endcap_Fw_XY.getParameter<double>("ymax"));
-  Cluster_Endcap_Fw_XY->setAxisTitle(
-      "L1 Cluster Forward Endcap position x [cm]", 1);
-  Cluster_Endcap_Fw_XY->setAxisTitle(
-      "L1 Cluster Forward Endcap position y [cm]", 2);
+  Cluster_Endcap_Fw_XY = iBooker.book2D(HistoName,
+                                        HistoName,
+                                        psTTCluster_Endcap_Fw_XY.getParameter<int32_t>("Nbinsx"),
+                                        psTTCluster_Endcap_Fw_XY.getParameter<double>("xmin"),
+                                        psTTCluster_Endcap_Fw_XY.getParameter<double>("xmax"),
+                                        psTTCluster_Endcap_Fw_XY.getParameter<int32_t>("Nbinsy"),
+                                        psTTCluster_Endcap_Fw_XY.getParameter<double>("ymin"),
+                                        psTTCluster_Endcap_Fw_XY.getParameter<double>("ymax"));
+  Cluster_Endcap_Fw_XY->setAxisTitle("L1 Cluster Forward Endcap position x [cm]", 1);
+  Cluster_Endcap_Fw_XY->setAxisTitle("L1 Cluster Forward Endcap position y [cm]", 2);
 
-  edm::ParameterSet psTTCluster_Endcap_Bw_XY =
-      conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Position");
+  edm::ParameterSet psTTCluster_Endcap_Bw_XY = conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Position");
   HistoName = "Cluster_Endcap_Bw_XY";
-  Cluster_Endcap_Bw_XY =
-      iBooker.book2D(HistoName, HistoName,
-                     psTTCluster_Endcap_Bw_XY.getParameter<int32_t>("Nbinsx"),
-                     psTTCluster_Endcap_Bw_XY.getParameter<double>("xmin"),
-                     psTTCluster_Endcap_Bw_XY.getParameter<double>("xmax"),
-                     psTTCluster_Endcap_Bw_XY.getParameter<int32_t>("Nbinsy"),
-                     psTTCluster_Endcap_Bw_XY.getParameter<double>("ymin"),
-                     psTTCluster_Endcap_Bw_XY.getParameter<double>("ymax"));
-  Cluster_Endcap_Bw_XY->setAxisTitle(
-      "L1 Cluster Backward Endcap position x [cm]", 1);
-  Cluster_Endcap_Bw_XY->setAxisTitle(
-      "L1 Cluster Backward Endcap position y [cm]", 2);
+  Cluster_Endcap_Bw_XY = iBooker.book2D(HistoName,
+                                        HistoName,
+                                        psTTCluster_Endcap_Bw_XY.getParameter<int32_t>("Nbinsx"),
+                                        psTTCluster_Endcap_Bw_XY.getParameter<double>("xmin"),
+                                        psTTCluster_Endcap_Bw_XY.getParameter<double>("xmax"),
+                                        psTTCluster_Endcap_Bw_XY.getParameter<int32_t>("Nbinsy"),
+                                        psTTCluster_Endcap_Bw_XY.getParameter<double>("ymin"),
+                                        psTTCluster_Endcap_Bw_XY.getParameter<double>("ymax"));
+  Cluster_Endcap_Bw_XY->setAxisTitle("L1 Cluster Backward Endcap position x [cm]", 1);
+  Cluster_Endcap_Bw_XY->setAxisTitle("L1 Cluster Backward Endcap position y [cm]", 2);
 
   // TTCluster #rho vs. z
-  edm::ParameterSet psTTCluster_RZ =
-      conf_.getParameter<edm::ParameterSet>("TH2TTCluster_RZ");
+  edm::ParameterSet psTTCluster_RZ = conf_.getParameter<edm::ParameterSet>("TH2TTCluster_RZ");
   HistoName = "Cluster_RZ";
-  Cluster_RZ = iBooker.book2D(HistoName, HistoName,
+  Cluster_RZ = iBooker.book2D(HistoName,
+                              HistoName,
                               psTTCluster_RZ.getParameter<int32_t>("Nbinsx"),
                               psTTCluster_RZ.getParameter<double>("xmin"),
                               psTTCluster_RZ.getParameter<double>("xmax"),
@@ -387,6 +359,6 @@ void OuterTrackerMonitorTTCluster::bookHistograms(DQMStore::IBooker &iBooker,
   Cluster_RZ->setAxisTitle("L1 Cluster position z [cm]", 1);
   Cluster_RZ->setAxisTitle("L1 Cluster position #rho [cm]", 2);
 
-} // end of method
+}  // end of method
 
 DEFINE_FWK_MODULE(OuterTrackerMonitorTTCluster);

--- a/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTStub.cc
+++ b/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTStub.cc
@@ -37,14 +37,11 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 // constructors and destructor
-OuterTrackerMonitorTTStub::OuterTrackerMonitorTTStub(
-    const edm::ParameterSet &iConfig)
-    : conf_(iConfig) {
+OuterTrackerMonitorTTStub::OuterTrackerMonitorTTStub(const edm::ParameterSet &iConfig) : conf_(iConfig) {
   // now do what ever initialization is needed
   topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
   tagTTStubsToken_ =
-      consumes<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>(
-          conf_.getParameter<edm::InputTag>("TTStubs"));
+      consumes<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>(conf_.getParameter<edm::InputTag>("TTStubs"));
 }
 
 OuterTrackerMonitorTTStub::~OuterTrackerMonitorTTStub() {
@@ -55,11 +52,9 @@ OuterTrackerMonitorTTStub::~OuterTrackerMonitorTTStub() {
 // member functions
 
 // ------------ method called for each event  ------------
-void OuterTrackerMonitorTTStub::analyze(const edm::Event &iEvent,
-                                        const edm::EventSetup &iSetup) {
+void OuterTrackerMonitorTTStub::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   /// Track Trigger Stubs
-  edm::Handle<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>
-      Phase2TrackerDigiTTStubHandle;
+  edm::Handle<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>> Phase2TrackerDigiTTStubHandle;
   iEvent.getByToken(tagTTStubsToken_, Phase2TrackerDigiTTStubHandle);
 
   /// Geometry
@@ -74,58 +69,44 @@ void OuterTrackerMonitorTTStub::analyze(const edm::Event &iEvent,
   theTrackerGeometry = tGeometryHandle.product();
 
   /// Loop over input Stubs
-  typename edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>::const_iterator
-      inputIter;
-  typename edmNew::DetSet<TTStub<Ref_Phase2TrackerDigi_>>::const_iterator
-      contentIter;
+  typename edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>::const_iterator inputIter;
+  typename edmNew::DetSet<TTStub<Ref_Phase2TrackerDigi_>>::const_iterator contentIter;
   // Adding protection
   if (!Phase2TrackerDigiTTStubHandle.isValid())
     return;
 
-  for (inputIter = Phase2TrackerDigiTTStubHandle->begin();
-       inputIter != Phase2TrackerDigiTTStubHandle->end(); ++inputIter) {
-    for (contentIter = inputIter->begin(); contentIter != inputIter->end();
-         ++contentIter) {
+  for (inputIter = Phase2TrackerDigiTTStubHandle->begin(); inputIter != Phase2TrackerDigiTTStubHandle->end();
+       ++inputIter) {
+    for (contentIter = inputIter->begin(); contentIter != inputIter->end(); ++contentIter) {
       /// Make reference stub
-      edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>,
-               TTStub<Ref_Phase2TrackerDigi_>>
-          tempStubRef =
-              edmNew::makeRefTo(Phase2TrackerDigiTTStubHandle, contentIter);
+      edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>> tempStubRef =
+          edmNew::makeRefTo(Phase2TrackerDigiTTStubHandle, contentIter);
 
       /// Get det ID (place of the stub)
       //  tempStubRef->getDetId() gives the stackDetId, not rawId
-      DetId detIdStub =
-          theTrackerGeometry
-              ->idToDet((tempStubRef->getClusterRef(0))->getDetId())
-              ->geographicalId();
+      DetId detIdStub = theTrackerGeometry->idToDet((tempStubRef->getClusterRef(0))->getDetId())->geographicalId();
 
       /// Get trigger displacement/offset
       double displStub = tempStubRef->getTriggerDisplacement();
       double offsetStub = tempStubRef->getTriggerOffset();
 
       /// Define position stub by position inner cluster
-      MeasurementPoint mp =
-          (tempStubRef->getClusterRef(0))->findAverageLocalCoordinates();
+      MeasurementPoint mp = (tempStubRef->getClusterRef(0))->findAverageLocalCoordinates();
       const GeomDet *theGeomDet = theTrackerGeometry->idToDet(detIdStub);
-      Global3DPoint posStub = theGeomDet->surface().toGlobal(
-          theGeomDet->topology().localPosition(mp));
+      Global3DPoint posStub = theGeomDet->surface().toGlobal(theGeomDet->topology().localPosition(mp));
 
       Stub_Eta->Fill(posStub.eta());
       Stub_Phi->Fill(posStub.phi());
       Stub_R->Fill(posStub.perp());
       Stub_RZ->Fill(posStub.z(), posStub.perp());
 
-      if (detIdStub.subdetId() ==
-          static_cast<int>(
-              StripSubdetector::TOB)) { // Phase 2 Outer Tracker Barrel
+      if (detIdStub.subdetId() == static_cast<int>(StripSubdetector::TOB)) {  // Phase 2 Outer Tracker Barrel
         Stub_Barrel->Fill(tTopo->layer(detIdStub));
         Stub_Barrel_XY->Fill(posStub.x(), posStub.y());
         Stub_Barrel_W->Fill(tTopo->layer(detIdStub), displStub - offsetStub);
         Stub_Barrel_O->Fill(tTopo->layer(detIdStub), offsetStub);
-      } else if (detIdStub.subdetId() ==
-                 static_cast<int>(
-                     StripSubdetector::TID)) { // Phase 2 Outer Tracker Endcap
-        int disc = tTopo->layer(detIdStub);    // returns wheel
+      } else if (detIdStub.subdetId() == static_cast<int>(StripSubdetector::TID)) {  // Phase 2 Outer Tracker Endcap
+        int disc = tTopo->layer(detIdStub);                                          // returns wheel
         int ring = tTopo->tidRing(detIdStub);
         Stub_Endcap_Disc->Fill(disc);
         Stub_Endcap_Ring->Fill(ring);
@@ -150,7 +131,7 @@ void OuterTrackerMonitorTTStub::analyze(const edm::Event &iEvent,
       }
     }
   }
-} // end of method
+}  // end of method
 
 // ------------ method called when starting to processes a run  ------------
 void OuterTrackerMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker,
@@ -160,52 +141,50 @@ void OuterTrackerMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker,
   const int numDiscs = 5;
   iBooker.setCurrentFolder(topFolderName_ + "/Stubs/Position");
 
-  edm::ParameterSet psTTStub_Barrel_XY =
-      conf_.getParameter<edm::ParameterSet>("TH2TTStub_Position");
+  edm::ParameterSet psTTStub_Barrel_XY = conf_.getParameter<edm::ParameterSet>("TH2TTStub_Position");
   HistoName = "Stub_Barrel_XY";
-  Stub_Barrel_XY = iBooker.book2D(
-      HistoName, HistoName, psTTStub_Barrel_XY.getParameter<int32_t>("Nbinsx"),
-      psTTStub_Barrel_XY.getParameter<double>("xmin"),
-      psTTStub_Barrel_XY.getParameter<double>("xmax"),
-      psTTStub_Barrel_XY.getParameter<int32_t>("Nbinsy"),
-      psTTStub_Barrel_XY.getParameter<double>("ymin"),
-      psTTStub_Barrel_XY.getParameter<double>("ymax"));
+  Stub_Barrel_XY = iBooker.book2D(HistoName,
+                                  HistoName,
+                                  psTTStub_Barrel_XY.getParameter<int32_t>("Nbinsx"),
+                                  psTTStub_Barrel_XY.getParameter<double>("xmin"),
+                                  psTTStub_Barrel_XY.getParameter<double>("xmax"),
+                                  psTTStub_Barrel_XY.getParameter<int32_t>("Nbinsy"),
+                                  psTTStub_Barrel_XY.getParameter<double>("ymin"),
+                                  psTTStub_Barrel_XY.getParameter<double>("ymax"));
   Stub_Barrel_XY->setAxisTitle("L1 Stub Barrel position x [cm]", 1);
   Stub_Barrel_XY->setAxisTitle("L1 Stub Barrel position y [cm]", 2);
 
-  edm::ParameterSet psTTStub_Endcap_Fw_XY =
-      conf_.getParameter<edm::ParameterSet>("TH2TTStub_Position");
+  edm::ParameterSet psTTStub_Endcap_Fw_XY = conf_.getParameter<edm::ParameterSet>("TH2TTStub_Position");
   HistoName = "Stub_Endcap_Fw_XY";
-  Stub_Endcap_Fw_XY =
-      iBooker.book2D(HistoName, HistoName,
-                     psTTStub_Endcap_Fw_XY.getParameter<int32_t>("Nbinsx"),
-                     psTTStub_Endcap_Fw_XY.getParameter<double>("xmin"),
-                     psTTStub_Endcap_Fw_XY.getParameter<double>("xmax"),
-                     psTTStub_Endcap_Fw_XY.getParameter<int32_t>("Nbinsy"),
-                     psTTStub_Endcap_Fw_XY.getParameter<double>("ymin"),
-                     psTTStub_Endcap_Fw_XY.getParameter<double>("ymax"));
+  Stub_Endcap_Fw_XY = iBooker.book2D(HistoName,
+                                     HistoName,
+                                     psTTStub_Endcap_Fw_XY.getParameter<int32_t>("Nbinsx"),
+                                     psTTStub_Endcap_Fw_XY.getParameter<double>("xmin"),
+                                     psTTStub_Endcap_Fw_XY.getParameter<double>("xmax"),
+                                     psTTStub_Endcap_Fw_XY.getParameter<int32_t>("Nbinsy"),
+                                     psTTStub_Endcap_Fw_XY.getParameter<double>("ymin"),
+                                     psTTStub_Endcap_Fw_XY.getParameter<double>("ymax"));
   Stub_Endcap_Fw_XY->setAxisTitle("L1 Stub Endcap position x [cm]", 1);
   Stub_Endcap_Fw_XY->setAxisTitle("L1 Stub Endcap position y [cm]", 2);
 
-  edm::ParameterSet psTTStub_Endcap_Bw_XY =
-      conf_.getParameter<edm::ParameterSet>("TH2TTStub_Position");
+  edm::ParameterSet psTTStub_Endcap_Bw_XY = conf_.getParameter<edm::ParameterSet>("TH2TTStub_Position");
   HistoName = "Stub_Endcap_Bw_XY";
-  Stub_Endcap_Bw_XY =
-      iBooker.book2D(HistoName, HistoName,
-                     psTTStub_Endcap_Bw_XY.getParameter<int32_t>("Nbinsx"),
-                     psTTStub_Endcap_Bw_XY.getParameter<double>("xmin"),
-                     psTTStub_Endcap_Bw_XY.getParameter<double>("xmax"),
-                     psTTStub_Endcap_Bw_XY.getParameter<int32_t>("Nbinsy"),
-                     psTTStub_Endcap_Bw_XY.getParameter<double>("ymin"),
-                     psTTStub_Endcap_Bw_XY.getParameter<double>("ymax"));
+  Stub_Endcap_Bw_XY = iBooker.book2D(HistoName,
+                                     HistoName,
+                                     psTTStub_Endcap_Bw_XY.getParameter<int32_t>("Nbinsx"),
+                                     psTTStub_Endcap_Bw_XY.getParameter<double>("xmin"),
+                                     psTTStub_Endcap_Bw_XY.getParameter<double>("xmax"),
+                                     psTTStub_Endcap_Bw_XY.getParameter<int32_t>("Nbinsy"),
+                                     psTTStub_Endcap_Bw_XY.getParameter<double>("ymin"),
+                                     psTTStub_Endcap_Bw_XY.getParameter<double>("ymax"));
   Stub_Endcap_Bw_XY->setAxisTitle("L1 Stub Endcap position x [cm]", 1);
   Stub_Endcap_Bw_XY->setAxisTitle("L1 Stub Endcap position y [cm]", 2);
 
   // TTStub #rho vs. z
-  edm::ParameterSet psTTStub_RZ =
-      conf_.getParameter<edm::ParameterSet>("TH2TTStub_RZ");
+  edm::ParameterSet psTTStub_RZ = conf_.getParameter<edm::ParameterSet>("TH2TTStub_RZ");
   HistoName = "Stub_RZ";
-  Stub_RZ = iBooker.book2D(HistoName, HistoName,
+  Stub_RZ = iBooker.book2D(HistoName,
+                           HistoName,
                            psTTStub_RZ.getParameter<int32_t>("Nbinsx"),
                            psTTStub_RZ.getParameter<double>("xmin"),
                            psTTStub_RZ.getParameter<double>("xmax"),
@@ -217,10 +196,10 @@ void OuterTrackerMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker,
 
   iBooker.setCurrentFolder(topFolderName_ + "/Stubs");
   // TTStub eta
-  edm::ParameterSet psTTStub_Eta =
-      conf_.getParameter<edm::ParameterSet>("TH1TTStub_Eta");
+  edm::ParameterSet psTTStub_Eta = conf_.getParameter<edm::ParameterSet>("TH1TTStub_Eta");
   HistoName = "Stub_Eta";
-  Stub_Eta = iBooker.book1D(HistoName, HistoName,
+  Stub_Eta = iBooker.book1D(HistoName,
+                            HistoName,
                             psTTStub_Eta.getParameter<int32_t>("Nbinsx"),
                             psTTStub_Eta.getParameter<double>("xmin"),
                             psTTStub_Eta.getParameter<double>("xmax"));
@@ -228,10 +207,10 @@ void OuterTrackerMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker,
   Stub_Eta->setAxisTitle("# L1 Stubs ", 2);
 
   // TTStub phi
-  edm::ParameterSet psTTStub_Phi =
-      conf_.getParameter<edm::ParameterSet>("TH1TTStub_Phi");
+  edm::ParameterSet psTTStub_Phi = conf_.getParameter<edm::ParameterSet>("TH1TTStub_Phi");
   HistoName = "Stub_Phi";
-  Stub_Phi = iBooker.book1D(HistoName, HistoName,
+  Stub_Phi = iBooker.book1D(HistoName,
+                            HistoName,
                             psTTStub_Phi.getParameter<int32_t>("Nbinsx"),
                             psTTStub_Phi.getParameter<double>("xmin"),
                             psTTStub_Phi.getParameter<double>("xmax"));
@@ -239,10 +218,10 @@ void OuterTrackerMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker,
   Stub_Phi->setAxisTitle("# L1 Stubs ", 2);
 
   // TTStub R
-  edm::ParameterSet psTTStub_R =
-      conf_.getParameter<edm::ParameterSet>("TH1TTStub_R");
+  edm::ParameterSet psTTStub_R = conf_.getParameter<edm::ParameterSet>("TH1TTStub_R");
   HistoName = "Stub_R";
-  Stub_R = iBooker.book1D(HistoName, HistoName,
+  Stub_R = iBooker.book1D(HistoName,
+                          HistoName,
                           psTTStub_R.getParameter<int32_t>("Nbinsx"),
                           psTTStub_R.getParameter<double>("xmin"),
                           psTTStub_R.getParameter<double>("xmax"));
@@ -251,10 +230,10 @@ void OuterTrackerMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker,
 
   iBooker.setCurrentFolder(topFolderName_ + "/Stubs/NStubs");
   // TTStub barrel stack
-  edm::ParameterSet psTTStub_Barrel =
-      conf_.getParameter<edm::ParameterSet>("TH1TTStub_Layers");
+  edm::ParameterSet psTTStub_Barrel = conf_.getParameter<edm::ParameterSet>("TH1TTStub_Layers");
   HistoName = "NStubs_Barrel";
-  Stub_Barrel = iBooker.book1D(HistoName, HistoName,
+  Stub_Barrel = iBooker.book1D(HistoName,
+                               HistoName,
                                psTTStub_Barrel.getParameter<int32_t>("Nbinsx"),
                                psTTStub_Barrel.getParameter<double>("xmin"),
                                psTTStub_Barrel.getParameter<double>("xmax"));
@@ -262,51 +241,54 @@ void OuterTrackerMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker,
   Stub_Barrel->setAxisTitle("# L1 Stubs ", 2);
 
   // TTStub Endcap stack
-  edm::ParameterSet psTTStub_ECDisc =
-      conf_.getParameter<edm::ParameterSet>("TH1TTStub_Discs");
+  edm::ParameterSet psTTStub_ECDisc = conf_.getParameter<edm::ParameterSet>("TH1TTStub_Discs");
   HistoName = "NStubs_Endcap_Disc";
-  Stub_Endcap_Disc = iBooker.book1D(
-      HistoName, HistoName, psTTStub_ECDisc.getParameter<int32_t>("Nbinsx"),
-      psTTStub_ECDisc.getParameter<double>("xmin"),
-      psTTStub_ECDisc.getParameter<double>("xmax"));
+  Stub_Endcap_Disc = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psTTStub_ECDisc.getParameter<int32_t>("Nbinsx"),
+                                    psTTStub_ECDisc.getParameter<double>("xmin"),
+                                    psTTStub_ECDisc.getParameter<double>("xmax"));
   Stub_Endcap_Disc->setAxisTitle("Endcap Disc", 1);
   Stub_Endcap_Disc->setAxisTitle("# L1 Stubs ", 2);
 
   // TTStub Endcap stack
   HistoName = "NStubs_Endcap_Disc_Fw";
-  Stub_Endcap_Disc_Fw = iBooker.book1D(
-      HistoName, HistoName, psTTStub_ECDisc.getParameter<int32_t>("Nbinsx"),
-      psTTStub_ECDisc.getParameter<double>("xmin"),
-      psTTStub_ECDisc.getParameter<double>("xmax"));
+  Stub_Endcap_Disc_Fw = iBooker.book1D(HistoName,
+                                       HistoName,
+                                       psTTStub_ECDisc.getParameter<int32_t>("Nbinsx"),
+                                       psTTStub_ECDisc.getParameter<double>("xmin"),
+                                       psTTStub_ECDisc.getParameter<double>("xmax"));
   Stub_Endcap_Disc_Fw->setAxisTitle("Forward Endcap Disc", 1);
   Stub_Endcap_Disc_Fw->setAxisTitle("# L1 Stubs ", 2);
 
   // TTStub Endcap stack
   HistoName = "NStubs_Endcap_Disc_Bw";
-  Stub_Endcap_Disc_Bw = iBooker.book1D(
-      HistoName, HistoName, psTTStub_ECDisc.getParameter<int32_t>("Nbinsx"),
-      psTTStub_ECDisc.getParameter<double>("xmin"),
-      psTTStub_ECDisc.getParameter<double>("xmax"));
+  Stub_Endcap_Disc_Bw = iBooker.book1D(HistoName,
+                                       HistoName,
+                                       psTTStub_ECDisc.getParameter<int32_t>("Nbinsx"),
+                                       psTTStub_ECDisc.getParameter<double>("xmin"),
+                                       psTTStub_ECDisc.getParameter<double>("xmax"));
   Stub_Endcap_Disc_Bw->setAxisTitle("Backward Endcap Disc", 1);
   Stub_Endcap_Disc_Bw->setAxisTitle("# L1 Stubs ", 2);
 
-  edm::ParameterSet psTTStub_ECRing =
-      conf_.getParameter<edm::ParameterSet>("TH1TTStub_Rings");
+  edm::ParameterSet psTTStub_ECRing = conf_.getParameter<edm::ParameterSet>("TH1TTStub_Rings");
   HistoName = "NStubs_Endcap_Ring";
-  Stub_Endcap_Ring = iBooker.book1D(
-      HistoName, HistoName, psTTStub_ECRing.getParameter<int32_t>("Nbinsx"),
-      psTTStub_ECRing.getParameter<double>("xmin"),
-      psTTStub_ECRing.getParameter<double>("xmax"));
+  Stub_Endcap_Ring = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psTTStub_ECRing.getParameter<int32_t>("Nbinsx"),
+                                    psTTStub_ECRing.getParameter<double>("xmin"),
+                                    psTTStub_ECRing.getParameter<double>("xmax"));
   Stub_Endcap_Ring->setAxisTitle("Endcap Ring", 1);
   Stub_Endcap_Ring->setAxisTitle("# L1 Stubs ", 2);
 
   for (int i = 0; i < numDiscs; i++) {
     HistoName = "NStubs_Disc+" + std::to_string(i + 1);
     // TTStub Endcap stack
-    Stub_Endcap_Ring_Fw[i] = iBooker.book1D(
-        HistoName, HistoName, psTTStub_ECRing.getParameter<int32_t>("Nbinsx"),
-        psTTStub_ECRing.getParameter<double>("xmin"),
-        psTTStub_ECRing.getParameter<double>("xmax"));
+    Stub_Endcap_Ring_Fw[i] = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psTTStub_ECRing.getParameter<int32_t>("Nbinsx"),
+                                            psTTStub_ECRing.getParameter<double>("xmin"),
+                                            psTTStub_ECRing.getParameter<double>("xmax"));
     Stub_Endcap_Ring_Fw[i]->setAxisTitle("Endcap Ring", 1);
     Stub_Endcap_Ring_Fw[i]->setAxisTitle("# L1 Stubs ", 2);
   }
@@ -314,142 +296,146 @@ void OuterTrackerMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker,
   for (int i = 0; i < numDiscs; i++) {
     HistoName = "NStubs_Disc-" + std::to_string(i + 1);
     // TTStub Endcap stack
-    Stub_Endcap_Ring_Bw[i] = iBooker.book1D(
-        HistoName, HistoName, psTTStub_ECRing.getParameter<int32_t>("Nbinsx"),
-        psTTStub_ECRing.getParameter<double>("xmin"),
-        psTTStub_ECRing.getParameter<double>("xmax"));
+    Stub_Endcap_Ring_Bw[i] = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psTTStub_ECRing.getParameter<int32_t>("Nbinsx"),
+                                            psTTStub_ECRing.getParameter<double>("xmin"),
+                                            psTTStub_ECRing.getParameter<double>("xmax"));
     Stub_Endcap_Ring_Bw[i]->setAxisTitle("Endcap Ring", 1);
     Stub_Endcap_Ring_Bw[i]->setAxisTitle("# L1 Stubs ", 2);
   }
 
   // TTStub displ/offset
-  edm::ParameterSet psTTStub_Barrel_2D =
-      conf_.getParameter<edm::ParameterSet>("TH2TTStub_DisOf_Layer");
-  edm::ParameterSet psTTStub_ECDisc_2D =
-      conf_.getParameter<edm::ParameterSet>("TH2TTStub_DisOf_Disc");
-  edm::ParameterSet psTTStub_ECRing_2D =
-      conf_.getParameter<edm::ParameterSet>("TH2TTStub_DisOf_Ring");
+  edm::ParameterSet psTTStub_Barrel_2D = conf_.getParameter<edm::ParameterSet>("TH2TTStub_DisOf_Layer");
+  edm::ParameterSet psTTStub_ECDisc_2D = conf_.getParameter<edm::ParameterSet>("TH2TTStub_DisOf_Disc");
+  edm::ParameterSet psTTStub_ECRing_2D = conf_.getParameter<edm::ParameterSet>("TH2TTStub_DisOf_Ring");
 
   iBooker.setCurrentFolder(topFolderName_ + "/Stubs/Width");
   HistoName = "Stub_Width_Barrel";
-  Stub_Barrel_W = iBooker.book2D(
-      HistoName, HistoName, psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsx"),
-      psTTStub_Barrel_2D.getParameter<double>("xmin"),
-      psTTStub_Barrel_2D.getParameter<double>("xmax"),
-      psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsy"),
-      psTTStub_Barrel_2D.getParameter<double>("ymin"),
-      psTTStub_Barrel_2D.getParameter<double>("ymax"));
+  Stub_Barrel_W = iBooker.book2D(HistoName,
+                                 HistoName,
+                                 psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsx"),
+                                 psTTStub_Barrel_2D.getParameter<double>("xmin"),
+                                 psTTStub_Barrel_2D.getParameter<double>("xmax"),
+                                 psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsy"),
+                                 psTTStub_Barrel_2D.getParameter<double>("ymin"),
+                                 psTTStub_Barrel_2D.getParameter<double>("ymax"));
   Stub_Barrel_W->setAxisTitle("Barrel Layer", 1);
   Stub_Barrel_W->setAxisTitle("Displacement - Offset", 2);
 
   HistoName = "Stub_Width_Endcap_Disc";
-  Stub_Endcap_Disc_W = iBooker.book2D(
-      HistoName, HistoName, psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsx"),
-      psTTStub_ECDisc_2D.getParameter<double>("xmin"),
-      psTTStub_ECDisc_2D.getParameter<double>("xmax"),
-      psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsy"),
-      psTTStub_ECDisc_2D.getParameter<double>("ymin"),
-      psTTStub_ECDisc_2D.getParameter<double>("ymax"));
+  Stub_Endcap_Disc_W = iBooker.book2D(HistoName,
+                                      HistoName,
+                                      psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsx"),
+                                      psTTStub_ECDisc_2D.getParameter<double>("xmin"),
+                                      psTTStub_ECDisc_2D.getParameter<double>("xmax"),
+                                      psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsy"),
+                                      psTTStub_ECDisc_2D.getParameter<double>("ymin"),
+                                      psTTStub_ECDisc_2D.getParameter<double>("ymax"));
   Stub_Endcap_Disc_W->setAxisTitle("Endcap Disc", 1);
   Stub_Endcap_Disc_W->setAxisTitle("Displacement - Offset", 2);
 
   HistoName = "Stub_Width_Endcap_Ring";
-  Stub_Endcap_Ring_W = iBooker.book2D(
-      HistoName, HistoName, psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
-      psTTStub_ECRing_2D.getParameter<double>("xmin"),
-      psTTStub_ECRing_2D.getParameter<double>("xmax"),
-      psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
-      psTTStub_ECRing_2D.getParameter<double>("ymin"),
-      psTTStub_ECRing_2D.getParameter<double>("ymax"));
+  Stub_Endcap_Ring_W = iBooker.book2D(HistoName,
+                                      HistoName,
+                                      psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
+                                      psTTStub_ECRing_2D.getParameter<double>("xmin"),
+                                      psTTStub_ECRing_2D.getParameter<double>("xmax"),
+                                      psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
+                                      psTTStub_ECRing_2D.getParameter<double>("ymin"),
+                                      psTTStub_ECRing_2D.getParameter<double>("ymax"));
   Stub_Endcap_Ring_W->setAxisTitle("Endcap Ring", 1);
   Stub_Endcap_Ring_W->setAxisTitle("Trigger Offset", 2);
 
   for (int i = 0; i < numDiscs; i++) {
     HistoName = "Stub_Width_Disc+" + std::to_string(i + 1);
-    Stub_Endcap_Ring_W_Fw[i] =
-        iBooker.book2D(HistoName, HistoName,
-                       psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
-                       psTTStub_ECRing_2D.getParameter<double>("xmin"),
-                       psTTStub_ECRing_2D.getParameter<double>("xmax"),
-                       psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
-                       psTTStub_ECRing_2D.getParameter<double>("ymin"),
-                       psTTStub_ECRing_2D.getParameter<double>("ymax"));
+    Stub_Endcap_Ring_W_Fw[i] = iBooker.book2D(HistoName,
+                                              HistoName,
+                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
+                                              psTTStub_ECRing_2D.getParameter<double>("xmin"),
+                                              psTTStub_ECRing_2D.getParameter<double>("xmax"),
+                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
+                                              psTTStub_ECRing_2D.getParameter<double>("ymin"),
+                                              psTTStub_ECRing_2D.getParameter<double>("ymax"));
     Stub_Endcap_Ring_W_Fw[i]->setAxisTitle("Endcap Ring", 1);
     Stub_Endcap_Ring_W_Fw[i]->setAxisTitle("Displacement - Offset", 2);
   }
 
   for (int i = 0; i < numDiscs; i++) {
     HistoName = "Stub_Width_Disc-" + std::to_string(i + 1);
-    Stub_Endcap_Ring_W_Bw[i] =
-        iBooker.book2D(HistoName, HistoName,
-                       psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
-                       psTTStub_ECRing_2D.getParameter<double>("xmin"),
-                       psTTStub_ECRing_2D.getParameter<double>("xmax"),
-                       psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
-                       psTTStub_ECRing_2D.getParameter<double>("ymin"),
-                       psTTStub_ECRing_2D.getParameter<double>("ymax"));
+    Stub_Endcap_Ring_W_Bw[i] = iBooker.book2D(HistoName,
+                                              HistoName,
+                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
+                                              psTTStub_ECRing_2D.getParameter<double>("xmin"),
+                                              psTTStub_ECRing_2D.getParameter<double>("xmax"),
+                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
+                                              psTTStub_ECRing_2D.getParameter<double>("ymin"),
+                                              psTTStub_ECRing_2D.getParameter<double>("ymax"));
     Stub_Endcap_Ring_W_Bw[i]->setAxisTitle("Endcap Ring", 1);
     Stub_Endcap_Ring_W_Bw[i]->setAxisTitle("Displacement - Offset", 2);
   }
 
   iBooker.setCurrentFolder(topFolderName_ + "/Stubs/Offset");
   HistoName = "Stub_Offset_Barrel";
-  Stub_Barrel_O = iBooker.book2D(
-      HistoName, HistoName, psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsx"),
-      psTTStub_Barrel_2D.getParameter<double>("xmin"),
-      psTTStub_Barrel_2D.getParameter<double>("xmax"),
-      psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsy"),
-      psTTStub_Barrel_2D.getParameter<double>("ymin"),
-      psTTStub_Barrel_2D.getParameter<double>("ymax"));
+  Stub_Barrel_O = iBooker.book2D(HistoName,
+                                 HistoName,
+                                 psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsx"),
+                                 psTTStub_Barrel_2D.getParameter<double>("xmin"),
+                                 psTTStub_Barrel_2D.getParameter<double>("xmax"),
+                                 psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsy"),
+                                 psTTStub_Barrel_2D.getParameter<double>("ymin"),
+                                 psTTStub_Barrel_2D.getParameter<double>("ymax"));
   Stub_Barrel_O->setAxisTitle("Barrel Layer", 1);
   Stub_Barrel_O->setAxisTitle("Trigger Offset", 2);
 
   HistoName = "Stub_Offset_Endcap_Disc";
-  Stub_Endcap_Disc_O = iBooker.book2D(
-      HistoName, HistoName, psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsx"),
-      psTTStub_ECDisc_2D.getParameter<double>("xmin"),
-      psTTStub_ECDisc_2D.getParameter<double>("xmax"),
-      psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsy"),
-      psTTStub_ECDisc_2D.getParameter<double>("ymin"),
-      psTTStub_ECDisc_2D.getParameter<double>("ymax"));
+  Stub_Endcap_Disc_O = iBooker.book2D(HistoName,
+                                      HistoName,
+                                      psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsx"),
+                                      psTTStub_ECDisc_2D.getParameter<double>("xmin"),
+                                      psTTStub_ECDisc_2D.getParameter<double>("xmax"),
+                                      psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsy"),
+                                      psTTStub_ECDisc_2D.getParameter<double>("ymin"),
+                                      psTTStub_ECDisc_2D.getParameter<double>("ymax"));
   Stub_Endcap_Disc_O->setAxisTitle("Endcap Disc", 1);
   Stub_Endcap_Disc_O->setAxisTitle("Trigger Offset", 2);
 
   HistoName = "Stub_Offset_Endcap_Ring";
-  Stub_Endcap_Ring_O = iBooker.book2D(
-      HistoName, HistoName, psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
-      psTTStub_ECRing_2D.getParameter<double>("xmin"),
-      psTTStub_ECRing_2D.getParameter<double>("xmax"),
-      psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
-      psTTStub_ECRing_2D.getParameter<double>("ymin"),
-      psTTStub_ECRing_2D.getParameter<double>("ymax"));
+  Stub_Endcap_Ring_O = iBooker.book2D(HistoName,
+                                      HistoName,
+                                      psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
+                                      psTTStub_ECRing_2D.getParameter<double>("xmin"),
+                                      psTTStub_ECRing_2D.getParameter<double>("xmax"),
+                                      psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
+                                      psTTStub_ECRing_2D.getParameter<double>("ymin"),
+                                      psTTStub_ECRing_2D.getParameter<double>("ymax"));
   Stub_Endcap_Ring_O->setAxisTitle("Endcap Ring", 1);
   Stub_Endcap_Ring_O->setAxisTitle("Trigger Offset", 2);
 
   for (int i = 0; i < numDiscs; i++) {
     HistoName = "Stub_Offset_Disc+" + std::to_string(i + 1);
-    Stub_Endcap_Ring_O_Fw[i] =
-        iBooker.book2D(HistoName, HistoName,
-                       psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
-                       psTTStub_ECRing_2D.getParameter<double>("xmin"),
-                       psTTStub_ECRing_2D.getParameter<double>("xmax"),
-                       psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
-                       psTTStub_ECRing_2D.getParameter<double>("ymin"),
-                       psTTStub_ECRing_2D.getParameter<double>("ymax"));
+    Stub_Endcap_Ring_O_Fw[i] = iBooker.book2D(HistoName,
+                                              HistoName,
+                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
+                                              psTTStub_ECRing_2D.getParameter<double>("xmin"),
+                                              psTTStub_ECRing_2D.getParameter<double>("xmax"),
+                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
+                                              psTTStub_ECRing_2D.getParameter<double>("ymin"),
+                                              psTTStub_ECRing_2D.getParameter<double>("ymax"));
     Stub_Endcap_Ring_O_Fw[i]->setAxisTitle("Endcap Ring", 1);
     Stub_Endcap_Ring_O_Fw[i]->setAxisTitle("Trigger Offset", 2);
   }
 
   for (int i = 0; i < numDiscs; i++) {
     HistoName = "Stub_Offset_Disc-" + std::to_string(i + 1);
-    Stub_Endcap_Ring_O_Bw[i] =
-        iBooker.book2D(HistoName, HistoName,
-                       psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
-                       psTTStub_ECRing_2D.getParameter<double>("xmin"),
-                       psTTStub_ECRing_2D.getParameter<double>("xmax"),
-                       psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
-                       psTTStub_ECRing_2D.getParameter<double>("ymin"),
-                       psTTStub_ECRing_2D.getParameter<double>("ymax"));
+    Stub_Endcap_Ring_O_Bw[i] = iBooker.book2D(HistoName,
+                                              HistoName,
+                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
+                                              psTTStub_ECRing_2D.getParameter<double>("xmin"),
+                                              psTTStub_ECRing_2D.getParameter<double>("xmax"),
+                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
+                                              psTTStub_ECRing_2D.getParameter<double>("ymin"),
+                                              psTTStub_ECRing_2D.getParameter<double>("ymax"));
     Stub_Endcap_Ring_O_Bw[i]->setAxisTitle("Endcap Ring", 1);
     Stub_Endcap_Ring_O_Bw[i]->setAxisTitle("Trigger Offset", 2);
   }

--- a/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTTrack.cc
+++ b/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTTrack.cc
@@ -36,12 +36,10 @@
 #include "SimTracker/TrackTriggerAssociation/interface/TTTrackAssociationMap.h"
 
 // constructors and destructor
-OuterTrackerMonitorTTTrack::OuterTrackerMonitorTTTrack(
-    const edm::ParameterSet &iConfig)
-    : conf_(iConfig) {
+OuterTrackerMonitorTTTrack::OuterTrackerMonitorTTTrack(const edm::ParameterSet &iConfig) : conf_(iConfig) {
   topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
-  ttTrackToken_ = consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>(
-      conf_.getParameter<edm::InputTag>("TTTracksTag"));
+  ttTrackToken_ =
+      consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>(conf_.getParameter<edm::InputTag>("TTTracksTag"));
   HQNStubs_ = conf_.getParameter<int>("HQNStubs");
   HQChi2dof_ = conf_.getParameter<double>("HQChi2dof");
 }
@@ -54,8 +52,7 @@ OuterTrackerMonitorTTTrack::~OuterTrackerMonitorTTTrack() {
 // member functions
 
 // ------------ method called for each event  ------------
-void OuterTrackerMonitorTTTrack::analyze(const edm::Event &iEvent,
-                                         const edm::EventSetup &iSetup) {
+void OuterTrackerMonitorTTTrack::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // L1 Primaries
   edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>> TTTrackHandle;
   iEvent.getByToken(ttTrackToken_, TTTrackHandle);
@@ -71,24 +68,21 @@ void OuterTrackerMonitorTTTrack::analyze(const edm::Event &iEvent,
   /// Loop over TTTracks
   unsigned int tkCnt = 0;
   for (auto iterTTTrack : *TTTrackHandle) {
-    edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>> tempTrackPtr(
-        TTTrackHandle, tkCnt++); /// Make the pointer
+    edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>> tempTrackPtr(TTTrackHandle, tkCnt++);  /// Make the pointer
 
     unsigned int nStubs = tempTrackPtr->getStubRefs().size();
     int nBarrelStubs = 0;
     int nECStubs = 0;
 
-    double track_d0 =
-        sqrt(tempTrackPtr->getPOCA().x() * tempTrackPtr->getPOCA().x() +
-             tempTrackPtr->getPOCA().y() * tempTrackPtr->getPOCA().y());
+    double track_d0 = sqrt(tempTrackPtr->getPOCA().x() * tempTrackPtr->getPOCA().x() +
+                           tempTrackPtr->getPOCA().y() * tempTrackPtr->getPOCA().y());
     double trackChi2 = tempTrackPtr->getChi2();
     double trackChi2R = tempTrackPtr->getChi2Red();
 
     Track_NStubs->Fill(nStubs);
     Track_Eta_NStubs->Fill(tempTrackPtr->getMomentum().eta(), nStubs);
 
-    std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>,
-                         TTStub<Ref_Phase2TrackerDigi_>>>
+    std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
         theStubs = iterTTTrack.getStubRefs();
     for (auto istub : theStubs) {
       bool inTIB = false;
@@ -99,7 +93,6 @@ void OuterTrackerMonitorTTTrack::analyze(const edm::Event &iEvent,
       // Verify if stubs are in EC or barrel
       DetId detId(istub->getDetId());
       if (detId.det() == DetId::Detector::Tracker) {
-
         if (detId.subdetId() == StripSubdetector::TIB)
           inTIB = true;
         else if (detId.subdetId() == StripSubdetector::TOB)
@@ -117,7 +110,7 @@ void OuterTrackerMonitorTTTrack::analyze(const edm::Event &iEvent,
         nECStubs++;
       else if (inTID)
         nECStubs++;
-    } // end loop over stubs
+    }  // end loop over stubs
 
     // HQ tracks: >=5 stubs and chi2/dof < 1
     if (nStubs >= HQNStubs_ && trackChi2R <= HQChi2dof_) {
@@ -132,8 +125,7 @@ void OuterTrackerMonitorTTTrack::analyze(const edm::Event &iEvent,
       Track_HQ_D0->Fill(track_d0);
       Track_HQ_Chi2Red_NStubs->Fill(nStubs, trackChi2R);
       Track_HQ_Chi2Red_Eta->Fill(tempTrackPtr->getMomentum().eta(), trackChi2R);
-      Track_HQ_Eta_BarrelStubs->Fill(tempTrackPtr->getMomentum().eta(),
-                                     nBarrelStubs);
+      Track_HQ_Eta_BarrelStubs->Fill(tempTrackPtr->getMomentum().eta(), nBarrelStubs);
       Track_HQ_Eta_ECStubs->Fill(tempTrackPtr->getMomentum().eta(), nECStubs);
       Track_HQ_Chi2_Probability->Fill(ChiSquaredProbability(trackChi2, nStubs));
     }
@@ -150,16 +142,15 @@ void OuterTrackerMonitorTTTrack::analyze(const edm::Event &iEvent,
     Track_LQ_D0->Fill(track_d0);
     Track_LQ_Chi2Red_NStubs->Fill(nStubs, trackChi2R);
     Track_LQ_Chi2Red_Eta->Fill(tempTrackPtr->getMomentum().eta(), trackChi2R);
-    Track_LQ_Eta_BarrelStubs->Fill(tempTrackPtr->getMomentum().eta(),
-                                   nBarrelStubs);
+    Track_LQ_Eta_BarrelStubs->Fill(tempTrackPtr->getMomentum().eta(), nBarrelStubs);
     Track_LQ_Eta_ECStubs->Fill(tempTrackPtr->getMomentum().eta(), nECStubs);
     Track_LQ_Chi2_Probability->Fill(ChiSquaredProbability(trackChi2, nStubs));
 
-  } // End of loop over TTTracks
+  }  // End of loop over TTTracks
 
   Track_HQ_N->Fill(numHQTracks);
   Track_LQ_N->Fill(numLQTracks);
-} // end of method
+}  // end of method
 
 // ------------ method called once each job just before starting event loop
 // ------------
@@ -171,26 +162,26 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
   iBooker.setCurrentFolder(topFolderName_ + "/Tracks/");
 
   // Number of stubs
-  edm::ParameterSet psTrack_NStubs =
-      conf_.getParameter<edm::ParameterSet>("TH1_NStubs");
+  edm::ParameterSet psTrack_NStubs = conf_.getParameter<edm::ParameterSet>("TH1_NStubs");
   HistoName = "Track_NStubs";
-  Track_NStubs = iBooker.book1D(HistoName, HistoName,
+  Track_NStubs = iBooker.book1D(HistoName,
+                                HistoName,
                                 psTrack_NStubs.getParameter<int32_t>("Nbinsx"),
                                 psTrack_NStubs.getParameter<double>("xmin"),
                                 psTrack_NStubs.getParameter<double>("xmax"));
   Track_NStubs->setAxisTitle("# L1 Stubs per L1 Track", 1);
   Track_NStubs->setAxisTitle("# L1 Tracks", 2);
 
-  edm::ParameterSet psTrack_Eta_NStubs =
-      conf_.getParameter<edm::ParameterSet>("TH2_Track_Eta_NStubs");
+  edm::ParameterSet psTrack_Eta_NStubs = conf_.getParameter<edm::ParameterSet>("TH2_Track_Eta_NStubs");
   HistoName = "Track_Eta_NStubs";
-  Track_Eta_NStubs = iBooker.book2D(
-      HistoName, HistoName, psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
-      psTrack_Eta_NStubs.getParameter<double>("xmin"),
-      psTrack_Eta_NStubs.getParameter<double>("xmax"),
-      psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
-      psTrack_Eta_NStubs.getParameter<double>("ymin"),
-      psTrack_Eta_NStubs.getParameter<double>("ymax"));
+  Track_Eta_NStubs = iBooker.book2D(HistoName,
+                                    HistoName,
+                                    psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
+                                    psTrack_Eta_NStubs.getParameter<double>("xmin"),
+                                    psTrack_Eta_NStubs.getParameter<double>("xmax"),
+                                    psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
+                                    psTrack_Eta_NStubs.getParameter<double>("ymin"),
+                                    psTrack_Eta_NStubs.getParameter<double>("ymax"));
   Track_Eta_NStubs->setAxisTitle("#eta", 1);
   Track_Eta_NStubs->setAxisTitle("# L1 Stubs", 2);
 
@@ -198,9 +189,9 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
   iBooker.setCurrentFolder(topFolderName_ + "/Tracks/LQ");
   // Nb of L1Tracks
   HistoName = "Track_LQ_N";
-  edm::ParameterSet psTrack_N =
-      conf_.getParameter<edm::ParameterSet>("TH1_NTracks");
-  Track_LQ_N = iBooker.book1D(HistoName, HistoName,
+  edm::ParameterSet psTrack_N = conf_.getParameter<edm::ParameterSet>("TH1_NTracks");
+  Track_LQ_N = iBooker.book1D(HistoName,
+                              HistoName,
                               psTrack_N.getParameter<int32_t>("Nbinsx"),
                               psTrack_N.getParameter<double>("xmin"),
                               psTrack_N.getParameter<double>("xmax"));
@@ -208,10 +199,10 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
   Track_LQ_N->setAxisTitle("# Events", 2);
 
   // Pt of the tracks
-  edm::ParameterSet psTrack_Pt =
-      conf_.getParameter<edm::ParameterSet>("TH1_Track_Pt");
+  edm::ParameterSet psTrack_Pt = conf_.getParameter<edm::ParameterSet>("TH1_Track_Pt");
   HistoName = "Track_LQ_Pt";
-  Track_LQ_Pt = iBooker.book1D(HistoName, HistoName,
+  Track_LQ_Pt = iBooker.book1D(HistoName,
+                               HistoName,
                                psTrack_Pt.getParameter<int32_t>("Nbinsx"),
                                psTrack_Pt.getParameter<double>("xmin"),
                                psTrack_Pt.getParameter<double>("xmax"));
@@ -219,10 +210,10 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
   Track_LQ_Pt->setAxisTitle("# L1 Tracks", 2);
 
   // Phi
-  edm::ParameterSet psTrack_Phi =
-      conf_.getParameter<edm::ParameterSet>("TH1_Track_Phi");
+  edm::ParameterSet psTrack_Phi = conf_.getParameter<edm::ParameterSet>("TH1_Track_Phi");
   HistoName = "Track_LQ_Phi";
-  Track_LQ_Phi = iBooker.book1D(HistoName, HistoName,
+  Track_LQ_Phi = iBooker.book1D(HistoName,
+                                HistoName,
                                 psTrack_Phi.getParameter<int32_t>("Nbinsx"),
                                 psTrack_Phi.getParameter<double>("xmin"),
                                 psTrack_Phi.getParameter<double>("xmax"));
@@ -230,10 +221,10 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
   Track_LQ_Phi->setAxisTitle("# L1 Tracks", 2);
 
   // D0
-  edm::ParameterSet psTrack_D0 =
-      conf_.getParameter<edm::ParameterSet>("TH1_Track_D0");
+  edm::ParameterSet psTrack_D0 = conf_.getParameter<edm::ParameterSet>("TH1_Track_D0");
   HistoName = "Track_LQ_D0";
-  Track_LQ_D0 = iBooker.book1D(HistoName, HistoName,
+  Track_LQ_D0 = iBooker.book1D(HistoName,
+                               HistoName,
                                psTrack_D0.getParameter<int32_t>("Nbinsx"),
                                psTrack_D0.getParameter<double>("xmin"),
                                psTrack_D0.getParameter<double>("xmax"));
@@ -241,10 +232,10 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
   Track_LQ_D0->setAxisTitle("# L1 Tracks", 2);
 
   // Eta
-  edm::ParameterSet psTrack_Eta =
-      conf_.getParameter<edm::ParameterSet>("TH1_Track_Eta");
+  edm::ParameterSet psTrack_Eta = conf_.getParameter<edm::ParameterSet>("TH1_Track_Eta");
   HistoName = "Track_LQ_Eta";
-  Track_LQ_Eta = iBooker.book1D(HistoName, HistoName,
+  Track_LQ_Eta = iBooker.book1D(HistoName,
+                                HistoName,
                                 psTrack_Eta.getParameter<int32_t>("Nbinsx"),
                                 psTrack_Eta.getParameter<double>("xmin"),
                                 psTrack_Eta.getParameter<double>("xmax"));
@@ -252,10 +243,10 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
   Track_LQ_Eta->setAxisTitle("# L1 Tracks", 2);
 
   // VtxZ
-  edm::ParameterSet psTrack_VtxZ =
-      conf_.getParameter<edm::ParameterSet>("TH1_Track_VtxZ");
+  edm::ParameterSet psTrack_VtxZ = conf_.getParameter<edm::ParameterSet>("TH1_Track_VtxZ");
   HistoName = "Track_LQ_VtxZ";
-  Track_LQ_VtxZ = iBooker.book1D(HistoName, HistoName,
+  Track_LQ_VtxZ = iBooker.book1D(HistoName,
+                                 HistoName,
                                  psTrack_VtxZ.getParameter<int32_t>("Nbinsx"),
                                  psTrack_VtxZ.getParameter<double>("xmin"),
                                  psTrack_VtxZ.getParameter<double>("xmax"));
@@ -263,10 +254,10 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
   Track_LQ_VtxZ->setAxisTitle("# L1 Tracks", 2);
 
   // chi2
-  edm::ParameterSet psTrack_Chi2 =
-      conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2");
+  edm::ParameterSet psTrack_Chi2 = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2");
   HistoName = "Track_LQ_Chi2";
-  Track_LQ_Chi2 = iBooker.book1D(HistoName, HistoName,
+  Track_LQ_Chi2 = iBooker.book1D(HistoName,
+                                 HistoName,
                                  psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
                                  psTrack_Chi2.getParameter<double>("xmin"),
                                  psTrack_Chi2.getParameter<double>("xmax"));
@@ -274,78 +265,78 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
   Track_LQ_Chi2->setAxisTitle("# L1 Tracks", 2);
 
   // chi2Red
-  edm::ParameterSet psTrack_Chi2Red =
-      conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2R");
+  edm::ParameterSet psTrack_Chi2Red = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2R");
   HistoName = "Track_LQ_Chi2Red";
-  Track_LQ_Chi2Red = iBooker.book1D(
-      HistoName, HistoName, psTrack_Chi2Red.getParameter<int32_t>("Nbinsx"),
-      psTrack_Chi2Red.getParameter<double>("xmin"),
-      psTrack_Chi2Red.getParameter<double>("xmax"));
+  Track_LQ_Chi2Red = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psTrack_Chi2Red.getParameter<int32_t>("Nbinsx"),
+                                    psTrack_Chi2Red.getParameter<double>("xmin"),
+                                    psTrack_Chi2Red.getParameter<double>("xmax"));
   Track_LQ_Chi2Red->setAxisTitle("L1 Track #chi^{2}/ndf", 1);
   Track_LQ_Chi2Red->setAxisTitle("# L1 Tracks", 2);
 
   // Chi2 prob
-  edm::ParameterSet psTrack_Chi2_Probability =
-      conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2_Probability");
+  edm::ParameterSet psTrack_Chi2_Probability = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2_Probability");
   HistoName = "Track_LQ_Chi2_Probability";
-  Track_LQ_Chi2_Probability =
-      iBooker.book1D(HistoName, HistoName,
-                     psTrack_Chi2_Probability.getParameter<int32_t>("Nbinsx"),
-                     psTrack_Chi2_Probability.getParameter<double>("xmin"),
-                     psTrack_Chi2_Probability.getParameter<double>("xmax"));
+  Track_LQ_Chi2_Probability = iBooker.book1D(HistoName,
+                                             HistoName,
+                                             psTrack_Chi2_Probability.getParameter<int32_t>("Nbinsx"),
+                                             psTrack_Chi2_Probability.getParameter<double>("xmin"),
+                                             psTrack_Chi2_Probability.getParameter<double>("xmax"));
   Track_LQ_Chi2_Probability->setAxisTitle("#chi^{2} probability", 1);
   Track_LQ_Chi2_Probability->setAxisTitle("# L1 Tracks", 2);
 
   // Reduced chi2 vs #stubs
-  edm::ParameterSet psTrack_Chi2Red_NStubs =
-      conf_.getParameter<edm::ParameterSet>("TH2_Track_Chi2R_NStubs");
+  edm::ParameterSet psTrack_Chi2Red_NStubs = conf_.getParameter<edm::ParameterSet>("TH2_Track_Chi2R_NStubs");
   HistoName = "Track_LQ_Chi2Red_NStubs";
-  Track_LQ_Chi2Red_NStubs =
-      iBooker.book2D(HistoName, HistoName,
-                     psTrack_Chi2Red_NStubs.getParameter<int32_t>("Nbinsx"),
-                     psTrack_Chi2Red_NStubs.getParameter<double>("xmin"),
-                     psTrack_Chi2Red_NStubs.getParameter<double>("xmax"),
-                     psTrack_Chi2Red_NStubs.getParameter<int32_t>("Nbinsy"),
-                     psTrack_Chi2Red_NStubs.getParameter<double>("ymin"),
-                     psTrack_Chi2Red_NStubs.getParameter<double>("ymax"));
+  Track_LQ_Chi2Red_NStubs = iBooker.book2D(HistoName,
+                                           HistoName,
+                                           psTrack_Chi2Red_NStubs.getParameter<int32_t>("Nbinsx"),
+                                           psTrack_Chi2Red_NStubs.getParameter<double>("xmin"),
+                                           psTrack_Chi2Red_NStubs.getParameter<double>("xmax"),
+                                           psTrack_Chi2Red_NStubs.getParameter<int32_t>("Nbinsy"),
+                                           psTrack_Chi2Red_NStubs.getParameter<double>("ymin"),
+                                           psTrack_Chi2Red_NStubs.getParameter<double>("ymax"));
   Track_LQ_Chi2Red_NStubs->setAxisTitle("# L1 Stubs", 1);
   Track_LQ_Chi2Red_NStubs->setAxisTitle("L1 Track #chi^{2}/ndf", 2);
 
   // chi2/dof vs eta
-  edm::ParameterSet psTrack_Chi2R_Eta =
-      conf_.getParameter<edm::ParameterSet>("TH2_Track_Chi2R_Eta");
+  edm::ParameterSet psTrack_Chi2R_Eta = conf_.getParameter<edm::ParameterSet>("TH2_Track_Chi2R_Eta");
   HistoName = "Track_LQ_Chi2Red_Eta";
-  Track_LQ_Chi2Red_Eta = iBooker.book2D(
-      HistoName, HistoName, psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsx"),
-      psTrack_Chi2R_Eta.getParameter<double>("xmin"),
-      psTrack_Chi2R_Eta.getParameter<double>("xmax"),
-      psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsy"),
-      psTrack_Chi2R_Eta.getParameter<double>("ymin"),
-      psTrack_Chi2R_Eta.getParameter<double>("ymax"));
+  Track_LQ_Chi2Red_Eta = iBooker.book2D(HistoName,
+                                        HistoName,
+                                        psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsx"),
+                                        psTrack_Chi2R_Eta.getParameter<double>("xmin"),
+                                        psTrack_Chi2R_Eta.getParameter<double>("xmax"),
+                                        psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsy"),
+                                        psTrack_Chi2R_Eta.getParameter<double>("ymin"),
+                                        psTrack_Chi2R_Eta.getParameter<double>("ymax"));
   Track_LQ_Chi2Red_Eta->setAxisTitle("#eta", 1);
   Track_LQ_Chi2Red_Eta->setAxisTitle("L1 Track #chi^{2}/ndf", 2);
 
   // Eta vs #stubs in barrel
   HistoName = "Track_LQ_Eta_BarrelStubs";
-  Track_LQ_Eta_BarrelStubs = iBooker.book2D(
-      HistoName, HistoName, psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
-      psTrack_Eta_NStubs.getParameter<double>("xmin"),
-      psTrack_Eta_NStubs.getParameter<double>("xmax"),
-      psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
-      psTrack_Eta_NStubs.getParameter<double>("ymin"),
-      psTrack_Eta_NStubs.getParameter<double>("ymax"));
+  Track_LQ_Eta_BarrelStubs = iBooker.book2D(HistoName,
+                                            HistoName,
+                                            psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
+                                            psTrack_Eta_NStubs.getParameter<double>("xmin"),
+                                            psTrack_Eta_NStubs.getParameter<double>("xmax"),
+                                            psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
+                                            psTrack_Eta_NStubs.getParameter<double>("ymin"),
+                                            psTrack_Eta_NStubs.getParameter<double>("ymax"));
   Track_LQ_Eta_BarrelStubs->setAxisTitle("#eta", 1);
   Track_LQ_Eta_BarrelStubs->setAxisTitle("# L1 Barrel Stubs", 2);
 
   // Eta vs #stubs in EC
   HistoName = "Track_LQ_Eta_ECStubs";
-  Track_LQ_Eta_ECStubs = iBooker.book2D(
-      HistoName, HistoName, psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
-      psTrack_Eta_NStubs.getParameter<double>("xmin"),
-      psTrack_Eta_NStubs.getParameter<double>("xmax"),
-      psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
-      psTrack_Eta_NStubs.getParameter<double>("ymin"),
-      psTrack_Eta_NStubs.getParameter<double>("ymax"));
+  Track_LQ_Eta_ECStubs = iBooker.book2D(HistoName,
+                                        HistoName,
+                                        psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
+                                        psTrack_Eta_NStubs.getParameter<double>("xmin"),
+                                        psTrack_Eta_NStubs.getParameter<double>("xmax"),
+                                        psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
+                                        psTrack_Eta_NStubs.getParameter<double>("ymin"),
+                                        psTrack_Eta_NStubs.getParameter<double>("ymax"));
   Track_LQ_Eta_ECStubs->setAxisTitle("#eta", 1);
   Track_LQ_Eta_ECStubs->setAxisTitle("# L1 EC Stubs", 2);
 
@@ -353,7 +344,8 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
   iBooker.setCurrentFolder(topFolderName_ + "/Tracks/HQ");
   // Nb of L1Tracks
   HistoName = "Track_HQ_N";
-  Track_HQ_N = iBooker.book1D(HistoName, HistoName,
+  Track_HQ_N = iBooker.book1D(HistoName,
+                              HistoName,
                               psTrack_N.getParameter<int32_t>("Nbinsx"),
                               psTrack_N.getParameter<double>("xmin"),
                               psTrack_N.getParameter<double>("xmax"));
@@ -362,7 +354,8 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
 
   // Pt of the tracks
   HistoName = "Track_HQ_Pt";
-  Track_HQ_Pt = iBooker.book1D(HistoName, HistoName,
+  Track_HQ_Pt = iBooker.book1D(HistoName,
+                               HistoName,
                                psTrack_Pt.getParameter<int32_t>("Nbinsx"),
                                psTrack_Pt.getParameter<double>("xmin"),
                                psTrack_Pt.getParameter<double>("xmax"));
@@ -371,7 +364,8 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
 
   // Phi
   HistoName = "Track_HQ_Phi";
-  Track_HQ_Phi = iBooker.book1D(HistoName, HistoName,
+  Track_HQ_Phi = iBooker.book1D(HistoName,
+                                HistoName,
                                 psTrack_Phi.getParameter<int32_t>("Nbinsx"),
                                 psTrack_Phi.getParameter<double>("xmin"),
                                 psTrack_Phi.getParameter<double>("xmax"));
@@ -380,7 +374,8 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
 
   // D0
   HistoName = "Track_HQ_D0";
-  Track_HQ_D0 = iBooker.book1D(HistoName, HistoName,
+  Track_HQ_D0 = iBooker.book1D(HistoName,
+                               HistoName,
                                psTrack_D0.getParameter<int32_t>("Nbinsx"),
                                psTrack_D0.getParameter<double>("xmin"),
                                psTrack_D0.getParameter<double>("xmax"));
@@ -389,7 +384,8 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
 
   // Eta
   HistoName = "Track_HQ_Eta";
-  Track_HQ_Eta = iBooker.book1D(HistoName, HistoName,
+  Track_HQ_Eta = iBooker.book1D(HistoName,
+                                HistoName,
                                 psTrack_Eta.getParameter<int32_t>("Nbinsx"),
                                 psTrack_Eta.getParameter<double>("xmin"),
                                 psTrack_Eta.getParameter<double>("xmax"));
@@ -398,7 +394,8 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
 
   // VtxZ
   HistoName = "Track_HQ_VtxZ";
-  Track_HQ_VtxZ = iBooker.book1D(HistoName, HistoName,
+  Track_HQ_VtxZ = iBooker.book1D(HistoName,
+                                 HistoName,
                                  psTrack_VtxZ.getParameter<int32_t>("Nbinsx"),
                                  psTrack_VtxZ.getParameter<double>("xmin"),
                                  psTrack_VtxZ.getParameter<double>("xmax"));
@@ -407,7 +404,8 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
 
   // chi2
   HistoName = "Track_HQ_Chi2";
-  Track_HQ_Chi2 = iBooker.book1D(HistoName, HistoName,
+  Track_HQ_Chi2 = iBooker.book1D(HistoName,
+                                 HistoName,
                                  psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
                                  psTrack_Chi2.getParameter<double>("xmin"),
                                  psTrack_Chi2.getParameter<double>("xmax"));
@@ -416,72 +414,76 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
 
   // chi2Red
   HistoName = "Track_HQ_Chi2Red";
-  Track_HQ_Chi2Red = iBooker.book1D(
-      HistoName, HistoName, psTrack_Chi2Red.getParameter<int32_t>("Nbinsx"),
-      psTrack_Chi2Red.getParameter<double>("xmin"),
-      psTrack_Chi2Red.getParameter<double>("xmax"));
+  Track_HQ_Chi2Red = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psTrack_Chi2Red.getParameter<int32_t>("Nbinsx"),
+                                    psTrack_Chi2Red.getParameter<double>("xmin"),
+                                    psTrack_Chi2Red.getParameter<double>("xmax"));
   Track_HQ_Chi2Red->setAxisTitle("L1 Track #chi^{2}/ndf", 1);
   Track_HQ_Chi2Red->setAxisTitle("# L1 Tracks", 2);
 
   // Chi2 prob
   HistoName = "Track_HQ_Chi2_Probability";
-  Track_HQ_Chi2_Probability =
-      iBooker.book1D(HistoName, HistoName,
-                     psTrack_Chi2_Probability.getParameter<int32_t>("Nbinsx"),
-                     psTrack_Chi2_Probability.getParameter<double>("xmin"),
-                     psTrack_Chi2_Probability.getParameter<double>("xmax"));
+  Track_HQ_Chi2_Probability = iBooker.book1D(HistoName,
+                                             HistoName,
+                                             psTrack_Chi2_Probability.getParameter<int32_t>("Nbinsx"),
+                                             psTrack_Chi2_Probability.getParameter<double>("xmin"),
+                                             psTrack_Chi2_Probability.getParameter<double>("xmax"));
   Track_HQ_Chi2_Probability->setAxisTitle("#chi^{2} probability", 1);
   Track_HQ_Chi2_Probability->setAxisTitle("# L1 Tracks", 2);
 
   // Reduced chi2 vs #stubs
   HistoName = "Track_HQ_Chi2Red_NStubs";
-  Track_HQ_Chi2Red_NStubs =
-      iBooker.book2D(HistoName, HistoName,
-                     psTrack_Chi2Red_NStubs.getParameter<int32_t>("Nbinsx"),
-                     psTrack_Chi2Red_NStubs.getParameter<double>("xmin"),
-                     psTrack_Chi2Red_NStubs.getParameter<double>("xmax"),
-                     psTrack_Chi2Red_NStubs.getParameter<int32_t>("Nbinsy"),
-                     psTrack_Chi2Red_NStubs.getParameter<double>("ymin"),
-                     psTrack_Chi2Red_NStubs.getParameter<double>("ymax"));
+  Track_HQ_Chi2Red_NStubs = iBooker.book2D(HistoName,
+                                           HistoName,
+                                           psTrack_Chi2Red_NStubs.getParameter<int32_t>("Nbinsx"),
+                                           psTrack_Chi2Red_NStubs.getParameter<double>("xmin"),
+                                           psTrack_Chi2Red_NStubs.getParameter<double>("xmax"),
+                                           psTrack_Chi2Red_NStubs.getParameter<int32_t>("Nbinsy"),
+                                           psTrack_Chi2Red_NStubs.getParameter<double>("ymin"),
+                                           psTrack_Chi2Red_NStubs.getParameter<double>("ymax"));
   Track_HQ_Chi2Red_NStubs->setAxisTitle("# L1 Stubs", 1);
   Track_HQ_Chi2Red_NStubs->setAxisTitle("L1 Track #chi^{2}/ndf", 2);
 
   // chi2/dof vs eta
   HistoName = "Track_HQ_Chi2Red_Eta";
-  Track_HQ_Chi2Red_Eta = iBooker.book2D(
-      HistoName, HistoName, psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsx"),
-      psTrack_Chi2R_Eta.getParameter<double>("xmin"),
-      psTrack_Chi2R_Eta.getParameter<double>("xmax"),
-      psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsy"),
-      psTrack_Chi2R_Eta.getParameter<double>("ymin"),
-      psTrack_Chi2R_Eta.getParameter<double>("ymax"));
+  Track_HQ_Chi2Red_Eta = iBooker.book2D(HistoName,
+                                        HistoName,
+                                        psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsx"),
+                                        psTrack_Chi2R_Eta.getParameter<double>("xmin"),
+                                        psTrack_Chi2R_Eta.getParameter<double>("xmax"),
+                                        psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsy"),
+                                        psTrack_Chi2R_Eta.getParameter<double>("ymin"),
+                                        psTrack_Chi2R_Eta.getParameter<double>("ymax"));
   Track_HQ_Chi2Red_Eta->setAxisTitle("#eta", 1);
   Track_HQ_Chi2Red_Eta->setAxisTitle("L1 Track #chi^{2}/ndf", 2);
 
   // eta vs #stubs in barrel
   HistoName = "Track_HQ_Eta_BarrelStubs";
-  Track_HQ_Eta_BarrelStubs = iBooker.book2D(
-      HistoName, HistoName, psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
-      psTrack_Eta_NStubs.getParameter<double>("xmin"),
-      psTrack_Eta_NStubs.getParameter<double>("xmax"),
-      psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
-      psTrack_Eta_NStubs.getParameter<double>("ymin"),
-      psTrack_Eta_NStubs.getParameter<double>("ymax"));
+  Track_HQ_Eta_BarrelStubs = iBooker.book2D(HistoName,
+                                            HistoName,
+                                            psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
+                                            psTrack_Eta_NStubs.getParameter<double>("xmin"),
+                                            psTrack_Eta_NStubs.getParameter<double>("xmax"),
+                                            psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
+                                            psTrack_Eta_NStubs.getParameter<double>("ymin"),
+                                            psTrack_Eta_NStubs.getParameter<double>("ymax"));
   Track_HQ_Eta_BarrelStubs->setAxisTitle("#eta", 1);
   Track_HQ_Eta_BarrelStubs->setAxisTitle("# L1 Barrel Stubs", 2);
 
   // eta vs #stubs in EC
   HistoName = "Track_HQ_Eta_ECStubs";
-  Track_HQ_Eta_ECStubs = iBooker.book2D(
-      HistoName, HistoName, psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
-      psTrack_Eta_NStubs.getParameter<double>("xmin"),
-      psTrack_Eta_NStubs.getParameter<double>("xmax"),
-      psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
-      psTrack_Eta_NStubs.getParameter<double>("ymin"),
-      psTrack_Eta_NStubs.getParameter<double>("ymax"));
+  Track_HQ_Eta_ECStubs = iBooker.book2D(HistoName,
+                                        HistoName,
+                                        psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
+                                        psTrack_Eta_NStubs.getParameter<double>("xmin"),
+                                        psTrack_Eta_NStubs.getParameter<double>("xmax"),
+                                        psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
+                                        psTrack_Eta_NStubs.getParameter<double>("ymin"),
+                                        psTrack_Eta_NStubs.getParameter<double>("ymax"));
   Track_HQ_Eta_ECStubs->setAxisTitle("#eta", 1);
   Track_HQ_Eta_ECStubs->setAxisTitle("# L1 EC Stubs", 2);
 
-} // end of method
+}  // end of method
 
 DEFINE_FWK_MODULE(OuterTrackerMonitorTTTrack);

--- a/DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h
+++ b/DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h
@@ -24,7 +24,6 @@ Usage:
 #include <string>
 
 class SiPixelFolderOrganizer {
-
 public:
   /// Constructor - getStore should be called false from multi-thread DQM
   /// applications
@@ -36,12 +35,9 @@ public:
   /// Set folder name for a module or plaquette
   // type is: BPIX  mod=0, lad=1, lay=2, phi=3,
   //         FPIX  mod=0, blade=4, disc=5, ring=6
-  bool setModuleFolder(const uint32_t &rawdetid = 0, int type = 0,
-                       bool isUpgrade = false);
-  bool setModuleFolder(DQMStore::IBooker &, const uint32_t &rawdetid = 0,
-                       int type = 0, bool isUpgrade = false);
-  void getModuleFolder(const uint32_t &rawdetid, std::string &path,
-                       bool isUpgrade);
+  bool setModuleFolder(const uint32_t &rawdetid = 0, int type = 0, bool isUpgrade = false);
+  bool setModuleFolder(DQMStore::IBooker &, const uint32_t &rawdetid = 0, int type = 0, bool isUpgrade = false);
+  void getModuleFolder(const uint32_t &rawdetid, std::string &path, bool isUpgrade);
 
   /// Set folder name for a FED (used in the case of errors without detId)
   bool setFedFolder(const uint32_t FedId);

--- a/DQM/SiPixelCommon/interface/SiPixelHistogramId.h
+++ b/DQM/SiPixelCommon/interface/SiPixelHistogramId.h
@@ -23,7 +23,6 @@
 #include <string>
 
 class SiPixelHistogramId {
-
 public:
   /// Constructor
   SiPixelHistogramId();

--- a/DQM/SiPixelCommon/src/SiPixelFolderOrganizer.cc
+++ b/DQM/SiPixelCommon/src/SiPixelFolderOrganizer.cc
@@ -14,8 +14,7 @@
 #include <sstream>
 
 /// Constructor
-SiPixelFolderOrganizer::SiPixelFolderOrganizer(bool getStore)
-    : topFolderName("Pixel") {
+SiPixelFolderOrganizer::SiPixelFolderOrganizer(bool getStore) : topFolderName("Pixel") {
   // Not allowed in multithread framework, but can still be called by other
   // modules not from DQM.
   if (getStore)
@@ -25,9 +24,7 @@ SiPixelFolderOrganizer::SiPixelFolderOrganizer(bool getStore)
 SiPixelFolderOrganizer::~SiPixelFolderOrganizer() {}
 
 // Overloaded function for calling outside of DQM framework
-bool SiPixelFolderOrganizer::setModuleFolder(const uint32_t &rawdetid, int type,
-                                             bool isUpgrade) {
-
+bool SiPixelFolderOrganizer::setModuleFolder(const uint32_t &rawdetid, int type, bool isUpgrade) {
   bool flag = false;
 
   if (rawdetid == 0) {
@@ -37,9 +34,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(const uint32_t &rawdetid, int type,
   ///
   /// Pixel Barrel
   ///
-  else if (DetId(rawdetid).subdetId() ==
-           static_cast<int>(PixelSubdetector::PixelBarrel)) {
-
+  else if (DetId(rawdetid).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) {
     if (!isUpgrade) {
       // for endcap types there is nothing to do:
       if (type > 3 && type != 7)
@@ -86,8 +81,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(const uint32_t &rawdetid, int type,
         return true;
 
       std::string subDetectorFolder = "Barrel";
-      PixelBarrelNameUpgrade::Shell DBshell =
-          PixelBarrelNameUpgrade(DetId(rawdetid)).shell();
+      PixelBarrelNameUpgrade::Shell DBshell = PixelBarrelNameUpgrade(DetId(rawdetid)).shell();
       int DBlayer = PixelBarrelNameUpgrade(DetId(rawdetid)).layerName();
       int DBladder = PixelBarrelNameUpgrade(DetId(rawdetid)).ladderName();
       int DBmodule = PixelBarrelNameUpgrade(DetId(rawdetid)).moduleName();
@@ -121,23 +115,20 @@ bool SiPixelFolderOrganizer::setModuleFolder(const uint32_t &rawdetid, int type,
 
       dbe_->setCurrentFolder(sfolder.str());
       flag = true;
-    } // endif(isUpgrade)
+    }  // endif(isUpgrade)
   }
 
   ///
   /// Pixel Endcap
   ///
-  else if (DetId(rawdetid).subdetId() ==
-           static_cast<int>(PixelSubdetector::PixelEndcap)) {
-
+  else if (DetId(rawdetid).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) {
     if (!isUpgrade) {
       // for barrel types there is nothing to do:
       if (type > 0 && type < 4)
         return true;
 
       std::string subDetectorFolder = "Endcap";
-      PixelEndcapName::HalfCylinder side =
-          PixelEndcapName(DetId(rawdetid)).halfCylinder();
+      PixelEndcapName::HalfCylinder side = PixelEndcapName(DetId(rawdetid)).halfCylinder();
       int disk = PixelEndcapName(DetId(rawdetid)).diskName();
       int blade = PixelEndcapName(DetId(rawdetid)).bladeName();
       int panel = PixelEndcapName(DetId(rawdetid)).pannelName();
@@ -154,8 +145,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(const uint32_t &rawdetid, int type,
 
       std::ostringstream sfolder;
 
-      sfolder << topFolderName << "/" << subDetectorFolder << "/HalfCylinder_"
-              << side << "/" << sdisk;
+      sfolder << topFolderName << "/" << subDetectorFolder << "/HalfCylinder_" << side << "/" << sdisk;
       if (type == 0 || type == 4) {
         sfolder << "/" << sblade;
       }
@@ -178,8 +168,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(const uint32_t &rawdetid, int type,
         return true;
 
       std::string subDetectorFolder = "Endcap";
-      PixelEndcapNameUpgrade::HalfCylinder side =
-          PixelEndcapNameUpgrade(DetId(rawdetid)).halfCylinder();
+      PixelEndcapNameUpgrade::HalfCylinder side = PixelEndcapNameUpgrade(DetId(rawdetid)).halfCylinder();
       int disk = PixelEndcapNameUpgrade(DetId(rawdetid)).diskName();
       int blade = PixelEndcapNameUpgrade(DetId(rawdetid)).bladeName();
       int panel = PixelEndcapNameUpgrade(DetId(rawdetid)).pannelName();
@@ -196,8 +185,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(const uint32_t &rawdetid, int type,
 
       std::ostringstream sfolder;
 
-      sfolder << topFolderName << "/" << subDetectorFolder << "/HalfCylinder_"
-              << side << "/" << sdisk;
+      sfolder << topFolderName << "/" << subDetectorFolder << "/HalfCylinder_" << side << "/" << sdisk;
       if (type == 0 || type == 4) {
         sfolder << "/" << sblade;
       }
@@ -213,20 +201,19 @@ bool SiPixelFolderOrganizer::setModuleFolder(const uint32_t &rawdetid, int type,
 
       dbe_->setCurrentFolder(sfolder.str());
       flag = true;
-    } // endifendcap&&isUpgrade
+    }  // endifendcap&&isUpgrade
   } else
-    throw cms::Exception("LogicError")
-        << "[SiPixelFolderOrganizer::setModuleFolder] Not a Pixel detector "
-           "DetId ";
+    throw cms::Exception("LogicError") << "[SiPixelFolderOrganizer::setModuleFolder] Not a Pixel detector "
+                                          "DetId ";
 
   return flag;
 }
 
 // Overloaded setModuleFolder for multithread safe operation
 bool SiPixelFolderOrganizer::setModuleFolder(DQMStore::IBooker &iBooker,
-                                             const uint32_t &rawdetid, int type,
+                                             const uint32_t &rawdetid,
+                                             int type,
                                              bool isUpgrade) {
-
   bool flag = false;
 
   if (rawdetid == 0) {
@@ -236,9 +223,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(DQMStore::IBooker &iBooker,
   ///
   /// Pixel Barrel
   ///
-  else if (DetId(rawdetid).subdetId() ==
-           static_cast<int>(PixelSubdetector::PixelBarrel)) {
-
+  else if (DetId(rawdetid).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) {
     if (!isUpgrade) {
       // for endcap types there is nothing to do:
       if (type > 3 && type != 7)
@@ -285,8 +270,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(DQMStore::IBooker &iBooker,
         return true;
 
       std::string subDetectorFolder = "Barrel";
-      PixelBarrelNameUpgrade::Shell DBshell =
-          PixelBarrelNameUpgrade(DetId(rawdetid)).shell();
+      PixelBarrelNameUpgrade::Shell DBshell = PixelBarrelNameUpgrade(DetId(rawdetid)).shell();
       int DBlayer = PixelBarrelNameUpgrade(DetId(rawdetid)).layerName();
       int DBladder = PixelBarrelNameUpgrade(DetId(rawdetid)).ladderName();
       int DBmodule = PixelBarrelNameUpgrade(DetId(rawdetid)).moduleName();
@@ -320,23 +304,20 @@ bool SiPixelFolderOrganizer::setModuleFolder(DQMStore::IBooker &iBooker,
 
       iBooker.setCurrentFolder(sfolder.str());
       flag = true;
-    } // endif(isUpgrade)
+    }  // endif(isUpgrade)
   }
 
   ///
   /// Pixel Endcap
   ///
-  else if (DetId(rawdetid).subdetId() ==
-           static_cast<int>(PixelSubdetector::PixelEndcap)) {
-
+  else if (DetId(rawdetid).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) {
     if (!isUpgrade) {
       // for barrel types there is nothing to do:
       if (type > 0 && type < 4)
         return true;
 
       std::string subDetectorFolder = "Endcap";
-      PixelEndcapName::HalfCylinder side =
-          PixelEndcapName(DetId(rawdetid)).halfCylinder();
+      PixelEndcapName::HalfCylinder side = PixelEndcapName(DetId(rawdetid)).halfCylinder();
       int disk = PixelEndcapName(DetId(rawdetid)).diskName();
       int blade = PixelEndcapName(DetId(rawdetid)).bladeName();
       int panel = PixelEndcapName(DetId(rawdetid)).pannelName();
@@ -353,8 +334,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(DQMStore::IBooker &iBooker,
 
       std::ostringstream sfolder;
 
-      sfolder << topFolderName << "/" << subDetectorFolder << "/HalfCylinder_"
-              << side << "/" << sdisk;
+      sfolder << topFolderName << "/" << subDetectorFolder << "/HalfCylinder_" << side << "/" << sdisk;
       if (type == 0 || type == 4) {
         sfolder << "/" << sblade;
       }
@@ -377,8 +357,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(DQMStore::IBooker &iBooker,
         return true;
 
       std::string subDetectorFolder = "Endcap";
-      PixelEndcapNameUpgrade::HalfCylinder side =
-          PixelEndcapNameUpgrade(DetId(rawdetid)).halfCylinder();
+      PixelEndcapNameUpgrade::HalfCylinder side = PixelEndcapNameUpgrade(DetId(rawdetid)).halfCylinder();
       int disk = PixelEndcapNameUpgrade(DetId(rawdetid)).diskName();
       int blade = PixelEndcapNameUpgrade(DetId(rawdetid)).bladeName();
       int panel = PixelEndcapNameUpgrade(DetId(rawdetid)).pannelName();
@@ -395,8 +374,7 @@ bool SiPixelFolderOrganizer::setModuleFolder(DQMStore::IBooker &iBooker,
 
       std::ostringstream sfolder;
 
-      sfolder << topFolderName << "/" << subDetectorFolder << "/HalfCylinder_"
-              << side << "/" << sdisk;
+      sfolder << topFolderName << "/" << subDetectorFolder << "/HalfCylinder_" << side << "/" << sdisk;
       if (type == 0 || type == 4) {
         sfolder << "/" << sblade;
       }
@@ -412,18 +390,16 @@ bool SiPixelFolderOrganizer::setModuleFolder(DQMStore::IBooker &iBooker,
 
       iBooker.setCurrentFolder(sfolder.str());
       flag = true;
-    } // endifendcap&&isUpgrade
+    }  // endifendcap&&isUpgrade
   } else
-    throw cms::Exception("LogicError")
-        << "[SiPixelFolderOrganizer::setModuleFolder] Not a Pixel detector "
-           "DetId ";
+    throw cms::Exception("LogicError") << "[SiPixelFolderOrganizer::setModuleFolder] Not a Pixel detector "
+                                          "DetId ";
 
   return flag;
 }
 
 // Overloaded setFedFolder for use outside of DQM framework
 bool SiPixelFolderOrganizer::setFedFolder(const uint32_t FedId) {
-
   std::string subDetectorFolder = "AdditionalPixelErrors";
   char sFed[80];
   sprintf(sFed, "FED_%i", FedId);
@@ -436,9 +412,7 @@ bool SiPixelFolderOrganizer::setFedFolder(const uint32_t FedId) {
 }
 
 // Overloaded setFedFolder to avoid accessing DQMStore directly.
-bool SiPixelFolderOrganizer::setFedFolder(DQMStore::IBooker &iBooker,
-                                          const uint32_t FedId) {
-
+bool SiPixelFolderOrganizer::setFedFolder(DQMStore::IBooker &iBooker, const uint32_t FedId) {
   std::string subDetectorFolder = "AdditionalPixelErrors";
   char sFed[80];
   sprintf(sFed, "FED_%i", FedId);
@@ -450,16 +424,11 @@ bool SiPixelFolderOrganizer::setFedFolder(DQMStore::IBooker &iBooker,
   return true;
 }
 
-void SiPixelFolderOrganizer::getModuleFolder(const uint32_t &rawdetid,
-                                             std::string &path,
-                                             bool isUpgrade) {
-
+void SiPixelFolderOrganizer::getModuleFolder(const uint32_t &rawdetid, std::string &path, bool isUpgrade) {
   path = topFolderName;
   if (rawdetid == 0) {
     return;
-  } else if ((DetId(rawdetid).subdetId() ==
-              static_cast<int>(PixelSubdetector::PixelBarrel)) &&
-             (!isUpgrade)) {
+  } else if ((DetId(rawdetid).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) && (!isUpgrade)) {
     std::string subDetectorFolder = "Barrel";
     PixelBarrelName::Shell DBshell = PixelBarrelName(DetId(rawdetid)).shell();
     int DBlayer = PixelBarrelName(DetId(rawdetid)).layerName();
@@ -475,8 +444,7 @@ void SiPixelFolderOrganizer::getModuleFolder(const uint32_t &rawdetid,
     sprintf(smodule, "Module_%i", DBmodule);
 
     std::ostringstream sfolder;
-    sfolder << topFolderName << "/" << subDetectorFolder << "/Shell_" << DBshell
-            << "/" << slayer << "/" << sladder;
+    sfolder << topFolderName << "/" << subDetectorFolder << "/Shell_" << DBshell << "/" << slayer << "/" << sladder;
     if (PixelBarrelName(DetId(rawdetid)).isHalfModule())
       sfolder << "H";
     else
@@ -490,12 +458,9 @@ void SiPixelFolderOrganizer::getModuleFolder(const uint32_t &rawdetid,
     // else path = path + "F";
     // path = path + "/" + smodule;
 
-  } else if ((DetId(rawdetid).subdetId() ==
-              static_cast<int>(PixelSubdetector::PixelBarrel)) &&
-             (isUpgrade)) {
+  } else if ((DetId(rawdetid).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) && (isUpgrade)) {
     std::string subDetectorFolder = "Barrel";
-    PixelBarrelNameUpgrade::Shell DBshell =
-        PixelBarrelNameUpgrade(DetId(rawdetid)).shell();
+    PixelBarrelNameUpgrade::Shell DBshell = PixelBarrelNameUpgrade(DetId(rawdetid)).shell();
     int DBlayer = PixelBarrelNameUpgrade(DetId(rawdetid)).layerName();
     int DBladder = PixelBarrelNameUpgrade(DetId(rawdetid)).ladderName();
     int DBmodule = PixelBarrelNameUpgrade(DetId(rawdetid)).moduleName();
@@ -509,8 +474,7 @@ void SiPixelFolderOrganizer::getModuleFolder(const uint32_t &rawdetid,
     sprintf(smodule, "Module_%i", DBmodule);
 
     std::ostringstream sfolder;
-    sfolder << topFolderName << "/" << subDetectorFolder << "/Shell_" << DBshell
-            << "/" << slayer << "/" << sladder;
+    sfolder << topFolderName << "/" << subDetectorFolder << "/Shell_" << DBshell << "/" << slayer << "/" << sladder;
     if (PixelBarrelNameUpgrade(DetId(rawdetid)).isHalfModule())
       sfolder << "H";
     else
@@ -524,12 +488,9 @@ void SiPixelFolderOrganizer::getModuleFolder(const uint32_t &rawdetid,
     // else path = path + "F";
     // path = path + "/" + smodule;
 
-  } else if ((DetId(rawdetid).subdetId() ==
-              static_cast<int>(PixelSubdetector::PixelEndcap)) &&
-             (!isUpgrade)) {
+  } else if ((DetId(rawdetid).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) && (!isUpgrade)) {
     std::string subDetectorFolder = "Endcap";
-    PixelEndcapName::HalfCylinder side =
-        PixelEndcapName(DetId(rawdetid)).halfCylinder();
+    PixelEndcapName::HalfCylinder side = PixelEndcapName(DetId(rawdetid)).halfCylinder();
     int disk = PixelEndcapName(DetId(rawdetid)).diskName();
     int blade = PixelEndcapName(DetId(rawdetid)).bladeName();
     int panel = PixelEndcapName(DetId(rawdetid)).pannelName();
@@ -546,20 +507,16 @@ void SiPixelFolderOrganizer::getModuleFolder(const uint32_t &rawdetid,
     sprintf(smodule, "Module_%i", module);
 
     std::ostringstream sfolder;
-    sfolder << topFolderName << "/" << subDetectorFolder << "/HalfCylinder_"
-            << side << "/" << sdisk << "/" << sblade << "/" << spanel << "/"
-            << smodule;
+    sfolder << topFolderName << "/" << subDetectorFolder << "/HalfCylinder_" << side << "/" << sdisk << "/" << sblade
+            << "/" << spanel << "/" << smodule;
     path = sfolder.str();
 
     // path = path + "/" + subDetectorFolder + "/" + shc + "/" + sdisk + "/" +
     // sblade + "/" + spanel + "/" + smodule;
 
-  } else if ((DetId(rawdetid).subdetId() ==
-              static_cast<int>(PixelSubdetector::PixelEndcap)) &&
-             (isUpgrade)) {
+  } else if ((DetId(rawdetid).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) && (isUpgrade)) {
     std::string subDetectorFolder = "Endcap";
-    PixelEndcapNameUpgrade::HalfCylinder side =
-        PixelEndcapNameUpgrade(DetId(rawdetid)).halfCylinder();
+    PixelEndcapNameUpgrade::HalfCylinder side = PixelEndcapNameUpgrade(DetId(rawdetid)).halfCylinder();
     int disk = PixelEndcapNameUpgrade(DetId(rawdetid)).diskName();
     int blade = PixelEndcapNameUpgrade(DetId(rawdetid)).bladeName();
     int panel = PixelEndcapNameUpgrade(DetId(rawdetid)).pannelName();
@@ -576,18 +533,16 @@ void SiPixelFolderOrganizer::getModuleFolder(const uint32_t &rawdetid,
     sprintf(smodule, "Module_%i", module);
 
     std::ostringstream sfolder;
-    sfolder << topFolderName << "/" << subDetectorFolder << "/HalfCylinder_"
-            << side << "/" << sdisk << "/" << sblade << "/" << spanel << "/"
-            << smodule;
+    sfolder << topFolderName << "/" << subDetectorFolder << "/HalfCylinder_" << side << "/" << sdisk << "/" << sblade
+            << "/" << spanel << "/" << smodule;
     path = sfolder.str();
 
     // path = path + "/" + subDetectorFolder + "/" + shc + "/" + sdisk + "/" +
     // sblade + "/" + spanel + "/" + smodule;
 
   } else
-    throw cms::Exception("LogicError")
-        << "[SiPixelFolderOrganizer::getModuleFolder] Not a Pixel detector "
-           "DetId ";
+    throw cms::Exception("LogicError") << "[SiPixelFolderOrganizer::getModuleFolder] Not a Pixel detector "
+                                          "DetId ";
 
   // std::cout<<"resulting final path name: "<<path<<std::endl;
 

--- a/DQM/SiPixelCommon/src/SiPixelHistogramId.cc
+++ b/DQM/SiPixelCommon/src/SiPixelHistogramId.cc
@@ -19,29 +19,23 @@
 using namespace edm;
 
 /// Constructor
-SiPixelHistogramId::SiPixelHistogramId()
-    : dataCollection_("defaultData"), separator_("_") {}
+SiPixelHistogramId::SiPixelHistogramId() : dataCollection_("defaultData"), separator_("_") {}
 /// Constructor with collection
-SiPixelHistogramId::SiPixelHistogramId(std::string dataCollection)
-    : dataCollection_(dataCollection), separator_("_") {}
+SiPixelHistogramId::SiPixelHistogramId(std::string dataCollection) : dataCollection_(dataCollection), separator_("_") {}
 
 /// Destructor
 SiPixelHistogramId::~SiPixelHistogramId() {}
 /// Create Histogram Id
-std::string SiPixelHistogramId::setHistoId(std::string variable,
-                                           uint32_t &rawId) {
+std::string SiPixelHistogramId::setHistoId(std::string variable, uint32_t &rawId) {
   std::string histoId;
   std::ostringstream rawIdString;
   rawIdString << rawId;
-  histoId =
-      variable + separator_ + dataCollection_ + separator_ + rawIdString.str();
+  histoId = variable + separator_ + dataCollection_ + separator_ + rawIdString.str();
 
   return histoId;
 }
 /// get Data Collection
-std::string SiPixelHistogramId::getDataCollection(std::string histoid) {
-  return returnIdPart(histoid, 2);
-}
+std::string SiPixelHistogramId::getDataCollection(std::string histoid) { return returnIdPart(histoid, 2); }
 /// get Raw Id
 uint32_t SiPixelHistogramId::getRawId(std::string histoid) {
   uint32_t local_component_id;
@@ -50,39 +44,28 @@ uint32_t SiPixelHistogramId::getRawId(std::string histoid) {
   return local_component_id;
 }
 /// get Part
-std::string SiPixelHistogramId::returnIdPart(std::string histoid,
-                                             uint32_t whichpart) {
-
+std::string SiPixelHistogramId::returnIdPart(std::string histoid, uint32_t whichpart) {
   size_t length1 = histoid.find(separator_, 0);
-  if (length1 == std::string::npos) { // no separator1 found
-    LogWarning("PixelDQM")
-        << "SiPixelHistogramId::returnIdPart - no regular histoid. Returning 0";
+  if (length1 == std::string::npos) {  // no separator1 found
+    LogWarning("PixelDQM") << "SiPixelHistogramId::returnIdPart - no regular histoid. Returning 0";
     return "0";
   }
-  std::string part1 =
-      histoid.substr(0, length1); // part of 'histoid' up to 'separator1'
+  std::string part1 = histoid.substr(0, length1);  // part of 'histoid' up to 'separator1'
   if (whichpart == 1)
     return part1;
-  std::string remain1 = histoid.substr(
-      length1 +
-      separator_.size()); // rest of 'histoid' starting at end of 'separator1'
+  std::string remain1 =
+      histoid.substr(length1 + separator_.size());  // rest of 'histoid' starting at end of 'separator1'
   size_t length2 = remain1.find(separator_, 0);
-  if (length2 == std::string::npos) { // no separator2 found
-    LogWarning("PixelDQM")
-        << "SiPixelHistogramId::returnIdPart - no regular histoid. Returning 0";
+  if (length2 == std::string::npos) {  // no separator2 found
+    LogWarning("PixelDQM") << "SiPixelHistogramId::returnIdPart - no regular histoid. Returning 0";
     return "0";
   }
-  std::string part2 =
-      remain1.substr(0, length2); // part of 'remain1' up to 'separator2'
+  std::string part2 = remain1.substr(0, length2);  // part of 'remain1' up to 'separator2'
   if (whichpart == 2)
     return part2;
-  std::string part3 = remain1.substr(
-      length2 +
-      separator_.size()); // rest of remain1 starting at end of 'separator2'
+  std::string part3 = remain1.substr(length2 + separator_.size());  // rest of remain1 starting at end of 'separator2'
   if (whichpart == 3)
     return part3;
-  LogWarning("PixelDQM")
-      << "SiPixelHistogramId::returnIdPart - no such whichpart=" << whichpart
-      << " returning 0";
+  LogWarning("PixelDQM") << "SiPixelHistogramId::returnIdPart - no such whichpart=" << whichpart << " returning 0";
   return "0";
 }

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModule.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModule.h
@@ -24,7 +24,7 @@
 #include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
 
 namespace edm {
-class EventSetup;
+  class EventSetup;
 }
 
 class SiPixelHitEfficiencyModule {
@@ -33,15 +33,24 @@ public:
   SiPixelHitEfficiencyModule(const uint32_t);
   ~SiPixelHitEfficiencyModule();
 
-  void book(const edm::ParameterSet &, edm::EventSetup const &,
-            DQMStore::IBooker &, int type = 0, bool isUpgrade = false);
-  void fill(const TrackerTopology *pTT, const LocalTrajectoryParameters &ltp,
-            bool isHitValid, bool modon = true, bool ladon = true,
-            bool layon = true, bool phion = true, bool bladeon = true,
-            bool diskon = true, bool ringon = true);
-  void computeEfficiencies(bool modon = true, bool ladon = true,
-                           bool layon = true, bool phion = true,
-                           bool bladeon = true, bool diskon = true,
+  void book(
+      const edm::ParameterSet &, edm::EventSetup const &, DQMStore::IBooker &, int type = 0, bool isUpgrade = false);
+  void fill(const TrackerTopology *pTT,
+            const LocalTrajectoryParameters &ltp,
+            bool isHitValid,
+            bool modon = true,
+            bool ladon = true,
+            bool layon = true,
+            bool phion = true,
+            bool bladeon = true,
+            bool diskon = true,
+            bool ringon = true);
+  void computeEfficiencies(bool modon = true,
+                           bool ladon = true,
+                           bool layon = true,
+                           bool phion = true,
+                           bool bladeon = true,
+                           bool diskon = true,
                            bool ringon = true);
   std::pair<double, double> eff(double nValid, double nMissing);
 

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySource.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySource.h
@@ -48,8 +48,7 @@ public:
   ~SiPixelHitEfficiencySource() override;
 
   void dqmBeginRun(const edm::Run &r, edm::EventSetup const &iSetup) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   virtual void fillClusterProbability(int, int, bool, double);
 
@@ -59,8 +58,7 @@ private:
   // edm::InputTag tracksrc_;
   edm::EDGetTokenT<reco::VertexCollection> vertexCollectionToken_;
   edm::EDGetTokenT<TrajTrackAssociationCollection> tracksrc_;
-  edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>>
-      clusterCollectionToken_;
+  edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> clusterCollectionToken_;
 
   edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrackerEventToken_;
 

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h
@@ -22,7 +22,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 
 namespace edm {
-class EventSetup;
+  class EventSetup;
 }
 
 class SiPixelTrackResidualModule {
@@ -31,18 +31,42 @@ public:
   SiPixelTrackResidualModule(const uint32_t);
   ~SiPixelTrackResidualModule();
 
-  void book(const edm::ParameterSet &, edm::EventSetup const &,
-            DQMStore::IBooker &, bool reducedSet = true, int type = 0,
+  void book(const edm::ParameterSet &,
+            edm::EventSetup const &,
+            DQMStore::IBooker &,
+            bool reducedSet = true,
+            int type = 0,
             bool isUpgrade = false);
-  void fill(const Measurement2DVector &, bool reducedSet = true,
-            bool modon = true, bool ladon = true, bool layon = true,
-            bool phion = true, bool bladeon = true, bool diskon = true,
+  void fill(const Measurement2DVector &,
+            bool reducedSet = true,
+            bool modon = true,
+            bool ladon = true,
+            bool layon = true,
+            bool phion = true,
+            bool bladeon = true,
+            bool diskon = true,
             bool ringon = true);
-  void fill(const SiPixelCluster &clust, bool onTrack, double corrCharge,
-            bool reducedSet, bool modon, bool ladon, bool layon, bool phion,
-            bool bladeon, bool diskon, bool ringon);
-  void nfill(int onTrack, int offTrack, bool reducedSet, bool modon, bool ladon,
-             bool layon, bool phion, bool bladeon, bool diskon, bool ringon);
+  void fill(const SiPixelCluster &clust,
+            bool onTrack,
+            double corrCharge,
+            bool reducedSet,
+            bool modon,
+            bool ladon,
+            bool layon,
+            bool phion,
+            bool bladeon,
+            bool diskon,
+            bool ringon);
+  void nfill(int onTrack,
+             int offTrack,
+             bool reducedSet,
+             bool modon,
+             bool ladon,
+             bool layon,
+             bool phion,
+             bool bladeon,
+             bool diskon,
+             bool ringon);
 
 private:
   uint32_t id_;

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSource.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSource.h
@@ -53,15 +53,25 @@ public:
   ~SiPixelTrackResidualSource() override;
 
   void dqmBeginRun(const edm::Run &r, edm::EventSetup const &iSetup) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void getrococcupancy(DetId detId, const edm::DetSetVector<PixelDigi> &diginp,
+  void getrococcupancy(DetId detId,
+                       const edm::DetSetVector<PixelDigi> &diginp,
                        const TrackerTopology *const tTopo,
                        std::vector<MonitorElement *> meinput);
-  void triplets(double x1, double y1, double z1, double x2, double y2,
-                double z2, double x3, double y3, double z3, double ptsig,
-                double &dc, double &dz, double kap);
+  void triplets(double x1,
+                double y1,
+                double z1,
+                double x2,
+                double y2,
+                double z2,
+                double x3,
+                double y3,
+                double z3,
+                double ptsig,
+                double &dc,
+                double &dz,
+                double kap);
 
   std::string topFolderName_;
 
@@ -191,12 +201,12 @@ private:
 
   void getepixrococcupancyontrk(const TrackerTopology *const tTopo,
                                 TransientTrackingRecHit::ConstRecHitPointer hit,
-                                float xclust, float yclust, float z,
+                                float xclust,
+                                float yclust,
+                                float z,
                                 MonitorElement *meinput);
-  void getepixrococcupancyofftrk(DetId detId,
-                                 const TrackerTopology *const tTopo,
-                                 float xclust, float yclust, float z,
-                                 MonitorElement *meinput);
+  void getepixrococcupancyofftrk(
+      DetId detId, const TrackerTopology *const tTopo, float xclust, float yclust, float z, MonitorElement *meinput);
 
   int noOfLayers;
   int noOfDisks;

--- a/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencyModule.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencyModule.cc
@@ -35,29 +35,23 @@
 
 using namespace std;
 
-SiPixelHitEfficiencyModule::SiPixelHitEfficiencyModule() : id_(0) {
-  bBookTracks = true;
-}
+SiPixelHitEfficiencyModule::SiPixelHitEfficiencyModule() : id_(0) { bBookTracks = true; }
 
-SiPixelHitEfficiencyModule::SiPixelHitEfficiencyModule(uint32_t id) : id_(id) {
-  bBookTracks = true;
-}
+SiPixelHitEfficiencyModule::SiPixelHitEfficiencyModule(uint32_t id) : id_(id) { bBookTracks = true; }
 
 SiPixelHitEfficiencyModule::~SiPixelHitEfficiencyModule() {}
 
 void SiPixelHitEfficiencyModule::book(const edm::ParameterSet &iConfig,
                                       edm::EventSetup const &iSetup,
-                                      DQMStore::IBooker &iBooker, int type,
+                                      DQMStore::IBooker &iBooker,
+                                      int type,
                                       bool isUpgrade) {
-
   edm::ESHandle<TrackerTopology> tTopoHandle;
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology *pTT = tTopoHandle.product();
 
-  bool barrel =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
-  bool endcap =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
   bool isHalfModule = false;
   if (barrel) {
     isHalfModule = PixelBarrelName(DetId(id_), pTT, isUpgrade).isHalfModule();
@@ -65,8 +59,7 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet &iConfig,
 
   edm::InputTag src = iConfig.getParameter<edm::InputTag>("src");
   debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
-  updateEfficiencies =
-      iConfig.getUntrackedParameter<bool>("updateEfficiencies", false);
+  updateEfficiencies = iConfig.getUntrackedParameter<bool>("updateEfficiencies", false);
   std::string hisID;
 
   int nbinangle = 28;
@@ -83,23 +76,19 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet &iConfig,
       meEfficiency_->setAxisTitle("Hit efficiency", 1);
 
       hisID = theHistogramId->setHistoId("efficiencyX", id_);
-      meEfficiencyX_ =
-          iBooker.book1D(hisID, "Hit efficiency in X", nbinX, -1.5, 1.5);
+      meEfficiencyX_ = iBooker.book1D(hisID, "Hit efficiency in X", nbinX, -1.5, 1.5);
       meEfficiencyX_->setAxisTitle("Hit efficiency in X", 1);
 
       hisID = theHistogramId->setHistoId("efficiencyY", id_);
-      meEfficiencyY_ =
-          iBooker.book1D(hisID, "Hit efficiency in Y", nbinY, -4., 4.);
+      meEfficiencyY_ = iBooker.book1D(hisID, "Hit efficiency in Y", nbinY, -4., 4.);
       meEfficiencyY_->setAxisTitle("Hit efficiency in Y", 1);
 
       hisID = theHistogramId->setHistoId("efficiencyAlpha", id_);
-      meEfficiencyAlpha_ = iBooker.book1D(hisID, "Hit efficiency in Alpha",
-                                          nbinangle, -3.5, 3.5);
+      meEfficiencyAlpha_ = iBooker.book1D(hisID, "Hit efficiency in Alpha", nbinangle, -3.5, 3.5);
       meEfficiencyAlpha_->setAxisTitle("Hit efficiency in Alpha", 1);
 
       hisID = theHistogramId->setHistoId("efficiencyBeta", id_);
-      meEfficiencyBeta_ =
-          iBooker.book1D(hisID, "Hit efficiency in Beta", nbinangle, -3.5, 3.5);
+      meEfficiencyBeta_ = iBooker.book1D(hisID, "Hit efficiency in Beta", nbinangle, -3.5, 3.5);
       meEfficiencyBeta_->setAxisTitle("Hit efficiency in Beta", 1);
     }
 
@@ -129,26 +118,20 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet &iConfig,
 
     if (updateEfficiencies) {
       // EFFICIENCY
-      meEfficiencyLad_ =
-          iBooker.book1D("efficiency_" + hisID, "Hit efficiency", 1, 0, 1.);
+      meEfficiencyLad_ = iBooker.book1D("efficiency_" + hisID, "Hit efficiency", 1, 0, 1.);
       meEfficiencyLad_->setAxisTitle("Hit efficiency", 1);
 
-      meEfficiencyXLad_ = iBooker.book1D(
-          "efficiencyX_" + hisID, "Hit efficiency in X", nbinX, -1.5, 1.5);
+      meEfficiencyXLad_ = iBooker.book1D("efficiencyX_" + hisID, "Hit efficiency in X", nbinX, -1.5, 1.5);
       meEfficiencyXLad_->setAxisTitle("Hit efficiency in X", 1);
 
-      meEfficiencyYLad_ = iBooker.book1D("efficiencyY_" + hisID,
-                                         "Hit efficiency in Y", nbinY, -4., 4.);
+      meEfficiencyYLad_ = iBooker.book1D("efficiencyY_" + hisID, "Hit efficiency in Y", nbinY, -4., 4.);
       meEfficiencyYLad_->setAxisTitle("Hit efficiency in Y", 1);
 
       meEfficiencyAlphaLad_ =
-          iBooker.book1D("efficiencyAlpha_" + hisID, "Hit efficiency in Alpha",
-                         nbinangle, -3.5, 3.5);
+          iBooker.book1D("efficiencyAlpha_" + hisID, "Hit efficiency in Alpha", nbinangle, -3.5, 3.5);
       meEfficiencyAlphaLad_->setAxisTitle("Hit efficiency in Alpha", 1);
 
-      meEfficiencyBetaLad_ =
-          iBooker.book1D("efficiencyBeta_" + hisID, "Hit efficiency in Beta",
-                         nbinangle, -3.5, 3.5);
+      meEfficiencyBetaLad_ = iBooker.book1D("efficiencyBeta_" + hisID, "Hit efficiency in Beta", nbinangle, -3.5, 3.5);
       meEfficiencyBetaLad_->setAxisTitle("Hit efficiency in Beta", 1);
     }
 
@@ -156,50 +139,38 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet &iConfig,
     meValidLad_ = iBooker.book1D("valid_" + hisID, "# Valid hits", 1, 0, 1.);
     meValidLad_->setAxisTitle("# Valid hits", 1);
 
-    meValidXLad_ = iBooker.book1D("validX_" + hisID, "# Valid hits in X", nbinX,
-                                  -1.5, 1.5);
+    meValidXLad_ = iBooker.book1D("validX_" + hisID, "# Valid hits in X", nbinX, -1.5, 1.5);
     meValidXLad_->setAxisTitle("# Valid hits in X", 1);
 
-    meValidYLad_ =
-        iBooker.book1D("validY_" + hisID, "# Valid hits in Y", nbinY, -4., 4.);
+    meValidYLad_ = iBooker.book1D("validY_" + hisID, "# Valid hits in Y", nbinY, -4., 4.);
     meValidYLad_->setAxisTitle("# Valid hits in Y", 1);
 
-    meValidModLad_ = iBooker.book1D("validMod_" + hisID,
-                                    "# Valid hits on Module", 4, 0.5, 4.5);
+    meValidModLad_ = iBooker.book1D("validMod_" + hisID, "# Valid hits on Module", 4, 0.5, 4.5);
     meValidModLad_->setAxisTitle("# Valid hits on Module", 1);
 
-    meValidAlphaLad_ = iBooker.book1D(
-        "validAlpha_" + hisID, "# Valid hits in Alpha", nbinangle, -3.5, 3.5);
+    meValidAlphaLad_ = iBooker.book1D("validAlpha_" + hisID, "# Valid hits in Alpha", nbinangle, -3.5, 3.5);
     meValidAlphaLad_->setAxisTitle("# Valid hits in Alpha", 1);
 
-    meValidBetaLad_ = iBooker.book1D(
-        "validBeta_" + hisID, "# Valid hits in Beta", nbinangle, -3.5, 3.5);
+    meValidBetaLad_ = iBooker.book1D("validBeta_" + hisID, "# Valid hits in Beta", nbinangle, -3.5, 3.5);
     meValidBetaLad_->setAxisTitle("# Valid hits in Beta", 1);
 
     // MISSING
-    meMissingLad_ =
-        iBooker.book1D("missing_" + hisID, "# Missing hits", 1, 0, 1.);
+    meMissingLad_ = iBooker.book1D("missing_" + hisID, "# Missing hits", 1, 0, 1.);
     meMissingLad_->setAxisTitle("# Missing hits", 1);
 
-    meMissingXLad_ = iBooker.book1D("missingX_" + hisID, "# Missing hits in X",
-                                    nbinX, -1.5, 1.5);
+    meMissingXLad_ = iBooker.book1D("missingX_" + hisID, "# Missing hits in X", nbinX, -1.5, 1.5);
     meMissingXLad_->setAxisTitle("# Missing hits in X", 1);
 
-    meMissingYLad_ = iBooker.book1D("missingY_" + hisID, "# Missing hits in Y",
-                                    nbinY, -4., 4.);
+    meMissingYLad_ = iBooker.book1D("missingY_" + hisID, "# Missing hits in Y", nbinY, -4., 4.);
     meMissingYLad_->setAxisTitle("# Missing hits in Y", 1);
 
-    meMissingModLad_ = iBooker.book1D("missingMod_" + hisID,
-                                      "# Missing hits on Module", 4, 0.5, 4.5);
+    meMissingModLad_ = iBooker.book1D("missingMod_" + hisID, "# Missing hits on Module", 4, 0.5, 4.5);
     meMissingModLad_->setAxisTitle("# Missing hits on Module", 1);
 
-    meMissingAlphaLad_ =
-        iBooker.book1D("missingAlpha_" + hisID, "# Missing hits in Alpha",
-                       nbinangle, -3.5, 3.5);
+    meMissingAlphaLad_ = iBooker.book1D("missingAlpha_" + hisID, "# Missing hits in Alpha", nbinangle, -3.5, 3.5);
     meMissingAlphaLad_->setAxisTitle("# Missing hits in Alpha", 1);
 
-    meMissingBetaLad_ = iBooker.book1D(
-        "missingBeta_" + hisID, "# Missing hits in Beta", nbinangle, -3.5, 3.5);
+    meMissingBetaLad_ = iBooker.book1D("missingBeta_" + hisID, "# Missing hits in Beta", nbinangle, -3.5, 3.5);
     meMissingBetaLad_->setAxisTitle("# Missing hits in Beta", 1);
   }
 
@@ -212,26 +183,20 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet &iConfig,
 
     if (updateEfficiencies) {
       // EFFICIENCY
-      meEfficiencyLay_ =
-          iBooker.book1D("efficiency_" + hisID, "Hit efficiency", 1, 0, 1.);
+      meEfficiencyLay_ = iBooker.book1D("efficiency_" + hisID, "Hit efficiency", 1, 0, 1.);
       meEfficiencyLay_->setAxisTitle("Hit efficiency", 1);
 
-      meEfficiencyXLay_ = iBooker.book1D(
-          "efficiencyX_" + hisID, "Hit efficiency in X", nbinX, -1.5, 1.5);
+      meEfficiencyXLay_ = iBooker.book1D("efficiencyX_" + hisID, "Hit efficiency in X", nbinX, -1.5, 1.5);
       meEfficiencyXLay_->setAxisTitle("Hit efficiency in X", 1);
 
-      meEfficiencyYLay_ = iBooker.book1D("efficiencyY_" + hisID,
-                                         "Hit efficiency in Y", nbinY, -4., 4.);
+      meEfficiencyYLay_ = iBooker.book1D("efficiencyY_" + hisID, "Hit efficiency in Y", nbinY, -4., 4.);
       meEfficiencyYLay_->setAxisTitle("Hit efficiency in Y", 1);
 
       meEfficiencyAlphaLay_ =
-          iBooker.book1D("efficiencyAlpha_" + hisID, "Hit efficiency in Alpha",
-                         nbinangle, -3.5, 3.5);
+          iBooker.book1D("efficiencyAlpha_" + hisID, "Hit efficiency in Alpha", nbinangle, -3.5, 3.5);
       meEfficiencyAlphaLay_->setAxisTitle("Hit efficiency in Alpha", 1);
 
-      meEfficiencyBetaLay_ =
-          iBooker.book1D("efficiencyBeta_" + hisID, "Hit efficiency in Beta",
-                         nbinangle, -3.5, 3.5);
+      meEfficiencyBetaLay_ = iBooker.book1D("efficiencyBeta_" + hisID, "Hit efficiency in Beta", nbinangle, -3.5, 3.5);
       meEfficiencyBetaLay_->setAxisTitle("Hit efficiency in Beta", 1);
     }
 
@@ -239,42 +204,32 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet &iConfig,
     meValidLay_ = iBooker.book1D("valid_" + hisID, "# Valid hits", 1, 0, 1.);
     meValidLay_->setAxisTitle("# Valid hits", 1);
 
-    meValidXLay_ = iBooker.book1D("validX_" + hisID, "# Valid hits in X", nbinX,
-                                  -1.5, 1.5);
+    meValidXLay_ = iBooker.book1D("validX_" + hisID, "# Valid hits in X", nbinX, -1.5, 1.5);
     meValidXLay_->setAxisTitle("# Valid hits in X", 1);
 
-    meValidYLay_ =
-        iBooker.book1D("validY_" + hisID, "# Valid hits in Y", nbinY, -4., 4.);
+    meValidYLay_ = iBooker.book1D("validY_" + hisID, "# Valid hits in Y", nbinY, -4., 4.);
     meValidYLay_->setAxisTitle("# Valid hits in Y", 1);
 
-    meValidAlphaLay_ = iBooker.book1D(
-        "validAlpha_" + hisID, "# Valid hits in Alpha", nbinangle, -3.5, 3.5);
+    meValidAlphaLay_ = iBooker.book1D("validAlpha_" + hisID, "# Valid hits in Alpha", nbinangle, -3.5, 3.5);
     meValidAlphaLay_->setAxisTitle("# Valid hits in Alpha", 1);
 
-    meValidBetaLay_ = iBooker.book1D(
-        "validBeta_" + hisID, "# Valid hits in Beta", nbinangle, -3.5, 3.5);
+    meValidBetaLay_ = iBooker.book1D("validBeta_" + hisID, "# Valid hits in Beta", nbinangle, -3.5, 3.5);
     meValidBetaLay_->setAxisTitle("# Valid hits in Beta", 1);
 
     // MISSING
-    meMissingLay_ =
-        iBooker.book1D("missing_" + hisID, "# Missing hits", 1, 0, 1.);
+    meMissingLay_ = iBooker.book1D("missing_" + hisID, "# Missing hits", 1, 0, 1.);
     meMissingLay_->setAxisTitle("# Missing hits", 1);
 
-    meMissingXLay_ = iBooker.book1D("missingX_" + hisID, "# Missing hits in X",
-                                    nbinX, -1.5, 1.5);
+    meMissingXLay_ = iBooker.book1D("missingX_" + hisID, "# Missing hits in X", nbinX, -1.5, 1.5);
     meMissingXLay_->setAxisTitle("# Missing hits in X", 1);
 
-    meMissingYLay_ = iBooker.book1D("missingY_" + hisID, "# Missing hits in Y",
-                                    nbinY, -4., 4.);
+    meMissingYLay_ = iBooker.book1D("missingY_" + hisID, "# Missing hits in Y", nbinY, -4., 4.);
     meMissingYLay_->setAxisTitle("# Missing hits in Y", 1);
 
-    meMissingAlphaLay_ =
-        iBooker.book1D("missingAlpha_" + hisID, "# Missing hits in Alpha",
-                       nbinangle, -3.5, 3.5);
+    meMissingAlphaLay_ = iBooker.book1D("missingAlpha_" + hisID, "# Missing hits in Alpha", nbinangle, -3.5, 3.5);
     meMissingAlphaLay_->setAxisTitle("# Missing hits in Alpha", 1);
 
-    meMissingBetaLay_ = iBooker.book1D(
-        "missingBeta_" + hisID, "# Missing hits in Beta", nbinangle, -3.5, 3.5);
+    meMissingBetaLay_ = iBooker.book1D("missingBeta_" + hisID, "# Missing hits in Beta", nbinangle, -3.5, 3.5);
     meMissingBetaLay_->setAxisTitle("# Missing hits in Beta", 1);
   }
 
@@ -287,26 +242,20 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet &iConfig,
 
     if (updateEfficiencies) {
       // EFFICIENCY
-      meEfficiencyPhi_ =
-          iBooker.book1D("efficiency_" + hisID, "Hit efficiency", 1, 0, 1.);
+      meEfficiencyPhi_ = iBooker.book1D("efficiency_" + hisID, "Hit efficiency", 1, 0, 1.);
       meEfficiencyPhi_->setAxisTitle("Hit efficiency", 1);
 
-      meEfficiencyXPhi_ = iBooker.book1D(
-          "efficiencyX_" + hisID, "Hit efficiency in X", nbinX, -1.5, 1.5);
+      meEfficiencyXPhi_ = iBooker.book1D("efficiencyX_" + hisID, "Hit efficiency in X", nbinX, -1.5, 1.5);
       meEfficiencyXPhi_->setAxisTitle("Hit efficiency in X", 1);
 
-      meEfficiencyYPhi_ = iBooker.book1D("efficiencyY_" + hisID,
-                                         "Hit efficiency in Y", nbinY, -4., 4.);
+      meEfficiencyYPhi_ = iBooker.book1D("efficiencyY_" + hisID, "Hit efficiency in Y", nbinY, -4., 4.);
       meEfficiencyYPhi_->setAxisTitle("Hit efficiency in Y", 1);
 
       meEfficiencyAlphaPhi_ =
-          iBooker.book1D("efficiencyAlpha_" + hisID, "Hit efficiency in Alpha",
-                         nbinangle, -3.5, 3.5);
+          iBooker.book1D("efficiencyAlpha_" + hisID, "Hit efficiency in Alpha", nbinangle, -3.5, 3.5);
       meEfficiencyAlphaPhi_->setAxisTitle("Hit efficiency in Alpha", 1);
 
-      meEfficiencyBetaPhi_ =
-          iBooker.book1D("efficiencyBeta_" + hisID, "Hit efficiency in Beta",
-                         nbinangle, -3.5, 3.5);
+      meEfficiencyBetaPhi_ = iBooker.book1D("efficiencyBeta_" + hisID, "Hit efficiency in Beta", nbinangle, -3.5, 3.5);
       meEfficiencyBetaPhi_->setAxisTitle("Hit efficiency in Beta", 1);
     }
 
@@ -314,42 +263,32 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet &iConfig,
     meValidPhi_ = iBooker.book1D("valid_" + hisID, "# Valid hits", 1, 0, 1.);
     meValidPhi_->setAxisTitle("# Valid hits", 1);
 
-    meValidXPhi_ = iBooker.book1D("validX_" + hisID, "# Valid hits in X", nbinX,
-                                  -1.5, 1.5);
+    meValidXPhi_ = iBooker.book1D("validX_" + hisID, "# Valid hits in X", nbinX, -1.5, 1.5);
     meValidXPhi_->setAxisTitle("# Valid hits in X", 1);
 
-    meValidYPhi_ =
-        iBooker.book1D("validY_" + hisID, "# Valid hits in Y", nbinY, -4., 4.);
+    meValidYPhi_ = iBooker.book1D("validY_" + hisID, "# Valid hits in Y", nbinY, -4., 4.);
     meValidYPhi_->setAxisTitle("# Valid hits in Y", 1);
 
-    meValidAlphaPhi_ = iBooker.book1D(
-        "validAlpha_" + hisID, "# Valid hits in Alpha", nbinangle, -3.5, 3.5);
+    meValidAlphaPhi_ = iBooker.book1D("validAlpha_" + hisID, "# Valid hits in Alpha", nbinangle, -3.5, 3.5);
     meValidAlphaPhi_->setAxisTitle("# Valid hits in Alpha", 1);
 
-    meValidBetaPhi_ = iBooker.book1D(
-        "validBeta_" + hisID, "# Valid hits in Beta", nbinangle, -3.5, 3.5);
+    meValidBetaPhi_ = iBooker.book1D("validBeta_" + hisID, "# Valid hits in Beta", nbinangle, -3.5, 3.5);
     meValidBetaPhi_->setAxisTitle("# Valid hits in Beta", 1);
 
     // MISSING
-    meMissingPhi_ =
-        iBooker.book1D("missing_" + hisID, "# Missing hits", 1, 0, 1.);
+    meMissingPhi_ = iBooker.book1D("missing_" + hisID, "# Missing hits", 1, 0, 1.);
     meMissingPhi_->setAxisTitle("# Missing hits", 1);
 
-    meMissingXPhi_ = iBooker.book1D("missingX_" + hisID, "# Missing hits in X",
-                                    nbinX, -1.5, 1.5);
+    meMissingXPhi_ = iBooker.book1D("missingX_" + hisID, "# Missing hits in X", nbinX, -1.5, 1.5);
     meMissingXPhi_->setAxisTitle("# Missing hits in X", 1);
 
-    meMissingYPhi_ = iBooker.book1D("missingY_" + hisID, "# Missing hits in Y",
-                                    nbinY, -4., 4.);
+    meMissingYPhi_ = iBooker.book1D("missingY_" + hisID, "# Missing hits in Y", nbinY, -4., 4.);
     meMissingYPhi_->setAxisTitle("# Missing hits in Y", 1);
 
-    meMissingAlphaPhi_ =
-        iBooker.book1D("missingAlpha_" + hisID, "# Missing hits in Alpha",
-                       nbinangle, -3.5, 3.5);
+    meMissingAlphaPhi_ = iBooker.book1D("missingAlpha_" + hisID, "# Missing hits in Alpha", nbinangle, -3.5, 3.5);
     meMissingAlphaPhi_->setAxisTitle("# Missing hits in Alpha", 1);
 
-    meMissingBetaPhi_ = iBooker.book1D(
-        "missingBeta_" + hisID, "# Missing hits in Beta", nbinangle, -3.5, 3.5);
+    meMissingBetaPhi_ = iBooker.book1D("missingBeta_" + hisID, "# Missing hits in Beta", nbinangle, -3.5, 3.5);
     meMissingBetaPhi_->setAxisTitle("# Missing hits in Beta", 1);
   }
 
@@ -363,70 +302,54 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet &iConfig,
 
     if (updateEfficiencies) {
       // EFFICIENCY
-      meEfficiencyBlade_ =
-          iBooker.book1D("efficiency_" + hisID, "Hit efficiency", 1, 0, 1.);
+      meEfficiencyBlade_ = iBooker.book1D("efficiency_" + hisID, "Hit efficiency", 1, 0, 1.);
       meEfficiencyBlade_->setAxisTitle("Hit efficiency", 1);
 
-      meEfficiencyXBlade_ = iBooker.book1D(
-          "efficiencyX_" + hisID, "Hit efficiency in X", nbinX, -1.5, 1.5);
+      meEfficiencyXBlade_ = iBooker.book1D("efficiencyX_" + hisID, "Hit efficiency in X", nbinX, -1.5, 1.5);
       meEfficiencyXBlade_->setAxisTitle("Hit efficiency in X", 1);
 
-      meEfficiencyYBlade_ = iBooker.book1D(
-          "efficiencyY_" + hisID, "Hit efficiency in Y", nbinY, -4., 4.);
+      meEfficiencyYBlade_ = iBooker.book1D("efficiencyY_" + hisID, "Hit efficiency in Y", nbinY, -4., 4.);
       meEfficiencyYBlade_->setAxisTitle("Hit efficiency in Y", 1);
 
       meEfficiencyAlphaBlade_ =
-          iBooker.book1D("efficiencyAlpha_" + hisID, "Hit efficiency in Alpha",
-                         nbinangle, -3.5, 3.5);
+          iBooker.book1D("efficiencyAlpha_" + hisID, "Hit efficiency in Alpha", nbinangle, -3.5, 3.5);
       meEfficiencyAlphaBlade_->setAxisTitle("Hit efficiency in Alpha", 1);
 
       meEfficiencyBetaBlade_ =
-          iBooker.book1D("efficiencyBeta_" + hisID, "Hit efficiency in Beta",
-                         nbinangle, -3.5, 3.5);
+          iBooker.book1D("efficiencyBeta_" + hisID, "Hit efficiency in Beta", nbinangle, -3.5, 3.5);
       meEfficiencyBetaBlade_->setAxisTitle("Hit efficiency in Beta", 1);
     }
 
     // VALID
-    meValidBlade_ =
-        iBooker.book1D("valid_" + hisID, "# Valid hits", 2, 0.5, 2.5);
+    meValidBlade_ = iBooker.book1D("valid_" + hisID, "# Valid hits", 2, 0.5, 2.5);
     meValidBlade_->setAxisTitle("# Valid hits", 1);
 
-    meValidXBlade_ = iBooker.book1D("validX_" + hisID, "# Valid hits in X",
-                                    nbinX, -1.5, 1.5);
+    meValidXBlade_ = iBooker.book1D("validX_" + hisID, "# Valid hits in X", nbinX, -1.5, 1.5);
     meValidXBlade_->setAxisTitle("# Valid hits in X", 1);
 
-    meValidYBlade_ =
-        iBooker.book1D("validY_" + hisID, "# Valid hits in Y", nbinY, -4., 4.);
+    meValidYBlade_ = iBooker.book1D("validY_" + hisID, "# Valid hits in Y", nbinY, -4., 4.);
     meValidYBlade_->setAxisTitle("# Valid hits in Y", 1);
 
-    meValidAlphaBlade_ = iBooker.book1D(
-        "validAlpha_" + hisID, "# Valid hits in Alpha", nbinangle, -3.5, 3.5);
+    meValidAlphaBlade_ = iBooker.book1D("validAlpha_" + hisID, "# Valid hits in Alpha", nbinangle, -3.5, 3.5);
     meValidAlphaBlade_->setAxisTitle("# Valid hits in Alpha", 1);
 
-    meValidBetaBlade_ = iBooker.book1D(
-        "validBeta_" + hisID, "# Valid hits in Beta", nbinangle, -3.5, 3.5);
+    meValidBetaBlade_ = iBooker.book1D("validBeta_" + hisID, "# Valid hits in Beta", nbinangle, -3.5, 3.5);
     meValidBetaBlade_->setAxisTitle("# Valid hits in Beta", 1);
 
     // MISSING
-    meMissingBlade_ =
-        iBooker.book1D("missing_" + hisID, "# Missing hits", 2, 0.5, 2.5);
+    meMissingBlade_ = iBooker.book1D("missing_" + hisID, "# Missing hits", 2, 0.5, 2.5);
     meMissingBlade_->setAxisTitle("# Missing hits", 1);
 
-    meMissingXBlade_ = iBooker.book1D("missingX_" + hisID,
-                                      "# Missing hits in X", nbinX, -1.5, 1.5);
+    meMissingXBlade_ = iBooker.book1D("missingX_" + hisID, "# Missing hits in X", nbinX, -1.5, 1.5);
     meMissingXBlade_->setAxisTitle("# Missing hits in X", 1);
 
-    meMissingYBlade_ = iBooker.book1D("missingY_" + hisID,
-                                      "# Missing hits in Y", nbinY, -4., 4.);
+    meMissingYBlade_ = iBooker.book1D("missingY_" + hisID, "# Missing hits in Y", nbinY, -4., 4.);
     meMissingYBlade_->setAxisTitle("# Missing hits in Y", 1);
 
-    meMissingAlphaBlade_ =
-        iBooker.book1D("missingAlpha_" + hisID, "# Missing hits in Alpha",
-                       nbinangle, -3.5, 3.5);
+    meMissingAlphaBlade_ = iBooker.book1D("missingAlpha_" + hisID, "# Missing hits in Alpha", nbinangle, -3.5, 3.5);
     meMissingAlphaBlade_->setAxisTitle("# Missing hits in Alpha", 1);
 
-    meMissingBetaBlade_ = iBooker.book1D(
-        "missingBeta_" + hisID, "# Missing hits in Beta", nbinangle, -3.5, 3.5);
+    meMissingBetaBlade_ = iBooker.book1D("missingBeta_" + hisID, "# Missing hits in Beta", nbinangle, -3.5, 3.5);
     meMissingBetaBlade_->setAxisTitle("# Missing hits in Beta", 1);
   }
 
@@ -440,26 +363,20 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet &iConfig,
 
     if (updateEfficiencies) {
       // EFFICIENCY
-      meEfficiencyDisk_ =
-          iBooker.book1D("efficiency_" + hisID, "Hit efficiency", 1, 0, 1.);
+      meEfficiencyDisk_ = iBooker.book1D("efficiency_" + hisID, "Hit efficiency", 1, 0, 1.);
       meEfficiencyDisk_->setAxisTitle("Hit efficiency", 1);
 
-      meEfficiencyXDisk_ = iBooker.book1D(
-          "efficiencyX_" + hisID, "Hit efficiency in X", nbinX, -1.5, 1.5);
+      meEfficiencyXDisk_ = iBooker.book1D("efficiencyX_" + hisID, "Hit efficiency in X", nbinX, -1.5, 1.5);
       meEfficiencyXDisk_->setAxisTitle("Hit efficiency in X", 1);
 
-      meEfficiencyYDisk_ = iBooker.book1D(
-          "efficiencyY_" + hisID, "Hit efficiency in Y", nbinY, -4., 4.);
+      meEfficiencyYDisk_ = iBooker.book1D("efficiencyY_" + hisID, "Hit efficiency in Y", nbinY, -4., 4.);
       meEfficiencyYDisk_->setAxisTitle("Hit efficiency in Y", 1);
 
       meEfficiencyAlphaDisk_ =
-          iBooker.book1D("efficiencyAlpha_" + hisID, "Hit efficiency in Alpha",
-                         nbinangle, -3.5, 3.5);
+          iBooker.book1D("efficiencyAlpha_" + hisID, "Hit efficiency in Alpha", nbinangle, -3.5, 3.5);
       meEfficiencyAlphaDisk_->setAxisTitle("Hit efficiency in Alpha", 1);
 
-      meEfficiencyBetaDisk_ =
-          iBooker.book1D("efficiencyBeta_" + hisID, "Hit efficiency in Beta",
-                         nbinangle, -3.5, 3.5);
+      meEfficiencyBetaDisk_ = iBooker.book1D("efficiencyBeta_" + hisID, "Hit efficiency in Beta", nbinangle, -3.5, 3.5);
       meEfficiencyBetaDisk_->setAxisTitle("Hit efficiency in Beta", 1);
     }
 
@@ -467,42 +384,32 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet &iConfig,
     meValidDisk_ = iBooker.book1D("valid_" + hisID, "# Valid hits", 1, 0, 1.);
     meValidDisk_->setAxisTitle("# Valid hits", 1);
 
-    meValidXDisk_ = iBooker.book1D("validX_" + hisID, "# Valid hits in X",
-                                   nbinX, -1.5, 1.5);
+    meValidXDisk_ = iBooker.book1D("validX_" + hisID, "# Valid hits in X", nbinX, -1.5, 1.5);
     meValidXDisk_->setAxisTitle("# Valid hits in X", 1);
 
-    meValidYDisk_ =
-        iBooker.book1D("validY_" + hisID, "# Valid hits in Y", nbinY, -4., 4.);
+    meValidYDisk_ = iBooker.book1D("validY_" + hisID, "# Valid hits in Y", nbinY, -4., 4.);
     meValidYDisk_->setAxisTitle("# Valid hits in Y", 1);
 
-    meValidAlphaDisk_ = iBooker.book1D(
-        "validAlpha_" + hisID, "# Valid hits in Alpha", nbinangle, -3.5, 3.5);
+    meValidAlphaDisk_ = iBooker.book1D("validAlpha_" + hisID, "# Valid hits in Alpha", nbinangle, -3.5, 3.5);
     meValidAlphaDisk_->setAxisTitle("# Valid hits in Alpha", 1);
 
-    meValidBetaDisk_ = iBooker.book1D(
-        "validBeta_" + hisID, "# Valid hits in Beta", nbinangle, -3.5, 3.5);
+    meValidBetaDisk_ = iBooker.book1D("validBeta_" + hisID, "# Valid hits in Beta", nbinangle, -3.5, 3.5);
     meValidBetaDisk_->setAxisTitle("# Valid hits in Beta", 1);
 
     // MISSING
-    meMissingDisk_ =
-        iBooker.book1D("missing_" + hisID, "# Missing hits", 1, 0, 1.);
+    meMissingDisk_ = iBooker.book1D("missing_" + hisID, "# Missing hits", 1, 0, 1.);
     meMissingDisk_->setAxisTitle("# Missing hits", 1);
 
-    meMissingXDisk_ = iBooker.book1D("missingX_" + hisID, "# Missing hits in X",
-                                     nbinX, -1.5, 1.5);
+    meMissingXDisk_ = iBooker.book1D("missingX_" + hisID, "# Missing hits in X", nbinX, -1.5, 1.5);
     meMissingXDisk_->setAxisTitle("# Missing hits in X", 1);
 
-    meMissingYDisk_ = iBooker.book1D("missingY_" + hisID, "# Missing hits in Y",
-                                     nbinY, -4., 4.);
+    meMissingYDisk_ = iBooker.book1D("missingY_" + hisID, "# Missing hits in Y", nbinY, -4., 4.);
     meMissingYDisk_->setAxisTitle("# Missing hits in Y", 1);
 
-    meMissingAlphaDisk_ =
-        iBooker.book1D("missingAlpha_" + hisID, "# Missing hits in Alpha",
-                       nbinangle, -3.5, 3.5);
+    meMissingAlphaDisk_ = iBooker.book1D("missingAlpha_" + hisID, "# Missing hits in Alpha", nbinangle, -3.5, 3.5);
     meMissingAlphaDisk_->setAxisTitle("# Missing hits in Alpha", 1);
 
-    meMissingBetaDisk_ = iBooker.book1D(
-        "missingBeta_" + hisID, "# Missing hits in Beta", nbinangle, -3.5, 3.5);
+    meMissingBetaDisk_ = iBooker.book1D("missingBeta_" + hisID, "# Missing hits in Beta", nbinangle, -3.5, 3.5);
     meMissingBetaDisk_->setAxisTitle("# Missing hits in Beta", 1);
   }
 
@@ -518,26 +425,20 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet &iConfig,
 
     if (updateEfficiencies) {
       // EFFICIENCY
-      meEfficiencyRing_ =
-          iBooker.book1D("efficiency_" + hisID, "Hit efficiency", 1, 0, 1.);
+      meEfficiencyRing_ = iBooker.book1D("efficiency_" + hisID, "Hit efficiency", 1, 0, 1.);
       meEfficiencyRing_->setAxisTitle("Hit efficiency", 1);
 
-      meEfficiencyXRing_ = iBooker.book1D(
-          "efficiencyX_" + hisID, "Hit efficiency in X", nbinX, -1.5, 1.5);
+      meEfficiencyXRing_ = iBooker.book1D("efficiencyX_" + hisID, "Hit efficiency in X", nbinX, -1.5, 1.5);
       meEfficiencyXRing_->setAxisTitle("Hit efficiency in X", 1);
 
-      meEfficiencyYRing_ = iBooker.book1D(
-          "efficiencyY_" + hisID, "Hit efficiency in Y", nbinY, -4., 4.);
+      meEfficiencyYRing_ = iBooker.book1D("efficiencyY_" + hisID, "Hit efficiency in Y", nbinY, -4., 4.);
       meEfficiencyYRing_->setAxisTitle("Hit efficiency in Y", 1);
 
       meEfficiencyAlphaRing_ =
-          iBooker.book1D("efficiencyAlpha_" + hisID, "Hit efficiency in Alpha",
-                         nbinangle, -3.5, 3.5);
+          iBooker.book1D("efficiencyAlpha_" + hisID, "Hit efficiency in Alpha", nbinangle, -3.5, 3.5);
       meEfficiencyAlphaRing_->setAxisTitle("Hit efficiency in Alpha", 1);
 
-      meEfficiencyBetaRing_ =
-          iBooker.book1D("efficiencyBeta_" + hisID, "Hit efficiency in Beta",
-                         nbinangle, -3.5, 3.5);
+      meEfficiencyBetaRing_ = iBooker.book1D("efficiencyBeta_" + hisID, "Hit efficiency in Beta", nbinangle, -3.5, 3.5);
       meEfficiencyBetaRing_->setAxisTitle("Hit efficiency in Beta", 1);
     }
 
@@ -545,56 +446,48 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet &iConfig,
     meValidRing_ = iBooker.book1D("valid_" + hisID, "# Valid hits", 1, 0, 1.);
     meValidRing_->setAxisTitle("# Valid hits", 1);
 
-    meValidXRing_ = iBooker.book1D("validX_" + hisID, "# Valid hits in X",
-                                   nbinX, -1.5, 1.5);
+    meValidXRing_ = iBooker.book1D("validX_" + hisID, "# Valid hits in X", nbinX, -1.5, 1.5);
     meValidXRing_->setAxisTitle("# Valid hits in X", 1);
 
-    meValidYRing_ =
-        iBooker.book1D("validY_" + hisID, "# Valid hits in Y", nbinY, -4., 4.);
+    meValidYRing_ = iBooker.book1D("validY_" + hisID, "# Valid hits in Y", nbinY, -4., 4.);
     meValidYRing_->setAxisTitle("# Valid hits in Y", 1);
 
-    meValidAlphaRing_ = iBooker.book1D(
-        "validAlpha_" + hisID, "# Valid hits in Alpha", nbinangle, -3.5, 3.5);
+    meValidAlphaRing_ = iBooker.book1D("validAlpha_" + hisID, "# Valid hits in Alpha", nbinangle, -3.5, 3.5);
     meValidAlphaRing_->setAxisTitle("# Valid hits in Alpha", 1);
 
-    meValidBetaRing_ = iBooker.book1D(
-        "validBeta_" + hisID, "# Valid hits in Beta", nbinangle, -3.5, 3.5);
+    meValidBetaRing_ = iBooker.book1D("validBeta_" + hisID, "# Valid hits in Beta", nbinangle, -3.5, 3.5);
     meValidBetaRing_->setAxisTitle("# Valid hits in Beta", 1);
 
     // MISSING
-    meMissingRing_ =
-        iBooker.book1D("missing_" + hisID, "# Missing hits", 1, 0, 1.);
+    meMissingRing_ = iBooker.book1D("missing_" + hisID, "# Missing hits", 1, 0, 1.);
     meMissingRing_->setAxisTitle("# Missing hits", 1);
 
-    meMissingXRing_ = iBooker.book1D("missingX_" + hisID, "# Missing hits in X",
-                                     nbinX, -1.5, 1.5);
+    meMissingXRing_ = iBooker.book1D("missingX_" + hisID, "# Missing hits in X", nbinX, -1.5, 1.5);
     meMissingXRing_->setAxisTitle("# Missing hits in X", 1);
 
-    meMissingYRing_ = iBooker.book1D("missingY_" + hisID, "# Missing hits in Y",
-                                     nbinY, -4., 4.);
+    meMissingYRing_ = iBooker.book1D("missingY_" + hisID, "# Missing hits in Y", nbinY, -4., 4.);
     meMissingYRing_->setAxisTitle("# Missing hits in Y", 1);
 
-    meMissingAlphaRing_ =
-        iBooker.book1D("missingAlpha_" + hisID, "# Missing hits in Alpha",
-                       nbinangle, -3.5, 3.5);
+    meMissingAlphaRing_ = iBooker.book1D("missingAlpha_" + hisID, "# Missing hits in Alpha", nbinangle, -3.5, 3.5);
     meMissingAlphaRing_->setAxisTitle("# Missing hits in Alpha", 1);
 
-    meMissingBetaRing_ = iBooker.book1D(
-        "missingBeta_" + hisID, "# Missing hits in Beta", nbinangle, -3.5, 3.5);
+    meMissingBetaRing_ = iBooker.book1D("missingBeta_" + hisID, "# Missing hits in Beta", nbinangle, -3.5, 3.5);
     meMissingBetaRing_->setAxisTitle("# Missing hits in Beta", 1);
   }
 }
 
 void SiPixelHitEfficiencyModule::fill(const TrackerTopology *pTT,
                                       const LocalTrajectoryParameters &ltp,
-                                      bool isHitValid, bool modon, bool ladon,
-                                      bool layon, bool phion, bool bladeon,
-                                      bool diskon, bool ringon) {
-
-  bool barrel =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
-  bool endcap =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+                                      bool isHitValid,
+                                      bool modon,
+                                      bool ladon,
+                                      bool layon,
+                                      bool phion,
+                                      bool bladeon,
+                                      bool diskon,
+                                      bool ringon) {
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
 
   LocalVector localDir = ltp.momentum() / ltp.momentum().mag();
   float prediction_alpha = atan2(localDir.z(), localDir.x());
@@ -707,316 +600,187 @@ void SiPixelHitEfficiencyModule::fill(const TrackerTopology *pTT,
     computeEfficiencies(modon, ladon, layon, phion, bladeon, diskon, ringon);
 }
 
-void SiPixelHitEfficiencyModule::computeEfficiencies(bool modon, bool ladon,
-                                                     bool layon, bool phion,
-                                                     bool bladeon, bool diskon,
-                                                     bool ringon) {
-
+void SiPixelHitEfficiencyModule::computeEfficiencies(
+    bool modon, bool ladon, bool layon, bool phion, bool bladeon, bool diskon, bool ringon) {
   if (debug_)
     std::cout << "Now Filling histos for detid " << id_ << std::endl;
 
-  bool barrel =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
-  bool endcap =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
 
   if (modon) {
-    meEfficiency_->setBinContent(
-        1,
-        (eff(meValid_->getBinContent(1), meMissing_->getBinContent(1))).first);
-    meEfficiency_->setBinError(
-        1,
-        (eff(meValid_->getBinContent(1), meMissing_->getBinContent(1))).second);
+    meEfficiency_->setBinContent(1, (eff(meValid_->getBinContent(1), meMissing_->getBinContent(1))).first);
+    meEfficiency_->setBinError(1, (eff(meValid_->getBinContent(1), meMissing_->getBinContent(1))).second);
   }
   if (ladon && barrel) {
-    meEfficiencyLad_->setBinContent(
-        1, (eff(meValidLad_->getBinContent(1), meMissingLad_->getBinContent(1)))
-               .first);
-    meEfficiencyLad_->setBinError(
-        1, (eff(meValidLad_->getBinContent(1), meMissingLad_->getBinContent(1)))
-               .second);
+    meEfficiencyLad_->setBinContent(1, (eff(meValidLad_->getBinContent(1), meMissingLad_->getBinContent(1))).first);
+    meEfficiencyLad_->setBinError(1, (eff(meValidLad_->getBinContent(1), meMissingLad_->getBinContent(1))).second);
     for (int i = 1; i <= meValidXLad_->getNbinsX(); ++i) {
       meEfficiencyXLad_->setBinContent(i,
-                                       (eff(meValidXLad_->getBinContent(i),
-                                            meMissingXLad_->getBinContent(i)))
-                                           .first);
-      meEfficiencyXLad_->setBinError(i, (eff(meValidXLad_->getBinContent(i),
-                                             meMissingXLad_->getBinContent(i)))
-                                            .second);
+                                       (eff(meValidXLad_->getBinContent(i), meMissingXLad_->getBinContent(i))).first);
+      meEfficiencyXLad_->setBinError(i, (eff(meValidXLad_->getBinContent(i), meMissingXLad_->getBinContent(i))).second);
     }
     for (int i = 1; i <= meValidYLad_->getNbinsX(); ++i) {
       meEfficiencyYLad_->setBinContent(i,
-                                       (eff(meValidYLad_->getBinContent(i),
-                                            meMissingYLad_->getBinContent(i)))
-                                           .first);
-      meEfficiencyYLad_->setBinError(i, (eff(meValidYLad_->getBinContent(i),
-                                             meMissingYLad_->getBinContent(i)))
-                                            .second);
+                                       (eff(meValidYLad_->getBinContent(i), meMissingYLad_->getBinContent(i))).first);
+      meEfficiencyYLad_->setBinError(i, (eff(meValidYLad_->getBinContent(i), meMissingYLad_->getBinContent(i))).second);
     }
     for (int i = 1; i <= meValidAlphaLad_->getNbinsX(); ++i) {
       meEfficiencyAlphaLad_->setBinContent(
-          i, (eff(meValidAlphaLad_->getBinContent(i),
-                  meMissingAlphaLad_->getBinContent(i)))
-                 .first);
+          i, (eff(meValidAlphaLad_->getBinContent(i), meMissingAlphaLad_->getBinContent(i))).first);
       meEfficiencyAlphaLad_->setBinError(
-          i, (eff(meValidAlphaLad_->getBinContent(i),
-                  meMissingAlphaLad_->getBinContent(i)))
-                 .second);
+          i, (eff(meValidAlphaLad_->getBinContent(i), meMissingAlphaLad_->getBinContent(i))).second);
     }
     for (int i = 1; i <= meValidBetaLad_->getNbinsX(); ++i) {
       meEfficiencyBetaLad_->setBinContent(
-          i, (eff(meValidBetaLad_->getBinContent(i),
-                  meMissingBetaLad_->getBinContent(i)))
-                 .first);
+          i, (eff(meValidBetaLad_->getBinContent(i), meMissingBetaLad_->getBinContent(i))).first);
       meEfficiencyBetaLad_->setBinError(
-          i, (eff(meValidBetaLad_->getBinContent(i),
-                  meMissingBetaLad_->getBinContent(i)))
-                 .second);
+          i, (eff(meValidBetaLad_->getBinContent(i), meMissingBetaLad_->getBinContent(i))).second);
     }
   }
 
   if (layon && barrel) {
-    meEfficiencyLay_->setBinContent(
-        1, (eff(meValidLay_->getBinContent(1), meMissingLay_->getBinContent(1)))
-               .first);
-    meEfficiencyLay_->setBinError(
-        1, (eff(meValidLay_->getBinContent(1), meMissingLay_->getBinContent(1)))
-               .second);
+    meEfficiencyLay_->setBinContent(1, (eff(meValidLay_->getBinContent(1), meMissingLay_->getBinContent(1))).first);
+    meEfficiencyLay_->setBinError(1, (eff(meValidLay_->getBinContent(1), meMissingLay_->getBinContent(1))).second);
     for (int i = 1; i <= meValidXLay_->getNbinsX(); ++i) {
       meEfficiencyXLay_->setBinContent(i,
-                                       (eff(meValidXLay_->getBinContent(i),
-                                            meMissingXLay_->getBinContent(i)))
-                                           .first);
-      meEfficiencyXLay_->setBinError(i, (eff(meValidXLay_->getBinContent(i),
-                                             meMissingXLay_->getBinContent(i)))
-                                            .second);
+                                       (eff(meValidXLay_->getBinContent(i), meMissingXLay_->getBinContent(i))).first);
+      meEfficiencyXLay_->setBinError(i, (eff(meValidXLay_->getBinContent(i), meMissingXLay_->getBinContent(i))).second);
     }
     for (int i = 1; i <= meValidYLay_->getNbinsX(); ++i) {
       meEfficiencyYLay_->setBinContent(i,
-                                       (eff(meValidYLay_->getBinContent(i),
-                                            meMissingYLay_->getBinContent(i)))
-                                           .first);
-      meEfficiencyYLay_->setBinError(i, (eff(meValidYLay_->getBinContent(i),
-                                             meMissingYLay_->getBinContent(i)))
-                                            .second);
+                                       (eff(meValidYLay_->getBinContent(i), meMissingYLay_->getBinContent(i))).first);
+      meEfficiencyYLay_->setBinError(i, (eff(meValidYLay_->getBinContent(i), meMissingYLay_->getBinContent(i))).second);
     }
     for (int i = 1; i <= meValidAlphaLay_->getNbinsX(); ++i) {
       meEfficiencyAlphaLay_->setBinContent(
-          i, (eff(meValidAlphaLay_->getBinContent(i),
-                  meMissingAlphaLay_->getBinContent(i)))
-                 .first);
+          i, (eff(meValidAlphaLay_->getBinContent(i), meMissingAlphaLay_->getBinContent(i))).first);
       meEfficiencyAlphaLay_->setBinError(
-          i, (eff(meValidAlphaLay_->getBinContent(i),
-                  meMissingAlphaLay_->getBinContent(i)))
-                 .second);
+          i, (eff(meValidAlphaLay_->getBinContent(i), meMissingAlphaLay_->getBinContent(i))).second);
     }
     for (int i = 1; i <= meValidBetaLay_->getNbinsX(); ++i) {
       meEfficiencyBetaLay_->setBinContent(
-          i, (eff(meValidBetaLay_->getBinContent(i),
-                  meMissingBetaLay_->getBinContent(i)))
-                 .first);
+          i, (eff(meValidBetaLay_->getBinContent(i), meMissingBetaLay_->getBinContent(i))).first);
       meEfficiencyBetaLay_->setBinError(
-          i, (eff(meValidBetaLay_->getBinContent(i),
-                  meMissingBetaLay_->getBinContent(i)))
-                 .second);
+          i, (eff(meValidBetaLay_->getBinContent(i), meMissingBetaLay_->getBinContent(i))).second);
     }
   }
 
   if (phion && barrel) {
-    meEfficiencyPhi_->setBinContent(
-        1, (eff(meValidPhi_->getBinContent(1), meMissingPhi_->getBinContent(1)))
-               .first);
-    meEfficiencyPhi_->setBinError(
-        1, (eff(meValidPhi_->getBinContent(1), meMissingPhi_->getBinContent(1)))
-               .second);
+    meEfficiencyPhi_->setBinContent(1, (eff(meValidPhi_->getBinContent(1), meMissingPhi_->getBinContent(1))).first);
+    meEfficiencyPhi_->setBinError(1, (eff(meValidPhi_->getBinContent(1), meMissingPhi_->getBinContent(1))).second);
     for (int i = 1; i <= meValidXPhi_->getNbinsX(); ++i) {
       meEfficiencyXPhi_->setBinContent(i,
-                                       (eff(meValidXPhi_->getBinContent(i),
-                                            meMissingXPhi_->getBinContent(i)))
-                                           .first);
-      meEfficiencyXPhi_->setBinError(i, (eff(meValidXPhi_->getBinContent(i),
-                                             meMissingXPhi_->getBinContent(i)))
-                                            .second);
+                                       (eff(meValidXPhi_->getBinContent(i), meMissingXPhi_->getBinContent(i))).first);
+      meEfficiencyXPhi_->setBinError(i, (eff(meValidXPhi_->getBinContent(i), meMissingXPhi_->getBinContent(i))).second);
     }
     for (int i = 1; i <= meValidYPhi_->getNbinsX(); ++i) {
       meEfficiencyYPhi_->setBinContent(i,
-                                       (eff(meValidYPhi_->getBinContent(i),
-                                            meMissingYPhi_->getBinContent(i)))
-                                           .first);
-      meEfficiencyYPhi_->setBinError(i, (eff(meValidYPhi_->getBinContent(i),
-                                             meMissingYPhi_->getBinContent(i)))
-                                            .second);
+                                       (eff(meValidYPhi_->getBinContent(i), meMissingYPhi_->getBinContent(i))).first);
+      meEfficiencyYPhi_->setBinError(i, (eff(meValidYPhi_->getBinContent(i), meMissingYPhi_->getBinContent(i))).second);
     }
     for (int i = 1; i <= meValidAlphaPhi_->getNbinsX(); ++i) {
       meEfficiencyAlphaPhi_->setBinContent(
-          i, (eff(meValidAlphaPhi_->getBinContent(i),
-                  meMissingAlphaPhi_->getBinContent(i)))
-                 .first);
+          i, (eff(meValidAlphaPhi_->getBinContent(i), meMissingAlphaPhi_->getBinContent(i))).first);
       meEfficiencyAlphaPhi_->setBinError(
-          i, (eff(meValidAlphaPhi_->getBinContent(i),
-                  meMissingAlphaPhi_->getBinContent(i)))
-                 .second);
+          i, (eff(meValidAlphaPhi_->getBinContent(i), meMissingAlphaPhi_->getBinContent(i))).second);
     }
     for (int i = 1; i <= meValidBetaPhi_->getNbinsX(); ++i) {
       meEfficiencyBetaPhi_->setBinContent(
-          i, (eff(meValidBetaPhi_->getBinContent(i),
-                  meMissingBetaPhi_->getBinContent(i)))
-                 .first);
+          i, (eff(meValidBetaPhi_->getBinContent(i), meMissingBetaPhi_->getBinContent(i))).first);
       meEfficiencyBetaPhi_->setBinError(
-          i, (eff(meValidBetaPhi_->getBinContent(i),
-                  meMissingBetaPhi_->getBinContent(i)))
-                 .second);
+          i, (eff(meValidBetaPhi_->getBinContent(i), meMissingBetaPhi_->getBinContent(i))).second);
     }
   }
   if (bladeon && endcap) {
     meEfficiencyBlade_->setBinContent(1,
-                                      (eff(meValidBlade_->getBinContent(1),
-                                           meMissingBlade_->getBinContent(1)))
-                                          .first);
-    meEfficiencyBlade_->setBinError(1, (eff(meValidBlade_->getBinContent(1),
-                                            meMissingBlade_->getBinContent(1)))
-                                           .second);
+                                      (eff(meValidBlade_->getBinContent(1), meMissingBlade_->getBinContent(1))).first);
+    meEfficiencyBlade_->setBinError(1,
+                                    (eff(meValidBlade_->getBinContent(1), meMissingBlade_->getBinContent(1))).second);
     for (int i = 1; i <= meValidXBlade_->getNbinsX(); ++i) {
       meEfficiencyXBlade_->setBinContent(
-          i, (eff(meValidXBlade_->getBinContent(i),
-                  meMissingXBlade_->getBinContent(i)))
-                 .first);
-      meEfficiencyXBlade_->setBinError(i,
-                                       (eff(meValidXBlade_->getBinContent(i),
-                                            meMissingXBlade_->getBinContent(i)))
-                                           .second);
+          i, (eff(meValidXBlade_->getBinContent(i), meMissingXBlade_->getBinContent(i))).first);
+      meEfficiencyXBlade_->setBinError(
+          i, (eff(meValidXBlade_->getBinContent(i), meMissingXBlade_->getBinContent(i))).second);
     }
     for (int i = 1; i <= meValidYBlade_->getNbinsX(); ++i) {
       meEfficiencyYBlade_->setBinContent(
-          i, (eff(meValidYBlade_->getBinContent(i),
-                  meMissingYBlade_->getBinContent(i)))
-                 .first);
-      meEfficiencyYBlade_->setBinError(i,
-                                       (eff(meValidYBlade_->getBinContent(i),
-                                            meMissingYBlade_->getBinContent(i)))
-                                           .second);
+          i, (eff(meValidYBlade_->getBinContent(i), meMissingYBlade_->getBinContent(i))).first);
+      meEfficiencyYBlade_->setBinError(
+          i, (eff(meValidYBlade_->getBinContent(i), meMissingYBlade_->getBinContent(i))).second);
     }
     for (int i = 1; i <= meValidAlphaBlade_->getNbinsX(); ++i) {
       meEfficiencyAlphaBlade_->setBinContent(
-          i, (eff(meValidAlphaBlade_->getBinContent(i),
-                  meMissingAlphaBlade_->getBinContent(i)))
-                 .first);
+          i, (eff(meValidAlphaBlade_->getBinContent(i), meMissingAlphaBlade_->getBinContent(i))).first);
       meEfficiencyAlphaBlade_->setBinError(
-          i, (eff(meValidAlphaBlade_->getBinContent(i),
-                  meMissingAlphaBlade_->getBinContent(i)))
-                 .second);
+          i, (eff(meValidAlphaBlade_->getBinContent(i), meMissingAlphaBlade_->getBinContent(i))).second);
     }
     for (int i = 1; i <= meValidBetaBlade_->getNbinsX(); ++i) {
       meEfficiencyBetaBlade_->setBinContent(
-          i, (eff(meValidBetaBlade_->getBinContent(i),
-                  meMissingBetaBlade_->getBinContent(i)))
-                 .first);
+          i, (eff(meValidBetaBlade_->getBinContent(i), meMissingBetaBlade_->getBinContent(i))).first);
       meEfficiencyBetaBlade_->setBinError(
-          i, (eff(meValidBetaBlade_->getBinContent(i),
-                  meMissingBetaBlade_->getBinContent(i)))
-                 .second);
+          i, (eff(meValidBetaBlade_->getBinContent(i), meMissingBetaBlade_->getBinContent(i))).second);
     }
   }
   if (diskon && endcap) {
-    meEfficiencyDisk_->setBinContent(1, (eff(meValidDisk_->getBinContent(1),
-                                             meMissingDisk_->getBinContent(1)))
-                                            .first);
-    meEfficiencyDisk_->setBinError(1, (eff(meValidDisk_->getBinContent(1),
-                                           meMissingDisk_->getBinContent(1)))
-                                          .second);
+    meEfficiencyDisk_->setBinContent(1, (eff(meValidDisk_->getBinContent(1), meMissingDisk_->getBinContent(1))).first);
+    meEfficiencyDisk_->setBinError(1, (eff(meValidDisk_->getBinContent(1), meMissingDisk_->getBinContent(1))).second);
     for (int i = 1; i <= meValidXDisk_->getNbinsX(); ++i) {
-      meEfficiencyXDisk_->setBinContent(i,
-                                        (eff(meValidXDisk_->getBinContent(i),
-                                             meMissingXDisk_->getBinContent(i)))
-                                            .first);
+      meEfficiencyXDisk_->setBinContent(
+          i, (eff(meValidXDisk_->getBinContent(i), meMissingXDisk_->getBinContent(i))).first);
       meEfficiencyXDisk_->setBinError(i,
-                                      (eff(meValidXDisk_->getBinContent(i),
-                                           meMissingXDisk_->getBinContent(i)))
-                                          .second);
+                                      (eff(meValidXDisk_->getBinContent(i), meMissingXDisk_->getBinContent(i))).second);
     }
     for (int i = 1; i <= meValidYDisk_->getNbinsX(); ++i) {
-      meEfficiencyYDisk_->setBinContent(i,
-                                        (eff(meValidYDisk_->getBinContent(i),
-                                             meMissingYDisk_->getBinContent(i)))
-                                            .first);
+      meEfficiencyYDisk_->setBinContent(
+          i, (eff(meValidYDisk_->getBinContent(i), meMissingYDisk_->getBinContent(i))).first);
       meEfficiencyYDisk_->setBinError(i,
-                                      (eff(meValidYDisk_->getBinContent(i),
-                                           meMissingYDisk_->getBinContent(i)))
-                                          .second);
+                                      (eff(meValidYDisk_->getBinContent(i), meMissingYDisk_->getBinContent(i))).second);
     }
     for (int i = 1; i <= meValidAlphaDisk_->getNbinsX(); ++i) {
       meEfficiencyAlphaDisk_->setBinContent(
-          i, (eff(meValidAlphaDisk_->getBinContent(i),
-                  meMissingAlphaDisk_->getBinContent(i)))
-                 .first);
+          i, (eff(meValidAlphaDisk_->getBinContent(i), meMissingAlphaDisk_->getBinContent(i))).first);
       meEfficiencyAlphaDisk_->setBinError(
-          i, (eff(meValidAlphaDisk_->getBinContent(i),
-                  meMissingAlphaDisk_->getBinContent(i)))
-                 .second);
+          i, (eff(meValidAlphaDisk_->getBinContent(i), meMissingAlphaDisk_->getBinContent(i))).second);
     }
     for (int i = 1; i <= meValidBetaDisk_->getNbinsX(); ++i) {
       meEfficiencyBetaDisk_->setBinContent(
-          i, (eff(meValidBetaDisk_->getBinContent(i),
-                  meMissingBetaDisk_->getBinContent(i)))
-                 .first);
+          i, (eff(meValidBetaDisk_->getBinContent(i), meMissingBetaDisk_->getBinContent(i))).first);
       meEfficiencyBetaDisk_->setBinError(
-          i, (eff(meValidBetaDisk_->getBinContent(i),
-                  meMissingBetaDisk_->getBinContent(i)))
-                 .second);
+          i, (eff(meValidBetaDisk_->getBinContent(i), meMissingBetaDisk_->getBinContent(i))).second);
     }
   }
   if (ringon && endcap) {
-    meEfficiencyRing_->setBinContent(1, (eff(meValidRing_->getBinContent(1),
-                                             meMissingRing_->getBinContent(1)))
-                                            .first);
-    meEfficiencyRing_->setBinError(1, (eff(meValidRing_->getBinContent(1),
-                                           meMissingRing_->getBinContent(1)))
-                                          .second);
+    meEfficiencyRing_->setBinContent(1, (eff(meValidRing_->getBinContent(1), meMissingRing_->getBinContent(1))).first);
+    meEfficiencyRing_->setBinError(1, (eff(meValidRing_->getBinContent(1), meMissingRing_->getBinContent(1))).second);
     for (int i = 1; i <= meValidXRing_->getNbinsX(); ++i) {
-      meEfficiencyXRing_->setBinContent(i,
-                                        (eff(meValidXRing_->getBinContent(i),
-                                             meMissingXRing_->getBinContent(i)))
-                                            .first);
+      meEfficiencyXRing_->setBinContent(
+          i, (eff(meValidXRing_->getBinContent(i), meMissingXRing_->getBinContent(i))).first);
       meEfficiencyXRing_->setBinError(i,
-                                      (eff(meValidXRing_->getBinContent(i),
-                                           meMissingXRing_->getBinContent(i)))
-                                          .second);
+                                      (eff(meValidXRing_->getBinContent(i), meMissingXRing_->getBinContent(i))).second);
     }
     for (int i = 1; i <= meValidYRing_->getNbinsX(); ++i) {
-      meEfficiencyYRing_->setBinContent(i,
-                                        (eff(meValidYRing_->getBinContent(i),
-                                             meMissingYRing_->getBinContent(i)))
-                                            .first);
+      meEfficiencyYRing_->setBinContent(
+          i, (eff(meValidYRing_->getBinContent(i), meMissingYRing_->getBinContent(i))).first);
       meEfficiencyYRing_->setBinError(i,
-                                      (eff(meValidYRing_->getBinContent(i),
-                                           meMissingYRing_->getBinContent(i)))
-                                          .second);
+                                      (eff(meValidYRing_->getBinContent(i), meMissingYRing_->getBinContent(i))).second);
     }
     for (int i = 1; i <= meValidAlphaRing_->getNbinsX(); ++i) {
       meEfficiencyAlphaRing_->setBinContent(
-          i, (eff(meValidAlphaRing_->getBinContent(i),
-                  meMissingAlphaRing_->getBinContent(i)))
-                 .first);
+          i, (eff(meValidAlphaRing_->getBinContent(i), meMissingAlphaRing_->getBinContent(i))).first);
       meEfficiencyAlphaRing_->setBinError(
-          i, (eff(meValidAlphaRing_->getBinContent(i),
-                  meMissingAlphaRing_->getBinContent(i)))
-                 .second);
+          i, (eff(meValidAlphaRing_->getBinContent(i), meMissingAlphaRing_->getBinContent(i))).second);
     }
     for (int i = 1; i <= meValidBetaRing_->getNbinsX(); ++i) {
       meEfficiencyBetaRing_->setBinContent(
-          i, (eff(meValidBetaRing_->getBinContent(i),
-                  meMissingBetaRing_->getBinContent(i)))
-                 .first);
+          i, (eff(meValidBetaRing_->getBinContent(i), meMissingBetaRing_->getBinContent(i))).first);
       meEfficiencyBetaRing_->setBinError(
-          i, (eff(meValidBetaRing_->getBinContent(i),
-                  meMissingBetaRing_->getBinContent(i)))
-                 .second);
+          i, (eff(meValidBetaRing_->getBinContent(i), meMissingBetaRing_->getBinContent(i))).second);
     }
   }
 }
 
-std::pair<double, double> SiPixelHitEfficiencyModule::eff(double nValid,
-                                                          double nMissing) {
+std::pair<double, double> SiPixelHitEfficiencyModule::eff(double nValid, double nMissing) {
   double efficiency = 0, error = 0;
   if (nValid + nMissing != 0) {
     efficiency = nValid / (nValid + nMissing);

--- a/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualModule.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualModule.cc
@@ -34,30 +34,24 @@
 using namespace std;
 using namespace edm;
 
-SiPixelTrackResidualModule::SiPixelTrackResidualModule() : id_(0) {
-  bBookTracks = true;
-}
+SiPixelTrackResidualModule::SiPixelTrackResidualModule() : id_(0) { bBookTracks = true; }
 
-SiPixelTrackResidualModule::SiPixelTrackResidualModule(uint32_t id) : id_(id) {
-  bBookTracks = true;
-}
+SiPixelTrackResidualModule::SiPixelTrackResidualModule(uint32_t id) : id_(id) { bBookTracks = true; }
 
 SiPixelTrackResidualModule::~SiPixelTrackResidualModule() {}
 
 void SiPixelTrackResidualModule::book(const edm::ParameterSet &iConfig,
                                       edm::EventSetup const &iSetup,
                                       DQMStore::IBooker &iBooker,
-                                      bool reducedSet, int type,
+                                      bool reducedSet,
+                                      int type,
                                       bool isUpgrade) {
-
   edm::ESHandle<TrackerTopology> tTopoHandle;
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology *pTT = tTopoHandle.product();
 
-  bool barrel =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
-  bool endcap =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
   bool isHalfModule = false;
   if (barrel) {
     isHalfModule = PixelBarrelName(DetId(id_), pTT, isUpgrade).isHalfModule();
@@ -69,63 +63,51 @@ void SiPixelTrackResidualModule::book(const edm::ParameterSet &iConfig,
   if (type == 0) {
     SiPixelHistogramId *theHistogramId = new SiPixelHistogramId(src.label());
     hisID = theHistogramId->setHistoId("residualX", id_);
-    meResidualX_ =
-        iBooker.book1D(hisID, "Hit-to-Track Residual in r-phi", 100, -150, 150);
+    meResidualX_ = iBooker.book1D(hisID, "Hit-to-Track Residual in r-phi", 100, -150, 150);
     meResidualX_->setAxisTitle("hit-to-track residual in r-phi (um)", 1);
     hisID = theHistogramId->setHistoId("residualY", id_);
-    meResidualY_ =
-        iBooker.book1D(hisID, "Hit-to-Track Residual in Z", 100, -300, 300);
+    meResidualY_ = iBooker.book1D(hisID, "Hit-to-Track Residual in Z", 100, -300, 300);
     meResidualY_->setAxisTitle("hit-to-track residual in z (um)", 1);
     // Number of clusters
     hisID = theHistogramId->setHistoId("nclusters_OnTrack", id_);
-    meNClusters_onTrack_ =
-        iBooker.book1D(hisID, "Number of Clusters (on Track)", 10, 0., 10.);
+    meNClusters_onTrack_ = iBooker.book1D(hisID, "Number of Clusters (on Track)", 10, 0., 10.);
     meNClusters_onTrack_->setAxisTitle("Number of Clusters on Track", 1);
     // Total cluster charge in ke
     hisID = theHistogramId->setHistoId("charge_OnTrack", id_);
-    meCharge_onTrack_ = iBooker.book1D(
-        hisID, "Normalized Cluster charge (on Track)", 100, 0., 200.);
+    meCharge_onTrack_ = iBooker.book1D(hisID, "Normalized Cluster charge (on Track)", 100, 0., 200.);
     meCharge_onTrack_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
     hisID = theHistogramId->setHistoId("size_OnTrack", id_);
-    meSize_onTrack_ =
-        iBooker.book1D(hisID, "Total cluster size (on Track)", 30, 0., 30.);
+    meSize_onTrack_ = iBooker.book1D(hisID, "Total cluster size (on Track)", 30, 0., 30.);
     meSize_onTrack_->setAxisTitle("Cluster size [number of pixels]", 1);
     // Number of clusters
     hisID = theHistogramId->setHistoId("nclusters_OffTrack", id_);
-    meNClusters_offTrack_ =
-        iBooker.book1D(hisID, "Number of Clusters (off Track)", 35, 0., 35.);
+    meNClusters_offTrack_ = iBooker.book1D(hisID, "Number of Clusters (off Track)", 35, 0., 35.);
     meNClusters_offTrack_->setAxisTitle("Number of Clusters off Track", 1);
     // Total cluster charge in ke
     hisID = theHistogramId->setHistoId("charge_OffTrack", id_);
-    meCharge_offTrack_ =
-        iBooker.book1D(hisID, "Cluster charge (off Track)", 100, 0., 200.);
+    meCharge_offTrack_ = iBooker.book1D(hisID, "Cluster charge (off Track)", 100, 0., 200.);
     meCharge_offTrack_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
     hisID = theHistogramId->setHistoId("size_OffTrack", id_);
-    meSize_offTrack_ =
-        iBooker.book1D(hisID, "Total cluster size (off Track)", 30, 0., 30.);
+    meSize_offTrack_ = iBooker.book1D(hisID, "Total cluster size (off Track)", 30, 0., 30.);
     meSize_offTrack_->setAxisTitle("Cluster size [number of pixels]", 1);
     if (!reducedSet) {
       // Cluster width on the x-axis
       hisID = theHistogramId->setHistoId("sizeX_OnTrack", id_);
-      meSizeX_onTrack_ = iBooker.book1D(
-          hisID, "Cluster x-width (rows) (on Track)", 10, 0., 10.);
+      meSizeX_onTrack_ = iBooker.book1D(hisID, "Cluster x-width (rows) (on Track)", 10, 0., 10.);
       meSizeX_onTrack_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
       hisID = theHistogramId->setHistoId("sizeY_OnTrack", id_);
-      meSizeY_onTrack_ = iBooker.book1D(
-          hisID, "Cluster y-width (columns) (on Track)", 15, 0., 15.);
+      meSizeY_onTrack_ = iBooker.book1D(hisID, "Cluster y-width (columns) (on Track)", 15, 0., 15.);
       meSizeY_onTrack_->setAxisTitle("Cluster y-size [columns]", 1);
       // Cluster width on the x-axis
       hisID = theHistogramId->setHistoId("sizeX_OffTrack", id_);
-      meSizeX_offTrack_ = iBooker.book1D(
-          hisID, "Cluster x-width (rows) (off Track)", 10, 0., 10.);
+      meSizeX_offTrack_ = iBooker.book1D(hisID, "Cluster x-width (rows) (off Track)", 10, 0., 10.);
       meSizeX_offTrack_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
       hisID = theHistogramId->setHistoId("sizeY_OffTrack", id_);
-      meSizeY_offTrack_ = iBooker.book1D(
-          hisID, "Cluster y-width (columns) (off Track)", 15, 0., 15.);
+      meSizeY_offTrack_ = iBooker.book1D(hisID, "Cluster y-width (columns) (off Track)", 15, 0., 15.);
       meSizeY_offTrack_->setAxisTitle("Cluster y-size [columns]", 1);
     }
     delete theHistogramId;
@@ -141,61 +123,46 @@ void SiPixelTrackResidualModule::book(const edm::ParameterSet &iConfig,
       hisID += "H";
     else
       hisID += "F";
-    meResidualXLad_ = iBooker.book1D(
-        "residualX_" + hisID, "Hit-to-Track Residual in r-phi", 100, -150, 150);
+    meResidualXLad_ = iBooker.book1D("residualX_" + hisID, "Hit-to-Track Residual in r-phi", 100, -150, 150);
     meResidualXLad_->setAxisTitle("hit-to-track residual in r-phi (um)", 1);
-    meResidualYLad_ = iBooker.book1D(
-        "residualY_" + hisID, "Hit-to-Track Residual in Z", 100, -300, 300);
+    meResidualYLad_ = iBooker.book1D("residualY_" + hisID, "Hit-to-Track Residual in Z", 100, -300, 300);
     meResidualYLad_->setAxisTitle("hit-to-track residual in z (um)", 1);
     // Number of clusters
     meNClusters_onTrackLad_ =
-        iBooker.book1D("nclusters_OnTrack_" + hisID,
-                       "Number of Clusters (on Track)", 10, 0., 10.);
+        iBooker.book1D("nclusters_OnTrack_" + hisID, "Number of Clusters (on Track)", 10, 0., 10.);
     meNClusters_onTrackLad_->setAxisTitle("Number of Clusters on Track", 1);
     // Total cluster charge in MeV
     meCharge_onTrackLad_ =
-        iBooker.book1D("charge_OnTrack_" + hisID,
-                       "Normalized Cluster charge (on Track)", 100, 0., 200.);
+        iBooker.book1D("charge_OnTrack_" + hisID, "Normalized Cluster charge (on Track)", 100, 0., 200.);
     meCharge_onTrackLad_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
-    meSize_onTrackLad_ = iBooker.book1D(
-        "size_OnTrack_" + hisID, "Total cluster size (on Track)", 30, 0., 30.);
+    meSize_onTrackLad_ = iBooker.book1D("size_OnTrack_" + hisID, "Total cluster size (on Track)", 30, 0., 30.);
     meSize_onTrackLad_->setAxisTitle("Cluster size [number of pixels]", 1);
     // Number of clusters
     meNClusters_offTrackLad_ =
-        iBooker.book1D("nclusters_OffTrack_" + hisID,
-                       "Number of Clusters (off Track)", 35, 0., 35.);
+        iBooker.book1D("nclusters_OffTrack_" + hisID, "Number of Clusters (off Track)", 35, 0., 35.);
     meNClusters_offTrackLad_->setAxisTitle("Number of Clusters off Track", 1);
     // Total cluster charge in MeV
-    meCharge_offTrackLad_ =
-        iBooker.book1D("charge_OffTrack_" + hisID, "Cluster charge (off Track)",
-                       100, 0., 200.);
+    meCharge_offTrackLad_ = iBooker.book1D("charge_OffTrack_" + hisID, "Cluster charge (off Track)", 100, 0., 200.);
     meCharge_offTrackLad_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
-    meSize_offTrackLad_ =
-        iBooker.book1D("size_OffTrack_" + hisID,
-                       "Total cluster size (off Track)", 30, 0., 30.);
+    meSize_offTrackLad_ = iBooker.book1D("size_OffTrack_" + hisID, "Total cluster size (off Track)", 30, 0., 30.);
     meSize_offTrackLad_->setAxisTitle("Cluster size [number of pixels]", 1);
     if (!reducedSet) {
       // Cluster width on the x-axis
       meSizeX_offTrackLad_ =
-          iBooker.book1D("sizeX_OffTrack_" + hisID,
-                         "Cluster x-width (rows) (off Track)", 10, 0., 10.);
+          iBooker.book1D("sizeX_OffTrack_" + hisID, "Cluster x-width (rows) (off Track)", 10, 0., 10.);
       meSizeX_offTrackLad_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
       meSizeY_offTrackLad_ =
-          iBooker.book1D("sizeY_OffTrack_" + hisID,
-                         "Cluster y-width (columns) (off Track)", 15, 0., 15.);
+          iBooker.book1D("sizeY_OffTrack_" + hisID, "Cluster y-width (columns) (off Track)", 15, 0., 15.);
       meSizeY_offTrackLad_->setAxisTitle("Cluster y-size [columns]", 1);
       // Cluster width on the x-axis
-      meSizeX_onTrackLad_ =
-          iBooker.book1D("sizeX_OnTrack_" + hisID,
-                         "Cluster x-width (rows) (on Track)", 10, 0., 10.);
+      meSizeX_onTrackLad_ = iBooker.book1D("sizeX_OnTrack_" + hisID, "Cluster x-width (rows) (on Track)", 10, 0., 10.);
       meSizeX_onTrackLad_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
       meSizeY_onTrackLad_ =
-          iBooker.book1D("sizeY_OnTrack_" + hisID,
-                         "Cluster y-width (columns) (on Track)", 15, 0., 15.);
+          iBooker.book1D("sizeY_OnTrack_" + hisID, "Cluster y-width (columns) (on Track)", 15, 0., 15.);
       meSizeY_onTrackLad_->setAxisTitle("Cluster y-size [columns]", 1);
     }
   }
@@ -206,61 +173,46 @@ void SiPixelTrackResidualModule::book(const edm::ParameterSet &iConfig,
     char slayer[80];
     sprintf(slayer, "Layer_%i", DBlayer);
     hisID = src.label() + "_" + slayer;
-    meResidualXLay_ = iBooker.book1D(
-        "residualX_" + hisID, "Hit-to-Track Residual in r-phi", 100, -150, 150);
+    meResidualXLay_ = iBooker.book1D("residualX_" + hisID, "Hit-to-Track Residual in r-phi", 100, -150, 150);
     meResidualXLay_->setAxisTitle("hit-to-track residual in r-phi (um)", 1);
-    meResidualYLay_ = iBooker.book1D(
-        "residualY_" + hisID, "Hit-to-Track Residual in Z", 100, -300, 300);
+    meResidualYLay_ = iBooker.book1D("residualY_" + hisID, "Hit-to-Track Residual in Z", 100, -300, 300);
     meResidualYLay_->setAxisTitle("hit-to-track residual in z (um)", 1);
     // Number of clusters
     meNClusters_onTrackLay_ =
-        iBooker.book1D("nclusters_OnTrack_" + hisID,
-                       "Number of Clusters (on Track)", 10, 0., 10.);
+        iBooker.book1D("nclusters_OnTrack_" + hisID, "Number of Clusters (on Track)", 10, 0., 10.);
     meNClusters_onTrackLay_->setAxisTitle("Number of Clusters on Track", 1);
     // Total cluster charge in MeV
     meCharge_onTrackLay_ =
-        iBooker.book1D("charge_OnTrack_" + hisID,
-                       "Normalized Cluster charge (on Track)", 100, 0., 200.);
+        iBooker.book1D("charge_OnTrack_" + hisID, "Normalized Cluster charge (on Track)", 100, 0., 200.);
     meCharge_onTrackLay_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
-    meSize_onTrackLay_ = iBooker.book1D(
-        "size_OnTrack_" + hisID, "Total cluster size (on Track)", 30, 0., 30.);
+    meSize_onTrackLay_ = iBooker.book1D("size_OnTrack_" + hisID, "Total cluster size (on Track)", 30, 0., 30.);
     meSize_onTrackLay_->setAxisTitle("Cluster size [number of pixels]", 1);
     // Number of clusters
     meNClusters_offTrackLay_ =
-        iBooker.book1D("nclusters_OffTrack_" + hisID,
-                       "Number of Clusters (off Track)", 35, 0., 35.);
+        iBooker.book1D("nclusters_OffTrack_" + hisID, "Number of Clusters (off Track)", 35, 0., 35.);
     meNClusters_offTrackLay_->setAxisTitle("Number of Clusters off Track", 1);
     // Total cluster charge in MeV
-    meCharge_offTrackLay_ =
-        iBooker.book1D("charge_OffTrack_" + hisID, "Cluster charge (off Track)",
-                       100, 0., 200.);
+    meCharge_offTrackLay_ = iBooker.book1D("charge_OffTrack_" + hisID, "Cluster charge (off Track)", 100, 0., 200.);
     meCharge_offTrackLay_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
-    meSize_offTrackLay_ =
-        iBooker.book1D("size_OffTrack_" + hisID,
-                       "Total cluster size (off Track)", 30, 0., 30.);
+    meSize_offTrackLay_ = iBooker.book1D("size_OffTrack_" + hisID, "Total cluster size (off Track)", 30, 0., 30.);
     meSize_offTrackLay_->setAxisTitle("Cluster size [number of pixels]", 1);
     if (!reducedSet) {
       // Cluster width on the x-axis
-      meSizeX_onTrackLay_ =
-          iBooker.book1D("sizeX_OnTrack_" + hisID,
-                         "Cluster x-width (rows) (on Track)", 10, 0., 10.);
+      meSizeX_onTrackLay_ = iBooker.book1D("sizeX_OnTrack_" + hisID, "Cluster x-width (rows) (on Track)", 10, 0., 10.);
       meSizeX_onTrackLay_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
       meSizeY_onTrackLay_ =
-          iBooker.book1D("sizeY_OnTrack_" + hisID,
-                         "Cluster y-width (columns) (on Track)", 15, 0., 15.);
+          iBooker.book1D("sizeY_OnTrack_" + hisID, "Cluster y-width (columns) (on Track)", 15, 0., 15.);
       meSizeY_onTrackLay_->setAxisTitle("Cluster y-size [columns]", 1);
       // Cluster width on the x-axis
       meSizeX_offTrackLay_ =
-          iBooker.book1D("sizeX_OffTrack_" + hisID,
-                         "Cluster x-width (rows) (off Track)", 10, 0., 10.);
+          iBooker.book1D("sizeX_OffTrack_" + hisID, "Cluster x-width (rows) (off Track)", 10, 0., 10.);
       meSizeX_offTrackLay_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
       meSizeY_offTrackLay_ =
-          iBooker.book1D("sizeY_OffTrack_" + hisID,
-                         "Cluster y-width (columns) (off Track)", 15, 0., 15.);
+          iBooker.book1D("sizeY_OffTrack_" + hisID, "Cluster y-width (columns) (off Track)", 15, 0., 15.);
       meSizeY_offTrackLay_->setAxisTitle("Cluster y-size [columns]", 1);
     }
   }
@@ -271,61 +223,46 @@ void SiPixelTrackResidualModule::book(const edm::ParameterSet &iConfig,
     char smodule[80];
     sprintf(smodule, "Ring_%i", DBmodule);
     hisID = src.label() + "_" + smodule;
-    meResidualXPhi_ = iBooker.book1D(
-        "residualX_" + hisID, "Hit-to-Track Residual in r-phi", 100, -150, 150);
+    meResidualXPhi_ = iBooker.book1D("residualX_" + hisID, "Hit-to-Track Residual in r-phi", 100, -150, 150);
     meResidualXPhi_->setAxisTitle("hit-to-track residual in r-phi (um)", 1);
-    meResidualYPhi_ = iBooker.book1D(
-        "residualY_" + hisID, "Hit-to-Track Residual in Z", 100, -300, 300);
+    meResidualYPhi_ = iBooker.book1D("residualY_" + hisID, "Hit-to-Track Residual in Z", 100, -300, 300);
     meResidualYPhi_->setAxisTitle("hit-to-track residual in z (um)", 1);
     // Number of clusters
     meNClusters_onTrackPhi_ =
-        iBooker.book1D("nclusters_OnTrack_" + hisID,
-                       "Number of Clusters (on Track)", 10, 0., 10.);
+        iBooker.book1D("nclusters_OnTrack_" + hisID, "Number of Clusters (on Track)", 10, 0., 10.);
     meNClusters_onTrackPhi_->setAxisTitle("Number of Clusters on Track", 1);
     // Total cluster charge in MeV
     meCharge_onTrackPhi_ =
-        iBooker.book1D("charge_OnTrack_" + hisID,
-                       "Normalized Cluster charge (on Track)", 100, 0., 200.);
+        iBooker.book1D("charge_OnTrack_" + hisID, "Normalized Cluster charge (on Track)", 100, 0., 200.);
     meCharge_onTrackPhi_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
-    meSize_onTrackPhi_ = iBooker.book1D(
-        "size_OnTrack_" + hisID, "Total cluster size (on Track)", 30, 0., 30.);
+    meSize_onTrackPhi_ = iBooker.book1D("size_OnTrack_" + hisID, "Total cluster size (on Track)", 30, 0., 30.);
     meSize_onTrackPhi_->setAxisTitle("Cluster size [number of pixels]", 1);
     // Number of clusters
     meNClusters_offTrackPhi_ =
-        iBooker.book1D("nclusters_OffTrack_" + hisID,
-                       "Number of Clusters (off Track)", 35, 0., 35.);
+        iBooker.book1D("nclusters_OffTrack_" + hisID, "Number of Clusters (off Track)", 35, 0., 35.);
     meNClusters_offTrackPhi_->setAxisTitle("Number of Clusters off Track", 1);
     // Total cluster charge in MeV
-    meCharge_offTrackPhi_ =
-        iBooker.book1D("charge_OffTrack_" + hisID, "Cluster charge (off Track)",
-                       100, 0., 200.);
+    meCharge_offTrackPhi_ = iBooker.book1D("charge_OffTrack_" + hisID, "Cluster charge (off Track)", 100, 0., 200.);
     meCharge_offTrackPhi_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
-    meSize_offTrackPhi_ =
-        iBooker.book1D("size_OffTrack_" + hisID,
-                       "Total cluster size (off Track)", 30, 0., 30.);
+    meSize_offTrackPhi_ = iBooker.book1D("size_OffTrack_" + hisID, "Total cluster size (off Track)", 30, 0., 30.);
     meSize_offTrackPhi_->setAxisTitle("Cluster size [number of pixels]", 1);
     if (!reducedSet) {
       // Cluster width on the x-axis
-      meSizeX_onTrackPhi_ =
-          iBooker.book1D("sizeX_OnTrack_" + hisID,
-                         "Cluster x-width (rows) (on Track)", 10, 0., 10.);
+      meSizeX_onTrackPhi_ = iBooker.book1D("sizeX_OnTrack_" + hisID, "Cluster x-width (rows) (on Track)", 10, 0., 10.);
       meSizeX_onTrackPhi_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
       meSizeY_onTrackPhi_ =
-          iBooker.book1D("sizeY_OnTrack_" + hisID,
-                         "Cluster y-width (columns) (on Track)", 15, 0., 15.);
+          iBooker.book1D("sizeY_OnTrack_" + hisID, "Cluster y-width (columns) (on Track)", 15, 0., 15.);
       meSizeY_onTrackPhi_->setAxisTitle("Cluster y-size [columns]", 1);
       // Cluster width on the x-axis
       meSizeX_offTrackPhi_ =
-          iBooker.book1D("sizeX_OffTrack_" + hisID,
-                         "Cluster x-width (rows) (off Track)", 10, 0., 10.);
+          iBooker.book1D("sizeX_OffTrack_" + hisID, "Cluster x-width (rows) (off Track)", 10, 0., 10.);
       meSizeX_offTrackPhi_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
       meSizeY_offTrackPhi_ =
-          iBooker.book1D("sizeY_OffTrack_" + hisID,
-                         "Cluster y-width (columns) (off Track)", 15, 0., 15.);
+          iBooker.book1D("sizeY_OffTrack_" + hisID, "Cluster y-width (columns) (off Track)", 15, 0., 15.);
       meSizeY_offTrackPhi_->setAxisTitle("Cluster y-size [columns]", 1);
     }
   }
@@ -336,61 +273,47 @@ void SiPixelTrackResidualModule::book(const edm::ParameterSet &iConfig,
     char sblade[80];
     sprintf(sblade, "Blade_%02i", blade);
     hisID = src.label() + "_" + sblade;
-    meResidualXBlade_ = iBooker.book1D(
-        "residualX_" + hisID, "Hit-to-Track Residual in r-phi", 100, -150, 150);
+    meResidualXBlade_ = iBooker.book1D("residualX_" + hisID, "Hit-to-Track Residual in r-phi", 100, -150, 150);
     meResidualXBlade_->setAxisTitle("hit-to-track residual in r-phi (um)", 1);
-    meResidualYBlade_ = iBooker.book1D(
-        "residualY_" + hisID, "Hit-to-Track Residual in Z", 100, -300, 300);
+    meResidualYBlade_ = iBooker.book1D("residualY_" + hisID, "Hit-to-Track Residual in Z", 100, -300, 300);
     meResidualYBlade_->setAxisTitle("hit-to-track residual in z (um)", 1);
     // Number of clusters
     meNClusters_onTrackBlade_ =
-        iBooker.book1D("nclusters_OnTrack_" + hisID,
-                       "Number of Clusters (on Track)", 10, 0., 10.);
+        iBooker.book1D("nclusters_OnTrack_" + hisID, "Number of Clusters (on Track)", 10, 0., 10.);
     meNClusters_onTrackBlade_->setAxisTitle("Number of Clusters on Track", 1);
     // Total cluster charge in MeV
     meCharge_onTrackBlade_ =
-        iBooker.book1D("charge_OnTrack_" + hisID,
-                       "Normalized Cluster charge (on Track)", 100, 0., 200.);
+        iBooker.book1D("charge_OnTrack_" + hisID, "Normalized Cluster charge (on Track)", 100, 0., 200.);
     meCharge_onTrackBlade_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
-    meSize_onTrackBlade_ = iBooker.book1D(
-        "size_OnTrack_" + hisID, "Total cluster size (on Track)", 30, 0., 30.);
+    meSize_onTrackBlade_ = iBooker.book1D("size_OnTrack_" + hisID, "Total cluster size (on Track)", 30, 0., 30.);
     meSize_onTrackBlade_->setAxisTitle("Cluster size [number of pixels]", 1);
     // Number of clusters
     meNClusters_offTrackBlade_ =
-        iBooker.book1D("nclusters_OffTrack_" + hisID,
-                       "Number of Clusters (off Track)", 35, 0., 35.);
+        iBooker.book1D("nclusters_OffTrack_" + hisID, "Number of Clusters (off Track)", 35, 0., 35.);
     meNClusters_offTrackBlade_->setAxisTitle("Number of Clusters off Track", 1);
     // Total cluster charge in MeV
-    meCharge_offTrackBlade_ =
-        iBooker.book1D("charge_OffTrack_" + hisID, "Cluster charge (off Track)",
-                       100, 0., 200.);
+    meCharge_offTrackBlade_ = iBooker.book1D("charge_OffTrack_" + hisID, "Cluster charge (off Track)", 100, 0., 200.);
     meCharge_offTrackBlade_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
-    meSize_offTrackBlade_ =
-        iBooker.book1D("size_OffTrack_" + hisID,
-                       "Total cluster size (off Track)", 30, 0., 30.);
+    meSize_offTrackBlade_ = iBooker.book1D("size_OffTrack_" + hisID, "Total cluster size (off Track)", 30, 0., 30.);
     meSize_offTrackBlade_->setAxisTitle("Cluster size [number of pixels]", 1);
     if (!reducedSet) {
       // Cluster width on the x-axis
       meSizeX_onTrackBlade_ =
-          iBooker.book1D("sizeX_OnTrack_" + hisID,
-                         "Cluster x-width (rows) (on Track)", 10, 0., 10.);
+          iBooker.book1D("sizeX_OnTrack_" + hisID, "Cluster x-width (rows) (on Track)", 10, 0., 10.);
       meSizeX_onTrackBlade_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
       meSizeY_onTrackBlade_ =
-          iBooker.book1D("sizeY_OnTrack_" + hisID,
-                         "Cluster y-width (columns) (on Track)", 15, 0., 15.);
+          iBooker.book1D("sizeY_OnTrack_" + hisID, "Cluster y-width (columns) (on Track)", 15, 0., 15.);
       meSizeY_onTrackBlade_->setAxisTitle("Cluster y-size [columns]", 1);
       // Cluster width on the x-axis
       meSizeX_offTrackBlade_ =
-          iBooker.book1D("sizeX_OffTrack_" + hisID,
-                         "Cluster x-width (rows) (off Track)", 10, 0., 10.);
+          iBooker.book1D("sizeX_OffTrack_" + hisID, "Cluster x-width (rows) (off Track)", 10, 0., 10.);
       meSizeX_offTrackBlade_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
       meSizeY_offTrackBlade_ =
-          iBooker.book1D("sizeY_OffTrack_" + hisID,
-                         "Cluster y-width (columns) (off Track)", 15, 0., 15.);
+          iBooker.book1D("sizeY_OffTrack_" + hisID, "Cluster y-width (columns) (off Track)", 15, 0., 15.);
       meSizeY_offTrackBlade_->setAxisTitle("Cluster y-size [columns]", 1);
     }
   }
@@ -402,61 +325,46 @@ void SiPixelTrackResidualModule::book(const edm::ParameterSet &iConfig,
     char sdisk[80];
     sprintf(sdisk, "Disk_%i", disk);
     hisID = src.label() + "_" + sdisk;
-    meResidualXDisk_ = iBooker.book1D(
-        "residualX_" + hisID, "Hit-to-Track Residual in r-phi", 100, -150, 150);
+    meResidualXDisk_ = iBooker.book1D("residualX_" + hisID, "Hit-to-Track Residual in r-phi", 100, -150, 150);
     meResidualXDisk_->setAxisTitle("hit-to-track residual in r-phi (um)", 1);
-    meResidualYDisk_ = iBooker.book1D(
-        "residualY_" + hisID, "Hit-to-Track Residual in Z", 100, -300, 300);
+    meResidualYDisk_ = iBooker.book1D("residualY_" + hisID, "Hit-to-Track Residual in Z", 100, -300, 300);
     meResidualYDisk_->setAxisTitle("hit-to-track residual in z (um)", 1);
     // Number of clusters
     meNClusters_onTrackDisk_ =
-        iBooker.book1D("nclusters_OnTrack_" + hisID,
-                       "Number of Clusters (on Track)", 10, 0., 10.);
+        iBooker.book1D("nclusters_OnTrack_" + hisID, "Number of Clusters (on Track)", 10, 0., 10.);
     meNClusters_onTrackDisk_->setAxisTitle("Number of Clusters on Track", 1);
     // Total cluster charge in MeV
     meCharge_onTrackDisk_ =
-        iBooker.book1D("charge_OnTrack_" + hisID,
-                       "Normalized Cluster charge (on Track)", 100, 0., 200.);
+        iBooker.book1D("charge_OnTrack_" + hisID, "Normalized Cluster charge (on Track)", 100, 0., 200.);
     meCharge_onTrackDisk_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
-    meSize_onTrackDisk_ = iBooker.book1D(
-        "size_OnTrack_" + hisID, "Total cluster size (on Track)", 30, 0., 30.);
+    meSize_onTrackDisk_ = iBooker.book1D("size_OnTrack_" + hisID, "Total cluster size (on Track)", 30, 0., 30.);
     meSize_onTrackDisk_->setAxisTitle("Cluster size [number of pixels]", 1);
     // Number of clusters
     meNClusters_offTrackDisk_ =
-        iBooker.book1D("nclusters_OffTrack_" + hisID,
-                       "Number of Clusters (off Track)", 35, 0., 35.);
+        iBooker.book1D("nclusters_OffTrack_" + hisID, "Number of Clusters (off Track)", 35, 0., 35.);
     meNClusters_offTrackDisk_->setAxisTitle("Number of Clusters off Track", 1);
     // Total cluster charge in MeV
-    meCharge_offTrackDisk_ =
-        iBooker.book1D("charge_OffTrack_" + hisID, "Cluster charge (off Track)",
-                       100, 0., 200.);
+    meCharge_offTrackDisk_ = iBooker.book1D("charge_OffTrack_" + hisID, "Cluster charge (off Track)", 100, 0., 200.);
     meCharge_offTrackDisk_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
-    meSize_offTrackDisk_ =
-        iBooker.book1D("size_OffTrack_" + hisID,
-                       "Total cluster size (off Track)", 30, 0., 30.);
+    meSize_offTrackDisk_ = iBooker.book1D("size_OffTrack_" + hisID, "Total cluster size (off Track)", 30, 0., 30.);
     meSize_offTrackDisk_->setAxisTitle("Cluster size [number of pixels]", 1);
     if (!reducedSet) {
       // Cluster width on the x-axis
-      meSizeX_onTrackDisk_ =
-          iBooker.book1D("sizeX_OnTrack_" + hisID,
-                         "Cluster x-width (rows) (on Track)", 10, 0., 10.);
+      meSizeX_onTrackDisk_ = iBooker.book1D("sizeX_OnTrack_" + hisID, "Cluster x-width (rows) (on Track)", 10, 0., 10.);
       meSizeX_onTrackDisk_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
       meSizeY_onTrackDisk_ =
-          iBooker.book1D("sizeY_OnTrack_" + hisID,
-                         "Cluster y-width (columns) (on Track)", 15, 0., 15.);
+          iBooker.book1D("sizeY_OnTrack_" + hisID, "Cluster y-width (columns) (on Track)", 15, 0., 15.);
       meSizeY_onTrackDisk_->setAxisTitle("Cluster y-size [columns]", 1);
       // Cluster width on the x-axis
       meSizeX_offTrackDisk_ =
-          iBooker.book1D("sizeX_OffTrack_" + hisID,
-                         "Cluster x-width (rows) (off Track)", 10, 0., 10.);
+          iBooker.book1D("sizeX_OffTrack_" + hisID, "Cluster x-width (rows) (off Track)", 10, 0., 10.);
       meSizeX_offTrackDisk_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
       meSizeY_offTrackDisk_ =
-          iBooker.book1D("sizeY_OffTrack_" + hisID,
-                         "Cluster y-width (columns) (off Track)", 15, 0., 15.);
+          iBooker.book1D("sizeY_OffTrack_" + hisID, "Cluster y-width (columns) (off Track)", 15, 0., 15.);
       meSizeY_offTrackDisk_->setAxisTitle("Cluster y-size [columns]", 1);
     }
   }
@@ -470,75 +378,62 @@ void SiPixelTrackResidualModule::book(const edm::ParameterSet &iConfig,
     char slab[80];
     sprintf(slab, "Panel_%i_Ring_%i", panel, module);
     hisID = src.label() + "_" + slab;
-    meResidualXRing_ = iBooker.book1D(
-        "residualX_" + hisID, "Hit-to-Track Residual in r-phi", 100, -150, 150);
+    meResidualXRing_ = iBooker.book1D("residualX_" + hisID, "Hit-to-Track Residual in r-phi", 100, -150, 150);
     meResidualXRing_->setAxisTitle("hit-to-track residual in r-phi (um)", 1);
-    meResidualYRing_ = iBooker.book1D(
-        "residualY_" + hisID, "Hit-to-Track Residual in Z", 100, -300, 300);
+    meResidualYRing_ = iBooker.book1D("residualY_" + hisID, "Hit-to-Track Residual in Z", 100, -300, 300);
     meResidualYRing_->setAxisTitle("hit-to-track residual in z (um)", 1);
     // Number of clusters
     meNClusters_onTrackRing_ =
-        iBooker.book1D("nclusters_OnTrack_" + hisID,
-                       "Number of Clusters (on Track)", 10, 0., 10.);
+        iBooker.book1D("nclusters_OnTrack_" + hisID, "Number of Clusters (on Track)", 10, 0., 10.);
     meNClusters_onTrackRing_->setAxisTitle("Number of Clusters on Track", 1);
     // Total cluster charge in MeV
     meCharge_onTrackRing_ =
-        iBooker.book1D("charge_OnTrack_" + hisID,
-                       "Normalized Cluster charge (on Track)", 100, 0., 200.);
+        iBooker.book1D("charge_OnTrack_" + hisID, "Normalized Cluster charge (on Track)", 100, 0., 200.);
     meCharge_onTrackRing_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
-    meSize_onTrackRing_ = iBooker.book1D(
-        "size_OnTrack_" + hisID, "Total cluster size (on Track)", 30, 0., 30.);
+    meSize_onTrackRing_ = iBooker.book1D("size_OnTrack_" + hisID, "Total cluster size (on Track)", 30, 0., 30.);
     meSize_onTrackRing_->setAxisTitle("Cluster size [number of pixels]", 1);
     // Number of clusters
     meNClusters_offTrackRing_ =
-        iBooker.book1D("nclusters_OffTrack_" + hisID,
-                       "Number of Clusters (off Track)", 35, 0., 35.);
+        iBooker.book1D("nclusters_OffTrack_" + hisID, "Number of Clusters (off Track)", 35, 0., 35.);
     meNClusters_offTrackRing_->setAxisTitle("Number of Clusters off Track", 1);
     // Total cluster charge in MeV
-    meCharge_offTrackRing_ =
-        iBooker.book1D("charge_OffTrack_" + hisID, "Cluster charge (off Track)",
-                       100, 0., 200.);
+    meCharge_offTrackRing_ = iBooker.book1D("charge_OffTrack_" + hisID, "Cluster charge (off Track)", 100, 0., 200.);
     meCharge_offTrackRing_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
-    meSize_offTrackRing_ =
-        iBooker.book1D("size_OffTrack_" + hisID,
-                       "Total cluster size (off Track)", 30, 0., 30.);
+    meSize_offTrackRing_ = iBooker.book1D("size_OffTrack_" + hisID, "Total cluster size (off Track)", 30, 0., 30.);
     meSize_offTrackRing_->setAxisTitle("Cluster size [number of pixels]", 1);
     if (!reducedSet) {
       // Cluster width on the x-axis
-      meSizeX_onTrackRing_ =
-          iBooker.book1D("sizeX_OnTrack_" + hisID,
-                         "Cluster x-width (rows) (on Track)", 10, 0., 10.);
+      meSizeX_onTrackRing_ = iBooker.book1D("sizeX_OnTrack_" + hisID, "Cluster x-width (rows) (on Track)", 10, 0., 10.);
       meSizeX_onTrackRing_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
       meSizeY_onTrackRing_ =
-          iBooker.book1D("sizeY_OnTrack_" + hisID,
-                         "Cluster y-width (columns) (on Track)", 15, 0., 15.);
+          iBooker.book1D("sizeY_OnTrack_" + hisID, "Cluster y-width (columns) (on Track)", 15, 0., 15.);
       meSizeY_onTrackRing_->setAxisTitle("Cluster y-size [columns]", 1);
       // Cluster width on the x-axis
       meSizeX_offTrackRing_ =
-          iBooker.book1D("sizeX_OffTrack_" + hisID,
-                         "Cluster x-width (rows) (off Track)", 10, 0., 10.);
+          iBooker.book1D("sizeX_OffTrack_" + hisID, "Cluster x-width (rows) (off Track)", 10, 0., 10.);
       meSizeX_offTrackRing_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
       meSizeY_offTrackRing_ =
-          iBooker.book1D("sizeY_OffTrack_" + hisID,
-                         "Cluster y-width (columns) (off Track)", 15, 0., 15.);
+          iBooker.book1D("sizeY_OffTrack_" + hisID, "Cluster y-width (columns) (off Track)", 15, 0., 15.);
       meSizeY_offTrackRing_->setAxisTitle("Cluster y-size [columns]", 1);
     }
   }
 }
 
 void SiPixelTrackResidualModule::fill(const Measurement2DVector &residual,
-                                      bool reducedSet, bool modon, bool ladon,
-                                      bool layon, bool phion, bool bladeon,
-                                      bool diskon, bool ringon) {
-
-  bool barrel =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
-  bool endcap =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+                                      bool reducedSet,
+                                      bool modon,
+                                      bool ladon,
+                                      bool layon,
+                                      bool phion,
+                                      bool bladeon,
+                                      bool diskon,
+                                      bool ringon) {
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
 
   if (modon) {
     (meResidualX_)->Fill(residual.x());
@@ -575,23 +470,26 @@ void SiPixelTrackResidualModule::fill(const Measurement2DVector &residual,
   }
 }
 
-void SiPixelTrackResidualModule::fill(const SiPixelCluster &clust, bool onTrack,
-                                      double corrCharge, bool reducedSet,
-                                      bool modon, bool ladon, bool layon,
-                                      bool phion, bool bladeon, bool diskon,
+void SiPixelTrackResidualModule::fill(const SiPixelCluster &clust,
+                                      bool onTrack,
+                                      double corrCharge,
+                                      bool reducedSet,
+                                      bool modon,
+                                      bool ladon,
+                                      bool layon,
+                                      bool phion,
+                                      bool bladeon,
+                                      bool diskon,
                                       bool ringon) {
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
 
-  bool barrel =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
-  bool endcap =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
-
-  float charge = 0.001 * (clust.charge()); // total charge of cluster
+  float charge = 0.001 * (clust.charge());  // total charge of cluster
   if (onTrack)
-    charge = corrCharge;     // corrected cluster charge
-  int size = clust.size();   // total size of cluster (in pixels)
-  int sizeX = clust.sizeX(); // size of cluster in x-clustrection
-  int sizeY = clust.sizeY(); // size of cluster in y-direction
+    charge = corrCharge;      // corrected cluster charge
+  int size = clust.size();    // total size of cluster (in pixels)
+  int sizeX = clust.sizeX();  // size of cluster in x-clustrection
+  int sizeY = clust.sizeY();  // size of cluster in y-direction
 
   if (onTrack) {
     if (modon) {
@@ -712,15 +610,18 @@ void SiPixelTrackResidualModule::fill(const SiPixelCluster &clust, bool onTrack,
   }
 }
 
-void SiPixelTrackResidualModule::nfill(int onTrack, int offTrack,
-                                       bool reducedSet, bool modon, bool ladon,
-                                       bool layon, bool phion, bool bladeon,
-                                       bool diskon, bool ringon) {
-
-  bool barrel =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
-  bool endcap =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+void SiPixelTrackResidualModule::nfill(int onTrack,
+                                       int offTrack,
+                                       bool reducedSet,
+                                       bool modon,
+                                       bool ladon,
+                                       bool layon,
+                                       bool phion,
+                                       bool bladeon,
+                                       bool diskon,
+                                       bool ringon) {
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
   bool fillOn = false;
   if (onTrack > 0)
     fillOn = true;

--- a/DQM/SiStripMonitorPedestals/interface/SiStripMonitorPedestals.h
+++ b/DQM/SiStripMonitorPedestals/interface/SiStripMonitorPedestals.h
@@ -60,8 +60,7 @@ public:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void endRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
   void endJob() override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:
   edm::EDGetTokenT<edm::DetSetVector<SiStripRawDigi>> digiToken_;

--- a/DQM/SiStripMonitorPedestals/interface/SiStripMonitorQuality.h
+++ b/DQM/SiStripMonitorPedestals/interface/SiStripMonitorQuality.h
@@ -49,8 +49,7 @@ public:
   explicit SiStripMonitorQuality(const edm::ParameterSet &);
   ~SiStripMonitorQuality() override;
 
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void endRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
   void endJob() override;

--- a/DQM/SiStripMonitorPedestals/interface/SiStripMonitorRawData.h
+++ b/DQM/SiStripMonitorPedestals/interface/SiStripMonitorRawData.h
@@ -51,8 +51,7 @@ public:
   explicit SiStripMonitorRawData(const edm::ParameterSet &);
   ~SiStripMonitorRawData() override;
 
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void endRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
   void endJob() override;

--- a/DQM/SiStripMonitorPedestals/src/SiStripMonitorPedestals.cc
+++ b/DQM/SiStripMonitorPedestals/src/SiStripMonitorPedestals.cc
@@ -51,24 +51,27 @@ const std::string SiStripMonitorPedestals::RunMode1 = "ConDBPlotsOnly";
 const std::string SiStripMonitorPedestals::RunMode2 = "CalculatedPlotsOnly";
 const std::string SiStripMonitorPedestals::RunMode3 = "AllPlots";
 
-SiStripMonitorPedestals::SiStripMonitorPedestals(
-    edm::ParameterSet const &iConfig)
-    : dqmStore_(edm::Service<DQMStore>().operator->()), conf_(iConfig),
+SiStripMonitorPedestals::SiStripMonitorPedestals(edm::ParameterSet const &iConfig)
+    : dqmStore_(edm::Service<DQMStore>().operator->()),
+      conf_(iConfig),
       pedsPSet_(iConfig.getParameter<edm::ParameterSet>("PedestalsPSet")),
-      analyzed(false), firstEvent(true), signalCutPeds_(4), nEvTot_(0),
-      nIteration_(0), apvFactory_(nullptr), m_cacheID_(0) {
+      analyzed(false),
+      firstEvent(true),
+      signalCutPeds_(4),
+      nEvTot_(0),
+      nIteration_(0),
+      apvFactory_(nullptr),
+      m_cacheID_(0) {
   // retrieve producer name of input StripDigiCollection
   std::string digiProducer = conf_.getParameter<std::string>("DigiProducer");
   std::string digiType = "VirginRaw";
-  digiToken_ = consumes<edm::DetSetVector<SiStripRawDigi>>(
-      edm::InputTag(digiProducer, digiType));
+  digiToken_ = consumes<edm::DetSetVector<SiStripRawDigi>>(edm::InputTag(digiProducer, digiType));
 
   edm::LogInfo("SiStripMonitorPedestals") << "SiStripMonitorPedestals  "
                                           << " Constructing....... ";
 
   theEventInitNumber_ = pedsPSet_.getParameter<int>("NumberOfEventsForInit");
-  theEventIterNumber_ =
-      pedsPSet_.getParameter<int>("NumberOfEventsForIteration");
+  theEventIterNumber_ = pedsPSet_.getParameter<int>("NumberOfEventsForIteration");
   NumCMstripsInGroup_ = pedsPSet_.getParameter<int>("NumCMstripsInGroup");
   runTypeFlag_ = conf_.getParameter<std::string>("RunTypeFlag");
 }
@@ -89,15 +92,12 @@ SiStripMonitorPedestals::~SiStripMonitorPedestals() {
 void SiStripMonitorPedestals::bookHistograms(DQMStore::IBooker &ibooker,
                                              const edm::Run &run,
                                              const edm::EventSetup &eSetup) {
-
-  unsigned long long cacheID =
-      eSetup.get<SiStripDetCablingRcd>().cacheIdentifier();
+  unsigned long long cacheID = eSetup.get<SiStripDetCablingRcd>().cacheIdentifier();
   if (m_cacheID_ != cacheID) {
     m_cacheID_ = cacheID;
     eSetup.get<SiStripDetCablingRcd>().get(detcabling);
-    edm::LogInfo("SiStripMonitorPedestals")
-        << "SiStripMonitorPedestals::bookHistograms: "
-        << " Creating MEs for new Cabling ";
+    edm::LogInfo("SiStripMonitorPedestals") << "SiStripMonitorPedestals::bookHistograms: "
+                                            << " Creating MEs for new Cabling ";
     createMEs(ibooker, eSetup);
   }
 
@@ -108,9 +108,7 @@ void SiStripMonitorPedestals::bookHistograms(DQMStore::IBooker &ibooker,
 //
 // -- Create Monitor Elements
 //
-void SiStripMonitorPedestals::createMEs(DQMStore::IBooker &ibooker,
-                                        const edm::EventSetup &es) {
-
+void SiStripMonitorPedestals::createMEs(DQMStore::IBooker &ibooker, const edm::EventSetup &es) {
   // Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   es.get<TrackerTopologyRcd>().get(tTopoHandle);
@@ -131,21 +129,18 @@ void SiStripMonitorPedestals::createMEs(DQMStore::IBooker &ibooker,
   // create SiStripFolderOrganizer
   SiStripFolderOrganizer folder_organizer;
 
-  edm::LogInfo("SiStripMonitorPedestals")
-      << "SiStripMonitorPedestals::createMEs: "
-      << "Number of Detector Present in cabling " << SelectedDetIds.size();
+  edm::LogInfo("SiStripMonitorPedestals") << "SiStripMonitorPedestals::createMEs: "
+                                          << "Number of Detector Present in cabling " << SelectedDetIds.size();
 
-  for (std::vector<uint32_t>::const_iterator idetid = SelectedDetIds.begin(),
-                                             iEnd = SelectedDetIds.end();
-       idetid != iEnd; ++idetid) {
-
+  for (std::vector<uint32_t>::const_iterator idetid = SelectedDetIds.begin(), iEnd = SelectedDetIds.end();
+       idetid != iEnd;
+       ++idetid) {
     uint32_t detid = *idetid;
 
     // Check consistency in DetId
     if (detid == 0 || detid == 0xFFFFFFFF) {
-      edm::LogError("SiStripMonitorPedestals")
-          << "SiStripMonitorPedestals::createMEs: "
-          << "Wrong DetId !!!!!! " << detid << " Neglecting !!!!!! ";
+      edm::LogError("SiStripMonitorPedestals") << "SiStripMonitorPedestals::createMEs: "
+                                               << "Wrong DetId !!!!!! " << detid << " Neglecting !!!!!! ";
       continue;
     }
 
@@ -153,9 +148,8 @@ void SiStripMonitorPedestals::createMEs(DQMStore::IBooker &ibooker,
 
     // Check consistency in Apv numbers
     if (apv_pairs < 1 || apv_pairs > 3) {
-      edm::LogError("SiStripMonitorPedestals")
-          << "SiStripMonitorPedestals::createMEs: Wrong APV Pairs  => detId "
-          << detid << " APV pairs " << apv_pairs << " Neglecting !!!!!! ";
+      edm::LogError("SiStripMonitorPedestals") << "SiStripMonitorPedestals::createMEs: Wrong APV Pairs  => detId "
+                                               << detid << " APV pairs " << apv_pairs << " Neglecting !!!!!! ";
       continue;
     }
     unsigned int napvs = apv_pairs * 2;
@@ -182,8 +176,7 @@ void SiStripMonitorPedestals::createMEs(DQMStore::IBooker &ibooker,
 
       std::string hid;
       // set appropriate folder using SiStripFolderOrganizer
-      folder_organizer.setDetectorFolder(
-          detid, tTopo); // pass the detid to this method
+      folder_organizer.setDetectorFolder(detid, tTopo);  // pass the detid to this method
 
       // if the deid already exists in the map, then reset MEs otherwise create
       // them
@@ -192,125 +185,109 @@ void SiStripMonitorPedestals::createMEs(DQMStore::IBooker &ibooker,
       if (runTypeFlag_ == RunMode1 || runTypeFlag_ == RunMode3) {
         // Pedestals histos
         hid = hidmanager.createHistoId("PedestalFromCondDB", "det", detid);
-        local_modmes.PedsPerStripDB = ibooker.book1D(
-            hid, hid, nStrip, 0.5, nStrip + 0.5); // to modify the size binning
+        local_modmes.PedsPerStripDB =
+            ibooker.book1D(hid, hid, nStrip, 0.5, nStrip + 0.5);  // to modify the size binning
         ibooker.tag(local_modmes.PedsPerStripDB, detid);
-        (local_modmes.PedsPerStripDB)
-            ->setAxisTitle("Pedestal from CondDB(ADC) vs Strip Number", 1);
+        (local_modmes.PedsPerStripDB)->setAxisTitle("Pedestal from CondDB(ADC) vs Strip Number", 1);
 
         hid = hidmanager.createHistoId("NoiseFromCondDB", "det", detid);
-        local_modmes.CMSubNoisePerStripDB =
-            ibooker.book1D(hid, hid, nStrip, 0.5, nStrip + 0.5);
+        local_modmes.CMSubNoisePerStripDB = ibooker.book1D(hid, hid, nStrip, 0.5, nStrip + 0.5);
         ibooker.tag(local_modmes.CMSubNoisePerStripDB, detid);
-        (local_modmes.CMSubNoisePerStripDB)
-            ->setAxisTitle("CMSubNoise from CondDB(ADC) vs Strip Number", 1);
+        (local_modmes.CMSubNoisePerStripDB)->setAxisTitle("CMSubNoise from CondDB(ADC) vs Strip Number", 1);
 
         hid = hidmanager.createHistoId("BadStripFlagCondDB", "det", detid);
-        local_modmes.BadStripsDB =
-            ibooker.book2D(hid, hid, nStrip, 0.5, nStrip + 0.5, 6, -0.5, 5.5);
+        local_modmes.BadStripsDB = ibooker.book2D(hid, hid, nStrip, 0.5, nStrip + 0.5, 6, -0.5, 5.5);
         ibooker.tag(local_modmes.BadStripsDB, detid);
-        (local_modmes.BadStripsDB)
-            ->setAxisTitle("Strip Flag from CondDB(ADC) vs Strip Number", 1);
+        (local_modmes.BadStripsDB)->setAxisTitle("Strip Flag from CondDB(ADC) vs Strip Number", 1);
       }
       if (runTypeFlag_ == RunMode2 || runTypeFlag_ == RunMode3) {
         // Pedestals histos
         hid = hidmanager.createHistoId("PedsPerStrip", "det", detid);
-        local_modmes.PedsPerStrip = ibooker.book1D(
-            hid, hid, nStrip, 0.5, nStrip + 0.5); // to modify the size binning
+        local_modmes.PedsPerStrip = ibooker.book1D(hid, hid, nStrip, 0.5, nStrip + 0.5);  // to modify the size binning
         ibooker.tag(local_modmes.PedsPerStrip, detid);
-        (local_modmes.PedsPerStrip)
-            ->setAxisTitle("Pedestal (ADC)  vs Strip Number ", 1);
+        (local_modmes.PedsPerStrip)->setAxisTitle("Pedestal (ADC)  vs Strip Number ", 1);
 
         hid = hidmanager.createHistoId("PedsDistribution", "det", detid);
-        local_modmes.PedsDistribution =
-            ibooker.book2D(hid, hid, napvs, -0.5, napvs - 0.5, 300, 200,
-                           500); // to modify the size binning
+        local_modmes.PedsDistribution = ibooker.book2D(hid,
+                                                       hid,
+                                                       napvs,
+                                                       -0.5,
+                                                       napvs - 0.5,
+                                                       300,
+                                                       200,
+                                                       500);  // to modify the size binning
         ibooker.tag(local_modmes.PedsDistribution, detid);
         (local_modmes.PedsDistribution)->setAxisTitle("Apv Number", 1);
-        (local_modmes.PedsDistribution)
-            ->setAxisTitle("Mean Pedestal Value (ADC)", 2);
+        (local_modmes.PedsDistribution)->setAxisTitle("Mean Pedestal Value (ADC)", 2);
 
         hid = hidmanager.createHistoId("PedsEvolution", "det", detid);
-        local_modmes.PedsEvolution =
-            ibooker.book2D(hid, hid, napvs, -0.5, napvs - 0.5, 50, 0.,
-                           50.); // to modify the size binning
+        local_modmes.PedsEvolution = ibooker.book2D(hid,
+                                                    hid,
+                                                    napvs,
+                                                    -0.5,
+                                                    napvs - 0.5,
+                                                    50,
+                                                    0.,
+                                                    50.);  // to modify the size binning
         ibooker.tag(local_modmes.PedsEvolution, detid);
         (local_modmes.PedsEvolution)->setAxisTitle("Apv Number", 1);
         (local_modmes.PedsEvolution)->setAxisTitle("Iteration Number", 2);
 
         // Noise histos
         hid = hidmanager.createHistoId("CMSubNoisePerStrip", "det", detid);
-        local_modmes.CMSubNoisePerStrip =
-            ibooker.book1D(hid, hid, nStrip, 0.5, nStrip + 0.5);
+        local_modmes.CMSubNoisePerStrip = ibooker.book1D(hid, hid, nStrip, 0.5, nStrip + 0.5);
         ibooker.tag(local_modmes.CMSubNoisePerStrip, detid);
-        (local_modmes.CMSubNoisePerStrip)
-            ->setAxisTitle("CMSubNoise (ADC) vs Strip Number", 1);
+        (local_modmes.CMSubNoisePerStrip)->setAxisTitle("CMSubNoise (ADC) vs Strip Number", 1);
 
         hid = hidmanager.createHistoId("RawNoisePerStrip", "det", detid);
-        local_modmes.RawNoisePerStrip =
-            ibooker.book1D(hid, hid, nStrip, 0.5, nStrip + 0.5);
+        local_modmes.RawNoisePerStrip = ibooker.book1D(hid, hid, nStrip, 0.5, nStrip + 0.5);
         ibooker.tag(local_modmes.RawNoisePerStrip, detid);
-        (local_modmes.RawNoisePerStrip)
-            ->setAxisTitle("RawNoise(ADC) vs Strip Number", 1);
+        (local_modmes.RawNoisePerStrip)->setAxisTitle("RawNoise(ADC) vs Strip Number", 1);
 
         hid = hidmanager.createHistoId("CMSubNoiseProfile", "det", detid);
-        local_modmes.CMSubNoiseProfile = ibooker.bookProfile(
-            hid, hid, nStrip, 0.5, nStrip + 0.5, 100, 0., 100.);
+        local_modmes.CMSubNoiseProfile = ibooker.bookProfile(hid, hid, nStrip, 0.5, nStrip + 0.5, 100, 0., 100.);
         ibooker.tag(local_modmes.CMSubNoiseProfile, detid);
-        (local_modmes.CMSubNoiseProfile)
-            ->setAxisTitle("Mean of CMSubNoise (ADC) vs Strip Number", 1);
+        (local_modmes.CMSubNoiseProfile)->setAxisTitle("Mean of CMSubNoise (ADC) vs Strip Number", 1);
 
         hid = hidmanager.createHistoId("RawNoiseProfile", "det", detid);
-        local_modmes.RawNoiseProfile = ibooker.bookProfile(
-            hid, hid, nStrip, 0.5, nStrip + 0.5, 100, 0., 100.);
+        local_modmes.RawNoiseProfile = ibooker.bookProfile(hid, hid, nStrip, 0.5, nStrip + 0.5, 100, 0., 100.);
         ibooker.tag(local_modmes.RawNoiseProfile, detid);
-        (local_modmes.RawNoiseProfile)
-            ->setAxisTitle("Mean of RawNoise (ADC) vs Strip Number", 1);
+        (local_modmes.RawNoiseProfile)->setAxisTitle("Mean of RawNoise (ADC) vs Strip Number", 1);
 
         hid = hidmanager.createHistoId("NoisyStrips", "det", detid);
-        local_modmes.NoisyStrips =
-            ibooker.book2D(hid, hid, nStrip, 0.5, nStrip + 0.5, 6, -0.5, 5.5);
+        local_modmes.NoisyStrips = ibooker.book2D(hid, hid, nStrip, 0.5, nStrip + 0.5, 6, -0.5, 5.5);
         ibooker.tag(local_modmes.NoisyStrips, detid);
         (local_modmes.NoisyStrips)->setAxisTitle("Strip Number", 1);
         (local_modmes.NoisyStrips)->setAxisTitle("Flag Value", 2);
 
         hid = hidmanager.createHistoId("NoisyStripDistribution", "det", detid);
-        local_modmes.NoisyStripDistribution =
-            ibooker.book1D(hid, hid, 11, -0.5, 10.5);
+        local_modmes.NoisyStripDistribution = ibooker.book1D(hid, hid, 11, -0.5, 10.5);
         ibooker.tag(local_modmes.NoisyStripDistribution, detid);
         (local_modmes.NoisyStripDistribution)->setAxisTitle("Flag Value", 1);
 
         // Common Mode histos
         hid = hidmanager.createHistoId("CMDistribution", "det", detid);
-        local_modmes.CMDistribution =
-            ibooker.book2D(hid, hid, napvs, -0.5, napvs - 0.5, 150, -15., 15.);
+        local_modmes.CMDistribution = ibooker.book2D(hid, hid, napvs, -0.5, napvs - 0.5, 150, -15., 15.);
         ibooker.tag(local_modmes.CMDistribution, detid);
-        (local_modmes.CMDistribution)
-            ->setAxisTitle("Common Mode (ADC) vs APV Number", 1);
+        (local_modmes.CMDistribution)->setAxisTitle("Common Mode (ADC) vs APV Number", 1);
 
         hid = hidmanager.createHistoId("CMSlopeDistribution", "det", detid);
-        local_modmes.CMSlopeDistribution = ibooker.book2D(
-            hid, hid, napvs, -0.5, napvs - 0.5, 100, -0.05, 0.05);
+        local_modmes.CMSlopeDistribution = ibooker.book2D(hid, hid, napvs, -0.5, napvs - 0.5, 100, -0.05, 0.05);
         ibooker.tag(local_modmes.CMSlopeDistribution, detid);
-        (local_modmes.CMSlopeDistribution)
-            ->setAxisTitle("Common Mode Slope vs APV Number", 1);
+        (local_modmes.CMSlopeDistribution)->setAxisTitle("Common Mode Slope vs APV Number", 1);
       }
       // data from CondDB
       // append to PedMEs
       PedMEs.insert(std::make_pair(detid, local_modmes));
-    } // newDetId
+    }  // newDetId
   }
   edm::LogInfo("SiStripMonitorPedestals")
-      << "SiStripMonitorPedestals::createMEs: Number of DETS used "
-      << PedMEs.size();
+      << "SiStripMonitorPedestals::createMEs: Number of DETS used " << PedMEs.size();
 }
 // ------------ method called to produce the data  ------------
-void SiStripMonitorPedestals::analyze(const edm::Event &iEvent,
-                                      const edm::EventSetup &eSetup) {
-
+void SiStripMonitorPedestals::analyze(const edm::Event &iEvent, const edm::EventSetup &eSetup) {
   edm::LogInfo("SiStripMonitorPedestals")
-      << "SiStripMonitorPedestals::analyze: Run " << iEvent.id().run()
-      << " Event " << iEvent.id().event();
+      << "SiStripMonitorPedestals::analyze: Run " << iEvent.id().run() << " Event " << iEvent.id().event();
 
   eSetup.get<SiStripDetCablingRcd>().get(detcabling);
 
@@ -331,40 +308,31 @@ void SiStripMonitorPedestals::analyze(const edm::Event &iEvent,
     nIteration_++;
 
   // loop over all MEs
-  for (std::map<uint32_t, ModMEs>::const_iterator i = PedMEs.begin();
-       i != PedMEs.end(); i++) {
+  for (std::map<uint32_t, ModMEs>::const_iterator i = PedMEs.begin(); i != PedMEs.end(); i++) {
     uint32_t detid = i->first;
     ModMEs local_modmes = i->second;
     // get iterators for digis belonging to one DetId, it is an iterator, i.e.
     // one element of the vector
-    std::vector<edm::DetSet<SiStripRawDigi>>::const_iterator digis =
-        digi_collection->find(detid);
-    if (digis == digi_collection->end() || digis->data.empty() ||
-        digis->data.size() > 768) {
+    std::vector<edm::DetSet<SiStripRawDigi>>::const_iterator digis = digi_collection->find(detid);
+    if (digis == digi_collection->end() || digis->data.empty() || digis->data.size() > 768) {
       if (digis == digi_collection->end()) {
-        edm::LogError("SiStripMonitorPedestals")
-            << " SiStripMonitorPedestals::analyze: Event " << nEvTot_
-            << " DetId " << detid << " at the end of Digi Collection!!!";
+        edm::LogError("SiStripMonitorPedestals") << " SiStripMonitorPedestals::analyze: Event " << nEvTot_ << " DetId "
+                                                 << detid << " at the end of Digi Collection!!!";
       } else {
-        edm::LogError("SiStripMonitorPedestals")
-            << " [SiStripMonitorPedestals::analyze: Event " << nEvTot_
-            << " DetId " << detid << " # of Digis " << digis->data.size();
+        edm::LogError("SiStripMonitorPedestals") << " [SiStripMonitorPedestals::analyze: Event " << nEvTot_ << " DetId "
+                                                 << detid << " # of Digis " << digis->data.size();
       }
-      std::vector<const FedChannelConnection *> fed_conns =
-          detcabling->getConnections(detid);
+      std::vector<const FedChannelConnection *> fed_conns = detcabling->getConnections(detid);
       bool firstchannel(true);
       for (unsigned int k = 0; k < fed_conns.size(); k++) {
         if (fed_conns[k] && fed_conns[k]->isConnected()) {
           if (firstchannel) {
-            edm::LogError("SiStripMonitorPedestals")
-                << " SiStripMonitorPedestals::analyze: Fed Id "
-                << fed_conns[k]->fedId() << " Channel "
-                << fed_conns[k]->fedCh();
+            edm::LogError("SiStripMonitorPedestals") << " SiStripMonitorPedestals::analyze: Fed Id "
+                                                     << fed_conns[k]->fedId() << " Channel " << fed_conns[k]->fedCh();
             firstchannel = false;
           } else
             edm::LogError("SiStripMonitorPedestals")
-                << "  SiStripMonitorPedestals::analyze: Channel "
-                << fed_conns[k]->fedCh();
+                << "  SiStripMonitorPedestals::analyze: Channel " << fed_conns[k]->fedCh();
         }
       }
       std::cout << std::endl;
@@ -372,8 +340,7 @@ void SiStripMonitorPedestals::analyze(const edm::Event &iEvent,
     }
 
     if (digis->data.empty()) {
-      edm::LogError("MonitorDigi_tmp")
-          << "[SiStripRawDigiToRaw::createFedBuffers] Zero digis found!";
+      edm::LogError("MonitorDigi_tmp") << "[SiStripRawDigiToRaw::createFedBuffers] Zero digis found!";
     }
     uint32_t id = detid;
     //    cout <<"Data size "<<digis->data.size()<<endl;
@@ -387,8 +354,7 @@ void SiStripMonitorPedestals::analyze(const edm::Event &iEvent,
         // unpacking the info looking at the right topology
         int numberCMBlocks = int(128. / NumCMstripsInGroup_);
         int ibin = 0;
-        for (std::vector<float>::const_iterator iped = tmp.begin();
-             iped != tmp.end(); iped++) {
+        for (std::vector<float>::const_iterator iped = tmp.begin(); iped != tmp.end(); iped++) {
           int iapv = int(ibin / numberCMBlocks);
           (local_modmes.CMDistribution)->Fill(iapv, static_cast<float>(*iped));
           ibin++;
@@ -399,20 +365,15 @@ void SiStripMonitorPedestals::analyze(const edm::Event &iEvent,
         tmp.clear();
         int iapv = 0;
         apvFactory_->getCommonModeSlope(id, tmp);
-        for (std::vector<float>::const_iterator it = tmp.begin();
-             it != tmp.end(); it++) {
-          (local_modmes.CMSlopeDistribution)
-              ->Fill(iapv, static_cast<float>(*it));
+        for (std::vector<float>::const_iterator it = tmp.begin(); it != tmp.end(); it++) {
+          (local_modmes.CMSlopeDistribution)->Fill(iapv, static_cast<float>(*it));
           iapv++;
         }
       }
     }
 
     // asking for the status
-    if ((nEvTot_ - theEventInitNumber_ - theEventIterNumber_) %
-            theEventIterNumber_ ==
-        1) {
-
+    if ((nEvTot_ - theEventInitNumber_ - theEventIterNumber_) % theEventIterNumber_ == 1) {
       std::vector<float> tmp;
       tmp.clear();
       apvFactory_->getPedestal(id, tmp);
@@ -422,75 +383,54 @@ void SiStripMonitorPedestals::analyze(const edm::Event &iEvent,
           std::vector<float> myPedPerApv;
           apvFactory_->getPedestal(id, i, myPedPerApv);
           float avarage = 0;
-          avarage =
-              std::accumulate(myPedPerApv.begin(), myPedPerApv.end(), avarage);
+          avarage = std::accumulate(myPedPerApv.begin(), myPedPerApv.end(), avarage);
           avarage = avarage / 128.;
-          (local_modmes.PedsEvolution)
-              ->setBinContent(i + 1, nIteration_, avarage);
+          (local_modmes.PedsEvolution)->setBinContent(i + 1, nIteration_, avarage);
         }
         int ibin = 0;
 
-        for (std::vector<float>::const_iterator iped = tmp.begin();
-             iped != tmp.end(); iped++) {
+        for (std::vector<float>::const_iterator iped = tmp.begin(); iped != tmp.end(); iped++) {
           int napv = int(ibin / 128.);
           ibin++;
           float last_value = (local_modmes.PedsPerStrip)->getBinContent(ibin);
           if (last_value != 0.) {
-            (local_modmes.PedsPerStrip)
-                ->setBinContent(ibin,
-                                (static_cast<float>(*iped) + last_value) / 2.);
+            (local_modmes.PedsPerStrip)->setBinContent(ibin, (static_cast<float>(*iped) + last_value) / 2.);
           } else {
-            (local_modmes.PedsPerStrip)
-                ->setBinContent(ibin, static_cast<float>(*iped));
+            (local_modmes.PedsPerStrip)->setBinContent(ibin, static_cast<float>(*iped));
           }
-          (local_modmes.PedsDistribution)
-              ->Fill(napv, static_cast<float>(*iped));
+          (local_modmes.PedsDistribution)->Fill(napv, static_cast<float>(*iped));
         }
       }
 
-      if (local_modmes.CMSubNoisePerStrip != nullptr &&
-          local_modmes.CMSubNoiseProfile != nullptr) {
+      if (local_modmes.CMSubNoisePerStrip != nullptr && local_modmes.CMSubNoiseProfile != nullptr) {
         tmp.clear();
         apvFactory_->getNoise(id, tmp);
         int ibin = 0;
-        for (std::vector<float>::const_iterator iped = tmp.begin();
-             iped != tmp.end(); iped++) {
+        for (std::vector<float>::const_iterator iped = tmp.begin(); iped != tmp.end(); iped++) {
           ibin++;
-          (local_modmes.CMSubNoiseProfile)
-              ->Fill(static_cast<double>(ibin * 1.), static_cast<float>(*iped));
+          (local_modmes.CMSubNoiseProfile)->Fill(static_cast<double>(ibin * 1.), static_cast<float>(*iped));
 
-          float last_value =
-              (local_modmes.CMSubNoisePerStrip)->getBinContent(ibin);
+          float last_value = (local_modmes.CMSubNoisePerStrip)->getBinContent(ibin);
           if (last_value != 0.) {
-            (local_modmes.CMSubNoisePerStrip)
-                ->setBinContent(ibin,
-                                (static_cast<float>(*iped) + last_value) / 2.);
+            (local_modmes.CMSubNoisePerStrip)->setBinContent(ibin, (static_cast<float>(*iped) + last_value) / 2.);
           } else {
-            (local_modmes.CMSubNoisePerStrip)
-                ->setBinContent(ibin, static_cast<float>(*iped));
+            (local_modmes.CMSubNoisePerStrip)->setBinContent(ibin, static_cast<float>(*iped));
           }
         }
       }
 
-      if (local_modmes.RawNoisePerStrip != nullptr &&
-          local_modmes.RawNoiseProfile != nullptr) {
+      if (local_modmes.RawNoisePerStrip != nullptr && local_modmes.RawNoiseProfile != nullptr) {
         tmp.clear();
         apvFactory_->getRawNoise(id, tmp);
         int ibin = 0;
-        for (std::vector<float>::const_iterator iped = tmp.begin();
-             iped != tmp.end(); iped++) {
+        for (std::vector<float>::const_iterator iped = tmp.begin(); iped != tmp.end(); iped++) {
           ibin++;
-          (local_modmes.RawNoiseProfile)
-              ->Fill(static_cast<double>(ibin * 1.), static_cast<float>(*iped));
-          float last_value =
-              (local_modmes.RawNoisePerStrip)->getBinContent(ibin);
+          (local_modmes.RawNoiseProfile)->Fill(static_cast<double>(ibin * 1.), static_cast<float>(*iped));
+          float last_value = (local_modmes.RawNoisePerStrip)->getBinContent(ibin);
           if (last_value != 0.) {
-            (local_modmes.RawNoisePerStrip)
-                ->setBinContent(ibin,
-                                (static_cast<float>(*iped) + last_value) / 2.);
+            (local_modmes.RawNoisePerStrip)->setBinContent(ibin, (static_cast<float>(*iped) + last_value) / 2.);
           } else {
-            (local_modmes.RawNoisePerStrip)
-                ->setBinContent(ibin, static_cast<float>(*iped));
+            (local_modmes.RawNoisePerStrip)->setBinContent(ibin, static_cast<float>(*iped));
           }
         }
       }
@@ -499,8 +439,7 @@ void SiStripMonitorPedestals::analyze(const edm::Event &iEvent,
         TkApvMask::MaskType temp;
         apvFactory_->getMask(id, temp);
         int ibin = 0;
-        for (TkApvMask::MaskType::const_iterator iped = temp.begin();
-             iped != temp.end(); iped++) {
+        for (TkApvMask::MaskType::const_iterator iped = temp.begin(); iped != temp.end(); iped++) {
           ibin++;
 
           if (nIteration_ < 2) {
@@ -512,8 +451,7 @@ void SiStripMonitorPedestals::analyze(const edm::Event &iEvent,
               (local_modmes.NoisyStrips)->Fill(ibin, 0.);
           } else {
             (local_modmes.NoisyStrips)->Fill(ibin, static_cast<float>(*iped));
-            (local_modmes.NoisyStripDistribution)
-                ->Fill(static_cast<float>(*iped));
+            (local_modmes.NoisyStripDistribution)->Fill(static_cast<float>(*iped));
           }
         }
       }
@@ -525,12 +463,10 @@ void SiStripMonitorPedestals::analyze(const edm::Event &iEvent,
 //
 // -- End Run
 //
-void SiStripMonitorPedestals::endRun(edm::Run const &run,
-                                     edm::EventSetup const &eSetup) {
+void SiStripMonitorPedestals::endRun(edm::Run const &run, edm::EventSetup const &eSetup) {
   bool outputMEsInRootFile = conf_.getParameter<bool>("OutputMEsInRootFile");
   if (outputMEsInRootFile) {
-    std::string outPutFileName =
-        conf_.getParameter<std::string>("OutPutFileName");
+    std::string outPutFileName = conf_.getParameter<std::string>("OutPutFileName");
     //    dqmStore_->showDirStructure();
     dqmStore_->save(outPutFileName);
   }
@@ -580,17 +516,14 @@ void SiStripMonitorPedestals::fillCondDBMEs(edm::EventSetup const &eSetup) {
 
   eSetup.get<SiStripPedestalsRcd>().get(pedestalHandle);
   eSetup.get<SiStripNoisesRcd>().get(noiseHandle);
-  std::string quality_label =
-      conf_.getParameter<std::string>("StripQualityLabel");
+  std::string quality_label = conf_.getParameter<std::string>("StripQualityLabel");
   eSetup.get<SiStripQualityRcd>().get(quality_label, qualityHandle);
 
-  for (std::map<uint32_t, ModMEs>::const_iterator i = PedMEs.begin();
-       i != PedMEs.end(); i++) {
+  for (std::map<uint32_t, ModMEs>::const_iterator i = PedMEs.begin(); i != PedMEs.end(); i++) {
     uint32_t detid = i->first;
     ModMEs local_modmes = i->second;
-    edm::LogInfo("SiStripMonitorPedestals")
-        << " SiStripMonitorPedestals::analyze: "
-        << " Get Ped/Noise/Bad Strips from CondDb for DetId " << detid;
+    edm::LogInfo("SiStripMonitorPedestals") << " SiStripMonitorPedestals::analyze: "
+                                            << " Get Ped/Noise/Bad Strips from CondDb for DetId " << detid;
     int nStrip = detcabling->nApvPairs(detid) * 256;
     // Get range of pedestal and noise for the detid
     SiStripNoises::Range noiseRange = noiseHandle->getRange(detid);
@@ -600,41 +533,34 @@ void SiStripMonitorPedestals::fillCondDBMEs(edm::EventSetup const &eSetup) {
     for (int istrip = 0; istrip < nStrip; ++istrip) {
       try {
         // Fill Pedestals
-        (local_modmes.PedsPerStripDB)
-            ->Fill(istrip + 1, pedestalHandle->getPed(istrip, pedRange));
+        (local_modmes.PedsPerStripDB)->Fill(istrip + 1, pedestalHandle->getPed(istrip, pedRange));
       } catch (cms::Exception &e) {
-        edm::LogError("SiStripMonitorPedestals")
-            << "[SiStripMonitorPedestals::analyze]  cms::Exception accessing "
-               "SiStripPedestalsService_.getPedestal("
-            << detid << "," << istrip << ") :  "
-            << " " << e.what();
+        edm::LogError("SiStripMonitorPedestals") << "[SiStripMonitorPedestals::analyze]  cms::Exception accessing "
+                                                    "SiStripPedestalsService_.getPedestal("
+                                                 << detid << "," << istrip << ") :  "
+                                                 << " " << e.what();
       }
       try {
         // Fill Noises
-        (local_modmes.CMSubNoisePerStripDB)
-            ->Fill(istrip + 1, noiseHandle->getNoise(istrip, noiseRange));
+        (local_modmes.CMSubNoisePerStripDB)->Fill(istrip + 1, noiseHandle->getNoise(istrip, noiseRange));
 
       } catch (cms::Exception &e) {
-        edm::LogError("SiStripMonitorPedestals")
-            << "[SiStripMonitorPedestals::analyze]  cms::Exception accessing "
-               "SiStripNoiseService_.getNoise("
-            << detid << "," << istrip << ") :  "
-            << " " << e.what();
+        edm::LogError("SiStripMonitorPedestals") << "[SiStripMonitorPedestals::analyze]  cms::Exception accessing "
+                                                    "SiStripNoiseService_.getNoise("
+                                                 << detid << "," << istrip << ") :  "
+                                                 << " " << e.what();
       }
       try {
         // Fill BadStripsNoise
-        (local_modmes.BadStripsDB)
-            ->Fill(istrip + 1,
-                   qualityHandle->IsStripBad(qualityRange, istrip) ? 1. : 0.);
+        (local_modmes.BadStripsDB)->Fill(istrip + 1, qualityHandle->IsStripBad(qualityRange, istrip) ? 1. : 0.);
 
       } catch (cms::Exception &e) {
-        edm::LogError("SiStripMonitorPedestals")
-            << "[SiStripMonitorPedestals::analyze]  cms::Exception accessing "
-               "SiStripNoiseService_.getDisable("
-            << detid << "," << istrip << ") :  "
-            << " " << e.what();
+        edm::LogError("SiStripMonitorPedestals") << "[SiStripMonitorPedestals::analyze]  cms::Exception accessing "
+                                                    "SiStripNoiseService_.getDisable("
+                                                 << detid << "," << istrip << ") :  "
+                                                 << " " << e.what();
       }
-    } // close istrip loop
+    }  // close istrip loop
   }
 }
 DEFINE_FWK_MODULE(SiStripMonitorPedestals);

--- a/DQM/SiStripMonitorPedestals/src/SiStripMonitorQuality.cc
+++ b/DQM/SiStripMonitorPedestals/src/SiStripMonitorQuality.cc
@@ -42,7 +42,8 @@
 #include <numeric>
 
 SiStripMonitorQuality::SiStripMonitorQuality(edm::ParameterSet const &iConfig)
-    : dqmStore_(edm::Service<DQMStore>().operator->()), conf_(iConfig),
+    : dqmStore_(edm::Service<DQMStore>().operator->()),
+      conf_(iConfig),
       m_cacheID_(0)
 
 {
@@ -58,9 +59,7 @@ SiStripMonitorQuality::~SiStripMonitorQuality() {
 void SiStripMonitorQuality::bookHistograms(DQMStore::IBooker &ibooker,
                                            const edm::Run &run,
                                            const edm::EventSetup &eSetup) {
-
-  unsigned long long cacheID =
-      eSetup.get<SiStripQualityRcd>().cacheIdentifier();
+  unsigned long long cacheID = eSetup.get<SiStripQualityRcd>().cacheIdentifier();
   if (m_cacheID_ == cacheID)
     return;
 
@@ -71,39 +70,32 @@ void SiStripMonitorQuality::bookHistograms(DQMStore::IBooker &ibooker,
 
   m_cacheID_ = cacheID;
 
-  std::string quality_label =
-      conf_.getParameter<std::string>("StripQualityLabel");
+  std::string quality_label = conf_.getParameter<std::string>("StripQualityLabel");
   eSetup.get<SiStripQualityRcd>().get(quality_label, stripQuality_);
   eSetup.get<SiStripDetCablingRcd>().get(detCabling_);
 
-  edm::LogInfo("SiStripMonitorQuality")
-      << "SiStripMonitorQuality::analyze: "
-      << " Reading SiStripQuality " << std::endl;
+  edm::LogInfo("SiStripMonitorQuality") << "SiStripMonitorQuality::analyze: "
+                                        << " Reading SiStripQuality " << std::endl;
 
-  SiStripBadStrip::RegistryIterator rbegin =
-      stripQuality_->getRegistryVectorBegin();
-  SiStripBadStrip::RegistryIterator rend =
-      stripQuality_->getRegistryVectorEnd();
+  SiStripBadStrip::RegistryIterator rbegin = stripQuality_->getRegistryVectorBegin();
+  SiStripBadStrip::RegistryIterator rend = stripQuality_->getRegistryVectorEnd();
   uint32_t detid;
 
   if (rbegin == rend)
     return;
 
   for (SiStripBadStrip::RegistryIterator rp = rbegin; rp != rend; ++rp) {
-
     detid = rp->detid;
     // Check consistency in DetId
     if (detid == 0 || detid == 0xFFFFFFFF) {
-      edm::LogError("SiStripMonitorQuality")
-          << "SiStripMonitorQuality::bookHistograms : "
-          << "Wrong DetId !!!!!! " << detid << " Neglecting !!!!!! ";
+      edm::LogError("SiStripMonitorQuality") << "SiStripMonitorQuality::bookHistograms : "
+                                             << "Wrong DetId !!!!!! " << detid << " Neglecting !!!!!! ";
       continue;
     }
     // check if the detid is connected in cabling
     if (!detCabling_->IsConnected(detid)) {
-      edm::LogError("SiStripMonitorQuality")
-          << "SiStripMonitorQuality::bookHistograms : "
-          << " DetId " << detid << " not connected,  Neglecting !!!!!! ";
+      edm::LogError("SiStripMonitorQuality") << "SiStripMonitorQuality::bookHistograms : "
+                                             << " DetId " << detid << " not connected,  Neglecting !!!!!! ";
       continue;
     }
 
@@ -117,7 +109,7 @@ void SiStripMonitorQuality::bookHistograms(DQMStore::IBooker &ibooker,
     SiStripFolderOrganizer folder_organizer;
     // set appropriate folder using SiStripFolderOrganizer
     folder_organizer.setDetectorFolder(detid,
-                                       tTopo); // pass the detid to this method
+                                       tTopo);  // pass the detid to this method
 
     std::string hid;
     hid = hidmanager.createHistoId("StripQualityFromCondDB", "det", detid);
@@ -131,10 +123,8 @@ void SiStripMonitorQuality::bookHistograms(DQMStore::IBooker &ibooker,
 }
 
 // ------------ method called to produce the data  ------------
-void SiStripMonitorQuality::analyze(edm::Event const &iEvent,
-                                    edm::EventSetup const &eSetup) {
-  unsigned long long cacheID =
-      eSetup.get<SiStripQualityRcd>().cacheIdentifier();
+void SiStripMonitorQuality::analyze(edm::Event const &iEvent, edm::EventSetup const &eSetup) {
+  unsigned long long cacheID = eSetup.get<SiStripQualityRcd>().cacheIdentifier();
   if (m_cacheID_ == cacheID)
     return;
 
@@ -145,45 +135,37 @@ void SiStripMonitorQuality::analyze(edm::Event const &iEvent,
 
   m_cacheID_ = cacheID;
 
-  std::string quality_label =
-      conf_.getParameter<std::string>("StripQualityLabel");
+  std::string quality_label = conf_.getParameter<std::string>("StripQualityLabel");
   eSetup.get<SiStripQualityRcd>().get(quality_label, stripQuality_);
   eSetup.get<SiStripDetCablingRcd>().get(detCabling_);
 
-  edm::LogInfo("SiStripMonitorQuality")
-      << "SiStripMonitorQuality::analyze: "
-      << " Reading SiStripQuality " << std::endl;
+  edm::LogInfo("SiStripMonitorQuality") << "SiStripMonitorQuality::analyze: "
+                                        << " Reading SiStripQuality " << std::endl;
 
-  SiStripBadStrip::RegistryIterator rbegin =
-      stripQuality_->getRegistryVectorBegin();
-  SiStripBadStrip::RegistryIterator rend =
-      stripQuality_->getRegistryVectorEnd();
+  SiStripBadStrip::RegistryIterator rbegin = stripQuality_->getRegistryVectorBegin();
+  SiStripBadStrip::RegistryIterator rend = stripQuality_->getRegistryVectorEnd();
   uint32_t detid;
 
   if (rbegin == rend)
     return;
 
   for (SiStripBadStrip::RegistryIterator rp = rbegin; rp != rend; ++rp) {
-
     detid = rp->detid;
     // Check consistency in DetId
     if (detid == 0 || detid == 0xFFFFFFFF) {
-      edm::LogError("SiStripMonitorQuality")
-          << "SiStripMonitorQuality::analyze : "
-          << "Wrong DetId !!!!!! " << detid << " Neglecting !!!!!! ";
+      edm::LogError("SiStripMonitorQuality") << "SiStripMonitorQuality::analyze : "
+                                             << "Wrong DetId !!!!!! " << detid << " Neglecting !!!!!! ";
       continue;
     }
     // check if the detid is connected in cabling
     if (!detCabling_->IsConnected(detid)) {
-      edm::LogError("SiStripMonitorQuality")
-          << "SiStripMonitorQuality::analyze : "
-          << " DetId " << detid << " not connected,  Neglecting !!!!!! ";
+      edm::LogError("SiStripMonitorQuality") << "SiStripMonitorQuality::analyze : "
+                                             << " DetId " << detid << " not connected,  Neglecting !!!!!! ";
       continue;
     }
     MonitorElement *me = getQualityME(detid, tTopo);
-    SiStripBadStrip::Range range =
-        SiStripBadStrip::Range(stripQuality_->getDataVectorBegin() + rp->ibegin,
-                               stripQuality_->getDataVectorBegin() + rp->iend);
+    SiStripBadStrip::Range range = SiStripBadStrip::Range(stripQuality_->getDataVectorBegin() + rp->ibegin,
+                                                          stripQuality_->getDataVectorBegin() + rp->iend);
     SiStripBadStrip::ContainerIterator it = range.first;
     for (; it != range.second; ++it) {
       unsigned int value = (*it);
@@ -199,11 +181,9 @@ void SiStripMonitorQuality::analyze(edm::Event const &iEvent,
 //
 // -- End Run
 //
-void SiStripMonitorQuality::endRun(edm::Run const &run,
-                                   edm::EventSetup const &eSetup) {
+void SiStripMonitorQuality::endRun(edm::Run const &run, edm::EventSetup const &eSetup) {
   bool outputMEsInRootFile = conf_.getParameter<bool>("OutputMEsInRootFile");
-  std::string outputFileName =
-      conf_.getParameter<std::string>("OutputFileName");
+  std::string outputFileName = conf_.getParameter<std::string>("OutputFileName");
   if (outputMEsInRootFile) {
     // dqmStore_->showDirStructure();
     dqmStore_->save(outputFileName);
@@ -219,10 +199,7 @@ void SiStripMonitorQuality::endJob(void) {
 //
 // -- End Job
 //
-MonitorElement *
-SiStripMonitorQuality::getQualityME(uint32_t idet,
-                                    const TrackerTopology *tTopo) {
-
+MonitorElement *SiStripMonitorQuality::getQualityME(uint32_t idet, const TrackerTopology *tTopo) {
   std::map<uint32_t, MonitorElement *>::iterator pos = QualityMEs.find(idet);
   MonitorElement *det_me = nullptr;
   if (pos != QualityMEs.end()) {
@@ -230,9 +207,8 @@ SiStripMonitorQuality::getQualityME(uint32_t idet,
     det_me->Reset();
   } else {
     // this should never happen because of bookHistograms()
-    edm::LogError("SiStripMonitorQuality")
-        << "SiStripMonitorQuality::getQualityME : "
-        << "Wrong DetId !!!!!! " << idet << " No ME found!";
+    edm::LogError("SiStripMonitorQuality") << "SiStripMonitorQuality::getQualityME : "
+                                           << "Wrong DetId !!!!!! " << idet << " No ME found!";
   }
   return det_me;
 }

--- a/DQM/SiStripMonitorPedestals/src/SiStripMonitorRawData.cc
+++ b/DQM/SiStripMonitorPedestals/src/SiStripMonitorRawData.cc
@@ -41,15 +41,16 @@
 #include <numeric>
 
 SiStripMonitorRawData::SiStripMonitorRawData(edm::ParameterSet const &iConfig)
-    : BadFedNumber(nullptr), dqmStore_(edm::Service<DQMStore>().operator->()),
-      conf_(iConfig), m_cacheID_(0)
+    : BadFedNumber(nullptr),
+      dqmStore_(edm::Service<DQMStore>().operator->()),
+      conf_(iConfig),
+      m_cacheID_(0)
 
 {
   // retrieve producer name of input StripDigiCollection
   std::string digiProducer = conf_.getParameter<std::string>("DigiProducer");
   std::string digiType = "VirginRaw";
-  digiToken_ = consumes<edm::DetSetVector<SiStripRawDigi>>(
-      edm::InputTag(digiProducer, digiType));
+  digiToken_ = consumes<edm::DetSetVector<SiStripRawDigi>>(edm::InputTag(digiProducer, digiType));
 
   edm::LogInfo("SiStripMonitorRawData") << "SiStripMonitorRawData  "
                                         << " Constructing....... ";
@@ -66,8 +67,7 @@ SiStripMonitorRawData::~SiStripMonitorRawData() {
 void SiStripMonitorRawData::bookHistograms(DQMStore::IBooker &ibooker,
                                            const edm::Run &run,
                                            const edm::EventSetup &eSetup) {
-  unsigned long long cacheID =
-      eSetup.get<SiStripDetCablingRcd>().cacheIdentifier();
+  unsigned long long cacheID = eSetup.get<SiStripDetCablingRcd>().cacheIdentifier();
 
   if (BadFedNumber)
     BadFedNumber->Reset();
@@ -77,26 +77,21 @@ void SiStripMonitorRawData::bookHistograms(DQMStore::IBooker &ibooker,
     SelectedDetIds.clear();
     detcabling->addActiveDetectorsRawIds(SelectedDetIds);
 
-    edm::LogInfo("SiStripMonitorRawData")
-        << "SiStripMonitorRawData::bookHistograms: "
-        << " Creating MEs for new Cabling ";
+    edm::LogInfo("SiStripMonitorRawData") << "SiStripMonitorRawData::bookHistograms: "
+                                          << " Creating MEs for new Cabling ";
     ibooker.setCurrentFolder("Track/GlobalParameter");
     if (!BadFedNumber) {
-      BadFedNumber = ibooker.book1D("FaultyFedNumberAndChannel",
-                                    "Faulty Fed Id and Channel and Numbers",
-                                    60000, 0.5, 600.5);
+      BadFedNumber =
+          ibooker.book1D("FaultyFedNumberAndChannel", "Faulty Fed Id and Channel and Numbers", 60000, 0.5, 600.5);
       BadFedNumber->setAxisTitle("Fed Id and Channel numbers", 1);
     }
   }
 }
 
 // ------------ method called to produce the data  ------------
-void SiStripMonitorRawData::analyze(edm::Event const &iEvent,
-                                    edm::EventSetup const &iSetup) {
-
-  edm::LogInfo("SiStripMonitorRawData")
-      << "SiStripMonitorRawData::analyze: Run " << iEvent.id().run()
-      << " Event " << iEvent.id().event();
+void SiStripMonitorRawData::analyze(edm::Event const &iEvent, edm::EventSetup const &iSetup) {
+  edm::LogInfo("SiStripMonitorRawData") << "SiStripMonitorRawData::analyze: Run " << iEvent.id().run() << " Event "
+                                        << iEvent.id().event();
 
   iSetup.get<SiStripDetCablingRcd>().get(detcabling);
 
@@ -104,15 +99,12 @@ void SiStripMonitorRawData::analyze(edm::Event const &iEvent,
   edm::Handle<edm::DetSetVector<SiStripRawDigi>> digi_collection;
   iEvent.getByToken(digiToken_, digi_collection);
 
-  for (std::vector<uint32_t>::const_iterator idetid = SelectedDetIds.begin(),
-                                             iEnd = SelectedDetIds.end();
-       idetid != iEnd; ++idetid) {
-    std::vector<edm::DetSet<SiStripRawDigi>>::const_iterator digis =
-        digi_collection->find((*idetid));
-    if (digis == digi_collection->end() || digis->data.empty() ||
-        digis->data.size() > 768) {
-      std::vector<const FedChannelConnection *> fed_conns =
-          detcabling->getConnections((*idetid));
+  for (std::vector<uint32_t>::const_iterator idetid = SelectedDetIds.begin(), iEnd = SelectedDetIds.end();
+       idetid != iEnd;
+       ++idetid) {
+    std::vector<edm::DetSet<SiStripRawDigi>>::const_iterator digis = digi_collection->find((*idetid));
+    if (digis == digi_collection->end() || digis->data.empty() || digis->data.size() > 768) {
+      std::vector<const FedChannelConnection *> fed_conns = detcabling->getConnections((*idetid));
       for (unsigned int k = 0; k < fed_conns.size(); k++) {
         if (fed_conns[k] && fed_conns[k]->isConnected()) {
           float fed_id = fed_conns[k]->fedId() + 0.01 * fed_conns[k]->fedCh();
@@ -126,11 +118,9 @@ void SiStripMonitorRawData::analyze(edm::Event const &iEvent,
 //
 // -- End Run
 //
-void SiStripMonitorRawData::endRun(edm::Run const &run,
-                                   edm::EventSetup const &eSetup) {
+void SiStripMonitorRawData::endRun(edm::Run const &run, edm::EventSetup const &eSetup) {
   bool outputMEsInRootFile = conf_.getParameter<bool>("OutputMEsInRootFile");
-  std::string outputFileName =
-      conf_.getParameter<std::string>("OutputFileName");
+  std::string outputFileName = conf_.getParameter<std::string>("OutputFileName");
   if (outputMEsInRootFile) {
     // dqmStore_->showDirStructure();
     dqmStore_->save(outputFileName);

--- a/DQM/TrackerMonitorTrack/interface/MonitorTrackResiduals.h
+++ b/DQM/TrackerMonitorTrack/interface/MonitorTrackResiduals.h
@@ -30,7 +30,7 @@ class MonitorElement;
 class DQMStore;
 class GenericTriggerEventFlag;
 namespace edm {
-class Event;
+  class Event;
 }
 
 enum TrackerType { TRACKERTYPE_STRIP, TRACKERTYPE_PIXEL };
@@ -43,14 +43,12 @@ public:
   ~MonitorTrackResidualsBase() override;
   void dqmBeginRun(const edm::Run &, const edm::EventSetup &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:
   // Own methods
   void createMEs(DQMStore::IBooker &, const edm::EventSetup &);
-  std::pair<std::string, int32_t>
-  findSubdetAndLayer(uint32_t ModuleID, const TrackerTopology *tTopo);
+  std::pair<std::string, int32_t> findSubdetAndLayer(uint32_t ModuleID, const TrackerTopology *tTopo);
 
   struct HistoPair {
     HistoPair() {
@@ -83,7 +81,6 @@ private:
 
 // Naming is for legacy reasons.
 typedef MonitorTrackResidualsBase<TRACKERTYPE_STRIP> MonitorTrackResiduals;
-typedef MonitorTrackResidualsBase<TRACKERTYPE_PIXEL>
-    SiPixelMonitorTrackResiduals;
+typedef MonitorTrackResidualsBase<TRACKERTYPE_PIXEL> SiPixelMonitorTrackResiduals;
 
 #endif

--- a/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc
+++ b/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc
@@ -17,16 +17,14 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 template <TrackerType pixel_or_strip>
-MonitorTrackResidualsBase<pixel_or_strip>::MonitorTrackResidualsBase(
-    const edm::ParameterSet &iConfig)
-    : conf_(iConfig), m_cacheID_(0),
+MonitorTrackResidualsBase<pixel_or_strip>::MonitorTrackResidualsBase(const edm::ParameterSet &iConfig)
+    : conf_(iConfig),
+      m_cacheID_(0),
       genTriggerEventFlag_(new GenericTriggerEventFlag(
-          iConfig.getParameter<edm::ParameterSet>("genericTriggerEventPSet"),
-          consumesCollector(), *this)),
+          iConfig.getParameter<edm::ParameterSet>("genericTriggerEventPSet"), consumesCollector(), *this)),
       avalidator_(iConfig, consumesCollector()) {
   ModOn = conf_.getParameter<bool>("Mod_On");
-  offlinePrimaryVerticesToken_ =
-      consumes<reco::VertexCollection>(std::string("offlinePrimaryVertices"));
+  offlinePrimaryVerticesToken_ = consumes<reco::VertexCollection>(std::string("offlinePrimaryVertices"));
 }
 
 template <TrackerType pixel_or_strip>
@@ -36,11 +34,10 @@ MonitorTrackResidualsBase<pixel_or_strip>::~MonitorTrackResidualsBase() {
 }
 
 template <TrackerType pixel_or_strip>
-void MonitorTrackResidualsBase<pixel_or_strip>::bookHistograms(
-    DQMStore::IBooker &ibooker, const edm::Run &run,
-    const edm::EventSetup &iSetup) {
-  unsigned long long cacheID =
-      iSetup.get<TrackerDigiGeometryRecord>().cacheIdentifier();
+void MonitorTrackResidualsBase<pixel_or_strip>::bookHistograms(DQMStore::IBooker &ibooker,
+                                                               const edm::Run &run,
+                                                               const edm::EventSetup &iSetup) {
+  unsigned long long cacheID = iSetup.get<TrackerDigiGeometryRecord>().cacheIdentifier();
   if (m_cacheID_ != cacheID) {
     m_cacheID_ = cacheID;
     this->createMEs(ibooker, iSetup);
@@ -51,65 +48,59 @@ void MonitorTrackResidualsBase<pixel_or_strip>::bookHistograms(
   edm::ESHandle<TkDetMap> tkDetMapHandle;
   iSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
   tkhisto_ResidualsMean = std::make_unique<TkHistoMap>(
-      tkDetMapHandle.product(), ibooker, topFolderName_, "TkHMap_ResidualsMean",
-      0.0, true);
+      tkDetMapHandle.product(), ibooker, topFolderName_, "TkHMap_ResidualsMean", 0.0, true);
 }
 
 template <TrackerType pixel_or_strip>
-void MonitorTrackResidualsBase<pixel_or_strip>::dqmBeginRun(
-    edm::Run const &run, edm::EventSetup const &iSetup) {
-
+void MonitorTrackResidualsBase<pixel_or_strip>::dqmBeginRun(edm::Run const &run, edm::EventSetup const &iSetup) {
   // Initialize the GenericTriggerEventFlag
   if (genTriggerEventFlag_->on())
     genTriggerEventFlag_->initRun(run, iSetup);
 }
 
 template <TrackerType pixel_or_strip>
-std::pair<std::string, int32_t>
-MonitorTrackResidualsBase<pixel_or_strip>::findSubdetAndLayer(
+std::pair<std::string, int32_t> MonitorTrackResidualsBase<pixel_or_strip>::findSubdetAndLayer(
     uint32_t ModuleID, const TrackerTopology *tTopo) {
   std::string subdet = "";
   int32_t layer = 0;
   auto id = DetId(ModuleID);
   switch (id.subdetId()) {
-  // Pixel Barrel, Endcap
-  case 1:
-    subdet = "BPIX";
-    layer = tTopo->pxbLayer(id);
-    break;
-  case 2:
-    subdet = "FPIX";
-    layer = tTopo->pxfDisk(id) * (tTopo->pxfSide(ModuleID) == 1 ? -1 : +1);
-    break;
-  // Strip TIB, TID, TOB, TEC
-  case 3:
-    subdet = "TIB";
-    layer = tTopo->tibLayer(id);
-    break;
-  case 4:
-    subdet = "TID";
-    layer = tTopo->tidWheel(id) * (tTopo->tidSide(ModuleID) == 1 ? -1 : +1);
-    break;
-  case 5:
-    subdet = "TOB";
-    layer = tTopo->tobLayer(id);
-    break;
-  case 6:
-    subdet = "TEC";
-    layer = tTopo->tecWheel(id) * (tTopo->tecSide(ModuleID) == 1 ? -1 : +1);
-    break;
-  default:
-    // TODO: Fail loudly.
-    subdet = "UNKNOWN";
-    layer = 0;
+    // Pixel Barrel, Endcap
+    case 1:
+      subdet = "BPIX";
+      layer = tTopo->pxbLayer(id);
+      break;
+    case 2:
+      subdet = "FPIX";
+      layer = tTopo->pxfDisk(id) * (tTopo->pxfSide(ModuleID) == 1 ? -1 : +1);
+      break;
+    // Strip TIB, TID, TOB, TEC
+    case 3:
+      subdet = "TIB";
+      layer = tTopo->tibLayer(id);
+      break;
+    case 4:
+      subdet = "TID";
+      layer = tTopo->tidWheel(id) * (tTopo->tidSide(ModuleID) == 1 ? -1 : +1);
+      break;
+    case 5:
+      subdet = "TOB";
+      layer = tTopo->tobLayer(id);
+      break;
+    case 6:
+      subdet = "TEC";
+      layer = tTopo->tecWheel(id) * (tTopo->tecSide(ModuleID) == 1 ? -1 : +1);
+      break;
+    default:
+      // TODO: Fail loudly.
+      subdet = "UNKNOWN";
+      layer = 0;
   }
   return std::make_pair(subdet, layer);
 }
 
 template <TrackerType pixel_or_strip>
-void MonitorTrackResidualsBase<pixel_or_strip>::createMEs(
-    DQMStore::IBooker &ibooker, const edm::EventSetup &iSetup) {
-
+void MonitorTrackResidualsBase<pixel_or_strip>::createMEs(DQMStore::IBooker &ibooker, const edm::EventSetup &iSetup) {
   // Retrieve tracker topology and geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
@@ -135,7 +126,7 @@ void MonitorTrackResidualsBase<pixel_or_strip>::createMEs(
 
   // Collect list of modules from Tracker Geometry
   // book histo per each detector module
-  auto ids = TG->detIds(); // or detUnitIds?
+  auto ids = TG->detIds();  // or detUnitIds?
   for (DetId id : ids) {
     auto ModuleID = id.rawId();
     auto isPixel = id.subdetId() == 1 || id.subdetId() == 2;
@@ -145,69 +136,59 @@ void MonitorTrackResidualsBase<pixel_or_strip>::createMEs(
     // Book module histogramms?
     if (ModOn) {
       switch (id.subdetId()) {
-      case 1:
-        pixel_organizer.setModuleFolder(ibooker, ModuleID, 0);
-        break;
-      case 2:
-        pixel_organizer.setModuleFolder(ibooker, ModuleID, 0);
-        break;
-      default:
-        strip_organizer.setDetectorFolder(ModuleID, tTopo);
+        case 1:
+          pixel_organizer.setModuleFolder(ibooker, ModuleID, 0);
+          break;
+        case 2:
+          pixel_organizer.setModuleFolder(ibooker, ModuleID, 0);
+          break;
+        default:
+          strip_organizer.setDetectorFolder(ModuleID, tTopo);
       }
       {
         // this sounds strip specific but also works for pixel
-        std::string hid =
-            hidmanager.createHistoId("HitResidualsX", "det", ModuleID);
-        std::string normhid = hidmanager.createHistoId(
-            "NormalizedHitResidualsX", "det", ModuleID);
+        std::string hid = hidmanager.createHistoId("HitResidualsX", "det", ModuleID);
+        std::string normhid = hidmanager.createHistoId("NormalizedHitResidualsX", "det", ModuleID);
         auto &histos = m_ModuleResiduals[std::make_pair("", ModuleID)];
-        histos.x.base = ibooker.book1D(hid, hid, i_residuals_Nbins,
-                                       d_residual_xmin, d_residual_xmax);
+        histos.x.base = ibooker.book1D(hid, hid, i_residuals_Nbins, d_residual_xmin, d_residual_xmax);
         histos.x.base->setAxisTitle("(x_{pred} - x_{rec})' [cm]");
-        histos.x.normed = ibooker.book1D(normhid, normhid, i_normres_Nbins,
-                                         d_normres_xmin, d_normres_xmax);
+        histos.x.normed = ibooker.book1D(normhid, normhid, i_normres_Nbins, d_normres_xmin, d_normres_xmax);
         histos.x.normed->setAxisTitle("(x_{pred} - x_{rec})'/#sigma");
       }
       {
-        std::string hid =
-            hidmanager.createHistoId("HitResidualsY", "det", ModuleID);
-        std::string normhid = hidmanager.createHistoId(
-            "NormalizedHitResidualsY", "det", ModuleID);
+        std::string hid = hidmanager.createHistoId("HitResidualsY", "det", ModuleID);
+        std::string normhid = hidmanager.createHistoId("NormalizedHitResidualsY", "det", ModuleID);
         auto &histos = m_ModuleResiduals[std::make_pair("", ModuleID)];
-        histos.y.base = ibooker.book1D(hid, hid, i_residuals_Nbins,
-                                       d_residual_xmin, d_residual_xmax);
+        histos.y.base = ibooker.book1D(hid, hid, i_residuals_Nbins, d_residual_xmin, d_residual_xmax);
         histos.y.base->setAxisTitle("(y_{pred} - y_{rec})' [cm]");
-        histos.y.normed = ibooker.book1D(normhid, normhid, i_normres_Nbins,
-                                         d_normres_xmin, d_normres_xmax);
+        histos.y.normed = ibooker.book1D(normhid, normhid, i_normres_Nbins, d_normres_xmin, d_normres_xmax);
         histos.y.normed->setAxisTitle("(y_{pred} - y_{rec})'/#sigma");
       }
     }
 
     auto subdetandlayer = findSubdetAndLayer(ModuleID, tTopo);
-    if (m_SubdetLayerResiduals.find(subdetandlayer) ==
-        m_SubdetLayerResiduals.end()) {
+    if (m_SubdetLayerResiduals.find(subdetandlayer) == m_SubdetLayerResiduals.end()) {
       // add new histograms
       auto &histos = m_SubdetLayerResiduals[subdetandlayer];
       switch (id.subdetId()) {
-      // Pixel Barrel, Endcap
-      // We can't use the folder organizer here (SiPixelActionExecutor.cc#1638
-      // does the same)
-      case 1:
-        ibooker.setCurrentFolder("Pixel/Barrel");
-        break;
-      case 2:
-        ibooker.setCurrentFolder("Pixel/Endcap");
-        break;
-      // All strip
-      default:
-        strip_organizer.setLayerFolder(ModuleID, tTopo, subdetandlayer.second);
+        // Pixel Barrel, Endcap
+        // We can't use the folder organizer here (SiPixelActionExecutor.cc#1638
+        // does the same)
+        case 1:
+          ibooker.setCurrentFolder("Pixel/Barrel");
+          break;
+        case 2:
+          ibooker.setCurrentFolder("Pixel/Endcap");
+          break;
+        // All strip
+        default:
+          strip_organizer.setLayerFolder(ModuleID, tTopo, subdetandlayer.second);
       }
 
       auto isBarrel = subdetandlayer.first.find("B") != std::string::npos;
 
-      auto xy = std::vector<std::pair<HistoPair &, const char *>>{
-          std::make_pair(std::ref(histos.x), "X"),
-          std::make_pair(std::ref(histos.y), "Y")};
+      auto xy = std::vector<std::pair<HistoPair &, const char *>>{std::make_pair(std::ref(histos.x), "X"),
+                                                                  std::make_pair(std::ref(histos.y), "Y")};
       for (auto &histopair : xy) {
         // book histogramms on layer level, check for barrel/pixel only for
         // correct labeling
@@ -216,25 +197,23 @@ void MonitorTrackResidualsBase<pixel_or_strip>::createMEs(
         if (!isPixel && histopair.second[0] == 'Y')
           continue;
 
-        std::string histoname =
-            isPixel
-                ? ( // Pixel name
-                      Form("HitResiduals%s_%s%d", histopair.second,
-                           isBarrel ? "L"
-                                    : (subdetandlayer.second > 0 ? "Dp" : "Dm"),
-                           std::abs(subdetandlayer.second)))
-                : (Form("HitResiduals_%s__%s__%d", // Strip TODO: We use a
-                                                   // legacy name.
-                        subdetandlayer.first.c_str(),
-                        isBarrel ? "Layer" : "wheel",
-                        std::abs(subdetandlayer.second)));
+        std::string histoname = isPixel ? (  // Pixel name
+                                              Form("HitResiduals%s_%s%d",
+                                                   histopair.second,
+                                                   isBarrel ? "L" : (subdetandlayer.second > 0 ? "Dp" : "Dm"),
+                                                   std::abs(subdetandlayer.second)))
+                                        : (Form("HitResiduals_%s__%s__%d",  // Strip TODO: We use a
+                                                                            // legacy name.
+                                                subdetandlayer.first.c_str(),
+                                                isBarrel ? "Layer" : "wheel",
+                                                std::abs(subdetandlayer.second)));
 
-        std::string histotitle =
-            Form("HitResiduals %s on %s%s full %s %d", histopair.second,
-                 subdetandlayer.first.c_str(),
-                 isBarrel ? "" : (subdetandlayer.second > 0 ? "+" : "-"),
-                 isBarrel ? "Layer" : (isPixel ? "Disk" : "Wheel"),
-                 std::abs(subdetandlayer.second));
+        std::string histotitle = Form("HitResiduals %s on %s%s full %s %d",
+                                      histopair.second,
+                                      subdetandlayer.first.c_str(),
+                                      isBarrel ? "" : (subdetandlayer.second > 0 ? "+" : "-"),
+                                      isBarrel ? "Layer" : (isPixel ? "Disk" : "Wheel"),
+                                      std::abs(subdetandlayer.second));
 
         std::string normhistoname = Form("Normalized%s", histoname.c_str());
         std::string normhistotitle = Form("Normalized%s", histotitle.c_str());
@@ -243,27 +222,22 @@ void MonitorTrackResidualsBase<pixel_or_strip>::createMEs(
         // histoname << std::endl;
 
         histopair.first.base =
-            ibooker.book1D(histoname.c_str(), histotitle.c_str(),
-                           i_residuals_Nbins, d_residual_xmin, d_residual_xmax);
+            ibooker.book1D(histoname.c_str(), histotitle.c_str(), i_residuals_Nbins, d_residual_xmin, d_residual_xmax);
         histopair.first.base->setAxisTitle("(x_{pred} - x_{rec})' [cm]");
 
-        histopair.first.normed =
-            ibooker.book1D(normhistoname.c_str(), normhistotitle.c_str(),
-                           i_normres_Nbins, d_normres_xmin, d_normres_xmax);
+        histopair.first.normed = ibooker.book1D(
+            normhistoname.c_str(), normhistotitle.c_str(), i_normres_Nbins, d_normres_xmin, d_normres_xmax);
         histopair.first.normed->setAxisTitle("(x_{pred} - x_{rec})'/#sigma");
       }
     }
-  } // end loop over activeDets
+  }  // end loop over activeDets
 }
 
 template <TrackerType pixel_or_strip>
-void MonitorTrackResidualsBase<pixel_or_strip>::analyze(
-    const edm::Event &iEvent, const edm::EventSetup &iSetup) {
-
+void MonitorTrackResidualsBase<pixel_or_strip>::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   auto vtracks = std::vector<TrackerValidationVariables::AVTrackStruct>();
   // Filter out events if Trigger Filtering is requested
-  if (genTriggerEventFlag_->on() &&
-      !genTriggerEventFlag_->accept(iEvent, iSetup))
+  if (genTriggerEventFlag_->on() && !genTriggerEventFlag_->accept(iEvent, iSetup))
     return;
 
   edm::Handle<reco::VertexCollection> vertices;
@@ -277,14 +251,14 @@ void MonitorTrackResidualsBase<pixel_or_strip>::analyze(
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology *const tTopo = tTopoHandle.product();
 
-  avalidator_.fillTrackQuantities(
-      iEvent, iSetup,
-      // tell the validator to only look at good tracks
-      [&](const reco::Track &track) -> bool {
-        return track.pt() > 0.75 &&
-               abs(track.dxy(primaryVertex.position())) < 5 * track.dxyError();
-      },
-      vtracks);
+  avalidator_.fillTrackQuantities(iEvent,
+                                  iSetup,
+                                  // tell the validator to only look at good tracks
+                                  [&](const reco::Track &track) -> bool {
+                                    return track.pt() > 0.75 &&
+                                           abs(track.dxy(primaryVertex.position())) < 5 * track.dxyError();
+                                  },
+                                  vtracks);
 
   for (auto &track : vtracks) {
     for (auto &it : track.hits) {

--- a/DQM/TrigXMonitorClient/interface/HLTScalersClient.h
+++ b/DQM/TrigXMonitorClient/interface/HLTScalersClient.h
@@ -78,8 +78,7 @@ public:
 
   public:
     // default constructor
-    CountLSFifo_t(unsigned int sz = 3)
-        : std::deque<CountLS_t>(), targetSize_(sz) {}
+    CountLSFifo_t(unsigned int sz = 3) : std::deque<CountLS_t>(), targetSize_(sz) {}
     unsigned int targetSize() const { return targetSize_; };
     double getCount(int ls) {
       CountLSFifo_t::iterator p = std::find(this->begin(), this->end(), ls);
@@ -91,11 +90,10 @@ public:
 
     void update(const CountLS_t &T) {
       // do we already have data for this LS?
-      CountLSFifo_t::iterator p =
-          std::find(this->begin(), this->end(), T.first);
-      if (p != this->end()) { // we already have data for this LS
+      CountLSFifo_t::iterator p = std::find(this->begin(), this->end(), T.first);
+      if (p != this->end()) {  // we already have data for this LS
         p->second = T.second;
-      } else { // new data
+      } else {  // new data
         this->push_back(T);
       }
       trim_();
@@ -134,8 +132,7 @@ public:
 
   /// End LumiBlock
   /// DQM Client Diagnostic should be performed here
-  void endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
-                          const edm::EventSetup &c) override;
+  void endLuminosityBlock(const edm::LuminosityBlock &lumiSeg, const edm::EventSetup &c) override;
 
   // unused
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
@@ -143,8 +140,8 @@ public:
 private:
   DQMStore *dbe_;
 
-  int nev_;   // Number of events processed
-  int nLumi_; // number of lumi blocks
+  int nev_;    // Number of events processed
+  int nLumi_;  // number of lumi blocks
   int currentRun_;
 
   MonitorElement *currentRate_;
@@ -153,14 +150,14 @@ private:
   std::vector<MonitorElement *> countHistories_;
 
   std::vector<MonitorElement *> hltCurrentRate_;
-  MonitorElement *hltRate_;  // global rate - any accept
-  MonitorElement *hltCount_; // globalCounts
+  MonitorElement *hltRate_;   // global rate - any accept
+  MonitorElement *hltCount_;  // globalCounts
   //  MonitorElement *hltCountN_; // globalCounts normalized
   MonitorElement *updates_;
   MonitorElement *mergeCount_;
 
   // Normalized
-  MonitorElement *hltNormRate_; // global rate - any accept
+  MonitorElement *hltNormRate_;  // global rate - any accept
   MonitorElement *currentNormRate_;
   std::vector<MonitorElement *> rateNormHistories_;
   std::vector<MonitorElement *> hltCurrentNormRate_;
@@ -183,4 +180,4 @@ private:
   CountLSFifo_t recentNormedOverallCountsPerLS_;
 };
 
-#endif // HLTSCALERSCLIENT_H
+#endif  // HLTSCALERSCLIENT_H

--- a/DQM/TrigXMonitorClient/interface/L1ScalersClient.h
+++ b/DQM/TrigXMonitorClient/interface/L1ScalersClient.h
@@ -42,8 +42,7 @@ public:
 
   /// End LumiBlock
   /// DQM Client Diagnostic should be performed here
-  void endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
-                          const edm::EventSetup &c) override;
+  void endLuminosityBlock(const edm::LuminosityBlock &lumiSeg, const edm::EventSetup &c) override;
 
   // unused
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
@@ -51,8 +50,8 @@ public:
 private:
   DQMStore *dbe_;
 
-  int nev_;   // Number of events processed
-  int nLumi_; // number of lumi blocks
+  int nev_;    // Number of events processed
+  int nLumi_;  // number of lumi blocks
   int currentRun_;
 
   float totAlgoPrevCount;
@@ -60,13 +59,13 @@ private:
 
   unsigned long int l1AlgoScalerCounters_[MAX_ALGOS];
   MonitorElement *l1AlgoCurrentRate_;
-  MonitorElement *l1AlgoRateHistories_[MAX_ALGOS]; // HARD CODE FOR NOW
+  MonitorElement *l1AlgoRateHistories_[MAX_ALGOS];  // HARD CODE FOR NOW
   MonitorElement *l1AlgoCurrentRatePerAlgo_[MAX_ALGOS];
   MonitorElement *totalAlgoRate_;
 
   unsigned long int l1TechTrigScalerCounters_[MAX_TT];
   MonitorElement *l1TechTrigCurrentRate_;
-  MonitorElement *l1TechTrigRateHistories_[MAX_TT]; // HARD CODE FOR NOW
+  MonitorElement *l1TechTrigRateHistories_[MAX_TT];  // HARD CODE FOR NOW
   MonitorElement *l1TechTrigCurrentRatePerAlgo_[MAX_TT];
   MonitorElement *totalTtRate_;
 
@@ -83,4 +82,4 @@ private:
   bool first_tt;
 };
 
-#endif // L1ScalersCLIENT_H
+#endif  // L1ScalersCLIENT_H

--- a/DQM/TrigXMonitorClient/src/HLTScalersClient.cc
+++ b/DQM/TrigXMonitorClient/src/HLTScalersClient.cc
@@ -60,13 +60,16 @@ const int kPerHisto = 20;
 
 /// Constructors
 HLTScalersClient::HLTScalersClient(const edm::ParameterSet &ps)
-    : dbe_(nullptr), nLumi_(0), currentRate_(nullptr),
-      currentLumiBlockNumber_(0), first_(true), missingPathNames_(true),
-      folderName_(ps.getUntrackedParameter<std::string>("dqmFolder",
-                                                        "HLT/HLScalers_EvF")),
-      kRateIntegWindow_(
-          ps.getUntrackedParameter<unsigned int>("rateIntegWindow", 3)),
-      processName_(ps.getParameter<std::string>("processName")), ignores_(),
+    : dbe_(nullptr),
+      nLumi_(0),
+      currentRate_(nullptr),
+      currentLumiBlockNumber_(0),
+      first_(true),
+      missingPathNames_(true),
+      folderName_(ps.getUntrackedParameter<std::string>("dqmFolder", "HLT/HLScalers_EvF")),
+      kRateIntegWindow_(ps.getUntrackedParameter<unsigned int>("rateIntegWindow", 3)),
+      processName_(ps.getParameter<std::string>("processName")),
+      ignores_(),
       debug_(ps.getUntrackedParameter<bool>("debugDump", false)),
       maxFU_(ps.getUntrackedParameter<unsigned int>("maxFU", false)),
       recentOverallCountsPerLS_(kRateIntegWindow_),
@@ -85,24 +88,21 @@ HLTScalersClient::HLTScalersClient(const edm::ParameterSet &ps)
 
   std::string rawdir(folderName_ + "/raw");
   dbe_->setCurrentFolder(rawdir);
-  hltRate_ = dbe_->book1D("hltRate", "Overall HLT Accept rate vs LS",
-                          MAX_LUMI_SEG_HLT, -0.5, MAX_LUMI_SEG_HLT - 0.5);
+  hltRate_ = dbe_->book1D("hltRate", "Overall HLT Accept rate vs LS", MAX_LUMI_SEG_HLT, -0.5, MAX_LUMI_SEG_HLT - 0.5);
   dbe_->setCurrentFolder(folderName_);
-  hltNormRate_ =
-      dbe_->book1D("hltRateNorm", "Overall HLT Accept rate vs LS, scaled",
-                   MAX_LUMI_SEG_HLT, -0.5, MAX_LUMI_SEG_HLT - 0.5);
-  hltCount_ = dbe_->book1D("hltCount", "Overall HLT Counts vs LS",
-                           MAX_LUMI_SEG_HLT, -0.5, MAX_LUMI_SEG_HLT - 0.5);
+  hltNormRate_ = dbe_->book1D(
+      "hltRateNorm", "Overall HLT Accept rate vs LS, scaled", MAX_LUMI_SEG_HLT, -0.5, MAX_LUMI_SEG_HLT - 0.5);
+  hltCount_ = dbe_->book1D("hltCount", "Overall HLT Counts vs LS", MAX_LUMI_SEG_HLT, -0.5, MAX_LUMI_SEG_HLT - 0.5);
   //   hltCountN_= dbe_->book1D("hltCountN", "Overall HLT Counts per LS vs LS",
   // 			  MAX_LUMI_SEG_HLT, -0.5, MAX_LUMI_SEG_HLT-0.5);
-  mergeCount_ = dbe_->book1D("mergeCount", "Number of merge counts vs LS",
-                             MAX_LUMI_SEG_HLT, -0.5, MAX_LUMI_SEG_HLT - 0.5);
+  mergeCount_ =
+      dbe_->book1D("mergeCount", "Number of merge counts vs LS", MAX_LUMI_SEG_HLT, -0.5, MAX_LUMI_SEG_HLT - 0.5);
 
   updates_ = dbe_->book1D("updates", "Status of Updates", 2, 0, 2);
   updates_->setBinLabel(1, "Good Updates");
   updates_->setBinLabel(2, "Incomplete Updates");
 
-} // end constructor
+}  // end constructor
 
 /// BeginJob
 void HLTScalersClient::beginJob(void) {
@@ -120,7 +120,7 @@ void HLTScalersClient::beginRun(const edm::Run &run, const edm::EventSetup &c) {
   first_ = true;
   LogDebug("HLTScalersClient") << "beginRun, run " << run.id();
 
-} // beginRun
+}  // beginRun
 
 /// EndRun
 void HLTScalersClient::endRun(const edm::Run &run, const edm::EventSetup &c) {
@@ -130,8 +130,7 @@ void HLTScalersClient::endRun(const edm::Run &run, const edm::EventSetup &c) {
 
 /// End LumiBlock
 /// DQM Client Diagnostic should be performed here
-void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
-                                          const edm::EventSetup &c) {
+void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg, const edm::EventSetup &c) {
   nLumi_ = lumiSeg.id().luminosityBlock();
   // PWDEBUG
   if (first_ && debug_)
@@ -151,7 +150,7 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
 
   int npaths = scalers->getNbinsX();
   if (npaths > MAX_PATHS)
-    npaths = MAX_PATHS; // HARD CODE FOR NOW
+    npaths = MAX_PATHS;  // HARD CODE FOR NOW
   LogDebug("HLTScalersClient") << "I see " << npaths << " paths. ";
 
   // set the bin labels on the first go-through
@@ -160,15 +159,11 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
   if (first_) {
     std::string rawdir(folderName_ + "/raw");
 
-    LogDebug("HLTScalersClient")
-        << "Setting up paths on first endLumiBlock " << npaths;
+    LogDebug("HLTScalersClient") << "Setting up paths on first endLumiBlock " << npaths;
     dbe_->setCurrentFolder(rawdir);
-    currentRate_ =
-        dbe_->book1D("cur_rate", "current lumi section rate per path", npaths,
-                     -0.5, npaths - 0.5);
-    currentNormRate_ = dbe_->book1D("cur_rate_norm",
-                                    "current norm. lumi section rate per path",
-                                    npaths, -0.5, npaths - 0.5);
+    currentRate_ = dbe_->book1D("cur_rate", "current lumi section rate per path", npaths, -0.5, npaths - 0.5);
+    currentNormRate_ =
+        dbe_->book1D("cur_rate_norm", "current norm. lumi section rate per path", npaths, -0.5, npaths - 0.5);
     recentPathCountsPerLS_.reserve(npaths);
     recentNormedPathCountsPerLS_.reserve(npaths);
     char rates_subfolder[256];
@@ -182,23 +177,20 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
     hltCurrentNormRate_.reserve(npaths);
     rateNormHistories_.reserve(npaths);
 
-    dbe_->setCurrentFolder(folderName_); // these belong in top-level
+    dbe_->setCurrentFolder(folderName_);  // these belong in top-level
     for (int i = 0; i < npaths; ++i) {
       dbe_->setCurrentFolder(std::string(rates_subfolder) + "/raw");
 
       char name[256];
       snprintf(name, 256, "raw_rate_p%03d", i);
       //     LogDebug("HLTScalersClient") << "name " << i << " is " << name ;
-      rateHistories_.push_back(dbe_->book1D(name, name, MAX_LUMI_SEG_HLT, -0.5,
-                                            MAX_LUMI_SEG_HLT - 0.5));
+      rateHistories_.push_back(dbe_->book1D(name, name, MAX_LUMI_SEG_HLT, -0.5, MAX_LUMI_SEG_HLT - 0.5));
       snprintf(name, 256, "norm_rate_p%03d", i);
       dbe_->setCurrentFolder(rates_subfolder);
-      rateNormHistories_.push_back(dbe_->book1D(name, name, MAX_LUMI_SEG_HLT,
-                                                -0.5, MAX_LUMI_SEG_HLT - 0.5));
+      rateNormHistories_.push_back(dbe_->book1D(name, name, MAX_LUMI_SEG_HLT, -0.5, MAX_LUMI_SEG_HLT - 0.5));
       dbe_->setCurrentFolder(counts_subfolder);
       snprintf(name, 256, "counts_p%03d", i);
-      countHistories_.push_back(dbe_->book1D(name, name, MAX_LUMI_SEG_HLT, -0.5,
-                                             MAX_LUMI_SEG_HLT - 0.5));
+      countHistories_.push_back(dbe_->book1D(name, name, MAX_LUMI_SEG_HLT, -0.5, MAX_LUMI_SEG_HLT - 0.5));
       // prefill the data structures
       recentPathCountsPerLS_.push_back(CountLSFifo_t(kRateIntegWindow_));
       recentNormedPathCountsPerLS_.push_back(CountLSFifo_t(2));
@@ -207,9 +199,9 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
 
     // split hlt scalers up into groups of 20
     const int maxlen = 40;
-    char metitle[maxlen];                    // histo name
-    char mename[maxlen];                     // ME name
-    int numHistos = int(npaths / kPerHisto); // this hasta be w/o remainders
+    char metitle[maxlen];                     // histo name
+    char mename[maxlen];                      // ME name
+    int numHistos = int(npaths / kPerHisto);  // this hasta be w/o remainders
 
     int remainder = npaths % kPerHisto;
     if (remainder)
@@ -219,17 +211,13 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
       int npath_low = kPerHisto * k;
       int npath_high = kPerHisto * (k + 1) - 1;
       snprintf(mename, maxlen, "hltScalers_%0d", k);
-      snprintf(metitle, maxlen, "HLT scalers - Paths %d to %d", npath_low,
-               npath_high);
+      snprintf(metitle, maxlen, "HLT scalers - Paths %d to %d", npath_low, npath_high);
       dbe_->setCurrentFolder(rawdir);
-      hltCurrentRate_.push_back(dbe_->book1D(
-          mename, metitle, kPerHisto, -0.5 + npath_low, npath_high + 0.5));
-      dbe_->setCurrentFolder(folderName_); // these belong in top-level
+      hltCurrentRate_.push_back(dbe_->book1D(mename, metitle, kPerHisto, -0.5 + npath_low, npath_high + 0.5));
+      dbe_->setCurrentFolder(folderName_);  // these belong in top-level
       snprintf(mename, maxlen, "hltScalersNorm_%0d", k);
-      snprintf(metitle, maxlen, "HLT Rate (scaled) - Paths %d to %d", npath_low,
-               npath_high);
-      hltCurrentNormRate_.push_back(dbe_->book1D(
-          mename, metitle, kPerHisto, -0.5 + npath_low, npath_high + 0.5));
+      snprintf(metitle, maxlen, "HLT Rate (scaled) - Paths %d to %d", npath_low, npath_high);
+      hltCurrentNormRate_.push_back(dbe_->book1D(mename, metitle, kPerHisto, -0.5 + npath_low, npath_high + 0.5));
     }
 
     first_ = false;
@@ -274,7 +262,7 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
             << "names.dat";
         perror(msg.str().c_str());
       }
-    } else { // open succeeded
+    } else {  // open succeeded
       missingPathNames_ = false;
       std::string line;
       while (!names.eof()) {
@@ -282,12 +270,11 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
         std::istringstream fnames(line);
         std::string label;
         int bin;
-        if (fnames.str().find("#") == 0) // skip comment lines
+        if (fnames.str().find("#") == 0)  // skip comment lines
           continue;
         if (fnames >> bin >> label) {
           if (debug_) {
-            std::cout << bin << "--" << label << "(" << ipath << ")"
-                      << std::endl;
+            std::cout << bin << "--" << label << "(" << ipath << ")" << std::endl;
           }
           currentRate_->setBinLabel(ipath, label);
           currentNormRate_->setBinLabel(ipath, label);
@@ -301,9 +288,9 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
           ++ipath;
           if (ipath > npaths)
             break;
-        } //
-      }   // loop lines
-    }     // open ok
+        }  //
+      }    // loop lines
+    }      // open ok
   }
 
   // END SETUP
@@ -315,12 +302,10 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
     nLumi = dbe_->get(nLumiHisto);
   }
   int testval = (nLumi != nullptr ? nLumi->getIntValue() : -1);
-  LogDebug("HLTScalersClient")
-      << "Lumi Block from DQM: " << testval << ", local is " << nLumi_;
+  LogDebug("HLTScalersClient") << "Lumi Block from DQM: " << testval << ", local is " << nLumi_;
   int nL = (nLumi != nullptr ? nLumi->getIntValue() : nLumi_);
   if (nL > MAX_LUMI_SEG_HLT) {
-    LogDebug("HLTScalersClient") << "Too many Lumi segments, " << nL
-                                 << " is greater than MAX_LUMI_SEG_HLT,"
+    LogDebug("HLTScalersClient") << "Too many Lumi segments, " << nL << " is greater than MAX_LUMI_SEG_HLT,"
                                  << " wrapping to " << (nL % MAX_LUMI_SEG_HLT);
     // nL = MAX_LUMI_SEG_HLT;
     nL = nL % MAX_LUMI_SEG_HLT;
@@ -343,10 +328,10 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
   // loop over current counts
 
   // this gets filled for all times. Mainly for debugging.
-  for (int i = 1; i <= npaths; ++i) { // bins start at 1
+  for (int i = 1; i <= npaths; ++i) {  // bins start at 1
     double current_count = scalers->getBinContent(i);
     // nb that this will now _overwrite_ some settings
-    countHistories_[i - 1]->setBinContent(nL, current_count); // good or bad
+    countHistories_[i - 1]->setBinContent(nL, current_count);  // good or bad
   }
 
   std::string overallScalerName(folderName_ + "/raw/hltOverallScaler");
@@ -363,7 +348,7 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
       if (!edm::isNotFinite(slope_err) && (slope_err >= 0))
         hltRate_->setBinError(nL, slope_err);
     }
-  } // found  histo
+  }  // found  histo
 
   if (num_fu >= 0.95 * maxFU_) {
     if (num_fu > maxFU_) {
@@ -372,15 +357,13 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
         std::cout << "maxFU is now " << maxFU_ << std::endl;
     }
     // good data
-    for (int i = 1; i <= npaths; ++i) { // bins start at 1
+    for (int i = 1; i <= npaths; ++i) {  // bins start at 1
       double current_count = scalers->getBinContent(i);
       // DEBUG
       if (!recentPathCountsPerLS_[i - 1].empty() && debug_)
-        std::cout << i << "\t-> good one: new => cnt, ls = " << current_count
-                  << ", " << nL
-                  << ", old = " << recentPathCountsPerLS_[i - 1].back().second
-                  << "\t" << recentPathCountsPerLS_[i - 1].back().first
-                  << std::endl;
+        std::cout << i << "\t-> good one: new => cnt, ls = " << current_count << ", " << nL
+                  << ", old = " << recentPathCountsPerLS_[i - 1].back().second << "\t"
+                  << recentPathCountsPerLS_[i - 1].back().first << std::endl;
       // END DEBUG
       recentPathCountsPerLS_[i - 1].update(CountLS_t(nL, current_count));
 
@@ -393,20 +376,18 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
       if (slope > 0) {
         rateHistories_[i - 1]->setBinContent(nL, slope);
         // set the current rate(s)
-        hltCurrentRate_[(i - 1) / kPerHisto]->setBinContent(i % kPerHisto,
-                                                            slope);
+        hltCurrentRate_[(i - 1) / kPerHisto]->setBinContent(i % kPerHisto, slope);
         currentRate_->setBinContent(i, slope);
         if (!edm::isNotFinite(slope_err) && (slope_err >= 0)) {
           currentRate_->setBinError(i, slope_err);
-          hltCurrentRate_[(i - 1) / kPerHisto]->setBinError(i % kPerHisto,
-                                                            slope_err);
+          hltCurrentRate_[(i - 1) / kPerHisto]->setBinError(i % kPerHisto, slope_err);
           rateHistories_[i - 1]->setBinError(nL, slope_err);
         }
       }
       //// HACK - normalized path rates
       //// END HACK
 
-    } // loop over paths
+    }  // loop over paths
 
     // ---------------------------- overall rate, absolute counts
     std::string overallScalerName(folderName_ + "/raw/hltOverallScaler");
@@ -423,11 +404,11 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
         if (!edm::isNotFinite(slope_err) && (slope_err >= 0))
           hltRate_->setBinError(nL, slope_err);
       }
-    }                  // found  histo
-    updates_->Fill(0); // good
-  }                    // check on number of FU's - good data
+    }                   // found  histo
+    updates_->Fill(0);  // good
+  }                     // check on number of FU's - good data
   else {
-    updates_->Fill(1); // missing updates
+    updates_->Fill(1);  // missing updates
   }
 
   // PW DEBUG
@@ -448,11 +429,10 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
     double cnt = hltScaler->getBinContent(1);
     //     hltCountN_->setBinContent(nL,cnt);
     if (debug_) {
-      std::cout << "Overall Norm: new => cnt, ls = " << cnt << ", " << nL
-                << ", num_fu = " << num_fu << std::endl;
+      std::cout << "Overall Norm: new => cnt, ls = " << cnt << ", " << nL << ", num_fu = " << num_fu << std::endl;
     }
     recentNormedOverallCountsPerLS_.update(CountLS_t(nL, cnt / num_fu));
-    cnt = recentNormedOverallCountsPerLS_.getCount(nL); // for dupes/partials
+    cnt = recentNormedOverallCountsPerLS_.getCount(nL);  // for dupes/partials
     double slope = cnt / num_fu / SECS_PER_LUMI_SECTION;
     if (debug_) {
       std::cout << "Normalized slope = " << slope << std::endl;
@@ -470,13 +450,12 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
       if (slope > 0) {
         rateNormHistories_[i - 1]->setBinContent(nL, slope);
         // set the current rate(s)
-        hltCurrentNormRate_[(i - 1) / kPerHisto]->setBinContent(i % kPerHisto,
-                                                                slope);
+        hltCurrentNormRate_[(i - 1) / kPerHisto]->setBinContent(i % kPerHisto, slope);
         currentNormRate_->setBinContent(i, slope);
       }
     }
   }
-#else // NOT LATER
+#else  // NOT LATER
   // ------ overall rate normalized - all data
   overallScalerName = std::string(folderName_ + "/raw/hltOverallScaler");
   hltScaler = dbe_->get(overallScalerName);
@@ -485,11 +464,11 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
     //     hltCountN_->setBinContent(nL,cnt);
     float sf = num_fu / maxFU_;
     if (debug_) {
-      std::cout << "Overall Norm: new => cnt, ls = " << cnt << ", " << nL
-                << ", num_fu = " << num_fu << ", sf = " << sf << std::endl;
+      std::cout << "Overall Norm: new => cnt, ls = " << cnt << ", " << nL << ", num_fu = " << num_fu << ", sf = " << sf
+                << std::endl;
     }
     recentNormedOverallCountsPerLS_.update(CountLS_t(nL, cnt / sf));
-    cnt = recentNormedOverallCountsPerLS_.getCount(nL); // for dupes/partials
+    cnt = recentNormedOverallCountsPerLS_.getCount(nL);  // for dupes/partials
     std::pair<double, double> sl = getSlope_(recentNormedOverallCountsPerLS_);
     double slope = sl.first;
     double slope_err = sl.second;
@@ -512,15 +491,13 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
     for (int i = 1; i <= npaths; ++i) {
       double cnt = scalersN->getBinContent(i);
       recentNormedPathCountsPerLS_[i - 1].update(CountLS_t(nL, cnt / sf));
-      std::pair<double, double> sl =
-          getSlope_(recentNormedPathCountsPerLS_[i - 1]);
+      std::pair<double, double> sl = getSlope_(recentNormedPathCountsPerLS_[i - 1]);
       double slope = sl.first;
       double slope_err = sl.second;
       if (slope >= 0) {
         rateNormHistories_[i - 1]->setBinContent(nL, slope);
         // set the current rate(s)
-        hltCurrentNormRate_[(i - 1) / kPerHisto]->setBinContent(i % kPerHisto,
-                                                                slope);
+        hltCurrentNormRate_[(i - 1) / kPerHisto]->setBinContent(i % kPerHisto, slope);
         currentNormRate_->setBinContent(i, slope);
         if (slope_err <= 0 && cnt > 0) {
           // ignores error on prev point, so scale by sqrt(2)
@@ -532,15 +509,14 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
         if (!edm::isNotFinite(slope_err) && (slope_err >= 0)) {
           rateNormHistories_[i - 1]->setBinError(nL, slope_err);
           // set the current rate(s)
-          hltCurrentNormRate_[(i - 1) / kPerHisto]->setBinError(i % kPerHisto,
-                                                                slope_err);
+          hltCurrentNormRate_[(i - 1) / kPerHisto]->setBinError(i % kPerHisto, slope_err);
           currentNormRate_->setBinError(i, slope_err);
         }
       }
     }
   }
 
-#endif // LATER
+#endif  // LATER
   //
 }
 
@@ -552,8 +528,7 @@ void HLTScalersClient::analyze(const edm::Event &e, const edm::EventSetup &c) {
 // this is probably overkill. Do a least-squares fit to get slope
 // note that the data is in units of counts, ls number
 // but we return a value in Hz...
-std::pair<double, double>
-HLTScalersClient::getSlope_(const HLTScalersClient::CountLSFifo_t &points) {
+std::pair<double, double> HLTScalersClient::getSlope_(const HLTScalersClient::CountLSFifo_t &points) {
   double slope, sigma_m;
   if (points.size() < points.targetSize()) {
     return std::pair<double, double>(-1, -1);
@@ -565,7 +540,7 @@ HLTScalersClient::getSlope_(const HLTScalersClient::CountLSFifo_t &points) {
     double delta_cnt = points.front().second - points.back().second;
     slope = delta_cnt / delta_ls;
     sigma_m = -1;
-  } else { // do a fit
+  } else {  // do a fit
     double xy = 0;
     double x = 0;
     double xsq = 0;

--- a/DQM/TrigXMonitorClient/src/L1ScalersClient.cc
+++ b/DQM/TrigXMonitorClient/src/L1ScalersClient.cc
@@ -16,43 +16,44 @@ using edm::LogWarning;
 
 #define SECS_PER_LUMI_SECTION 23.31040958083832;
 const int kPerHisto = 20;
-const int kNumAlgoHistos =
-    MAX_ALGOS / kPerHisto;                   // this hasta be w/o remainders
-const int kNumTTHistos = MAX_TT / kPerHisto; // this hasta be w/o remainders
+const int kNumAlgoHistos = MAX_ALGOS / kPerHisto;  // this hasta be w/o remainders
+const int kNumTTHistos = MAX_TT / kPerHisto;       // this hasta be w/o remainders
 
 /// Constructors
 L1ScalersClient::L1ScalersClient(const edm::ParameterSet &ps)
-    : dbe_(nullptr), nLumi_(0), l1AlgoCurrentRate_(nullptr),
-      l1TechTrigCurrentRate_(nullptr), selected_(nullptr), bxSelected_(nullptr),
-      algoSelected_(ps.getUntrackedParameter<std::vector<int>>(
-          "algoMonitorBits", std::vector<int>())),
-      techSelected_(ps.getUntrackedParameter<std::vector<int>>(
-          "techMonitorBits", std::vector<int>())),
-      folderName_(ps.getUntrackedParameter<std::string>("dqmFolder",
-                                                        "L1T/L1Scalers_EvF")),
-      currentLumiBlockNumber_(0), first_algo(true), first_tt(true) {
+    : dbe_(nullptr),
+      nLumi_(0),
+      l1AlgoCurrentRate_(nullptr),
+      l1TechTrigCurrentRate_(nullptr),
+      selected_(nullptr),
+      bxSelected_(nullptr),
+      algoSelected_(ps.getUntrackedParameter<std::vector<int>>("algoMonitorBits", std::vector<int>())),
+      techSelected_(ps.getUntrackedParameter<std::vector<int>>("techMonitorBits", std::vector<int>())),
+      folderName_(ps.getUntrackedParameter<std::string>("dqmFolder", "L1T/L1Scalers_EvF")),
+      currentLumiBlockNumber_(0),
+      first_algo(true),
+      first_tt(true) {
   LogDebug("Status") << "constructor";
   // get back-end interface
   dbe_ = edm::Service<DQMStore>().operator->();
-  assert(dbe_ != nullptr); // blammo!
+  assert(dbe_ != nullptr);  // blammo!
   dbe_->setCurrentFolder(folderName_);
 
   l1AlgoCurrentRate_ =
-      dbe_->book1D("algo_cur_rate", "current lumi section rate per Algo Bits",
-                   MAX_ALGOS, -0.5, MAX_ALGOS - 0.5);
+      dbe_->book1D("algo_cur_rate", "current lumi section rate per Algo Bits", MAX_ALGOS, -0.5, MAX_ALGOS - 0.5);
 
   l1TechTrigCurrentRate_ =
-      dbe_->book1D("tt_cur_rate", "current lumi section rate per Tech. Trig.s",
-                   MAX_TT, -0.5, MAX_TT - 0.5);
+      dbe_->book1D("tt_cur_rate", "current lumi section rate per Tech. Trig.s", MAX_TT, -0.5, MAX_TT - 0.5);
   // ----------------------
   numSelected_ = algoSelected_.size() + techSelected_.size();
   selected_ = dbe_->book1D("l1BitsSel",
                            "Selected L1 Algorithm"
                            " and tech Bits",
-                           numSelected_, -0.5, numSelected_ - 0.5);
-  bxSelected_ =
-      dbe_->book2D("l1BitsBxSel", "Selected L1 Algorithm Bits vs Bx", 3600,
-                   -0.5, 3599.5, numSelected_, -0.5, numSelected_ - 0.5);
+                           numSelected_,
+                           -0.5,
+                           numSelected_ - 0.5);
+  bxSelected_ = dbe_->book2D(
+      "l1BitsBxSel", "Selected L1 Algorithm Bits vs Bx", 3600, -0.5, 3599.5, numSelected_, -0.5, numSelected_ - 0.5);
   int j = 1;
   for (unsigned int i = 0; i < algoSelected_.size(); ++i) {
     char title[256];
@@ -70,10 +71,8 @@ L1ScalersClient::L1ScalersClient(const edm::ParameterSet &ps)
   }
 
   // book individual bit rates vs lumi for algo bits.
-  totalAlgoRate_ = dbe_->book1D("totAlgoRate", "Total Algo Rate", MAX_LUMI_SEG,
-                                -0.5, MAX_LUMI_SEG - 0.5);
-  totalTtRate_ = dbe_->book1D("totTtRate", "Total Tech Rate", MAX_LUMI_SEG,
-                              -0.5, MAX_LUMI_SEG - 0.5);
+  totalAlgoRate_ = dbe_->book1D("totAlgoRate", "Total Algo Rate", MAX_LUMI_SEG, -0.5, MAX_LUMI_SEG - 0.5);
+  totalTtRate_ = dbe_->book1D("totTtRate", "Total Tech Rate", MAX_LUMI_SEG, -0.5, MAX_LUMI_SEG - 0.5);
 
   totAlgoPrevCount = 0UL;
   totTtPrevCount = 0UL;
@@ -83,12 +82,11 @@ L1ScalersClient::L1ScalersClient(const edm::ParameterSet &ps)
 
   for (int i = 0; i < MAX_ALGOS; ++i) {
     l1AlgoScalerCounters_[i] = 0UL;
-    l1AlgoRateHistories_[i] = nullptr; // not really needed but ...
+    l1AlgoRateHistories_[i] = nullptr;  // not really needed but ...
     char name[256];
     snprintf(name, 256, "rate_algobit%03d", i);
     LogDebug("Parameter") << "name " << i << " is " << name;
-    l1AlgoRateHistories_[i] =
-        dbe_->book1D(name, name, MAX_LUMI_SEG, -0.5, MAX_LUMI_SEG - 0.5);
+    l1AlgoRateHistories_[i] = dbe_->book1D(name, name, MAX_LUMI_SEG, -0.5, MAX_LUMI_SEG - 0.5);
   }
 
   // book individual bit rates vs lumi for technical trigger bits.
@@ -98,28 +96,25 @@ L1ScalersClient::L1ScalersClient(const edm::ParameterSet &ps)
 
   for (int i = 0; i < MAX_TT; ++i) {
     l1TechTrigScalerCounters_[i] = 0UL;
-    l1TechTrigRateHistories_[i] = nullptr; // not really needed but ...
+    l1TechTrigRateHistories_[i] = nullptr;  // not really needed but ...
     char name[256];
     snprintf(name, 256, "rate_ttbit%03d", i);
     LogDebug("Parameter") << "name " << i << " is " << name;
-    l1TechTrigRateHistories_[i] =
-        dbe_->book1D(name, name, MAX_LUMI_SEG, -0.5, MAX_LUMI_SEG - 0.5);
+    l1TechTrigRateHistories_[i] = dbe_->book1D(name, name, MAX_LUMI_SEG, -0.5, MAX_LUMI_SEG - 0.5);
   }
 
   // split l1 scalers up into groups of 20, assuming total of 140 bits
   std::string algodir2 = "/AlgoBits";
   dbe_->setCurrentFolder(folderName_ + algodir2);
 
-  char metitle1[40]; // histo name
-  char mename1[40];  // ME name
+  char metitle1[40];  // histo name
+  char mename1[40];   // ME name
   for (int k = 0; k < kNumAlgoHistos; k++) {
     int npath_low = kPerHisto * k;
     int npath_high = kPerHisto * (k + 1) - 1;
     snprintf(mename1, 40, "L1AlgoBits_%0d", k);
-    snprintf(metitle1, 40, "L1 rates - Algo Bits %d to %d", npath_low,
-             npath_high);
-    l1AlgoCurrentRatePerAlgo_[k] = dbe_->book1D(
-        mename1, metitle1, kPerHisto, -0.5 + npath_low, npath_high + 0.5);
+    snprintf(metitle1, 40, "L1 rates - Algo Bits %d to %d", npath_low, npath_high);
+    l1AlgoCurrentRatePerAlgo_[k] = dbe_->book1D(mename1, metitle1, kPerHisto, -0.5 + npath_low, npath_high + 0.5);
   }
 
   // split l1 scalers up into groups of 20, assuming total of 80 technical bits
@@ -127,16 +122,14 @@ L1ScalersClient::L1ScalersClient(const edm::ParameterSet &ps)
   std::string techdir2 = "/TechBits";
   dbe_->setCurrentFolder(folderName_ + techdir2);
 
-  char metitle2[40]; // histo name
-  char mename2[40];  // ME name
+  char metitle2[40];  // histo name
+  char mename2[40];   // ME name
   for (int k = 0; k < kNumTTHistos; k++) {
     int npath_low = kPerHisto * k;
     int npath_high = kPerHisto * (k + 1) - 1;
     snprintf(mename2, 40, "L1TechBits_%0d", k);
-    snprintf(metitle2, 40, "L1 rates - Tech. Trig. Bits %d to %d", npath_low,
-             npath_high);
-    l1TechTrigCurrentRatePerAlgo_[k] = dbe_->book1D(
-        mename2, metitle2, kPerHisto, -0.5 + npath_low, npath_high + 0.5);
+    snprintf(metitle2, 40, "L1 rates - Tech. Trig. Bits %d to %d", npath_low, npath_high);
+    l1TechTrigCurrentRatePerAlgo_[k] = dbe_->book1D(mename2, metitle2, kPerHisto, -0.5 + npath_low, npath_high + 0.5);
   }
 
   std::ostringstream params;
@@ -167,16 +160,13 @@ void L1ScalersClient::endRun(const edm::Run &run, const edm::EventSetup &c) {}
 
 /// End LumiBlock
 /// DQM Client Diagnostic should be performed here
-void L1ScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
-                                         const edm::EventSetup &c) {
+void L1ScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg, const edm::EventSetup &c) {
   nLumi_ = lumiSeg.id().luminosityBlock();
 
   // get EvF data
 
-  MonitorElement *algoScalers =
-      dbe_->get(folderName_ + std::string("/l1AlgoBits"));
-  MonitorElement *ttScalers =
-      dbe_->get(folderName_ + std::string("/l1TechBits"));
+  MonitorElement *algoScalers = dbe_->get(folderName_ + std::string("/l1AlgoBits"));
+  MonitorElement *ttScalers = dbe_->get(folderName_ + std::string("/l1TechBits"));
 
   if (algoScalers == nullptr || ttScalers == nullptr) {
     LogInfo("Status") << "cannot get l1 scalers histogram, bailing out.";
@@ -187,9 +177,9 @@ void L1ScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
   int nttbits = ttScalers->getNbinsX();
 
   if (nalgobits > MAX_ALGOS)
-    nalgobits = MAX_ALGOS; // HARD CODE FOR NOW
+    nalgobits = MAX_ALGOS;  // HARD CODE FOR NOW
   if (nttbits > MAX_TT)
-    nttbits = MAX_TT; // HARD CODE FOR NOW
+    nttbits = MAX_TT;  // HARD CODE FOR NOW
 
   LogDebug("Status") << "I see " << nalgobits << " algo paths. ";
   LogDebug("Status") << "I see " << nttbits << " tt paths. ";
@@ -225,13 +215,11 @@ void L1ScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
   MonitorElement *nLumi = dbe_->get(folderName_ + std::string("nLumiBlock"));
 
   int testval = (nLumi != nullptr ? nLumi->getIntValue() : -1);
-  LogDebug("Parameter") << "Lumi Block from DQM: " << testval << ", local is "
-                        << nLumi_;
+  LogDebug("Parameter") << "Lumi Block from DQM: " << testval << ", local is " << nLumi_;
 
   int nL = (nLumi != nullptr ? nLumi->getIntValue() : nLumi_);
   if (nL > MAX_LUMI_SEG) {
-    LogDebug("Status") << "Too many Lumi segments, " << nL
-                       << " is greater than MAX_LUMI_SEG,"
+    LogDebug("Status") << "Too many Lumi segments, " << nL << " is greater than MAX_LUMI_SEG,"
                        << " wrapping to " << (nL % MAX_LUMI_SEG);
     nL = nL % MAX_LUMI_SEG;
   }
@@ -239,21 +227,19 @@ void L1ScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
   if (delta_t < 0) {
     LogDebug("Status") << " time is negative ... " << delta_t;
     delta_t = -delta_t;
-  } else if (nL == currentLumiBlockNumber_) { // divide-by-zero
+  } else if (nL == currentLumiBlockNumber_) {  // divide-by-zero
     LogInfo("Status") << "divide by zero: same lumi section 2x " << nL;
     return;
   }
   // selected ---------------------  fill in the rates for th
-  int currSlot = 1; // for selected bits histogram
-  MonitorElement *algoBx =
-      dbe_->get(folderName_ + std::string("/l1AlgoBits_Vs_Bx"));
+  int currSlot = 1;  // for selected bits histogram
+  MonitorElement *algoBx = dbe_->get(folderName_ + std::string("/l1AlgoBits_Vs_Bx"));
   // selected ---------------------  end
-  for (int i = 1; i <= nalgobits; ++i) { // bins start at 1
+  for (int i = 1; i <= nalgobits; ++i) {  // bins start at 1
     float current_count = algoScalers->getBinContent(i);
     // selected -------------------- start
-    int bit = i - 1; //
-    if (std::find(algoSelected_.begin(), algoSelected_.end(), bit) !=
-        algoSelected_.end()) {
+    int bit = i - 1;  //
+    if (std::find(algoSelected_.begin(), algoSelected_.end(), bit) != algoSelected_.end()) {
       selected_->setBinContent(currSlot, current_count);
       if (algoBx) {
         for (int j = 1; j <= 3600; ++j) {
@@ -268,23 +254,20 @@ void L1ScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
       LogDebug("Parameter") << "rate path " << i << " is " << rate;
     }
     l1AlgoCurrentRate_->setBinContent(i, rate);
-    l1AlgoCurrentRatePerAlgo_[i / kPerHisto]->setBinContent(i % kPerHisto,
-                                                            rate);
+    l1AlgoCurrentRatePerAlgo_[i / kPerHisto]->setBinContent(i % kPerHisto, rate);
     // currentRate_->setBinError(i, error);
     l1AlgoScalerCounters_[i - 1] = (unsigned long)(current_count);
     l1AlgoRateHistories_[i - 1]->setBinContent(nL, rate);
   }
   // selected ----------------- start
-  MonitorElement *techBx =
-      dbe_->get(folderName_ + std::string("/l1TechBits_Vs_Bx"));
+  MonitorElement *techBx = dbe_->get(folderName_ + std::string("/l1TechBits_Vs_Bx"));
   // selected ----------------- end
 
-  for (int i = 1; i <= nttbits; ++i) { // bins start at 1
+  for (int i = 1; i <= nttbits; ++i) {  // bins start at 1
     float current_count = ttScalers->getBinContent(i);
     // selected -------------------- start
-    int bit = i - 1; //
-    if (std::find(techSelected_.begin(), techSelected_.end(), bit) !=
-        techSelected_.end()) {
+    int bit = i - 1;  //
+    if (std::find(techSelected_.begin(), techSelected_.end(), bit) != techSelected_.end()) {
       selected_->setBinContent(currSlot, current_count);
       if (techBx) {
         for (int j = 1; j <= 3600; ++j) {
@@ -299,18 +282,15 @@ void L1ScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
       LogDebug("Parameter") << "rate path " << i << " is " << rate;
     }
     l1TechTrigCurrentRate_->setBinContent(i, rate);
-    l1TechTrigCurrentRatePerAlgo_[i / kPerHisto]->setBinContent(i % kPerHisto,
-                                                                rate);
+    l1TechTrigCurrentRatePerAlgo_[i / kPerHisto]->setBinContent(i % kPerHisto, rate);
     // currentRate_->setBinError(i, error);
     l1TechTrigScalerCounters_[i - 1] = (unsigned long)(current_count);
     l1TechTrigRateHistories_[i - 1]->setBinContent(nL, rate);
   }
 
   //  compute total rate
-  MonitorElement *l1AlgoCounter =
-      dbe_->get(folderName_ + std::string("/l1AlgoCounter"));
-  MonitorElement *l1TtCounter =
-      dbe_->get(folderName_ + std::string("/l1TtCounter"));
+  MonitorElement *l1AlgoCounter = dbe_->get(folderName_ + std::string("/l1AlgoCounter"));
+  MonitorElement *l1TtCounter = dbe_->get(folderName_ + std::string("/l1TtCounter"));
   if (l1AlgoCounter != nullptr && l1TtCounter != nullptr) {
     float totAlgoCount = l1AlgoCounter->getIntValue();
     float totTtCount = l1TtCounter->getIntValue();

--- a/DQMOffline/CalibMuon/interface/DTPreCalibrationTask.h
+++ b/DQMOffline/CalibMuon/interface/DTPreCalibrationTask.h
@@ -28,7 +28,6 @@ class DQMStore;
 class MonitorElement;
 
 class DTPreCalibrationTask : public DQMEDAnalyzer {
-
 public:
   /// Constructor
   DTPreCalibrationTask(const edm::ParameterSet &ps);
@@ -36,8 +35,7 @@ public:
   /// Destructor
   ~DTPreCalibrationTask() override;
 
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
   /// Book histos

--- a/DQMOffline/CalibMuon/interface/DTnoiseDBValidation.h
+++ b/DQMOffline/CalibMuon/interface/DTnoiseDBValidation.h
@@ -38,8 +38,7 @@ public:
   void beginRun(const edm::Run &run, const edm::EventSetup &setup) override;
   void endRun(edm::Run const &, edm::EventSetup const &) override;
   void endJob() override;
-  void analyze(const edm::Event &event, const edm::EventSetup &setup) override {
-  }
+  void analyze(const edm::Event &event, const edm::EventSetup &setup) override {}
 
 protected:
 private:
@@ -49,8 +48,7 @@ private:
   // The DB label
   std::string labelDBRef_;
   std::string labelDB_;
-  std::string diffTestName_, wheelTestName_, stationTestName_, sectorTestName_,
-      layerTestName_;
+  std::string diffTestName_, wheelTestName_, stationTestName_, sectorTestName_, layerTestName_;
 
   bool outputMEsInRootFile_;
   std::string outputFileName_;

--- a/DQMOffline/CalibMuon/interface/DTt0DBValidation.h
+++ b/DQMOffline/CalibMuon/interface/DTt0DBValidation.h
@@ -41,8 +41,7 @@ public:
   void beginRun(const edm::Run &run, const edm::EventSetup &setup) override;
   void endRun(edm::Run const &, edm::EventSetup const &) override;
   void endJob() override;
-  void analyze(const edm::Event &event, const edm::EventSetup &setup) override {
-  }
+  void analyze(const edm::Event &event, const edm::EventSetup &setup) override {}
 
 private:
   void bookHistos(DTLayerId lId, int firstWire, int lastWire);

--- a/DQMOffline/CalibMuon/interface/DTtTrigDBValidation.h
+++ b/DQMOffline/CalibMuon/interface/DTtTrigDBValidation.h
@@ -21,7 +21,6 @@
 class TFile;
 
 class DTtTrigDBValidation : public DQMEDAnalyzer {
-
 public:
   /// Constructor
   DTtTrigDBValidation(const edm::ParameterSet &pset);
@@ -30,8 +29,7 @@ public:
   ~DTtTrigDBValidation() override;
 
   /// Operations
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
 private:

--- a/DQMOffline/CalibMuon/src/DTnoiseDBValidation.cc
+++ b/DQMOffline/CalibMuon/src/DTnoiseDBValidation.cc
@@ -38,9 +38,7 @@ using namespace edm;
 using namespace std;
 
 DTnoiseDBValidation::DTnoiseDBValidation(const ParameterSet &pset) {
-
-  LogVerbatim("NoiseDBValidation")
-      << "[DTnoiseDBValidation] Constructor called!";
+  LogVerbatim("NoiseDBValidation") << "[DTnoiseDBValidation] Constructor called!";
 
   // Get the DQM needed services
   dbe_ = edm::Service<DQMStore>().operator->();
@@ -79,8 +77,7 @@ DTnoiseDBValidation::DTnoiseDBValidation(const ParameterSet &pset) {
 
 DTnoiseDBValidation::~DTnoiseDBValidation() {}
 
-void DTnoiseDBValidation::beginRun(const edm::Run &run,
-                                   const EventSetup &setup) {
+void DTnoiseDBValidation::beginRun(const edm::Run &run, const EventSetup &setup) {
   ESHandle<DTStatusFlag> noiseRef;
   setup.get<DTStatusFlagRcd>().get(labelDBRef_, noiseRef);
   noiseRefMap_ = &*noiseRef;
@@ -92,36 +89,27 @@ void DTnoiseDBValidation::beginRun(const edm::Run &run,
   // Get the geometry
   setup.get<MuonGeometryRecord>().get(dtGeom_);
 
-  LogVerbatim("NoiseDBValidation")
-      << "[DTnoiseDBValidation] Parameters initialization";
+  LogVerbatim("NoiseDBValidation") << "[DTnoiseDBValidation] Parameters initialization";
 
   noisyCellsRef_ = 0;
   noisyCellsValid_ = 0;
 
   // Histo booking
-  diffHisto_ = dbe_->book1D(
-      "noisyCellDiff",
-      "percentual (wrt the previous db) total number of noisy cells", 1, 0.5,
-      1.5);
+  diffHisto_ =
+      dbe_->book1D("noisyCellDiff", "percentual (wrt the previous db) total number of noisy cells", 1, 0.5, 1.5);
   diffHisto_->setBinLabel(1, "Diff");
-  wheelHisto_ =
-      dbe_->book1D("wheelOccupancy",
-                   "percentual noisy cells occupancy per wheel", 5, -2.5, 2.5);
+  wheelHisto_ = dbe_->book1D("wheelOccupancy", "percentual noisy cells occupancy per wheel", 5, -2.5, 2.5);
   wheelHisto_->setBinLabel(1, "Wh-2");
   wheelHisto_->setBinLabel(2, "Wh-1");
   wheelHisto_->setBinLabel(3, "Wh0");
   wheelHisto_->setBinLabel(4, "Wh1");
   wheelHisto_->setBinLabel(5, "Wh2");
-  stationHisto_ =
-      dbe_->book1D("stationOccupancy",
-                   "percentual noisy cells occupancy per station", 4, 0.5, 4.5);
+  stationHisto_ = dbe_->book1D("stationOccupancy", "percentual noisy cells occupancy per station", 4, 0.5, 4.5);
   stationHisto_->setBinLabel(1, "St1");
   stationHisto_->setBinLabel(2, "St2");
   stationHisto_->setBinLabel(3, "St3");
   stationHisto_->setBinLabel(4, "St4");
-  sectorHisto_ = dbe_->book1D("sectorOccupancy",
-                              "percentual noisy cells occupancy per sector", 12,
-                              0.5, 12.5);
+  sectorHisto_ = dbe_->book1D("sectorOccupancy", "percentual noisy cells occupancy per sector", 12, 0.5, 12.5);
   sectorHisto_->setBinLabel(1, "Sect1");
   sectorHisto_->setBinLabel(2, "Sect2");
   sectorHisto_->setBinLabel(3, "Sect3");
@@ -134,9 +122,7 @@ void DTnoiseDBValidation::beginRun(const edm::Run &run,
   sectorHisto_->setBinLabel(10, "Sect10");
   sectorHisto_->setBinLabel(11, "Sect11");
   sectorHisto_->setBinLabel(12, "Sect12");
-  layerHisto_ =
-      dbe_->book1D("layerOccupancy",
-                   "percentual noisy cells occupancy per layer", 3, 0.5, 3.5);
+  layerHisto_ = dbe_->book1D("layerOccupancy", "percentual noisy cells occupancy per layer", 3, 0.5, 3.5);
   layerHisto_->setBinLabel(1, "First 10 bins");
   layerHisto_->setBinLabel(2, "Middle bins");
   layerHisto_->setBinLabel(3, "Last 10 bins");
@@ -152,21 +138,25 @@ void DTnoiseDBValidation::beginRun(const edm::Run &run,
   layerMap.clear();
 
   // Loop over reference DB entries
-  for (DTStatusFlag::const_iterator noise = noiseRefMap_->begin();
-       noise != noiseRefMap_->end(); noise++) {
-    DTWireId wireId((*noise).first.wheelId, (*noise).first.stationId,
-                    (*noise).first.sectorId, (*noise).first.slId,
-                    (*noise).first.layerId, (*noise).first.cellId);
+  for (DTStatusFlag::const_iterator noise = noiseRefMap_->begin(); noise != noiseRefMap_->end(); noise++) {
+    DTWireId wireId((*noise).first.wheelId,
+                    (*noise).first.stationId,
+                    (*noise).first.sectorId,
+                    (*noise).first.slId,
+                    (*noise).first.layerId,
+                    (*noise).first.cellId);
     LogVerbatim("NoiseDBValidation") << "Ref. noisy wire: " << wireId;
     ++noisyCellsRef_;
   }
 
   // Loop over validation DB entries
-  for (DTStatusFlag::const_iterator noise = noiseMap_->begin();
-       noise != noiseMap_->end(); noise++) {
-    DTWireId wireId((*noise).first.wheelId, (*noise).first.stationId,
-                    (*noise).first.sectorId, (*noise).first.slId,
-                    (*noise).first.layerId, (*noise).first.cellId);
+  for (DTStatusFlag::const_iterator noise = noiseMap_->begin(); noise != noiseMap_->end(); noise++) {
+    DTWireId wireId((*noise).first.wheelId,
+                    (*noise).first.stationId,
+                    (*noise).first.sectorId,
+                    (*noise).first.slId,
+                    (*noise).first.layerId,
+                    (*noise).first.cellId);
     LogVerbatim("NoiseDBValidation") << "Valid. noisy wire: " << wireId;
     ++noisyCellsValid_;
 
@@ -174,8 +164,7 @@ void DTnoiseDBValidation::beginRun(const edm::Run &run,
     stMap[(*noise).first.stationId]++;
     sectMap[(*noise).first.sectorId]++;
 
-    const DTTopology &dtTopo =
-        dtGeom_->layer(wireId.layerId())->specificTopology();
+    const DTTopology &dtTopo = dtGeom_->layer(wireId.layerId())->specificTopology();
     const int lastWire = dtTopo.lastChannel();
     if ((*noise).first.cellId <= 10)
       layerMap[1]++;
@@ -196,102 +185,84 @@ void DTnoiseDBValidation::beginRun(const edm::Run &run,
   diffHisto_->Fill(1, abs(noisyCellsRef_ - noisyCellsValid_) * scale);
 
   scale = 1 / double(noisyCellsValid_);
-  for (map<int, int>::const_iterator wheel = whMap.begin();
-       wheel != whMap.end(); wheel++) {
+  for (map<int, int>::const_iterator wheel = whMap.begin(); wheel != whMap.end(); wheel++) {
     wheelHisto_->Fill((*wheel).first, ((*wheel).second) * scale);
   }
-  for (map<int, int>::const_iterator station = stMap.begin();
-       station != stMap.end(); station++) {
+  for (map<int, int>::const_iterator station = stMap.begin(); station != stMap.end(); station++) {
     stationHisto_->Fill((*station).first, ((*station).second) * scale);
   }
-  for (map<int, int>::const_iterator sector = sectMap.begin();
-       sector != sectMap.end(); sector++) {
+  for (map<int, int>::const_iterator sector = sectMap.begin(); sector != sectMap.end(); sector++) {
     sectorHisto_->Fill((*sector).first, ((*sector).second) * scale);
   }
-  for (map<int, int>::const_iterator layer = layerMap.begin();
-       layer != layerMap.end(); layer++) {
+  for (map<int, int>::const_iterator layer = layerMap.begin(); layer != layerMap.end(); layer++) {
     layerHisto_->Fill((*layer).first, ((*layer).second) * scale);
   }
 }
 
-void DTnoiseDBValidation::endRun(edm::Run const &run,
-                                 edm::EventSetup const &setup) {
-
+void DTnoiseDBValidation::endRun(edm::Run const &run, edm::EventSetup const &setup) {
   // test on difference histo
   // string testCriterionName;
   // testCriterionName =
   // parameters.getUntrackedParameter<string>("diffTestName","noiseDifferenceInRange");
   const QReport *theDiffQReport = diffHisto_->getQReport(diffTestName_);
   if (theDiffQReport) {
-    vector<dqm::me_util::Channel> badChannels =
-        theDiffQReport->getBadChannels();
-    for (vector<dqm::me_util::Channel>::iterator channel = badChannels.begin();
-         channel != badChannels.end(); channel++) {
-      LogWarning("NoiseDBValidation")
-          << " Bad partial difference of noisy channels! Contents : "
-          << (*channel).getContents();
+    vector<dqm::me_util::Channel> badChannels = theDiffQReport->getBadChannels();
+    for (vector<dqm::me_util::Channel>::iterator channel = badChannels.begin(); channel != badChannels.end();
+         channel++) {
+      LogWarning("NoiseDBValidation") << " Bad partial difference of noisy channels! Contents : "
+                                      << (*channel).getContents();
     }
   }
   // testCriterionName =
   // parameters.getUntrackedParameter<string>("wheelTestName","noiseWheelOccInRange");
   const QReport *theDiffQReport2 = wheelHisto_->getQReport(wheelTestName_);
   if (theDiffQReport2) {
-    vector<dqm::me_util::Channel> badChannels =
-        theDiffQReport2->getBadChannels();
-    for (vector<dqm::me_util::Channel>::iterator channel = badChannels.begin();
-         channel != badChannels.end(); channel++) {
+    vector<dqm::me_util::Channel> badChannels = theDiffQReport2->getBadChannels();
+    for (vector<dqm::me_util::Channel>::iterator channel = badChannels.begin(); channel != badChannels.end();
+         channel++) {
       int wheel = (*channel).getBin() - 3;
-      LogWarning("NoiseDBValidation")
-          << " Bad percentual occupancy for wheel : " << wheel
-          << "  Contents : " << (*channel).getContents();
+      LogWarning("NoiseDBValidation") << " Bad percentual occupancy for wheel : " << wheel
+                                      << "  Contents : " << (*channel).getContents();
     }
   }
   // testCriterionName =
   // parameters.getUntrackedParameter<string>("stationTestName","noiseStationOccInRange");
   const QReport *theDiffQReport3 = stationHisto_->getQReport(stationTestName_);
   if (theDiffQReport3) {
-    vector<dqm::me_util::Channel> badChannels =
-        theDiffQReport3->getBadChannels();
-    for (vector<dqm::me_util::Channel>::iterator channel = badChannels.begin();
-         channel != badChannels.end(); channel++) {
-      LogWarning("NoiseDBValidation")
-          << " Bad percentual occupancy for station : " << (*channel).getBin()
-          << "  Contents : " << (*channel).getContents();
+    vector<dqm::me_util::Channel> badChannels = theDiffQReport3->getBadChannels();
+    for (vector<dqm::me_util::Channel>::iterator channel = badChannels.begin(); channel != badChannels.end();
+         channel++) {
+      LogWarning("NoiseDBValidation") << " Bad percentual occupancy for station : " << (*channel).getBin()
+                                      << "  Contents : " << (*channel).getContents();
     }
   }
   // testCriterionName =
   // parameters.getUntrackedParameter<string>("sectorTestName","noiseSectorOccInRange");
   const QReport *theDiffQReport4 = sectorHisto_->getQReport(sectorTestName_);
   if (theDiffQReport4) {
-    vector<dqm::me_util::Channel> badChannels =
-        theDiffQReport4->getBadChannels();
-    for (vector<dqm::me_util::Channel>::iterator channel = badChannels.begin();
-         channel != badChannels.end(); channel++) {
-      LogWarning("NoiseDBValidation")
-          << " Bad percentual occupancy for sector : " << (*channel).getBin()
-          << "  Contents : " << (*channel).getContents();
+    vector<dqm::me_util::Channel> badChannels = theDiffQReport4->getBadChannels();
+    for (vector<dqm::me_util::Channel>::iterator channel = badChannels.begin(); channel != badChannels.end();
+         channel++) {
+      LogWarning("NoiseDBValidation") << " Bad percentual occupancy for sector : " << (*channel).getBin()
+                                      << "  Contents : " << (*channel).getContents();
     }
   }
   // testCriterionName =
   // parameters.getUntrackedParameter<string>("layerTestName","noiseLayerOccInRange");
   const QReport *theDiffQReport5 = layerHisto_->getQReport(layerTestName_);
   if (theDiffQReport5) {
-    vector<dqm::me_util::Channel> badChannels =
-        theDiffQReport5->getBadChannels();
-    for (vector<dqm::me_util::Channel>::iterator channel = badChannels.begin();
-         channel != badChannels.end(); channel++) {
+    vector<dqm::me_util::Channel> badChannels = theDiffQReport5->getBadChannels();
+    for (vector<dqm::me_util::Channel>::iterator channel = badChannels.begin(); channel != badChannels.end();
+         channel++) {
       if ((*channel).getBin() == 1)
-        LogWarning("NoiseDBValidation")
-            << " Bad percentual occupancy for the first 10 wires! Contents : "
-            << (*channel).getContents();
+        LogWarning("NoiseDBValidation") << " Bad percentual occupancy for the first 10 wires! Contents : "
+                                        << (*channel).getContents();
       if ((*channel).getBin() == 2)
-        LogWarning("NoiseDBValidation")
-            << " Bad percentual occupancy for the middle wires! Contents : "
-            << (*channel).getContents();
+        LogWarning("NoiseDBValidation") << " Bad percentual occupancy for the middle wires! Contents : "
+                                        << (*channel).getContents();
       if ((*channel).getBin() == 3)
-        LogWarning("NoiseDBValidation")
-            << " Bad percentual occupancy for the last 10 wires! Contents : "
-            << (*channel).getContents();
+        LogWarning("NoiseDBValidation") << " Bad percentual occupancy for the last 10 wires! Contents : "
+                                        << (*channel).getContents();
     }
   }
 }
@@ -305,30 +276,27 @@ void DTnoiseDBValidation::endJob() {
 void DTnoiseDBValidation::bookHisto(const DTChamberId &chId) {
   stringstream histoName;
   histoName << "NoiseOccupancy"
-            << "_W" << chId.wheel() << "_St" << chId.station() << "_Sec"
-            << chId.sector();
+            << "_W" << chId.wheel() << "_St" << chId.station() << "_Sec" << chId.sector();
 
-  if (noiseHistoMap_.find(chId) == noiseHistoMap_.end()) { // Redundant check
+  if (noiseHistoMap_.find(chId) == noiseHistoMap_.end()) {  // Redundant check
     // Get the chamber from the geometry
     int nWiresMax = 0;
     const DTChamber *dtchamber = dtGeom_->chamber(chId);
     const vector<const DTSuperLayer *> &superlayers = dtchamber->superLayers();
 
     // Loop over layers and find the max # of wires
-    for (vector<const DTSuperLayer *>::const_iterator sl = superlayers.begin();
-         sl != superlayers.end(); ++sl) { // loop over SLs
+    for (vector<const DTSuperLayer *>::const_iterator sl = superlayers.begin(); sl != superlayers.end();
+         ++sl) {  // loop over SLs
       vector<const DTLayer *> layers = (*sl)->layers();
-      for (vector<const DTLayer *>::const_iterator lay = layers.begin();
-           lay != layers.end(); ++lay) { // loop over layers
+      for (vector<const DTLayer *>::const_iterator lay = layers.begin(); lay != layers.end();
+           ++lay) {  // loop over layers
         int nWires = (*lay)->specificTopology().channels();
         if (nWires > nWiresMax)
           nWiresMax = nWires;
       }
     }
 
-    noiseHistoMap_[chId] =
-        dbe_->book2D(histoName.str(), "Noise occupancy", nWiresMax, 1,
-                     (nWiresMax + 1), 12, 1, 13);
+    noiseHistoMap_[chId] = dbe_->book2D(histoName.str(), "Noise occupancy", nWiresMax, 1, (nWiresMax + 1), 12, 1, 13);
     for (int i_sl = 1; i_sl <= 3; ++i_sl) {
       for (int i_lay = 1; i_lay <= 4; ++i_lay) {
         int binNumber = 4 * (i_sl - 1) + i_lay;

--- a/DQMOffline/CalibMuon/src/DTt0DBValidation.cc
+++ b/DQMOffline/CalibMuon/src/DTt0DBValidation.cc
@@ -36,7 +36,6 @@ using namespace edm;
 using namespace std;
 
 DTt0DBValidation::DTt0DBValidation(const ParameterSet &pset) {
-
   metname_ = "InterChannelSynchDBValidation";
   LogVerbatim(metname_) << "[DTt0DBValidation] Constructor called!";
 
@@ -62,21 +61,18 @@ DTt0DBValidation::DTt0DBValidation(const ParameterSet &pset) {
 DTt0DBValidation::~DTt0DBValidation() {}
 
 void DTt0DBValidation::beginRun(const edm::Run &run, const EventSetup &setup) {
-
   metname_ = "InterChannelSynchDBValidation";
   LogVerbatim(metname_) << "[DTt0DBValidation] Parameters initialization";
 
   ESHandle<DTT0> t0_Ref;
   setup.get<DTT0Rcd>().get(labelDBRef_, t0_Ref);
   tZeroRefMap_ = &*t0_Ref;
-  LogVerbatim(metname_) << "[DTt0DBValidation] reference T0 version: "
-                        << t0_Ref->version();
+  LogVerbatim(metname_) << "[DTt0DBValidation] reference T0 version: " << t0_Ref->version();
 
   ESHandle<DTT0> t0;
   setup.get<DTT0Rcd>().get(labelDB_, t0);
   tZeroMap_ = &*t0;
-  LogVerbatim(metname_) << "[DTt0DBValidation] T0 to validate version: "
-                        << t0->version();
+  LogVerbatim(metname_) << "[DTt0DBValidation] T0 to validate version: " << t0->version();
 
   // book&reset the summary histos
   for (int wheel = -2; wheel <= 2; wheel++) {
@@ -88,8 +84,7 @@ void DTt0DBValidation::beginRun(const edm::Run &run, const EventSetup &setup) {
   setup.get<MuonGeometryRecord>().get(dtGeom_);
 
   // Loop over Ref DB entries
-  for (DTT0::const_iterator tzero = tZeroRefMap_->begin();
-       tzero != tZeroRefMap_->end(); tzero++) {
+  for (DTT0::const_iterator tzero = tZeroRefMap_->begin(); tzero != tZeroRefMap_->end(); tzero++) {
     // t0s and rms are TDC counts
     // @@@ NEW DTT0 FORMAT
     //    DTWireId wireId((*tzero).first.wheelId,
@@ -107,16 +102,14 @@ void DTt0DBValidation::beginRun(const edm::Run &run, const EventSetup &setup) {
     float t0rms;
     tZeroRefMap_->get(wireId, t0mean, t0rms, DTTimeUnits::counts);
     LogTrace(metname_) << "Ref Wire: " << wireId << endl
-                       << " T0 mean (TDC counts): " << t0mean
-                       << " T0_rms (TDC counts): " << t0rms;
+                       << " T0 mean (TDC counts): " << t0mean << " T0_rms (TDC counts): " << t0rms;
 
     t0RefMap_[wireId].push_back(t0mean);
     t0RefMap_[wireId].push_back(t0rms);
   }
 
   // Loop over Ref DB entries
-  for (DTT0::const_iterator tzero = tZeroMap_->begin();
-       tzero != tZeroMap_->end(); tzero++) {
+  for (DTT0::const_iterator tzero = tZeroMap_->begin(); tzero != tZeroMap_->end(); tzero++) {
     // t0s and rms are TDC counts
     // @@@ NEW DTT0 FORMAT
     //    DTWireId wireId((*tzero).first.wheelId,
@@ -134,18 +127,15 @@ void DTt0DBValidation::beginRun(const edm::Run &run, const EventSetup &setup) {
     float t0rms;
     tZeroMap_->get(wireId, t0mean, t0rms, DTTimeUnits::counts);
     LogTrace(metname_) << "Wire: " << wireId << endl
-                       << " T0 mean (TDC counts): " << t0mean
-                       << " T0_rms (TDC counts): " << t0rms;
+                       << " T0 mean (TDC counts): " << t0mean << " T0_rms (TDC counts): " << t0rms;
 
     t0Map_[wireId].push_back(t0mean);
     t0Map_[wireId].push_back(t0rms);
   }
 
   double difference = 0;
-  for (map<DTWireId, vector<float>>::const_iterator theMap = t0RefMap_.begin();
-       theMap != t0RefMap_.end(); theMap++) {
+  for (map<DTWireId, vector<float>>::const_iterator theMap = t0RefMap_.begin(); theMap != t0RefMap_.end(); theMap++) {
     if (t0Map_.find((*theMap).first) != t0Map_.end()) {
-
       // Compute the difference
       difference = t0Map_[(*theMap).first][0] - (*theMap).second[0];
 
@@ -158,46 +148,33 @@ void DTt0DBValidation::beginRun(const edm::Run &run, const EventSetup &setup) {
         bookHistos(layerId, firstWire, lastWire);
       }
 
-      LogTrace(metname_) << "Filling the histo for wire: " << (*theMap).first
-                         << "  difference: " << difference;
+      LogTrace(metname_) << "Filling the histo for wire: " << (*theMap).first << "  difference: " << difference;
       t0DiffHistos_[layerId]->Fill((*theMap).first.wire(), difference);
     }
-  } // Loop over the t0 map reference
+  }  // Loop over the t0 map reference
 }
 
-void DTt0DBValidation::endRun(edm::Run const &run,
-                              edm::EventSetup const &setup) {
-
+void DTt0DBValidation::endRun(edm::Run const &run, edm::EventSetup const &setup) {
   // Check the histos
   string testCriterionName = t0TestName_;
-  for (map<DTLayerId, MonitorElement *>::const_iterator hDiff =
-           t0DiffHistos_.begin();
-       hDiff != t0DiffHistos_.end(); hDiff++) {
-
-    const QReport *theDiffQReport =
-        (*hDiff).second->getQReport(testCriterionName);
+  for (map<DTLayerId, MonitorElement *>::const_iterator hDiff = t0DiffHistos_.begin(); hDiff != t0DiffHistos_.end();
+       hDiff++) {
+    const QReport *theDiffQReport = (*hDiff).second->getQReport(testCriterionName);
     if (theDiffQReport) {
-      int xBin = ((*hDiff).first.station() - 1) * 12 + (*hDiff).first.layer() +
-                 4 * ((*hDiff).first.superlayer() - 1);
+      int xBin = ((*hDiff).first.station() - 1) * 12 + (*hDiff).first.layer() + 4 * ((*hDiff).first.superlayer() - 1);
       if ((*hDiff).first.station() == 4 && (*hDiff).first.superlayer() == 3)
-        xBin = ((*hDiff).first.station() - 1) * 12 + (*hDiff).first.layer() +
-               4 * ((*hDiff).first.superlayer() - 2);
+        xBin = ((*hDiff).first.station() - 1) * 12 + (*hDiff).first.layer() + 4 * ((*hDiff).first.superlayer() - 2);
 
       int qReportStatus = theDiffQReport->getStatus() / 100;
-      wheelSummary_[(*hDiff).first.wheel()]->setBinContent(
-          xBin, (*hDiff).first.sector(), qReportStatus);
+      wheelSummary_[(*hDiff).first.wheel()]->setBinContent(xBin, (*hDiff).first.sector(), qReportStatus);
 
-      LogVerbatim(metname_) << "-------- layer: " << (*hDiff).first << "  "
-                            << theDiffQReport->getMessage() << " ------- "
-                            << theDiffQReport->getStatus() << " ------- "
-                            << setprecision(3) << theDiffQReport->getQTresult();
-      vector<dqm::me_util::Channel> badChannels =
-          theDiffQReport->getBadChannels();
-      for (vector<dqm::me_util::Channel>::iterator channel =
-               badChannels.begin();
-           channel != badChannels.end(); channel++) {
-        LogVerbatim(metname_) << "layer: " << (*hDiff).first
-                              << " Bad channel: " << (*channel).getBin()
+      LogVerbatim(metname_) << "-------- layer: " << (*hDiff).first << "  " << theDiffQReport->getMessage()
+                            << " ------- " << theDiffQReport->getStatus() << " ------- " << setprecision(3)
+                            << theDiffQReport->getQTresult();
+      vector<dqm::me_util::Channel> badChannels = theDiffQReport->getBadChannels();
+      for (vector<dqm::me_util::Channel>::iterator channel = badChannels.begin(); channel != badChannels.end();
+           channel++) {
+        LogVerbatim(metname_) << "layer: " << (*hDiff).first << " Bad channel: " << (*channel).getBin()
                               << "  Contents : " << (*channel).getContents();
 
         // wheelSummary_[(*hDiff).first.wheel()]->Fill(xBin,(*hDiff).first.sector());
@@ -214,7 +191,6 @@ void DTt0DBValidation::endJob() {
 
 // Book a set of histograms for a given Layer
 void DTt0DBValidation::bookHistos(DTLayerId lId, int firstWire, int lastWire) {
-
   LogTrace(metname_) << "   Booking histos for L: " << lId;
 
   // Compose the chamber name
@@ -229,18 +205,18 @@ void DTt0DBValidation::bookHistos(DTLayerId lId, int firstWire, int lastWire) {
   stringstream layer;
   layer << lId.layer();
 
-  string lHistoName = "_W" + wheel.str() + "_St" + station.str() + "_Sec" +
-                      sector.str() + "_SL" + superLayer.str() + "_L" +
-                      layer.str();
+  string lHistoName = "_W" + wheel.str() + "_St" + station.str() + "_Sec" + sector.str() + "_SL" + superLayer.str() +
+                      "_L" + layer.str();
 
-  dbe_->setCurrentFolder("DT/DtCalib/InterChannelSynchDBValidation/Wheel" +
-                         wheel.str() + "/Station" + station.str() + "/Sector" +
-                         sector.str() + "/SuperLayer" + superLayer.str());
+  dbe_->setCurrentFolder("DT/DtCalib/InterChannelSynchDBValidation/Wheel" + wheel.str() + "/Station" + station.str() +
+                         "/Sector" + sector.str() + "/SuperLayer" + superLayer.str());
   // Create the monitor elements
   MonitorElement *hDifference;
-  hDifference = dbe_->book1D(
-      "T0Difference" + lHistoName, "difference between the two t0 values",
-      lastWire - firstWire + 1, firstWire - 0.5, lastWire + 0.5);
+  hDifference = dbe_->book1D("T0Difference" + lHistoName,
+                             "difference between the two t0 values",
+                             lastWire - firstWire + 1,
+                             firstWire - 0.5,
+                             lastWire + 0.5);
 
   t0DiffHistos_[lId] = hDifference;
 }
@@ -250,10 +226,8 @@ void DTt0DBValidation::bookHistos(int wheel) {
   dbe_->setCurrentFolder("DT/DtCalib/InterChannelSynchDBValidation");
   stringstream wh;
   wh << wheel;
-  wheelSummary_[wheel] =
-      dbe_->book2D("SummaryWrongT0_W" + wh.str(),
-                   "W" + wh.str() + ": summary of wrong t0 differences", 44, 1,
-                   45, 14, 1, 15);
+  wheelSummary_[wheel] = dbe_->book2D(
+      "SummaryWrongT0_W" + wh.str(), "W" + wh.str() + ": summary of wrong t0 differences", 44, 1, 45, 14, 1, 15);
   wheelSummary_[wheel]->setBinLabel(1, "M1L1", 1);
   wheelSummary_[wheel]->setBinLabel(2, "M1L2", 1);
   wheelSummary_[wheel]->setBinLabel(3, "M1L3", 1);

--- a/HLTriggerOffline/B2G/interface/B2GDoubleLeptonHLTValidation.h
+++ b/HLTriggerOffline/B2G/interface/B2GDoubleLeptonHLTValidation.h
@@ -56,13 +56,10 @@ public:
 
 private:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   /// deduce monitorPath from label, the label is expected
   /// to be of type 'selectionPath:monitorPath'
-  std::string monitorPath(const std::string &label) const {
-    return label.substr(label.find(':') + 1);
-  };
+  std::string monitorPath(const std::string &label) const { return label.substr(label.find(':') + 1); };
   /// set configurable labels for trigger monitoring histograms
   void triggerBinLabels(const std::vector<std::string> &labels);
 
@@ -104,13 +101,10 @@ private:
   bool isSel_ = false;
 };
 
-inline void B2GDoubleLeptonHLTValidation::triggerBinLabels(
-    const std::vector<std::string> &labels) {
+inline void B2GDoubleLeptonHLTValidation::triggerBinLabels(const std::vector<std::string> &labels) {
   for (unsigned int idx = 0; idx < labels.size(); ++idx) {
-    hNumTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]",
-                                1);
-    hDenTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]",
-                                1);
+    hNumTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]", 1);
+    hDenTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]", 1);
   }
 }
 
@@ -125,41 +119,32 @@ inline void B2GDoubleLeptonHLTValidation::triggerBinLabels(
 //
 // constructors and destructor
 //
-B2GDoubleLeptonHLTValidation::B2GDoubleLeptonHLTValidation(
-    const edm::ParameterSet &iConfig)
-    : sDir_(iConfig.getUntrackedParameter<std::string>(
-          "sDir", "HLTValidation/B2G/Efficiencies/")),
-      sElectrons_(iConfig.getUntrackedParameter<std::string>("sElectrons",
-                                                             "gsfElectrons")),
+B2GDoubleLeptonHLTValidation::B2GDoubleLeptonHLTValidation(const edm::ParameterSet &iConfig)
+    : sDir_(iConfig.getUntrackedParameter<std::string>("sDir", "HLTValidation/B2G/Efficiencies/")),
+      sElectrons_(iConfig.getUntrackedParameter<std::string>("sElectrons", "gsfElectrons")),
       ptElectrons_(iConfig.getUntrackedParameter<double>("ptElectrons", 0.)),
       etaElectrons_(iConfig.getUntrackedParameter<double>("etaElectrons", 0.)),
       isoElectrons_(iConfig.getUntrackedParameter<double>("isoElectrons", 0.)),
-      minElectrons_(
-          iConfig.getUntrackedParameter<unsigned int>("minElectrons", 0)),
+      minElectrons_(iConfig.getUntrackedParameter<unsigned int>("minElectrons", 0)),
       sMuons_(iConfig.getUntrackedParameter<std::string>("sMuons", "muons")),
       ptMuons_(iConfig.getUntrackedParameter<double>("ptMuons", 0.)),
       etaMuons_(iConfig.getUntrackedParameter<double>("etaMuons", 0.)),
       isoMuons_(iConfig.getUntrackedParameter<double>("isoMuons", 0.)),
       minMuons_(iConfig.getUntrackedParameter<unsigned int>("minMuons", 0)),
       minLeptons_(iConfig.getUntrackedParameter<unsigned int>("minLeptons", 0)),
-      sTrigger_(iConfig.getUntrackedParameter<std::string>("sTrigger",
-                                                           "TriggerResults")),
-      vsPaths_(
-          iConfig.getUntrackedParameter<std::vector<std::string>>("vsPaths"))
+      sTrigger_(iConfig.getUntrackedParameter<std::string>("sTrigger", "TriggerResults")),
+      vsPaths_(iConfig.getUntrackedParameter<std::vector<std::string>>("vsPaths"))
 
 {
   // Electrons
-  tokElectrons_ =
-      consumes<edm::View<reco::GsfElectron>>(edm::InputTag(sElectrons_));
+  tokElectrons_ = consumes<edm::View<reco::GsfElectron>>(edm::InputTag(sElectrons_));
   // Muons
   tokMuons_ = consumes<edm::View<reco::Muon>>(edm::InputTag(sMuons_));
   // Trigger
-  tokTrigger_ =
-      consumes<edm::TriggerResults>(edm::InputTag(sTrigger_, "", "HLT"));
+  tokTrigger_ = consumes<edm::TriggerResults>(edm::InputTag(sTrigger_, "", "HLT"));
 }
 
 B2GDoubleLeptonHLTValidation::~B2GDoubleLeptonHLTValidation() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }

--- a/HLTriggerOffline/B2G/interface/B2GHadronicHLTValidation.h
+++ b/HLTriggerOffline/B2G/interface/B2GHadronicHLTValidation.h
@@ -56,13 +56,10 @@ public:
 
 private:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   /// deduce monitorPath from label, the label is expected
   /// to be of type 'selectionPath:monitorPath'
-  std::string monitorPath(const std::string &label) const {
-    return label.substr(label.find(':') + 1);
-  };
+  std::string monitorPath(const std::string &label) const { return label.substr(label.find(':') + 1); };
   /// set configurable labels for trigger monitoring histograms
   void triggerBinLabels(const std::vector<std::string> &labels);
 
@@ -94,13 +91,10 @@ private:
   bool isSel_ = false;
 };
 
-inline void B2GHadronicHLTValidation::triggerBinLabels(
-    const std::vector<std::string> &labels) {
+inline void B2GHadronicHLTValidation::triggerBinLabels(const std::vector<std::string> &labels) {
   for (unsigned int idx = 0; idx < labels.size(); ++idx) {
-    hNumTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]",
-                                1);
-    hDenTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]",
-                                1);
+    hNumTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]", 1);
+    hDenTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]", 1);
   }
 }
 
@@ -115,10 +109,8 @@ inline void B2GHadronicHLTValidation::triggerBinLabels(
 //
 // constructors and destructor
 //
-B2GHadronicHLTValidation::B2GHadronicHLTValidation(
-    const edm::ParameterSet &iConfig)
-    : sDir_(iConfig.getUntrackedParameter<std::string>(
-          "sDir", "HLTValidation/B2G/Efficiencies/")),
+B2GHadronicHLTValidation::B2GHadronicHLTValidation(const edm::ParameterSet &iConfig)
+    : sDir_(iConfig.getUntrackedParameter<std::string>("sDir", "HLTValidation/B2G/Efficiencies/")),
       sJets_(iConfig.getUntrackedParameter<std::string>("sJets", "ak5PFJets")),
       ptJets_(iConfig.getUntrackedParameter<double>("ptJets", 0.)),
       ptJets0_(iConfig.getUntrackedParameter<double>("ptJets0", 0.)),
@@ -126,21 +118,17 @@ B2GHadronicHLTValidation::B2GHadronicHLTValidation(
       etaJets_(iConfig.getUntrackedParameter<double>("etaJets", 0.)),
       minJets_(iConfig.getUntrackedParameter<unsigned int>("minJets", 0)),
       htMin_(iConfig.getUntrackedParameter<double>("htMin", 0.0)),
-      sTrigger_(iConfig.getUntrackedParameter<std::string>("sTrigger",
-                                                           "TriggerResults")),
-      vsPaths_(
-          iConfig.getUntrackedParameter<std::vector<std::string>>("vsPaths"))
+      sTrigger_(iConfig.getUntrackedParameter<std::string>("sTrigger", "TriggerResults")),
+      vsPaths_(iConfig.getUntrackedParameter<std::vector<std::string>>("vsPaths"))
 
 {
   // Jets
   tokJets_ = consumes<edm::View<reco::Jet>>(edm::InputTag(sJets_));
   // Trigger
-  tokTrigger_ =
-      consumes<edm::TriggerResults>(edm::InputTag(sTrigger_, "", "HLT"));
+  tokTrigger_ = consumes<edm::TriggerResults>(edm::InputTag(sTrigger_, "", "HLT"));
 }
 
 B2GHadronicHLTValidation::~B2GHadronicHLTValidation() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }

--- a/HLTriggerOffline/B2G/interface/B2GSingleLeptonHLTValidation.h
+++ b/HLTriggerOffline/B2G/interface/B2GSingleLeptonHLTValidation.h
@@ -56,13 +56,10 @@ public:
 
 private:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   /// deduce monitorPath from label, the label is expected
   /// to be of type 'selectionPath:monitorPath'
-  std::string monitorPath(const std::string &label) const {
-    return label.substr(label.find(':') + 1);
-  };
+  std::string monitorPath(const std::string &label) const { return label.substr(label.find(':') + 1); };
   /// set configurable labels for trigger monitoring histograms
   void triggerBinLabels(const std::vector<std::string> &labels);
 
@@ -113,13 +110,10 @@ private:
   bool isSel_ = false;
 };
 
-inline void B2GSingleLeptonHLTValidation::triggerBinLabels(
-    const std::vector<std::string> &labels) {
+inline void B2GSingleLeptonHLTValidation::triggerBinLabels(const std::vector<std::string> &labels) {
   for (unsigned int idx = 0; idx < labels.size(); ++idx) {
-    hNumTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]",
-                                1);
-    hDenTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]",
-                                1);
+    hNumTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]", 1);
+    hDenTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]", 1);
   }
 }
 
@@ -134,17 +128,13 @@ inline void B2GSingleLeptonHLTValidation::triggerBinLabels(
 //
 // constructors and destructor
 //
-B2GSingleLeptonHLTValidation::B2GSingleLeptonHLTValidation(
-    const edm::ParameterSet &iConfig)
-    : sDir_(iConfig.getUntrackedParameter<std::string>(
-          "sDir", "HLTValidation/B2G/Efficiencies/")),
-      sElectrons_(iConfig.getUntrackedParameter<std::string>("sElectrons",
-                                                             "gsfElectrons")),
+B2GSingleLeptonHLTValidation::B2GSingleLeptonHLTValidation(const edm::ParameterSet &iConfig)
+    : sDir_(iConfig.getUntrackedParameter<std::string>("sDir", "HLTValidation/B2G/Efficiencies/")),
+      sElectrons_(iConfig.getUntrackedParameter<std::string>("sElectrons", "gsfElectrons")),
       ptElectrons_(iConfig.getUntrackedParameter<double>("ptElectrons", 0.)),
       etaElectrons_(iConfig.getUntrackedParameter<double>("etaElectrons", 0.)),
       isoElectrons_(iConfig.getUntrackedParameter<double>("isoElectrons", 0.)),
-      minElectrons_(
-          iConfig.getUntrackedParameter<unsigned int>("minElectrons", 0)),
+      minElectrons_(iConfig.getUntrackedParameter<unsigned int>("minElectrons", 0)),
       sMuons_(iConfig.getUntrackedParameter<std::string>("sMuons", "muons")),
       ptMuons_(iConfig.getUntrackedParameter<double>("ptMuons", 0.)),
       etaMuons_(iConfig.getUntrackedParameter<double>("etaMuons", 0.)),
@@ -156,26 +146,21 @@ B2GSingleLeptonHLTValidation::B2GSingleLeptonHLTValidation(
       ptJets1_(iConfig.getUntrackedParameter<double>("ptJets1", 0.)),
       etaJets_(iConfig.getUntrackedParameter<double>("etaJets", 0.)),
       minJets_(iConfig.getUntrackedParameter<unsigned int>("minJets", 0)),
-      sTrigger_(iConfig.getUntrackedParameter<std::string>("sTrigger",
-                                                           "TriggerResults")),
-      vsPaths_(
-          iConfig.getUntrackedParameter<std::vector<std::string>>("vsPaths"))
+      sTrigger_(iConfig.getUntrackedParameter<std::string>("sTrigger", "TriggerResults")),
+      vsPaths_(iConfig.getUntrackedParameter<std::vector<std::string>>("vsPaths"))
 
 {
   // Electrons
-  tokElectrons_ =
-      consumes<edm::View<reco::GsfElectron>>(edm::InputTag(sElectrons_));
+  tokElectrons_ = consumes<edm::View<reco::GsfElectron>>(edm::InputTag(sElectrons_));
   // Muons
   tokMuons_ = consumes<edm::View<reco::Muon>>(edm::InputTag(sMuons_));
   // Jets
   tokJets_ = consumes<edm::View<reco::Jet>>(edm::InputTag(sJets_));
   // Trigger
-  tokTrigger_ =
-      consumes<edm::TriggerResults>(edm::InputTag(sTrigger_, "", "HLT"));
+  tokTrigger_ = consumes<edm::TriggerResults>(edm::InputTag(sTrigger_, "", "HLT"));
 }
 
 B2GSingleLeptonHLTValidation::~B2GSingleLeptonHLTValidation() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }

--- a/HLTriggerOffline/B2G/src/B2GDoubleLeptonHLTValidation.cc
+++ b/HLTriggerOffline/B2G/src/B2GDoubleLeptonHLTValidation.cc
@@ -43,8 +43,7 @@ harvesting
 //
 
 // ------------ method called for each event  ------------
-void B2GDoubleLeptonHLTValidation::analyze(const edm::Event &iEvent,
-                                           const edm::EventSetup &iSetup) {
+void B2GDoubleLeptonHLTValidation::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
 
   isAll_ = false;
@@ -53,11 +52,9 @@ void B2GDoubleLeptonHLTValidation::analyze(const edm::Event &iEvent,
   // Electrons
   Handle<edm::View<reco::GsfElectron>> electrons;
   if (!iEvent.getByToken(tokElectrons_, electrons))
-    edm::LogWarning("B2GDoubleLeptonHLTValidation")
-        << "Electrons collection not found \n";
+    edm::LogWarning("B2GDoubleLeptonHLTValidation") << "Electrons collection not found \n";
   unsigned int nGoodE = 0;
-  for (edm::View<reco::GsfElectron>::const_iterator e = electrons->begin();
-       e != electrons->end(); ++e) {
+  for (edm::View<reco::GsfElectron>::const_iterator e = electrons->begin(); e != electrons->end(); ++e) {
     if (e->pt() < ptElectrons_)
       continue;
     if (fabs(e->eta()) > etaElectrons_)
@@ -70,11 +67,9 @@ void B2GDoubleLeptonHLTValidation::analyze(const edm::Event &iEvent,
   // Muons
   Handle<edm::View<reco::Muon>> muons;
   if (!iEvent.getByToken(tokMuons_, muons))
-    edm::LogWarning("B2GDoubleLeptonHLTValidation")
-        << "Muons collection not found \n";
+    edm::LogWarning("B2GDoubleLeptonHLTValidation") << "Muons collection not found \n";
   unsigned int nGoodM = 0;
-  for (edm::View<reco::Muon>::const_iterator m = muons->begin();
-       m != muons->end(); ++m) {
+  for (edm::View<reco::Muon>::const_iterator m = muons->begin(); m != muons->end(); ++m) {
     if (!m->isPFMuon() || !m->isGlobalMuon())
       continue;
     if (m->pt() < ptMuons_)
@@ -87,21 +82,18 @@ void B2GDoubleLeptonHLTValidation::analyze(const edm::Event &iEvent,
       mu_ = muons->ptrAt(m - muons->begin());
   }
 
-  if (nGoodE >= minElectrons_ && nGoodM >= minMuons_ &&
-      nGoodE + nGoodM >= minLeptons_)
+  if (nGoodE >= minElectrons_ && nGoodM >= minMuons_ && nGoodE + nGoodM >= minLeptons_)
     isAll_ = true;
 
   // Trigger
   Handle<edm::TriggerResults> triggerTable;
   if (!iEvent.getByToken(tokTrigger_, triggerTable))
-    edm::LogWarning("B2GDoubleLeptonHLTValidation")
-        << "Trigger collection not found \n";
+    edm::LogWarning("B2GDoubleLeptonHLTValidation") << "Trigger collection not found \n";
   const edm::TriggerNames &triggerNames = iEvent.triggerNames(*triggerTable);
   bool isInteresting = false;
   for (unsigned int i = 0; i < triggerNames.triggerNames().size(); ++i) {
     for (unsigned int j = 0; j < vsPaths_.size(); j++) {
-      if (triggerNames.triggerNames()[i].find(vsPaths_[j]) !=
-          std::string::npos) {
+      if (triggerNames.triggerNames()[i].find(vsPaths_[j]) != std::string::npos) {
         isInteresting = true;
         break;
       }
@@ -143,8 +135,7 @@ void B2GDoubleLeptonHLTValidation::analyze(const edm::Event &iEvent,
 
     for (unsigned int i = 0; i < triggerNames.triggerNames().size(); ++i) {
       for (unsigned int j = 0; j < vsPaths_.size(); j++) {
-        if (triggerNames.triggerNames()[i].find(vsPaths_[j]) !=
-            std::string::npos) {
+        if (triggerNames.triggerNames()[i].find(vsPaths_[j]) != std::string::npos) {
           hNumTriggerMon->Fill(j + 0.5);
         }
       }
@@ -153,9 +144,7 @@ void B2GDoubleLeptonHLTValidation::analyze(const edm::Event &iEvent,
 }
 
 // ------------ booking histograms -----------
-void B2GDoubleLeptonHLTValidation::bookHistograms(DQMStore::IBooker &dbe,
-                                                  edm::Run const &,
-                                                  edm::EventSetup const &) {
+void B2GDoubleLeptonHLTValidation::bookHistograms(DQMStore::IBooker &dbe, edm::Run const &, edm::EventSetup const &) {
   dbe.setCurrentFolder(sDir_);
   hDenLeptonPt = dbe.book1D("PtLeptonAll", "PtLeptonAll", 50, 0., 2500.);
   hDenLeptonEta = dbe.book1D("EtaLeptonAll", "EtaLeptonAll", 30, -3., 3.);
@@ -164,18 +153,15 @@ void B2GDoubleLeptonHLTValidation::bookHistograms(DQMStore::IBooker &dbe,
   // determine number of bins for trigger monitoring
   unsigned int nPaths = vsPaths_.size();
   // monitored trigger occupancy for single lepton triggers
-  hNumTriggerMon =
-      dbe.book1D("TriggerMonSel", "TriggerMonSel", nPaths, 0., nPaths);
-  hDenTriggerMon =
-      dbe.book1D("TriggerMonAll", "TriggerMonAll", nPaths, 0., nPaths);
+  hNumTriggerMon = dbe.book1D("TriggerMonSel", "TriggerMonSel", nPaths, 0., nPaths);
+  hDenTriggerMon = dbe.book1D("TriggerMonAll", "TriggerMonAll", nPaths, 0., nPaths);
   // set bin labels for trigger monitoring
   triggerBinLabels(vsPaths_);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the
 // module  ------------
-void B2GDoubleLeptonHLTValidation::fillDescriptions(
-    edm::ConfigurationDescriptions &descriptions) {
+void B2GDoubleLeptonHLTValidation::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   // The following says we do not know what parameters are allowed so do no
   // validation
   // Please change this to state exactly what you do use, even if it is no

--- a/HLTriggerOffline/B2G/src/B2GHadronicHLTValidation.cc
+++ b/HLTriggerOffline/B2G/src/B2GHadronicHLTValidation.cc
@@ -42,8 +42,7 @@ harvesting
 //
 
 // ------------ method called for each event  ------------
-void B2GHadronicHLTValidation::analyze(const edm::Event &iEvent,
-                                       const edm::EventSetup &iSetup) {
+void B2GHadronicHLTValidation::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
 
   isAll_ = false;
@@ -52,8 +51,7 @@ void B2GHadronicHLTValidation::analyze(const edm::Event &iEvent,
   // Jets
   Handle<edm::View<reco::Jet>> jets;
   if (!iEvent.getByToken(tokJets_, jets))
-    edm::LogWarning("B2GHadronicHLTValidation")
-        << "Jets collection not found \n";
+    edm::LogWarning("B2GHadronicHLTValidation") << "Jets collection not found \n";
   unsigned int nGoodJ = 0;
   double ht = 0.0;
   // Check to see if we want asymmetric jet pt cuts
@@ -71,8 +69,7 @@ void B2GHadronicHLTValidation::analyze(const edm::Event &iEvent,
       }
     }
   } else if (minJets_ > 0 || htMin_ > 0) {
-    for (edm::View<reco::Jet>::const_iterator j = jets->begin();
-         j != jets->end(); ++j) {
+    for (edm::View<reco::Jet>::const_iterator j = jets->begin(); j != jets->end(); ++j) {
       if (j->pt() < ptJets_)
         continue;
       if (fabs(j->eta()) > etaJets_)
@@ -90,12 +87,10 @@ void B2GHadronicHLTValidation::analyze(const edm::Event &iEvent,
   // Trigger
   Handle<edm::TriggerResults> triggerTable;
   if (!iEvent.getByToken(tokTrigger_, triggerTable))
-    edm::LogWarning("B2GHadronicHLTValidation")
-        << "Trigger collection not found \n";
+    edm::LogWarning("B2GHadronicHLTValidation") << "Trigger collection not found \n";
   const edm::TriggerNames &triggerNames = iEvent.triggerNames(*triggerTable);
   bool isInteresting = false;
   for (unsigned int i = 0; i < triggerNames.triggerNames().size(); ++i) {
-
     TString name = triggerNames.triggerNames()[i].c_str();
     for (unsigned int j = 0; j < vsPaths_.size(); j++) {
       if (name.Contains(TString(vsPaths_[j]), TString::kIgnoreCase)) {
@@ -137,9 +132,7 @@ void B2GHadronicHLTValidation::analyze(const edm::Event &iEvent,
 }
 
 // ------------ booking histograms -----------
-void B2GHadronicHLTValidation::bookHistograms(DQMStore::IBooker &dbe,
-                                              edm::Run const &,
-                                              edm::EventSetup const &) {
+void B2GHadronicHLTValidation::bookHistograms(DQMStore::IBooker &dbe, edm::Run const &, edm::EventSetup const &) {
   dbe.setCurrentFolder(sDir_);
   hDenJetPt = dbe.book1D("PtLastJetAll", "PtLastJetAll", 60, 0., 3000.);
   hDenJetEta = dbe.book1D("EtaLastJetAll", "EtaLastJetAll", 30, -3., 3.);
@@ -148,18 +141,15 @@ void B2GHadronicHLTValidation::bookHistograms(DQMStore::IBooker &dbe,
   // determine number of bins for trigger monitoring
   unsigned int nPaths = vsPaths_.size();
   // monitored trigger occupancy for single lepton triggers
-  hNumTriggerMon =
-      dbe.book1D("TriggerMonSel", "TriggerMonSel", nPaths, 0., nPaths);
-  hDenTriggerMon =
-      dbe.book1D("TriggerMonAll", "TriggerMonAll", nPaths, 0., nPaths);
+  hNumTriggerMon = dbe.book1D("TriggerMonSel", "TriggerMonSel", nPaths, 0., nPaths);
+  hDenTriggerMon = dbe.book1D("TriggerMonAll", "TriggerMonAll", nPaths, 0., nPaths);
   // set bin labels for trigger monitoring
   triggerBinLabels(vsPaths_);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the
 // module  ------------
-void B2GHadronicHLTValidation::fillDescriptions(
-    edm::ConfigurationDescriptions &descriptions) {
+void B2GHadronicHLTValidation::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   // The following says we do not know what parameters are allowed so do no
   // validation
   // Please change this to state exactly what you do use, even if it is no

--- a/HLTriggerOffline/B2G/src/B2GSingleLeptonHLTValidation.cc
+++ b/HLTriggerOffline/B2G/src/B2GSingleLeptonHLTValidation.cc
@@ -43,8 +43,7 @@ harvesting
 //
 
 // ------------ method called for each event  ------------
-void B2GSingleLeptonHLTValidation::analyze(const edm::Event &iEvent,
-                                           const edm::EventSetup &iSetup) {
+void B2GSingleLeptonHLTValidation::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
 
   isAll_ = false;
@@ -53,11 +52,9 @@ void B2GSingleLeptonHLTValidation::analyze(const edm::Event &iEvent,
   // Electrons
   Handle<edm::View<reco::GsfElectron>> electrons;
   if (!iEvent.getByToken(tokElectrons_, electrons))
-    edm::LogWarning("B2GSingleLeptonHLTValidation")
-        << "Electrons collection not found \n";
+    edm::LogWarning("B2GSingleLeptonHLTValidation") << "Electrons collection not found \n";
   unsigned int nGoodE = 0;
-  for (edm::View<reco::GsfElectron>::const_iterator e = electrons->begin();
-       e != electrons->end(); ++e) {
+  for (edm::View<reco::GsfElectron>::const_iterator e = electrons->begin(); e != electrons->end(); ++e) {
     if (e->pt() < ptElectrons_)
       continue;
     if (fabs(e->eta()) > etaElectrons_)
@@ -69,11 +66,9 @@ void B2GSingleLeptonHLTValidation::analyze(const edm::Event &iEvent,
   // Muons
   Handle<edm::View<reco::Muon>> muons;
   if (!iEvent.getByToken(tokMuons_, muons))
-    edm::LogWarning("B2GSingleLeptonHLTValidation")
-        << "Muons collection not found \n";
+    edm::LogWarning("B2GSingleLeptonHLTValidation") << "Muons collection not found \n";
   unsigned int nGoodM = 0;
-  for (edm::View<reco::Muon>::const_iterator m = muons->begin();
-       m != muons->end(); ++m) {
+  for (edm::View<reco::Muon>::const_iterator m = muons->begin(); m != muons->end(); ++m) {
     if (!m->isPFMuon() || !m->isGlobalMuon())
       continue;
     if (m->pt() < ptMuons_)
@@ -87,8 +82,7 @@ void B2GSingleLeptonHLTValidation::analyze(const edm::Event &iEvent,
   // Jets
   Handle<edm::View<reco::Jet>> jets;
   if (!iEvent.getByToken(tokJets_, jets))
-    edm::LogWarning("B2GSingleLeptonHLTValidation")
-        << "Jets collection not found \n";
+    edm::LogWarning("B2GSingleLeptonHLTValidation") << "Jets collection not found \n";
   unsigned int nGoodJ = 0;
 
   // Check to see if we want asymmetric jet pt cuts
@@ -106,8 +100,7 @@ void B2GSingleLeptonHLTValidation::analyze(const edm::Event &iEvent,
       }
     }
   } else {
-    for (edm::View<reco::Jet>::const_iterator j = jets->begin();
-         j != jets->end(); ++j) {
+    for (edm::View<reco::Jet>::const_iterator j = jets->begin(); j != jets->end(); ++j) {
       if (j->pt() < ptJets_)
         continue;
       if (fabs(j->eta()) > etaJets_)
@@ -124,12 +117,10 @@ void B2GSingleLeptonHLTValidation::analyze(const edm::Event &iEvent,
   // Trigger
   Handle<edm::TriggerResults> triggerTable;
   if (!iEvent.getByToken(tokTrigger_, triggerTable))
-    edm::LogWarning("B2GSingleLeptonHLTValidation")
-        << "Trigger collection not found \n";
+    edm::LogWarning("B2GSingleLeptonHLTValidation") << "Trigger collection not found \n";
   const edm::TriggerNames &triggerNames = iEvent.triggerNames(*triggerTable);
   bool isInteresting = false;
   for (unsigned int i = 0; i < triggerNames.triggerNames().size(); ++i) {
-
     TString name = triggerNames.triggerNames()[i].c_str();
     for (unsigned int j = 0; j < vsPaths_.size(); j++) {
       if (name.Contains(TString(vsPaths_[j]), TString::kIgnoreCase)) {
@@ -189,9 +180,7 @@ void B2GSingleLeptonHLTValidation::analyze(const edm::Event &iEvent,
 }
 
 // ------------ booking histograms -----------
-void B2GSingleLeptonHLTValidation::bookHistograms(DQMStore::IBooker &dbe,
-                                                  edm::Run const &,
-                                                  edm::EventSetup const &) {
+void B2GSingleLeptonHLTValidation::bookHistograms(DQMStore::IBooker &dbe, edm::Run const &, edm::EventSetup const &) {
   dbe.setCurrentFolder(sDir_);
   hDenLeptonPt = dbe.book1D("PtLeptonAll", "PtLeptonAll", 50, 0., 2500.);
   hDenLeptonEta = dbe.book1D("EtaLeptonAll", "EtaLeptonAll", 30, -3., 3.);
@@ -204,18 +193,15 @@ void B2GSingleLeptonHLTValidation::bookHistograms(DQMStore::IBooker &dbe,
   // determine number of bins for trigger monitoring
   unsigned int nPaths = vsPaths_.size();
   // monitored trigger occupancy for single lepton triggers
-  hNumTriggerMon =
-      dbe.book1D("TriggerMonSel", "TriggerMonSel", nPaths, 0., nPaths);
-  hDenTriggerMon =
-      dbe.book1D("TriggerMonAll", "TriggerMonAll", nPaths, 0., nPaths);
+  hNumTriggerMon = dbe.book1D("TriggerMonSel", "TriggerMonSel", nPaths, 0., nPaths);
+  hDenTriggerMon = dbe.book1D("TriggerMonAll", "TriggerMonAll", nPaths, 0., nPaths);
   // set bin labels for trigger monitoring
   triggerBinLabels(vsPaths_);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the
 // module  ------------
-void B2GSingleLeptonHLTValidation::fillDescriptions(
-    edm::ConfigurationDescriptions &descriptions) {
+void B2GSingleLeptonHLTValidation::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   // The following says we do not know what parameters are allowed so do no
   // validation
   // Please change this to state exactly what you do use, even if it is no

--- a/HLTriggerOffline/JetMET/interface/HLTJetMETValidation.h
+++ b/HLTriggerOffline/JetMET/interface/HLTJetMETValidation.h
@@ -49,24 +49,20 @@
 #include <vector>
 
 namespace edm {
-class TriggerNames;
+  class TriggerNames;
 }
 
 class HLTJetMETValidation : public DQMEDAnalyzer {
-
 public:
   explicit HLTJetMETValidation(const edm::ParameterSet &);
   ~HLTJetMETValidation() override;
 
 private:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &iRun,
-                      edm::EventSetup const &iSetup) override;
-  void dqmBeginRun(edm::Run const &iRun,
-                   edm::EventSetup const &iSetup) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &iRun, edm::EventSetup const &iSetup) override;
+  void dqmBeginRun(edm::Run const &iRun, edm::EventSetup const &iSetup) override;
 
-  void getHLTResults(const edm::TriggerResults &,
-                     const edm::TriggerNames &triggerNames);
+  void getHLTResults(const edm::TriggerResults &, const edm::TriggerNames &triggerNames);
 
   /// InputTag of TriggerEventWithRefs to analyze
   edm::EDGetTokenT<trigger::TriggerEventWithRefs> triggerEventObject_;

--- a/HLTriggerOffline/JetMET/interface/JetMETDQMPostProcessor.h
+++ b/HLTriggerOffline/JetMET/interface/JetMETDQMPostProcessor.h
@@ -15,22 +15,22 @@ public:
   ~JetMETDQMPostProcessor() override{};
 
   void dqmEndJob(DQMStore::IBooker &,
-                 DQMStore::IGetter &) override; // performed in the endJob
+                 DQMStore::IGetter &) override;  // performed in the endJob
 
-  TProfile *dividehistos(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter,
+  TProfile *dividehistos(DQMStore::IBooker &ibooker,
+                         DQMStore::IGetter &igetter,
                          const std::string &numName,
                          const std::string &denomName,
-                         const std::string &outName, const std::string &label,
+                         const std::string &outName,
+                         const std::string &label,
                          const std::string &titel);
 
 private:
   std::string subDir_, patternJetTrg_, patternMetTrg_;
 
-  void Efficiency(int passing, int total, double level, double &mode,
-                  double &lowerBound, double &upperBound);
+  void Efficiency(int passing, int total, double level, double &mode, double &lowerBound, double &upperBound);
 
-  TH1F *getHistogram(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter,
-                     const std::string &histoPath);
+  TH1F *getHistogram(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter, const std::string &histoPath);
 };
 
 #endif

--- a/HLTriggerOffline/JetMET/src/HLTJetMETValidation.cc
+++ b/HLTriggerOffline/JetMET/src/HLTJetMETValidation.cc
@@ -11,24 +11,16 @@ using namespace l1extra;
 using namespace trigger;
 
 HLTJetMETValidation::HLTJetMETValidation(const edm::ParameterSet &ps)
-    : triggerEventObject_(consumes<TriggerEventWithRefs>(
-          ps.getUntrackedParameter<edm::InputTag>("triggerEventObject"))),
-      PFJetAlgorithm(consumes<PFJetCollection>(
-          ps.getUntrackedParameter<edm::InputTag>("PFJetAlgorithm"))),
-      GenJetAlgorithm(consumes<GenJetCollection>(
-          ps.getUntrackedParameter<edm::InputTag>("GenJetAlgorithm"))),
-      CaloMETColl(consumes<CaloMETCollection>(
-          ps.getUntrackedParameter<edm::InputTag>("CaloMETCollection"))),
-      GenMETColl(consumes<GenMETCollection>(
-          ps.getUntrackedParameter<edm::InputTag>("GenMETCollection"))),
-      HLTriggerResults(consumes<edm::TriggerResults>(
-          ps.getParameter<edm::InputTag>("HLTriggerResults"))),
-      triggerTag_(
-          ps.getUntrackedParameter<std::string>("DQMFolder", "SingleJet")),
-      patternJetTrg_(
-          ps.getUntrackedParameter<std::string>("PatternJetTrg", "")),
-      patternMetTrg_(
-          ps.getUntrackedParameter<std::string>("PatternMetTrg", "")),
+    : triggerEventObject_(
+          consumes<TriggerEventWithRefs>(ps.getUntrackedParameter<edm::InputTag>("triggerEventObject"))),
+      PFJetAlgorithm(consumes<PFJetCollection>(ps.getUntrackedParameter<edm::InputTag>("PFJetAlgorithm"))),
+      GenJetAlgorithm(consumes<GenJetCollection>(ps.getUntrackedParameter<edm::InputTag>("GenJetAlgorithm"))),
+      CaloMETColl(consumes<CaloMETCollection>(ps.getUntrackedParameter<edm::InputTag>("CaloMETCollection"))),
+      GenMETColl(consumes<GenMETCollection>(ps.getUntrackedParameter<edm::InputTag>("GenMETCollection"))),
+      HLTriggerResults(consumes<edm::TriggerResults>(ps.getParameter<edm::InputTag>("HLTriggerResults"))),
+      triggerTag_(ps.getUntrackedParameter<std::string>("DQMFolder", "SingleJet")),
+      patternJetTrg_(ps.getUntrackedParameter<std::string>("PatternJetTrg", "")),
+      patternMetTrg_(ps.getUntrackedParameter<std::string>("PatternMetTrg", "")),
       patternMuTrg_(ps.getUntrackedParameter<std::string>("PatternMuTrg", "")),
       HLTinit_(false) {
   evtCnt = 0;
@@ -41,9 +33,7 @@ HLTJetMETValidation::~HLTJetMETValidation() {}
 //
 
 // ------------ method called when starting to processes a run ------------
-void HLTJetMETValidation::dqmBeginRun(edm::Run const &iRun,
-                                      edm::EventSetup const &iSetup) {
-
+void HLTJetMETValidation::dqmBeginRun(edm::Run const &iRun, edm::EventSetup const &iSetup) {
   bool foundMuTrg = false;
   std::string trgMuNm;
   bool changedConfig = true;
@@ -54,8 +44,7 @@ void HLTJetMETValidation::dqmBeginRun(edm::Run const &iRun,
   TPRegexp patternMu(patternMuTrg_);
 
   if (!hltConfig_.init(iRun, iSetup, "HLT", changedConfig)) {
-    edm::LogError("HLTJetMETValidation")
-        << "Initialization of HLTConfigProvider failed!!";
+    edm::LogError("HLTJetMETValidation") << "Initialization of HLTConfigProvider failed!!";
     return;
   }
 
@@ -81,9 +70,9 @@ void HLTJetMETValidation::dqmBeginRun(edm::Run const &iRun,
   //----set the denominator paths
   for (size_t it = 0; it < hltTrgJet.size(); it++) {
     if (it == 0 && foundMuTrg)
-      hltTrgJetLow.push_back(trgMuNm); //--lowest threshold uses muon path
+      hltTrgJetLow.push_back(trgMuNm);  //--lowest threshold uses muon path
     if (it == 0 && !foundMuTrg)
-      hltTrgJetLow.push_back(hltTrgJet[it]); //---if no muon then itself
+      hltTrgJetLow.push_back(hltTrgJet[it]);  //---if no muon then itself
     if (it != 0)
       hltTrgJetLow.push_back(hltTrgJet[it - 1]);
     // std::cout<<hltTrgJet[it].c_str()<<"
@@ -144,114 +133,77 @@ void HLTJetMETValidation::dqmBeginRun(edm::Run const &iRun,
 void HLTJetMETValidation::bookHistograms(DQMStore::IBooker &iBooker,
                                          edm::Run const &iRun,
                                          edm::EventSetup const &iSetup) {
-
   //----define DQM folders and elements
   for (size_t it = 0; it < hltTrgJet.size(); it++) {
     // std::cout<<hltTrgJet[it].c_str()<<"
     // "<<hltTrgJetLow[it].c_str()<<std::endl;
-    std::string trgPathName =
-        HLTConfigProvider::removeVersion(triggerTag_ + hltTrgJet[it]);
+    std::string trgPathName = HLTConfigProvider::removeVersion(triggerTag_ + hltTrgJet[it]);
     // std::cout << "str = " << triggerTag_+hltTrgJet[it].c_str() << std::endl;
     // std::cout << "trgPathName = " << trgPathName << std::endl;
     iBooker.setCurrentFolder(trgPathName);
-    _meHLTJetPt.push_back(
-        iBooker.book1D("_meHLTJetPt", "Single HLT Jet Pt", 100, 0, 500));
-    _meHLTJetPtTrgMC.push_back(iBooker.book1D(
-        "_meHLTJetPtTrgMC", "Single HLT Jet Pt - HLT Triggered", 100, 0, 500));
-    _meHLTJetPtTrg.push_back(iBooker.book1D(
-        "_meHLTJetPtTrg", "Single HLT Jet Pt - HLT Triggered", 100, 0, 500));
+    _meHLTJetPt.push_back(iBooker.book1D("_meHLTJetPt", "Single HLT Jet Pt", 100, 0, 500));
+    _meHLTJetPtTrgMC.push_back(iBooker.book1D("_meHLTJetPtTrgMC", "Single HLT Jet Pt - HLT Triggered", 100, 0, 500));
+    _meHLTJetPtTrg.push_back(iBooker.book1D("_meHLTJetPtTrg", "Single HLT Jet Pt - HLT Triggered", 100, 0, 500));
     _meHLTJetPtTrgLow.push_back(
-        iBooker.book1D("_meHLTJetPtTrgLow",
-                       "Single HLT Jet Pt - HLT Triggered Low", 100, 0, 500));
+        iBooker.book1D("_meHLTJetPtTrgLow", "Single HLT Jet Pt - HLT Triggered Low", 100, 0, 500));
 
-    _meHLTJetEta.push_back(
-        iBooker.book1D("_meHLTJetEta", "Single HLT Jet Eta", 100, -10, 10));
+    _meHLTJetEta.push_back(iBooker.book1D("_meHLTJetEta", "Single HLT Jet Eta", 100, -10, 10));
     _meHLTJetEtaTrgMC.push_back(
-        iBooker.book1D("_meHLTJetEtaTrgMC",
-                       "Single HLT Jet Eta - HLT Triggered", 100, -10, 10));
-    _meHLTJetEtaTrg.push_back(iBooker.book1D(
-        "_meHLTJetEtaTrg", "Single HLT Jet Eta - HLT Triggered", 100, -10, 10));
+        iBooker.book1D("_meHLTJetEtaTrgMC", "Single HLT Jet Eta - HLT Triggered", 100, -10, 10));
+    _meHLTJetEtaTrg.push_back(iBooker.book1D("_meHLTJetEtaTrg", "Single HLT Jet Eta - HLT Triggered", 100, -10, 10));
     _meHLTJetEtaTrgLow.push_back(
-        iBooker.book1D("_meHLTJetEtaTrgLow",
-                       "Single HLT Jet Eta - HLT Triggered Low", 100, -10, 10));
+        iBooker.book1D("_meHLTJetEtaTrgLow", "Single HLT Jet Eta - HLT Triggered Low", 100, -10, 10));
 
-    _meHLTJetPhi.push_back(
-        iBooker.book1D("_meHLTJetPhi", "Single HLT Jet Phi", 100, -4., 4.));
+    _meHLTJetPhi.push_back(iBooker.book1D("_meHLTJetPhi", "Single HLT Jet Phi", 100, -4., 4.));
     _meHLTJetPhiTrgMC.push_back(
-        iBooker.book1D("_meHLTJetPhiTrgMC",
-                       "Single HLT Jet Phi - HLT Triggered", 100, -4., 4.));
-    _meHLTJetPhiTrg.push_back(iBooker.book1D(
-        "_meHLTJetPhiTrg", "Single HLT Jet Phi - HLT Triggered", 100, -4., 4.));
+        iBooker.book1D("_meHLTJetPhiTrgMC", "Single HLT Jet Phi - HLT Triggered", 100, -4., 4.));
+    _meHLTJetPhiTrg.push_back(iBooker.book1D("_meHLTJetPhiTrg", "Single HLT Jet Phi - HLT Triggered", 100, -4., 4.));
     _meHLTJetPhiTrgLow.push_back(
-        iBooker.book1D("_meHLTJetPhiTrgLow",
-                       "Single HLT Jet Phi - HLT Triggered Low", 100, -4., 4.));
+        iBooker.book1D("_meHLTJetPhiTrgLow", "Single HLT Jet Phi - HLT Triggered Low", 100, -4., 4.));
 
-    _meGenJetPt.push_back(
-        iBooker.book1D("_meGenJetPt", "Single Generated Jet Pt", 100, 0, 500));
+    _meGenJetPt.push_back(iBooker.book1D("_meGenJetPt", "Single Generated Jet Pt", 100, 0, 500));
     _meGenJetPtTrgMC.push_back(
-        iBooker.book1D("_meGenJetPtTrgMC",
-                       "Single Generated Jet Pt - HLT Triggered", 100, 0, 500));
-    _meGenJetPtTrg.push_back(
-        iBooker.book1D("_meGenJetPtTrg",
-                       "Single Generated Jet Pt - HLT Triggered", 100, 0, 500));
-    _meGenJetPtTrgLow.push_back(iBooker.book1D(
-        "_meGenJetPtTrgLow", "Single Generated Jet Pt - HLT Triggered Low", 100,
-        0, 500));
+        iBooker.book1D("_meGenJetPtTrgMC", "Single Generated Jet Pt - HLT Triggered", 100, 0, 500));
+    _meGenJetPtTrg.push_back(iBooker.book1D("_meGenJetPtTrg", "Single Generated Jet Pt - HLT Triggered", 100, 0, 500));
+    _meGenJetPtTrgLow.push_back(
+        iBooker.book1D("_meGenJetPtTrgLow", "Single Generated Jet Pt - HLT Triggered Low", 100, 0, 500));
 
-    _meGenJetEta.push_back(iBooker.book1D(
-        "_meGenJetEta", "Single Generated Jet Eta", 100, -10, 10));
-    _meGenJetEtaTrgMC.push_back(iBooker.book1D(
-        "_meGenJetEtaTrgMC", "Single Generated Jet Eta - HLT Triggered", 100,
-        -10, 10));
-    _meGenJetEtaTrg.push_back(iBooker.book1D(
-        "_meGenJetEtaTrg", "Single Generated Jet Eta - HLT Triggered", 100, -10,
-        10));
-    _meGenJetEtaTrgLow.push_back(iBooker.book1D(
-        "_meGenJetEtaTrgLow", "Single Generated Jet Eta - HLT Triggered Low",
-        100, -10, 10));
+    _meGenJetEta.push_back(iBooker.book1D("_meGenJetEta", "Single Generated Jet Eta", 100, -10, 10));
+    _meGenJetEtaTrgMC.push_back(
+        iBooker.book1D("_meGenJetEtaTrgMC", "Single Generated Jet Eta - HLT Triggered", 100, -10, 10));
+    _meGenJetEtaTrg.push_back(
+        iBooker.book1D("_meGenJetEtaTrg", "Single Generated Jet Eta - HLT Triggered", 100, -10, 10));
+    _meGenJetEtaTrgLow.push_back(
+        iBooker.book1D("_meGenJetEtaTrgLow", "Single Generated Jet Eta - HLT Triggered Low", 100, -10, 10));
 
-    _meGenJetPhi.push_back(iBooker.book1D(
-        "_meGenJetPhi", "Single Generated Jet Phi", 100, -4., 4.));
-    _meGenJetPhiTrgMC.push_back(iBooker.book1D(
-        "_meGenJetPhiTrgMC", "Single Generated Jet Phi - HLT Triggered", 100,
-        -4., 4.));
-    _meGenJetPhiTrg.push_back(iBooker.book1D(
-        "_meGenJetPhiTrg", "Single Generated Jet Phi - HLT Triggered", 100, -4.,
-        4.));
-    _meGenJetPhiTrgLow.push_back(iBooker.book1D(
-        "_meGenJetPhiTrgLow", "Single Generated Jet Phi - HLT Triggered Low",
-        100, -4., 4.));
+    _meGenJetPhi.push_back(iBooker.book1D("_meGenJetPhi", "Single Generated Jet Phi", 100, -4., 4.));
+    _meGenJetPhiTrgMC.push_back(
+        iBooker.book1D("_meGenJetPhiTrgMC", "Single Generated Jet Phi - HLT Triggered", 100, -4., 4.));
+    _meGenJetPhiTrg.push_back(
+        iBooker.book1D("_meGenJetPhiTrg", "Single Generated Jet Phi - HLT Triggered", 100, -4., 4.));
+    _meGenJetPhiTrgLow.push_back(
+        iBooker.book1D("_meGenJetPhiTrgLow", "Single Generated Jet Phi - HLT Triggered Low", 100, -4., 4.));
   }
   for (size_t it = 0; it < hltTrgMet.size(); it++) {
     // std::cout<<hltTrgMet[it].c_str()<<"
     // "<<hltTrgMetLow[it].c_str()<<std::endl;
-    std::string trgPathName =
-        HLTConfigProvider::removeVersion(triggerTag_ + hltTrgMet[it]);
+    std::string trgPathName = HLTConfigProvider::removeVersion(triggerTag_ + hltTrgMet[it]);
     iBooker.setCurrentFolder(trgPathName);
-    _meHLTMET.push_back(
-        iBooker.book1D("_meHLTMET", "HLT Missing ET", 100, 0, 500));
-    _meHLTMETTrgMC.push_back(iBooker.book1D(
-        "_meHLTMETTrgMC", "HLT Missing ET - HLT Triggered", 100, 0, 500));
-    _meHLTMETTrg.push_back(iBooker.book1D(
-        "_meHLTMETTrg", "HLT Missing ET - HLT Triggered", 100, 0, 500));
-    _meHLTMETTrgLow.push_back(iBooker.book1D(
-        "_meHLTMETTrgLow", "HLT Missing ET - HLT Triggered Low", 100, 0, 500));
+    _meHLTMET.push_back(iBooker.book1D("_meHLTMET", "HLT Missing ET", 100, 0, 500));
+    _meHLTMETTrgMC.push_back(iBooker.book1D("_meHLTMETTrgMC", "HLT Missing ET - HLT Triggered", 100, 0, 500));
+    _meHLTMETTrg.push_back(iBooker.book1D("_meHLTMETTrg", "HLT Missing ET - HLT Triggered", 100, 0, 500));
+    _meHLTMETTrgLow.push_back(iBooker.book1D("_meHLTMETTrgLow", "HLT Missing ET - HLT Triggered Low", 100, 0, 500));
 
-    _meGenMET.push_back(
-        iBooker.book1D("_meGenMET", "Generated Missing ET", 100, 0, 500));
-    _meGenMETTrgMC.push_back(iBooker.book1D(
-        "_meGenMETTrgMC", "Generated Missing ET - HLT Triggered", 100, 0, 500));
-    _meGenMETTrg.push_back(iBooker.book1D(
-        "_meGenMETTrg", "Generated Missing ET - HLT Triggered", 100, 0, 500));
-    _meGenMETTrgLow.push_back(iBooker.book1D(
-        "_meGenMETTrgLow", "Generated Missing ET - HLT Triggered Low", 100, 0,
-        500));
+    _meGenMET.push_back(iBooker.book1D("_meGenMET", "Generated Missing ET", 100, 0, 500));
+    _meGenMETTrgMC.push_back(iBooker.book1D("_meGenMETTrgMC", "Generated Missing ET - HLT Triggered", 100, 0, 500));
+    _meGenMETTrg.push_back(iBooker.book1D("_meGenMETTrg", "Generated Missing ET - HLT Triggered", 100, 0, 500));
+    _meGenMETTrgLow.push_back(
+        iBooker.book1D("_meGenMETTrgLow", "Generated Missing ET - HLT Triggered Low", 100, 0, 500));
   }
 }
 
 // ------------ method called for each event ------------
-void HLTJetMETValidation::analyze(const edm::Event &iEvent,
-                                  const edm::EventSetup &iSetup) {
+void HLTJetMETValidation::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace std;
   using namespace edm;
   using namespace reco;
@@ -354,8 +306,7 @@ void HLTJetMETValidation::analyze(const edm::Event &iEvent,
   if (pfJets.isValid()) {
     // Loop over the PFJets and fill some histograms
     int jetInd = 0;
-    for (PFJetCollection::const_iterator pf = pfJets->begin();
-         pf != pfJets->end(); ++pf) {
+    for (PFJetCollection::const_iterator pf = pfJets->begin(); pf != pfJets->end(); ++pf) {
       // std::cout << "PF JET #" << jetInd << std::endl << pf->print() <<
       // std::endl;
       if (jetInd == 0) {
@@ -387,7 +338,7 @@ void HLTJetMETValidation::analyze(const edm::Event &iEvent,
         }
         jetInd++;
       }
-    } // loop over pfjets
+    }  // loop over pfjets
   } else {
     // std::cout << "  -- No PFJets" << std::endl;
     // if (evtCnt==1) edm::LogWarning("HLTJetMETValidation") << "  -- No
@@ -404,8 +355,7 @@ void HLTJetMETValidation::analyze(const edm::Event &iEvent,
   if (genJets.isValid()) {
     // Loop over the GenJets and fill some histograms
     int jetInd = 0;
-    for (GenJetCollection::const_iterator gen = genJets->begin();
-         gen != genJets->end(); ++gen) {
+    for (GenJetCollection::const_iterator gen = genJets->begin(); gen != genJets->end(); ++gen) {
       if (jetInd == 0) {
         genJetPt = gen->pt();
         genJetEta = gen->eta();
@@ -457,8 +407,7 @@ void HLTJetMETValidation::analyze(const edm::Event &iEvent,
         _meHLTMET[it]->Fill(calMet);
         if (myTrigM.size() > it && myTrigM[it])
           _meHLTMETTrgMC[it]->Fill(calMet);
-        if (myTrigM.size() > it && myTrigMLow.size() > it && myTrigM[it] &&
-            myTrigMLow[it])
+        if (myTrigM.size() > it && myTrigMLow.size() > it && myTrigM[it] && myTrigMLow[it])
           _meHLTMETTrg[it]->Fill(calMet);
         if (myTrigMLow.size() > it && myTrigMLow[it])
           _meHLTMETTrgLow[it]->Fill(calMet);
@@ -482,8 +431,7 @@ void HLTJetMETValidation::analyze(const edm::Event &iEvent,
         _meGenMET[it]->Fill(genMet);
         if (myTrigM.size() > it && myTrigM[it])
           _meGenMETTrgMC[it]->Fill(genMet);
-        if (myTrigM.size() > it && myTrigMLow.size() > it && myTrigM[it] &&
-            myTrigMLow[it])
+        if (myTrigM.size() > it && myTrigMLow.size() > it && myTrigM[it] && myTrigMLow[it])
           _meGenMETTrg[it]->Fill(genMet);
         if (myTrigMLow.size() > it && myTrigMLow[it])
           _meGenMETTrgLow[it]->Fill(genMet);
@@ -496,9 +444,7 @@ void HLTJetMETValidation::analyze(const edm::Event &iEvent,
   }
 }
 
-void HLTJetMETValidation::getHLTResults(const edm::TriggerResults &hltresults,
-                                        const edm::TriggerNames &triggerNames) {
-
+void HLTJetMETValidation::getHLTResults(const edm::TriggerResults &hltresults, const edm::TriggerNames &triggerNames) {
   int ntrigs = hltresults.size();
   if (!HLTinit_) {
     HLTinit_ = true;

--- a/HLTriggerOffline/JetMET/src/JetMETDQMPostProcessor.cc
+++ b/HLTriggerOffline/JetMET/src/JetMETDQMPostProcessor.cc
@@ -19,8 +19,7 @@ JetMETDQMPostProcessor::JetMETDQMPostProcessor(const edm::ParameterSet &pset) {
   patternMetTrg_ = pset.getUntrackedParameter<std::string>("PatternMetTrg", "");
 }
 
-void JetMETDQMPostProcessor::dqmEndJob(DQMStore::IBooker &ibooker,
-                                       DQMStore::IGetter &igetter) {
+void JetMETDQMPostProcessor::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
   //////////////////////////////////
   // setup DQM stor               //
   //////////////////////////////////
@@ -35,15 +34,12 @@ void JetMETDQMPostProcessor::dqmEndJob(DQMStore::IBooker &ibooker,
   if (igetter.dirExists(subDir_))
     ibooker.cd(subDir_);
   else {
-    edm::LogWarning("JetMETDQMPostProcessor")
-        << "cannot find directory: " << subDir_ << " , skipping";
+    edm::LogWarning("JetMETDQMPostProcessor") << "cannot find directory: " << subDir_ << " , skipping";
     return;
   }
 
   std::vector<std::string> subdirectories = igetter.getSubdirs();
-  for (std::vector<std::string>::iterator dir = subdirectories.begin();
-       dir != subdirectories.end(); dir++) {
-
+  for (std::vector<std::string>::iterator dir = subdirectories.begin(); dir != subdirectories.end(); dir++) {
     ibooker.cd(*dir);
 
     isJetDir = false;
@@ -55,70 +51,132 @@ void JetMETDQMPostProcessor::dqmEndJob(DQMStore::IBooker &ibooker,
       isMetDir = true;
 
     if (isMetDir) {
-
       // std::cout << "JetMETDQMPostProcessor - Met paths: " << ibooker.pwd() <<
       // " " << *dir << std::endl;
 
       // GenMET
-      dividehistos(ibooker, igetter, "_meGenMETTrgMC", "_meGenMET",
-                   "_meTurnOngMET", "Gen Missing ET",
+      dividehistos(ibooker,
+                   igetter,
+                   "_meGenMETTrgMC",
+                   "_meGenMET",
+                   "_meTurnOngMET",
+                   "Gen Missing ET",
                    "Gen Missing ET Turn-On RelVal");
-      dividehistos(ibooker, igetter, "_meGenMETTrg", "_meGenMETTrgLow",
-                   "_meTurnOngMETLow", "Gen Missing ETLow",
+      dividehistos(ibooker,
+                   igetter,
+                   "_meGenMETTrg",
+                   "_meGenMETTrgLow",
+                   "_meTurnOngMETLow",
+                   "Gen Missing ETLow",
                    "Gen Missing ET Turn-On Data");
 
       // HLTMET
-      dividehistos(ibooker, igetter, "_meHLTMETTrgMC", "_meHLTMET",
-                   "_meTurnOnhMET", "HLT Missing ET",
+      dividehistos(ibooker,
+                   igetter,
+                   "_meHLTMETTrgMC",
+                   "_meHLTMET",
+                   "_meTurnOnhMET",
+                   "HLT Missing ET",
                    "HLT Missing ET Turn-On RelVal");
-      dividehistos(ibooker, igetter, "_meHLTMETTrg", "_meHLTMETTrgLow",
-                   "_meTurnOnhMETLow", "HLT Missing ETLow",
+      dividehistos(ibooker,
+                   igetter,
+                   "_meHLTMETTrg",
+                   "_meHLTMETTrgLow",
+                   "_meTurnOnhMETLow",
+                   "HLT Missing ETLow",
                    "HLT Missing ET Turn-On Data");
     }
 
     if (isJetDir) {
-
       // std::cout << "JetMETDQMPostProcessor - Jet paths: " << ibooker.pwd() <<
       // " " << *dir << std::endl;
 
       // GenJets
-      dividehistos(ibooker, igetter, "_meGenJetPtTrgMC", "_meGenJetPt",
-                   "_meTurnOngJetPt", "Gen Jet Pt",
+      dividehistos(ibooker,
+                   igetter,
+                   "_meGenJetPtTrgMC",
+                   "_meGenJetPt",
+                   "_meTurnOngJetPt",
+                   "Gen Jet Pt",
                    "Gen Jet Pt Turn-On RelVal");
-      dividehistos(ibooker, igetter, "_meGenJetPtTrg", "_meGenJetPtTrgLow",
-                   "_meTurnOngJetPt", "Gen Jet PtLow",
+      dividehistos(ibooker,
+                   igetter,
+                   "_meGenJetPtTrg",
+                   "_meGenJetPtTrgLow",
+                   "_meTurnOngJetPt",
+                   "Gen Jet PtLow",
                    "Gen Jet Pt Turn-On Data");
-      dividehistos(ibooker, igetter, "_meGenJetEtaTrgMC", "_meGenJetEta",
-                   "_meTurnOngJetEta", "Gen Jet Eta",
+      dividehistos(ibooker,
+                   igetter,
+                   "_meGenJetEtaTrgMC",
+                   "_meGenJetEta",
+                   "_meTurnOngJetEta",
+                   "Gen Jet Eta",
                    "Gen Jet Eta Turn-On RelVal");
-      dividehistos(ibooker, igetter, "_meGenJetEtaTrg", "_meGenJetEtaTrgLow",
-                   "_meTurnOngJetEta", "Gen Jet EtaLow",
+      dividehistos(ibooker,
+                   igetter,
+                   "_meGenJetEtaTrg",
+                   "_meGenJetEtaTrgLow",
+                   "_meTurnOngJetEta",
+                   "Gen Jet EtaLow",
                    "Gen Jet Eta Turn-On Data");
-      dividehistos(ibooker, igetter, "_meGenJetPhiTrgMC", "_meGenJetPhi",
-                   "_meTurnOngJetPhi", "Gen Jet Phi",
+      dividehistos(ibooker,
+                   igetter,
+                   "_meGenJetPhiTrgMC",
+                   "_meGenJetPhi",
+                   "_meTurnOngJetPhi",
+                   "Gen Jet Phi",
                    "Gen Jet Phi Turn-On RelVal");
-      dividehistos(ibooker, igetter, "_meGenJetPhiTrg", "_meGenJetPhiTrgLow",
-                   "_meTurnOngJetPhi", "Gen Jet PhiLow",
+      dividehistos(ibooker,
+                   igetter,
+                   "_meGenJetPhiTrg",
+                   "_meGenJetPhiTrgLow",
+                   "_meTurnOngJetPhi",
+                   "Gen Jet PhiLow",
                    "Gen Jet Phi Turn-On Data");
 
       // HLTJets
-      dividehistos(ibooker, igetter, "_meHLTJetPtTrgMC", "_meHLTJetPt",
-                   "_meTurnOnhJetPt", "HLT Jet Pt",
+      dividehistos(ibooker,
+                   igetter,
+                   "_meHLTJetPtTrgMC",
+                   "_meHLTJetPt",
+                   "_meTurnOnhJetPt",
+                   "HLT Jet Pt",
                    "HLT Jet Pt Turn-On RelVal");
-      dividehistos(ibooker, igetter, "_meHLTJetPtTrg", "_meHLTJetPtTrgLow",
-                   "_meTurnOnhJetPt", "HLT Jet PtLow",
+      dividehistos(ibooker,
+                   igetter,
+                   "_meHLTJetPtTrg",
+                   "_meHLTJetPtTrgLow",
+                   "_meTurnOnhJetPt",
+                   "HLT Jet PtLow",
                    "HLT Jet Pt Turn-On Data");
-      dividehistos(ibooker, igetter, "_meHLTJetEtaTrgMC", "_meHLTJetEta",
-                   "_meTurnOnhJetEta", "HLT Jet Eta",
+      dividehistos(ibooker,
+                   igetter,
+                   "_meHLTJetEtaTrgMC",
+                   "_meHLTJetEta",
+                   "_meTurnOnhJetEta",
+                   "HLT Jet Eta",
                    "HLT Jet Eta Turn-On RelVal");
-      dividehistos(ibooker, igetter, "_meHLTJetEtaTrg", "_meHLTJetEtaTrgLow",
-                   "_meTurnOnhJetEta", "HLT Jet EtaLow",
+      dividehistos(ibooker,
+                   igetter,
+                   "_meHLTJetEtaTrg",
+                   "_meHLTJetEtaTrgLow",
+                   "_meTurnOnhJetEta",
+                   "HLT Jet EtaLow",
                    "HLT Jet Eta Turn-On Data");
-      dividehistos(ibooker, igetter, "_meHLTJetPhiTrgMC", "_meHLTJetPhi",
-                   "_meTurnOnhJetPhi", "HLT Jet Phi",
+      dividehistos(ibooker,
+                   igetter,
+                   "_meHLTJetPhiTrgMC",
+                   "_meHLTJetPhi",
+                   "_meTurnOnhJetPhi",
+                   "HLT Jet Phi",
                    "HLT Jet Phi Turn-On RelVal");
-      dividehistos(ibooker, igetter, "_meHLTJetPhiTrg", "_meHLTJetPhiTrgLow",
-                   "_meTurnOnhJetPhi", "HLT Jet PhiLow",
+      dividehistos(ibooker,
+                   igetter,
+                   "_meHLTJetPhiTrg",
+                   "_meHLTJetPhiTrgLow",
+                   "_meTurnOnhJetPhi",
+                   "HLT Jet PhiLow",
                    "HLT Jet Phi Turn-On Data");
     }
 
@@ -145,20 +203,17 @@ TProfile *JetMETDQMPostProcessor::dividehistos(DQMStore::IBooker &ibooker,
 
   if (num == nullptr)
     edm::LogWarning("JetMETDQMPostProcessor")
-        << "numerator histogram " << ibooker.pwd() + "/" + numName
-        << " does not exist";
+        << "numerator histogram " << ibooker.pwd() + "/" + numName << " does not exist";
   if (denom == nullptr)
     edm::LogWarning("JetMETDQMPostProcessor")
-        << "denominator histogram " << ibooker.pwd() + "/" + denomName
-        << " does not exist";
+        << "denominator histogram " << ibooker.pwd() + "/" + denomName << " does not exist";
 
   // Check if histograms actually exist
   if (!num || !denom)
     return nullptr;
 
   MonitorElement *meOut = ibooker.bookProfile(
-      outName, titel, num->GetXaxis()->GetNbins(), num->GetXaxis()->GetXmin(),
-      num->GetXaxis()->GetXmax(), 0., 1.2);
+      outName, titel, num->GetXaxis()->GetNbins(), num->GetXaxis()->GetXmin(), num->GetXaxis()->GetXmax(), 0., 1.2);
   meOut->setEfficiencyFlag();
   TProfile *out = meOut->getTProfile();
   out->GetXaxis()->SetTitle(label.c_str());
@@ -172,8 +227,7 @@ TProfile *JetMETDQMPostProcessor::dividehistos(DQMStore::IBooker &ibooker,
 
   for (int i = 1; i <= num->GetNbinsX(); i++) {
     double e, low, high;
-    Efficiency((int)num->GetBinContent(i), (int)denom->GetBinContent(i), 0.683,
-               e, low, high);
+    Efficiency((int)num->GetBinContent(i), (int)denom->GetBinContent(i), 0.683, e, low, high);
     double err = e - low > high - e ? e - low : high - e;
     // here is the trick to store info in TProfile:
     out->SetBinContent(i, e);
@@ -196,9 +250,8 @@ TH1F *JetMETDQMPostProcessor::getHistogram(DQMStore::IBooker &ibooker,
 }
 
 //----------------------------------------------------------------------
-void JetMETDQMPostProcessor::Efficiency(int passing, int total, double level,
-                                        double &mode, double &lowerBound,
-                                        double &upperBound) {
+void JetMETDQMPostProcessor::Efficiency(
+    int passing, int total, double level, double &mode, double &lowerBound, double &upperBound) {
   // protection
   if (total == 0) {
     mode = 0.5;

--- a/HLTriggerOffline/Tau/interface/HLTTauMCProducer.h
+++ b/HLTriggerOffline/Tau/interface/HLTTauMCProducer.h
@@ -31,7 +31,6 @@ typedef math::XYZTLorentzVectorD LorentzVector;
 typedef std::vector<LorentzVector> LorentzVectorCollection;
 
 class HLTTauMCProducer : public edm::EDProducer {
-
 public:
   explicit HLTTauMCProducer(const edm::ParameterSet &);
   ~HLTTauMCProducer() override;
@@ -39,9 +38,7 @@ public:
   void produce(edm::Event &, const edm::EventSetup &) override;
 
 private:
-  void getGenDecayProducts(const reco::GenParticleRef &,
-                           reco::GenParticleRefVector &, int status = 1,
-                           int pdgId = 0);
+  void getGenDecayProducts(const reco::GenParticleRef &, reco::GenParticleRefVector &, int status = 1, int pdgId = 0);
 
   enum tauDecayModes {
     kElectron,

--- a/HLTriggerOffline/Tau/interface/HLTTauRefCombiner.h
+++ b/HLTriggerOffline/Tau/interface/HLTTauRefCombiner.h
@@ -19,7 +19,6 @@ for matching in the Tau HLT
 #include <vector>
 
 class HLTTauRefCombiner : public edm::EDProducer {
-
 public:
   explicit HLTTauRefCombiner(const edm::ParameterSet &);
   ~HLTTauRefCombiner() override;
@@ -30,13 +29,12 @@ private:
   typedef math::XYZTLorentzVectorD LorentzVector;
   typedef std::vector<LorentzVector> LorentzVectorCollection;
 
-  std::vector<edm::EDGetTokenT<LorentzVectorCollection>>
-      inputColl_;       // Input LV Collections
-  double matchDeltaR_;  // Delta R for matching
-  std::string outName_; // outputObjectName
+  std::vector<edm::EDGetTokenT<LorentzVectorCollection>> inputColl_;  // Input LV Collections
+  double matchDeltaR_;                                                // Delta R for matching
+  std::string outName_;                                               // outputObjectName
 
   bool match(const LorentzVector &,
-             const LorentzVectorCollection &); // See if this Jet Is Matched
+             const LorentzVectorCollection &);  // See if this Jet Is Matched
 };
 
 #endif

--- a/HLTriggerOffline/Tau/interface/HLTTauRelvalQTester.h
+++ b/HLTriggerOffline/Tau/interface/HLTTauRelvalQTester.h
@@ -7,8 +7,7 @@ public:
 
 protected:
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
-  void endLuminosityBlock(edm::LuminosityBlock const &lumiSeg,
-                          edm::EventSetup const &c) override;
+  void endLuminosityBlock(edm::LuminosityBlock const &lumiSeg, edm::EventSetup const &c) override;
   void endRun(const edm::Run &r, const edm::EventSetup &c) override;
   void endJob() override;
 

--- a/HLTriggerOffline/Tau/src/HLTTauMCProducer.cc
+++ b/HLTriggerOffline/Tau/src/HLTTauMCProducer.cc
@@ -5,13 +5,10 @@ using namespace std;
 using namespace reco;
 
 HLTTauMCProducer::HLTTauMCProducer(const edm::ParameterSet &mc) {
-
   // One Parameter Set per Collection
 
-  MC_ = consumes<GenParticleCollection>(
-      mc.getUntrackedParameter<edm::InputTag>("GenParticles"));
-  MCMET_ = consumes<GenMETCollection>(
-      mc.getUntrackedParameter<edm::InputTag>("GenMET"));
+  MC_ = consumes<GenParticleCollection>(mc.getUntrackedParameter<edm::InputTag>("GenParticles"));
+  MCMET_ = consumes<GenMETCollection>(mc.getUntrackedParameter<edm::InputTag>("GenMET"));
   ptMinMCTau_ = mc.getUntrackedParameter<double>("ptMinTau", 5.);
   ptMinMCMuon_ = mc.getUntrackedParameter<double>("ptMinMuon", 2.);
   ptMinMCElectron_ = mc.getUntrackedParameter<double>("ptMinElectron", 5.);
@@ -38,22 +35,14 @@ HLTTauMCProducer::~HLTTauMCProducer() {}
 void HLTTauMCProducer::produce(edm::Event &iEvent, const edm::EventSetup &iES) {
   // All the code from HLTTauMCInfo is here :-)
 
-  unique_ptr<LorentzVectorCollection> product_Electrons(
-      new LorentzVectorCollection);
-  unique_ptr<LorentzVectorCollection> product_Muons(
-      new LorentzVectorCollection);
-  unique_ptr<LorentzVectorCollection> product_Leptons(
-      new LorentzVectorCollection);
-  unique_ptr<LorentzVectorCollection> product_OneProng(
-      new LorentzVectorCollection);
-  unique_ptr<LorentzVectorCollection> product_ThreeProng(
-      new LorentzVectorCollection);
-  unique_ptr<LorentzVectorCollection> product_OneAndThreeProng(
-      new LorentzVectorCollection);
-  unique_ptr<LorentzVectorCollection> product_Other(
-      new LorentzVectorCollection);
-  unique_ptr<LorentzVectorCollection> product_Neutrina(
-      new LorentzVectorCollection);
+  unique_ptr<LorentzVectorCollection> product_Electrons(new LorentzVectorCollection);
+  unique_ptr<LorentzVectorCollection> product_Muons(new LorentzVectorCollection);
+  unique_ptr<LorentzVectorCollection> product_Leptons(new LorentzVectorCollection);
+  unique_ptr<LorentzVectorCollection> product_OneProng(new LorentzVectorCollection);
+  unique_ptr<LorentzVectorCollection> product_ThreeProng(new LorentzVectorCollection);
+  unique_ptr<LorentzVectorCollection> product_OneAndThreeProng(new LorentzVectorCollection);
+  unique_ptr<LorentzVectorCollection> product_Other(new LorentzVectorCollection);
+  unique_ptr<LorentzVectorCollection> product_Neutrina(new LorentzVectorCollection);
   unique_ptr<LorentzVectorCollection> product_MET(new LorentzVectorCollection);
   unique_ptr<std::vector<int>> product_Mothers(new std::vector<int>);
 
@@ -68,8 +57,7 @@ void HLTTauMCProducer::produce(edm::Event &iEvent, const edm::EventSetup &iES) {
   iEvent.getByToken(MCMET_, genMet);
   LorentzVector MET(0., 0., 0., 0.);
   if (genMet.isValid()) {
-    MET = LorentzVector(genMet->front().px(), genMet->front().py(), 0,
-                        genMet->front().pt());
+    MET = LorentzVector(genMet->front().px(), genMet->front().py(), 0, genMet->front().pt());
   }
   product_MET->push_back(MET);
 
@@ -77,13 +65,11 @@ void HLTTauMCProducer::produce(edm::Event &iEvent, const edm::EventSetup &iES) {
   // It is not guaranteed that primary bosons are stored in event history.
   // Is it really needed when check if taus from the boson is removed?
   // Kept for backward compatibility
-  for (GenParticleCollection::const_iterator p = genParticles->begin();
-       p != genParticles->end(); ++p) {
+  for (GenParticleCollection::const_iterator p = genParticles->begin(); p != genParticles->end(); ++p) {
     // Check the PDG ID
     bool pdg_ok = false;
     for (size_t pi = 0; pi < m_PDG_.size(); ++pi) {
-      if (abs((*p).pdgId()) == m_PDG_[pi] &&
-          ((*p).isHardProcess() || (*p).status() == 3)) {
+      if (abs((*p).pdgId()) == m_PDG_[pi] && ((*p).isHardProcess() || (*p).status() == 3)) {
         pdg_ok = true;
         // cout<<" Bsoson particles: "<< (*p).pdgId()<< " " <<(*p).status() << "
         // "<< pdg_ok<<endl;
@@ -97,13 +83,12 @@ void HLTTauMCProducer::produce(edm::Event &iEvent, const edm::EventSetup &iES) {
 
       TLorentzVector Boson((*p).px(), (*p).py(), (*p).pz(), (*p).energy());
     }
-  } // End of search for the bosons
+  }  // End of search for the bosons
 
   // Look for taus
   GenParticleRefVector allTaus;
   unsigned index = 0;
-  for (GenParticleCollection::const_iterator p = genParticles->begin();
-       p != genParticles->end(); ++p, ++index) {
+  for (GenParticleCollection::const_iterator p = genParticles->begin(); p != genParticles->end(); ++p, ++index) {
     const GenParticle &genP = *p;
     // accept only isPromptDecayed() particles
     if (!genP.isPromptDecayed())
@@ -120,15 +105,13 @@ void HLTTauMCProducer::produce(edm::Event &iEvent, const edm::EventSetup &iES) {
   }
 
   // Find stable tau decay products and build visible taus
-  for (GenParticleRefVector::const_iterator t = allTaus.begin();
-       t != allTaus.end(); ++t) {
+  for (GenParticleRefVector::const_iterator t = allTaus.begin(); t != allTaus.end(); ++t) {
     // look for all stable (status=1) decay products
     GenParticleRefVector decayProducts;
     getGenDecayProducts(*t, decayProducts, 1);
 
     // build visible taus and recognize decay mode
     if (!decayProducts.empty()) {
-
       LorentzVector Visible_Taus(0., 0., 0., 0.);
       LorentzVector TauDecayProduct(0., 0., 0., 0.);
       LorentzVector Neutrino(0., 0., 0., 0.);
@@ -141,22 +124,20 @@ void HLTTauMCProducer::produce(edm::Event &iEvent, const edm::EventSetup &iES) {
       int numNeutrinos = 0;
       int numOtherParticles = 0;
 
-      for (GenParticleRefVector::const_iterator pit = decayProducts.begin();
-           pit != decayProducts.end(); ++pit) {
+      for (GenParticleRefVector::const_iterator pit = decayProducts.begin(); pit != decayProducts.end(); ++pit) {
         int pdg_id = abs((*pit)->pdgId());
         if (pdg_id == 11)
           numElectrons++;
         else if (pdg_id == 13)
           numMuons++;
         else if (pdg_id == 211 || pdg_id == 321)
-          numChargedPions++; // Count both pi+ and K+
+          numChargedPions++;  // Count both pi+ and K+
         else if (pdg_id == 111 || pdg_id == 130 || pdg_id == 310)
-          numNeutralPions++; // Count both pi0 and K0_L/S
+          numNeutralPions++;  // Count both pi0 and K0_L/S
         else if (pdg_id == 12 || pdg_id == 14 || pdg_id == 16) {
           numNeutrinos++;
           if (pdg_id == 16) {
-            Neutrino.SetPxPyPzE((*pit)->px(), (*pit)->py(), (*pit)->pz(),
-                                (*pit)->energy());
+            Neutrino.SetPxPyPzE((*pit)->px(), (*pit)->py(), (*pit)->pz(), (*pit)->energy());
           }
         } else if (pdg_id == 22)
           numPhotons++;
@@ -165,8 +146,7 @@ void HLTTauMCProducer::produce(edm::Event &iEvent, const edm::EventSetup &iES) {
         }
 
         if (pdg_id != 12 && pdg_id != 14 && pdg_id != 16) {
-          TauDecayProduct.SetPxPyPzE((*pit)->px(), (*pit)->py(), (*pit)->pz(),
-                                     (*pit)->energy());
+          TauDecayProduct.SetPxPyPzE((*pit)->px(), (*pit)->py(), (*pit)->pz(), (*pit)->energy());
           Visible_Taus += TauDecayProduct;
         }
         //		  cout<< "This has to be the same: " << (*pit)->pdgId()
@@ -186,84 +166,81 @@ void HLTTauMCProducer::produce(edm::Event &iEvent, const edm::EventSetup &iES) {
         } else {
           //--- hadronic tau decays
           switch (numChargedPions) {
-          case 1:
-            if (numNeutralPions != 0) {
-              tauDecayMode = kOther;
+            case 1:
+              if (numNeutralPions != 0) {
+                tauDecayMode = kOther;
+                break;
+              }
+              switch (numPhotons) {
+                case 0:
+                  tauDecayMode = kOneProng0pi0;
+                  break;
+                case 2:
+                  tauDecayMode = kOneProng1pi0;
+                  break;
+                case 4:
+                  tauDecayMode = kOneProng2pi0;
+                  break;
+                default:
+                  tauDecayMode = kOther;
+                  break;
+              }
               break;
-            }
-            switch (numPhotons) {
-            case 0:
-              tauDecayMode = kOneProng0pi0;
+            case 3:
+              if (numNeutralPions != 0) {
+                tauDecayMode = kOther;
+                break;
+              }
+              switch (numPhotons) {
+                case 0:
+                  tauDecayMode = kThreeProng0pi0;
+                  break;
+                case 2:
+                  tauDecayMode = kThreeProng1pi0;
+                  break;
+                default:
+                  tauDecayMode = kOther;
+                  break;
+              }
               break;
-            case 2:
-              tauDecayMode = kOneProng1pi0;
-              break;
-            case 4:
-              tauDecayMode = kOneProng2pi0;
-              break;
-            default:
-              tauDecayMode = kOther;
-              break;
-            }
-            break;
-          case 3:
-            if (numNeutralPions != 0) {
-              tauDecayMode = kOther;
-              break;
-            }
-            switch (numPhotons) {
-            case 0:
-              tauDecayMode = kThreeProng0pi0;
-              break;
-            case 2:
-              tauDecayMode = kThreeProng1pi0;
-              break;
-            default:
-              tauDecayMode = kOther;
-              break;
-            }
-            break;
           }
         }
       }
 
       //		  cout<< "So we have a: " << tauDecayMode <<endl;
       if (tauDecayMode == kElectron) {
-        if ((Visible_Taus.eta() > etaMin && Visible_Taus.eta() < etaMax &&
-             Visible_Taus.phi() > phiMin && Visible_Taus.phi() < phiMax) &&
+        if ((Visible_Taus.eta() > etaMin && Visible_Taus.eta() < etaMax && Visible_Taus.phi() > phiMin &&
+             Visible_Taus.phi() < phiMax) &&
             (Visible_Taus.pt() > ptMinMCElectron_)) {
           product_Electrons->push_back(Visible_Taus);
           product_Leptons->push_back(Visible_Taus);
         }
       } else if (tauDecayMode == kMuon) {
-        if ((Visible_Taus.eta() > etaMin && Visible_Taus.eta() < etaMax &&
-             Visible_Taus.phi() > phiMin && Visible_Taus.phi() < phiMax) &&
+        if ((Visible_Taus.eta() > etaMin && Visible_Taus.eta() < etaMax && Visible_Taus.phi() > phiMin &&
+             Visible_Taus.phi() < phiMax) &&
             (Visible_Taus.pt() > ptMinMCMuon_)) {
           product_Muons->push_back(Visible_Taus);
           product_Leptons->push_back(Visible_Taus);
         }
-      } else if (tauDecayMode == kOneProng0pi0 ||
-                 tauDecayMode == kOneProng1pi0 ||
-                 tauDecayMode == kOneProng2pi0) {
-        if ((Visible_Taus.eta() > etaMin && Visible_Taus.eta() < etaMax &&
-             Visible_Taus.phi() > phiMin && Visible_Taus.phi() < phiMax) &&
+      } else if (tauDecayMode == kOneProng0pi0 || tauDecayMode == kOneProng1pi0 || tauDecayMode == kOneProng2pi0) {
+        if ((Visible_Taus.eta() > etaMin && Visible_Taus.eta() < etaMax && Visible_Taus.phi() > phiMin &&
+             Visible_Taus.phi() < phiMax) &&
             (Visible_Taus.pt() > ptMinMCTau_)) {
           product_OneProng->push_back(Visible_Taus);
           product_OneAndThreeProng->push_back(Visible_Taus);
           product_Neutrina->push_back(Neutrino);
         }
-      } else if (tauDecayMode == kThreeProng0pi0 ||
-                 tauDecayMode == kThreeProng1pi0) {
-        if ((Visible_Taus.eta() > etaMin && Visible_Taus.eta() < etaMax &&
-             Visible_Taus.phi() > phiMin && Visible_Taus.phi() < phiMax) &&
+      } else if (tauDecayMode == kThreeProng0pi0 || tauDecayMode == kThreeProng1pi0) {
+        if ((Visible_Taus.eta() > etaMin && Visible_Taus.eta() < etaMax && Visible_Taus.phi() > phiMin &&
+             Visible_Taus.phi() < phiMax) &&
             (Visible_Taus.pt() > ptMinMCTau_)) {
           product_ThreeProng->push_back(Visible_Taus);
           product_OneAndThreeProng->push_back(Visible_Taus);
           product_Neutrina->push_back(Neutrino);
         }
       } else if (tauDecayMode == kOther) {
-        if ((Visible_Taus.eta() > etaMin && Visible_Taus.eta() < etaMax &&
-             Visible_Taus.phi() > phiMin && Visible_Taus.phi() < phiMax) &&
+        if ((Visible_Taus.eta() > etaMin && Visible_Taus.eta() < etaMax && Visible_Taus.phi() > phiMin &&
+             Visible_Taus.phi() < phiMax) &&
             (Visible_Taus.pt() > ptMinMCTau_)) {
           product_Other->push_back(Visible_Taus);
         }
@@ -276,8 +253,7 @@ void HLTTauMCProducer::produce(edm::Event &iEvent, const edm::EventSetup &iES) {
   iEvent.put(std::move(product_Muons), "LeptonicTauMuons");
   iEvent.put(std::move(product_OneProng), "HadronicTauOneProng");
   iEvent.put(std::move(product_ThreeProng), "HadronicTauThreeProng");
-  iEvent.put(std::move(product_OneAndThreeProng),
-             "HadronicTauOneAndThreeProng");
+  iEvent.put(std::move(product_OneAndThreeProng), "HadronicTauOneAndThreeProng");
   iEvent.put(std::move(product_Other), "TauOther");
   iEvent.put(std::move(product_Neutrina), "Neutrina");
   iEvent.put(std::move(product_MET), "MET");
@@ -288,16 +264,12 @@ void HLTTauMCProducer::produce(edm::Event &iEvent, const edm::EventSetup &iES) {
 
 void HLTTauMCProducer::getGenDecayProducts(const GenParticleRef &mother,
                                            GenParticleRefVector &products,
-                                           int status, int pdgId) {
-
+                                           int status,
+                                           int pdgId) {
   const GenParticleRefVector &daughterRefs = mother->daughterRefVector();
 
-  for (GenParticleRefVector::const_iterator d = daughterRefs.begin();
-       d != daughterRefs.end(); ++d) {
-
-    if ((status == 0 || (*d)->status() == status) &&
-        (pdgId == 0 || std::abs((*d)->pdgId()) == pdgId)) {
-
+  for (GenParticleRefVector::const_iterator d = daughterRefs.begin(); d != daughterRefs.end(); ++d) {
+    if ((status == 0 || (*d)->status() == status) && (pdgId == 0 || std::abs((*d)->pdgId()) == pdgId)) {
       products.push_back(*d);
     } else
       getGenDecayProducts(*d, products, status, pdgId);

--- a/HLTriggerOffline/Tau/src/HLTTauRefCombiner.cc
+++ b/HLTriggerOffline/Tau/src/HLTTauRefCombiner.cc
@@ -5,11 +5,9 @@ using namespace edm;
 using namespace std;
 
 HLTTauRefCombiner::HLTTauRefCombiner(const edm::ParameterSet &iConfig) {
-  std::vector<edm::InputTag> inputCollVector_ =
-      iConfig.getParameter<std::vector<InputTag>>("InputCollections");
+  std::vector<edm::InputTag> inputCollVector_ = iConfig.getParameter<std::vector<InputTag>>("InputCollections");
   for (unsigned int ii = 0; ii < inputCollVector_.size(); ++ii) {
-    inputColl_.push_back(
-        consumes<LorentzVectorCollection>(inputCollVector_[ii]));
+    inputColl_.push_back(consumes<LorentzVectorCollection>(inputCollVector_[ii]));
   }
   matchDeltaR_ = iConfig.getParameter<double>("MatchDeltaR");
   outName_ = iConfig.getParameter<string>("OutputCollection");
@@ -19,8 +17,7 @@ HLTTauRefCombiner::HLTTauRefCombiner(const edm::ParameterSet &iConfig) {
 
 HLTTauRefCombiner::~HLTTauRefCombiner() {}
 
-void HLTTauRefCombiner::produce(edm::Event &iEvent,
-                                const edm::EventSetup &iES) {
+void HLTTauRefCombiner::produce(edm::Event &iEvent, const edm::EventSetup &iES) {
   unique_ptr<LorentzVectorCollection> out_product(new LorentzVectorCollection);
 
   // Create The Handles..
@@ -63,13 +60,11 @@ void HLTTauRefCombiner::produce(edm::Event &iEvent,
   }
 }
 
-bool HLTTauRefCombiner::match(const LorentzVector &lv,
-                              const LorentzVectorCollection &lvcol) {
+bool HLTTauRefCombiner::match(const LorentzVector &lv, const LorentzVectorCollection &lvcol) {
   bool matched = false;
 
   if (!lvcol.empty())
-    for (LorentzVectorCollection::const_iterator it = lvcol.begin();
-         it != lvcol.end(); ++it) {
+    for (LorentzVectorCollection::const_iterator it = lvcol.begin(); it != lvcol.end(); ++it) {
       double delta = ROOT::Math::VectorUtil::DeltaR(lv, *it);
       if (delta < matchDeltaR_) {
         matched = true;

--- a/HLTriggerOffline/Tau/src/HLTTauRelvalQTester.cc
+++ b/HLTriggerOffline/Tau/src/HLTTauRelvalQTester.cc
@@ -1,18 +1,15 @@
 #include "HLTriggerOffline/Tau/interface/HLTTauRelvalQTester.h"
 //#include "DataFormats/Math/interface/LorentzVector.h"
 
-HLTTauRelvalQTester::HLTTauRelvalQTester(const edm::ParameterSet &ps)
-    : QualityTester(ps) {
-  refMothers_ =
-      consumes<std::vector<int>>(ps.getParameter<edm::InputTag>("refMothers"));
+HLTTauRelvalQTester::HLTTauRelvalQTester(const edm::ParameterSet &ps) : QualityTester(ps) {
+  refMothers_ = consumes<std::vector<int>>(ps.getParameter<edm::InputTag>("refMothers"));
   mothers_ = ps.getParameter<std::vector<int>>("mothers");
   runQTests = false;
 }
 
 HLTTauRelvalQTester::~HLTTauRelvalQTester() {}
 
-void HLTTauRelvalQTester::analyze(const edm::Event &e,
-                                  const edm::EventSetup &c) {
+void HLTTauRelvalQTester::analyze(const edm::Event &e, const edm::EventSetup &c) {
   edm::Handle<std::vector<int>> refMothers;
   if (e.getByToken(refMothers_, refMothers))
     for (unsigned int i = 0; i < refMothers->size(); ++i) {
@@ -28,13 +25,10 @@ void HLTTauRelvalQTester::analyze(const edm::Event &e,
     }
 }
 
-void HLTTauRelvalQTester::endLuminosityBlock(
-    edm::LuminosityBlock const &lumiSeg, edm::EventSetup const &c) {
+void HLTTauRelvalQTester::endLuminosityBlock(edm::LuminosityBlock const &lumiSeg, edm::EventSetup const &c) {
   QualityTester::endLuminosityBlock(lumiSeg, c);
 }
 
-void HLTTauRelvalQTester::endRun(const edm::Run &r, const edm::EventSetup &c) {
-  QualityTester::endRun(r, c);
-}
+void HLTTauRelvalQTester::endRun(const edm::Run &r, const edm::EventSetup &c) { QualityTester::endRun(r, c); }
 
 void HLTTauRelvalQTester::endJob() { QualityTester::endJob(); }

--- a/HLTriggerOffline/Top/interface/TopDiLeptonHLTValidation.h
+++ b/HLTriggerOffline/Top/interface/TopDiLeptonHLTValidation.h
@@ -59,13 +59,10 @@ public:
 
 private:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   /// deduce monitorPath from label, the label is expected
   /// to be of type 'selectionPath:monitorPath'
-  std::string monitorPath(const std::string &label) const {
-    return label.substr(label.find(':') + 1);
-  };
+  std::string monitorPath(const std::string &label) const { return label.substr(label.find(':') + 1); };
   /// set configurable labels for trigger monitoring histograms
   void triggerBinLabels(const std::vector<std::string> &labels);
 
@@ -116,13 +113,10 @@ private:
   bool isSel_ = false;
 };
 
-inline void TopDiLeptonHLTValidation::triggerBinLabels(
-    const std::vector<std::string> &labels) {
+inline void TopDiLeptonHLTValidation::triggerBinLabels(const std::vector<std::string> &labels) {
   for (unsigned int idx = 0; idx < labels.size(); ++idx) {
-    hNumTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]",
-                                1);
-    hDenTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]",
-                                1);
+    hNumTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]", 1);
+    hDenTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]", 1);
   }
 }
 
@@ -137,17 +131,13 @@ inline void TopDiLeptonHLTValidation::triggerBinLabels(
 //
 // constructors and destructor
 //
-TopDiLeptonHLTValidation::TopDiLeptonHLTValidation(
-    const edm::ParameterSet &iConfig)
-    : sDir_(iConfig.getUntrackedParameter<std::string>(
-          "sDir", "Validation/Top/Efficiencies/")),
-      sElectrons_(iConfig.getUntrackedParameter<std::string>("sElectrons",
-                                                             "gsfElectrons")),
+TopDiLeptonHLTValidation::TopDiLeptonHLTValidation(const edm::ParameterSet &iConfig)
+    : sDir_(iConfig.getUntrackedParameter<std::string>("sDir", "Validation/Top/Efficiencies/")),
+      sElectrons_(iConfig.getUntrackedParameter<std::string>("sElectrons", "gsfElectrons")),
       ptElectrons_(iConfig.getUntrackedParameter<double>("ptElectrons", 0.)),
       etaElectrons_(iConfig.getUntrackedParameter<double>("etaElectrons", 0.)),
       isoElectrons_(iConfig.getUntrackedParameter<double>("isoElectrons", 0.)),
-      minElectrons_(
-          iConfig.getUntrackedParameter<unsigned int>("minElectrons", 0)),
+      minElectrons_(iConfig.getUntrackedParameter<unsigned int>("minElectrons", 0)),
       sMuons_(iConfig.getUntrackedParameter<std::string>("sMuons", "muons")),
       ptMuons_(iConfig.getUntrackedParameter<double>("ptMuons", 0.)),
       etaMuons_(iConfig.getUntrackedParameter<double>("etaMuons", 0.)),
@@ -158,13 +148,11 @@ TopDiLeptonHLTValidation::TopDiLeptonHLTValidation(
       etaJets_(iConfig.getUntrackedParameter<double>("etaJets", 0.)),
       minJets_(iConfig.getUntrackedParameter<unsigned int>("minJets", 0)),
       iTrigger_(iConfig.getUntrackedParameter<edm::InputTag>("iTrigger")),
-      vsPaths_(
-          iConfig.getUntrackedParameter<std::vector<std::string>>("vsPaths"))
+      vsPaths_(iConfig.getUntrackedParameter<std::vector<std::string>>("vsPaths"))
 
 {
   // Electrons
-  tokElectrons_ =
-      consumes<edm::View<reco::GsfElectron>>(edm::InputTag(sElectrons_));
+  tokElectrons_ = consumes<edm::View<reco::GsfElectron>>(edm::InputTag(sElectrons_));
   // Muons
   tokMuons_ = consumes<edm::View<reco::Muon>>(edm::InputTag(sMuons_));
   // Jets
@@ -174,7 +162,6 @@ TopDiLeptonHLTValidation::TopDiLeptonHLTValidation(
 }
 
 TopDiLeptonHLTValidation::~TopDiLeptonHLTValidation() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }

--- a/HLTriggerOffline/Top/interface/TopSingleLeptonHLTValidation.h
+++ b/HLTriggerOffline/Top/interface/TopSingleLeptonHLTValidation.h
@@ -56,13 +56,10 @@ public:
 
 private:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   /// deduce monitorPath from label, the label is expected
   /// to be of type 'selectionPath:monitorPath'
-  std::string monitorPath(const std::string &label) const {
-    return label.substr(label.find(':') + 1);
-  };
+  std::string monitorPath(const std::string &label) const { return label.substr(label.find(':') + 1); };
   /// set configurable labels for trigger monitoring histograms
   void triggerBinLabels(const std::vector<std::string> &labels);
 
@@ -111,13 +108,10 @@ private:
   bool isSel_ = false;
 };
 
-inline void TopSingleLeptonHLTValidation::triggerBinLabels(
-    const std::vector<std::string> &labels) {
+inline void TopSingleLeptonHLTValidation::triggerBinLabels(const std::vector<std::string> &labels) {
   for (unsigned int idx = 0; idx < labels.size(); ++idx) {
-    hNumTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]",
-                                1);
-    hDenTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]",
-                                1);
+    hNumTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]", 1);
+    hDenTriggerMon->setBinLabel(idx + 1, "[" + monitorPath(labels[idx]) + "]", 1);
   }
 }
 
@@ -132,17 +126,13 @@ inline void TopSingleLeptonHLTValidation::triggerBinLabels(
 //
 // constructors and destructor
 //
-TopSingleLeptonHLTValidation::TopSingleLeptonHLTValidation(
-    const edm::ParameterSet &iConfig)
-    : sDir_(iConfig.getUntrackedParameter<std::string>(
-          "sDir", "HLTValidation/Top/Efficiencies/")),
-      sElectrons_(iConfig.getUntrackedParameter<std::string>("sElectrons",
-                                                             "gsfElectrons")),
+TopSingleLeptonHLTValidation::TopSingleLeptonHLTValidation(const edm::ParameterSet &iConfig)
+    : sDir_(iConfig.getUntrackedParameter<std::string>("sDir", "HLTValidation/Top/Efficiencies/")),
+      sElectrons_(iConfig.getUntrackedParameter<std::string>("sElectrons", "gsfElectrons")),
       ptElectrons_(iConfig.getUntrackedParameter<double>("ptElectrons", 0.)),
       etaElectrons_(iConfig.getUntrackedParameter<double>("etaElectrons", 0.)),
       isoElectrons_(iConfig.getUntrackedParameter<double>("isoElectrons", 0.)),
-      minElectrons_(
-          iConfig.getUntrackedParameter<unsigned int>("minElectrons", 0)),
+      minElectrons_(iConfig.getUntrackedParameter<unsigned int>("minElectrons", 0)),
       sMuons_(iConfig.getUntrackedParameter<std::string>("sMuons", "muons")),
       ptMuons_(iConfig.getUntrackedParameter<double>("ptMuons", 0.)),
       etaMuons_(iConfig.getUntrackedParameter<double>("etaMuons", 0.)),
@@ -153,13 +143,11 @@ TopSingleLeptonHLTValidation::TopSingleLeptonHLTValidation(
       etaJets_(iConfig.getUntrackedParameter<double>("etaJets", 0.)),
       minJets_(iConfig.getUntrackedParameter<unsigned int>("minJets", 0)),
       iTrigger_(iConfig.getUntrackedParameter<edm::InputTag>("iTrigger")),
-      vsPaths_(
-          iConfig.getUntrackedParameter<std::vector<std::string>>("vsPaths"))
+      vsPaths_(iConfig.getUntrackedParameter<std::vector<std::string>>("vsPaths"))
 
 {
   // Electrons
-  tokElectrons_ =
-      consumes<edm::View<reco::GsfElectron>>(edm::InputTag(sElectrons_));
+  tokElectrons_ = consumes<edm::View<reco::GsfElectron>>(edm::InputTag(sElectrons_));
   // Muons
   tokMuons_ = consumes<edm::View<reco::Muon>>(edm::InputTag(sMuons_));
   // Jets
@@ -169,7 +157,6 @@ TopSingleLeptonHLTValidation::TopSingleLeptonHLTValidation(
 }
 
 TopSingleLeptonHLTValidation::~TopSingleLeptonHLTValidation() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }

--- a/HLTriggerOffline/Top/src/TopDiLeptonHLTValidation.cc
+++ b/HLTriggerOffline/Top/src/TopDiLeptonHLTValidation.cc
@@ -44,8 +44,7 @@ harvesting
 //
 
 // ------------ method called for each event  ------------
-void TopDiLeptonHLTValidation::analyze(const edm::Event &iEvent,
-                                       const edm::EventSetup &iSetup) {
+void TopDiLeptonHLTValidation::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
 
   isAll_ = false;
@@ -54,19 +53,14 @@ void TopDiLeptonHLTValidation::analyze(const edm::Event &iEvent,
   // Electrons
   Handle<edm::View<reco::GsfElectron>> electrons;
   if (!iEvent.getByToken(tokElectrons_, electrons))
-    edm::LogWarning("TopDiLeptonHLTValidation")
-        << "Electrons collection not found \n";
+    edm::LogWarning("TopDiLeptonHLTValidation") << "Electrons collection not found \n";
   unsigned int nGoodE = 0;
-  for (edm::View<reco::GsfElectron>::const_iterator e = electrons->begin();
-       e != electrons->end(); ++e) {
+  for (edm::View<reco::GsfElectron>::const_iterator e = electrons->begin(); e != electrons->end(); ++e) {
     if (e->pt() < ptElectrons_)
       continue;
     if (fabs(e->eta()) > etaElectrons_)
       continue;
-    if ((e->dr03TkSumPt() + e->dr03EcalRecHitSumEt() +
-         e->dr03HcalTowerSumEt()) /
-            e->pt() >
-        isoElectrons_)
+    if ((e->dr03TkSumPt() + e->dr03EcalRecHitSumEt() + e->dr03HcalTowerSumEt()) / e->pt() > isoElectrons_)
       continue;
     nGoodE++;
     if (nGoodE == 1)
@@ -77,19 +71,16 @@ void TopDiLeptonHLTValidation::analyze(const edm::Event &iEvent,
   // Muons
   Handle<edm::View<reco::Muon>> muons;
   if (!iEvent.getByToken(tokMuons_, muons))
-    edm::LogWarning("TopDiLeptonHLTValidation")
-        << "Muons collection not found \n";
+    edm::LogWarning("TopDiLeptonHLTValidation") << "Muons collection not found \n";
   unsigned int nGoodM = 0;
-  for (edm::View<reco::Muon>::const_iterator m = muons->begin();
-       m != muons->end(); ++m) {
+  for (edm::View<reco::Muon>::const_iterator m = muons->begin(); m != muons->end(); ++m) {
     if (!m->isPFMuon() || (!m->isGlobalMuon() && !m->isTrackerMuon()))
       continue;
     if (m->pt() < ptMuons_)
       continue;
     if (fabs(m->eta()) > etaMuons_)
       continue;
-    if (((m->pfIsolationR04()).sumChargedHadronPt +
-         (m->pfIsolationR04()).sumPhotonEt +
+    if (((m->pfIsolationR04()).sumChargedHadronPt + (m->pfIsolationR04()).sumPhotonEt +
          (m->pfIsolationR04()).sumNeutralHadronEt) /
             m->pt() >
         isoMuons_)
@@ -103,11 +94,9 @@ void TopDiLeptonHLTValidation::analyze(const edm::Event &iEvent,
   // Jets
   Handle<edm::View<reco::Jet>> jets;
   if (!iEvent.getByToken(tokJets_, jets))
-    edm::LogWarning("TopDiLeptonHLTValidation")
-        << "Jets collection not found \n";
+    edm::LogWarning("TopDiLeptonHLTValidation") << "Jets collection not found \n";
   unsigned int nGoodJ = 0;
-  for (edm::View<reco::Jet>::const_iterator j = jets->begin(); j != jets->end();
-       ++j) {
+  for (edm::View<reco::Jet>::const_iterator j = jets->begin(); j != jets->end(); ++j) {
     if (j->pt() < ptJets_)
       continue;
     if (fabs(j->eta()) > etaJets_)
@@ -123,12 +112,10 @@ void TopDiLeptonHLTValidation::analyze(const edm::Event &iEvent,
   // Trigger
   Handle<edm::TriggerResults> triggerTable;
   if (!iEvent.getByToken(tokTrigger_, triggerTable))
-    edm::LogWarning("TopDiLeptonHLTValidation")
-        << "Trigger collection not found \n";
+    edm::LogWarning("TopDiLeptonHLTValidation") << "Trigger collection not found \n";
   const edm::TriggerNames &triggerNames = iEvent.triggerNames(*triggerTable);
   unsigned int isInteresting = 0;
   for (unsigned int i = 0; i < triggerNames.triggerNames().size(); ++i) {
-
     TString name = triggerNames.triggerNames()[i].c_str();
     for (unsigned int j = 0; j < vsPaths_.size(); j++) {
       if (name.Contains(TString(vsPaths_[j]), TString::kIgnoreCase)) {
@@ -193,9 +180,7 @@ void TopDiLeptonHLTValidation::analyze(const edm::Event &iEvent,
 }
 
 // ------------ booking histograms -----------
-void TopDiLeptonHLTValidation::bookHistograms(DQMStore::IBooker &dbe,
-                                              edm::Run const &,
-                                              edm::EventSetup const &) {
+void TopDiLeptonHLTValidation::bookHistograms(DQMStore::IBooker &dbe, edm::Run const &, edm::EventSetup const &) {
   dbe.setCurrentFolder(sDir_);
   hDenLeptonPt = dbe.book1D("PtLeptonAll", "PtLeptonAll", 50, 0., 250.);
   hDenLeptonEta = dbe.book1D("EtaLeptonAll", "EtaLeptonAll", 30, -3., 3.);
@@ -208,18 +193,15 @@ void TopDiLeptonHLTValidation::bookHistograms(DQMStore::IBooker &dbe,
   // determine number of bins for trigger monitoring
   unsigned int nPaths = vsPaths_.size();
   // monitored trigger occupancy for single lepton triggers
-  hNumTriggerMon =
-      dbe.book1D("TriggerMonSel", "TriggerMonSel", nPaths, 0., nPaths);
-  hDenTriggerMon =
-      dbe.book1D("TriggerMonAll", "TriggerMonAll", nPaths, 0., nPaths);
+  hNumTriggerMon = dbe.book1D("TriggerMonSel", "TriggerMonSel", nPaths, 0., nPaths);
+  hDenTriggerMon = dbe.book1D("TriggerMonAll", "TriggerMonAll", nPaths, 0., nPaths);
   // set bin labels for trigger monitoring
   triggerBinLabels(vsPaths_);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the
 // module  ------------
-void TopDiLeptonHLTValidation::fillDescriptions(
-    edm::ConfigurationDescriptions &descriptions) {
+void TopDiLeptonHLTValidation::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   // The following says we do not know what parameters are allowed so do no
   // validation
   // Please change this to state exactly what you do use, even if it is no

--- a/HLTriggerOffline/Top/src/TopSingleLeptonHLTValidation.cc
+++ b/HLTriggerOffline/Top/src/TopSingleLeptonHLTValidation.cc
@@ -43,8 +43,7 @@ harvesting
 //
 
 // ------------ method called for each event  ------------
-void TopSingleLeptonHLTValidation::analyze(const edm::Event &iEvent,
-                                           const edm::EventSetup &iSetup) {
+void TopSingleLeptonHLTValidation::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
 
   isAll_ = false;
@@ -53,19 +52,14 @@ void TopSingleLeptonHLTValidation::analyze(const edm::Event &iEvent,
   // Electrons
   Handle<edm::View<reco::GsfElectron>> electrons;
   if (!iEvent.getByToken(tokElectrons_, electrons))
-    edm::LogWarning("TopSingleLeptonHLTValidation")
-        << "Electrons collection not found \n";
+    edm::LogWarning("TopSingleLeptonHLTValidation") << "Electrons collection not found \n";
   unsigned int nGoodE = 0;
-  for (edm::View<reco::GsfElectron>::const_iterator e = electrons->begin();
-       e != electrons->end(); ++e) {
+  for (edm::View<reco::GsfElectron>::const_iterator e = electrons->begin(); e != electrons->end(); ++e) {
     if (e->pt() < ptElectrons_)
       continue;
     if (fabs(e->eta()) > etaElectrons_)
       continue;
-    if ((e->dr03TkSumPt() + e->dr03EcalRecHitSumEt() +
-         e->dr03HcalTowerSumEt()) /
-            e->pt() >
-        isoElectrons_)
+    if ((e->dr03TkSumPt() + e->dr03EcalRecHitSumEt() + e->dr03HcalTowerSumEt()) / e->pt() > isoElectrons_)
       continue;
     nGoodE++;
     if (nGoodE == 1)
@@ -74,19 +68,16 @@ void TopSingleLeptonHLTValidation::analyze(const edm::Event &iEvent,
   // Muons
   Handle<edm::View<reco::Muon>> muons;
   if (!iEvent.getByToken(tokMuons_, muons))
-    edm::LogWarning("TopSingleLeptonHLTValidation")
-        << "Muons collection not found \n";
+    edm::LogWarning("TopSingleLeptonHLTValidation") << "Muons collection not found \n";
   unsigned int nGoodM = 0;
-  for (edm::View<reco::Muon>::const_iterator m = muons->begin();
-       m != muons->end(); ++m) {
+  for (edm::View<reco::Muon>::const_iterator m = muons->begin(); m != muons->end(); ++m) {
     if (!m->isPFMuon() || !m->isGlobalMuon())
       continue;
     if (m->pt() < ptMuons_)
       continue;
     if (fabs(m->eta()) > etaMuons_)
       continue;
-    if (((m->pfIsolationR04()).sumChargedHadronPt +
-         (m->pfIsolationR04()).sumPhotonEt +
+    if (((m->pfIsolationR04()).sumChargedHadronPt + (m->pfIsolationR04()).sumPhotonEt +
          (m->pfIsolationR04()).sumNeutralHadronEt) /
             m->pt() >
         isoMuons_)
@@ -98,12 +89,10 @@ void TopSingleLeptonHLTValidation::analyze(const edm::Event &iEvent,
   // Jets
   Handle<edm::View<reco::Jet>> jets;
   if (!iEvent.getByToken(tokJets_, jets))
-    edm::LogWarning("TopSingleLeptonHLTValidation")
-        << "Jets collection not found \n";
+    edm::LogWarning("TopSingleLeptonHLTValidation") << "Jets collection not found \n";
   unsigned int nGoodJ = 0;
   if (minJets_ == 4) {
-    for (edm::View<reco::Jet>::const_iterator j = jets->begin();
-         j != jets->end(); ++j) {
+    for (edm::View<reco::Jet>::const_iterator j = jets->begin(); j != jets->end(); ++j) {
       if (nGoodJ < 1 && j->pt() < 55)
         continue;
       if (nGoodJ < 2 && j->pt() < 45)
@@ -119,8 +108,7 @@ void TopSingleLeptonHLTValidation::analyze(const edm::Event &iEvent,
         jet_ = &(*j);
     }
   } else {
-    for (edm::View<reco::Jet>::const_iterator j = jets->begin();
-         j != jets->end(); ++j) {
+    for (edm::View<reco::Jet>::const_iterator j = jets->begin(); j != jets->end(); ++j) {
       if (j->pt() < ptJets_)
         continue;
       if (fabs(j->eta()) > etaJets_)
@@ -137,12 +125,10 @@ void TopSingleLeptonHLTValidation::analyze(const edm::Event &iEvent,
   // Trigger
   Handle<edm::TriggerResults> triggerTable;
   if (!iEvent.getByToken(tokTrigger_, triggerTable))
-    edm::LogWarning("TopSingleLeptonHLTValidation")
-        << "Trigger collection not found \n";
+    edm::LogWarning("TopSingleLeptonHLTValidation") << "Trigger collection not found \n";
   const edm::TriggerNames &triggerNames = iEvent.triggerNames(*triggerTable);
   unsigned int isInteresting = 0;
   for (unsigned int i = 0; i < triggerNames.triggerNames().size(); ++i) {
-
     TString name = triggerNames.triggerNames()[i].c_str();
     for (unsigned int j = 0; j < vsPaths_.size(); j++) {
       if (name.Contains(TString(vsPaths_[j]), TString::kIgnoreCase)) {
@@ -191,9 +177,7 @@ void TopSingleLeptonHLTValidation::analyze(const edm::Event &iEvent,
 }
 
 // ------------ booking histograms -----------
-void TopSingleLeptonHLTValidation::bookHistograms(DQMStore::IBooker &dbe,
-                                                  edm::Run const &,
-                                                  edm::EventSetup const &) {
+void TopSingleLeptonHLTValidation::bookHistograms(DQMStore::IBooker &dbe, edm::Run const &, edm::EventSetup const &) {
   dbe.setCurrentFolder(sDir_);
   hDenLeptonPt = dbe.book1D("PtLeptonAll", "PtLeptonAll", 50, 0., 250.);
   hDenLeptonEta = dbe.book1D("EtaLeptonAll", "EtaLeptonAll", 30, -3., 3.);
@@ -206,18 +190,15 @@ void TopSingleLeptonHLTValidation::bookHistograms(DQMStore::IBooker &dbe,
   // determine number of bins for trigger monitoring
   unsigned int nPaths = vsPaths_.size();
   // monitored trigger occupancy for single lepton triggers
-  hNumTriggerMon =
-      dbe.book1D("TriggerMonSel", "TriggerMonSel", nPaths, 0., nPaths);
-  hDenTriggerMon =
-      dbe.book1D("TriggerMonAll", "TriggerMonAll", nPaths, 0., nPaths);
+  hNumTriggerMon = dbe.book1D("TriggerMonSel", "TriggerMonSel", nPaths, 0., nPaths);
+  hDenTriggerMon = dbe.book1D("TriggerMonAll", "TriggerMonAll", nPaths, 0., nPaths);
   // set bin labels for trigger monitoring
   triggerBinLabels(vsPaths_);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the
 // module  ------------
-void TopSingleLeptonHLTValidation::fillDescriptions(
-    edm::ConfigurationDescriptions &descriptions) {
+void TopSingleLeptonHLTValidation::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   // The following says we do not know what parameters are allowed so do no
   // validation
   // Please change this to state exactly what you do use, even if it is no

--- a/Validation/CSCRecHits/src/CSCRecHit2DValidation.cc
+++ b/Validation/CSCRecHits/src/CSCRecHit2DValidation.cc
@@ -2,28 +2,24 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Validation/CSCRecHits/src/CSCRecHit2DValidation.h"
 
-CSCRecHit2DValidation::CSCRecHit2DValidation(const edm::InputTag &inputTag,
-                                             edm::ConsumesCollector &&iC)
+CSCRecHit2DValidation::CSCRecHit2DValidation(const edm::InputTag &inputTag, edm::ConsumesCollector &&iC)
     : CSCBaseValidation(inputTag), theNPerEventPlot(nullptr) {
   rechits_Token_ = iC.consumes<CSCRecHit2DCollection>(inputTag);
 }
 
 CSCRecHit2DValidation::~CSCRecHit2DValidation() {
   for (int i = 0; i < 10; ++i) {
-    edm::LogInfo("CSCRecHitValidation")
-        << "Resolution of " << theResolutionPlots[i]->getName() << " is "
-        << theResolutionPlots[i]->getRMS();
-    edm::LogInfo("CSCRecHitValidation")
-        << "Peak Time is " << theTPeaks[i]->getMean();
+    edm::LogInfo("CSCRecHitValidation") << "Resolution of " << theResolutionPlots[i]->getName() << " is "
+                                        << theResolutionPlots[i]->getRMS();
+    edm::LogInfo("CSCRecHitValidation") << "Peak Time is " << theTPeaks[i]->getMean();
   }
 }
 
 void CSCRecHit2DValidation::bookHistograms(DQMStore::IBooker &iBooker) {
-  theNPerEventPlot = iBooker.book1D(
-      "CSCRecHitsPerEvent", "Number of CSC Rec Hits per event", 100, 0, 500);
+  theNPerEventPlot = iBooker.book1D("CSCRecHitsPerEvent", "Number of CSC Rec Hits per event", 100, 0, 500);
   for (int i = 0; i < 10; ++i) {
-    char title1[200], title2[200], title3[200], title4[200], title5[200],
-        title6[200], title7[200], title8[200], title9[200];
+    char title1[200], title2[200], title3[200], title4[200], title5[200], title6[200], title7[200], title8[200],
+        title9[200];
     sprintf(title1, "CSCRecHitResolution%d", i + 1);
     sprintf(title2, "CSCRecHitPull%d", i + 1);
     sprintf(title3, "CSCRecHitYResolution%d", i + 1);
@@ -40,16 +36,13 @@ void CSCRecHit2DValidation::bookHistograms(DQMStore::IBooker &iBooker) {
     theYPullPlots[i] = iBooker.book1D(title4, title4, 100, -3, 3);
     theRecHitPosInStrip[i] = iBooker.book1D(title5, title5, 100, -2, 2);
     theSimHitPosInStrip[i] = iBooker.book1D(title6, title6, 100, -2, 2);
-    theScatterPlots[i] =
-        iBooker.book2D(title7, title7, 200, -20, 20, 200, -250, 250);
-    theSimHitScatterPlots[i] =
-        iBooker.book2D(title8, title8, 200, -20, 20, 200, -250, 250);
+    theScatterPlots[i] = iBooker.book2D(title7, title7, 200, -20, 20, 200, -250, 250);
+    theSimHitScatterPlots[i] = iBooker.book2D(title8, title8, 200, -20, 20, 200, -250, 250);
     theTPeaks[i] = iBooker.book1D(title9, title9, 200, 0, 400);
   }
 }
 
-void CSCRecHit2DValidation::analyze(const edm::Event &e,
-                                    const edm::EventSetup &eventSetup) {
+void CSCRecHit2DValidation::analyze(const edm::Event &e, const edm::EventSetup &eventSetup) {
   // get the collection of CSCRecHrecHitItrD
   edm::Handle<CSCRecHit2DCollection> hRecHits;
   e.getByToken(rechits_Token_, hRecHits);
@@ -57,8 +50,8 @@ void CSCRecHit2DValidation::analyze(const edm::Event &e,
 
   unsigned nPerEvent = 0;
 
-  for (CSCRecHit2DCollection::const_iterator recHitItr = cscRecHits->begin();
-       recHitItr != cscRecHits->end(); recHitItr++) {
+  for (CSCRecHit2DCollection::const_iterator recHitItr = cscRecHits->begin(); recHitItr != cscRecHits->end();
+       recHitItr++) {
     ++nPerEvent;
     int detId = (*recHitItr).cscDetId().rawId();
     edm::PSimHitContainer simHits = theSimHitMap->hits(detId);
@@ -84,8 +77,7 @@ void CSCRecHit2DValidation::analyze(const edm::Event &e,
   std::vector<int> layersWithSimHits = theSimHitMap->detsWithHits();
   for (unsigned i = 0; i < layersWithSimHits.size(); ++i) {
     edm::PSimHitContainer simHits = theSimHitMap->hits(layersWithSimHits[i]);
-    for (edm::PSimHitContainer::const_iterator hitItr = simHits.begin();
-         hitItr != simHits.end(); ++hitItr) {
+    for (edm::PSimHitContainer::const_iterator hitItr = simHits.begin(); hitItr != simHits.end(); ++hitItr) {
       const CSCLayer *layer = findLayer(layersWithSimHits[i]);
       int chamberType = layer->chamber()->specs()->chamberType();
       float localX = hitItr->localPosition().x();
@@ -111,12 +103,10 @@ void CSCRecHit2DValidation::plotResolution(const PSimHit &simHit,
   double dphi = recHitPos.phi() - simHitPos.phi();
   double rdphi = recHitPos.perp() * dphi;
   theResolutionPlots[chamberType - 1]->Fill(rdphi);
-  thePullPlots[chamberType - 1]->Fill(rdphi /
-                                      sqrt(recHit.localPositionError().xx()));
+  thePullPlots[chamberType - 1]->Fill(rdphi / sqrt(recHit.localPositionError().xx()));
   double dy = recHit.localPosition().y() - simHit.localPosition().y();
   theYResolutionPlots[chamberType - 1]->Fill(dy);
-  theYPullPlots[chamberType - 1]->Fill(dy /
-                                       sqrt(recHit.localPositionError().yy()));
+  theYPullPlots[chamberType - 1]->Fill(dy / sqrt(recHit.localPositionError().yy()));
 
   const CSCLayerGeometry *layerGeometry = layer->geometry();
   float recStrip = layerGeometry->strip(recHit.localPosition());

--- a/Validation/CSCRecHits/src/CSCRecHit2DValidation.h
+++ b/Validation/CSCRecHits/src/CSCRecHit2DValidation.h
@@ -11,8 +11,7 @@
 
 class CSCRecHit2DValidation : public CSCBaseValidation {
 public:
-  CSCRecHit2DValidation(const edm::InputTag &inputTag,
-                        edm::ConsumesCollector &&iC);
+  CSCRecHit2DValidation(const edm::InputTag &inputTag, edm::ConsumesCollector &&iC);
   ~CSCRecHit2DValidation() override;
   void bookHistograms(DQMStore::IBooker &);
   void analyze(const edm::Event &, const edm::EventSetup &) override;
@@ -20,8 +19,7 @@ public:
 private:
   edm::EDGetTokenT<CSCRecHit2DCollection> rechits_Token_;
 
-  void plotResolution(const PSimHit &simHit, const CSCRecHit2D &recHit,
-                      const CSCLayer *layer, int chamberType);
+  void plotResolution(const PSimHit &simHit, const CSCRecHit2D &recHit, const CSCLayer *layer, int chamberType);
 
   MonitorElement *theNPerEventPlot;
   MonitorElement *theResolutionPlots[10];

--- a/Validation/CSCRecHits/src/CSCRecHitValidation.cc
+++ b/Validation/CSCRecHits/src/CSCRecHitValidation.cc
@@ -7,14 +7,12 @@
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h>
 
 CSCRecHitValidation::CSCRecHitValidation(const edm::ParameterSet &ps)
-    : theSimHitMap(ps.getParameter<edm::InputTag>("simHitsTag"),
-                   consumesCollector()),
-      theCSCGeometry(nullptr), the2DValidation(nullptr),
+    : theSimHitMap(ps.getParameter<edm::InputTag>("simHitsTag"), consumesCollector()),
+      theCSCGeometry(nullptr),
+      the2DValidation(nullptr),
       theSegmentValidation(nullptr) {
-  the2DValidation = new CSCRecHit2DValidation(
-      ps.getParameter<edm::InputTag>("recHitLabel"), consumesCollector());
-  theSegmentValidation = new CSCSegmentValidation(
-      ps.getParameter<edm::InputTag>("segmentLabel"), consumesCollector());
+  the2DValidation = new CSCRecHit2DValidation(ps.getParameter<edm::InputTag>("recHitLabel"), consumesCollector());
+  theSegmentValidation = new CSCSegmentValidation(ps.getParameter<edm::InputTag>("segmentLabel"), consumesCollector());
 }
 
 CSCRecHitValidation::~CSCRecHitValidation() {
@@ -22,17 +20,14 @@ CSCRecHitValidation::~CSCRecHitValidation() {
   delete theSegmentValidation;
 }
 
-void CSCRecHitValidation::bookHistograms(DQMStore::IBooker &iBooker,
-                                         edm::Run const &iRun,
-                                         edm::EventSetup const &) {
+void CSCRecHitValidation::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const &iRun, edm::EventSetup const &) {
   iBooker.setCurrentFolder("CSCRecHitsV/CSCRecHitTask");
 
   the2DValidation->bookHistograms(iBooker);
   theSegmentValidation->bookHistograms(iBooker);
 }
 
-void CSCRecHitValidation::analyze(const edm::Event &e,
-                                  const edm::EventSetup &eventSetup) {
+void CSCRecHitValidation::analyze(const edm::Event &e, const edm::EventSetup &eventSetup) {
   theSimHitMap.fill(e);
 
   // find the geometry & conditions for this event

--- a/Validation/CSCRecHits/src/CSCRecHitValidation.h
+++ b/Validation/CSCRecHits/src/CSCRecHitValidation.h
@@ -20,8 +20,7 @@ class CSCRecHitValidation : public DQMEDAnalyzer {
 public:
   explicit CSCRecHitValidation(const edm::ParameterSet &);
   ~CSCRecHitValidation() override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
 private:

--- a/Validation/CSCRecHits/src/CSCSegmentValidation.cc
+++ b/Validation/CSCRecHits/src/CSCSegmentValidation.cc
@@ -2,50 +2,32 @@
 #include "Validation/CSCRecHits/src/CSCSegmentValidation.h"
 #include <algorithm>
 
-CSCSegmentValidation::CSCSegmentValidation(const edm::InputTag &inputTag,
-                                           edm::ConsumesCollector &&iC)
-    : CSCBaseValidation(inputTag), theLayerHitsPerChamber(),
-      theChamberSegmentMap(), theShowerThreshold(10) {
+CSCSegmentValidation::CSCSegmentValidation(const edm::InputTag &inputTag, edm::ConsumesCollector &&iC)
+    : CSCBaseValidation(inputTag), theLayerHitsPerChamber(), theChamberSegmentMap(), theShowerThreshold(10) {
   segments_Token_ = iC.consumes<CSCSegmentCollection>(inputTag);
 }
 
 CSCSegmentValidation::~CSCSegmentValidation() {}
 
 void CSCSegmentValidation::bookHistograms(DQMStore::IBooker &iBooker) {
-  theNPerEventPlot = iBooker.book1D(
-      "CSCSegmentsPerEvent", "Number of CSC segments per event", 100, 0, 50);
-  theNRecHitsPlot = iBooker.book1D(
-      "CSCRecHitsPerSegment", "Number of CSC rec hits per segment", 8, 0, 7);
+  theNPerEventPlot = iBooker.book1D("CSCSegmentsPerEvent", "Number of CSC segments per event", 100, 0, 50);
+  theNRecHitsPlot = iBooker.book1D("CSCRecHitsPerSegment", "Number of CSC rec hits per segment", 8, 0, 7);
   theNPerChamberTypePlot =
-      iBooker.book1D("CSCSegmentsPerChamberType",
-                     "Number of CSC segments per chamber type", 11, 0, 10);
-  theTypePlot4HitsNoShower =
-      iBooker.book1D("CSCSegments4HitsNoShower", "", 100, 0, 10);
-  theTypePlot4HitsNoShowerSeg =
-      iBooker.book1D("CSCSegments4HitsNoShowerSeg", "", 100, 0, 10);
-  theTypePlot4HitsShower =
-      iBooker.book1D("CSCSegments4HitsShower", "", 100, 0, 10);
-  theTypePlot4HitsShowerSeg =
-      iBooker.book1D("CSCSegments4HitsShowerSeg", "", 100, 0, 10);
-  theTypePlot5HitsNoShower =
-      iBooker.book1D("CSCSegments5HitsNoShower", "", 100, 0, 10);
-  theTypePlot5HitsNoShowerSeg =
-      iBooker.book1D("CSCSegments5HitsNoShowerSeg", "", 100, 0, 10);
-  theTypePlot5HitsShower =
-      iBooker.book1D("CSCSegments5HitsShower", "", 100, 0, 10);
-  theTypePlot5HitsShowerSeg =
-      iBooker.book1D("CSCSegments5HitsShowerSeg", "", 100, 0, 10);
-  theTypePlot6HitsNoShower =
-      iBooker.book1D("CSCSegments6HitsNoShower", "", 100, 0, 10);
-  theTypePlot6HitsNoShowerSeg =
-      iBooker.book1D("CSCSegments6HitsNoShowerSeg", "", 100, 0, 10);
-  theTypePlot6HitsShower =
-      iBooker.book1D("CSCSegments6HitsShower", "", 100, 0, 10);
-  theTypePlot6HitsShowerSeg =
-      iBooker.book1D("CSCSegments6HitsShowerSeg", "", 100, 0, 10);
+      iBooker.book1D("CSCSegmentsPerChamberType", "Number of CSC segments per chamber type", 11, 0, 10);
+  theTypePlot4HitsNoShower = iBooker.book1D("CSCSegments4HitsNoShower", "", 100, 0, 10);
+  theTypePlot4HitsNoShowerSeg = iBooker.book1D("CSCSegments4HitsNoShowerSeg", "", 100, 0, 10);
+  theTypePlot4HitsShower = iBooker.book1D("CSCSegments4HitsShower", "", 100, 0, 10);
+  theTypePlot4HitsShowerSeg = iBooker.book1D("CSCSegments4HitsShowerSeg", "", 100, 0, 10);
+  theTypePlot5HitsNoShower = iBooker.book1D("CSCSegments5HitsNoShower", "", 100, 0, 10);
+  theTypePlot5HitsNoShowerSeg = iBooker.book1D("CSCSegments5HitsNoShowerSeg", "", 100, 0, 10);
+  theTypePlot5HitsShower = iBooker.book1D("CSCSegments5HitsShower", "", 100, 0, 10);
+  theTypePlot5HitsShowerSeg = iBooker.book1D("CSCSegments5HitsShowerSeg", "", 100, 0, 10);
+  theTypePlot6HitsNoShower = iBooker.book1D("CSCSegments6HitsNoShower", "", 100, 0, 10);
+  theTypePlot6HitsNoShowerSeg = iBooker.book1D("CSCSegments6HitsNoShowerSeg", "", 100, 0, 10);
+  theTypePlot6HitsShower = iBooker.book1D("CSCSegments6HitsShower", "", 100, 0, 10);
+  theTypePlot6HitsShowerSeg = iBooker.book1D("CSCSegments6HitsShowerSeg", "", 100, 0, 10);
   for (int i = 0; i < 10; ++i) {
-    char title1[200], title2[200], title3[200], title4[200], title5[200],
-        title6[200], title7[200], title8[200];
+    char title1[200], title2[200], title3[200], title4[200], title5[200], title6[200], title7[200], title8[200];
     sprintf(title1, "CSCSegmentRdPhiResolution%d", i + 1);
     sprintf(title2, "CSCSegmentRdPhiPull%d", i + 1);
     sprintf(title3, "CSCSegmentThetaResolution%d", i + 1);
@@ -66,8 +48,7 @@ void CSCSegmentValidation::bookHistograms(DQMStore::IBooker &iBooker) {
   }
 }
 
-void CSCSegmentValidation::analyze(const edm::Event &e,
-                                   const edm::EventSetup &eventSetup) {
+void CSCSegmentValidation::analyze(const edm::Event &e, const edm::EventSetup &eventSetup) {
   // get the collection of CSCRecHsegmentItrD
   edm::Handle<CSCSegmentCollection> hRecHits;
   e.getByToken(segments_Token_, hRecHits);
@@ -75,8 +56,8 @@ void CSCSegmentValidation::analyze(const edm::Event &e,
 
   theChamberSegmentMap.clear();
   unsigned nPerEvent = 0;
-  for (CSCSegmentCollection::const_iterator segmentItr = cscRecHits->begin();
-       segmentItr != cscRecHits->end(); segmentItr++) {
+  for (CSCSegmentCollection::const_iterator segmentItr = cscRecHits->begin(); segmentItr != cscRecHits->end();
+       segmentItr++) {
     ++nPerEvent;
     int detId = segmentItr->geographicalId().rawId();
     int chamberType = whatChamberType(detId);
@@ -101,9 +82,9 @@ void CSCSegmentValidation::analyze(const edm::Event &e,
 
 void CSCSegmentValidation::fillEfficiencyPlots() {
   // now plot efficiency by looping over all chambers with hits
-  for (ChamberHitMap::const_iterator mapItr = theLayerHitsPerChamber.begin(),
-                                     mapEnd = theLayerHitsPerChamber.end();
-       mapItr != mapEnd; ++mapItr) {
+  for (ChamberHitMap::const_iterator mapItr = theLayerHitsPerChamber.begin(), mapEnd = theLayerHitsPerChamber.end();
+       mapItr != mapEnd;
+       ++mapItr) {
     int chamberId = mapItr->first;
     int nHitsInChamber = mapItr->second.size();
     bool isShower = (nHitsInChamber > theShowerThreshold);
@@ -117,7 +98,6 @@ void CSCSegmentValidation::fillEfficiencyPlots() {
     int nLayersHit = v.size();
 
     if (nLayersHit == 4) {
-
       if (isShower)
         theTypePlot4HitsShower->Fill(chamberType);
       else
@@ -132,7 +112,6 @@ void CSCSegmentValidation::fillEfficiencyPlots() {
     }
 
     if (nLayersHit == 5) {
-
       if (isShower)
         theTypePlot5HitsShower->Fill(chamberType);
       else
@@ -147,7 +126,6 @@ void CSCSegmentValidation::fillEfficiencyPlots() {
     }
 
     if (nLayersHit == 6) {
-
       if (isShower)
         theTypePlot6HitsShower->Fill(chamberType);
       else
@@ -188,10 +166,8 @@ void CSCSegmentValidation::plotResolution(const PSimHit &simHit,
   double sigmax = sqrt(segment.localPositionError().xx());
   // double sigmay = sqrt(segment.localPositionError().yy());
 
-  double ddxdz =
-      segmentDir.x() / segmentDir.z() - simHitDir.x() / simHitDir.z();
-  double ddydz =
-      segmentDir.y() / segmentDir.z() - simHitDir.y() / simHitDir.z();
+  double ddxdz = segmentDir.x() / segmentDir.z() - simHitDir.x() / simHitDir.z();
+  double ddydz = segmentDir.y() / segmentDir.z() - simHitDir.y() / simHitDir.z();
   double sigmadxdz = sqrt(segment.localDirectionError().xx());
   double sigmadydz = sqrt(segment.localDirectionError().yy());
 
@@ -209,9 +185,9 @@ void CSCSegmentValidation::plotResolution(const PSimHit &simHit,
 void CSCSegmentValidation::fillLayerHitsPerChamber() {
   theLayerHitsPerChamber.clear();
   std::vector<int> layersHit = theSimHitMap->detsWithHits();
-  for (std::vector<int>::const_iterator layerItr = layersHit.begin(),
-                                        layersHitEnd = layersHit.end();
-       layerItr != layersHitEnd; ++layerItr) {
+  for (std::vector<int>::const_iterator layerItr = layersHit.begin(), layersHitEnd = layersHit.end();
+       layerItr != layersHitEnd;
+       ++layerItr) {
     CSCDetId layerId(*layerItr);
     CSCDetId chamberId = layerId.chamberId();
     int nhits = theSimHitMap->hits(*layerItr).size();
@@ -223,10 +199,8 @@ void CSCSegmentValidation::fillLayerHitsPerChamber() {
 }
 
 namespace CSCSegmentValidationUtils {
-bool SimHitPabsLessThan(const PSimHit &p1, const PSimHit &p2) {
-  return p1.pabs() < p2.pabs();
-}
-} // namespace CSCSegmentValidationUtils
+  bool SimHitPabsLessThan(const PSimHit &p1, const PSimHit &p2) { return p1.pabs() < p2.pabs(); }
+}  // namespace CSCSegmentValidationUtils
 
 const PSimHit *CSCSegmentValidation::keyHit(int chamberId) const {
   const PSimHit *result = nullptr;
@@ -236,8 +210,7 @@ const PSimHit *CSCSegmentValidation::keyHit(int chamberId) const {
   if (!layerHits.empty()) {
     // pick the hit with maximum energy
     edm::PSimHitContainer::const_iterator hitItr =
-        std::max_element(layerHits.begin(), layerHits.end(),
-                         CSCSegmentValidationUtils::SimHitPabsLessThan);
+        std::max_element(layerHits.begin(), layerHits.end(), CSCSegmentValidationUtils::SimHitPabsLessThan);
     result = &(*hitItr);
   }
   return result;

--- a/Validation/CSCRecHits/src/CSCSegmentValidation.h
+++ b/Validation/CSCRecHits/src/CSCSegmentValidation.h
@@ -11,15 +11,13 @@
 
 class CSCSegmentValidation : public CSCBaseValidation {
 public:
-  CSCSegmentValidation(const edm::InputTag &inputTag,
-                       edm::ConsumesCollector &&iC);
+  CSCSegmentValidation(const edm::InputTag &inputTag, edm::ConsumesCollector &&iC);
   ~CSCSegmentValidation() override;
   void bookHistograms(DQMStore::IBooker &);
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
 private:
-  void plotResolution(const PSimHit &simHit, const CSCSegment &recHit,
-                      const CSCLayer *layer, int chamberType);
+  void plotResolution(const PSimHit &simHit, const CSCSegment &recHit, const CSCLayer *layer, int chamberType);
 
   bool hasSegment(int chamberId) const;
   static int whatChamberType(int detId);

--- a/Validation/EcalHits/interface/EcalBarrelSimHitsValidation.h
+++ b/Validation/EcalHits/interface/EcalBarrelSimHitsValidation.h
@@ -33,7 +33,6 @@
 #include <vector>
 
 class EcalBarrelSimHitsValidation : public edm::EDAnalyzer {
-
   typedef std::map<uint32_t, float, std::less<uint32_t>> MapType;
 
 public:
@@ -56,16 +55,14 @@ protected:
 private:
   uint32_t getUnitWithMaxEnergy(MapType &themap);
 
-  virtual float energyInMatrixEB(int nCellInEta, int nCellInPhi, int centralEta,
-                                 int centralPhi, int centralZ, MapType &themap);
+  virtual float energyInMatrixEB(
+      int nCellInEta, int nCellInPhi, int centralEta, int centralPhi, int centralZ, MapType &themap);
 
-  std::vector<uint32_t> getIdsAroundMax(int nCellInEta, int nCellInPhi,
-                                        int centralEta, int centralPhi,
-                                        int centralZ, MapType &themap);
+  std::vector<uint32_t> getIdsAroundMax(
+      int nCellInEta, int nCellInPhi, int centralEta, int centralPhi, int centralZ, MapType &themap);
 
-  bool fillEBMatrix(int nCellInEta, int nCellInPhi, int CentralEta,
-                    int CentralPhi, int CentralZ, MapType &fillmap,
-                    MapType &themap);
+  bool fillEBMatrix(
+      int nCellInEta, int nCellInPhi, int CentralEta, int CentralPhi, int CentralZ, MapType &fillmap, MapType &themap);
 
   float eCluster2x2(MapType &themap);
   float eCluster4x4(float e33, MapType &themap);

--- a/Validation/EcalHits/interface/EcalEndcapSimHitsValidation.h
+++ b/Validation/EcalHits/interface/EcalEndcapSimHitsValidation.h
@@ -34,7 +34,6 @@
 #include <vector>
 
 class EcalEndcapSimHitsValidation : public edm::EDAnalyzer {
-
   typedef std::map<uint32_t, float, std::less<uint32_t>> MapType;
 
 public:
@@ -57,15 +56,13 @@ protected:
 private:
   uint32_t getUnitWithMaxEnergy(MapType &themap);
 
-  virtual float energyInMatrixEE(int nCellInX, int nCellInY, int centralX,
-                                 int centralY, int centralZ, MapType &themap);
+  virtual float energyInMatrixEE(int nCellInX, int nCellInY, int centralX, int centralY, int centralZ, MapType &themap);
 
-  std::vector<uint32_t> getIdsAroundMax(int nCellInX, int nCellInY,
-                                        int centralX, int centralY,
-                                        int centralZ, MapType &themap);
+  std::vector<uint32_t> getIdsAroundMax(
+      int nCellInX, int nCellInY, int centralX, int centralY, int centralZ, MapType &themap);
 
-  bool fillEEMatrix(int nCellInX, int nCellInY, int CentralX, int CentralY,
-                    int CentralZ, MapType &fillmap, MapType &themap);
+  bool fillEEMatrix(
+      int nCellInX, int nCellInY, int CentralX, int CentralY, int CentralZ, MapType &fillmap, MapType &themap);
 
   float eCluster2x2(MapType &themap);
   float eCluster4x4(float e33, MapType &themap);

--- a/Validation/EcalHits/interface/EcalPreshowerSimHitsValidation.h
+++ b/Validation/EcalHits/interface/EcalPreshowerSimHitsValidation.h
@@ -34,7 +34,6 @@
 #include <vector>
 
 class EcalPreshowerSimHitsValidation : public edm::EDAnalyzer {
-
   typedef std::map<uint32_t, float, std::less<uint32_t>> MapType;
 
 public:

--- a/Validation/EcalHits/interface/EcalSimHitsValidProducer.h
+++ b/Validation/EcalHits/interface/EcalSimHitsValidProducer.h
@@ -19,7 +19,7 @@ class EndOfEvent;
 class PEcalValidInfo;
 
 namespace edm {
-class ParameterSet;
+  class ParameterSet;
 }
 
 class EcalSimHitsValidProducer : public SimProducer,
@@ -36,10 +36,8 @@ public:
   void produce(edm::Event &, const edm::EventSetup &) override;
 
 private:
-  EcalSimHitsValidProducer(const EcalSimHitsValidProducer &) =
-      delete; // stop default
-  const EcalSimHitsValidProducer &
-  operator=(const EcalSimHitsValidProducer &) = delete; // stop default
+  EcalSimHitsValidProducer(const EcalSimHitsValidProducer &) = delete;                   // stop default
+  const EcalSimHitsValidProducer &operator=(const EcalSimHitsValidProducer &) = delete;  // stop default
 
   void update(const BeginOfEvent *) override;
   void update(const G4Step *) override;
@@ -50,18 +48,14 @@ private:
 private:
   uint32_t getUnitWithMaxEnergy(MapType &themap);
 
-  float energyInEEMatrix(int nCellInX, int nCellInY, int centralX, int centralY,
-                         int centralZ, MapType &themap);
-  float energyInEBMatrix(int nCellInX, int nCellInY, int centralX, int centralY,
-                         int centralZ, MapType &themap);
+  float energyInEEMatrix(int nCellInX, int nCellInY, int centralX, int centralY, int centralZ, MapType &themap);
+  float energyInEBMatrix(int nCellInX, int nCellInY, int centralX, int centralY, int centralZ, MapType &themap);
 
-  bool fillEEMatrix(int nCellInEta, int nCellInPhi, int CentralEta,
-                    int CentralPhi, int CentralZ, MapType &fillmap,
-                    MapType &themap);
+  bool fillEEMatrix(
+      int nCellInEta, int nCellInPhi, int CentralEta, int CentralPhi, int CentralZ, MapType &fillmap, MapType &themap);
 
-  bool fillEBMatrix(int nCellInEta, int nCellInPhi, int CentralEta,
-                    int CentralPhi, int CentralZ, MapType &fillmap,
-                    MapType &themap);
+  bool fillEBMatrix(
+      int nCellInEta, int nCellInPhi, int CentralEta, int CentralPhi, int CentralZ, MapType &fillmap, MapType &themap);
 
   float eCluster2x2(MapType &themap);
   float eCluster4x4(float e33, MapType &themap);

--- a/Validation/EcalHits/interface/EcalSimHitsValidation.h
+++ b/Validation/EcalHits/interface/EcalSimHitsValidation.h
@@ -39,7 +39,6 @@
 #include <vector>
 
 class EcalSimHitsValidation : public edm::EDAnalyzer {
-
   typedef std::map<uint32_t, float, std::less<uint32_t>> MapType;
 
 public:

--- a/Validation/EcalHits/src/EcalBarrelSimHitsValidation.cc
+++ b/Validation/EcalHits/src/EcalBarrelSimHitsValidation.cc
@@ -14,17 +14,14 @@ using namespace cms;
 using namespace edm;
 using namespace std;
 
-EcalBarrelSimHitsValidation::EcalBarrelSimHitsValidation(
-    const edm::ParameterSet &ps)
+EcalBarrelSimHitsValidation::EcalBarrelSimHitsValidation(const edm::ParameterSet &ps)
     : g4InfoLabel(ps.getParameter<std::string>("moduleLabelG4")),
       EBHitsCollection(ps.getParameter<std::string>("EBHitsCollection")),
-      ValidationCollection(
-          ps.getParameter<std::string>("ValidationCollection")) {
-
-  EBHitsToken = consumes<edm::PCaloHitContainer>(
-      edm::InputTag(std::string(g4InfoLabel), std::string(EBHitsCollection)));
-  ValidationCollectionToken = consumes<PEcalValidInfo>(edm::InputTag(
-      std::string(g4InfoLabel), std::string(ValidationCollection)));
+      ValidationCollection(ps.getParameter<std::string>("ValidationCollection")) {
+  EBHitsToken =
+      consumes<edm::PCaloHitContainer>(edm::InputTag(std::string(g4InfoLabel), std::string(EBHitsCollection)));
+  ValidationCollectionToken =
+      consumes<PEcalValidInfo>(edm::InputTag(std::string(g4InfoLabel), std::string(ValidationCollection)));
   // verbosity switch
   verbose_ = ps.getUntrackedParameter<bool>("verbose", false);
 
@@ -90,8 +87,7 @@ EcalBarrelSimHitsValidation::EcalBarrelSimHitsValidation(
     meEBOccupancy_ = dbe_->book2D(histo, histo, 360, 0., 360., 170, -85., 85.);
 
     sprintf(histo, "EB longitudinal shower profile");
-    meEBLongitudinalShower_ =
-        dbe_->bookProfile(histo, histo, 26, 0., 26., 100, 0., 20000.);
+    meEBLongitudinalShower_ = dbe_->bookProfile(histo, histo, 26, 0., 26., 100, 0., 20000.);
 
     sprintf(histo, "EB hits energy spectrum");
     meEBhitEnergy_ = dbe_->book1D(histo, histo, 4000, 0., 400.);
@@ -100,12 +96,10 @@ EcalBarrelSimHitsValidation::EcalBarrelSimHitsValidation(
     meEBhitLog10Energy_ = dbe_->book1D(histo, histo, 140, -10., 4.);
 
     sprintf(histo, "EB hits log10energy spectrum vs normalized energy");
-    meEBhitLog10EnergyNorm_ =
-        dbe_->bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
+    meEBhitLog10EnergyNorm_ = dbe_->bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
 
     sprintf(histo, "EB hits log10energy spectrum vs normalized energy25");
-    meEBhitLog10Energy25Norm_ =
-        dbe_->bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
+    meEBhitLog10Energy25Norm_ = dbe_->bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
 
     sprintf(histo, "EB hits energy spectrum 2");
     meEBhitEnergy2_ = dbe_->book1D(histo, histo, 1000, 0., 0.001);
@@ -159,18 +153,14 @@ EcalBarrelSimHitsValidation::~EcalBarrelSimHitsValidation() {}
 void EcalBarrelSimHitsValidation::beginJob() {}
 
 void EcalBarrelSimHitsValidation::endJob() {
-
   // for (int myStep=0; myStep<26; myStep++){
   //  if (meEBLongitudinalShower_) meEBLongitudinalShower_->Fill(float(myStep),
   //  eRLength[myStep]/myEntries);
   //}
 }
 
-void EcalBarrelSimHitsValidation::analyze(const edm::Event &e,
-                                          const edm::EventSetup &c) {
-
-  edm::LogInfo("EventInfo")
-      << " Run = " << e.id().run() << " Event = " << e.id().event();
+void EcalBarrelSimHitsValidation::analyze(const edm::Event &e, const edm::EventSetup &c) {
+  edm::LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();
 
   edm::Handle<edm::PCaloHitContainer> EcalHitsEB;
   e.getByToken(EBHitsToken, EcalHitsEB);
@@ -183,14 +173,12 @@ void EcalBarrelSimHitsValidation::analyze(const edm::Event &e,
   e.getByToken(ValidationCollectionToken, MyPEcalValidInfo);
 
   std::vector<PCaloHit> theEBCaloHits;
-  theEBCaloHits.insert(theEBCaloHits.end(), EcalHitsEB->begin(),
-                       EcalHitsEB->end());
+  theEBCaloHits.insert(theEBCaloHits.end(), EcalHitsEB->begin(), EcalHitsEB->end());
 
   myEntries++;
 
   double EBEnergy_ = 0.;
-  std::map<unsigned int, std::vector<PCaloHit *>, std::less<unsigned int>>
-      CaloHitMap;
+  std::map<unsigned int, std::vector<PCaloHit *>, std::less<unsigned int>> CaloHitMap;
 
   double eb1 = 0.0;
   double eb4 = 0.0;
@@ -203,9 +191,7 @@ void EcalBarrelSimHitsValidation::analyze(const edm::Event &e,
   MapType ebmap;
   uint32_t nEBHits = 0;
 
-  for (std::vector<PCaloHit>::iterator isim = theEBCaloHits.begin();
-       isim != theEBCaloHits.end(); ++isim) {
-
+  for (std::vector<PCaloHit>::iterator isim = theEBCaloHits.begin(); isim != theEBCaloHits.end(); ++isim) {
     if (isim->time() > 500.) {
       continue;
     }
@@ -215,9 +201,7 @@ void EcalBarrelSimHitsValidation::analyze(const edm::Event &e,
     EBDetId ebid(isim->id());
 
     LogDebug("HitInfo") << " CaloHit " << isim->getName() << "\n"
-                        << " DetID = " << isim->id()
-                        << " EBDetId = " << ebid.ieta() << " " << ebid.iphi()
-                        << "\n"
+                        << " DetID = " << isim->id() << " EBDetId = " << ebid.ieta() << " " << ebid.iphi() << "\n"
                         << " Time = " << isim->time() << "\n"
                         << " Track Id = " << isim->geantTrackId() << "\n"
                         << " Energy = " << isim->energy();
@@ -243,15 +227,11 @@ void EcalBarrelSimHitsValidation::analyze(const edm::Event &e,
   if (menEBCrystals_)
     menEBCrystals_->Fill(ebmap.size());
   if (meEBcrystalEnergy_) {
-    for (std::map<uint32_t, float, std::less<uint32_t>>::iterator it =
-             ebmap.begin();
-         it != ebmap.end(); ++it)
+    for (std::map<uint32_t, float, std::less<uint32_t>>::iterator it = ebmap.begin(); it != ebmap.end(); ++it)
       meEBcrystalEnergy_->Fill((*it).second);
   }
   if (meEBcrystalEnergy2_) {
-    for (std::map<uint32_t, float, std::less<uint32_t>>::iterator it =
-             ebmap.begin();
-         it != ebmap.end(); ++it)
+    for (std::map<uint32_t, float, std::less<uint32_t>>::iterator it = ebmap.begin(); it != ebmap.end(); ++it)
       meEBcrystalEnergy2_->Fill((*it).second);
   }
 
@@ -259,7 +239,6 @@ void EcalBarrelSimHitsValidation::analyze(const edm::Event &e,
     menEBHits_->Fill(nEBHits);
 
   if (nEBHits > 0) {
-
     uint32_t ebcenterid = getUnitWithMaxEnergy(ebmap);
     EBDetId myEBid(ebcenterid);
     int bx = myEBid.ietaAbs();
@@ -281,8 +260,7 @@ void EcalBarrelSimHitsValidation::analyze(const edm::Event &e,
     for (unsigned i = 0; i < 25; i++) {
       for (unsigned int j = 0; j < CaloHitMap[ids25[i]].size(); j++) {
         if (CaloHitMap[ids25[i]][j]->energy() > 0) {
-          int log10i =
-              int((log10(CaloHitMap[ids25[i]][j]->energy()) + 10.) * 10.);
+          int log10i = int((log10(CaloHitMap[ids25[i]][j]->energy()) + 10.) * 10.);
           if (log10i >= 0 && log10i < 140)
             econtr25[log10i] += CaloHitMap[ids25[i]][j]->energy();
         }
@@ -318,15 +296,13 @@ void EcalBarrelSimHitsValidation::analyze(const edm::Event &e,
 
     if (meEBhitLog10EnergyNorm_ && EBEnergy_ != 0) {
       for (int i = 0; i < 140; i++) {
-        meEBhitLog10EnergyNorm_->Fill(-10. + (float(i) + 0.5) / 10.,
-                                      econtr[i] / EBEnergy_);
+        meEBhitLog10EnergyNorm_->Fill(-10. + (float(i) + 0.5) / 10., econtr[i] / EBEnergy_);
       }
     }
 
     if (meEBhitLog10Energy25Norm_ && eb25 != 0) {
       for (int i = 0; i < 140; i++) {
-        meEBhitLog10Energy25Norm_->Fill(-10. + (float(i) + 0.5) / 10.,
-                                        econtr25[i] / eb25);
+        meEBhitLog10Energy25Norm_->Fill(-10. + (float(i) + 0.5) / 10., econtr25[i] / eb25);
       }
     }
   }
@@ -339,17 +315,14 @@ void EcalBarrelSimHitsValidation::analyze(const edm::Event &e,
       for (int myStep = 0; myStep < 26; myStep++) {
         eRLength[myStep] += BX0[myStep];
         if (meEBLongitudinalShower_)
-          meEBLongitudinalShower_->Fill(float(myStep),
-                                        eRLength[myStep] / myEntries);
+          meEBLongitudinalShower_->Fill(float(myStep), eRLength[myStep] / myEntries);
       }
     }
   }
 }
 
 float EcalBarrelSimHitsValidation::energyInMatrixEB(
-    int nCellInEta, int nCellInPhi, int centralEta, int centralPhi,
-    int centralZ, MapType &themap) {
-
+    int nCellInEta, int nCellInPhi, int centralEta, int centralPhi, int centralZ, MapType &themap) {
   int ncristals = 0;
   float totalEnergy = 0.;
 
@@ -360,7 +333,6 @@ float EcalBarrelSimHitsValidation::energyInMatrixEB(
 
   for (int ieta = startEta; ieta < startEta + nCellInEta; ieta++) {
     for (int iphi = startPhi; iphi < startPhi + nCellInPhi; iphi++) {
-
       uint32_t index;
       if (abs(ieta) > 85 || abs(ieta) < 1) {
         continue;
@@ -378,17 +350,13 @@ float EcalBarrelSimHitsValidation::energyInMatrixEB(
     }
   }
 
-  LogDebug("GeomInfo") << nCellInEta << " x " << nCellInPhi
-                       << " EB matrix energy = " << totalEnergy << " for "
+  LogDebug("GeomInfo") << nCellInEta << " x " << nCellInPhi << " EB matrix energy = " << totalEnergy << " for "
                        << ncristals << " crystals";
   return totalEnergy;
 }
 
-std::vector<uint32_t>
-EcalBarrelSimHitsValidation::getIdsAroundMax(int nCellInEta, int nCellInPhi,
-                                             int centralEta, int centralPhi,
-                                             int centralZ, MapType &themap) {
-
+std::vector<uint32_t> EcalBarrelSimHitsValidation::getIdsAroundMax(
+    int nCellInEta, int nCellInPhi, int centralEta, int centralPhi, int centralZ, MapType &themap) {
   int ncristals = 0;
   std::vector<uint32_t> ids(nCellInEta * nCellInPhi);
 
@@ -399,7 +367,6 @@ EcalBarrelSimHitsValidation::getIdsAroundMax(int nCellInEta, int nCellInPhi,
 
   for (int ieta = startEta; ieta < startEta + nCellInEta; ieta++) {
     for (int iphi = startPhi; iphi < startPhi + nCellInPhi; iphi++) {
-
       uint32_t index;
       if (abs(ieta) > 85 || abs(ieta) < 1) {
         continue;
@@ -419,10 +386,8 @@ EcalBarrelSimHitsValidation::getIdsAroundMax(int nCellInEta, int nCellInPhi,
   return ids;
 }
 
-bool EcalBarrelSimHitsValidation::fillEBMatrix(int nCellInEta, int nCellInPhi,
-                                               int CentralEta, int CentralPhi,
-                                               int CentralZ, MapType &fillmap,
-                                               MapType &themap) {
+bool EcalBarrelSimHitsValidation::fillEBMatrix(
+    int nCellInEta, int nCellInPhi, int CentralEta, int CentralPhi, int CentralZ, MapType &fillmap, MapType &themap) {
   int goBackInEta = nCellInEta / 2;
   int goBackInPhi = nCellInPhi / 2;
 
@@ -483,38 +448,31 @@ float EcalBarrelSimHitsValidation::eCluster4x4(float e33, MapType &themap) {
   float e0_24 = themap[20] + themap[21] + themap[22] + themap[23] + themap[24];
 
   if ((e0_4 > e0_24 || e0_4 == e0_24) && (e0_20 > e4_24 || e0_20 == e4_24))
-    return E44 = e33 + themap[0] + themap[1] + themap[2] + themap[3] +
-                 themap[5] + themap[10] + themap[15];
+    return E44 = e33 + themap[0] + themap[1] + themap[2] + themap[3] + themap[5] + themap[10] + themap[15];
   else if ((e0_4 > e0_24 || e0_4 == e0_24) && (e0_20 < e4_24 || e0_20 == e4_24))
-    return E44 = e33 + themap[1] + themap[2] + themap[3] + themap[4] +
-                 themap[9] + themap[14] + themap[19];
+    return E44 = e33 + themap[1] + themap[2] + themap[3] + themap[4] + themap[9] + themap[14] + themap[19];
   else if ((e0_4 < e0_24 || e0_4 == e0_24) && (e0_20 > e4_24 || e0_20 == e4_24))
-    return E44 = e33 + themap[5] + themap[10] + themap[15] + themap[20] +
-                 themap[21] + themap[22] + themap[23];
+    return E44 = e33 + themap[5] + themap[10] + themap[15] + themap[20] + themap[21] + themap[22] + themap[23];
   else if ((e0_4 < e0_24 || e0_4 == e0_24) && (e0_20 < e4_24 || e0_20 == e4_24))
-    return E44 = e33 + themap[21] + themap[22] + themap[23] + themap[24] +
-                 themap[9] + themap[14] + themap[19];
+    return E44 = e33 + themap[21] + themap[22] + themap[23] + themap[24] + themap[9] + themap[14] + themap[19];
   else {
     return E44;
   }
 }
 
 uint32_t EcalBarrelSimHitsValidation::getUnitWithMaxEnergy(MapType &themap) {
-
   // look for max
   uint32_t unitWithMaxEnergy = 0;
   float maxEnergy = 0.;
 
   MapType::iterator iter;
   for (iter = themap.begin(); iter != themap.end(); iter++) {
-
     if (maxEnergy < (*iter).second) {
       maxEnergy = (*iter).second;
       unitWithMaxEnergy = (*iter).first;
     }
   }
 
-  LogDebug("GeomInfo") << " max energy of " << maxEnergy << " GeV in Unit id "
-                       << unitWithMaxEnergy;
+  LogDebug("GeomInfo") << " max energy of " << maxEnergy << " GeV in Unit id " << unitWithMaxEnergy;
   return unitWithMaxEnergy;
 }

--- a/Validation/EcalHits/src/EcalEndcapSimHitsValidation.cc
+++ b/Validation/EcalHits/src/EcalEndcapSimHitsValidation.cc
@@ -14,17 +14,14 @@ using namespace cms;
 using namespace edm;
 using namespace std;
 
-EcalEndcapSimHitsValidation::EcalEndcapSimHitsValidation(
-    const edm::ParameterSet &ps)
+EcalEndcapSimHitsValidation::EcalEndcapSimHitsValidation(const edm::ParameterSet &ps)
     : g4InfoLabel(ps.getParameter<std::string>("moduleLabelG4")),
       EEHitsCollection(ps.getParameter<std::string>("EEHitsCollection")),
-      ValidationCollection(
-          ps.getParameter<std::string>("ValidationCollection")) {
-
-  EEHitsToken = consumes<edm::PCaloHitContainer>(
-      edm::InputTag(std::string(g4InfoLabel), std::string(EEHitsCollection)));
-  ValidationCollectionToken = consumes<PEcalValidInfo>(edm::InputTag(
-      std::string(g4InfoLabel), std::string(ValidationCollection)));
+      ValidationCollection(ps.getParameter<std::string>("ValidationCollection")) {
+  EEHitsToken =
+      consumes<edm::PCaloHitContainer>(edm::InputTag(std::string(g4InfoLabel), std::string(EEHitsCollection)));
+  ValidationCollectionToken =
+      consumes<PEcalValidInfo>(edm::InputTag(std::string(g4InfoLabel), std::string(ValidationCollection)));
   // verbosity switch
   verbose_ = ps.getUntrackedParameter<bool>("verbose", false);
 
@@ -102,8 +99,7 @@ EcalEndcapSimHitsValidation::EcalEndcapSimHitsValidation(
     meEEzmOccupancy_ = dbe_->book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
 
     sprintf(histo, "EE longitudinal shower profile");
-    meEELongitudinalShower_ =
-        dbe_->bookProfile(histo, histo, 26, 0, 26, 100, 0, 20000);
+    meEELongitudinalShower_ = dbe_->bookProfile(histo, histo, 26, 0, 26, 100, 0, 20000);
 
     sprintf(histo, "EE hits energy spectrum");
     meEEHitEnergy_ = dbe_->book1D(histo, histo, 4000, 0., 400.);
@@ -112,12 +108,10 @@ EcalEndcapSimHitsValidation::EcalEndcapSimHitsValidation(
     meEEhitLog10Energy_ = dbe_->book1D(histo, histo, 140, -10., 4.);
 
     sprintf(histo, "EE hits log10energy spectrum vs normalized energy");
-    meEEhitLog10EnergyNorm_ =
-        dbe_->bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
+    meEEhitLog10EnergyNorm_ = dbe_->bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
 
     sprintf(histo, "EE hits log10energy spectrum vs normalized energy25");
-    meEEhitLog10Energy25Norm_ =
-        dbe_->bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
+    meEEhitLog10Energy25Norm_ = dbe_->bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
 
     sprintf(histo, "EE hits energy spectrum 2");
     meEEHitEnergy2_ = dbe_->book1D(histo, histo, 1000, 0., 0.001);
@@ -171,18 +165,14 @@ EcalEndcapSimHitsValidation::~EcalEndcapSimHitsValidation() {}
 void EcalEndcapSimHitsValidation::beginJob() {}
 
 void EcalEndcapSimHitsValidation::endJob() {
-
   // for ( int myStep = 0; myStep<26; myStep++){
   //  if (meEELongitudinalShower_) meEELongitudinalShower_->Fill(float(myStep),
   //  eRLength[myStep]/myEntries);
   //}
 }
 
-void EcalEndcapSimHitsValidation::analyze(const edm::Event &e,
-                                          const edm::EventSetup &c) {
-
-  edm::LogInfo("EventInfo")
-      << " Run = " << e.id().run() << " Event = " << e.id().event();
+void EcalEndcapSimHitsValidation::analyze(const edm::Event &e, const edm::EventSetup &c) {
+  edm::LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();
 
   edm::Handle<edm::PCaloHitContainer> EcalHitsEE;
   e.getByToken(EEHitsToken, EcalHitsEE);
@@ -195,13 +185,11 @@ void EcalEndcapSimHitsValidation::analyze(const edm::Event &e,
   e.getByToken(ValidationCollectionToken, MyPEcalValidInfo);
 
   std::vector<PCaloHit> theEECaloHits;
-  theEECaloHits.insert(theEECaloHits.end(), EcalHitsEE->begin(),
-                       EcalHitsEE->end());
+  theEECaloHits.insert(theEECaloHits.end(), EcalHitsEE->begin(), EcalHitsEE->end());
 
   myEntries++;
 
-  std::map<unsigned int, std::vector<PCaloHit *>, std::less<unsigned int>>
-      CaloHitMap;
+  std::map<unsigned int, std::vector<PCaloHit *>, std::less<unsigned int>> CaloHitMap;
 
   double EEetzp_ = 0.;
   double EEetzm_ = 0.;
@@ -220,9 +208,7 @@ void EcalEndcapSimHitsValidation::analyze(const edm::Event &e,
   uint32_t nEEzpHits = 0;
   uint32_t nEEzmHits = 0;
 
-  for (std::vector<PCaloHit>::iterator isim = theEECaloHits.begin();
-       isim != theEECaloHits.end(); ++isim) {
-
+  for (std::vector<PCaloHit>::iterator isim = theEECaloHits.begin(); isim != theEECaloHits.end(); ++isim) {
     if (isim->time() > 500.) {
       continue;
     }
@@ -232,9 +218,7 @@ void EcalEndcapSimHitsValidation::analyze(const edm::Event &e,
     EEDetId eeid(isim->id());
 
     LogDebug("HitInfo") << " CaloHit " << isim->getName() << "\n"
-                        << " DetID = " << isim->id()
-                        << " EEDetId = " << eeid.ix() << " " << eeid.iy()
-                        << "\n"
+                        << " DetID = " << isim->id() << " EEDetId = " << eeid.ix() << " " << eeid.iy() << "\n"
                         << " Time = " << isim->time() << "\n"
                         << " Track Id = " << isim->geantTrackId() << "\n"
                         << " Energy = " << isim->energy();
@@ -275,15 +259,11 @@ void EcalEndcapSimHitsValidation::analyze(const edm::Event &e,
     meEEzmCrystals_->Fill(eemapzm.size());
 
   if (meEEcrystalEnergy_) {
-    for (std::map<uint32_t, float, std::less<uint32_t>>::iterator it =
-             eemap.begin();
-         it != eemap.end(); ++it)
+    for (std::map<uint32_t, float, std::less<uint32_t>>::iterator it = eemap.begin(); it != eemap.end(); ++it)
       meEEcrystalEnergy_->Fill((*it).second);
   }
   if (meEEcrystalEnergy2_) {
-    for (std::map<uint32_t, float, std::less<uint32_t>>::iterator it =
-             eemap.begin();
-         it != eemap.end(); ++it)
+    for (std::map<uint32_t, float, std::less<uint32_t>>::iterator it = eemap.begin(); it != eemap.end(); ++it)
       meEEcrystalEnergy2_->Fill((*it).second);
   }
 
@@ -294,7 +274,6 @@ void EcalEndcapSimHitsValidation::analyze(const edm::Event &e,
 
   int nEEHits = nEEzmHits + nEEzpHits;
   if (nEEHits > 0) {
-
     uint32_t eecenterid = getUnitWithMaxEnergy(eemap);
     EEDetId myEEid(eecenterid);
     int bx = myEEid.ix();
@@ -316,8 +295,7 @@ void EcalEndcapSimHitsValidation::analyze(const edm::Event &e,
     for (unsigned i = 0; i < 25; i++) {
       for (unsigned int j = 0; j < CaloHitMap[ids25[i]].size(); j++) {
         if (CaloHitMap[ids25[i]][j]->energy() > 0) {
-          int log10i =
-              int((log10(CaloHitMap[ids25[i]][j]->energy()) + 10.) * 10.);
+          int log10i = int((log10(CaloHitMap[ids25[i]][j]->energy()) + 10.) * 10.);
           if (log10i >= 0 && log10i < 140)
             econtr25[log10i] += CaloHitMap[ids25[i]][j]->energy();
         }
@@ -353,15 +331,13 @@ void EcalEndcapSimHitsValidation::analyze(const edm::Event &e,
 
     if (meEEhitLog10EnergyNorm_ && (EEetzp_ + EEetzm_) != 0) {
       for (int i = 0; i < 140; i++) {
-        meEEhitLog10EnergyNorm_->Fill(-10. + (float(i) + 0.5) / 10.,
-                                      econtr[i] / (EEetzp_ + EEetzm_));
+        meEEhitLog10EnergyNorm_->Fill(-10. + (float(i) + 0.5) / 10., econtr[i] / (EEetzp_ + EEetzm_));
       }
     }
 
     if (meEEhitLog10Energy25Norm_ && ee25 != 0) {
       for (int i = 0; i < 140; i++) {
-        meEEhitLog10Energy25Norm_->Fill(-10. + (float(i) + 0.5) / 10.,
-                                        econtr25[i] / ee25);
+        meEEhitLog10Energy25Norm_->Fill(-10. + (float(i) + 0.5) / 10., econtr25[i] / ee25);
       }
     }
   }
@@ -374,18 +350,14 @@ void EcalEndcapSimHitsValidation::analyze(const edm::Event &e,
       for (int myStep = 0; myStep < 26; myStep++) {
         eRLength[myStep] += EX0[myStep];
         if (meEELongitudinalShower_)
-          meEELongitudinalShower_->Fill(float(myStep),
-                                        eRLength[myStep] / myEntries);
+          meEELongitudinalShower_->Fill(float(myStep), eRLength[myStep] / myEntries);
       }
     }
   }
 }
 
-float EcalEndcapSimHitsValidation::energyInMatrixEE(int nCellInX, int nCellInY,
-                                                    int centralX, int centralY,
-                                                    int centralZ,
-                                                    MapType &themap) {
-
+float EcalEndcapSimHitsValidation::energyInMatrixEE(
+    int nCellInX, int nCellInY, int centralX, int centralY, int centralZ, MapType &themap) {
   int ncristals = 0;
   float totalEnergy = 0.;
 
@@ -409,17 +381,13 @@ float EcalEndcapSimHitsValidation::energyInMatrixEE(int nCellInX, int nCellInY,
     }
   }
 
-  LogDebug("GeomInfo") << nCellInX << " x " << nCellInY
-                       << " EE matrix energy = " << totalEnergy << " for "
-                       << ncristals << " crystals";
+  LogDebug("GeomInfo") << nCellInX << " x " << nCellInY << " EE matrix energy = " << totalEnergy << " for " << ncristals
+                       << " crystals";
   return totalEnergy;
 }
 
-std::vector<uint32_t>
-EcalEndcapSimHitsValidation::getIdsAroundMax(int nCellInX, int nCellInY,
-                                             int centralX, int centralY,
-                                             int centralZ, MapType &themap) {
-
+std::vector<uint32_t> EcalEndcapSimHitsValidation::getIdsAroundMax(
+    int nCellInX, int nCellInY, int centralX, int centralY, int centralZ, MapType &themap) {
   int ncristals = 0;
   std::vector<uint32_t> ids(nCellInX * nCellInY);
 
@@ -446,10 +414,8 @@ EcalEndcapSimHitsValidation::getIdsAroundMax(int nCellInX, int nCellInY,
   return ids;
 }
 
-bool EcalEndcapSimHitsValidation::fillEEMatrix(int nCellInX, int nCellInY,
-                                               int CentralX, int CentralY,
-                                               int CentralZ, MapType &fillmap,
-                                               MapType &themap) {
+bool EcalEndcapSimHitsValidation::fillEEMatrix(
+    int nCellInX, int nCellInY, int CentralX, int CentralY, int CentralZ, MapType &fillmap, MapType &themap) {
   int goBackInX = nCellInX / 2;
   int goBackInY = nCellInY / 2;
 
@@ -458,9 +424,7 @@ bool EcalEndcapSimHitsValidation::fillEEMatrix(int nCellInX, int nCellInY,
 
   int i = 0;
   for (int ix = startX; ix < startX + nCellInX; ix++) {
-
     for (int iy = startY; iy < startY + nCellInY; iy++) {
-
       uint32_t index;
 
       if (EEDetId::validDetId(ix, iy, CentralZ)) {
@@ -507,38 +471,31 @@ float EcalEndcapSimHitsValidation::eCluster4x4(float e33, MapType &themap) {
   float e0_24 = themap[20] + themap[21] + themap[22] + themap[23] + themap[24];
 
   if ((e0_4 > e0_24 || e0_4 == e0_24) && (e0_20 > e4_24 || e0_20 == e4_24))
-    return E44 = e33 + themap[0] + themap[1] + themap[2] + themap[3] +
-                 themap[5] + themap[10] + themap[15];
+    return E44 = e33 + themap[0] + themap[1] + themap[2] + themap[3] + themap[5] + themap[10] + themap[15];
   else if ((e0_4 > e0_24 || e0_4 == e0_24) && (e0_20 < e4_24 || e0_20 == e4_24))
-    return E44 = e33 + themap[1] + themap[2] + themap[3] + themap[4] +
-                 themap[9] + themap[14] + themap[19];
+    return E44 = e33 + themap[1] + themap[2] + themap[3] + themap[4] + themap[9] + themap[14] + themap[19];
   else if ((e0_4 < e0_24 || e0_4 == e0_24) && (e0_20 > e4_24 || e0_20 == e4_24))
-    return E44 = e33 + themap[5] + themap[10] + themap[15] + themap[20] +
-                 themap[21] + themap[22] + themap[23];
+    return E44 = e33 + themap[5] + themap[10] + themap[15] + themap[20] + themap[21] + themap[22] + themap[23];
   else if ((e0_4 < e0_24 || e0_4 == e0_24) && (e0_20 < e4_24 || e0_20 == e4_24))
-    return E44 = e33 + themap[21] + themap[22] + themap[23] + themap[24] +
-                 themap[9] + themap[14] + themap[19];
+    return E44 = e33 + themap[21] + themap[22] + themap[23] + themap[24] + themap[9] + themap[14] + themap[19];
   else {
     return E44;
   }
 }
 
 uint32_t EcalEndcapSimHitsValidation::getUnitWithMaxEnergy(MapType &themap) {
-
   // look for max
   uint32_t unitWithMaxEnergy = 0;
   float maxEnergy = 0.;
 
   MapType::iterator iter;
   for (iter = themap.begin(); iter != themap.end(); iter++) {
-
     if (maxEnergy < (*iter).second) {
       maxEnergy = (*iter).second;
       unitWithMaxEnergy = (*iter).first;
     }
   }
 
-  LogDebug("GeomInfo") << " max energy of " << maxEnergy << " GeV in Unit id "
-                       << unitWithMaxEnergy;
+  LogDebug("GeomInfo") << " max energy of " << maxEnergy << " GeV in Unit id " << unitWithMaxEnergy;
   return unitWithMaxEnergy;
 }

--- a/Validation/EcalHits/src/EcalPreshowerSimHitsValidation.cc
+++ b/Validation/EcalHits/src/EcalPreshowerSimHitsValidation.cc
@@ -15,20 +15,18 @@ using namespace cms;
 using namespace edm;
 using namespace std;
 
-EcalPreshowerSimHitsValidation::EcalPreshowerSimHitsValidation(
-    const edm::ParameterSet &ps)
+EcalPreshowerSimHitsValidation::EcalPreshowerSimHitsValidation(const edm::ParameterSet &ps)
     :
 
       HepMCLabel(ps.getParameter<std::string>("moduleLabelMC")),
       g4InfoLabel(ps.getParameter<std::string>("moduleLabelG4")),
       EEHitsCollection(ps.getParameter<std::string>("EEHitsCollection")),
       ESHitsCollection(ps.getParameter<std::string>("ESHitsCollection")) {
-
   HepMCToken = consumes<edm::HepMCProduct>(HepMCLabel);
-  EEHitsToken = consumes<edm::PCaloHitContainer>(
-      edm::InputTag(std::string(g4InfoLabel), std::string(EEHitsCollection)));
-  ESHitsToken = consumes<edm::PCaloHitContainer>(
-      edm::InputTag(std::string(g4InfoLabel), std::string(ESHitsCollection)));
+  EEHitsToken =
+      consumes<edm::PCaloHitContainer>(edm::InputTag(std::string(g4InfoLabel), std::string(EEHitsCollection)));
+  ESHitsToken =
+      consumes<edm::PCaloHitContainer>(edm::InputTag(std::string(g4InfoLabel), std::string(ESHitsCollection)));
   // verbosity switch
   verbose_ = ps.getUntrackedParameter<bool>("verbose", false);
 
@@ -102,8 +100,7 @@ EcalPreshowerSimHitsValidation::EcalPreshowerSimHitsValidation(
     meEShitLog10Energy_ = dbe_->book1D(histo, histo, 140, -10., 4.);
 
     sprintf(histo, "ES hits log10energy spectrum vs normalized energy");
-    meEShitLog10EnergyNorm_ =
-        dbe_->bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
+    meEShitLog10EnergyNorm_ = dbe_->bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
 
     sprintf(histo, "ES E1+07E2 z+");
     meE1alphaE2zp_ = dbe_->book1D(histo, histo, 100, 0., 0.05);
@@ -112,12 +109,10 @@ EcalPreshowerSimHitsValidation::EcalPreshowerSimHitsValidation(
     meE1alphaE2zm_ = dbe_->book1D(histo, histo, 100, 0., 0.05);
 
     sprintf(histo, "EE vs ES z+");
-    meEEoverESzp_ =
-        dbe_->bookProfile(histo, histo, 250, 0., 500., 200, 0., 200.);
+    meEEoverESzp_ = dbe_->bookProfile(histo, histo, 250, 0., 500., 200, 0., 200.);
 
     sprintf(histo, "EE vs ES z-");
-    meEEoverESzm_ =
-        dbe_->bookProfile(histo, histo, 250, 0., 500., 200, 0., 200.);
+    meEEoverESzm_ = dbe_->bookProfile(histo, histo, 250, 0., 500., 200, 0., 200.);
 
     sprintf(histo, "ES ene2oEne1 z+");
     me2eszpOver1eszp_ = dbe_->book1D(histo, histo, 50, 0., 10.);
@@ -133,11 +128,8 @@ void EcalPreshowerSimHitsValidation::beginJob() {}
 
 void EcalPreshowerSimHitsValidation::endJob() {}
 
-void EcalPreshowerSimHitsValidation::analyze(const edm::Event &e,
-                                             const edm::EventSetup &c) {
-
-  edm::LogInfo("EventInfo")
-      << " Run = " << e.id().run() << " Event = " << e.id().event();
+void EcalPreshowerSimHitsValidation::analyze(const edm::Event &e, const edm::EventSetup &c) {
+  edm::LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();
 
   edm::Handle<edm::HepMCProduct> MCEvt;
   e.getByToken(HepMCToken, MCEvt);
@@ -150,14 +142,12 @@ void EcalPreshowerSimHitsValidation::analyze(const edm::Event &e,
 
   std::vector<PCaloHit> theEECaloHits;
   if (EcalHitsEE.isValid()) {
-    theEECaloHits.insert(theEECaloHits.end(), EcalHitsEE->begin(),
-                         EcalHitsEE->end());
+    theEECaloHits.insert(theEECaloHits.end(), EcalHitsEE->begin(), EcalHitsEE->end());
   }
 
   std::vector<PCaloHit> theESCaloHits;
   if (EcalHitsES.isValid()) {
-    theESCaloHits.insert(theESCaloHits.end(), EcalHitsES->begin(),
-                         EcalHitsES->end());
+    theESCaloHits.insert(theESCaloHits.end(), EcalHitsES->begin(), EcalHitsES->end());
   }
 
   double ESEnergy_ = 0.;
@@ -167,8 +157,7 @@ void EcalPreshowerSimHitsValidation::analyze(const edm::Event &e,
   // endcap
   double EEetzp_ = 0.;
   double EEetzm_ = 0.;
-  for (std::vector<PCaloHit>::iterator isim = theEECaloHits.begin();
-       isim != theEECaloHits.end(); ++isim) {
+  for (std::vector<PCaloHit>::iterator isim = theEECaloHits.begin(); isim != theEECaloHits.end(); ++isim) {
     EEDetId eeid(isim->id());
     if (eeid.zside() > 0)
       EEetzp_ += isim->energy();
@@ -186,17 +175,14 @@ void EcalPreshowerSimHitsValidation::analyze(const edm::Event &e,
   double ESet2zm_ = 0.;
   std::vector<double> econtr(140, 0.);
 
-  for (std::vector<PCaloHit>::iterator isim = theESCaloHits.begin();
-       isim != theESCaloHits.end(); ++isim) {
+  for (std::vector<PCaloHit>::iterator isim = theESCaloHits.begin(); isim != theESCaloHits.end(); ++isim) {
     // CaloHitMap[(*isim).id()].push_back((*isim));
 
     ESDetId esid(isim->id());
 
     LogDebug("HitInfo") << " CaloHit " << isim->getName() << "\n"
-                        << " DetID = " << isim->id() << " ESDetId: z side "
-                        << esid.zside() << "  plane " << esid.plane()
-                        << esid.six() << ',' << esid.siy() << ':'
-                        << esid.strip() << "\n"
+                        << " DetID = " << isim->id() << " ESDetId: z side " << esid.zside() << "  plane "
+                        << esid.plane() << esid.six() << ',' << esid.siy() << ':' << esid.strip() << "\n"
                         << " Time = " << isim->time() << "\n"
                         << " Track Id = " << isim->geantTrackId() << "\n"
                         << " Energy = " << isim->energy();
@@ -248,15 +234,13 @@ void EcalPreshowerSimHitsValidation::analyze(const edm::Event &e,
 
   if (meEShitLog10EnergyNorm_ && ESEnergy_ != 0) {
     for (int i = 0; i < 140; i++) {
-      meEShitLog10EnergyNorm_->Fill(-10. + (float(i) + 0.5) / 10.,
-                                    econtr[i] / ESEnergy_);
+      meEShitLog10EnergyNorm_->Fill(-10. + (float(i) + 0.5) / 10., econtr[i] / ESEnergy_);
     }
   }
 
-  for (HepMC::GenEvent::particle_const_iterator p =
-           MCEvt->GetEvent()->particles_begin();
-       p != MCEvt->GetEvent()->particles_end(); ++p) {
-
+  for (HepMC::GenEvent::particle_const_iterator p = MCEvt->GetEvent()->particles_begin();
+       p != MCEvt->GetEvent()->particles_end();
+       ++p) {
     double htheta = (*p)->momentum().theta();
     double heta = -99999.;
     if (tan(htheta * 0.5) > 0) {
@@ -264,7 +248,6 @@ void EcalPreshowerSimHitsValidation::analyze(const edm::Event &e,
     }
 
     if (heta > 1.653 && heta < 2.6) {
-
       if (meE1alphaE2zp_)
         meE1alphaE2zp_->Fill(ESet1zp_ + 0.7 * ESet2zp_);
       if (meEEoverESzp_)

--- a/Validation/EcalHits/src/EcalSimHitsValidProducer.cc
+++ b/Validation/EcalHits/src/EcalSimHitsValidProducer.cc
@@ -16,17 +16,39 @@
 
 #include <iostream>
 
-EcalSimHitsValidProducer::EcalSimHitsValidProducer(
-    const edm::ParameterSet &iPSet)
-    : ee1(0.0), ee4(0.0), ee9(0.0), ee16(0.0), ee25(0.0), eb1(0.0), eb4(0.0),
-      eb9(0.0), eb16(0.0), eb25(0.0), totalEInEE(0.0), totalEInEB(0),
-      totalEInES(0.0), totalEInEEzp(0.0), totalEInEEzm(0.0), totalEInESzp(0.0),
-      totalEInESzm(0.0), totalHits(0), nHitsInEE(0), nHitsInEB(0), nHitsInES(0),
-      nHitsIn1ES(0), nHitsIn2ES(0), nCrystalInEB(0), nCrystalInEEzp(0),
-      nCrystalInEEzm(0), nHitsIn1ESzp(0), nHitsIn1ESzm(0), nHitsIn2ESzp(0),
-      nHitsIn2ESzm(0), thePID(0),
-      label(iPSet.getUntrackedParameter<std::string>("instanceLabel",
-                                                     "EcalValidInfo")) {
+EcalSimHitsValidProducer::EcalSimHitsValidProducer(const edm::ParameterSet &iPSet)
+    : ee1(0.0),
+      ee4(0.0),
+      ee9(0.0),
+      ee16(0.0),
+      ee25(0.0),
+      eb1(0.0),
+      eb4(0.0),
+      eb9(0.0),
+      eb16(0.0),
+      eb25(0.0),
+      totalEInEE(0.0),
+      totalEInEB(0),
+      totalEInES(0.0),
+      totalEInEEzp(0.0),
+      totalEInEEzm(0.0),
+      totalEInESzp(0.0),
+      totalEInESzm(0.0),
+      totalHits(0),
+      nHitsInEE(0),
+      nHitsInEB(0),
+      nHitsInES(0),
+      nHitsIn1ES(0),
+      nHitsIn2ES(0),
+      nCrystalInEB(0),
+      nCrystalInEEzp(0),
+      nCrystalInEEzm(0),
+      nHitsIn1ESzp(0),
+      nHitsIn1ESzm(0),
+      nHitsIn2ESzp(0),
+      nHitsIn2ESzm(0),
+      thePID(0),
+      label(iPSet.getUntrackedParameter<std::string>("instanceLabel", "EcalValidInfo")) {
   produces<PEcalValidInfo>(label);
 
   for (int i = 0; i < 26; i++) {
@@ -192,7 +214,6 @@ void EcalSimHitsValidProducer::update(const BeginOfEvent *) {
 }
 
 void EcalSimHitsValidProducer::update(const EndOfEvent *evt) {
-
   int trackID = 0;
   G4PrimaryParticle *thePrim = nullptr;
   int nvertex = (*evt)()->GetNumberOfPrimaryVertex();
@@ -202,8 +223,7 @@ void EcalSimHitsValidProducer::update(const EndOfEvent *evt) {
     for (int i = 0; i < nvertex; i++) {
       G4PrimaryVertex *avertex = (*evt)()->GetPrimaryVertex(i);
       if (avertex == nullptr)
-        edm::LogWarning("EcalSimHitsValidProducer")
-            << " Pointer to vertex is NULL!";
+        edm::LogWarning("EcalSimHitsValidProducer") << " Pointer to vertex is NULL!";
       else {
         float x0 = avertex->GetX0();
         float y0 = avertex->GetY0();
@@ -213,8 +233,7 @@ void EcalSimHitsValidProducer::update(const EndOfEvent *evt) {
 
         int npart = avertex->GetNumberOfParticle();
         if (npart == 0)
-          edm::LogWarning("EcalSimHitsValidProducer")
-              << " No primary particle in this event";
+          edm::LogWarning("EcalSimHitsValidProducer") << " No primary particle in this event";
         else {
           if (thePrim == nullptr)
             thePrim = avertex->GetPrimary(trackID);
@@ -223,7 +242,7 @@ void EcalSimHitsValidProducer::update(const EndOfEvent *evt) {
     }
 
     // the direction of momentum of primary particles
-    double pInit = 0; // etaInit =0, phiInit =0, // UNUSED
+    double pInit = 0;  // etaInit =0, phiInit =0, // UNUSED
     if (thePrim != nullptr) {
       double px = thePrim->GetPx();
       double py = thePrim->GetPy();
@@ -244,8 +263,7 @@ void EcalSimHitsValidProducer::update(const EndOfEvent *evt) {
 
       thePID = thePrim->GetPDGcode();
     } else {
-      edm::LogWarning("EcalSimHitsValidProducer")
-          << " Could not find the primary particle!!";
+      edm::LogWarning("EcalSimHitsValidProducer") << " Could not find the primary particle!!";
     }
   }
   // hit map for EB for matrices
@@ -330,7 +348,6 @@ void EcalSimHitsValidProducer::update(const EndOfEvent *evt) {
     ESDetId esid = ESDetId(aHit->getUnitID());
 
     if (esid.zside() == -1) {
-
       totalEInESzm += aHit->getEnergyDeposit();
 
       if (esid.plane() == 1) {
@@ -342,7 +359,6 @@ void EcalSimHitsValidProducer::update(const EndOfEvent *evt) {
       }
     }
     if (esid.zside() == 1) {
-
       totalEInESzp += aHit->getEnergyDeposit();
 
       if (esid.plane() == 1) {
@@ -421,10 +437,8 @@ void EcalSimHitsValidProducer::update(const G4Step *aStep) {
   }
 }
 
-bool EcalSimHitsValidProducer::fillEEMatrix(int nCellInEta, int nCellInPhi,
-                                            int CentralEta, int CentralPhi,
-                                            int CentralZ, MapType &fillmap,
-                                            MapType &themap) {
+bool EcalSimHitsValidProducer::fillEEMatrix(
+    int nCellInEta, int nCellInPhi, int CentralEta, int CentralPhi, int CentralZ, MapType &fillmap, MapType &themap) {
   int goBackInEta = nCellInEta / 2;
   int goBackInPhi = nCellInPhi / 2;
 
@@ -433,7 +447,6 @@ bool EcalSimHitsValidProducer::fillEEMatrix(int nCellInEta, int nCellInPhi,
 
   int i = 0;
   for (int ieta = startEta; ieta < startEta + nCellInEta; ieta++) {
-
     for (int iphi = startPhi; iphi < startPhi + nCellInPhi; iphi++) {
       uint32_t index;
 
@@ -454,10 +467,8 @@ bool EcalSimHitsValidProducer::fillEEMatrix(int nCellInEta, int nCellInPhi,
     return false;
 }
 
-bool EcalSimHitsValidProducer::fillEBMatrix(int nCellInEta, int nCellInPhi,
-                                            int CentralEta, int CentralPhi,
-                                            int CentralZ, MapType &fillmap,
-                                            MapType &themap) {
+bool EcalSimHitsValidProducer::fillEBMatrix(
+    int nCellInEta, int nCellInPhi, int CentralEta, int CentralPhi, int CentralZ, MapType &fillmap, MapType &themap) {
   int goBackInEta = nCellInEta / 2;
   int goBackInPhi = nCellInPhi / 2;
 
@@ -518,27 +529,20 @@ float EcalSimHitsValidProducer::eCluster4x4(float e33, MapType &themap) {
   float e0_24 = themap[20] + themap[21] + themap[22] + themap[23] + themap[24];
 
   if ((e0_4 > e0_24 || e0_4 == e0_24) && (e0_20 > e4_24 || e0_20 == e4_24))
-    return E44 = e33 + themap[0] + themap[1] + themap[2] + themap[3] +
-                 themap[5] + themap[10] + themap[15];
+    return E44 = e33 + themap[0] + themap[1] + themap[2] + themap[3] + themap[5] + themap[10] + themap[15];
   else if ((e0_4 > e0_24 || e0_4 == e0_24) && (e0_20 < e4_24 || e0_20 == e4_24))
-    return E44 = e33 + themap[1] + themap[2] + themap[3] + themap[4] +
-                 themap[9] + themap[14] + themap[19];
+    return E44 = e33 + themap[1] + themap[2] + themap[3] + themap[4] + themap[9] + themap[14] + themap[19];
   else if ((e0_4 < e0_24 || e0_4 == e0_24) && (e0_20 > e4_24 || e0_20 == e4_24))
-    return E44 = e33 + themap[5] + themap[10] + themap[15] + themap[20] +
-                 themap[21] + themap[22] + themap[23];
+    return E44 = e33 + themap[5] + themap[10] + themap[15] + themap[20] + themap[21] + themap[22] + themap[23];
   else if ((e0_4 < e0_24 || e0_4 == e0_24) && (e0_20 < e4_24 || e0_20 == e4_24))
-    return E44 = e33 + themap[21] + themap[22] + themap[23] + themap[24] +
-                 themap[9] + themap[14] + themap[19];
+    return E44 = e33 + themap[21] + themap[22] + themap[23] + themap[24] + themap[9] + themap[14] + themap[19];
   else {
     return E44;
   }
 }
 
-float EcalSimHitsValidProducer::energyInEEMatrix(int nCellInX, int nCellInY,
-                                                 int centralX, int centralY,
-                                                 int centralZ,
-                                                 MapType &themap) {
-
+float EcalSimHitsValidProducer::energyInEEMatrix(
+    int nCellInX, int nCellInY, int centralX, int centralY, int centralZ, MapType &themap) {
   int ncristals = 0;
   float totalEnergy = 0.;
 
@@ -549,7 +553,6 @@ float EcalSimHitsValidProducer::energyInEEMatrix(int nCellInX, int nCellInY,
 
   for (int ix = startX; ix < startX + nCellInX; ix++) {
     for (int iy = startY; iy < startY + nCellInY; iy++) {
-
       uint32_t index;
       if (EEDetId::validDetId(ix, iy, centralZ)) {
         index = EEDetId(ix, iy, centralZ).rawId();
@@ -561,24 +564,19 @@ float EcalSimHitsValidProducer::energyInEEMatrix(int nCellInX, int nCellInY,
       ncristals += 1;
 
       LogDebug("EcalSimHitsValidProducer")
-          << " EnergyInEEMatrix: ix - iy - E = " << ix << "  " << iy << " "
-          << themap[index];
+          << " EnergyInEEMatrix: ix - iy - E = " << ix << "  " << iy << " " << themap[index];
     }
   }
 
-  LogDebug("EcalSimHitsValidProducer")
-      << " EnergyInEEMatrix: energy in " << nCellInX << " cells in x times "
-      << nCellInY << " cells in y matrix = " << totalEnergy << " for "
-      << ncristals << " crystals";
+  LogDebug("EcalSimHitsValidProducer") << " EnergyInEEMatrix: energy in " << nCellInX << " cells in x times "
+                                       << nCellInY << " cells in y matrix = " << totalEnergy << " for " << ncristals
+                                       << " crystals";
 
   return totalEnergy;
 }
 
-float EcalSimHitsValidProducer::energyInEBMatrix(int nCellInEta, int nCellInPhi,
-                                                 int centralEta, int centralPhi,
-                                                 int centralZ,
-                                                 MapType &themap) {
-
+float EcalSimHitsValidProducer::energyInEBMatrix(
+    int nCellInEta, int nCellInPhi, int centralEta, int centralPhi, int centralZ, MapType &themap) {
   int ncristals = 0;
   float totalEnergy = 0.;
 
@@ -589,7 +587,6 @@ float EcalSimHitsValidProducer::energyInEBMatrix(int nCellInEta, int nCellInPhi,
 
   for (int ieta = startEta; ieta < startEta + nCellInEta; ieta++) {
     for (int iphi = startPhi; iphi < startPhi + nCellInPhi; iphi++) {
-
       uint32_t index;
       if (abs(ieta) > 85 || abs(ieta) < 1) {
         continue;
@@ -606,36 +603,31 @@ float EcalSimHitsValidProducer::energyInEBMatrix(int nCellInEta, int nCellInPhi,
       ncristals += 1;
 
       LogDebug("EcalSimHitsValidProducer")
-          << " EnergyInEBMatrix: ieta - iphi - E = " << ieta << "  " << iphi
-          << " " << themap[index];
+          << " EnergyInEBMatrix: ieta - iphi - E = " << ieta << "  " << iphi << " " << themap[index];
     }
   }
 
-  LogDebug("EcalSimHitsValidProducer")
-      << " EnergyInEBMatrix: energy in " << nCellInEta << " cells in eta times "
-      << nCellInPhi << " cells in phi matrix = " << totalEnergy << " for "
-      << ncristals << " crystals";
+  LogDebug("EcalSimHitsValidProducer") << " EnergyInEBMatrix: energy in " << nCellInEta << " cells in eta times "
+                                       << nCellInPhi << " cells in phi matrix = " << totalEnergy << " for " << ncristals
+                                       << " crystals";
 
   return totalEnergy;
 }
 
 uint32_t EcalSimHitsValidProducer::getUnitWithMaxEnergy(MapType &themap) {
-
   uint32_t unitWithMaxEnergy = 0;
   float maxEnergy = 0.;
 
   MapType::iterator iter;
   for (iter = themap.begin(); iter != themap.end(); iter++) {
-
     if (maxEnergy < (*iter).second) {
       maxEnergy = (*iter).second;
       unitWithMaxEnergy = (*iter).first;
     }
   }
 
-  LogDebug("EcalSimHitsValidProducer")
-      << " Max energy of " << maxEnergy << " MeV was found in Unit id 0x"
-      << std::hex << unitWithMaxEnergy << std::dec;
+  LogDebug("EcalSimHitsValidProducer") << " Max energy of " << maxEnergy << " MeV was found in Unit id 0x" << std::hex
+                                       << unitWithMaxEnergy << std::dec;
 
   return unitWithMaxEnergy;
 }

--- a/Validation/EcalHits/src/EcalSimHitsValidation.cc
+++ b/Validation/EcalHits/src/EcalSimHitsValidation.cc
@@ -19,25 +19,21 @@ using namespace std;
 
 EcalSimHitsValidation::EcalSimHitsValidation(const edm::ParameterSet &ps)
     : g4InfoLabel(ps.getParameter<std::string>("moduleLabelG4")),
-      HepMCToken(consumes<edm::HepMCProduct>(
-          ps.getParameter<std::string>("moduleLabelMC"))) {
-  EBHitsCollectionToken = consumes<edm::PCaloHitContainer>(edm::InputTag(
-      g4InfoLabel, ps.getParameter<std::string>("EBHitsCollection")));
-  EEHitsCollectionToken = consumes<edm::PCaloHitContainer>(edm::InputTag(
-      g4InfoLabel, ps.getParameter<std::string>("EEHitsCollection")));
-  ESHitsCollectionToken = consumes<edm::PCaloHitContainer>(edm::InputTag(
-      g4InfoLabel, ps.getParameter<std::string>("ESHitsCollection")));
+      HepMCToken(consumes<edm::HepMCProduct>(ps.getParameter<std::string>("moduleLabelMC"))) {
+  EBHitsCollectionToken =
+      consumes<edm::PCaloHitContainer>(edm::InputTag(g4InfoLabel, ps.getParameter<std::string>("EBHitsCollection")));
+  EEHitsCollectionToken =
+      consumes<edm::PCaloHitContainer>(edm::InputTag(g4InfoLabel, ps.getParameter<std::string>("EEHitsCollection")));
+  ESHitsCollectionToken =
+      consumes<edm::PCaloHitContainer>(edm::InputTag(g4InfoLabel, ps.getParameter<std::string>("ESHitsCollection")));
 
   // DQM ROOT output
   outputFile_ = ps.getUntrackedParameter<std::string>("outputFile", "");
 
   if (!outputFile_.empty()) {
-    edm::LogInfo("OutputInfo")
-        << " Ecal SimHits Task histograms will be saved to "
-        << outputFile_.c_str();
+    edm::LogInfo("OutputInfo") << " Ecal SimHits Task histograms will be saved to " << outputFile_.c_str();
   } else {
-    edm::LogInfo("OutputInfo")
-        << " Ecal SimHits Task histograms will NOT be saved";
+    edm::LogInfo("OutputInfo") << " Ecal SimHits Task histograms will NOT be saved";
   }
 
   // verbosity switch
@@ -94,7 +90,6 @@ EcalSimHitsValidation::EcalSimHitsValidation(const edm::ParameterSet &ps)
 }
 
 EcalSimHitsValidation::~EcalSimHitsValidation() {
-
   if (!outputFile_.empty() && dbe_)
     dbe_->save(outputFile_);
 }
@@ -103,11 +98,8 @@ void EcalSimHitsValidation::beginJob() {}
 
 void EcalSimHitsValidation::endJob() {}
 
-void EcalSimHitsValidation::analyze(const edm::Event &e,
-                                    const edm::EventSetup &c) {
-
-  edm::LogInfo("EventInfo")
-      << " Run = " << e.id().run() << " Event = " << e.id().event();
+void EcalSimHitsValidation::analyze(const edm::Event &e, const edm::EventSetup &c) {
+  edm::LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();
 
   std::vector<PCaloHit> theEBCaloHits;
   std::vector<PCaloHit> theEECaloHits;
@@ -123,10 +115,9 @@ void EcalSimHitsValidation::analyze(const edm::Event &e,
   e.getByToken(EEHitsCollectionToken, EcalHitsEE);
   e.getByToken(ESHitsCollectionToken, EcalHitsES);
 
-  for (HepMC::GenEvent::particle_const_iterator p =
-           MCEvt->GetEvent()->particles_begin();
-       p != MCEvt->GetEvent()->particles_end(); ++p) {
-
+  for (HepMC::GenEvent::particle_const_iterator p = MCEvt->GetEvent()->particles_begin();
+       p != MCEvt->GetEvent()->particles_end();
+       ++p) {
     double htheta = (*p)->momentum().theta();
     double heta = -99999.;
     if (tan(htheta * 0.5) > 0) {
@@ -136,10 +127,8 @@ void EcalSimHitsValidation::analyze(const edm::Event &e,
     hphi = (hphi >= 0) ? hphi : hphi + 2 * M_PI;
     hphi = hphi / M_PI * 180.;
 
-    LogDebug("EventInfo") << "Particle gun type form MC = "
-                          << abs((*p)->pdg_id()) << "\n"
-                          << "Energy = " << (*p)->momentum().e()
-                          << " Eta = " << heta << " Phi = " << hphi;
+    LogDebug("EventInfo") << "Particle gun type form MC = " << abs((*p)->pdg_id()) << "\n"
+                          << "Energy = " << (*p)->momentum().e() << " Eta = " << heta << " Phi = " << hphi;
 
     if (meGunEnergy_)
       meGunEnergy_->Fill((*p)->momentum().e());
@@ -151,30 +140,24 @@ void EcalSimHitsValidation::analyze(const edm::Event &e,
 
   double EBEnergy_ = 0.;
   if (EcalHitsEB.isValid()) {
-    theEBCaloHits.insert(theEBCaloHits.end(), EcalHitsEB->begin(),
-                         EcalHitsEB->end());
-    for (std::vector<PCaloHit>::iterator isim = theEBCaloHits.begin();
-         isim != theEBCaloHits.end(); ++isim) {
+    theEBCaloHits.insert(theEBCaloHits.end(), EcalHitsEB->begin(), EcalHitsEB->end());
+    for (std::vector<PCaloHit>::iterator isim = theEBCaloHits.begin(); isim != theEBCaloHits.end(); ++isim) {
       EBEnergy_ += isim->energy();
     }
   }
 
   double EEEnergy_ = 0.;
   if (EcalHitsEE.isValid()) {
-    theEECaloHits.insert(theEECaloHits.end(), EcalHitsEE->begin(),
-                         EcalHitsEE->end());
-    for (std::vector<PCaloHit>::iterator isim = theEECaloHits.begin();
-         isim != theEECaloHits.end(); ++isim) {
+    theEECaloHits.insert(theEECaloHits.end(), EcalHitsEE->begin(), EcalHitsEE->end());
+    for (std::vector<PCaloHit>::iterator isim = theEECaloHits.begin(); isim != theEECaloHits.end(); ++isim) {
       EEEnergy_ += isim->energy();
     }
   }
 
   double ESEnergy_ = 0.;
   if (EcalHitsES.isValid()) {
-    theESCaloHits.insert(theESCaloHits.end(), EcalHitsES->begin(),
-                         EcalHitsES->end());
-    for (std::vector<PCaloHit>::iterator isim = theESCaloHits.begin();
-         isim != theESCaloHits.end(); ++isim) {
+    theESCaloHits.insert(theESCaloHits.end(), EcalHitsES->begin(), EcalHitsES->end());
+    for (std::vector<PCaloHit>::iterator isim = theESCaloHits.begin(); isim != theESCaloHits.end(); ++isim) {
       ESEnergy_ += isim->energy();
     }
   }

--- a/Validation/EcalRecHits/interface/EcalBarrelRecHitsValidation.h
+++ b/Validation/EcalRecHits/interface/EcalBarrelRecHitsValidation.h
@@ -36,7 +36,6 @@
 #include <vector>
 
 class EcalBarrelRecHitsValidation : public DQMEDAnalyzer {
-
 public:
   /// Constructor
   EcalBarrelRecHitsValidation(const edm::ParameterSet &ps);
@@ -46,8 +45,7 @@ public:
 
 protected:
   /// Analyze
-  void bookHistograms(DQMStore::IBooker &i, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &i, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
 
 private:
@@ -55,8 +53,7 @@ private:
 
   // fix for consumes
   edm::EDGetTokenT<EBDigiCollection> EBdigiCollection_token_;
-  edm::EDGetTokenT<EBUncalibratedRecHitCollection>
-      EBuncalibrechitCollection_token_;
+  edm::EDGetTokenT<EBUncalibratedRecHitCollection> EBuncalibrechitCollection_token_;
 
   MonitorElement *meEBUncalibRecHitsOccupancy_;
   MonitorElement *meEBUncalibRecHitsAmplitude_;

--- a/Validation/EcalRecHits/interface/EcalEndcapRecHitsValidation.h
+++ b/Validation/EcalRecHits/interface/EcalEndcapRecHitsValidation.h
@@ -36,7 +36,6 @@
 #include <vector>
 
 class EcalEndcapRecHitsValidation : public DQMEDAnalyzer {
-
 public:
   /// Constructor
   EcalEndcapRecHitsValidation(const edm::ParameterSet &ps);
@@ -45,8 +44,7 @@ public:
   ~EcalEndcapRecHitsValidation() override;
 
 protected:
-  void bookHistograms(DQMStore::IBooker &i, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &i, edm::Run const &, edm::EventSetup const &) override;
 
   /// Analyze
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
@@ -56,8 +54,7 @@ private:
 
   // fix for consumes
   edm::EDGetTokenT<EEDigiCollection> EEdigiCollection_token_;
-  edm::EDGetTokenT<EEUncalibratedRecHitCollection>
-      EEuncalibrechitCollection_token_;
+  edm::EDGetTokenT<EEUncalibratedRecHitCollection> EEuncalibrechitCollection_token_;
 
   MonitorElement *meEEUncalibRecHitsOccupancyPlus_;
   MonitorElement *meEEUncalibRecHitsOccupancyMinus_;

--- a/Validation/EcalRecHits/interface/EcalPreshowerRecHitsValidation.h
+++ b/Validation/EcalRecHits/interface/EcalPreshowerRecHitsValidation.h
@@ -33,7 +33,6 @@
 #include <vector>
 
 class EcalPreshowerRecHitsValidation : public DQMEDAnalyzer {
-
 public:
   /// Constructor
   EcalPreshowerRecHitsValidation(const edm::ParameterSet &ps);
@@ -42,16 +41,14 @@ public:
   ~EcalPreshowerRecHitsValidation() override;
 
 protected:
-  void bookHistograms(DQMStore::IBooker &i, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &i, edm::Run const &, edm::EventSetup const &) override;
   /// Analyze
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
 
 private:
   bool verbose_;
 
-  edm::EDGetTokenT<EEUncalibratedRecHitCollection>
-      EEuncalibrechitCollection_token_;
+  edm::EDGetTokenT<EEUncalibratedRecHitCollection> EEuncalibrechitCollection_token_;
   edm::EDGetTokenT<EERecHitCollection> EErechitCollection_token_;
   edm::EDGetTokenT<ESRecHitCollection> ESrechitCollection_token_;
 

--- a/Validation/EcalRecHits/interface/EcalRecHitsValidation.h
+++ b/Validation/EcalRecHits/interface/EcalRecHitsValidation.h
@@ -42,7 +42,6 @@
 #include <vector>
 
 class EcalRecHitsValidation : public DQMEDAnalyzer {
-
   typedef std::map<uint32_t, float, std::less<uint32_t>> MapType;
 
 public:
@@ -53,16 +52,13 @@ public:
   ~EcalRecHitsValidation() override;
 
 protected:
-  void bookHistograms(DQMStore::IBooker &i, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &i, edm::Run const &, edm::EventSetup const &) override;
   /// Analyze
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
 
   uint32_t getUnitWithMaxEnergy(MapType &themap);
-  void findBarrelMatrix(int nCellInEta, int nCellInPhi, int CentralEta,
-                        int CentralPhi, int CentralZ, MapType &themap);
-  void findEndcapMatrix(int nCellInX, int nCellInY, int CentralX, int CentralY,
-                        int CentralZ, MapType &themap);
+  void findBarrelMatrix(int nCellInEta, int nCellInPhi, int CentralEta, int CentralPhi, int CentralZ, MapType &themap);
+  void findEndcapMatrix(int nCellInX, int nCellInY, int CentralX, int CentralY, int CentralZ, MapType &themap);
 
 private:
   std::string HepMCLabel;
@@ -82,10 +78,8 @@ private:
   edm::EDGetTokenT<EBRecHitCollection> EBrechitCollection_Token_;
   edm::EDGetTokenT<EERecHitCollection> EErechitCollection_Token_;
   edm::EDGetTokenT<ESRecHitCollection> ESrechitCollection_Token_;
-  edm::EDGetTokenT<EBUncalibratedRecHitCollection>
-      EBuncalibrechitCollection_Token_;
-  edm::EDGetTokenT<EEUncalibratedRecHitCollection>
-      EEuncalibrechitCollection_Token_;
+  edm::EDGetTokenT<EBUncalibratedRecHitCollection> EBuncalibrechitCollection_Token_;
+  edm::EDGetTokenT<EEUncalibratedRecHitCollection> EEuncalibrechitCollection_Token_;
   edm::EDGetTokenT<CrossingFrame<PCaloHit>> EBHits_Token_;
   edm::EDGetTokenT<CrossingFrame<PCaloHit>> EEHits_Token_;
   edm::EDGetTokenT<CrossingFrame<PCaloHit>> ESHits_Token_;

--- a/Validation/EcalRecHits/interface/EcalTBValidation.h
+++ b/Validation/EcalRecHits/interface/EcalTBValidation.h
@@ -23,8 +23,7 @@ public:
   explicit EcalTBValidation(const edm::ParameterSet &);
   ~EcalTBValidation() override;
 
-  void bookHistograms(DQMStore::IBooker &i, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &i, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
 private:

--- a/Validation/EcalRecHits/src/EcalBarrelRecHitsValidation.cc
+++ b/Validation/EcalRecHits/src/EcalBarrelRecHitsValidation.cc
@@ -13,14 +13,11 @@ using namespace cms;
 using namespace edm;
 using namespace std;
 
-EcalBarrelRecHitsValidation::EcalBarrelRecHitsValidation(
-    const ParameterSet &ps) {
-
+EcalBarrelRecHitsValidation::EcalBarrelRecHitsValidation(const ParameterSet &ps) {
   // ----------------------
-  EBdigiCollection_token_ = consumes<EBDigiCollection>(
-      ps.getParameter<edm::InputTag>("EBdigiCollection"));
-  EBuncalibrechitCollection_token_ = consumes<EBUncalibratedRecHitCollection>(
-      ps.getParameter<edm::InputTag>("EBuncalibrechitCollection"));
+  EBdigiCollection_token_ = consumes<EBDigiCollection>(ps.getParameter<edm::InputTag>("EBdigiCollection"));
+  EBuncalibrechitCollection_token_ =
+      consumes<EBUncalibratedRecHitCollection>(ps.getParameter<edm::InputTag>("EBuncalibrechitCollection"));
 
   // ----------------------
   // verbosity switch
@@ -57,8 +54,7 @@ void EcalBarrelRecHitsValidation::bookHistograms(DQMStore::IBooker &ibooker,
   ibooker.setCurrentFolder("EcalRecHitsV/EcalBarrelRecHitsTask");
 
   sprintf(histo, "EB Occupancy");
-  meEBUncalibRecHitsOccupancy_ =
-      ibooker.book2D(histo, histo, 170, -85., 85., 360, 0., 360.);
+  meEBUncalibRecHitsOccupancy_ = ibooker.book2D(histo, histo, 170, -85., 85., 360, 0., 360.);
 
   sprintf(histo, "EB Amplitude");
   meEBUncalibRecHitsAmplitude_ = ibooker.book1D(histo, histo, 201, -20., 4000.);
@@ -73,54 +69,42 @@ void EcalBarrelRecHitsValidation::bookHistograms(DQMStore::IBooker &ibooker,
   meEBUncalibRecHitsChi2_ = ibooker.book1D(histo, histo, 100, 18000., 22000.);
 
   sprintf(histo, "EB RecHit Max Sample Ratio");
-  meEBUncalibRecHitMaxSampleRatio_ =
-      ibooker.book1D(histo, histo, 120, 0.90, 1.05);
+  meEBUncalibRecHitMaxSampleRatio_ = ibooker.book1D(histo, histo, 120, 0.90, 1.05);
 
   sprintf(histo, "EB Occupancy gt 100 adc counts");
-  meEBUncalibRecHitsOccupancyGt100adc_ =
-      ibooker.book2D(histo, histo, 170, -85., 85., 360, 0., 360.);
+  meEBUncalibRecHitsOccupancyGt100adc_ = ibooker.book2D(histo, histo, 170, -85., 85., 360, 0., 360.);
 
   sprintf(histo, "EB Amplitude gt 100 adc counts");
-  meEBUncalibRecHitsAmplitudeGt100adc_ =
-      ibooker.book1D(histo, histo, 200, 0., 4000.);
+  meEBUncalibRecHitsAmplitudeGt100adc_ = ibooker.book1D(histo, histo, 200, 0., 4000.);
 
   sprintf(histo, "EB Pedestal gt 100 adc counts");
-  meEBUncalibRecHitsPedestalGt100adc_ =
-      ibooker.book1D(histo, histo, 50, 190., 210.);
+  meEBUncalibRecHitsPedestalGt100adc_ = ibooker.book1D(histo, histo, 50, 190., 210.);
 
   sprintf(histo, "EB Jitter gt 100 adc counts");
-  meEBUncalibRecHitsJitterGt100adc_ =
-      ibooker.book1D(histo, histo, 100, 0., 100.);
+  meEBUncalibRecHitsJitterGt100adc_ = ibooker.book1D(histo, histo, 100, 0., 100.);
 
   sprintf(histo, "EB Chi2 gt 100 adc counts");
-  meEBUncalibRecHitsChi2Gt100adc_ =
-      ibooker.book1D(histo, histo, 100, 18000., 22000.);
+  meEBUncalibRecHitsChi2Gt100adc_ = ibooker.book1D(histo, histo, 100, 18000., 22000.);
 
   sprintf(histo, "EB RecHit Max Sample Ratio gt 100 adc counts");
-  meEBUncalibRecHitMaxSampleRatioGt100adc_ =
-      ibooker.book1D(histo, histo, 120, 0.90, 1.05);
+  meEBUncalibRecHitMaxSampleRatioGt100adc_ = ibooker.book1D(histo, histo, 120, 0.90, 1.05);
 
   sprintf(histo, "EB Amplitude Full Map");
-  meEBUncalibRecHitsAmpFullMap_ = ibooker.bookProfile2D(
-      histo, histo, 170, -85., 85., 360, 0., 360., 200, 0., 4000.);
+  meEBUncalibRecHitsAmpFullMap_ = ibooker.bookProfile2D(histo, histo, 170, -85., 85., 360, 0., 360., 200, 0., 4000.);
 
   sprintf(histo, "EB Pedestal Full Map");
-  meEBUncalibRecHitsPedFullMap_ = ibooker.bookProfile2D(
-      histo, histo, 170, -85., 85., 360, 0., 360., 50, 194., 201.);
+  meEBUncalibRecHitsPedFullMap_ = ibooker.bookProfile2D(histo, histo, 170, -85., 85., 360, 0., 360., 50, 194., 201.);
 
   for (int i = 0; i < 36; i++) {
     sprintf(histo, "EB Amp SM%02d", i + 1);
-    meEBUncalibRecHitAmplMap_[i] = ibooker.bookProfile2D(
-        histo, histo, 85, 0., 85., 20, 0., 20., 200, 0., 4000.);
+    meEBUncalibRecHitAmplMap_[i] = ibooker.bookProfile2D(histo, histo, 85, 0., 85., 20, 0., 20., 200, 0., 4000.);
 
     sprintf(histo, "EB Ped SM%02d", i + 1);
-    meEBUncalibRecHitPedMap_[i] = ibooker.bookProfile2D(
-        histo, histo, 85, 0., 85., 20, 0., 20., 50, 194., 201.);
+    meEBUncalibRecHitPedMap_[i] = ibooker.bookProfile2D(histo, histo, 85, 0., 85., 20, 0., 20., 50, 194., 201.);
   }
 }
 
 void EcalBarrelRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
-
   const EBUncalibratedRecHitCollection *EBUncalibRecHit = nullptr;
   Handle<EBUncalibratedRecHitCollection> EcalUncalibRecHitEB;
   e.getByToken(EBuncalibrechitCollection_token_, EcalUncalibRecHitEB);
@@ -145,9 +129,9 @@ void EcalBarrelRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
 
   // ----------------------
   // loop over UncalibRecHits
-  for (EcalUncalibratedRecHitCollection::const_iterator uncalibRecHit =
-           EBUncalibRecHit->begin();
-       uncalibRecHit != EBUncalibRecHit->end(); ++uncalibRecHit) {
+  for (EcalUncalibratedRecHitCollection::const_iterator uncalibRecHit = EBUncalibRecHit->begin();
+       uncalibRecHit != EBUncalibRecHit->end();
+       ++uncalibRecHit) {
     EBDetId EBid = EBDetId(uncalibRecHit->id());
 
     // general checks
@@ -162,11 +146,9 @@ void EcalBarrelRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
     if (meEBUncalibRecHitsChi2_)
       meEBUncalibRecHitsChi2_->Fill(uncalibRecHit->chi2());
     if (meEBUncalibRecHitsAmpFullMap_)
-      meEBUncalibRecHitsAmpFullMap_->Fill(EBid.ieta(), EBid.iphi(),
-                                          uncalibRecHit->amplitude());
+      meEBUncalibRecHitsAmpFullMap_->Fill(EBid.ieta(), EBid.iphi(), uncalibRecHit->amplitude());
     if (meEBUncalibRecHitsPedFullMap_)
-      meEBUncalibRecHitsPedFullMap_->Fill(EBid.ieta(), EBid.iphi(),
-                                          uncalibRecHit->pedestal());
+      meEBUncalibRecHitsPedFullMap_->Fill(EBid.ieta(), EBid.iphi(), uncalibRecHit->pedestal());
 
     // general checks, with threshold at 3.5 GeV = 100 ADC counts
     if (uncalibRecHit->amplitude() > 100) {
@@ -190,11 +172,9 @@ void EcalBarrelRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
     float xie = ie - 0.5;
     float xip = ip - 0.5;
     if (meEBUncalibRecHitPedMap_[ism - 1])
-      meEBUncalibRecHitPedMap_[ism - 1]->Fill(xie, xip,
-                                              uncalibRecHit->pedestal());
+      meEBUncalibRecHitPedMap_[ism - 1]->Fill(xie, xip, uncalibRecHit->pedestal());
     if (meEBUncalibRecHitAmplMap_[ism - 1])
-      meEBUncalibRecHitAmplMap_[ism - 1]->Fill(xie, xip,
-                                               uncalibRecHit->amplitude());
+      meEBUncalibRecHitAmplMap_[ism - 1]->Fill(xie, xip, uncalibRecHit->amplitude());
 
     if (!skipDigis) {
       // find the rechit corresponding digi and the max sample
@@ -217,27 +197,20 @@ void EcalBarrelRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
       const EcalPedestals *myped = ecalPeds.product();
       EcalPedestalsMap::const_iterator it = myped->getMap().find(EBid);
       if (it != myped->getMap().end()) {
-
-        if (eMax > (*it).mean_x1 + 5 * (*it).rms_x1 &&
-            eMax != 0) { // only real signal RecHit
+        if (eMax > (*it).mean_x1 + 5 * (*it).rms_x1 && eMax != 0) {  // only real signal RecHit
 
           if (meEBUncalibRecHitMaxSampleRatio_)
-            meEBUncalibRecHitMaxSampleRatio_->Fill(
-                (uncalibRecHit->amplitude() + uncalibRecHit->pedestal()) /
-                eMax);
-          if (meEBUncalibRecHitMaxSampleRatioGt100adc_ &&
-              (uncalibRecHit->amplitude() > 100))
-            meEBUncalibRecHitMaxSampleRatioGt100adc_->Fill(
-                (uncalibRecHit->amplitude() + uncalibRecHit->pedestal()) /
-                eMax);
+            meEBUncalibRecHitMaxSampleRatio_->Fill((uncalibRecHit->amplitude() + uncalibRecHit->pedestal()) / eMax);
+          if (meEBUncalibRecHitMaxSampleRatioGt100adc_ && (uncalibRecHit->amplitude() > 100))
+            meEBUncalibRecHitMaxSampleRatioGt100adc_->Fill((uncalibRecHit->amplitude() + uncalibRecHit->pedestal()) /
+                                                           eMax);
           LogDebug("EcalRecHitsTaskInfo")
-              << "barrel, eMax = " << eMax << " Amplitude = "
-              << uncalibRecHit->amplitude() + uncalibRecHit->pedestal();
+              << "barrel, eMax = " << eMax << " Amplitude = " << uncalibRecHit->amplitude() + uncalibRecHit->pedestal();
         } else
           continue;
       } else
         continue;
     }
 
-  } // loop over the UncalibratedRecHitCollection
+  }  // loop over the UncalibratedRecHitCollection
 }

--- a/Validation/EcalRecHits/src/EcalEndcapRecHitsValidation.cc
+++ b/Validation/EcalRecHits/src/EcalEndcapRecHitsValidation.cc
@@ -13,14 +13,11 @@ using namespace cms;
 using namespace edm;
 using namespace std;
 
-EcalEndcapRecHitsValidation::EcalEndcapRecHitsValidation(
-    const ParameterSet &ps) {
-
+EcalEndcapRecHitsValidation::EcalEndcapRecHitsValidation(const ParameterSet &ps) {
   // ----------------------
-  EEdigiCollection_token_ = consumes<EEDigiCollection>(
-      ps.getParameter<edm::InputTag>("EEdigiCollection"));
-  EEuncalibrechitCollection_token_ = consumes<EEUncalibratedRecHitCollection>(
-      ps.getParameter<edm::InputTag>("EEuncalibrechitCollection"));
+  EEdigiCollection_token_ = consumes<EEDigiCollection>(ps.getParameter<edm::InputTag>("EEdigiCollection"));
+  EEuncalibrechitCollection_token_ =
+      consumes<EEUncalibratedRecHitCollection>(ps.getParameter<edm::InputTag>("EEuncalibrechitCollection"));
 
   // ----------------------
   // verbosity switch
@@ -50,18 +47,15 @@ EcalEndcapRecHitsValidation::~EcalEndcapRecHitsValidation() {}
 void EcalEndcapRecHitsValidation::bookHistograms(DQMStore::IBooker &ibooker,
                                                  edm::Run const &,
                                                  edm::EventSetup const &) {
-
   Char_t histo[200];
 
   ibooker.setCurrentFolder("EcalRecHitsV/EcalEndcapRecHitsTask");
 
   sprintf(histo, "EE+ Occupancy");
-  meEEUncalibRecHitsOccupancyPlus_ =
-      ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
+  meEEUncalibRecHitsOccupancyPlus_ = ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
 
   sprintf(histo, "EE- Occupancy");
-  meEEUncalibRecHitsOccupancyMinus_ =
-      ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
+  meEEUncalibRecHitsOccupancyMinus_ = ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
 
   sprintf(histo, "EE Amplitude");
   meEEUncalibRecHitsAmplitude_ = ibooker.book1D(histo, histo, 201, -20., 4000.);
@@ -76,48 +70,37 @@ void EcalEndcapRecHitsValidation::bookHistograms(DQMStore::IBooker &ibooker,
   meEEUncalibRecHitsChi2_ = ibooker.book1D(histo, histo, 100, 18000., 22000.);
 
   sprintf(histo, "EE RecHit Max Sample Ratio");
-  meEEUncalibRecHitMaxSampleRatio_ =
-      ibooker.book1D(histo, histo, 120, 0.90, 1.05);
+  meEEUncalibRecHitMaxSampleRatio_ = ibooker.book1D(histo, histo, 120, 0.90, 1.05);
 
   sprintf(histo, "EE+ Occupancy gt 60 adc counts");
-  meEEUncalibRecHitsOccupancyPlusGt60adc_ =
-      ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
+  meEEUncalibRecHitsOccupancyPlusGt60adc_ = ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
 
   sprintf(histo, "EE- Occupancy gt 60 adc counts");
-  meEEUncalibRecHitsOccupancyMinusGt60adc_ =
-      ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
+  meEEUncalibRecHitsOccupancyMinusGt60adc_ = ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
 
   sprintf(histo, "EE Amplitude gt 60 adc counts");
-  meEEUncalibRecHitsAmplitudeGt60adc_ =
-      ibooker.book1D(histo, histo, 200, 0., 4000.);
+  meEEUncalibRecHitsAmplitudeGt60adc_ = ibooker.book1D(histo, histo, 200, 0., 4000.);
 
   sprintf(histo, "EE Pedestal gt 60 adc counts");
-  meEEUncalibRecHitsPedestalGt60adc_ =
-      ibooker.book1D(histo, histo, 50, 190., 210.);
+  meEEUncalibRecHitsPedestalGt60adc_ = ibooker.book1D(histo, histo, 50, 190., 210.);
 
   sprintf(histo, "EE Jitter gt 60 adc counts");
-  meEEUncalibRecHitsJitterGt60adc_ =
-      ibooker.book1D(histo, histo, 100, 0., 100.);
+  meEEUncalibRecHitsJitterGt60adc_ = ibooker.book1D(histo, histo, 100, 0., 100.);
 
   sprintf(histo, "EE Chi2 gt 60 adc counts");
-  meEEUncalibRecHitsChi2Gt60adc_ =
-      ibooker.book1D(histo, histo, 100, 18000., 22000.);
+  meEEUncalibRecHitsChi2Gt60adc_ = ibooker.book1D(histo, histo, 100, 18000., 22000.);
 
   sprintf(histo, "EE RecHit Max Sample Ratio gt 60 adc counts");
-  meEEUncalibRecHitMaxSampleRatioGt60adc_ =
-      ibooker.book1D(histo, histo, 120, 0.90, 1.05);
+  meEEUncalibRecHitMaxSampleRatioGt60adc_ = ibooker.book1D(histo, histo, 120, 0.90, 1.05);
 
   sprintf(histo, "EE Amplitude Full Map");
-  meEEUncalibRecHitsAmpFullMap_ = ibooker.bookProfile2D(
-      histo, histo, 100, 0., 100., 100, 0., 100., 200, 0., 4000.);
+  meEEUncalibRecHitsAmpFullMap_ = ibooker.bookProfile2D(histo, histo, 100, 0., 100., 100, 0., 100., 200, 0., 4000.);
 
   sprintf(histo, "EE Pedestal Full Map");
-  meEEUncalibRecHitsPedFullMap_ = ibooker.bookProfile2D(
-      histo, histo, 100, 0., 100., 100, 0., 100., 50, 194., 201.);
+  meEEUncalibRecHitsPedFullMap_ = ibooker.bookProfile2D(histo, histo, 100, 0., 100., 100, 0., 100., 50, 194., 201.);
 }
 
 void EcalEndcapRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
-
   const EEUncalibratedRecHitCollection *EEUncalibRecHit = nullptr;
   Handle<EEUncalibratedRecHitCollection> EcalUncalibRecHitEE;
   e.getByToken(EEuncalibrechitCollection_token_, EcalUncalibRecHitEE);
@@ -142,9 +125,9 @@ void EcalEndcapRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
 
   // ----------------------
   // loop over UncalibRecHits
-  for (EcalUncalibratedRecHitCollection::const_iterator uncalibRecHit =
-           EEUncalibRecHit->begin();
-       uncalibRecHit != EEUncalibRecHit->end(); ++uncalibRecHit) {
+  for (EcalUncalibratedRecHitCollection::const_iterator uncalibRecHit = EEUncalibRecHit->begin();
+       uncalibRecHit != EEUncalibRecHit->end();
+       ++uncalibRecHit) {
     EEDetId EEid = EEDetId(uncalibRecHit->id());
 
     int mySide = EEid.zside();
@@ -167,11 +150,9 @@ void EcalEndcapRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
     if (meEEUncalibRecHitsChi2_)
       meEEUncalibRecHitsChi2_->Fill(uncalibRecHit->chi2());
     if (meEEUncalibRecHitsAmpFullMap_)
-      meEEUncalibRecHitsAmpFullMap_->Fill(EEid.ix(), EEid.iy(),
-                                          uncalibRecHit->amplitude());
+      meEEUncalibRecHitsAmpFullMap_->Fill(EEid.ix(), EEid.iy(), uncalibRecHit->amplitude());
     if (meEEUncalibRecHitsPedFullMap_)
-      meEEUncalibRecHitsPedFullMap_->Fill(EEid.ix(), EEid.iy(),
-                                          uncalibRecHit->pedestal());
+      meEEUncalibRecHitsPedFullMap_->Fill(EEid.ix(), EEid.iy(), uncalibRecHit->pedestal());
 
     // general checks, with threshold at 60 ADC counts
     if (uncalibRecHit->amplitude() > 60) {
@@ -214,30 +195,23 @@ void EcalEndcapRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
       const EcalPedestals *myped = ecalPeds.product();
       EcalPedestalsMap::const_iterator it = myped->getMap().find(EEid);
       if (it != myped->getMap().end()) {
-
-        if (eMax > (*it).mean_x1 + 5 * (*it).rms_x1 &&
-            eMax != 0) { // only real signal RecHit
+        if (eMax > (*it).mean_x1 + 5 * (*it).rms_x1 && eMax != 0) {  // only real signal RecHit
 
           if (meEEUncalibRecHitMaxSampleRatio_) {
-            meEEUncalibRecHitMaxSampleRatio_->Fill(
-                (uncalibRecHit->amplitude() + uncalibRecHit->pedestal()) /
-                eMax);
+            meEEUncalibRecHitMaxSampleRatio_->Fill((uncalibRecHit->amplitude() + uncalibRecHit->pedestal()) / eMax);
           }
 
-          if (meEEUncalibRecHitMaxSampleRatioGt60adc_ &&
-              (uncalibRecHit->amplitude() > 60)) {
-            meEEUncalibRecHitMaxSampleRatioGt60adc_->Fill(
-                (uncalibRecHit->amplitude() + uncalibRecHit->pedestal()) /
-                eMax);
+          if (meEEUncalibRecHitMaxSampleRatioGt60adc_ && (uncalibRecHit->amplitude() > 60)) {
+            meEEUncalibRecHitMaxSampleRatioGt60adc_->Fill((uncalibRecHit->amplitude() + uncalibRecHit->pedestal()) /
+                                                          eMax);
           }
 
           LogDebug("EcalRecHitsTaskInfo")
-              << "endcap, eMax = " << eMax << " Amplitude = "
-              << uncalibRecHit->amplitude() + uncalibRecHit->pedestal();
+              << "endcap, eMax = " << eMax << " Amplitude = " << uncalibRecHit->amplitude() + uncalibRecHit->pedestal();
         } else
           continue;
       } else
         continue;
     }
-  } // loop over the UncalibratedRecHitCollection
+  }  // loop over the UncalibratedRecHitCollection
 }

--- a/Validation/EcalRecHits/src/EcalPreshowerRecHitsValidation.cc
+++ b/Validation/EcalRecHits/src/EcalPreshowerRecHitsValidation.cc
@@ -14,33 +14,29 @@ using namespace cms;
 using namespace edm;
 using namespace std;
 
-EcalPreshowerRecHitsValidation::EcalPreshowerRecHitsValidation(
-    const ParameterSet &ps) {
-
+EcalPreshowerRecHitsValidation::EcalPreshowerRecHitsValidation(const ParameterSet &ps) {
   // ----------------------
-  EEuncalibrechitCollection_token_ = consumes<EEUncalibratedRecHitCollection>(
-      ps.getParameter<edm::InputTag>("EEuncalibrechitCollection"));
-  EErechitCollection_token_ = consumes<EERecHitCollection>(
-      ps.getParameter<edm::InputTag>("EErechitCollection"));
-  ESrechitCollection_token_ = consumes<ESRecHitCollection>(
-      ps.getParameter<edm::InputTag>("ESrechitCollection"));
+  EEuncalibrechitCollection_token_ =
+      consumes<EEUncalibratedRecHitCollection>(ps.getParameter<edm::InputTag>("EEuncalibrechitCollection"));
+  EErechitCollection_token_ = consumes<EERecHitCollection>(ps.getParameter<edm::InputTag>("EErechitCollection"));
+  ESrechitCollection_token_ = consumes<ESRecHitCollection>(ps.getParameter<edm::InputTag>("ESrechitCollection"));
 
   // ----------------------
   // verbosity switch
   verbose_ = ps.getUntrackedParameter<bool>("verbose", false);
 
   // ----------------------
-  meESRecHitsEnergy_ = nullptr; // total energy
+  meESRecHitsEnergy_ = nullptr;  // total energy
   meESRecHitsEnergy_zp1st_ = nullptr;
   meESRecHitsEnergy_zp2nd_ = nullptr;
   meESRecHitsEnergy_zm1st_ = nullptr;
   meESRecHitsEnergy_zm2nd_ = nullptr;
-  meESRecHitsMultip_ = nullptr; // total multiplicity
+  meESRecHitsMultip_ = nullptr;  // total multiplicity
   meESRecHitsMultip_zp1st_ = nullptr;
   meESRecHitsMultip_zp2nd_ = nullptr;
   meESRecHitsMultip_zm1st_ = nullptr;
   meESRecHitsMultip_zm2nd_ = nullptr;
-  meESEERecHitsEnergy_zp_ = nullptr; // versus EE energy
+  meESEERecHitsEnergy_zp_ = nullptr;  // versus EE energy
   meESEERecHitsEnergy_zm_ = nullptr;
 
   for (int kk = 0; kk < 32; kk++) {
@@ -56,7 +52,6 @@ EcalPreshowerRecHitsValidation::~EcalPreshowerRecHitsValidation() {}
 void EcalPreshowerRecHitsValidation::bookHistograms(DQMStore::IBooker &ibooker,
                                                     edm::Run const &,
                                                     edm::EventSetup const &) {
-
   Char_t histo[200];
 
   ibooker.setCurrentFolder("EcalRecHitsV/EcalPreshowerRecHitsTask");
@@ -92,35 +87,27 @@ void EcalPreshowerRecHitsValidation::bookHistograms(DQMStore::IBooker &ibooker,
   meESRecHitsMultip_zm2nd_ = ibooker.book1D(histo, histo, 100, 0., 700.);
 
   sprintf(histo, "Preshower EE vs ES energy Side+");
-  meESEERecHitsEnergy_zp_ =
-      ibooker.book2D(histo, histo, 100, 0., 0.2, 100, 0., 150.);
+  meESEERecHitsEnergy_zp_ = ibooker.book2D(histo, histo, 100, 0., 0.2, 100, 0., 150.);
 
   sprintf(histo, "Preshower EE vs ES energy Side-");
-  meESEERecHitsEnergy_zm_ =
-      ibooker.book2D(histo, histo, 100, 0., 0.2, 100, 0., 150.);
+  meESEERecHitsEnergy_zm_ = ibooker.book2D(histo, histo, 100, 0., 0.2, 100, 0., 150.);
 
   for (int kk = 0; kk < 32; kk++) {
     sprintf(histo, "ES Occupancy Plane1 Side+ Strip%02d", kk + 1);
-    meESRecHitsStripOccupancy_zp1st_[kk] =
-        ibooker.book2D(histo, histo, 40, 0., 40., 40, 0., 40.);
+    meESRecHitsStripOccupancy_zp1st_[kk] = ibooker.book2D(histo, histo, 40, 0., 40., 40, 0., 40.);
 
     sprintf(histo, "ES Occupancy Plane2 Side+ Strip%02d", kk + 1);
-    meESRecHitsStripOccupancy_zp2nd_[kk] =
-        ibooker.book2D(histo, histo, 40, 0., 40., 40, 0., 40.);
+    meESRecHitsStripOccupancy_zp2nd_[kk] = ibooker.book2D(histo, histo, 40, 0., 40., 40, 0., 40.);
 
     sprintf(histo, "ES Occupancy Plane1 Side- Strip%02d", kk + 1);
-    meESRecHitsStripOccupancy_zm1st_[kk] =
-        ibooker.book2D(histo, histo, 40, 0., 40., 40, 0., 40.);
+    meESRecHitsStripOccupancy_zm1st_[kk] = ibooker.book2D(histo, histo, 40, 0., 40., 40, 0., 40.);
 
     sprintf(histo, "ES Occupancy Plane2 Side- Strip%02d", kk + 1);
-    meESRecHitsStripOccupancy_zm2nd_[kk] =
-        ibooker.book2D(histo, histo, 40, 0., 40., 40, 0., 40.);
+    meESRecHitsStripOccupancy_zm2nd_[kk] = ibooker.book2D(histo, histo, 40, 0., 40., 40, 0., 40.);
   }
 }
 
-void EcalPreshowerRecHitsValidation::analyze(const Event &e,
-                                             const EventSetup &c) {
-
+void EcalPreshowerRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
   const ESRecHitCollection *ESRecHit = nullptr;
   Handle<ESRecHitCollection> EcalRecHitES;
   e.getByToken(ESrechitCollection_token_, EcalRecHitES);
@@ -165,8 +152,7 @@ void EcalPreshowerRecHitsValidation::analyze(const Event &e,
   float ene_zm2nd = 0.;
 
   // ES
-  for (ESRecHitCollection::const_iterator recHit = ESRecHit->begin();
-       recHit != ESRecHit->end(); ++recHit) {
+  for (ESRecHitCollection::const_iterator recHit = ESRecHit->begin(); recHit != ESRecHit->end(); ++recHit) {
     ESDetId ESid = ESDetId(recHit->id());
 
     int zside = ESid.zside();
@@ -228,16 +214,15 @@ void EcalPreshowerRecHitsValidation::analyze(const Event &e,
       }
     }
 
-  } // loop over the ES RecHitCollection
+  }  // loop over the ES RecHitCollection
 
   // EE
   double zpEE = 0.;
   double zmEE = 0.;
   if (!skipEE) {
-
-    for (EcalUncalibratedRecHitCollection::const_iterator uncalibRecHit =
-             EEUncalibRecHit->begin();
-         uncalibRecHit != EEUncalibRecHit->end(); ++uncalibRecHit) {
+    for (EcalUncalibratedRecHitCollection::const_iterator uncalibRecHit = EEUncalibRecHit->begin();
+         uncalibRecHit != EEUncalibRecHit->end();
+         ++uncalibRecHit) {
       EEDetId EEid = EEDetId(uncalibRecHit->id());
       int mySide = EEid.zside();
 

--- a/Validation/EcalRecHits/src/EcalRecHitsValidation.cc
+++ b/Validation/EcalRecHits/src/EcalRecHitsValidation.cc
@@ -21,47 +21,36 @@ using namespace edm;
 using namespace std;
 
 EcalRecHitsValidation::EcalRecHitsValidation(const ParameterSet &ps) {
-
   // ----------------------
   HepMCLabel = ps.getParameter<std::string>("moduleLabelMC");
   hitsProducer_ = ps.getParameter<std::string>("hitsProducer");
   EBrechitCollection_ = ps.getParameter<edm::InputTag>("EBrechitCollection");
   EErechitCollection_ = ps.getParameter<edm::InputTag>("EErechitCollection");
   ESrechitCollection_ = ps.getParameter<edm::InputTag>("ESrechitCollection");
-  EBuncalibrechitCollection_ =
-      ps.getParameter<edm::InputTag>("EBuncalibrechitCollection");
-  EEuncalibrechitCollection_ =
-      ps.getParameter<edm::InputTag>("EEuncalibrechitCollection");
+  EBuncalibrechitCollection_ = ps.getParameter<edm::InputTag>("EBuncalibrechitCollection");
+  EEuncalibrechitCollection_ = ps.getParameter<edm::InputTag>("EEuncalibrechitCollection");
   // fix for consumes
-  HepMCLabel_Token_ =
-      consumes<HepMCProduct>(ps.getParameter<std::string>("moduleLabelMC"));
-  EBrechitCollection_Token_ = consumes<EBRecHitCollection>(
-      ps.getParameter<edm::InputTag>("EBrechitCollection"));
-  EErechitCollection_Token_ = consumes<EERecHitCollection>(
-      ps.getParameter<edm::InputTag>("EErechitCollection"));
-  ESrechitCollection_Token_ = consumes<ESRecHitCollection>(
-      ps.getParameter<edm::InputTag>("ESrechitCollection"));
-  EBuncalibrechitCollection_Token_ = consumes<EBUncalibratedRecHitCollection>(
-      ps.getParameter<edm::InputTag>("EBuncalibrechitCollection"));
-  EEuncalibrechitCollection_Token_ = consumes<EEUncalibratedRecHitCollection>(
-      ps.getParameter<edm::InputTag>("EEuncalibrechitCollection"));
-  EBHits_Token_ = consumes<CrossingFrame<PCaloHit>>(edm::InputTag(
-      std::string("mix"), ps.getParameter<std::string>("hitsProducer") +
-                              std::string("EcalHitsEB")));
-  EEHits_Token_ = consumes<CrossingFrame<PCaloHit>>(edm::InputTag(
-      std::string("mix"), ps.getParameter<std::string>("hitsProducer") +
-                              std::string("EcalHitsEE")));
-  ESHits_Token_ = consumes<CrossingFrame<PCaloHit>>(edm::InputTag(
-      std::string("mix"), ps.getParameter<std::string>("hitsProducer") +
-                              std::string("EcalHitsES")));
+  HepMCLabel_Token_ = consumes<HepMCProduct>(ps.getParameter<std::string>("moduleLabelMC"));
+  EBrechitCollection_Token_ = consumes<EBRecHitCollection>(ps.getParameter<edm::InputTag>("EBrechitCollection"));
+  EErechitCollection_Token_ = consumes<EERecHitCollection>(ps.getParameter<edm::InputTag>("EErechitCollection"));
+  ESrechitCollection_Token_ = consumes<ESRecHitCollection>(ps.getParameter<edm::InputTag>("ESrechitCollection"));
+  EBuncalibrechitCollection_Token_ =
+      consumes<EBUncalibratedRecHitCollection>(ps.getParameter<edm::InputTag>("EBuncalibrechitCollection"));
+  EEuncalibrechitCollection_Token_ =
+      consumes<EEUncalibratedRecHitCollection>(ps.getParameter<edm::InputTag>("EEuncalibrechitCollection"));
+  EBHits_Token_ = consumes<CrossingFrame<PCaloHit>>(
+      edm::InputTag(std::string("mix"), ps.getParameter<std::string>("hitsProducer") + std::string("EcalHitsEB")));
+  EEHits_Token_ = consumes<CrossingFrame<PCaloHit>>(
+      edm::InputTag(std::string("mix"), ps.getParameter<std::string>("hitsProducer") + std::string("EcalHitsEE")));
+  ESHits_Token_ = consumes<CrossingFrame<PCaloHit>>(
+      edm::InputTag(std::string("mix"), ps.getParameter<std::string>("hitsProducer") + std::string("EcalHitsES")));
 
   // ----------------------
   // DQM ROOT output
   outputFile_ = ps.getUntrackedParameter<string>("outputFile", "");
 
   if (!outputFile_.empty()) {
-    LogInfo("OutputInfo") << " Ecal RecHits Task histograms will be saved to '"
-                          << outputFile_.c_str() << "'";
+    LogInfo("OutputInfo") << " Ecal RecHits Task histograms will be saved to '" << outputFile_.c_str() << "'";
   } else {
     LogInfo("OutputInfo") << " Ecal RecHits Task histograms will NOT be saved";
   }
@@ -126,10 +115,7 @@ EcalRecHitsValidation::EcalRecHitsValidation(const ParameterSet &ps) {
 
 EcalRecHitsValidation::~EcalRecHitsValidation() {}
 
-void EcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ibooker,
-                                           edm::Run const &,
-                                           edm::EventSetup const &) {
-
+void EcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const &) {
   std::string histo;
 
   ibooker.setCurrentFolder("EcalRecHitsV/EcalRecHitsTask");
@@ -144,71 +130,55 @@ void EcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ibooker,
   meGunPhi_ = ibooker.book1D(histo.c_str(), histo.c_str(), 360, 0., 360.);
 
   histo = "EcalRecHitsTask Barrel RecSimHit Ratio";
-  meEBRecHitSimHitRatio_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+  meEBRecHitSimHitRatio_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
 
   histo = "EcalRecHitsTask Endcap RecSimHit Ratio";
-  meEERecHitSimHitRatio_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+  meEERecHitSimHitRatio_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
 
   histo = "EcalRecHitsTask Preshower RecSimHit Ratio";
-  meESRecHitSimHitRatio_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+  meESRecHitSimHitRatio_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
 
   histo = "EcalRecHitsTask Barrel RecSimHit Ratio gt 3p5 GeV";
-  meEBRecHitSimHitRatioGt35_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
+  meEBRecHitSimHitRatioGt35_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
 
   histo = "EcalRecHitsTask Endcap RecSimHit Ratio gt 3p5 GeV";
-  meEERecHitSimHitRatioGt35_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
+  meEERecHitSimHitRatioGt35_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
 
   histo = "EcalRecHitsTask Barrel Unc RecSimHit Ratio";
-  meEBUnRecHitSimHitRatio_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+  meEBUnRecHitSimHitRatio_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
 
   histo = "EcalRecHitsTask Endcap Unc RecSimHit Ratio";
-  meEEUnRecHitSimHitRatio_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+  meEEUnRecHitSimHitRatio_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
 
   histo = "EcalRecHitsTask Barrel RecSimHit Ratio Channel Status=10 11";
-  meEBRecHitSimHitRatio1011_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+  meEBRecHitSimHitRatio1011_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
 
   histo = "EcalRecHitsTask Endcap RecSimHit Ratio Channel Status=10 11";
-  meEERecHitSimHitRatio1011_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+  meEERecHitSimHitRatio1011_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
 
   histo = "EcalRecHitsTask Barrel RecSimHit Ratio Channel Status=12";
-  meEBRecHitSimHitRatio12_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+  meEBRecHitSimHitRatio12_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
 
   histo = "EcalRecHitsTask Endcap RecSimHit Ratio Channel Status=12";
-  meEERecHitSimHitRatio12_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+  meEERecHitSimHitRatio12_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
 
   histo = "EcalRecHitsTask Barrel RecSimHit Ratio Channel Status=13";
-  meEBRecHitSimHitRatio13_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+  meEBRecHitSimHitRatio13_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
 
   histo = "EcalRecHitsTask Endcap RecSimHit Ratio Channel Status=13";
-  meEERecHitSimHitRatio13_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+  meEERecHitSimHitRatio13_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
 
   histo = "EcalRecHitsTask Barrel Unc RecSimHit Ratio gt 3p5 GeV";
-  meEBUnRecHitSimHitRatioGt35_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
+  meEBUnRecHitSimHitRatioGt35_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
 
   histo = "EcalRecHitsTask Endcap Unc RecSimHit Ratio gt 3p5 GeV";
-  meEEUnRecHitSimHitRatioGt35_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
+  meEEUnRecHitSimHitRatioGt35_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
 
   histo = "EcalRecHitsTask Barrel Rec E5x5";
   meEBe5x5_ = ibooker.book1D(histo.c_str(), histo.c_str(), 4000, 0., 400.);
 
   histo = "EcalRecHitsTask Barrel Rec E5x5 over Sim E5x5";
-  meEBe5x5OverSimHits_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
+  meEBe5x5OverSimHits_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
 
   histo = "EcalRecHitsTask Barrel Rec E5x5 over gun energy";
   meEBe5x5OverGun_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
@@ -217,95 +187,96 @@ void EcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ibooker,
   meEEe5x5_ = ibooker.book1D(histo.c_str(), histo.c_str(), 4000, 0., 400.);
 
   histo = "EcalRecHitsTask Endcap Rec E5x5 over Sim E5x5";
-  meEEe5x5OverSimHits_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
+  meEEe5x5OverSimHits_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
 
   histo = "EcalRecHitsTask Endcap Rec E5x5 over gun energy";
   meEEe5x5OverGun_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
 
   meEBRecHitLog10Energy_ =
-      ibooker.book1D("EcalRecHitsTask Barrel Log10 Energy",
-                     "EcalRecHitsTask Barrel Log10 Energy", 90, -5., 4.);
+      ibooker.book1D("EcalRecHitsTask Barrel Log10 Energy", "EcalRecHitsTask Barrel Log10 Energy", 90, -5., 4.);
   meEERecHitLog10Energy_ =
-      ibooker.book1D("EcalRecHitsTask Endcap Log10 Energy",
-                     "EcalRecHitsTask Endcap Log10 Energy", 90, -5., 4.);
+      ibooker.book1D("EcalRecHitsTask Endcap Log10 Energy", "EcalRecHitsTask Endcap Log10 Energy", 90, -5., 4.);
   meESRecHitLog10Energy_ =
-      ibooker.book1D("EcalRecHitsTask Preshower Log10 Energy",
-                     "EcalRecHitsTask Preshower Log10 Energy", 90, -5., 4.);
-  meEBRecHitLog10EnergyContr_ =
-      ibooker.bookProfile("EcalRecHits Barrel Log10En vs Hit Contribution",
-                          "EcalRecHits Barrel Log10En vs Hit Contribution", 90,
-                          -5., 4., 100, 0., 1.);
-  meEERecHitLog10EnergyContr_ =
-      ibooker.bookProfile("EcalRecHits Endcap Log10En vs Hit Contribution",
-                          "EcalRecHits Endcap Log10En vs Hit Contribution", 90,
-                          -5., 4., 100, 0., 1.);
-  meESRecHitLog10EnergyContr_ =
-      ibooker.bookProfile("EcalRecHits Preshower Log10En vs Hit Contribution",
-                          "EcalRecHits Preshower Log10En vs Hit Contribution",
-                          90, -5., 4., 100, 0., 1.);
-  meEBRecHitLog10Energy5x5Contr_ =
-      ibooker.bookProfile("EcalRecHits Barrel Log10En5x5 vs Hit Contribution",
-                          "EcalRecHits Barrel Log10En5x5 vs Hit Contribution",
-                          90, -5., 4., 100, 0., 1.);
-  meEERecHitLog10Energy5x5Contr_ =
-      ibooker.bookProfile("EcalRecHits Endcap Log10En5x5 vs Hit Contribution",
-                          "EcalRecHits Endcap Log10En5x5 vs Hit Contribution",
-                          90, -5., 4., 100, 0., 1.);
+      ibooker.book1D("EcalRecHitsTask Preshower Log10 Energy", "EcalRecHitsTask Preshower Log10 Energy", 90, -5., 4.);
+  meEBRecHitLog10EnergyContr_ = ibooker.bookProfile("EcalRecHits Barrel Log10En vs Hit Contribution",
+                                                    "EcalRecHits Barrel Log10En vs Hit Contribution",
+                                                    90,
+                                                    -5.,
+                                                    4.,
+                                                    100,
+                                                    0.,
+                                                    1.);
+  meEERecHitLog10EnergyContr_ = ibooker.bookProfile("EcalRecHits Endcap Log10En vs Hit Contribution",
+                                                    "EcalRecHits Endcap Log10En vs Hit Contribution",
+                                                    90,
+                                                    -5.,
+                                                    4.,
+                                                    100,
+                                                    0.,
+                                                    1.);
+  meESRecHitLog10EnergyContr_ = ibooker.bookProfile("EcalRecHits Preshower Log10En vs Hit Contribution",
+                                                    "EcalRecHits Preshower Log10En vs Hit Contribution",
+                                                    90,
+                                                    -5.,
+                                                    4.,
+                                                    100,
+                                                    0.,
+                                                    1.);
+  meEBRecHitLog10Energy5x5Contr_ = ibooker.bookProfile("EcalRecHits Barrel Log10En5x5 vs Hit Contribution",
+                                                       "EcalRecHits Barrel Log10En5x5 vs Hit Contribution",
+                                                       90,
+                                                       -5.,
+                                                       4.,
+                                                       100,
+                                                       0.,
+                                                       1.);
+  meEERecHitLog10Energy5x5Contr_ = ibooker.bookProfile("EcalRecHits Endcap Log10En5x5 vs Hit Contribution",
+                                                       "EcalRecHits Endcap Log10En5x5 vs Hit Contribution",
+                                                       90,
+                                                       -5.,
+                                                       4.,
+                                                       100,
+                                                       0.,
+                                                       1.);
 
   histo = "EB Occupancy Flag=5 6";
-  meEBRecHitsOccupancyFlag5_6_ =
-      ibooker.book2D(histo, histo, 170, -85., 85., 360, 0., 360.);
+  meEBRecHitsOccupancyFlag5_6_ = ibooker.book2D(histo, histo, 170, -85., 85., 360, 0., 360.);
   histo = "EB Occupancy Flag=8 9";
-  meEBRecHitsOccupancyFlag8_9_ =
-      ibooker.book2D(histo, histo, 170, -85., 85., 360, 0., 360.);
+  meEBRecHitsOccupancyFlag8_9_ = ibooker.book2D(histo, histo, 170, -85., 85., 360, 0., 360.);
 
   histo = "EE+ Occupancy Flag=5 6";
-  meEERecHitsOccupancyPlusFlag5_6_ =
-      ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
+  meEERecHitsOccupancyPlusFlag5_6_ = ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
   histo = "EE- Occupancy Flag=5 6";
-  meEERecHitsOccupancyMinusFlag5_6_ =
-      ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
+  meEERecHitsOccupancyMinusFlag5_6_ = ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
   histo = "EE+ Occupancy Flag=8 9";
-  meEERecHitsOccupancyPlusFlag8_9_ =
-      ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
+  meEERecHitsOccupancyPlusFlag8_9_ = ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
   histo = "EE- Occupancy Flag=8 9";
-  meEERecHitsOccupancyMinusFlag8_9_ =
-      ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
+  meEERecHitsOccupancyMinusFlag8_9_ = ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
 
   histo = "EcalRecHitsTask Barrel Reco Flags";
   meEBRecHitFlags_ = ibooker.book1D(histo.c_str(), histo.c_str(), 10, 0., 10.);
   histo = "EcalRecHitsTask Endcap Reco Flags";
   meEERecHitFlags_ = ibooker.book1D(histo.c_str(), histo.c_str(), 10, 0., 10.);
   histo = "EcalRecHitsTask Barrel RecSimHit Ratio vs SimHit Flag=5 6";
-  meEBRecHitSimHitvsSimHitFlag5_6_ =
-      ibooker.book2D(histo.c_str(), histo.c_str(), 80, 0., 2., 4000, 0., 400.);
+  meEBRecHitSimHitvsSimHitFlag5_6_ = ibooker.book2D(histo.c_str(), histo.c_str(), 80, 0., 2., 4000, 0., 400.);
   histo = "EcalRecHitsTask Endcap RecSimHit Ratio vs SimHit Flag=5 6";
-  meEERecHitSimHitvsSimHitFlag5_6_ =
-      ibooker.book2D(histo.c_str(), histo.c_str(), 80, 0., 2., 4000, 0., 400.);
+  meEERecHitSimHitvsSimHitFlag5_6_ = ibooker.book2D(histo.c_str(), histo.c_str(), 80, 0., 2., 4000, 0., 400.);
   histo = "EcalRecHitsTask Barrel RecSimHit Ratio Flag=6";
-  meEBRecHitSimHitFlag6_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+  meEBRecHitSimHitFlag6_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
   histo = "EcalRecHitsTask Endcap RecSimHit Ratio Flag=6";
-  meEERecHitSimHitFlag6_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+  meEERecHitSimHitFlag6_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
   histo = "EcalRecHitsTask Barrel RecSimHit Ratio Flag=7";
-  meEBRecHitSimHitFlag7_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+  meEBRecHitSimHitFlag7_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
   histo = "EcalRecHitsTask Endcap RecSimHit Ratio Flag=7";
-  meEERecHitSimHitFlag7_ =
-      ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+  meEERecHitSimHitFlag7_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
   histo = "EcalRecHitsTask Barrel 5x5 RecSimHit Ratio vs SimHit Flag=8";
-  meEB5x5RecHitSimHitvsSimHitFlag8_ =
-      ibooker.book2D(histo.c_str(), histo.c_str(), 80, 0., 2., 4000, 0., 400.);
+  meEB5x5RecHitSimHitvsSimHitFlag8_ = ibooker.book2D(histo.c_str(), histo.c_str(), 80, 0., 2., 4000, 0., 400.);
 }
 
 void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
-
   // Temporary stuff
 
-  LogInfo("EcalRecHitsTask, EventInfo: ")
-      << " Run = " << e.id().run() << " Event = " << e.id().event();
+  LogInfo("EcalRecHitsTask, EventInfo: ") << " Run = " << e.id().run() << " Event = " << e.id().event();
 
   // ADC -> GeV Scale
   edm::ESHandle<EcalADCToGeVConstant> pAgc;
@@ -375,9 +346,9 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
   // gun
   double eGun = 0.;
   if (!skipMC) {
-    for (HepMC::GenEvent::particle_const_iterator p =
-             MCEvt->GetEvent()->particles_begin();
-         p != MCEvt->GetEvent()->particles_end(); ++p) {
+    for (HepMC::GenEvent::particle_const_iterator p = MCEvt->GetEvent()->particles_begin();
+         p != MCEvt->GetEvent()->particles_end();
+         ++p) {
       double htheta = (*p)->momentum().theta();
       double heta = -99999.;
       if (tan(htheta * 0.5) > 0) {
@@ -387,8 +358,7 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
       hphi = (hphi >= 0) ? hphi : hphi + 2 * M_PI;
       hphi = hphi / M_PI * 180.;
 
-      LogDebug("EventInfo") << "EcalRecHitsTask: Particle gun type form MC = "
-                            << abs((*p)->pdg_id()) << "\n"
+      LogDebug("EventInfo") << "EcalRecHitsTask: Particle gun type form MC = " << abs((*p)->pdg_id()) << "\n"
                             << "Energy = " << (*p)->momentum().e() << "\n"
                             << "Eta = " << heta << "\n"
                             << "Phi = " << hphi;
@@ -409,7 +379,6 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
   // BARREL
 
   if (!skipBarrel) {
-
     // 1) loop over simHits
     e.getByToken(EBHits_Token_, crossingFrame);
     const MixCollection<PCaloHit> barrelHits(crossingFrame.product());
@@ -428,19 +397,18 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
     for (auto const &iHit : barrelHits) {
       EBDetId ebid = EBDetId(iHit.id());
 
-      LogDebug("SimHitInfo, barrel")
-          << "CaloHit " << iHit.getName() << " DetID = " << iHit.id() << "\n"
-          << "Energy = " << iHit.energy() << " Time = " << iHit.time() << "\n"
-          << "EBDetId = " << ebid.ieta() << " " << ebid.iphi();
+      LogDebug("SimHitInfo, barrel") << "CaloHit " << iHit.getName() << " DetID = " << iHit.id() << "\n"
+                                     << "Energy = " << iHit.energy() << " Time = " << iHit.time() << "\n"
+                                     << "EBDetId = " << ebid.ieta() << " " << ebid.iphi();
 
       uint32_t crystid = ebid.rawId();
       ebSimMap[crystid] += iHit.energy();
     }
 
     // 2) loop over RecHits
-    for (EcalUncalibratedRecHitCollection::const_iterator uncalibRecHit =
-             EBUncalibRecHit->begin();
-         uncalibRecHit != EBUncalibRecHit->end(); ++uncalibRecHit) {
+    for (EcalUncalibratedRecHitCollection::const_iterator uncalibRecHit = EBUncalibRecHit->begin();
+         uncalibRecHit != EBUncalibRecHit->end();
+         ++uncalibRecHit) {
       EBDetId EBid = EBDetId(uncalibRecHit->id());
 
       // Find corresponding recHit
@@ -466,20 +434,17 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
           meEBUnRecHitSimHitRatio_->Fill(uncEnergy / ebSimMap[EBid.rawId()]);
         }
         if (meEBUnRecHitSimHitRatioGt35_ && (myRecHit->energy() > 3.5)) {
-          meEBUnRecHitSimHitRatioGt35_->Fill(uncEnergy /
-                                             ebSimMap[EBid.rawId()]);
+          meEBUnRecHitSimHitRatioGt35_->Fill(uncEnergy / ebSimMap[EBid.rawId()]);
         }
       }
 
       if (myRecHit != EBRecHit->end()) {
         if (ebSimMap[EBid.rawId()] != 0.) {
           if (meEBRecHitSimHitRatio_) {
-            meEBRecHitSimHitRatio_->Fill(myRecHit->energy() /
-                                         ebSimMap[EBid.rawId()]);
+            meEBRecHitSimHitRatio_->Fill(myRecHit->energy() / ebSimMap[EBid.rawId()]);
           }
           if (meEBRecHitSimHitRatioGt35_ && (myRecHit->energy() > 3.5)) {
-            meEBRecHitSimHitRatioGt35_->Fill(myRecHit->energy() /
-                                             ebSimMap[EBid.rawId()]);
+            meEBRecHitSimHitRatioGt35_->Fill(myRecHit->energy() / ebSimMap[EBid.rawId()]);
           }
           uint16_t sc = 0;
           edm::ESHandle<EcalChannelStatus> pEcs;
@@ -496,12 +461,10 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
           }
 
           if (meEBRecHitSimHitRatio1011_ != nullptr && (sc == 10 || sc == 11)) {
-            meEBRecHitSimHitRatio1011_->Fill(myRecHit->energy() /
-                                             ebSimMap[EBid.rawId()]);
+            meEBRecHitSimHitRatio1011_->Fill(myRecHit->energy() / ebSimMap[EBid.rawId()]);
           }
           if (meEBRecHitSimHitRatio12_ != nullptr && sc == 12) {
-            meEBRecHitSimHitRatio12_->Fill(myRecHit->energy() /
-                                           ebSimMap[EBid.rawId()]);
+            meEBRecHitSimHitRatio12_->Fill(myRecHit->energy() / ebSimMap[EBid.rawId()]);
           }
 
           edm::ESHandle<EcalTrigTowerConstituentsMap> pttMap;
@@ -513,52 +476,38 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
           if (ttMap != nullptr) {
             EcalTrigTowerDetId ttDetId = EBid.tower();
             std::vector<DetId> vid = ttMap->constituentsOf(ttDetId);
-            for (std::vector<DetId>::const_iterator dit = vid.begin();
-                 dit != vid.end(); dit++) {
+            for (std::vector<DetId>::const_iterator dit = vid.begin(); dit != vid.end(); dit++) {
               EBDetId ttEBid = EBDetId(*dit);
               ttSimEnergy += ebSimMap[ttEBid.rawId()];
             }
             if (!vid.empty())
               ttSimEnergy = ttSimEnergy / vid.size();
           }
-          if (meEBRecHitSimHitRatio13_ != nullptr && sc == 13 &&
-              ttSimEnergy != 0)
+          if (meEBRecHitSimHitRatio13_ != nullptr && sc == 13 && ttSimEnergy != 0)
             meEBRecHitSimHitRatio13_->Fill(myRecHit->energy() / ttSimEnergy);
 
           int flag = myRecHit->recoFlag();
           if (meEBRecHitFlags_ != nullptr)
             meEBRecHitFlags_->Fill(flag);
           if (meEBRecHitSimHitvsSimHitFlag5_6_ &&
-              (flag == EcalRecHit::kSaturated ||
-               flag == EcalRecHit::kLeadingEdgeRecovered))
-            meEBRecHitSimHitvsSimHitFlag5_6_->Fill(myRecHit->energy() /
-                                                       ebSimMap[EBid.rawId()],
-                                                   ebSimMap[EBid.rawId()]);
-          if (meEBRecHitSimHitFlag6_ &&
-              (flag == EcalRecHit::kLeadingEdgeRecovered))
-            meEBRecHitSimHitFlag6_->Fill(myRecHit->energy() /
-                                         ebSimMap[EBid.rawId()]);
-          if (meEBRecHitSimHitFlag7_ &&
-              (flag == EcalRecHit::kNeighboursRecovered))
-            meEBRecHitSimHitFlag6_->Fill(myRecHit->energy() /
-                                         ebSimMap[EBid.rawId()]);
-          if (meEB5x5RecHitSimHitvsSimHitFlag8_ &&
-              (flag == EcalRecHit::kTowerRecovered) && ttSimEnergy != 0)
-            meEB5x5RecHitSimHitvsSimHitFlag8_->Fill(
-                myRecHit->energy() / ttSimEnergy, ttSimEnergy);
+              (flag == EcalRecHit::kSaturated || flag == EcalRecHit::kLeadingEdgeRecovered))
+            meEBRecHitSimHitvsSimHitFlag5_6_->Fill(myRecHit->energy() / ebSimMap[EBid.rawId()], ebSimMap[EBid.rawId()]);
+          if (meEBRecHitSimHitFlag6_ && (flag == EcalRecHit::kLeadingEdgeRecovered))
+            meEBRecHitSimHitFlag6_->Fill(myRecHit->energy() / ebSimMap[EBid.rawId()]);
+          if (meEBRecHitSimHitFlag7_ && (flag == EcalRecHit::kNeighboursRecovered))
+            meEBRecHitSimHitFlag6_->Fill(myRecHit->energy() / ebSimMap[EBid.rawId()]);
+          if (meEB5x5RecHitSimHitvsSimHitFlag8_ && (flag == EcalRecHit::kTowerRecovered) && ttSimEnergy != 0)
+            meEB5x5RecHitSimHitvsSimHitFlag8_->Fill(myRecHit->energy() / ttSimEnergy, ttSimEnergy);
 
           if (meEBRecHitsOccupancyFlag5_6_ &&
-              ((flag == EcalRecHit::kSaturated) ||
-               (flag == EcalRecHit::kLeadingEdgeRecovered)))
+              ((flag == EcalRecHit::kSaturated) || (flag == EcalRecHit::kLeadingEdgeRecovered)))
             meEBRecHitsOccupancyFlag5_6_->Fill(EBid.ieta(), EBid.iphi());
-          if (meEBRecHitsOccupancyFlag8_9_ &&
-              ((flag == EcalRecHit::kTowerRecovered) ||
-               (flag == EcalRecHit::kDead)))
+          if (meEBRecHitsOccupancyFlag8_9_ && ((flag == EcalRecHit::kTowerRecovered) || (flag == EcalRecHit::kDead)))
             meEBRecHitsOccupancyFlag8_9_->Fill(EBid.ieta(), EBid.iphi());
         }
       } else
         continue;
-    } // loop over the UncalibratedRecHitCollection
+    }  // loop over the UncalibratedRecHitCollection
 
     // RecHits matrix
     uint32_t ebcenterid = getUnitWithMaxEnergy(ebRecMap);
@@ -588,15 +537,13 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
 
     if (meEBRecHitLog10EnergyContr_ && ebtotal != 0) {
       for (int i = 0; i < ebcSize; i++) {
-        meEBRecHitLog10EnergyContr_->Fill(-5. + (float(i) + 0.5) / 10.,
-                                          ebcontr[i] / ebtotal);
+        meEBRecHitLog10EnergyContr_->Fill(-5. + (float(i) + 0.5) / 10., ebcontr[i] / ebtotal);
       }
     }
 
     if (meEBRecHitLog10Energy5x5Contr_ && e5x5rec != 0) {
       for (int i = 0; i < ebcSize; i++) {
-        meEBRecHitLog10Energy5x5Contr_->Fill(-5. + (float(i) + 0.5) / 10.,
-                                             ebcontr25[i] / e5x5rec);
+        meEBRecHitLog10Energy5x5Contr_->Fill(-5. + (float(i) + 0.5) / 10., ebcontr25[i] / e5x5rec);
       }
     }
   }
@@ -605,7 +552,6 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
   // ENDCAP
 
   if (!skipEndcap) {
-
     // 1) loop over simHits
     e.getByToken(EEHits_Token_, crossingFrame);
     const MixCollection<PCaloHit> endcapHits(crossingFrame.product());
@@ -624,20 +570,18 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
     for (auto const &iHit : endcapHits) {
       EEDetId eeid(iHit.id());
 
-      LogDebug("Endcap, HitInfo")
-          << " CaloHit " << iHit.getName() << " DetID = " << iHit.id() << "\n"
-          << "Energy = " << iHit.energy() << " Time = " << iHit.time() << "\n"
-          << "EEDetId side " << eeid.zside() << " = " << eeid.ix() << " "
-          << eeid.iy();
+      LogDebug("Endcap, HitInfo") << " CaloHit " << iHit.getName() << " DetID = " << iHit.id() << "\n"
+                                  << "Energy = " << iHit.energy() << " Time = " << iHit.time() << "\n"
+                                  << "EEDetId side " << eeid.zside() << " = " << eeid.ix() << " " << eeid.iy();
 
       uint32_t crystid = eeid.rawId();
       eeSimMap[crystid] += iHit.energy();
     }
 
     // 2) loop over RecHits
-    for (EcalUncalibratedRecHitCollection::const_iterator uncalibRecHit =
-             EEUncalibRecHit->begin();
-         uncalibRecHit != EEUncalibRecHit->end(); ++uncalibRecHit) {
+    for (EcalUncalibratedRecHitCollection::const_iterator uncalibRecHit = EEUncalibRecHit->begin();
+         uncalibRecHit != EEUncalibRecHit->end();
+         ++uncalibRecHit) {
       EEDetId EEid = EEDetId(uncalibRecHit->id());
 
       // Find corresponding recHit
@@ -663,20 +607,17 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
           meEEUnRecHitSimHitRatio_->Fill(uncEnergy / eeSimMap[EEid.rawId()]);
         }
         if (meEEUnRecHitSimHitRatioGt35_ && (myRecHit->energy() > 3.5)) {
-          meEEUnRecHitSimHitRatioGt35_->Fill(uncEnergy /
-                                             eeSimMap[EEid.rawId()]);
+          meEEUnRecHitSimHitRatioGt35_->Fill(uncEnergy / eeSimMap[EEid.rawId()]);
         }
       }
 
       if (myRecHit != EERecHit->end()) {
         if (eeSimMap[EEid.rawId()] != 0.) {
           if (meEERecHitSimHitRatio_) {
-            meEERecHitSimHitRatio_->Fill(myRecHit->energy() /
-                                         eeSimMap[EEid.rawId()]);
+            meEERecHitSimHitRatio_->Fill(myRecHit->energy() / eeSimMap[EEid.rawId()]);
           }
           if (meEERecHitSimHitRatioGt35_ && (myRecHit->energy() > 3.5)) {
-            meEERecHitSimHitRatioGt35_->Fill(myRecHit->energy() /
-                                             eeSimMap[EEid.rawId()]);
+            meEERecHitSimHitRatioGt35_->Fill(myRecHit->energy() / eeSimMap[EEid.rawId()]);
           }
 
           edm::ESHandle<EcalChannelStatus> pEcs;
@@ -690,18 +631,14 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
             if (csmi != ecs->end())
               csc = *csmi;
             uint16_t sc = csc.getStatusCode();
-            if (meEERecHitSimHitRatio1011_ != nullptr &&
-                (sc == 10 || sc == 11)) {
-              meEERecHitSimHitRatio1011_->Fill(myRecHit->energy() /
-                                               eeSimMap[EEid.rawId()]);
+            if (meEERecHitSimHitRatio1011_ != nullptr && (sc == 10 || sc == 11)) {
+              meEERecHitSimHitRatio1011_->Fill(myRecHit->energy() / eeSimMap[EEid.rawId()]);
             }
             if (meEERecHitSimHitRatio12_ != nullptr && sc == 12) {
-              meEERecHitSimHitRatio12_->Fill(myRecHit->energy() /
-                                             eeSimMap[EEid.rawId()]);
+              meEERecHitSimHitRatio12_->Fill(myRecHit->energy() / eeSimMap[EEid.rawId()]);
             }
             if (meEERecHitSimHitRatio13_ != nullptr && sc == 13) {
-              meEERecHitSimHitRatio13_->Fill(myRecHit->energy() /
-                                             eeSimMap[EEid.rawId()]);
+              meEERecHitSimHitRatio13_->Fill(myRecHit->energy() / eeSimMap[EEid.rawId()]);
             }
           }
 
@@ -709,44 +646,33 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
           if (meEERecHitFlags_ != nullptr)
             meEERecHitFlags_->Fill(flag);
           if (meEERecHitSimHitvsSimHitFlag5_6_ &&
-              (flag == EcalRecHit::kSaturated ||
-               flag == EcalRecHit::kLeadingEdgeRecovered))
-            meEERecHitSimHitvsSimHitFlag5_6_->Fill(myRecHit->energy() /
-                                                       eeSimMap[EEid.rawId()],
-                                                   eeSimMap[EEid.rawId()]);
-          if (meEERecHitSimHitFlag6_ &&
-              (flag == EcalRecHit::kLeadingEdgeRecovered))
-            meEERecHitSimHitFlag6_->Fill(myRecHit->energy() /
-                                         eeSimMap[EEid.rawId()]);
-          if (meEERecHitSimHitFlag7_ &&
-              (flag == EcalRecHit::kNeighboursRecovered))
-            meEERecHitSimHitFlag6_->Fill(myRecHit->energy() /
-                                         eeSimMap[EEid.rawId()]);
+              (flag == EcalRecHit::kSaturated || flag == EcalRecHit::kLeadingEdgeRecovered))
+            meEERecHitSimHitvsSimHitFlag5_6_->Fill(myRecHit->energy() / eeSimMap[EEid.rawId()], eeSimMap[EEid.rawId()]);
+          if (meEERecHitSimHitFlag6_ && (flag == EcalRecHit::kLeadingEdgeRecovered))
+            meEERecHitSimHitFlag6_->Fill(myRecHit->energy() / eeSimMap[EEid.rawId()]);
+          if (meEERecHitSimHitFlag7_ && (flag == EcalRecHit::kNeighboursRecovered))
+            meEERecHitSimHitFlag6_->Fill(myRecHit->energy() / eeSimMap[EEid.rawId()]);
 
           if (EEid.zside() > 0) {
             if (meEERecHitsOccupancyPlusFlag5_6_ &&
-                ((flag == EcalRecHit::kSaturated) ||
-                 (flag == EcalRecHit::kLeadingEdgeRecovered)))
+                ((flag == EcalRecHit::kSaturated) || (flag == EcalRecHit::kLeadingEdgeRecovered)))
               meEERecHitsOccupancyPlusFlag5_6_->Fill(EEid.ix(), EEid.iy());
             if (meEERecHitsOccupancyPlusFlag8_9_ &&
-                ((flag == EcalRecHit::kTowerRecovered) ||
-                 (flag == EcalRecHit::kDead)))
+                ((flag == EcalRecHit::kTowerRecovered) || (flag == EcalRecHit::kDead)))
               meEERecHitsOccupancyPlusFlag8_9_->Fill(EEid.ix(), EEid.iy());
           }
           if (EEid.zside() < 0) {
             if (meEERecHitsOccupancyMinusFlag5_6_ &&
-                ((flag == EcalRecHit::kSaturated) ||
-                 (flag == EcalRecHit::kLeadingEdgeRecovered)))
+                ((flag == EcalRecHit::kSaturated) || (flag == EcalRecHit::kLeadingEdgeRecovered)))
               meEERecHitsOccupancyMinusFlag5_6_->Fill(EEid.ix(), EEid.iy());
             if (meEERecHitsOccupancyMinusFlag8_9_ &&
-                ((flag == EcalRecHit::kTowerRecovered) ||
-                 (flag == EcalRecHit::kDead)))
+                ((flag == EcalRecHit::kTowerRecovered) || (flag == EcalRecHit::kDead)))
               meEERecHitsOccupancyMinusFlag8_9_->Fill(EEid.ix(), EEid.iy());
           }
         }
       } else
         continue;
-    } // loop over the UncalibratedechitCollection
+    }  // loop over the UncalibratedechitCollection
 
     // RecHits matrix
     uint32_t eecenterid = getUnitWithMaxEnergy(eeRecMap);
@@ -776,15 +702,13 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
 
     if (meEERecHitLog10EnergyContr_ && eetotal != 0) {
       for (int i = 0; i < eecSize; i++) {
-        meEERecHitLog10EnergyContr_->Fill(-5. + (float(i) + 0.5) / 10.,
-                                          eecontr[i] / eetotal);
+        meEERecHitLog10EnergyContr_->Fill(-5. + (float(i) + 0.5) / 10., eecontr[i] / eetotal);
       }
     }
 
     if (meEERecHitLog10Energy5x5Contr_ && e5x5rec != 0) {
       for (int i = 0; i < eecSize; i++) {
-        meEERecHitLog10Energy5x5Contr_->Fill(-5. + (float(i) + 0.5) / 10.,
-                                             eecontr25[i] / e5x5rec);
+        meEERecHitLog10Energy5x5Contr_->Fill(-5. + (float(i) + 0.5) / 10., eecontr25[i] / e5x5rec);
       }
     }
   }
@@ -793,7 +717,6 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
   // PRESHOWER
 
   if (!skipPreshower) {
-
     // 1) loop over simHits
     e.getByToken(ESHits_Token_, crossingFrame);
     const MixCollection<PCaloHit> preshowerHits(crossingFrame.product());
@@ -808,22 +731,18 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
 
     for (auto const &iHit : preshowerHits) {
       ESDetId esid(iHit.id());
-      LogDebug("Preshower, HitInfo")
-          << " CaloHit " << iHit.getName() << " DetID = " << iHit.id() << "\n"
-          << "Energy = " << iHit.energy() << " Time = " << iHit.time() << "\n"
-          << "ESDetId strip " << esid.strip() << " = " << esid.six() << " "
-          << esid.siy();
+      LogDebug("Preshower, HitInfo") << " CaloHit " << iHit.getName() << " DetID = " << iHit.id() << "\n"
+                                     << "Energy = " << iHit.energy() << " Time = " << iHit.time() << "\n"
+                                     << "ESDetId strip " << esid.strip() << " = " << esid.six() << " " << esid.siy();
 
       uint32_t crystid = esid.rawId();
       esSimMap[crystid] += iHit.energy();
     }
 
     // 2) loop over RecHits
-    for (EcalRecHitCollection::const_iterator recHit = ESRecHit->begin();
-         recHit != ESRecHit->end(); ++recHit) {
+    for (EcalRecHitCollection::const_iterator recHit = ESRecHit->begin(); recHit != ESRecHit->end(); ++recHit) {
       ESDetId ESid = ESDetId(recHit->id());
       if (esSimMap[ESid.rawId()] != 0.) {
-
         // Fill log10(Energy) stuff...
         estotal += recHit->energy();
         if (recHit->energy() > 0) {
@@ -835,31 +754,27 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
         }
 
         if (meESRecHitSimHitRatio_) {
-          meESRecHitSimHitRatio_->Fill(recHit->energy() /
-                                       esSimMap[ESid.rawId()]);
+          meESRecHitSimHitRatio_->Fill(recHit->energy() / esSimMap[ESid.rawId()]);
         }
       } else
         continue;
-    } // loop over the RechitCollection
+    }  // loop over the RechitCollection
 
     if (meESRecHitLog10EnergyContr_ && estotal != 0) {
       for (int i = 0; i < escSize; i++) {
-        meESRecHitLog10EnergyContr_->Fill(-5. + (float(i) + 0.5) / 10.,
-                                          escontr[i] / estotal);
+        meESRecHitLog10EnergyContr_->Fill(-5. + (float(i) + 0.5) / 10., escontr[i] / estotal);
       }
     }
   }
 }
 
 uint32_t EcalRecHitsValidation::getUnitWithMaxEnergy(MapType &themap) {
-
   // look for max
   uint32_t unitWithMaxEnergy = 0;
   float maxEnergy = 0.;
 
   MapType::iterator iter;
   for (iter = themap.begin(); iter != themap.end(); iter++) {
-
     if (maxEnergy < (*iter).second) {
       maxEnergy = (*iter).second;
       unitWithMaxEnergy = (*iter).first;
@@ -869,10 +784,8 @@ uint32_t EcalRecHitsValidation::getUnitWithMaxEnergy(MapType &themap) {
   return unitWithMaxEnergy;
 }
 
-void EcalRecHitsValidation::findBarrelMatrix(int nCellInEta, int nCellInPhi,
-                                             int CentralEta, int CentralPhi,
-                                             int CentralZ, MapType &themap) {
-
+void EcalRecHitsValidation::findBarrelMatrix(
+    int nCellInEta, int nCellInPhi, int CentralEta, int CentralPhi, int CentralZ, MapType &themap) {
   int goBackInEta = nCellInEta / 2;
   int goBackInPhi = nCellInPhi / 2;
   int matrixSize = nCellInEta * nCellInPhi;
@@ -901,9 +814,8 @@ void EcalRecHitsValidation::findBarrelMatrix(int nCellInEta, int nCellInPhi,
   }
 }
 
-void EcalRecHitsValidation::findEndcapMatrix(int nCellInX, int nCellInY,
-                                             int CentralX, int CentralY,
-                                             int CentralZ, MapType &themap) {
+void EcalRecHitsValidation::findEndcapMatrix(
+    int nCellInX, int nCellInY, int CentralX, int CentralY, int CentralZ, MapType &themap) {
   int goBackInX = nCellInX / 2;
   int goBackInY = nCellInY / 2;
   crystalMatrix.clear();
@@ -912,9 +824,7 @@ void EcalRecHitsValidation::findEndcapMatrix(int nCellInX, int nCellInY,
   int startY = CentralY - goBackInY;
 
   for (int ix = startX; ix < startX + nCellInX; ix++) {
-
     for (int iy = startY; iy < startY + nCellInY; iy++) {
-
       uint32_t index;
 
       if (EEDetId::validDetId(ix, iy, CentralZ)) {

--- a/Validation/EcalRecHits/src/EcalTBValidation.cc
+++ b/Validation/EcalRecHits/src/EcalTBValidation.cc
@@ -13,7 +13,6 @@
 #include <string>
 
 EcalTBValidation::EcalTBValidation(const edm::ParameterSet &config) {
-
   data_ = config.getUntrackedParameter<int>("data", -1000);
   xtalInBeam_ = config.getUntrackedParameter<int>("xtalInBeam", -1000);
 
@@ -21,28 +20,18 @@ EcalTBValidation::EcalTBValidation(const edm::ParameterSet &config) {
   digiProducer_ = config.getParameter<std::string>("digiProducer");
   hitCollection_ = config.getParameter<std::string>("hitCollection");
   hitProducer_ = config.getParameter<std::string>("hitProducer");
-  hodoRecInfoCollection_ =
-      config.getParameter<std::string>("hodoRecInfoCollection");
-  hodoRecInfoProducer_ =
-      config.getParameter<std::string>("hodoRecInfoProducer");
-  tdcRecInfoCollection_ =
-      config.getParameter<std::string>("tdcRecInfoCollection");
+  hodoRecInfoCollection_ = config.getParameter<std::string>("hodoRecInfoCollection");
+  hodoRecInfoProducer_ = config.getParameter<std::string>("hodoRecInfoProducer");
+  tdcRecInfoCollection_ = config.getParameter<std::string>("tdcRecInfoCollection");
   tdcRecInfoProducer_ = config.getParameter<std::string>("tdcRecInfoProducer");
-  eventHeaderCollection_ =
-      config.getParameter<std::string>("eventHeaderCollection");
-  eventHeaderProducer_ =
-      config.getParameter<std::string>("eventHeaderProducer");
+  eventHeaderCollection_ = config.getParameter<std::string>("eventHeaderCollection");
+  eventHeaderProducer_ = config.getParameter<std::string>("eventHeaderProducer");
 
-  digi_Token_ =
-      consumes<EBDigiCollection>(edm::InputTag(digiProducer_, digiCollection_));
-  hit_Token_ = consumes<EBUncalibratedRecHitCollection>(
-      edm::InputTag(hitProducer_, hitCollection_));
-  hodoRec_Token_ = consumes<EcalTBHodoscopeRecInfo>(
-      edm::InputTag(hodoRecInfoProducer_, hodoRecInfoCollection_));
-  tdcRec_Token_ = consumes<EcalTBTDCRecInfo>(
-      edm::InputTag(tdcRecInfoProducer_, tdcRecInfoCollection_));
-  eventHeader_Token_ =
-      consumes<EcalTBEventHeader>(edm::InputTag(eventHeaderProducer_));
+  digi_Token_ = consumes<EBDigiCollection>(edm::InputTag(digiProducer_, digiCollection_));
+  hit_Token_ = consumes<EBUncalibratedRecHitCollection>(edm::InputTag(hitProducer_, hitCollection_));
+  hodoRec_Token_ = consumes<EcalTBHodoscopeRecInfo>(edm::InputTag(hodoRecInfoProducer_, hodoRecInfoCollection_));
+  tdcRec_Token_ = consumes<EcalTBTDCRecInfo>(edm::InputTag(tdcRecInfoProducer_, tdcRecInfoCollection_));
+  eventHeader_Token_ = consumes<EcalTBEventHeader>(edm::InputTag(eventHeaderProducer_));
   // rootfile_              =
   // config.getUntrackedParameter<std::string>("rootfile","EcalTBValidation.root");
 
@@ -75,10 +64,7 @@ EcalTBValidation::EcalTBValidation(const edm::ParameterSet &config) {
 
 EcalTBValidation::~EcalTBValidation() {}
 
-void EcalTBValidation::bookHistograms(DQMStore::IBooker &ibooker,
-                                      edm::Run const &,
-                                      edm::EventSetup const &) {
-
+void EcalTBValidation::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const &) {
   std::string hname;
   ibooker.setCurrentFolder("EcalRecHitsV/EcalTBValidationTask");
 
@@ -128,9 +114,7 @@ void EcalTBValidation::bookHistograms(DQMStore::IBooker &ibooker,
   meETBShape_ = ibooker.book2D(hname, hname, 250, 0, 10, 350, 0, 3500);
 }
 
-void EcalTBValidation::analyze(const edm::Event &event,
-                               const edm::EventSetup &setup) {
-
+void EcalTBValidation::analyze(const edm::Event &event, const edm::EventSetup &setup) {
   using namespace edm;
   using namespace cms;
 
@@ -141,8 +125,7 @@ void EcalTBValidation::analyze(const edm::Event &event,
   if (pdigis.isValid()) {
     theDigis = pdigis.product();
   } else {
-    std::cerr << "Error! can't get the product " << digiCollection_.c_str()
-              << std::endl;
+    std::cerr << "Error! can't get the product " << digiCollection_.c_str() << std::endl;
     return;
   }
 
@@ -153,8 +136,7 @@ void EcalTBValidation::analyze(const edm::Event &event,
   if (phits.isValid()) {
     theHits = phits.product();
   } else {
-    std::cerr << "Error! can't get the product " << hitCollection_.c_str()
-              << std::endl;
+    std::cerr << "Error! can't get the product " << hitCollection_.c_str() << std::endl;
     return;
   }
 
@@ -165,8 +147,7 @@ void EcalTBValidation::analyze(const edm::Event &event,
   if (pHodo.isValid()) {
     theHodo = pHodo.product();
   } else {
-    std::cerr << "Error! can't get the product "
-              << hodoRecInfoCollection_.c_str() << std::endl;
+    std::cerr << "Error! can't get the product " << hodoRecInfoCollection_.c_str() << std::endl;
     return;
   }
 
@@ -177,8 +158,7 @@ void EcalTBValidation::analyze(const edm::Event &event,
   if (pTDC.isValid()) {
     theTDC = pTDC.product();
   } else {
-    std::cerr << "Error! can't get the product "
-              << tdcRecInfoCollection_.c_str() << std::endl;
+    std::cerr << "Error! can't get the product " << tdcRecInfoCollection_.c_str() << std::endl;
     return;
   }
 
@@ -189,8 +169,7 @@ void EcalTBValidation::analyze(const edm::Event &event,
   if (pEventHeader.isValid()) {
     evtHeader = pEventHeader.product();
   } else {
-    std::cerr << "Error! can't get the product " << eventHeaderProducer_.c_str()
-              << std::endl;
+    std::cerr << "Error! can't get the product " << eventHeaderProducer_.c_str() << std::endl;
     return;
   }
 
@@ -236,8 +215,8 @@ void EcalTBValidation::analyze(const edm::Event &event,
       if (icry == 12) {
         ampl1x1 = theAmpl;
       }
-      if (icry == 6 || icry == 7 || icry == 8 || icry == 11 || icry == 12 ||
-          icry == 13 || icry == 16 || icry == 17 || icry == 18) {
+      if (icry == 6 || icry == 7 || icry == 8 || icry == 11 || icry == 12 || icry == 13 || icry == 16 || icry == 17 ||
+          icry == 18) {
         ampl3x3 += theAmpl;
       }
     }

--- a/Validation/GlobalHits/interface/GlobalHitsAnalyzer.h
+++ b/Validation/GlobalHits/interface/GlobalHitsAnalyzer.h
@@ -72,7 +72,6 @@
 #include "TString.h"
 
 class GlobalHitsAnalyzer : public DQMEDAnalyzer {
-
 public:
   // typedef std::vector<float> FloatVector;
 
@@ -81,8 +80,7 @@ public:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
 protected:
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:
   // production related methods
@@ -249,7 +247,7 @@ private:
   // private statistics information
   unsigned int count;
 
-}; // end class declaration
+};  // end class declaration
 
 #endif
 

--- a/Validation/GlobalHits/interface/GlobalHitsHistogrammer.h
+++ b/Validation/GlobalHits/interface/GlobalHitsHistogrammer.h
@@ -72,15 +72,13 @@
 #include "TString.h"
 
 class GlobalHitsHistogrammer : public DQMEDAnalyzer {
-
 public:
   // typedef std::vector<float> FloatVector;
 
   explicit GlobalHitsHistogrammer(const edm::ParameterSet &);
   ~GlobalHitsHistogrammer() override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:
   //  parameter information
@@ -183,6 +181,6 @@ private:
   // private statistics information
   unsigned int count;
 
-}; // end class declaration
+};  // end class declaration
 
 #endif

--- a/Validation/GlobalHits/interface/GlobalHitsProdHist.h
+++ b/Validation/GlobalHits/interface/GlobalHitsProdHist.h
@@ -72,7 +72,6 @@
 #include "TString.h"
 
 class GlobalHitsProdHist : public edm::one::EDProducer<edm::EndRunProducer> {
-
 public:
   // typedef std::vector<float> FloatVector;
 
@@ -225,7 +224,7 @@ private:
   // private statistics information
   unsigned int count;
 
-}; // end class declaration
+};  // end class declaration
 
 #endif
 

--- a/Validation/GlobalHits/interface/GlobalHitsProdHistStripper.h
+++ b/Validation/GlobalHits/interface/GlobalHitsProdHistStripper.h
@@ -40,7 +40,6 @@
 #include "TString.h"
 
 class GlobalHitsProdHistStripper : public edm::EDAnalyzer {
-
 public:
   // typedef std::vector<float> FloatVector;
 
@@ -154,6 +153,6 @@ private:
   // private statistics information
   unsigned int count;
 
-}; // end class declaration
+};  // end class declaration
 
 #endif

--- a/Validation/GlobalHits/interface/GlobalHitsProducer.h
+++ b/Validation/GlobalHits/interface/GlobalHitsProducer.h
@@ -73,7 +73,6 @@
 class PGlobalSimHit;
 
 class GlobalHitsProducer : public edm::EDProducer {
-
 public:
   typedef std::vector<float> FloatVector;
 
@@ -227,7 +226,7 @@ private:
   // private statistics information
   unsigned int count;
 
-}; // end class declaration
+};  // end class declaration
 
 #endif
 

--- a/Validation/GlobalHits/interface/GlobalHitsTester.h
+++ b/Validation/GlobalHits/interface/GlobalHitsTester.h
@@ -74,13 +74,11 @@
 #include "TString.h"
 
 class GlobalHitsTester : public DQMEDAnalyzer {
-
 public:
   explicit GlobalHitsTester(const edm::ParameterSet &);
   ~GlobalHitsTester() override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:
   std::string fName;

--- a/Validation/GlobalHits/src/GlobalHitsAnalyzer.cc
+++ b/Validation/GlobalHits/src/GlobalHitsAnalyzer.cc
@@ -16,12 +16,16 @@
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 
 GlobalHitsAnalyzer::GlobalHitsAnalyzer(const edm::ParameterSet &iPSet)
-    : fName(""), verbosity(0), frequency(0), vtxunit(0), label(""),
-      getAllProvenances(false), printProvenanceInfo(false), testNumber(false),
-      G4VtxSrc_Token_(consumes<edm::SimVertexContainer>(
-          (iPSet.getParameter<edm::InputTag>("G4VtxSrc")))),
-      G4TrkSrc_Token_(consumes<edm::SimTrackContainer>(
-          iPSet.getParameter<edm::InputTag>("G4TrkSrc"))),
+    : fName(""),
+      verbosity(0),
+      frequency(0),
+      vtxunit(0),
+      label(""),
+      getAllProvenances(false),
+      printProvenanceInfo(false),
+      testNumber(false),
+      G4VtxSrc_Token_(consumes<edm::SimVertexContainer>((iPSet.getParameter<edm::InputTag>("G4VtxSrc")))),
+      G4TrkSrc_Token_(consumes<edm::SimTrackContainer>(iPSet.getParameter<edm::InputTag>("G4TrkSrc"))),
       count(0) {
   consumesMany<edm::HepMCProduct>();
   std::string MsgLoggerCat = "GlobalHitsAnalyzer_GlobalHitsAnalyzer";
@@ -31,11 +35,9 @@ GlobalHitsAnalyzer::GlobalHitsAnalyzer(const edm::ParameterSet &iPSet)
   verbosity = iPSet.getUntrackedParameter<int>("Verbosity");
   frequency = iPSet.getUntrackedParameter<int>("Frequency");
   vtxunit = iPSet.getUntrackedParameter<int>("VtxUnit");
-  edm::ParameterSet m_Prov =
-      iPSet.getParameter<edm::ParameterSet>("ProvenanceLookup");
+  edm::ParameterSet m_Prov = iPSet.getParameter<edm::ParameterSet>("ProvenanceLookup");
   getAllProvenances = m_Prov.getUntrackedParameter<bool>("GetAllProvenances");
-  printProvenanceInfo =
-      m_Prov.getUntrackedParameter<bool>("PrintProvenanceInfo");
+  printProvenanceInfo = m_Prov.getUntrackedParameter<bool>("PrintProvenanceInfo");
   testNumber = iPSet.getUntrackedParameter<bool>("testNumber");
 
   // get Labels to use to extract information
@@ -64,54 +66,33 @@ GlobalHitsAnalyzer::GlobalHitsAnalyzer(const edm::ParameterSet &iPSet)
   HCalSrc_ = iPSet.getParameter<edm::InputTag>("HCalSrc");
 
   // fix for consumes
-  PxlBrlLowSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("PxlBrlLowSrc"));
-  PxlBrlHighSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("PxlBrlHighSrc"));
-  PxlFwdLowSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("PxlFwdLowSrc"));
-  PxlFwdHighSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("PxlFwdHighSrc"));
+  PxlBrlLowSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("PxlBrlLowSrc"));
+  PxlBrlHighSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("PxlBrlHighSrc"));
+  PxlFwdLowSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("PxlFwdLowSrc"));
+  PxlFwdHighSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("PxlFwdHighSrc"));
 
-  SiTIBLowSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("SiTIBLowSrc"));
-  SiTIBHighSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("SiTIBHighSrc"));
-  SiTOBLowSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("SiTOBLowSrc"));
-  SiTOBHighSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("SiTOBHighSrc"));
-  SiTIDLowSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("SiTIDLowSrc"));
-  SiTIDHighSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("SiTIDHighSrc"));
-  SiTECLowSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("SiTECLowSrc"));
-  SiTECHighSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("SiTECHighSrc"));
+  SiTIBLowSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTIBLowSrc"));
+  SiTIBHighSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTIBHighSrc"));
+  SiTOBLowSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTOBLowSrc"));
+  SiTOBHighSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTOBHighSrc"));
+  SiTIDLowSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTIDLowSrc"));
+  SiTIDHighSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTIDHighSrc"));
+  SiTECLowSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTECLowSrc"));
+  SiTECHighSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTECHighSrc"));
 
-  MuonCscSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("MuonCscSrc"));
-  MuonDtSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("MuonDtSrc"));
-  MuonRpcSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("MuonRpcSrc"));
+  MuonCscSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("MuonCscSrc"));
+  MuonDtSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("MuonDtSrc"));
+  MuonRpcSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("MuonRpcSrc"));
 
-  ECalEBSrc_Token_ = consumes<edm::PCaloHitContainer>(
-      iPSet.getParameter<edm::InputTag>("ECalEBSrc"));
-  ECalEESrc_Token_ = consumes<edm::PCaloHitContainer>(
-      iPSet.getParameter<edm::InputTag>("ECalEESrc"));
-  ECalESSrc_Token_ = consumes<edm::PCaloHitContainer>(
-      iPSet.getParameter<edm::InputTag>("ECalESSrc"));
-  HCalSrc_Token_ = consumes<edm::PCaloHitContainer>(
-      iPSet.getParameter<edm::InputTag>("HCalSrc"));
+  ECalEBSrc_Token_ = consumes<edm::PCaloHitContainer>(iPSet.getParameter<edm::InputTag>("ECalEBSrc"));
+  ECalEESrc_Token_ = consumes<edm::PCaloHitContainer>(iPSet.getParameter<edm::InputTag>("ECalEESrc"));
+  ECalESSrc_Token_ = consumes<edm::PCaloHitContainer>(iPSet.getParameter<edm::InputTag>("ECalESSrc"));
+  HCalSrc_Token_ = consumes<edm::PCaloHitContainer>(iPSet.getParameter<edm::InputTag>("HCalSrc"));
 
   // determine whether to process subdetector or not
   validHepMCevt = iPSet.getUntrackedParameter<bool>("validHepMCevt");
-  validG4VtxContainer =
-      iPSet.getUntrackedParameter<bool>("validG4VtxContainer");
-  validG4trkContainer =
-      iPSet.getUntrackedParameter<bool>("validG4trkContainer");
+  validG4VtxContainer = iPSet.getUntrackedParameter<bool>("validG4VtxContainer");
+  validG4trkContainer = iPSet.getUntrackedParameter<bool>("validG4trkContainer");
   validPxlBrlLow = iPSet.getUntrackedParameter<bool>("validPxlBrlLow", true);
   validPxlBrlHigh = iPSet.getUntrackedParameter<bool>("validPxlBrlHigh", true);
   validPxlFwdLow = iPSet.getUntrackedParameter<bool>("validPxlFwdLow", true);
@@ -147,44 +128,25 @@ GlobalHitsAnalyzer::GlobalHitsAnalyzer(const edm::ParameterSet &iPSet)
         << "    VtxUnit               = " << vtxunit << "\n"
         << "    GetProv               = " << getAllProvenances << "\n"
         << "    PrintProv             = " << printProvenanceInfo << "\n"
-        << "    PxlBrlLowSrc          = " << PxlBrlLowSrc_.label() << ":"
-        << PxlBrlLowSrc_.instance() << "\n"
-        << "    PxlBrlHighSrc         = " << PxlBrlHighSrc_.label() << ":"
-        << PxlBrlHighSrc_.instance() << "\n"
-        << "    PxlFwdLowSrc          = " << PxlFwdLowSrc_.label() << ":"
-        << PxlBrlLowSrc_.instance() << "\n"
-        << "    PxlFwdHighSrc         = " << PxlFwdHighSrc_.label() << ":"
-        << PxlBrlHighSrc_.instance() << "\n"
-        << "    SiTIBLowSrc           = " << SiTIBLowSrc_.label() << ":"
-        << SiTIBLowSrc_.instance() << "\n"
-        << "    SiTIBHighSrc          = " << SiTIBHighSrc_.label() << ":"
-        << SiTIBHighSrc_.instance() << "\n"
-        << "    SiTOBLowSrc           = " << SiTOBLowSrc_.label() << ":"
-        << SiTOBLowSrc_.instance() << "\n"
-        << "    SiTOBHighSrc          = " << SiTOBHighSrc_.label() << ":"
-        << SiTOBHighSrc_.instance() << "\n"
-        << "    SiTIDLowSrc           = " << SiTIDLowSrc_.label() << ":"
-        << SiTIDLowSrc_.instance() << "\n"
-        << "    SiTIDHighSrc          = " << SiTIDHighSrc_.label() << ":"
-        << SiTIDHighSrc_.instance() << "\n"
-        << "    SiTECLowSrc           = " << SiTECLowSrc_.label() << ":"
-        << SiTECLowSrc_.instance() << "\n"
-        << "    SiTECHighSrc          = " << SiTECHighSrc_.label() << ":"
-        << SiTECHighSrc_.instance() << "\n"
-        << "    MuonCscSrc            = " << MuonCscSrc_.label() << ":"
-        << MuonCscSrc_.instance() << "\n"
-        << "    MuonDtSrc             = " << MuonDtSrc_.label() << ":"
-        << MuonDtSrc_.instance() << "\n"
-        << "    MuonRpcSrc            = " << MuonRpcSrc_.label() << ":"
-        << MuonRpcSrc_.instance() << "\n"
-        << "    ECalEBSrc             = " << ECalEBSrc_.label() << ":"
-        << ECalEBSrc_.instance() << "\n"
-        << "    ECalEESrc             = " << ECalEESrc_.label() << ":"
-        << ECalEESrc_.instance() << "\n"
-        << "    ECalESSrc             = " << ECalESSrc_.label() << ":"
-        << ECalESSrc_.instance() << "\n"
-        << "    HCalSrc               = " << HCalSrc_.label() << ":"
-        << HCalSrc_.instance() << "\n"
+        << "    PxlBrlLowSrc          = " << PxlBrlLowSrc_.label() << ":" << PxlBrlLowSrc_.instance() << "\n"
+        << "    PxlBrlHighSrc         = " << PxlBrlHighSrc_.label() << ":" << PxlBrlHighSrc_.instance() << "\n"
+        << "    PxlFwdLowSrc          = " << PxlFwdLowSrc_.label() << ":" << PxlBrlLowSrc_.instance() << "\n"
+        << "    PxlFwdHighSrc         = " << PxlFwdHighSrc_.label() << ":" << PxlBrlHighSrc_.instance() << "\n"
+        << "    SiTIBLowSrc           = " << SiTIBLowSrc_.label() << ":" << SiTIBLowSrc_.instance() << "\n"
+        << "    SiTIBHighSrc          = " << SiTIBHighSrc_.label() << ":" << SiTIBHighSrc_.instance() << "\n"
+        << "    SiTOBLowSrc           = " << SiTOBLowSrc_.label() << ":" << SiTOBLowSrc_.instance() << "\n"
+        << "    SiTOBHighSrc          = " << SiTOBHighSrc_.label() << ":" << SiTOBHighSrc_.instance() << "\n"
+        << "    SiTIDLowSrc           = " << SiTIDLowSrc_.label() << ":" << SiTIDLowSrc_.instance() << "\n"
+        << "    SiTIDHighSrc          = " << SiTIDHighSrc_.label() << ":" << SiTIDHighSrc_.instance() << "\n"
+        << "    SiTECLowSrc           = " << SiTECLowSrc_.label() << ":" << SiTECLowSrc_.instance() << "\n"
+        << "    SiTECHighSrc          = " << SiTECHighSrc_.label() << ":" << SiTECHighSrc_.instance() << "\n"
+        << "    MuonCscSrc            = " << MuonCscSrc_.label() << ":" << MuonCscSrc_.instance() << "\n"
+        << "    MuonDtSrc             = " << MuonDtSrc_.label() << ":" << MuonDtSrc_.instance() << "\n"
+        << "    MuonRpcSrc            = " << MuonRpcSrc_.label() << ":" << MuonRpcSrc_.instance() << "\n"
+        << "    ECalEBSrc             = " << ECalEBSrc_.label() << ":" << ECalEBSrc_.instance() << "\n"
+        << "    ECalEESrc             = " << ECalEESrc_.label() << ":" << ECalEESrc_.instance() << "\n"
+        << "    ECalESSrc             = " << ECalESSrc_.label() << ":" << ECalESSrc_.instance() << "\n"
+        << "    HCalSrc               = " << HCalSrc_.label() << ":" << HCalSrc_.instance() << "\n"
         << "\n"
         << "    validHepMCevt         = "
         << ":" << validHepMCevt << "\n"
@@ -292,9 +254,7 @@ GlobalHitsAnalyzer::GlobalHitsAnalyzer(const edm::ParameterSet &iPSet)
 
 GlobalHitsAnalyzer::~GlobalHitsAnalyzer() {}
 
-void GlobalHitsAnalyzer::bookHistograms(DQMStore::IBooker &iBooker,
-                                        edm::Run const &run,
-                                        edm::EventSetup const &es) {
+void GlobalHitsAnalyzer::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const &run, edm::EventSetup const &es) {
   // book histograms
   Char_t hname[200];
   Char_t htitle[200];
@@ -399,8 +359,7 @@ void GlobalHitsAnalyzer::bookHistograms(DQMStore::IBooker &iBooker,
   sprintf(hname, "hGeantVtxMulti");
   sprintf(htitle, "Geant vertices outgoing multiplicity");
   meGeantVtxMulti = iBooker.book1D(hname, htitle, 20, 0., 20);
-  meGeantVtxMulti->setAxisTitle(
-      "multiplicity of particles attached to a SimVertex", 1);
+  meGeantVtxMulti->setAxisTitle("multiplicity of particles attached to a SimVertex", 1);
   meGeantVtxMulti->setAxisTitle("Count", 2);
 
   // ECal
@@ -707,8 +666,7 @@ void GlobalHitsAnalyzer::bookHistograms(DQMStore::IBooker &iBooker,
   meMuonRpcBR->setAxisTitle("Count", 2);
 }
 
-void GlobalHitsAnalyzer::analyze(const edm::Event &iEvent,
-                                 const edm::EventSetup &iSetup) {
+void GlobalHitsAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   std::string MsgLoggerCat = "GlobalHitsAnalyzer_analyze";
 
   // keep track of number of events processed
@@ -719,24 +677,21 @@ void GlobalHitsAnalyzer::analyze(const edm::Event &iEvent,
   edm::EventNumber_t nevt = iEvent.id().event();
 
   if (verbosity > 0) {
-    edm::LogInfo(MsgLoggerCat) << "Processing run " << nrun << ", event "
-                               << nevt << " (" << count << " events total)";
+    edm::LogInfo(MsgLoggerCat) << "Processing run " << nrun << ", event " << nevt << " (" << count << " events total)";
   } else if (verbosity == 0) {
     if (nevt % frequency == 0 || nevt == 1) {
-      edm::LogInfo(MsgLoggerCat) << "Processing run " << nrun << ", event "
-                                 << nevt << " (" << count << " events total)";
+      edm::LogInfo(MsgLoggerCat) << "Processing run " << nrun << ", event " << nevt << " (" << count
+                                 << " events total)";
     }
   }
 
   // look at information available in the event
   if (getAllProvenances) {
-
     std::vector<const edm::StableProvenance *> AllProv;
     iEvent.getAllStableProvenance(AllProv);
 
     if (verbosity >= 0)
-      edm::LogInfo(MsgLoggerCat)
-          << "Number of Provenances = " << AllProv.size();
+      edm::LogInfo(MsgLoggerCat) << "Number of Provenances = " << AllProv.size();
 
     if (printProvenanceInfo && (verbosity >= 0)) {
       TString eventout("\nProvenance info:\n");
@@ -781,7 +736,6 @@ void GlobalHitsAnalyzer::analyze(const edm::Event &iEvent,
 
 //==================fill and store functions================================
 void GlobalHitsAnalyzer::fillG4MC(const edm::Event &iEvent) {
-
   std::string MsgLoggerCat = "GlobalHitsAnalyzer_fillG4MC";
 
   TString eventout;
@@ -799,8 +753,7 @@ void GlobalHitsAnalyzer::fillG4MC(const edm::Event &iEvent) {
   // should have the information needed
   for (unsigned int i = 0; i < AllHepMCEvt.size(); ++i) {
     HepMCEvt = AllHepMCEvt[i];
-    if ((HepMCEvt.provenance()->branchDescription()).moduleLabel() ==
-        "generatorSmeared")
+    if ((HepMCEvt.provenance()->branchDescription()).moduleLabel() == "generatorSmeared")
       break;
   }
 
@@ -832,9 +785,9 @@ void GlobalHitsAnalyzer::fillG4MC(const edm::Event &iEvent) {
   // convert unit stored in SimVertex to mm
   float unit = 0.;
   if (vtxunit == 0)
-    unit = 1.; // already in mm
+    unit = 1.;  // already in mm
   if (vtxunit == 1)
-    unit = 10.; // stored in cm, convert to mm
+    unit = 10.;  // stored in cm, convert to mm
 
   edm::Handle<edm::SimVertexContainer> G4VtxContainer;
   iEvent.getByToken(G4VtxSrc_Token_, G4VtxContainer);
@@ -850,14 +803,11 @@ void GlobalHitsAnalyzer::fillG4MC(const edm::Event &iEvent) {
   if (validG4VtxContainer) {
     int i = 0;
     edm::SimVertexContainer::const_iterator itVtx;
-    for (itVtx = G4VtxContainer->begin(); itVtx != G4VtxContainer->end();
-         ++itVtx) {
-
+    for (itVtx = G4VtxContainer->begin(); itVtx != G4VtxContainer->end(); ++itVtx) {
       ++i;
 
       const math::XYZTLorentzVector G4Vtx1(
-          itVtx->position().x(), itVtx->position().y(), itVtx->position().z(),
-          itVtx->position().e());
+          itVtx->position().x(), itVtx->position().y(), itVtx->position().z(), itVtx->position().e());
 
       double G4Vtx[4];
       G4Vtx1.GetCoordinates(G4Vtx);
@@ -890,8 +840,7 @@ void GlobalHitsAnalyzer::fillG4MC(const edm::Event &iEvent) {
         int multi = 0;
         if (G4TrkContainer.isValid()) {
           edm::SimTrackContainer::const_iterator itTrk;
-          for (itTrk = G4TrkContainer->begin(); itTrk != G4TrkContainer->end();
-               ++itTrk) {
+          for (itTrk = G4TrkContainer->begin(); itTrk != G4TrkContainer->end(); ++itTrk) {
             if ((*itTrk).vertIndex() == i) {
               multi++;
             }
@@ -922,20 +871,16 @@ void GlobalHitsAnalyzer::fillG4MC(const edm::Event &iEvent) {
   if (validG4trkContainer) {
     int i = 0;
     edm::SimTrackContainer::const_iterator itTrk;
-    for (itTrk = G4TrkContainer->begin(); itTrk != G4TrkContainer->end();
-         ++itTrk) {
-
+    for (itTrk = G4TrkContainer->begin(); itTrk != G4TrkContainer->end(); ++itTrk) {
       ++i;
 
       const math::XYZTLorentzVector G4Trk1(
-          itTrk->momentum().x(), itTrk->momentum().y(), itTrk->momentum().z(),
-          itTrk->momentum().e());
+          itTrk->momentum().x(), itTrk->momentum().y(), itTrk->momentum().z(), itTrk->momentum().e());
       double G4Trk[4];
       G4Trk1.GetCoordinates(G4Trk);
 
       if (meGeantTrkPt)
-        meGeantTrkPt->Fill(std::log10(
-            std::max(sqrt(G4Trk[0] * G4Trk[0] + G4Trk[1] * G4Trk[1]), -9.)));
+        meGeantTrkPt->Fill(std::log10(std::max(sqrt(G4Trk[0] * G4Trk[0] + G4Trk[1] * G4Trk[1]), -9.)));
       if (meGeantTrkE)
         meGeantTrkE->Fill(std::log10(std::max(G4Trk[3], -9.)));
     }
@@ -957,9 +902,7 @@ void GlobalHitsAnalyzer::fillG4MC(const edm::Event &iEvent) {
   return;
 }
 
-void GlobalHitsAnalyzer::fillTrk(const edm::Event &iEvent,
-                                 const edm::EventSetup &iSetup) {
-
+void GlobalHitsAnalyzer::fillTrk(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   nPxlHits = 0;
   std::string MsgLoggerCat = "GlobalHitsAnalyzer_fillTrk";
 
@@ -971,8 +914,7 @@ void GlobalHitsAnalyzer::fillTrk(const edm::Event &iEvent,
   edm::ESHandle<TrackerGeometry> theTrackerGeometry;
   iSetup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry);
   if (!theTrackerGeometry.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerDigiGeometryRecord in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerDigiGeometryRecord in event!";
     return;
   }
   const TrackerGeometry &theTracker(*theTrackerGeometry);
@@ -988,30 +930,25 @@ void GlobalHitsAnalyzer::fillTrk(const edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> PxlBrlLowContainer;
   iEvent.getByToken(PxlBrlLowSrc_Token_, PxlBrlLowContainer);
   if (!PxlBrlLowContainer.isValid()) {
-    LogDebug(MsgLoggerCat)
-        << "Unable to find TrackerHitsPixelBarrelLowTof in event!";
+    LogDebug(MsgLoggerCat) << "Unable to find TrackerHitsPixelBarrelLowTof in event!";
     validPxlBrlLow = false;
   }
   // extract high container
   edm::Handle<edm::PSimHitContainer> PxlBrlHighContainer;
   iEvent.getByToken(PxlBrlHighSrc_Token_, PxlBrlHighContainer);
   if (!PxlBrlHighContainer.isValid()) {
-    LogDebug(MsgLoggerCat)
-        << "Unable to find TrackerHitsPixelBarrelHighTof in event!";
+    LogDebug(MsgLoggerCat) << "Unable to find TrackerHitsPixelBarrelHighTof in event!";
     validPxlBrlHigh = false;
   }
   // place both containers into new container
   if (validPxlBrlLow)
-    thePxlBrlHits.insert(thePxlBrlHits.end(), PxlBrlLowContainer->begin(),
-                         PxlBrlLowContainer->end());
+    thePxlBrlHits.insert(thePxlBrlHits.end(), PxlBrlLowContainer->begin(), PxlBrlLowContainer->end());
   if (validPxlBrlHigh)
-    thePxlBrlHits.insert(thePxlBrlHits.end(), PxlBrlHighContainer->begin(),
-                         PxlBrlHighContainer->end());
+    thePxlBrlHits.insert(thePxlBrlHits.end(), PxlBrlHighContainer->begin(), PxlBrlHighContainer->end());
 
   // cycle through new container
   int i = 0, j = 0;
   for (itHit = thePxlBrlHits.begin(); itHit != thePxlBrlHits.end(); ++itHit) {
-
     ++i;
 
     // create a DetId from the detUnitId
@@ -1021,13 +958,11 @@ void GlobalHitsAnalyzer::fillTrk(const edm::Event &iEvent,
 
     // check that expected detector is returned
     if ((detector == dTrk) && (subdetector == sdPxlBrl)) {
-
       // get the GeomDetUnit from the geometry using theDetUnitID
       const GeomDetUnit *theDet = theTracker.idToDetUnit(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get GeomDetUnit from PxlBrlHits for Hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from PxlBrlHits for Hit " << i;
         continue;
       }
 
@@ -1046,13 +981,11 @@ void GlobalHitsAnalyzer::fillTrk(const edm::Event &iEvent,
         meTrackerPxEta->Fill(bSurface.toGlobal(itHit->localPosition()).eta());
 
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "PxlBrl PSimHit " << i << " is expected to be (det,subdet) = ("
-          << dTrk << "," << sdPxlBrl << "); value returned is: (" << detector
-          << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "PxlBrl PSimHit " << i << " is expected to be (det,subdet) = (" << dTrk << ","
+                                    << sdPxlBrl << "); value returned is: (" << detector << "," << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through PxlBrl Hits
+    }  // end detector type check
+  }    // end loop through PxlBrl Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of Pixel Barrel Hits collected:..... ";
@@ -1069,31 +1002,26 @@ void GlobalHitsAnalyzer::fillTrk(const edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> PxlFwdLowContainer;
   iEvent.getByToken(PxlFwdLowSrc_Token_, PxlFwdLowContainer);
   if (!PxlFwdLowContainer.isValid()) {
-    LogDebug(MsgLoggerCat)
-        << "Unable to find TrackerHitsPixelEndcapLowTof in event!";
+    LogDebug(MsgLoggerCat) << "Unable to find TrackerHitsPixelEndcapLowTof in event!";
     validPxlFwdLow = false;
   }
   // extract high container
   edm::Handle<edm::PSimHitContainer> PxlFwdHighContainer;
   iEvent.getByToken(PxlFwdHighSrc_Token_, PxlFwdHighContainer);
   if (!PxlFwdHighContainer.isValid()) {
-    LogDebug("GlobalHitsAnalyzer_fillTrk")
-        << "Unable to find TrackerHitsPixelEndcapHighTof in event!";
+    LogDebug("GlobalHitsAnalyzer_fillTrk") << "Unable to find TrackerHitsPixelEndcapHighTof in event!";
     validPxlFwdHigh = false;
   }
   // place both containers into new container
   if (validPxlFwdLow)
-    thePxlFwdHits.insert(thePxlFwdHits.end(), PxlFwdLowContainer->begin(),
-                         PxlFwdLowContainer->end());
+    thePxlFwdHits.insert(thePxlFwdHits.end(), PxlFwdLowContainer->begin(), PxlFwdLowContainer->end());
   if (validPxlFwdHigh)
-    thePxlFwdHits.insert(thePxlFwdHits.end(), PxlFwdHighContainer->begin(),
-                         PxlFwdHighContainer->end());
+    thePxlFwdHits.insert(thePxlFwdHits.end(), PxlFwdHighContainer->begin(), PxlFwdHighContainer->end());
 
   // cycle through new container
   i = 0;
   j = 0;
   for (itHit = thePxlFwdHits.begin(); itHit != thePxlFwdHits.end(); ++itHit) {
-
     ++i;
 
     // create a DetId from the detUnitId
@@ -1103,13 +1031,11 @@ void GlobalHitsAnalyzer::fillTrk(const edm::Event &iEvent,
 
     // check that expected detector is returned
     if ((detector == dTrk) && (subdetector == sdPxlFwd)) {
-
       // get the GeomDetUnit from the geometry using theDetUnitID
       const GeomDetUnit *theDet = theTracker.idToDetUnit(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get GeomDetUnit from PxlFwdHits for Hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from PxlFwdHits for Hit " << i;
         ;
         continue;
       }
@@ -1129,13 +1055,11 @@ void GlobalHitsAnalyzer::fillTrk(const edm::Event &iEvent,
         meTrackerPxEta->Fill(bSurface.toGlobal(itHit->localPosition()).eta());
 
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "PxlFwd PSimHit " << i << " is expected to be (det,subdet) = ("
-          << dTrk << "," << sdPxlFwd << "); value returned is: (" << detector
-          << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "PxlFwd PSimHit " << i << " is expected to be (det,subdet) = (" << dTrk << ","
+                                    << sdPxlFwd << "); value returned is: (" << detector << "," << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through PxlFwd Hits
+    }  // end detector type check
+  }    // end loop through PxlFwd Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of Pixel Forward Hits collected:.... ";
@@ -1184,23 +1108,18 @@ void GlobalHitsAnalyzer::fillTrk(const edm::Event &iEvent,
   }
   // place all containers into new container
   if (validSiTIBLow)
-    theSiBrlHits.insert(theSiBrlHits.end(), SiTIBLowContainer->begin(),
-                        SiTIBLowContainer->end());
+    theSiBrlHits.insert(theSiBrlHits.end(), SiTIBLowContainer->begin(), SiTIBLowContainer->end());
   if (validSiTIBHigh)
-    theSiBrlHits.insert(theSiBrlHits.end(), SiTIBHighContainer->begin(),
-                        SiTIBHighContainer->end());
+    theSiBrlHits.insert(theSiBrlHits.end(), SiTIBHighContainer->begin(), SiTIBHighContainer->end());
   if (validSiTOBLow)
-    theSiBrlHits.insert(theSiBrlHits.end(), SiTOBLowContainer->begin(),
-                        SiTOBLowContainer->end());
+    theSiBrlHits.insert(theSiBrlHits.end(), SiTOBLowContainer->begin(), SiTOBLowContainer->end());
   if (validSiTOBHigh)
-    theSiBrlHits.insert(theSiBrlHits.end(), SiTOBHighContainer->begin(),
-                        SiTOBHighContainer->end());
+    theSiBrlHits.insert(theSiBrlHits.end(), SiTOBHighContainer->begin(), SiTOBHighContainer->end());
 
   // cycle through new container
   i = 0;
   j = 0;
   for (itHit = theSiBrlHits.begin(); itHit != theSiBrlHits.end(); ++itHit) {
-
     ++i;
 
     // create a DetId from the detUnitId
@@ -1209,15 +1128,12 @@ void GlobalHitsAnalyzer::fillTrk(const edm::Event &iEvent,
     int subdetector = theDetUnitId.subdetId();
 
     // check that expected detector is returned
-    if ((detector == dTrk) &&
-        ((subdetector == sdSiTIB) || (subdetector == sdSiTOB))) {
-
+    if ((detector == dTrk) && ((subdetector == sdSiTIB) || (subdetector == sdSiTOB))) {
       // get the GeomDetUnit from the geometry using theDetUnitID
       const GeomDetUnit *theDet = theTracker.idToDetUnit(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get GeomDetUnit from SiBrlHits for Hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from SiBrlHits for Hit " << i;
         continue;
       }
 
@@ -1236,13 +1152,12 @@ void GlobalHitsAnalyzer::fillTrk(const edm::Event &iEvent,
         meTrackerSiEta->Fill(bSurface.toGlobal(itHit->localPosition()).eta());
 
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "SiBrl PSimHit " << i << " is expected to be (det,subdet) = ("
-          << dTrk << "," << sdSiTIB << " || " << sdSiTOB
-          << "); value returned is: (" << detector << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "SiBrl PSimHit " << i << " is expected to be (det,subdet) = (" << dTrk << ","
+                                    << sdSiTIB << " || " << sdSiTOB << "); value returned is: (" << detector << ","
+                                    << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through SiBrl Hits
+    }  // end detector type check
+  }    // end loop through SiBrl Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of Silicon Barrel Hits collected:... ";
@@ -1266,8 +1181,7 @@ void GlobalHitsAnalyzer::fillTrk(const edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> SiTIDHighContainer;
   iEvent.getByToken(SiTIDHighSrc_Token_, SiTIDHighContainer);
   if (!SiTIDHighContainer.isValid()) {
-    LogDebug("GlobalHitsAnalyzer_fillTrk")
-        << "Unable to find TrackerHitsTIDHighTof in event!";
+    LogDebug("GlobalHitsAnalyzer_fillTrk") << "Unable to find TrackerHitsTIDHighTof in event!";
     validSiTIDHigh = false;
   }
   // extract TEC low container
@@ -1286,23 +1200,18 @@ void GlobalHitsAnalyzer::fillTrk(const edm::Event &iEvent,
   }
   // place all containers into new container
   if (validSiTIDLow)
-    theSiFwdHits.insert(theSiFwdHits.end(), SiTIDLowContainer->begin(),
-                        SiTIDLowContainer->end());
+    theSiFwdHits.insert(theSiFwdHits.end(), SiTIDLowContainer->begin(), SiTIDLowContainer->end());
   if (validSiTIDHigh)
-    theSiFwdHits.insert(theSiFwdHits.end(), SiTIDHighContainer->begin(),
-                        SiTIDHighContainer->end());
+    theSiFwdHits.insert(theSiFwdHits.end(), SiTIDHighContainer->begin(), SiTIDHighContainer->end());
   if (validSiTECLow)
-    theSiFwdHits.insert(theSiFwdHits.end(), SiTECLowContainer->begin(),
-                        SiTECLowContainer->end());
+    theSiFwdHits.insert(theSiFwdHits.end(), SiTECLowContainer->begin(), SiTECLowContainer->end());
   if (validSiTECHigh)
-    theSiFwdHits.insert(theSiFwdHits.end(), SiTECHighContainer->begin(),
-                        SiTECHighContainer->end());
+    theSiFwdHits.insert(theSiFwdHits.end(), SiTECHighContainer->begin(), SiTECHighContainer->end());
 
   // cycle through container
   i = 0;
   j = 0;
   for (itHit = theSiFwdHits.begin(); itHit != theSiFwdHits.end(); ++itHit) {
-
     ++i;
 
     // create a DetId from the detUnitId
@@ -1311,15 +1220,12 @@ void GlobalHitsAnalyzer::fillTrk(const edm::Event &iEvent,
     int subdetector = theDetUnitId.subdetId();
 
     // check that expected detector is returned
-    if ((detector == dTrk) &&
-        ((subdetector == sdSiTID) || (subdetector == sdSiTEC))) {
-
+    if ((detector == dTrk) && ((subdetector == sdSiTID) || (subdetector == sdSiTEC))) {
       // get the GeomDetUnit from the geometry using theDetUnitID
       const GeomDetUnit *theDet = theTracker.idToDetUnit(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get GeomDetUnit from SiFwdHits Hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from SiFwdHits Hit " << i;
         return;
       }
 
@@ -1338,13 +1244,12 @@ void GlobalHitsAnalyzer::fillTrk(const edm::Event &iEvent,
         meTrackerSiEta->Fill(bSurface.toGlobal(itHit->localPosition()).eta());
 
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "SiFwd PSimHit " << i << " is expected to be (det,subdet) = ("
-          << dTrk << "," << sdSiTOB << " || " << sdSiTEC
-          << "); value returned is: (" << detector << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "SiFwd PSimHit " << i << " is expected to be (det,subdet) = (" << dTrk << ","
+                                    << sdSiTOB << " || " << sdSiTEC << "); value returned is: (" << detector << ","
+                                    << subdetector << ")";
       continue;
-    } // end check detector type
-  }   // end loop through SiFwd Hits
+    }  // end check detector type
+  }    // end loop through SiFwd Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of Silicon Forward Hits collected:.. ";
@@ -1364,8 +1269,7 @@ void GlobalHitsAnalyzer::fillTrk(const edm::Event &iEvent,
   return;
 }
 
-void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent,
-                                  const edm::EventSetup &iSetup) {
+void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   nMuonHits = 0;
   std::string MsgLoggerCat = "GlobalHitsAnalyzer_fillMuon";
 
@@ -1383,8 +1287,7 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent,
   edm::ESHandle<CSCGeometry> theCSCGeometry;
   iSetup.get<MuonGeometryRecord>().get(theCSCGeometry);
   if (!theCSCGeometry.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find MuonGeometryRecord for the CSCGeometry in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the CSCGeometry in event!";
     return;
   }
   const CSCGeometry &theCSCMuon(*theCSCGeometry);
@@ -1400,9 +1303,7 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent,
   if (validMuonCSC) {
     // cycle through container
     int i = 0, j = 0;
-    for (itHit = MuonCSCContainer->begin(); itHit != MuonCSCContainer->end();
-         ++itHit) {
-
+    for (itHit = MuonCSCContainer->begin(); itHit != MuonCSCContainer->end(); ++itHit) {
       ++i;
 
       // create a DetId from the detUnitId
@@ -1412,13 +1313,11 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent,
 
       // check that expected detector is returned
       if ((detector == dMuon) && (subdetector == sdMuonCSC)) {
-
         // get the GeomDetUnit from the geometry using theDetUnitID
         const GeomDetUnit *theDet = theCSCMuon.idToDetUnit(theDetUnitId);
 
         if (!theDet) {
-          edm::LogWarning(MsgLoggerCat)
-              << "Unable to get GeomDetUnit from theCSCMuon for hit " << i;
+          edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from theCSCMuon for hit " << i;
           continue;
         }
 
@@ -1439,13 +1338,12 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent,
           meMuonEta->Fill(bSurface.toGlobal(itHit->localPosition()).eta());
 
       } else {
-        edm::LogWarning(MsgLoggerCat)
-            << "MuonCsc PSimHit " << i << " is expected to be (det,subdet) = ("
-            << dMuon << "," << sdMuonCSC << "); value returned is: ("
-            << detector << "," << subdetector << ")";
+        edm::LogWarning(MsgLoggerCat) << "MuonCsc PSimHit " << i << " is expected to be (det,subdet) = (" << dMuon
+                                      << "," << sdMuonCSC << "); value returned is: (" << detector << "," << subdetector
+                                      << ")";
         continue;
-      } // end detector type check
-    }   // end loop through CSC Hits
+      }  // end detector type check
+    }    // end loop through CSC Hits
 
     if (verbosity > 1) {
       eventout += "\n          Number of CSC muon Hits collected:......... ";
@@ -1462,8 +1360,7 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent,
   edm::ESHandle<DTGeometry> theDTGeometry;
   iSetup.get<MuonGeometryRecord>().get(theDTGeometry);
   if (!theDTGeometry.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find MuonGeometryRecord for the DTGeometry in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the DTGeometry in event!";
     return;
   }
   const DTGeometry &theDTMuon(*theDTGeometry);
@@ -1479,9 +1376,7 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent,
   if (validMuonDt) {
     // cycle through container
     int i = 0, j = 0;
-    for (itHit = MuonDtContainer->begin(); itHit != MuonDtContainer->end();
-         ++itHit) {
-
+    for (itHit = MuonDtContainer->begin(); itHit != MuonDtContainer->end(); ++itHit) {
       ++i;
 
       // create a DetId from the detUnitId
@@ -1491,7 +1386,6 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent,
 
       // check that expected detector is returned
       if ((detector == dMuon) && (subdetector == sdMuonDT)) {
-
         // CSC uses wires and layers rather than the full detID
         // get the wireId
         DTWireId wireId(itHit->detUnitId());
@@ -1500,8 +1394,7 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent,
         const DTLayer *theDet = theDTMuon.layer(wireId.layerId());
 
         if (!theDet) {
-          edm::LogWarning(MsgLoggerCat)
-              << "Unable to get GeomDetUnit from theDtMuon for hit " << i;
+          edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from theDtMuon for hit " << i;
           continue;
         }
 
@@ -1522,13 +1415,11 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent,
           meMuonEta->Fill(bSurface.toGlobal(itHit->localPosition()).eta());
 
       } else {
-        edm::LogWarning(MsgLoggerCat)
-            << "MuonDt PSimHit " << i << " is expected to be (det,subdet) = ("
-            << dMuon << "," << sdMuonDT << "); value returned is: (" << detector
-            << "," << subdetector << ")";
+        edm::LogWarning(MsgLoggerCat) << "MuonDt PSimHit " << i << " is expected to be (det,subdet) = (" << dMuon << ","
+                                      << sdMuonDT << "); value returned is: (" << detector << "," << subdetector << ")";
         continue;
-      } // end detector type check
-    }   // end loop through DT Hits
+      }  // end detector type check
+    }    // end loop through DT Hits
 
     if (verbosity > 1) {
       eventout += "\n          Number of DT muon Hits collected:.......... ";
@@ -1546,8 +1437,7 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent,
   edm::ESHandle<RPCGeometry> theRPCGeometry;
   iSetup.get<MuonGeometryRecord>().get(theRPCGeometry);
   if (!theRPCGeometry.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find MuonGeometryRecord for the RPCGeometry in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the RPCGeometry in event!";
     return;
   }
   const RPCGeometry &theRPCMuon(*theRPCGeometry);
@@ -1564,9 +1454,7 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent,
     // cycle through container
     int i = 0, j = 0;
     int RPCBrl = 0, RPCFwd = 0;
-    for (itHit = MuonRPCContainer->begin(); itHit != MuonRPCContainer->end();
-         ++itHit) {
-
+    for (itHit = MuonRPCContainer->begin(); itHit != MuonRPCContainer->end(); ++itHit) {
       ++i;
 
       // create a DetID from the detUnitId
@@ -1576,7 +1464,6 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent,
 
       // check that expected detector is returned
       if ((detector == dMuon) && (subdetector == sdMuonRPC)) {
-
         // get an RPCDetID from the detUnitID
         RPCDetId RPCId(itHit->detUnitId());
 
@@ -1587,8 +1474,7 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent,
         const GeomDetUnit *theDet = theRPCMuon.idToDetUnit(theDetUnitId);
 
         if (!theDet) {
-          edm::LogWarning(MsgLoggerCat)
-              << "Unable to get GeomDetUnit from theRPCMuon for hit " << i;
+          edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from theRPCMuon for hit " << i;
           continue;
         }
 
@@ -1627,18 +1513,16 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent,
             meMuonEta->Fill(bSurface.toGlobal(itHit->localPosition()).eta());
 
         } else {
-          edm::LogWarning(MsgLoggerCat)
-              << "Invalid region for RPC Muon hit" << i;
+          edm::LogWarning(MsgLoggerCat) << "Invalid region for RPC Muon hit" << i;
           continue;
-        } // end check of region
+        }  // end check of region
       } else {
-        edm::LogWarning(MsgLoggerCat)
-            << "MuonRpc PSimHit " << i << " is expected to be (det,subdet) = ("
-            << dMuon << "," << sdMuonRPC << "); value returned is: ("
-            << detector << "," << subdetector << ")";
+        edm::LogWarning(MsgLoggerCat) << "MuonRpc PSimHit " << i << " is expected to be (det,subdet) = (" << dMuon
+                                      << "," << sdMuonRPC << "); value returned is: (" << detector << "," << subdetector
+                                      << ")";
         continue;
-      } // end detector type check
-    }   // end loop through RPC Hits
+      }  // end detector type check
+    }    // end loop through RPC Hits
 
     if (verbosity > 1) {
       eventout += "\n          Number of RPC muon Hits collected:......... ";
@@ -1663,8 +1547,7 @@ void GlobalHitsAnalyzer::fillMuon(const edm::Event &iEvent,
   return;
 }
 
-void GlobalHitsAnalyzer::fillECal(const edm::Event &iEvent,
-                                  const edm::EventSetup &iSetup) {
+void GlobalHitsAnalyzer::fillECal(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   std::string MsgLoggerCat = "GlobalHitsAnalyzer_fillECal";
 
   TString eventout;
@@ -1675,8 +1558,7 @@ void GlobalHitsAnalyzer::fillECal(const edm::Event &iEvent,
   edm::ESHandle<CaloGeometry> theCaloGeometry;
   iSetup.get<CaloGeometryRecord>().get(theCaloGeometry);
   if (!theCaloGeometry.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find CaloGeometryRecord in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometryRecord in event!";
     return;
   }
   const CaloGeometry &theCalo(*theCaloGeometry);
@@ -1704,16 +1586,13 @@ void GlobalHitsAnalyzer::fillECal(const edm::Event &iEvent,
   }
   // place both containers into new container
   if (validEB)
-    theECalHits.insert(theECalHits.end(), EBContainer->begin(),
-                       EBContainer->end());
+    theECalHits.insert(theECalHits.end(), EBContainer->begin(), EBContainer->end());
   if (validEE)
-    theECalHits.insert(theECalHits.end(), EEContainer->begin(),
-                       EEContainer->end());
+    theECalHits.insert(theECalHits.end(), EEContainer->begin(), EEContainer->end());
 
   // cycle through new container
   int i = 0, j = 0;
   for (itHit = theECalHits.begin(); itHit != theECalHits.end(); ++itHit) {
-
     ++i;
 
     // create a DetId from the detUnitId
@@ -1722,16 +1601,12 @@ void GlobalHitsAnalyzer::fillECal(const edm::Event &iEvent,
     int subdetector = theDetUnitId.subdetId();
 
     // check that expected detector is returned
-    if ((detector == dEcal) &&
-        ((subdetector == sdEcalBrl) || (subdetector == sdEcalFwd))) {
-
+    if ((detector == dEcal) && ((subdetector == sdEcalBrl) || (subdetector == sdEcalFwd))) {
       // get the Cell geometry
-      auto theDet = (theCalo.getSubdetectorGeometry(theDetUnitId))
-                        ->getGeometry(theDetUnitId);
+      auto theDet = (theCalo.getSubdetectorGeometry(theDetUnitId))->getGeometry(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get CaloCellGeometry from ECalHits for Hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get CaloCellGeometry from ECalHits for Hit " << i;
         continue;
       }
 
@@ -1754,13 +1629,12 @@ void GlobalHitsAnalyzer::fillECal(const edm::Event &iEvent,
         meCaloEcalEta->Fill(globalposition.eta());
 
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "ECal PCaloHit " << i << " is expected to be (det,subdet) = ("
-          << dEcal << "," << sdEcalBrl << " || " << sdEcalFwd
-          << "); value returned is: (" << detector << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "ECal PCaloHit " << i << " is expected to be (det,subdet) = (" << dEcal << ","
+                                    << sdEcalBrl << " || " << sdEcalFwd << "); value returned is: (" << detector << ","
+                                    << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through ECal Hits
+    }  // end detector type check
+  }    // end loop through ECal Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of ECal Hits collected:............. ";
@@ -1786,9 +1660,7 @@ void GlobalHitsAnalyzer::fillECal(const edm::Event &iEvent,
   if (validPresh) {
     // cycle through container
     int i = 0, j = 0;
-    for (itHit = PreShContainer->begin(); itHit != PreShContainer->end();
-         ++itHit) {
-
+    for (itHit = PreShContainer->begin(); itHit != PreShContainer->end(); ++itHit) {
       ++i;
 
       // create a DetId from the detUnitId
@@ -1798,15 +1670,11 @@ void GlobalHitsAnalyzer::fillECal(const edm::Event &iEvent,
 
       // check that expected detector is returned
       if ((detector == dEcal) && (subdetector == sdEcalPS)) {
-
         // get the Cell geometry
-        auto theDet = (theCalo.getSubdetectorGeometry(theDetUnitId))
-                          ->getGeometry(theDetUnitId);
+        auto theDet = (theCalo.getSubdetectorGeometry(theDetUnitId))->getGeometry(theDetUnitId);
 
         if (!theDet) {
-          edm::LogWarning(MsgLoggerCat)
-              << "Unable to get CaloCellGeometry from PreShContainer for Hit "
-              << i;
+          edm::LogWarning(MsgLoggerCat) << "Unable to get CaloCellGeometry from PreShContainer for Hit " << i;
           continue;
         }
 
@@ -1829,13 +1697,11 @@ void GlobalHitsAnalyzer::fillECal(const edm::Event &iEvent,
           meCaloPreShEta->Fill(globalposition.eta());
 
       } else {
-        edm::LogWarning(MsgLoggerCat)
-            << "PreSh PCaloHit " << i << " is expected to be (det,subdet) = ("
-            << dEcal << "," << sdEcalPS << "); value returned is: (" << detector
-            << "," << subdetector << ")";
+        edm::LogWarning(MsgLoggerCat) << "PreSh PCaloHit " << i << " is expected to be (det,subdet) = (" << dEcal << ","
+                                      << sdEcalPS << "); value returned is: (" << detector << "," << subdetector << ")";
         continue;
-      } // end detector type check
-    }   // end loop through PreShower Hits
+      }  // end detector type check
+    }    // end loop through PreShower Hits
 
     if (verbosity > 1) {
       eventout += "\n          Number of PreSh Hits collected:............ ";
@@ -1854,8 +1720,7 @@ void GlobalHitsAnalyzer::fillECal(const edm::Event &iEvent,
   return;
 }
 
-void GlobalHitsAnalyzer::fillHCal(const edm::Event &iEvent,
-                                  const edm::EventSetup &iSetup) {
+void GlobalHitsAnalyzer::fillHCal(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   std::string MsgLoggerCat = "GlobalHitsAnalyzer_fillHCal";
 
   TString eventout;
@@ -1866,8 +1731,7 @@ void GlobalHitsAnalyzer::fillHCal(const edm::Event &iEvent,
   edm::ESHandle<CaloGeometry> theCaloGeometry;
   iSetup.get<CaloGeometryRecord>().get(theCaloGeometry);
   if (!theCaloGeometry.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find CaloGeometryRecord in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometryRecord in event!";
     return;
   }
   const CaloGeometry &theCalo(*theCaloGeometry);
@@ -1893,9 +1757,7 @@ void GlobalHitsAnalyzer::fillHCal(const edm::Event &iEvent,
   if (validHcal) {
     // cycle through container
     int i = 0, j = 0;
-    for (itHit = HCalContainer->begin(); itHit != HCalContainer->end();
-         ++itHit) {
-
+    for (itHit = HCalContainer->begin(); itHit != HCalContainer->end(); ++itHit) {
       ++i;
 
       // create a DetId from the detUnitId
@@ -1910,17 +1772,13 @@ void GlobalHitsAnalyzer::fillHCal(const edm::Event &iEvent,
       int subdetector = theDetUnitId.subdetId();
 
       // check that expected detector is returned
-      if ((detector == dHcal) &&
-          ((subdetector == sdHcalBrl) || (subdetector == sdHcalEC) ||
-           (subdetector == sdHcalOut) || (subdetector == sdHcalFwd))) {
-
+      if ((detector == dHcal) && ((subdetector == sdHcalBrl) || (subdetector == sdHcalEC) ||
+                                  (subdetector == sdHcalOut) || (subdetector == sdHcalFwd))) {
         // get the Cell geometry
-        const HcalGeometry *theDet = dynamic_cast<const HcalGeometry *>(
-            theCalo.getSubdetectorGeometry(theDetUnitId));
+        const HcalGeometry *theDet = dynamic_cast<const HcalGeometry *>(theCalo.getSubdetectorGeometry(theDetUnitId));
 
         if (!theDet) {
-          edm::LogWarning(MsgLoggerCat)
-              << "Unable to get HcalGeometry from HCalContainer for Hit " << i;
+          edm::LogWarning(MsgLoggerCat) << "Unable to get HcalGeometry from HCalContainer for Hit " << i;
           continue;
         }
 
@@ -1943,14 +1801,12 @@ void GlobalHitsAnalyzer::fillHCal(const edm::Event &iEvent,
           meCaloHcalEta->Fill(globalposition.eta());
 
       } else {
-        edm::LogWarning(MsgLoggerCat)
-            << "HCal PCaloHit " << i << " is expected to be (det,subdet) = ("
-            << dHcal << "," << sdHcalBrl << " || " << sdHcalEC << " || "
-            << sdHcalOut << " || " << sdHcalFwd << "); value returned is: ("
-            << detector << "," << subdetector << ")";
+        edm::LogWarning(MsgLoggerCat) << "HCal PCaloHit " << i << " is expected to be (det,subdet) = (" << dHcal << ","
+                                      << sdHcalBrl << " || " << sdHcalEC << " || " << sdHcalOut << " || " << sdHcalFwd
+                                      << "); value returned is: (" << detector << "," << subdetector << ")";
         continue;
-      } // end detector type check
-    }   // end loop through HCal Hits
+      }  // end detector type check
+    }    // end loop through HCal Hits
 
     if (verbosity > 1) {
       eventout += "\n          Number of HCal Hits collected:............. ";

--- a/Validation/GlobalHits/src/GlobalHitsHistogrammer.cc
+++ b/Validation/GlobalHits/src/GlobalHitsHistogrammer.cc
@@ -9,8 +9,14 @@
 // #include "DQMServices/Core/interface/DQMStore.h"
 
 GlobalHitsHistogrammer::GlobalHitsHistogrammer(const edm::ParameterSet &iPSet)
-    : fName(""), verbosity(0), frequency(0), vtxunit(0), label(""),
-      getAllProvenances(false), printProvenanceInfo(false), count(0) {
+    : fName(""),
+      verbosity(0),
+      frequency(0),
+      vtxunit(0),
+      label(""),
+      getAllProvenances(false),
+      printProvenanceInfo(false),
+      count(0) {
   std::string MsgLoggerCat = "GlobalHitsHistogrammer_GlobalHitsHistogrammer";
 
   // get information from parameter set
@@ -20,17 +26,14 @@ GlobalHitsHistogrammer::GlobalHitsHistogrammer(const edm::ParameterSet &iPSet)
   vtxunit = iPSet.getUntrackedParameter<int>("VtxUnit");
   outputfile = iPSet.getParameter<std::string>("OutputFile");
   doOutput = iPSet.getParameter<bool>("DoOutput");
-  edm::ParameterSet m_Prov =
-      iPSet.getParameter<edm::ParameterSet>("ProvenanceLookup");
+  edm::ParameterSet m_Prov = iPSet.getParameter<edm::ParameterSet>("ProvenanceLookup");
   getAllProvenances = m_Prov.getUntrackedParameter<bool>("GetAllProvenances");
-  printProvenanceInfo =
-      m_Prov.getUntrackedParameter<bool>("PrintProvenanceInfo");
+  printProvenanceInfo = m_Prov.getUntrackedParameter<bool>("PrintProvenanceInfo");
 
   // get Labels to use to extract information
   GlobalHitSrc_ = iPSet.getParameter<edm::InputTag>("GlobalHitSrc");
   // fix for consumes
-  GlobalHitSrc_Token_ = consumes<PGlobalSimHit>(
-      iPSet.getParameter<edm::InputTag>("GlobalHitSrc"));
+  GlobalHitSrc_Token_ = consumes<PGlobalSimHit>(iPSet.getParameter<edm::InputTag>("GlobalHitSrc"));
 
   // use value of first digit to determine default output level (inclusive)
   // 0 is none, 1 is basic, 2 is fill output, 3 is gather output
@@ -38,27 +41,23 @@ GlobalHitsHistogrammer::GlobalHitsHistogrammer(const edm::ParameterSet &iPSet)
 
   // print out Parameter Set information being used
   if (verbosity >= 0) {
-    edm::LogInfo(MsgLoggerCat)
-        << "\n===============================\n"
-        << "Initialized as EDAnalyzer with parameter values:\n"
-        << "    Name          = " << fName << "\n"
-        << "    Verbosity     = " << verbosity << "\n"
-        << "    Frequency     = " << frequency << "\n"
-        << "    VtxUnit       = " << vtxunit << "\n"
-        << "    OutputFile    = " << outputfile << "\n"
-        << "    DoOutput      = " << doOutput << "\n"
-        << "    GetProv       = " << getAllProvenances << "\n"
-        << "    PrintProv     = " << printProvenanceInfo << "\n"
-        << "    GlobalHitSrc  = " << GlobalHitSrc_.label() << ":"
-        << GlobalHitSrc_.instance() << "\n"
-        << "===============================\n";
+    edm::LogInfo(MsgLoggerCat) << "\n===============================\n"
+                               << "Initialized as EDAnalyzer with parameter values:\n"
+                               << "    Name          = " << fName << "\n"
+                               << "    Verbosity     = " << verbosity << "\n"
+                               << "    Frequency     = " << frequency << "\n"
+                               << "    VtxUnit       = " << vtxunit << "\n"
+                               << "    OutputFile    = " << outputfile << "\n"
+                               << "    DoOutput      = " << doOutput << "\n"
+                               << "    GetProv       = " << getAllProvenances << "\n"
+                               << "    PrintProv     = " << printProvenanceInfo << "\n"
+                               << "    GlobalHitSrc  = " << GlobalHitSrc_.label() << ":" << GlobalHitSrc_.instance()
+                               << "\n"
+                               << "===============================\n";
   }
 }
 
-void GlobalHitsHistogrammer::bookHistograms(DQMStore::IBooker &ibooker,
-                                            edm::Run const &,
-                                            edm::EventSetup const &) {
-
+void GlobalHitsHistogrammer::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const &) {
   // initialize monitor elements
   for (Int_t i = 0; i < 2; ++i) {
     meMCRGP[i] = nullptr;
@@ -498,8 +497,7 @@ void GlobalHitsHistogrammer::bookHistograms(DQMStore::IBooker &ibooker,
 
 GlobalHitsHistogrammer::~GlobalHitsHistogrammer() {}
 
-void GlobalHitsHistogrammer::analyze(const edm::Event &iEvent,
-                                     const edm::EventSetup &iSetup) {
+void GlobalHitsHistogrammer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   std::string MsgLoggerCat = "GlobalHitsHistogrammer_analyze";
 
   // keep track of number of events processed
@@ -510,24 +508,21 @@ void GlobalHitsHistogrammer::analyze(const edm::Event &iEvent,
   edm::EventNumber_t nevt = iEvent.id().event();
 
   if (verbosity > 0) {
-    edm::LogInfo(MsgLoggerCat) << "Processing run " << nrun << ", event "
-                               << nevt << " (" << count << " events total)";
+    edm::LogInfo(MsgLoggerCat) << "Processing run " << nrun << ", event " << nevt << " (" << count << " events total)";
   } else if (verbosity == 0) {
     if (nevt % frequency == 0 || nevt == 1) {
-      edm::LogInfo(MsgLoggerCat) << "Processing run " << nrun << ", event "
-                                 << nevt << " (" << count << " events total)";
+      edm::LogInfo(MsgLoggerCat) << "Processing run " << nrun << ", event " << nevt << " (" << count
+                                 << " events total)";
     }
   }
 
   // look at information available in the event
   if (getAllProvenances) {
-
     std::vector<const edm::StableProvenance *> AllProv;
     iEvent.getAllStableProvenance(AllProv);
 
     if (verbosity >= 0)
-      edm::LogInfo(MsgLoggerCat)
-          << "Number of Provenances = " << AllProv.size();
+      edm::LogInfo(MsgLoggerCat) << "Number of Provenances = " << AllProv.size();
 
     if (printProvenanceInfo && (verbosity >= 0)) {
       TString eventout("\nProvenance info:\n");
@@ -635,8 +630,7 @@ void GlobalHitsHistogrammer::analyze(const edm::Event &iEvent,
   }
 
   // get Pixel Barrel info
-  std::vector<PGlobalSimHit::BrlHit> PxlBrlHits =
-      srcGlobalHits->getPxlBrlHits();
+  std::vector<PGlobalSimHit::BrlHit> PxlBrlHits = srcGlobalHits->getPxlBrlHits();
   for (unsigned int i = 0; i < PxlBrlHits.size(); ++i) {
     meTrackerPxPhi->Fill(PxlBrlHits[i].phi);
     meTrackerPxEta->Fill(PxlBrlHits[i].eta);
@@ -645,8 +639,7 @@ void GlobalHitsHistogrammer::analyze(const edm::Event &iEvent,
   }
 
   // get Pixel Forward info
-  std::vector<PGlobalSimHit::FwdHit> PxlFwdHits =
-      srcGlobalHits->getPxlFwdHits();
+  std::vector<PGlobalSimHit::FwdHit> PxlFwdHits = srcGlobalHits->getPxlFwdHits();
   for (unsigned int i = 0; i < PxlFwdHits.size(); ++i) {
     meTrackerPxPhi->Fill(PxlFwdHits[i].phi);
     meTrackerPxEta->Fill(PxlFwdHits[i].eta);
@@ -673,8 +666,7 @@ void GlobalHitsHistogrammer::analyze(const edm::Event &iEvent,
   }
 
   // get Muon CSC info
-  std::vector<PGlobalSimHit::FwdHit> MuonCscHits =
-      srcGlobalHits->getMuonCscHits();
+  std::vector<PGlobalSimHit::FwdHit> MuonCscHits = srcGlobalHits->getMuonCscHits();
   for (unsigned int i = 0; i < MuonCscHits.size(); ++i) {
     meMuonPhi->Fill(MuonCscHits[i].phi);
     meMuonEta->Fill(MuonCscHits[i].eta);
@@ -685,8 +677,7 @@ void GlobalHitsHistogrammer::analyze(const edm::Event &iEvent,
   }
 
   // get Muon DT info
-  std::vector<PGlobalSimHit::BrlHit> MuonDtHits =
-      srcGlobalHits->getMuonDtHits();
+  std::vector<PGlobalSimHit::BrlHit> MuonDtHits = srcGlobalHits->getMuonDtHits();
   for (unsigned int i = 0; i < MuonDtHits.size(); ++i) {
     meMuonPhi->Fill(MuonDtHits[i].phi);
     meMuonEta->Fill(MuonDtHits[i].eta);
@@ -697,8 +688,7 @@ void GlobalHitsHistogrammer::analyze(const edm::Event &iEvent,
   }
 
   // get Muon RPC forward info
-  std::vector<PGlobalSimHit::FwdHit> MuonRpcFwdHits =
-      srcGlobalHits->getMuonRpcFwdHits();
+  std::vector<PGlobalSimHit::FwdHit> MuonRpcFwdHits = srcGlobalHits->getMuonRpcFwdHits();
   for (unsigned int i = 0; i < MuonRpcFwdHits.size(); ++i) {
     meMuonPhi->Fill(MuonRpcFwdHits[i].phi);
     meMuonEta->Fill(MuonRpcFwdHits[i].eta);
@@ -709,8 +699,7 @@ void GlobalHitsHistogrammer::analyze(const edm::Event &iEvent,
   }
 
   // get Muon RPC barrel info
-  std::vector<PGlobalSimHit::BrlHit> MuonRpcBrlHits =
-      srcGlobalHits->getMuonRpcBrlHits();
+  std::vector<PGlobalSimHit::BrlHit> MuonRpcBrlHits = srcGlobalHits->getMuonRpcBrlHits();
   for (unsigned int i = 0; i < MuonRpcBrlHits.size(); ++i) {
     meMuonPhi->Fill(MuonRpcBrlHits[i].phi);
     meMuonEta->Fill(MuonRpcBrlHits[i].eta);

--- a/Validation/GlobalHits/src/GlobalHitsProdHist.cc
+++ b/Validation/GlobalHits/src/GlobalHitsProdHist.cc
@@ -10,12 +10,14 @@
 #include "Validation/GlobalHits/interface/GlobalHitsProdHist.h"
 
 GlobalHitsProdHist::GlobalHitsProdHist(const edm::ParameterSet &iPSet)
-    : fName(""), verbosity(0), frequency(0), vtxunit(0),
-      getAllProvenances(false), printProvenanceInfo(false),
-      G4VtxSrc_Token_(consumes<edm::SimVertexContainer>(
-          (iPSet.getParameter<edm::InputTag>("G4VtxSrc")))),
-      G4TrkSrc_Token_(consumes<edm::SimTrackContainer>(
-          iPSet.getParameter<edm::InputTag>("G4TrkSrc"))),
+    : fName(""),
+      verbosity(0),
+      frequency(0),
+      vtxunit(0),
+      getAllProvenances(false),
+      printProvenanceInfo(false),
+      G4VtxSrc_Token_(consumes<edm::SimVertexContainer>((iPSet.getParameter<edm::InputTag>("G4VtxSrc")))),
+      G4TrkSrc_Token_(consumes<edm::SimTrackContainer>(iPSet.getParameter<edm::InputTag>("G4TrkSrc"))),
       count(0) {
   std::string MsgLoggerCat = "GlobalHitsProdHist_GlobalHitsProdHist";
 
@@ -24,11 +26,9 @@ GlobalHitsProdHist::GlobalHitsProdHist(const edm::ParameterSet &iPSet)
   verbosity = iPSet.getUntrackedParameter<int>("Verbosity");
   frequency = iPSet.getUntrackedParameter<int>("Frequency");
   vtxunit = iPSet.getUntrackedParameter<int>("VtxUnit");
-  edm::ParameterSet m_Prov =
-      iPSet.getParameter<edm::ParameterSet>("ProvenanceLookup");
+  edm::ParameterSet m_Prov = iPSet.getParameter<edm::ParameterSet>("ProvenanceLookup");
   getAllProvenances = m_Prov.getUntrackedParameter<bool>("GetAllProvenances");
-  printProvenanceInfo =
-      m_Prov.getUntrackedParameter<bool>("PrintProvenanceInfo");
+  printProvenanceInfo = m_Prov.getUntrackedParameter<bool>("PrintProvenanceInfo");
 
   // get Labels to use to extract information
   PxlBrlLowSrc_ = iPSet.getParameter<edm::InputTag>("PxlBrlLowSrc");
@@ -70,44 +70,25 @@ GlobalHitsProdHist::GlobalHitsProdHist(const edm::ParameterSet &iPSet)
         << "    VtxUnit       = " << vtxunit << "\n"
         << "    GetProv       = " << getAllProvenances << "\n"
         << "    PrintProv     = " << printProvenanceInfo << "\n"
-        << "    PxlBrlLowSrc  = " << PxlBrlLowSrc_.label() << ":"
-        << PxlBrlLowSrc_.instance() << "\n"
-        << "    PxlBrlHighSrc = " << PxlBrlHighSrc_.label() << ":"
-        << PxlBrlHighSrc_.instance() << "\n"
-        << "    PxlFwdLowSrc  = " << PxlFwdLowSrc_.label() << ":"
-        << PxlBrlLowSrc_.instance() << "\n"
-        << "    PxlFwdHighSrc = " << PxlFwdHighSrc_.label() << ":"
-        << PxlBrlHighSrc_.instance() << "\n"
-        << "    SiTIBLowSrc   = " << SiTIBLowSrc_.label() << ":"
-        << SiTIBLowSrc_.instance() << "\n"
-        << "    SiTIBHighSrc  = " << SiTIBHighSrc_.label() << ":"
-        << SiTIBHighSrc_.instance() << "\n"
-        << "    SiTOBLowSrc   = " << SiTOBLowSrc_.label() << ":"
-        << SiTOBLowSrc_.instance() << "\n"
-        << "    SiTOBHighSrc  = " << SiTOBHighSrc_.label() << ":"
-        << SiTOBHighSrc_.instance() << "\n"
-        << "    SiTIDLowSrc   = " << SiTIDLowSrc_.label() << ":"
-        << SiTIDLowSrc_.instance() << "\n"
-        << "    SiTIDHighSrc  = " << SiTIDHighSrc_.label() << ":"
-        << SiTIDHighSrc_.instance() << "\n"
-        << "    SiTECLowSrc   = " << SiTECLowSrc_.label() << ":"
-        << SiTECLowSrc_.instance() << "\n"
-        << "    SiTECHighSrc  = " << SiTECHighSrc_.label() << ":"
-        << SiTECHighSrc_.instance() << "\n"
-        << "    MuonCscSrc    = " << MuonCscSrc_.label() << ":"
-        << MuonCscSrc_.instance() << "\n"
-        << "    MuonDtSrc     = " << MuonDtSrc_.label() << ":"
-        << MuonDtSrc_.instance() << "\n"
-        << "    MuonRpcSrc    = " << MuonRpcSrc_.label() << ":"
-        << MuonRpcSrc_.instance() << "\n"
-        << "    ECalEBSrc     = " << ECalEBSrc_.label() << ":"
-        << ECalEBSrc_.instance() << "\n"
-        << "    ECalEESrc     = " << ECalEESrc_.label() << ":"
-        << ECalEESrc_.instance() << "\n"
-        << "    ECalESSrc     = " << ECalESSrc_.label() << ":"
-        << ECalESSrc_.instance() << "\n"
-        << "    HCalSrc       = " << HCalSrc_.label() << ":"
-        << HCalSrc_.instance() << "\n"
+        << "    PxlBrlLowSrc  = " << PxlBrlLowSrc_.label() << ":" << PxlBrlLowSrc_.instance() << "\n"
+        << "    PxlBrlHighSrc = " << PxlBrlHighSrc_.label() << ":" << PxlBrlHighSrc_.instance() << "\n"
+        << "    PxlFwdLowSrc  = " << PxlFwdLowSrc_.label() << ":" << PxlBrlLowSrc_.instance() << "\n"
+        << "    PxlFwdHighSrc = " << PxlFwdHighSrc_.label() << ":" << PxlBrlHighSrc_.instance() << "\n"
+        << "    SiTIBLowSrc   = " << SiTIBLowSrc_.label() << ":" << SiTIBLowSrc_.instance() << "\n"
+        << "    SiTIBHighSrc  = " << SiTIBHighSrc_.label() << ":" << SiTIBHighSrc_.instance() << "\n"
+        << "    SiTOBLowSrc   = " << SiTOBLowSrc_.label() << ":" << SiTOBLowSrc_.instance() << "\n"
+        << "    SiTOBHighSrc  = " << SiTOBHighSrc_.label() << ":" << SiTOBHighSrc_.instance() << "\n"
+        << "    SiTIDLowSrc   = " << SiTIDLowSrc_.label() << ":" << SiTIDLowSrc_.instance() << "\n"
+        << "    SiTIDHighSrc  = " << SiTIDHighSrc_.label() << ":" << SiTIDHighSrc_.instance() << "\n"
+        << "    SiTECLowSrc   = " << SiTECLowSrc_.label() << ":" << SiTECLowSrc_.instance() << "\n"
+        << "    SiTECHighSrc  = " << SiTECHighSrc_.label() << ":" << SiTECHighSrc_.instance() << "\n"
+        << "    MuonCscSrc    = " << MuonCscSrc_.label() << ":" << MuonCscSrc_.instance() << "\n"
+        << "    MuonDtSrc     = " << MuonDtSrc_.label() << ":" << MuonDtSrc_.instance() << "\n"
+        << "    MuonRpcSrc    = " << MuonRpcSrc_.label() << ":" << MuonRpcSrc_.instance() << "\n"
+        << "    ECalEBSrc     = " << ECalEBSrc_.label() << ":" << ECalEBSrc_.instance() << "\n"
+        << "    ECalEESrc     = " << ECalEESrc_.label() << ":" << ECalEESrc_.instance() << "\n"
+        << "    ECalESSrc     = " << ECalESSrc_.label() << ":" << ECalESSrc_.instance() << "\n"
+        << "    HCalSrc       = " << HCalSrc_.label() << ":" << HCalSrc_.instance() << "\n"
         << "===============================\n";
   }
 
@@ -607,8 +588,7 @@ GlobalHitsProdHist::GlobalHitsProdHist(const edm::ParameterSet &iPSet)
 
   // create persistent objects
   for (std::size_t i = 0; i < histName_.size(); ++i) {
-    produces<TH1F, edm::Transition::EndRun>(histName_[i])
-        .setBranchAlias(histName_[i]);
+    produces<TH1F, edm::Transition::EndRun>(histName_[i]).setBranchAlias(histName_[i]);
   }
 }
 
@@ -619,13 +599,11 @@ void GlobalHitsProdHist::beginJob() { return; }
 void GlobalHitsProdHist::endJob() {
   std::string MsgLoggerCat = "GlobalHitsProdHist_endJob";
   if (verbosity >= 0)
-    edm::LogInfo(MsgLoggerCat)
-        << "Terminating having processed " << count << " events.";
+    edm::LogInfo(MsgLoggerCat) << "Terminating having processed " << count << " events.";
   return;
 }
 
-void GlobalHitsProdHist::produce(edm::Event &iEvent,
-                                 const edm::EventSetup &iSetup) {
+void GlobalHitsProdHist::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   std::string MsgLoggerCat = "GlobalHitsProdHist_produce";
 
   // keep track of number of events processed
@@ -636,24 +614,21 @@ void GlobalHitsProdHist::produce(edm::Event &iEvent,
   edm::EventNumber_t nevt = iEvent.id().event();
 
   if (verbosity > 0) {
-    edm::LogInfo(MsgLoggerCat) << "Processing run " << nrun << ", event "
-                               << nevt << " (" << count << " events total)";
+    edm::LogInfo(MsgLoggerCat) << "Processing run " << nrun << ", event " << nevt << " (" << count << " events total)";
   } else if (verbosity == 0) {
     if (nevt % frequency == 0 || nevt == 1) {
-      edm::LogInfo(MsgLoggerCat) << "Processing run " << nrun << ", event "
-                                 << nevt << " (" << count << " events total)";
+      edm::LogInfo(MsgLoggerCat) << "Processing run " << nrun << ", event " << nevt << " (" << count
+                                 << " events total)";
     }
   }
 
   // look at information available in the event
   if (getAllProvenances) {
-
     std::vector<const edm::StableProvenance *> AllProv;
     iEvent.getAllStableProvenance(AllProv);
 
     if (verbosity >= 0)
-      edm::LogInfo(MsgLoggerCat)
-          << "Number of Provenances = " << AllProv.size();
+      edm::LogInfo(MsgLoggerCat) << "Number of Provenances = " << AllProv.size();
 
     if (printProvenanceInfo && (verbosity >= 0)) {
       TString eventout("\nProvenance info:\n");
@@ -696,9 +671,7 @@ void GlobalHitsProdHist::produce(edm::Event &iEvent,
   return;
 }
 
-void GlobalHitsProdHist::endRunProduce(edm::Run &iRun,
-                                       const edm::EventSetup &iSetup) {
-
+void GlobalHitsProdHist::endRunProduce(edm::Run &iRun, const edm::EventSetup &iSetup) {
   std::string MsgLoggerCat = "GlobalHitsProdHist_endRun";
 
   TString eventout;
@@ -732,7 +705,6 @@ void GlobalHitsProdHist::endRunProduce(edm::Run &iRun,
 
 //==================fill and store functions================================
 void GlobalHitsProdHist::fillG4MC(edm::Event &iEvent) {
-
   std::string MsgLoggerCat = "GlobalHitsProdHist_fillG4MC";
 
   TString eventout;
@@ -750,8 +722,7 @@ void GlobalHitsProdHist::fillG4MC(edm::Event &iEvent) {
   // should have the information needed
   for (unsigned int i = 0; i < AllHepMCEvt.size(); ++i) {
     HepMCEvt = AllHepMCEvt[i];
-    if ((HepMCEvt.provenance()->branchDescription()).moduleLabel() ==
-        "generatorSmeared")
+    if ((HepMCEvt.provenance()->branchDescription()).moduleLabel() == "generatorSmeared")
       break;
   }
 
@@ -781,9 +752,9 @@ void GlobalHitsProdHist::fillG4MC(edm::Event &iEvent) {
   // convert unit stored in SimVertex to mm
   float unit = 0.;
   if (vtxunit == 0)
-    unit = 1.; // already in mm
+    unit = 1.;  // already in mm
   if (vtxunit == 1)
-    unit = 10.; // stored in cm, convert to mm
+    unit = 10.;  // stored in cm, convert to mm
 
   edm::Handle<edm::SimVertexContainer> G4VtxContainer;
   iEvent.getByToken(G4VtxSrc_Token_, G4VtxContainer);
@@ -793,14 +764,11 @@ void GlobalHitsProdHist::fillG4MC(edm::Event &iEvent) {
   }
   int i = 0;
   edm::SimVertexContainer::const_iterator itVtx;
-  for (itVtx = G4VtxContainer->begin(); itVtx != G4VtxContainer->end();
-       ++itVtx) {
-
+  for (itVtx = G4VtxContainer->begin(); itVtx != G4VtxContainer->end(); ++itVtx) {
     ++i;
 
     const math::XYZTLorentzVector G4Vtx1(
-        itVtx->position().x(), itVtx->position().y(), itVtx->position().z(),
-        itVtx->position().e());
+        itVtx->position().x(), itVtx->position().y(), itVtx->position().z(), itVtx->position().e());
 
     double G4Vtx[4];
     G4Vtx1.GetCoordinates(G4Vtx);
@@ -842,14 +810,11 @@ void GlobalHitsProdHist::fillG4MC(edm::Event &iEvent) {
   }
   i = 0;
   edm::SimTrackContainer::const_iterator itTrk;
-  for (itTrk = G4TrkContainer->begin(); itTrk != G4TrkContainer->end();
-       ++itTrk) {
-
+  for (itTrk = G4TrkContainer->begin(); itTrk != G4TrkContainer->end(); ++itTrk) {
     ++i;
 
     const math::XYZTLorentzVector G4Trk1(
-        itTrk->momentum().x(), itTrk->momentum().y(), itTrk->momentum().z(),
-        itTrk->momentum().e());
+        itTrk->momentum().x(), itTrk->momentum().y(), itTrk->momentum().z(), itTrk->momentum().e());
     double G4Trk[4];
     G4Trk1.GetCoordinates(G4Trk);
 
@@ -875,9 +840,7 @@ void GlobalHitsProdHist::fillG4MC(edm::Event &iEvent) {
   return;
 }
 
-void GlobalHitsProdHist::fillTrk(edm::Event &iEvent,
-                                 const edm::EventSetup &iSetup) {
-
+void GlobalHitsProdHist::fillTrk(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   nPxlHits = 0;
   std::string MsgLoggerCat = "GlobalHitsProdHist_fillTrk";
 
@@ -889,8 +852,7 @@ void GlobalHitsProdHist::fillTrk(edm::Event &iEvent,
   edm::ESHandle<TrackerGeometry> theTrackerGeometry;
   iSetup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry);
   if (!theTrackerGeometry.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerDigiGeometryRecord in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerDigiGeometryRecord in event!";
     return;
   }
   const TrackerGeometry &theTracker(*theTrackerGeometry);
@@ -906,28 +868,23 @@ void GlobalHitsProdHist::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> PxlBrlLowContainer;
   iEvent.getByToken(PxlBrlLowSrc_Token_, PxlBrlLowContainer);
   if (!PxlBrlLowContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsPixelBarrelLowTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsPixelBarrelLowTof in event!";
     return;
   }
   // extract high container
   edm::Handle<edm::PSimHitContainer> PxlBrlHighContainer;
   iEvent.getByToken(PxlBrlHighSrc_Token_, PxlBrlHighContainer);
   if (!PxlBrlHighContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsPixelBarrelHighTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsPixelBarrelHighTof in event!";
     return;
   }
   // place both containers into new container
-  thePxlBrlHits.insert(thePxlBrlHits.end(), PxlBrlLowContainer->begin(),
-                       PxlBrlLowContainer->end());
-  thePxlBrlHits.insert(thePxlBrlHits.end(), PxlBrlHighContainer->begin(),
-                       PxlBrlHighContainer->end());
+  thePxlBrlHits.insert(thePxlBrlHits.end(), PxlBrlLowContainer->begin(), PxlBrlLowContainer->end());
+  thePxlBrlHits.insert(thePxlBrlHits.end(), PxlBrlHighContainer->begin(), PxlBrlHighContainer->end());
 
   // cycle through new container
   int i = 0, j = 0;
   for (itHit = thePxlBrlHits.begin(); itHit != thePxlBrlHits.end(); ++itHit) {
-
     ++i;
 
     // create a DetId from the detUnitId
@@ -937,13 +894,11 @@ void GlobalHitsProdHist::fillTrk(edm::Event &iEvent,
 
     // check that expected detector is returned
     if ((detector == dTrk) && (subdetector == sdPxlBrl)) {
-
       // get the GeomDetUnit from the geometry using theDetUnitID
       const GeomDetUnit *theDet = theTracker.idToDetUnit(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get GeomDetUnit from PxlBrlHits for Hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from PxlBrlHits for Hit " << i;
         continue;
       }
 
@@ -962,13 +917,11 @@ void GlobalHitsProdHist::fillTrk(edm::Event &iEvent,
         hTrackerPxEta->Fill(bSurface.toGlobal(itHit->localPosition()).eta());
 
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "PxlBrl PSimHit " << i << " is expected to be (det,subdet) = ("
-          << dTrk << "," << sdPxlBrl << "); value returned is: (" << detector
-          << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "PxlBrl PSimHit " << i << " is expected to be (det,subdet) = (" << dTrk << ","
+                                    << sdPxlBrl << "); value returned is: (" << detector << "," << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through PxlBrl Hits
+    }  // end detector type check
+  }    // end loop through PxlBrl Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of Pixel Barrel Hits collected:..... ";
@@ -985,29 +938,24 @@ void GlobalHitsProdHist::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> PxlFwdLowContainer;
   iEvent.getByToken(PxlFwdLowSrc_Token_, PxlFwdLowContainer);
   if (!PxlFwdLowContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsPixelEndcapLowTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsPixelEndcapLowTof in event!";
     return;
   }
   // extract high container
   edm::Handle<edm::PSimHitContainer> PxlFwdHighContainer;
   iEvent.getByToken(PxlFwdHighSrc_Token_, PxlFwdHighContainer);
   if (!PxlFwdHighContainer.isValid()) {
-    edm::LogWarning("GlobalHitsProdHist_fillTrk")
-        << "Unable to find TrackerHitsPixelEndcapHighTof in event!";
+    edm::LogWarning("GlobalHitsProdHist_fillTrk") << "Unable to find TrackerHitsPixelEndcapHighTof in event!";
     return;
   }
   // place both containers into new container
-  thePxlFwdHits.insert(thePxlFwdHits.end(), PxlFwdLowContainer->begin(),
-                       PxlFwdLowContainer->end());
-  thePxlFwdHits.insert(thePxlFwdHits.end(), PxlFwdHighContainer->begin(),
-                       PxlFwdHighContainer->end());
+  thePxlFwdHits.insert(thePxlFwdHits.end(), PxlFwdLowContainer->begin(), PxlFwdLowContainer->end());
+  thePxlFwdHits.insert(thePxlFwdHits.end(), PxlFwdHighContainer->begin(), PxlFwdHighContainer->end());
 
   // cycle through new container
   i = 0;
   j = 0;
   for (itHit = thePxlFwdHits.begin(); itHit != thePxlFwdHits.end(); ++itHit) {
-
     ++i;
 
     // create a DetId from the detUnitId
@@ -1017,13 +965,11 @@ void GlobalHitsProdHist::fillTrk(edm::Event &iEvent,
 
     // check that expected detector is returned
     if ((detector == dTrk) && (subdetector == sdPxlFwd)) {
-
       // get the GeomDetUnit from the geometry using theDetUnitID
       const GeomDetUnit *theDet = theTracker.idToDetUnit(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get GeomDetUnit from PxlFwdHits for Hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from PxlFwdHits for Hit " << i;
         ;
         continue;
       }
@@ -1043,13 +989,11 @@ void GlobalHitsProdHist::fillTrk(edm::Event &iEvent,
         hTrackerPxEta->Fill(bSurface.toGlobal(itHit->localPosition()).eta());
 
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "PxlFwd PSimHit " << i << " is expected to be (det,subdet) = ("
-          << dTrk << "," << sdPxlFwd << "); value returned is: (" << detector
-          << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "PxlFwd PSimHit " << i << " is expected to be (det,subdet) = (" << dTrk << ","
+                                    << sdPxlFwd << "); value returned is: (" << detector << "," << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through PxlFwd Hits
+    }  // end detector type check
+  }    // end loop through PxlFwd Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of Pixel Forward Hits collected:.... ";
@@ -1072,49 +1016,40 @@ void GlobalHitsProdHist::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> SiTIBLowContainer;
   iEvent.getByToken(SiTIBLowSrc_Token_, SiTIBLowContainer);
   if (!SiTIBLowContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsTIBLowTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsTIBLowTof in event!";
     return;
   }
   // extract TIB high container
   edm::Handle<edm::PSimHitContainer> SiTIBHighContainer;
   iEvent.getByToken(SiTIBHighSrc_Token_, SiTIBHighContainer);
   if (!SiTIBHighContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsTIBHighTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsTIBHighTof in event!";
     return;
   }
   // extract TOB low container
   edm::Handle<edm::PSimHitContainer> SiTOBLowContainer;
   iEvent.getByToken(SiTOBLowSrc_Token_, SiTOBLowContainer);
   if (!SiTOBLowContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsTOBLowTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsTOBLowTof in event!";
     return;
   }
   // extract TOB high container
   edm::Handle<edm::PSimHitContainer> SiTOBHighContainer;
   iEvent.getByToken(SiTOBHighSrc_Token_, SiTOBHighContainer);
   if (!SiTOBHighContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsTOBHighTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsTOBHighTof in event!";
     return;
   }
   // place all containers into new container
-  theSiBrlHits.insert(theSiBrlHits.end(), SiTIBLowContainer->begin(),
-                      SiTIBLowContainer->end());
-  theSiBrlHits.insert(theSiBrlHits.end(), SiTIBHighContainer->begin(),
-                      SiTIBHighContainer->end());
-  theSiBrlHits.insert(theSiBrlHits.end(), SiTOBLowContainer->begin(),
-                      SiTOBLowContainer->end());
-  theSiBrlHits.insert(theSiBrlHits.end(), SiTOBHighContainer->begin(),
-                      SiTOBHighContainer->end());
+  theSiBrlHits.insert(theSiBrlHits.end(), SiTIBLowContainer->begin(), SiTIBLowContainer->end());
+  theSiBrlHits.insert(theSiBrlHits.end(), SiTIBHighContainer->begin(), SiTIBHighContainer->end());
+  theSiBrlHits.insert(theSiBrlHits.end(), SiTOBLowContainer->begin(), SiTOBLowContainer->end());
+  theSiBrlHits.insert(theSiBrlHits.end(), SiTOBHighContainer->begin(), SiTOBHighContainer->end());
 
   // cycle through new container
   i = 0;
   j = 0;
   for (itHit = theSiBrlHits.begin(); itHit != theSiBrlHits.end(); ++itHit) {
-
     ++i;
 
     // create a DetId from the detUnitId
@@ -1123,15 +1058,12 @@ void GlobalHitsProdHist::fillTrk(edm::Event &iEvent,
     int subdetector = theDetUnitId.subdetId();
 
     // check that expected detector is returned
-    if ((detector == dTrk) &&
-        ((subdetector == sdSiTIB) || (subdetector == sdSiTOB))) {
-
+    if ((detector == dTrk) && ((subdetector == sdSiTIB) || (subdetector == sdSiTOB))) {
       // get the GeomDetUnit from the geometry using theDetUnitID
       const GeomDetUnit *theDet = theTracker.idToDetUnit(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get GeomDetUnit from SiBrlHits for Hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from SiBrlHits for Hit " << i;
         continue;
       }
 
@@ -1150,13 +1082,12 @@ void GlobalHitsProdHist::fillTrk(edm::Event &iEvent,
         hTrackerSiEta->Fill(bSurface.toGlobal(itHit->localPosition()).eta());
 
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "SiBrl PSimHit " << i << " is expected to be (det,subdet) = ("
-          << dTrk << "," << sdSiTIB << " || " << sdSiTOB
-          << "); value returned is: (" << detector << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "SiBrl PSimHit " << i << " is expected to be (det,subdet) = (" << dTrk << ","
+                                    << sdSiTIB << " || " << sdSiTOB << "); value returned is: (" << detector << ","
+                                    << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through SiBrl Hits
+    }  // end detector type check
+  }    // end loop through SiBrl Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of Silicon Barrel Hits collected:... ";
@@ -1173,49 +1104,40 @@ void GlobalHitsProdHist::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> SiTIDLowContainer;
   iEvent.getByToken(SiTIDLowSrc_Token_, SiTIDLowContainer);
   if (!SiTIDLowContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsTIDLowTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsTIDLowTof in event!";
     return;
   }
   // extract TID high container
   edm::Handle<edm::PSimHitContainer> SiTIDHighContainer;
   iEvent.getByToken(SiTIDHighSrc_Token_, SiTIDHighContainer);
   if (!SiTIDHighContainer.isValid()) {
-    edm::LogWarning("GlobalHitsProdHist_fillTrk")
-        << "Unable to find TrackerHitsTIDHighTof in event!";
+    edm::LogWarning("GlobalHitsProdHist_fillTrk") << "Unable to find TrackerHitsTIDHighTof in event!";
     return;
   }
   // extract TEC low container
   edm::Handle<edm::PSimHitContainer> SiTECLowContainer;
   iEvent.getByToken(SiTECLowSrc_Token_, SiTECLowContainer);
   if (!SiTECLowContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsTECLowTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsTECLowTof in event!";
     return;
   }
   // extract TEC high container
   edm::Handle<edm::PSimHitContainer> SiTECHighContainer;
   iEvent.getByToken(SiTECHighSrc_Token_, SiTECHighContainer);
   if (!SiTECHighContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsTECHighTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsTECHighTof in event!";
     return;
   }
   // place all containers into new container
-  theSiFwdHits.insert(theSiFwdHits.end(), SiTIDLowContainer->begin(),
-                      SiTIDLowContainer->end());
-  theSiFwdHits.insert(theSiFwdHits.end(), SiTIDHighContainer->begin(),
-                      SiTIDHighContainer->end());
-  theSiFwdHits.insert(theSiFwdHits.end(), SiTECLowContainer->begin(),
-                      SiTECLowContainer->end());
-  theSiFwdHits.insert(theSiFwdHits.end(), SiTECHighContainer->begin(),
-                      SiTECHighContainer->end());
+  theSiFwdHits.insert(theSiFwdHits.end(), SiTIDLowContainer->begin(), SiTIDLowContainer->end());
+  theSiFwdHits.insert(theSiFwdHits.end(), SiTIDHighContainer->begin(), SiTIDHighContainer->end());
+  theSiFwdHits.insert(theSiFwdHits.end(), SiTECLowContainer->begin(), SiTECLowContainer->end());
+  theSiFwdHits.insert(theSiFwdHits.end(), SiTECHighContainer->begin(), SiTECHighContainer->end());
 
   // cycle through container
   i = 0;
   j = 0;
   for (itHit = theSiFwdHits.begin(); itHit != theSiFwdHits.end(); ++itHit) {
-
     ++i;
 
     // create a DetId from the detUnitId
@@ -1224,15 +1146,12 @@ void GlobalHitsProdHist::fillTrk(edm::Event &iEvent,
     int subdetector = theDetUnitId.subdetId();
 
     // check that expected detector is returned
-    if ((detector == dTrk) &&
-        ((subdetector == sdSiTID) || (subdetector == sdSiTEC))) {
-
+    if ((detector == dTrk) && ((subdetector == sdSiTID) || (subdetector == sdSiTEC))) {
       // get the GeomDetUnit from the geometry using theDetUnitID
       const GeomDetUnit *theDet = theTracker.idToDetUnit(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get GeomDetUnit from SiFwdHits Hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from SiFwdHits Hit " << i;
         return;
       }
 
@@ -1251,13 +1170,12 @@ void GlobalHitsProdHist::fillTrk(edm::Event &iEvent,
         hTrackerSiEta->Fill(bSurface.toGlobal(itHit->localPosition()).eta());
 
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "SiFwd PSimHit " << i << " is expected to be (det,subdet) = ("
-          << dTrk << "," << sdSiTOB << " || " << sdSiTEC
-          << "); value returned is: (" << detector << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "SiFwd PSimHit " << i << " is expected to be (det,subdet) = (" << dTrk << ","
+                                    << sdSiTOB << " || " << sdSiTEC << "); value returned is: (" << detector << ","
+                                    << subdetector << ")";
       continue;
-    } // end check detector type
-  }   // end loop through SiFwd Hits
+    }  // end check detector type
+  }    // end loop through SiFwd Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of Silicon Forward Hits collected:.. ";
@@ -1277,8 +1195,7 @@ void GlobalHitsProdHist::fillTrk(edm::Event &iEvent,
   return;
 }
 
-void GlobalHitsProdHist::fillMuon(edm::Event &iEvent,
-                                  const edm::EventSetup &iSetup) {
+void GlobalHitsProdHist::fillMuon(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   nMuonHits = 0;
   std::string MsgLoggerCat = "GlobalHitsProdHist_fillMuon";
 
@@ -1296,8 +1213,7 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent,
   edm::ESHandle<CSCGeometry> theCSCGeometry;
   iSetup.get<MuonGeometryRecord>().get(theCSCGeometry);
   if (!theCSCGeometry.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find MuonGeometryRecord for the CSCGeometry in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the CSCGeometry in event!";
     return;
   }
   const CSCGeometry &theCSCMuon(*theCSCGeometry);
@@ -1312,9 +1228,7 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent,
 
   // cycle through container
   int i = 0, j = 0;
-  for (itHit = MuonCSCContainer->begin(); itHit != MuonCSCContainer->end();
-       ++itHit) {
-
+  for (itHit = MuonCSCContainer->begin(); itHit != MuonCSCContainer->end(); ++itHit) {
     ++i;
 
     // create a DetId from the detUnitId
@@ -1324,13 +1238,11 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent,
 
     // check that expected detector is returned
     if ((detector == dMuon) && (subdetector == sdMuonCSC)) {
-
       // get the GeomDetUnit from the geometry using theDetUnitID
       const GeomDetUnit *theDet = theCSCMuon.idToDetUnit(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get GeomDetUnit from theCSCMuon for hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from theCSCMuon for hit " << i;
         continue;
       }
 
@@ -1351,13 +1263,11 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent,
         hMuonEta->Fill(bSurface.toGlobal(itHit->localPosition()).eta());
 
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "MuonCsc PSimHit " << i << " is expected to be (det,subdet) = ("
-          << dMuon << "," << sdMuonCSC << "); value returned is: (" << detector
-          << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "MuonCsc PSimHit " << i << " is expected to be (det,subdet) = (" << dMuon << ","
+                                    << sdMuonCSC << "); value returned is: (" << detector << "," << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through CSC Hits
+    }  // end detector type check
+  }    // end loop through CSC Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of CSC muon Hits collected:......... ";
@@ -1373,8 +1283,7 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent,
   edm::ESHandle<DTGeometry> theDTGeometry;
   iSetup.get<MuonGeometryRecord>().get(theDTGeometry);
   if (!theDTGeometry.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find MuonGeometryRecord for the DTGeometry in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the DTGeometry in event!";
     return;
   }
   const DTGeometry &theDTMuon(*theDTGeometry);
@@ -1389,9 +1298,7 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent,
 
   // cycle through container
   i = 0, j = 0;
-  for (itHit = MuonDtContainer->begin(); itHit != MuonDtContainer->end();
-       ++itHit) {
-
+  for (itHit = MuonDtContainer->begin(); itHit != MuonDtContainer->end(); ++itHit) {
     ++i;
 
     // create a DetId from the detUnitId
@@ -1401,7 +1308,6 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent,
 
     // check that expected detector is returned
     if ((detector == dMuon) && (subdetector == sdMuonDT)) {
-
       // CSC uses wires and layers rather than the full detID
       // get the wireId
       DTWireId wireId(itHit->detUnitId());
@@ -1410,8 +1316,7 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent,
       const DTLayer *theDet = theDTMuon.layer(wireId.layerId());
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get GeomDetUnit from theDtMuon for hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from theDtMuon for hit " << i;
         continue;
       }
 
@@ -1432,13 +1337,11 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent,
         hMuonEta->Fill(bSurface.toGlobal(itHit->localPosition()).eta());
 
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "MuonDt PSimHit " << i << " is expected to be (det,subdet) = ("
-          << dMuon << "," << sdMuonDT << "); value returned is: (" << detector
-          << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "MuonDt PSimHit " << i << " is expected to be (det,subdet) = (" << dMuon << ","
+                                    << sdMuonDT << "); value returned is: (" << detector << "," << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through DT Hits
+    }  // end detector type check
+  }    // end loop through DT Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of DT muon Hits collected:.......... ";
@@ -1455,8 +1358,7 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent,
   edm::ESHandle<RPCGeometry> theRPCGeometry;
   iSetup.get<MuonGeometryRecord>().get(theRPCGeometry);
   if (!theRPCGeometry.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find MuonGeometryRecord for the RPCGeometry in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the RPCGeometry in event!";
     return;
   }
   const RPCGeometry &theRPCMuon(*theRPCGeometry);
@@ -1472,9 +1374,7 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent,
   // cycle through container
   i = 0, j = 0;
   int RPCBrl = 0, RPCFwd = 0;
-  for (itHit = MuonRPCContainer->begin(); itHit != MuonRPCContainer->end();
-       ++itHit) {
-
+  for (itHit = MuonRPCContainer->begin(); itHit != MuonRPCContainer->end(); ++itHit) {
     ++i;
 
     // create a DetID from the detUnitId
@@ -1484,7 +1384,6 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent,
 
     // check that expected detector is returned
     if ((detector == dMuon) && (subdetector == sdMuonRPC)) {
-
       // get an RPCDetID from the detUnitID
       RPCDetId RPCId(itHit->detUnitId());
 
@@ -1495,8 +1394,7 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent,
       const GeomDetUnit *theDet = theRPCMuon.idToDetUnit(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get GeomDetUnit from theRPCMuon for hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from theRPCMuon for hit " << i;
         continue;
       }
 
@@ -1537,15 +1435,13 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent,
       } else {
         edm::LogWarning(MsgLoggerCat) << "Invalid region for RPC Muon hit" << i;
         continue;
-      } // end check of region
+      }  // end check of region
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "MuonRpc PSimHit " << i << " is expected to be (det,subdet) = ("
-          << dMuon << "," << sdMuonRPC << "); value returned is: (" << detector
-          << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "MuonRpc PSimHit " << i << " is expected to be (det,subdet) = (" << dMuon << ","
+                                    << sdMuonRPC << "); value returned is: (" << detector << "," << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through RPC Hits
+    }  // end detector type check
+  }    // end loop through RPC Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of RPC muon Hits collected:......... ";
@@ -1569,8 +1465,7 @@ void GlobalHitsProdHist::fillMuon(edm::Event &iEvent,
   return;
 }
 
-void GlobalHitsProdHist::fillECal(edm::Event &iEvent,
-                                  const edm::EventSetup &iSetup) {
+void GlobalHitsProdHist::fillECal(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   std::string MsgLoggerCat = "GlobalHitsProdHist_fillECal";
 
   TString eventout;
@@ -1581,8 +1476,7 @@ void GlobalHitsProdHist::fillECal(edm::Event &iEvent,
   edm::ESHandle<CaloGeometry> theCaloGeometry;
   iSetup.get<CaloGeometryRecord>().get(theCaloGeometry);
   if (!theCaloGeometry.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find CaloGeometryRecord in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometryRecord in event!";
     return;
   }
   const CaloGeometry &theCalo(*theCaloGeometry);
@@ -1609,15 +1503,12 @@ void GlobalHitsProdHist::fillECal(edm::Event &iEvent,
     return;
   }
   // place both containers into new container
-  theECalHits.insert(theECalHits.end(), EBContainer->begin(),
-                     EBContainer->end());
-  theECalHits.insert(theECalHits.end(), EEContainer->begin(),
-                     EEContainer->end());
+  theECalHits.insert(theECalHits.end(), EBContainer->begin(), EBContainer->end());
+  theECalHits.insert(theECalHits.end(), EEContainer->begin(), EEContainer->end());
 
   // cycle through new container
   int i = 0, j = 0;
   for (itHit = theECalHits.begin(); itHit != theECalHits.end(); ++itHit) {
-
     ++i;
 
     // create a DetId from the detUnitId
@@ -1626,16 +1517,12 @@ void GlobalHitsProdHist::fillECal(edm::Event &iEvent,
     int subdetector = theDetUnitId.subdetId();
 
     // check that expected detector is returned
-    if ((detector == dEcal) &&
-        ((subdetector == sdEcalBrl) || (subdetector == sdEcalFwd))) {
-
+    if ((detector == dEcal) && ((subdetector == sdEcalBrl) || (subdetector == sdEcalFwd))) {
       // get the Cell geometry
-      auto theDet = (theCalo.getSubdetectorGeometry(theDetUnitId))
-                        ->getGeometry(theDetUnitId);
+      auto theDet = (theCalo.getSubdetectorGeometry(theDetUnitId))->getGeometry(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get CaloCellGeometry from ECalHits for Hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get CaloCellGeometry from ECalHits for Hit " << i;
         continue;
       }
 
@@ -1658,13 +1545,12 @@ void GlobalHitsProdHist::fillECal(edm::Event &iEvent,
         hCaloEcalEta->Fill(globalposition.eta());
 
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "ECal PCaloHit " << i << " is expected to be (det,subdet) = ("
-          << dEcal << "," << sdEcalBrl << " || " << sdEcalFwd
-          << "); value returned is: (" << detector << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "ECal PCaloHit " << i << " is expected to be (det,subdet) = (" << dEcal << ","
+                                    << sdEcalBrl << " || " << sdEcalFwd << "); value returned is: (" << detector << ","
+                                    << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through ECal Hits
+    }  // end detector type check
+  }    // end loop through ECal Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of ECal Hits collected:............. ";
@@ -1689,9 +1575,7 @@ void GlobalHitsProdHist::fillECal(edm::Event &iEvent,
 
   // cycle through container
   i = 0, j = 0;
-  for (itHit = PreShContainer->begin(); itHit != PreShContainer->end();
-       ++itHit) {
-
+  for (itHit = PreShContainer->begin(); itHit != PreShContainer->end(); ++itHit) {
     ++i;
 
     // create a DetId from the detUnitId
@@ -1701,15 +1585,11 @@ void GlobalHitsProdHist::fillECal(edm::Event &iEvent,
 
     // check that expected detector is returned
     if ((detector == dEcal) && (subdetector == sdEcalPS)) {
-
       // get the Cell geometry
-      auto theDet = (theCalo.getSubdetectorGeometry(theDetUnitId))
-                        ->getGeometry(theDetUnitId);
+      auto theDet = (theCalo.getSubdetectorGeometry(theDetUnitId))->getGeometry(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get CaloCellGeometry from PreShContainer for Hit "
-            << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get CaloCellGeometry from PreShContainer for Hit " << i;
         continue;
       }
 
@@ -1732,13 +1612,11 @@ void GlobalHitsProdHist::fillECal(edm::Event &iEvent,
         hCaloPreShEta->Fill(globalposition.eta());
 
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "PreSh PCaloHit " << i << " is expected to be (det,subdet) = ("
-          << dEcal << "," << sdEcalPS << "); value returned is: (" << detector
-          << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "PreSh PCaloHit " << i << " is expected to be (det,subdet) = (" << dEcal << ","
+                                    << sdEcalPS << "); value returned is: (" << detector << "," << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through PreShower Hits
+    }  // end detector type check
+  }    // end loop through PreShower Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of PreSh Hits collected:............ ";
@@ -1756,8 +1634,7 @@ void GlobalHitsProdHist::fillECal(edm::Event &iEvent,
   return;
 }
 
-void GlobalHitsProdHist::fillHCal(edm::Event &iEvent,
-                                  const edm::EventSetup &iSetup) {
+void GlobalHitsProdHist::fillHCal(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   std::string MsgLoggerCat = "GlobalHitsProdHist_fillHCal";
 
   TString eventout;
@@ -1768,8 +1645,7 @@ void GlobalHitsProdHist::fillHCal(edm::Event &iEvent,
   edm::ESHandle<CaloGeometry> theCaloGeometry;
   iSetup.get<CaloGeometryRecord>().get(theCaloGeometry);
   if (!theCaloGeometry.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find CaloGeometryRecord in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometryRecord in event!";
     return;
   }
   const CaloGeometry &theCalo(*theCaloGeometry);
@@ -1791,7 +1667,6 @@ void GlobalHitsProdHist::fillHCal(edm::Event &iEvent,
   // cycle through container
   int i = 0, j = 0;
   for (itHit = HCalContainer->begin(); itHit != HCalContainer->end(); ++itHit) {
-
     ++i;
 
     // create a DetId from the detUnitId
@@ -1800,17 +1675,13 @@ void GlobalHitsProdHist::fillHCal(edm::Event &iEvent,
     int subdetector = theDetUnitId.subdetId();
 
     // check that expected detector is returned
-    if ((detector == dHcal) &&
-        ((subdetector == sdHcalBrl) || (subdetector == sdHcalEC) ||
-         (subdetector == sdHcalOut) || (subdetector == sdHcalFwd))) {
-
+    if ((detector == dHcal) && ((subdetector == sdHcalBrl) || (subdetector == sdHcalEC) || (subdetector == sdHcalOut) ||
+                                (subdetector == sdHcalFwd))) {
       // get the Cell geometry
-      const HcalGeometry *theDet = dynamic_cast<const HcalGeometry *>(
-          theCalo.getSubdetectorGeometry(theDetUnitId));
+      const HcalGeometry *theDet = dynamic_cast<const HcalGeometry *>(theCalo.getSubdetectorGeometry(theDetUnitId));
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get HcalGeometry from HCalContainer for Hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get HcalGeometry from HCalContainer for Hit " << i;
         continue;
       }
 
@@ -1833,14 +1704,12 @@ void GlobalHitsProdHist::fillHCal(edm::Event &iEvent,
         hCaloHcalEta->Fill(globalposition.eta());
 
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "HCal PCaloHit " << i << " is expected to be (det,subdet) = ("
-          << dHcal << "," << sdHcalBrl << " || " << sdHcalEC << " || "
-          << sdHcalOut << " || " << sdHcalFwd << "); value returned is: ("
-          << detector << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "HCal PCaloHit " << i << " is expected to be (det,subdet) = (" << dHcal << ","
+                                    << sdHcalBrl << " || " << sdHcalEC << " || " << sdHcalOut << " || " << sdHcalFwd
+                                    << "); value returned is: (" << detector << "," << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through HCal Hits
+    }  // end detector type check
+  }    // end loop through HCal Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of HCal Hits collected:............. ";

--- a/Validation/GlobalHits/src/GlobalHitsProdHistStripper.cc
+++ b/Validation/GlobalHits/src/GlobalHitsProdHistStripper.cc
@@ -9,13 +9,16 @@
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "Validation/GlobalHits/interface/GlobalHitsProdHistStripper.h"
 
-GlobalHitsProdHistStripper::GlobalHitsProdHistStripper(
-    const edm::ParameterSet &iPSet)
-    : fName(""), verbosity(0), frequency(0), vtxunit(0),
-      getAllProvenances(false), printProvenanceInfo(false), outputfile(""),
+GlobalHitsProdHistStripper::GlobalHitsProdHistStripper(const edm::ParameterSet &iPSet)
+    : fName(""),
+      verbosity(0),
+      frequency(0),
+      vtxunit(0),
+      getAllProvenances(false),
+      printProvenanceInfo(false),
+      outputfile(""),
       count(0) {
-  std::string MsgLoggerCat =
-      "GlobalHitsProdHistStripper_GlobalHitsProdHistStripper";
+  std::string MsgLoggerCat = "GlobalHitsProdHistStripper_GlobalHitsProdHistStripper";
 
   // get information from parameter set
   fName = iPSet.getUntrackedParameter<std::string>("Name");
@@ -24,11 +27,9 @@ GlobalHitsProdHistStripper::GlobalHitsProdHistStripper(
   vtxunit = iPSet.getUntrackedParameter<int>("VtxUnit");
   outputfile = iPSet.getParameter<std::string>("OutputFile");
   doOutput = iPSet.getParameter<bool>("DoOutput");
-  edm::ParameterSet m_Prov =
-      iPSet.getParameter<edm::ParameterSet>("ProvenanceLookup");
+  edm::ParameterSet m_Prov = iPSet.getParameter<edm::ParameterSet>("ProvenanceLookup");
   getAllProvenances = m_Prov.getUntrackedParameter<bool>("GetAllProvenances");
-  printProvenanceInfo =
-      m_Prov.getUntrackedParameter<bool>("PrintProvenanceInfo");
+  printProvenanceInfo = m_Prov.getUntrackedParameter<bool>("PrintProvenanceInfo");
 
   // use value of first digit to determine default output level (inclusive)
   // 0 is none, 1 is basic, 2 is fill output, 3 is gather output
@@ -52,18 +53,17 @@ GlobalHitsProdHistStripper::GlobalHitsProdHistStripper(
 
   // print out Parameter Set information being used
   if (verbosity >= 0) {
-    edm::LogInfo(MsgLoggerCat)
-        << "\n===============================\n"
-        << "Initialized as EDAnalyzer with parameter values:\n"
-        << "    Name           = " << fName << "\n"
-        << "    Verbosity      = " << verbosity << "\n"
-        << "    Frequency      = " << frequency << "\n"
-        << "    VtxUnit        = " << vtxunit << "\n"
-        << "    OutputFile     = " << outputfile << "\n"
-        << "    DoOutput      = " << doOutput << "\n"
-        << "    GetProv        = " << getAllProvenances << "\n"
-        << "    PrintProv      = " << printProvenanceInfo << "\n"
-        << "===============================\n";
+    edm::LogInfo(MsgLoggerCat) << "\n===============================\n"
+                               << "Initialized as EDAnalyzer with parameter values:\n"
+                               << "    Name           = " << fName << "\n"
+                               << "    Verbosity      = " << verbosity << "\n"
+                               << "    Frequency      = " << frequency << "\n"
+                               << "    VtxUnit        = " << vtxunit << "\n"
+                               << "    OutputFile     = " << outputfile << "\n"
+                               << "    DoOutput      = " << doOutput << "\n"
+                               << "    GetProv        = " << getAllProvenances << "\n"
+                               << "    PrintProv      = " << printProvenanceInfo << "\n"
+                               << "===============================\n";
   }
 }
 
@@ -78,13 +78,11 @@ void GlobalHitsProdHistStripper::beginJob(void) { return; }
 void GlobalHitsProdHistStripper::endJob() {
   std::string MsgLoggerCat = "GlobalHitsProdHistStripper_endJob";
   if (verbosity >= 0)
-    edm::LogInfo(MsgLoggerCat)
-        << "Terminating having processed " << count << " runs.";
+    edm::LogInfo(MsgLoggerCat) << "Terminating having processed " << count << " runs.";
   return;
 }
 
-void GlobalHitsProdHistStripper::beginRun(const edm::Run &iRun,
-                                          const edm::EventSetup &iSetup) {
+void GlobalHitsProdHistStripper::beginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
   std::string MsgLoggerCat = "GlobalHitsProdHistStripper_beginRun";
   // keep track of number of runs processed
   ++count;
@@ -92,23 +90,19 @@ void GlobalHitsProdHistStripper::beginRun(const edm::Run &iRun,
   int nrun = iRun.run();
 
   if (verbosity > 0) {
-    edm::LogInfo(MsgLoggerCat)
-        << "Processing run " << nrun << " (" << count << " runs total)";
+    edm::LogInfo(MsgLoggerCat) << "Processing run " << nrun << " (" << count << " runs total)";
   } else if (verbosity == 0) {
     if (nrun % frequency == 0 || count == 1) {
-      edm::LogInfo(MsgLoggerCat)
-          << "Processing run " << nrun << " (" << count << " runs total)";
+      edm::LogInfo(MsgLoggerCat) << "Processing run " << nrun << " (" << count << " runs total)";
     }
   }
 
   if (getAllProvenances) {
-
     std::vector<const edm::StableProvenance *> AllProv;
     iRun.getAllStableProvenance(AllProv);
 
     if (verbosity >= 0)
-      edm::LogInfo(MsgLoggerCat)
-          << "Number of Provenances = " << AllProv.size();
+      edm::LogInfo(MsgLoggerCat) << "Number of Provenances = " << AllProv.size();
 
     if (printProvenanceInfo && (verbosity >= 0)) {
       TString eventout("\nProvenance info:\n");
@@ -136,8 +130,7 @@ void GlobalHitsProdHistStripper::beginRun(const edm::Run &iRun,
   return;
 }
 
-void GlobalHitsProdHistStripper::endRun(const edm::Run &iRun,
-                                        const edm::EventSetup &iSetup) {
+void GlobalHitsProdHistStripper::endRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
   std::string MsgLoggerCat = "GlobalHitsProdHistStripper_endRun";
 
   edm::Handle<TH1F> histogram1D;
@@ -149,8 +142,7 @@ void GlobalHitsProdHistStripper::endRun(const edm::Run &iRun,
   for (uint i = 0; i < allhistogram1D.size(); ++i) {
     histogram1D = allhistogram1D[i];
     if (!histogram1D.isValid()) {
-      edm::LogWarning(MsgLoggerCat)
-          << "Invalid histogram extracted from event.";
+      edm::LogWarning(MsgLoggerCat) << "Invalid histogram extracted from event.";
       continue;
     }
 
@@ -177,8 +169,7 @@ void GlobalHitsProdHistStripper::endRun(const edm::Run &iRun,
               << std::endl;
     */
 
-    if ((histogram1D.provenance()->branchDescription()).moduleLabel() !=
-        "globalhitsprodhist")
+    if ((histogram1D.provenance()->branchDescription()).moduleLabel() != "globalhitsprodhist")
       continue;
 
     std::string histname = histogram1D->GetName();
@@ -191,8 +182,7 @@ void GlobalHitsProdHistStripper::endRun(const edm::Run &iRun,
         dbe->setCurrentFolder("GlobalHitsV/ECal");
       } else if (subhist1 == "CaloH") {
         dbe->setCurrentFolder("GlobalHitsV/HCal");
-      } else if (subhist1 == "Geant" || subhist2 == "MCG4" ||
-                 subhist1 == "MCRGP") {
+      } else if (subhist1 == "Geant" || subhist2 == "MCG4" || subhist1 == "MCRGP") {
         dbe->setCurrentFolder("GlobalHitsV/MCGeant");
       } else if (subhist2 == "Muon") {
         dbe->setCurrentFolder("GlobalHitsV/Muon");
@@ -200,7 +190,8 @@ void GlobalHitsProdHistStripper::endRun(const edm::Run &iRun,
         dbe->setCurrentFolder("GlobalHitsV/Tracker");
       }
 
-      me[i] = dbe->book1D(histname, histogram1D->GetTitle(),
+      me[i] = dbe->book1D(histname,
+                          histogram1D->GetTitle(),
                           histogram1D->GetXaxis()->GetNbins(),
                           histogram1D->GetXaxis()->GetXmin(),
                           histogram1D->GetXaxis()->GetXmax());
@@ -264,7 +255,4 @@ return;
 }
 */
 
-void GlobalHitsProdHistStripper::analyze(const edm::Event &iEvent,
-                                         const edm::EventSetup &iSetup) {
-  return;
-}
+void GlobalHitsProdHistStripper::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) { return; }

--- a/Validation/GlobalHits/src/GlobalHitsProducer.cc
+++ b/Validation/GlobalHits/src/GlobalHitsProducer.cc
@@ -10,12 +10,16 @@
 #include "Validation/GlobalHits/interface/GlobalHitsProducer.h"
 
 GlobalHitsProducer::GlobalHitsProducer(const edm::ParameterSet &iPSet)
-    : fName(""), verbosity(0), frequency(0), vtxunit(0), label(""),
-      getAllProvenances(false), printProvenanceInfo(false), nRawGenPart(0),
-      G4VtxSrc_Token_(consumes<edm::SimVertexContainer>(
-          (iPSet.getParameter<edm::InputTag>("G4VtxSrc")))),
-      G4TrkSrc_Token_(consumes<edm::SimTrackContainer>(
-          iPSet.getParameter<edm::InputTag>("G4TrkSrc"))),
+    : fName(""),
+      verbosity(0),
+      frequency(0),
+      vtxunit(0),
+      label(""),
+      getAllProvenances(false),
+      printProvenanceInfo(false),
+      nRawGenPart(0),
+      G4VtxSrc_Token_(consumes<edm::SimVertexContainer>((iPSet.getParameter<edm::InputTag>("G4VtxSrc")))),
+      G4TrkSrc_Token_(consumes<edm::SimTrackContainer>(iPSet.getParameter<edm::InputTag>("G4TrkSrc"))),
       // ECalEBSrc_(""), ECalEESrc_(""), ECalESSrc_(""), HCalSrc_(""),
       // PxlBrlLowSrc_(""), PxlBrlHighSrc_(""), PxlFwdLowSrc_(""),
       // PxlFwdHighSrc_(""), SiTIBLowSrc_(""), SiTIBHighSrc_(""),
@@ -31,11 +35,9 @@ GlobalHitsProducer::GlobalHitsProducer(const edm::ParameterSet &iPSet)
   frequency = iPSet.getUntrackedParameter<int>("Frequency");
   vtxunit = iPSet.getUntrackedParameter<int>("VtxUnit");
   label = iPSet.getParameter<std::string>("Label");
-  edm::ParameterSet m_Prov =
-      iPSet.getParameter<edm::ParameterSet>("ProvenanceLookup");
+  edm::ParameterSet m_Prov = iPSet.getParameter<edm::ParameterSet>("ProvenanceLookup");
   getAllProvenances = m_Prov.getUntrackedParameter<bool>("GetAllProvenances");
-  printProvenanceInfo =
-      m_Prov.getUntrackedParameter<bool>("PrintProvenanceInfo");
+  printProvenanceInfo = m_Prov.getUntrackedParameter<bool>("PrintProvenanceInfo");
 
   // get Labels to use to extract information
   PxlBrlLowSrc_ = iPSet.getParameter<edm::InputTag>("PxlBrlLowSrc");
@@ -63,47 +65,28 @@ GlobalHitsProducer::GlobalHitsProducer(const edm::ParameterSet &iPSet)
   HCalSrc_ = iPSet.getParameter<edm::InputTag>("HCalSrc");
 
   // fix for consumes
-  PxlBrlLowSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("PxlBrlLowSrc"));
-  PxlBrlHighSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("PxlBrlHighSrc"));
-  PxlFwdLowSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("PxlFwdLowSrc"));
-  PxlFwdHighSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("PxlFwdHighSrc"));
+  PxlBrlLowSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("PxlBrlLowSrc"));
+  PxlBrlHighSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("PxlBrlHighSrc"));
+  PxlFwdLowSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("PxlFwdLowSrc"));
+  PxlFwdHighSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("PxlFwdHighSrc"));
 
-  SiTIBLowSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("SiTIBLowSrc"));
-  SiTIBHighSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("SiTIBHighSrc"));
-  SiTOBLowSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("SiTOBLowSrc"));
-  SiTOBHighSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("SiTOBHighSrc"));
-  SiTIDLowSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("SiTIDLowSrc"));
-  SiTIDHighSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("SiTIDHighSrc"));
-  SiTECLowSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("SiTECLowSrc"));
-  SiTECHighSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("SiTECHighSrc"));
+  SiTIBLowSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTIBLowSrc"));
+  SiTIBHighSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTIBHighSrc"));
+  SiTOBLowSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTOBLowSrc"));
+  SiTOBHighSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTOBHighSrc"));
+  SiTIDLowSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTIDLowSrc"));
+  SiTIDHighSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTIDHighSrc"));
+  SiTECLowSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTECLowSrc"));
+  SiTECHighSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTECHighSrc"));
 
-  MuonCscSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("MuonCscSrc"));
-  MuonDtSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("MuonDtSrc"));
-  MuonRpcSrc_Token_ = consumes<edm::PSimHitContainer>(
-      iPSet.getParameter<edm::InputTag>("MuonRpcSrc"));
+  MuonCscSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("MuonCscSrc"));
+  MuonDtSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("MuonDtSrc"));
+  MuonRpcSrc_Token_ = consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("MuonRpcSrc"));
 
-  ECalEBSrc_Token_ = consumes<edm::PCaloHitContainer>(
-      iPSet.getParameter<edm::InputTag>("ECalEBSrc"));
-  ECalEESrc_Token_ = consumes<edm::PCaloHitContainer>(
-      iPSet.getParameter<edm::InputTag>("ECalEESrc"));
-  ECalESSrc_Token_ = consumes<edm::PCaloHitContainer>(
-      iPSet.getParameter<edm::InputTag>("ECalESSrc"));
-  HCalSrc_Token_ = consumes<edm::PCaloHitContainer>(
-      iPSet.getParameter<edm::InputTag>("HCalSrc"));
+  ECalEBSrc_Token_ = consumes<edm::PCaloHitContainer>(iPSet.getParameter<edm::InputTag>("ECalEBSrc"));
+  ECalEESrc_Token_ = consumes<edm::PCaloHitContainer>(iPSet.getParameter<edm::InputTag>("ECalEESrc"));
+  ECalESSrc_Token_ = consumes<edm::PCaloHitContainer>(iPSet.getParameter<edm::InputTag>("ECalESSrc"));
+  HCalSrc_Token_ = consumes<edm::PCaloHitContainer>(iPSet.getParameter<edm::InputTag>("HCalSrc"));
 
   // use value of first digit to determine default output level (inclusive)
   // 0 is none, 1 is basic, 2 is fill output, 3 is gather output
@@ -124,44 +107,25 @@ GlobalHitsProducer::GlobalHitsProducer(const edm::ParameterSet &iPSet)
         << "    Label         = " << label << "\n"
         << "    GetProv       = " << getAllProvenances << "\n"
         << "    PrintProv     = " << printProvenanceInfo << "\n"
-        << "    PxlBrlLowSrc  = " << PxlBrlLowSrc_.label() << ":"
-        << PxlBrlLowSrc_.instance() << "\n"
-        << "    PxlBrlHighSrc = " << PxlBrlHighSrc_.label() << ":"
-        << PxlBrlHighSrc_.instance() << "\n"
-        << "    PxlFwdLowSrc  = " << PxlFwdLowSrc_.label() << ":"
-        << PxlBrlLowSrc_.instance() << "\n"
-        << "    PxlFwdHighSrc = " << PxlFwdHighSrc_.label() << ":"
-        << PxlBrlHighSrc_.instance() << "\n"
-        << "    SiTIBLowSrc   = " << SiTIBLowSrc_.label() << ":"
-        << SiTIBLowSrc_.instance() << "\n"
-        << "    SiTIBHighSrc  = " << SiTIBHighSrc_.label() << ":"
-        << SiTIBHighSrc_.instance() << "\n"
-        << "    SiTOBLowSrc   = " << SiTOBLowSrc_.label() << ":"
-        << SiTOBLowSrc_.instance() << "\n"
-        << "    SiTOBHighSrc  = " << SiTOBHighSrc_.label() << ":"
-        << SiTOBHighSrc_.instance() << "\n"
-        << "    SiTIDLowSrc   = " << SiTIDLowSrc_.label() << ":"
-        << SiTIDLowSrc_.instance() << "\n"
-        << "    SiTIDHighSrc  = " << SiTIDHighSrc_.label() << ":"
-        << SiTIDHighSrc_.instance() << "\n"
-        << "    SiTECLowSrc   = " << SiTECLowSrc_.label() << ":"
-        << SiTECLowSrc_.instance() << "\n"
-        << "    SiTECHighSrc  = " << SiTECHighSrc_.label() << ":"
-        << SiTECHighSrc_.instance() << "\n"
-        << "    MuonCscSrc    = " << MuonCscSrc_.label() << ":"
-        << MuonCscSrc_.instance() << "\n"
-        << "    MuonDtSrc     = " << MuonDtSrc_.label() << ":"
-        << MuonDtSrc_.instance() << "\n"
-        << "    MuonRpcSrc    = " << MuonRpcSrc_.label() << ":"
-        << MuonRpcSrc_.instance() << "\n"
-        << "    ECalEBSrc     = " << ECalEBSrc_.label() << ":"
-        << ECalEBSrc_.instance() << "\n"
-        << "    ECalEESrc     = " << ECalEESrc_.label() << ":"
-        << ECalEESrc_.instance() << "\n"
-        << "    ECalESSrc     = " << ECalESSrc_.label() << ":"
-        << ECalESSrc_.instance() << "\n"
-        << "    HCalSrc       = " << HCalSrc_.label() << ":"
-        << HCalSrc_.instance() << "\n"
+        << "    PxlBrlLowSrc  = " << PxlBrlLowSrc_.label() << ":" << PxlBrlLowSrc_.instance() << "\n"
+        << "    PxlBrlHighSrc = " << PxlBrlHighSrc_.label() << ":" << PxlBrlHighSrc_.instance() << "\n"
+        << "    PxlFwdLowSrc  = " << PxlFwdLowSrc_.label() << ":" << PxlBrlLowSrc_.instance() << "\n"
+        << "    PxlFwdHighSrc = " << PxlFwdHighSrc_.label() << ":" << PxlBrlHighSrc_.instance() << "\n"
+        << "    SiTIBLowSrc   = " << SiTIBLowSrc_.label() << ":" << SiTIBLowSrc_.instance() << "\n"
+        << "    SiTIBHighSrc  = " << SiTIBHighSrc_.label() << ":" << SiTIBHighSrc_.instance() << "\n"
+        << "    SiTOBLowSrc   = " << SiTOBLowSrc_.label() << ":" << SiTOBLowSrc_.instance() << "\n"
+        << "    SiTOBHighSrc  = " << SiTOBHighSrc_.label() << ":" << SiTOBHighSrc_.instance() << "\n"
+        << "    SiTIDLowSrc   = " << SiTIDLowSrc_.label() << ":" << SiTIDLowSrc_.instance() << "\n"
+        << "    SiTIDHighSrc  = " << SiTIDHighSrc_.label() << ":" << SiTIDHighSrc_.instance() << "\n"
+        << "    SiTECLowSrc   = " << SiTECLowSrc_.label() << ":" << SiTECLowSrc_.instance() << "\n"
+        << "    SiTECHighSrc  = " << SiTECHighSrc_.label() << ":" << SiTECHighSrc_.instance() << "\n"
+        << "    MuonCscSrc    = " << MuonCscSrc_.label() << ":" << MuonCscSrc_.instance() << "\n"
+        << "    MuonDtSrc     = " << MuonDtSrc_.label() << ":" << MuonDtSrc_.instance() << "\n"
+        << "    MuonRpcSrc    = " << MuonRpcSrc_.label() << ":" << MuonRpcSrc_.instance() << "\n"
+        << "    ECalEBSrc     = " << ECalEBSrc_.label() << ":" << ECalEBSrc_.instance() << "\n"
+        << "    ECalEESrc     = " << ECalEESrc_.label() << ":" << ECalEESrc_.instance() << "\n"
+        << "    ECalESSrc     = " << ECalESSrc_.label() << ":" << ECalESSrc_.instance() << "\n"
+        << "    HCalSrc       = " << HCalSrc_.label() << ":" << HCalSrc_.instance() << "\n"
         << "===============================\n";
   }
 
@@ -176,13 +140,11 @@ void GlobalHitsProducer::beginJob(void) { return; }
 void GlobalHitsProducer::endJob() {
   std::string MsgLoggerCat = "GlobalHitsProducer_endJob";
   if (verbosity >= 0)
-    edm::LogInfo(MsgLoggerCat)
-        << "Terminating having processed " << count << " events.";
+    edm::LogInfo(MsgLoggerCat) << "Terminating having processed " << count << " events.";
   return;
 }
 
-void GlobalHitsProducer::produce(edm::Event &iEvent,
-                                 const edm::EventSetup &iSetup) {
+void GlobalHitsProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   std::string MsgLoggerCat = "GlobalHitsProducer_produce";
 
   // keep track of number of events processed
@@ -193,12 +155,11 @@ void GlobalHitsProducer::produce(edm::Event &iEvent,
   edm::EventNumber_t nevt = iEvent.id().event();
 
   if (verbosity > 0) {
-    edm::LogInfo(MsgLoggerCat) << "Processing run " << nrun << ", event "
-                               << nevt << " (" << count << " events total)";
+    edm::LogInfo(MsgLoggerCat) << "Processing run " << nrun << ", event " << nevt << " (" << count << " events total)";
   } else if (verbosity == 0) {
     if (nevt % frequency == 0 || nevt == 1) {
-      edm::LogInfo(MsgLoggerCat) << "Processing run " << nrun << ", event "
-                                 << nevt << " (" << count << " events total)";
+      edm::LogInfo(MsgLoggerCat) << "Processing run " << nrun << ", event " << nevt << " (" << count
+                                 << " events total)";
     }
   }
 
@@ -207,13 +168,11 @@ void GlobalHitsProducer::produce(edm::Event &iEvent,
 
   // look at information available in the event
   if (getAllProvenances) {
-
     std::vector<const edm::StableProvenance *> AllProv;
     iEvent.getAllStableProvenance(AllProv);
 
     if (verbosity >= 0)
-      edm::LogInfo(MsgLoggerCat)
-          << "Number of Provenances = " << AllProv.size();
+      edm::LogInfo(MsgLoggerCat) << "Number of Provenances = " << AllProv.size();
 
     if (printProvenanceInfo && (verbosity >= 0)) {
       TString eventout("\nProvenance info:\n");
@@ -279,7 +238,6 @@ void GlobalHitsProducer::produce(edm::Event &iEvent,
 
 //==================fill and store functions================================
 void GlobalHitsProducer::fillG4MC(edm::Event &iEvent) {
-
   std::string MsgLoggerCat = "GlobalHitsProducer_fillG4MC";
 
   TString eventout;
@@ -297,8 +255,7 @@ void GlobalHitsProducer::fillG4MC(edm::Event &iEvent) {
   // should have the information needed
   for (unsigned int i = 0; i < AllHepMCEvt.size(); ++i) {
     HepMCEvt = AllHepMCEvt[i];
-    if ((HepMCEvt.provenance()->branchDescription()).moduleLabel() ==
-        "generatorSmeared")
+    if ((HepMCEvt.provenance()->branchDescription()).moduleLabel() == "generatorSmeared")
       break;
   }
 
@@ -323,9 +280,9 @@ void GlobalHitsProducer::fillG4MC(edm::Event &iEvent) {
   // convert unit stored in SimVertex to mm
   float unit = 0.;
   if (vtxunit == 0)
-    unit = 1.; // already in mm
+    unit = 1.;  // already in mm
   if (vtxunit == 1)
-    unit = 10.; // stored in cm, convert to mm
+    unit = 10.;  // stored in cm, convert to mm
 
   edm::Handle<edm::SimVertexContainer> G4VtxContainer;
   iEvent.getByToken(G4VtxSrc_Token_, G4VtxContainer);
@@ -335,14 +292,11 @@ void GlobalHitsProducer::fillG4MC(edm::Event &iEvent) {
   }
   int i = 0;
   edm::SimVertexContainer::const_iterator itVtx;
-  for (itVtx = G4VtxContainer->begin(); itVtx != G4VtxContainer->end();
-       ++itVtx) {
-
+  for (itVtx = G4VtxContainer->begin(); itVtx != G4VtxContainer->end(); ++itVtx) {
     ++i;
 
     const math::XYZTLorentzVector G4Vtx1(
-        itVtx->position().x(), itVtx->position().y(), itVtx->position().z(),
-        itVtx->position().e());
+        itVtx->position().x(), itVtx->position().y(), itVtx->position().z(), itVtx->position().e());
     double G4Vtx[4];
     G4Vtx1.GetCoordinates(G4Vtx);
 
@@ -368,19 +322,16 @@ void GlobalHitsProducer::fillG4MC(edm::Event &iEvent) {
   }
   i = 0;
   edm::SimTrackContainer::const_iterator itTrk;
-  for (itTrk = G4TrkContainer->begin(); itTrk != G4TrkContainer->end();
-       ++itTrk) {
-
+  for (itTrk = G4TrkContainer->begin(); itTrk != G4TrkContainer->end(); ++itTrk) {
     ++i;
 
     const math::XYZTLorentzVector G4Trk1(
-        itTrk->momentum().x(), itTrk->momentum().y(), itTrk->momentum().z(),
-        itTrk->momentum().e());
+        itTrk->momentum().x(), itTrk->momentum().y(), itTrk->momentum().z(), itTrk->momentum().e());
     double G4Trk[4];
     G4Trk1.GetCoordinates(G4Trk);
 
-    G4TrkPt.push_back(sqrt(G4Trk[0] * G4Trk[0] + G4Trk[1] * G4Trk[1])); // GeV
-    G4TrkE.push_back(G4Trk[3]);                                         // GeV
+    G4TrkPt.push_back(sqrt(G4Trk[0] * G4Trk[0] + G4Trk[1] * G4Trk[1]));  // GeV
+    G4TrkE.push_back(G4Trk[3]);                                          // GeV
   }
 
   if (verbosity > 1) {
@@ -421,7 +372,7 @@ void GlobalHitsProducer::storeG4MC(PGlobalSimHit &product) {
       eventout += ")";
     }
     edm::LogInfo(MsgLoggerCat) << eventout << "\n";
-  } // end verbose output
+  }  // end verbose output
 
   product.putRawGenPart(nRawGenPart);
   product.putG4Vtx(G4VtxX, G4VtxY, G4VtxZ);
@@ -430,8 +381,7 @@ void GlobalHitsProducer::storeG4MC(PGlobalSimHit &product) {
   return;
 }
 
-void GlobalHitsProducer::fillTrk(edm::Event &iEvent,
-                                 const edm::EventSetup &iSetup) {
+void GlobalHitsProducer::fillTrk(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   std::string MsgLoggerCat = "GlobalHitsProducer_fillTrk";
 
   TString eventout;
@@ -442,8 +392,7 @@ void GlobalHitsProducer::fillTrk(edm::Event &iEvent,
   edm::ESHandle<TrackerGeometry> theTrackerGeometry;
   iSetup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry);
   if (!theTrackerGeometry.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerDigiGeometryRecord in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerDigiGeometryRecord in event!";
     return;
   }
   const TrackerGeometry &theTracker(*theTrackerGeometry);
@@ -459,28 +408,23 @@ void GlobalHitsProducer::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> PxlBrlLowContainer;
   iEvent.getByToken(PxlBrlLowSrc_Token_, PxlBrlLowContainer);
   if (!PxlBrlLowContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsPixelBarrelLowTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsPixelBarrelLowTof in event!";
     return;
   }
   // extract high container
   edm::Handle<edm::PSimHitContainer> PxlBrlHighContainer;
   iEvent.getByToken(PxlBrlHighSrc_Token_, PxlBrlHighContainer);
   if (!PxlBrlHighContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsPixelBarrelHighTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsPixelBarrelHighTof in event!";
     return;
   }
   // place both containers into new container
-  thePxlBrlHits.insert(thePxlBrlHits.end(), PxlBrlLowContainer->begin(),
-                       PxlBrlLowContainer->end());
-  thePxlBrlHits.insert(thePxlBrlHits.end(), PxlBrlHighContainer->begin(),
-                       PxlBrlHighContainer->end());
+  thePxlBrlHits.insert(thePxlBrlHits.end(), PxlBrlLowContainer->begin(), PxlBrlLowContainer->end());
+  thePxlBrlHits.insert(thePxlBrlHits.end(), PxlBrlHighContainer->begin(), PxlBrlHighContainer->end());
 
   // cycle through new container
   int i = 0, j = 0;
   for (itHit = thePxlBrlHits.begin(); itHit != thePxlBrlHits.end(); ++itHit) {
-
     ++i;
 
     // create a DetId from the detUnitId
@@ -490,13 +434,11 @@ void GlobalHitsProducer::fillTrk(edm::Event &iEvent,
 
     // check that expected detector is returned
     if ((detector == dTrk) && (subdetector == sdPxlBrl)) {
-
       // get the GeomDetUnit from the geometry using theDetUnitID
       const GeomDetUnit *theDet = theTracker.idToDetUnit(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get GeomDetUnit from PxlBrlHits for Hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from PxlBrlHits for Hit " << i;
         continue;
       }
 
@@ -512,13 +454,11 @@ void GlobalHitsProducer::fillTrk(edm::Event &iEvent,
       PxlBrlEta.push_back(bSurface.toGlobal(itHit->localPosition()).eta());
 
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "PxlBrl PSimHit " << i << " is expected to be (det,subdet) = ("
-          << dTrk << "," << sdPxlBrl << "); value returned is: (" << detector
-          << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "PxlBrl PSimHit " << i << " is expected to be (det,subdet) = (" << dTrk << ","
+                                    << sdPxlBrl << "); value returned is: (" << detector << "," << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through PxlBrl Hits
+    }  // end detector type check
+  }    // end loop through PxlBrl Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of Pixel Barrel Hits collected:..... ";
@@ -533,29 +473,24 @@ void GlobalHitsProducer::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> PxlFwdLowContainer;
   iEvent.getByToken(PxlFwdLowSrc_Token_, PxlFwdLowContainer);
   if (!PxlFwdLowContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsPixelEndcapLowTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsPixelEndcapLowTof in event!";
     return;
   }
   // extract high container
   edm::Handle<edm::PSimHitContainer> PxlFwdHighContainer;
   iEvent.getByToken(PxlFwdHighSrc_Token_, PxlFwdHighContainer);
   if (!PxlFwdHighContainer.isValid()) {
-    edm::LogWarning("GlobalHitsProducer_fillTrk")
-        << "Unable to find TrackerHitsPixelEndcapHighTof in event!";
+    edm::LogWarning("GlobalHitsProducer_fillTrk") << "Unable to find TrackerHitsPixelEndcapHighTof in event!";
     return;
   }
   // place both containers into new container
-  thePxlFwdHits.insert(thePxlFwdHits.end(), PxlFwdLowContainer->begin(),
-                       PxlFwdLowContainer->end());
-  thePxlFwdHits.insert(thePxlFwdHits.end(), PxlFwdHighContainer->begin(),
-                       PxlFwdHighContainer->end());
+  thePxlFwdHits.insert(thePxlFwdHits.end(), PxlFwdLowContainer->begin(), PxlFwdLowContainer->end());
+  thePxlFwdHits.insert(thePxlFwdHits.end(), PxlFwdHighContainer->begin(), PxlFwdHighContainer->end());
 
   // cycle through new container
   i = 0;
   j = 0;
   for (itHit = thePxlFwdHits.begin(); itHit != thePxlFwdHits.end(); ++itHit) {
-
     ++i;
 
     // create a DetId from the detUnitId
@@ -565,13 +500,11 @@ void GlobalHitsProducer::fillTrk(edm::Event &iEvent,
 
     // check that expected detector is returned
     if ((detector == dTrk) && (subdetector == sdPxlFwd)) {
-
       // get the GeomDetUnit from the geometry using theDetUnitID
       const GeomDetUnit *theDet = theTracker.idToDetUnit(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get GeomDetUnit from PxlFwdHits for Hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from PxlFwdHits for Hit " << i;
         ;
         continue;
       }
@@ -587,13 +520,11 @@ void GlobalHitsProducer::fillTrk(edm::Event &iEvent,
       PxlFwdPhi.push_back(bSurface.toGlobal(itHit->localPosition()).phi());
       PxlFwdEta.push_back(bSurface.toGlobal(itHit->localPosition()).eta());
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "PxlFwd PSimHit " << i << " is expected to be (det,subdet) = ("
-          << dTrk << "," << sdPxlFwd << "); value returned is: (" << detector
-          << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "PxlFwd PSimHit " << i << " is expected to be (det,subdet) = (" << dTrk << ","
+                                    << sdPxlFwd << "); value returned is: (" << detector << "," << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through PxlFwd Hits
+    }  // end detector type check
+  }    // end loop through PxlFwd Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of Pixel Forward Hits collected:.... ";
@@ -608,49 +539,40 @@ void GlobalHitsProducer::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> SiTIBLowContainer;
   iEvent.getByToken(SiTIBLowSrc_Token_, SiTIBLowContainer);
   if (!SiTIBLowContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsTIBLowTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsTIBLowTof in event!";
     return;
   }
   // extract TIB high container
   edm::Handle<edm::PSimHitContainer> SiTIBHighContainer;
   iEvent.getByToken(SiTIBHighSrc_Token_, SiTIBHighContainer);
   if (!SiTIBHighContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsTIBHighTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsTIBHighTof in event!";
     return;
   }
   // extract TOB low container
   edm::Handle<edm::PSimHitContainer> SiTOBLowContainer;
   iEvent.getByToken(SiTOBLowSrc_Token_, SiTOBLowContainer);
   if (!SiTOBLowContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsTOBLowTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsTOBLowTof in event!";
     return;
   }
   // extract TOB high container
   edm::Handle<edm::PSimHitContainer> SiTOBHighContainer;
   iEvent.getByToken(SiTOBHighSrc_Token_, SiTOBHighContainer);
   if (!SiTOBHighContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsTOBHighTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsTOBHighTof in event!";
     return;
   }
   // place all containers into new container
-  theSiBrlHits.insert(theSiBrlHits.end(), SiTIBLowContainer->begin(),
-                      SiTIBLowContainer->end());
-  theSiBrlHits.insert(theSiBrlHits.end(), SiTIBHighContainer->begin(),
-                      SiTIBHighContainer->end());
-  theSiBrlHits.insert(theSiBrlHits.end(), SiTOBLowContainer->begin(),
-                      SiTOBLowContainer->end());
-  theSiBrlHits.insert(theSiBrlHits.end(), SiTOBHighContainer->begin(),
-                      SiTOBHighContainer->end());
+  theSiBrlHits.insert(theSiBrlHits.end(), SiTIBLowContainer->begin(), SiTIBLowContainer->end());
+  theSiBrlHits.insert(theSiBrlHits.end(), SiTIBHighContainer->begin(), SiTIBHighContainer->end());
+  theSiBrlHits.insert(theSiBrlHits.end(), SiTOBLowContainer->begin(), SiTOBLowContainer->end());
+  theSiBrlHits.insert(theSiBrlHits.end(), SiTOBHighContainer->begin(), SiTOBHighContainer->end());
 
   // cycle through new container
   i = 0;
   j = 0;
   for (itHit = theSiBrlHits.begin(); itHit != theSiBrlHits.end(); ++itHit) {
-
     ++i;
 
     // create a DetId from the detUnitId
@@ -659,15 +581,12 @@ void GlobalHitsProducer::fillTrk(edm::Event &iEvent,
     int subdetector = theDetUnitId.subdetId();
 
     // check that expected detector is returned
-    if ((detector == dTrk) &&
-        ((subdetector == sdSiTIB) || (subdetector == sdSiTOB))) {
-
+    if ((detector == dTrk) && ((subdetector == sdSiTIB) || (subdetector == sdSiTOB))) {
       // get the GeomDetUnit from the geometry using theDetUnitID
       const GeomDetUnit *theDet = theTracker.idToDetUnit(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get GeomDetUnit from SiBrlHits for Hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from SiBrlHits for Hit " << i;
         continue;
       }
 
@@ -682,13 +601,12 @@ void GlobalHitsProducer::fillTrk(edm::Event &iEvent,
       SiBrlPhi.push_back(bSurface.toGlobal(itHit->localPosition()).phi());
       SiBrlEta.push_back(bSurface.toGlobal(itHit->localPosition()).eta());
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "SiBrl PSimHit " << i << " is expected to be (det,subdet) = ("
-          << dTrk << "," << sdSiTIB << " || " << sdSiTOB
-          << "); value returned is: (" << detector << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "SiBrl PSimHit " << i << " is expected to be (det,subdet) = (" << dTrk << ","
+                                    << sdSiTIB << " || " << sdSiTOB << "); value returned is: (" << detector << ","
+                                    << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through SiBrl Hits
+    }  // end detector type check
+  }    // end loop through SiBrl Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of Silicon Barrel Hits collected:... ";
@@ -703,49 +621,40 @@ void GlobalHitsProducer::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> SiTIDLowContainer;
   iEvent.getByToken(SiTIDLowSrc_Token_, SiTIDLowContainer);
   if (!SiTIDLowContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsTIDLowTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsTIDLowTof in event!";
     return;
   }
   // extract TID high container
   edm::Handle<edm::PSimHitContainer> SiTIDHighContainer;
   iEvent.getByToken(SiTIDHighSrc_Token_, SiTIDHighContainer);
   if (!SiTIDHighContainer.isValid()) {
-    edm::LogWarning("GlobalHitsProducer_fillTrk")
-        << "Unable to find TrackerHitsTIDHighTof in event!";
+    edm::LogWarning("GlobalHitsProducer_fillTrk") << "Unable to find TrackerHitsTIDHighTof in event!";
     return;
   }
   // extract TEC low container
   edm::Handle<edm::PSimHitContainer> SiTECLowContainer;
   iEvent.getByToken(SiTECLowSrc_Token_, SiTECLowContainer);
   if (!SiTECLowContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsTECLowTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsTECLowTof in event!";
     return;
   }
   // extract TEC high container
   edm::Handle<edm::PSimHitContainer> SiTECHighContainer;
   iEvent.getByToken(SiTECHighSrc_Token_, SiTECHighContainer);
   if (!SiTECHighContainer.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find TrackerHitsTECHighTof in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find TrackerHitsTECHighTof in event!";
     return;
   }
   // place all containers into new container
-  theSiFwdHits.insert(theSiFwdHits.end(), SiTIDLowContainer->begin(),
-                      SiTIDLowContainer->end());
-  theSiFwdHits.insert(theSiFwdHits.end(), SiTIDHighContainer->begin(),
-                      SiTIDHighContainer->end());
-  theSiFwdHits.insert(theSiFwdHits.end(), SiTECLowContainer->begin(),
-                      SiTECLowContainer->end());
-  theSiFwdHits.insert(theSiFwdHits.end(), SiTECHighContainer->begin(),
-                      SiTECHighContainer->end());
+  theSiFwdHits.insert(theSiFwdHits.end(), SiTIDLowContainer->begin(), SiTIDLowContainer->end());
+  theSiFwdHits.insert(theSiFwdHits.end(), SiTIDHighContainer->begin(), SiTIDHighContainer->end());
+  theSiFwdHits.insert(theSiFwdHits.end(), SiTECLowContainer->begin(), SiTECLowContainer->end());
+  theSiFwdHits.insert(theSiFwdHits.end(), SiTECHighContainer->begin(), SiTECHighContainer->end());
 
   // cycle through container
   i = 0;
   j = 0;
   for (itHit = theSiFwdHits.begin(); itHit != theSiFwdHits.end(); ++itHit) {
-
     ++i;
 
     // create a DetId from the detUnitId
@@ -754,15 +663,12 @@ void GlobalHitsProducer::fillTrk(edm::Event &iEvent,
     int subdetector = theDetUnitId.subdetId();
 
     // check that expected detector is returned
-    if ((detector == dTrk) &&
-        ((subdetector == sdSiTID) || (subdetector == sdSiTEC))) {
-
+    if ((detector == dTrk) && ((subdetector == sdSiTID) || (subdetector == sdSiTEC))) {
       // get the GeomDetUnit from the geometry using theDetUnitID
       const GeomDetUnit *theDet = theTracker.idToDetUnit(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get GeomDetUnit from SiFwdHits Hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from SiFwdHits Hit " << i;
         return;
       }
 
@@ -777,13 +683,12 @@ void GlobalHitsProducer::fillTrk(edm::Event &iEvent,
       SiFwdPhi.push_back(bSurface.toGlobal(itHit->localPosition()).phi());
       SiFwdEta.push_back(bSurface.toGlobal(itHit->localPosition()).eta());
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "SiFwd PSimHit " << i << " is expected to be (det,subdet) = ("
-          << dTrk << "," << sdSiTOB << " || " << sdSiTEC
-          << "); value returned is: (" << detector << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "SiFwd PSimHit " << i << " is expected to be (det,subdet) = (" << dTrk << ","
+                                    << sdSiTOB << " || " << sdSiTEC << "); value returned is: (" << detector << ","
+                                    << subdetector << ")";
       continue;
-    } // end check detector type
-  }   // end loop through SiFwd Hits
+    }  // end check detector type
+  }    // end loop through SiFwd Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of Silicon Forward Hits collected:.. ";
@@ -812,7 +717,7 @@ void GlobalHitsProducer::storeTrk(PGlobalSimHit &product) {
       eventout += ", ";
       eventout += PxlBrlEta[i];
       eventout += ")";
-    } // end PxlBrl output
+    }  // end PxlBrl output
     eventout += "\n       nPxlFwdHits        = ";
     eventout += PxlFwdToF.size();
     for (unsigned int i = 0; i < PxlFwdToF.size(); ++i) {
@@ -825,7 +730,7 @@ void GlobalHitsProducer::storeTrk(PGlobalSimHit &product) {
       eventout += ", ";
       eventout += PxlFwdEta[i];
       eventout += ")";
-    } // end PxlFwd output
+    }  // end PxlFwd output
     eventout += "\n       nSiBrlHits         = ";
     eventout += SiBrlToF.size();
     for (unsigned int i = 0; i < SiBrlToF.size(); ++i) {
@@ -838,7 +743,7 @@ void GlobalHitsProducer::storeTrk(PGlobalSimHit &product) {
       eventout += ", ";
       eventout += SiBrlEta[i];
       eventout += ")";
-    } // end SiBrl output
+    }  // end SiBrl output
     eventout += "\n       nSiFwdHits         = ";
     eventout += SiFwdToF.size();
     for (unsigned int i = 0; i < SiFwdToF.size(); ++i) {
@@ -851,9 +756,9 @@ void GlobalHitsProducer::storeTrk(PGlobalSimHit &product) {
       eventout += ", ";
       eventout += SiFwdEta[i];
       eventout += ")";
-    } // end SiFwd output
+    }  // end SiFwd output
     edm::LogInfo(MsgLoggerCat) << eventout << "\n";
-  } // end verbose output
+  }  // end verbose output
 
   product.putPxlBrlHits(PxlBrlToF, PxlBrlR, PxlBrlPhi, PxlBrlEta);
   product.putPxlFwdHits(PxlFwdToF, PxlFwdZ, PxlFwdPhi, PxlFwdEta);
@@ -863,8 +768,7 @@ void GlobalHitsProducer::storeTrk(PGlobalSimHit &product) {
   return;
 }
 
-void GlobalHitsProducer::fillMuon(edm::Event &iEvent,
-                                  const edm::EventSetup &iSetup) {
+void GlobalHitsProducer::fillMuon(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   std::string MsgLoggerCat = "GlobalHitsProducer_fillMuon";
 
   TString eventout;
@@ -882,8 +786,7 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent,
   edm::ESHandle<CSCGeometry> theCSCGeometry;
   iSetup.get<MuonGeometryRecord>().get(theCSCGeometry);
   if (!theCSCGeometry.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find MuonGeometryRecord for the CSCGeometry in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the CSCGeometry in event!";
     return;
   }
   const CSCGeometry &theCSCMuon(*theCSCGeometry);
@@ -898,9 +801,7 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent,
 
   // cycle through container
   int i = 0, j = 0;
-  for (itHit = MuonCSCContainer->begin(); itHit != MuonCSCContainer->end();
-       ++itHit) {
-
+  for (itHit = MuonCSCContainer->begin(); itHit != MuonCSCContainer->end(); ++itHit) {
     ++i;
 
     // create a DetId from the detUnitId
@@ -910,13 +811,11 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent,
 
     // check that expected detector is returned
     if ((detector == dMuon) && (subdetector == sdMuonCSC)) {
-
       // get the GeomDetUnit from the geometry using theDetUnitID
       const GeomDetUnit *theDet = theCSCMuon.idToDetUnit(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get GeomDetUnit from theCSCMuon for hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from theCSCMuon for hit " << i;
         continue;
       }
 
@@ -931,13 +830,11 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent,
       MuonCscPhi.push_back(bSurface.toGlobal(itHit->localPosition()).phi());
       MuonCscEta.push_back(bSurface.toGlobal(itHit->localPosition()).eta());
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "MuonCsc PSimHit " << i << " is expected to be (det,subdet) = ("
-          << dMuon << "," << sdMuonCSC << "); value returned is: (" << detector
-          << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "MuonCsc PSimHit " << i << " is expected to be (det,subdet) = (" << dMuon << ","
+                                    << sdMuonCSC << "); value returned is: (" << detector << "," << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through CSC Hits
+    }  // end detector type check
+  }    // end loop through CSC Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of CSC muon Hits collected:......... ";
@@ -952,8 +849,7 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent,
   edm::ESHandle<DTGeometry> theDTGeometry;
   iSetup.get<MuonGeometryRecord>().get(theDTGeometry);
   if (!theDTGeometry.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find MuonGeometryRecord for the DTGeometry in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the DTGeometry in event!";
     return;
   }
   const DTGeometry &theDTMuon(*theDTGeometry);
@@ -968,9 +864,7 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent,
 
   // cycle through container
   i = 0, j = 0;
-  for (itHit = MuonDtContainer->begin(); itHit != MuonDtContainer->end();
-       ++itHit) {
-
+  for (itHit = MuonDtContainer->begin(); itHit != MuonDtContainer->end(); ++itHit) {
     ++i;
 
     // create a DetId from the detUnitId
@@ -980,7 +874,6 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent,
 
     // check that expected detector is returned
     if ((detector == dMuon) && (subdetector == sdMuonDT)) {
-
       // CSC uses wires and layers rather than the full detID
       // get the wireId
       DTWireId wireId(itHit->detUnitId());
@@ -989,8 +882,7 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent,
       const DTLayer *theDet = theDTMuon.layer(wireId.layerId());
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get GeomDetUnit from theDtMuon for hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from theDtMuon for hit " << i;
         continue;
       }
 
@@ -1005,13 +897,11 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent,
       MuonDtPhi.push_back(bSurface.toGlobal(itHit->localPosition()).phi());
       MuonDtEta.push_back(bSurface.toGlobal(itHit->localPosition()).eta());
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "MuonDt PSimHit " << i << " is expected to be (det,subdet) = ("
-          << dMuon << "," << sdMuonDT << "); value returned is: (" << detector
-          << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "MuonDt PSimHit " << i << " is expected to be (det,subdet) = (" << dMuon << ","
+                                    << sdMuonDT << "); value returned is: (" << detector << "," << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through DT Hits
+    }  // end detector type check
+  }    // end loop through DT Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of DT muon Hits collected:.......... ";
@@ -1027,8 +917,7 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent,
   edm::ESHandle<RPCGeometry> theRPCGeometry;
   iSetup.get<MuonGeometryRecord>().get(theRPCGeometry);
   if (!theRPCGeometry.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find MuonGeometryRecord for the RPCGeometry in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find MuonGeometryRecord for the RPCGeometry in event!";
     return;
   }
   const RPCGeometry &theRPCMuon(*theRPCGeometry);
@@ -1044,9 +933,7 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent,
   // cycle through container
   i = 0, j = 0;
   int RPCBrl = 0, RPCFwd = 0;
-  for (itHit = MuonRPCContainer->begin(); itHit != MuonRPCContainer->end();
-       ++itHit) {
-
+  for (itHit = MuonRPCContainer->begin(); itHit != MuonRPCContainer->end(); ++itHit) {
     ++i;
 
     // create a DetID from the detUnitId
@@ -1056,7 +943,6 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent,
 
     // check that expected detector is returned
     if ((detector == dMuon) && (subdetector == sdMuonRPC)) {
-
       // get an RPCDetID from the detUnitID
       RPCDetId RPCId(itHit->detUnitId());
 
@@ -1067,8 +953,7 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent,
       const GeomDetUnit *theDet = theRPCMuon.idToDetUnit(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get GeomDetUnit from theRPCMuon for hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get GeomDetUnit from theRPCMuon for hit " << i;
         continue;
       }
 
@@ -1083,31 +968,25 @@ void GlobalHitsProducer::fillMuon(edm::Event &iEvent,
 
         MuonRpcFwdToF.push_back(itHit->tof());
         MuonRpcFwdZ.push_back(bSurface.toGlobal(itHit->localPosition()).z());
-        MuonRpcFwdPhi.push_back(
-            bSurface.toGlobal(itHit->localPosition()).phi());
-        MuonRpcFwdEta.push_back(
-            bSurface.toGlobal(itHit->localPosition()).eta());
+        MuonRpcFwdPhi.push_back(bSurface.toGlobal(itHit->localPosition()).phi());
+        MuonRpcFwdEta.push_back(bSurface.toGlobal(itHit->localPosition()).eta());
       } else if (region == sdMuonRPCRgnBrl) {
         ++RPCBrl;
 
         MuonRpcBrlToF.push_back(itHit->tof());
         MuonRpcBrlR.push_back(bSurface.toGlobal(itHit->localPosition()).perp());
-        MuonRpcBrlPhi.push_back(
-            bSurface.toGlobal(itHit->localPosition()).phi());
-        MuonRpcBrlEta.push_back(
-            bSurface.toGlobal(itHit->localPosition()).eta());
+        MuonRpcBrlPhi.push_back(bSurface.toGlobal(itHit->localPosition()).phi());
+        MuonRpcBrlEta.push_back(bSurface.toGlobal(itHit->localPosition()).eta());
       } else {
         edm::LogWarning(MsgLoggerCat) << "Invalid region for RPC Muon hit" << i;
         continue;
-      } // end check of region
+      }  // end check of region
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "MuonRpc PSimHit " << i << " is expected to be (det,subdet) = ("
-          << dMuon << "," << sdMuonRPC << "); value returned is: (" << detector
-          << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "MuonRpc PSimHit " << i << " is expected to be (det,subdet) = (" << dMuon << ","
+                                    << sdMuonRPC << "); value returned is: (" << detector << "," << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through RPC Hits
+    }  // end detector type check
+  }    // end loop through RPC Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of RPC muon Hits collected:......... ";
@@ -1140,7 +1019,7 @@ void GlobalHitsProducer::storeMuon(PGlobalSimHit &product) {
       eventout += ", ";
       eventout += MuonCscEta[i];
       eventout += ")";
-    } // end MuonCsc output
+    }  // end MuonCsc output
     eventout += "\n       nMuonDtHits        = ";
     eventout += MuonDtToF.size();
     for (unsigned int i = 0; i < MuonDtToF.size(); ++i) {
@@ -1153,7 +1032,7 @@ void GlobalHitsProducer::storeMuon(PGlobalSimHit &product) {
       eventout += ", ";
       eventout += MuonDtEta[i];
       eventout += ")";
-    } // end MuonDt output
+    }  // end MuonDt output
     eventout += "\n       nMuonRpcBrlHits    = ";
     eventout += MuonRpcBrlToF.size();
     for (unsigned int i = 0; i < MuonRpcBrlToF.size(); ++i) {
@@ -1166,7 +1045,7 @@ void GlobalHitsProducer::storeMuon(PGlobalSimHit &product) {
       eventout += ", ";
       eventout += MuonRpcBrlEta[i];
       eventout += ")";
-    } // end MuonRpcBrl output
+    }  // end MuonRpcBrl output
     eventout += "\n       nMuonRpcFwdHits    = ";
     eventout += MuonRpcFwdToF.size();
     for (unsigned int i = 0; i < MuonRpcFwdToF.size(); ++i) {
@@ -1179,22 +1058,19 @@ void GlobalHitsProducer::storeMuon(PGlobalSimHit &product) {
       eventout += ", ";
       eventout += MuonRpcFwdEta[i];
       eventout += ")";
-    } // end MuonRpcFwd output
+    }  // end MuonRpcFwd output
     edm::LogInfo(MsgLoggerCat) << eventout << "\n";
-  } // end verbose output
+  }  // end verbose output
 
   product.putMuonCscHits(MuonCscToF, MuonCscZ, MuonCscPhi, MuonCscEta);
   product.putMuonDtHits(MuonDtToF, MuonDtR, MuonDtPhi, MuonDtEta);
-  product.putMuonRpcBrlHits(MuonRpcBrlToF, MuonRpcBrlR, MuonRpcBrlPhi,
-                            MuonRpcBrlEta);
-  product.putMuonRpcFwdHits(MuonRpcFwdToF, MuonRpcFwdZ, MuonRpcFwdPhi,
-                            MuonRpcFwdEta);
+  product.putMuonRpcBrlHits(MuonRpcBrlToF, MuonRpcBrlR, MuonRpcBrlPhi, MuonRpcBrlEta);
+  product.putMuonRpcFwdHits(MuonRpcFwdToF, MuonRpcFwdZ, MuonRpcFwdPhi, MuonRpcFwdEta);
 
   return;
 }
 
-void GlobalHitsProducer::fillECal(edm::Event &iEvent,
-                                  const edm::EventSetup &iSetup) {
+void GlobalHitsProducer::fillECal(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   std::string MsgLoggerCat = "GlobalHitsProducer_fillECal";
 
   TString eventout;
@@ -1205,8 +1081,7 @@ void GlobalHitsProducer::fillECal(edm::Event &iEvent,
   edm::ESHandle<CaloGeometry> theCaloGeometry;
   iSetup.get<CaloGeometryRecord>().get(theCaloGeometry);
   if (!theCaloGeometry.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find CaloGeometryRecord in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometryRecord in event!";
     return;
   }
   const CaloGeometry &theCalo(*theCaloGeometry);
@@ -1233,15 +1108,12 @@ void GlobalHitsProducer::fillECal(edm::Event &iEvent,
     return;
   }
   // place both containers into new container
-  theECalHits.insert(theECalHits.end(), EBContainer->begin(),
-                     EBContainer->end());
-  theECalHits.insert(theECalHits.end(), EEContainer->begin(),
-                     EEContainer->end());
+  theECalHits.insert(theECalHits.end(), EBContainer->begin(), EBContainer->end());
+  theECalHits.insert(theECalHits.end(), EEContainer->begin(), EEContainer->end());
 
   // cycle through new container
   int i = 0, j = 0;
   for (itHit = theECalHits.begin(); itHit != theECalHits.end(); ++itHit) {
-
     ++i;
 
     // create a DetId from the detUnitId
@@ -1250,16 +1122,12 @@ void GlobalHitsProducer::fillECal(edm::Event &iEvent,
     int subdetector = theDetUnitId.subdetId();
 
     // check that expected detector is returned
-    if ((detector == dEcal) &&
-        ((subdetector == sdEcalBrl) || (subdetector == sdEcalFwd))) {
-
+    if ((detector == dEcal) && ((subdetector == sdEcalBrl) || (subdetector == sdEcalFwd))) {
       // get the Cell geometry
-      auto theDet = (theCalo.getSubdetectorGeometry(theDetUnitId))
-                        ->getGeometry(theDetUnitId);
+      auto theDet = (theCalo.getSubdetectorGeometry(theDetUnitId))->getGeometry(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get CaloCellGeometry from ECalHits for Hit " << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get CaloCellGeometry from ECalHits for Hit " << i;
         continue;
       }
 
@@ -1275,13 +1143,12 @@ void GlobalHitsProducer::fillECal(edm::Event &iEvent,
       ECalEta.push_back(globalposition.eta());
 
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "ECal PCaloHit " << i << " is expected to be (det,subdet) = ("
-          << dEcal << "," << sdEcalBrl << " || " << sdEcalFwd
-          << "); value returned is: (" << detector << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "ECal PCaloHit " << i << " is expected to be (det,subdet) = (" << dEcal << ","
+                                    << sdEcalBrl << " || " << sdEcalFwd << "); value returned is: (" << detector << ","
+                                    << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through ECal Hits
+    }  // end detector type check
+  }    // end loop through ECal Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of ECal Hits collected:............. ";
@@ -1301,9 +1168,7 @@ void GlobalHitsProducer::fillECal(edm::Event &iEvent,
 
   // cycle through container
   i = 0, j = 0;
-  for (itHit = PreShContainer->begin(); itHit != PreShContainer->end();
-       ++itHit) {
-
+  for (itHit = PreShContainer->begin(); itHit != PreShContainer->end(); ++itHit) {
     ++i;
 
     // create a DetId from the detUnitId
@@ -1313,15 +1178,11 @@ void GlobalHitsProducer::fillECal(edm::Event &iEvent,
 
     // check that expected detector is returned
     if ((detector == dEcal) && (subdetector == sdEcalPS)) {
-
       // get the Cell geometry
-      auto theDet = (theCalo.getSubdetectorGeometry(theDetUnitId))
-                        ->getGeometry(theDetUnitId);
+      auto theDet = (theCalo.getSubdetectorGeometry(theDetUnitId))->getGeometry(theDetUnitId);
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get CaloCellGeometry from PreShContainer for Hit "
-            << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get CaloCellGeometry from PreShContainer for Hit " << i;
         continue;
       }
 
@@ -1337,13 +1198,11 @@ void GlobalHitsProducer::fillECal(edm::Event &iEvent,
       PreShEta.push_back(globalposition.eta());
 
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "PreSh PCaloHit " << i << " is expected to be (det,subdet) = ("
-          << dEcal << "," << sdEcalPS << "); value returned is: (" << detector
-          << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "PreSh PCaloHit " << i << " is expected to be (det,subdet) = (" << dEcal << ","
+                                    << sdEcalPS << "); value returned is: (" << detector << "," << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through PreShower Hits
+    }  // end detector type check
+  }    // end loop through PreShower Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of PreSh Hits collected:............ ";
@@ -1372,7 +1231,7 @@ void GlobalHitsProducer::storeECal(PGlobalSimHit &product) {
       eventout += ", ";
       eventout += ECalEta[i];
       eventout += ")";
-    } // end ECal output
+    }  // end ECal output
     eventout += "\n       nPreShHits         = ";
     eventout += PreShE.size();
     for (unsigned int i = 0; i < PreShE.size(); ++i) {
@@ -1385,9 +1244,9 @@ void GlobalHitsProducer::storeECal(PGlobalSimHit &product) {
       eventout += ", ";
       eventout += PreShEta[i];
       eventout += ")";
-    } // end PreShower output
+    }  // end PreShower output
     edm::LogInfo(MsgLoggerCat) << eventout << "\n";
-  } // end verbose output
+  }  // end verbose output
 
   product.putECalHits(ECalE, ECalToF, ECalPhi, ECalEta);
   product.putPreShHits(PreShE, PreShToF, PreShPhi, PreShEta);
@@ -1395,8 +1254,7 @@ void GlobalHitsProducer::storeECal(PGlobalSimHit &product) {
   return;
 }
 
-void GlobalHitsProducer::fillHCal(edm::Event &iEvent,
-                                  const edm::EventSetup &iSetup) {
+void GlobalHitsProducer::fillHCal(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   std::string MsgLoggerCat = "GlobalHitsProducer_fillHCal";
 
   TString eventout;
@@ -1407,8 +1265,7 @@ void GlobalHitsProducer::fillHCal(edm::Event &iEvent,
   edm::ESHandle<CaloGeometry> theCaloGeometry;
   iSetup.get<CaloGeometryRecord>().get(theCaloGeometry);
   if (!theCaloGeometry.isValid()) {
-    edm::LogWarning(MsgLoggerCat)
-        << "Unable to find CaloGeometryRecord in event!";
+    edm::LogWarning(MsgLoggerCat) << "Unable to find CaloGeometryRecord in event!";
     return;
   }
   const CaloGeometry &theCalo(*theCaloGeometry);
@@ -1430,7 +1287,6 @@ void GlobalHitsProducer::fillHCal(edm::Event &iEvent,
   // cycle through container
   int i = 0, j = 0;
   for (itHit = HCalContainer->begin(); itHit != HCalContainer->end(); ++itHit) {
-
     ++i;
 
     // create a DetId from the detUnitId
@@ -1439,18 +1295,13 @@ void GlobalHitsProducer::fillHCal(edm::Event &iEvent,
     int subdetector = theDetUnitId.subdetId();
 
     // check that expected detector is returned
-    if ((detector == dHcal) &&
-        ((subdetector == sdHcalBrl) || (subdetector == sdHcalEC) ||
-         (subdetector == sdHcalOut) || (subdetector == sdHcalFwd))) {
-
+    if ((detector == dHcal) && ((subdetector == sdHcalBrl) || (subdetector == sdHcalEC) || (subdetector == sdHcalOut) ||
+                                (subdetector == sdHcalFwd))) {
       // get the Cell geometry
-      const HcalGeometry *theDet = dynamic_cast<const HcalGeometry *>(
-          theCalo.getSubdetectorGeometry(theDetUnitId));
+      const HcalGeometry *theDet = dynamic_cast<const HcalGeometry *>(theCalo.getSubdetectorGeometry(theDetUnitId));
 
       if (!theDet) {
-        edm::LogWarning(MsgLoggerCat)
-            << "Unable to get CaloCellGeometry from HCalContainer for Hit "
-            << i;
+        edm::LogWarning(MsgLoggerCat) << "Unable to get CaloCellGeometry from HCalContainer for Hit " << i;
         continue;
       }
 
@@ -1466,14 +1317,12 @@ void GlobalHitsProducer::fillHCal(edm::Event &iEvent,
       HCalEta.push_back(globalposition.eta());
 
     } else {
-      edm::LogWarning(MsgLoggerCat)
-          << "HCal PCaloHit " << i << " is expected to be (det,subdet) = ("
-          << dHcal << "," << sdHcalBrl << " || " << sdHcalEC << " || "
-          << sdHcalOut << " || " << sdHcalFwd << "); value returned is: ("
-          << detector << "," << subdetector << ")";
+      edm::LogWarning(MsgLoggerCat) << "HCal PCaloHit " << i << " is expected to be (det,subdet) = (" << dHcal << ","
+                                    << sdHcalBrl << " || " << sdHcalEC << " || " << sdHcalOut << " || " << sdHcalFwd
+                                    << "); value returned is: (" << detector << "," << subdetector << ")";
       continue;
-    } // end detector type check
-  }   // end loop through HCal Hits
+    }  // end detector type check
+  }    // end loop through HCal Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of HCal Hits collected:............. ";
@@ -1502,9 +1351,9 @@ void GlobalHitsProducer::storeHCal(PGlobalSimHit &product) {
       eventout += ", ";
       eventout += HCalEta[i];
       eventout += ")";
-    } // end HCal output
+    }  // end HCal output
     edm::LogInfo(MsgLoggerCat) << eventout << "\n";
-  } // end verbose output
+  }  // end verbose output
 
   product.putHCalHits(HCalE, HCalToF, HCalPhi, HCalEta);
 

--- a/Validation/GlobalHits/src/GlobalHitsTester.cc
+++ b/Validation/GlobalHits/src/GlobalHitsTester.cc
@@ -2,8 +2,14 @@
 #include "Validation/GlobalHits/interface/GlobalHitsTester.h"
 
 GlobalHitsTester::GlobalHitsTester(const edm::ParameterSet &iPSet)
-    : fName(""), verbosity(0), frequency(0), vtxunit(0), label(""),
-      getAllProvenances(false), printProvenanceInfo(false), count(0) {
+    : fName(""),
+      verbosity(0),
+      frequency(0),
+      vtxunit(0),
+      label(""),
+      getAllProvenances(false),
+      printProvenanceInfo(false),
+      count(0) {
   std::string MsgLoggerCat = "GlobalHitsTester_GlobalHitsTester";
 
   fName = iPSet.getUntrackedParameter<std::string>("Name");
@@ -12,34 +18,28 @@ GlobalHitsTester::GlobalHitsTester(const edm::ParameterSet &iPSet)
   vtxunit = iPSet.getUntrackedParameter<int>("VtxUnit");
   outputfile = iPSet.getParameter<std::string>("OutputFile");
   doOutput = iPSet.getParameter<bool>("DoOutput");
-  edm::ParameterSet m_Prov =
-      iPSet.getParameter<edm::ParameterSet>("ProvenanceLookup");
+  edm::ParameterSet m_Prov = iPSet.getParameter<edm::ParameterSet>("ProvenanceLookup");
   getAllProvenances = m_Prov.getUntrackedParameter<bool>("GetAllProvenances");
-  printProvenanceInfo =
-      m_Prov.getUntrackedParameter<bool>("PrintProvenanceInfo");
+  printProvenanceInfo = m_Prov.getUntrackedParameter<bool>("PrintProvenanceInfo");
 
   if (verbosity >= 0) {
-    edm::LogInfo(MsgLoggerCat)
-        << "\n===============================\n"
-        << "Initialized as EDAnalyzer with parameter values:\n"
-        << "    Name          = " << fName << "\n"
-        << "    Verbosity     = " << verbosity << "\n"
-        << "    Frequency     = " << frequency << "\n"
-        << "    VtxUnit       = " << vtxunit << "\n"
-        << "    OutputFile    = " << outputfile << "\n"
-        << "    DoOutput      = " << doOutput << "\n"
-        << "    GetProv       = " << getAllProvenances << "\n"
-        << "    PrintProv     = " << printProvenanceInfo << "\n"
-        << "===============================\n";
+    edm::LogInfo(MsgLoggerCat) << "\n===============================\n"
+                               << "Initialized as EDAnalyzer with parameter values:\n"
+                               << "    Name          = " << fName << "\n"
+                               << "    Verbosity     = " << verbosity << "\n"
+                               << "    Frequency     = " << frequency << "\n"
+                               << "    VtxUnit       = " << vtxunit << "\n"
+                               << "    OutputFile    = " << outputfile << "\n"
+                               << "    DoOutput      = " << doOutput << "\n"
+                               << "    GetProv       = " << getAllProvenances << "\n"
+                               << "    PrintProv     = " << printProvenanceInfo << "\n"
+                               << "===============================\n";
   }
 }
 
 GlobalHitsTester::~GlobalHitsTester() {}
 
-void GlobalHitsTester::bookHistograms(DQMStore::IBooker &ibooker,
-                                      edm::Run const &,
-                                      edm::EventSetup const &) {
-
+void GlobalHitsTester::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const &) {
   meTestString = nullptr;
   meTestInt = nullptr;
   meTestFloat = nullptr;
@@ -63,20 +63,16 @@ void GlobalHitsTester::bookHistograms(DQMStore::IBooker &ibooker,
   meTestTH1F = ibooker.book1D("Random1D", "Random1D", 100, -10., 10.);
 
   ibooker.setCurrentFolder("GlobalTestV/TH2F");
-  meTestTH2F =
-      ibooker.book2D("Random2D", "Random2D", 100, -10, 10., 100, -10., 10.);
+  meTestTH2F = ibooker.book2D("Random2D", "Random2D", 100, -10, 10., 100, -10., 10.);
 
   ibooker.setCurrentFolder("GlobalTestV/TH3F");
-  meTestTH3F = ibooker.book3D("Random3D", "Random3D", 100, -10., 10., 100, -10.,
-                              10., 100, -10., 10.);
+  meTestTH3F = ibooker.book3D("Random3D", "Random3D", 100, -10., 10., 100, -10., 10., 100, -10., 10.);
 
   ibooker.setCurrentFolder("GlobalTestV/TProfile");
-  meTestProfile1 = ibooker.bookProfile("Profile1", "Profile1", 100, -10., 10.,
-                                       100, -10., 10.);
+  meTestProfile1 = ibooker.bookProfile("Profile1", "Profile1", 100, -10., 10., 100, -10., 10.);
 
   ibooker.setCurrentFolder("GlobalTestV/TProfile2D");
-  meTestProfile2 = ibooker.bookProfile2D("Profile2", "Profile2", 100, -10., 10.,
-                                         100, -10, 10., 100, -10., 10.);
+  meTestProfile2 = ibooker.bookProfile2D("Profile2", "Profile2", 100, -10., 10., 100, -10, 10., 100, -10., 10.);
 
   ibooker.tag(meTestTH1F, 1);
   ibooker.tag(meTestTH2F, 2);
@@ -88,9 +84,7 @@ void GlobalHitsTester::bookHistograms(DQMStore::IBooker &ibooker,
   ibooker.tag(meTestFloat, 8);
 }
 
-void GlobalHitsTester::analyze(const edm::Event &iEvent,
-                               const edm::EventSetup &iSetup) {
-
+void GlobalHitsTester::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   for (int i = 0; i < 1000; ++i) {
     RandomVal1 = Random->Gaus(0., 1.);
     RandomVal2 = Random->Gaus(0., 1.);

--- a/Validation/L1T/interface/L1Validator.h
+++ b/Validation/L1T/interface/L1Validator.h
@@ -73,8 +73,7 @@ public:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
 protected:
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:
   // ----------member data ---------------------------
@@ -93,17 +92,13 @@ private:
 
   //---------------helper functions------------------
 private:
-  const reco::LeafCandidate *
-  FindBest(const reco::GenParticle *,
-           const std::vector<l1extra::L1EmParticle> *,
-           const std::vector<l1extra::L1EmParticle> *);
-  const reco::LeafCandidate *
-  FindBest(const reco::GenParticle *,
-           const std::vector<l1extra::L1JetParticle> *,
-           const std::vector<l1extra::L1JetParticle> *);
-  const reco::LeafCandidate *
-  FindBest(const reco::GenParticle *,
-           const std::vector<l1extra::L1MuonParticle> *);
+  const reco::LeafCandidate *FindBest(const reco::GenParticle *,
+                                      const std::vector<l1extra::L1EmParticle> *,
+                                      const std::vector<l1extra::L1EmParticle> *);
+  const reco::LeafCandidate *FindBest(const reco::GenParticle *,
+                                      const std::vector<l1extra::L1JetParticle> *,
+                                      const std::vector<l1extra::L1JetParticle> *);
+  const reco::LeafCandidate *FindBest(const reco::GenParticle *, const std::vector<l1extra::L1MuonParticle> *);
 };
 
 //

--- a/Validation/L1T/plugins/L1Validator.cc
+++ b/Validation/L1T/plugins/L1Validator.cc
@@ -29,61 +29,50 @@
 #include "TFile.h"
 
 // defining as a macro instead of a function because inheritance doesn't work:
-#define FINDRECOPART(TYPE, COLLECTION1, COLLECTION2)                           \
-  const TYPE *RecoPart = NULL;                                                 \
-  double BestDist = 999.;                                                      \
-  for (uint i = 0; i < COLLECTION1->size(); i++) {                             \
-    const TYPE *ThisPart = &COLLECTION1->at(i);                                \
-    double ThisDist = reco::deltaR(GenPart->eta(), GenPart->phi(),             \
-                                   ThisPart->eta(), ThisPart->phi());          \
-    if (ThisDist < 1.0 && ThisDist < BestDist) {                               \
-      BestDist = ThisDist;                                                     \
-      RecoPart = ThisPart;                                                     \
-    }                                                                          \
-  }                                                                            \
-  if (COLLECTION1.product() != COLLECTION2.product()) {                        \
-    for (uint i = 0; i < COLLECTION2->size(); i++) {                           \
-      const TYPE *ThisPart = &COLLECTION2->at(i);                              \
-      double ThisDist = reco::deltaR(GenPart->eta(), GenPart->phi(),           \
-                                     ThisPart->eta(), ThisPart->phi());        \
-      if (ThisDist < 1.0 && ThisDist < BestDist) {                             \
-        BestDist = ThisDist;                                                   \
-        RecoPart = ThisPart;                                                   \
-      }                                                                        \
-    }                                                                          \
+#define FINDRECOPART(TYPE, COLLECTION1, COLLECTION2)                                                    \
+  const TYPE *RecoPart = NULL;                                                                          \
+  double BestDist = 999.;                                                                               \
+  for (uint i = 0; i < COLLECTION1->size(); i++) {                                                      \
+    const TYPE *ThisPart = &COLLECTION1->at(i);                                                         \
+    double ThisDist = reco::deltaR(GenPart->eta(), GenPart->phi(), ThisPart->eta(), ThisPart->phi());   \
+    if (ThisDist < 1.0 && ThisDist < BestDist) {                                                        \
+      BestDist = ThisDist;                                                                              \
+      RecoPart = ThisPart;                                                                              \
+    }                                                                                                   \
+  }                                                                                                     \
+  if (COLLECTION1.product() != COLLECTION2.product()) {                                                 \
+    for (uint i = 0; i < COLLECTION2->size(); i++) {                                                    \
+      const TYPE *ThisPart = &COLLECTION2->at(i);                                                       \
+      double ThisDist = reco::deltaR(GenPart->eta(), GenPart->phi(), ThisPart->eta(), ThisPart->phi()); \
+      if (ThisDist < 1.0 && ThisDist < BestDist) {                                                      \
+        BestDist = ThisDist;                                                                            \
+        RecoPart = ThisPart;                                                                            \
+      }                                                                                                 \
+    }                                                                                                   \
   }
 
 L1Validator::L1Validator(const edm::ParameterSet &iConfig) {
   _dirName = iConfig.getParameter<std::string>("dirName");
-  _GenSource = consumes<reco::GenParticleCollection>(
-      iConfig.getParameter<edm::InputTag>("GenSource"));
+  _GenSource = consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("GenSource"));
 
-  _L1MuonBXSource = consumes<l1t::MuonBxCollection>(
-      iConfig.getParameter<edm::InputTag>("L1MuonBXSource"));
-  _L1EGammaBXSource = consumes<l1t::EGammaBxCollection>(
-      iConfig.getParameter<edm::InputTag>("L1EGammaBXSource"));
-  _L1TauBXSource = consumes<l1t::TauBxCollection>(
-      iConfig.getParameter<edm::InputTag>("L1TauBXSource"));
-  _L1JetBXSource = consumes<l1t::JetBxCollection>(
-      iConfig.getParameter<edm::InputTag>("L1JetBXSource"));
-  _srcToken = mayConsume<GenEventInfoProduct>(
-      iConfig.getParameter<edm::InputTag>("srcToken"));
-  _L1GenJetSource = consumes<reco::GenJetCollection>(
-      iConfig.getParameter<edm::InputTag>("L1GenJetSource"));
+  _L1MuonBXSource = consumes<l1t::MuonBxCollection>(iConfig.getParameter<edm::InputTag>("L1MuonBXSource"));
+  _L1EGammaBXSource = consumes<l1t::EGammaBxCollection>(iConfig.getParameter<edm::InputTag>("L1EGammaBXSource"));
+  _L1TauBXSource = consumes<l1t::TauBxCollection>(iConfig.getParameter<edm::InputTag>("L1TauBXSource"));
+  _L1JetBXSource = consumes<l1t::JetBxCollection>(iConfig.getParameter<edm::InputTag>("L1JetBXSource"));
+  _srcToken = mayConsume<GenEventInfoProduct>(iConfig.getParameter<edm::InputTag>("srcToken"));
+  _L1GenJetSource = consumes<reco::GenJetCollection>(iConfig.getParameter<edm::InputTag>("L1GenJetSource"));
 
   //_fileName = iConfig.getParameter<std::string>("fileName");
 }
 
 L1Validator::~L1Validator() {}
 
-void L1Validator::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const &,
-                                 edm::EventSetup const &) {
+void L1Validator::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const &, edm::EventSetup const &) {
   // iBooker.setCurrentFolder(_dirName);
   _Hists.Book(iBooker, _dirName);
 };
 
-void L1Validator::analyze(const edm::Event &iEvent,
-                          const edm::EventSetup &iSetup) {
+void L1Validator::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
   using namespace std;
   using namespace l1extra;
@@ -147,7 +136,6 @@ void L1Validator::analyze(const edm::Event &iEvent,
   // For gen jet
 
   for (auto &Genjet : *GenJets) {
-
     // eta within calorimeter acceptance 4.7
     if (fabs((&Genjet)->eta()) > 4.7)
       continue;
@@ -163,10 +151,8 @@ void L1Validator::analyze(const edm::Event &iEvent,
     for (int iBx = JetsBX->getFirstBX(); iBx <= JetsBX->getLastBX(); ++iBx) {
       if (iBx > 0)
         continue;
-      for (std::vector<l1t::Jet>::const_iterator jet = JetsBX->begin(iBx);
-           jet != JetsBX->end(iBx); ++jet) {
-        double idR = reco::deltaR((&Genjet)->eta(), (&Genjet)->phi(),
-                                  jet->eta(), jet->phi());
+      for (std::vector<l1t::Jet>::const_iterator jet = JetsBX->begin(iBx); jet != JetsBX->end(iBx); ++jet) {
+        double idR = reco::deltaR((&Genjet)->eta(), (&Genjet)->phi(), jet->eta(), jet->phi());
         if (idR < minDR) {
           minDR = idR;
           L1Part = &(*jet);
@@ -188,7 +174,7 @@ void L1Validator::analyze(const edm::Event &iEvent,
       continue;
 
     /// select the final state (i.e status==1) muons (pdg==+/-13)
-    if (status == 1 && abs(pdg) == 13) { // Muon
+    if (status == 1 && abs(pdg) == 13) {  // Muon
 
       // eta within tracker acceptance 2.4
       if (fabs(GenPart->eta()) > 2.4)
@@ -196,14 +182,11 @@ void L1Validator::analyze(const edm::Event &iEvent,
 
       // match L1T object
       const l1t::Muon *L1Part = nullptr;
-      for (int iBx = MuonsBX->getFirstBX(); iBx <= MuonsBX->getLastBX();
-           ++iBx) {
+      for (int iBx = MuonsBX->getFirstBX(); iBx <= MuonsBX->getLastBX(); ++iBx) {
         if (iBx > 0)
           continue;
-        for (std::vector<l1t::Muon>::const_iterator mu = MuonsBX->begin(iBx);
-             mu != MuonsBX->end(iBx); ++mu) {
-          double idR = reco::deltaR(GenPart->eta(), GenPart->phi(), mu->eta(),
-                                    mu->phi());
+        for (std::vector<l1t::Muon>::const_iterator mu = MuonsBX->begin(iBx); mu != MuonsBX->end(iBx); ++mu) {
+          double idR = reco::deltaR(GenPart->eta(), GenPart->phi(), mu->eta(), mu->phi());
           if (idR < minDR) {
             minDR = idR;
             L1Part = &(*mu);
@@ -214,7 +197,7 @@ void L1Validator::analyze(const edm::Event &iEvent,
 
       /// select the final state (i.e status==1) electrons (pdg==+/-11) and
       /// photons (pdg==22)
-    } else if (status == 1 && (abs(pdg) == 11 || pdg == 22)) { // Egamma
+    } else if (status == 1 && (abs(pdg) == 11 || pdg == 22)) {  // Egamma
 
       // eta within EM calorimeter acceptance 2.5
       if (fabs(GenPart->eta()) > 2.5)
@@ -226,15 +209,11 @@ void L1Validator::analyze(const edm::Event &iEvent,
 
       // match L1T object
       const l1t::EGamma *L1Part = nullptr;
-      for (int iBx = EGammasBX->getFirstBX(); iBx <= EGammasBX->getLastBX();
-           ++iBx) {
+      for (int iBx = EGammasBX->getFirstBX(); iBx <= EGammasBX->getLastBX(); ++iBx) {
         if (iBx > 0)
           continue;
-        for (std::vector<l1t::EGamma>::const_iterator eg =
-                 EGammasBX->begin(iBx);
-             eg != EGammasBX->end(iBx); ++eg) {
-          double idR = reco::deltaR(GenPart->eta(), GenPart->phi(), eg->eta(),
-                                    eg->phi());
+        for (std::vector<l1t::EGamma>::const_iterator eg = EGammasBX->begin(iBx); eg != EGammasBX->end(iBx); ++eg) {
+          double idR = reco::deltaR(GenPart->eta(), GenPart->phi(), eg->eta(), eg->phi());
           if (idR < minDR) {
             minDR = idR;
             L1Part = &(*eg);
@@ -245,7 +224,7 @@ void L1Validator::analyze(const edm::Event &iEvent,
 
       /// select the matrix element (i.e status==2) taus (pdg==+/-15) before
       /// decay
-    } else if (status == 2 && abs(pdg) == 15) { // Tau
+    } else if (status == 2 && abs(pdg) == 15) {  // Tau
 
       // eta within tracker acceptance 2.4
       if (fabs(GenPart->eta()) > 2.4)
@@ -256,10 +235,8 @@ void L1Validator::analyze(const edm::Event &iEvent,
       for (int iBx = TausBX->getFirstBX(); iBx <= TausBX->getLastBX(); ++iBx) {
         if (iBx > 0)
           continue;
-        for (std::vector<l1t::Tau>::const_iterator tau = TausBX->begin(iBx);
-             tau != TausBX->end(iBx); ++tau) {
-          double idR = reco::deltaR(GenPart->eta(), GenPart->phi(), tau->eta(),
-                                    tau->phi());
+        for (std::vector<l1t::Tau>::const_iterator tau = TausBX->begin(iBx); tau != TausBX->end(iBx); ++tau) {
+          double idR = reco::deltaR(GenPart->eta(), GenPart->phi(), tau->eta(), tau->phi());
           if (idR < minDR) {
             minDR = idR;
             L1Part = &(*tau);
@@ -273,17 +250,15 @@ void L1Validator::analyze(const edm::Event &iEvent,
 
 // The next three are exactly the same, but apparently inheritance doesn't work
 // like I thought it did.
-const reco::LeafCandidate *L1Validator::FindBest(
-    const reco::GenParticle *GenPart,
-    const std::vector<l1extra::L1EmParticle> *Collection1,
-    const std::vector<l1extra::L1EmParticle> *Collection2 = nullptr) {
+const reco::LeafCandidate *L1Validator::FindBest(const reco::GenParticle *GenPart,
+                                                 const std::vector<l1extra::L1EmParticle> *Collection1,
+                                                 const std::vector<l1extra::L1EmParticle> *Collection2 = nullptr) {
   const reco::LeafCandidate *BestPart = nullptr;
   double BestDR = 999.;
 
   for (uint i = 0; i < Collection1->size(); i++) {
     const reco::LeafCandidate *ThisPart = &Collection1->at(i);
-    double ThisDR = reco::deltaR(GenPart->eta(), GenPart->phi(),
-                                 ThisPart->eta(), ThisPart->phi());
+    double ThisDR = reco::deltaR(GenPart->eta(), GenPart->phi(), ThisPart->eta(), ThisPart->phi());
     if (ThisDR < BestDR) {
       BestDR = ThisDR;
       BestPart = ThisPart;
@@ -295,8 +270,7 @@ const reco::LeafCandidate *L1Validator::FindBest(
 
   for (uint i = 0; i < Collection2->size(); i++) {
     const reco::LeafCandidate *ThisPart = &Collection2->at(i);
-    double ThisDR = reco::deltaR(GenPart->eta(), GenPart->phi(),
-                                 ThisPart->eta(), ThisPart->phi());
+    double ThisDR = reco::deltaR(GenPart->eta(), GenPart->phi(), ThisPart->eta(), ThisPart->phi());
     if (ThisDR < BestDR) {
       BestDR = ThisDR;
       BestPart = ThisPart;
@@ -306,17 +280,15 @@ const reco::LeafCandidate *L1Validator::FindBest(
   return BestPart;
 }
 
-const reco::LeafCandidate *L1Validator::FindBest(
-    const reco::GenParticle *GenPart,
-    const std::vector<l1extra::L1JetParticle> *Collection1,
-    const std::vector<l1extra::L1JetParticle> *Collection2 = nullptr) {
+const reco::LeafCandidate *L1Validator::FindBest(const reco::GenParticle *GenPart,
+                                                 const std::vector<l1extra::L1JetParticle> *Collection1,
+                                                 const std::vector<l1extra::L1JetParticle> *Collection2 = nullptr) {
   const reco::LeafCandidate *BestPart = nullptr;
   double BestDR = 999.;
 
   for (uint i = 0; i < Collection1->size(); i++) {
     const reco::LeafCandidate *ThisPart = &Collection1->at(i);
-    double ThisDR = reco::deltaR(GenPart->eta(), GenPart->phi(),
-                                 ThisPart->eta(), ThisPart->phi());
+    double ThisDR = reco::deltaR(GenPart->eta(), GenPart->phi(), ThisPart->eta(), ThisPart->phi());
     if (ThisDR < BestDR) {
       BestDR = ThisDR;
       BestPart = ThisPart;
@@ -328,8 +300,7 @@ const reco::LeafCandidate *L1Validator::FindBest(
 
   for (uint i = 0; i < Collection2->size(); i++) {
     const reco::LeafCandidate *ThisPart = &Collection2->at(i);
-    double ThisDR = reco::deltaR(GenPart->eta(), GenPart->phi(),
-                                 ThisPart->eta(), ThisPart->phi());
+    double ThisDR = reco::deltaR(GenPart->eta(), GenPart->phi(), ThisPart->eta(), ThisPart->phi());
     if (ThisDR < BestDR) {
       BestDR = ThisDR;
       BestPart = ThisPart;
@@ -339,16 +310,14 @@ const reco::LeafCandidate *L1Validator::FindBest(
   return BestPart;
 }
 
-const reco::LeafCandidate *
-L1Validator::FindBest(const reco::GenParticle *GenPart,
-                      const std::vector<l1extra::L1MuonParticle> *Collection1) {
+const reco::LeafCandidate *L1Validator::FindBest(const reco::GenParticle *GenPart,
+                                                 const std::vector<l1extra::L1MuonParticle> *Collection1) {
   const reco::LeafCandidate *BestPart = nullptr;
   double BestDR = 999.;
 
   for (uint i = 0; i < Collection1->size(); i++) {
     const reco::LeafCandidate *ThisPart = &Collection1->at(i);
-    double ThisDR = reco::deltaR(GenPart->eta(), GenPart->phi(),
-                                 ThisPart->eta(), ThisPart->phi());
+    double ThisDR = reco::deltaR(GenPart->eta(), GenPart->phi(), ThisPart->eta(), ThisPart->phi());
     if (ThisDR < BestDR) {
       BestDR = ThisDR;
       BestPart = ThisPart;
@@ -360,8 +329,7 @@ L1Validator::FindBest(const reco::GenParticle *GenPart,
 
 // ------------ method fills 'descriptions' with the allowed parameters for the
 // module  ------------
-void L1Validator::fillDescriptions(
-    edm::ConfigurationDescriptions &descriptions) {
+void L1Validator::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   // The following says we do not know what parameters are allowed so do no
   // validation
   // Please change this to state exactly what you do use, even if it is no

--- a/Validation/L1T/src/L1ValidatorHists.cc
+++ b/Validation/L1T/src/L1ValidatorHists.cc
@@ -34,98 +34,98 @@ void L1ValidatorHists::Book(DQMStore::IBooker &iBooker, std::string dirname) {
 
   iBooker.setCurrentFolder(dirname + "/numerators_denominators");
   for (int i = 0; i < Type::Number; i++) {
-    Eff_Pt_Denom[i] = iBooker.book1D(
-        (Name[i] + "_Eff_Pt_Denom").c_str(),
-        (Name[i] + " Efficiency vs Pt Denom; Gen p_{T} [GeV]; Entries").c_str(),
-        Nptbin, ptbins);
-    Eff_Pt_Nomin[i] = iBooker.book1D(
-        (Name[i] + "_Eff_Pt_Nomin").c_str(),
-        (Name[i] + " Efficiency vs Pt Nomin; Gen p_{T} [GeV]; Entries").c_str(),
-        Nptbin, ptbins);
-    Eff_Eta_Denom[i] = iBooker.book1D(
-        (Name[i] + "_Eff_Eta_Denom").c_str(),
-        (Name[i] + " Efficiency vs #eta Denom; Gen #eta; Entries").c_str(), 80,
-        -4, 4);
-    Eff_Eta_Nomin[i] = iBooker.book1D(
-        (Name[i] + "_Eff_Eta_Nomin").c_str(),
-        (Name[i] + " Efficiency vs #eta Nomin; Gen #eta; Entries").c_str(), 80,
-        -4, 4);
-    TurnOn_15_Denom[i] = iBooker.book1D(
-        (Name[i] + "_TurnOn_15_Denom").c_str(),
-        (Name[i] + " Turn On (15 GeV) Denom; Gen p_{T} [GeV]; Entries").c_str(),
-        Nptbin, ptbins);
-    TurnOn_15_Nomin[i] = iBooker.book1D(
-        (Name[i] + "_TurnOn_15_Nomin").c_str(),
-        (Name[i] + " Turn On (15 GeV) Nomin; Gen p_{T} [GeV]; Entries").c_str(),
-        Nptbin, ptbins);
-    TurnOn_30_Denom[i] = iBooker.book1D(
-        (Name[i] + "_TurnOn_30_Denom").c_str(),
-        (Name[i] + " Turn On (30 GeV) Denom; Gen p_{T} [GeV]; Entries").c_str(),
-        Nptbin, ptbins);
-    TurnOn_30_Nomin[i] = iBooker.book1D(
-        (Name[i] + "_TurnOn_30_Nomin").c_str(),
-        (Name[i] + " Turn On (30 GeV) Nomin; Gen p_{T} [GeV]; Entries").c_str(),
-        Nptbin, ptbins);
+    Eff_Pt_Denom[i] = iBooker.book1D((Name[i] + "_Eff_Pt_Denom").c_str(),
+                                     (Name[i] + " Efficiency vs Pt Denom; Gen p_{T} [GeV]; Entries").c_str(),
+                                     Nptbin,
+                                     ptbins);
+    Eff_Pt_Nomin[i] = iBooker.book1D((Name[i] + "_Eff_Pt_Nomin").c_str(),
+                                     (Name[i] + " Efficiency vs Pt Nomin; Gen p_{T} [GeV]; Entries").c_str(),
+                                     Nptbin,
+                                     ptbins);
+    Eff_Eta_Denom[i] = iBooker.book1D((Name[i] + "_Eff_Eta_Denom").c_str(),
+                                      (Name[i] + " Efficiency vs #eta Denom; Gen #eta; Entries").c_str(),
+                                      80,
+                                      -4,
+                                      4);
+    Eff_Eta_Nomin[i] = iBooker.book1D((Name[i] + "_Eff_Eta_Nomin").c_str(),
+                                      (Name[i] + " Efficiency vs #eta Nomin; Gen #eta; Entries").c_str(),
+                                      80,
+                                      -4,
+                                      4);
+    TurnOn_15_Denom[i] = iBooker.book1D((Name[i] + "_TurnOn_15_Denom").c_str(),
+                                        (Name[i] + " Turn On (15 GeV) Denom; Gen p_{T} [GeV]; Entries").c_str(),
+                                        Nptbin,
+                                        ptbins);
+    TurnOn_15_Nomin[i] = iBooker.book1D((Name[i] + "_TurnOn_15_Nomin").c_str(),
+                                        (Name[i] + " Turn On (15 GeV) Nomin; Gen p_{T} [GeV]; Entries").c_str(),
+                                        Nptbin,
+                                        ptbins);
+    TurnOn_30_Denom[i] = iBooker.book1D((Name[i] + "_TurnOn_30_Denom").c_str(),
+                                        (Name[i] + " Turn On (30 GeV) Denom; Gen p_{T} [GeV]; Entries").c_str(),
+                                        Nptbin,
+                                        ptbins);
+    TurnOn_30_Nomin[i] = iBooker.book1D((Name[i] + "_TurnOn_30_Nomin").c_str(),
+                                        (Name[i] + " Turn On (30 GeV) Nomin; Gen p_{T} [GeV]; Entries").c_str(),
+                                        Nptbin,
+                                        ptbins);
   }
 
   iBooker.setCurrentFolder(dirname);
   for (int i = 0; i < Type::Number; i++) {
-    N[i] = iBooker.book1D((Name[i] + "_N").c_str(),
-                          ("L1 " + Name[i] + " Number with BX=0").c_str(), 16,
-                          -0.5, 15.5);
+    N[i] = iBooker.book1D((Name[i] + "_N").c_str(), ("L1 " + Name[i] + " Number with BX=0").c_str(), 16, -0.5, 15.5);
 
-    Eff_Pt[i] = iBooker.book1D(
-        (Name[i] + "_Eff_Pt").c_str(),
-        (Name[i] + " Efficiency vs Pt; Gen p_{T} [GeV]; L1T Efficiency")
-            .c_str(),
-        Nptbin, ptbins);
+    Eff_Pt[i] = iBooker.book1D((Name[i] + "_Eff_Pt").c_str(),
+                               (Name[i] + " Efficiency vs Pt; Gen p_{T} [GeV]; L1T Efficiency").c_str(),
+                               Nptbin,
+                               ptbins);
     Eff_Pt[i]->setEfficiencyFlag();
-    Eff_Eta[i] = iBooker.book1D(
-        (Name[i] + "_Eff_Eta").c_str(),
-        (Name[i] +
-         " Efficiency vs #eta (Gen p_{T} > 10GeV); Gen #eta; L1T Efficiency")
-            .c_str(),
-        80, -4, 4);
+    Eff_Eta[i] = iBooker.book1D((Name[i] + "_Eff_Eta").c_str(),
+                                (Name[i] + " Efficiency vs #eta (Gen p_{T} > 10GeV); Gen #eta; L1T Efficiency").c_str(),
+                                80,
+                                -4,
+                                4);
     Eff_Eta[i]->setEfficiencyFlag();
-    TurnOn_15[i] = iBooker.book1D(
-        (Name[i] + "_TurnOn_15").c_str(),
-        (Name[i] + " Turn On (15 GeV); Gen p_{T} [GeV]; L1T Efficiency")
-            .c_str(),
-        Nptbin, ptbins);
+    TurnOn_15[i] = iBooker.book1D((Name[i] + "_TurnOn_15").c_str(),
+                                  (Name[i] + " Turn On (15 GeV); Gen p_{T} [GeV]; L1T Efficiency").c_str(),
+                                  Nptbin,
+                                  ptbins);
     TurnOn_15[i]->setEfficiencyFlag();
-    TurnOn_30[i] = iBooker.book1D(
-        (Name[i] + "_TurnOn_30").c_str(),
-        (Name[i] + " Turn On (30 GeV); Gen p_{T} [GeV]; L1T Efficiency")
-            .c_str(),
-        Nptbin, ptbins);
+    TurnOn_30[i] = iBooker.book1D((Name[i] + "_TurnOn_30").c_str(),
+                                  (Name[i] + " Turn On (30 GeV); Gen p_{T} [GeV]; L1T Efficiency").c_str(),
+                                  Nptbin,
+                                  ptbins);
     TurnOn_30[i]->setEfficiencyFlag();
     dR[i] = iBooker.book1D(
-        (Name[i] + "_dR").c_str(),
-        (Name[i] + " #DeltaR; #DeltaR(L1 object, Gen object); Entries").c_str(),
-        40, 0, 1);
-    dR_vs_Pt[i] =
-        iBooker.book2D((Name[i] + "_dR_vs_Pt").c_str(),
-                       (Name[i] + " #DeltaR vs p_{T}; Gen p_{T} [GeV]; "
-                                  "#DeltaR(L1 object, Gen object); Entries")
-                           .c_str(),
-                       12, 0, 120, 40, 0, 1);
-    dPt[i] = iBooker.book1D(
-        (Name[i] + "_dPt").c_str(),
-        (Name[i] +
-         " #Deltap_{T}; (p_{T}^{L1}-p_{T}^{Gen})/p_{T}^{Gen}; Entries")
-            .c_str(),
-        100, -2, 2);
-    dPt_vs_Pt[i] = iBooker.book2D(
-        (Name[i] + "_dPt_vs_Pt").c_str(),
-        (Name[i] + " #Deltap_{T} vs p_{T}; Gen p_{T} [GeV]; "
-                   "(p_{T}^{L1}-p_{T}^{Gen})/p_{T}^{Gen}; Entries")
-            .c_str(),
-        12, 0, 120, 40, -2, 2);
+        (Name[i] + "_dR").c_str(), (Name[i] + " #DeltaR; #DeltaR(L1 object, Gen object); Entries").c_str(), 40, 0, 1);
+    dR_vs_Pt[i] = iBooker.book2D((Name[i] + "_dR_vs_Pt").c_str(),
+                                 (Name[i] + " #DeltaR vs p_{T}; Gen p_{T} [GeV]; "
+                                            "#DeltaR(L1 object, Gen object); Entries")
+                                     .c_str(),
+                                 12,
+                                 0,
+                                 120,
+                                 40,
+                                 0,
+                                 1);
+    dPt[i] = iBooker.book1D((Name[i] + "_dPt").c_str(),
+                            (Name[i] + " #Deltap_{T}; (p_{T}^{L1}-p_{T}^{Gen})/p_{T}^{Gen}; Entries").c_str(),
+                            100,
+                            -2,
+                            2);
+    dPt_vs_Pt[i] = iBooker.book2D((Name[i] + "_dPt_vs_Pt").c_str(),
+                                  (Name[i] + " #Deltap_{T} vs p_{T}; Gen p_{T} [GeV]; "
+                                             "(p_{T}^{L1}-p_{T}^{Gen})/p_{T}^{Gen}; Entries")
+                                      .c_str(),
+                                  12,
+                                  0,
+                                  120,
+                                  40,
+                                  -2,
+                                  2);
   }
 }
 
-void L1ValidatorHists::Fill(int i, const reco::LeafCandidate *GenPart,
-                            const reco::LeafCandidate *L1Part) {
+void L1ValidatorHists::Fill(int i, const reco::LeafCandidate *GenPart, const reco::LeafCandidate *L1Part) {
   double GenPartPt = GenPart->pt();
   // fill the overflow in the last bin
   if (GenPart->pt() >= 160.0)
@@ -137,8 +137,7 @@ void L1ValidatorHists::Fill(int i, const reco::LeafCandidate *GenPart,
     TurnOn_15_Denom[i]->Fill(GenPartPt);
     TurnOn_30_Denom[i]->Fill(GenPartPt);
   } else {
-    double idR = reco::deltaR(GenPart->eta(), GenPart->phi(), L1Part->eta(),
-                              L1Part->phi());
+    double idR = reco::deltaR(GenPart->eta(), GenPart->phi(), L1Part->eta(), L1Part->phi());
     bool matched = idR < 0.15;
     Eff_Pt_Denom[i]->Fill(GenPartPt);
     if (GenPart->pt() > 10)
@@ -156,8 +155,7 @@ void L1ValidatorHists::Fill(int i, const reco::LeafCandidate *GenPart,
     dR[i]->Fill(idR);
     dPt[i]->Fill((L1Part->pt() - GenPart->pt()) / GenPart->pt());
     dR_vs_Pt[i]->Fill(GenPart->pt(), idR);
-    dPt_vs_Pt[i]->Fill(GenPart->pt(),
-                       (L1Part->pt() - GenPart->pt()) / GenPart->pt());
+    dPt_vs_Pt[i]->Fill(GenPart->pt(), (L1Part->pt() - GenPart->pt()) / GenPart->pt());
   }
 }
 

--- a/Validation/MuonGEMRecHits/interface/GEMRecHitMatcher.h
+++ b/Validation/MuonGEMRecHits/interface/GEMRecHitMatcher.h
@@ -41,8 +41,10 @@ public:
   typedef matching::Digi RecHit;
   typedef matching::DigiContainer RecHitContainer;
 
-  GEMRecHitMatcher(const SimHitMatcher &sh, const edm::Event &,
-                   const GEMGeometry &geom, const edm::ParameterSet &cfg,
+  GEMRecHitMatcher(const SimHitMatcher &sh,
+                   const edm::Event &,
+                   const GEMGeometry &geom,
+                   const edm::ParameterSet &cfg,
                    edm::EDGetToken &);
 
   ~GEMRecHitMatcher();

--- a/Validation/MuonGEMRecHits/interface/GEMRecHitTrackMatch.h
+++ b/Validation/MuonGEMRecHits/interface/GEMRecHitTrackMatch.h
@@ -16,8 +16,7 @@ class GEMRecHitTrackMatch : public GEMTrackMatch {
 public:
   explicit GEMRecHitTrackMatch(const edm::ParameterSet &ps);
   ~GEMRecHitTrackMatch() override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &e, const edm::EventSetup &) override;
 
 private:

--- a/Validation/MuonGEMRecHits/interface/GEMRecHitsValidation.h
+++ b/Validation/MuonGEMRecHits/interface/GEMRecHitsValidation.h
@@ -10,17 +10,23 @@ class GEMRecHitsValidation : public GEMBaseValidation {
 public:
   explicit GEMRecHitsValidation(const edm::ParameterSet &);
   ~GEMRecHitsValidation() override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &e, const edm::EventSetup &) override;
-  MonitorElement *BookHist1D(DQMStore::IBooker &, const char *name,
-                             const char *label, unsigned int region_num,
-                             unsigned int station_num, unsigned int layer_num,
-                             const unsigned int Nbin, const Float_t xMin,
+  MonitorElement *BookHist1D(DQMStore::IBooker &,
+                             const char *name,
+                             const char *label,
+                             unsigned int region_num,
+                             unsigned int station_num,
+                             unsigned int layer_num,
+                             const unsigned int Nbin,
+                             const Float_t xMin,
                              const Float_t xMax);
-  MonitorElement *BookHist1D(DQMStore::IBooker &, const char *name,
-                             const char *label, unsigned int region_num,
-                             const unsigned int Nbin, const Float_t xMin,
+  MonitorElement *BookHist1D(DQMStore::IBooker &,
+                             const char *name,
+                             const char *label,
+                             unsigned int region_num,
+                             const unsigned int Nbin,
+                             const Float_t xMin,
                              const Float_t xMax);
 
 private:

--- a/Validation/MuonGEMRecHits/plugins/MuonGEMRecHitsHarvestor.h
+++ b/Validation/MuonGEMRecHits/plugins/MuonGEMRecHitsHarvestor.h
@@ -23,9 +23,8 @@ public:
   ~MuonGEMRecHitsHarvestor() override;
 
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
-  void ProcessBooking(DQMStore::IBooker &, DQMStore::IGetter &,
-                      const char *label, TString suffix, TH1F *track_hist,
-                      TH1F *sh_hist);
+  void ProcessBooking(
+      DQMStore::IBooker &, DQMStore::IGetter &, const char *label, TString suffix, TH1F *track_hist, TH1F *sh_hist);
   TProfile *ComputeEff(TH1F *num, TH1F *denum);
 
 private:

--- a/Validation/MuonGEMRecHits/src/GEMRecHitMatcher.cc
+++ b/Validation/MuonGEMRecHits/src/GEMRecHitMatcher.cc
@@ -8,7 +8,8 @@
 using namespace std;
 using namespace matching;
 
-GEMRecHitMatcher::GEMRecHitMatcher(const SimHitMatcher &sh, const edm::Event &e,
+GEMRecHitMatcher::GEMRecHitMatcher(const SimHitMatcher &sh,
+                                   const edm::Event &e,
                                    const GEMGeometry &geom,
                                    const edm::ParameterSet &cfg,
                                    edm::EDGetToken &gem_recHitToken)
@@ -28,24 +29,18 @@ GEMRecHitMatcher::GEMRecHitMatcher(const SimHitMatcher &sh, const edm::Event &e,
 
 GEMRecHitMatcher::~GEMRecHitMatcher() {}
 
-void GEMRecHitMatcher::init(const edm::Event &e) {
-  matchRecHitsToSimTrack(*gem_rechits_.product());
-}
+void GEMRecHitMatcher::init(const edm::Event &e) { matchRecHitsToSimTrack(*gem_rechits_.product()); }
 
-void GEMRecHitMatcher::matchRecHitsToSimTrack(
-    const GEMRecHitCollection &rechits) {
-
+void GEMRecHitMatcher::matchRecHitsToSimTrack(const GEMRecHitCollection &rechits) {
   auto det_ids = simhit_matcher_.detIdsGEM();
   for (auto id : det_ids) {
     GEMDetId p_id(id);
-    GEMDetId superch_id(p_id.region(), p_id.ring(), p_id.station(), 1,
-                        p_id.chamber(), 0);
+    GEMDetId superch_id(p_id.region(), p_id.ring(), p_id.station(), 1, p_id.chamber(), 0);
 
     auto hit_strips = simhit_matcher_.hitStripsInDetId(id, matchDeltaStrip_);
     if (verbose()) {
       cout << "hit_strips_fat ";
-      copy(hit_strips.begin(), hit_strips.end(),
-           ostream_iterator<int>(cout, " "));
+      copy(hit_strips.begin(), hit_strips.end(), ostream_iterator<int>(cout, " "));
       cout << endl;
     }
 
@@ -64,7 +59,6 @@ void GEMRecHitMatcher::matchRecHitsToSimTrack(
       bool stripFound = false;
 
       for (int i = firstStrip; i < (firstStrip + cls); i++) {
-
         if (hit_strips.find(i) != hit_strips.end())
           stripFound = true;
         // std::cout<<i<<" "<<firstStrip<<" "<<cls<<" "<<stripFound<<std::endl;
@@ -75,8 +69,7 @@ void GEMRecHitMatcher::matchRecHitsToSimTrack(
       if (verbose())
         cout << "oki" << endl;
 
-      auto myrechit = make_digi(id, d->firstClusterStrip(), d->BunchX(),
-                                GEM_STRIP, d->clusterSize());
+      auto myrechit = make_digi(id, d->firstClusterStrip(), d->BunchX(), GEM_STRIP, d->clusterSize());
       detid_to_recHits_[id].push_back(myrechit);
       chamber_to_recHits_[p_id.chamberId().rawId()].push_back(myrechit);
       superchamber_to_recHits_[superch_id()].push_back(myrechit);
@@ -105,29 +98,25 @@ std::set<unsigned int> GEMRecHitMatcher::superChamberIds() const {
   return result;
 }
 
-const GEMRecHitMatcher::RecHitContainer &
-GEMRecHitMatcher::recHitsInDetId(unsigned int detid) const {
+const GEMRecHitMatcher::RecHitContainer &GEMRecHitMatcher::recHitsInDetId(unsigned int detid) const {
   if (detid_to_recHits_.find(detid) == detid_to_recHits_.end())
     return no_recHits_;
   return detid_to_recHits_.at(detid);
 }
 
-const GEMRecHitMatcher::RecHitContainer &
-GEMRecHitMatcher::recHitsInChamber(unsigned int detid) const {
+const GEMRecHitMatcher::RecHitContainer &GEMRecHitMatcher::recHitsInChamber(unsigned int detid) const {
   if (chamber_to_recHits_.find(detid) == chamber_to_recHits_.end())
     return no_recHits_;
   return chamber_to_recHits_.at(detid);
 }
 
-const GEMRecHitMatcher::RecHitContainer &
-GEMRecHitMatcher::recHitsInSuperChamber(unsigned int detid) const {
+const GEMRecHitMatcher::RecHitContainer &GEMRecHitMatcher::recHitsInSuperChamber(unsigned int detid) const {
   if (superchamber_to_recHits_.find(detid) == superchamber_to_recHits_.end())
     return no_recHits_;
   return superchamber_to_recHits_.at(detid);
 }
 
-int GEMRecHitMatcher::nLayersWithRecHitsInSuperChamber(
-    unsigned int detid) const {
+int GEMRecHitMatcher::nLayersWithRecHitsInSuperChamber(unsigned int detid) const {
   set<int> layers;
   /*
   auto recHits = recHitsInSuperChamber(detid);
@@ -178,11 +167,10 @@ GlobalPoint GEMRecHitMatcher::recHitPosition(const RecHit &rechit) const {
   return gp;
 }
 
-GlobalPoint
-GEMRecHitMatcher::recHitMeanPosition(const RecHitContainer &rechit) const {
+GlobalPoint GEMRecHitMatcher::recHitMeanPosition(const RecHitContainer &rechit) const {
   GlobalPoint point_zero;
   if (rechit.empty())
-    return point_zero; // point "zero"
+    return point_zero;  // point "zero"
 
   float sumx, sumy, sumz;
   sumx = sumy = sumz = 0.f;

--- a/Validation/MuonGEMRecHits/src/GEMRecHitTrackMatch.cc
+++ b/Validation/MuonGEMRecHits/src/GEMRecHitTrackMatch.cc
@@ -10,19 +10,13 @@
 #include <TMath.h>
 
 using namespace std;
-GEMRecHitTrackMatch::GEMRecHitTrackMatch(const edm::ParameterSet &ps)
-    : GEMTrackMatch(ps) {
-  std::string simInputLabel_ =
-      ps.getUntrackedParameter<std::string>("simInputLabel");
-  simHitsToken_ = consumes<edm::PSimHitContainer>(
-      edm::InputTag(simInputLabel_, "MuonGEMHits"));
-  simTracksToken_ = consumes<edm::SimTrackContainer>(
-      ps.getParameter<edm::InputTag>("simTrackCollection"));
-  simVerticesToken_ = consumes<edm::SimVertexContainer>(
-      ps.getParameter<edm::InputTag>("simVertexCollection"));
+GEMRecHitTrackMatch::GEMRecHitTrackMatch(const edm::ParameterSet &ps) : GEMTrackMatch(ps) {
+  std::string simInputLabel_ = ps.getUntrackedParameter<std::string>("simInputLabel");
+  simHitsToken_ = consumes<edm::PSimHitContainer>(edm::InputTag(simInputLabel_, "MuonGEMHits"));
+  simTracksToken_ = consumes<edm::SimTrackContainer>(ps.getParameter<edm::InputTag>("simTrackCollection"));
+  simVerticesToken_ = consumes<edm::SimVertexContainer>(ps.getParameter<edm::InputTag>("simVertexCollection"));
 
-  gem_recHitToken_ = consumes<GEMRecHitCollection>(
-      ps.getParameter<edm::InputTag>("gemRecHitInput"));
+  gem_recHitToken_ = consumes<GEMRecHitCollection>(ps.getParameter<edm::InputTag>("gemRecHitInput"));
 
   detailPlot_ = ps.getParameter<bool>("detailPlot");
   cfg_ = ps;
@@ -31,18 +25,14 @@ GEMRecHitTrackMatch::GEMRecHitTrackMatch(const edm::ParameterSet &ps)
 void GEMRecHitTrackMatch::bookHistograms(DQMStore::IBooker &ibooker,
                                          edm::Run const &run,
                                          edm::EventSetup const &iSetup) {
-  edm::LogInfo("GEMRecHitTrackMatch")
-      << "GEM RecHitTrackMatch :: bookHistograms" << std::endl;
+  edm::LogInfo("GEMRecHitTrackMatch") << "GEM RecHitTrackMatch :: bookHistograms" << std::endl;
   edm::ESHandle<GEMGeometry> hGeom;
   iSetup.get<MuonGeometryRecord>().get(hGeom);
   const GEMGeometry &geom = *hGeom;
-  edm::LogInfo("GEMRecHitTrackMatch")
-      << "GEM RecHitTrackMatch :: about to set the geometry" << std::endl;
+  edm::LogInfo("GEMRecHitTrackMatch") << "GEM RecHitTrackMatch :: about to set the geometry" << std::endl;
   setGeometry(geom);
-  edm::LogInfo("GEMRecHitTrackMatch")
-      << "GEM RecHitTrackMatch :: successfully set the geometry" << std::endl;
-  edm::LogInfo("GEMRecHitTrackMatch")
-      << "GEM RecHitTrackMatch :: geom = " << &geom << std::endl;
+  edm::LogInfo("GEMRecHitTrackMatch") << "GEM RecHitTrackMatch :: successfully set the geometry" << std::endl;
+  edm::LogInfo("GEMRecHitTrackMatch") << "GEM RecHitTrackMatch :: geom = " << &geom << std::endl;
 
   ibooker.setCurrentFolder("MuonGEMRecHitsV/GEMRecHitsTask");
   edm::LogInfo("GEMRecHitTrackMatch") << "ibooker set current folder\n";
@@ -54,45 +44,35 @@ void GEMRecHitTrackMatch::bookHistograms(DQMStore::IBooker &ibooker,
   nstation = geom.regions()[0]->stations().size();
   for (unsigned int j = 0; j < nstation; j++) {
     string track_eta_name = string("track_eta") + s_suffix.at(j);
-    string track_eta_title =
-        string("track_eta") + ";SimTrack |#eta|;# of tracks";
-    track_eta[j] = ibooker.book1D(
-        track_eta_name.c_str(), track_eta_title.c_str(), 140, minEta_, maxEta_);
+    string track_eta_title = string("track_eta") + ";SimTrack |#eta|;# of tracks";
+    track_eta[j] = ibooker.book1D(track_eta_name.c_str(), track_eta_title.c_str(), 140, minEta_, maxEta_);
 
     for (unsigned int k = 0; k < c_suffix.size(); k++) {
       string suffix = string(s_suffix[j]) + string(c_suffix[k]);
       string track_phi_name = string("track_phi") + suffix;
-      string track_phi_title =
-          string("track_phi") + suffix + ";SimTrack #phi;# of tracks";
-      track_phi[j][k] = ibooker.book1D(track_phi_name.c_str(),
-                                       track_phi_title.c_str(), 200, -PI, PI);
+      string track_phi_title = string("track_phi") + suffix + ";SimTrack #phi;# of tracks";
+      track_phi[j][k] = ibooker.book1D(track_phi_name.c_str(), track_phi_title.c_str(), 200, -PI, PI);
     }
 
     for (unsigned int i = 0; i < l_suffix.size(); i++) {
       string suffix = string(s_suffix[j]) + string(l_suffix[i]);
       string rh_eta_name = string("rh_eta") + suffix;
       string rh_eta_title = rh_eta_name + "; tracks |#eta|; # of tracks";
-      rh_eta[i][j] = ibooker.book1D(rh_eta_name.c_str(), rh_eta_title.c_str(),
-                                    140, minEta_, maxEta_);
+      rh_eta[i][j] = ibooker.book1D(rh_eta_name.c_str(), rh_eta_title.c_str(), 140, minEta_, maxEta_);
 
       string rh_sh_eta_name = string("rh_sh_eta") + suffix;
       string rh_sh_eta_title = rh_sh_eta_name + "; tracks |#eta|; # of tracks";
-      rh_sh_eta[i][j] =
-          ibooker.book1D(rh_sh_eta_name.c_str(), rh_sh_eta_title.c_str(), 140,
-                         minEta_, maxEta_);
+      rh_sh_eta[i][j] = ibooker.book1D(rh_sh_eta_name.c_str(), rh_sh_eta_title.c_str(), 140, minEta_, maxEta_);
 
       for (unsigned int k = 0; k < c_suffix.size(); k++) {
-        suffix =
-            string(s_suffix[j]) + string(l_suffix[i]) + string(c_suffix[k]);
+        suffix = string(s_suffix[j]) + string(l_suffix[i]) + string(c_suffix[k]);
         string rh_phi_name = string("rh_phi") + suffix;
         string rh_phi_title = rh_phi_name + "; tracks #phi; # of tracks";
-        rh_phi[i][j][k] = ibooker.book1D((rh_phi_name).c_str(),
-                                         rh_phi_title.c_str(), 200, -PI, PI);
+        rh_phi[i][j][k] = ibooker.book1D((rh_phi_name).c_str(), rh_phi_title.c_str(), 200, -PI, PI);
 
         string rh_sh_phi_name = string("rh_sh_phi") + suffix;
         string rh_sh_phi_title = rh_sh_phi_name + "; tracks #phi; # of tracks";
-        rh_sh_phi[i][j][k] = ibooker.book1D(
-            (rh_sh_phi_name).c_str(), rh_sh_phi_title.c_str(), 200, -PI, PI);
+        rh_sh_phi[i][j][k] = ibooker.book1D((rh_sh_phi_name).c_str(), rh_sh_phi_title.c_str(), 200, -PI, PI);
       }
     }
   }
@@ -100,10 +80,8 @@ void GEMRecHitTrackMatch::bookHistograms(DQMStore::IBooker &ibooker,
 
 GEMRecHitTrackMatch::~GEMRecHitTrackMatch() {}
 
-void GEMRecHitTrackMatch::analyze(const edm::Event &iEvent,
-                                  const edm::EventSetup &iSetup) {
-  edm::LogInfo("GEMRecHitTrackMatch")
-      << "GEM RecHitTrackMatch :: analyze" << std::endl;
+void GEMRecHitTrackMatch::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  edm::LogInfo("GEMRecHitTrackMatch") << "GEM RecHitTrackMatch :: analyze" << std::endl;
   edm::ESHandle<GEMGeometry> hGeom;
   iSetup.get<MuonGeometryRecord>().get(hGeom);
   const GEMGeometry &geom = *hGeom;
@@ -131,10 +109,8 @@ void GEMRecHitTrackMatch::analyze(const edm::Event &iEvent,
     // match hits and rechits to this SimTrack
 
     const SimHitMatcher &match_sh =
-        SimHitMatcher(t, iEvent, geom, cfg_, simHitsToken_, simTracksToken_,
-                      simVerticesToken_);
-    const GEMRecHitMatcher &match_rh =
-        GEMRecHitMatcher(match_sh, iEvent, geom, cfg_, gem_recHitToken_);
+        SimHitMatcher(t, iEvent, geom, cfg_, simHitsToken_, simTracksToken_, simVerticesToken_);
+    const GEMRecHitMatcher &match_rh = GEMRecHitMatcher(match_sh, iEvent, geom, cfg_, gem_recHitToken_);
 
     track_.pt = t.momentum().pt();
     // std::cout << "SimTrack pt value :  " << track_.pt << "\n";
@@ -159,8 +135,7 @@ void GEMRecHitTrackMatch::analyze(const edm::Event &iEvent,
       else if (id.chamber() % 2 == 1)
         track_.hitOdd[id.station() - 1] = true;
       else {
-        edm::LogInfo("GEMRecHitTrackMatch")
-            << "Error to get chamber id" << std::endl;
+        edm::LogInfo("GEMRecHitTrackMatch") << "Error to get chamber id" << std::endl;
       }
 
       track_.gem_sh[id.station() - 1][(id.layer() - 1)] = true;
@@ -174,18 +149,15 @@ void GEMRecHitTrackMatch::analyze(const edm::Event &iEvent,
     }
 
     FillWithTrigger(track_eta, fabs(track_.eta));
-    FillWithTrigger(track_phi, fabs(track_.eta), track_.phi, track_.hitOdd,
-                    track_.hitEven);
+    FillWithTrigger(track_phi, fabs(track_.eta), track_.phi, track_.hitOdd, track_.hitEven);
 
     FillWithTrigger(rh_sh_eta, track_.gem_sh, fabs(track_.eta));
     FillWithTrigger(rh_eta, track_.gem_rh, fabs(track_.eta));
 
     // Separate station.
 
-    FillWithTrigger(rh_sh_phi, track_.gem_sh, fabs(track_.eta), track_.phi,
-                    track_.hitOdd, track_.hitEven);
-    FillWithTrigger(rh_phi, track_.gem_rh, fabs(track_.eta), track_.phi,
-                    track_.hitOdd, track_.hitEven);
+    FillWithTrigger(rh_sh_phi, track_.gem_sh, fabs(track_.eta), track_.phi, track_.hitOdd, track_.hitEven);
+    FillWithTrigger(rh_phi, track_.gem_rh, fabs(track_.eta), track_.phi, track_.hitOdd, track_.hitEven);
 
     /*
 

--- a/Validation/MuonIdentification/interface/MuonIdVal.h
+++ b/Validation/MuonIdentification/interface/MuonIdVal.h
@@ -60,8 +60,7 @@ public:
   ~MuonIdVal() override;
 
 private:
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   virtual void Fill(MonitorElement *, float);
 
@@ -78,16 +77,13 @@ private:
   edm::InputTag inputMuonCosmicCompatibilityValueMap_;
   edm::InputTag inputMuonShowerInformationValueMap_;
   edm::EDGetTokenT<reco::MuonCollection> inputMuonCollectionToken_;
-  edm::EDGetTokenT<DTRecSegment4DCollection>
-      inputDTRecSegment4DCollectionToken_;
+  edm::EDGetTokenT<DTRecSegment4DCollection> inputDTRecSegment4DCollectionToken_;
   edm::EDGetTokenT<CSCSegmentCollection> inputCSCSegmentCollectionToken_;
   edm::EDGetTokenT<reco::MuonTimeExtraMap> inputMuonTimeExtraValueMapCombToken_;
   edm::EDGetTokenT<reco::MuonTimeExtraMap> inputMuonTimeExtraValueMapDTToken_;
   edm::EDGetTokenT<reco::MuonTimeExtraMap> inputMuonTimeExtraValueMapCSCToken_;
-  edm::EDGetTokenT<edm::ValueMap<reco::MuonCosmicCompatibility>>
-      inputMuonCosmicCompatibilityValueMapToken_;
-  edm::EDGetTokenT<edm::ValueMap<reco::MuonShower>>
-      inputMuonShowerInformationValueMapToken_;
+  edm::EDGetTokenT<edm::ValueMap<reco::MuonCosmicCompatibility>> inputMuonCosmicCompatibilityValueMapToken_;
+  edm::EDGetTokenT<edm::ValueMap<reco::MuonShower>> inputMuonShowerInformationValueMapToken_;
   bool useTrackerMuons_;
   bool useGlobalMuons_;
   bool useTrackerMuonsNotGlobalMuons_;
@@ -106,8 +102,7 @@ private:
   edm::Handle<reco::MuonTimeExtraMap> combinedMuonTimeExtraValueMapH_;
   edm::Handle<reco::MuonTimeExtraMap> cscMuonTimeExtraValueMapH_;
   edm::Handle<reco::MuonTimeExtraMap> dtMuonTimeExtraValueMapH_;
-  edm::Handle<edm::ValueMap<reco::MuonCosmicCompatibility>>
-      muonCosmicCompatibilityValueMapH_;
+  edm::Handle<edm::ValueMap<reco::MuonCosmicCompatibility>> muonCosmicCompatibilityValueMapH_;
   edm::Handle<edm::ValueMap<reco::MuonShower>> muonShowerInformationValueMapH_;
   edm::ESHandle<GlobalTrackingGeometry> geometry_;
 

--- a/Validation/MuonIdentification/src/MuonIdVal.cc
+++ b/Validation/MuonIdentification/src/MuonIdVal.cc
@@ -2,62 +2,44 @@
 
 MuonIdVal::MuonIdVal(const edm::ParameterSet &ps) {
   iConfig = ps;
-  inputMuonCollection_ =
-      iConfig.getParameter<edm::InputTag>("inputMuonCollection");
-  inputDTRecSegment4DCollection_ =
-      iConfig.getParameter<edm::InputTag>("inputDTRecSegment4DCollection");
-  inputCSCSegmentCollection_ =
-      iConfig.getParameter<edm::InputTag>("inputCSCSegmentCollection");
-  inputMuonTimeExtraValueMap_ =
-      iConfig.getParameter<edm::InputTag>("inputMuonTimeExtraValueMap");
-  inputMuonCosmicCompatibilityValueMap_ = iConfig.getParameter<edm::InputTag>(
-      "inputMuonCosmicCompatibilityValueMap");
-  inputMuonShowerInformationValueMap_ =
-      iConfig.getParameter<edm::InputTag>("inputMuonShowerInformationValueMap");
+  inputMuonCollection_ = iConfig.getParameter<edm::InputTag>("inputMuonCollection");
+  inputDTRecSegment4DCollection_ = iConfig.getParameter<edm::InputTag>("inputDTRecSegment4DCollection");
+  inputCSCSegmentCollection_ = iConfig.getParameter<edm::InputTag>("inputCSCSegmentCollection");
+  inputMuonTimeExtraValueMap_ = iConfig.getParameter<edm::InputTag>("inputMuonTimeExtraValueMap");
+  inputMuonCosmicCompatibilityValueMap_ = iConfig.getParameter<edm::InputTag>("inputMuonCosmicCompatibilityValueMap");
+  inputMuonShowerInformationValueMap_ = iConfig.getParameter<edm::InputTag>("inputMuonShowerInformationValueMap");
   useTrackerMuons_ = iConfig.getUntrackedParameter<bool>("useTrackerMuons");
   useGlobalMuons_ = iConfig.getUntrackedParameter<bool>("useGlobalMuons");
-  useTrackerMuonsNotGlobalMuons_ =
-      iConfig.getUntrackedParameter<bool>("useTrackerMuonsNotGlobalMuons");
-  useGlobalMuonsNotTrackerMuons_ =
-      iConfig.getUntrackedParameter<bool>("useGlobalMuonsNotTrackerMuons");
+  useTrackerMuonsNotGlobalMuons_ = iConfig.getUntrackedParameter<bool>("useTrackerMuonsNotGlobalMuons");
+  useGlobalMuonsNotTrackerMuons_ = iConfig.getUntrackedParameter<bool>("useGlobalMuonsNotTrackerMuons");
   makeEnergyPlots_ = iConfig.getUntrackedParameter<bool>("makeEnergyPlots");
   makeTimePlots_ = iConfig.getUntrackedParameter<bool>("makeTimePlots");
   make2DPlots_ = iConfig.getUntrackedParameter<bool>("make2DPlots");
-  makeAllChamberPlots_ =
-      iConfig.getUntrackedParameter<bool>("makeAllChamberPlots");
-  makeCosmicCompatibilityPlots_ =
-      iConfig.getUntrackedParameter<bool>("makeCosmicCompatibilityPlots");
-  makeShowerInformationPlots_ =
-      iConfig.getUntrackedParameter<bool>("makeShowerInformationPlots");
+  makeAllChamberPlots_ = iConfig.getUntrackedParameter<bool>("makeAllChamberPlots");
+  makeCosmicCompatibilityPlots_ = iConfig.getUntrackedParameter<bool>("makeCosmicCompatibilityPlots");
+  makeShowerInformationPlots_ = iConfig.getUntrackedParameter<bool>("makeShowerInformationPlots");
   baseFolder_ = iConfig.getUntrackedParameter<std::string>("baseFolder");
 
-  inputMuonCollectionToken_ =
-      consumes<reco::MuonCollection>(inputMuonCollection_);
-  inputDTRecSegment4DCollectionToken_ =
-      consumes<DTRecSegment4DCollection>(inputDTRecSegment4DCollection_);
-  inputCSCSegmentCollectionToken_ =
-      consumes<CSCSegmentCollection>(inputCSCSegmentCollection_);
-  inputMuonTimeExtraValueMapCombToken_ = consumes<reco::MuonTimeExtraMap>(
-      edm::InputTag(inputMuonTimeExtraValueMap_.label(), "combined"));
-  inputMuonTimeExtraValueMapDTToken_ = consumes<reco::MuonTimeExtraMap>(
-      edm::InputTag(inputMuonTimeExtraValueMap_.label(), "csc"));
-  inputMuonTimeExtraValueMapCSCToken_ = consumes<reco::MuonTimeExtraMap>(
-      edm::InputTag(inputMuonTimeExtraValueMap_.label(), "dt"));
+  inputMuonCollectionToken_ = consumes<reco::MuonCollection>(inputMuonCollection_);
+  inputDTRecSegment4DCollectionToken_ = consumes<DTRecSegment4DCollection>(inputDTRecSegment4DCollection_);
+  inputCSCSegmentCollectionToken_ = consumes<CSCSegmentCollection>(inputCSCSegmentCollection_);
+  inputMuonTimeExtraValueMapCombToken_ =
+      consumes<reco::MuonTimeExtraMap>(edm::InputTag(inputMuonTimeExtraValueMap_.label(), "combined"));
+  inputMuonTimeExtraValueMapDTToken_ =
+      consumes<reco::MuonTimeExtraMap>(edm::InputTag(inputMuonTimeExtraValueMap_.label(), "csc"));
+  inputMuonTimeExtraValueMapCSCToken_ =
+      consumes<reco::MuonTimeExtraMap>(edm::InputTag(inputMuonTimeExtraValueMap_.label(), "dt"));
   inputMuonCosmicCompatibilityValueMapToken_ =
-      consumes<edm::ValueMap<reco::MuonCosmicCompatibility>>(
-          inputMuonCosmicCompatibilityValueMap_);
+      consumes<edm::ValueMap<reco::MuonCosmicCompatibility>>(inputMuonCosmicCompatibilityValueMap_);
   inputMuonShowerInformationValueMapToken_ =
-      consumes<edm::ValueMap<reco::MuonShower>>(
-          inputMuonShowerInformationValueMap_);
+      consumes<edm::ValueMap<reco::MuonShower>>(inputMuonShowerInformationValueMap_);
 
-  subsystemname_ = iConfig.getUntrackedParameter<std::string>("subSystemFolder",
-                                                              "YourSubsystem");
+  subsystemname_ = iConfig.getUntrackedParameter<std::string>("subSystemFolder", "YourSubsystem");
 }
 
 MuonIdVal::~MuonIdVal() {}
 
-void MuonIdVal::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &,
-                               const edm::EventSetup &) {
+void MuonIdVal::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &, const edm::EventSetup &) {
   char name[100], title[200];
   ibooker.setCurrentFolder(baseFolder_);
 
@@ -66,8 +48,7 @@ void MuonIdVal::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &,
   for (unsigned int i = 0; i < 4; i++) {
     if ((i == 0 && !useTrackerMuons_) || (i == 1 && !useGlobalMuons_))
       continue;
-    if ((i == 2 && !useTrackerMuonsNotGlobalMuons_) ||
-        (i == 3 && !useGlobalMuonsNotTrackerMuons_))
+    if ((i == 2 && !useTrackerMuonsNotGlobalMuons_) || (i == 3 && !useGlobalMuonsNotTrackerMuons_))
       continue;
     if (i == 0)
       ibooker.setCurrentFolder(baseFolder_ + "/TrackerMuons");
@@ -79,306 +60,229 @@ void MuonIdVal::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &,
       ibooker.setCurrentFolder(baseFolder_ + "/GlobalMuonsNotTrackerMuons");
 
     if (makeEnergyPlots_) {
-      hEnergyEMBarrel[i] = ibooker.book1D(
-          "hEnergyEMBarrel", "Energy in ECAL Barrel", 100, -0.5, 2.);
-      hEnergyHABarrel[i] = ibooker.book1D(
-          "hEnergyHABarrel", "Energy in HCAL Barrel", 100, -4., 12.);
+      hEnergyEMBarrel[i] = ibooker.book1D("hEnergyEMBarrel", "Energy in ECAL Barrel", 100, -0.5, 2.);
+      hEnergyHABarrel[i] = ibooker.book1D("hEnergyHABarrel", "Energy in HCAL Barrel", 100, -4., 12.);
       hEnergyHO[i] = ibooker.book1D("hEnergyHO", "Energy HO", 100, -2., 5.);
-      hEnergyEMEndcap[i] = ibooker.book1D(
-          "hEnergyEMEndcap", "Energy in ECAL Endcap", 100, -0.5, 2.);
-      hEnergyHAEndcap[i] = ibooker.book1D(
-          "hEnergyHAEndcap", "Energy in HCAL Endcap", 100, -4., 12.);
+      hEnergyEMEndcap[i] = ibooker.book1D("hEnergyEMEndcap", "Energy in ECAL Endcap", 100, -0.5, 2.);
+      hEnergyHAEndcap[i] = ibooker.book1D("hEnergyHAEndcap", "Energy in HCAL Endcap", 100, -4., 12.);
     }
 
     if (makeTimePlots_) {
-      hMuonTimeNDOF[i] =
-          ibooker.book1D("hMuonTimeNDOF", "MuonTime NDOF", 52, -1.5, 50.5);
-      hMuonTimeTimeAtIpInOut[i] = ibooker.book1D(
-          "hMuonTimeTimeAtIpInOut", "MuonTime TimeAtIpInOut", 100, -20., 20.);
+      hMuonTimeNDOF[i] = ibooker.book1D("hMuonTimeNDOF", "MuonTime NDOF", 52, -1.5, 50.5);
+      hMuonTimeTimeAtIpInOut[i] = ibooker.book1D("hMuonTimeTimeAtIpInOut", "MuonTime TimeAtIpInOut", 100, -20., 20.);
       hMuonTimeTimeAtIpInOutErr[i] =
-          ibooker.book1D("hMuonTimeTimeAtIpInOutErr",
-                         "MuonTime TimeAtIpInOutErr", 100, 0., 8.);
-      hMuonTimeTimeAtIpOutIn[i] = ibooker.book1D(
-          "hMuonTimeTimeAtIpOutIn", "MuonTime TimeAtIpOutIn", 100, -1., 75.);
+          ibooker.book1D("hMuonTimeTimeAtIpInOutErr", "MuonTime TimeAtIpInOutErr", 100, 0., 8.);
+      hMuonTimeTimeAtIpOutIn[i] = ibooker.book1D("hMuonTimeTimeAtIpOutIn", "MuonTime TimeAtIpOutIn", 100, -1., 75.);
       hMuonTimeTimeAtIpOutInErr[i] =
-          ibooker.book1D("hMuonTimeTimeAtIpOutInErr",
-                         "MuonTime TimeAtIpOutInErr", 100, 0., 8.);
+          ibooker.book1D("hMuonTimeTimeAtIpOutInErr", "MuonTime TimeAtIpOutInErr", 100, 0., 8.);
       hMuonTimeExtraCombinedNDOF[i] =
-          ibooker.book1D("hMuonTimeExtraCombinedNDOF",
-                         "MuonTimeExtra Combined NDOF", 52, -1.5, 50.5);
-      hMuonTimeExtraCombinedTimeAtIpInOut[i] = ibooker.book1D(
-          "hMuonTimeExtraCombinedTimeAtIpInOut",
-          "MuonTimeExtra Combined TimeAtIpInOut", 100, -20., 20.);
+          ibooker.book1D("hMuonTimeExtraCombinedNDOF", "MuonTimeExtra Combined NDOF", 52, -1.5, 50.5);
+      hMuonTimeExtraCombinedTimeAtIpInOut[i] =
+          ibooker.book1D("hMuonTimeExtraCombinedTimeAtIpInOut", "MuonTimeExtra Combined TimeAtIpInOut", 100, -20., 20.);
       hMuonTimeExtraCombinedTimeAtIpInOutErr[i] = ibooker.book1D(
-          "hMuonTimeExtraCombinedTimeAtIpInOutErr",
-          "MuonTimeExtra Combined TimeAtIpInOutErr", 100, 0., 8.);
+          "hMuonTimeExtraCombinedTimeAtIpInOutErr", "MuonTimeExtra Combined TimeAtIpInOutErr", 100, 0., 8.);
       hMuonTimeExtraCombinedTimeAtIpOutIn[i] =
-          ibooker.book1D("hMuonTimeExtraCombinedTimeAtIpOutIn",
-                         "MuonTimeExtra Combined TimeAtIpOutIn", 100, -1., 75.);
+          ibooker.book1D("hMuonTimeExtraCombinedTimeAtIpOutIn", "MuonTimeExtra Combined TimeAtIpOutIn", 100, -1., 75.);
       hMuonTimeExtraCombinedTimeAtIpOutInErr[i] = ibooker.book1D(
-          "hMuonTimeExtraCombinedTimeAtIpOutInErr",
-          "MuonTimeExtra Combined TimeAtIpOutInErr", 100, 0., 8.);
-      hMuonTimeExtraCSCNDOF[i] = ibooker.book1D(
-          "hMuonTimeExtraCSCNDOF", "MuonTimeExtra CSC NDOF", 52, -1.5, 50.5);
+          "hMuonTimeExtraCombinedTimeAtIpOutInErr", "MuonTimeExtra Combined TimeAtIpOutInErr", 100, 0., 8.);
+      hMuonTimeExtraCSCNDOF[i] = ibooker.book1D("hMuonTimeExtraCSCNDOF", "MuonTimeExtra CSC NDOF", 52, -1.5, 50.5);
       hMuonTimeExtraCSCTimeAtIpInOut[i] =
-          ibooker.book1D("hMuonTimeExtraCSCTimeAtIpInOut",
-                         "MuonTimeExtra CSC TimeAtIpInOut", 100, -20., 20.);
+          ibooker.book1D("hMuonTimeExtraCSCTimeAtIpInOut", "MuonTimeExtra CSC TimeAtIpInOut", 100, -20., 20.);
       hMuonTimeExtraCSCTimeAtIpInOutErr[i] =
-          ibooker.book1D("hMuonTimeExtraCSCTimeAtIpInOutErr",
-                         "MuonTimeExtra CSC TimeAtIpInOutErr", 100, 0., 8.);
+          ibooker.book1D("hMuonTimeExtraCSCTimeAtIpInOutErr", "MuonTimeExtra CSC TimeAtIpInOutErr", 100, 0., 8.);
       hMuonTimeExtraCSCTimeAtIpOutIn[i] =
-          ibooker.book1D("hMuonTimeExtraCSCTimeAtIpOutIn",
-                         "MuonTimeExtra CSC TimeAtIpOutIn", 100, -1., 75.);
+          ibooker.book1D("hMuonTimeExtraCSCTimeAtIpOutIn", "MuonTimeExtra CSC TimeAtIpOutIn", 100, -1., 75.);
       hMuonTimeExtraCSCTimeAtIpOutInErr[i] =
-          ibooker.book1D("hMuonTimeExtraCSCTimeAtIpOutInErr",
-                         "MuonTimeExtra CSC TimeAtIpOutInErr", 100, 0., 8.);
-      hMuonTimeExtraDTNDOF[i] = ibooker.book1D(
-          "hMuonTimeExtraDTNDOF", "MuonTimeExtra DT NDOF", 52, -1.5, 50.5);
+          ibooker.book1D("hMuonTimeExtraCSCTimeAtIpOutInErr", "MuonTimeExtra CSC TimeAtIpOutInErr", 100, 0., 8.);
+      hMuonTimeExtraDTNDOF[i] = ibooker.book1D("hMuonTimeExtraDTNDOF", "MuonTimeExtra DT NDOF", 52, -1.5, 50.5);
       hMuonTimeExtraDTTimeAtIpInOut[i] =
-          ibooker.book1D("hMuonTimeExtraDTTimeAtIpInOut",
-                         "MuonTimeExtra DT TimeAtIpInOut", 100, -20., 20.);
+          ibooker.book1D("hMuonTimeExtraDTTimeAtIpInOut", "MuonTimeExtra DT TimeAtIpInOut", 100, -20., 20.);
       hMuonTimeExtraDTTimeAtIpInOutErr[i] =
-          ibooker.book1D("hMuonTimeExtraDTTimeAtIpInOutErr",
-                         "MuonTimeExtra DT TimeAtIpInOutErr", 100, 0., 8.);
+          ibooker.book1D("hMuonTimeExtraDTTimeAtIpInOutErr", "MuonTimeExtra DT TimeAtIpInOutErr", 100, 0., 8.);
       hMuonTimeExtraDTTimeAtIpOutIn[i] =
-          ibooker.book1D("hMuonTimeExtraDTTimeAtIpOutIn",
-                         "MuonTimeExtra DT TimeAtIpOutIn", 100, -1., 75.);
+          ibooker.book1D("hMuonTimeExtraDTTimeAtIpOutIn", "MuonTimeExtra DT TimeAtIpOutIn", 100, -1., 75.);
       hMuonTimeExtraDTTimeAtIpOutInErr[i] =
-          ibooker.book1D("hMuonTimeExtraDTTimeAtIpOutInErr",
-                         "MuonTimeExtra DT TimeAtIpOutInErr", 100, 0., 8.);
+          ibooker.book1D("hMuonTimeExtraDTTimeAtIpOutInErr", "MuonTimeExtra DT TimeAtIpOutInErr", 100, 0., 8.);
     }
 
-    hCaloCompat[i] =
-        ibooker.book1D("hCaloCompat", "Calo Compatibility", 101, -0.05, 1.05);
-    hSegmentCompat[i] = ibooker.book1D(
-        "hSegmentCompat", "Segment Compatibility", 101, -0.05, 1.05);
+    hCaloCompat[i] = ibooker.book1D("hCaloCompat", "Calo Compatibility", 101, -0.05, 1.05);
+    hSegmentCompat[i] = ibooker.book1D("hSegmentCompat", "Segment Compatibility", 101, -0.05, 1.05);
     if (make2DPlots_)
       hCaloSegmentCompat[i] = ibooker.book2D(
-          "hCaloSegmentCompat", "Calo Compatibility vs. Segment Compatibility",
-          101, -0.05, 1.05, 101, -0.05, 1.05);
-    hMuonQualityTrkRelChi2[i] = ibooker.book1D(
-        "hMuonQualityTrkRelChi2", "MuonQuality TrkRelChi2", 100, 0., 1.5);
-    hMuonQualityStaRelChi2[i] = ibooker.book1D(
-        "hMuonQualityStaRelChi2", "MuonQuality StaRelChi2", 100, 0., 3.);
-    hMuonQualityTrkKink[i] = ibooker.book1D(
-        "hMuonQualityTrkKink", "MuonQuality TrkKink", 100, 0., 150.);
+          "hCaloSegmentCompat", "Calo Compatibility vs. Segment Compatibility", 101, -0.05, 1.05, 101, -0.05, 1.05);
+    hMuonQualityTrkRelChi2[i] = ibooker.book1D("hMuonQualityTrkRelChi2", "MuonQuality TrkRelChi2", 100, 0., 1.5);
+    hMuonQualityStaRelChi2[i] = ibooker.book1D("hMuonQualityStaRelChi2", "MuonQuality StaRelChi2", 100, 0., 3.);
+    hMuonQualityTrkKink[i] = ibooker.book1D("hMuonQualityTrkKink", "MuonQuality TrkKink", 100, 0., 150.);
     hGlobalMuonPromptTightBool[i] =
-        ibooker.book1D("hGlobalMuonPromptTightBool",
-                       "GlobalMuonPromptTight Boolean", 2, -0.5, 1.5);
-    hTMLastStationLooseBool[i] = ibooker.book1D(
-        "hTMLastStationLooseBool", "TMLastStationLoose Boolean", 2, -0.5, 1.5);
-    hTMLastStationTightBool[i] = ibooker.book1D(
-        "hTMLastStationTightBool", "TMLastStationTight Boolean", 2, -0.5, 1.5);
+        ibooker.book1D("hGlobalMuonPromptTightBool", "GlobalMuonPromptTight Boolean", 2, -0.5, 1.5);
+    hTMLastStationLooseBool[i] = ibooker.book1D("hTMLastStationLooseBool", "TMLastStationLoose Boolean", 2, -0.5, 1.5);
+    hTMLastStationTightBool[i] = ibooker.book1D("hTMLastStationTightBool", "TMLastStationTight Boolean", 2, -0.5, 1.5);
     hTM2DCompatibilityLooseBool[i] =
-        ibooker.book1D("hTM2DCompatibilityLooseBool",
-                       "TM2DCompatibilityLoose Boolean", 2, -0.5, 1.5);
+        ibooker.book1D("hTM2DCompatibilityLooseBool", "TM2DCompatibilityLoose Boolean", 2, -0.5, 1.5);
     hTM2DCompatibilityTightBool[i] =
-        ibooker.book1D("hTM2DCompatibilityTightBool",
-                       "TM2DCompatibilityTight Boolean", 2, -0.5, 1.5);
-    hTMOneStationLooseBool[i] = ibooker.book1D(
-        "hTMOneStationLooseBool", "TMOneStationLoose Boolean", 2, -0.5, 1.5);
-    hTMOneStationTightBool[i] = ibooker.book1D(
-        "hTMOneStationTightBool", "TMOneStationTight Boolean", 2, -0.5, 1.5);
+        ibooker.book1D("hTM2DCompatibilityTightBool", "TM2DCompatibilityTight Boolean", 2, -0.5, 1.5);
+    hTMOneStationLooseBool[i] = ibooker.book1D("hTMOneStationLooseBool", "TMOneStationLoose Boolean", 2, -0.5, 1.5);
+    hTMOneStationTightBool[i] = ibooker.book1D("hTMOneStationTightBool", "TMOneStationTight Boolean", 2, -0.5, 1.5);
     hTMLastStationOptimizedLowPtLooseBool[i] = ibooker.book1D(
-        "hTMLastStationOptimizedLowPtLooseBool",
-        "TMLastStationOptimizedLowPtLoose Boolean", 2, -0.5, 1.5);
+        "hTMLastStationOptimizedLowPtLooseBool", "TMLastStationOptimizedLowPtLoose Boolean", 2, -0.5, 1.5);
     hTMLastStationOptimizedLowPtTightBool[i] = ibooker.book1D(
-        "hTMLastStationOptimizedLowPtTightBool",
-        "TMLastStationOptimizedLowPtTight Boolean", 2, -0.5, 1.5);
+        "hTMLastStationOptimizedLowPtTightBool", "TMLastStationOptimizedLowPtTight Boolean", 2, -0.5, 1.5);
     hGMTkChiCompatibilityBool[i] =
-        ibooker.book1D("hGMTkChiCompatibilityBool",
-                       "GMTkChiCompatibility Boolean", 2, -0.5, 1.5);
+        ibooker.book1D("hGMTkChiCompatibilityBool", "GMTkChiCompatibility Boolean", 2, -0.5, 1.5);
     hGMStaChiCompatibilityBool[i] =
-        ibooker.book1D("hGMStaChiCompatibilityBool",
-                       "GMStaChiCompatibility Boolean", 2, -0.5, 1.5);
-    hGMTkKinkTightBool[i] = ibooker.book1D(
-        "hGMTkKinkTightBool", "GMTkKinkTight Boolean", 2, -0.5, 1.5);
+        ibooker.book1D("hGMStaChiCompatibilityBool", "GMStaChiCompatibility Boolean", 2, -0.5, 1.5);
+    hGMTkKinkTightBool[i] = ibooker.book1D("hGMTkKinkTightBool", "GMTkKinkTight Boolean", 2, -0.5, 1.5);
     hTMLastStationAngLooseBool[i] =
-        ibooker.book1D("hTMLastStationAngLooseBool",
-                       "TMLastStationAngLoose Boolean", 2, -0.5, 1.5);
+        ibooker.book1D("hTMLastStationAngLooseBool", "TMLastStationAngLoose Boolean", 2, -0.5, 1.5);
     hTMLastStationAngTightBool[i] =
-        ibooker.book1D("hTMLastStationAngTightBool",
-                       "TMLastStationAngTight Boolean", 2, -0.5, 1.5);
+        ibooker.book1D("hTMLastStationAngTightBool", "TMLastStationAngTight Boolean", 2, -0.5, 1.5);
     hTMOneStationAngLooseBool[i] =
-        ibooker.book1D("hTMOneStationAngLooseBool",
-                       "TMOneStationAngLoose Boolean", 2, -0.5, 1.5);
+        ibooker.book1D("hTMOneStationAngLooseBool", "TMOneStationAngLoose Boolean", 2, -0.5, 1.5);
     hTMOneStationAngTightBool[i] =
-        ibooker.book1D("hTMOneStationAngTightBool",
-                       "TMOneStationAngTight Boolean", 2, -0.5, 1.5);
+        ibooker.book1D("hTMOneStationAngTightBool", "TMOneStationAngTight Boolean", 2, -0.5, 1.5);
     hTMLastStationOptimizedBarrelLowPtLooseBool[i] = ibooker.book1D(
-        "hTMLastStationOptimizedBarrelLowPtLooseBool",
-        "TMLastStationOptimizedBarrelLowPtLoose Boolean", 2, -0.5, 1.5);
+        "hTMLastStationOptimizedBarrelLowPtLooseBool", "TMLastStationOptimizedBarrelLowPtLoose Boolean", 2, -0.5, 1.5);
     hTMLastStationOptimizedBarrelLowPtTightBool[i] = ibooker.book1D(
-        "hTMLastStationOptimizedBarrelLowPtTightBool",
-        "TMLastStationOptimizedBarrelLowPtTight Boolean", 2, -0.5, 1.5);
+        "hTMLastStationOptimizedBarrelLowPtTightBool", "TMLastStationOptimizedBarrelLowPtTight Boolean", 2, -0.5, 1.5);
 
     if (makeCosmicCompatibilityPlots_) {
       hCombinedCosmicCompat[i] =
-          ibooker.book1D("hCombinedCosmicCompat",
-                         "hCombinedCosmicCompatibility float", 40, 0., 10.);
-      hTimeCosmicCompat[i] = ibooker.book1D(
-          "hTimeCosmicCompat", "hTimeCosmicCompatibility float", 6, 0., 3.);
-      hB2BCosmicCompat[i] = ibooker.book1D(
-          "hB2BCosmicCompat", "Number of back-to-back partners", 10, 0, 10);
-      hOverlapCosmicCompat[i] = ibooker.book1D(
-          "hOverlapCosmicCompat", "Overlap between muons and 1Leg", 2, 0, 2);
+          ibooker.book1D("hCombinedCosmicCompat", "hCombinedCosmicCompatibility float", 40, 0., 10.);
+      hTimeCosmicCompat[i] = ibooker.book1D("hTimeCosmicCompat", "hTimeCosmicCompatibility float", 6, 0., 3.);
+      hB2BCosmicCompat[i] = ibooker.book1D("hB2BCosmicCompat", "Number of back-to-back partners", 10, 0, 10);
+      hOverlapCosmicCompat[i] = ibooker.book1D("hOverlapCosmicCompat", "Overlap between muons and 1Leg", 2, 0, 2);
     }
 
     // by station
     for (int station = 0; station < 4; ++station) {
-
       if (makeShowerInformationPlots_) {
         sprintf(name, "hMuonShowerSizeT%i", station + 1);
         sprintf(title, "Station %i Transverse Cluster Size", station + 1);
-        hMuonShowerSizeT[i][station] =
-            ibooker.book1D(name, title, 1000, 0, 500);
+        hMuonShowerSizeT[i][station] = ibooker.book1D(name, title, 1000, 0, 500);
         sprintf(name, "hMuonShowerDeltaR%i", station + 1);
         sprintf(title, "Station %i DeltaR", station + 1);
-        hMuonShowerDeltaR[i][station] =
-            ibooker.book1D(name, title, 5000, 0, 0.5);
+        hMuonShowerDeltaR[i][station] = ibooker.book1D(name, title, 5000, 0, 0.5);
         sprintf(name, "hMuonAllHits%i", station + 1);
-        sprintf(title, "Station %i Number of 1D DT or 2D CSC RecHits",
-                station + 1);
+        sprintf(title, "Station %i Number of 1D DT or 2D CSC RecHits", station + 1);
         hMuonAllHits[i][station] = ibooker.book1D(name, title, 400, 0, 400);
         sprintf(name, "hMuonHitsFromSegments%i", station + 1);
-        sprintf(title, "Station %i Hits used by 4D DT or 3D CSC Segments",
-                station + 1);
-        hMuonHitsFromSegments[i][station] =
-            ibooker.book1D(name, title, 400, 0, 400);
+        sprintf(title, "Station %i Hits used by 4D DT or 3D CSC Segments", station + 1);
+        hMuonHitsFromSegments[i][station] = ibooker.book1D(name, title, 400, 0, 400);
         sprintf(name, "hMuonUncorrelatedHits%i", station + 1);
         sprintf(title, "Station %i Uncorrelated Hits", station + 1);
-        hMuonUncorrelatedHits[i][station] =
-            ibooker.book1D(name, title, 400, 0, 400);
+        hMuonUncorrelatedHits[i][station] = ibooker.book1D(name, title, 400, 0, 400);
       }
 
       sprintf(name, "hDT%iPullxPropErr", station + 1);
-      sprintf(title, "DT Station %i Pull X w/ Propagation Error Only",
-              station + 1);
+      sprintf(title, "DT Station %i Pull X w/ Propagation Error Only", station + 1);
       hDTPullxPropErr[i][station] = ibooker.book1D(name, title, 100, -20., 20.);
 
       sprintf(name, "hDT%iPulldXdZPropErr", station + 1);
-      sprintf(title, "DT Station %i Pull DxDz w/ Propagation Error Only",
-              station + 1);
-      hDTPulldXdZPropErr[i][station] =
-          ibooker.book1D(name, title, 100, -20., 20.);
+      sprintf(title, "DT Station %i Pull DxDz w/ Propagation Error Only", station + 1);
+      hDTPulldXdZPropErr[i][station] = ibooker.book1D(name, title, 100, -20., 20.);
 
       if (station < 3) {
         sprintf(name, "hDT%iPullyPropErr", station + 1);
-        sprintf(title, "DT Station %i Pull Y w/ Propagation Error Only",
-                station + 1);
-        hDTPullyPropErr[i][station] =
-            ibooker.book1D(name, title, 100, -20., 20.);
+        sprintf(title, "DT Station %i Pull Y w/ Propagation Error Only", station + 1);
+        hDTPullyPropErr[i][station] = ibooker.book1D(name, title, 100, -20., 20.);
 
         sprintf(name, "hDT%iPulldYdZPropErr", station + 1);
-        sprintf(title, "DT Station %i Pull DyDz w/ Propagation Error Only",
-                station + 1);
-        hDTPulldYdZPropErr[i][station] =
-            ibooker.book1D(name, title, 100, -20., 20.);
+        sprintf(title, "DT Station %i Pull DyDz w/ Propagation Error Only", station + 1);
+        hDTPulldYdZPropErr[i][station] = ibooker.book1D(name, title, 100, -20., 20.);
       }
 
       sprintf(name, "hDT%iDistWithSegment", station + 1);
       sprintf(title, "DT Station %i Dist When There Is A Segment", station + 1);
-      hDTDistWithSegment[i][station] =
-          ibooker.book1D(name, title, 100, -140., 30.);
+      hDTDistWithSegment[i][station] = ibooker.book1D(name, title, 100, -140., 30.);
 
       sprintf(name, "hDT%iDistWithNoSegment", station + 1);
-      sprintf(title, "DT Station %i Dist When There Is No Segment",
-              station + 1);
-      hDTDistWithNoSegment[i][station] =
-          ibooker.book1D(name, title, 100, -140., 30.);
+      sprintf(title, "DT Station %i Dist When There Is No Segment", station + 1);
+      hDTDistWithNoSegment[i][station] = ibooker.book1D(name, title, 100, -140., 30.);
 
       sprintf(name, "hDT%iPullDistWithSegment", station + 1);
-      sprintf(title, "DT Station %i Pull Dist When There Is A Segment",
-              station + 1);
-      hDTPullDistWithSegment[i][station] =
-          ibooker.book1D(name, title, 100, -140., 30.);
+      sprintf(title, "DT Station %i Pull Dist When There Is A Segment", station + 1);
+      hDTPullDistWithSegment[i][station] = ibooker.book1D(name, title, 100, -140., 30.);
 
       sprintf(name, "hDT%iPullDistWithNoSegment", station + 1);
-      sprintf(title, "DT Station %i Pull Dist When There Is No Segment",
-              station + 1);
-      hDTPullDistWithNoSegment[i][station] =
-          ibooker.book1D(name, title, 100, -140., 30.);
+      sprintf(title, "DT Station %i Pull Dist When There Is No Segment", station + 1);
+      hDTPullDistWithNoSegment[i][station] = ibooker.book1D(name, title, 100, -140., 30.);
 
       sprintf(name, "hCSC%iPullxPropErr", station + 1);
-      sprintf(title, "CSC Station %i Pull X w/ Propagation Error Only",
-              station + 1);
-      hCSCPullxPropErr[i][station] =
-          ibooker.book1D(name, title, 100, -20., 20.);
+      sprintf(title, "CSC Station %i Pull X w/ Propagation Error Only", station + 1);
+      hCSCPullxPropErr[i][station] = ibooker.book1D(name, title, 100, -20., 20.);
 
       sprintf(name, "hCSC%iPulldXdZPropErr", station + 1);
-      sprintf(title, "CSC Station %i Pull DxDz w/ Propagation Error Only",
-              station + 1);
-      hCSCPulldXdZPropErr[i][station] =
-          ibooker.book1D(name, title, 100, -20., 20.);
+      sprintf(title, "CSC Station %i Pull DxDz w/ Propagation Error Only", station + 1);
+      hCSCPulldXdZPropErr[i][station] = ibooker.book1D(name, title, 100, -20., 20.);
 
       sprintf(name, "hCSC%iPullyPropErr", station + 1);
-      sprintf(title, "CSC Station %i Pull Y w/ Propagation Error Only",
-              station + 1);
-      hCSCPullyPropErr[i][station] =
-          ibooker.book1D(name, title, 100, -20., 20.);
+      sprintf(title, "CSC Station %i Pull Y w/ Propagation Error Only", station + 1);
+      hCSCPullyPropErr[i][station] = ibooker.book1D(name, title, 100, -20., 20.);
 
       sprintf(name, "hCSC%iPulldYdZPropErr", station + 1);
-      sprintf(title, "CSC Station %i Pull DyDz w/ Propagation Error Only",
-              station + 1);
-      hCSCPulldYdZPropErr[i][station] =
-          ibooker.book1D(name, title, 100, -50., 50.);
+      sprintf(title, "CSC Station %i Pull DyDz w/ Propagation Error Only", station + 1);
+      hCSCPulldYdZPropErr[i][station] = ibooker.book1D(name, title, 100, -50., 50.);
 
       sprintf(name, "hCSC%iDistWithSegment", station + 1);
-      sprintf(title, "CSC Station %i Dist When There Is A Segment",
-              station + 1);
-      hCSCDistWithSegment[i][station] =
-          ibooker.book1D(name, title, 100, -70., 20.);
+      sprintf(title, "CSC Station %i Dist When There Is A Segment", station + 1);
+      hCSCDistWithSegment[i][station] = ibooker.book1D(name, title, 100, -70., 20.);
 
       sprintf(name, "hCSC%iDistWithNoSegment", station + 1);
-      sprintf(title, "CSC Station %i Dist When There Is No Segment",
-              station + 1);
-      hCSCDistWithNoSegment[i][station] =
-          ibooker.book1D(name, title, 100, -70., 20.);
+      sprintf(title, "CSC Station %i Dist When There Is No Segment", station + 1);
+      hCSCDistWithNoSegment[i][station] = ibooker.book1D(name, title, 100, -70., 20.);
 
       sprintf(name, "hCSC%iPullDistWithSegment", station + 1);
-      sprintf(title, "CSC Station %i Pull Dist When There Is A Segment",
-              station + 1);
-      hCSCPullDistWithSegment[i][station] =
-          ibooker.book1D(name, title, 100, -70., 20.);
+      sprintf(title, "CSC Station %i Pull Dist When There Is A Segment", station + 1);
+      hCSCPullDistWithSegment[i][station] = ibooker.book1D(name, title, 100, -70., 20.);
 
       sprintf(name, "hCSC%iPullDistWithNoSegment", station + 1);
-      sprintf(title, "CSC Station %i Pull Dist When There Is No Segment",
-              station + 1);
-      hCSCPullDistWithNoSegment[i][station] =
-          ibooker.book1D(name, title, 100, -70., 20.);
-    } // station
+      sprintf(title, "CSC Station %i Pull Dist When There Is No Segment", station + 1);
+      hCSCPullDistWithNoSegment[i][station] = ibooker.book1D(name, title, 100, -70., 20.);
+    }  // station
   }
 
   if (make2DPlots_) {
     ibooker.setCurrentFolder(baseFolder_);
     hSegmentIsAssociatedRZ =
-        ibooker.book2D("hSegmentIsAssociatedRZ", "R-Z of Associated Segments",
-                       2140, -1070., 1070., 850, 0., 850.);
+        ibooker.book2D("hSegmentIsAssociatedRZ", "R-Z of Associated Segments", 2140, -1070., 1070., 850, 0., 850.);
     hSegmentIsAssociatedXY =
-        ibooker.book2D("hSegmentIsAssociatedXY", "X-Y of Associated Segments",
-                       1700, -850., 850., 1700, -850., 850.);
+        ibooker.book2D("hSegmentIsAssociatedXY", "X-Y of Associated Segments", 1700, -850., 850., 1700, -850., 850.);
     hSegmentIsNotAssociatedRZ = ibooker.book2D(
-        "hSegmentIsNotAssociatedRZ", "R-Z of Not Associated Segments", 2140,
-        -1070., 1070., 850, 0., 850.);
+        "hSegmentIsNotAssociatedRZ", "R-Z of Not Associated Segments", 2140, -1070., 1070., 850, 0., 850.);
     hSegmentIsNotAssociatedXY = ibooker.book2D(
-        "hSegmentIsNotAssociatedXY", "X-Y of Not Associated Segments", 1700,
-        -850., 850., 1700, -850., 850.);
-    hSegmentIsBestDrAssociatedRZ =
-        ibooker.book2D("hSegmentIsBestDrAssociatedRZ",
-                       "R-Z of Best in Station by #DeltaR Associated Segments",
-                       2140, -1070., 1070., 850, 0., 850.);
-    hSegmentIsBestDrAssociatedXY =
-        ibooker.book2D("hSegmentIsBestDrAssociatedXY",
-                       "X-Y of Best in Station by #DeltaR Associated Segments",
-                       1700, -850., 850., 1700, -850., 850.);
-    hSegmentIsBestDrNotAssociatedRZ = ibooker.book2D(
-        "hSegmentIsBestDrNotAssociatedRZ",
-        "R-Z of Best in Station by #DeltaR Not Associated Segments", 2140,
-        -1070., 1070., 850, 0., 850.);
-    hSegmentIsBestDrNotAssociatedXY = ibooker.book2D(
-        "hSegmentIsBestDrNotAssociatedXY",
-        "X-Y of Best in Station by #DeltaR Not Associated Segments", 1700,
-        -850., 850., 1700, -850., 850.);
+        "hSegmentIsNotAssociatedXY", "X-Y of Not Associated Segments", 1700, -850., 850., 1700, -850., 850.);
+    hSegmentIsBestDrAssociatedRZ = ibooker.book2D("hSegmentIsBestDrAssociatedRZ",
+                                                  "R-Z of Best in Station by #DeltaR Associated Segments",
+                                                  2140,
+                                                  -1070.,
+                                                  1070.,
+                                                  850,
+                                                  0.,
+                                                  850.);
+    hSegmentIsBestDrAssociatedXY = ibooker.book2D("hSegmentIsBestDrAssociatedXY",
+                                                  "X-Y of Best in Station by #DeltaR Associated Segments",
+                                                  1700,
+                                                  -850.,
+                                                  850.,
+                                                  1700,
+                                                  -850.,
+                                                  850.);
+    hSegmentIsBestDrNotAssociatedRZ = ibooker.book2D("hSegmentIsBestDrNotAssociatedRZ",
+                                                     "R-Z of Best in Station by #DeltaR Not Associated Segments",
+                                                     2140,
+                                                     -1070.,
+                                                     1070.,
+                                                     850,
+                                                     0.,
+                                                     850.);
+    hSegmentIsBestDrNotAssociatedXY = ibooker.book2D("hSegmentIsBestDrNotAssociatedXY",
+                                                     "X-Y of Best in Station by #DeltaR Not Associated Segments",
+                                                     1700,
+                                                     -850.,
+                                                     850.,
+                                                     1700,
+                                                     -850.,
+                                                     850.);
   }
 
   if (useTrackerMuons_ && makeAllChamberPlots_) {
@@ -390,59 +294,53 @@ void MuonIdVal::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &,
       for (int wheel = 0; wheel < 5; ++wheel) {
         // DT sectors: 1 -> 14
         for (int sector = 0; sector < 14; ++sector) {
-          sprintf(name, "hDTChamberDx_%i_%i_%i", station + 1, wheel - 2,
-                  sector + 1);
-          sprintf(title, "DT Chamber Delta X: Station %i Wheel %i Sector %i",
-                  station + 1, wheel - 2, sector + 1);
-          hDTChamberDx[station][wheel][sector] =
-              ibooker.book1D(name, title, 100, -100., 100.);
+          sprintf(name, "hDTChamberDx_%i_%i_%i", station + 1, wheel - 2, sector + 1);
+          sprintf(title, "DT Chamber Delta X: Station %i Wheel %i Sector %i", station + 1, wheel - 2, sector + 1);
+          hDTChamberDx[station][wheel][sector] = ibooker.book1D(name, title, 100, -100., 100.);
 
           if (station < 3) {
-            sprintf(name, "hDTChamberDy_%i_%i_%i", station + 1, wheel - 2,
-                    sector + 1);
-            sprintf(title, "DT Chamber Delta Y: Station %i Wheel %i Sector %i",
-                    station + 1, wheel - 2, sector + 1);
-            hDTChamberDy[station][wheel][sector] =
-                ibooker.book1D(name, title, 100, -150., 150.);
+            sprintf(name, "hDTChamberDy_%i_%i_%i", station + 1, wheel - 2, sector + 1);
+            sprintf(title, "DT Chamber Delta Y: Station %i Wheel %i Sector %i", station + 1, wheel - 2, sector + 1);
+            hDTChamberDy[station][wheel][sector] = ibooker.book1D(name, title, 100, -150., 150.);
           }
 
-          sprintf(name, "hDTChamberEdgeXWithSegment_%i_%i_%i", station + 1,
-                  wheel - 2, sector + 1);
+          sprintf(name, "hDTChamberEdgeXWithSegment_%i_%i_%i", station + 1, wheel - 2, sector + 1);
           sprintf(title,
                   "DT Chamber Edge X When There Is A Segment: Station %i Wheel "
                   "%i Sector %i",
-                  station + 1, wheel - 2, sector + 1);
-          hDTChamberEdgeXWithSegment[station][wheel][sector] =
-              ibooker.book1D(name, title, 100, -140., 30.);
+                  station + 1,
+                  wheel - 2,
+                  sector + 1);
+          hDTChamberEdgeXWithSegment[station][wheel][sector] = ibooker.book1D(name, title, 100, -140., 30.);
 
-          sprintf(name, "hDTChamberEdgeXWithNoSegment_%i_%i_%i", station + 1,
-                  wheel - 2, sector + 1);
+          sprintf(name, "hDTChamberEdgeXWithNoSegment_%i_%i_%i", station + 1, wheel - 2, sector + 1);
           sprintf(title,
                   "DT Chamber Edge X When There Is No Segment: Station %i "
                   "Wheel %i Sector %i",
-                  station + 1, wheel - 2, sector + 1);
-          hDTChamberEdgeXWithNoSegment[station][wheel][sector] =
-              ibooker.book1D(name, title, 100, -140., 30.);
+                  station + 1,
+                  wheel - 2,
+                  sector + 1);
+          hDTChamberEdgeXWithNoSegment[station][wheel][sector] = ibooker.book1D(name, title, 100, -140., 30.);
 
-          sprintf(name, "hDTChamberEdgeYWithSegment_%i_%i_%i", station + 1,
-                  wheel - 2, sector + 1);
+          sprintf(name, "hDTChamberEdgeYWithSegment_%i_%i_%i", station + 1, wheel - 2, sector + 1);
           sprintf(title,
                   "DT Chamber Edge Y When There Is A Segment: Station %i Wheel "
                   "%i Sector %i",
-                  station + 1, wheel - 2, sector + 1);
-          hDTChamberEdgeYWithSegment[station][wheel][sector] =
-              ibooker.book1D(name, title, 100, -140., 30.);
+                  station + 1,
+                  wheel - 2,
+                  sector + 1);
+          hDTChamberEdgeYWithSegment[station][wheel][sector] = ibooker.book1D(name, title, 100, -140., 30.);
 
-          sprintf(name, "hDTChamberEdgeYWithNoSegment_%i_%i_%i", station + 1,
-                  wheel - 2, sector + 1);
+          sprintf(name, "hDTChamberEdgeYWithNoSegment_%i_%i_%i", station + 1, wheel - 2, sector + 1);
           sprintf(title,
                   "DT Chamber Edge Y When There Is No Segment: Station %i "
                   "Wheel %i Sector %i",
-                  station + 1, wheel - 2, sector + 1);
-          hDTChamberEdgeYWithNoSegment[station][wheel][sector] =
-              ibooker.book1D(name, title, 100, -140., 30.);
-        } // sector
-      }   // wheel
+                  station + 1,
+                  wheel - 2,
+                  sector + 1);
+          hDTChamberEdgeYWithNoSegment[station][wheel][sector] = ibooker.book1D(name, title, 100, -140., 30.);
+        }  // sector
+      }    // wheel
 
       // CSC endcaps: 1 -> 2
       for (int endcap = 0; endcap < 2; ++endcap) {
@@ -450,90 +348,87 @@ void MuonIdVal::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &,
         for (int ring = 0; ring < 4; ++ring) {
           // CSC chambers: 1 -> 36
           for (int chamber = 0; chamber < 36; ++chamber) {
-            sprintf(name, "hCSCChamberDx_%i_%i_%i_%i", endcap + 1, station + 1,
-                    ring + 1, chamber + 1);
-            sprintf(
-                title,
-                "CSC Chamber Delta X: Endcap %i Station %i Ring %i Chamber %i",
-                endcap + 1, station + 1, ring + 1, chamber + 1);
-            hCSCChamberDx[endcap][station][ring][chamber] =
-                ibooker.book1D(name, title, 100, -50., 50.);
+            sprintf(name, "hCSCChamberDx_%i_%i_%i_%i", endcap + 1, station + 1, ring + 1, chamber + 1);
+            sprintf(title,
+                    "CSC Chamber Delta X: Endcap %i Station %i Ring %i Chamber %i",
+                    endcap + 1,
+                    station + 1,
+                    ring + 1,
+                    chamber + 1);
+            hCSCChamberDx[endcap][station][ring][chamber] = ibooker.book1D(name, title, 100, -50., 50.);
 
-            sprintf(name, "hCSCChamberDy_%i_%i_%i_%i", endcap + 1, station + 1,
-                    ring + 1, chamber + 1);
-            sprintf(
-                title,
-                "CSC Chamber Delta Y: Endcap %i Station %i Ring %i Chamber %i",
-                endcap + 1, station + 1, ring + 1, chamber + 1);
-            hCSCChamberDy[endcap][station][ring][chamber] =
-                ibooker.book1D(name, title, 100, -50., 50.);
+            sprintf(name, "hCSCChamberDy_%i_%i_%i_%i", endcap + 1, station + 1, ring + 1, chamber + 1);
+            sprintf(title,
+                    "CSC Chamber Delta Y: Endcap %i Station %i Ring %i Chamber %i",
+                    endcap + 1,
+                    station + 1,
+                    ring + 1,
+                    chamber + 1);
+            hCSCChamberDy[endcap][station][ring][chamber] = ibooker.book1D(name, title, 100, -50., 50.);
 
-            sprintf(name, "hCSCChamberEdgeXWithSegment_%i_%i_%i_%i", endcap + 1,
-                    station + 1, ring + 1, chamber + 1);
+            sprintf(name, "hCSCChamberEdgeXWithSegment_%i_%i_%i_%i", endcap + 1, station + 1, ring + 1, chamber + 1);
             sprintf(title,
                     "CSC Chamber Edge X When There Is A Segment: Endcap %i "
                     "Station %i Ring %i Chamber %i",
-                    endcap + 1, station + 1, ring + 1, chamber + 1);
-            hCSCChamberEdgeXWithSegment[endcap][station][ring][chamber] =
-                ibooker.book1D(name, title, 100, -70., 20.);
+                    endcap + 1,
+                    station + 1,
+                    ring + 1,
+                    chamber + 1);
+            hCSCChamberEdgeXWithSegment[endcap][station][ring][chamber] = ibooker.book1D(name, title, 100, -70., 20.);
 
-            sprintf(name, "hCSCChamberEdgeXWithNoSegment_%i_%i_%i_%i",
-                    endcap + 1, station + 1, ring + 1, chamber + 1);
+            sprintf(name, "hCSCChamberEdgeXWithNoSegment_%i_%i_%i_%i", endcap + 1, station + 1, ring + 1, chamber + 1);
             sprintf(title,
                     "CSC Chamber Edge X When There Is No Segment: Endcap %i "
                     "Station %i Ring %i Chamber %i",
-                    endcap + 1, station + 1, ring + 1, chamber + 1);
-            hCSCChamberEdgeXWithNoSegment[endcap][station][ring][chamber] =
-                ibooker.book1D(name, title, 100, -70., 20.);
+                    endcap + 1,
+                    station + 1,
+                    ring + 1,
+                    chamber + 1);
+            hCSCChamberEdgeXWithNoSegment[endcap][station][ring][chamber] = ibooker.book1D(name, title, 100, -70., 20.);
 
-            sprintf(name, "hCSCChamberEdgeYWithSegment_%i_%i_%i_%i", endcap + 1,
-                    station + 1, ring + 1, chamber + 1);
+            sprintf(name, "hCSCChamberEdgeYWithSegment_%i_%i_%i_%i", endcap + 1, station + 1, ring + 1, chamber + 1);
             sprintf(title,
                     "CSC Chamber Edge Y When There Is A Segment: Endcap %i "
                     "Station %i Ring %i Chamber %i",
-                    endcap + 1, station + 1, ring + 1, chamber + 1);
-            hCSCChamberEdgeYWithSegment[endcap][station][ring][chamber] =
-                ibooker.book1D(name, title, 100, -70., 20.);
+                    endcap + 1,
+                    station + 1,
+                    ring + 1,
+                    chamber + 1);
+            hCSCChamberEdgeYWithSegment[endcap][station][ring][chamber] = ibooker.book1D(name, title, 100, -70., 20.);
 
-            sprintf(name, "hCSCChamberEdgeYWithNoSegment_%i_%i_%i_%i",
-                    endcap + 1, station + 1, ring + 1, chamber + 1);
+            sprintf(name, "hCSCChamberEdgeYWithNoSegment_%i_%i_%i_%i", endcap + 1, station + 1, ring + 1, chamber + 1);
             sprintf(title,
                     "CSC Chamber Edge Y When There Is No Segment: Endcap %i "
                     "Station %i Ring %i Chamber %i",
-                    endcap + 1, station + 1, ring + 1, chamber + 1);
-            hCSCChamberEdgeYWithNoSegment[endcap][station][ring][chamber] =
-                ibooker.book1D(name, title, 100, -70., 20.);
-          } // chamber
-        }   // ring
-      }     // endcap
-    }       // station
+                    endcap + 1,
+                    station + 1,
+                    ring + 1,
+                    chamber + 1);
+            hCSCChamberEdgeYWithNoSegment[endcap][station][ring][chamber] = ibooker.book1D(name, title, 100, -70., 20.);
+          }  // chamber
+        }    // ring
+      }      // endcap
+    }        // station
   }
 }
 
-void MuonIdVal::analyze(const edm::Event &iEvent,
-                        const edm::EventSetup &iSetup) {
+void MuonIdVal::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
   using namespace reco;
 
   iEvent.getByToken(inputMuonCollectionToken_, muonCollectionH_);
   iEvent.getByToken(inputDTRecSegment4DCollectionToken_, dtSegmentCollectionH_);
   iEvent.getByToken(inputCSCSegmentCollectionToken_, cscSegmentCollectionH_);
-  iEvent.getByToken(inputMuonTimeExtraValueMapCombToken_,
-                    combinedMuonTimeExtraValueMapH_);
-  iEvent.getByToken(inputMuonTimeExtraValueMapCSCToken_,
-                    cscMuonTimeExtraValueMapH_);
-  iEvent.getByToken(inputMuonTimeExtraValueMapDTToken_,
-                    dtMuonTimeExtraValueMapH_);
-  iEvent.getByToken(inputMuonShowerInformationValueMapToken_,
-                    muonShowerInformationValueMapH_);
-  iEvent.getByToken(inputMuonCosmicCompatibilityValueMapToken_,
-                    muonCosmicCompatibilityValueMapH_);
+  iEvent.getByToken(inputMuonTimeExtraValueMapCombToken_, combinedMuonTimeExtraValueMapH_);
+  iEvent.getByToken(inputMuonTimeExtraValueMapCSCToken_, cscMuonTimeExtraValueMapH_);
+  iEvent.getByToken(inputMuonTimeExtraValueMapDTToken_, dtMuonTimeExtraValueMapH_);
+  iEvent.getByToken(inputMuonShowerInformationValueMapToken_, muonShowerInformationValueMapH_);
+  iEvent.getByToken(inputMuonCosmicCompatibilityValueMapToken_, muonCosmicCompatibilityValueMapH_);
 
   iSetup.get<GlobalTrackingGeometryRecord>().get(geometry_);
 
   unsigned int muonIdx = 0;
-  for (MuonCollection::const_iterator muon = muonCollectionH_->begin();
-       muon != muonCollectionH_->end(); ++muon) {
+  for (MuonCollection::const_iterator muon = muonCollectionH_->begin(); muon != muonCollectionH_->end(); ++muon) {
     // trackerMuon == 0; globalMuon == 1; trackerMuon && !globalMuon == 2;
     // globalMuon && !trackerMuon == 3
     for (unsigned int i = 0; i < 4; i++) {
@@ -541,11 +436,9 @@ void MuonIdVal::analyze(const edm::Event &iEvent,
         continue;
       if (i == 1 && (!useGlobalMuons_ || !muon->isGlobalMuon()))
         continue;
-      if (i == 2 && (!useTrackerMuonsNotGlobalMuons_ ||
-                     (!(muon->isTrackerMuon() && !muon->isGlobalMuon()))))
+      if (i == 2 && (!useTrackerMuonsNotGlobalMuons_ || (!(muon->isTrackerMuon() && !muon->isGlobalMuon()))))
         continue;
-      if (i == 3 && (!useGlobalMuonsNotTrackerMuons_ ||
-                     (!(muon->isGlobalMuon() && !muon->isTrackerMuon()))))
+      if (i == 3 && (!useGlobalMuonsNotTrackerMuons_ || (!(muon->isGlobalMuon() && !muon->isTrackerMuon()))))
         continue;
 
       if (makeEnergyPlots_ && muon->isEnergyValid()) {
@@ -574,133 +467,91 @@ void MuonIdVal::analyze(const edm::Event &iEvent,
         }
 
         MuonRef muonRef(muonCollectionH_, muonIdx);
-        MuonTimeExtra combinedMuonTimeExtra =
-            (*combinedMuonTimeExtraValueMapH_)[muonRef];
+        MuonTimeExtra combinedMuonTimeExtra = (*combinedMuonTimeExtraValueMapH_)[muonRef];
         MuonTimeExtra cscMuonTimeExtra = (*cscMuonTimeExtraValueMapH_)[muonRef];
         MuonTimeExtra dtMuonTimeExtra = (*dtMuonTimeExtraValueMapH_)[muonRef];
 
         hMuonTimeExtraCombinedNDOF[i]->Fill(combinedMuonTimeExtra.nDof());
-        hMuonTimeExtraCombinedTimeAtIpInOut[i]->Fill(
-            combinedMuonTimeExtra.timeAtIpInOut());
-        hMuonTimeExtraCombinedTimeAtIpInOutErr[i]->Fill(
-            combinedMuonTimeExtra.timeAtIpInOutErr());
-        hMuonTimeExtraCombinedTimeAtIpOutIn[i]->Fill(
-            combinedMuonTimeExtra.timeAtIpOutIn());
-        hMuonTimeExtraCombinedTimeAtIpOutInErr[i]->Fill(
-            combinedMuonTimeExtra.timeAtIpOutInErr());
+        hMuonTimeExtraCombinedTimeAtIpInOut[i]->Fill(combinedMuonTimeExtra.timeAtIpInOut());
+        hMuonTimeExtraCombinedTimeAtIpInOutErr[i]->Fill(combinedMuonTimeExtra.timeAtIpInOutErr());
+        hMuonTimeExtraCombinedTimeAtIpOutIn[i]->Fill(combinedMuonTimeExtra.timeAtIpOutIn());
+        hMuonTimeExtraCombinedTimeAtIpOutInErr[i]->Fill(combinedMuonTimeExtra.timeAtIpOutInErr());
         hMuonTimeExtraCSCNDOF[i]->Fill(cscMuonTimeExtra.nDof());
-        hMuonTimeExtraCSCTimeAtIpInOut[i]->Fill(
-            cscMuonTimeExtra.timeAtIpInOut());
-        hMuonTimeExtraCSCTimeAtIpInOutErr[i]->Fill(
-            cscMuonTimeExtra.timeAtIpInOutErr());
-        hMuonTimeExtraCSCTimeAtIpOutIn[i]->Fill(
-            cscMuonTimeExtra.timeAtIpOutIn());
-        hMuonTimeExtraCSCTimeAtIpOutInErr[i]->Fill(
-            cscMuonTimeExtra.timeAtIpOutInErr());
+        hMuonTimeExtraCSCTimeAtIpInOut[i]->Fill(cscMuonTimeExtra.timeAtIpInOut());
+        hMuonTimeExtraCSCTimeAtIpInOutErr[i]->Fill(cscMuonTimeExtra.timeAtIpInOutErr());
+        hMuonTimeExtraCSCTimeAtIpOutIn[i]->Fill(cscMuonTimeExtra.timeAtIpOutIn());
+        hMuonTimeExtraCSCTimeAtIpOutInErr[i]->Fill(cscMuonTimeExtra.timeAtIpOutInErr());
         hMuonTimeExtraDTNDOF[i]->Fill(dtMuonTimeExtra.nDof());
         hMuonTimeExtraDTTimeAtIpInOut[i]->Fill(dtMuonTimeExtra.timeAtIpInOut());
-        hMuonTimeExtraDTTimeAtIpInOutErr[i]->Fill(
-            dtMuonTimeExtra.timeAtIpInOutErr());
+        hMuonTimeExtraDTTimeAtIpInOutErr[i]->Fill(dtMuonTimeExtra.timeAtIpInOutErr());
         hMuonTimeExtraDTTimeAtIpOutIn[i]->Fill(dtMuonTimeExtra.timeAtIpOutIn());
-        hMuonTimeExtraDTTimeAtIpOutInErr[i]->Fill(
-            dtMuonTimeExtra.timeAtIpOutInErr());
+        hMuonTimeExtraDTTimeAtIpOutInErr[i]->Fill(dtMuonTimeExtra.timeAtIpOutInErr());
       }
 
       if (muon->isCaloCompatibilityValid())
         hCaloCompat[i]->Fill(muon->caloCompatibility());
       hSegmentCompat[i]->Fill(muon::segmentCompatibility(*muon));
       if (make2DPlots_ && muon->isCaloCompatibilityValid())
-        hCaloSegmentCompat[i]->Fill(muon->caloCompatibility(),
-                                    muon::segmentCompatibility(*muon));
+        hCaloSegmentCompat[i]->Fill(muon->caloCompatibility(), muon::segmentCompatibility(*muon));
       if (muon->isQualityValid()) {
         hMuonQualityTrkRelChi2[i]->Fill(muon->combinedQuality().trkRelChi2);
         hMuonQualityStaRelChi2[i]->Fill(muon->combinedQuality().staRelChi2);
         hMuonQualityTrkKink[i]->Fill(muon->combinedQuality().trkKink);
       }
-      hGlobalMuonPromptTightBool[i]->Fill(
-          muon::isGoodMuon(*muon, muon::GlobalMuonPromptTight));
-      hTMLastStationLooseBool[i]->Fill(
-          muon::isGoodMuon(*muon, muon::TMLastStationLoose));
-      hTMLastStationTightBool[i]->Fill(
-          muon::isGoodMuon(*muon, muon::TMLastStationTight));
-      hTM2DCompatibilityLooseBool[i]->Fill(
-          muon::isGoodMuon(*muon, muon::TM2DCompatibilityLoose));
-      hTM2DCompatibilityTightBool[i]->Fill(
-          muon::isGoodMuon(*muon, muon::TM2DCompatibilityTight));
-      hTMOneStationLooseBool[i]->Fill(
-          muon::isGoodMuon(*muon, muon::TMOneStationLoose));
-      hTMOneStationTightBool[i]->Fill(
-          muon::isGoodMuon(*muon, muon::TMOneStationTight));
-      hTMLastStationOptimizedLowPtLooseBool[i]->Fill(
-          muon::isGoodMuon(*muon, muon::TMLastStationOptimizedLowPtLoose));
-      hTMLastStationOptimizedLowPtTightBool[i]->Fill(
-          muon::isGoodMuon(*muon, muon::TMLastStationOptimizedLowPtTight));
-      hGMTkChiCompatibilityBool[i]->Fill(
-          muon::isGoodMuon(*muon, muon::GMTkChiCompatibility));
-      hGMStaChiCompatibilityBool[i]->Fill(
-          muon::isGoodMuon(*muon, muon::GMStaChiCompatibility));
+      hGlobalMuonPromptTightBool[i]->Fill(muon::isGoodMuon(*muon, muon::GlobalMuonPromptTight));
+      hTMLastStationLooseBool[i]->Fill(muon::isGoodMuon(*muon, muon::TMLastStationLoose));
+      hTMLastStationTightBool[i]->Fill(muon::isGoodMuon(*muon, muon::TMLastStationTight));
+      hTM2DCompatibilityLooseBool[i]->Fill(muon::isGoodMuon(*muon, muon::TM2DCompatibilityLoose));
+      hTM2DCompatibilityTightBool[i]->Fill(muon::isGoodMuon(*muon, muon::TM2DCompatibilityTight));
+      hTMOneStationLooseBool[i]->Fill(muon::isGoodMuon(*muon, muon::TMOneStationLoose));
+      hTMOneStationTightBool[i]->Fill(muon::isGoodMuon(*muon, muon::TMOneStationTight));
+      hTMLastStationOptimizedLowPtLooseBool[i]->Fill(muon::isGoodMuon(*muon, muon::TMLastStationOptimizedLowPtLoose));
+      hTMLastStationOptimizedLowPtTightBool[i]->Fill(muon::isGoodMuon(*muon, muon::TMLastStationOptimizedLowPtTight));
+      hGMTkChiCompatibilityBool[i]->Fill(muon::isGoodMuon(*muon, muon::GMTkChiCompatibility));
+      hGMStaChiCompatibilityBool[i]->Fill(muon::isGoodMuon(*muon, muon::GMStaChiCompatibility));
       hGMTkKinkTightBool[i]->Fill(muon::isGoodMuon(*muon, muon::GMTkKinkTight));
-      hTMLastStationAngLooseBool[i]->Fill(
-          muon::isGoodMuon(*muon, muon::TMLastStationAngLoose));
-      hTMLastStationAngTightBool[i]->Fill(
-          muon::isGoodMuon(*muon, muon::TMLastStationAngTight));
-      hTMOneStationAngLooseBool[i]->Fill(
-          muon::isGoodMuon(*muon, muon::TMOneStationAngLoose));
-      hTMOneStationAngTightBool[i]->Fill(
-          muon::isGoodMuon(*muon, muon::TMOneStationAngTight));
-      hTMLastStationOptimizedBarrelLowPtLooseBool[i]->Fill(muon::isGoodMuon(
-          *muon, muon::TMLastStationOptimizedBarrelLowPtLoose));
-      hTMLastStationOptimizedBarrelLowPtTightBool[i]->Fill(muon::isGoodMuon(
-          *muon, muon::TMLastStationOptimizedBarrelLowPtTight));
+      hTMLastStationAngLooseBool[i]->Fill(muon::isGoodMuon(*muon, muon::TMLastStationAngLoose));
+      hTMLastStationAngTightBool[i]->Fill(muon::isGoodMuon(*muon, muon::TMLastStationAngTight));
+      hTMOneStationAngLooseBool[i]->Fill(muon::isGoodMuon(*muon, muon::TMOneStationAngLoose));
+      hTMOneStationAngTightBool[i]->Fill(muon::isGoodMuon(*muon, muon::TMOneStationAngTight));
+      hTMLastStationOptimizedBarrelLowPtLooseBool[i]->Fill(
+          muon::isGoodMuon(*muon, muon::TMLastStationOptimizedBarrelLowPtLoose));
+      hTMLastStationOptimizedBarrelLowPtTightBool[i]->Fill(
+          muon::isGoodMuon(*muon, muon::TMLastStationOptimizedBarrelLowPtTight));
 
       if (makeCosmicCompatibilityPlots_) {
         MuonRef muonRef(muonCollectionH_, muonIdx);
-        MuonCosmicCompatibility muonCosmicCompatibility =
-            (*muonCosmicCompatibilityValueMapH_)[muonRef];
-        hCombinedCosmicCompat[i]->Fill(
-            muonCosmicCompatibility.cosmicCompatibility);
+        MuonCosmicCompatibility muonCosmicCompatibility = (*muonCosmicCompatibilityValueMapH_)[muonRef];
+        hCombinedCosmicCompat[i]->Fill(muonCosmicCompatibility.cosmicCompatibility);
         hTimeCosmicCompat[i]->Fill(muonCosmicCompatibility.timeCompatibility);
-        hB2BCosmicCompat[i]->Fill(
-            muonCosmicCompatibility.backToBackCompatibility);
-        hOverlapCosmicCompat[i]->Fill(
-            muonCosmicCompatibility.overlapCompatibility);
+        hB2BCosmicCompat[i]->Fill(muonCosmicCompatibility.backToBackCompatibility);
+        hOverlapCosmicCompat[i]->Fill(muonCosmicCompatibility.overlapCompatibility);
       }
 
       // by station
       for (int station = 0; station < 4; ++station) {
-
         if (makeShowerInformationPlots_) {
           MuonRef muonRef(muonCollectionH_, muonIdx);
-          MuonShower muonShowerInformation =
-              (*muonShowerInformationValueMapH_)[muonRef];
+          MuonShower muonShowerInformation = (*muonShowerInformationValueMapH_)[muonRef];
 
-          hMuonShowerSizeT[i][station]->Fill(
-              (muonShowerInformation.stationShowerSizeT).at(station));
-          hMuonShowerDeltaR[i][station]->Fill(
-              (muonShowerInformation.stationShowerDeltaR.at(station)));
-          hMuonAllHits[i][station]->Fill(
-              (muonShowerInformation.nStationHits.at(station)));
-          hMuonHitsFromSegments[i][station]->Fill(
-              (muonShowerInformation.nStationCorrelatedHits.at(station)));
-          hMuonUncorrelatedHits[i][station]->Fill(
-              (muonShowerInformation.nStationHits.at(station)) -
-              muonShowerInformation.nStationCorrelatedHits.at(station));
+          hMuonShowerSizeT[i][station]->Fill((muonShowerInformation.stationShowerSizeT).at(station));
+          hMuonShowerDeltaR[i][station]->Fill((muonShowerInformation.stationShowerDeltaR.at(station)));
+          hMuonAllHits[i][station]->Fill((muonShowerInformation.nStationHits.at(station)));
+          hMuonHitsFromSegments[i][station]->Fill((muonShowerInformation.nStationCorrelatedHits.at(station)));
+          hMuonUncorrelatedHits[i][station]->Fill((muonShowerInformation.nStationHits.at(station)) -
+                                                  muonShowerInformation.nStationCorrelatedHits.at(station));
         }
 
         Fill(hDTPullxPropErr[i][station],
-             muon->pullX(station + 1, MuonSubdetId::DT,
-                         Muon::SegmentAndTrackArbitration, false));
+             muon->pullX(station + 1, MuonSubdetId::DT, Muon::SegmentAndTrackArbitration, false));
         Fill(hDTPulldXdZPropErr[i][station],
-             muon->pullDxDz(station + 1, MuonSubdetId::DT,
-                            Muon::SegmentAndTrackArbitration, false));
+             muon->pullDxDz(station + 1, MuonSubdetId::DT, Muon::SegmentAndTrackArbitration, false));
 
         if (station < 3) {
           Fill(hDTPullyPropErr[i][station],
-               muon->pullY(station + 1, MuonSubdetId::DT,
-                           Muon::SegmentAndTrackArbitration, false));
+               muon->pullY(station + 1, MuonSubdetId::DT, Muon::SegmentAndTrackArbitration, false));
           Fill(hDTPulldYdZPropErr[i][station],
-               muon->pullDyDz(station + 1, MuonSubdetId::DT,
-                              Muon::SegmentAndTrackArbitration, false));
+               muon->pullDyDz(station + 1, MuonSubdetId::DT, Muon::SegmentAndTrackArbitration, false));
         }
 
         float distance = muon->trackDist(station + 1, MuonSubdetId::DT);
@@ -708,8 +559,7 @@ void MuonIdVal::analyze(const edm::Event &iEvent,
         if (error == 0)
           error = 0.000001;
 
-        if (muon->numberOfSegments(station + 1, MuonSubdetId::DT,
-                                   Muon::NoArbitration) > 0) {
+        if (muon->numberOfSegments(station + 1, MuonSubdetId::DT, Muon::NoArbitration) > 0) {
           Fill(hDTDistWithSegment[i][station], distance);
           Fill(hDTPullDistWithSegment[i][station], distance / error);
         } else {
@@ -718,41 +568,36 @@ void MuonIdVal::analyze(const edm::Event &iEvent,
         }
 
         Fill(hCSCPullxPropErr[i][station],
-             muon->pullX(station + 1, MuonSubdetId::CSC,
-                         Muon::SegmentAndTrackArbitration, false));
+             muon->pullX(station + 1, MuonSubdetId::CSC, Muon::SegmentAndTrackArbitration, false));
         Fill(hCSCPulldXdZPropErr[i][station],
-             muon->pullDxDz(station + 1, MuonSubdetId::CSC,
-                            Muon::SegmentAndTrackArbitration, false));
+             muon->pullDxDz(station + 1, MuonSubdetId::CSC, Muon::SegmentAndTrackArbitration, false));
         Fill(hCSCPullyPropErr[i][station],
-             muon->pullY(station + 1, MuonSubdetId::CSC,
-                         Muon::SegmentAndTrackArbitration, false));
+             muon->pullY(station + 1, MuonSubdetId::CSC, Muon::SegmentAndTrackArbitration, false));
         Fill(hCSCPulldYdZPropErr[i][station],
-             muon->pullDyDz(station + 1, MuonSubdetId::CSC,
-                            Muon::SegmentAndTrackArbitration, false));
+             muon->pullDyDz(station + 1, MuonSubdetId::CSC, Muon::SegmentAndTrackArbitration, false));
 
         distance = muon->trackDist(station + 1, MuonSubdetId::CSC);
         error = muon->trackDistErr(station + 1, MuonSubdetId::CSC);
         if (error == 0)
           error = 0.000001;
 
-        if (muon->numberOfSegments(station + 1, MuonSubdetId::CSC,
-                                   Muon::NoArbitration) > 0) {
+        if (muon->numberOfSegments(station + 1, MuonSubdetId::CSC, Muon::NoArbitration) > 0) {
           Fill(hCSCDistWithSegment[i][station], distance);
           Fill(hCSCPullDistWithSegment[i][station], distance / error);
         } else {
           Fill(hCSCDistWithNoSegment[i][station], distance);
           Fill(hCSCPullDistWithNoSegment[i][station], distance / error);
         }
-      } // station
+      }  // station
     }
 
     if (!useTrackerMuons_ || !muon->isTrackerMuon())
       continue;
     if (makeAllChamberPlots_) {
       // by chamber
-      for (std::vector<MuonChamberMatch>::const_iterator chamberMatch =
-               muon->matches().begin();
-           chamberMatch != muon->matches().end(); ++chamberMatch) {
+      for (std::vector<MuonChamberMatch>::const_iterator chamberMatch = muon->matches().begin();
+           chamberMatch != muon->matches().end();
+           ++chamberMatch) {
         int station = chamberMatch->station();
 
         if (chamberMatch->detector() == MuonSubdetId::DT) {
@@ -761,31 +606,22 @@ void MuonIdVal::analyze(const edm::Event &iEvent,
           int sector = dtId.sector();
 
           if (chamberMatch->segmentMatches.empty()) {
-            Fill(hDTChamberEdgeXWithNoSegment[station - 1][wheel + 2]
-                                             [sector - 1],
-                 chamberMatch->edgeX);
-            Fill(hDTChamberEdgeYWithNoSegment[station - 1][wheel + 2]
-                                             [sector - 1],
-                 chamberMatch->edgeY);
+            Fill(hDTChamberEdgeXWithNoSegment[station - 1][wheel + 2][sector - 1], chamberMatch->edgeX);
+            Fill(hDTChamberEdgeYWithNoSegment[station - 1][wheel + 2][sector - 1], chamberMatch->edgeY);
           } else {
-            Fill(hDTChamberEdgeXWithSegment[station - 1][wheel + 2][sector - 1],
-                 chamberMatch->edgeX);
-            Fill(hDTChamberEdgeYWithSegment[station - 1][wheel + 2][sector - 1],
-                 chamberMatch->edgeY);
+            Fill(hDTChamberEdgeXWithSegment[station - 1][wheel + 2][sector - 1], chamberMatch->edgeX);
+            Fill(hDTChamberEdgeYWithSegment[station - 1][wheel + 2][sector - 1], chamberMatch->edgeY);
 
-            for (std::vector<MuonSegmentMatch>::const_iterator segmentMatch =
-                     chamberMatch->segmentMatches.begin();
+            for (std::vector<MuonSegmentMatch>::const_iterator segmentMatch = chamberMatch->segmentMatches.begin();
                  segmentMatch != chamberMatch->segmentMatches.end();
                  ++segmentMatch) {
               if (segmentMatch->isMask(MuonSegmentMatch::BestInChamberByDR)) {
-                Fill(hDTChamberDx[station - 1][wheel + 2][sector - 1],
-                     chamberMatch->x - segmentMatch->x);
+                Fill(hDTChamberDx[station - 1][wheel + 2][sector - 1], chamberMatch->x - segmentMatch->x);
                 if (station < 4)
-                  Fill(hDTChamberDy[station - 1][wheel + 2][sector - 1],
-                       chamberMatch->y - segmentMatch->y);
+                  Fill(hDTChamberDy[station - 1][wheel + 2][sector - 1], chamberMatch->y - segmentMatch->y);
                 break;
               }
-            } // segmentMatch
+            }  // segmentMatch
           }
 
           continue;
@@ -798,197 +634,148 @@ void MuonIdVal::analyze(const edm::Event &iEvent,
           int chamber = cscId.chamber();
 
           if (chamberMatch->segmentMatches.empty()) {
-            Fill(hCSCChamberEdgeXWithNoSegment[endcap - 1][station - 1]
-                                              [ring - 1][chamber - 1],
-                 chamberMatch->edgeX);
-            Fill(hCSCChamberEdgeYWithNoSegment[endcap - 1][station - 1]
-                                              [ring - 1][chamber - 1],
-                 chamberMatch->edgeY);
+            Fill(hCSCChamberEdgeXWithNoSegment[endcap - 1][station - 1][ring - 1][chamber - 1], chamberMatch->edgeX);
+            Fill(hCSCChamberEdgeYWithNoSegment[endcap - 1][station - 1][ring - 1][chamber - 1], chamberMatch->edgeY);
           } else {
-            Fill(hCSCChamberEdgeXWithSegment[endcap - 1][station - 1][ring - 1]
-                                            [chamber - 1],
-                 chamberMatch->edgeX);
-            Fill(hCSCChamberEdgeYWithSegment[endcap - 1][station - 1][ring - 1]
-                                            [chamber - 1],
-                 chamberMatch->edgeY);
+            Fill(hCSCChamberEdgeXWithSegment[endcap - 1][station - 1][ring - 1][chamber - 1], chamberMatch->edgeX);
+            Fill(hCSCChamberEdgeYWithSegment[endcap - 1][station - 1][ring - 1][chamber - 1], chamberMatch->edgeY);
 
-            for (std::vector<MuonSegmentMatch>::const_iterator segmentMatch =
-                     chamberMatch->segmentMatches.begin();
+            for (std::vector<MuonSegmentMatch>::const_iterator segmentMatch = chamberMatch->segmentMatches.begin();
                  segmentMatch != chamberMatch->segmentMatches.end();
                  ++segmentMatch) {
               if (segmentMatch->isMask(MuonSegmentMatch::BestInChamberByDR)) {
-                Fill(hCSCChamberDx[endcap - 1][station - 1][ring - 1]
-                                  [chamber - 1],
-                     chamberMatch->x - segmentMatch->x);
-                Fill(hCSCChamberDy[endcap - 1][station - 1][ring - 1]
-                                  [chamber - 1],
-                     chamberMatch->y - segmentMatch->y);
+                Fill(hCSCChamberDx[endcap - 1][station - 1][ring - 1][chamber - 1], chamberMatch->x - segmentMatch->x);
+                Fill(hCSCChamberDy[endcap - 1][station - 1][ring - 1][chamber - 1], chamberMatch->y - segmentMatch->y);
                 break;
               }
-            } // segmentMatch
+            }  // segmentMatch
           }
         }
-      } // chamberMatch
+      }  // chamberMatch
     }
     ++muonIdx;
-  } // muon
+  }  // muon
 
   if (!make2DPlots_)
     return;
 
-  for (DTRecSegment4DCollection::const_iterator segment =
-           dtSegmentCollectionH_->begin();
-       segment != dtSegmentCollectionH_->end(); ++segment) {
+  for (DTRecSegment4DCollection::const_iterator segment = dtSegmentCollectionH_->begin();
+       segment != dtSegmentCollectionH_->end();
+       ++segment) {
     LocalPoint segmentLocalPosition = segment->localPosition();
     LocalVector segmentLocalDirection = segment->localDirection();
     LocalError segmentLocalPositionError = segment->localPositionError();
     LocalError segmentLocalDirectionError = segment->localDirectionError();
-    const GeomDet *segmentGeomDet =
-        geometry_->idToDet(segment->geographicalId());
-    GlobalPoint segmentGlobalPosition =
-        segmentGeomDet->toGlobal(segment->localPosition());
+    const GeomDet *segmentGeomDet = geometry_->idToDet(segment->geographicalId());
+    GlobalPoint segmentGlobalPosition = segmentGeomDet->toGlobal(segment->localPosition());
     bool segmentFound = false;
     bool segmentBestDrFound = false;
 
-    for (MuonCollection::const_iterator muon = muonCollectionH_->begin();
-         muon != muonCollectionH_->end(); ++muon) {
+    for (MuonCollection::const_iterator muon = muonCollectionH_->begin(); muon != muonCollectionH_->end(); ++muon) {
       if (!muon->isMatchesValid())
         continue;
 
-      for (std::vector<MuonChamberMatch>::const_iterator chamberMatch =
-               muon->matches().begin();
-           chamberMatch != muon->matches().end(); ++chamberMatch) {
-        for (std::vector<MuonSegmentMatch>::const_iterator segmentMatch =
-                 chamberMatch->segmentMatches.begin();
+      for (std::vector<MuonChamberMatch>::const_iterator chamberMatch = muon->matches().begin();
+           chamberMatch != muon->matches().end();
+           ++chamberMatch) {
+        for (std::vector<MuonSegmentMatch>::const_iterator segmentMatch = chamberMatch->segmentMatches.begin();
              segmentMatch != chamberMatch->segmentMatches.end();
              ++segmentMatch) {
           if (fabs(segmentMatch->x - segmentLocalPosition.x()) < 1E-6 &&
               fabs(segmentMatch->y - segmentLocalPosition.y()) < 1E-6 &&
-              fabs(segmentMatch->dXdZ - segmentLocalDirection.x() /
-                                            segmentLocalDirection.z()) < 1E-6 &&
-              fabs(segmentMatch->dYdZ - segmentLocalDirection.y() /
-                                            segmentLocalDirection.z()) < 1E-6 &&
-              fabs(segmentMatch->xErr - sqrt(segmentLocalPositionError.xx())) <
-                  1E-6 &&
-              fabs(segmentMatch->yErr - sqrt(segmentLocalPositionError.yy())) <
-                  1E-6 &&
-              fabs(segmentMatch->dXdZErr -
-                   sqrt(segmentLocalDirectionError.xx())) < 1E-6 &&
-              fabs(segmentMatch->dYdZErr -
-                   sqrt(segmentLocalDirectionError.yy())) < 1E-6) {
+              fabs(segmentMatch->dXdZ - segmentLocalDirection.x() / segmentLocalDirection.z()) < 1E-6 &&
+              fabs(segmentMatch->dYdZ - segmentLocalDirection.y() / segmentLocalDirection.z()) < 1E-6 &&
+              fabs(segmentMatch->xErr - sqrt(segmentLocalPositionError.xx())) < 1E-6 &&
+              fabs(segmentMatch->yErr - sqrt(segmentLocalPositionError.yy())) < 1E-6 &&
+              fabs(segmentMatch->dXdZErr - sqrt(segmentLocalDirectionError.xx())) < 1E-6 &&
+              fabs(segmentMatch->dYdZErr - sqrt(segmentLocalDirectionError.yy())) < 1E-6) {
             segmentFound = true;
             if (segmentMatch->isMask(reco::MuonSegmentMatch::BestInStationByDR))
               segmentBestDrFound = true;
             break;
           }
-        } // segmentMatch
+        }  // segmentMatch
         if (segmentFound)
           break;
-      } // chamberMatch
+      }  // chamberMatch
       if (segmentFound)
         break;
-    } // muon
+    }  // muon
 
     if (segmentFound) {
-      hSegmentIsAssociatedRZ->Fill(segmentGlobalPosition.z(),
-                                   segmentGlobalPosition.perp());
-      hSegmentIsAssociatedXY->Fill(segmentGlobalPosition.x(),
-                                   segmentGlobalPosition.y());
+      hSegmentIsAssociatedRZ->Fill(segmentGlobalPosition.z(), segmentGlobalPosition.perp());
+      hSegmentIsAssociatedXY->Fill(segmentGlobalPosition.x(), segmentGlobalPosition.y());
 
       if (segmentBestDrFound) {
-        hSegmentIsBestDrAssociatedRZ->Fill(segmentGlobalPosition.z(),
-                                           segmentGlobalPosition.perp());
-        hSegmentIsBestDrAssociatedXY->Fill(segmentGlobalPosition.x(),
-                                           segmentGlobalPosition.y());
+        hSegmentIsBestDrAssociatedRZ->Fill(segmentGlobalPosition.z(), segmentGlobalPosition.perp());
+        hSegmentIsBestDrAssociatedXY->Fill(segmentGlobalPosition.x(), segmentGlobalPosition.y());
       }
     } else {
-      hSegmentIsNotAssociatedRZ->Fill(segmentGlobalPosition.z(),
-                                      segmentGlobalPosition.perp());
-      hSegmentIsNotAssociatedXY->Fill(segmentGlobalPosition.x(),
-                                      segmentGlobalPosition.y());
-      hSegmentIsBestDrNotAssociatedRZ->Fill(segmentGlobalPosition.z(),
-                                            segmentGlobalPosition.perp());
-      hSegmentIsBestDrNotAssociatedXY->Fill(segmentGlobalPosition.x(),
-                                            segmentGlobalPosition.y());
+      hSegmentIsNotAssociatedRZ->Fill(segmentGlobalPosition.z(), segmentGlobalPosition.perp());
+      hSegmentIsNotAssociatedXY->Fill(segmentGlobalPosition.x(), segmentGlobalPosition.y());
+      hSegmentIsBestDrNotAssociatedRZ->Fill(segmentGlobalPosition.z(), segmentGlobalPosition.perp());
+      hSegmentIsBestDrNotAssociatedXY->Fill(segmentGlobalPosition.x(), segmentGlobalPosition.y());
     }
-  } // dt segment
+  }  // dt segment
 
-  for (CSCSegmentCollection::const_iterator segment =
-           cscSegmentCollectionH_->begin();
-       segment != cscSegmentCollectionH_->end(); ++segment) {
+  for (CSCSegmentCollection::const_iterator segment = cscSegmentCollectionH_->begin();
+       segment != cscSegmentCollectionH_->end();
+       ++segment) {
     LocalPoint segmentLocalPosition = segment->localPosition();
     LocalVector segmentLocalDirection = segment->localDirection();
     LocalError segmentLocalPositionError = segment->localPositionError();
     LocalError segmentLocalDirectionError = segment->localDirectionError();
-    const GeomDet *segmentGeomDet =
-        geometry_->idToDet(segment->geographicalId());
-    GlobalPoint segmentGlobalPosition =
-        segmentGeomDet->toGlobal(segment->localPosition());
+    const GeomDet *segmentGeomDet = geometry_->idToDet(segment->geographicalId());
+    GlobalPoint segmentGlobalPosition = segmentGeomDet->toGlobal(segment->localPosition());
     bool segmentFound = false;
     bool segmentBestDrFound = false;
 
-    for (MuonCollection::const_iterator muon = muonCollectionH_->begin();
-         muon != muonCollectionH_->end(); ++muon) {
+    for (MuonCollection::const_iterator muon = muonCollectionH_->begin(); muon != muonCollectionH_->end(); ++muon) {
       if (!muon->isMatchesValid())
         continue;
 
-      for (std::vector<MuonChamberMatch>::const_iterator chamberMatch =
-               muon->matches().begin();
-           chamberMatch != muon->matches().end(); ++chamberMatch) {
-        for (std::vector<MuonSegmentMatch>::const_iterator segmentMatch =
-                 chamberMatch->segmentMatches.begin();
+      for (std::vector<MuonChamberMatch>::const_iterator chamberMatch = muon->matches().begin();
+           chamberMatch != muon->matches().end();
+           ++chamberMatch) {
+        for (std::vector<MuonSegmentMatch>::const_iterator segmentMatch = chamberMatch->segmentMatches.begin();
              segmentMatch != chamberMatch->segmentMatches.end();
              ++segmentMatch) {
           if (fabs(segmentMatch->x - segmentLocalPosition.x()) < 1E-6 &&
               fabs(segmentMatch->y - segmentLocalPosition.y()) < 1E-6 &&
-              fabs(segmentMatch->dXdZ - segmentLocalDirection.x() /
-                                            segmentLocalDirection.z()) < 1E-6 &&
-              fabs(segmentMatch->dYdZ - segmentLocalDirection.y() /
-                                            segmentLocalDirection.z()) < 1E-6 &&
-              fabs(segmentMatch->xErr - sqrt(segmentLocalPositionError.xx())) <
-                  1E-6 &&
-              fabs(segmentMatch->yErr - sqrt(segmentLocalPositionError.yy())) <
-                  1E-6 &&
-              fabs(segmentMatch->dXdZErr -
-                   sqrt(segmentLocalDirectionError.xx())) < 1E-6 &&
-              fabs(segmentMatch->dYdZErr -
-                   sqrt(segmentLocalDirectionError.yy())) < 1E-6) {
+              fabs(segmentMatch->dXdZ - segmentLocalDirection.x() / segmentLocalDirection.z()) < 1E-6 &&
+              fabs(segmentMatch->dYdZ - segmentLocalDirection.y() / segmentLocalDirection.z()) < 1E-6 &&
+              fabs(segmentMatch->xErr - sqrt(segmentLocalPositionError.xx())) < 1E-6 &&
+              fabs(segmentMatch->yErr - sqrt(segmentLocalPositionError.yy())) < 1E-6 &&
+              fabs(segmentMatch->dXdZErr - sqrt(segmentLocalDirectionError.xx())) < 1E-6 &&
+              fabs(segmentMatch->dYdZErr - sqrt(segmentLocalDirectionError.yy())) < 1E-6) {
             segmentFound = true;
             if (segmentMatch->isMask(reco::MuonSegmentMatch::BestInStationByDR))
               segmentBestDrFound = true;
             break;
           }
-        } // segmentMatch
+        }  // segmentMatch
         if (segmentFound)
           break;
-      } // chamberMatch
+      }  // chamberMatch
       if (segmentFound)
         break;
-    } // muon
+    }  // muon
 
     if (segmentFound) {
-      hSegmentIsAssociatedRZ->Fill(segmentGlobalPosition.z(),
-                                   segmentGlobalPosition.perp());
-      hSegmentIsAssociatedXY->Fill(segmentGlobalPosition.x(),
-                                   segmentGlobalPosition.y());
+      hSegmentIsAssociatedRZ->Fill(segmentGlobalPosition.z(), segmentGlobalPosition.perp());
+      hSegmentIsAssociatedXY->Fill(segmentGlobalPosition.x(), segmentGlobalPosition.y());
 
       if (segmentBestDrFound) {
-        hSegmentIsBestDrAssociatedRZ->Fill(segmentGlobalPosition.z(),
-                                           segmentGlobalPosition.perp());
-        hSegmentIsBestDrAssociatedXY->Fill(segmentGlobalPosition.x(),
-                                           segmentGlobalPosition.y());
+        hSegmentIsBestDrAssociatedRZ->Fill(segmentGlobalPosition.z(), segmentGlobalPosition.perp());
+        hSegmentIsBestDrAssociatedXY->Fill(segmentGlobalPosition.x(), segmentGlobalPosition.y());
       }
     } else {
-      hSegmentIsNotAssociatedRZ->Fill(segmentGlobalPosition.z(),
-                                      segmentGlobalPosition.perp());
-      hSegmentIsNotAssociatedXY->Fill(segmentGlobalPosition.x(),
-                                      segmentGlobalPosition.y());
-      hSegmentIsBestDrNotAssociatedRZ->Fill(segmentGlobalPosition.z(),
-                                            segmentGlobalPosition.perp());
-      hSegmentIsBestDrNotAssociatedXY->Fill(segmentGlobalPosition.x(),
-                                            segmentGlobalPosition.y());
+      hSegmentIsNotAssociatedRZ->Fill(segmentGlobalPosition.z(), segmentGlobalPosition.perp());
+      hSegmentIsNotAssociatedXY->Fill(segmentGlobalPosition.x(), segmentGlobalPosition.y());
+      hSegmentIsBestDrNotAssociatedRZ->Fill(segmentGlobalPosition.z(), segmentGlobalPosition.perp());
+      hSegmentIsBestDrNotAssociatedXY->Fill(segmentGlobalPosition.x(), segmentGlobalPosition.y());
     }
-  } // csc segment
+  }  // csc segment
 }
 
 void MuonIdVal::Fill(MonitorElement *me, float f) {

--- a/Validation/MuonME0Validation/interface/ME0BaseValidation.h
+++ b/Validation/MuonME0Validation/interface/ME0BaseValidation.h
@@ -24,12 +24,10 @@ public:
   explicit ME0BaseValidation(const edm::ParameterSet &ps);
   ~ME0BaseValidation() override;
   void analyze(const edm::Event &e, const edm::EventSetup &) override = 0;
-  MonitorElement *BookHistZR(DQMStore::IBooker &, const char *name,
-                             const char *label, unsigned int region_num,
-                             unsigned int layer_num = 99);
-  MonitorElement *BookHistXY(DQMStore::IBooker &, const char *name,
-                             const char *label, unsigned int region_num,
-                             unsigned int layer_num = 99);
+  MonitorElement *BookHistZR(
+      DQMStore::IBooker &, const char *name, const char *label, unsigned int region_num, unsigned int layer_num = 99);
+  MonitorElement *BookHistXY(
+      DQMStore::IBooker &, const char *name, const char *label, unsigned int region_num, unsigned int layer_num = 99);
 
 protected:
   std::vector<std::string> regionLabel;

--- a/Validation/MuonME0Validation/interface/ME0DigisValidation.h
+++ b/Validation/MuonME0Validation/interface/ME0DigisValidation.h
@@ -10,11 +10,9 @@ class ME0DigisValidation : public ME0BaseValidation {
 public:
   explicit ME0DigisValidation(const edm::ParameterSet &);
   ~ME0DigisValidation() override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &e, const edm::EventSetup &) override;
-  bool isMatched(const int, const int, const int, const int, const int,
-                 const int);
+  bool isMatched(const int, const int, const int, const int, const int, const int);
 
 private:
   MonitorElement *num_evts;

--- a/Validation/MuonME0Validation/interface/ME0HitsValidation.h
+++ b/Validation/MuonME0Validation/interface/ME0HitsValidation.h
@@ -7,8 +7,7 @@ class ME0HitsValidation : public ME0BaseValidation {
 public:
   explicit ME0HitsValidation(const edm::ParameterSet &);
   ~ME0HitsValidation() override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &e, const edm::EventSetup &) override;
 
 private:

--- a/Validation/MuonME0Validation/interface/ME0RecHitsValidation.h
+++ b/Validation/MuonME0Validation/interface/ME0RecHitsValidation.h
@@ -12,8 +12,7 @@ class ME0RecHitsValidation : public ME0BaseValidation {
 public:
   explicit ME0RecHitsValidation(const edm::ParameterSet &);
   ~ME0RecHitsValidation() override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &e, const edm::EventSetup &) override;
 
 private:

--- a/Validation/MuonME0Validation/interface/ME0SegmentsValidation.h
+++ b/Validation/MuonME0Validation/interface/ME0SegmentsValidation.h
@@ -17,14 +17,11 @@ class ME0SegmentsValidation : public ME0BaseValidation {
 public:
   explicit ME0SegmentsValidation(const edm::ParameterSet &);
   ~ME0SegmentsValidation() override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &e, const edm::EventSetup &) override;
-  std::pair<int, int> isMatched(ME0DetId, LocalPoint,
-                                edm::Handle<ME0DigiPreRecoCollection>);
+  std::pair<int, int> isMatched(ME0DetId, LocalPoint, edm::Handle<ME0DigiPreRecoCollection>);
   bool isSimTrackGood(edm::SimTrackContainer::const_iterator simTrack);
-  bool isSimMatched(edm::SimTrackContainer::const_iterator,
-                    edm::PSimHitContainer::const_iterator);
+  bool isSimMatched(edm::SimTrackContainer::const_iterator, edm::PSimHitContainer::const_iterator);
 
 private:
   MonitorElement *me0_specRH_xy[2][6];
@@ -33,13 +30,11 @@ private:
 
   MonitorElement *me0_segment_chi2, *me0_segment_redchi2, *me0_segment_ndof;
   MonitorElement *me0_segment_time, *me0_segment_timeErr;
-  MonitorElement *me0_segment_numRH, *me0_segment_numRHSig,
-      *me0_segment_numRHBkg;
+  MonitorElement *me0_segment_numRH, *me0_segment_numRHSig, *me0_segment_numRHBkg;
   MonitorElement *me0_segment_EtaRH, *me0_segment_PhiRH, *me0_segment_size;
 
   MonitorElement *me0_simsegment_eta, *me0_simsegment_pt, *me0_simsegment_phi;
-  MonitorElement *me0_matchedsimsegment_eta, *me0_matchedsimsegment_pt,
-      *me0_matchedsimsegment_phi;
+  MonitorElement *me0_matchedsimsegment_eta, *me0_matchedsimsegment_pt, *me0_matchedsimsegment_phi;
 
   MonitorElement *me0_specRH_DeltaX[2][6];
   MonitorElement *me0_specRH_DeltaY[2][6];
@@ -57,11 +52,8 @@ private:
   double pt_min_;
   bool isMuonGun_;
 
-  typedef std::map<edm::SimTrackContainer::const_iterator,
-                   edm::PSimHitContainer>
-      MapTypeSim;
-  typedef std::map<ME0SegmentCollection::const_iterator, std::vector<ME0RecHit>>
-      MapTypeSeg;
+  typedef std::map<edm::SimTrackContainer::const_iterator, edm::PSimHitContainer> MapTypeSim;
+  typedef std::map<ME0SegmentCollection::const_iterator, std::vector<ME0RecHit>> MapTypeSeg;
 };
 
 #endif

--- a/Validation/MuonME0Validation/plugins/MuonME0DigisHarvestor.cc
+++ b/Validation/MuonME0Validation/plugins/MuonME0DigisHarvestor.cc
@@ -35,16 +35,16 @@ MuonME0DigisHarvestor::MuonME0DigisHarvestor(const edm::ParameterSet &ps) {
 
 MuonME0DigisHarvestor::~MuonME0DigisHarvestor() {}
 
-TProfile *MuonME0DigisHarvestor::ComputeEff(TH1F *num, TH1F *denum,
-                                            std::string nameHist) {
+TProfile *MuonME0DigisHarvestor::ComputeEff(TH1F *num, TH1F *denum, std::string nameHist) {
   std::string name = "eff_" + nameHist;
   std::string title = "Digi Efficiency" + std::string(num->GetTitle());
-  TProfile *efficHist =
-      new TProfile(name.c_str(), title.c_str(), denum->GetXaxis()->GetNbins(),
-                   denum->GetXaxis()->GetXmin(), denum->GetXaxis()->GetXmax());
+  TProfile *efficHist = new TProfile(name.c_str(),
+                                     title.c_str(),
+                                     denum->GetXaxis()->GetNbins(),
+                                     denum->GetXaxis()->GetXmin(),
+                                     denum->GetXaxis()->GetXmax());
 
   for (int i = 1; i <= denum->GetNbinsX(); i++) {
-
     double nNum = num->GetBinContent(i);
     double nDenum = denum->GetBinContent(i);
     if (nDenum == 0 || nNum == 0) {
@@ -55,36 +55,27 @@ TProfile *MuonME0DigisHarvestor::ComputeEff(TH1F *num, TH1F *denum,
       nDenum = nNum;
       nNum = temp;
       edm::LogWarning("MuonME0DigisHarvestor")
-          << "Alert! specific bin's num is bigger than denum " << i << " "
-          << nNum << " " << nDenum;
+          << "Alert! specific bin's num is bigger than denum " << i << " " << nNum << " " << nDenum;
     }
     const double effVal = nNum / nDenum;
     efficHist->SetBinContent(i, effVal);
     efficHist->SetBinEntries(i, 1);
     efficHist->SetBinError(i, 0);
-    const double errLo =
-        TEfficiency::ClopperPearson((int)nDenum, (int)nNum, 0.683, false);
-    const double errUp =
-        TEfficiency::ClopperPearson((int)nDenum, (int)nNum, 0.683, true);
-    const double errVal =
-        (effVal - errLo > errUp - effVal) ? effVal - errLo : errUp - effVal;
+    const double errLo = TEfficiency::ClopperPearson((int)nDenum, (int)nNum, 0.683, false);
+    const double errUp = TEfficiency::ClopperPearson((int)nDenum, (int)nNum, 0.683, true);
+    const double errVal = (effVal - errLo > errUp - effVal) ? effVal - errLo : errUp - effVal;
     efficHist->SetBinError(i, sqrt(effVal * effVal + errVal * errVal));
   }
   return efficHist;
 }
 
-void MuonME0DigisHarvestor::ProcessBooking(DQMStore::IBooker &ibooker,
-                                           DQMStore::IGetter &ig,
-                                           std::string nameHist, TH1F *num,
-                                           TH1F *den) {
-
+void MuonME0DigisHarvestor::ProcessBooking(
+    DQMStore::IBooker &ibooker, DQMStore::IGetter &ig, std::string nameHist, TH1F *num, TH1F *den) {
   if (num != nullptr && den != nullptr) {
-
     TProfile *profile = ComputeEff(num, den, nameHist);
 
     TString x_axis_title = TString(num->GetXaxis()->GetTitle());
-    TString title =
-        TString::Format("Digi Efficiency;%s;Eff.", x_axis_title.Data());
+    TString title = TString::Format("Digi Efficiency;%s;Eff.", x_axis_title.Data());
 
     profile->SetTitle(title.Data());
     ibooker.bookProfile(profile->GetName(), profile);
@@ -92,7 +83,6 @@ void MuonME0DigisHarvestor::ProcessBooking(DQMStore::IBooker &ibooker,
     delete profile;
 
   } else {
-
     edm::LogWarning("MuonME0DigisHarvestor") << "Can not find histograms";
     if (num == nullptr)
       edm::LogWarning("MuonME0DigisHarvestor") << "num not found";
@@ -102,13 +92,10 @@ void MuonME0DigisHarvestor::ProcessBooking(DQMStore::IBooker &ibooker,
   return;
 }
 
-TH1F *MuonME0DigisHarvestor::ComputeBKG(TH1F *hist1, TH1F *hist2,
-                                        std::string nameHist) {
-
+TH1F *MuonME0DigisHarvestor::ComputeBKG(TH1F *hist1, TH1F *hist2, std::string nameHist) {
   std::string name = "rate_" + nameHist;
   hist1->SetName(name.c_str());
   for (int bin = 1; bin <= hist1->GetNbinsX(); ++bin) {
-
     double R_min = hist1->GetBinCenter(bin) - 0.5 * hist1->GetBinWidth(bin);
     double R_max = hist1->GetBinCenter(bin) + 0.5 * hist1->GetBinWidth(bin);
 
@@ -118,33 +105,25 @@ TH1F *MuonME0DigisHarvestor::ComputeBKG(TH1F *hist1, TH1F *hist2,
   }
 
   int nEvts = hist2->GetEntries();
-  float scale =
-      6 * 2 * nEvts * 3 *
-      25e-9; // New redigitizer saves hits only in the BX range: [-1,+1], so the
-             // number of background hits has to be divided by 3
+  float scale = 6 * 2 * nEvts * 3 * 25e-9;  // New redigitizer saves hits only in the BX range: [-1,+1], so the
+                                            // number of background hits has to be divided by 3
   hist1->Scale(1.0 / scale);
   return hist1;
 }
 
-void MuonME0DigisHarvestor::ProcessBookingBKG(DQMStore::IBooker &ibooker,
-                                              DQMStore::IGetter &ig,
-                                              std::string nameHist, TH1F *hist1,
-                                              TH1F *hist2) {
-
+void MuonME0DigisHarvestor::ProcessBookingBKG(
+    DQMStore::IBooker &ibooker, DQMStore::IGetter &ig, std::string nameHist, TH1F *hist1, TH1F *hist2) {
   if (hist1 != nullptr && hist2 != nullptr) {
-
     TH1F *rate = ComputeBKG(hist1, hist2, nameHist);
 
     TString x_axis_title = TString(hist1->GetXaxis()->GetTitle());
     TString origTitle = TString(hist1->GetTitle());
-    TString title = TString::Format((origTitle + ";%s;Rate [Hz/cm^{2}]").Data(),
-                                    x_axis_title.Data());
+    TString title = TString::Format((origTitle + ";%s;Rate [Hz/cm^{2}]").Data(), x_axis_title.Data());
 
     rate->SetTitle(title.Data());
     ibooker.book1D(rate->GetName(), rate);
 
   } else {
-
     edm::LogWarning("MuonME0DigisHarvestor") << "Can not find histograms";
     if (hist1 == nullptr)
       edm::LogWarning("MuonME0DigisHarvestor") << "num not found";
@@ -154,8 +133,7 @@ void MuonME0DigisHarvestor::ProcessBookingBKG(DQMStore::IBooker &ibooker,
   return;
 }
 
-void MuonME0DigisHarvestor::dqmEndJob(DQMStore::IBooker &ibooker,
-                                      DQMStore::IGetter &ig) {
+void MuonME0DigisHarvestor::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &ig) {
   ig.setCurrentFolder(dbe_path_);
 
   const char *l_suffix[6] = {"_l1", "_l2", "_l3", "_l4", "_l5", "_l6"};
@@ -163,44 +141,30 @@ void MuonME0DigisHarvestor::dqmEndJob(DQMStore::IBooker &ibooker,
 
   TString eta_label_den_tot = TString(dbe_path_) + "me0_strip_dg_den_eta_tot";
   TString eta_label_num_tot = TString(dbe_path_) + "me0_strip_dg_num_eta_tot";
-  if (ig.get(eta_label_num_tot.Data()) != nullptr &&
-      ig.get(eta_label_den_tot.Data()) != nullptr) {
-
-    TH1F *num_vs_eta_tot =
-        (TH1F *)ig.get(eta_label_num_tot.Data())->getTH1F()->Clone();
+  if (ig.get(eta_label_num_tot.Data()) != nullptr && ig.get(eta_label_den_tot.Data()) != nullptr) {
+    TH1F *num_vs_eta_tot = (TH1F *)ig.get(eta_label_num_tot.Data())->getTH1F()->Clone();
     num_vs_eta_tot->Sumw2();
-    TH1F *den_vs_eta_tot =
-        (TH1F *)ig.get(eta_label_den_tot.Data())->getTH1F()->Clone();
+    TH1F *den_vs_eta_tot = (TH1F *)ig.get(eta_label_den_tot.Data())->getTH1F()->Clone();
     den_vs_eta_tot->Sumw2();
 
-    ProcessBooking(ibooker, ig, "me0_strip_dg_eta_tot", num_vs_eta_tot,
-                   den_vs_eta_tot);
+    ProcessBooking(ibooker, ig, "me0_strip_dg_eta_tot", num_vs_eta_tot, den_vs_eta_tot);
 
     delete num_vs_eta_tot;
     delete den_vs_eta_tot;
 
   } else
     edm::LogWarning("MuonME0DigisHarvestor")
-        << "Can not find histograms: " << eta_label_num_tot << " or "
-        << eta_label_den_tot;
+        << "Can not find histograms: " << eta_label_num_tot << " or " << eta_label_den_tot;
 
   for (int i = 0; i < 2; i++) {
-
     for (int j = 0; j < 6; j++) {
+      TString eta_label_den = TString(dbe_path_) + "me0_strip_dg_den_eta" + r_suffix[i] + l_suffix[j];
+      TString eta_label_num = TString(dbe_path_) + "me0_strip_dg_num_eta" + r_suffix[i] + l_suffix[j];
 
-      TString eta_label_den = TString(dbe_path_) + "me0_strip_dg_den_eta" +
-                              r_suffix[i] + l_suffix[j];
-      TString eta_label_num = TString(dbe_path_) + "me0_strip_dg_num_eta" +
-                              r_suffix[i] + l_suffix[j];
-
-      if (ig.get(eta_label_num.Data()) != nullptr &&
-          ig.get(eta_label_den.Data()) != nullptr) {
-
-        TH1F *num_vs_eta =
-            (TH1F *)ig.get(eta_label_num.Data())->getTH1F()->Clone();
+      if (ig.get(eta_label_num.Data()) != nullptr && ig.get(eta_label_den.Data()) != nullptr) {
+        TH1F *num_vs_eta = (TH1F *)ig.get(eta_label_num.Data())->getTH1F()->Clone();
         num_vs_eta->Sumw2();
-        TH1F *den_vs_eta =
-            (TH1F *)ig.get(eta_label_den.Data())->getTH1F()->Clone();
+        TH1F *den_vs_eta = (TH1F *)ig.get(eta_label_den.Data())->getTH1F()->Clone();
         den_vs_eta->Sumw2();
 
         std::string r_s = r_suffix[i];
@@ -213,8 +177,7 @@ void MuonME0DigisHarvestor::dqmEndJob(DQMStore::IBooker &ibooker,
 
       } else
         edm::LogWarning("MuonME0DigisHarvestor")
-            << "Can not find histograms: " << eta_label_num << " "
-            << eta_label_den;
+            << "Can not find histograms: " << eta_label_num << " " << eta_label_den;
     }
   }
 
@@ -224,33 +187,26 @@ void MuonME0DigisHarvestor::dqmEndJob(DQMStore::IBooker &ibooker,
   TString label_evts = TString(dbe_path_) + "num_evts";
 
   if (ig.get(label_evts.Data()) != nullptr) {
-
     TH1F *numEvts = (TH1F *)ig.get(label_evts.Data())->getTH1F()->Clone();
 
     if (ig.get(label_eleBkg.Data()) != nullptr) {
-
       TH1F *eleBkg = (TH1F *)ig.get(label_eleBkg.Data())->getTH1F()->Clone();
       eleBkg->Sumw2();
-      ProcessBookingBKG(ibooker, ig, "me0_strip_dg_elePosBkg_rad", eleBkg,
-                        numEvts);
+      ProcessBookingBKG(ibooker, ig, "me0_strip_dg_elePosBkg_rad", eleBkg, numEvts);
 
       delete eleBkg;
     }
     if (ig.get(label_neuBkg.Data()) != nullptr) {
-
       TH1F *neuBkg = (TH1F *)ig.get(label_neuBkg.Data())->getTH1F()->Clone();
       neuBkg->Sumw2();
-      ProcessBookingBKG(ibooker, ig, "me0_strip_dg_neuBkg_rad", neuBkg,
-                        numEvts);
+      ProcessBookingBKG(ibooker, ig, "me0_strip_dg_neuBkg_rad", neuBkg, numEvts);
 
       delete neuBkg;
     }
     if (ig.get(label_totBkg.Data()) != nullptr) {
-
       TH1F *totBkg = (TH1F *)ig.get(label_totBkg.Data())->getTH1F()->Clone();
       totBkg->Sumw2();
-      ProcessBookingBKG(ibooker, ig, "me0_strip_dg_totBkg_rad", totBkg,
-                        numEvts);
+      ProcessBookingBKG(ibooker, ig, "me0_strip_dg_totBkg_rad", totBkg, numEvts);
 
       delete totBkg;
     }

--- a/Validation/MuonME0Validation/plugins/MuonME0DigisHarvestor.h
+++ b/Validation/MuonME0Validation/plugins/MuonME0DigisHarvestor.h
@@ -23,10 +23,9 @@ public:
   ~MuonME0DigisHarvestor() override;
 
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
-  void ProcessBooking(DQMStore::IBooker &, DQMStore::IGetter &,
-                      std::string nameHist, TH1F *num, TH1F *den);
-  void ProcessBookingBKG(DQMStore::IBooker &ibooker, DQMStore::IGetter &ig,
-                         std::string nameHist, TH1F *hist, TH1F *hist2);
+  void ProcessBooking(DQMStore::IBooker &, DQMStore::IGetter &, std::string nameHist, TH1F *num, TH1F *den);
+  void ProcessBookingBKG(
+      DQMStore::IBooker &ibooker, DQMStore::IGetter &ig, std::string nameHist, TH1F *hist, TH1F *hist2);
   TProfile *ComputeEff(TH1F *num, TH1F *denum, std::string nameHist);
   TH1F *ComputeBKG(TH1F *hist1, TH1F *hist2, std::string nameHist);
 

--- a/Validation/MuonME0Validation/plugins/MuonME0SegHarvestor.cc
+++ b/Validation/MuonME0Validation/plugins/MuonME0SegHarvestor.cc
@@ -35,16 +35,16 @@ MuonME0SegHarvestor::MuonME0SegHarvestor(const edm::ParameterSet &ps) {
 
 MuonME0SegHarvestor::~MuonME0SegHarvestor() {}
 
-TProfile *MuonME0SegHarvestor::ComputeEff(TH1F *num, TH1F *denum,
-                                          std::string nameHist) {
+TProfile *MuonME0SegHarvestor::ComputeEff(TH1F *num, TH1F *denum, std::string nameHist) {
   std::string name = "eff_" + nameHist;
   std::string title = "Segment Efficiency" + std::string(num->GetTitle());
-  TProfile *efficHist =
-      new TProfile(name.c_str(), title.c_str(), denum->GetXaxis()->GetNbins(),
-                   denum->GetXaxis()->GetXmin(), denum->GetXaxis()->GetXmax());
+  TProfile *efficHist = new TProfile(name.c_str(),
+                                     title.c_str(),
+                                     denum->GetXaxis()->GetNbins(),
+                                     denum->GetXaxis()->GetXmin(),
+                                     denum->GetXaxis()->GetXmax());
 
   for (int i = 1; i <= denum->GetNbinsX(); i++) {
-
     double nNum = num->GetBinContent(i);
     double nDenum = denum->GetBinContent(i);
     if (nDenum == 0 || nNum == 0) {
@@ -55,36 +55,27 @@ TProfile *MuonME0SegHarvestor::ComputeEff(TH1F *num, TH1F *denum,
       nDenum = nNum;
       nNum = temp;
       edm::LogWarning("MuonME0SegHarvestor")
-          << "Alert! specific bin's num is bigger than denum " << i << " "
-          << nNum << " " << nDenum;
+          << "Alert! specific bin's num is bigger than denum " << i << " " << nNum << " " << nDenum;
     }
     const double effVal = nNum / nDenum;
     efficHist->SetBinContent(i, effVal);
     efficHist->SetBinEntries(i, 1);
     efficHist->SetBinError(i, 0);
-    const double errLo =
-        TEfficiency::ClopperPearson((int)nDenum, (int)nNum, 0.683, false);
-    const double errUp =
-        TEfficiency::ClopperPearson((int)nDenum, (int)nNum, 0.683, true);
-    const double errVal =
-        (effVal - errLo > errUp - effVal) ? effVal - errLo : errUp - effVal;
+    const double errLo = TEfficiency::ClopperPearson((int)nDenum, (int)nNum, 0.683, false);
+    const double errUp = TEfficiency::ClopperPearson((int)nDenum, (int)nNum, 0.683, true);
+    const double errVal = (effVal - errLo > errUp - effVal) ? effVal - errLo : errUp - effVal;
     efficHist->SetBinError(i, sqrt(effVal * effVal + errVal * errVal));
   }
   return efficHist;
 }
 
-void MuonME0SegHarvestor::ProcessBooking(DQMStore::IBooker &ibooker,
-                                         DQMStore::IGetter &ig,
-                                         std::string nameHist, TH1F *num,
-                                         TH1F *den) {
-
+void MuonME0SegHarvestor::ProcessBooking(
+    DQMStore::IBooker &ibooker, DQMStore::IGetter &ig, std::string nameHist, TH1F *num, TH1F *den) {
   if (num != nullptr && den != nullptr) {
-
     TProfile *profile = ComputeEff(num, den, nameHist);
 
     TString x_axis_title = TString(num->GetXaxis()->GetTitle());
-    TString title =
-        TString::Format("Segment Efficiency;%s;Eff.", x_axis_title.Data());
+    TString title = TString::Format("Segment Efficiency;%s;Eff.", x_axis_title.Data());
 
     profile->SetTitle(title.Data());
     ibooker.bookProfile(profile->GetName(), profile);
@@ -92,7 +83,6 @@ void MuonME0SegHarvestor::ProcessBooking(DQMStore::IBooker &ibooker,
     delete profile;
 
   } else {
-
     edm::LogWarning("MuonME0SegHarvestor") << "Can not find histograms";
     if (num == nullptr)
       edm::LogWarning("MuonME0SegHarvestor") << "num not found";
@@ -102,8 +92,7 @@ void MuonME0SegHarvestor::ProcessBooking(DQMStore::IBooker &ibooker,
   return;
 }
 
-void MuonME0SegHarvestor::dqmEndJob(DQMStore::IBooker &ibooker,
-                                    DQMStore::IGetter &ig) {
+void MuonME0SegHarvestor::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &ig) {
   ig.setCurrentFolder(dbe_path_);
 
   TString eta_label_den = TString(dbe_path_) + "me0_simsegment_eta";
@@ -113,28 +102,21 @@ void MuonME0SegHarvestor::dqmEndJob(DQMStore::IBooker &ibooker,
   TString phi_label_den = TString(dbe_path_) + "me0_simsegment_phi";
   TString phi_label_num = TString(dbe_path_) + "me0_matchedsimsegment_phi";
 
-  if (ig.get(eta_label_num.Data()) != nullptr &&
-      ig.get(eta_label_den.Data()) != nullptr) {
-
+  if (ig.get(eta_label_num.Data()) != nullptr && ig.get(eta_label_den.Data()) != nullptr) {
     TH1F *num_vs_eta = (TH1F *)ig.get(eta_label_num.Data())->getTH1F()->Clone();
     num_vs_eta->Sumw2();
     TH1F *den_vs_eta = (TH1F *)ig.get(eta_label_den.Data())->getTH1F()->Clone();
     den_vs_eta->Sumw2();
 
-    ProcessBooking(ibooker, ig, "me0segment_eff_vs_eta", num_vs_eta,
-                   den_vs_eta);
+    ProcessBooking(ibooker, ig, "me0segment_eff_vs_eta", num_vs_eta, den_vs_eta);
 
     delete num_vs_eta;
     delete den_vs_eta;
 
   } else
-    edm::LogWarning("MuonME0SegHarvestor")
-        << "Can not find histograms: " << eta_label_num << " or "
-        << eta_label_den;
+    edm::LogWarning("MuonME0SegHarvestor") << "Can not find histograms: " << eta_label_num << " or " << eta_label_den;
 
-  if (ig.get(pt_label_num.Data()) != nullptr &&
-      ig.get(pt_label_den.Data()) != nullptr) {
-
+  if (ig.get(pt_label_num.Data()) != nullptr && ig.get(pt_label_den.Data()) != nullptr) {
     TH1F *num_vs_pt = (TH1F *)ig.get(pt_label_num.Data())->getTH1F()->Clone();
     num_vs_pt->Sumw2();
     TH1F *den_vs_pt = (TH1F *)ig.get(pt_label_den.Data())->getTH1F()->Clone();
@@ -146,28 +128,21 @@ void MuonME0SegHarvestor::dqmEndJob(DQMStore::IBooker &ibooker,
     delete den_vs_pt;
 
   } else
-    edm::LogWarning("MuonME0SegHarvestor")
-        << "Can not find histograms: " << pt_label_num << " or "
-        << pt_label_den;
+    edm::LogWarning("MuonME0SegHarvestor") << "Can not find histograms: " << pt_label_num << " or " << pt_label_den;
 
-  if (ig.get(phi_label_num.Data()) != nullptr &&
-      ig.get(phi_label_den.Data()) != nullptr) {
-
+  if (ig.get(phi_label_num.Data()) != nullptr && ig.get(phi_label_den.Data()) != nullptr) {
     TH1F *num_vs_phi = (TH1F *)ig.get(phi_label_num.Data())->getTH1F()->Clone();
     num_vs_phi->Sumw2();
     TH1F *den_vs_phi = (TH1F *)ig.get(phi_label_den.Data())->getTH1F()->Clone();
     den_vs_phi->Sumw2();
 
-    ProcessBooking(ibooker, ig, "me0segment_eff_vs_phi", num_vs_phi,
-                   den_vs_phi);
+    ProcessBooking(ibooker, ig, "me0segment_eff_vs_phi", num_vs_phi, den_vs_phi);
 
     delete num_vs_phi;
     delete den_vs_phi;
 
   } else
-    edm::LogWarning("MuonME0SegHarvestor")
-        << "Can not find histograms: " << phi_label_num << " or "
-        << phi_label_den;
+    edm::LogWarning("MuonME0SegHarvestor") << "Can not find histograms: " << phi_label_num << " or " << phi_label_den;
 }
 
 // define this as a plug-in

--- a/Validation/MuonME0Validation/plugins/MuonME0SegHarvestor.h
+++ b/Validation/MuonME0Validation/plugins/MuonME0SegHarvestor.h
@@ -23,8 +23,7 @@ public:
   ~MuonME0SegHarvestor() override;
 
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
-  void ProcessBooking(DQMStore::IBooker &, DQMStore::IGetter &,
-                      std::string nameHist, TH1F *num, TH1F *den);
+  void ProcessBooking(DQMStore::IBooker &, DQMStore::IGetter &, std::string nameHist, TH1F *num, TH1F *den);
   TProfile *ComputeEff(TH1F *num, TH1F *denum, std::string nameHist);
 
 private:

--- a/Validation/MuonME0Validation/src/ME0BaseValidation.cc
+++ b/Validation/MuonME0Validation/src/ME0BaseValidation.cc
@@ -20,23 +20,17 @@ ME0BaseValidation::ME0BaseValidation(const edm::ParameterSet &ps) {
 
 ME0BaseValidation::~ME0BaseValidation() {}
 
-MonitorElement *ME0BaseValidation::BookHistZR(DQMStore::IBooker &ibooker,
-                                              const char *name,
-                                              const char *label,
-                                              unsigned int region_num,
-                                              unsigned int layer_num) {
+MonitorElement *ME0BaseValidation::BookHistZR(
+    DQMStore::IBooker &ibooker, const char *name, const char *label, unsigned int region_num, unsigned int layer_num) {
   string hist_name, hist_label;
-  if (layer_num == 0 || layer_num == 1 || layer_num == 2 || layer_num == 3 ||
-      layer_num == 4 || layer_num == 5 || layer_num == 6) {
-    hist_name = name + string("_zr_r") + regionLabel[region_num] + "_l" +
-                layerLabel[layer_num];
-    hist_label = label + string(" occupancy : region") +
-                 regionLabel[region_num] + " layer " + layerLabel[layer_num] +
+  if (layer_num == 0 || layer_num == 1 || layer_num == 2 || layer_num == 3 || layer_num == 4 || layer_num == 5 ||
+      layer_num == 6) {
+    hist_name = name + string("_zr_r") + regionLabel[region_num] + "_l" + layerLabel[layer_num];
+    hist_label = label + string(" occupancy : region") + regionLabel[region_num] + " layer " + layerLabel[layer_num] +
                  " " + " ; globalZ [cm]; globalR[cm]";
   } else {
     hist_name = name + string("_zr_r") + regionLabel[region_num];
-    hist_label = label + string(" occupancy : region") +
-                 regionLabel[region_num] + " ; globalZ [cm]; globalR[cm]";
+    hist_label = label + string(" occupancy : region") + regionLabel[region_num] + " ; globalZ [cm]; globalR[cm]";
   }
   int xbin = (int)nBinZR_[0];
   int ybin = (int)nBinZR_[1];
@@ -55,28 +49,20 @@ MonitorElement *ME0BaseValidation::BookHistZR(DQMStore::IBooker &ibooker,
     xmin = RangeZR_[0];
     xmax = RangeZR_[1];
   }
-  return ibooker.book2D(hist_name, hist_label, xbin, xmin, xmax, ybin, ymin,
-                        ymax);
+  return ibooker.book2D(hist_name, hist_label, xbin, xmin, xmax, ybin, ymin, ymax);
 }
 
-MonitorElement *ME0BaseValidation::BookHistXY(DQMStore::IBooker &ibooker,
-                                              const char *name,
-                                              const char *label,
-                                              unsigned int region_num,
-                                              unsigned int layer_num) {
+MonitorElement *ME0BaseValidation::BookHistXY(
+    DQMStore::IBooker &ibooker, const char *name, const char *label, unsigned int region_num, unsigned int layer_num) {
   string hist_name, hist_label;
-  if (layer_num == 0 || layer_num == 1 || layer_num == 2 || layer_num == 3 ||
-      layer_num == 4 || layer_num == 5 || layer_num == 6) {
-    hist_name = name + string("_xy_r") + regionLabel[region_num] + "_l" +
-                layerLabel[layer_num];
-    hist_label = label + string(" occupancy : region") +
-                 regionLabel[region_num] + " layer " + layerLabel[layer_num] +
+  if (layer_num == 0 || layer_num == 1 || layer_num == 2 || layer_num == 3 || layer_num == 4 || layer_num == 5 ||
+      layer_num == 6) {
+    hist_name = name + string("_xy_r") + regionLabel[region_num] + "_l" + layerLabel[layer_num];
+    hist_label = label + string(" occupancy : region") + regionLabel[region_num] + " layer " + layerLabel[layer_num] +
                  " " + " ; globalX [cm]; globalY[cm]";
   } else {
     hist_name = name + string("_xy_r") + regionLabel[region_num];
-    hist_label = label + string(" occupancy : region") +
-                 regionLabel[region_num] + " ; globalX [cm]; globalY[cm]";
+    hist_label = label + string(" occupancy : region") + regionLabel[region_num] + " ; globalX [cm]; globalY[cm]";
   }
-  return ibooker.book2D(hist_name, hist_label, nBinXY_, -160, 160, nBinXY_,
-                        -160, 160);
+  return ibooker.book2D(hist_name, hist_label, nBinXY_, -160, 160, nBinXY_, -160, 160);
 }

--- a/Validation/MuonME0Validation/src/ME0DigisValidation.cc
+++ b/Validation/MuonME0Validation/src/ME0DigisValidation.cc
@@ -1,12 +1,9 @@
 #include "Validation/MuonME0Validation/interface/ME0DigisValidation.h"
 #include <TMath.h>
 
-ME0DigisValidation::ME0DigisValidation(const edm::ParameterSet &cfg)
-    : ME0BaseValidation(cfg) {
-  InputTagToken_ = consumes<edm::PSimHitContainer>(
-      cfg.getParameter<edm::InputTag>("simInputLabel"));
-  InputTagToken_Digi = consumes<ME0DigiPreRecoCollection>(
-      cfg.getParameter<edm::InputTag>("digiInputLabel"));
+ME0DigisValidation::ME0DigisValidation(const edm::ParameterSet &cfg) : ME0BaseValidation(cfg) {
+  InputTagToken_ = consumes<edm::PSimHitContainer>(cfg.getParameter<edm::InputTag>("simInputLabel"));
+  InputTagToken_Digi = consumes<ME0DigiPreRecoCollection>(cfg.getParameter<edm::InputTag>("digiInputLabel"));
   sigma_x_ = cfg.getParameter<double>("sigma_x");
   sigma_y_ = cfg.getParameter<double>("sigma_y");
 }
@@ -14,83 +11,69 @@ ME0DigisValidation::ME0DigisValidation(const edm::ParameterSet &cfg)
 void ME0DigisValidation::bookHistograms(DQMStore::IBooker &ibooker,
                                         edm::Run const &Run,
                                         edm::EventSetup const &iSetup) {
-
   LogDebug("MuonME0DigisValidation") << "Info: Loading Geometry information\n";
   ibooker.setCurrentFolder("MuonME0DigisV/ME0DigisTask");
 
   unsigned int nregion = 2;
 
-  edm::LogInfo("MuonME0DigisValidation")
-      << "+++ Info : # of region: " << nregion << std::endl;
+  edm::LogInfo("MuonME0DigisValidation") << "+++ Info : # of region: " << nregion << std::endl;
 
-  LogDebug("MuonME0DigisValidation")
-      << "+++ Info : finish to get geometry information from ES.\n";
+  LogDebug("MuonME0DigisValidation") << "+++ Info : finish to get geometry information from ES.\n";
 
-  num_evts = ibooker.book1D("num_evts", "Number of events; ; Number of events",
-                            1, 0, 2);
+  num_evts = ibooker.book1D("num_evts", "Number of events; ; Number of events", 1, 0, 2);
 
   me0_strip_dg_x_local_tot =
-      ibooker.book1D("me0_strip_dg_x_local_tot",
-                     "Local X; X_{local} [cm]; Entries", 60, -30.0, +30.0);
+      ibooker.book1D("me0_strip_dg_x_local_tot", "Local X; X_{local} [cm]; Entries", 60, -30.0, +30.0);
   me0_strip_dg_y_local_tot =
-      ibooker.book1D("me0_strip_dg_y_local_tot",
-                     "Local Y; Y_{local} [cm]; Entries", 100, -50.0, +50.0);
-  me0_strip_dg_time_tot = ibooker.book1D(
-      "me0_strip_dg_time_tot", "ToF; ToF [ns]; Entries", 400, -200, +200);
+      ibooker.book1D("me0_strip_dg_y_local_tot", "Local Y; Y_{local} [cm]; Entries", 100, -50.0, +50.0);
+  me0_strip_dg_time_tot = ibooker.book1D("me0_strip_dg_time_tot", "ToF; ToF [ns]; Entries", 400, -200, +200);
 
-  me0_strip_dg_dx_local_tot_Muon = ibooker.book1D(
-      "me0_strip_dg_dx_local_tot",
-      "Local DeltaX; #Delta X_{local} [cm]; Entries", 50, -0.1, +0.1);
-  me0_strip_dg_dy_local_tot_Muon = ibooker.book1D(
-      "me0_strip_dg_dy_local_tot",
-      "Local DeltaY; #Delta Y_{local} [cm]; Entries", 500, -10.0, +10.0);
+  me0_strip_dg_dx_local_tot_Muon =
+      ibooker.book1D("me0_strip_dg_dx_local_tot", "Local DeltaX; #Delta X_{local} [cm]; Entries", 50, -0.1, +0.1);
+  me0_strip_dg_dy_local_tot_Muon =
+      ibooker.book1D("me0_strip_dg_dy_local_tot", "Local DeltaY; #Delta Y_{local} [cm]; Entries", 500, -10.0, +10.0);
   me0_strip_dg_dphi_global_tot_Muon = ibooker.book1D(
-      "me0_strip_dg_dphi_global_tot",
-      "Global DeltaPhi; #Delta #phi_{global} [rad]; Entries", 50, -0.01, +0.01);
+      "me0_strip_dg_dphi_global_tot", "Global DeltaPhi; #Delta #phi_{global} [rad]; Entries", 50, -0.01, +0.01);
   me0_strip_dg_dtime_tot_Muon =
-      ibooker.book1D("me0_strip_dg_dtime_tot",
-                     "DeltaToF; #Delta ToF [ns]; Entries", 50, -5, +5);
+      ibooker.book1D("me0_strip_dg_dtime_tot", "DeltaToF; #Delta ToF [ns]; Entries", 50, -5, +5);
 
-  me0_strip_dg_dphi_vs_phi_global_tot_Muon =
-      ibooker.book2D("me0_strip_dg_dphi_vs_phi_global_tot",
-                     "Global DeltaPhi vs. Phi; #phi_{global} [rad]; #Delta "
-                     "#phi_{global} [rad]",
-                     72, -M_PI, +M_PI, 50, -0.01, +0.01);
+  me0_strip_dg_dphi_vs_phi_global_tot_Muon = ibooker.book2D("me0_strip_dg_dphi_vs_phi_global_tot",
+                                                            "Global DeltaPhi vs. Phi; #phi_{global} [rad]; #Delta "
+                                                            "#phi_{global} [rad]",
+                                                            72,
+                                                            -M_PI,
+                                                            +M_PI,
+                                                            50,
+                                                            -0.01,
+                                                            +0.01);
 
-  me0_strip_dg_den_eta_tot = ibooker.book1D(
-      "me0_strip_dg_den_eta_tot", "Denominator; #eta; Entries", 12, 1.8, 3.0);
-  me0_strip_dg_num_eta_tot = ibooker.book1D(
-      "me0_strip_dg_num_eta_tot", "Numerator; #eta; Entries", 12, 1.8, 3.0);
+  me0_strip_dg_den_eta_tot = ibooker.book1D("me0_strip_dg_den_eta_tot", "Denominator; #eta; Entries", 12, 1.8, 3.0);
+  me0_strip_dg_num_eta_tot = ibooker.book1D("me0_strip_dg_num_eta_tot", "Numerator; #eta; Entries", 12, 1.8, 3.0);
 
   float bins[] = {62.3, 70.0, 77.7, 87.1, 96.4, 108.2, 119.9, 134.7, 149.5};
   int binnum = sizeof(bins) / sizeof(float) - 1;
 
-  me0_strip_dg_bkg_rad_tot = ibooker.book1D(
-      "me0_strip_dg_bkg_radius_tot",
-      "Total neutron background; Radius [cm]; Entries", binnum, bins);
+  me0_strip_dg_bkg_rad_tot =
+      ibooker.book1D("me0_strip_dg_bkg_radius_tot", "Total neutron background; Radius [cm]; Entries", binnum, bins);
   me0_strip_dg_bkgElePos_rad = ibooker.book1D(
-      "me0_strip_dg_bkgElePos_radius",
-      "Neutron background: electrons+positrons; Radius [cm]; Entries", binnum,
-      bins);
+      "me0_strip_dg_bkgElePos_radius", "Neutron background: electrons+positrons; Radius [cm]; Entries", binnum, bins);
   me0_strip_dg_bkgNeutral_rad = ibooker.book1D(
-      "me0_strip_dg_bkgNeutral_radius",
-      "Neutron background: gammas+neutrons; Radius [cm]; Entries", binnum,
-      bins);
+      "me0_strip_dg_bkgNeutral_radius", "Neutron background: gammas+neutrons; Radius [cm]; Entries", binnum, bins);
 
-  me0_strip_exp_bkg_rad_tot = ibooker.book1D(
-      "me0_strip_exp_bkg_radius_tot",
-      "Total expected neutron background; Radius [cm]; Hit Rate [Hz/cm^{2}]",
-      binnum, bins);
-  me0_strip_exp_bkgElePos_rad =
-      ibooker.book1D("me0_strip_exp_bkgElePos_radius",
-                     "Expected neutron background: electrons+positrons; Radius "
-                     "[cm]; Hit Rate [Hz/cm^{2}]",
-                     binnum, bins);
-  me0_strip_exp_bkgNeutral_rad =
-      ibooker.book1D("me0_strip_exp_bkgNeutral_radius",
-                     "Expected neutron background: gammas+neutrons; Radius "
-                     "[cm]; Hit Rate [Hz/cm^{2}]",
-                     binnum, bins);
+  me0_strip_exp_bkg_rad_tot = ibooker.book1D("me0_strip_exp_bkg_radius_tot",
+                                             "Total expected neutron background; Radius [cm]; Hit Rate [Hz/cm^{2}]",
+                                             binnum,
+                                             bins);
+  me0_strip_exp_bkgElePos_rad = ibooker.book1D("me0_strip_exp_bkgElePos_radius",
+                                               "Expected neutron background: electrons+positrons; Radius "
+                                               "[cm]; Hit Rate [Hz/cm^{2}]",
+                                               binnum,
+                                               bins);
+  me0_strip_exp_bkgNeutral_rad = ibooker.book1D("me0_strip_exp_bkgNeutral_radius",
+                                                "Expected neutron background: gammas+neutrons; Radius "
+                                                "[cm]; Hit Rate [Hz/cm^{2}]",
+                                                binnum,
+                                                bins);
 
   std::vector<double> neuBkg, eleBkg;
   neuBkg.push_back(899644.0);
@@ -109,14 +92,12 @@ void ME0DigisValidation::bookHistograms(DQMStore::IBooker &ibooker,
   eleBkg.push_back(1.44368e-08);
 
   for (int i = 1; i < me0_strip_exp_bkgNeutral_rad->getTH1F()->GetSize(); i++) {
-
     double pos = me0_strip_exp_bkgNeutral_rad->getTH1F()->GetBinCenter(i);
     double neutral = 0;
     double charged = 0;
 
     double pos_helper = 1.0;
     for (int j = 0; j < 7; ++j) {
-
       neutral += neuBkg[j] * pos_helper;
       charged += eleBkg[j] * pos_helper;
       pos_helper *= pos;
@@ -128,73 +109,55 @@ void ME0DigisValidation::bookHistograms(DQMStore::IBooker &ibooker,
   }
 
   for (unsigned int region_num = 0; region_num < nregion; region_num++) {
-    me0_strip_dg_zr_tot[region_num] =
-        BookHistZR(ibooker, "me0_strip_dg_tot", "Digi", region_num);
-    me0_strip_dg_zr_tot_Muon[region_num] =
-        BookHistZR(ibooker, "me0_strip_dg_tot_Muon", "Digi Muon", region_num);
+    me0_strip_dg_zr_tot[region_num] = BookHistZR(ibooker, "me0_strip_dg_tot", "Digi", region_num);
+    me0_strip_dg_zr_tot_Muon[region_num] = BookHistZR(ibooker, "me0_strip_dg_tot_Muon", "Digi Muon", region_num);
     for (unsigned int layer_num = 0; layer_num < 6; layer_num++) {
-
       std::string hist_name_for_dx_local =
-          std::string("me0_strip_dg_dx_local") + regionLabel[region_num] +
-          "_l" + layerLabel[layer_num];
+          std::string("me0_strip_dg_dx_local") + regionLabel[region_num] + "_l" + layerLabel[layer_num];
       std::string hist_name_for_dy_local =
-          std::string("me0_strip_dg_dy_local") + regionLabel[region_num] +
-          "_l" + layerLabel[layer_num];
+          std::string("me0_strip_dg_dy_local") + regionLabel[region_num] + "_l" + layerLabel[layer_num];
       std::string hist_name_for_dphi_global =
-          std::string("me0_strip_dg_dphi_global") + regionLabel[region_num] +
-          "_l" + layerLabel[layer_num];
+          std::string("me0_strip_dg_dphi_global") + regionLabel[region_num] + "_l" + layerLabel[layer_num];
 
-      std::string hist_name_for_den_eta = std::string("me0_strip_dg_den_eta") +
-                                          regionLabel[region_num] + "_l" +
-                                          layerLabel[layer_num];
-      std::string hist_name_for_num_eta = std::string("me0_strip_dg_num_eta") +
-                                          regionLabel[region_num] + "_l" +
-                                          layerLabel[layer_num];
+      std::string hist_name_for_den_eta =
+          std::string("me0_strip_dg_den_eta") + regionLabel[region_num] + "_l" + layerLabel[layer_num];
+      std::string hist_name_for_num_eta =
+          std::string("me0_strip_dg_num_eta") + regionLabel[region_num] + "_l" + layerLabel[layer_num];
 
-      std::string hist_label_for_dx_local =
-          "Local DeltaX: region" + regionLabel[region_num] + " layer " +
-          layerLabel[layer_num] + " ; #Delta X_{local} [cm]; Entries";
-      std::string hist_label_for_dy_local =
-          "Local DeltaY: region" + regionLabel[region_num] + " layer " +
-          layerLabel[layer_num] + " ; #Delta Y_{local} [cm]; Entries";
-      std::string hist_label_for_dphi_global =
-          "Global DeltaPhi: region" + regionLabel[region_num] + " layer " +
-          layerLabel[layer_num] + " ; #Delta #phi_{global} [rad]; Entries";
+      std::string hist_label_for_dx_local = "Local DeltaX: region" + regionLabel[region_num] + " layer " +
+                                            layerLabel[layer_num] + " ; #Delta X_{local} [cm]; Entries";
+      std::string hist_label_for_dy_local = "Local DeltaY: region" + regionLabel[region_num] + " layer " +
+                                            layerLabel[layer_num] + " ; #Delta Y_{local} [cm]; Entries";
+      std::string hist_label_for_dphi_global = "Global DeltaPhi: region" + regionLabel[region_num] + " layer " +
+                                               layerLabel[layer_num] + " ; #Delta #phi_{global} [rad]; Entries";
 
       std::string hist_label_for_den_eta =
-          "Denominator: region" + regionLabel[region_num] + " layer " +
-          layerLabel[layer_num] + " ; #eta; Entries";
+          "Denominator: region" + regionLabel[region_num] + " layer " + layerLabel[layer_num] + " ; #eta; Entries";
       std::string hist_label_for_num_eta =
-          "Numerator: region" + regionLabel[region_num] + " layer " +
-          layerLabel[layer_num] + " ; #eta; Entries";
+          "Numerator: region" + regionLabel[region_num] + " layer " + layerLabel[layer_num] + " ; #eta; Entries";
 
-      me0_strip_dg_xy[region_num][layer_num] =
-          BookHistXY(ibooker, "me0_strip_dg", "Digi", region_num, layer_num);
-      me0_strip_dg_xy_Muon[region_num][layer_num] = BookHistXY(
-          ibooker, "me0_strip_dg_Muon", "Digi Muon", region_num, layer_num);
+      me0_strip_dg_xy[region_num][layer_num] = BookHistXY(ibooker, "me0_strip_dg", "Digi", region_num, layer_num);
+      me0_strip_dg_xy_Muon[region_num][layer_num] =
+          BookHistXY(ibooker, "me0_strip_dg_Muon", "Digi Muon", region_num, layer_num);
 
       me0_strip_dg_dx_local_Muon[region_num][layer_num] =
-          ibooker.book1D(hist_name_for_dx_local.c_str(),
-                         hist_label_for_dx_local.c_str(), 50, -0.1, +0.1);
+          ibooker.book1D(hist_name_for_dx_local.c_str(), hist_label_for_dx_local.c_str(), 50, -0.1, +0.1);
       me0_strip_dg_dy_local_Muon[region_num][layer_num] =
-          ibooker.book1D(hist_name_for_dy_local.c_str(),
-                         hist_label_for_dy_local.c_str(), 500, -10.0, +10.0);
+          ibooker.book1D(hist_name_for_dy_local.c_str(), hist_label_for_dy_local.c_str(), 500, -10.0, +10.0);
       me0_strip_dg_dphi_global_Muon[region_num][layer_num] =
-          ibooker.book1D(hist_name_for_dphi_global.c_str(),
-                         hist_label_for_dphi_global.c_str(), 50, -0.01, +0.01);
+          ibooker.book1D(hist_name_for_dphi_global.c_str(), hist_label_for_dphi_global.c_str(), 50, -0.01, +0.01);
 
-      me0_strip_dg_den_eta[region_num][layer_num] = ibooker.book1D(
-          hist_name_for_den_eta, hist_label_for_den_eta, 12, 1.8, 3.0);
-      me0_strip_dg_num_eta[region_num][layer_num] = ibooker.book1D(
-          hist_name_for_num_eta, hist_label_for_num_eta, 12, 1.8, 3.0);
+      me0_strip_dg_den_eta[region_num][layer_num] =
+          ibooker.book1D(hist_name_for_den_eta, hist_label_for_den_eta, 12, 1.8, 3.0);
+      me0_strip_dg_num_eta[region_num][layer_num] =
+          ibooker.book1D(hist_name_for_num_eta, hist_label_for_num_eta, 12, 1.8, 3.0);
     }
   }
 }
 
 ME0DigisValidation::~ME0DigisValidation() {}
 
-void ME0DigisValidation::analyze(const edm::Event &e,
-                                 const edm::EventSetup &iSetup) {
+void ME0DigisValidation::analyze(const edm::Event &e, const edm::EventSetup &iSetup) {
   edm::ESHandle<ME0Geometry> hGeom;
   iSetup.get<MuonGeometryRecord>().get(hGeom);
   const ME0Geometry *ME0Geometry_ = (&*hGeom);
@@ -206,23 +169,20 @@ void ME0DigisValidation::analyze(const edm::Event &e,
   e.getByToken(InputTagToken_Digi, ME0Digis);
 
   if (!ME0Hits.isValid() | !ME0Digis.isValid()) {
-    edm::LogError("ME0DigisValidation")
-        << "Cannot get ME0Hits/ME0Digis by Token simInputTagToken";
+    edm::LogError("ME0DigisValidation") << "Cannot get ME0Hits/ME0Digis by Token simInputTagToken";
     return;
   }
 
   num_evts->Fill(1);
   bool toBeCounted1 = true;
 
-  for (ME0DigiPreRecoCollection::DigiRangeIterator cItr = ME0Digis->begin();
-       cItr != ME0Digis->end(); cItr++) {
+  for (ME0DigiPreRecoCollection::DigiRangeIterator cItr = ME0Digis->begin(); cItr != ME0Digis->end(); cItr++) {
     ME0DetId id = (*cItr).first;
 
     const GeomDet *gdet = ME0Geometry_->idToDet(id);
     if (gdet == nullptr) {
-      edm::LogWarning("ME0DigisValidation")
-          << "Getting DetId failed. Discard this gem strip hit. Maybe it comes "
-             "from unmatched geometry.";
+      edm::LogWarning("ME0DigisValidation") << "Getting DetId failed. Discard this gem strip hit. Maybe it comes "
+                                               "from unmatched geometry.";
       continue;
     }
     const BoundPlane &surface = gdet->surface();
@@ -233,9 +193,7 @@ void ME0DigisValidation::analyze(const edm::Event &e,
     int roll = (int)id.roll();
 
     ME0DigiPreRecoCollection::const_iterator digiItr;
-    for (digiItr = (*cItr).second.first; digiItr != (*cItr).second.second;
-         ++digiItr) {
-
+    for (digiItr = (*cItr).second.first; digiItr != (*cItr).second.second; ++digiItr) {
       LocalPoint lp(digiItr->x(), digiItr->y(), 0);
 
       GlobalPoint gp = surface.toGlobal(lp);
@@ -265,19 +223,16 @@ void ME0DigisValidation::analyze(const edm::Event &e,
       bool toBeCounted2 = true;
 
       if (isPrompt == 1 && abs(particleType) == 13) {
-
         me0_strip_dg_zr_tot_Muon[region_num]->Fill(g_z, g_r);
         me0_strip_dg_xy_Muon[region_num][layer_num]->Fill(g_x, g_y);
 
         for (auto hits = ME0Hits->begin(); hits != ME0Hits->end(); hits++) {
-
           int particleType_sh = hits->particleType();
           int evtId_sh = hits->eventId().event();
           int bx_sh = hits->eventId().bunchCrossing();
           int procType_sh = hits->processType();
 
-          if (!(abs(particleType_sh) == 13 && evtId_sh == 0 && bx_sh == 0 &&
-                procType_sh == 0))
+          if (!(abs(particleType_sh) == 13 && evtId_sh == 0 && bx_sh == 0 && procType_sh == 0))
             continue;
 
           const ME0DetId id(hits->detUnitId());
@@ -294,18 +249,14 @@ void ME0DigisValidation::analyze(const edm::Event &e,
           int layer_sh_num = layer_sh - 1;
 
           LocalPoint lp_sh = hits->localPosition();
-          GlobalPoint gp_sh =
-              ME0Geometry_->idToDet(id)->surface().toGlobal(lp_sh);
+          GlobalPoint gp_sh = ME0Geometry_->idToDet(id)->surface().toGlobal(lp_sh);
 
           if (toBeCounted1) {
-
-            me0_strip_dg_den_eta[region_sh_num][layer_sh_num]->Fill(
-                fabs(gp_sh.eta()));
+            me0_strip_dg_den_eta[region_sh_num][layer_sh_num]->Fill(fabs(gp_sh.eta()));
             me0_strip_dg_den_eta_tot->Fill(fabs(gp_sh.eta()));
           }
 
-          if (!(region == region_sh && layer == layer_sh &&
-                chamber == chamber_sh && roll == roll_sh))
+          if (!(region == region_sh && layer == layer_sh && chamber == chamber_sh && roll == roll_sh))
             continue;
 
           float dx_loc = lp_sh.x() - lp.x();
@@ -313,15 +264,13 @@ void ME0DigisValidation::analyze(const edm::Event &e,
           float dphi_glob = gp_sh.phi() - gp.phi();
           float deta_glob = gp_sh.eta() - gp.eta();
 
-          if (!(fabs(dphi_glob) < 3 * sigma_x_ &&
-                fabs(deta_glob) < 3 * sigma_y_))
+          if (!(fabs(dphi_glob) < 3 * sigma_x_ && fabs(deta_glob) < 3 * sigma_y_))
             continue;
 
           float timeOfFlight_sh = hits->tof();
           const LocalPoint centralLP(0., 0., 0.);
-          const GlobalPoint centralGP(
-              ME0Geometry_->idToDet(id)->surface().toGlobal(centralLP));
-          float centralTOF(centralGP.mag() / 29.98); // speed of light
+          const GlobalPoint centralGP(ME0Geometry_->idToDet(id)->surface().toGlobal(centralLP));
+          float centralTOF(centralGP.mag() / 29.98);  // speed of light
           float timeOfFlight_sh_corr = timeOfFlight_sh - centralTOF;
 
           me0_strip_dg_dx_local_Muon[region_num][layer_num]->Fill(dx_loc);
@@ -332,20 +281,16 @@ void ME0DigisValidation::analyze(const edm::Event &e,
           me0_strip_dg_dy_local_tot_Muon->Fill(dy_loc);
           me0_strip_dg_dphi_global_tot_Muon->Fill(dphi_glob);
 
-          me0_strip_dg_dphi_vs_phi_global_tot_Muon->Fill(gp_sh.phi(),
-                                                         dphi_glob);
-          me0_strip_dg_dtime_tot_Muon->Fill(timeOfFlight -
-                                            timeOfFlight_sh_corr);
+          me0_strip_dg_dphi_vs_phi_global_tot_Muon->Fill(gp_sh.phi(), dphi_glob);
+          me0_strip_dg_dtime_tot_Muon->Fill(timeOfFlight - timeOfFlight_sh_corr);
 
           if (toBeCounted2) {
-
-            me0_strip_dg_num_eta[region_num][layer_num]->Fill(
-                fabs(gp_sh.eta()));
+            me0_strip_dg_num_eta[region_num][layer_num]->Fill(fabs(gp_sh.eta()));
             me0_strip_dg_num_eta_tot->Fill(fabs(gp_sh.eta()));
           }
           toBeCounted2 = false;
 
-        } // loop SH
+        }  // loop SH
 
         toBeCounted1 = false;
 
@@ -354,16 +299,13 @@ void ME0DigisValidation::analyze(const edm::Event &e,
         me0_strip_dg_xy[region_num][layer_num]->Fill(g_x, g_y);
       }
 
-      if ((abs(particleType) == 11 || abs(particleType) == 22 ||
-           abs(particleType) == 2112) &&
-          isPrompt == 0)
+      if ((abs(particleType) == 11 || abs(particleType) == 22 || abs(particleType) == 2112) && isPrompt == 0)
         me0_strip_dg_bkg_rad_tot->Fill(fabs(gp.perp()));
       if ((abs(particleType) == 11) && isPrompt == 0)
         me0_strip_dg_bkgElePos_rad->Fill(fabs(gp.perp()));
-      if ((abs(particleType) == 22 || abs(particleType) == 2112) &&
-          isPrompt == 0)
+      if ((abs(particleType) == 22 || abs(particleType) == 2112) && isPrompt == 0)
         me0_strip_dg_bkgNeutral_rad->Fill(fabs(gp.perp()));
 
-    } // loop DG
+    }  // loop DG
   }
 }

--- a/Validation/MuonME0Validation/src/ME0HitsValidation.cc
+++ b/Validation/MuonME0Validation/src/ME0HitsValidation.cc
@@ -2,88 +2,62 @@
 #include "Validation/MuonME0Validation/interface/ME0HitsValidation.h"
 #include <TMath.h>
 
-ME0HitsValidation::ME0HitsValidation(const edm::ParameterSet &cfg)
-    : ME0BaseValidation(cfg) {
-  InputTagToken_ = consumes<edm::PSimHitContainer>(
-      cfg.getParameter<edm::InputTag>("simInputLabel"));
+ME0HitsValidation::ME0HitsValidation(const edm::ParameterSet &cfg) : ME0BaseValidation(cfg) {
+  InputTagToken_ = consumes<edm::PSimHitContainer>(cfg.getParameter<edm::InputTag>("simInputLabel"));
 }
 
-void ME0HitsValidation::bookHistograms(DQMStore::IBooker &ibooker,
-                                       edm::Run const &Run,
-                                       edm::EventSetup const &iSetup) {
-
+void ME0HitsValidation::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &Run, edm::EventSetup const &iSetup) {
   LogDebug("MuonME0HitsValidation") << "Info : Loading Geometry information\n";
   ibooker.setCurrentFolder("MuonME0HitsV/ME0HitsTask");
 
   unsigned int nregion = 2;
 
-  edm::LogInfo("MuonME0HitsValidation")
-      << "+++ Info : # of region : " << nregion << std::endl;
+  edm::LogInfo("MuonME0HitsValidation") << "+++ Info : # of region : " << nregion << std::endl;
 
-  LogDebug("MuonME0HitsValidation")
-      << "+++ Info : finish to get geometry information from ES.\n";
+  LogDebug("MuonME0HitsValidation") << "+++ Info : finish to get geometry information from ES.\n";
 
   for (unsigned int region_num = 0; region_num < nregion; region_num++) {
-    me0_sh_tot_zr[region_num] =
-        BookHistZR(ibooker, "me0_sh", "SimHit", region_num);
+    me0_sh_tot_zr[region_num] = BookHistZR(ibooker, "me0_sh", "SimHit", region_num);
     for (unsigned int layer_num = 0; layer_num < 6; layer_num++) {
-      me0_sh_zr[region_num][layer_num] =
-          BookHistZR(ibooker, "me0_sh", "SimHit", region_num, layer_num);
-      me0_sh_xy[region_num][layer_num] =
-          BookHistXY(ibooker, "me0_sh", "SimHit", region_num, layer_num);
-      std::string hist_name_for_tof = std::string("me0_sh_tof_r") +
-                                      regionLabel[region_num] + "_l" +
-                                      layerLabel[layer_num];
-      std::string hist_name_for_tofMu = std::string("me0_sh_tofMuon_r") +
-                                        regionLabel[region_num] + "_l" +
-                                        layerLabel[layer_num];
-      std::string hist_name_for_eloss = std::string("me0_sh_energyloss_r") +
-                                        regionLabel[region_num] + "_l" +
-                                        layerLabel[layer_num];
+      me0_sh_zr[region_num][layer_num] = BookHistZR(ibooker, "me0_sh", "SimHit", region_num, layer_num);
+      me0_sh_xy[region_num][layer_num] = BookHistXY(ibooker, "me0_sh", "SimHit", region_num, layer_num);
+      std::string hist_name_for_tof =
+          std::string("me0_sh_tof_r") + regionLabel[region_num] + "_l" + layerLabel[layer_num];
+      std::string hist_name_for_tofMu =
+          std::string("me0_sh_tofMuon_r") + regionLabel[region_num] + "_l" + layerLabel[layer_num];
+      std::string hist_name_for_eloss =
+          std::string("me0_sh_energyloss_r") + regionLabel[region_num] + "_l" + layerLabel[layer_num];
       std::string hist_name_for_elossMu =
-          std::string("me0_sh_energylossMuon_r") + regionLabel[region_num] +
-          "_l" + layerLabel[layer_num];
-      std::string hist_label_for_xy =
-          "SimHit occupancy : region" + regionLabel[region_num] + " layer " +
-          layerLabel[layer_num] + " ; globalX [cm]; globalY[cm]";
-      std::string hist_label_for_tof =
-          "SimHit TOF : region" + regionLabel[region_num] + " layer " +
-          layerLabel[layer_num] + " " + " ; Time of flight [ns] ; entries";
-      std::string hist_label_for_tofMu = "SimHit TOF(Muon only) : region" +
-                                         regionLabel[region_num] + " layer " +
-                                         layerLabel[layer_num] + " " +
-                                         " ; Time of flight [ns] ; entries";
-      std::string hist_label_for_eloss =
-          "SimHit energy loss : region" + regionLabel[region_num] + " layer " +
-          layerLabel[layer_num] + " " + " ; Energy loss [eV] ; entries";
-      std::string hist_label_for_elossMu =
-          "SimHit energy loss(Muon only) : region" + regionLabel[region_num] +
-          " layer " + layerLabel[layer_num] + " " +
-          " ; Energy loss [eV] ; entries";
+          std::string("me0_sh_energylossMuon_r") + regionLabel[region_num] + "_l" + layerLabel[layer_num];
+      std::string hist_label_for_xy = "SimHit occupancy : region" + regionLabel[region_num] + " layer " +
+                                      layerLabel[layer_num] + " ; globalX [cm]; globalY[cm]";
+      std::string hist_label_for_tof = "SimHit TOF : region" + regionLabel[region_num] + " layer " +
+                                       layerLabel[layer_num] + " " + " ; Time of flight [ns] ; entries";
+      std::string hist_label_for_tofMu = "SimHit TOF(Muon only) : region" + regionLabel[region_num] + " layer " +
+                                         layerLabel[layer_num] + " " + " ; Time of flight [ns] ; entries";
+      std::string hist_label_for_eloss = "SimHit energy loss : region" + regionLabel[region_num] + " layer " +
+                                         layerLabel[layer_num] + " " + " ; Energy loss [eV] ; entries";
+      std::string hist_label_for_elossMu = "SimHit energy loss(Muon only) : region" + regionLabel[region_num] +
+                                           " layer " + layerLabel[layer_num] + " " + " ; Energy loss [eV] ; entries";
 
       double tof_min, tof_max;
       tof_min = 10;
       tof_max = 30;
       me0_sh_tof[region_num][layer_num] =
-          ibooker.book1D(hist_name_for_tof.c_str(), hist_label_for_tof.c_str(),
-                         40, tof_min, tof_max);
+          ibooker.book1D(hist_name_for_tof.c_str(), hist_label_for_tof.c_str(), 40, tof_min, tof_max);
       me0_sh_tofMu[region_num][layer_num] =
-          ibooker.book1D(hist_name_for_tofMu.c_str(),
-                         hist_label_for_tofMu.c_str(), 40, tof_min, tof_max);
+          ibooker.book1D(hist_name_for_tofMu.c_str(), hist_label_for_tofMu.c_str(), 40, tof_min, tof_max);
       me0_sh_eloss[region_num][layer_num] =
-          ibooker.book1D(hist_name_for_eloss.c_str(),
-                         hist_label_for_eloss.c_str(), 60, 0., 6000.);
+          ibooker.book1D(hist_name_for_eloss.c_str(), hist_label_for_eloss.c_str(), 60, 0., 6000.);
       me0_sh_elossMu[region_num][layer_num] =
-          ibooker.book1D(hist_name_for_elossMu.c_str(),
-                         hist_label_for_elossMu.c_str(), 60, 0., 6000.);
+          ibooker.book1D(hist_name_for_elossMu.c_str(), hist_label_for_elossMu.c_str(), 60, 0., 6000.);
     }
   }
 }
 
 ME0HitsValidation::~ME0HitsValidation() {}
 
-void ME0HitsValidation::analyze(const edm::Event &e,
-                                const edm::EventSetup &iSetup) {
+void ME0HitsValidation::analyze(const edm::Event &e, const edm::EventSetup &iSetup) {
   edm::ESHandle<ME0Geometry> hGeom;
   iSetup.get<MuonGeometryRecord>().get(hGeom);
   const ME0Geometry *ME0Geometry_ = (&*hGeom);
@@ -91,8 +65,7 @@ void ME0HitsValidation::analyze(const edm::Event &e,
   edm::Handle<edm::PSimHitContainer> ME0Hits;
   e.getByToken(InputTagToken_, ME0Hits);
   if (!ME0Hits.isValid()) {
-    edm::LogError("ME0HitsValidation")
-        << "Cannot get ME0Hits by Token simInputTagToken";
+    edm::LogError("ME0HitsValidation") << "Cannot get ME0Hits by Token simInputTagToken";
     return;
   }
 
@@ -100,7 +73,6 @@ void ME0HitsValidation::analyze(const edm::Event &e,
   Float_t energyLossMuon = 0;
 
   for (auto hits = ME0Hits->begin(); hits != ME0Hits->end(); hits++) {
-
     const ME0DetId id(hits->detUnitId());
     Int_t region = id.region();
     Int_t layer = id.layer();
@@ -113,8 +85,7 @@ void ME0HitsValidation::analyze(const edm::Event &e,
 
     const LocalPoint hitLP(hits->localPosition());
 
-    const GlobalPoint hitGP(
-        ME0Geometry_->idToDet(hits->detUnitId())->surface().toGlobal(hitLP));
+    const GlobalPoint hitGP(ME0Geometry_->idToDet(hits->detUnitId())->surface().toGlobal(hitLP));
     Float_t g_r = hitGP.perp();
     Float_t g_x = hitGP.x();
     Float_t g_y = hitGP.y();
@@ -127,8 +98,7 @@ void ME0HitsValidation::analyze(const edm::Event &e,
       energyLossMuon = hits->energyLoss();
       // fill histos for Muons only
       me0_sh_tofMu[(int)(region / 2. + 0.5)][layer - 1]->Fill(timeOfFlightMuon);
-      me0_sh_elossMu[(int)(region / 2. + 0.5)][layer - 1]->Fill(energyLossMuon *
-                                                                1.e9);
+      me0_sh_elossMu[(int)(region / 2. + 0.5)][layer - 1]->Fill(energyLossMuon * 1.e9);
     }
 
     me0_sh_zr[(int)(region / 2. + 0.5)][layer - 1]->Fill(g_z, g_r);

--- a/Validation/MuonME0Validation/src/ME0RecHitsValidation.cc
+++ b/Validation/MuonME0Validation/src/ME0RecHitsValidation.cc
@@ -1,82 +1,64 @@
 #include "Validation/MuonME0Validation/interface/ME0RecHitsValidation.h"
 #include <TMath.h>
 
-ME0RecHitsValidation::ME0RecHitsValidation(const edm::ParameterSet &cfg)
-    : ME0BaseValidation(cfg) {
-  InputTagToken_ = consumes<edm::PSimHitContainer>(
-      cfg.getParameter<edm::InputTag>("simInputLabel"));
-  InputTagToken_RecHit = consumes<ME0RecHitCollection>(
-      cfg.getParameter<edm::InputTag>("recHitInputLabel"));
+ME0RecHitsValidation::ME0RecHitsValidation(const edm::ParameterSet &cfg) : ME0BaseValidation(cfg) {
+  InputTagToken_ = consumes<edm::PSimHitContainer>(cfg.getParameter<edm::InputTag>("simInputLabel"));
+  InputTagToken_RecHit = consumes<ME0RecHitCollection>(cfg.getParameter<edm::InputTag>("recHitInputLabel"));
 }
 
 void ME0RecHitsValidation::bookHistograms(DQMStore::IBooker &ibooker,
                                           edm::Run const &Run,
                                           edm::EventSetup const &iSetup) {
-
-  LogDebug("MuonME0RecHitsValidation")
-      << "Info : Loading Geometry information\n";
+  LogDebug("MuonME0RecHitsValidation") << "Info : Loading Geometry information\n";
   ibooker.setCurrentFolder("MuonME0RecHitsV/ME0RecHitsTask");
 
   unsigned int nregion = 2;
 
-  edm::LogInfo("MuonME0RecHitsValidation")
-      << "+++ Info : # of region : " << nregion << std::endl;
+  edm::LogInfo("MuonME0RecHitsValidation") << "+++ Info : # of region : " << nregion << std::endl;
 
-  LogDebug("MuonME0RecHitsValidation")
-      << "+++ Info : finish to get geometry information from ES.\n";
+  LogDebug("MuonME0RecHitsValidation") << "+++ Info : finish to get geometry information from ES.\n";
 
   for (unsigned int region_num = 0; region_num < nregion; region_num++) {
-    me0_rh_zr[region_num] =
-        BookHistZR(ibooker, "me0_rh_tot", "Digi", region_num);
+    me0_rh_zr[region_num] = BookHistZR(ibooker, "me0_rh_tot", "Digi", region_num);
     for (unsigned int layer_num = 0; layer_num < 6; layer_num++) {
-      me0_rh_xy[region_num][layer_num] =
-          BookHistXY(ibooker, "me0_rh", "RecHit", region_num, layer_num);
+      me0_rh_xy[region_num][layer_num] = BookHistXY(ibooker, "me0_rh", "RecHit", region_num, layer_num);
 
-      std::string histo_name_DeltaX = std::string("me0_rh_DeltaX_r") +
-                                      regionLabel[region_num] + "_l" +
-                                      layerLabel[layer_num];
-      std::string histo_name_DeltaY = std::string("me0_rh_DeltaY_r") +
-                                      regionLabel[region_num] + "_l" +
-                                      layerLabel[layer_num];
-      std::string histo_label_DeltaX =
-          "RecHit Delta X : region" + regionLabel[region_num] + " layer " +
-          layerLabel[layer_num] + " " + " ; x_{SimHit} - x_{RecHit} ; entries";
-      std::string histo_label_DeltaY =
-          "RecHit Delta Y : region" + regionLabel[region_num] + " layer " +
-          layerLabel[layer_num] + " " + " ; y_{SimHit} - y_{RecHit} ; entries";
+      std::string histo_name_DeltaX =
+          std::string("me0_rh_DeltaX_r") + regionLabel[region_num] + "_l" + layerLabel[layer_num];
+      std::string histo_name_DeltaY =
+          std::string("me0_rh_DeltaY_r") + regionLabel[region_num] + "_l" + layerLabel[layer_num];
+      std::string histo_label_DeltaX = "RecHit Delta X : region" + regionLabel[region_num] + " layer " +
+                                       layerLabel[layer_num] + " " + " ; x_{SimHit} - x_{RecHit} ; entries";
+      std::string histo_label_DeltaY = "RecHit Delta Y : region" + regionLabel[region_num] + " layer " +
+                                       layerLabel[layer_num] + " " + " ; y_{SimHit} - y_{RecHit} ; entries";
 
-      me0_rh_DeltaX[region_num][layer_num] = ibooker.book1D(
-          histo_name_DeltaX.c_str(), histo_label_DeltaX.c_str(), 100, -10, 10);
-      me0_rh_DeltaY[region_num][layer_num] = ibooker.book1D(
-          histo_name_DeltaY.c_str(), histo_label_DeltaY.c_str(), 100, -10, 10);
+      me0_rh_DeltaX[region_num][layer_num] =
+          ibooker.book1D(histo_name_DeltaX.c_str(), histo_label_DeltaX.c_str(), 100, -10, 10);
+      me0_rh_DeltaY[region_num][layer_num] =
+          ibooker.book1D(histo_name_DeltaY.c_str(), histo_label_DeltaY.c_str(), 100, -10, 10);
 
-      std::string histo_name_PullX = std::string("me0_rh_PullX_r") +
-                                     regionLabel[region_num] + "_l" +
-                                     layerLabel[layer_num];
-      std::string histo_name_PullY = std::string("me0_rh_PullY_r") +
-                                     regionLabel[region_num] + "_l" +
-                                     layerLabel[layer_num];
-      std::string histo_label_PullX =
-          "RecHit Pull X : region" + regionLabel[region_num] + " layer " +
-          layerLabel[layer_num] + " " +
-          " ; #frac{x_{SimHit} - x_{RecHit}}{#sigma_{x,RecHit}} ; entries";
-      std::string histo_label_PullY =
-          "RecHit Pull Y : region" + regionLabel[region_num] + " layer " +
-          layerLabel[layer_num] + " " +
-          " ; #frac{y_{SimHit} - y_{RecHit}}{#sigma_{y,RecHit}} ; entries";
+      std::string histo_name_PullX =
+          std::string("me0_rh_PullX_r") + regionLabel[region_num] + "_l" + layerLabel[layer_num];
+      std::string histo_name_PullY =
+          std::string("me0_rh_PullY_r") + regionLabel[region_num] + "_l" + layerLabel[layer_num];
+      std::string histo_label_PullX = "RecHit Pull X : region" + regionLabel[region_num] + " layer " +
+                                      layerLabel[layer_num] + " " +
+                                      " ; #frac{x_{SimHit} - x_{RecHit}}{#sigma_{x,RecHit}} ; entries";
+      std::string histo_label_PullY = "RecHit Pull Y : region" + regionLabel[region_num] + " layer " +
+                                      layerLabel[layer_num] + " " +
+                                      " ; #frac{y_{SimHit} - y_{RecHit}}{#sigma_{y,RecHit}} ; entries";
 
-      me0_rh_PullX[region_num][layer_num] = ibooker.book1D(
-          histo_name_PullX.c_str(), histo_label_DeltaX.c_str(), 100, -10, 10);
-      me0_rh_PullY[region_num][layer_num] = ibooker.book1D(
-          histo_name_PullY.c_str(), histo_label_DeltaY.c_str(), 100, -10, 10);
+      me0_rh_PullX[region_num][layer_num] =
+          ibooker.book1D(histo_name_PullX.c_str(), histo_label_DeltaX.c_str(), 100, -10, 10);
+      me0_rh_PullY[region_num][layer_num] =
+          ibooker.book1D(histo_name_PullY.c_str(), histo_label_DeltaY.c_str(), 100, -10, 10);
     }
   }
 }
 
 ME0RecHitsValidation::~ME0RecHitsValidation() {}
 
-void ME0RecHitsValidation::analyze(const edm::Event &e,
-                                   const edm::EventSetup &iSetup) {
+void ME0RecHitsValidation::analyze(const edm::Event &e, const edm::EventSetup &iSetup) {
   edm::ESHandle<ME0Geometry> hGeom;
   iSetup.get<MuonGeometryRecord>().get(hGeom);
   const ME0Geometry *ME0Geometry_ = (&*hGeom);
@@ -87,13 +69,11 @@ void ME0RecHitsValidation::analyze(const edm::Event &e,
   e.getByToken(InputTagToken_RecHit, ME0RecHits);
 
   if (!ME0Hits.isValid() | !ME0RecHits.isValid()) {
-    edm::LogError("ME0RecHitsValidation")
-        << "Cannot get ME0Hits/ME0RecHits by Token simInputTagToken";
+    edm::LogError("ME0RecHitsValidation") << "Cannot get ME0Hits/ME0RecHits by Token simInputTagToken";
     return;
   }
 
   for (auto hits = ME0Hits->begin(); hits != ME0Hits->end(); hits++) {
-
     const ME0DetId id(hits->detUnitId());
     Int_t sh_region = id.region();
     Int_t sh_layer = id.layer();
@@ -109,9 +89,7 @@ void ME0RecHitsValidation::analyze(const edm::Event &e,
 
     const LocalPoint hitLP(hits->localPosition());
 
-    for (ME0RecHitCollection::const_iterator recHit = ME0RecHits->begin();
-         recHit != ME0RecHits->end(); ++recHit) {
-
+    for (ME0RecHitCollection::const_iterator recHit = ME0RecHits->begin(); recHit != ME0RecHits->end(); ++recHit) {
       Float_t x = recHit->localPosition().x();
       Float_t xErr = recHit->localPositionError().xx();
       Float_t y = recHit->localPosition().y();
@@ -130,8 +108,7 @@ void ME0RecHitsValidation::analyze(const edm::Event &e,
       Short_t roll = (Short_t)id.roll();
 
       LocalPoint rhLP = recHit->localPosition();
-      GlobalPoint rhGP =
-          ME0Geometry_->idToDet((*recHit).me0Id())->surface().toGlobal(rhLP);
+      GlobalPoint rhGP = ME0Geometry_->idToDet((*recHit).me0Id())->surface().toGlobal(rhLP);
 
       Float_t globalR = rhGP.perp();
       Float_t globalX = rhGP.x();
@@ -147,18 +124,14 @@ void ME0RecHitsValidation::analyze(const edm::Event &e,
         continue;
 
       std::vector<int> stripsFired;
-      for (int i = firstClusterStrip; i < (firstClusterStrip + clusterSize);
-           i++) {
-
+      for (int i = firstClusterStrip; i < (firstClusterStrip + clusterSize); i++) {
         stripsFired.push_back(i);
       }
 
-      const bool cond1(sh_region == region and sh_layer == layer and
-                       sh_station == station);
+      const bool cond1(sh_region == region and sh_layer == layer and sh_station == station);
       const bool cond2(sh_chamber == chamber and sh_roll == roll);
       const bool cond3(
-          (std::find(stripsFired.begin(), stripsFired.end(),
-                     (firstClusterStrip + 1)) != stripsFired.end()) or
+          (std::find(stripsFired.begin(), stripsFired.end(), (firstClusterStrip + 1)) != stripsFired.end()) or
           clusterSize == 0);
 
       int region_num = 0;
@@ -169,7 +142,6 @@ void ME0RecHitsValidation::analyze(const edm::Event &e,
       int layer_num = layer - 1;
 
       if (cond1 and cond2 and cond3) {
-
         me0_rh_xy[region_num][layer_num]->Fill(globalX, globalY);
         me0_rh_zr[region_num]->Fill(globalZ, globalR);
 

--- a/Validation/MuonME0Validation/src/ME0SegmentsValidation.cc
+++ b/Validation/MuonME0Validation/src/ME0SegmentsValidation.cc
@@ -2,16 +2,11 @@
 #include "Validation/MuonME0Validation/interface/ME0SegmentsValidation.h"
 #include <TMath.h>
 
-ME0SegmentsValidation::ME0SegmentsValidation(const edm::ParameterSet &cfg)
-    : ME0BaseValidation(cfg) {
-  InputTagToken_Segments = consumes<ME0SegmentCollection>(
-      cfg.getParameter<edm::InputTag>("segmentInputLabel"));
-  InputTagToken_Digis = consumes<ME0DigiPreRecoCollection>(
-      cfg.getParameter<edm::InputTag>("digiInputLabel"));
-  InputTagToken_ = consumes<edm::PSimHitContainer>(
-      cfg.getParameter<edm::InputTag>("simInputLabel"));
-  InputTagTokenST_ = consumes<edm::SimTrackContainer>(
-      cfg.getParameter<edm::InputTag>("simInputLabelST"));
+ME0SegmentsValidation::ME0SegmentsValidation(const edm::ParameterSet &cfg) : ME0BaseValidation(cfg) {
+  InputTagToken_Segments = consumes<ME0SegmentCollection>(cfg.getParameter<edm::InputTag>("segmentInputLabel"));
+  InputTagToken_Digis = consumes<ME0DigiPreRecoCollection>(cfg.getParameter<edm::InputTag>("digiInputLabel"));
+  InputTagToken_ = consumes<edm::PSimHitContainer>(cfg.getParameter<edm::InputTag>("simInputLabel"));
+  InputTagTokenST_ = consumes<edm::SimTrackContainer>(cfg.getParameter<edm::InputTag>("simInputLabelST"));
   sigma_x_ = cfg.getParameter<double>("sigma_x");
   sigma_y_ = cfg.getParameter<double>("sigma_y");
   eta_max_ = cfg.getParameter<double>("eta_max");
@@ -27,127 +22,93 @@ void ME0SegmentsValidation::bookHistograms(DQMStore::IBooker &ibooker,
   // iSetup.get<MuonGeometryRecord>().get(hGeom);
   // const ME0Geometry* ME0Geometry_ =( &*hGeom);
 
-  LogDebug("MuonME0SegmentsValidation")
-      << "Info : Loading Geometry information\n";
+  LogDebug("MuonME0SegmentsValidation") << "Info : Loading Geometry information\n";
   ibooker.setCurrentFolder("MuonME0RecHitsV/ME0SegmentsTask");
 
   unsigned int nregion = 2;
 
-  edm::LogInfo("MuonME0SegmentsValidation")
-      << "+++ Info : # of region : " << nregion << std::endl;
+  edm::LogInfo("MuonME0SegmentsValidation") << "+++ Info : # of region : " << nregion << std::endl;
 
-  LogDebug("MuonME0SegmentsValidation")
-      << "+++ Info : finish to get geometry information from ES.\n";
+  LogDebug("MuonME0SegmentsValidation") << "+++ Info : finish to get geometry information from ES.\n";
 
-  me0_simsegment_eta =
-      ibooker.book1D("me0_simsegment_eta",
-                     "SimSegment Eta Distribution; #eta; entries", 8, 2.0, 2.8);
-  me0_simsegment_pt = ibooker.book1D(
-      "me0_simsegment_pt", "SimSegment pT Distribution; p_{T}; entries", 20,
-      0.0, 100.0);
-  me0_simsegment_phi = ibooker.book1D(
-      "me0_simsegment_phi", "SimSegments phi Distribution; #phi; entries", 18,
-      -M_PI, +M_PI);
+  me0_simsegment_eta = ibooker.book1D("me0_simsegment_eta", "SimSegment Eta Distribution; #eta; entries", 8, 2.0, 2.8);
+  me0_simsegment_pt = ibooker.book1D("me0_simsegment_pt", "SimSegment pT Distribution; p_{T}; entries", 20, 0.0, 100.0);
+  me0_simsegment_phi =
+      ibooker.book1D("me0_simsegment_phi", "SimSegments phi Distribution; #phi; entries", 18, -M_PI, +M_PI);
 
-  me0_matchedsimsegment_eta = ibooker.book1D(
-      "me0_matchedsimsegment_eta",
-      "Matched SimSegment Eta Distribution; #eta; entries", 8, 2.0, 2.8);
-  me0_matchedsimsegment_pt = ibooker.book1D(
-      "me0_matchedsimsegment_pt",
-      "Matched SimSegment pT Distribution; p_{T}; entries", 20, 0.0, 100.0);
+  me0_matchedsimsegment_eta =
+      ibooker.book1D("me0_matchedsimsegment_eta", "Matched SimSegment Eta Distribution; #eta; entries", 8, 2.0, 2.8);
+  me0_matchedsimsegment_pt =
+      ibooker.book1D("me0_matchedsimsegment_pt", "Matched SimSegment pT Distribution; p_{T}; entries", 20, 0.0, 100.0);
   me0_matchedsimsegment_phi = ibooker.book1D(
-      "me0_matchedsimsegment_phi",
-      "Matched SimSegments phi Distribution; #phi; entries", 18, -M_PI, +M_PI);
+      "me0_matchedsimsegment_phi", "Matched SimSegments phi Distribution; #phi; entries", 18, -M_PI, +M_PI);
 
-  me0_segment_chi2 = ibooker.book1D(
-      "me0_seg_Chi2", "#chi^{2}; #chi^{2}; # Segments", 100, 0, 100);
-  me0_segment_redchi2 =
-      ibooker.book1D("me0_seg_ReducedChi2",
-                     "#chi^{2}/ndof; #chi^{2}/ndof; # Segments", 100, 0, 5);
-  me0_segment_ndof =
-      ibooker.book1D("me0_seg_ndof", "ndof; ndof; #Segments", 50, 0, 50);
-  me0_segment_numRH = ibooker.book1D(
-      "me0_seg_NumberRH", "Number of fitted RecHits; # RecHits; entries", 11,
-      -0.5, 10.5);
-  me0_segment_numRHSig = ibooker.book1D(
-      "me0_seg_NumberRHSig",
-      "Number of fitted Signal RecHits; # RecHits; entries", 11, -0.5, 10.5);
-  me0_segment_numRHBkg = ibooker.book1D(
-      "me0_seg_NumberRHBkg", "Number of fitted BKG RecHits; # RecHits; entries",
-      11, -0.5, 10.5);
+  me0_segment_chi2 = ibooker.book1D("me0_seg_Chi2", "#chi^{2}; #chi^{2}; # Segments", 100, 0, 100);
+  me0_segment_redchi2 = ibooker.book1D("me0_seg_ReducedChi2", "#chi^{2}/ndof; #chi^{2}/ndof; # Segments", 100, 0, 5);
+  me0_segment_ndof = ibooker.book1D("me0_seg_ndof", "ndof; ndof; #Segments", 50, 0, 50);
+  me0_segment_numRH =
+      ibooker.book1D("me0_seg_NumberRH", "Number of fitted RecHits; # RecHits; entries", 11, -0.5, 10.5);
+  me0_segment_numRHSig =
+      ibooker.book1D("me0_seg_NumberRHSig", "Number of fitted Signal RecHits; # RecHits; entries", 11, -0.5, 10.5);
+  me0_segment_numRHBkg =
+      ibooker.book1D("me0_seg_NumberRHBkg", "Number of fitted BKG RecHits; # RecHits; entries", 11, -0.5, 10.5);
   // me0_segment_EtaRH   = ibooker.book1D("me0_specRH_globalEta","Fitted RecHits
   // Eta Distribution; #eta; entries",200,-4.0,4.0); me0_segment_PhiRH   =
   // ibooker.book1D("me0_specRH_globalPhi","Fitted RecHits Phi Distribution;
   // #eta; entries",18,-3.14,3.14);
-  me0_segment_time = ibooker.book1D(
-      "me0_seg_time", "Segment Timing; ns; entries", 300, -150, 150);
-  me0_segment_timeErr = ibooker.book1D(
-      "me0_seg_timErr", "Segment Timing Error; ns; entries", 50, 0, 0.5);
-  me0_segment_size = ibooker.book1D(
-      "me0_seg_size", "Segment Multiplicity; Number of ME0 segments; entries",
-      200, 0, 200);
+  me0_segment_time = ibooker.book1D("me0_seg_time", "Segment Timing; ns; entries", 300, -150, 150);
+  me0_segment_timeErr = ibooker.book1D("me0_seg_timErr", "Segment Timing Error; ns; entries", 50, 0, 0.5);
+  me0_segment_size =
+      ibooker.book1D("me0_seg_size", "Segment Multiplicity; Number of ME0 segments; entries", 200, 0, 200);
 
   for (unsigned int region_num = 0; region_num < nregion; region_num++) {
-    me0_specRH_zr[region_num] =
-        BookHistZR(ibooker, "me0_specRH_tot", "Segment RecHits", region_num);
+    me0_specRH_zr[region_num] = BookHistZR(ibooker, "me0_specRH_tot", "Segment RecHits", region_num);
     for (unsigned int layer_num = 0; layer_num < 6; layer_num++) {
-
       // me0_strip_dg_zr[region_num][layer_num] =
       // BookHistZR(ibooker,"me0_strip_dg","SimHit",region_num,layer_num);
-      me0_specRH_xy[region_num][layer_num] = BookHistXY(
-          ibooker, "me0_specRH", "Segment RecHits", region_num, layer_num);
+      me0_specRH_xy[region_num][layer_num] =
+          BookHistXY(ibooker, "me0_specRH", "Segment RecHits", region_num, layer_num);
       // me0_rh_xy_Muon[region_num][layer_num] =
       // BookHistXY(ibooker,"me0_rh","RecHit Muon",region_num,layer_num);
 
-      std::string histo_name_DeltaX = std::string("me0_specRH_DeltaX_r") +
-                                      regionLabel[region_num] + "_l" +
-                                      layerLabel[layer_num];
-      std::string histo_name_DeltaY = std::string("me0_specRH_DeltaY_r") +
-                                      regionLabel[region_num] + "_l" +
-                                      layerLabel[layer_num];
-      std::string histo_label_DeltaX =
-          "Segment RecHits Delta X : region" + regionLabel[region_num] +
-          " layer " + layerLabel[layer_num] + " " +
-          " ; x_{SimHit} - x_{Segment RecHits} ; entries";
-      std::string histo_label_DeltaY =
-          "Segment RecHits Delta Y : region" + regionLabel[region_num] +
-          " layer " + layerLabel[layer_num] + " " +
-          " ; y_{SimHit} - y_{Segment RecHit} ; entries";
+      std::string histo_name_DeltaX =
+          std::string("me0_specRH_DeltaX_r") + regionLabel[region_num] + "_l" + layerLabel[layer_num];
+      std::string histo_name_DeltaY =
+          std::string("me0_specRH_DeltaY_r") + regionLabel[region_num] + "_l" + layerLabel[layer_num];
+      std::string histo_label_DeltaX = "Segment RecHits Delta X : region" + regionLabel[region_num] + " layer " +
+                                       layerLabel[layer_num] + " " + " ; x_{SimHit} - x_{Segment RecHits} ; entries";
+      std::string histo_label_DeltaY = "Segment RecHits Delta Y : region" + regionLabel[region_num] + " layer " +
+                                       layerLabel[layer_num] + " " + " ; y_{SimHit} - y_{Segment RecHit} ; entries";
 
-      me0_specRH_DeltaX[region_num][layer_num] = ibooker.book1D(
-          histo_name_DeltaX.c_str(), histo_label_DeltaX.c_str(), 100, -10, 10);
-      me0_specRH_DeltaY[region_num][layer_num] = ibooker.book1D(
-          histo_name_DeltaY.c_str(), histo_label_DeltaY.c_str(), 100, -10, 10);
+      me0_specRH_DeltaX[region_num][layer_num] =
+          ibooker.book1D(histo_name_DeltaX.c_str(), histo_label_DeltaX.c_str(), 100, -10, 10);
+      me0_specRH_DeltaY[region_num][layer_num] =
+          ibooker.book1D(histo_name_DeltaY.c_str(), histo_label_DeltaY.c_str(), 100, -10, 10);
 
-      std::string histo_name_PullX = std::string("me0_specRH_PullX_r") +
-                                     regionLabel[region_num] + "_l" +
-                                     layerLabel[layer_num];
-      std::string histo_name_PullY = std::string("me0_specRH_PullY_r") +
-                                     regionLabel[region_num] + "_l" +
-                                     layerLabel[layer_num];
-      std::string histo_label_PullX = "Segment RecHits Pull X : region" +
-                                      regionLabel[region_num] + " layer " +
+      std::string histo_name_PullX =
+          std::string("me0_specRH_PullX_r") + regionLabel[region_num] + "_l" + layerLabel[layer_num];
+      std::string histo_name_PullY =
+          std::string("me0_specRH_PullY_r") + regionLabel[region_num] + "_l" + layerLabel[layer_num];
+      std::string histo_label_PullX = "Segment RecHits Pull X : region" + regionLabel[region_num] + " layer " +
                                       layerLabel[layer_num] + " " +
                                       " ; #frac{x_{SimHit} - x_{Segment "
                                       "RecHit}}{#sigma_{x,RecHit}} ; entries";
-      std::string histo_label_PullY = "Segment RecHits Pull Y : region" +
-                                      regionLabel[region_num] + " layer " +
+      std::string histo_label_PullY = "Segment RecHits Pull Y : region" + regionLabel[region_num] + " layer " +
                                       layerLabel[layer_num] + " " +
                                       " ; #frac{y_{SimHit} - y_{Segment "
                                       "RecHit}}{#sigma_{y,RecHit}} ; entries";
 
-      me0_specRH_PullX[region_num][layer_num] = ibooker.book1D(
-          histo_name_PullX.c_str(), histo_label_DeltaX.c_str(), 100, -10, 10);
-      me0_specRH_PullY[region_num][layer_num] = ibooker.book1D(
-          histo_name_PullY.c_str(), histo_label_DeltaY.c_str(), 100, -10, 10);
+      me0_specRH_PullX[region_num][layer_num] =
+          ibooker.book1D(histo_name_PullX.c_str(), histo_label_DeltaX.c_str(), 100, -10, 10);
+      me0_specRH_PullY[region_num][layer_num] =
+          ibooker.book1D(histo_name_PullY.c_str(), histo_label_DeltaY.c_str(), 100, -10, 10);
     }
   }
 }
 
 ME0SegmentsValidation::~ME0SegmentsValidation() {}
 
-void ME0SegmentsValidation::analyze(const edm::Event &e,
-                                    const edm::EventSetup &iSetup) {
+void ME0SegmentsValidation::analyze(const edm::Event &e, const edm::EventSetup &iSetup) {
   edm::ESHandle<ME0Geometry> hGeom;
   iSetup.get<MuonGeometryRecord>().get(hGeom);
   const ME0Geometry *ME0Geometry_ = (&*hGeom);
@@ -165,20 +126,17 @@ void ME0SegmentsValidation::analyze(const edm::Event &e,
   e.getByToken(InputTagToken_Digis, ME0Digis);
 
   if (!ME0Digis.isValid()) {
-    edm::LogError("ME0SegmentsValidation")
-        << "Cannot get ME0Digis by Token InputTagToken";
+    edm::LogError("ME0SegmentsValidation") << "Cannot get ME0Digis by Token InputTagToken";
     return;
   }
 
   if (!ME0Segments.isValid()) {
-    edm::LogError("ME0SegmentsValidation")
-        << "Cannot get ME0RecHits/ME0Segments by Token InputTagToken";
+    edm::LogError("ME0SegmentsValidation") << "Cannot get ME0RecHits/ME0Segments by Token InputTagToken";
     return;
   }
 
   if (!ME0Hits.isValid()) {
-    edm::LogError("ME0HitsValidation")
-        << "Cannot get ME0Hits by Token simInputTagToken";
+    edm::LogError("ME0HitsValidation") << "Cannot get ME0Hits by Token simInputTagToken";
     return;
   }
 
@@ -188,37 +146,30 @@ void ME0SegmentsValidation::analyze(const edm::Event &e,
   int countST = 0;
 
   edm::SimTrackContainer::const_iterator simTrack;
-  for (simTrack = simTracks->begin(); simTrack != simTracks->end();
-       ++simTrack) {
-
+  for (simTrack = simTracks->begin(); simTrack != simTracks->end(); ++simTrack) {
     edm::PSimHitContainer selectedME0Hits;
 
     if (!isSimTrackGood(simTrack))
       continue;
     int count = 0;
 
-    for (edm::PSimHitContainer::const_iterator itHit = ME0Hits->begin();
-         itHit != ME0Hits->end(); ++itHit) {
-
+    for (edm::PSimHitContainer::const_iterator itHit = ME0Hits->begin(); itHit != ME0Hits->end(); ++itHit) {
       int particleType_sh = itHit->particleType();
       int evtId_sh = itHit->eventId().event();
       int bx_sh = itHit->eventId().bunchCrossing();
       int procType_sh = itHit->processType();
-      if (!(abs(particleType_sh) == 13 && evtId_sh == 0 && bx_sh == 0 &&
-            procType_sh == 0))
+      if (!(abs(particleType_sh) == 13 && evtId_sh == 0 && bx_sh == 0 && procType_sh == 0))
         continue;
 
       if (isSimMatched(simTrack, itHit)) {
-
         ++count;
         selectedME0Hits.push_back(*itHit);
         ;
       }
 
-    } // End loop SHs
+    }  // End loop SHs
 
     if (selectedME0Hits.size() >= 3) {
-
       myMap.insert(MapTypeSim::value_type(simTrack, selectedME0Hits));
       me0_simsegment_eta->Fill(std::abs((*simTrack).momentum().eta()));
       me0_simsegment_pt->Fill((*simTrack).momentum().pt());
@@ -230,7 +181,6 @@ void ME0SegmentsValidation::analyze(const edm::Event &e,
   me0_segment_size->Fill(ME0Segments->size());
 
   for (auto me0s = ME0Segments->begin(); me0s != ME0Segments->end(); me0s++) {
-
     // The ME0 Ensamble DetId refers to layer = 1
     ME0DetId id = me0s->me0DetId();
     auto chamber = ME0Geometry_->chamber(id);
@@ -263,14 +213,12 @@ void ME0SegmentsValidation::analyze(const edm::Event &e,
     std::vector<ME0RecHit> selectedME0RecHits;
 
     for (auto rh = me0rhs.begin(); rh != me0rhs.end(); rh++) {
-
       auto me0id = rh->me0Id();
       auto rhr = ME0Geometry_->etaPartition(me0id);
       auto rhLP = rh->localPosition();
 
       auto result = isMatched(me0id, rhLP, ME0Digis);
       if (result.second == 1) {
-
         ++numberRHSig;
         selectedME0RecHits.push_back(*rh);
 
@@ -283,9 +231,8 @@ void ME0SegmentsValidation::analyze(const edm::Event &e,
       float xe = segLP.x() + segLD.x() * rhLPSegm.z() / segLD.z();
       float ye = segLP.y() + segLD.y() * rhLPSegm.z() / segLD.z();
       float ze = rhLPSegm.z();
-      LocalPoint extrPoint(xe, ye, ze); // in segment rest frame
-      auto extSegm =
-          rhr->toLocal(chamber->toGlobal(extrPoint)); // in layer restframe
+      LocalPoint extrPoint(xe, ye, ze);                           // in segment rest frame
+      auto extSegm = rhr->toLocal(chamber->toGlobal(extrPoint));  // in layer restframe
 
       int region = me0id.region();
       int layer = me0id.layer();
@@ -330,23 +277,22 @@ void ME0SegmentsValidation::analyze(const edm::Event &e,
 
   //------------------- SimToReco -------------------
 
-  for (auto const &st : myMap) { // loop over the signal simTracks
+  for (auto const &st : myMap) {  // loop over the signal simTracks
 
     int num_sh = st.second.size();
     bool isThereOneSegmentMatched = false;
 
-    for (auto const &seg :
-         myMapSeg) { // loop over the reconstructed me0 segments
+    for (auto const &seg : myMapSeg) {  // loop over the reconstructed me0 segments
 
       int num_sh_matched = 0;
       if (seg.second.empty())
         continue;
 
-      for (auto const &sh : st.second) { // loop over the me0 simHits left by
-                                         // the signal simTracks
+      for (auto const &sh : st.second) {  // loop over the me0 simHits left by
+                                          // the signal simTracks
 
-        for (auto const &rh : seg.second) { // loop over the tracking recHits
-                                            // already matched to signal digis
+        for (auto const &rh : seg.second) {  // loop over the tracking recHits
+                                             // already matched to signal digis
 
           auto me0id = rh.me0Id();
           int region_rh = (int)me0id.region();
@@ -360,26 +306,23 @@ void ME0SegmentsValidation::analyze(const edm::Event &e,
           int chamber_sh = id.chamber();
           int roll_sh = id.roll();
 
-          if (!(region_sh == region_rh && chamber_sh == chamber_rh &&
-                layer_sh == layer_rh && roll_sh == roll_rh))
+          if (!(region_sh == region_rh && chamber_sh == chamber_rh && layer_sh == layer_rh && roll_sh == roll_rh))
             continue;
 
           LocalPoint lp_sh = sh.localPosition();
           LocalPoint lp_rh = rh.localPosition();
 
-          GlobalPoint gp_sh =
-              ME0Geometry_->idToDet(id)->surface().toGlobal(lp_sh);
-          GlobalPoint gp =
-              ME0Geometry_->idToDet((rh).me0Id())->surface().toGlobal(lp_rh);
+          GlobalPoint gp_sh = ME0Geometry_->idToDet(id)->surface().toGlobal(lp_sh);
+          GlobalPoint gp = ME0Geometry_->idToDet((rh).me0Id())->surface().toGlobal(lp_rh);
           float dphi_glob = gp_sh.phi() - gp.phi();
           float deta_glob = gp_sh.eta() - gp.eta();
 
           if (fabs(dphi_glob) < 3 * sigma_x_ && fabs(deta_glob) < 3 * sigma_y_)
             ++num_sh_matched;
 
-        } // End loop over RHs
+        }  // End loop over RHs
 
-      } // End loop over SHs
+      }  // End loop over SHs
 
       float quality = 0;
       if (num_sh != 0)
@@ -387,22 +330,21 @@ void ME0SegmentsValidation::analyze(const edm::Event &e,
       if (quality > 0)
         isThereOneSegmentMatched = true;
 
-    } // End loop over segments
+    }  // End loop over segments
 
     // Fill hsitograms
     if (isThereOneSegmentMatched) {
-
       me0_matchedsimsegment_eta->Fill(std::abs((*(st.first)).momentum().eta()));
       me0_matchedsimsegment_pt->Fill((*(st.first)).momentum().pt());
       me0_matchedsimsegment_phi->Fill((*(st.first)).momentum().phi());
     }
 
-  } // End loop over STs
+  }  // End loop over STs
 }
 
-std::pair<int, int> ME0SegmentsValidation::isMatched(
-    ME0DetId me0id, LocalPoint rhLP,
-    edm::Handle<ME0DigiPreRecoCollection> ME0Digis) {
+std::pair<int, int> ME0SegmentsValidation::isMatched(ME0DetId me0id,
+                                                     LocalPoint rhLP,
+                                                     edm::Handle<ME0DigiPreRecoCollection> ME0Digis) {
   int region_rh = (int)me0id.region();
   int layer_rh = (int)me0id.layer();
   int roll_rh = (int)me0id.roll();
@@ -414,9 +356,7 @@ std::pair<int, int> ME0SegmentsValidation::isMatched(
   int particleType = 0;
   int isPrompt = -1;
 
-  for (ME0DigiPreRecoCollection::DigiRangeIterator cItr = ME0Digis->begin();
-       cItr != ME0Digis->end(); cItr++) {
-
+  for (ME0DigiPreRecoCollection::DigiRangeIterator cItr = ME0Digis->begin(); cItr != ME0Digis->end(); cItr++) {
     ME0DetId id = (*cItr).first;
 
     int region_dg = (int)id.region();
@@ -434,9 +374,7 @@ std::pair<int, int> ME0SegmentsValidation::isMatched(
       continue;
 
     ME0DigiPreRecoCollection::const_iterator digiItr;
-    for (digiItr = (*cItr).second.first; digiItr != (*cItr).second.second;
-         ++digiItr) {
-
+    for (digiItr = (*cItr).second.first; digiItr != (*cItr).second.second; ++digiItr) {
       float l_x_dg = digiItr->x();
       float l_y_dg = digiItr->y();
 
@@ -456,27 +394,23 @@ std::pair<int, int> ME0SegmentsValidation::isMatched(
   return result;
 }
 
-bool ME0SegmentsValidation::isSimTrackGood(
-    edm::SimTrackContainer::const_iterator t) {
-
+bool ME0SegmentsValidation::isSimTrackGood(edm::SimTrackContainer::const_iterator t) {
   if ((*t).noVertex() && !isMuonGun_)
     return false;
   if ((*t).noGenpart() && !isMuonGun_)
     return false;
   if (std::abs((*t).type()) != 13)
-    return false; // only interested in direct muon simtracks
+    return false;  // only interested in direct muon simtracks
   if ((*t).momentum().pt() < pt_min_)
     return false;
   const float eta(std::abs((*t).momentum().eta()));
   if (eta < eta_min_ || eta > eta_max_)
-    return false; // no GEMs could be in such eta
+    return false;  // no GEMs could be in such eta
   return true;
 }
 
-bool ME0SegmentsValidation::isSimMatched(
-    edm::SimTrackContainer::const_iterator simTrack,
-    edm::PSimHitContainer::const_iterator itHit) {
-
+bool ME0SegmentsValidation::isSimMatched(edm::SimTrackContainer::const_iterator simTrack,
+                                         edm::PSimHitContainer::const_iterator itHit) {
   bool result = false;
   int trackId = simTrack->trackId();
   int trackId_sim = itHit->trackId();

--- a/Validation/RPCRecHits/interface/RPCPointVsRecHit.h
+++ b/Validation/RPCRecHits/interface/RPCPointVsRecHit.h
@@ -21,10 +21,8 @@ public:
   RPCPointVsRecHit(const edm::ParameterSet &pset);
   ~RPCPointVsRecHit() override{};
 
-  void analyze(const edm::Event &event,
-               const edm::EventSetup &eventSetup) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void analyze(const edm::Event &event, const edm::EventSetup &eventSetup) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:
   edm::EDGetTokenT<RPCRecHitCollection> refHitToken_, recHitToken_;
@@ -33,4 +31,4 @@ private:
   RPCValidHistograms h_;
 };
 
-#endif // Validation_RPCRecHits_RPCPointVsRecHit_h
+#endif  // Validation_RPCRecHits_RPCPointVsRecHit_h

--- a/Validation/RPCRecHits/interface/RPCRecHitValid.h
+++ b/Validation/RPCRecHits/interface/RPCRecHitValid.h
@@ -26,10 +26,8 @@ public:
   RPCRecHitValid(const edm::ParameterSet &pset);
   ~RPCRecHitValid() override{};
 
-  void analyze(const edm::Event &event,
-               const edm::EventSetup &eventSetup) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void analyze(const edm::Event &event, const edm::EventSetup &eventSetup) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:
   typedef edm::PSimHitContainer SimHits;
@@ -49,32 +47,20 @@ private:
 
   MEP h_eventCount;
 
-  MEP h_nRPCHitPerSimMuon, h_nRPCHitPerSimMuonBarrel,
-      h_nRPCHitPerSimMuonOverlap, h_nRPCHitPerSimMuonEndcap;
-  MEP h_nRPCHitPerRecoMuon, h_nRPCHitPerRecoMuonBarrel,
-      h_nRPCHitPerRecoMuonOverlap, h_nRPCHitPerRecoMuonEndcap;
-  MEP h_simMuonBarrel_pt, h_simMuonOverlap_pt, h_simMuonEndcap_pt,
-      h_simMuonNoRPC_pt;
-  MEP h_simMuonBarrel_eta, h_simMuonOverlap_eta, h_simMuonEndcap_eta,
-      h_simMuonNoRPC_eta;
-  MEP h_simMuonBarrel_phi, h_simMuonOverlap_phi, h_simMuonEndcap_phi,
-      h_simMuonNoRPC_phi;
-  MEP h_recoMuonBarrel_pt, h_recoMuonOverlap_pt, h_recoMuonEndcap_pt,
-      h_recoMuonNoRPC_pt;
-  MEP h_recoMuonBarrel_eta, h_recoMuonOverlap_eta, h_recoMuonEndcap_eta,
-      h_recoMuonNoRPC_eta;
-  MEP h_recoMuonBarrel_phi, h_recoMuonOverlap_phi, h_recoMuonEndcap_phi,
-      h_recoMuonNoRPC_phi;
+  MEP h_nRPCHitPerSimMuon, h_nRPCHitPerSimMuonBarrel, h_nRPCHitPerSimMuonOverlap, h_nRPCHitPerSimMuonEndcap;
+  MEP h_nRPCHitPerRecoMuon, h_nRPCHitPerRecoMuonBarrel, h_nRPCHitPerRecoMuonOverlap, h_nRPCHitPerRecoMuonEndcap;
+  MEP h_simMuonBarrel_pt, h_simMuonOverlap_pt, h_simMuonEndcap_pt, h_simMuonNoRPC_pt;
+  MEP h_simMuonBarrel_eta, h_simMuonOverlap_eta, h_simMuonEndcap_eta, h_simMuonNoRPC_eta;
+  MEP h_simMuonBarrel_phi, h_simMuonOverlap_phi, h_simMuonEndcap_phi, h_simMuonNoRPC_phi;
+  MEP h_recoMuonBarrel_pt, h_recoMuonOverlap_pt, h_recoMuonEndcap_pt, h_recoMuonNoRPC_pt;
+  MEP h_recoMuonBarrel_eta, h_recoMuonOverlap_eta, h_recoMuonEndcap_eta, h_recoMuonNoRPC_eta;
+  MEP h_recoMuonBarrel_phi, h_recoMuonOverlap_phi, h_recoMuonEndcap_phi, h_recoMuonNoRPC_phi;
   MEP h_simParticleType, h_simParticleTypeBarrel, h_simParticleTypeEndcap;
 
-  MEP h_refPunchOccupancyBarrel_wheel, h_refPunchOccupancyEndcap_disk,
-      h_refPunchOccupancyBarrel_station;
-  MEP h_refPunchOccupancyBarrel_wheel_station,
-      h_refPunchOccupancyEndcap_disk_ring;
-  MEP h_recPunchOccupancyBarrel_wheel, h_recPunchOccupancyEndcap_disk,
-      h_recPunchOccupancyBarrel_station;
-  MEP h_recPunchOccupancyBarrel_wheel_station,
-      h_recPunchOccupancyEndcap_disk_ring;
+  MEP h_refPunchOccupancyBarrel_wheel, h_refPunchOccupancyEndcap_disk, h_refPunchOccupancyBarrel_station;
+  MEP h_refPunchOccupancyBarrel_wheel_station, h_refPunchOccupancyEndcap_disk_ring;
+  MEP h_recPunchOccupancyBarrel_wheel, h_recPunchOccupancyEndcap_disk, h_recPunchOccupancyBarrel_station;
+  MEP h_recPunchOccupancyBarrel_wheel_station, h_recPunchOccupancyEndcap_disk_ring;
 
   MEP h_matchOccupancyBarrel_detId;
   MEP h_matchOccupancyEndcap_detId;
@@ -88,4 +74,4 @@ private:
   std::map<int, int> detIdToIndexMapBarrel_, detIdToIndexMapEndcap_;
 };
 
-#endif // Validation_RPCRecHits_RPCRecHitValid_h
+#endif  // Validation_RPCRecHits_RPCRecHitValid_h

--- a/Validation/RPCRecHits/interface/RPCRecHitValidClient.h
+++ b/Validation/RPCRecHits/interface/RPCRecHitValidClient.h
@@ -26,4 +26,4 @@ private:
   std::string subDir_;
 };
 
-#endif // Validation_RPCRecHits_RPCRecHitValidClient_h
+#endif  // Validation_RPCRecHits_RPCRecHitValidClient_h

--- a/Validation/RPCRecHits/interface/RPCValidHistograms.h
+++ b/Validation/RPCRecHits/interface/RPCValidHistograms.h
@@ -27,12 +27,9 @@ struct RPCValidHistograms {
   MEP timeBarrel, timeEndcap, timeIRPC, timeCRPC;
 
   // Occupancy 1D
-  MEP refHitOccupancyBarrel_wheel, refHitOccupancyEndcap_disk,
-      refHitOccupancyBarrel_station;
-  MEP recHitOccupancyBarrel_wheel, recHitOccupancyEndcap_disk,
-      recHitOccupancyBarrel_station;
-  MEP matchOccupancyBarrel_wheel, matchOccupancyEndcap_disk,
-      matchOccupancyBarrel_station;
+  MEP refHitOccupancyBarrel_wheel, refHitOccupancyEndcap_disk, refHitOccupancyBarrel_station;
+  MEP recHitOccupancyBarrel_wheel, recHitOccupancyEndcap_disk, recHitOccupancyBarrel_station;
+  MEP matchOccupancyBarrel_wheel, matchOccupancyEndcap_disk, matchOccupancyBarrel_station;
 
   // Occupancy 2D
   MEP refHitOccupancyBarrel_wheel_station, refHitOccupancyEndcap_disk_ring;

--- a/Validation/RPCRecHits/src/RPCPointVsRecHit.cc
+++ b/Validation/RPCRecHits/src/RPCPointVsRecHit.cc
@@ -13,16 +13,13 @@ using namespace std;
 typedef MonitorElement *MEP;
 
 RPCPointVsRecHit::RPCPointVsRecHit(const edm::ParameterSet &pset) {
-  refHitToken_ =
-      consumes<RPCRecHitCollection>(pset.getParameter<edm::InputTag>("refHit"));
-  recHitToken_ =
-      consumes<RPCRecHitCollection>(pset.getParameter<edm::InputTag>("recHit"));
+  refHitToken_ = consumes<RPCRecHitCollection>(pset.getParameter<edm::InputTag>("refHit"));
+  recHitToken_ = consumes<RPCRecHitCollection>(pset.getParameter<edm::InputTag>("recHit"));
 
   subDir_ = pset.getParameter<std::string>("subDir");
 }
 
-void RPCPointVsRecHit::analyze(const edm::Event &event,
-                               const edm::EventSetup &eventSetup) {
+void RPCPointVsRecHit::analyze(const edm::Event &event, const edm::EventSetup &eventSetup) {
   // Get the RPC Geometry
   edm::ESHandle<RPCGeometry> rpcGeom;
   eventSetup.get<MuonGeometryRecord>().get(rpcGeom);
@@ -30,8 +27,7 @@ void RPCPointVsRecHit::analyze(const edm::Event &event,
   // Retrieve RefHits from the event
   edm::Handle<RPCRecHitCollection> refHitHandle;
   if (!event.getByToken(refHitToken_, refHitHandle)) {
-    edm::LogInfo("RPCPointVsRecHit")
-        << "Cannot find reference hit collection\n";
+    edm::LogInfo("RPCPointVsRecHit") << "Cannot find reference hit collection\n";
     return;
   }
 
@@ -46,8 +42,7 @@ void RPCPointVsRecHit::analyze(const edm::Event &event,
 
   // Loop over refHits, fill histograms which does not need associations
   int nRefHitBarrel = 0, nRefHitEndcap = 0;
-  for (RecHitIter refHitIter = refHitHandle->begin();
-       refHitIter != refHitHandle->end(); ++refHitIter) {
+  for (RecHitIter refHitIter = refHitHandle->begin(); refHitIter != refHitHandle->end(); ++refHitIter) {
     const RPCDetId detId = static_cast<const RPCDetId>(refHitIter->rpcId());
     const RPCRoll *roll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(detId()));
     if (!roll)
@@ -75,8 +70,7 @@ void RPCPointVsRecHit::analyze(const edm::Event &event,
   // Loop over recHits, fill histograms which does not need associations
   int sumClusterSizeBarrel = 0, sumClusterSizeEndcap = 0;
   int nRecHitBarrel = 0, nRecHitEndcap = 0;
-  for (RecHitIter recHitIter = recHitHandle->begin();
-       recHitIter != recHitHandle->end(); ++recHitIter) {
+  for (RecHitIter recHitIter = recHitHandle->begin(); recHitIter != recHitHandle->end(); ++recHitIter) {
     const RPCDetId detId = static_cast<const RPCDetId>(recHitIter->rpcId());
     const RPCRoll *roll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(detId()));
     if (!roll)
@@ -114,12 +108,10 @@ void RPCPointVsRecHit::analyze(const edm::Event &event,
     h_.avgClusterSize->Fill(double(sumClusterSize) / nRecHit);
 
     if (nRecHitBarrel > 0) {
-      h_.avgClusterSizeBarrel->Fill(double(sumClusterSizeBarrel) /
-                                    nRecHitBarrel);
+      h_.avgClusterSizeBarrel->Fill(double(sumClusterSizeBarrel) / nRecHitBarrel);
     }
     if (nRecHitEndcap > 0) {
-      h_.avgClusterSizeEndcap->Fill(double(sumClusterSizeEndcap) /
-                                    nRecHitEndcap);
+      h_.avgClusterSizeEndcap->Fill(double(sumClusterSizeEndcap) / nRecHitEndcap);
     }
   }
 
@@ -127,22 +119,17 @@ void RPCPointVsRecHit::analyze(const edm::Event &event,
   typedef std::map<RecHitIter, RecHitIter> RecToRecHitMap;
   RecToRecHitMap refToRecHitMap;
 
-  for (RecHitIter refHitIter = refHitHandle->begin();
-       refHitIter != refHitHandle->end(); ++refHitIter) {
+  for (RecHitIter refHitIter = refHitHandle->begin(); refHitIter != refHitHandle->end(); ++refHitIter) {
     const RPCDetId refDetId = static_cast<const RPCDetId>(refHitIter->rpcId());
-    const RPCRoll *refRoll =
-        dynamic_cast<const RPCRoll *>(rpcGeom->roll(refDetId));
+    const RPCRoll *refRoll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(refDetId));
     if (!refRoll)
       continue;
 
     const double refX = refHitIter->localPosition().x();
 
-    for (RecHitIter recHitIter = recHitHandle->begin();
-         recHitIter != recHitHandle->end(); ++recHitIter) {
-      const RPCDetId recDetId =
-          static_cast<const RPCDetId>(recHitIter->rpcId());
-      const RPCRoll *recRoll =
-          dynamic_cast<const RPCRoll *>(rpcGeom->roll(recDetId));
+    for (RecHitIter recHitIter = recHitHandle->begin(); recHitIter != recHitHandle->end(); ++recHitIter) {
+      const RPCDetId recDetId = static_cast<const RPCDetId>(recHitIter->rpcId());
+      const RPCRoll *recRoll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(recDetId));
       if (!recRoll)
         continue;
 
@@ -153,13 +140,11 @@ void RPCPointVsRecHit::analyze(const edm::Event &event,
       const double newDx = fabs(recX - refX);
 
       // Associate RefHit to RecHit
-      RecToRecHitMap::const_iterator prevRefToReco =
-          refToRecHitMap.find(refHitIter);
+      RecToRecHitMap::const_iterator prevRefToReco = refToRecHitMap.find(refHitIter);
       if (prevRefToReco == refToRecHitMap.end()) {
         refToRecHitMap.insert(std::make_pair(refHitIter, recHitIter));
       } else {
-        const double oldDx =
-            fabs(prevRefToReco->second->localPosition().x() - refX);
+        const double oldDx = fabs(prevRefToReco->second->localPosition().x() - refX);
 
         if (newDx < oldDx) {
           refToRecHitMap[refHitIter] = recHitIter;
@@ -170,8 +155,7 @@ void RPCPointVsRecHit::analyze(const edm::Event &event,
 
   // Now we have refHit-recHit mapping
   // So we can fill up relavant histograms
-  for (RecToRecHitMap::const_iterator match = refToRecHitMap.begin();
-       match != refToRecHitMap.end(); ++match) {
+  for (RecToRecHitMap::const_iterator match = refToRecHitMap.begin(); match != refToRecHitMap.end(); ++match) {
     RecHitIter refHitIter = match->first;
     RecHitIter recHitIter = match->second;
 

--- a/Validation/RPCRecHits/src/RPCRecHitValid.cc
+++ b/Validation/RPCRecHits/src/RPCRecHitValid.cc
@@ -26,26 +26,20 @@ typedef MonitorElement *MEP;
 RPCRecHitValid::RPCRecHitValid(const edm::ParameterSet &pset) {
   simHitToken_ = consumes<SimHits>(pset.getParameter<edm::InputTag>("simHit"));
   recHitToken_ = consumes<RecHits>(pset.getParameter<edm::InputTag>("recHit"));
-  simParticleToken_ =
-      consumes<SimParticles>(pset.getParameter<edm::InputTag>("simTrack"));
-  simHitAssocToken_ =
-      consumes<SimHitAssoc>(pset.getParameter<edm::InputTag>("simHitAssoc"));
-  muonToken_ =
-      consumes<reco::MuonCollection>(pset.getParameter<edm::InputTag>("muon"));
+  simParticleToken_ = consumes<SimParticles>(pset.getParameter<edm::InputTag>("simTrack"));
+  simHitAssocToken_ = consumes<SimHitAssoc>(pset.getParameter<edm::InputTag>("simHitAssoc"));
+  muonToken_ = consumes<reco::MuonCollection>(pset.getParameter<edm::InputTag>("muon"));
 
   subDir_ = pset.getParameter<std::string>("subDir");
 }
 
-void RPCRecHitValid::bookHistograms(DQMStore::IBooker &booker,
-                                    edm::Run const &run,
-                                    edm::EventSetup const &eventSetup) {
+void RPCRecHitValid::bookHistograms(DQMStore::IBooker &booker, edm::Run const &run, edm::EventSetup const &eventSetup) {
   // Book MonitorElements
   h_.bookHistograms(booker, subDir_);
 
   // SimHit plots, not compatible to RPCPoint-RPCRecHit comparison
   booker.setCurrentFolder(subDir_ + "/HitProperty");
-  h_simParticleType =
-      booker.book1D("SimHitPType", "SimHit particle type", 11, 0, 11);
+  h_simParticleType = booker.book1D("SimHitPType", "SimHit particle type", 11, 0, 11);
   h_simParticleType->getTH1()->SetMinimum(0);
   if (TH1 *h = h_simParticleType->getTH1()) {
     h->GetXaxis()->SetBinLabel(1, "#mu^{-}");
@@ -63,30 +57,21 @@ void RPCRecHitValid::bookHistograms(DQMStore::IBooker &booker,
 
   booker.setCurrentFolder(subDir_ + "/Track");
 
-  h_nRPCHitPerSimMuon = booker.book1D(
-      "NRPCHitPerSimMuon", "Number of RPC SimHit per SimMuon", 11, -0.5, 10.5);
+  h_nRPCHitPerSimMuon = booker.book1D("NRPCHitPerSimMuon", "Number of RPC SimHit per SimMuon", 11, -0.5, 10.5);
   h_nRPCHitPerSimMuonBarrel =
-      booker.book1D("NRPCHitPerSimMuonBarrel",
-                    "Number of RPC SimHit per SimMuon", 11, -0.5, 10.5);
+      booker.book1D("NRPCHitPerSimMuonBarrel", "Number of RPC SimHit per SimMuon", 11, -0.5, 10.5);
   h_nRPCHitPerSimMuonOverlap =
-      booker.book1D("NRPCHitPerSimMuonOverlap",
-                    "Number of RPC SimHit per SimMuon", 11, -0.5, 10.5);
+      booker.book1D("NRPCHitPerSimMuonOverlap", "Number of RPC SimHit per SimMuon", 11, -0.5, 10.5);
   h_nRPCHitPerSimMuonEndcap =
-      booker.book1D("NRPCHitPerSimMuonEndcap",
-                    "Number of RPC SimHit per SimMuon", 11, -0.5, 10.5);
+      booker.book1D("NRPCHitPerSimMuonEndcap", "Number of RPC SimHit per SimMuon", 11, -0.5, 10.5);
 
-  h_nRPCHitPerRecoMuon =
-      booker.book1D("NRPCHitPerRecoMuon", "Number of RPC RecHit per RecoMuon",
-                    11, -0.5, 10.5);
+  h_nRPCHitPerRecoMuon = booker.book1D("NRPCHitPerRecoMuon", "Number of RPC RecHit per RecoMuon", 11, -0.5, 10.5);
   h_nRPCHitPerRecoMuonBarrel =
-      booker.book1D("NRPCHitPerRecoMuonBarrel",
-                    "Number of RPC RecHit per RecoMuon", 11, -0.5, 10.5);
+      booker.book1D("NRPCHitPerRecoMuonBarrel", "Number of RPC RecHit per RecoMuon", 11, -0.5, 10.5);
   h_nRPCHitPerRecoMuonOverlap =
-      booker.book1D("NRPCHitPerRecoMuonOverlap",
-                    "Number of RPC RecHit per RecoMuon", 11, -0.5, 10.5);
+      booker.book1D("NRPCHitPerRecoMuonOverlap", "Number of RPC RecHit per RecoMuon", 11, -0.5, 10.5);
   h_nRPCHitPerRecoMuonEndcap =
-      booker.book1D("NRPCHitPerRecoMuonEndcap",
-                    "Number of RPC RecHit per RecoMuon", 11, -0.5, 10.5);
+      booker.book1D("NRPCHitPerRecoMuonEndcap", "Number of RPC RecHit per RecoMuon", 11, -0.5, 10.5);
 
   h_nRPCHitPerSimMuon->getTH1()->SetMinimum(0);
   h_nRPCHitPerSimMuonBarrel->getTH1()->SetMinimum(0);
@@ -100,77 +85,47 @@ void RPCRecHitValid::bookHistograms(DQMStore::IBooker &booker,
 
   float ptBins[] = {0, 1, 2, 5, 10, 20, 30, 50, 100, 200, 300, 500};
   const int nPtBins = sizeof(ptBins) / sizeof(float) - 1;
-  h_simMuonBarrel_pt = booker.book1D(
-      "SimMuonBarrel_pt", "SimMuon RPCHit in Barrel  p_{T};p_{T} [GeV/c^{2}]",
-      nPtBins, ptBins);
-  h_simMuonOverlap_pt = booker.book1D(
-      "SimMuonOverlap_pt", "SimMuon RPCHit in Overlap p_{T};p_{T} [GeV/c^{2}]",
-      nPtBins, ptBins);
-  h_simMuonEndcap_pt = booker.book1D(
-      "SimMuonEndcap_pt", "SimMuon RPCHit in Endcap  p_{T};p_{T} [GeV/c^{2}]",
-      nPtBins, ptBins);
-  h_simMuonNoRPC_pt = booker.book1D(
-      "SimMuonNoRPC_pt", "SimMuon without RPCHit p_{T};p_{T} [GeV/c^{2}]",
-      nPtBins, ptBins);
-  h_simMuonBarrel_eta =
-      booker.book1D("SimMuonBarrel_eta", "SimMuon RPCHit in Barrel  #eta;#eta",
-                    50, -2.5, 2.5);
-  h_simMuonOverlap_eta =
-      booker.book1D("SimMuonOverlap_eta", "SimMuon RPCHit in Overlap #eta;#eta",
-                    50, -2.5, 2.5);
-  h_simMuonEndcap_eta =
-      booker.book1D("SimMuonEndcap_eta", "SimMuon RPCHit in Endcap  #eta;#eta",
-                    50, -2.5, 2.5);
-  h_simMuonNoRPC_eta = booker.book1D(
-      "SimMuonNoRPC_eta", "SimMuon without RPCHit #eta;#eta", 50, -2.5, 2.5);
+  h_simMuonBarrel_pt =
+      booker.book1D("SimMuonBarrel_pt", "SimMuon RPCHit in Barrel  p_{T};p_{T} [GeV/c^{2}]", nPtBins, ptBins);
+  h_simMuonOverlap_pt =
+      booker.book1D("SimMuonOverlap_pt", "SimMuon RPCHit in Overlap p_{T};p_{T} [GeV/c^{2}]", nPtBins, ptBins);
+  h_simMuonEndcap_pt =
+      booker.book1D("SimMuonEndcap_pt", "SimMuon RPCHit in Endcap  p_{T};p_{T} [GeV/c^{2}]", nPtBins, ptBins);
+  h_simMuonNoRPC_pt =
+      booker.book1D("SimMuonNoRPC_pt", "SimMuon without RPCHit p_{T};p_{T} [GeV/c^{2}]", nPtBins, ptBins);
+  h_simMuonBarrel_eta = booker.book1D("SimMuonBarrel_eta", "SimMuon RPCHit in Barrel  #eta;#eta", 50, -2.5, 2.5);
+  h_simMuonOverlap_eta = booker.book1D("SimMuonOverlap_eta", "SimMuon RPCHit in Overlap #eta;#eta", 50, -2.5, 2.5);
+  h_simMuonEndcap_eta = booker.book1D("SimMuonEndcap_eta", "SimMuon RPCHit in Endcap  #eta;#eta", 50, -2.5, 2.5);
+  h_simMuonNoRPC_eta = booker.book1D("SimMuonNoRPC_eta", "SimMuon without RPCHit #eta;#eta", 50, -2.5, 2.5);
   h_simMuonBarrel_phi =
-      booker.book1D("SimMuonBarrel_phi", "SimMuon RPCHit in Barrel  #phi;#phi",
-                    36, -TMath::Pi(), TMath::Pi());
+      booker.book1D("SimMuonBarrel_phi", "SimMuon RPCHit in Barrel  #phi;#phi", 36, -TMath::Pi(), TMath::Pi());
   h_simMuonOverlap_phi =
-      booker.book1D("SimMuonOverlap_phi", "SimMuon RPCHit in Overlap #phi;#phi",
-                    36, -TMath::Pi(), TMath::Pi());
+      booker.book1D("SimMuonOverlap_phi", "SimMuon RPCHit in Overlap #phi;#phi", 36, -TMath::Pi(), TMath::Pi());
   h_simMuonEndcap_phi =
-      booker.book1D("SimMuonEndcap_phi", "SimMuon RPCHit in Endcap  #phi;#phi",
-                    36, -TMath::Pi(), TMath::Pi());
+      booker.book1D("SimMuonEndcap_phi", "SimMuon RPCHit in Endcap  #phi;#phi", 36, -TMath::Pi(), TMath::Pi());
   h_simMuonNoRPC_phi =
-      booker.book1D("SimMuonNoRPC_phi", "SimMuon without RPCHit #phi;#phi", 36,
-                    -TMath::Pi(), TMath::Pi());
+      booker.book1D("SimMuonNoRPC_phi", "SimMuon without RPCHit #phi;#phi", 36, -TMath::Pi(), TMath::Pi());
 
-  h_recoMuonBarrel_pt = booker.book1D(
-      "RecoMuonBarrel_pt", "RecoMuon RPCHit in Barrel  p_{T};p_{T} [GeV/c^{2}]",
-      nPtBins, ptBins);
-  h_recoMuonOverlap_pt = booker.book1D(
-      "RecoMuonOverlap_pt",
-      "RecoMuon RPCHit in Overlap p_{T};p_{T} [GeV/c^{2}]", nPtBins, ptBins);
-  h_recoMuonEndcap_pt = booker.book1D(
-      "RecoMuonEndcap_pt", "RecoMuon RPCHit in Endcap  p_{T};p_{T} [GeV/c^{2}]",
-      nPtBins, ptBins);
-  h_recoMuonNoRPC_pt = booker.book1D(
-      "RecoMuonNoRPC_pt", "RecoMuon without RPCHit p_{T};p_{T} [GeV/c^{2}]",
-      nPtBins, ptBins);
-  h_recoMuonBarrel_eta =
-      booker.book1D("RecoMuonBarrel_eta",
-                    "RecoMuon RPCHit in Barrel  #eta;#eta", 50, -2.5, 2.5);
-  h_recoMuonOverlap_eta =
-      booker.book1D("RecoMuonOverlap_eta",
-                    "RecoMuon RPCHit in Overlap #eta;#eta", 50, -2.5, 2.5);
-  h_recoMuonEndcap_eta =
-      booker.book1D("RecoMuonEndcap_eta",
-                    "RecoMuon RPCHit in Endcap  #eta;#eta", 50, -2.5, 2.5);
-  h_recoMuonNoRPC_eta = booker.book1D(
-      "RecoMuonNoRPC_eta", "RecoMuon without RPCHit #eta;#eta", 50, -2.5, 2.5);
-  h_recoMuonBarrel_phi = booker.book1D("RecoMuonBarrel_phi",
-                                       "RecoMuon RPCHit in Barrel  #phi;#phi",
-                                       36, -TMath::Pi(), TMath::Pi());
-  h_recoMuonOverlap_phi = booker.book1D("RecoMuonOverlap_phi",
-                                        "RecoMuon RPCHit in Overlap #phi;#phi",
-                                        36, -TMath::Pi(), TMath::Pi());
-  h_recoMuonEndcap_phi = booker.book1D("RecoMuonEndcap_phi",
-                                       "RecoMuon RPCHit in Endcap  #phi;#phi",
-                                       36, -TMath::Pi(), TMath::Pi());
+  h_recoMuonBarrel_pt =
+      booker.book1D("RecoMuonBarrel_pt", "RecoMuon RPCHit in Barrel  p_{T};p_{T} [GeV/c^{2}]", nPtBins, ptBins);
+  h_recoMuonOverlap_pt =
+      booker.book1D("RecoMuonOverlap_pt", "RecoMuon RPCHit in Overlap p_{T};p_{T} [GeV/c^{2}]", nPtBins, ptBins);
+  h_recoMuonEndcap_pt =
+      booker.book1D("RecoMuonEndcap_pt", "RecoMuon RPCHit in Endcap  p_{T};p_{T} [GeV/c^{2}]", nPtBins, ptBins);
+  h_recoMuonNoRPC_pt =
+      booker.book1D("RecoMuonNoRPC_pt", "RecoMuon without RPCHit p_{T};p_{T} [GeV/c^{2}]", nPtBins, ptBins);
+  h_recoMuonBarrel_eta = booker.book1D("RecoMuonBarrel_eta", "RecoMuon RPCHit in Barrel  #eta;#eta", 50, -2.5, 2.5);
+  h_recoMuonOverlap_eta = booker.book1D("RecoMuonOverlap_eta", "RecoMuon RPCHit in Overlap #eta;#eta", 50, -2.5, 2.5);
+  h_recoMuonEndcap_eta = booker.book1D("RecoMuonEndcap_eta", "RecoMuon RPCHit in Endcap  #eta;#eta", 50, -2.5, 2.5);
+  h_recoMuonNoRPC_eta = booker.book1D("RecoMuonNoRPC_eta", "RecoMuon without RPCHit #eta;#eta", 50, -2.5, 2.5);
+  h_recoMuonBarrel_phi =
+      booker.book1D("RecoMuonBarrel_phi", "RecoMuon RPCHit in Barrel  #phi;#phi", 36, -TMath::Pi(), TMath::Pi());
+  h_recoMuonOverlap_phi =
+      booker.book1D("RecoMuonOverlap_phi", "RecoMuon RPCHit in Overlap #phi;#phi", 36, -TMath::Pi(), TMath::Pi());
+  h_recoMuonEndcap_phi =
+      booker.book1D("RecoMuonEndcap_phi", "RecoMuon RPCHit in Endcap  #phi;#phi", 36, -TMath::Pi(), TMath::Pi());
   h_recoMuonNoRPC_phi =
-      booker.book1D("RecoMuonNoRPC_phi", "RecoMuon without RPCHit #phi;#phi",
-                    36, -TMath::Pi(), TMath::Pi());
+      booker.book1D("RecoMuonNoRPC_phi", "RecoMuon without RPCHit #phi;#phi", 36, -TMath::Pi(), TMath::Pi());
 
   h_simMuonBarrel_pt->getTH1()->SetMinimum(0);
   h_simMuonOverlap_pt->getTH1()->SetMinimum(0);
@@ -211,23 +166,17 @@ void RPCRecHitValid::bookHistograms(DQMStore::IBooker &booker,
   h_eventCount->Fill(3);
 
   h_refPunchOccupancyBarrel_wheel =
-      booker.book1D("RefPunchOccupancyBarrel_wheel",
-                    "RefPunchthrough occupancy", 5, -2.5, 2.5);
+      booker.book1D("RefPunchOccupancyBarrel_wheel", "RefPunchthrough occupancy", 5, -2.5, 2.5);
   h_refPunchOccupancyEndcap_disk =
-      booker.book1D("RefPunchOccupancyEndcap_disk", "RefPunchthrough occupancy",
-                    9, -4.5, 4.5);
+      booker.book1D("RefPunchOccupancyEndcap_disk", "RefPunchthrough occupancy", 9, -4.5, 4.5);
   h_refPunchOccupancyBarrel_station =
-      booker.book1D("RefPunchOccupancyBarrel_station",
-                    "RefPunchthrough occupancy", 4, 0.5, 4.5);
+      booker.book1D("RefPunchOccupancyBarrel_station", "RefPunchthrough occupancy", 4, 0.5, 4.5);
   h_recPunchOccupancyBarrel_wheel =
-      booker.book1D("RecPunchOccupancyBarrel_wheel",
-                    "Punchthrough recHit occupancy", 5, -2.5, 2.5);
+      booker.book1D("RecPunchOccupancyBarrel_wheel", "Punchthrough recHit occupancy", 5, -2.5, 2.5);
   h_recPunchOccupancyEndcap_disk =
-      booker.book1D("RecPunchOccupancyEndcap_disk",
-                    "Punchthrough recHit occupancy", 9, -4.5, 4.5);
+      booker.book1D("RecPunchOccupancyEndcap_disk", "Punchthrough recHit occupancy", 9, -4.5, 4.5);
   h_recPunchOccupancyBarrel_station =
-      booker.book1D("RecPunchOccupancyBarrel_station",
-                    "Punchthrough recHit occupancy", 4, 0.5, 4.5);
+      booker.book1D("RecPunchOccupancyBarrel_station", "Punchthrough recHit occupancy", 4, 0.5, 4.5);
 
   h_refPunchOccupancyBarrel_wheel->getTH1()->SetMinimum(0);
   h_refPunchOccupancyEndcap_disk->getTH1()->SetMinimum(0);
@@ -237,17 +186,13 @@ void RPCRecHitValid::bookHistograms(DQMStore::IBooker &booker,
   h_recPunchOccupancyBarrel_station->getTH1()->SetMinimum(0);
 
   h_refPunchOccupancyBarrel_wheel_station =
-      booker.book2D("RefPunchOccupancyBarrel_wheel_station",
-                    "RefPunchthrough occupancy", 5, -2.5, 2.5, 4, 0.5, 4.5);
+      booker.book2D("RefPunchOccupancyBarrel_wheel_station", "RefPunchthrough occupancy", 5, -2.5, 2.5, 4, 0.5, 4.5);
   h_refPunchOccupancyEndcap_disk_ring =
-      booker.book2D("RefPunchOccupancyEndcap_disk_ring",
-                    "RefPunchthrough occupancy", 9, -4.5, 4.5, 4, 0.5, 4.5);
-  h_recPunchOccupancyBarrel_wheel_station =
-      booker.book2D("RecPunchOccupancyBarrel_wheel_station",
-                    "Punchthrough recHit occupancy", 5, -2.5, 2.5, 4, 0.5, 4.5);
+      booker.book2D("RefPunchOccupancyEndcap_disk_ring", "RefPunchthrough occupancy", 9, -4.5, 4.5, 4, 0.5, 4.5);
+  h_recPunchOccupancyBarrel_wheel_station = booker.book2D(
+      "RecPunchOccupancyBarrel_wheel_station", "Punchthrough recHit occupancy", 5, -2.5, 2.5, 4, 0.5, 4.5);
   h_recPunchOccupancyEndcap_disk_ring =
-      booker.book2D("RecPunchOccupancyEndcap_disk_ring",
-                    "Punchthrough recHit occupancy", 9, -4.5, 4.5, 4, 0.5, 4.5);
+      booker.book2D("RecPunchOccupancyEndcap_disk_ring", "Punchthrough recHit occupancy", 9, -4.5, 4.5, 4, 0.5, 4.5);
 
   h_refPunchOccupancyBarrel_wheel_station->getTH2F()->SetOption("COLZ");
   h_refPunchOccupancyEndcap_disk_ring->getTH2F()->SetOption("COLZ");
@@ -271,46 +216,32 @@ void RPCRecHitValid::bookHistograms(DQMStore::IBooker &booker,
 
   for (int i = 1; i <= 5; ++i) {
     TString binLabel = Form("Wheel %d", i - 3);
-    h_refPunchOccupancyBarrel_wheel->getTH1()->GetXaxis()->SetBinLabel(
-        i, binLabel);
-    h_refPunchOccupancyBarrel_wheel_station->getTH2F()->GetXaxis()->SetBinLabel(
-        i, binLabel);
-    h_recPunchOccupancyBarrel_wheel->getTH1()->GetXaxis()->SetBinLabel(
-        i, binLabel);
-    h_recPunchOccupancyBarrel_wheel_station->getTH2F()->GetXaxis()->SetBinLabel(
-        i, binLabel);
+    h_refPunchOccupancyBarrel_wheel->getTH1()->GetXaxis()->SetBinLabel(i, binLabel);
+    h_refPunchOccupancyBarrel_wheel_station->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
+    h_recPunchOccupancyBarrel_wheel->getTH1()->GetXaxis()->SetBinLabel(i, binLabel);
+    h_recPunchOccupancyBarrel_wheel_station->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
   }
 
   for (int i = 1; i <= 9; ++i) {
     TString binLabel = Form("Disk %d", i - 5);
-    h_refPunchOccupancyEndcap_disk->getTH1()->GetXaxis()->SetBinLabel(i,
-                                                                      binLabel);
-    h_refPunchOccupancyEndcap_disk_ring->getTH2F()->GetXaxis()->SetBinLabel(
-        i, binLabel);
-    h_recPunchOccupancyEndcap_disk->getTH1()->GetXaxis()->SetBinLabel(i,
-                                                                      binLabel);
-    h_recPunchOccupancyEndcap_disk_ring->getTH2F()->GetXaxis()->SetBinLabel(
-        i, binLabel);
+    h_refPunchOccupancyEndcap_disk->getTH1()->GetXaxis()->SetBinLabel(i, binLabel);
+    h_refPunchOccupancyEndcap_disk_ring->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
+    h_recPunchOccupancyEndcap_disk->getTH1()->GetXaxis()->SetBinLabel(i, binLabel);
+    h_recPunchOccupancyEndcap_disk_ring->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
   }
 
   for (int i = 1; i <= 4; ++i) {
     TString binLabel = Form("Station %d", i);
-    h_refPunchOccupancyBarrel_station->getTH1()->GetXaxis()->SetBinLabel(
-        i, binLabel);
-    h_refPunchOccupancyBarrel_wheel_station->getTH2F()->GetYaxis()->SetBinLabel(
-        i, binLabel);
-    h_recPunchOccupancyBarrel_station->getTH1()->GetXaxis()->SetBinLabel(
-        i, binLabel);
-    h_recPunchOccupancyBarrel_wheel_station->getTH2F()->GetYaxis()->SetBinLabel(
-        i, binLabel);
+    h_refPunchOccupancyBarrel_station->getTH1()->GetXaxis()->SetBinLabel(i, binLabel);
+    h_refPunchOccupancyBarrel_wheel_station->getTH2F()->GetYaxis()->SetBinLabel(i, binLabel);
+    h_recPunchOccupancyBarrel_station->getTH1()->GetXaxis()->SetBinLabel(i, binLabel);
+    h_recPunchOccupancyBarrel_wheel_station->getTH2F()->GetYaxis()->SetBinLabel(i, binLabel);
   }
 
   for (int i = 1; i <= 4; ++i) {
     TString binLabel = Form("Ring %d", i);
-    h_refPunchOccupancyEndcap_disk_ring->getTH2F()->GetYaxis()->SetBinLabel(
-        i, binLabel);
-    h_recPunchOccupancyEndcap_disk_ring->getTH2F()->GetYaxis()->SetBinLabel(
-        i, binLabel);
+    h_refPunchOccupancyEndcap_disk_ring->getTH2F()->GetYaxis()->SetBinLabel(i, binLabel);
+    h_recPunchOccupancyEndcap_disk_ring->getTH2F()->GetYaxis()->SetBinLabel(i, binLabel);
   }
 
   // Book roll-by-roll histograms
@@ -348,30 +279,30 @@ void RPCRecHitValid::bookHistograms(DQMStore::IBooker &booker,
   }
 
   booker.setCurrentFolder(subDir_ + "/Occupancy");
-  h_matchOccupancyBarrel_detId =
-      booker.book1D("MatchOccupancyBarrel_detId",
-                    "Matched hit occupancy;roll index (can be arbitrary)",
-                    nRPCRollBarrel, 0, nRPCRollBarrel);
-  h_matchOccupancyEndcap_detId =
-      booker.book1D("MatchOccupancyEndcap_detId",
-                    "Matched hit occupancy;roll index (can be arbitrary)",
-                    nRPCRollEndcap, 0, nRPCRollEndcap);
-  h_refOccupancyBarrel_detId =
-      booker.book1D("RefOccupancyBarrel_detId",
-                    "Reference hit occupancy;roll index (can be arbitrary)",
-                    nRPCRollBarrel, 0, nRPCRollBarrel);
-  h_refOccupancyEndcap_detId =
-      booker.book1D("RefOccupancyEndcap_detId",
-                    "Reference hit occupancy;roll index (can be arbitrary)",
-                    nRPCRollEndcap, 0, nRPCRollEndcap);
-  h_noiseOccupancyBarrel_detId =
-      booker.book1D("NoiseOccupancyBarrel_detId",
-                    "Noise occupancy;roll index (can be arbitrary)",
-                    nRPCRollBarrel, 0, nRPCRollBarrel);
-  h_noiseOccupancyEndcap_detId =
-      booker.book1D("NoiseOccupancyEndcap_detId",
-                    "Noise occupancy;roll index (can be arbitrary)",
-                    nRPCRollEndcap, 0, nRPCRollEndcap);
+  h_matchOccupancyBarrel_detId = booker.book1D("MatchOccupancyBarrel_detId",
+                                               "Matched hit occupancy;roll index (can be arbitrary)",
+                                               nRPCRollBarrel,
+                                               0,
+                                               nRPCRollBarrel);
+  h_matchOccupancyEndcap_detId = booker.book1D("MatchOccupancyEndcap_detId",
+                                               "Matched hit occupancy;roll index (can be arbitrary)",
+                                               nRPCRollEndcap,
+                                               0,
+                                               nRPCRollEndcap);
+  h_refOccupancyBarrel_detId = booker.book1D("RefOccupancyBarrel_detId",
+                                             "Reference hit occupancy;roll index (can be arbitrary)",
+                                             nRPCRollBarrel,
+                                             0,
+                                             nRPCRollBarrel);
+  h_refOccupancyEndcap_detId = booker.book1D("RefOccupancyEndcap_detId",
+                                             "Reference hit occupancy;roll index (can be arbitrary)",
+                                             nRPCRollEndcap,
+                                             0,
+                                             nRPCRollEndcap);
+  h_noiseOccupancyBarrel_detId = booker.book1D(
+      "NoiseOccupancyBarrel_detId", "Noise occupancy;roll index (can be arbitrary)", nRPCRollBarrel, 0, nRPCRollBarrel);
+  h_noiseOccupancyEndcap_detId = booker.book1D(
+      "NoiseOccupancyEndcap_detId", "Noise occupancy;roll index (can be arbitrary)", nRPCRollEndcap, 0, nRPCRollEndcap);
 
   h_matchOccupancyBarrel_detId->getTH1()->SetMinimum(0);
   h_matchOccupancyEndcap_detId->getTH1()->SetMinimum(0);
@@ -380,20 +311,17 @@ void RPCRecHitValid::bookHistograms(DQMStore::IBooker &booker,
   h_noiseOccupancyBarrel_detId->getTH1()->SetMinimum(0);
   h_noiseOccupancyEndcap_detId->getTH1()->SetMinimum(0);
 
-  h_rollAreaBarrel_detId =
-      booker.bookProfile("RollAreaBarrel_detId", "Roll area;roll index;Area",
-                         nRPCRollBarrel, 0., 1. * nRPCRollBarrel, 0., 1e5);
-  h_rollAreaEndcap_detId =
-      booker.bookProfile("RollAreaEndcap_detId", "Roll area;roll index;Area",
-                         nRPCRollEndcap, 0., 1. * nRPCRollEndcap, 0., 1e5);
+  h_rollAreaBarrel_detId = booker.bookProfile(
+      "RollAreaBarrel_detId", "Roll area;roll index;Area", nRPCRollBarrel, 0., 1. * nRPCRollBarrel, 0., 1e5);
+  h_rollAreaEndcap_detId = booker.bookProfile(
+      "RollAreaEndcap_detId", "Roll area;roll index;Area", nRPCRollEndcap, 0., 1. * nRPCRollEndcap, 0., 1e5);
 
   for (auto detIdToIndex : detIdToIndexMapBarrel_) {
     const int rawId = detIdToIndex.first;
     const int index = detIdToIndex.second;
 
     const RPCDetId rpcDetId = static_cast<const RPCDetId>(rawId);
-    const RPCRoll *roll =
-        dynamic_cast<const RPCRoll *>(rpcGeom->roll(rpcDetId));
+    const RPCRoll *roll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(rpcDetId));
 
     // RPCGeomServ rpcSrv(roll->id());
     // if ( !roll->specs()->isRPC() ) { cout << "\nNoRPC : " << rpcSrv.name() <<
@@ -410,8 +338,7 @@ void RPCRecHitValid::bookHistograms(DQMStore::IBooker &booker,
     const int index = detIdToIndex.second;
 
     const RPCDetId rpcDetId = static_cast<const RPCDetId>(rawId);
-    const RPCRoll *roll =
-        dynamic_cast<const RPCRoll *>(rpcGeom->roll(rpcDetId));
+    const RPCRoll *roll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(rpcDetId));
 
     // RPCGeomServ rpcSrv(roll->id());
     // if ( !roll->specs()->isRPC() ) { cout << "\nNoRPC : " << rpcSrv.name() <<
@@ -424,8 +351,7 @@ void RPCRecHitValid::bookHistograms(DQMStore::IBooker &booker,
   }
 }
 
-void RPCRecHitValid::analyze(const edm::Event &event,
-                             const edm::EventSetup &eventSetup) {
+void RPCRecHitValid::analyze(const edm::Event &event, const edm::EventSetup &eventSetup) {
   h_eventCount->Fill(1);
 
   // Get the RPC Geometry
@@ -449,17 +375,14 @@ void RPCRecHitValid::analyze(const edm::Event &event,
   // Get SimParticles
   edm::Handle<TrackingParticleCollection> simParticleHandle;
   if (!event.getByToken(simParticleToken_, simParticleHandle)) {
-    edm::LogInfo("RPCRecHitValid")
-        << "Cannot find TrackingParticle collection\n";
+    edm::LogInfo("RPCRecHitValid") << "Cannot find TrackingParticle collection\n";
     return;
   }
 
   // Get SimParticle to SimHit association map
-  edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList>
-      simHitsTPAssoc;
+  edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc;
   if (!event.getByToken(simHitAssocToken_, simHitsTPAssoc)) {
-    edm::LogInfo("RPCRecHitValid")
-        << "Cannot find TrackingParticle to SimHit association map\n";
+    edm::LogInfo("RPCRecHitValid") << "Cannot find TrackingParticle to SimHit association map\n";
     return;
   }
 
@@ -480,16 +403,15 @@ void RPCRecHitValid::analyze(const edm::Event &event,
   for (int i = 0, n = simParticleHandle->size(); i < n; ++i) {
     TrackingParticleRef simParticle(simParticleHandle, i);
     if (simParticle->pt() < 1.0 or simParticle->p() < 2.5)
-      continue; // globalMuon acceptance
+      continue;  // globalMuon acceptance
 
     // Collect SimHits from this Tracking Particle
     SimHitRefs simHitsFromParticle;
-    auto range = std::equal_range(
-        simHitsTPAssoc->begin(), simHitsTPAssoc->end(),
-        std::make_pair(simParticle, TrackPSimHitRef()),
-        SimHitTPAssociationProducer::simHitTPAssociationListGreater);
-    for (auto simParticleToHit = range.first; simParticleToHit != range.second;
-         ++simParticleToHit) {
+    auto range = std::equal_range(simHitsTPAssoc->begin(),
+                                  simHitsTPAssoc->end(),
+                                  std::make_pair(simParticle, TrackPSimHitRef()),
+                                  SimHitTPAssociationProducer::simHitTPAssociationListGreater);
+    for (auto simParticleToHit = range.first; simParticleToHit != range.second; ++simParticleToHit) {
       auto simHit = simParticleToHit->second;
       const DetId detId(simHit->detUnitId());
       if (detId.det() != DetId::Muon or detId.subdetId() != MuonSubdetId::RPC)
@@ -501,17 +423,14 @@ void RPCRecHitValid::analyze(const edm::Event &event,
     const bool hasRPCHit = nRPCHit > 0;
 
     if (abs(simParticle->pdgId()) == 13) {
-      muonSimHits.insert(muonSimHits.end(), simHitsFromParticle.begin(),
-                         simHitsFromParticle.end());
+      muonSimHits.insert(muonSimHits.end(), simHitsFromParticle.begin(), simHitsFromParticle.end());
 
       // Count number of Barrel hits and Endcap hits
       int nRPCHitBarrel = 0;
       int nRPCHitEndcap = 0;
       for (auto simHit : simHitsFromParticle) {
-        const RPCDetId rpcDetId =
-            static_cast<const RPCDetId>(simHit->detUnitId());
-        const RPCRoll *roll =
-            dynamic_cast<const RPCRoll *>(rpcGeom->roll(rpcDetId));
+        const RPCDetId rpcDetId = static_cast<const RPCDetId>(simHit->detUnitId());
+        const RPCRoll *roll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(rpcDetId));
         if (!roll)
           continue;
 
@@ -544,45 +463,44 @@ void RPCRecHitValid::analyze(const edm::Event &event,
         h_simMuonNoRPC_phi->Fill(simParticle->phi());
       }
     } else {
-      pthrSimHits.insert(pthrSimHits.end(), simHitsFromParticle.begin(),
-                         simHitsFromParticle.end());
+      pthrSimHits.insert(pthrSimHits.end(), simHitsFromParticle.begin(), simHitsFromParticle.end());
     }
 
     if (hasRPCHit) {
       switch (simParticle->pdgId()) {
-      case 13:
-        h_simParticleType->Fill(0);
-        break;
-      case -13:
-        h_simParticleType->Fill(1);
-        break;
-      case 11:
-        h_simParticleType->Fill(2);
-        break;
-      case -11:
-        h_simParticleType->Fill(3);
-        break;
-      case 211:
-        h_simParticleType->Fill(4);
-        break;
-      case -211:
-        h_simParticleType->Fill(5);
-        break;
-      case 321:
-        h_simParticleType->Fill(6);
-        break;
-      case -321:
-        h_simParticleType->Fill(7);
-        break;
-      case 2212:
-        h_simParticleType->Fill(8);
-        break;
-      case -2212:
-        h_simParticleType->Fill(9);
-        break;
-      default:
-        h_simParticleType->Fill(10);
-        break;
+        case 13:
+          h_simParticleType->Fill(0);
+          break;
+        case -13:
+          h_simParticleType->Fill(1);
+          break;
+        case 11:
+          h_simParticleType->Fill(2);
+          break;
+        case -11:
+          h_simParticleType->Fill(3);
+          break;
+        case 211:
+          h_simParticleType->Fill(4);
+          break;
+        case -211:
+          h_simParticleType->Fill(5);
+          break;
+        case 321:
+          h_simParticleType->Fill(6);
+          break;
+        case -321:
+          h_simParticleType->Fill(7);
+          break;
+        case 2212:
+          h_simParticleType->Fill(8);
+          break;
+        case -2212:
+          h_simParticleType->Fill(9);
+          break;
+        default:
+          h_simParticleType->Fill(10);
+          break;
       }
     }
   }
@@ -606,15 +524,13 @@ void RPCRecHitValid::analyze(const edm::Event &event,
       h_.refHitOccupancyBarrel_station->Fill(station);
       h_.refHitOccupancyBarrel_wheel_station->Fill(ring, station);
 
-      h_refOccupancyBarrel_detId->Fill(
-          detIdToIndexMapBarrel_[simHit->detUnitId()]);
+      h_refOccupancyBarrel_detId->Fill(detIdToIndexMapBarrel_[simHit->detUnitId()]);
     } else {
       ++nRefHitEndcap;
       h_.refHitOccupancyEndcap_disk->Fill(region * station);
       h_.refHitOccupancyEndcap_disk_ring->Fill(region * station, ring);
 
-      h_refOccupancyEndcap_detId->Fill(
-          detIdToIndexMapEndcap_[simHit->detUnitId()]);
+      h_refOccupancyEndcap_detId->Fill(detIdToIndexMapEndcap_[simHit->detUnitId()]);
     }
   }
 
@@ -637,15 +553,13 @@ void RPCRecHitValid::analyze(const edm::Event &event,
       h_refPunchOccupancyBarrel_station->Fill(station);
       h_refPunchOccupancyBarrel_wheel_station->Fill(ring, station);
 
-      h_refOccupancyBarrel_detId->Fill(
-          detIdToIndexMapBarrel_[simHit->detUnitId()]);
+      h_refOccupancyBarrel_detId->Fill(detIdToIndexMapBarrel_[simHit->detUnitId()]);
     } else {
       ++nRefHitEndcap;
       h_refPunchOccupancyEndcap_disk->Fill(region * station);
       h_refPunchOccupancyEndcap_disk_ring->Fill(region * station, ring);
 
-      h_refOccupancyEndcap_detId->Fill(
-          detIdToIndexMapEndcap_[simHit->detUnitId()]);
+      h_refOccupancyEndcap_detId->Fill(detIdToIndexMapEndcap_[simHit->detUnitId()]);
     }
   }
   h_.nRefHitBarrel->Fill(nRefHitBarrel);
@@ -654,8 +568,7 @@ void RPCRecHitValid::analyze(const edm::Event &event,
   // Loop over recHits, fill histograms which does not need associations
   int sumClusterSizeBarrel = 0, sumClusterSizeEndcap = 0;
   int nRecHitBarrel = 0, nRecHitEndcap = 0;
-  for (RecHitIter recHitIter = recHitHandle->begin();
-       recHitIter != recHitHandle->end(); ++recHitIter) {
+  for (RecHitIter recHitIter = recHitHandle->begin(); recHitIter != recHitHandle->end(); ++recHitIter) {
     const RPCDetId detId = static_cast<const RPCDetId>(recHitIter->rpcId());
     const RPCRoll *roll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(detId()));
     if (!roll)
@@ -668,9 +581,7 @@ void RPCRecHitValid::analyze(const edm::Event &event,
     // const int layer = roll->id().layer();
     // const int subSector = roll->id().subsector();
 
-    const double time = recHitIter->timeError() >= 0
-                            ? recHitIter->time()
-                            : recHitIter->BunchX() * 25;
+    const double time = recHitIter->timeError() >= 0 ? recHitIter->time() : recHitIter->BunchX() * 25;
 
     h_.clusterSize->Fill(recHitIter->clusterSize());
 
@@ -707,12 +618,10 @@ void RPCRecHitValid::analyze(const edm::Event &event,
     h_.avgClusterSize->Fill(double(sumClusterSize) / nRecHit);
 
     if (nRecHitBarrel > 0) {
-      h_.avgClusterSizeBarrel->Fill(double(sumClusterSizeBarrel) /
-                                    nRecHitBarrel);
+      h_.avgClusterSizeBarrel->Fill(double(sumClusterSizeBarrel) / nRecHitBarrel);
     }
     if (nRecHitEndcap > 0) {
-      h_.avgClusterSizeEndcap->Fill(double(sumClusterSizeEndcap) /
-                                    nRecHitEndcap);
+      h_.avgClusterSizeEndcap->Fill(double(sumClusterSizeEndcap) / nRecHitEndcap);
     }
   }
 
@@ -727,12 +636,9 @@ void RPCRecHitValid::analyze(const edm::Event &event,
 
     const double simX = simHit->localPosition().x();
 
-    for (RecHitIter recHitIter = recHitHandle->begin();
-         recHitIter != recHitHandle->end(); ++recHitIter) {
-      const RPCDetId recDetId =
-          static_cast<const RPCDetId>(recHitIter->rpcId());
-      const RPCRoll *recRoll =
-          dynamic_cast<const RPCRoll *>(rpcGeom->roll(recDetId));
+    for (RecHitIter recHitIter = recHitHandle->begin(); recHitIter != recHitHandle->end(); ++recHitIter) {
+      const RPCDetId recDetId = static_cast<const RPCDetId>(recHitIter->rpcId());
+      const RPCRoll *recRoll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(recDetId));
       if (!recRoll)
         continue;
 
@@ -743,13 +649,11 @@ void RPCRecHitValid::analyze(const edm::Event &event,
       const double newDx = fabs(recX - simX);
 
       // Associate SimHit to RecHit
-      SimToRecHitMap::const_iterator prevSimToReco =
-          simToRecHitMap.find(simHit);
+      SimToRecHitMap::const_iterator prevSimToReco = simToRecHitMap.find(simHit);
       if (prevSimToReco == simToRecHitMap.end()) {
         simToRecHitMap.insert(std::make_pair(simHit, recHitIter));
       } else {
-        const double oldDx =
-            fabs(prevSimToReco->second->localPosition().x() - simX);
+        const double oldDx = fabs(prevSimToReco->second->localPosition().x() - simX);
 
         if (newDx < oldDx) {
           simToRecHitMap[simHit] = recHitIter;
@@ -817,8 +721,7 @@ void RPCRecHitValid::analyze(const edm::Event &event,
   h_.nMatchHitEndcap->Fill(nMatchHitEndcap);
 
   // Reco Muon hits
-  for (reco::MuonCollection::const_iterator muon = muonHandle->begin();
-       muon != muonHandle->end(); ++muon) {
+  for (reco::MuonCollection::const_iterator muon = muonHandle->begin(); muon != muonHandle->end(); ++muon) {
     if (!muon->isGlobalMuon())
       continue;
 
@@ -826,8 +729,7 @@ void RPCRecHitValid::analyze(const edm::Event &event,
     int nRPCHitEndcap = 0;
 
     const reco::TrackRef glbTrack = muon->globalTrack();
-    for (trackingRecHit_iterator recHit = glbTrack->recHitsBegin();
-         recHit != glbTrack->recHitsEnd(); ++recHit) {
+    for (trackingRecHit_iterator recHit = glbTrack->recHitsBegin(); recHit != glbTrack->recHitsEnd(); ++recHit) {
       if (!(*recHit)->isValid())
         continue;
       const DetId detId = (*recHit)->geographicalId();
@@ -866,8 +768,7 @@ void RPCRecHitValid::analyze(const edm::Event &event,
   }
 
   // Find Non-muon hits
-  for (RecHitIter recHitIter = recHitHandle->begin();
-       recHitIter != recHitHandle->end(); ++recHitIter) {
+  for (RecHitIter recHitIter = recHitHandle->begin(); recHitIter != recHitHandle->end(); ++recHitIter) {
     const RPCDetId detId = static_cast<const RPCDetId>(recHitIter->rpcId());
     const RPCRoll *roll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(detId));
 
@@ -894,8 +795,7 @@ void RPCRecHitValid::analyze(const edm::Event &event,
         if (absSimHitPType == 13)
           continue;
 
-        const RPCDetId simDetId =
-            static_cast<const RPCDetId>(simHit->detUnitId());
+        const RPCDetId simDetId = static_cast<const RPCDetId>(simHit->detUnitId());
         if (simDetId == detId)
           ++nPunchMatched;
       }
@@ -914,11 +814,9 @@ void RPCRecHitValid::analyze(const edm::Event &event,
   }
 
   // Find noise recHits : RecHits without SimHit match
-  for (RecHitIter recHitIter = recHitHandle->begin();
-       recHitIter != recHitHandle->end(); ++recHitIter) {
+  for (RecHitIter recHitIter = recHitHandle->begin(); recHitIter != recHitHandle->end(); ++recHitIter) {
     const RPCDetId recDetId = static_cast<const RPCDetId>(recHitIter->rpcId());
-    const RPCRoll *roll =
-        dynamic_cast<const RPCRoll *>(rpcGeom->roll(recDetId));
+    const RPCRoll *roll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(recDetId));
 
     const int region = roll->id().region();
     //    const int ring = roll->id().ring(); // UNUSED VARIABLE
@@ -931,12 +829,9 @@ void RPCRecHitValid::analyze(const edm::Event &event,
     const double recErrX = sqrt(recHitIter->localPositionError().xx());
 
     bool matched = false;
-    for (SimHitIter simHitIter = simHitHandle->begin();
-         simHitIter != simHitHandle->end(); ++simHitIter) {
-      const RPCDetId simDetId =
-          static_cast<const RPCDetId>(simHitIter->detUnitId());
-      const RPCRoll *simRoll =
-          dynamic_cast<const RPCRoll *>(rpcGeom->roll(simDetId));
+    for (SimHitIter simHitIter = simHitHandle->begin(); simHitIter != simHitHandle->end(); ++simHitIter) {
+      const RPCDetId simDetId = static_cast<const RPCDetId>(simHitIter->detUnitId());
+      const RPCRoll *simRoll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(simDetId));
       if (!simRoll)
         continue;
 
@@ -954,11 +849,9 @@ void RPCRecHitValid::analyze(const edm::Event &event,
 
     if (!matched) {
       if (region == 0) {
-        h_noiseOccupancyBarrel_detId->Fill(
-            detIdToIndexMapBarrel_[recDetId.rawId()]);
+        h_noiseOccupancyBarrel_detId->Fill(detIdToIndexMapBarrel_[recDetId.rawId()]);
       } else {
-        h_noiseOccupancyEndcap_detId->Fill(
-            detIdToIndexMapEndcap_[recDetId.rawId()]);
+        h_noiseOccupancyEndcap_detId->Fill(detIdToIndexMapEndcap_[recDetId.rawId()]);
       }
     }
   }

--- a/Validation/RPCRecHits/src/RPCRecHitValidClient.cc
+++ b/Validation/RPCRecHits/src/RPCRecHitValidClient.cc
@@ -13,49 +13,47 @@ RPCRecHitValidClient::RPCRecHitValidClient(const edm::ParameterSet &pset) {
   subDir_ = pset.getParameter<std::string>("subDir");
 }
 
-void RPCRecHitValidClient::dqmEndJob(DQMStore::IBooker &booker,
-                                     DQMStore::IGetter &getter) {
+void RPCRecHitValidClient::dqmEndJob(DQMStore::IBooker &booker, DQMStore::IGetter &getter) {
   booker.setCurrentFolder(subDir_);
-  MEP me_rollEfficiencyBarrel_eff = booker.book1D(
-      "RollEfficiencyBarrel_eff", "Roll efficiency in Barrel;Efficiency [%]",
-      50 + 2, -2, 100 + 2);
-  MEP me_rollEfficiencyEndcap_eff = booker.book1D(
-      "RollEfficiencyEndcap_eff", "Roll efficiency in Endcap;Efficiency [%]",
-      50 + 2, -2, 100 + 2);
-  MEP me_rollEfficiencyStatCutOffBarrel_eff = booker.book1D(
-      "RollEfficiencyCutOffBarrel_eff",
-      "Roll efficiency in Barrel without low stat chamber;Efficiency [%]",
-      50 + 2, -2, 100 + 2);
-  MEP me_rollEfficiencyStatCutOffEndcap_eff = booker.book1D(
-      "RollEfficiencyCutOffEndcap_eff",
-      "Roll efficiency in Endcap without low stat chamber;Efficiency [%]",
-      50 + 2, -2, 100 + 2);
+  MEP me_rollEfficiencyBarrel_eff =
+      booker.book1D("RollEfficiencyBarrel_eff", "Roll efficiency in Barrel;Efficiency [%]", 50 + 2, -2, 100 + 2);
+  MEP me_rollEfficiencyEndcap_eff =
+      booker.book1D("RollEfficiencyEndcap_eff", "Roll efficiency in Endcap;Efficiency [%]", 50 + 2, -2, 100 + 2);
+  MEP me_rollEfficiencyStatCutOffBarrel_eff =
+      booker.book1D("RollEfficiencyCutOffBarrel_eff",
+                    "Roll efficiency in Barrel without low stat chamber;Efficiency [%]",
+                    50 + 2,
+                    -2,
+                    100 + 2);
+  MEP me_rollEfficiencyStatCutOffEndcap_eff =
+      booker.book1D("RollEfficiencyCutOffEndcap_eff",
+                    "Roll efficiency in Endcap without low stat chamber;Efficiency [%]",
+                    50 + 2,
+                    -2,
+                    100 + 2);
 
   const double maxNoise = 1e-7;
-  MEP me_rollNoiseBarrel_noise =
-      booker.book1D("RollNoiseBarrel_noise",
-                    "Roll noise in Barrel;Noise level [Event^{-1}cm^{-2}]",
-                    25 + 2, -maxNoise / 25, maxNoise + maxNoise / 25);
-  MEP me_rollNoiseEndcap_noise =
-      booker.book1D("RollNoiseEndcap_noise",
-                    "Roll noise in Endcap;Noise level [Event^{-1}cm^{-2}]",
-                    25 + 2, -maxNoise / 25, maxNoise + maxNoise / 25);
+  MEP me_rollNoiseBarrel_noise = booker.book1D("RollNoiseBarrel_noise",
+                                               "Roll noise in Barrel;Noise level [Event^{-1}cm^{-2}]",
+                                               25 + 2,
+                                               -maxNoise / 25,
+                                               maxNoise + maxNoise / 25);
+  MEP me_rollNoiseEndcap_noise = booker.book1D("RollNoiseEndcap_noise",
+                                               "Roll noise in Endcap;Noise level [Event^{-1}cm^{-2}]",
+                                               25 + 2,
+                                               -maxNoise / 25,
+                                               maxNoise + maxNoise / 25);
 
-  MEP me_matchOccupancyBarrel_detId =
-      getter.get(subDir_ + "/Occupancy/MatchOccupancyBarrel_detId");
-  MEP me_matchOccupancyEndcap_detId =
-      getter.get(subDir_ + "/Occupancy/MatchOccupancyEndcap_detId");
-  MEP me_refOccupancyBarrel_detId =
-      getter.get(subDir_ + "/Occupancy/RefOccupancyBarrel_detId");
-  MEP me_refOccupancyEndcap_detId =
-      getter.get(subDir_ + "/Occupancy/RefOccupancyEndcap_detId");
+  MEP me_matchOccupancyBarrel_detId = getter.get(subDir_ + "/Occupancy/MatchOccupancyBarrel_detId");
+  MEP me_matchOccupancyEndcap_detId = getter.get(subDir_ + "/Occupancy/MatchOccupancyEndcap_detId");
+  MEP me_refOccupancyBarrel_detId = getter.get(subDir_ + "/Occupancy/RefOccupancyBarrel_detId");
+  MEP me_refOccupancyEndcap_detId = getter.get(subDir_ + "/Occupancy/RefOccupancyEndcap_detId");
 
   if (me_matchOccupancyBarrel_detId and me_refOccupancyBarrel_detId) {
     TH1 *h_matchOccupancyBarrel_detId = me_matchOccupancyBarrel_detId->getTH1();
     TH1 *h_refOccupancyBarrel_detId = me_refOccupancyBarrel_detId->getTH1();
 
-    for (int bin = 1, nBin = h_matchOccupancyBarrel_detId->GetNbinsX();
-         bin <= nBin; ++bin) {
+    for (int bin = 1, nBin = h_matchOccupancyBarrel_detId->GetNbinsX(); bin <= nBin; ++bin) {
       const double nRec = h_matchOccupancyBarrel_detId->GetBinContent(bin);
       const double nRef = h_refOccupancyBarrel_detId->GetBinContent(bin);
 
@@ -71,8 +69,7 @@ void RPCRecHitValidClient::dqmEndJob(DQMStore::IBooker &booker,
     TH1 *h_matchOccupancyEndcap_detId = me_matchOccupancyEndcap_detId->getTH1();
     TH1 *h_refOccupancyEndcap_detId = me_refOccupancyEndcap_detId->getTH1();
 
-    for (int bin = 1, nBin = h_matchOccupancyEndcap_detId->GetNbinsX();
-         bin <= nBin; ++bin) {
+    for (int bin = 1, nBin = h_matchOccupancyEndcap_detId->GetNbinsX(); bin <= nBin; ++bin) {
       const double nRec = h_matchOccupancyEndcap_detId->GetBinContent(bin);
       const double nRef = h_refOccupancyEndcap_detId->GetBinContent(bin);
 
@@ -85,47 +82,36 @@ void RPCRecHitValidClient::dqmEndJob(DQMStore::IBooker &booker,
   }
 
   MEP me_eventCount = getter.get(subDir_ + "/Occupancy/EventCount");
-  const double nEvent =
-      me_eventCount ? me_eventCount->getTH1()->GetBinContent(1) : 1;
-  MEP me_noiseOccupancyBarrel_detId =
-      getter.get(subDir_ + "/Occupancy/NoiseOccupancyBarrel_detId");
-  MEP me_rollAreaBarrel_detId =
-      getter.get(subDir_ + "/Occupancy/RollAreaBarrel_detId");
+  const double nEvent = me_eventCount ? me_eventCount->getTH1()->GetBinContent(1) : 1;
+  MEP me_noiseOccupancyBarrel_detId = getter.get(subDir_ + "/Occupancy/NoiseOccupancyBarrel_detId");
+  MEP me_rollAreaBarrel_detId = getter.get(subDir_ + "/Occupancy/RollAreaBarrel_detId");
   if (me_noiseOccupancyBarrel_detId and me_rollAreaBarrel_detId) {
     TH1 *h_noiseOccupancyBarrel_detId = me_noiseOccupancyBarrel_detId->getTH1();
     TH1 *h_rollAreaBarrel_detId = me_rollAreaBarrel_detId->getTH1();
 
-    for (int bin = 1, nBin = h_noiseOccupancyBarrel_detId->GetNbinsX();
-         bin <= nBin; ++bin) {
-      const double noiseCount =
-          h_noiseOccupancyBarrel_detId->GetBinContent(bin);
+    for (int bin = 1, nBin = h_noiseOccupancyBarrel_detId->GetNbinsX(); bin <= nBin; ++bin) {
+      const double noiseCount = h_noiseOccupancyBarrel_detId->GetBinContent(bin);
       const double area = h_rollAreaBarrel_detId->GetBinContent(bin);
       const double noiseLevel = area > 0 ? noiseCount / area / nEvent : 0;
       if (noiseLevel == 0.)
-        me_rollNoiseBarrel_noise->Fill(
-            -maxNoise / 50); // Fill underflow bin if noise is exactly zero
+        me_rollNoiseBarrel_noise->Fill(-maxNoise / 50);  // Fill underflow bin if noise is exactly zero
       else
         me_rollNoiseBarrel_noise->Fill(std::min(noiseLevel, maxNoise));
     }
   }
 
-  MEP me_noiseOccupancyEndcap_detId =
-      getter.get(subDir_ + "/Occupancy/NoiseOccupancyEndcap_detId");
-  MEP me_rollAreaEndcap_detId =
-      getter.get(subDir_ + "/Occupancy/RollAreaEndcap_detId");
+  MEP me_noiseOccupancyEndcap_detId = getter.get(subDir_ + "/Occupancy/NoiseOccupancyEndcap_detId");
+  MEP me_rollAreaEndcap_detId = getter.get(subDir_ + "/Occupancy/RollAreaEndcap_detId");
   if (me_noiseOccupancyEndcap_detId and me_rollAreaEndcap_detId) {
     TH1 *h_noiseOccupancyEndcap_detId = me_noiseOccupancyEndcap_detId->getTH1();
     TH1 *h_rollAreaEndcap_detId = me_rollAreaEndcap_detId->getTH1();
 
-    for (int bin = 1, nBin = h_noiseOccupancyEndcap_detId->GetNbinsX();
-         bin <= nBin; ++bin) {
-      const double noiseCount =
-          h_noiseOccupancyEndcap_detId->GetBinContent(bin);
+    for (int bin = 1, nBin = h_noiseOccupancyEndcap_detId->GetNbinsX(); bin <= nBin; ++bin) {
+      const double noiseCount = h_noiseOccupancyEndcap_detId->GetBinContent(bin);
       const double area = h_rollAreaEndcap_detId->GetBinContent(bin);
       const double noiseLevel = area > 0 ? noiseCount / area / nEvent : 0;
       if (noiseLevel == 0)
-        me_rollNoiseEndcap_noise->Fill(
-            -maxNoise / 50); // Fill underflow bin if noise if exactly zero
+        me_rollNoiseEndcap_noise->Fill(-maxNoise / 50);  // Fill underflow bin if noise if exactly zero
       else
         me_rollNoiseEndcap_noise->Fill(std::min(noiseLevel, maxNoise));
     }

--- a/Validation/RPCRecHits/src/RPCValidHistograms.cc
+++ b/Validation/RPCRecHits/src/RPCValidHistograms.cc
@@ -2,8 +2,7 @@
 
 #include "TAxis.h"
 
-void RPCValidHistograms::bookHistograms(DQMStore::IBooker &booker,
-                                        const std::string &subDir) {
+void RPCValidHistograms::bookHistograms(DQMStore::IBooker &booker, const std::string &subDir) {
   if (booked_) {
     edm::LogError("RPCValidHistograms") << "Histogram is already booked\n";
     return;
@@ -14,61 +13,35 @@ void RPCValidHistograms::bookHistograms(DQMStore::IBooker &booker,
 
   // Book histograms
   booker.setCurrentFolder(subDir + "/HitProperty");
-  clusterSize =
-      booker.book1D("ClusterSize", "Cluster size;Cluster size", 11, -0.5, 10.5);
-  clusterSizeBarrel =
-      booker.book1D("ClusterSizeBarrel", "Cluster size in Barrel;Cluster size",
-                    11, -0.5, 10.5);
-  clusterSizeEndcap =
-      booker.book1D("ClusterSizeEndcap", "Cluster size in Endcap;Cluster size",
-                    11, -0.5, 10.5);
+  clusterSize = booker.book1D("ClusterSize", "Cluster size;Cluster size", 11, -0.5, 10.5);
+  clusterSizeBarrel = booker.book1D("ClusterSizeBarrel", "Cluster size in Barrel;Cluster size", 11, -0.5, 10.5);
+  clusterSizeEndcap = booker.book1D("ClusterSizeEndcap", "Cluster size in Endcap;Cluster size", 11, -0.5, 10.5);
 
-  avgClusterSize = booker.book1D("AverageClusterSize",
-                                 "Average cluster size;Average clsuter size",
-                                 11, -0.5, 10.5);
-  avgClusterSizeBarrel = booker.book1D(
-      "AverageClusterSizeBarrel",
-      "Average cluster size in Barrel;Average clsuter size", 11, -0.5, 10.5);
-  avgClusterSizeEndcap = booker.book1D(
-      "AverageClusterSizeEndcap",
-      "Average cluster size in Endcap;Average clsuter size", 11, -0.5, 10.5);
+  avgClusterSize = booker.book1D("AverageClusterSize", "Average cluster size;Average clsuter size", 11, -0.5, 10.5);
+  avgClusterSizeBarrel =
+      booker.book1D("AverageClusterSizeBarrel", "Average cluster size in Barrel;Average clsuter size", 11, -0.5, 10.5);
+  avgClusterSizeEndcap =
+      booker.book1D("AverageClusterSizeEndcap", "Average cluster size in Endcap;Average clsuter size", 11, -0.5, 10.5);
 
-  nRecHitBarrel = booker.book1D(
-      "NRecHitBarrel",
-      "Number of RPC recHits per event in Barrel;Number of RPC hits", 25, 0,
-      25);
-  nRecHitEndcap = booker.book1D(
-      "NRecHitEndcap",
-      "Number of RPC recHits per event in Endcap;Number of RPC hits", 25, 0,
-      25);
+  nRecHitBarrel =
+      booker.book1D("NRecHitBarrel", "Number of RPC recHits per event in Barrel;Number of RPC hits", 25, 0, 25);
+  nRecHitEndcap =
+      booker.book1D("NRecHitEndcap", "Number of RPC recHits per event in Endcap;Number of RPC hits", 25, 0, 25);
 
-  nRefHitBarrel = booker.book1D(
-      "NRefHitBarrel",
-      "Number of reference hits per event in Barrel;Number of RPC hits", 25, 0,
-      25);
-  nRefHitEndcap = booker.book1D(
-      "NRefHitEndcap",
-      "Number of reference hits per event in Endcap;Number of RPC hits", 25, 0,
-      25);
+  nRefHitBarrel =
+      booker.book1D("NRefHitBarrel", "Number of reference hits per event in Barrel;Number of RPC hits", 25, 0, 25);
+  nRefHitEndcap =
+      booker.book1D("NRefHitEndcap", "Number of reference hits per event in Endcap;Number of RPC hits", 25, 0, 25);
 
   nMatchHitBarrel = booker.book1D(
-      "nMatchBarrel",
-      "Number of matched reference hits per event in Barrel;Number of RPC hits",
-      25, 0, 25);
+      "nMatchBarrel", "Number of matched reference hits per event in Barrel;Number of RPC hits", 25, 0, 25);
   nMatchHitEndcap = booker.book1D(
-      "nMatchEndcap",
-      "Number of matched reference hits per event in Endcap;Number of RPC hits",
-      25, 0, 25);
+      "nMatchEndcap", "Number of matched reference hits per event in Endcap;Number of RPC hits", 25, 0, 25);
 
-  timeBarrel = booker.book1D(
-      "RecHitTimeBarrel", "RecHit time in Barrel;Time (ns)", 100, -12.5, 12.5);
-  timeEndcap = booker.book1D(
-      "RecHitTimeEndcap", "RecHit time in Endcap;Time (ns)", 100, -12.5, 12.5);
-  timeIRPC = booker.book1D("RecHitTimeIRPC", "RecHit time of iRPC;Time (ns)",
-                           100, -12.5, 12.5);
-  timeCRPC =
-      booker.book1D("RecHitTimeCPRC", "RecHit time in current RPC;Time (ns)",
-                    100, -12.5, 12.5);
+  timeBarrel = booker.book1D("RecHitTimeBarrel", "RecHit time in Barrel;Time (ns)", 100, -12.5, 12.5);
+  timeEndcap = booker.book1D("RecHitTimeEndcap", "RecHit time in Endcap;Time (ns)", 100, -12.5, 12.5);
+  timeIRPC = booker.book1D("RecHitTimeIRPC", "RecHit time of iRPC;Time (ns)", 100, -12.5, 12.5);
+  timeCRPC = booker.book1D("RecHitTimeCPRC", "RecHit time in current RPC;Time (ns)", 100, -12.5, 12.5);
 
   clusterSize->getTH1()->SetMinimum(0);
   clusterSizeBarrel->getTH1()->SetMinimum(0);
@@ -89,26 +62,18 @@ void RPCValidHistograms::bookHistograms(DQMStore::IBooker &booker,
 
   // Occupancy 1D
   booker.setCurrentFolder(subDir + "/Occupancy");
-  refHitOccupancyBarrel_wheel = booker.book1D(
-      "RefHitOccupancyBarrel_wheel", "Reference Hit occupancy", 5, -2.5, 2.5);
-  refHitOccupancyEndcap_disk = booker.book1D(
-      "RefHitOccupancyEndcap_disk", "Reference Hit occupancy", 9, -4.5, 4.5);
-  refHitOccupancyBarrel_station = booker.book1D(
-      "RefHitOccupancyBarrel_station", "Reference Hit occupancy", 4, 0.5, 4.5);
+  refHitOccupancyBarrel_wheel = booker.book1D("RefHitOccupancyBarrel_wheel", "Reference Hit occupancy", 5, -2.5, 2.5);
+  refHitOccupancyEndcap_disk = booker.book1D("RefHitOccupancyEndcap_disk", "Reference Hit occupancy", 9, -4.5, 4.5);
+  refHitOccupancyBarrel_station =
+      booker.book1D("RefHitOccupancyBarrel_station", "Reference Hit occupancy", 4, 0.5, 4.5);
 
-  recHitOccupancyBarrel_wheel = booker.book1D("RecHitOccupancyBarrel_wheel",
-                                              "RecHit occupancy", 5, -2.5, 2.5);
-  recHitOccupancyEndcap_disk = booker.book1D("RecHitOccupancyEndcap_disk",
-                                             "RecHit occupancy", 9, -4.5, 4.5);
-  recHitOccupancyBarrel_station = booker.book1D(
-      "RecHitOccupancyBarrel_station", "RecHit occupancy", 4, 0.5, 4.5);
+  recHitOccupancyBarrel_wheel = booker.book1D("RecHitOccupancyBarrel_wheel", "RecHit occupancy", 5, -2.5, 2.5);
+  recHitOccupancyEndcap_disk = booker.book1D("RecHitOccupancyEndcap_disk", "RecHit occupancy", 9, -4.5, 4.5);
+  recHitOccupancyBarrel_station = booker.book1D("RecHitOccupancyBarrel_station", "RecHit occupancy", 4, 0.5, 4.5);
 
-  matchOccupancyBarrel_wheel = booker.book1D(
-      "MatchOccupancyBarrel_wheel", "Matched hit occupancy", 5, -2.5, 2.5);
-  matchOccupancyEndcap_disk = booker.book1D(
-      "MatchOccupancyEndcap_disk", "Matched hit occupancy", 9, -4.5, 4.5);
-  matchOccupancyBarrel_station = booker.book1D(
-      "MatchOccupancyBarrel_station", "Matched hit occupancy", 4, 0.5, 4.5);
+  matchOccupancyBarrel_wheel = booker.book1D("MatchOccupancyBarrel_wheel", "Matched hit occupancy", 5, -2.5, 2.5);
+  matchOccupancyEndcap_disk = booker.book1D("MatchOccupancyEndcap_disk", "Matched hit occupancy", 9, -4.5, 4.5);
+  matchOccupancyBarrel_station = booker.book1D("MatchOccupancyBarrel_station", "Matched hit occupancy", 4, 0.5, 4.5);
 
   refHitOccupancyBarrel_wheel->getTH1()->SetMinimum(0);
   refHitOccupancyEndcap_disk->getTH1()->SetMinimum(0);
@@ -124,25 +89,19 @@ void RPCValidHistograms::bookHistograms(DQMStore::IBooker &booker,
 
   // Occupancy 2D
   refHitOccupancyBarrel_wheel_station =
-      booker.book2D("RefHitOccupancyBarrel_wheel_station",
-                    "Reference hit occupancy", 5, -2.5, 2.5, 4, 0.5, 4.5);
+      booker.book2D("RefHitOccupancyBarrel_wheel_station", "Reference hit occupancy", 5, -2.5, 2.5, 4, 0.5, 4.5);
   refHitOccupancyEndcap_disk_ring =
-      booker.book2D("RefHitOccupancyEndcap_disk_ring",
-                    "Reference hit occupancy", 9, -4.5, 4.5, 4, 0.5, 4.5);
+      booker.book2D("RefHitOccupancyEndcap_disk_ring", "Reference hit occupancy", 9, -4.5, 4.5, 4, 0.5, 4.5);
 
   recHitOccupancyBarrel_wheel_station =
-      booker.book2D("RecHitOccupancyBarrel_wheel_station", "RecHit occupancy",
-                    5, -2.5, 2.5, 4, 0.5, 4.5);
+      booker.book2D("RecHitOccupancyBarrel_wheel_station", "RecHit occupancy", 5, -2.5, 2.5, 4, 0.5, 4.5);
   recHitOccupancyEndcap_disk_ring =
-      booker.book2D("RecHitOccupancyEndcap_disk_ring", "RecHit occupancy", 9,
-                    -4.5, 4.5, 4, 0.5, 4.5);
+      booker.book2D("RecHitOccupancyEndcap_disk_ring", "RecHit occupancy", 9, -4.5, 4.5, 4, 0.5, 4.5);
 
   matchOccupancyBarrel_wheel_station =
-      booker.book2D("MatchOccupancyBarrel_wheel_station",
-                    "Matched hit occupancy", 5, -2.5, 2.5, 4, 0.5, 4.5);
+      booker.book2D("MatchOccupancyBarrel_wheel_station", "Matched hit occupancy", 5, -2.5, 2.5, 4, 0.5, 4.5);
   matchOccupancyEndcap_disk_ring =
-      booker.book2D("MatchOccupancyEndcap_disk_ring", "Matched hit occupancy",
-                    9, -4.5, 4.5, 4, 0.5, 4.5);
+      booker.book2D("MatchOccupancyEndcap_disk_ring", "Matched hit occupancy", 9, -4.5, 4.5, 4, 0.5, 4.5);
 
   refHitOccupancyBarrel_wheel_station->getTH2F()->SetMinimum(0);
   refHitOccupancyEndcap_disk_ring->getTH2F()->SetMinimum(0);
@@ -155,26 +114,16 @@ void RPCValidHistograms::bookHistograms(DQMStore::IBooker &booker,
 
   // Residuals
   booker.setCurrentFolder(subDir + "/Residual");
-  resBarrel = booker.book1D(
-      "ResBarrel", "Global Residuals for Barrel;Residual [cm]", 100, -8, 8);
-  resEndcap = booker.book1D(
-      "ResEndcap", "Global Residuals for Endcap;Residual [cm]", 100, -8, 8);
+  resBarrel = booker.book1D("ResBarrel", "Global Residuals for Barrel;Residual [cm]", 100, -8, 8);
+  resEndcap = booker.book1D("ResEndcap", "Global Residuals for Endcap;Residual [cm]", 100, -8, 8);
 
   resBarrel->getTH1()->SetMinimum(0);
   resEndcap->getTH1()->SetMinimum(0);
 
-  res_wheel_res =
-      booker.book2D("Res_wheel_res", "Residuals vs Wheel;;Residual [cm]", 5,
-                    -2.5, 2.5, 50, -8, 8);
-  res_disk_res =
-      booker.book2D("Res_disk_res", "Residuals vs Disk;;Residual [cm]", 9, -4.5,
-                    4.5, 50, -8, 8);
-  res_station_res =
-      booker.book2D("Res_station_res", "Redisuals vs Station;;Residual [cm]", 4,
-                    0.5, 4.5, 50, -8, 8);
-  res_ring_res =
-      booker.book2D("Res_ring_res", "Redisuals vs Ring;;Residual [cm]", 4, 0.5,
-                    4.5, 50, -8, 8);
+  res_wheel_res = booker.book2D("Res_wheel_res", "Residuals vs Wheel;;Residual [cm]", 5, -2.5, 2.5, 50, -8, 8);
+  res_disk_res = booker.book2D("Res_disk_res", "Residuals vs Disk;;Residual [cm]", 9, -4.5, 4.5, 50, -8, 8);
+  res_station_res = booker.book2D("Res_station_res", "Redisuals vs Station;;Residual [cm]", 4, 0.5, 4.5, 50, -8, 8);
+  res_ring_res = booker.book2D("Res_ring_res", "Redisuals vs Ring;;Residual [cm]", 4, 0.5, 4.5, 50, -8, 8);
 
   res_wheel_res->getTH2F()->SetMinimum(0);
   res_disk_res->getTH2F()->SetMinimum(0);
@@ -182,22 +131,16 @@ void RPCValidHistograms::bookHistograms(DQMStore::IBooker &booker,
   res_ring_res->getTH2F()->SetMinimum(0);
 
   // Pulls
-  pullBarrel =
-      booker.book1D("PullBarrel", "Global Pull for Barrel;Pull", 100, -3, 3);
-  pullEndcap =
-      booker.book1D("PullEndcap", "Global Pull for Endcap;Pull", 100, -3, 3);
+  pullBarrel = booker.book1D("PullBarrel", "Global Pull for Barrel;Pull", 100, -3, 3);
+  pullEndcap = booker.book1D("PullEndcap", "Global Pull for Endcap;Pull", 100, -3, 3);
 
   pullBarrel->getTH1()->SetMinimum(0);
   pullEndcap->getTH1()->SetMinimum(0);
 
-  pull_wheel_pull = booker.book2D("Pull_wheel_pull", "Pull vs Wheel;;Pull", 5,
-                                  -2.5, 2.5, 50, -3, 3);
-  pull_disk_pull = booker.book2D("Pull_disk_pull", "Pull vs Disk;;Pull", 9,
-                                 -4.5, 4.5, 50, -3, 3);
-  pull_station_pull = booker.book2D(
-      "Pull_station_pull", "Pull vs Station;;Pull", 4, 0.5, 4.5, 50, -3, 3);
-  pull_ring_pull = booker.book2D("Pull_ring_pull", "Pull vs Ring;;Pull", 4, 0.5,
-                                 4.5, 50, -3, 3);
+  pull_wheel_pull = booker.book2D("Pull_wheel_pull", "Pull vs Wheel;;Pull", 5, -2.5, 2.5, 50, -3, 3);
+  pull_disk_pull = booker.book2D("Pull_disk_pull", "Pull vs Disk;;Pull", 9, -4.5, 4.5, 50, -3, 3);
+  pull_station_pull = booker.book2D("Pull_station_pull", "Pull vs Station;;Pull", 4, 0.5, 4.5, 50, -3, 3);
+  pull_ring_pull = booker.book2D("Pull_ring_pull", "Pull vs Ring;;Pull", 4, 0.5, 4.5, 50, -3, 3);
 
   pull_wheel_pull->getTH2F()->SetMinimum(0);
   pull_disk_pull->getTH2F()->SetMinimum(0);
@@ -260,18 +203,13 @@ void RPCValidHistograms::bookHistograms(DQMStore::IBooker &booker,
   for (int i = 1; i <= 5; ++i) {
     TString binLabel = Form("Wheel %d", i - 3);
 
-    refHitOccupancyBarrel_wheel->getTH1F()->GetXaxis()->SetBinLabel(i,
-                                                                    binLabel);
-    recHitOccupancyBarrel_wheel->getTH1F()->GetXaxis()->SetBinLabel(i,
-                                                                    binLabel);
+    refHitOccupancyBarrel_wheel->getTH1F()->GetXaxis()->SetBinLabel(i, binLabel);
+    recHitOccupancyBarrel_wheel->getTH1F()->GetXaxis()->SetBinLabel(i, binLabel);
     matchOccupancyBarrel_wheel->getTH1F()->GetXaxis()->SetBinLabel(i, binLabel);
 
-    refHitOccupancyBarrel_wheel_station->getTH2F()->GetXaxis()->SetBinLabel(
-        i, binLabel);
-    recHitOccupancyBarrel_wheel_station->getTH2F()->GetXaxis()->SetBinLabel(
-        i, binLabel);
-    matchOccupancyBarrel_wheel_station->getTH2F()->GetXaxis()->SetBinLabel(
-        i, binLabel);
+    refHitOccupancyBarrel_wheel_station->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
+    recHitOccupancyBarrel_wheel_station->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
+    matchOccupancyBarrel_wheel_station->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
 
     res_wheel_res->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
     pull_wheel_pull->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
@@ -284,12 +222,9 @@ void RPCValidHistograms::bookHistograms(DQMStore::IBooker &booker,
     recHitOccupancyEndcap_disk->getTH1F()->GetXaxis()->SetBinLabel(i, binLabel);
     matchOccupancyEndcap_disk->getTH1F()->GetXaxis()->SetBinLabel(i, binLabel);
 
-    refHitOccupancyEndcap_disk_ring->getTH2F()->GetXaxis()->SetBinLabel(
-        i, binLabel);
-    recHitOccupancyEndcap_disk_ring->getTH2F()->GetXaxis()->SetBinLabel(
-        i, binLabel);
-    matchOccupancyEndcap_disk_ring->getTH2F()->GetXaxis()->SetBinLabel(
-        i, binLabel);
+    refHitOccupancyEndcap_disk_ring->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
+    recHitOccupancyEndcap_disk_ring->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
+    matchOccupancyEndcap_disk_ring->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
 
     res_disk_res->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
     pull_disk_pull->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
@@ -298,19 +233,13 @@ void RPCValidHistograms::bookHistograms(DQMStore::IBooker &booker,
   for (int i = 1; i <= 4; ++i) {
     TString binLabel = Form("Station %d", i);
 
-    refHitOccupancyBarrel_station->getTH1F()->GetXaxis()->SetBinLabel(i,
-                                                                      binLabel);
-    recHitOccupancyBarrel_station->getTH1F()->GetXaxis()->SetBinLabel(i,
-                                                                      binLabel);
-    matchOccupancyBarrel_station->getTH1F()->GetXaxis()->SetBinLabel(i,
-                                                                     binLabel);
+    refHitOccupancyBarrel_station->getTH1F()->GetXaxis()->SetBinLabel(i, binLabel);
+    recHitOccupancyBarrel_station->getTH1F()->GetXaxis()->SetBinLabel(i, binLabel);
+    matchOccupancyBarrel_station->getTH1F()->GetXaxis()->SetBinLabel(i, binLabel);
 
-    refHitOccupancyBarrel_wheel_station->getTH2F()->GetYaxis()->SetBinLabel(
-        i, binLabel);
-    recHitOccupancyBarrel_wheel_station->getTH2F()->GetYaxis()->SetBinLabel(
-        i, binLabel);
-    matchOccupancyBarrel_wheel_station->getTH2F()->GetYaxis()->SetBinLabel(
-        i, binLabel);
+    refHitOccupancyBarrel_wheel_station->getTH2F()->GetYaxis()->SetBinLabel(i, binLabel);
+    recHitOccupancyBarrel_wheel_station->getTH2F()->GetYaxis()->SetBinLabel(i, binLabel);
+    matchOccupancyBarrel_wheel_station->getTH2F()->GetYaxis()->SetBinLabel(i, binLabel);
 
     res_station_res->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
     pull_station_pull->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
@@ -319,12 +248,9 @@ void RPCValidHistograms::bookHistograms(DQMStore::IBooker &booker,
   for (int i = 1; i <= 4; ++i) {
     TString binLabel = Form("Ring %d", i);
 
-    refHitOccupancyEndcap_disk_ring->getTH2F()->GetYaxis()->SetBinLabel(
-        i, binLabel);
-    recHitOccupancyEndcap_disk_ring->getTH2F()->GetYaxis()->SetBinLabel(
-        i, binLabel);
-    matchOccupancyEndcap_disk_ring->getTH2F()->GetYaxis()->SetBinLabel(
-        i, binLabel);
+    refHitOccupancyEndcap_disk_ring->getTH2F()->GetYaxis()->SetBinLabel(i, binLabel);
+    recHitOccupancyEndcap_disk_ring->getTH2F()->GetYaxis()->SetBinLabel(i, binLabel);
+    matchOccupancyEndcap_disk_ring->getTH2F()->GetYaxis()->SetBinLabel(i, binLabel);
   }
 
   booked_ = true;

--- a/Validation/RecoJets/plugins/JetTester.cc
+++ b/Validation/RecoJets/plugins/JetTester.cc
@@ -27,8 +27,7 @@ JetTester::JetTester(const edm::ParameterSet &iConfig)
   }
 
   // consumes
-  pvToken_ = consumes<std::vector<reco::Vertex>>(
-      iConfig.getParameter<edm::InputTag>("primVertex"));
+  pvToken_ = consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("primVertex"));
   if (isCaloJet)
     caloJetsToken_ = consumes<reco::CaloJetCollection>(mInputCollection);
   if (isPFJet)
@@ -36,8 +35,7 @@ JetTester::JetTester(const edm::ParameterSet &iConfig)
   if (isMiniAODJet)
     patJetsToken_ = consumes<pat::JetCollection>(mInputCollection);
   mInputGenCollection = iConfig.getParameter<edm::InputTag>("srcGen");
-  genJetsToken_ =
-      consumes<reco::GenJetCollection>(edm::InputTag(mInputGenCollection));
+  genJetsToken_ = consumes<reco::GenJetCollection>(edm::InputTag(mInputGenCollection));
   evtToken_ = consumes<GenEventInfoProduct>(edm::InputTag("generator"));
   if (!isMiniAODJet && !mJetCorrector.label().empty()) {
     jetCorrectorToken_ = consumes<reco::JetCorrector>(mJetCorrector);
@@ -266,9 +264,7 @@ JetTester::JetTester(const edm::ParameterSet &iConfig)
   genPartonPDGID = nullptr;
 }
 
-void JetTester::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &iRun,
-                               edm::EventSetup const &) {
-
+void JetTester::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &iRun, edm::EventSetup const &) {
   ibooker.setCurrentFolder("JetMET/JetValidation/" + mInputCollection.label());
 
   double log10PtMin = 0.50;
@@ -276,15 +272,12 @@ void JetTester::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &iRun,
   int log10PtBins = 26;
 
   // if eta range changed here need change in JetTesterPostProcessor as well
-  double etaRange[91] = {
-      -6.0, -5.8, -5.6, -5.4, -5.2, -5.0, -4.8, -4.6, -4.4, -4.2, -4.0, -3.8,
-      -3.6, -3.4, -3.2, -3.0, -2.9, -2.8, -2.7, -2.6, -2.5, -2.4, -2.3, -2.2,
-      -2.1, -2.0, -1.9, -1.8, -1.7, -1.6, -1.5, -1.4, -1.3, -1.2, -1.1, -1.0,
-      -0.9, -0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0.0,  0.1,  0.2,
-      0.3,  0.4,  0.5,  0.6,  0.7,  0.8,  0.9,  1.0,  1.1,  1.2,  1.3,  1.4,
-      1.5,  1.6,  1.7,  1.8,  1.9,  2.0,  2.1,  2.2,  2.3,  2.4,  2.5,  2.6,
-      2.7,  2.8,  2.9,  3.0,  3.2,  3.4,  3.6,  3.8,  4.0,  4.2,  4.4,  4.6,
-      4.8,  5.0,  5.2,  5.4,  5.6,  5.8,  6.0};
+  double etaRange[91] = {-6.0, -5.8, -5.6, -5.4, -5.2, -5.0, -4.8, -4.6, -4.4, -4.2, -4.0, -3.8, -3.6, -3.4, -3.2, -3.0,
+                         -2.9, -2.8, -2.7, -2.6, -2.5, -2.4, -2.3, -2.2, -2.1, -2.0, -1.9, -1.8, -1.7, -1.6, -1.5, -1.4,
+                         -1.3, -1.2, -1.1, -1.0, -0.9, -0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0.0,  0.1,  0.2,
+                         0.3,  0.4,  0.5,  0.6,  0.7,  0.8,  0.9,  1.0,  1.1,  1.2,  1.3,  1.4,  1.5,  1.6,  1.7,  1.8,
+                         1.9,  2.0,  2.1,  2.2,  2.3,  2.4,  2.5,  2.6,  2.7,  2.8,  2.9,  3.0,  3.2,  3.4,  3.6,  3.8,
+                         4.0,  4.2,  4.4,  4.6,  4.8,  5.0,  5.2,  5.4,  5.6,  5.8,  6.0};
 
   // Event variables
   mNvtx = ibooker.book1D("Nvtx", "number of vertices", 60, 0, 60);
@@ -302,88 +295,63 @@ void JetTester::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &iRun,
   if (isMiniAODJet) {
     hadronFlavor = ibooker.book1D("HadronFlavor", "HadronFlavor", 44, -22, 22);
     partonFlavor = ibooker.book1D("PartonFlavor", "PartonFlavor", 44, -22, 22);
-    genPartonPDGID =
-        ibooker.book1D("genPartonPDGID", "genPartonPDGID", 44, -22, 22);
+    genPartonPDGID = ibooker.book1D("genPartonPDGID", "genPartonPDGID", 44, -22, 22);
   }
   // Corrected jets
-  if (isMiniAODJet ||
-      !mJetCorrector.label().empty()) { // if correction label is filled, but
-                                        // fill also for MiniAOD though
+  if (isMiniAODJet || !mJetCorrector.label().empty()) {  // if correction label is filled, but
+                                                         // fill also for MiniAOD though
     mCorrJetPt = ibooker.book1D("CorrJetPt", "CorrJetPt", 150, 0, 1500);
     mCorrJetEta = ibooker.book1D("CorrJetEta", "CorrJetEta Pt>20", 60, -6, 6);
-    mCorrJetPhi =
-        ibooker.book1D("CorrJetPhi", "CorrJetPhi Pt>20", 70, -3.5, 3.5);
-    mCorrJetEta_Pt40 =
-        ibooker.book1D("CorrJetEta_Pt40", "CorrJetEta Pt>40", 60, -6, 6);
-    mCorrJetPhi_Pt40 =
-        ibooker.book1D("CorrJetPhi_Pt40", "CorrJetPhi Pt>40", 70, -3.5, 3.5);
+    mCorrJetPhi = ibooker.book1D("CorrJetPhi", "CorrJetPhi Pt>20", 70, -3.5, 3.5);
+    mCorrJetEta_Pt40 = ibooker.book1D("CorrJetEta_Pt40", "CorrJetEta Pt>40", 60, -6, 6);
+    mCorrJetPhi_Pt40 = ibooker.book1D("CorrJetPhi_Pt40", "CorrJetPhi Pt>40", 70, -3.5, 3.5);
 
     // Corrected jets profiles
     mPtCorrOverReco_Pt_B =
-        ibooker.bookProfile("PtCorrOverReco_Pt_B", "0<|eta|<1.5", log10PtBins,
-                            log10PtMin, log10PtMax, 0, 5, " ");
+        ibooker.bookProfile("PtCorrOverReco_Pt_B", "0<|eta|<1.5", log10PtBins, log10PtMin, log10PtMax, 0, 5, " ");
     mPtCorrOverReco_Pt_E =
-        ibooker.bookProfile("PtCorrOverReco_Pt_E", "1.5<|eta|<3", log10PtBins,
-                            log10PtMin, log10PtMax, 0, 5, " ");
+        ibooker.bookProfile("PtCorrOverReco_Pt_E", "1.5<|eta|<3", log10PtBins, log10PtMin, log10PtMax, 0, 5, " ");
     mPtCorrOverReco_Pt_F =
-        ibooker.bookProfile("PtCorrOverReco_Pt_F", "3<|eta|<6", log10PtBins,
-                            log10PtMin, log10PtMax, 0, 5, " ");
+        ibooker.bookProfile("PtCorrOverReco_Pt_F", "3<|eta|<6", log10PtBins, log10PtMin, log10PtMax, 0, 5, " ");
 
-    mPtCorrOverReco_Eta_20_40 = ibooker.bookProfile(
-        "PtCorrOverReco_Eta_20_40", "20<genPt<40", 90, etaRange, 0, 5, " ");
-    mPtCorrOverReco_Eta_40_200 = ibooker.bookProfile(
-        "PtCorrOverReco_Eta_40_200", "40<genPt<200", 90, etaRange, 0, 5, " ");
-    mPtCorrOverReco_Eta_200_600 = ibooker.bookProfile(
-        "PtCorrOverReco_Eta_200_600", "200<genPt<600", 90, etaRange, 0, 5, " ");
+    mPtCorrOverReco_Eta_20_40 = ibooker.bookProfile("PtCorrOverReco_Eta_20_40", "20<genPt<40", 90, etaRange, 0, 5, " ");
+    mPtCorrOverReco_Eta_40_200 =
+        ibooker.bookProfile("PtCorrOverReco_Eta_40_200", "40<genPt<200", 90, etaRange, 0, 5, " ");
+    mPtCorrOverReco_Eta_200_600 =
+        ibooker.bookProfile("PtCorrOverReco_Eta_200_600", "200<genPt<600", 90, etaRange, 0, 5, " ");
     mPtCorrOverReco_Eta_600_1500 =
-        ibooker.bookProfile("PtCorrOverReco_Eta_600_1500", "600<genPt<1500", 90,
-                            etaRange, 0, 5, " ");
+        ibooker.bookProfile("PtCorrOverReco_Eta_600_1500", "600<genPt<1500", 90, etaRange, 0, 5, " ");
     mPtCorrOverReco_Eta_1500_3500 =
-        ibooker.bookProfile("PtCorrOverReco_Eta_1500_3500", "1500<genPt<3500",
-                            90, etaRange, 0, 5, " ");
+        ibooker.bookProfile("PtCorrOverReco_Eta_1500_3500", "1500<genPt<3500", 90, etaRange, 0, 5, " ");
     mPtCorrOverReco_Eta_3500_5000 =
-        ibooker.bookProfile("PtCorrOverReco_Eta_3500_5000", "3500<genPt<5000",
-                            90, etaRange, 0, 5, " ");
+        ibooker.bookProfile("PtCorrOverReco_Eta_3500_5000", "3500<genPt<5000", 90, etaRange, 0, 5, " ");
     mPtCorrOverReco_Eta_5000_6500 =
-        ibooker.bookProfile("PtCorrOverReco_Eta_5000_6500", "5000<genPt<6500",
-                            90, etaRange, 0, 5, " ");
-    mPtCorrOverReco_Eta_3500 = ibooker.bookProfile(
-        "PtCorrOverReco_Eta_3500", "genPt>3500", 90, etaRange, 0, 5, " ");
+        ibooker.bookProfile("PtCorrOverReco_Eta_5000_6500", "5000<genPt<6500", 90, etaRange, 0, 5, " ");
+    mPtCorrOverReco_Eta_3500 = ibooker.bookProfile("PtCorrOverReco_Eta_3500", "genPt>3500", 90, etaRange, 0, 5, " ");
 
     mPtCorrOverGen_GenPt_B =
-        ibooker.bookProfile("PtCorrOverGen_GenPt_B", "0<|eta|<1.5", log10PtBins,
-                            log10PtMin, log10PtMax, 0.8, 1.2, " ");
+        ibooker.bookProfile("PtCorrOverGen_GenPt_B", "0<|eta|<1.5", log10PtBins, log10PtMin, log10PtMax, 0.8, 1.2, " ");
     mPtCorrOverGen_GenPt_E =
-        ibooker.bookProfile("PtCorrOverGen_GenPt_E", "1.5<|eta|<3", log10PtBins,
-                            log10PtMin, log10PtMax, 0.8, 1.2, " ");
+        ibooker.bookProfile("PtCorrOverGen_GenPt_E", "1.5<|eta|<3", log10PtBins, log10PtMin, log10PtMax, 0.8, 1.2, " ");
     mPtCorrOverGen_GenPt_F =
-        ibooker.bookProfile("PtCorrOverGen_GenPt_F", "3<|eta|<6", log10PtBins,
-                            log10PtMin, log10PtMax, 0.8, 1.2, " ");
+        ibooker.bookProfile("PtCorrOverGen_GenPt_F", "3<|eta|<6", log10PtBins, log10PtMin, log10PtMax, 0.8, 1.2, " ");
     // if eta range changed here need change in JetTesterPostProcessor as well
     mPtCorrOverGen_GenEta_20_40 =
-        ibooker.bookProfile("PtCorrOverGen_GenEta_20_40", "20<genPt<40;#eta",
-                            90, etaRange, 0.8, 1.2, " ");
+        ibooker.bookProfile("PtCorrOverGen_GenEta_20_40", "20<genPt<40;#eta", 90, etaRange, 0.8, 1.2, " ");
     mPtCorrOverGen_GenEta_40_200 =
-        ibooker.bookProfile("PtCorrOverGen_GenEta_40_200", "40<genPt<200;#eta",
-                            90, etaRange, 0.8, 1.2, " ");
+        ibooker.bookProfile("PtCorrOverGen_GenEta_40_200", "40<genPt<200;#eta", 90, etaRange, 0.8, 1.2, " ");
     mPtCorrOverGen_GenEta_200_600 =
-        ibooker.bookProfile("PtCorrOverGen_GenEta_200_600",
-                            "200<genPt<600;#eta", 90, etaRange, 0.8, 1.2, " ");
+        ibooker.bookProfile("PtCorrOverGen_GenEta_200_600", "200<genPt<600;#eta", 90, etaRange, 0.8, 1.2, " ");
     mPtCorrOverGen_GenEta_600_1500 =
-        ibooker.bookProfile("PtCorrOverGen_GenEta_600_1500",
-                            "600<genPt<1500;#eta", 90, etaRange, 0.8, 1.2, " ");
-    mPtCorrOverGen_GenEta_1500_3500 = ibooker.bookProfile(
-        "PtCorrOverGen_GenEta_1500_3500", "1500<genPt<3500;#eta", 90, etaRange,
-        0.8, 1.2, " ");
-    mPtCorrOverGen_GenEta_3500_5000 = ibooker.bookProfile(
-        "PtCorrOverGen_GenEta_3500_5000", "3500<genPt<5000;#eta", 90, etaRange,
-        0.8, 1.2, " ");
-    mPtCorrOverGen_GenEta_5000_6500 = ibooker.bookProfile(
-        "PtCorrOverGen_GenEta_5000_6500", "5000<genPt<6500;#eta", 90, etaRange,
-        0.8, 1.2, " ");
+        ibooker.bookProfile("PtCorrOverGen_GenEta_600_1500", "600<genPt<1500;#eta", 90, etaRange, 0.8, 1.2, " ");
+    mPtCorrOverGen_GenEta_1500_3500 =
+        ibooker.bookProfile("PtCorrOverGen_GenEta_1500_3500", "1500<genPt<3500;#eta", 90, etaRange, 0.8, 1.2, " ");
+    mPtCorrOverGen_GenEta_3500_5000 =
+        ibooker.bookProfile("PtCorrOverGen_GenEta_3500_5000", "3500<genPt<5000;#eta", 90, etaRange, 0.8, 1.2, " ");
+    mPtCorrOverGen_GenEta_5000_6500 =
+        ibooker.bookProfile("PtCorrOverGen_GenEta_5000_6500", "5000<genPt<6500;#eta", 90, etaRange, 0.8, 1.2, " ");
     mPtCorrOverGen_GenEta_3500 =
-        ibooker.bookProfile("PtCorrOverGen_GenEta_3500", "genPt>3500;#eta", 90,
-                            etaRange, 0.8, 1.2, " ");
+        ibooker.bookProfile("PtCorrOverGen_GenEta_3500", "genPt>3500;#eta", 90, etaRange, 0.8, 1.2, " ");
   }
 
   mGenEta = ibooker.book1D("GenEta", "GenEta", 120, -6, 6);
@@ -396,139 +364,81 @@ void JetTester::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &iRun,
   mDeltaPhi = ibooker.book1D("DeltaPhi", "DeltaPhi", 100, -0.5, 0.5);
   mDeltaPt = ibooker.book1D("DeltaPt", "DeltaPt", 100, -1.0, 1.0);
 
-  mPtRecoOverGen_B_20_40 =
-      ibooker.book1D("PtRecoOverGen_B_20_40", "20<genpt<40", 90, 0, 2);
-  mPtRecoOverGen_E_20_40 =
-      ibooker.book1D("PtRecoOverGen_E_20_40", "20<genpt<40", 90, 0, 2);
-  mPtRecoOverGen_F_20_40 =
-      ibooker.book1D("PtRecoOverGen_F_20_40", "20<genpt<40", 90, 0, 2);
-  mPtRecoOverGen_B_40_200 =
-      ibooker.book1D("PtRecoOverGen_B_40_200", "40<genpt<200", 90, 0, 2);
-  mPtRecoOverGen_E_40_200 =
-      ibooker.book1D("PtRecoOverGen_E_40_200", "40<genpt<200", 90, 0, 2);
-  mPtRecoOverGen_F_40_200 =
-      ibooker.book1D("PtRecoOverGen_F_40_200", "40<genpt<200", 90, 0, 2);
-  mPtRecoOverGen_B_200_600 =
-      ibooker.book1D("PtRecoOverGen_B_200_600", "200<genpt<600", 90, 0, 2);
-  mPtRecoOverGen_E_200_600 =
-      ibooker.book1D("PtRecoOverGen_E_200_600", "200<genpt<600", 90, 0, 2);
-  mPtRecoOverGen_F_200_600 =
-      ibooker.book1D("PtRecoOverGen_F_200_600", "200<genpt<600", 90, 0, 2);
-  mPtRecoOverGen_B_600_1500 =
-      ibooker.book1D("PtRecoOverGen_B_600_1500", "600<genpt<1500", 90, 0, 2);
-  mPtRecoOverGen_E_600_1500 =
-      ibooker.book1D("PtRecoOverGen_E_600_1500", "600<genpt<1500", 90, 0, 2);
-  mPtRecoOverGen_F_600_1500 =
-      ibooker.book1D("PtRecoOverGen_F_600_1500", "600<genpt<1500", 90, 0, 2);
-  mPtRecoOverGen_B_1500_3500 =
-      ibooker.book1D("PtRecoOverGen_B_1500_3500", "1500<genpt<3500", 90, 0, 2);
-  mPtRecoOverGen_E_1500_3500 =
-      ibooker.book1D("PtRecoOverGen_E_1500_3500", "1500<genpt<3500", 90, 0, 2);
-  mPtRecoOverGen_F_1500_3500 =
-      ibooker.book1D("PtRecoOverGen_F_1500_3500", "1500<genpt<3500", 90, 0, 2);
-  mPtRecoOverGen_B_3500_5000 =
-      ibooker.book1D("PtRecoOverGen_B_3500_5000", "3500<genpt<5000", 90, 0, 2);
-  mPtRecoOverGen_E_3500_5000 =
-      ibooker.book1D("PtRecoOverGen_E_3500_5000", "3500<genpt<5000", 90, 0, 2);
-  mPtRecoOverGen_B_5000_6500 =
-      ibooker.book1D("PtRecoOverGen_B_5000_6500", "5000<genpt<6500", 90, 0, 2);
-  mPtRecoOverGen_E_5000_6500 =
-      ibooker.book1D("PtRecoOverGen_E_5000_6500", "5000<genpt<6500", 90, 0, 2);
-  mPtRecoOverGen_B_3500 =
-      ibooker.book1D("PtRecoOverGen_B_3500", "genpt>3500", 90, 0, 2);
-  mPtRecoOverGen_E_3500 =
-      ibooker.book1D("PtRecoOverGen_E_3500", "genpt>3500", 90, 0, 2);
-  mPtRecoOverGen_F_3500 =
-      ibooker.book1D("PtRecoOverGen_F_3500", "genpt>3500", 90, 0, 2);
+  mPtRecoOverGen_B_20_40 = ibooker.book1D("PtRecoOverGen_B_20_40", "20<genpt<40", 90, 0, 2);
+  mPtRecoOverGen_E_20_40 = ibooker.book1D("PtRecoOverGen_E_20_40", "20<genpt<40", 90, 0, 2);
+  mPtRecoOverGen_F_20_40 = ibooker.book1D("PtRecoOverGen_F_20_40", "20<genpt<40", 90, 0, 2);
+  mPtRecoOverGen_B_40_200 = ibooker.book1D("PtRecoOverGen_B_40_200", "40<genpt<200", 90, 0, 2);
+  mPtRecoOverGen_E_40_200 = ibooker.book1D("PtRecoOverGen_E_40_200", "40<genpt<200", 90, 0, 2);
+  mPtRecoOverGen_F_40_200 = ibooker.book1D("PtRecoOverGen_F_40_200", "40<genpt<200", 90, 0, 2);
+  mPtRecoOverGen_B_200_600 = ibooker.book1D("PtRecoOverGen_B_200_600", "200<genpt<600", 90, 0, 2);
+  mPtRecoOverGen_E_200_600 = ibooker.book1D("PtRecoOverGen_E_200_600", "200<genpt<600", 90, 0, 2);
+  mPtRecoOverGen_F_200_600 = ibooker.book1D("PtRecoOverGen_F_200_600", "200<genpt<600", 90, 0, 2);
+  mPtRecoOverGen_B_600_1500 = ibooker.book1D("PtRecoOverGen_B_600_1500", "600<genpt<1500", 90, 0, 2);
+  mPtRecoOverGen_E_600_1500 = ibooker.book1D("PtRecoOverGen_E_600_1500", "600<genpt<1500", 90, 0, 2);
+  mPtRecoOverGen_F_600_1500 = ibooker.book1D("PtRecoOverGen_F_600_1500", "600<genpt<1500", 90, 0, 2);
+  mPtRecoOverGen_B_1500_3500 = ibooker.book1D("PtRecoOverGen_B_1500_3500", "1500<genpt<3500", 90, 0, 2);
+  mPtRecoOverGen_E_1500_3500 = ibooker.book1D("PtRecoOverGen_E_1500_3500", "1500<genpt<3500", 90, 0, 2);
+  mPtRecoOverGen_F_1500_3500 = ibooker.book1D("PtRecoOverGen_F_1500_3500", "1500<genpt<3500", 90, 0, 2);
+  mPtRecoOverGen_B_3500_5000 = ibooker.book1D("PtRecoOverGen_B_3500_5000", "3500<genpt<5000", 90, 0, 2);
+  mPtRecoOverGen_E_3500_5000 = ibooker.book1D("PtRecoOverGen_E_3500_5000", "3500<genpt<5000", 90, 0, 2);
+  mPtRecoOverGen_B_5000_6500 = ibooker.book1D("PtRecoOverGen_B_5000_6500", "5000<genpt<6500", 90, 0, 2);
+  mPtRecoOverGen_E_5000_6500 = ibooker.book1D("PtRecoOverGen_E_5000_6500", "5000<genpt<6500", 90, 0, 2);
+  mPtRecoOverGen_B_3500 = ibooker.book1D("PtRecoOverGen_B_3500", "genpt>3500", 90, 0, 2);
+  mPtRecoOverGen_E_3500 = ibooker.book1D("PtRecoOverGen_E_3500", "genpt>3500", 90, 0, 2);
+  mPtRecoOverGen_F_3500 = ibooker.book1D("PtRecoOverGen_F_3500", "genpt>3500", 90, 0, 2);
 
-  mMassRecoOverGen_B_20_40 =
-      ibooker.book1D("MassRecoOverGen_B_20_40", "20<genpt<40", 90, 0, 3);
-  mMassRecoOverGen_E_20_40 =
-      ibooker.book1D("MassRecoOverGen_E_20_40", "20<genpt<40", 90, 0, 3);
-  mMassRecoOverGen_F_20_40 =
-      ibooker.book1D("MassRecoOverGen_F_20_40", "20<genpt<40", 90, 0, 3);
-  mMassRecoOverGen_B_40_200 =
-      ibooker.book1D("MassRecoOverGen_B_40_200", "40<genpt<200", 90, 0, 3);
-  mMassRecoOverGen_E_40_200 =
-      ibooker.book1D("MassRecoOverGen_E_40_200", "40<genpt<200", 90, 0, 3);
-  mMassRecoOverGen_F_40_200 =
-      ibooker.book1D("MassRecoOverGen_F_40_200", "40<genpt<200", 90, 0, 3);
-  mMassRecoOverGen_B_200_500 =
-      ibooker.book1D("MassRecoOverGen_B_200_500", "200<genpt<500", 90, 0, 3);
-  mMassRecoOverGen_E_200_500 =
-      ibooker.book1D("MassRecoOverGen_E_200_500", "200<genpt<500", 90, 0, 3);
-  mMassRecoOverGen_F_200_500 =
-      ibooker.book1D("MassRecoOverGen_F_200_500", "200<genpt<500", 90, 0, 3);
-  mMassRecoOverGen_B_500_750 =
-      ibooker.book1D("MassRecoOverGen_B_500_750", "500<genpt<750", 90, 0, 3);
-  mMassRecoOverGen_E_500_750 =
-      ibooker.book1D("MassRecoOverGen_E_500_750", "500<genpt<750", 90, 0, 3);
-  mMassRecoOverGen_F_500_750 =
-      ibooker.book1D("MassRecoOverGen_F_500_750", "500<genpt<750", 90, 0, 3);
-  mMassRecoOverGen_B_750_1000 =
-      ibooker.book1D("MassRecoOverGen_B_750_1000", "750<genpt<1000", 90, 0, 3);
-  mMassRecoOverGen_E_750_1000 =
-      ibooker.book1D("MassRecoOverGen_E_750_1000", "750<genpt<1000", 90, 0, 3);
-  mMassRecoOverGen_F_750_1000 =
-      ibooker.book1D("MassRecoOverGen_F_750_1000", "750<genpt<1000", 90, 0, 3);
-  mMassRecoOverGen_B_1000_1500 = ibooker.book1D("MassRecoOverGen_B_1000_1500",
-                                                "1000<genpt<1500", 90, 0, 3);
-  mMassRecoOverGen_E_1000_1500 = ibooker.book1D("MassRecoOverGen_E_1000_1500",
-                                                "1000<genpt<1500", 90, 0, 3);
-  mMassRecoOverGen_F_1000_1500 = ibooker.book1D("MassRecoOverGen_F_1000_1500",
-                                                "1000<genpt<1500", 90, 0, 3);
-  mMassRecoOverGen_B_1500_3500 = ibooker.book1D("MassRecoOverGen_B_1500_3500",
-                                                "1500<genpt<3500", 90, 0, 3);
-  mMassRecoOverGen_E_1500_3500 = ibooker.book1D("MassRecoOverGen_E_1500_3500",
-                                                "1500<genpt<3500", 90, 0, 3);
-  mMassRecoOverGen_F_1500 =
-      ibooker.book1D("MassRecoOverGen_F_1500", "genpt>1500", 90, 0, 3);
-  mMassRecoOverGen_B_3500_5000 = ibooker.book1D("MassRecoOverGen_B_3500_5000",
-                                                "3500<genpt<5000", 90, 0, 3);
-  mMassRecoOverGen_E_3500_5000 = ibooker.book1D("MassRecoOverGen_E_3500_5000",
-                                                "3500<genpt<5000", 90, 0, 3);
-  mMassRecoOverGen_B_5000 =
-      ibooker.book1D("MassRecoOverGen_B_5000", "genpt>5000", 90, 0, 3);
-  mMassRecoOverGen_E_5000 =
-      ibooker.book1D("MassRecoOverGen_E_5000", "genpt>5000", 90, 0, 3);
+  mMassRecoOverGen_B_20_40 = ibooker.book1D("MassRecoOverGen_B_20_40", "20<genpt<40", 90, 0, 3);
+  mMassRecoOverGen_E_20_40 = ibooker.book1D("MassRecoOverGen_E_20_40", "20<genpt<40", 90, 0, 3);
+  mMassRecoOverGen_F_20_40 = ibooker.book1D("MassRecoOverGen_F_20_40", "20<genpt<40", 90, 0, 3);
+  mMassRecoOverGen_B_40_200 = ibooker.book1D("MassRecoOverGen_B_40_200", "40<genpt<200", 90, 0, 3);
+  mMassRecoOverGen_E_40_200 = ibooker.book1D("MassRecoOverGen_E_40_200", "40<genpt<200", 90, 0, 3);
+  mMassRecoOverGen_F_40_200 = ibooker.book1D("MassRecoOverGen_F_40_200", "40<genpt<200", 90, 0, 3);
+  mMassRecoOverGen_B_200_500 = ibooker.book1D("MassRecoOverGen_B_200_500", "200<genpt<500", 90, 0, 3);
+  mMassRecoOverGen_E_200_500 = ibooker.book1D("MassRecoOverGen_E_200_500", "200<genpt<500", 90, 0, 3);
+  mMassRecoOverGen_F_200_500 = ibooker.book1D("MassRecoOverGen_F_200_500", "200<genpt<500", 90, 0, 3);
+  mMassRecoOverGen_B_500_750 = ibooker.book1D("MassRecoOverGen_B_500_750", "500<genpt<750", 90, 0, 3);
+  mMassRecoOverGen_E_500_750 = ibooker.book1D("MassRecoOverGen_E_500_750", "500<genpt<750", 90, 0, 3);
+  mMassRecoOverGen_F_500_750 = ibooker.book1D("MassRecoOverGen_F_500_750", "500<genpt<750", 90, 0, 3);
+  mMassRecoOverGen_B_750_1000 = ibooker.book1D("MassRecoOverGen_B_750_1000", "750<genpt<1000", 90, 0, 3);
+  mMassRecoOverGen_E_750_1000 = ibooker.book1D("MassRecoOverGen_E_750_1000", "750<genpt<1000", 90, 0, 3);
+  mMassRecoOverGen_F_750_1000 = ibooker.book1D("MassRecoOverGen_F_750_1000", "750<genpt<1000", 90, 0, 3);
+  mMassRecoOverGen_B_1000_1500 = ibooker.book1D("MassRecoOverGen_B_1000_1500", "1000<genpt<1500", 90, 0, 3);
+  mMassRecoOverGen_E_1000_1500 = ibooker.book1D("MassRecoOverGen_E_1000_1500", "1000<genpt<1500", 90, 0, 3);
+  mMassRecoOverGen_F_1000_1500 = ibooker.book1D("MassRecoOverGen_F_1000_1500", "1000<genpt<1500", 90, 0, 3);
+  mMassRecoOverGen_B_1500_3500 = ibooker.book1D("MassRecoOverGen_B_1500_3500", "1500<genpt<3500", 90, 0, 3);
+  mMassRecoOverGen_E_1500_3500 = ibooker.book1D("MassRecoOverGen_E_1500_3500", "1500<genpt<3500", 90, 0, 3);
+  mMassRecoOverGen_F_1500 = ibooker.book1D("MassRecoOverGen_F_1500", "genpt>1500", 90, 0, 3);
+  mMassRecoOverGen_B_3500_5000 = ibooker.book1D("MassRecoOverGen_B_3500_5000", "3500<genpt<5000", 90, 0, 3);
+  mMassRecoOverGen_E_3500_5000 = ibooker.book1D("MassRecoOverGen_E_3500_5000", "3500<genpt<5000", 90, 0, 3);
+  mMassRecoOverGen_B_5000 = ibooker.book1D("MassRecoOverGen_B_5000", "genpt>5000", 90, 0, 3);
+  mMassRecoOverGen_E_5000 = ibooker.book1D("MassRecoOverGen_E_5000", "genpt>5000", 90, 0, 3);
 
   // Generation profiles
   mPtRecoOverGen_GenPt_B =
-      ibooker.bookProfile("PtRecoOverGen_GenPt_B", "0<|eta|<1.5", log10PtBins,
-                          log10PtMin, log10PtMax, 0, 2, " ");
+      ibooker.bookProfile("PtRecoOverGen_GenPt_B", "0<|eta|<1.5", log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
   mPtRecoOverGen_GenPt_E =
-      ibooker.bookProfile("PtRecoOverGen_GenPt_E", "1.5<|eta|<3", log10PtBins,
-                          log10PtMin, log10PtMax, 0, 2, " ");
+      ibooker.bookProfile("PtRecoOverGen_GenPt_E", "1.5<|eta|<3", log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
   mPtRecoOverGen_GenPt_F =
-      ibooker.bookProfile("PtRecoOverGen_GenPt_F", "3<|eta|<6", log10PtBins,
-                          log10PtMin, log10PtMax, 0, 2, " ");
-  mPtRecoOverGen_GenPhi_B = ibooker.bookProfile(
-      "PtRecoOverGen_GenPhi_B", "0<|eta|<1.5", 70, -3.5, 3.5, 0, 2, " ");
-  mPtRecoOverGen_GenPhi_E = ibooker.bookProfile(
-      "PtRecoOverGen_GenPhi_E", "1.5<|eta|<3", 70, -3.5, 3.5, 0, 2, " ");
-  mPtRecoOverGen_GenPhi_F = ibooker.bookProfile(
-      "PtRecoOverGen_GenPhi_F", "3<|eta|<6", 70, -3.5, 3.5, 0, 2, " ");
+      ibooker.bookProfile("PtRecoOverGen_GenPt_F", "3<|eta|<6", log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
+  mPtRecoOverGen_GenPhi_B = ibooker.bookProfile("PtRecoOverGen_GenPhi_B", "0<|eta|<1.5", 70, -3.5, 3.5, 0, 2, " ");
+  mPtRecoOverGen_GenPhi_E = ibooker.bookProfile("PtRecoOverGen_GenPhi_E", "1.5<|eta|<3", 70, -3.5, 3.5, 0, 2, " ");
+  mPtRecoOverGen_GenPhi_F = ibooker.bookProfile("PtRecoOverGen_GenPhi_F", "3<|eta|<6", 70, -3.5, 3.5, 0, 2, " ");
   // if eta range changed here need change in JetTesterPostProcessor as well
-  mPtRecoOverGen_GenEta_20_40 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_20_40", "20<genpt<40", 90, etaRange, 0, 2, " ");
-  mPtRecoOverGen_GenEta_40_200 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_40_200", "40<genpt<200", 90, etaRange, 0, 2, " ");
-  mPtRecoOverGen_GenEta_200_600 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_200_600", "200<genpt<600", 90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_20_40 =
+      ibooker.bookProfile("PtRecoOverGen_GenEta_20_40", "20<genpt<40", 90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_40_200 =
+      ibooker.bookProfile("PtRecoOverGen_GenEta_40_200", "40<genpt<200", 90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_200_600 =
+      ibooker.bookProfile("PtRecoOverGen_GenEta_200_600", "200<genpt<600", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_600_1500 =
-      ibooker.bookProfile("PtRecoOverGen_GenEta_600_1500", "600<genpt<1500", 90,
-                          etaRange, 0, 2, " ");
+      ibooker.bookProfile("PtRecoOverGen_GenEta_600_1500", "600<genpt<1500", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_1500_3500 =
-      ibooker.bookProfile("PtRecoOverGen_GenEta_1500_3500", "1500<genpt<3500",
-                          90, etaRange, 0, 2, " ");
+      ibooker.bookProfile("PtRecoOverGen_GenEta_1500_3500", "1500<genpt<3500", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_3500_5000 =
-      ibooker.bookProfile("PtRecoOverGen_GenEta_3500_5000", "3500<genpt<5000",
-                          90, etaRange, 0, 2, " ");
+      ibooker.bookProfile("PtRecoOverGen_GenEta_3500_5000", "3500<genpt<5000", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_5000_6500 =
-      ibooker.bookProfile("PtRecoOverGen_GenEta_5000_6500", "5000<genpt<6500",
-                          90, etaRange, 0, 2, " ");
-  mPtRecoOverGen_GenEta_3500 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_3500", "genpt>3500", 90, etaRange, 0, 2, " ");
+      ibooker.bookProfile("PtRecoOverGen_GenEta_5000_6500", "5000<genpt<6500", 90, etaRange, 0, 2, " ");
+  mPtRecoOverGen_GenEta_3500 = ibooker.bookProfile("PtRecoOverGen_GenEta_3500", "genpt>3500", 90, etaRange, 0, 2, " ");
 
   // Some jet algebra
   //------------------------------------------------------------------------
@@ -536,35 +446,23 @@ void JetTester::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &iRun,
   mPhiFirst = ibooker.book1D("PhiFirst", "PhiFirst", 70, -3.5, 3.5);
   mPtFirst = ibooker.book1D("PtFirst", "PtFirst", 50, 0, 1000);
   mMjj = ibooker.book1D("Mjj", "Mjj", 100, 0, 2000);
-  mNJetsEta_B_20_40 =
-      ibooker.book1D("NJetsEta_B_20_40", "NJetsEta_B 20<Pt<40", 15, 0, 15);
-  mNJetsEta_E_20_40 =
-      ibooker.book1D("NJetsEta_E_20_40", "NJetsEta_E 20<Pt<40", 15, 0, 15);
+  mNJetsEta_B_20_40 = ibooker.book1D("NJetsEta_B_20_40", "NJetsEta_B 20<Pt<40", 15, 0, 15);
+  mNJetsEta_E_20_40 = ibooker.book1D("NJetsEta_E_20_40", "NJetsEta_E 20<Pt<40", 15, 0, 15);
   mNJetsEta_B_40 = ibooker.book1D("NJetsEta_B", "NJetsEta_B 40<Pt", 15, 0, 15);
   mNJetsEta_E_40 = ibooker.book1D("NJetsEta_E", "NJetsEta_E 40<Pt", 15, 0, 15);
   mNJets_40 = ibooker.book1D("NJets", "NJets 40>Pt", 15, 0, 15);
-  mNJets1 = ibooker.bookProfile("NJets1", "Number of jets above Pt threshold",
-                                100, 0, 200, 100, 0, 50, "s");
-  mNJets2 = ibooker.bookProfile("NJets2", "Number of jets above Pt threshold",
-                                100, 0, 4000, 100, 0, 50, "s");
+  mNJets1 = ibooker.bookProfile("NJets1", "Number of jets above Pt threshold", 100, 0, 200, 100, 0, 50, "s");
+  mNJets2 = ibooker.bookProfile("NJets2", "Number of jets above Pt threshold", 100, 0, 4000, 100, 0, 50, "s");
 
   if (isCaloJet) {
-    maxEInEmTowers =
-        ibooker.book1D("maxEInEmTowers", "maxEInEmTowers", 50, 0, 500);
-    maxEInHadTowers =
-        ibooker.book1D("maxEInHadTowers", "maxEInHadTowers", 50, 0, 500);
-    energyFractionHadronic = ibooker.book1D("energyFractionHadronic",
-                                            "energyFractionHadronic", 50, 0, 1);
-    emEnergyFraction =
-        ibooker.book1D("emEnergyFraction", "emEnergyFraction", 50, 0, 1);
-    hadEnergyInHB =
-        ibooker.book1D("hadEnergyInHB", "hadEnergyInHB", 50, 0, 500);
-    hadEnergyInHO =
-        ibooker.book1D("hadEnergyInHO", "hadEnergyInHO", 50, 0, 500);
-    hadEnergyInHE =
-        ibooker.book1D("hadEnergyInHE", "hadEnergyInHE", 50, 0, 500);
-    hadEnergyInHF =
-        ibooker.book1D("hadEnergyInHF", "hadEnergyInHF", 50, 0, 500);
+    maxEInEmTowers = ibooker.book1D("maxEInEmTowers", "maxEInEmTowers", 50, 0, 500);
+    maxEInHadTowers = ibooker.book1D("maxEInHadTowers", "maxEInHadTowers", 50, 0, 500);
+    energyFractionHadronic = ibooker.book1D("energyFractionHadronic", "energyFractionHadronic", 50, 0, 1);
+    emEnergyFraction = ibooker.book1D("emEnergyFraction", "emEnergyFraction", 50, 0, 1);
+    hadEnergyInHB = ibooker.book1D("hadEnergyInHB", "hadEnergyInHB", 50, 0, 500);
+    hadEnergyInHO = ibooker.book1D("hadEnergyInHO", "hadEnergyInHO", 50, 0, 500);
+    hadEnergyInHE = ibooker.book1D("hadEnergyInHE", "hadEnergyInHE", 50, 0, 500);
+    hadEnergyInHF = ibooker.book1D("hadEnergyInHF", "hadEnergyInHF", 50, 0, 500);
     emEnergyInEB = ibooker.book1D("emEnergyInEB", "emEnergyInEB", 50, 0, 500);
     emEnergyInEE = ibooker.book1D("emEnergyInEE", "emEnergyInEE", 50, 0, 500);
     emEnergyInHF = ibooker.book1D("emEnergyInHF", "emEnergyInHF", 50, 0, 500);
@@ -574,64 +472,39 @@ void JetTester::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &iRun,
   }
 
   if (isPFJet || isMiniAODJet) {
-    muonMultiplicity =
-        ibooker.book1D("muonMultiplicity", "muonMultiplicity", 10, 0, 10);
-    chargedMultiplicity = ibooker.book1D("chargedMultiplicity",
-                                         "chargedMultiplicity", 100, 0, 100);
-    chargedEmEnergy =
-        ibooker.book1D("chargedEmEnergy", "chargedEmEnergy", 100, 0, 500);
-    neutralEmEnergy =
-        ibooker.book1D("neutralEmEnergy", "neutralEmEnergy", 100, 0, 500);
-    chargedHadronEnergy = ibooker.book1D("chargedHadronEnergy",
-                                         "chargedHadronEnergy", 100, 0, 500);
-    neutralHadronEnergy = ibooker.book1D("neutralHadronEnergy",
-                                         "neutralHadronEnergy", 100, 0, 500);
-    chargedHadronEnergyFraction = ibooker.book1D(
-        "chargedHadronEnergyFraction", "chargedHadronEnergyFraction", 50, 0, 1);
-    neutralHadronEnergyFraction = ibooker.book1D(
-        "neutralHadronEnergyFraction", "neutralHadronEnergyFraction", 50, 0, 1);
-    chargedEmEnergyFraction = ibooker.book1D(
-        "chargedEmEnergyFraction", "chargedEmEnergyFraction", 50, 0, 1);
-    neutralEmEnergyFraction = ibooker.book1D(
-        "neutralEmEnergyFraction", "neutralEmEnergyFraction", 50, 0, 1);
+    muonMultiplicity = ibooker.book1D("muonMultiplicity", "muonMultiplicity", 10, 0, 10);
+    chargedMultiplicity = ibooker.book1D("chargedMultiplicity", "chargedMultiplicity", 100, 0, 100);
+    chargedEmEnergy = ibooker.book1D("chargedEmEnergy", "chargedEmEnergy", 100, 0, 500);
+    neutralEmEnergy = ibooker.book1D("neutralEmEnergy", "neutralEmEnergy", 100, 0, 500);
+    chargedHadronEnergy = ibooker.book1D("chargedHadronEnergy", "chargedHadronEnergy", 100, 0, 500);
+    neutralHadronEnergy = ibooker.book1D("neutralHadronEnergy", "neutralHadronEnergy", 100, 0, 500);
+    chargedHadronEnergyFraction =
+        ibooker.book1D("chargedHadronEnergyFraction", "chargedHadronEnergyFraction", 50, 0, 1);
+    neutralHadronEnergyFraction =
+        ibooker.book1D("neutralHadronEnergyFraction", "neutralHadronEnergyFraction", 50, 0, 1);
+    chargedEmEnergyFraction = ibooker.book1D("chargedEmEnergyFraction", "chargedEmEnergyFraction", 50, 0, 1);
+    neutralEmEnergyFraction = ibooker.book1D("neutralEmEnergyFraction", "neutralEmEnergyFraction", 50, 0, 1);
     photonEnergy = ibooker.book1D("photonEnergy", "photonEnergy", 50, 0, 500);
-    photonEnergyFraction = ibooker.book1D("photonEnergyFraction",
-                                          "photonEnergyFraction", 50, 0, 1);
-    electronEnergy =
-        ibooker.book1D("electronEnergy", "electronEnergy", 50, 0, 500);
-    electronEnergyFraction = ibooker.book1D("electronEnergyFraction",
-                                            "electronEnergyFraction", 50, 0, 1);
+    photonEnergyFraction = ibooker.book1D("photonEnergyFraction", "photonEnergyFraction", 50, 0, 1);
+    electronEnergy = ibooker.book1D("electronEnergy", "electronEnergy", 50, 0, 500);
+    electronEnergyFraction = ibooker.book1D("electronEnergyFraction", "electronEnergyFraction", 50, 0, 1);
     muonEnergy = ibooker.book1D("muonEnergy", "muonEnergy", 50, 0, 500);
-    muonEnergyFraction =
-        ibooker.book1D("muonEnergyFraction", "muonEnergyFraction", 50, 0, 1);
-    HFHadronEnergy =
-        ibooker.book1D("HFHadronEnergy", "HFHadronEnergy", 50, 0, 500);
-    HFHadronEnergyFraction = ibooker.book1D("HFHadronEnergyFraction",
-                                            "HFHadronEnergyFraction", 50, 0, 1);
+    muonEnergyFraction = ibooker.book1D("muonEnergyFraction", "muonEnergyFraction", 50, 0, 1);
+    HFHadronEnergy = ibooker.book1D("HFHadronEnergy", "HFHadronEnergy", 50, 0, 500);
+    HFHadronEnergyFraction = ibooker.book1D("HFHadronEnergyFraction", "HFHadronEnergyFraction", 50, 0, 1);
     HFEMEnergy = ibooker.book1D("HFEMEnergy", "HFEMEnergy", 50, 0, 500);
-    HFEMEnergyFraction =
-        ibooker.book1D("HFEMEnergyFraction", "HFEMEnergyFraction", 50, 0, 1);
-    chargedHadronMultiplicity = ibooker.book1D(
-        "chargedHadronMultiplicity", "chargedHadronMultiplicity", 50, 0, 50);
-    neutralHadronMultiplicity = ibooker.book1D(
-        "neutralHadronMultiplicity", "neutralHadronMultiplicity", 50, 0, 50);
-    photonMultiplicity =
-        ibooker.book1D("photonMultiplicity", "photonMultiplicity", 10, 0, 10);
-    electronMultiplicity = ibooker.book1D("electronMultiplicity",
-                                          "electronMultiplicity", 10, 0, 10);
-    HFHadronMultiplicity = ibooker.book1D("HFHadronMultiplicity",
-                                          "HFHadronMultiplicity", 50, 0, 50);
-    HFEMMultiplicity =
-        ibooker.book1D("HFEMMultiplicity", "HFEMMultiplicity", 50, 0, 50);
-    chargedMuEnergy =
-        ibooker.book1D("chargedMuEnergy", "chargedMuEnergy", 50, 0, 500);
-    chargedMuEnergyFraction = ibooker.book1D(
-        "chargedMuEnergyFraction", "chargedMuEnergyFraction", 50, 0, 1);
-    neutralMultiplicity =
-        ibooker.book1D("neutralMultiplicity", "neutralMultiplicity", 50, 0, 50);
+    HFEMEnergyFraction = ibooker.book1D("HFEMEnergyFraction", "HFEMEnergyFraction", 50, 0, 1);
+    chargedHadronMultiplicity = ibooker.book1D("chargedHadronMultiplicity", "chargedHadronMultiplicity", 50, 0, 50);
+    neutralHadronMultiplicity = ibooker.book1D("neutralHadronMultiplicity", "neutralHadronMultiplicity", 50, 0, 50);
+    photonMultiplicity = ibooker.book1D("photonMultiplicity", "photonMultiplicity", 10, 0, 10);
+    electronMultiplicity = ibooker.book1D("electronMultiplicity", "electronMultiplicity", 10, 0, 10);
+    HFHadronMultiplicity = ibooker.book1D("HFHadronMultiplicity", "HFHadronMultiplicity", 50, 0, 50);
+    HFEMMultiplicity = ibooker.book1D("HFEMMultiplicity", "HFEMMultiplicity", 50, 0, 50);
+    chargedMuEnergy = ibooker.book1D("chargedMuEnergy", "chargedMuEnergy", 50, 0, 500);
+    chargedMuEnergyFraction = ibooker.book1D("chargedMuEnergyFraction", "chargedMuEnergyFraction", 50, 0, 1);
+    neutralMultiplicity = ibooker.book1D("neutralMultiplicity", "neutralMultiplicity", 50, 0, 50);
     HOEnergy = ibooker.book1D("HOEnergy", "HOEnergy", 50, 0, 500);
-    HOEnergyFraction =
-        ibooker.book1D("HOEnergyFraction", "HOEnergyFraction", 50, 0, 1);
+    HOEnergyFraction = ibooker.book1D("HOEnergyFraction", "HOEnergyFraction", 50, 0, 1);
   }
 }
 
@@ -643,8 +516,7 @@ JetTester::~JetTester() {}
 //------------------------------------------------------------------------------
 // analyze
 //------------------------------------------------------------------------------
-void JetTester::analyze(const edm::Event &mEvent,
-                        const edm::EventSetup &mSetup) {
+void JetTester::analyze(const edm::Event &mEvent, const edm::EventSetup &mSetup) {
   // Get the primary vertices
   //----------------------------------------------------------------------------
   edm::Handle<vector<reco::Vertex>> pvHandle;
@@ -654,8 +526,7 @@ void JetTester::analyze(const edm::Event &mEvent,
 
   if (pvHandle.isValid()) {
     for (unsigned i = 0; i < pvHandle->size(); i++) {
-      if ((*pvHandle)[i].ndof() > 4 && (fabs((*pvHandle)[i].z()) <= 24) &&
-          (fabs((*pvHandle)[i].position().rho()) <= 2))
+      if ((*pvHandle)[i].ndof() > 4 && (fabs((*pvHandle)[i].z()) <= 24) && (fabs((*pvHandle)[i].position().rho()) <= 2))
         nGoodVertices++;
     }
   }
@@ -739,16 +610,13 @@ void JetTester::analyze(const edm::Event &mEvent,
     bool pass_lowjet = false;
     bool pass_mediumjet = false;
     if (!isMiniAODJet) {
-      if ((recoJets[ijet].pt() > 20.) &&
-          (recoJets[ijet].pt() < mRecoJetPtThreshold)) {
+      if ((recoJets[ijet].pt() > 20.) && (recoJets[ijet].pt() < mRecoJetPtThreshold)) {
         pass_lowjet = true;
       }
     }
     if (isMiniAODJet) {
-      if ((recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected")) >
-              20. &&
-          ((recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected")) <
-           mRecoJetPtThreshold)) {
+      if ((recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected")) > 20. &&
+          ((recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected")) < mRecoJetPtThreshold)) {
         pass_lowjet = true;
       }
     }
@@ -764,25 +632,20 @@ void JetTester::analyze(const edm::Event &mEvent,
       }
     }
     if (isMiniAODJet) {
-      if ((recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected")) >
-          mRecoJetPtThreshold) {
+      if ((recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected")) > mRecoJetPtThreshold) {
         pass_mediumjet = true;
       }
     }
     if (pass_mediumjet) {
       if (isMiniAODJet) {
-        if ((recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected")) >
-            pt_first) {
+        if ((recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected")) > pt_first) {
           pt_second = pt_first;
-          pt_first =
-              recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected");
+          pt_first = recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected");
           index_second_jet = index_first_jet;
           index_first_jet = ijet;
-        } else if ((recoJets[ijet].pt() *
-                    (*patJets)[ijet].jecFactor("Uncorrected")) > pt_second) {
+        } else if ((recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected")) > pt_second) {
           index_second_jet = ijet;
-          pt_second =
-              recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected");
+          pt_second = recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected");
         }
       }
       // counting forward and barrel jets
@@ -810,17 +673,13 @@ void JetTester::analyze(const edm::Event &mEvent,
           mMass->Fill(recoJets[ijet].mass());
       } else {
         if (mEnergy)
-          mEnergy->Fill(recoJets[ijet].energy() *
-                        (*patJets)[ijet].jecFactor("Uncorrected"));
+          mEnergy->Fill(recoJets[ijet].energy() * (*patJets)[ijet].jecFactor("Uncorrected"));
         if (mP)
-          mP->Fill(recoJets[ijet].p() *
-                   (*patJets)[ijet].jecFactor("Uncorrected"));
+          mP->Fill(recoJets[ijet].p() * (*patJets)[ijet].jecFactor("Uncorrected"));
         if (mPt)
-          mPt->Fill(recoJets[ijet].pt() *
-                    (*patJets)[ijet].jecFactor("Uncorrected"));
+          mPt->Fill(recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected"));
         if (mMass)
-          mMass->Fill(recoJets[ijet].mass() *
-                      (*patJets)[ijet].jecFactor("Uncorrected"));
+          mMass->Fill(recoJets[ijet].mass() * (*patJets)[ijet].jecFactor("Uncorrected"));
       }
       if (mConstituents)
         mConstituents->Fill(recoJets[ijet].nConstituents());
@@ -861,8 +720,7 @@ void JetTester::analyze(const edm::Event &mEvent,
       if (isCaloJet) {
         maxEInEmTowers->Fill((*caloJets)[ijet].maxEInEmTowers());
         maxEInHadTowers->Fill((*caloJets)[ijet].maxEInHadTowers());
-        energyFractionHadronic->Fill(
-            (*caloJets)[ijet].energyFractionHadronic());
+        energyFractionHadronic->Fill((*caloJets)[ijet].energyFractionHadronic());
         emEnergyFraction->Fill((*caloJets)[ijet].emEnergyFraction());
         hadEnergyInHB->Fill((*caloJets)[ijet].hadEnergyInHB());
         hadEnergyInHO->Fill((*caloJets)[ijet].hadEnergyInHO());
@@ -883,14 +741,10 @@ void JetTester::analyze(const edm::Event &mEvent,
         neutralEmEnergy->Fill((*pfJets)[ijet].neutralEmEnergy());
         chargedHadronEnergy->Fill((*pfJets)[ijet].chargedHadronEnergy());
         neutralHadronEnergy->Fill((*pfJets)[ijet].neutralHadronEnergy());
-        chargedHadronEnergyFraction->Fill(
-            (*pfJets)[ijet].chargedHadronEnergyFraction());
-        neutralHadronEnergyFraction->Fill(
-            (*pfJets)[ijet].neutralHadronEnergyFraction());
-        chargedEmEnergyFraction->Fill(
-            (*pfJets)[ijet].chargedEmEnergyFraction());
-        neutralEmEnergyFraction->Fill(
-            (*pfJets)[ijet].neutralEmEnergyFraction());
+        chargedHadronEnergyFraction->Fill((*pfJets)[ijet].chargedHadronEnergyFraction());
+        neutralHadronEnergyFraction->Fill((*pfJets)[ijet].neutralHadronEnergyFraction());
+        chargedEmEnergyFraction->Fill((*pfJets)[ijet].chargedEmEnergyFraction());
+        neutralEmEnergyFraction->Fill((*pfJets)[ijet].neutralEmEnergyFraction());
         photonEnergy->Fill((*pfJets)[ijet].photonEnergy());
         photonEnergyFraction->Fill((*pfJets)[ijet].photonEnergyFraction());
         electronEnergy->Fill((*pfJets)[ijet].electronEnergy());
@@ -901,17 +755,14 @@ void JetTester::analyze(const edm::Event &mEvent,
         HFHadronEnergyFraction->Fill((*pfJets)[ijet].HFHadronEnergyFraction());
         HFEMEnergy->Fill((*pfJets)[ijet].HFEMEnergy());
         HFEMEnergyFraction->Fill((*pfJets)[ijet].HFEMEnergyFraction());
-        chargedHadronMultiplicity->Fill(
-            (*pfJets)[ijet].chargedHadronMultiplicity());
-        neutralHadronMultiplicity->Fill(
-            (*pfJets)[ijet].neutralHadronMultiplicity());
+        chargedHadronMultiplicity->Fill((*pfJets)[ijet].chargedHadronMultiplicity());
+        neutralHadronMultiplicity->Fill((*pfJets)[ijet].neutralHadronMultiplicity());
         photonMultiplicity->Fill((*pfJets)[ijet].photonMultiplicity());
         electronMultiplicity->Fill((*pfJets)[ijet].electronMultiplicity());
         HFHadronMultiplicity->Fill((*pfJets)[ijet].HFHadronMultiplicity());
         HFEMMultiplicity->Fill((*pfJets)[ijet].HFEMMultiplicity());
         chargedMuEnergy->Fill((*pfJets)[ijet].chargedMuEnergy());
-        chargedMuEnergyFraction->Fill(
-            (*pfJets)[ijet].chargedMuEnergyFraction());
+        chargedMuEnergyFraction->Fill((*pfJets)[ijet].chargedMuEnergyFraction());
         neutralMultiplicity->Fill((*pfJets)[ijet].neutralMultiplicity());
         HOEnergy->Fill((*pfJets)[ijet].hoEnergy());
         HOEnergyFraction->Fill((*pfJets)[ijet].hoEnergyFraction());
@@ -923,14 +774,10 @@ void JetTester::analyze(const edm::Event &mEvent,
         neutralEmEnergy->Fill((*patJets)[ijet].neutralEmEnergy());
         chargedHadronEnergy->Fill((*patJets)[ijet].chargedHadronEnergy());
         neutralHadronEnergy->Fill((*patJets)[ijet].neutralHadronEnergy());
-        chargedHadronEnergyFraction->Fill(
-            (*patJets)[ijet].chargedHadronEnergyFraction());
-        neutralHadronEnergyFraction->Fill(
-            (*patJets)[ijet].neutralHadronEnergyFraction());
-        chargedEmEnergyFraction->Fill(
-            (*patJets)[ijet].chargedEmEnergyFraction());
-        neutralEmEnergyFraction->Fill(
-            (*patJets)[ijet].neutralEmEnergyFraction());
+        chargedHadronEnergyFraction->Fill((*patJets)[ijet].chargedHadronEnergyFraction());
+        neutralHadronEnergyFraction->Fill((*patJets)[ijet].neutralHadronEnergyFraction());
+        chargedEmEnergyFraction->Fill((*patJets)[ijet].chargedEmEnergyFraction());
+        neutralEmEnergyFraction->Fill((*patJets)[ijet].neutralEmEnergyFraction());
         photonEnergy->Fill((*patJets)[ijet].photonEnergy());
         photonEnergyFraction->Fill((*patJets)[ijet].photonEnergyFraction());
         electronEnergy->Fill((*patJets)[ijet].electronEnergy());
@@ -941,22 +788,19 @@ void JetTester::analyze(const edm::Event &mEvent,
         HFHadronEnergyFraction->Fill((*patJets)[ijet].HFHadronEnergyFraction());
         HFEMEnergy->Fill((*patJets)[ijet].HFEMEnergy());
         HFEMEnergyFraction->Fill((*patJets)[ijet].HFEMEnergyFraction());
-        chargedHadronMultiplicity->Fill(
-            (*patJets)[ijet].chargedHadronMultiplicity());
-        neutralHadronMultiplicity->Fill(
-            (*patJets)[ijet].neutralHadronMultiplicity());
+        chargedHadronMultiplicity->Fill((*patJets)[ijet].chargedHadronMultiplicity());
+        neutralHadronMultiplicity->Fill((*patJets)[ijet].neutralHadronMultiplicity());
         photonMultiplicity->Fill((*patJets)[ijet].photonMultiplicity());
         electronMultiplicity->Fill((*patJets)[ijet].electronMultiplicity());
         HFHadronMultiplicity->Fill((*patJets)[ijet].HFHadronMultiplicity());
         HFEMMultiplicity->Fill((*patJets)[ijet].HFEMMultiplicity());
         chargedMuEnergy->Fill((*patJets)[ijet].chargedMuEnergy());
-        chargedMuEnergyFraction->Fill(
-            (*patJets)[ijet].chargedMuEnergyFraction());
+        chargedMuEnergyFraction->Fill((*patJets)[ijet].chargedMuEnergyFraction());
         neutralMultiplicity->Fill((*patJets)[ijet].neutralMultiplicity());
         HOEnergy->Fill((*patJets)[ijet].hoEnergy());
         HOEnergyFraction->Fill((*patJets)[ijet].hoEnergyFraction());
       }
-    } // fill quantities for medium jets
+    }  // fill quantities for medium jets
   }
 
   if (mNJetsEta_B_20_40)
@@ -981,16 +825,13 @@ void JetTester::analyze(const edm::Event &mEvent,
       if (mPhiFirst)
         mPhiFirst->Fill(recoJets[index_first_jet].phi());
       if (mPtFirst)
-        mPtFirst->Fill(recoJets[index_first_jet].pt() *
-                       (*patJets)[index_first_jet].jecFactor("Uncorrected"));
+        mPtFirst->Fill(recoJets[index_first_jet].pt() * (*patJets)[index_first_jet].jecFactor("Uncorrected"));
       nJet++;
-      p4tmp[0] = recoJets[index_first_jet].p4() *
-                 (*patJets)[index_first_jet].jecFactor("Uncorrected");
+      p4tmp[0] = recoJets[index_first_jet].p4() * (*patJets)[index_first_jet].jecFactor("Uncorrected");
     }
     if (index_second_jet > -1) {
       nJet++;
-      p4tmp[1] = recoJets[index_second_jet].p4() *
-                 (*patJets)[index_second_jet].jecFactor("Uncorrected");
+      p4tmp[1] = recoJets[index_second_jet].p4() * (*patJets)[index_second_jet].jecFactor("Uncorrected");
     }
     if (nJet >= 2) {
       if (mMjj)
@@ -1014,11 +855,9 @@ void JetTester::analyze(const edm::Event &mEvent,
         if (recoJets[ijet].pt() > ptStep2)
           njets2++;
       } else {
-        if ((recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected")) >
-            ptStep1)
+        if ((recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected")) > ptStep1)
           njets1++;
-        if ((recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected")) >
-            ptStep2)
+        if ((recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected")) > ptStep2)
           njets2++;
       }
       mNJets1->Fill(ptStep1, njets1);
@@ -1075,8 +914,7 @@ void JetTester::analyze(const edm::Event &mEvent,
       double ijetEta = recoJets[ijet].eta();
       double ijetPt = recoJets[ijet].pt();
       if (isMiniAODJet) {
-        ijetPt =
-            recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected");
+        ijetPt = recoJets[ijet].pt() * (*patJets)[ijet].jecFactor("Uncorrected");
       }
       double ratio = correctedJet.pt() / ijetPt;
       if (isMiniAODJet) {
@@ -1135,8 +973,7 @@ void JetTester::analyze(const edm::Event &mEvent,
     if (!genJets.isValid())
       return;
 
-    for (GenJetCollection::const_iterator gjet = genJets->begin();
-         gjet != genJets->end(); gjet++) {
+    for (GenJetCollection::const_iterator gjet = genJets->begin(); gjet != genJets->end(); gjet++) {
       // for MiniAOD we have here intrinsic thresholds, introduce also threshold
       // for RECO
       if (gjet->pt() > mMatchGenPtThreshold) {
@@ -1156,10 +993,9 @@ void JetTester::analyze(const edm::Event &mEvent,
     }
 
     if (!(mInputGenCollection.label().empty())) {
-      for (GenJetCollection::const_iterator gjet = genJets->begin();
-           gjet != genJets->end(); gjet++) {
+      for (GenJetCollection::const_iterator gjet = genJets->begin(); gjet != genJets->end(); gjet++) {
         if (fabs(gjet->eta()) > 6.)
-          continue; // Out of the detector
+          continue;  // Out of the detector
         if (gjet->pt() < mMatchGenPtThreshold)
           continue;
         if (recoJets.empty())
@@ -1181,8 +1017,7 @@ void JetTester::analyze(const edm::Event &mEvent,
           }
           double CorrJetPt = correctedJet.pt();
           if (CorrJetPt > 10) {
-            double CorrdR = deltaR(gjet->eta(), gjet->phi(), correctedJet.eta(),
-                                   correctedJet.phi());
+            double CorrdR = deltaR(gjet->eta(), gjet->phi(), correctedJet.eta(), correctedJet.phi());
             if (CorrdR < CorrdeltaRBest) {
               CorrJetMassBest = correctedJet.mass();
               CorrdeltaRBest = CorrdR;
@@ -1196,17 +1031,25 @@ void JetTester::analyze(const edm::Event &mEvent,
         // use mass after jet energy correction -> for MiniAOD that is the case
         // per default
         if (!isMiniAODJet) {
-          fillMatchHists(gjet->eta(), gjet->phi(), gjet->pt(), gjet->mass(),
-                         recoJets[iMatch].eta(), recoJets[iMatch].phi(),
-                         recoJets[iMatch].pt(), CorrJetMassBest);
+          fillMatchHists(gjet->eta(),
+                         gjet->phi(),
+                         gjet->pt(),
+                         gjet->mass(),
+                         recoJets[iMatch].eta(),
+                         recoJets[iMatch].phi(),
+                         recoJets[iMatch].pt(),
+                         CorrJetMassBest);
         } else {
-          fillMatchHists(gjet->eta(), gjet->phi(), gjet->pt(), gjet->mass(),
-                         (*patJets)[iMatch].eta(), (*patJets)[iMatch].phi(),
-                         (*patJets)[iMatch].pt() *
-                             (*patJets)[iMatch].jecFactor("Uncorrected"),
+          fillMatchHists(gjet->eta(),
+                         gjet->phi(),
+                         gjet->pt(),
+                         gjet->mass(),
+                         (*patJets)[iMatch].eta(),
+                         (*patJets)[iMatch].phi(),
+                         (*patJets)[iMatch].pt() * (*patJets)[iMatch].jecFactor("Uncorrected"),
                          recoJets[iMatch].mass());
         }
-        if (pass_correction_flag) { // fill only for corrected jets
+        if (pass_correction_flag) {  // fill only for corrected jets
           if (CorrdeltaRBest < mRThreshold) {
             double response = CorrJetPtBest / gjet->pt();
 
@@ -1245,10 +1088,14 @@ void JetTester::analyze(const edm::Event &mEvent,
 //------------------------------------------------------------------------------
 // fillMatchHists
 //------------------------------------------------------------------------------
-void JetTester::fillMatchHists(const double GenEta, const double GenPhi,
-                               const double GenPt, const double GenMass,
-                               const double RecoEta, const double RecoPhi,
-                               const double RecoPt, const double RecoMass) {
+void JetTester::fillMatchHists(const double GenEta,
+                               const double GenPhi,
+                               const double GenPt,
+                               const double GenMass,
+                               const double RecoEta,
+                               const double RecoPhi,
+                               const double RecoPt,
+                               const double RecoMass) {
   if (GenPt > mMatchGenPtThreshold) {
     mDeltaEta->Fill(GenEta - RecoEta);
     mDeltaPhi->Fill(GenPhi - RecoPhi);

--- a/Validation/RecoJets/plugins/JetTester.h
+++ b/Validation/RecoJets/plugins/JetTester.h
@@ -47,14 +47,17 @@ public:
   ~JetTester() override;
 
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:
-  void fillMatchHists(const double GenEta, const double GenPhi,
-                      const double GenPt, const double GenMass,
-                      const double RecoEta, const double RecoPhi,
-                      const double RecoPt, const double RecoMass);
+  void fillMatchHists(const double GenEta,
+                      const double GenPhi,
+                      const double GenPt,
+                      const double GenMass,
+                      const double RecoEta,
+                      const double RecoPhi,
+                      const double RecoPt,
+                      const double RecoMass);
 
   edm::InputTag mInputCollection;
   edm::InputTag mInputGenCollection;

--- a/Validation/RecoJets/plugins/JetTesterPostProcessor.cc
+++ b/Validation/RecoJets/plugins/JetTesterPostProcessor.cc
@@ -15,8 +15,7 @@
 //
 // constructors and destructor
 //
-JetTesterPostProcessor::JetTesterPostProcessor(
-    const edm::ParameterSet &iConfig) {
+JetTesterPostProcessor::JetTesterPostProcessor(const edm::ParameterSet &iConfig) {
   inputJetLabelRECO_ = iConfig.getParameter<edm::InputTag>("JetTypeRECO");
   inputJetLabelMiniAOD_ = iConfig.getParameter<edm::InputTag>("JetTypeMiniAOD");
 }
@@ -24,8 +23,7 @@ JetTesterPostProcessor::JetTesterPostProcessor(
 JetTesterPostProcessor::~JetTesterPostProcessor() {}
 
 // ------------ method called right after a run ends ------------
-void JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker &ibook_,
-                                       DQMStore::IGetter &iget_) {
+void JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker &ibook_, DQMStore::IGetter &iget_) {
   std::vector<std::string> subDirVec;
   std::string RunDir = "JetMET/JetValidation/";
   iget_.setCurrentFolder(RunDir);
@@ -52,12 +50,9 @@ void JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker &ibook_,
     MonitorElement *mPt_Reco = iget_.get(rundir_reco + "/" + "Pt");
     MonitorElement *mPhi_Reco = iget_.get(rundir_reco + "/" + "Phi");
     MonitorElement *mEta_Reco = iget_.get(rundir_reco + "/" + "Eta");
-    MonitorElement *mCorrJetPt_Reco =
-        iget_.get(rundir_reco + "/" + "CorrJetPt");
-    MonitorElement *mCorrJetPhi_Reco =
-        iget_.get(rundir_reco + "/" + "CorrJetPhi");
-    MonitorElement *mCorrJetEta_Reco =
-        iget_.get(rundir_reco + "/" + "CorrJetEta");
+    MonitorElement *mCorrJetPt_Reco = iget_.get(rundir_reco + "/" + "CorrJetPt");
+    MonitorElement *mCorrJetPhi_Reco = iget_.get(rundir_reco + "/" + "CorrJetPhi");
+    MonitorElement *mCorrJetEta_Reco = iget_.get(rundir_reco + "/" + "CorrJetEta");
     /*
     map_string_vec.push_back("Pt");
     map_string_vec.push_back("Phi");
@@ -78,14 +73,10 @@ void JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker &ibook_,
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"CorrJetEta"
     ,mCorrJetEta_Reco));
     */
-    MonitorElement *mPtCorrOverReco_Eta_20_40_Reco =
-        iget_.get(rundir_reco + "/" + "PtCorrOverReco_Eta_20_40");
-    MonitorElement *mPtCorrOverReco_Eta_200_600_Reco =
-        iget_.get(rundir_reco + "/" + "PtCorrOverReco_Eta_200_600");
-    MonitorElement *mPtCorrOverReco_Eta_1500_3500_Reco =
-        iget_.get(rundir_reco + "/" + "PtCorrOverReco_Eta_1500_3500");
-    MonitorElement *mPtCorrOverGen_GenEta_40_200_Reco =
-        iget_.get(rundir_reco + "/" + "PtCorrOverGen_GenEta_40_200");
+    MonitorElement *mPtCorrOverReco_Eta_20_40_Reco = iget_.get(rundir_reco + "/" + "PtCorrOverReco_Eta_20_40");
+    MonitorElement *mPtCorrOverReco_Eta_200_600_Reco = iget_.get(rundir_reco + "/" + "PtCorrOverReco_Eta_200_600");
+    MonitorElement *mPtCorrOverReco_Eta_1500_3500_Reco = iget_.get(rundir_reco + "/" + "PtCorrOverReco_Eta_1500_3500");
+    MonitorElement *mPtCorrOverGen_GenEta_40_200_Reco = iget_.get(rundir_reco + "/" + "PtCorrOverGen_GenEta_40_200");
     MonitorElement *mPtCorrOverGen_GenEta_600_1500_Reco =
         iget_.get(rundir_reco + "/" + "PtCorrOverGen_GenEta_600_1500");
     MonitorElement *mDeltaEta_Reco = iget_.get(rundir_reco + "/" + "DeltaEta");
@@ -93,18 +84,12 @@ void JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker &ibook_,
     MonitorElement *mDeltaPt_Reco = iget_.get(rundir_reco + "/" + "DeltaPt");
     MonitorElement *mMjj_Reco = iget_.get(rundir_reco + "/" + "Mjj");
     MonitorElement *mNJets40_Reco = iget_.get(rundir_reco + "/" + "NJets");
-    MonitorElement *mchargedHadronMultiplicity_Reco =
-        iget_.get(rundir_reco + "/" + "chargedHadronMultiplicity");
-    MonitorElement *mneutralHadronMultiplicity_Reco =
-        iget_.get(rundir_reco + "/" + "neutralHadronMultiplicity");
-    MonitorElement *mphotonMultiplicity_Reco =
-        iget_.get(rundir_reco + "/" + "photonMultiplicity");
-    MonitorElement *mphotonEnergyFraction_Reco =
-        iget_.get(rundir_reco + "/" + "photonEnergyFraction");
-    MonitorElement *mneutralHadronEnergyFraction_Reco =
-        iget_.get(rundir_reco + "/" + "neutralHadronEnergyFraction");
-    MonitorElement *mchargedHadronEnergyFraction_Reco =
-        iget_.get(rundir_reco + "/" + "chargedHadronEnergyFraction");
+    MonitorElement *mchargedHadronMultiplicity_Reco = iget_.get(rundir_reco + "/" + "chargedHadronMultiplicity");
+    MonitorElement *mneutralHadronMultiplicity_Reco = iget_.get(rundir_reco + "/" + "neutralHadronMultiplicity");
+    MonitorElement *mphotonMultiplicity_Reco = iget_.get(rundir_reco + "/" + "photonMultiplicity");
+    MonitorElement *mphotonEnergyFraction_Reco = iget_.get(rundir_reco + "/" + "photonEnergyFraction");
+    MonitorElement *mneutralHadronEnergyFraction_Reco = iget_.get(rundir_reco + "/" + "neutralHadronEnergyFraction");
+    MonitorElement *mchargedHadronEnergyFraction_Reco = iget_.get(rundir_reco + "/" + "chargedHadronEnergyFraction");
 
     std::vector<MonitorElement *> ME_Reco;
     ME_Reco.push_back(mGenPt_Reco);
@@ -134,21 +119,15 @@ void JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker &ibook_,
     ME_Reco.push_back(mchargedHadronEnergyFraction_Reco);
 
     MonitorElement *mGenPt_MiniAOD = iget_.get(rundir_miniaod + "/" + "GenPt");
-    MonitorElement *mGenPhi_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "GenPhi");
-    MonitorElement *mGenEta_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "GenEta");
+    MonitorElement *mGenPhi_MiniAOD = iget_.get(rundir_miniaod + "/" + "GenPhi");
+    MonitorElement *mGenEta_MiniAOD = iget_.get(rundir_miniaod + "/" + "GenEta");
     MonitorElement *mPt_MiniAOD = iget_.get(rundir_miniaod + "/" + "Pt");
     MonitorElement *mPhi_MiniAOD = iget_.get(rundir_miniaod + "/" + "Phi");
     MonitorElement *mEta_MiniAOD = iget_.get(rundir_miniaod + "/" + "Eta");
-    MonitorElement *mCorrJetPt_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "CorrJetPt");
-    MonitorElement *mCorrJetPhi_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "CorrJetPhi");
-    MonitorElement *mCorrJetEta_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "CorrJetEta");
-    MonitorElement *mPtCorrOverReco_Eta_20_40_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "PtCorrOverReco_Eta_20_40");
+    MonitorElement *mCorrJetPt_MiniAOD = iget_.get(rundir_miniaod + "/" + "CorrJetPt");
+    MonitorElement *mCorrJetPhi_MiniAOD = iget_.get(rundir_miniaod + "/" + "CorrJetPhi");
+    MonitorElement *mCorrJetEta_MiniAOD = iget_.get(rundir_miniaod + "/" + "CorrJetEta");
+    MonitorElement *mPtCorrOverReco_Eta_20_40_MiniAOD = iget_.get(rundir_miniaod + "/" + "PtCorrOverReco_Eta_20_40");
     MonitorElement *mPtCorrOverReco_Eta_200_600_MiniAOD =
         iget_.get(rundir_miniaod + "/" + "PtCorrOverReco_Eta_200_600");
     MonitorElement *mPtCorrOverReco_Eta_1500_3500_MiniAOD =
@@ -157,23 +136,15 @@ void JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker &ibook_,
         iget_.get(rundir_miniaod + "/" + "PtCorrOverGen_GenEta_40_200");
     MonitorElement *mPtCorrOverGen_GenEta_600_1500_MiniAOD =
         iget_.get(rundir_miniaod + "/" + "PtCorrOverGen_GenEta_600_1500");
-    MonitorElement *mDeltaEta_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "DeltaEta");
-    MonitorElement *mDeltaPhi_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "DeltaPhi");
-    MonitorElement *mDeltaPt_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "DeltaPt");
+    MonitorElement *mDeltaEta_MiniAOD = iget_.get(rundir_miniaod + "/" + "DeltaEta");
+    MonitorElement *mDeltaPhi_MiniAOD = iget_.get(rundir_miniaod + "/" + "DeltaPhi");
+    MonitorElement *mDeltaPt_MiniAOD = iget_.get(rundir_miniaod + "/" + "DeltaPt");
     MonitorElement *mMjj_MiniAOD = iget_.get(rundir_miniaod + "/" + "Mjj");
-    MonitorElement *mNJets40_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "NJets");
-    MonitorElement *mchargedHadronMultiplicity_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "chargedHadronMultiplicity");
-    MonitorElement *mneutralHadronMultiplicity_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "neutralHadronMultiplicity");
-    MonitorElement *mphotonMultiplicity_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "photonMultiplicity");
-    MonitorElement *mphotonEnergyFraction_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "photonEnergyFraction");
+    MonitorElement *mNJets40_MiniAOD = iget_.get(rundir_miniaod + "/" + "NJets");
+    MonitorElement *mchargedHadronMultiplicity_MiniAOD = iget_.get(rundir_miniaod + "/" + "chargedHadronMultiplicity");
+    MonitorElement *mneutralHadronMultiplicity_MiniAOD = iget_.get(rundir_miniaod + "/" + "neutralHadronMultiplicity");
+    MonitorElement *mphotonMultiplicity_MiniAOD = iget_.get(rundir_miniaod + "/" + "photonMultiplicity");
+    MonitorElement *mphotonEnergyFraction_MiniAOD = iget_.get(rundir_miniaod + "/" + "photonEnergyFraction");
     MonitorElement *mneutralHadronEnergyFraction_MiniAOD =
         iget_.get(rundir_miniaod + "/" + "neutralHadronEnergyFraction");
     MonitorElement *mchargedHadronEnergyFraction_MiniAOD =
@@ -207,82 +178,55 @@ void JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker &ibook_,
     ME_MiniAOD.push_back(mchargedHadronEnergyFraction_MiniAOD);
 
     ibook_.setCurrentFolder(RunDir + "MiniAOD_over_RECO");
-    mGenPt_MiniAOD_over_Reco = ibook_.book1D(
-        "GenPt_MiniAOD_over_RECO", (TH1F *)mGenPt_Reco->getRootObject());
-    mGenPhi_MiniAOD_over_Reco = ibook_.book1D(
-        "GenPhi_MiniAOD_over_RECO", (TH1F *)mGenPhi_Reco->getRootObject());
-    mGenEta_MiniAOD_over_Reco = ibook_.book1D(
-        "GenEta_MiniAOD_over_RECO", (TH1F *)mGenEta_Reco->getRootObject());
-    mPt_MiniAOD_over_Reco = ibook_.book1D("Pt_MiniAOD_over_RECO",
-                                          (TH1F *)mPt_Reco->getRootObject());
-    mPhi_MiniAOD_over_Reco = ibook_.book1D("Phi_MiniAOD_over_RECO",
-                                           (TH1F *)mPhi_Reco->getRootObject());
-    mEta_MiniAOD_over_Reco = ibook_.book1D("Eta_MiniAOD_over_RECO",
-                                           (TH1F *)mEta_Reco->getRootObject());
+    mGenPt_MiniAOD_over_Reco = ibook_.book1D("GenPt_MiniAOD_over_RECO", (TH1F *)mGenPt_Reco->getRootObject());
+    mGenPhi_MiniAOD_over_Reco = ibook_.book1D("GenPhi_MiniAOD_over_RECO", (TH1F *)mGenPhi_Reco->getRootObject());
+    mGenEta_MiniAOD_over_Reco = ibook_.book1D("GenEta_MiniAOD_over_RECO", (TH1F *)mGenEta_Reco->getRootObject());
+    mPt_MiniAOD_over_Reco = ibook_.book1D("Pt_MiniAOD_over_RECO", (TH1F *)mPt_Reco->getRootObject());
+    mPhi_MiniAOD_over_Reco = ibook_.book1D("Phi_MiniAOD_over_RECO", (TH1F *)mPhi_Reco->getRootObject());
+    mEta_MiniAOD_over_Reco = ibook_.book1D("Eta_MiniAOD_over_RECO", (TH1F *)mEta_Reco->getRootObject());
     mCorrJetPt_MiniAOD_over_Reco =
-        ibook_.book1D("CorrJetPt_MiniAOD_over_RECO",
-                      (TH1F *)mCorrJetPt_Reco->getRootObject());
+        ibook_.book1D("CorrJetPt_MiniAOD_over_RECO", (TH1F *)mCorrJetPt_Reco->getRootObject());
     mCorrJetPhi_MiniAOD_over_Reco =
-        ibook_.book1D("CorrJetPhi_MiniAOD_over_RECO",
-                      (TH1F *)mCorrJetPhi_Reco->getRootObject());
+        ibook_.book1D("CorrJetPhi_MiniAOD_over_RECO", (TH1F *)mCorrJetPhi_Reco->getRootObject());
     mCorrJetEta_MiniAOD_over_Reco =
-        ibook_.book1D("CorrJetEta_MiniAOD_over_RECO",
-                      (TH1F *)mCorrJetEta_Reco->getRootObject());
+        ibook_.book1D("CorrJetEta_MiniAOD_over_RECO", (TH1F *)mCorrJetEta_Reco->getRootObject());
 
     // if eta range changed here need change in JetTester as well
-    float etarange[91] = {
-        -6.0, -5.8, -5.6, -5.4, -5.2, -5.0, -4.8, -4.6, -4.4, -4.2, -4.0, -3.8,
-        -3.6, -3.4, -3.2, -3.0, -2.9, -2.8, -2.7, -2.6, -2.5, -2.4, -2.3, -2.2,
-        -2.1, -2.0, -1.9, -1.8, -1.7, -1.6, -1.5, -1.4, -1.3, -1.2, -1.1, -1.0,
-        -0.9, -0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0.0,  0.1,  0.2,
-        0.3,  0.4,  0.5,  0.6,  0.7,  0.8,  0.9,  1.0,  1.1,  1.2,  1.3,  1.4,
-        1.5,  1.6,  1.7,  1.8,  1.9,  2.0,  2.1,  2.2,  2.3,  2.4,  2.5,  2.6,
-        2.7,  2.8,  2.9,  3.0,  3.2,  3.4,  3.6,  3.8,  4.0,  4.2,  4.4,  4.6,
-        4.8,  5.0,  5.2,  5.4,  5.6,  5.8,  6.0};
+    float etarange[91] = {-6.0, -5.8, -5.6, -5.4, -5.2, -5.0, -4.8, -4.6, -4.4, -4.2, -4.0, -3.8, -3.6,
+                          -3.4, -3.2, -3.0, -2.9, -2.8, -2.7, -2.6, -2.5, -2.4, -2.3, -2.2, -2.1, -2.0,
+                          -1.9, -1.8, -1.7, -1.6, -1.5, -1.4, -1.3, -1.2, -1.1, -1.0, -0.9, -0.8, -0.7,
+                          -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0.0,  0.1,  0.2,  0.3,  0.4,  0.5,  0.6,
+                          0.7,  0.8,  0.9,  1.0,  1.1,  1.2,  1.3,  1.4,  1.5,  1.6,  1.7,  1.8,  1.9,
+                          2.0,  2.1,  2.2,  2.3,  2.4,  2.5,  2.6,  2.7,  2.8,  2.9,  3.0,  3.2,  3.4,
+                          3.6,  3.8,  4.0,  4.2,  4.4,  4.6,  4.8,  5.0,  5.2,  5.4,  5.6,  5.8,  6.0};
 
     mPtCorrOverReco_Eta_20_40_MiniAOD_over_Reco =
-        ibook_.book1D("PtCorrOverReco_Eta_20_40_MiniAOD_over_RECO",
-                      "20<genpt<40", 90, etarange);
+        ibook_.book1D("PtCorrOverReco_Eta_20_40_MiniAOD_over_RECO", "20<genpt<40", 90, etarange);
     mPtCorrOverReco_Eta_200_600_MiniAOD_over_Reco =
-        ibook_.book1D("PtCorrOverReco_Eta_200_600_MiniAOD_over_RECO",
-                      "200<genpt<600", 90, etarange);
+        ibook_.book1D("PtCorrOverReco_Eta_200_600_MiniAOD_over_RECO", "200<genpt<600", 90, etarange);
     mPtCorrOverReco_Eta_1500_3500_MiniAOD_over_Reco =
-        ibook_.book1D("PtCorrOverReco_Eta_1500_3500_MiniAOD_over_RECO",
-                      "1500<genpt<3500", 90, etarange);
+        ibook_.book1D("PtCorrOverReco_Eta_1500_3500_MiniAOD_over_RECO", "1500<genpt<3500", 90, etarange);
     mPtCorrOverGen_GenEta_40_200_MiniAOD_over_Reco =
-        ibook_.book1D("PtCorrOverGen_GenEta_40_200_MiniAOD_over_RECO",
-                      "40<genpt<200", 90, etarange);
+        ibook_.book1D("PtCorrOverGen_GenEta_40_200_MiniAOD_over_RECO", "40<genpt<200", 90, etarange);
     mPtCorrOverGen_GenEta_600_1500_MiniAOD_over_Reco =
-        ibook_.book1D("PtCorrOverGen_GenEta_600_1500_MiniAOD_over_RECO",
-                      "600<genpt<1500", 90, etarange);
-    mDeltaPt_MiniAOD_over_Reco = ibook_.book1D(
-        "DeltaPt_MiniAOD_over_RECO", (TH1F *)mDeltaPt_Reco->getRootObject());
-    mDeltaPhi_MiniAOD_over_Reco = ibook_.book1D(
-        "DeltaPhi_MiniAOD_over_RECO", (TH1F *)mDeltaPhi_Reco->getRootObject());
-    mDeltaEta_MiniAOD_over_Reco = ibook_.book1D(
-        "DeltaEta_MiniAOD_over_RECO", (TH1F *)mDeltaEta_Reco->getRootObject());
-    mMjj_MiniAOD_over_Reco = ibook_.book1D("Mjj_MiniAOD_over_RECO",
-                                           (TH1F *)mMjj_Reco->getRootObject());
-    mNJets40_MiniAOD_over_Reco = ibook_.book1D(
-        "NJets_MiniAOD_over_RECO", (TH1F *)mNJets40_Reco->getRootObject());
-    mchargedHadronMultiplicity_MiniAOD_over_Reco =
-        ibook_.book1D("chargedHadronMultiplicity_MiniAOD_over_RECO",
-                      (TH1F *)mchargedHadronMultiplicity_Reco->getRootObject());
-    mneutralHadronMultiplicity_MiniAOD_over_Reco =
-        ibook_.book1D("neutralHadronMultiplicity_MiniAOD_over_RECO",
-                      (TH1F *)mneutralHadronMultiplicity_Reco->getRootObject());
+        ibook_.book1D("PtCorrOverGen_GenEta_600_1500_MiniAOD_over_RECO", "600<genpt<1500", 90, etarange);
+    mDeltaPt_MiniAOD_over_Reco = ibook_.book1D("DeltaPt_MiniAOD_over_RECO", (TH1F *)mDeltaPt_Reco->getRootObject());
+    mDeltaPhi_MiniAOD_over_Reco = ibook_.book1D("DeltaPhi_MiniAOD_over_RECO", (TH1F *)mDeltaPhi_Reco->getRootObject());
+    mDeltaEta_MiniAOD_over_Reco = ibook_.book1D("DeltaEta_MiniAOD_over_RECO", (TH1F *)mDeltaEta_Reco->getRootObject());
+    mMjj_MiniAOD_over_Reco = ibook_.book1D("Mjj_MiniAOD_over_RECO", (TH1F *)mMjj_Reco->getRootObject());
+    mNJets40_MiniAOD_over_Reco = ibook_.book1D("NJets_MiniAOD_over_RECO", (TH1F *)mNJets40_Reco->getRootObject());
+    mchargedHadronMultiplicity_MiniAOD_over_Reco = ibook_.book1D(
+        "chargedHadronMultiplicity_MiniAOD_over_RECO", (TH1F *)mchargedHadronMultiplicity_Reco->getRootObject());
+    mneutralHadronMultiplicity_MiniAOD_over_Reco = ibook_.book1D(
+        "neutralHadronMultiplicity_MiniAOD_over_RECO", (TH1F *)mneutralHadronMultiplicity_Reco->getRootObject());
     mphotonMultiplicity_MiniAOD_over_Reco =
-        ibook_.book1D("photonMultiplicity_MiniAOD_over_RECO",
-                      (TH1F *)mphotonMultiplicity_Reco->getRootObject());
+        ibook_.book1D("photonMultiplicity_MiniAOD_over_RECO", (TH1F *)mphotonMultiplicity_Reco->getRootObject());
     mchargedHadronEnergyFraction_MiniAOD_over_Reco = ibook_.book1D(
-        "chargedHadronEnergyFraction_MiniAOD_over_RECO",
-        (TH1F *)mchargedHadronEnergyFraction_Reco->getRootObject());
+        "chargedHadronEnergyFraction_MiniAOD_over_RECO", (TH1F *)mchargedHadronEnergyFraction_Reco->getRootObject());
     mneutralHadronEnergyFraction_MiniAOD_over_Reco = ibook_.book1D(
-        "neutralHadronEnergyFraction_MiniAOD_over_RECO",
-        (TH1F *)mneutralHadronEnergyFraction_Reco->getRootObject());
+        "neutralHadronEnergyFraction_MiniAOD_over_RECO", (TH1F *)mneutralHadronEnergyFraction_Reco->getRootObject());
     mphotonEnergyFraction_MiniAOD_over_Reco =
-        ibook_.book1D("photonEnergyFraction_MiniAOD_over_RECO",
-                      (TH1F *)mphotonEnergyFraction_Reco->getRootObject());
+        ibook_.book1D("photonEnergyFraction_MiniAOD_over_RECO", (TH1F *)mphotonEnergyFraction_Reco->getRootObject());
 
     std::vector<MonitorElement *> ME_MiniAOD_over_Reco;
     ME_MiniAOD_over_Reco.push_back(mGenPt_MiniAOD_over_Reco);
@@ -295,29 +239,21 @@ void JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker &ibook_,
     ME_MiniAOD_over_Reco.push_back(mCorrJetPhi_MiniAOD_over_Reco);
     ME_MiniAOD_over_Reco.push_back(mCorrJetEta_MiniAOD_over_Reco);
     ME_MiniAOD_over_Reco.push_back(mPtCorrOverReco_Eta_20_40_MiniAOD_over_Reco);
-    ME_MiniAOD_over_Reco.push_back(
-        mPtCorrOverReco_Eta_200_600_MiniAOD_over_Reco);
-    ME_MiniAOD_over_Reco.push_back(
-        mPtCorrOverReco_Eta_1500_3500_MiniAOD_over_Reco);
-    ME_MiniAOD_over_Reco.push_back(
-        mPtCorrOverGen_GenEta_40_200_MiniAOD_over_Reco);
-    ME_MiniAOD_over_Reco.push_back(
-        mPtCorrOverGen_GenEta_600_1500_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mPtCorrOverReco_Eta_200_600_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mPtCorrOverReco_Eta_1500_3500_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mPtCorrOverGen_GenEta_40_200_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mPtCorrOverGen_GenEta_600_1500_MiniAOD_over_Reco);
     ME_MiniAOD_over_Reco.push_back(mDeltaEta_MiniAOD_over_Reco);
     ME_MiniAOD_over_Reco.push_back(mDeltaPhi_MiniAOD_over_Reco);
     ME_MiniAOD_over_Reco.push_back(mDeltaPt_MiniAOD_over_Reco);
     ME_MiniAOD_over_Reco.push_back(mMjj_MiniAOD_over_Reco);
     ME_MiniAOD_over_Reco.push_back(mNJets40_MiniAOD_over_Reco);
-    ME_MiniAOD_over_Reco.push_back(
-        mchargedHadronMultiplicity_MiniAOD_over_Reco);
-    ME_MiniAOD_over_Reco.push_back(
-        mneutralHadronMultiplicity_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mchargedHadronMultiplicity_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mneutralHadronMultiplicity_MiniAOD_over_Reco);
     ME_MiniAOD_over_Reco.push_back(mphotonMultiplicity_MiniAOD_over_Reco);
     ME_MiniAOD_over_Reco.push_back(mphotonEnergyFraction_MiniAOD_over_Reco);
-    ME_MiniAOD_over_Reco.push_back(
-        mneutralHadronEnergyFraction_MiniAOD_over_Reco);
-    ME_MiniAOD_over_Reco.push_back(
-        mchargedHadronEnergyFraction_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mneutralHadronEnergyFraction_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mchargedHadronEnergyFraction_MiniAOD_over_Reco);
     for (unsigned int j = 0; j < ME_MiniAOD_over_Reco.size(); j++) {
       MonitorElement *monReco = ME_Reco[j];
       if (monReco && monReco->getRootObject()) {
@@ -327,9 +263,7 @@ void JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker &ibook_,
           if (monMiniAOD_over_RECO && monMiniAOD_over_RECO->getRootObject()) {
             for (int i = 0; i <= (monMiniAOD_over_RECO->getNbinsX() + 1); i++) {
               if (monReco->getBinContent(i) != 0) {
-                monMiniAOD_over_RECO->setBinContent(
-                    i,
-                    monMiniAOD->getBinContent(i) / monReco->getBinContent(i));
+                monMiniAOD_over_RECO->setBinContent(i, monMiniAOD->getBinContent(i) / monReco->getBinContent(i));
               } else if (monMiniAOD->getBinContent(i) != 0) {
                 monMiniAOD_over_RECO->setBinContent(i, -0.5);
               }

--- a/Validation/RecoJets/plugins/JetTester_HeavyIons.cc
+++ b/Validation/RecoJets/plugins/JetTester_HeavyIons.cc
@@ -20,13 +20,10 @@ JetTester_HeavyIons::JetTester_HeavyIons(const edm::ParameterSet &iConfig)
       Background(iConfig.getParameter<edm::InputTag>("Background")),
       mRecoJetPtThreshold(iConfig.getParameter<double>("recoJetPtThreshold")),
       mMatchGenPtThreshold(iConfig.getParameter<double>("matchGenPtThreshold")),
-      mGenEnergyFractionThreshold(
-          iConfig.getParameter<double>("genEnergyFractionThreshold")),
-      mReverseEnergyFractionThreshold(
-          iConfig.getParameter<double>("reverseEnergyFractionThreshold")),
+      mGenEnergyFractionThreshold(iConfig.getParameter<double>("genEnergyFractionThreshold")),
+      mReverseEnergyFractionThreshold(iConfig.getParameter<double>("reverseEnergyFractionThreshold")),
       mRThreshold(iConfig.getParameter<double>("RThreshold")),
-      JetCorrectionService(
-          iConfig.getParameter<std::string>("JetCorrections")) {
+      JetCorrectionService(iConfig.getParameter<std::string>("JetCorrections")) {
   std::string inputCollectionLabel(mInputCollection.label());
 
   isCaloJet = (std::string("calo") == JetType);
@@ -34,8 +31,7 @@ JetTester_HeavyIons::JetTester_HeavyIons(const edm::ParameterSet &iConfig)
   isPFJet = (std::string("pf") == JetType);
 
   // consumes
-  pvToken_ = consumes<std::vector<reco::Vertex>>(
-      edm::InputTag("offlinePrimaryVertices"));
+  pvToken_ = consumes<std::vector<reco::Vertex>>(edm::InputTag("offlinePrimaryVertices"));
   caloTowersToken_ = consumes<CaloTowerCollection>(edm::InputTag("towerMaker"));
   if (isCaloJet)
     caloJetsToken_ = consumes<reco::CaloJetCollection>(mInputCollection);
@@ -46,23 +42,19 @@ JetTester_HeavyIons::JetTester_HeavyIons(const edm::ParameterSet &iConfig)
       basicJetsToken_ = consumes<reco::BasicJetCollection>(mInputCollection);
   }
 
-  genJetsToken_ =
-      consumes<reco::GenJetCollection>(edm::InputTag(mInputGenCollection));
+  genJetsToken_ = consumes<reco::GenJetCollection>(edm::InputTag(mInputGenCollection));
   evtToken_ = consumes<GenEventInfoProduct>(edm::InputTag("generator"));
   pfCandToken_ = consumes<reco::PFCandidateCollection>(mInputPFCandCollection);
   pfCandViewToken_ = consumes<reco::CandidateView>(mInputPFCandCollection);
-  caloCandViewToken_ =
-      consumes<reco::CandidateView>(edm::InputTag("towerMaker"));
+  caloCandViewToken_ = consumes<reco::CandidateView>(edm::InputTag("towerMaker"));
   backgrounds_ = consumes<edm::ValueMap<reco::VoronoiBackground>>(Background);
   backgrounds_value_ = consumes<std::vector<float>>(Background);
   centralityTag_ = iConfig.getParameter<InputTag>("centralitycollection");
   centralityToken = consumes<reco::Centrality>(centralityTag_);
 
-  centralityBinTag_ =
-      (iConfig.getParameter<edm::InputTag>("centralitybincollection"));
+  centralityBinTag_ = (iConfig.getParameter<edm::InputTag>("centralitybincollection"));
   centralityBinToken = consumes<int>(centralityBinTag_);
-  hiVertexToken_ =
-      consumes<std::vector<reco::Vertex>>(edm::InputTag("hiSelectedVertex"));
+  hiVertexToken_ = consumes<std::vector<reco::Vertex>>(edm::InputTag("hiSelectedVertex"));
 
   // need to initialize the PF cand histograms : which are also event variables
   if (isPFJet) {
@@ -91,41 +83,41 @@ JetTester_HeavyIons::JetTester_HeavyIons(const edm::ParameterSet &iConfig)
     mSumPFPt_2p043_2p650 = nullptr;
     mSumPFPt_2p650_5p191 = nullptr;
 
-    mPFCandpT_vs_eta_Unknown = nullptr;       // pf id 0
-    mPFCandpT_vs_eta_ChargedHadron = nullptr; // pf id - 1
-    mPFCandpT_vs_eta_electron = nullptr;      // pf id - 2
-    mPFCandpT_vs_eta_muon = nullptr;          // pf id - 3
-    mPFCandpT_vs_eta_photon = nullptr;        // pf id - 4
-    mPFCandpT_vs_eta_NeutralHadron = nullptr; // pf id - 5
-    mPFCandpT_vs_eta_HadE_inHF = nullptr;     // pf id - 6
-    mPFCandpT_vs_eta_EME_inHF = nullptr;      // pf id - 7
+    mPFCandpT_vs_eta_Unknown = nullptr;        // pf id 0
+    mPFCandpT_vs_eta_ChargedHadron = nullptr;  // pf id - 1
+    mPFCandpT_vs_eta_electron = nullptr;       // pf id - 2
+    mPFCandpT_vs_eta_muon = nullptr;           // pf id - 3
+    mPFCandpT_vs_eta_photon = nullptr;         // pf id - 4
+    mPFCandpT_vs_eta_NeutralHadron = nullptr;  // pf id - 5
+    mPFCandpT_vs_eta_HadE_inHF = nullptr;      // pf id - 6
+    mPFCandpT_vs_eta_EME_inHF = nullptr;       // pf id - 7
 
-    mPFCandpT_Barrel_Unknown = nullptr;       // pf id 0
-    mPFCandpT_Barrel_ChargedHadron = nullptr; // pf id - 1
-    mPFCandpT_Barrel_electron = nullptr;      // pf id - 2
-    mPFCandpT_Barrel_muon = nullptr;          // pf id - 3
-    mPFCandpT_Barrel_photon = nullptr;        // pf id - 4
-    mPFCandpT_Barrel_NeutralHadron = nullptr; // pf id - 5
-    mPFCandpT_Barrel_HadE_inHF = nullptr;     // pf id - 6
-    mPFCandpT_Barrel_EME_inHF = nullptr;      // pf id - 7
+    mPFCandpT_Barrel_Unknown = nullptr;        // pf id 0
+    mPFCandpT_Barrel_ChargedHadron = nullptr;  // pf id - 1
+    mPFCandpT_Barrel_electron = nullptr;       // pf id - 2
+    mPFCandpT_Barrel_muon = nullptr;           // pf id - 3
+    mPFCandpT_Barrel_photon = nullptr;         // pf id - 4
+    mPFCandpT_Barrel_NeutralHadron = nullptr;  // pf id - 5
+    mPFCandpT_Barrel_HadE_inHF = nullptr;      // pf id - 6
+    mPFCandpT_Barrel_EME_inHF = nullptr;       // pf id - 7
 
-    mPFCandpT_Endcap_Unknown = nullptr;       // pf id 0
-    mPFCandpT_Endcap_ChargedHadron = nullptr; // pf id - 1
-    mPFCandpT_Endcap_electron = nullptr;      // pf id - 2
-    mPFCandpT_Endcap_muon = nullptr;          // pf id - 3
-    mPFCandpT_Endcap_photon = nullptr;        // pf id - 4
-    mPFCandpT_Endcap_NeutralHadron = nullptr; // pf id - 5
-    mPFCandpT_Endcap_HadE_inHF = nullptr;     // pf id - 6
-    mPFCandpT_Endcap_EME_inHF = nullptr;      // pf id - 7
+    mPFCandpT_Endcap_Unknown = nullptr;        // pf id 0
+    mPFCandpT_Endcap_ChargedHadron = nullptr;  // pf id - 1
+    mPFCandpT_Endcap_electron = nullptr;       // pf id - 2
+    mPFCandpT_Endcap_muon = nullptr;           // pf id - 3
+    mPFCandpT_Endcap_photon = nullptr;         // pf id - 4
+    mPFCandpT_Endcap_NeutralHadron = nullptr;  // pf id - 5
+    mPFCandpT_Endcap_HadE_inHF = nullptr;      // pf id - 6
+    mPFCandpT_Endcap_EME_inHF = nullptr;       // pf id - 7
 
-    mPFCandpT_Forward_Unknown = nullptr;       // pf id 0
-    mPFCandpT_Forward_ChargedHadron = nullptr; // pf id - 1
-    mPFCandpT_Forward_electron = nullptr;      // pf id - 2
-    mPFCandpT_Forward_muon = nullptr;          // pf id - 3
-    mPFCandpT_Forward_photon = nullptr;        // pf id - 4
-    mPFCandpT_Forward_NeutralHadron = nullptr; // pf id - 5
-    mPFCandpT_Forward_HadE_inHF = nullptr;     // pf id - 6
-    mPFCandpT_Forward_EME_inHF = nullptr;      // pf id - 7
+    mPFCandpT_Forward_Unknown = nullptr;        // pf id 0
+    mPFCandpT_Forward_ChargedHadron = nullptr;  // pf id - 1
+    mPFCandpT_Forward_electron = nullptr;       // pf id - 2
+    mPFCandpT_Forward_muon = nullptr;           // pf id - 3
+    mPFCandpT_Forward_photon = nullptr;         // pf id - 4
+    mPFCandpT_Forward_NeutralHadron = nullptr;  // pf id - 5
+    mPFCandpT_Forward_HadE_inHF = nullptr;      // pf id - 6
+    mPFCandpT_Forward_EME_inHF = nullptr;       // pf id - 7
   }
   if (isCaloJet) {
     mNCalopart = nullptr;
@@ -312,10 +304,7 @@ JetTester_HeavyIons::JetTester_HeavyIons(const edm::ParameterSet &iConfig)
   mPtRecoOverGen_GenEta_300_Inf_Cent_50_80 = nullptr;
 }
 
-void JetTester_HeavyIons::bookHistograms(DQMStore::IBooker &ibooker,
-                                         edm::Run const &iRun,
-                                         edm::EventSetup const &) {
-
+void JetTester_HeavyIons::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &iRun, edm::EventSetup const &) {
   ibooker.setCurrentFolder("JetMET/JetValidation/" + mInputCollection.label());
 
   double log10PtMin = 0.50;
@@ -323,333 +312,294 @@ void JetTester_HeavyIons::bookHistograms(DQMStore::IBooker &ibooker,
   int log10PtBins = 26;
 
   static const size_t ncms_hcal_edge_pseudorapidity = 82 + 1;
-  static const double
-      cms_hcal_edge_pseudorapidity[ncms_hcal_edge_pseudorapidity] = {
-          -5.191, -4.889, -4.716, -4.538, -4.363, -4.191, -4.013, -3.839,
-          -3.664, -3.489, -3.314, -3.139, -2.964, -2.853, -2.650, -2.500,
-          -2.322, -2.172, -2.043, -1.930, -1.830, -1.740, -1.653, -1.566,
-          -1.479, -1.392, -1.305, -1.218, -1.131, -1.044, -0.957, -0.879,
-          -0.783, -0.696, -0.609, -0.522, -0.435, -0.348, -0.261, -0.174,
-          -0.087, 0.000,  0.087,  0.174,  0.261,  0.348,  0.435,  0.522,
-          0.609,  0.696,  0.783,  0.879,  0.957,  1.044,  1.131,  1.218,
-          1.305,  1.392,  1.479,  1.566,  1.653,  1.740,  1.830,  1.930,
-          2.043,  2.172,  2.322,  2.500,  2.650,  2.853,  2.964,  3.139,
-          3.314,  3.489,  3.664,  3.839,  4.013,  4.191,  4.363,  4.538,
-          4.716,  4.889,  5.191};
+  static const double cms_hcal_edge_pseudorapidity[ncms_hcal_edge_pseudorapidity] = {
+      -5.191, -4.889, -4.716, -4.538, -4.363, -4.191, -4.013, -3.839, -3.664, -3.489, -3.314, -3.139, -2.964, -2.853,
+      -2.650, -2.500, -2.322, -2.172, -2.043, -1.930, -1.830, -1.740, -1.653, -1.566, -1.479, -1.392, -1.305, -1.218,
+      -1.131, -1.044, -0.957, -0.879, -0.783, -0.696, -0.609, -0.522, -0.435, -0.348, -0.261, -0.174, -0.087, 0.000,
+      0.087,  0.174,  0.261,  0.348,  0.435,  0.522,  0.609,  0.696,  0.783,  0.879,  0.957,  1.044,  1.131,  1.218,
+      1.305,  1.392,  1.479,  1.566,  1.653,  1.740,  1.830,  1.930,  2.043,  2.172,  2.322,  2.500,  2.650,  2.853,
+      2.964,  3.139,  3.314,  3.489,  3.664,  3.839,  4.013,  4.191,  4.363,  4.538,  4.716,  4.889,  5.191};
 
-  double etaRange[91] = {
-      -6.0, -5.8, -5.6, -5.4, -5.2, -5.0, -4.8, -4.6, -4.4, -4.2, -4.0, -3.8,
-      -3.6, -3.4, -3.2, -3.0, -2.9, -2.8, -2.7, -2.6, -2.5, -2.4, -2.3, -2.2,
-      -2.1, -2.0, -1.9, -1.8, -1.7, -1.6, -1.5, -1.4, -1.3, -1.2, -1.1, -1.0,
-      -0.9, -0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0.0,  0.1,  0.2,
-      0.3,  0.4,  0.5,  0.6,  0.7,  0.8,  0.9,  1.0,  1.1,  1.2,  1.3,  1.4,
-      1.5,  1.6,  1.7,  1.8,  1.9,  2.0,  2.1,  2.2,  2.3,  2.4,  2.5,  2.6,
-      2.7,  2.8,  2.9,  3.0,  3.2,  3.4,  3.6,  3.8,  4.0,  4.2,  4.4,  4.6,
-      4.8,  5.0,  5.2,  5.4,  5.6,  5.8,  6.0};
+  double etaRange[91] = {-6.0, -5.8, -5.6, -5.4, -5.2, -5.0, -4.8, -4.6, -4.4, -4.2, -4.0, -3.8, -3.6, -3.4, -3.2, -3.0,
+                         -2.9, -2.8, -2.7, -2.6, -2.5, -2.4, -2.3, -2.2, -2.1, -2.0, -1.9, -1.8, -1.7, -1.6, -1.5, -1.4,
+                         -1.3, -1.2, -1.1, -1.0, -0.9, -0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0.0,  0.1,  0.2,
+                         0.3,  0.4,  0.5,  0.6,  0.7,  0.8,  0.9,  1.0,  1.1,  1.2,  1.3,  1.4,  1.5,  1.6,  1.7,  1.8,
+                         1.9,  2.0,  2.1,  2.2,  2.3,  2.4,  2.5,  2.6,  2.7,  2.8,  2.9,  3.0,  3.2,  3.4,  3.6,  3.8,
+                         4.0,  4.2,  4.4,  4.6,  4.8,  5.0,  5.2,  5.4,  5.6,  5.8,  6.0};
 
-  double edge_pseudorapidity[etaBins_ + 1] = {
-      -5.191, -2.650, -2.043, -1.740, -1.479, -1.131, -0.783, -0.522,
-      0.522,  0.783,  1.131,  1.479,  1.740,  2.043,  2.650,  5.191};
+  double edge_pseudorapidity[etaBins_ + 1] = {-5.191,
+                                              -2.650,
+                                              -2.043,
+                                              -1.740,
+                                              -1.479,
+                                              -1.131,
+                                              -0.783,
+                                              -0.522,
+                                              0.522,
+                                              0.783,
+                                              1.131,
+                                              1.479,
+                                              1.740,
+                                              2.043,
+                                              2.650,
+                                              5.191};
 
-  TH2F *h2D_etabins_vs_pt2 =
-      new TH2F("h2D_etabins_vs_pt2", "etaBins (x axis), sum pt^{2} (y axis)",
-               etaBins_, edge_pseudorapidity, 10000, 0, 10000);
-  TH2F *h2D_etabins_vs_pt =
-      new TH2F("h2D_etabins_vs_pt", "etaBins (x axis), sum pt (y axis)",
-               etaBins_, edge_pseudorapidity, 10000, -1000, 1000);
-  TH2F *h2D_etabins_vs_phi =
-      new TH2F("h2D_etabins_vs_phi",
-               "candidate map, eta(x axis), phi (y axis), pt (z axis)",
-               ncms_hcal_edge_pseudorapidity - 1, cms_hcal_edge_pseudorapidity,
-               36, -TMath::Pi(), TMath::Pi());
+  TH2F *h2D_etabins_vs_pt2 = new TH2F(
+      "h2D_etabins_vs_pt2", "etaBins (x axis), sum pt^{2} (y axis)", etaBins_, edge_pseudorapidity, 10000, 0, 10000);
+  TH2F *h2D_etabins_vs_pt = new TH2F(
+      "h2D_etabins_vs_pt", "etaBins (x axis), sum pt (y axis)", etaBins_, edge_pseudorapidity, 10000, -1000, 1000);
+  TH2F *h2D_etabins_vs_phi = new TH2F("h2D_etabins_vs_phi",
+                                      "candidate map, eta(x axis), phi (y axis), pt (z axis)",
+                                      ncms_hcal_edge_pseudorapidity - 1,
+                                      cms_hcal_edge_pseudorapidity,
+                                      36,
+                                      -TMath::Pi(),
+                                      TMath::Pi());
   TH2F *h2D_pfcand_etabins_vs_pt =
-      new TH2F("h2D_etabins_vs_pt", ";#eta;sum p_{T}", etaBins_,
-               edge_pseudorapidity, 300, 0, 300);
+      new TH2F("h2D_etabins_vs_pt", ";#eta;sum p_{T}", etaBins_, edge_pseudorapidity, 300, 0, 300);
 
   if (isPFJet) {
-
-    mNPFpart = ibooker.book1D("NPFpart", "No of particle flow candidates", 1000,
-                              0, 10000);
+    mNPFpart = ibooker.book1D("NPFpart", "No of particle flow candidates", 1000, 0, 10000);
     mPFPt = ibooker.book1D("PFPt", "PF candidate p_{T}", 1000, -5000, 5000);
     mPFEta = ibooker.book1D("PFEta", "PF candidate #eta", 120, -6, 6);
     mPFPhi = ibooker.book1D("PFPhi", "PF candidate #phi", 70, -3.5, 3.5);
     mPFArea = ibooker.book1D("PFArea", "VS PF candidate area", 100, 0, 4);
 
-    mSumPFPt = ibooker.book1D("SumPFPt", "Sum of initial PF p_{T}", 1000,
-                              -10000, 10000);
+    mSumPFPt = ibooker.book1D("SumPFPt", "Sum of initial PF p_{T}", 1000, -10000, 10000);
 
-    mSumSquaredPFPt = ibooker.book1D(
-        "SumSquaredPFPt", "Sum of initial PF p_{T} squared", 10000, 0, 10000);
+    mSumSquaredPFPt = ibooker.book1D("SumSquaredPFPt", "Sum of initial PF p_{T} squared", 10000, 0, 10000);
 
     mSumPFPt_HF = ibooker.book2D(
-        "SumPFPt_HF", "HF energy (y axis) vs Sum initial PF p_{T} (x axis)",
-        1000, -1000, 1000, 1000, 0, 10000);
+        "SumPFPt_HF", "HF energy (y axis) vs Sum initial PF p_{T} (x axis)", 1000, -1000, 1000, 1000, 0, 10000);
 
-    mSumPFPt_n5p191_n2p650 = ibooker.book1D(
-        "mSumPFPt_n5p191_n2p650", "Sum PFPt  in the eta range -5.191 to -2.650",
-        1000, -5000, 5000);
-    mSumPFPt_n2p650_n2p043 = ibooker.book1D(
-        "mSumPFPt_n2p650_n2p043",
-        "Sum PFPt  in the eta range -2.650 to -2.043 ", 1000, -5000, 5000);
-    mSumPFPt_n2p043_n1p740 = ibooker.book1D(
-        "mSumPFPt_n2p043_n1p740", "Sum PFPt  in the eta range -2.043 to -1.740",
-        1000, -1000, 1000);
-    mSumPFPt_n1p740_n1p479 = ibooker.book1D(
-        "mSumPFPt_n1p740_n1p479", "Sum PFPt  in the eta range -1.740 to -1.479",
-        1000, -1000, 1000);
-    mSumPFPt_n1p479_n1p131 = ibooker.book1D(
-        "mSumPFPt_n1p479_n1p131", "Sum PFPt  in the eta range -1.479 to -1.131",
-        1000, -1000, 1000);
-    mSumPFPt_n1p131_n0p783 = ibooker.book1D(
-        "mSumPFPt_n1p131_n0p783", "Sum PFPt  in the eta range -1.131 to -0.783",
-        1000, -1000, 1000);
-    mSumPFPt_n0p783_n0p522 = ibooker.book1D(
-        "mSumPFPt_n0p783_n0p522", "Sum PFPt  in the eta range -0.783 to -0.522",
-        1000, -1000, 1000);
-    mSumPFPt_n0p522_0p522 = ibooker.book1D(
-        "mSumPFPt_n0p522_0p522", "Sum PFPt  in the eta range -0.522 to 0.522",
-        1000, -1000, 1000);
-    mSumPFPt_0p522_0p783 = ibooker.book1D(
-        "mSumPFPt_0p522_0p783", "Sum PFPt  in the eta range 0.522 to 0.783",
-        1000, -1000, 1000);
-    mSumPFPt_0p783_1p131 = ibooker.book1D(
-        "mSumPFPt_0p783_1p131", "Sum PFPt  in the eta range 0.783 to 1.131",
-        1000, -1000, 1000);
-    mSumPFPt_1p131_1p479 = ibooker.book1D(
-        "mSumPFPt_1p131_1p479", "Sum PFPt  in the eta range 1.131 to 1.479",
-        1000, -1000, 1000);
-    mSumPFPt_1p479_1p740 = ibooker.book1D(
-        "mSumPFPt_1p479_1p740", "Sum PFPt  in the eta range 1.479 to 1.740",
-        1000, -1000, 1000);
-    mSumPFPt_1p740_2p043 = ibooker.book1D(
-        "mSumPFPt_1p740_2p043", "Sum PFPt  in the eta range 1.740 to 2.043",
-        1000, -1000, 1000);
-    mSumPFPt_2p043_2p650 = ibooker.book1D(
-        "mSumPFPt_2p043_2p650", "Sum PFPt  in the eta range 2.043 to 2.650",
-        1000, -5000, 5000);
-    mSumPFPt_2p650_5p191 = ibooker.book1D(
-        "mSumPFPt_2p650_5p191", "Sum PFPt  in the eta range 2.650 to 5.191",
-        1000, -5000, 5000);
+    mSumPFPt_n5p191_n2p650 =
+        ibooker.book1D("mSumPFPt_n5p191_n2p650", "Sum PFPt  in the eta range -5.191 to -2.650", 1000, -5000, 5000);
+    mSumPFPt_n2p650_n2p043 =
+        ibooker.book1D("mSumPFPt_n2p650_n2p043", "Sum PFPt  in the eta range -2.650 to -2.043 ", 1000, -5000, 5000);
+    mSumPFPt_n2p043_n1p740 =
+        ibooker.book1D("mSumPFPt_n2p043_n1p740", "Sum PFPt  in the eta range -2.043 to -1.740", 1000, -1000, 1000);
+    mSumPFPt_n1p740_n1p479 =
+        ibooker.book1D("mSumPFPt_n1p740_n1p479", "Sum PFPt  in the eta range -1.740 to -1.479", 1000, -1000, 1000);
+    mSumPFPt_n1p479_n1p131 =
+        ibooker.book1D("mSumPFPt_n1p479_n1p131", "Sum PFPt  in the eta range -1.479 to -1.131", 1000, -1000, 1000);
+    mSumPFPt_n1p131_n0p783 =
+        ibooker.book1D("mSumPFPt_n1p131_n0p783", "Sum PFPt  in the eta range -1.131 to -0.783", 1000, -1000, 1000);
+    mSumPFPt_n0p783_n0p522 =
+        ibooker.book1D("mSumPFPt_n0p783_n0p522", "Sum PFPt  in the eta range -0.783 to -0.522", 1000, -1000, 1000);
+    mSumPFPt_n0p522_0p522 =
+        ibooker.book1D("mSumPFPt_n0p522_0p522", "Sum PFPt  in the eta range -0.522 to 0.522", 1000, -1000, 1000);
+    mSumPFPt_0p522_0p783 =
+        ibooker.book1D("mSumPFPt_0p522_0p783", "Sum PFPt  in the eta range 0.522 to 0.783", 1000, -1000, 1000);
+    mSumPFPt_0p783_1p131 =
+        ibooker.book1D("mSumPFPt_0p783_1p131", "Sum PFPt  in the eta range 0.783 to 1.131", 1000, -1000, 1000);
+    mSumPFPt_1p131_1p479 =
+        ibooker.book1D("mSumPFPt_1p131_1p479", "Sum PFPt  in the eta range 1.131 to 1.479", 1000, -1000, 1000);
+    mSumPFPt_1p479_1p740 =
+        ibooker.book1D("mSumPFPt_1p479_1p740", "Sum PFPt  in the eta range 1.479 to 1.740", 1000, -1000, 1000);
+    mSumPFPt_1p740_2p043 =
+        ibooker.book1D("mSumPFPt_1p740_2p043", "Sum PFPt  in the eta range 1.740 to 2.043", 1000, -1000, 1000);
+    mSumPFPt_2p043_2p650 =
+        ibooker.book1D("mSumPFPt_2p043_2p650", "Sum PFPt  in the eta range 2.043 to 2.650", 1000, -5000, 5000);
+    mSumPFPt_2p650_5p191 =
+        ibooker.book1D("mSumPFPt_2p650_5p191", "Sum PFPt  in the eta range 2.650 to 5.191", 1000, -5000, 5000);
 
-    mPFCandpT_vs_eta_Unknown = ibooker.book2D(
-        "PF_cand_X_unknown", h2D_pfcand_etabins_vs_pt); // pf id 0
-    mPFCandpT_vs_eta_ChargedHadron = ibooker.book2D(
-        "PF_cand_chargedHad", h2D_pfcand_etabins_vs_pt); // pf id - 1
-    mPFCandpT_vs_eta_electron = ibooker.book2D(
-        "PF_cand_electron", h2D_pfcand_etabins_vs_pt); // pf id - 2
-    mPFCandpT_vs_eta_muon =
-        ibooker.book2D("PF_cand_muon", h2D_pfcand_etabins_vs_pt); // pf id - 3
-    mPFCandpT_vs_eta_photon =
-        ibooker.book2D("PF_cand_photon", h2D_pfcand_etabins_vs_pt); // pf id - 4
-    mPFCandpT_vs_eta_NeutralHadron = ibooker.book2D(
-        "PF_cand_neutralHad", h2D_pfcand_etabins_vs_pt); // pf id - 5
-    mPFCandpT_vs_eta_HadE_inHF = ibooker.book2D(
-        "PF_cand_HadEner_inHF", h2D_pfcand_etabins_vs_pt); // pf id - 6
-    mPFCandpT_vs_eta_EME_inHF = ibooker.book2D(
-        "PF_cand_EMEner_inHF", h2D_pfcand_etabins_vs_pt); // pf id - 7
+    mPFCandpT_vs_eta_Unknown = ibooker.book2D("PF_cand_X_unknown", h2D_pfcand_etabins_vs_pt);         // pf id 0
+    mPFCandpT_vs_eta_ChargedHadron = ibooker.book2D("PF_cand_chargedHad", h2D_pfcand_etabins_vs_pt);  // pf id - 1
+    mPFCandpT_vs_eta_electron = ibooker.book2D("PF_cand_electron", h2D_pfcand_etabins_vs_pt);         // pf id - 2
+    mPFCandpT_vs_eta_muon = ibooker.book2D("PF_cand_muon", h2D_pfcand_etabins_vs_pt);                 // pf id - 3
+    mPFCandpT_vs_eta_photon = ibooker.book2D("PF_cand_photon", h2D_pfcand_etabins_vs_pt);             // pf id - 4
+    mPFCandpT_vs_eta_NeutralHadron = ibooker.book2D("PF_cand_neutralHad", h2D_pfcand_etabins_vs_pt);  // pf id - 5
+    mPFCandpT_vs_eta_HadE_inHF = ibooker.book2D("PF_cand_HadEner_inHF", h2D_pfcand_etabins_vs_pt);    // pf id - 6
+    mPFCandpT_vs_eta_EME_inHF = ibooker.book2D("PF_cand_EMEner_inHF", h2D_pfcand_etabins_vs_pt);      // pf id - 7
 
-    mPFCandpT_Barrel_Unknown = ibooker.book1D(
-        "mPFCandpT_Barrel_Unknown",
-        Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta), 300, 0,
-        300); // pf id  - 0
-    mPFCandpT_Barrel_ChargedHadron = ibooker.book1D(
-        "mPFCandpT_Barrel_ChargedHadron",
-        Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta), 300, 0,
-        300); // pf id - 1
-    mPFCandpT_Barrel_electron = ibooker.book1D(
-        "mPFCandpT_Barrel_electron",
-        Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta), 300, 0,
-        300); // pf id - 2
-    mPFCandpT_Barrel_muon = ibooker.book1D(
-        "mPFCandpT_Barrel_muon",
-        Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta), 300, 0,
-        300); // pf id - 3
-    mPFCandpT_Barrel_photon = ibooker.book1D(
-        "mPFCandpT_Barrel_photon",
-        Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta), 300, 0,
-        300); // pf id - 4
-    mPFCandpT_Barrel_NeutralHadron = ibooker.book1D(
-        "mPFCandpT_Barrel_NeutralHadron",
-        Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta), 300, 0,
-        300); // pf id - 5
-    mPFCandpT_Barrel_HadE_inHF = ibooker.book1D(
-        "mPFCandpT_Barrel_HadE_inHF",
-        Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta), 300, 0,
-        300); // pf id - 6
-    mPFCandpT_Barrel_EME_inHF = ibooker.book1D(
-        "mPFCandpT_Barrel_EME_inHF",
-        Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta), 300, 0,
-        300); // pf id - 7
+    mPFCandpT_Barrel_Unknown = ibooker.book1D("mPFCandpT_Barrel_Unknown",
+                                              Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),
+                                              300,
+                                              0,
+                                              300);  // pf id  - 0
+    mPFCandpT_Barrel_ChargedHadron = ibooker.book1D("mPFCandpT_Barrel_ChargedHadron",
+                                                    Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),
+                                                    300,
+                                                    0,
+                                                    300);  // pf id - 1
+    mPFCandpT_Barrel_electron = ibooker.book1D("mPFCandpT_Barrel_electron",
+                                               Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),
+                                               300,
+                                               0,
+                                               300);  // pf id - 2
+    mPFCandpT_Barrel_muon = ibooker.book1D("mPFCandpT_Barrel_muon",
+                                           Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),
+                                           300,
+                                           0,
+                                           300);  // pf id - 3
+    mPFCandpT_Barrel_photon = ibooker.book1D("mPFCandpT_Barrel_photon",
+                                             Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),
+                                             300,
+                                             0,
+                                             300);  // pf id - 4
+    mPFCandpT_Barrel_NeutralHadron = ibooker.book1D("mPFCandpT_Barrel_NeutralHadron",
+                                                    Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),
+                                                    300,
+                                                    0,
+                                                    300);  // pf id - 5
+    mPFCandpT_Barrel_HadE_inHF = ibooker.book1D("mPFCandpT_Barrel_HadE_inHF",
+                                                Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),
+                                                300,
+                                                0,
+                                                300);  // pf id - 6
+    mPFCandpT_Barrel_EME_inHF = ibooker.book1D("mPFCandpT_Barrel_EME_inHF",
+                                               Form(";PF candidate p_{T}, |#eta|<%2.2f; counts", BarrelEta),
+                                               300,
+                                               0,
+                                               300);  // pf id - 7
 
     mPFCandpT_Endcap_Unknown =
         ibooker.book1D("mPFCandpT_Endcap_Unknown",
-                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts",
-                            BarrelEta, EndcapEta),
-                       300, 0, 300); // pf id - 0
+                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),
+                       300,
+                       0,
+                       300);  // pf id - 0
     mPFCandpT_Endcap_ChargedHadron =
         ibooker.book1D("mPFCandpT_Endcap_ChargedHadron",
-                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts",
-                            BarrelEta, EndcapEta),
-                       300, 0, 300); // pf id - 1
+                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),
+                       300,
+                       0,
+                       300);  // pf id - 1
     mPFCandpT_Endcap_electron =
         ibooker.book1D("mPFCandpT_Endcap_electron",
-                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts",
-                            BarrelEta, EndcapEta),
-                       300, 0, 300); // pf id - 2
+                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),
+                       300,
+                       0,
+                       300);  // pf id - 2
     mPFCandpT_Endcap_muon =
         ibooker.book1D("mPFCandpT_Endcap_muon",
-                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts",
-                            BarrelEta, EndcapEta),
-                       300, 0, 300); // pf id - 3
+                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),
+                       300,
+                       0,
+                       300);  // pf id - 3
     mPFCandpT_Endcap_photon =
         ibooker.book1D("mPFCandpT_Endcap_photon",
-                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts",
-                            BarrelEta, EndcapEta),
-                       300, 0, 300); // pf id - 4
+                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),
+                       300,
+                       0,
+                       300);  // pf id - 4
     mPFCandpT_Endcap_NeutralHadron =
         ibooker.book1D("mPFCandpT_Endcap_NeutralHadron",
-                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts",
-                            BarrelEta, EndcapEta),
-                       300, 0, 300); // pf id - 5
+                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),
+                       300,
+                       0,
+                       300);  // pf id - 5
     mPFCandpT_Endcap_HadE_inHF =
         ibooker.book1D("mPFCandpT_Endcap_HadE_inHF",
-                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts",
-                            BarrelEta, EndcapEta),
-                       300, 0, 300); // pf id - 6
+                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),
+                       300,
+                       0,
+                       300);  // pf id - 6
     mPFCandpT_Endcap_EME_inHF =
         ibooker.book1D("mPFCandpT_Endcap_EME_inHF",
-                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts",
-                            BarrelEta, EndcapEta),
-                       300, 0, 300); // pf id - 7
+                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", BarrelEta, EndcapEta),
+                       300,
+                       0,
+                       300);  // pf id - 7
 
     mPFCandpT_Forward_Unknown =
         ibooker.book1D("mPFCandpT_Forward_Unknown",
-                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts",
-                            EndcapEta, ForwardEta),
-                       300, 0, 300); // pf id - 0
+                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),
+                       300,
+                       0,
+                       300);  // pf id - 0
     mPFCandpT_Forward_ChargedHadron =
         ibooker.book1D("mPFCandpT_Forward_ChargedHadron",
-                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts",
-                            EndcapEta, ForwardEta),
-                       300, 0, 300); // pf id - 1
+                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),
+                       300,
+                       0,
+                       300);  // pf id - 1
     mPFCandpT_Forward_electron =
         ibooker.book1D("mPFCandpT_Forward_electron",
-                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts",
-                            EndcapEta, ForwardEta),
-                       300, 0, 300); // pf id - 2
+                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),
+                       300,
+                       0,
+                       300);  // pf id - 2
     mPFCandpT_Forward_muon =
         ibooker.book1D("mPFCandpT_Forward_muon",
-                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts",
-                            EndcapEta, ForwardEta),
-                       300, 0, 300); // pf id - 3
+                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),
+                       300,
+                       0,
+                       300);  // pf id - 3
     mPFCandpT_Forward_photon =
         ibooker.book1D("mPFCandpT_Forward_photon",
-                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts",
-                            EndcapEta, ForwardEta),
-                       300, 0, 300); // pf id - 4
+                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),
+                       300,
+                       0,
+                       300);  // pf id - 4
     mPFCandpT_Forward_NeutralHadron =
         ibooker.book1D("mPFCandpT_Forward_NeutralHadron",
-                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts",
-                            EndcapEta, ForwardEta),
-                       300, 0, 300); // pf id - 5
+                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),
+                       300,
+                       0,
+                       300);  // pf id - 5
     mPFCandpT_Forward_HadE_inHF =
         ibooker.book1D("mPFCandpT_Forward_HadE_inHF",
-                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts",
-                            EndcapEta, ForwardEta),
-                       300, 0, 300); // pf id - 6
+                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),
+                       300,
+                       0,
+                       300);  // pf id - 6
     mPFCandpT_Forward_EME_inHF =
         ibooker.book1D("mPFCandpT_Forward_EME_inHF",
-                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts",
-                            EndcapEta, ForwardEta),
-                       300, 0, 300); // pf id - 7
+                       Form(";PF candidate p_{T}, %2.2f<|#eta|<%2.2f; counts", EndcapEta, ForwardEta),
+                       300,
+                       0,
+                       300);  // pf id - 7
   }
 
   if (isCaloJet) {
-
-    mNCalopart = ibooker.book1D("NCalopart", "No of particle flow candidates",
-                                1000, 0, 10000);
-    mCaloPt =
-        ibooker.book1D("CaloPt", "Calo candidate p_{T}", 1000, -5000, 5000);
+    mNCalopart = ibooker.book1D("NCalopart", "No of particle flow candidates", 1000, 0, 10000);
+    mCaloPt = ibooker.book1D("CaloPt", "Calo candidate p_{T}", 1000, -5000, 5000);
     mCaloEta = ibooker.book1D("CaloEta", "Calo candidate #eta", 120, -6, 6);
     mCaloPhi = ibooker.book1D("CaloPhi", "Calo candidate #phi", 70, -3.5, 3.5);
     mCaloArea = ibooker.book1D("CaloArea", "VS Calo candidate area", 100, 0, 4);
 
-    mSumCaloPt =
-        ibooker.book1D("SumCaloPt", "Sum Calo p_{T}", 1000, -10000, 10000);
+    mSumCaloPt = ibooker.book1D("SumCaloPt", "Sum Calo p_{T}", 1000, -10000, 10000);
 
-    mSumSquaredCaloPt = ibooker.book1D(
-        "SumSquaredCaloPt", "Sum of initial Calo tower p_{T} squared", 10000, 0,
-        10000);
+    mSumSquaredCaloPt = ibooker.book1D("SumSquaredCaloPt", "Sum of initial Calo tower p_{T} squared", 10000, 0, 10000);
 
-    mSumCaloPt_HF = ibooker.book2D("SumCaloPt_HF",
-                                   "HF Energy (y axis) vs Sum Calo tower p_{T}",
-                                   1000, -1000, 1000, 1000, 0, 10000);
+    mSumCaloPt_HF =
+        ibooker.book2D("SumCaloPt_HF", "HF Energy (y axis) vs Sum Calo tower p_{T}", 1000, -1000, 1000, 1000, 0, 10000);
 
     mSumCaloPt_n5p191_n2p650 = ibooker.book1D(
-        "mSumCaloPt_n5p191_n2p650",
-        "Sum Calo tower pT variable in the eta range -5.191 to -2.650", 1000,
-        -5000, 5000);
+        "mSumCaloPt_n5p191_n2p650", "Sum Calo tower pT variable in the eta range -5.191 to -2.650", 1000, -5000, 5000);
     mSumCaloPt_n2p650_n2p043 = ibooker.book1D(
-        "mSumCaloPt_n2p650_n2p043",
-        "Sum Calo tower pT variable in the eta range -2.650 to -2.043", 1000,
-        -5000, 5000);
+        "mSumCaloPt_n2p650_n2p043", "Sum Calo tower pT variable in the eta range -2.650 to -2.043", 1000, -5000, 5000);
     mSumCaloPt_n2p043_n1p740 = ibooker.book1D(
-        "mSumCaloPt_n2p043_n1p740",
-        "Sum Calo tower pT variable in the eta range -2.043 to -1.740", 1000,
-        -1000, 1000);
+        "mSumCaloPt_n2p043_n1p740", "Sum Calo tower pT variable in the eta range -2.043 to -1.740", 1000, -1000, 1000);
     mSumCaloPt_n1p740_n1p479 = ibooker.book1D(
-        "mSumCaloPt_n1p740_n1p479",
-        "Sum Calo tower pT variable in the eta range -1.740 to -1.479", 1000,
-        -1000, 1000);
+        "mSumCaloPt_n1p740_n1p479", "Sum Calo tower pT variable in the eta range -1.740 to -1.479", 1000, -1000, 1000);
     mSumCaloPt_n1p479_n1p131 = ibooker.book1D(
-        "mSumCaloPt_n1p479_n1p131",
-        "Sum Calo tower pT variable in the eta range -1.479 to -1.131", 1000,
-        -1000, 1000);
+        "mSumCaloPt_n1p479_n1p131", "Sum Calo tower pT variable in the eta range -1.479 to -1.131", 1000, -1000, 1000);
     mSumCaloPt_n1p131_n0p783 = ibooker.book1D(
-        "mSumCaloPt_n1p131_n0p783",
-        "Sum Calo tower pT variable in the eta range -1.131 to -0.783", 1000,
-        -1000, 1000);
+        "mSumCaloPt_n1p131_n0p783", "Sum Calo tower pT variable in the eta range -1.131 to -0.783", 1000, -1000, 1000);
     mSumCaloPt_n0p783_n0p522 = ibooker.book1D(
-        "mSumCaloPt_n0p783_n0p522",
-        "Sum Calo tower pT variable in the eta range -0.783 to -0.522", 1000,
-        -1000, 1000);
+        "mSumCaloPt_n0p783_n0p522", "Sum Calo tower pT variable in the eta range -0.783 to -0.522", 1000, -1000, 1000);
     mSumCaloPt_n0p522_0p522 = ibooker.book1D(
-        "mSumCaloPt_n0p522_0p522",
-        "Sum Calo tower pT variable in the eta range -0.522 to 0.522", 1000,
-        -1000, 1000);
+        "mSumCaloPt_n0p522_0p522", "Sum Calo tower pT variable in the eta range -0.522 to 0.522", 1000, -1000, 1000);
     mSumCaloPt_0p522_0p783 = ibooker.book1D(
-        "mSumCaloPt_0p522_0p783",
-        "Sum Calo tower pT variable in the eta range 0.522 to 0.783", 1000,
-        -1000, 1000);
+        "mSumCaloPt_0p522_0p783", "Sum Calo tower pT variable in the eta range 0.522 to 0.783", 1000, -1000, 1000);
     mSumCaloPt_0p783_1p131 = ibooker.book1D(
-        "mSumCaloPt_0p783_1p131",
-        "Sum Calo tower pT variable in the eta range 0.783 to 1.131", 1000,
-        -1000, 1000);
+        "mSumCaloPt_0p783_1p131", "Sum Calo tower pT variable in the eta range 0.783 to 1.131", 1000, -1000, 1000);
     mSumCaloPt_1p131_1p479 = ibooker.book1D(
-        "mSumCaloPt_1p131_1p479",
-        "Sum Calo tower pT variable in the eta range 1.131 to 1.479", 1000,
-        -1000, 1000);
+        "mSumCaloPt_1p131_1p479", "Sum Calo tower pT variable in the eta range 1.131 to 1.479", 1000, -1000, 1000);
     mSumCaloPt_1p479_1p740 = ibooker.book1D(
-        "mSumCaloPt_1p479_1p740",
-        "Sum Calo tower pT variable in the eta range 1.479 to 1.740", 1000,
-        -1000, 1000);
+        "mSumCaloPt_1p479_1p740", "Sum Calo tower pT variable in the eta range 1.479 to 1.740", 1000, -1000, 1000);
     mSumCaloPt_1p740_2p043 = ibooker.book1D(
-        "mSumCaloPt_1p740_2p043",
-        "Sum Calo tower pT variable in the eta range 1.740 to 2.043", 1000,
-        -1000, 1000);
+        "mSumCaloPt_1p740_2p043", "Sum Calo tower pT variable in the eta range 1.740 to 2.043", 1000, -1000, 1000);
     mSumCaloPt_2p043_2p650 = ibooker.book1D(
-        "mSumCaloPt_2p043_2p650",
-        "Sum Calo tower pT variable in the eta range 2.043 to 2.650", 1000,
-        -5000, 5000);
+        "mSumCaloPt_2p043_2p650", "Sum Calo tower pT variable in the eta range 2.043 to 2.650", 1000, -5000, 5000);
     mSumCaloPt_2p650_5p191 = ibooker.book1D(
-        "mSumCaloPt_2p650_5p191",
-        "Sum Calo tower pT variable in the eta range 2.650 to 5.191", 1000,
-        -5000, 5000);
+        "mSumCaloPt_2p650_5p191", "Sum Calo tower pT variable in the eta range 2.650 to 5.191", 1000, -5000, 5000);
   }
 
   // particle flow variables histograms
-  mSumpt = ibooker.book1D(
-      "SumpT", "Sum p_{T} of all the PF candidates per event", 1000, 0, 10000);
+  mSumpt = ibooker.book1D("SumpT", "Sum p_{T} of all the PF candidates per event", 1000, 0, 10000);
 
   // Event variables
   mNvtx = ibooker.book1D("Nvtx", "number of vertices", 60, 0, 60);
@@ -665,8 +615,7 @@ void JetTester_HeavyIons::bookHistograms(DQMStore::IBooker &ibooker,
   mConstituents = ibooker.book1D("Constituents", "Constituents", 100, 0, 100);
   mJetArea = ibooker.book1D("JetArea", "JetArea", 100, 0, 4);
   mjetpileup = ibooker.book1D("jetPileUp", "jetPileUp", 100, 0, 150);
-  mNJets_40 =
-      ibooker.book1D("NJets_pt_greater_40", "NJets pT > 40 GeV", 50, 0, 100);
+  mNJets_40 = ibooker.book1D("NJets_pt_greater_40", "NJets pT > 40 GeV", 50, 0, 100);
   mNJets = ibooker.book1D("NJets", "NJets", 50, 0, 100);
 
   mGenEta = ibooker.book1D("Gen Eta", ";gen jet #eta;counts", 120, -6, 6);
@@ -674,412 +623,350 @@ void JetTester_HeavyIons::bookHistograms(DQMStore::IBooker &ibooker,
   mGenPt = ibooker.book1D("Gen pT", "gen jet p_{T}", 250, 0, 1000);
   mPtHat = ibooker.book1D("pThat", "#hat{p_{T}}", 250, 0, 1000);
 
-  mPtRecoOverGen_B_20_30_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_B_20_30_Cent_0_10",
-      "20<genpt<30; recopt/genpt (0-10%) (Barrel);counts", 90, 0, 2);
-  mPtRecoOverGen_E_20_30_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_E_20_30_Cent_0_10",
-      "20<genpt<30; recopt/genpt (0-10%) (EndCap);counts", 90, 0, 2);
-  mPtRecoOverGen_F_20_30_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_F_20_30_Cent_0_10",
-      "20<genpt<30; recopt/genpt (0-10%) (Forward);counts", 90, 0, 2);
-  mPtRecoOverGen_B_30_50_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_B_30_50_Cent_0_10",
-      "30<genpt<50; recopt/genpt (0-10%) (Barrel);counts", 90, 0, 2);
-  mPtRecoOverGen_E_30_50_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_E_30_50_Cent_0_10",
-      "30<genpt<50; recopt/genpt (0-10%) (EndCap);counts", 90, 0, 2);
-  mPtRecoOverGen_F_30_50_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_F_30_50_Cent_0_10",
-      "30<genpt<50; recopt/genpt (0-10%) (Forward);counts", 90, 0, 2);
-  mPtRecoOverGen_B_50_80_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_B_50_80_Cent_0_10",
-      "50<genpt<80; recopt/genpt (0-10%) (Barrel);counts", 90, 0, 2);
-  mPtRecoOverGen_E_50_80_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_E_50_80_Cent_0_10",
-      "50<genpt<80; recopt/genpt (0-10%) (EndCap);counts", 90, 0, 2);
-  mPtRecoOverGen_F_50_80_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_F_50_80_Cent_0_10",
-      "50<genpt<80; recopt/genpt (0-10%) (Forward);counts", 90, 0, 2);
+  mPtRecoOverGen_B_20_30_Cent_0_10 =
+      ibooker.book1D("PtRecoOverGen_B_20_30_Cent_0_10", "20<genpt<30; recopt/genpt (0-10%) (Barrel);counts", 90, 0, 2);
+  mPtRecoOverGen_E_20_30_Cent_0_10 =
+      ibooker.book1D("PtRecoOverGen_E_20_30_Cent_0_10", "20<genpt<30; recopt/genpt (0-10%) (EndCap);counts", 90, 0, 2);
+  mPtRecoOverGen_F_20_30_Cent_0_10 =
+      ibooker.book1D("PtRecoOverGen_F_20_30_Cent_0_10", "20<genpt<30; recopt/genpt (0-10%) (Forward);counts", 90, 0, 2);
+  mPtRecoOverGen_B_30_50_Cent_0_10 =
+      ibooker.book1D("PtRecoOverGen_B_30_50_Cent_0_10", "30<genpt<50; recopt/genpt (0-10%) (Barrel);counts", 90, 0, 2);
+  mPtRecoOverGen_E_30_50_Cent_0_10 =
+      ibooker.book1D("PtRecoOverGen_E_30_50_Cent_0_10", "30<genpt<50; recopt/genpt (0-10%) (EndCap);counts", 90, 0, 2);
+  mPtRecoOverGen_F_30_50_Cent_0_10 =
+      ibooker.book1D("PtRecoOverGen_F_30_50_Cent_0_10", "30<genpt<50; recopt/genpt (0-10%) (Forward);counts", 90, 0, 2);
+  mPtRecoOverGen_B_50_80_Cent_0_10 =
+      ibooker.book1D("PtRecoOverGen_B_50_80_Cent_0_10", "50<genpt<80; recopt/genpt (0-10%) (Barrel);counts", 90, 0, 2);
+  mPtRecoOverGen_E_50_80_Cent_0_10 =
+      ibooker.book1D("PtRecoOverGen_E_50_80_Cent_0_10", "50<genpt<80; recopt/genpt (0-10%) (EndCap);counts", 90, 0, 2);
+  mPtRecoOverGen_F_50_80_Cent_0_10 =
+      ibooker.book1D("PtRecoOverGen_F_50_80_Cent_0_10", "50<genpt<80; recopt/genpt (0-10%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_80_120_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_B_80_120_Cent_0_10",
-      "80<genpt<120; recopt/genpt (0-10%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_80_120_Cent_0_10", "80<genpt<120; recopt/genpt (0-10%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_80_120_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_E_80_120_Cent_0_10",
-      "80<genpt<120; recopt/genpt (0-10%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_80_120_Cent_0_10", "80<genpt<120; recopt/genpt (0-10%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_80_120_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_F_80_120_Cent_0_10",
-      "80<genpt<120; recopt/genpt (0-10%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_80_120_Cent_0_10", "80<genpt<120; recopt/genpt (0-10%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_120_180_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_B_120_180_Cent_0_10",
-      "120<genpt<180; recopt/genpt (0-10%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_120_180_Cent_0_10", "120<genpt<180; recopt/genpt (0-10%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_120_180_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_E_120_180_Cent_0_10",
-      "120<genpt<180; recopt/genpt (0-10%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_120_180_Cent_0_10", "120<genpt<180; recopt/genpt (0-10%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_120_180_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_F_120_180_Cent_0_10",
-      "120<genpt<180; recopt/genpt (0-10%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_120_180_Cent_0_10", "120<genpt<180; recopt/genpt (0-10%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_180_300_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_B_180_300_Cent_0_10",
-      "180<genpt<300; recopt/genpt (0-10%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_180_300_Cent_0_10", "180<genpt<300; recopt/genpt (0-10%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_180_300_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_E_180_300_Cent_0_10",
-      "180<genpt<300; recopt/genpt (0-10%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_180_300_Cent_0_10", "180<genpt<300; recopt/genpt (0-10%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_180_300_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_F_180_300_Cent_0_10",
-      "180<genpt<300; recopt/genpt (0-10%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_180_300_Cent_0_10", "180<genpt<300; recopt/genpt (0-10%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_300_Inf_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_B_300_Inf_Cent_0_10",
-      "300<genpt<Inf; recopt/genpt (0-10%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_300_Inf_Cent_0_10", "300<genpt<Inf; recopt/genpt (0-10%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_300_Inf_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_E_300_Inf_Cent_0_10",
-      "300<genpt<Inf; recopt/genpt (0-10%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_300_Inf_Cent_0_10", "300<genpt<Inf; recopt/genpt (0-10%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_300_Inf_Cent_0_10 = ibooker.book1D(
-      "PtRecoOverGen_F_300_Inf_Cent_0_10",
-      "300<genpt<Inf; recopt/genpt (0-10%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_300_Inf_Cent_0_10", "300<genpt<Inf; recopt/genpt (0-10%) (Forward);counts", 90, 0, 2);
 
   mPtRecoOverGen_B_20_30_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_B_20_30_Cent_10_30",
-      "20<genpt<30; recopt/genpt (10-30%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_20_30_Cent_10_30", "20<genpt<30; recopt/genpt (10-30%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_20_30_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_E_20_30_Cent_10_30",
-      "20<genpt<30; recopt/genpt (10-30%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_20_30_Cent_10_30", "20<genpt<30; recopt/genpt (10-30%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_20_30_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_F_20_30_Cent_10_30",
-      "20<genpt<30; recopt/genpt (10-30%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_20_30_Cent_10_30", "20<genpt<30; recopt/genpt (10-30%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_30_50_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_B_30_50_Cent_10_30",
-      "30<genpt<50; recopt/genpt (10-30%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_30_50_Cent_10_30", "30<genpt<50; recopt/genpt (10-30%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_30_50_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_E_30_50_Cent_10_30",
-      "30<genpt<50; recopt/genpt (10-30%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_30_50_Cent_10_30", "30<genpt<50; recopt/genpt (10-30%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_30_50_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_F_30_50_Cent_10_30",
-      "30<genpt<50; recopt/genpt (10-30%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_30_50_Cent_10_30", "30<genpt<50; recopt/genpt (10-30%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_50_80_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_B_50_80_Cent_10_30",
-      "50<genpt<80; recopt/genpt (10-30%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_50_80_Cent_10_30", "50<genpt<80; recopt/genpt (10-30%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_50_80_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_E_50_80_Cent_10_30",
-      "50<genpt<80; recopt/genpt (10-30%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_50_80_Cent_10_30", "50<genpt<80; recopt/genpt (10-30%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_50_80_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_F_50_80_Cent_10_30",
-      "50<genpt<80; recopt/genpt (10-30%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_50_80_Cent_10_30", "50<genpt<80; recopt/genpt (10-30%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_80_120_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_B_80_120_Cent_10_30",
-      "80<genpt<120; recopt/genpt (10-30%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_80_120_Cent_10_30", "80<genpt<120; recopt/genpt (10-30%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_80_120_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_E_80_120_Cent_10_30",
-      "80<genpt<120; recopt/genpt (10-30%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_80_120_Cent_10_30", "80<genpt<120; recopt/genpt (10-30%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_80_120_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_F_80_120_Cent_10_30",
-      "80<genpt<120; recopt/genpt (10-30%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_80_120_Cent_10_30", "80<genpt<120; recopt/genpt (10-30%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_120_180_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_B_120_180_Cent_10_30",
-      "120<genpt<180; recopt/genpt (10-30%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_120_180_Cent_10_30", "120<genpt<180; recopt/genpt (10-30%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_120_180_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_E_120_180_Cent_10_30",
-      "120<genpt<180; recopt/genpt (10-30%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_120_180_Cent_10_30", "120<genpt<180; recopt/genpt (10-30%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_120_180_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_F_120_180_Cent_10_30",
-      "120<genpt<180; recopt/genpt (10-30%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_120_180_Cent_10_30", "120<genpt<180; recopt/genpt (10-30%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_180_300_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_B_180_300_Cent_10_30",
-      "180<genpt<300; recopt/genpt (10-30%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_180_300_Cent_10_30", "180<genpt<300; recopt/genpt (10-30%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_180_300_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_E_180_300_Cent_10_30",
-      "180<genpt<300; recopt/genpt (10-30%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_180_300_Cent_10_30", "180<genpt<300; recopt/genpt (10-30%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_180_300_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_F_180_300_Cent_10_30",
-      "180<genpt<300; recopt/genpt (10-30%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_180_300_Cent_10_30", "180<genpt<300; recopt/genpt (10-30%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_300_Inf_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_B_300_Inf_Cent_10_30",
-      "300<genpt<Inf; recopt/genpt (10-30%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_300_Inf_Cent_10_30", "300<genpt<Inf; recopt/genpt (10-30%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_300_Inf_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_E_300_Inf_Cent_10_30",
-      "300<genpt<Inf; recopt/genpt (10-30%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_300_Inf_Cent_10_30", "300<genpt<Inf; recopt/genpt (10-30%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_300_Inf_Cent_10_30 = ibooker.book1D(
-      "PtRecoOverGen_F_300_Inf_Cent_10_30",
-      "300<genpt<Inf; recopt/genpt (10-30%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_300_Inf_Cent_10_30", "300<genpt<Inf; recopt/genpt (10-30%) (Forward);counts", 90, 0, 2);
 
   mPtRecoOverGen_B_20_30_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_B_20_30_Cent_30_50",
-      "20<genpt<30; recopt/genpt (30-50%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_20_30_Cent_30_50", "20<genpt<30; recopt/genpt (30-50%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_20_30_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_E_20_30_Cent_30_50",
-      "20<genpt<30; recopt/genpt (30-50%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_20_30_Cent_30_50", "20<genpt<30; recopt/genpt (30-50%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_20_30_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_F_20_30_Cent_30_50",
-      "20<genpt<30; recopt/genpt (30-50%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_20_30_Cent_30_50", "20<genpt<30; recopt/genpt (30-50%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_30_50_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_B_30_50_Cent_30_50",
-      "30<genpt<50; recopt/genpt (30-50%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_30_50_Cent_30_50", "30<genpt<50; recopt/genpt (30-50%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_30_50_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_E_30_50_Cent_30_50",
-      "30<genpt<50; recopt/genpt (30-50%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_30_50_Cent_30_50", "30<genpt<50; recopt/genpt (30-50%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_30_50_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_F_30_50_Cent_30_50",
-      "30<genpt<50; recopt/genpt (30-50%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_30_50_Cent_30_50", "30<genpt<50; recopt/genpt (30-50%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_50_80_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_B_50_80_Cent_30_50",
-      "50<genpt<80; recopt/genpt (30-50%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_50_80_Cent_30_50", "50<genpt<80; recopt/genpt (30-50%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_50_80_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_E_50_80_Cent_30_50",
-      "50<genpt<80; recopt/genpt (30-50%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_50_80_Cent_30_50", "50<genpt<80; recopt/genpt (30-50%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_50_80_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_F_50_80_Cent_30_50",
-      "50<genpt<80; recopt/genpt (30-50%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_50_80_Cent_30_50", "50<genpt<80; recopt/genpt (30-50%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_80_120_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_B_80_120_Cent_30_50",
-      "80<genpt<120; recopt/genpt (30-50%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_80_120_Cent_30_50", "80<genpt<120; recopt/genpt (30-50%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_80_120_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_E_80_120_Cent_30_50",
-      "80<genpt<120; recopt/genpt (30-50%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_80_120_Cent_30_50", "80<genpt<120; recopt/genpt (30-50%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_80_120_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_F_80_120_Cent_30_50",
-      "80<genpt<120; recopt/genpt (30-50%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_80_120_Cent_30_50", "80<genpt<120; recopt/genpt (30-50%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_120_180_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_B_120_180_Cent_30_50",
-      "120<genpt<180; recopt/genpt (30-50%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_120_180_Cent_30_50", "120<genpt<180; recopt/genpt (30-50%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_120_180_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_E_120_180_Cent_30_50",
-      "120<genpt<180; recopt/genpt (30-50%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_120_180_Cent_30_50", "120<genpt<180; recopt/genpt (30-50%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_120_180_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_F_120_180_Cent_30_50",
-      "120<genpt<180; recopt/genpt (30-50%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_120_180_Cent_30_50", "120<genpt<180; recopt/genpt (30-50%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_180_300_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_B_180_300_Cent_30_50",
-      "180<genpt<300; recopt/genpt (30-50%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_180_300_Cent_30_50", "180<genpt<300; recopt/genpt (30-50%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_180_300_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_E_180_300_Cent_30_50",
-      "180<genpt<300; recopt/genpt (30-50%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_180_300_Cent_30_50", "180<genpt<300; recopt/genpt (30-50%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_180_300_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_F_180_300_Cent_30_50",
-      "180<genpt<300; recopt/genpt (30-50%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_180_300_Cent_30_50", "180<genpt<300; recopt/genpt (30-50%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_300_Inf_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_B_300_Inf_Cent_30_50",
-      "300<genpt<Inf; recopt/genpt (30-50%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_300_Inf_Cent_30_50", "300<genpt<Inf; recopt/genpt (30-50%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_300_Inf_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_E_300_Inf_Cent_30_50",
-      "300<genpt<Inf; recopt/genpt (30-50%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_300_Inf_Cent_30_50", "300<genpt<Inf; recopt/genpt (30-50%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_300_Inf_Cent_30_50 = ibooker.book1D(
-      "PtRecoOverGen_F_300_Inf_Cent_30_50",
-      "300<genpt<Inf; recopt/genpt (30-50%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_300_Inf_Cent_30_50", "300<genpt<Inf; recopt/genpt (30-50%) (Forward);counts", 90, 0, 2);
 
   mPtRecoOverGen_B_20_30_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_B_20_30_Cent_50_80",
-      "20<genpt<30; recopt/genpt (50-80%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_20_30_Cent_50_80", "20<genpt<30; recopt/genpt (50-80%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_20_30_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_E_20_30_Cent_50_80",
-      "20<genpt<30; recopt/genpt (50-80%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_20_30_Cent_50_80", "20<genpt<30; recopt/genpt (50-80%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_20_30_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_F_20_30_Cent_50_80",
-      "20<genpt<30; recopt/genpt (50-80%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_20_30_Cent_50_80", "20<genpt<30; recopt/genpt (50-80%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_30_50_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_B_30_50_Cent_50_80",
-      "30<genpt<50; recopt/genpt (50-80%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_30_50_Cent_50_80", "30<genpt<50; recopt/genpt (50-80%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_30_50_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_E_30_50_Cent_50_80",
-      "30<genpt<50; recopt/genpt (50-80%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_30_50_Cent_50_80", "30<genpt<50; recopt/genpt (50-80%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_30_50_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_F_30_50_Cent_50_80",
-      "30<genpt<50; recopt/genpt (50-80%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_30_50_Cent_50_80", "30<genpt<50; recopt/genpt (50-80%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_50_80_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_B_50_80_Cent_50_80",
-      "50<genpt<80; recopt/genpt (50-80%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_50_80_Cent_50_80", "50<genpt<80; recopt/genpt (50-80%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_50_80_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_E_50_80_Cent_50_80",
-      "50<genpt<80; recopt/genpt (50-80%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_50_80_Cent_50_80", "50<genpt<80; recopt/genpt (50-80%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_50_80_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_F_50_80_Cent_50_80",
-      "50<genpt<80; recopt/genpt (50-80%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_50_80_Cent_50_80", "50<genpt<80; recopt/genpt (50-80%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_80_120_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_B_80_120_Cent_50_80",
-      "80<genpt<120; recopt/genpt (50-80%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_80_120_Cent_50_80", "80<genpt<120; recopt/genpt (50-80%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_80_120_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_E_80_120_Cent_50_80",
-      "80<genpt<120; recopt/genpt (50-80%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_80_120_Cent_50_80", "80<genpt<120; recopt/genpt (50-80%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_80_120_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_F_80_120_Cent_50_80",
-      "80<genpt<120; recopt/genpt (50-80%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_80_120_Cent_50_80", "80<genpt<120; recopt/genpt (50-80%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_120_180_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_B_120_180_Cent_50_80",
-      "120<genpt<180; recopt/genpt (50-80%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_120_180_Cent_50_80", "120<genpt<180; recopt/genpt (50-80%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_120_180_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_E_120_180_Cent_50_80",
-      "120<genpt<180; recopt/genpt (50-80%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_120_180_Cent_50_80", "120<genpt<180; recopt/genpt (50-80%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_120_180_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_F_120_180_Cent_50_80",
-      "120<genpt<180; recopt/genpt (50-80%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_120_180_Cent_50_80", "120<genpt<180; recopt/genpt (50-80%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_180_300_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_B_180_300_Cent_50_80",
-      "180<genpt<300; recopt/genpt (50-80%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_180_300_Cent_50_80", "180<genpt<300; recopt/genpt (50-80%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_180_300_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_E_180_300_Cent_50_80",
-      "180<genpt<300; recopt/genpt (50-80%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_180_300_Cent_50_80", "180<genpt<300; recopt/genpt (50-80%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_180_300_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_F_180_300_Cent_50_80",
-      "180<genpt<300; recopt/genpt (50-80%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_180_300_Cent_50_80", "180<genpt<300; recopt/genpt (50-80%) (Forward);counts", 90, 0, 2);
   mPtRecoOverGen_B_300_Inf_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_B_300_Inf_Cent_50_80",
-      "300<genpt<Inf; recopt/genpt (50-80%) (Barrel);counts", 90, 0, 2);
+      "PtRecoOverGen_B_300_Inf_Cent_50_80", "300<genpt<Inf; recopt/genpt (50-80%) (Barrel);counts", 90, 0, 2);
   mPtRecoOverGen_E_300_Inf_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_E_300_Inf_Cent_50_80",
-      "300<genpt<Inf; recopt/genpt (50-80%) (EndCap);counts", 90, 0, 2);
+      "PtRecoOverGen_E_300_Inf_Cent_50_80", "300<genpt<Inf; recopt/genpt (50-80%) (EndCap);counts", 90, 0, 2);
   mPtRecoOverGen_F_300_Inf_Cent_50_80 = ibooker.book1D(
-      "PtRecoOverGen_F_300_Inf_Cent_50_80",
-      "300<genpt<Inf; recopt/genpt (50-80%) (Forward);counts", 90, 0, 2);
+      "PtRecoOverGen_F_300_Inf_Cent_50_80", "300<genpt<Inf; recopt/genpt (50-80%) (Forward);counts", 90, 0, 2);
 
-  mPtRecoOverGen_GenPt_B_Cent_0_10 = ibooker.bookProfile(
-      "PtRecoOverGen_GenPt_B_Cent_0_10",
-      Form("|#eta|<%2.2f, (0-10cent);genpt;recopt/genpt", BarrelEta),
-      log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
-  mPtRecoOverGen_GenPt_E_Cent_0_10 = ibooker.bookProfile(
-      "PtRecoOverGen_GenPt_E_Cent_0_10",
-      Form("%2.2f<|#eta|<%2.2f, (0-10cent);genpt;recopt/genpt", BarrelEta,
-           EndcapEta),
-      log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
-  mPtRecoOverGen_GenPt_F_Cent_0_10 = ibooker.bookProfile(
-      "PtRecoOverGen_GenPt_F_Cent_0_10",
-      Form("%2.2f<|#eta|<%2.2f, (0-10cent);genpt;recopt/genpt", EndcapEta,
-           ForwardEta),
-      log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
-  mPtRecoOverGen_GenPt_B_Cent_10_30 = ibooker.bookProfile(
-      "PtRecoOverGen_GenPt_B_Cent_10_30",
-      Form("|#eta|<%2.2f, (10-30cent);genpt;recopt/genpt", BarrelEta),
-      log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
-  mPtRecoOverGen_GenPt_E_Cent_10_30 = ibooker.bookProfile(
-      "PtRecoOverGen_GenPt_E_Cent_10_30",
-      Form("%2.2f<|#eta|<%2.2f, (10-30cent);genpt;recopt/genpt", BarrelEta,
-           EndcapEta),
-      log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
-  mPtRecoOverGen_GenPt_F_Cent_10_30 = ibooker.bookProfile(
-      "PtRecoOverGen_GenPt_F_Cent_10_30",
-      Form("%2.2f<|#eta|<%2.2f, (10-30cent);genpt;recopt/genpt", EndcapEta,
-           ForwardEta),
-      log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
-  mPtRecoOverGen_GenPt_B_Cent_30_50 = ibooker.bookProfile(
-      "PtRecoOverGen_GenPt_B_Cent_30_50",
-      Form("|#eta|<%2.2f, (30-50cent);genpt;recopt/genpt", BarrelEta),
-      log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
-  mPtRecoOverGen_GenPt_E_Cent_30_50 = ibooker.bookProfile(
-      "PtRecoOverGen_GenPt_E_Cent_30_50",
-      Form("%2.2f<|#eta|<%2.2f, (30-50cent);genpt;recopt/genpt", BarrelEta,
-           EndcapEta),
-      log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
-  mPtRecoOverGen_GenPt_F_Cent_30_50 = ibooker.bookProfile(
-      "PtRecoOverGen_GenPt_F_Cent_30_50",
-      Form("%2.2f<|#eta|<%2.2f, (30-50cent);genpt;recopt/genpt", EndcapEta,
-           ForwardEta),
-      log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
-  mPtRecoOverGen_GenPt_B_Cent_50_80 = ibooker.bookProfile(
-      "PtRecoOverGen_GenPt_B_Cent_50_80",
-      Form("|#eta|<%2.2f, (50-80cent);genpt;recopt/genpt", BarrelEta),
-      log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
-  mPtRecoOverGen_GenPt_E_Cent_50_80 = ibooker.bookProfile(
-      "PtRecoOverGen_GenPt_E_Cent_50_80",
-      Form("%2.2f<|#eta|<%2.2f, (50-80cent);genpt;recopt/genpt", BarrelEta,
-           EndcapEta),
-      log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
-  mPtRecoOverGen_GenPt_F_Cent_50_80 = ibooker.bookProfile(
-      "PtRecoOverGen_GenPt_F_Cent_50_80",
-      Form("%2.2f<|#eta|<%2.2f, (50-80cent);genpt;recopt/genpt", EndcapEta,
-           ForwardEta),
-      log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
+  mPtRecoOverGen_GenPt_B_Cent_0_10 = ibooker.bookProfile("PtRecoOverGen_GenPt_B_Cent_0_10",
+                                                         Form("|#eta|<%2.2f, (0-10cent);genpt;recopt/genpt", BarrelEta),
+                                                         log10PtBins,
+                                                         log10PtMin,
+                                                         log10PtMax,
+                                                         0,
+                                                         2,
+                                                         " ");
+  mPtRecoOverGen_GenPt_E_Cent_0_10 =
+      ibooker.bookProfile("PtRecoOverGen_GenPt_E_Cent_0_10",
+                          Form("%2.2f<|#eta|<%2.2f, (0-10cent);genpt;recopt/genpt", BarrelEta, EndcapEta),
+                          log10PtBins,
+                          log10PtMin,
+                          log10PtMax,
+                          0,
+                          2,
+                          " ");
+  mPtRecoOverGen_GenPt_F_Cent_0_10 =
+      ibooker.bookProfile("PtRecoOverGen_GenPt_F_Cent_0_10",
+                          Form("%2.2f<|#eta|<%2.2f, (0-10cent);genpt;recopt/genpt", EndcapEta, ForwardEta),
+                          log10PtBins,
+                          log10PtMin,
+                          log10PtMax,
+                          0,
+                          2,
+                          " ");
+  mPtRecoOverGen_GenPt_B_Cent_10_30 =
+      ibooker.bookProfile("PtRecoOverGen_GenPt_B_Cent_10_30",
+                          Form("|#eta|<%2.2f, (10-30cent);genpt;recopt/genpt", BarrelEta),
+                          log10PtBins,
+                          log10PtMin,
+                          log10PtMax,
+                          0,
+                          2,
+                          " ");
+  mPtRecoOverGen_GenPt_E_Cent_10_30 =
+      ibooker.bookProfile("PtRecoOverGen_GenPt_E_Cent_10_30",
+                          Form("%2.2f<|#eta|<%2.2f, (10-30cent);genpt;recopt/genpt", BarrelEta, EndcapEta),
+                          log10PtBins,
+                          log10PtMin,
+                          log10PtMax,
+                          0,
+                          2,
+                          " ");
+  mPtRecoOverGen_GenPt_F_Cent_10_30 =
+      ibooker.bookProfile("PtRecoOverGen_GenPt_F_Cent_10_30",
+                          Form("%2.2f<|#eta|<%2.2f, (10-30cent);genpt;recopt/genpt", EndcapEta, ForwardEta),
+                          log10PtBins,
+                          log10PtMin,
+                          log10PtMax,
+                          0,
+                          2,
+                          " ");
+  mPtRecoOverGen_GenPt_B_Cent_30_50 =
+      ibooker.bookProfile("PtRecoOverGen_GenPt_B_Cent_30_50",
+                          Form("|#eta|<%2.2f, (30-50cent);genpt;recopt/genpt", BarrelEta),
+                          log10PtBins,
+                          log10PtMin,
+                          log10PtMax,
+                          0,
+                          2,
+                          " ");
+  mPtRecoOverGen_GenPt_E_Cent_30_50 =
+      ibooker.bookProfile("PtRecoOverGen_GenPt_E_Cent_30_50",
+                          Form("%2.2f<|#eta|<%2.2f, (30-50cent);genpt;recopt/genpt", BarrelEta, EndcapEta),
+                          log10PtBins,
+                          log10PtMin,
+                          log10PtMax,
+                          0,
+                          2,
+                          " ");
+  mPtRecoOverGen_GenPt_F_Cent_30_50 =
+      ibooker.bookProfile("PtRecoOverGen_GenPt_F_Cent_30_50",
+                          Form("%2.2f<|#eta|<%2.2f, (30-50cent);genpt;recopt/genpt", EndcapEta, ForwardEta),
+                          log10PtBins,
+                          log10PtMin,
+                          log10PtMax,
+                          0,
+                          2,
+                          " ");
+  mPtRecoOverGen_GenPt_B_Cent_50_80 =
+      ibooker.bookProfile("PtRecoOverGen_GenPt_B_Cent_50_80",
+                          Form("|#eta|<%2.2f, (50-80cent);genpt;recopt/genpt", BarrelEta),
+                          log10PtBins,
+                          log10PtMin,
+                          log10PtMax,
+                          0,
+                          2,
+                          " ");
+  mPtRecoOverGen_GenPt_E_Cent_50_80 =
+      ibooker.bookProfile("PtRecoOverGen_GenPt_E_Cent_50_80",
+                          Form("%2.2f<|#eta|<%2.2f, (50-80cent);genpt;recopt/genpt", BarrelEta, EndcapEta),
+                          log10PtBins,
+                          log10PtMin,
+                          log10PtMax,
+                          0,
+                          2,
+                          " ");
+  mPtRecoOverGen_GenPt_F_Cent_50_80 =
+      ibooker.bookProfile("PtRecoOverGen_GenPt_F_Cent_50_80",
+                          Form("%2.2f<|#eta|<%2.2f, (50-80cent);genpt;recopt/genpt", EndcapEta, ForwardEta),
+                          log10PtBins,
+                          log10PtMin,
+                          log10PtMax,
+                          0,
+                          2,
+                          " ");
 
   mPtRecoOverGen_GenEta_20_30_Cent_0_10 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_20_30_Cent_0_10",
-      "20<genpt<30 (0-10%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_20_30_Cent_0_10", "20<genpt<30 (0-10%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_30_50_Cent_0_10 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_30_50_Cent_0_10",
-      "30<genpt<50 (0-10%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_30_50_Cent_0_10", "30<genpt<50 (0-10%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_50_80_Cent_0_10 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_50_80_Cent_0_10",
-      "50<genpt<80 (0-10%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_50_80_Cent_0_10", "50<genpt<80 (0-10%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_80_120_Cent_0_10 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_80_120_Cent_0_10",
-      "80<genpt<120 (0-10%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_80_120_Cent_0_10", "80<genpt<120 (0-10%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_120_180_Cent_0_10 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_120_180_Cent_0_10",
-      "120<genpt<180 (0-10%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_120_180_Cent_0_10", "120<genpt<180 (0-10%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_180_300_Cent_0_10 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_180_300_Cent_0_10",
-      "180<genpt<300 (0-10%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_180_300_Cent_0_10", "180<genpt<300 (0-10%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_300_Inf_Cent_0_10 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_300_Inf_Cent_0_10",
-      "300<genpt<Inf (0-10%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_300_Inf_Cent_0_10", "300<genpt<Inf (0-10%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
 
   mPtRecoOverGen_GenEta_20_30_Cent_10_30 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_20_30_Cent_10_30",
-      "20<genpt<30 (10-30%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_20_30_Cent_10_30", "20<genpt<30 (10-30%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_30_50_Cent_10_30 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_30_50_Cent_10_30",
-      "30<genpt<50 (10-30%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_30_50_Cent_10_30", "30<genpt<50 (10-30%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_50_80_Cent_10_30 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_50_80_Cent_10_30",
-      "50<genpt<80 (10-30%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_50_80_Cent_10_30", "50<genpt<80 (10-30%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_80_120_Cent_10_30 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_80_120_Cent_10_30",
-      "80<genpt<120 (10-30%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_80_120_Cent_10_30", "80<genpt<120 (10-30%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_120_180_Cent_10_30 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_120_180_Cent_10_30",
-      "120<genpt<180 (10-30%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_120_180_Cent_10_30", "120<genpt<180 (10-30%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_180_300_Cent_10_30 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_180_300_Cent_10_30",
-      "180<genpt<300 (10-30%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_180_300_Cent_10_30", "180<genpt<300 (10-30%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_300_Inf_Cent_10_30 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_300_Inf_Cent_10_30",
-      "300<genpt<Inf (10-30%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_300_Inf_Cent_10_30", "300<genpt<Inf (10-30%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
 
   mPtRecoOverGen_GenEta_20_30_Cent_30_50 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_20_30_Cent_30_50",
-      "20<genpt<30 (30-50%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_20_30_Cent_30_50", "20<genpt<30 (30-50%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_30_50_Cent_30_50 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_30_50_Cent_30_50",
-      "30<genpt<50 (30-50%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_30_50_Cent_30_50", "30<genpt<50 (30-50%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_50_80_Cent_30_50 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_50_80_Cent_30_50",
-      "50<genpt<80 (30-50%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_50_80_Cent_30_50", "50<genpt<80 (30-50%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_80_120_Cent_30_50 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_80_120_Cent_30_50",
-      "80<genpt<120 (30-50%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_80_120_Cent_30_50", "80<genpt<120 (30-50%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_120_180_Cent_30_50 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_120_180_Cent_30_50",
-      "120<genpt<180 (30-50%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_120_180_Cent_30_50", "120<genpt<180 (30-50%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_180_300_Cent_30_50 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_180_300_Cent_30_50",
-      "180<genpt<300 (30-50%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_180_300_Cent_30_50", "180<genpt<300 (30-50%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_300_Inf_Cent_30_50 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_300_Inf_Cent_30_50",
-      "300<genpt<Inf (30-50%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_300_Inf_Cent_30_50", "300<genpt<Inf (30-50%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
 
   mPtRecoOverGen_GenEta_20_30_Cent_50_80 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_20_30_Cent_50_80",
-      "20<genpt<30 (50-80%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_20_30_Cent_50_80", "20<genpt<30 (50-80%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_30_50_Cent_50_80 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_30_50_Cent_50_80",
-      "30<genpt<50 (50-80%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_30_50_Cent_50_80", "30<genpt<50 (50-80%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_50_80_Cent_50_80 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_50_80_Cent_50_80",
-      "50<genpt<80 (50-80%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_50_80_Cent_50_80", "50<genpt<80 (50-80%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_80_120_Cent_50_80 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_80_120_Cent_50_80",
-      "80<genpt<120 (50-80%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_80_120_Cent_50_80", "80<genpt<120 (50-80%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_120_180_Cent_50_80 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_120_180_Cent_50_80",
-      "120<genpt<180 (50-80%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_120_180_Cent_50_80", "120<genpt<180 (50-80%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_180_300_Cent_50_80 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_180_300_Cent_50_80",
-      "180<genpt<300 (50-80%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_180_300_Cent_50_80", "180<genpt<300 (50-80%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
   mPtRecoOverGen_GenEta_300_Inf_Cent_50_80 = ibooker.bookProfile(
-      "PtRecoOverGen_GenEta_300_Inf_Cent_50_80",
-      "300<genpt<Inf (50-80%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
+      "PtRecoOverGen_GenEta_300_Inf_Cent_50_80", "300<genpt<Inf (50-80%);geneta;recopt/genpt", 90, etaRange, 0, 2, " ");
 
   if (mOutputFile.empty())
     LogInfo("OutputInfo") << " Histograms will NOT be saved";
   else
-    LogInfo("OutputInfo") << " Histograms will be saved to file:"
-                          << mOutputFile;
+    LogInfo("OutputInfo") << " Histograms will be saved to file:" << mOutputFile;
 
   delete h2D_etabins_vs_pt2;
   delete h2D_etabins_vs_pt;
@@ -1113,8 +1000,7 @@ JetTester_HeavyIons::~JetTester_HeavyIons() {}
 //------------------------------------------------------------------------------
 // analyze
 //------------------------------------------------------------------------------
-void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
-                                  const edm::EventSetup &mSetup) {
+void JetTester_HeavyIons::analyze(const edm::Event &mEvent, const edm::EventSetup &mSetup) {
   // Get the primary vertices
   //----------------------------------------------------------------------------
   edm::Handle<vector<reco::Vertex>> pvHandle;
@@ -1142,8 +1028,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
 
   if (pvHandle.isValid()) {
     for (unsigned i = 0; i < pvHandle->size(); i++) {
-      if ((*pvHandle)[i].ndof() > 4 && (fabs((*pvHandle)[i].z()) <= 24) &&
-          (fabs((*pvHandle)[i].position().rho()) <= 2))
+      if ((*pvHandle)[i].ndof() > 4 && (fabs((*pvHandle)[i].z()) <= 24) && (fabs((*pvHandle)[i].position().rho()) <= 2))
         nGoodVertices++;
     }
   }
@@ -1170,7 +1055,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
 
   // get the centrality
   edm::Handle<reco::Centrality> cent;
-  mEvent.getByToken(centralityToken, cent); //_centralitytag comes from the cfg
+  mEvent.getByToken(centralityToken, cent);  //_centralitytag comes from the cfg
 
   mHF->Fill(cent->EtHFtowerSum());
   Float_t HF_energy = cent->EtHFtowerSum();
@@ -1229,23 +1114,33 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
   Float_t caloPhi = 0;
   Float_t SumPt_value = 0;
 
-  double edge_pseudorapidity[etaBins_ + 1] = {
-      -5.191, -2.650, -2.043, -1.740, -1.479, -1.131, -0.783, -0.522,
-      0.522,  0.783,  1.131,  1.479,  1.740,  2.043,  2.650,  5.191};
+  double edge_pseudorapidity[etaBins_ + 1] = {-5.191,
+                                              -2.650,
+                                              -2.043,
+                                              -1.740,
+                                              -1.479,
+                                              -1.131,
+                                              -0.783,
+                                              -0.522,
+                                              0.522,
+                                              0.783,
+                                              1.131,
+                                              1.479,
+                                              1.740,
+                                              2.043,
+                                              2.650,
+                                              5.191};
 
   if (isCaloJet) {
-
     Float_t SumCaloPt[etaBins_];
     Float_t SumSquaredCaloPt[etaBins_];
 
     for (int i = 0; i < etaBins_; i++) {
-
       SumCaloPt[i] = 0;
       SumSquaredCaloPt[i] = 0;
     }
 
     for (unsigned icand = 0; icand < caloCandidates->size(); icand++) {
-
       const CaloTower &tower = (*caloCandidates)[icand];
       reco::CandidateViewRef ref(calocandidates_, icand);
       if (tower.p4(vtx).Et() < 0.1)
@@ -1258,13 +1153,12 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
       caloPhi = tower.p4(vtx).Phi();
 
       for (size_t k = 0; k < nedge_pseudorapidity - 1; k++) {
-        if (caloEta >= edge_pseudorapidity[k] &&
-            caloEta < edge_pseudorapidity[k + 1]) {
+        if (caloEta >= edge_pseudorapidity[k] && caloEta < edge_pseudorapidity[k + 1]) {
           SumCaloPt[k] = SumCaloPt[k] + caloPt;
           SumSquaredCaloPt[k] = SumSquaredCaloPt[k] + caloPt * caloPt;
-        } // eta selection statement
+        }  // eta selection statement
 
-      } // eta bin loop
+      }  // eta bin loop
 
       SumPt_value = SumPt_value + caloPt;
 
@@ -1272,7 +1166,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
       mCaloEta->Fill(caloEta);
       mCaloPhi->Fill(caloPhi);
 
-    } // calo tower candidate  loop
+    }  // calo tower candidate  loop
 
     Float_t Evt_SumCaloPt = 0;
 
@@ -1295,12 +1189,11 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
     mSumCaloPt_2p650_5p191->Fill(SumCaloPt[14]);
 
     for (size_t k = 0; k < nedge_pseudorapidity - 1; k++) {
-
       Evt_SumCaloPt = Evt_SumCaloPt + SumCaloPt[k];
 
       Evt_SumSquaredCaloPt = Evt_SumSquaredCaloPt + SumSquaredCaloPt[k];
 
-    } // eta bin loop
+    }  // eta bin loop
 
     mSumCaloPt->Fill(Evt_SumCaloPt);
 
@@ -1311,22 +1204,19 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
     mNCalopart->Fill(NCaloTower);
     mSumpt->Fill(SumPt_value);
 
-  } // is calo jet
+  }  // is calo jet
 
   if (isPFJet) {
-
     Float_t SumPFPt[etaBins_];
 
     Float_t SumSquaredPFPt[etaBins_];
 
     for (int i = 0; i < etaBins_; i++) {
-
       SumPFPt[i] = 0;
       SumSquaredPFPt[i] = 0;
     }
 
     for (unsigned icand = 0; icand < pfCandidateColl->size(); icand++) {
-
       const reco::PFCandidate pfCandidate = pfCandidateColl->at(icand);
       reco::CandidateViewRef ref(pfcandidates_, icand);
 
@@ -1351,82 +1241,81 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
         inForward = true;
 
       switch (pfID) {
-      case 0:
-        mPFCandpT_vs_eta_Unknown->Fill(pfPt, pfEta);
-        if (inBarrel)
-          mPFCandpT_Barrel_Unknown->Fill(pfPt);
-        if (inEndcap)
-          mPFCandpT_Endcap_Unknown->Fill(pfPt);
-        if (inForward)
-          mPFCandpT_Forward_Unknown->Fill(pfPt);
-      case 1:
-        mPFCandpT_vs_eta_ChargedHadron->Fill(pfPt, pfEta);
-        if (inBarrel)
-          mPFCandpT_Barrel_ChargedHadron->Fill(pfPt);
-        if (inEndcap)
-          mPFCandpT_Endcap_ChargedHadron->Fill(pfPt);
-        if (inForward)
-          mPFCandpT_Forward_ChargedHadron->Fill(pfPt);
-      case 2:
-        mPFCandpT_vs_eta_electron->Fill(pfPt, pfEta);
-        if (inBarrel)
-          mPFCandpT_Barrel_electron->Fill(pfPt);
-        if (inEndcap)
-          mPFCandpT_Endcap_electron->Fill(pfPt);
-        if (inForward)
-          mPFCandpT_Forward_electron->Fill(pfPt);
-      case 3:
-        mPFCandpT_vs_eta_muon->Fill(pfPt, pfEta);
-        if (inBarrel)
-          mPFCandpT_Barrel_muon->Fill(pfPt);
-        if (inEndcap)
-          mPFCandpT_Endcap_muon->Fill(pfPt);
-        if (inForward)
-          mPFCandpT_Forward_muon->Fill(pfPt);
-      case 4:
-        mPFCandpT_vs_eta_photon->Fill(pfPt, pfEta);
-        if (inBarrel)
-          mPFCandpT_Barrel_photon->Fill(pfPt);
-        if (inEndcap)
-          mPFCandpT_Endcap_photon->Fill(pfPt);
-        if (inForward)
-          mPFCandpT_Forward_photon->Fill(pfPt);
-      case 5:
-        mPFCandpT_vs_eta_NeutralHadron->Fill(pfPt, pfEta);
-        if (inBarrel)
-          mPFCandpT_Barrel_NeutralHadron->Fill(pfPt);
-        if (inEndcap)
-          mPFCandpT_Endcap_NeutralHadron->Fill(pfPt);
-        if (inForward)
-          mPFCandpT_Forward_NeutralHadron->Fill(pfPt);
-      case 6:
-        mPFCandpT_vs_eta_HadE_inHF->Fill(pfPt, pfEta);
-        if (inBarrel)
-          mPFCandpT_Barrel_HadE_inHF->Fill(pfPt);
-        if (inEndcap)
-          mPFCandpT_Endcap_HadE_inHF->Fill(pfPt);
-        if (inForward)
-          mPFCandpT_Forward_HadE_inHF->Fill(pfPt);
-      case 7:
-        mPFCandpT_vs_eta_EME_inHF->Fill(pfPt, pfEta);
-        if (inBarrel)
-          mPFCandpT_Barrel_EME_inHF->Fill(pfPt);
-        if (inEndcap)
-          mPFCandpT_Endcap_EME_inHF->Fill(pfPt);
-        if (inForward)
-          mPFCandpT_Forward_EME_inHF->Fill(pfPt);
+        case 0:
+          mPFCandpT_vs_eta_Unknown->Fill(pfPt, pfEta);
+          if (inBarrel)
+            mPFCandpT_Barrel_Unknown->Fill(pfPt);
+          if (inEndcap)
+            mPFCandpT_Endcap_Unknown->Fill(pfPt);
+          if (inForward)
+            mPFCandpT_Forward_Unknown->Fill(pfPt);
+        case 1:
+          mPFCandpT_vs_eta_ChargedHadron->Fill(pfPt, pfEta);
+          if (inBarrel)
+            mPFCandpT_Barrel_ChargedHadron->Fill(pfPt);
+          if (inEndcap)
+            mPFCandpT_Endcap_ChargedHadron->Fill(pfPt);
+          if (inForward)
+            mPFCandpT_Forward_ChargedHadron->Fill(pfPt);
+        case 2:
+          mPFCandpT_vs_eta_electron->Fill(pfPt, pfEta);
+          if (inBarrel)
+            mPFCandpT_Barrel_electron->Fill(pfPt);
+          if (inEndcap)
+            mPFCandpT_Endcap_electron->Fill(pfPt);
+          if (inForward)
+            mPFCandpT_Forward_electron->Fill(pfPt);
+        case 3:
+          mPFCandpT_vs_eta_muon->Fill(pfPt, pfEta);
+          if (inBarrel)
+            mPFCandpT_Barrel_muon->Fill(pfPt);
+          if (inEndcap)
+            mPFCandpT_Endcap_muon->Fill(pfPt);
+          if (inForward)
+            mPFCandpT_Forward_muon->Fill(pfPt);
+        case 4:
+          mPFCandpT_vs_eta_photon->Fill(pfPt, pfEta);
+          if (inBarrel)
+            mPFCandpT_Barrel_photon->Fill(pfPt);
+          if (inEndcap)
+            mPFCandpT_Endcap_photon->Fill(pfPt);
+          if (inForward)
+            mPFCandpT_Forward_photon->Fill(pfPt);
+        case 5:
+          mPFCandpT_vs_eta_NeutralHadron->Fill(pfPt, pfEta);
+          if (inBarrel)
+            mPFCandpT_Barrel_NeutralHadron->Fill(pfPt);
+          if (inEndcap)
+            mPFCandpT_Endcap_NeutralHadron->Fill(pfPt);
+          if (inForward)
+            mPFCandpT_Forward_NeutralHadron->Fill(pfPt);
+        case 6:
+          mPFCandpT_vs_eta_HadE_inHF->Fill(pfPt, pfEta);
+          if (inBarrel)
+            mPFCandpT_Barrel_HadE_inHF->Fill(pfPt);
+          if (inEndcap)
+            mPFCandpT_Endcap_HadE_inHF->Fill(pfPt);
+          if (inForward)
+            mPFCandpT_Forward_HadE_inHF->Fill(pfPt);
+        case 7:
+          mPFCandpT_vs_eta_EME_inHF->Fill(pfPt, pfEta);
+          if (inBarrel)
+            mPFCandpT_Barrel_EME_inHF->Fill(pfPt);
+          if (inEndcap)
+            mPFCandpT_Endcap_EME_inHF->Fill(pfPt);
+          if (inForward)
+            mPFCandpT_Forward_EME_inHF->Fill(pfPt);
       }
 
       for (size_t k = 0; k < nedge_pseudorapidity - 1; k++) {
-        if (pfEta >= edge_pseudorapidity[k] &&
-            pfEta < edge_pseudorapidity[k + 1]) {
+        if (pfEta >= edge_pseudorapidity[k] && pfEta < edge_pseudorapidity[k + 1]) {
           SumPFPt[k] = SumPFPt[k] + pfPt;
 
           SumSquaredPFPt[k] = SumSquaredPFPt[k] + pfPt * pfPt;
 
-        } // eta selection statement
+        }  // eta selection statement
 
-      } // eta bin loop
+      }  // eta bin loop
 
       SumPt_value = SumPt_value + pfPt;
 
@@ -1434,7 +1323,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
       mPFEta->Fill(pfEta);
       mPFPhi->Fill(pfPhi);
 
-    } // pf candidate loop
+    }  // pf candidate loop
 
     Float_t Evt_SumPFPt = 0;
 
@@ -1457,12 +1346,11 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
     mSumPFPt_2p650_5p191->Fill(SumPFPt[14]);
 
     for (size_t k = 0; k < nedge_pseudorapidity - 1; k++) {
-
       Evt_SumPFPt = Evt_SumPFPt + SumPFPt[k];
 
       Evt_SumSquaredPFPt = Evt_SumSquaredPFPt + SumSquaredPFPt[k];
 
-    } // eta bin loop
+    }  // eta bin loop
 
     mSumPFPt->Fill(Evt_SumPFPt);
 
@@ -1507,7 +1395,6 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
   mNJets->Fill(recoJets.size());
 
   for (unsigned ijet = 0; ijet < recoJets.size(); ijet++) {
-
     if (recoJets[ijet].pt() > mRecoJetPtThreshold) {
       // counting forward and barrel jets
       // get an idea of no of jets with pT>40 GeV
@@ -1540,7 +1427,6 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
 
   // Gen level information:
   if (!mEvent.isRealData()) {
-
     // Get ptHat
     //------------------------------------------------------------------------
     edm::Handle<GenEventInfoProduct> myGenEvt;
@@ -1561,8 +1447,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
     if (!genJets.isValid())
       return;
 
-    for (GenJetCollection::const_iterator gjet = genJets->begin();
-         gjet != genJets->end(); gjet++) {
+    for (GenJetCollection::const_iterator gjet = genJets->begin(); gjet != genJets->end(); gjet++) {
       if (gjet->pt() > mMatchGenPtThreshold) {
         if (mGenEta)
           mGenEta->Fill(gjet->eta());
@@ -1574,10 +1459,9 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
     }
 
     if (!(mInputGenCollection.label().empty())) {
-      for (GenJetCollection::const_iterator gjet = genJets->begin();
-           gjet != genJets->end(); gjet++) {
+      for (GenJetCollection::const_iterator gjet = genJets->begin(); gjet != genJets->end(); gjet++) {
         if (fabs(gjet->eta()) > 6.)
-          continue; // Out of the detector
+          continue;  // Out of the detector
         if (gjet->pt() < mMatchGenPtThreshold)
           continue;
         if (recoJets.empty())
@@ -1602,8 +1486,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
         for (unsigned ijet = 0; ijet < recoJets.size(); ++ijet) {
           double recoPt = recoJets[ijet].pt();
           if (recoPt > 10) {
-            double delR = deltaR(gjet->eta(), gjet->phi(), recoJets[ijet].eta(),
-                                 recoJets[ijet].phi());
+            double delR = deltaR(gjet->eta(), gjet->phi(), recoJets[ijet].eta(), recoJets[ijet].phi());
             if (delR < deltaRBest) {
               deltaRBest = delR;
               JetPtBest = recoPt;
@@ -1664,7 +1547,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_20_30_Cent_0_10->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_20_30_Cent_0_10->Fill(response);
-            } //
+            }  //
             if (ismidCentral) {
               mPtRecoOverGen_GenEta_20_30_Cent_10_30->Fill(geneta, response);
               if (inBarrel)
@@ -1673,7 +1556,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_20_30_Cent_10_30->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_20_30_Cent_10_30->Fill(response);
-            } //
+            }  //
             if (ismidPeripheral) {
               mPtRecoOverGen_GenEta_20_30_Cent_30_50->Fill(geneta, response);
               if (inBarrel)
@@ -1682,7 +1565,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_20_30_Cent_30_50->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_20_30_Cent_30_50->Fill(response);
-            } //
+            }  //
             if (isPeripheral) {
               mPtRecoOverGen_GenEta_20_30_Cent_50_80->Fill(geneta, response);
               if (inBarrel)
@@ -1691,8 +1574,8 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_20_30_Cent_50_80->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_20_30_Cent_50_80->Fill(response);
-            } //
-          }   // pt bin 20-30
+            }  //
+          }    // pt bin 20-30
 
           if (gjet->pt() >= 30 && gjet->pt() < 50) {
             if (isCentral) {
@@ -1703,7 +1586,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_30_50_Cent_0_10->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_30_50_Cent_0_10->Fill(response);
-            } //
+            }  //
             if (ismidCentral) {
               mPtRecoOverGen_GenEta_30_50_Cent_10_30->Fill(geneta, response);
               if (inBarrel)
@@ -1712,7 +1595,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_30_50_Cent_10_30->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_30_50_Cent_10_30->Fill(response);
-            } //
+            }  //
             if (ismidPeripheral) {
               mPtRecoOverGen_GenEta_30_50_Cent_30_50->Fill(geneta, response);
               if (inBarrel)
@@ -1721,7 +1604,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_30_50_Cent_30_50->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_30_50_Cent_30_50->Fill(response);
-            } //
+            }  //
             if (isPeripheral) {
               mPtRecoOverGen_GenEta_30_50_Cent_50_80->Fill(geneta, response);
               if (inBarrel)
@@ -1730,8 +1613,8 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_30_50_Cent_50_80->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_30_50_Cent_50_80->Fill(response);
-            } //
-          }   // pt bin 30-50
+            }  //
+          }    // pt bin 30-50
 
           if (gjet->pt() >= 50 && gjet->pt() < 80) {
             if (isCentral) {
@@ -1742,7 +1625,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_50_80_Cent_0_10->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_50_80_Cent_0_10->Fill(response);
-            } //
+            }  //
             if (ismidCentral) {
               mPtRecoOverGen_GenEta_50_80_Cent_10_30->Fill(geneta, response);
               if (inBarrel)
@@ -1751,7 +1634,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_50_80_Cent_10_30->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_50_80_Cent_10_30->Fill(response);
-            } //
+            }  //
             if (ismidPeripheral) {
               mPtRecoOverGen_GenEta_50_80_Cent_30_50->Fill(geneta, response);
               if (inBarrel)
@@ -1760,7 +1643,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_50_80_Cent_30_50->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_50_80_Cent_30_50->Fill(response);
-            } //
+            }  //
             if (isPeripheral) {
               mPtRecoOverGen_GenEta_50_80_Cent_50_80->Fill(geneta, response);
               if (inBarrel)
@@ -1769,8 +1652,8 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_50_80_Cent_50_80->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_50_80_Cent_50_80->Fill(response);
-            } //
-          }   // pt bin 50-80
+            }  //
+          }    // pt bin 50-80
 
           if (gjet->pt() >= 80 && gjet->pt() < 120) {
             if (isCentral) {
@@ -1781,7 +1664,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_80_120_Cent_0_10->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_80_120_Cent_0_10->Fill(response);
-            } //
+            }  //
             if (ismidCentral) {
               mPtRecoOverGen_GenEta_80_120_Cent_10_30->Fill(geneta, response);
               if (inBarrel)
@@ -1790,7 +1673,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_80_120_Cent_10_30->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_80_120_Cent_10_30->Fill(response);
-            } //
+            }  //
             if (ismidPeripheral) {
               mPtRecoOverGen_GenEta_80_120_Cent_30_50->Fill(geneta, response);
               if (inBarrel)
@@ -1799,7 +1682,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_80_120_Cent_30_50->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_80_120_Cent_30_50->Fill(response);
-            } //
+            }  //
             if (isPeripheral) {
               mPtRecoOverGen_GenEta_80_120_Cent_50_80->Fill(geneta, response);
               if (inBarrel)
@@ -1808,8 +1691,8 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_80_120_Cent_50_80->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_80_120_Cent_50_80->Fill(response);
-            } //
-          }   // pt bin 80-120
+            }  //
+          }    // pt bin 80-120
 
           if (gjet->pt() >= 120 && gjet->pt() < 180) {
             if (isCentral) {
@@ -1820,7 +1703,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_120_180_Cent_0_10->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_120_180_Cent_0_10->Fill(response);
-            } //
+            }  //
             if (ismidCentral) {
               mPtRecoOverGen_GenEta_120_180_Cent_10_30->Fill(geneta, response);
               if (inBarrel)
@@ -1829,7 +1712,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_120_180_Cent_10_30->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_120_180_Cent_10_30->Fill(response);
-            } //
+            }  //
             if (ismidPeripheral) {
               mPtRecoOverGen_GenEta_120_180_Cent_30_50->Fill(geneta, response);
               if (inBarrel)
@@ -1838,7 +1721,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_120_180_Cent_30_50->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_120_180_Cent_30_50->Fill(response);
-            } //
+            }  //
             if (isPeripheral) {
               mPtRecoOverGen_GenEta_120_180_Cent_50_80->Fill(geneta, response);
               if (inBarrel)
@@ -1847,8 +1730,8 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_120_180_Cent_50_80->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_120_180_Cent_50_80->Fill(response);
-            } //
-          }   // pt bin 120-180
+            }  //
+          }    // pt bin 120-180
 
           if (gjet->pt() >= 180 && gjet->pt() < 300) {
             if (isCentral) {
@@ -1859,7 +1742,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_180_300_Cent_0_10->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_180_300_Cent_0_10->Fill(response);
-            } //
+            }  //
             if (ismidCentral) {
               mPtRecoOverGen_GenEta_180_300_Cent_10_30->Fill(geneta, response);
               if (inBarrel)
@@ -1868,7 +1751,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_180_300_Cent_10_30->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_180_300_Cent_10_30->Fill(response);
-            } //
+            }  //
             if (ismidPeripheral) {
               mPtRecoOverGen_GenEta_180_300_Cent_30_50->Fill(geneta, response);
               if (inBarrel)
@@ -1877,7 +1760,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_180_300_Cent_30_50->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_180_300_Cent_30_50->Fill(response);
-            } //
+            }  //
             if (isPeripheral) {
               mPtRecoOverGen_GenEta_180_300_Cent_50_80->Fill(geneta, response);
               if (inBarrel)
@@ -1886,8 +1769,8 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_180_300_Cent_50_80->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_180_300_Cent_50_80->Fill(response);
-            } //
-          }   // pt bin 180-300
+            }  //
+          }    // pt bin 180-300
 
           if (gjet->pt() >= 300) {
             if (isCentral) {
@@ -1898,7 +1781,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_300_Inf_Cent_0_10->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_300_Inf_Cent_0_10->Fill(response);
-            } //
+            }  //
             if (ismidCentral) {
               mPtRecoOverGen_GenEta_300_Inf_Cent_10_30->Fill(geneta, response);
               if (inBarrel)
@@ -1907,7 +1790,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_300_Inf_Cent_10_30->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_300_Inf_Cent_10_30->Fill(response);
-            } //
+            }  //
             if (ismidPeripheral) {
               mPtRecoOverGen_GenEta_300_Inf_Cent_30_50->Fill(geneta, response);
               if (inBarrel)
@@ -1916,7 +1799,7 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_300_Inf_Cent_30_50->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_300_Inf_Cent_30_50->Fill(response);
-            } //
+            }  //
             if (isPeripheral) {
               mPtRecoOverGen_GenEta_300_Inf_Cent_50_80->Fill(geneta, response);
               if (inBarrel)
@@ -1925,14 +1808,14 @@ void JetTester_HeavyIons::analyze(const edm::Event &mEvent,
                 mPtRecoOverGen_E_300_Inf_Cent_50_80->Fill(response);
               if (inForward)
                 mPtRecoOverGen_F_300_Inf_Cent_50_80->Fill(response);
-            } //
-          }   // pt bin 300-Inf
+            }  //
+          }    // pt bin 300-Inf
 
-        } // delta R < mRthreshold
+        }  // delta R < mRthreshold
 
-      } // gen jet collection loop
+      }  // gen jet collection loop
 
-    } // not empty gen collection
+    }  // not empty gen collection
 
-  } // is the event real
+  }  // is the event real
 }

--- a/Validation/RecoJets/plugins/JetTester_HeavyIons.h
+++ b/Validation/RecoJets/plugins/JetTester_HeavyIons.h
@@ -82,16 +82,18 @@ public:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   // virtual void beginJob();
   // virtual void endJob();
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   // reco::Vertex::Point getVtx(const edm::Event& ev);
 
   // double getEt(const DetID )
 
 private:
-  void fillMatchHists(const double GenEta, const double GenPhi,
-                      const double GenPt, const double RecoEta,
-                      const double RecoPhi, const double RecoPt);
+  void fillMatchHists(const double GenEta,
+                      const double GenPhi,
+                      const double GenPt,
+                      const double RecoEta,
+                      const double RecoPhi,
+                      const double RecoPt);
 
   edm::InputTag mInputCollection;
   edm::InputTag mInputGenCollection;
@@ -431,41 +433,41 @@ private:
   MonitorElement *mPtRecoOverGen_GenEta_180_300_Cent_50_80;
   MonitorElement *mPtRecoOverGen_GenEta_300_Inf_Cent_50_80;
 
-  MonitorElement *mPFCandpT_vs_eta_Unknown;       // pf id 0
-  MonitorElement *mPFCandpT_vs_eta_ChargedHadron; // pf id - 1
-  MonitorElement *mPFCandpT_vs_eta_electron;      // pf id - 2
-  MonitorElement *mPFCandpT_vs_eta_muon;          // pf id - 3
-  MonitorElement *mPFCandpT_vs_eta_photon;        // pf id - 4
-  MonitorElement *mPFCandpT_vs_eta_NeutralHadron; // pf id - 5
-  MonitorElement *mPFCandpT_vs_eta_HadE_inHF;     // pf id - 6
-  MonitorElement *mPFCandpT_vs_eta_EME_inHF;      // pf id - 7
+  MonitorElement *mPFCandpT_vs_eta_Unknown;        // pf id 0
+  MonitorElement *mPFCandpT_vs_eta_ChargedHadron;  // pf id - 1
+  MonitorElement *mPFCandpT_vs_eta_electron;       // pf id - 2
+  MonitorElement *mPFCandpT_vs_eta_muon;           // pf id - 3
+  MonitorElement *mPFCandpT_vs_eta_photon;         // pf id - 4
+  MonitorElement *mPFCandpT_vs_eta_NeutralHadron;  // pf id - 5
+  MonitorElement *mPFCandpT_vs_eta_HadE_inHF;      // pf id - 6
+  MonitorElement *mPFCandpT_vs_eta_EME_inHF;       // pf id - 7
 
-  MonitorElement *mPFCandpT_Barrel_Unknown;       // pf id 0
-  MonitorElement *mPFCandpT_Barrel_ChargedHadron; // pf id - 1
-  MonitorElement *mPFCandpT_Barrel_electron;      // pf id - 2
-  MonitorElement *mPFCandpT_Barrel_muon;          // pf id - 3
-  MonitorElement *mPFCandpT_Barrel_photon;        // pf id - 4
-  MonitorElement *mPFCandpT_Barrel_NeutralHadron; // pf id - 5
-  MonitorElement *mPFCandpT_Barrel_HadE_inHF;     // pf id - 6
-  MonitorElement *mPFCandpT_Barrel_EME_inHF;      // pf id - 7
+  MonitorElement *mPFCandpT_Barrel_Unknown;        // pf id 0
+  MonitorElement *mPFCandpT_Barrel_ChargedHadron;  // pf id - 1
+  MonitorElement *mPFCandpT_Barrel_electron;       // pf id - 2
+  MonitorElement *mPFCandpT_Barrel_muon;           // pf id - 3
+  MonitorElement *mPFCandpT_Barrel_photon;         // pf id - 4
+  MonitorElement *mPFCandpT_Barrel_NeutralHadron;  // pf id - 5
+  MonitorElement *mPFCandpT_Barrel_HadE_inHF;      // pf id - 6
+  MonitorElement *mPFCandpT_Barrel_EME_inHF;       // pf id - 7
 
-  MonitorElement *mPFCandpT_Endcap_Unknown;       // pf id 0
-  MonitorElement *mPFCandpT_Endcap_ChargedHadron; // pf id - 1
-  MonitorElement *mPFCandpT_Endcap_electron;      // pf id - 2
-  MonitorElement *mPFCandpT_Endcap_muon;          // pf id - 3
-  MonitorElement *mPFCandpT_Endcap_photon;        // pf id - 4
-  MonitorElement *mPFCandpT_Endcap_NeutralHadron; // pf id - 5
-  MonitorElement *mPFCandpT_Endcap_HadE_inHF;     // pf id - 6
-  MonitorElement *mPFCandpT_Endcap_EME_inHF;      // pf id - 7
+  MonitorElement *mPFCandpT_Endcap_Unknown;        // pf id 0
+  MonitorElement *mPFCandpT_Endcap_ChargedHadron;  // pf id - 1
+  MonitorElement *mPFCandpT_Endcap_electron;       // pf id - 2
+  MonitorElement *mPFCandpT_Endcap_muon;           // pf id - 3
+  MonitorElement *mPFCandpT_Endcap_photon;         // pf id - 4
+  MonitorElement *mPFCandpT_Endcap_NeutralHadron;  // pf id - 5
+  MonitorElement *mPFCandpT_Endcap_HadE_inHF;      // pf id - 6
+  MonitorElement *mPFCandpT_Endcap_EME_inHF;       // pf id - 7
 
-  MonitorElement *mPFCandpT_Forward_Unknown;       // pf id 0
-  MonitorElement *mPFCandpT_Forward_ChargedHadron; // pf id - 1
-  MonitorElement *mPFCandpT_Forward_electron;      // pf id - 2
-  MonitorElement *mPFCandpT_Forward_muon;          // pf id - 3
-  MonitorElement *mPFCandpT_Forward_photon;        // pf id - 4
-  MonitorElement *mPFCandpT_Forward_NeutralHadron; // pf id - 5
-  MonitorElement *mPFCandpT_Forward_HadE_inHF;     // pf id - 6
-  MonitorElement *mPFCandpT_Forward_EME_inHF;      // pf id - 7
+  MonitorElement *mPFCandpT_Forward_Unknown;        // pf id 0
+  MonitorElement *mPFCandpT_Forward_ChargedHadron;  // pf id - 1
+  MonitorElement *mPFCandpT_Forward_electron;       // pf id - 2
+  MonitorElement *mPFCandpT_Forward_muon;           // pf id - 3
+  MonitorElement *mPFCandpT_Forward_photon;         // pf id - 4
+  MonitorElement *mPFCandpT_Forward_NeutralHadron;  // pf id - 5
+  MonitorElement *mPFCandpT_Forward_HadE_inHF;      // pf id - 6
+  MonitorElement *mPFCandpT_Forward_EME_inHF;       // pf id - 7
 
   // Parameters
 

--- a/Validation/RecoMET/plugins/METTester.cc
+++ b/Validation/RecoMET/plugins/METTester.cc
@@ -31,7 +31,6 @@ using namespace std;
 using namespace edm;
 
 METTester::METTester(const edm::ParameterSet &iConfig) {
-
   inputMETLabel_ = iConfig.getParameter<edm::InputTag>("InputMETLabel");
   METType_ = iConfig.getUntrackedParameter<std::string>("METType");
 
@@ -42,8 +41,7 @@ METTester::METTester(const edm::ParameterSet &iConfig) {
   isGenMET = (std::string("gen") == METType_);
   isMiniAODMET = (std::string("miniaod") == METType_);
 
-  pvToken_ = consumes<std::vector<reco::Vertex>>(
-      iConfig.getParameter<edm::InputTag>("PrimaryVertices"));
+  pvToken_ = consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("PrimaryVertices"));
   if (isCaloMET)
     caloMETsToken_ = consumes<reco::CaloMETCollection>(inputMETLabel_);
   if (isPFMET)
@@ -53,10 +51,8 @@ METTester::METTester(const edm::ParameterSet &iConfig) {
   if (isGenMET)
     genMETsToken_ = consumes<reco::GenMETCollection>(inputMETLabel_);
   if (!isMiniAODMET) {
-    genMETsTrueToken_ =
-        consumes<reco::GenMETCollection>(edm::InputTag("genMetTrue"));
-    genMETsCaloToken_ =
-        consumes<reco::GenMETCollection>(edm::InputTag("genMetCalo"));
+    genMETsTrueToken_ = consumes<reco::GenMETCollection>(edm::InputTag("genMetTrue"));
+    genMETsCaloToken_ = consumes<reco::GenMETCollection>(edm::InputTag("genMetCalo"));
   }
 
   // Events variables
@@ -130,8 +126,7 @@ METTester::METTester(const edm::ParameterSet &iConfig) {
   mMETDifference_GenMETTrue_MET400to500 = nullptr;
   mMETDifference_GenMETTrue_MET500 = nullptr;
 }
-void METTester::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &iRun,
-                               edm::EventSetup const & /* iSetup */) {
+void METTester::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &iRun, edm::EventSetup const & /* iSetup */) {
   ibooker.setCurrentFolder("JetMET/METValidation/" + inputMETLabel_.label());
 
   mNvertex = ibooker.book1D("Nvertex", "Nvertex", 80, 0, 80);
@@ -140,151 +135,95 @@ void METTester::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &iRun,
   mMETSig = ibooker.book1D("METSig", "METSig", 25, 0, 24.5);
   mMET = ibooker.book1D("MET", "MET (20 GeV binning)", 100, 0, 2000);
   mMETFine = ibooker.book1D("METFine", "MET (2 GeV binning)", 1000, 0, 2000);
-  mMET_Nvtx = ibooker.bookProfile("MET_Nvtx", "MET vs. nvtx", 60, 0., 60., 0.,
-                                  2000., " ");
+  mMET_Nvtx = ibooker.bookProfile("MET_Nvtx", "MET vs. nvtx", 60, 0., 60., 0., 2000., " ");
   mMETPhi = ibooker.book1D("METPhi", "METPhi", 80, -4, 4);
-  mSumET = ibooker.book1D("SumET", "SumET", 200, 0, 4000); // 10GeV
-  mMETDifference_GenMETTrue = ibooker.book1D(
-      "METDifference_GenMETTrue", "METDifference_GenMETTrue", 500, -500, 500);
-  mMETDeltaPhi_GenMETTrue = ibooker.book1D("METDeltaPhi_GenMETTrue",
-                                           "METDeltaPhi_GenMETTrue", 80, 0, 4);
+  mSumET = ibooker.book1D("SumET", "SumET", 200, 0, 4000);  // 10GeV
+  mMETDifference_GenMETTrue = ibooker.book1D("METDifference_GenMETTrue", "METDifference_GenMETTrue", 500, -500, 500);
+  mMETDeltaPhi_GenMETTrue = ibooker.book1D("METDeltaPhi_GenMETTrue", "METDeltaPhi_GenMETTrue", 80, 0, 4);
 
   if (isMiniAODMET) {
-    mMETUnc_JetResUp =
-        ibooker.book1D("METUnc_JetResUp", "METUnc_JetResUp", 200, -10, 10);
-    mMETUnc_JetResDown =
-        ibooker.book1D("METUnc_JetResDown", "METUnc_JetResDown", 200, -10, 10);
-    mMETUnc_JetEnUp =
-        ibooker.book1D("METUnc_JetEnUp", "METUnc_JetEnUp", 200, -10, 10);
-    mMETUnc_JetEnDown =
-        ibooker.book1D("METUnc_JetEnDown", "METUnc_JetEnDown", 200, -10, 10);
-    mMETUnc_MuonEnUp =
-        ibooker.book1D("METUnc_MuonEnUp", "METUnc_MuonEnUp", 200, -10, 10);
-    mMETUnc_MuonEnDown =
-        ibooker.book1D("METUnc_MuonEnDown", "METUnc_MuonEnDown", 200, -10, 10);
-    mMETUnc_ElectronEnUp = ibooker.book1D("METUnc_ElectronEnUp",
-                                          "METUnc_ElectronEnUp", 200, -10, 10);
-    mMETUnc_ElectronEnDown = ibooker.book1D(
-        "METUnc_ElectronEnDown", "METUnc_ElectronEnDown", 200, -10, 10);
-    mMETUnc_TauEnUp =
-        ibooker.book1D("METUnc_TauEnUp", "METUnc_TauEnUp", 200, -10, 10);
-    mMETUnc_TauEnDown =
-        ibooker.book1D("METUnc_TauEnDown", "METUnc_TauEnDown", 200, -10, 10);
-    mMETUnc_UnclusteredEnUp = ibooker.book1D(
-        "METUnc_UnclusteredEnUp", "METUnc_UnclusteredEnUp", 200, -10, 10);
-    mMETUnc_UnclusteredEnDown = ibooker.book1D(
-        "METUnc_UnclusteredEnDown", "METUnc_UnclusteredEnDown", 200, -10, 10);
-    mMETUnc_PhotonEnUp = ibooker.book1D(
-        "METUnc_UnclusteredEnDown", "METUnc_UnclusteredEnDown", 200, -10, 10);
-    mMETUnc_PhotonEnDown = ibooker.book1D("METUnc_PhotonEnDown",
-                                          "METUnc_PhotonEnDown", 200, -10, 10);
+    mMETUnc_JetResUp = ibooker.book1D("METUnc_JetResUp", "METUnc_JetResUp", 200, -10, 10);
+    mMETUnc_JetResDown = ibooker.book1D("METUnc_JetResDown", "METUnc_JetResDown", 200, -10, 10);
+    mMETUnc_JetEnUp = ibooker.book1D("METUnc_JetEnUp", "METUnc_JetEnUp", 200, -10, 10);
+    mMETUnc_JetEnDown = ibooker.book1D("METUnc_JetEnDown", "METUnc_JetEnDown", 200, -10, 10);
+    mMETUnc_MuonEnUp = ibooker.book1D("METUnc_MuonEnUp", "METUnc_MuonEnUp", 200, -10, 10);
+    mMETUnc_MuonEnDown = ibooker.book1D("METUnc_MuonEnDown", "METUnc_MuonEnDown", 200, -10, 10);
+    mMETUnc_ElectronEnUp = ibooker.book1D("METUnc_ElectronEnUp", "METUnc_ElectronEnUp", 200, -10, 10);
+    mMETUnc_ElectronEnDown = ibooker.book1D("METUnc_ElectronEnDown", "METUnc_ElectronEnDown", 200, -10, 10);
+    mMETUnc_TauEnUp = ibooker.book1D("METUnc_TauEnUp", "METUnc_TauEnUp", 200, -10, 10);
+    mMETUnc_TauEnDown = ibooker.book1D("METUnc_TauEnDown", "METUnc_TauEnDown", 200, -10, 10);
+    mMETUnc_UnclusteredEnUp = ibooker.book1D("METUnc_UnclusteredEnUp", "METUnc_UnclusteredEnUp", 200, -10, 10);
+    mMETUnc_UnclusteredEnDown = ibooker.book1D("METUnc_UnclusteredEnDown", "METUnc_UnclusteredEnDown", 200, -10, 10);
+    mMETUnc_PhotonEnUp = ibooker.book1D("METUnc_UnclusteredEnDown", "METUnc_UnclusteredEnDown", 200, -10, 10);
+    mMETUnc_PhotonEnDown = ibooker.book1D("METUnc_PhotonEnDown", "METUnc_PhotonEnDown", 200, -10, 10);
   }
   if (!isMiniAODMET) {
-    mMETDifference_GenMETCalo = ibooker.book1D(
-        "METDifference_GenMETCalo", "METDifference_GenMETCalo", 500, -500, 500);
-    mMETDeltaPhi_GenMETCalo = ibooker.book1D(
-        "METDeltaPhi_GenMETCalo", "METDeltaPhi_GenMETCalo", 80, 0, 4);
+    mMETDifference_GenMETCalo = ibooker.book1D("METDifference_GenMETCalo", "METDifference_GenMETCalo", 500, -500, 500);
+    mMETDeltaPhi_GenMETCalo = ibooker.book1D("METDeltaPhi_GenMETCalo", "METDeltaPhi_GenMETCalo", 80, 0, 4);
   }
   if (!isGenMET) {
     mMETDifference_GenMETTrue_MET0to20 =
-        ibooker.book1D("METResolution_GenMETTrue_MET0to20",
-                       "METResolution_GenMETTrue_MET0to20", 500, -500, 500);
+        ibooker.book1D("METResolution_GenMETTrue_MET0to20", "METResolution_GenMETTrue_MET0to20", 500, -500, 500);
     mMETDifference_GenMETTrue_MET20to40 =
-        ibooker.book1D("METResolution_GenMETTrue_MET20to40",
-                       "METResolution_GenMETTrue_MET20to40", 500, -500, 500);
+        ibooker.book1D("METResolution_GenMETTrue_MET20to40", "METResolution_GenMETTrue_MET20to40", 500, -500, 500);
     mMETDifference_GenMETTrue_MET40to60 =
-        ibooker.book1D("METResolution_GenMETTrue_MET40to60",
-                       "METResolution_GenMETTrue_MET40to60", 500, -500, 500);
+        ibooker.book1D("METResolution_GenMETTrue_MET40to60", "METResolution_GenMETTrue_MET40to60", 500, -500, 500);
     mMETDifference_GenMETTrue_MET60to80 =
-        ibooker.book1D("METResolution_GenMETTrue_MET60to80",
-                       "METResolution_GenMETTrue_MET60to80", 500, -500, 500);
+        ibooker.book1D("METResolution_GenMETTrue_MET60to80", "METResolution_GenMETTrue_MET60to80", 500, -500, 500);
     mMETDifference_GenMETTrue_MET80to100 =
-        ibooker.book1D("METResolution_GenMETTrue_MET80to100",
-                       "METResolution_GenMETTrue_MET80to100", 500, -500, 500);
+        ibooker.book1D("METResolution_GenMETTrue_MET80to100", "METResolution_GenMETTrue_MET80to100", 500, -500, 500);
     mMETDifference_GenMETTrue_MET100to150 =
-        ibooker.book1D("METResolution_GenMETTrue_MET100to150",
-                       "METResolution_GenMETTrue_MET100to150", 500, -500, 500);
+        ibooker.book1D("METResolution_GenMETTrue_MET100to150", "METResolution_GenMETTrue_MET100to150", 500, -500, 500);
     mMETDifference_GenMETTrue_MET150to200 =
-        ibooker.book1D("METResolution_GenMETTrue_MET150to200",
-                       "METResolution_GenMETTrue_MET150to200", 500, -500, 500);
+        ibooker.book1D("METResolution_GenMETTrue_MET150to200", "METResolution_GenMETTrue_MET150to200", 500, -500, 500);
     mMETDifference_GenMETTrue_MET200to300 =
-        ibooker.book1D("METResolution_GenMETTrue_MET200to300",
-                       "METResolution_GenMETTrue_MET200to300", 500, -500, 500);
+        ibooker.book1D("METResolution_GenMETTrue_MET200to300", "METResolution_GenMETTrue_MET200to300", 500, -500, 500);
     mMETDifference_GenMETTrue_MET300to400 =
-        ibooker.book1D("METResolution_GenMETTrue_MET300to400",
-                       "METResolution_GenMETTrue_MET300to400", 500, -500, 500);
+        ibooker.book1D("METResolution_GenMETTrue_MET300to400", "METResolution_GenMETTrue_MET300to400", 500, -500, 500);
     mMETDifference_GenMETTrue_MET400to500 =
-        ibooker.book1D("METResolution_GenMETTrue_MET400to500",
-                       "METResolution_GenMETTrue_MET400to500", 500, -500, 500);
+        ibooker.book1D("METResolution_GenMETTrue_MET400to500", "METResolution_GenMETTrue_MET400to500", 500, -500, 500);
     mMETDifference_GenMETTrue_MET500 =
-        ibooker.book1D("METResolution_GenMETTrue_MET500",
-                       "METResolution_GenMETTrue_MET500", 500, -500, 500);
+        ibooker.book1D("METResolution_GenMETTrue_MET500", "METResolution_GenMETTrue_MET500", 500, -500, 500);
   }
   if (isCaloMET) {
-    mCaloMaxEtInEmTowers = ibooker.book1D(
-        "CaloMaxEtInEmTowers", "CaloMaxEtInEmTowers", 300, 0, 1500); // 5GeV
-    mCaloMaxEtInHadTowers = ibooker.book1D(
-        "CaloMaxEtInHadTowers", "CaloMaxEtInHadTowers", 300, 0, 1500); // 5GeV
-    mCaloEtFractionHadronic = ibooker.book1D(
-        "CaloEtFractionHadronic", "CaloEtFractionHadronic", 100, 0, 1);
-    mCaloEmEtFraction =
-        ibooker.book1D("CaloEmEtFraction", "CaloEmEtFraction", 100, 0, 1);
-    mCaloHadEtInHB =
-        ibooker.book1D("CaloHadEtInHB", "CaloHadEtInHB", 200, 0, 2000); // 5GeV
-    mCaloHadEtInHE =
-        ibooker.book1D("CaloHadEtInHE", "CaloHadEtInHE", 100, 0, 500); // 5GeV
-    mCaloHadEtInHO =
-        ibooker.book1D("CaloHadEtInHO", "CaloHadEtInHO", 100, 0, 200); // 5GeV
-    mCaloHadEtInHF =
-        ibooker.book1D("CaloHadEtInHF", "CaloHadEtInHF", 100, 0, 200); // 5GeV
+    mCaloMaxEtInEmTowers = ibooker.book1D("CaloMaxEtInEmTowers", "CaloMaxEtInEmTowers", 300, 0, 1500);     // 5GeV
+    mCaloMaxEtInHadTowers = ibooker.book1D("CaloMaxEtInHadTowers", "CaloMaxEtInHadTowers", 300, 0, 1500);  // 5GeV
+    mCaloEtFractionHadronic = ibooker.book1D("CaloEtFractionHadronic", "CaloEtFractionHadronic", 100, 0, 1);
+    mCaloEmEtFraction = ibooker.book1D("CaloEmEtFraction", "CaloEmEtFraction", 100, 0, 1);
+    mCaloHadEtInHB = ibooker.book1D("CaloHadEtInHB", "CaloHadEtInHB", 200, 0, 2000);  // 5GeV
+    mCaloHadEtInHE = ibooker.book1D("CaloHadEtInHE", "CaloHadEtInHE", 100, 0, 500);   // 5GeV
+    mCaloHadEtInHO = ibooker.book1D("CaloHadEtInHO", "CaloHadEtInHO", 100, 0, 200);   // 5GeV
+    mCaloHadEtInHF = ibooker.book1D("CaloHadEtInHF", "CaloHadEtInHF", 100, 0, 200);   // 5GeV
     mCaloSETInpHF = ibooker.book1D("CaloSETInpHF", "CaloSETInpHF", 100, 0, 500);
     mCaloSETInmHF = ibooker.book1D("CaloSETInmHF", "CaloSETInmHF", 100, 0, 500);
-    mCaloEmEtInEE =
-        ibooker.book1D("CaloEmEtInEE", "CaloEmEtInEE", 100, 0, 500); // 5GeV
-    mCaloEmEtInEB =
-        ibooker.book1D("CaloEmEtInEB", "CaloEmEtInEB", 100, 0, 500); // 5GeV
-    mCaloEmEtInHF =
-        ibooker.book1D("CaloEmEtInHF", "CaloEmEtInHF", 100, 0, 500); // 5GeV
+    mCaloEmEtInEE = ibooker.book1D("CaloEmEtInEE", "CaloEmEtInEE", 100, 0, 500);  // 5GeV
+    mCaloEmEtInEB = ibooker.book1D("CaloEmEtInEB", "CaloEmEtInEB", 100, 0, 500);  // 5GeV
+    mCaloEmEtInHF = ibooker.book1D("CaloEmEtInHF", "CaloEmEtInHF", 100, 0, 500);  // 5GeV
   }
 
   if (isGenMET) {
-    mNeutralEMEtFraction = ibooker.book1D(
-        "GenNeutralEMEtFraction", "GenNeutralEMEtFraction", 120, 0.0, 1.2);
-    mNeutralHadEtFraction = ibooker.book1D(
-        "GenNeutralHadEtFraction", "GenNeutralHadEtFraction", 120, 0.0, 1.2);
-    mChargedEMEtFraction = ibooker.book1D(
-        "GenChargedEMEtFraction", "GenChargedEMEtFraction", 120, 0.0, 1.2);
-    mChargedHadEtFraction = ibooker.book1D(
-        "GenChargedHadEtFraction", "GenChargedHadEtFraction", 120, 0.0, 1.2);
-    mMuonEtFraction =
-        ibooker.book1D("GenMuonEtFraction", "GenMuonEtFraction", 120, 0.0, 1.2);
-    mInvisibleEtFraction = ibooker.book1D(
-        "GenInvisibleEtFraction", "GenInvisibleEtFraction", 120, 0.0, 1.2);
+    mNeutralEMEtFraction = ibooker.book1D("GenNeutralEMEtFraction", "GenNeutralEMEtFraction", 120, 0.0, 1.2);
+    mNeutralHadEtFraction = ibooker.book1D("GenNeutralHadEtFraction", "GenNeutralHadEtFraction", 120, 0.0, 1.2);
+    mChargedEMEtFraction = ibooker.book1D("GenChargedEMEtFraction", "GenChargedEMEtFraction", 120, 0.0, 1.2);
+    mChargedHadEtFraction = ibooker.book1D("GenChargedHadEtFraction", "GenChargedHadEtFraction", 120, 0.0, 1.2);
+    mMuonEtFraction = ibooker.book1D("GenMuonEtFraction", "GenMuonEtFraction", 120, 0.0, 1.2);
+    mInvisibleEtFraction = ibooker.book1D("GenInvisibleEtFraction", "GenInvisibleEtFraction", 120, 0.0, 1.2);
   }
 
   if (isPFMET || isMiniAODMET) {
-    mPFphotonEtFraction =
-        ibooker.book1D("photonEtFraction", "photonEtFraction", 100, 0, 1);
-    mPFneutralHadronEtFraction = ibooker.book1D(
-        "neutralHadronEtFraction", "neutralHadronEtFraction", 100, 0, 1);
-    mPFelectronEtFraction =
-        ibooker.book1D("electronEtFraction", "electronEtFraction", 100, 0, 1);
-    mPFchargedHadronEtFraction = ibooker.book1D(
-        "chargedHadronEtFraction", "chargedHadronEtFraction", 100, 0, 1);
-    mPFHFHadronEtFraction =
-        ibooker.book1D("HFHadronEtFraction", "HFHadronEtFraction", 100, 0, 1);
-    mPFmuonEtFraction =
-        ibooker.book1D("muonEtFraction", "muonEtFraction", 100, 0, 1);
-    mPFHFEMEtFraction =
-        ibooker.book1D("HFEMEtFraction", "HFEMEtFraction", 100, 0, 1);
+    mPFphotonEtFraction = ibooker.book1D("photonEtFraction", "photonEtFraction", 100, 0, 1);
+    mPFneutralHadronEtFraction = ibooker.book1D("neutralHadronEtFraction", "neutralHadronEtFraction", 100, 0, 1);
+    mPFelectronEtFraction = ibooker.book1D("electronEtFraction", "electronEtFraction", 100, 0, 1);
+    mPFchargedHadronEtFraction = ibooker.book1D("chargedHadronEtFraction", "chargedHadronEtFraction", 100, 0, 1);
+    mPFHFHadronEtFraction = ibooker.book1D("HFHadronEtFraction", "HFHadronEtFraction", 100, 0, 1);
+    mPFmuonEtFraction = ibooker.book1D("muonEtFraction", "muonEtFraction", 100, 0, 1);
+    mPFHFEMEtFraction = ibooker.book1D("HFEMEtFraction", "HFEMEtFraction", 100, 0, 1);
 
     if (!isMiniAODMET) {
       mPFphotonEt = ibooker.book1D("photonEt", "photonEt", 100, 0, 1000);
-      mPFneutralHadronEt =
-          ibooker.book1D("neutralHadronEt", "neutralHadronEt", 100, 0, 1000);
+      mPFneutralHadronEt = ibooker.book1D("neutralHadronEt", "neutralHadronEt", 100, 0, 1000);
       mPFelectronEt = ibooker.book1D("electronEt", "electronEt", 100, 0, 1000);
-      mPFchargedHadronEt =
-          ibooker.book1D("chargedHadronEt", "chargedHadronEt", 100, 0, 1000);
+      mPFchargedHadronEt = ibooker.book1D("chargedHadronEt", "chargedHadronEt", 100, 0, 1000);
       mPFmuonEt = ibooker.book1D("muonEt", "muonEt", 100, 0, 1000);
       mPFHFHadronEt = ibooker.book1D("HFHadronEt", "HFHadronEt", 100, 0, 500);
       mPFHFEMEt = ibooker.book1D("HFEMEt", "HFEMEt", 100, 0, 300);
@@ -293,13 +232,12 @@ void METTester::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &iRun,
 }
 
 void METTester::analyze(const edm::Event &iEvent,
-                        const edm::EventSetup &iSetup) { // int counter(0);
+                        const edm::EventSetup &iSetup) {  // int counter(0);
 
   edm::Handle<reco::VertexCollection> pvHandle;
   iEvent.getByToken(pvToken_, pvHandle);
   if (!pvHandle.isValid()) {
-    std::cout << __FUNCTION__ << ":" << __LINE__
-              << ":pvHandle handle not found!" << std::endl;
+    std::cout << __FUNCTION__ << ":" << __LINE__ << ":pvHandle handle not found!" << std::endl;
     assert(false);
   }
   const int nvtx = pvHandle->size();
@@ -407,8 +345,7 @@ void METTester::analyze(const edm::Event &iEvent,
         mMETDifference_GenMETTrue_MET500->Fill(MET - genMET);
 
     } else {
-      edm::LogInfo("OutputInfo")
-          << " failed to retrieve data required by MET Task:  genMetTrue";
+      edm::LogInfo("OutputInfo") << " failed to retrieve data required by MET Task:  genMetTrue";
     }
   }
   if (!isMiniAODMET) {
@@ -421,11 +358,9 @@ void METTester::analyze(const edm::Event &iEvent,
       const double genMETPhi = genMetCalo->phi();
 
       mMETDifference_GenMETCalo->Fill(MET - genMET);
-      mMETDeltaPhi_GenMETCalo->Fill(
-          TMath::ACos(TMath::Cos(METPhi - genMETPhi)));
+      mMETDeltaPhi_GenMETCalo->Fill(TMath::ACos(TMath::Cos(METPhi - genMETPhi)));
     } else {
-      edm::LogInfo("OutputInfo")
-          << " failed to retrieve data required by MET Task:  genMetCalo";
+      edm::LogInfo("OutputInfo") << " failed to retrieve data required by MET Task:  genMetCalo";
     }
   }
   if (isCaloMET) {
@@ -506,14 +441,11 @@ void METTester::analyze(const edm::Event &iEvent,
     mMETUnc_MuonEnUp->Fill(MET - patmet->shiftedPt(pat::MET::MuonEnUp));
     mMETUnc_MuonEnDown->Fill(MET - patmet->shiftedPt(pat::MET::MuonEnDown));
     mMETUnc_ElectronEnUp->Fill(MET - patmet->shiftedPt(pat::MET::ElectronEnUp));
-    mMETUnc_ElectronEnDown->Fill(MET -
-                                 patmet->shiftedPt(pat::MET::ElectronEnDown));
+    mMETUnc_ElectronEnDown->Fill(MET - patmet->shiftedPt(pat::MET::ElectronEnDown));
     mMETUnc_TauEnUp->Fill(MET - patmet->shiftedPt(pat::MET::TauEnUp));
     mMETUnc_TauEnDown->Fill(MET - patmet->shiftedPt(pat::MET::TauEnDown));
-    mMETUnc_UnclusteredEnUp->Fill(MET -
-                                  patmet->shiftedPt(pat::MET::UnclusteredEnUp));
-    mMETUnc_UnclusteredEnDown->Fill(
-        MET - patmet->shiftedPt(pat::MET::UnclusteredEnDown));
+    mMETUnc_UnclusteredEnUp->Fill(MET - patmet->shiftedPt(pat::MET::UnclusteredEnUp));
+    mMETUnc_UnclusteredEnDown->Fill(MET - patmet->shiftedPt(pat::MET::UnclusteredEnDown));
     mMETUnc_PhotonEnUp->Fill(MET - patmet->shiftedPt(pat::MET::PhotonEnUp));
     mMETUnc_PhotonEnDown->Fill(MET - patmet->shiftedPt(pat::MET::PhotonEnDown));
 
@@ -523,8 +455,8 @@ void METTester::analyze(const edm::Event &iEvent,
       mPFelectronEtFraction->Fill(patmet->ChargedEMEtFraction());
       mPFchargedHadronEtFraction->Fill(patmet->ChargedHadEtFraction());
       mPFmuonEtFraction->Fill(patmet->MuonEtFraction());
-      mPFHFHadronEtFraction->Fill(patmet->Type6EtFraction()); // HFHadrons
-      mPFHFEMEtFraction->Fill(patmet->Type7EtFraction());     // HFEMEt
+      mPFHFHadronEtFraction->Fill(patmet->Type6EtFraction());  // HFHadrons
+      mPFHFEMEtFraction->Fill(patmet->Type7EtFraction());      // HFEMEt
     }
   }
 }

--- a/Validation/RecoMET/plugins/METTester.h
+++ b/Validation/RecoMET/plugins/METTester.h
@@ -53,8 +53,7 @@ public:
   explicit METTester(const edm::ParameterSet &);
 
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:
   std::map<std::string, MonitorElement *> me;
@@ -176,4 +175,4 @@ private:
   bool isMiniAODMET;
 };
 
-#endif // METTESTER_H
+#endif  // METTESTER_H

--- a/Validation/RecoMET/plugins/METTesterPostProcessor.cc
+++ b/Validation/RecoMET/plugins/METTesterPostProcessor.cc
@@ -15,14 +15,12 @@
 //
 // constructors and destructor
 //
-METTesterPostProcessor::METTesterPostProcessor(
-    const edm::ParameterSet &iConfig) {}
+METTesterPostProcessor::METTesterPostProcessor(const edm::ParameterSet &iConfig) {}
 
 METTesterPostProcessor::~METTesterPostProcessor() {}
 
 // ------------ method called right after a run ends ------------
-void METTesterPostProcessor::dqmEndJob(DQMStore::IBooker &ibook_,
-                                       DQMStore::IGetter &iget_) {
+void METTesterPostProcessor::dqmEndJob(DQMStore::IBooker &ibook_, DQMStore::IGetter &iget_) {
   std::vector<std::string> subDirVec;
   std::string RunDir = "JetMET/METValidation/";
   iget_.setCurrentFolder(RunDir);
@@ -30,21 +28,17 @@ void METTesterPostProcessor::dqmEndJob(DQMStore::IBooker &ibook_,
   // bin definition for resolution plot -> last bin contains overflow too, but
   // for plotting purposes show up to 1 TeV only
   int nBins = 11;
-  float bins[] = {0.,   20.,  40.,  60.,  80.,  100.,
-                  150., 200., 300., 400., 500., 1000};
+  float bins[] = {0., 20., 40., 60., 80., 100., 150., 200., 300., 400., 500., 1000};
   // loop over met subdirectories
   for (int i = 0; i < int(met_dirs.size()); i++) {
     ibook_.setCurrentFolder(met_dirs[i]);
     mMETDifference_GenMETTrue_METResolution =
-        ibook_.book1D("METResolution_GenMETTrue_InMETBins",
-                      "METResolution_GenMETTrue_InMETBins", nBins, bins);
+        ibook_.book1D("METResolution_GenMETTrue_InMETBins", "METResolution_GenMETTrue_InMETBins", nBins, bins);
     FillMETRes(met_dirs[i], iget_);
   }
 }
 
-void METTesterPostProcessor::FillMETRes(std::string metdir,
-                                        DQMStore::IGetter &iget) {
-
+void METTesterPostProcessor::FillMETRes(std::string metdir, DQMStore::IGetter &iget) {
   mMETDifference_GenMETTrue_MET0to20 = nullptr;
   mMETDifference_GenMETTrue_MET20to40 = nullptr;
   mMETDifference_GenMETTrue_MET40to60 = nullptr;
@@ -57,79 +51,45 @@ void METTesterPostProcessor::FillMETRes(std::string metdir,
   mMETDifference_GenMETTrue_MET400to500 = nullptr;
   mMETDifference_GenMETTrue_MET500 = nullptr;
 
-  mMETDifference_GenMETTrue_MET0to20 =
-      iget.get(metdir + "/METResolution_GenMETTrue_MET0to20");
-  mMETDifference_GenMETTrue_MET20to40 =
-      iget.get(metdir + "/METResolution_GenMETTrue_MET20to40");
-  mMETDifference_GenMETTrue_MET40to60 =
-      iget.get(metdir + "/METResolution_GenMETTrue_MET40to60");
-  mMETDifference_GenMETTrue_MET60to80 =
-      iget.get(metdir + "/METResolution_GenMETTrue_MET60to80");
-  mMETDifference_GenMETTrue_MET80to100 =
-      iget.get(metdir + "/METResolution_GenMETTrue_MET80to100");
-  mMETDifference_GenMETTrue_MET100to150 =
-      iget.get(metdir + "/METResolution_GenMETTrue_MET100to150");
-  mMETDifference_GenMETTrue_MET150to200 =
-      iget.get(metdir + "/METResolution_GenMETTrue_MET150to200");
-  mMETDifference_GenMETTrue_MET200to300 =
-      iget.get(metdir + "/METResolution_GenMETTrue_MET200to300");
-  mMETDifference_GenMETTrue_MET300to400 =
-      iget.get(metdir + "/METResolution_GenMETTrue_MET300to400");
-  mMETDifference_GenMETTrue_MET400to500 =
-      iget.get(metdir + "/METResolution_GenMETTrue_MET400to500");
-  mMETDifference_GenMETTrue_MET500 =
-      iget.get(metdir + "/METResolution_GenMETTrue_MET500");
+  mMETDifference_GenMETTrue_MET0to20 = iget.get(metdir + "/METResolution_GenMETTrue_MET0to20");
+  mMETDifference_GenMETTrue_MET20to40 = iget.get(metdir + "/METResolution_GenMETTrue_MET20to40");
+  mMETDifference_GenMETTrue_MET40to60 = iget.get(metdir + "/METResolution_GenMETTrue_MET40to60");
+  mMETDifference_GenMETTrue_MET60to80 = iget.get(metdir + "/METResolution_GenMETTrue_MET60to80");
+  mMETDifference_GenMETTrue_MET80to100 = iget.get(metdir + "/METResolution_GenMETTrue_MET80to100");
+  mMETDifference_GenMETTrue_MET100to150 = iget.get(metdir + "/METResolution_GenMETTrue_MET100to150");
+  mMETDifference_GenMETTrue_MET150to200 = iget.get(metdir + "/METResolution_GenMETTrue_MET150to200");
+  mMETDifference_GenMETTrue_MET200to300 = iget.get(metdir + "/METResolution_GenMETTrue_MET200to300");
+  mMETDifference_GenMETTrue_MET300to400 = iget.get(metdir + "/METResolution_GenMETTrue_MET300to400");
+  mMETDifference_GenMETTrue_MET400to500 = iget.get(metdir + "/METResolution_GenMETTrue_MET400to500");
+  mMETDifference_GenMETTrue_MET500 = iget.get(metdir + "/METResolution_GenMETTrue_MET500");
   if (mMETDifference_GenMETTrue_MET0to20 &&
-      mMETDifference_GenMETTrue_MET0to20
-          ->getRootObject()) { // check one object, if existing, then the
-                               // remaining ME's exist too
+      mMETDifference_GenMETTrue_MET0to20->getRootObject()) {  // check one object, if existing, then the
+                                                              // remaining ME's exist too
     // for genmet none of these ME's are filled
-    mMETDifference_GenMETTrue_METResolution->setBinContent(
-        1, mMETDifference_GenMETTrue_MET0to20->getMean());
-    mMETDifference_GenMETTrue_METResolution->setBinContent(
-        2, mMETDifference_GenMETTrue_MET20to40->getMean());
-    mMETDifference_GenMETTrue_METResolution->setBinContent(
-        3, mMETDifference_GenMETTrue_MET40to60->getMean());
-    mMETDifference_GenMETTrue_METResolution->setBinContent(
-        4, mMETDifference_GenMETTrue_MET60to80->getMean());
-    mMETDifference_GenMETTrue_METResolution->setBinContent(
-        5, mMETDifference_GenMETTrue_MET80to100->getMean());
-    mMETDifference_GenMETTrue_METResolution->setBinContent(
-        6, mMETDifference_GenMETTrue_MET100to150->getMean());
-    mMETDifference_GenMETTrue_METResolution->setBinContent(
-        7, mMETDifference_GenMETTrue_MET150to200->getMean());
-    mMETDifference_GenMETTrue_METResolution->setBinContent(
-        8, mMETDifference_GenMETTrue_MET200to300->getMean());
-    mMETDifference_GenMETTrue_METResolution->setBinContent(
-        9, mMETDifference_GenMETTrue_MET300to400->getMean());
-    mMETDifference_GenMETTrue_METResolution->setBinContent(
-        10, mMETDifference_GenMETTrue_MET400to500->getMean());
-    mMETDifference_GenMETTrue_METResolution->setBinContent(
-        11, mMETDifference_GenMETTrue_MET500->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(1, mMETDifference_GenMETTrue_MET0to20->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(2, mMETDifference_GenMETTrue_MET20to40->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(3, mMETDifference_GenMETTrue_MET40to60->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(4, mMETDifference_GenMETTrue_MET60to80->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(5, mMETDifference_GenMETTrue_MET80to100->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(6, mMETDifference_GenMETTrue_MET100to150->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(7, mMETDifference_GenMETTrue_MET150to200->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(8, mMETDifference_GenMETTrue_MET200to300->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(9, mMETDifference_GenMETTrue_MET300to400->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(10, mMETDifference_GenMETTrue_MET400to500->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(11, mMETDifference_GenMETTrue_MET500->getMean());
 
     // the error computation should be done in a postProcessor in the harvesting
     // step otherwise the histograms will be just summed
-    mMETDifference_GenMETTrue_METResolution->setBinError(
-        1, mMETDifference_GenMETTrue_MET0to20->getRMS());
-    mMETDifference_GenMETTrue_METResolution->setBinError(
-        2, mMETDifference_GenMETTrue_MET20to40->getRMS());
-    mMETDifference_GenMETTrue_METResolution->setBinError(
-        3, mMETDifference_GenMETTrue_MET40to60->getRMS());
-    mMETDifference_GenMETTrue_METResolution->setBinError(
-        4, mMETDifference_GenMETTrue_MET60to80->getRMS());
-    mMETDifference_GenMETTrue_METResolution->setBinError(
-        5, mMETDifference_GenMETTrue_MET80to100->getRMS());
-    mMETDifference_GenMETTrue_METResolution->setBinError(
-        6, mMETDifference_GenMETTrue_MET100to150->getRMS());
-    mMETDifference_GenMETTrue_METResolution->setBinError(
-        7, mMETDifference_GenMETTrue_MET150to200->getRMS());
-    mMETDifference_GenMETTrue_METResolution->setBinError(
-        8, mMETDifference_GenMETTrue_MET200to300->getRMS());
-    mMETDifference_GenMETTrue_METResolution->setBinError(
-        9, mMETDifference_GenMETTrue_MET300to400->getRMS());
-    mMETDifference_GenMETTrue_METResolution->setBinError(
-        10, mMETDifference_GenMETTrue_MET400to500->getRMS());
-    mMETDifference_GenMETTrue_METResolution->setBinError(
-        11, mMETDifference_GenMETTrue_MET500->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(1, mMETDifference_GenMETTrue_MET0to20->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(2, mMETDifference_GenMETTrue_MET20to40->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(3, mMETDifference_GenMETTrue_MET40to60->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(4, mMETDifference_GenMETTrue_MET60to80->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(5, mMETDifference_GenMETTrue_MET80to100->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(6, mMETDifference_GenMETTrue_MET100to150->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(7, mMETDifference_GenMETTrue_MET150to200->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(8, mMETDifference_GenMETTrue_MET200to300->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(9, mMETDifference_GenMETTrue_MET300to400->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(10, mMETDifference_GenMETTrue_MET400to500->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(11, mMETDifference_GenMETTrue_MET500->getRMS());
   }
 }

--- a/Validation/RecoMET/plugins/METTesterPostProcessorHarvesting.cc
+++ b/Validation/RecoMET/plugins/METTesterPostProcessorHarvesting.cc
@@ -15,8 +15,7 @@
 //
 // constructors and destructor
 //
-METTesterPostProcessorHarvesting::METTesterPostProcessorHarvesting(
-    const edm::ParameterSet &iConfig) {
+METTesterPostProcessorHarvesting::METTesterPostProcessorHarvesting(const edm::ParameterSet &iConfig) {
   inputMETLabelRECO_ = iConfig.getParameter<edm::InputTag>("METTypeRECO");
   inputMETLabelMiniAOD_ = iConfig.getParameter<edm::InputTag>("METTypeMiniAOD");
 }
@@ -24,8 +23,7 @@ METTesterPostProcessorHarvesting::METTesterPostProcessorHarvesting(
 METTesterPostProcessorHarvesting::~METTesterPostProcessorHarvesting() {}
 
 // ------------ method called right after a run ends ------------
-void METTesterPostProcessorHarvesting::dqmEndJob(DQMStore::IBooker &ibook_,
-                                                 DQMStore::IGetter &iget_) {
+void METTesterPostProcessorHarvesting::dqmEndJob(DQMStore::IBooker &ibook_, DQMStore::IGetter &iget_) {
   std::vector<std::string> subDirVec;
   std::string RunDir = "JetMET/METValidation/";
   iget_.setCurrentFolder(RunDir);
@@ -47,20 +45,13 @@ void METTesterPostProcessorHarvesting::dqmEndJob(DQMStore::IBooker &ibook_,
     MonitorElement *mMET_Reco = iget_.get(rundir_reco + "/" + "MET");
     MonitorElement *mMETPhi_Reco = iget_.get(rundir_reco + "/" + "METPhi");
     MonitorElement *mSumET_Reco = iget_.get(rundir_reco + "/" + "SumET");
-    MonitorElement *mMETDifference_GenMETTrue_Reco =
-        iget_.get(rundir_reco + "/" + "METDifference_GenMETTrue");
-    MonitorElement *mMETDeltaPhi_GenMETTrue_Reco =
-        iget_.get(rundir_reco + "/" + "METDeltaPhi_GenMETTrue");
-    MonitorElement *mPFPhotonEtFraction_Reco =
-        iget_.get(rundir_reco + "/" + "photonEtFraction");
-    MonitorElement *mPFNeutralHadronEtFraction_Reco =
-        iget_.get(rundir_reco + "/" + "neutralHadronEtFraction");
-    MonitorElement *mPFChargedHadronEtFraction_Reco =
-        iget_.get(rundir_reco + "/" + "chargedHadronEtFraction");
-    MonitorElement *mPFHFHadronEtFraction_Reco =
-        iget_.get(rundir_reco + "/" + "HFHadronEtFraction");
-    MonitorElement *mPFHFEMEtFraction_Reco =
-        iget_.get(rundir_reco + "/" + "HFEMEtFraction");
+    MonitorElement *mMETDifference_GenMETTrue_Reco = iget_.get(rundir_reco + "/" + "METDifference_GenMETTrue");
+    MonitorElement *mMETDeltaPhi_GenMETTrue_Reco = iget_.get(rundir_reco + "/" + "METDeltaPhi_GenMETTrue");
+    MonitorElement *mPFPhotonEtFraction_Reco = iget_.get(rundir_reco + "/" + "photonEtFraction");
+    MonitorElement *mPFNeutralHadronEtFraction_Reco = iget_.get(rundir_reco + "/" + "neutralHadronEtFraction");
+    MonitorElement *mPFChargedHadronEtFraction_Reco = iget_.get(rundir_reco + "/" + "chargedHadronEtFraction");
+    MonitorElement *mPFHFHadronEtFraction_Reco = iget_.get(rundir_reco + "/" + "HFHadronEtFraction");
+    MonitorElement *mPFHFEMEtFraction_Reco = iget_.get(rundir_reco + "/" + "HFEMEtFraction");
     MonitorElement *mMETDifference_GenMETTrue_MET20to40_Reco =
         iget_.get(rundir_reco + "/" + "METResolution_GenMETTrue_MET20to40");
     MonitorElement *mMETDifference_GenMETTrue_MET100to150_Reco =
@@ -84,29 +75,21 @@ void METTesterPostProcessorHarvesting::dqmEndJob(DQMStore::IBooker &ibook_,
     ME_Reco.push_back(mMETDifference_GenMETTrue_MET300to400_Reco);
 
     MonitorElement *mMET_MiniAOD = iget_.get(rundir_miniaod + "/" + "MET");
-    MonitorElement *mMETPhi_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "METPhi");
+    MonitorElement *mMETPhi_MiniAOD = iget_.get(rundir_miniaod + "/" + "METPhi");
     MonitorElement *mSumET_MiniAOD = iget_.get(rundir_miniaod + "/" + "SumET");
-    MonitorElement *mMETDifference_GenMETTrue_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "METDifference_GenMETTrue");
-    MonitorElement *mMETDeltaPhi_GenMETTrue_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "METDeltaPhi_GenMETTrue");
-    MonitorElement *mPFPhotonEtFraction_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "photonEtFraction");
-    MonitorElement *mPFNeutralHadronEtFraction_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "neutralHadronEtFraction");
-    MonitorElement *mPFChargedHadronEtFraction_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "chargedHadronEtFraction");
-    MonitorElement *mPFHFHadronEtFraction_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "HFHadronEtFraction");
-    MonitorElement *mPFHFEMEtFraction_MiniAOD =
-        iget_.get(rundir_miniaod + "/" + "HFEMEtFraction");
+    MonitorElement *mMETDifference_GenMETTrue_MiniAOD = iget_.get(rundir_miniaod + "/" + "METDifference_GenMETTrue");
+    MonitorElement *mMETDeltaPhi_GenMETTrue_MiniAOD = iget_.get(rundir_miniaod + "/" + "METDeltaPhi_GenMETTrue");
+    MonitorElement *mPFPhotonEtFraction_MiniAOD = iget_.get(rundir_miniaod + "/" + "photonEtFraction");
+    MonitorElement *mPFNeutralHadronEtFraction_MiniAOD = iget_.get(rundir_miniaod + "/" + "neutralHadronEtFraction");
+    MonitorElement *mPFChargedHadronEtFraction_MiniAOD = iget_.get(rundir_miniaod + "/" + "chargedHadronEtFraction");
+    MonitorElement *mPFHFHadronEtFraction_MiniAOD = iget_.get(rundir_miniaod + "/" + "HFHadronEtFraction");
+    MonitorElement *mPFHFEMEtFraction_MiniAOD = iget_.get(rundir_miniaod + "/" + "HFEMEtFraction");
     MonitorElement *mMETDifference_GenMETTrue_MET20to40_MiniAOD =
         iget_.get(rundir_miniaod + "/" + "METResolution_GenMETTrue_MET20to40");
-    MonitorElement *mMETDifference_GenMETTrue_MET100to150_MiniAOD = iget_.get(
-        rundir_miniaod + "/" + "METResolution_GenMETTrue_MET100to150");
-    MonitorElement *mMETDifference_GenMETTrue_MET300to400_MiniAOD = iget_.get(
-        rundir_miniaod + "/" + "METResolution_GenMETTrue_MET300to400");
+    MonitorElement *mMETDifference_GenMETTrue_MET100to150_MiniAOD =
+        iget_.get(rundir_miniaod + "/" + "METResolution_GenMETTrue_MET100to150");
+    MonitorElement *mMETDifference_GenMETTrue_MET300to400_MiniAOD =
+        iget_.get(rundir_miniaod + "/" + "METResolution_GenMETTrue_MET300to400");
 
     std::vector<MonitorElement *> ME_MiniAOD;
     ME_MiniAOD.push_back(mMET_MiniAOD);
@@ -124,42 +107,32 @@ void METTesterPostProcessorHarvesting::dqmEndJob(DQMStore::IBooker &ibook_,
     ME_MiniAOD.push_back(mMETDifference_GenMETTrue_MET300to400_MiniAOD);
 
     ibook_.setCurrentFolder(RunDir + "MiniAOD_over_RECO");
-    mMET_MiniAOD_over_Reco = ibook_.book1D("MET_MiniAOD_over_RECO",
-                                           (TH1F *)mMET_Reco->getRootObject());
-    mMETPhi_MiniAOD_over_Reco = ibook_.book1D(
-        "METPhi_MiniAOD_over_RECO", (TH1F *)mMETPhi_Reco->getRootObject());
-    mSumET_MiniAOD_over_Reco = ibook_.book1D(
-        "SumET_MiniAOD_over_RECO", (TH1F *)mSumET_Reco->getRootObject());
-    mMETDifference_GenMETTrue_MiniAOD_over_Reco =
-        ibook_.book1D("METDifference_GenMETTrue_MiniAOD_over_RECO",
-                      (TH1F *)mMETDifference_GenMETTrue_Reco->getRootObject());
-    mMETDeltaPhi_GenMETTrue_MiniAOD_over_Reco =
-        ibook_.book1D("METDeltaPhi_GenMETTrue_MiniAOD_over_RECO",
-                      (TH1F *)mMETDeltaPhi_GenMETTrue_Reco->getRootObject());
+    mMET_MiniAOD_over_Reco = ibook_.book1D("MET_MiniAOD_over_RECO", (TH1F *)mMET_Reco->getRootObject());
+    mMETPhi_MiniAOD_over_Reco = ibook_.book1D("METPhi_MiniAOD_over_RECO", (TH1F *)mMETPhi_Reco->getRootObject());
+    mSumET_MiniAOD_over_Reco = ibook_.book1D("SumET_MiniAOD_over_RECO", (TH1F *)mSumET_Reco->getRootObject());
+    mMETDifference_GenMETTrue_MiniAOD_over_Reco = ibook_.book1D(
+        "METDifference_GenMETTrue_MiniAOD_over_RECO", (TH1F *)mMETDifference_GenMETTrue_Reco->getRootObject());
+    mMETDeltaPhi_GenMETTrue_MiniAOD_over_Reco = ibook_.book1D("METDeltaPhi_GenMETTrue_MiniAOD_over_RECO",
+                                                              (TH1F *)mMETDeltaPhi_GenMETTrue_Reco->getRootObject());
     mPFPhotonEtFraction_MiniAOD_over_Reco =
-        ibook_.book1D("photonEtFraction_MiniAOD_over_RECO",
-                      (TH1F *)mPFPhotonEtFraction_Reco->getRootObject());
-    mPFNeutralHadronEtFraction_MiniAOD_over_Reco =
-        ibook_.book1D("neutralHadronEtFraction_MiniAOD_over_RECO",
-                      (TH1F *)mPFNeutralHadronEtFraction_Reco->getRootObject());
-    mPFChargedHadronEtFraction_MiniAOD_over_Reco =
-        ibook_.book1D("chargedHadronEtFraction_MiniAOD_over_RECO",
-                      (TH1F *)mPFChargedHadronEtFraction_Reco->getRootObject());
+        ibook_.book1D("photonEtFraction_MiniAOD_over_RECO", (TH1F *)mPFPhotonEtFraction_Reco->getRootObject());
+    mPFNeutralHadronEtFraction_MiniAOD_over_Reco = ibook_.book1D(
+        "neutralHadronEtFraction_MiniAOD_over_RECO", (TH1F *)mPFNeutralHadronEtFraction_Reco->getRootObject());
+    mPFChargedHadronEtFraction_MiniAOD_over_Reco = ibook_.book1D(
+        "chargedHadronEtFraction_MiniAOD_over_RECO", (TH1F *)mPFChargedHadronEtFraction_Reco->getRootObject());
     mPFHFHadronEtFraction_MiniAOD_over_Reco =
-        ibook_.book1D("HFHadronEtFraction_MiniAOD_over_RECO",
-                      (TH1F *)mPFHFHadronEtFraction_Reco->getRootObject());
+        ibook_.book1D("HFHadronEtFraction_MiniAOD_over_RECO", (TH1F *)mPFHFHadronEtFraction_Reco->getRootObject());
     mPFHFEMEtFraction_MiniAOD_over_Reco =
-        ibook_.book1D("HFEMEtEtFraction_MiniAOD_over_RECO",
-                      (TH1F *)mPFHFEMEtFraction_Reco->getRootObject());
-    mMETDifference_GenMETTrue_MET20to40_MiniAOD_over_Reco = ibook_.book1D(
-        "METResolution_GenMETTrue_MET20to40_MiniAOD_over_RECO",
-        (TH1F *)mMETDifference_GenMETTrue_MET20to40_Reco->getRootObject());
-    mMETDifference_GenMETTrue_MET100to150_MiniAOD_over_Reco = ibook_.book1D(
-        "METResolution_GenMETTrue_MET100to150_MiniAOD_over_RECO",
-        (TH1F *)mMETDifference_GenMETTrue_MET100to150_Reco->getRootObject());
-    mMETDifference_GenMETTrue_MET300to400_MiniAOD_over_Reco = ibook_.book1D(
-        "METResolution_GenMETTrue_MET300to400_MiniAOD_over_RECO",
-        (TH1F *)mMETDifference_GenMETTrue_MET300to400_Reco->getRootObject());
+        ibook_.book1D("HFEMEtEtFraction_MiniAOD_over_RECO", (TH1F *)mPFHFEMEtFraction_Reco->getRootObject());
+    mMETDifference_GenMETTrue_MET20to40_MiniAOD_over_Reco =
+        ibook_.book1D("METResolution_GenMETTrue_MET20to40_MiniAOD_over_RECO",
+                      (TH1F *)mMETDifference_GenMETTrue_MET20to40_Reco->getRootObject());
+    mMETDifference_GenMETTrue_MET100to150_MiniAOD_over_Reco =
+        ibook_.book1D("METResolution_GenMETTrue_MET100to150_MiniAOD_over_RECO",
+                      (TH1F *)mMETDifference_GenMETTrue_MET100to150_Reco->getRootObject());
+    mMETDifference_GenMETTrue_MET300to400_MiniAOD_over_Reco =
+        ibook_.book1D("METResolution_GenMETTrue_MET300to400_MiniAOD_over_RECO",
+                      (TH1F *)mMETDifference_GenMETTrue_MET300to400_Reco->getRootObject());
 
     std::vector<MonitorElement *> ME_MiniAOD_over_Reco;
     ME_MiniAOD_over_Reco.push_back(mMET_MiniAOD_over_Reco);
@@ -168,18 +141,13 @@ void METTesterPostProcessorHarvesting::dqmEndJob(DQMStore::IBooker &ibook_,
     ME_MiniAOD_over_Reco.push_back(mMETDifference_GenMETTrue_MiniAOD_over_Reco);
     ME_MiniAOD_over_Reco.push_back(mMETDeltaPhi_GenMETTrue_MiniAOD_over_Reco);
     ME_MiniAOD_over_Reco.push_back(mPFPhotonEtFraction_MiniAOD_over_Reco);
-    ME_MiniAOD_over_Reco.push_back(
-        mPFNeutralHadronEtFraction_MiniAOD_over_Reco);
-    ME_MiniAOD_over_Reco.push_back(
-        mPFChargedHadronEtFraction_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mPFNeutralHadronEtFraction_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mPFChargedHadronEtFraction_MiniAOD_over_Reco);
     ME_MiniAOD_over_Reco.push_back(mPFHFHadronEtFraction_MiniAOD_over_Reco);
     ME_MiniAOD_over_Reco.push_back(mPFHFEMEtFraction_MiniAOD_over_Reco);
-    ME_MiniAOD_over_Reco.push_back(
-        mMETDifference_GenMETTrue_MET20to40_MiniAOD_over_Reco);
-    ME_MiniAOD_over_Reco.push_back(
-        mMETDifference_GenMETTrue_MET100to150_MiniAOD_over_Reco);
-    ME_MiniAOD_over_Reco.push_back(
-        mMETDifference_GenMETTrue_MET300to400_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mMETDifference_GenMETTrue_MET20to40_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mMETDifference_GenMETTrue_MET100to150_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mMETDifference_GenMETTrue_MET300to400_MiniAOD_over_Reco);
 
     for (unsigned int j = 0; j < ME_MiniAOD_over_Reco.size(); j++) {
       MonitorElement *monReco = ME_Reco[j];
@@ -190,9 +158,7 @@ void METTesterPostProcessorHarvesting::dqmEndJob(DQMStore::IBooker &ibook_,
           if (monMiniAOD_over_RECO && monMiniAOD_over_RECO->getRootObject()) {
             for (int i = 0; i <= (monMiniAOD_over_RECO->getNbinsX() + 1); i++) {
               if (monReco->getBinContent(i) != 0) {
-                monMiniAOD_over_RECO->setBinContent(
-                    i,
-                    monMiniAOD->getBinContent(i) / monReco->getBinContent(i));
+                monMiniAOD_over_RECO->setBinContent(i, monMiniAOD->getBinContent(i) / monReco->getBinContent(i));
               } else if (monMiniAOD->getBinContent(i) != 0) {
                 monMiniAOD_over_RECO->setBinContent(i, -0.5);
               }

--- a/Validation/RecoPixelVertexing/test/PixelTrackVal.cc
+++ b/Validation/RecoPixelVertexing/test/PixelTrackVal.cc
@@ -28,7 +28,10 @@
 #include <iostream>
 #include <vector>
 
-template <class T> T sqr(T t) { return t * t; }
+template <class T>
+T sqr(T t) {
+  return t * t;
+}
 
 class PixelTrackVal : public edm::EDAnalyzer {
 public:
@@ -49,17 +52,14 @@ private:
 
 PixelTrackVal::PixelTrackVal(const edm::ParameterSet &conf)
     : verbose_(conf.getUntrackedParameter<unsigned int>("Verbosity",
-                                                        0)) // How noisy?
+                                                        0))  // How noisy?
       ,
-      file_(conf.getUntrackedParameter<std::string>("HistoFile",
-                                                    "pixelTrackHistos.root")),
+      file_(conf.getUntrackedParameter<std::string>("HistoFile", "pixelTrackHistos.root")),
       hList(0),
-      trackCollectionToken_(consumes<reco::TrackCollection>(
-          edm::InputTag(conf.getParameter<std::string>("TrackCollection")))),
-      simTrackContainerToken_(consumes<edm::SimTrackContainer>(
-          conf.getParameter<edm::InputTag>("simG4"))),
-      simVertexContainerToken_(consumes<edm::SimVertexContainer>(
-          conf.getParameter<edm::InputTag>("simG4"))) {
+      trackCollectionToken_(
+          consumes<reco::TrackCollection>(edm::InputTag(conf.getParameter<std::string>("TrackCollection")))),
+      simTrackContainerToken_(consumes<edm::SimTrackContainer>(conf.getParameter<edm::InputTag>("simG4"))),
+      simVertexContainerToken_(consumes<edm::SimVertexContainer>(conf.getParameter<edm::InputTag>("simG4"))) {
   edm::LogInfo("PixelTrackVal") << " CTOR";
 }
 
@@ -71,13 +71,11 @@ void PixelTrackVal::beginJob() {
   hList.Add(new TH1F("h_TIP", "h_TIP", 100, -0.1, 0.1));
   hList.Add(new TH1F("h_VtxZ", "h_VtxZ", 100, -0.1, 0.1));
   hList.Add(new TH1F("h_VtxZ_Pull", "h_VtxZ_Pull", 80, 0., 8));
-  hList.Add(new TH1F("h_Nan", "Illegal values for x,y,z,xx,xy,xz,yy,yz,zz", 9,
-                     0.5, 9.5));
+  hList.Add(new TH1F("h_Nan", "Illegal values for x,y,z,xx,xy,xz,yy,yz,zz", 9, 0.5, 9.5));
   hList.SetOwner();
 }
 
 void PixelTrackVal::analyze(const edm::Event &ev, const edm::EventSetup &es) {
-
   std::cout << "*** PixelTrackVal, analyze event: " << ev.id() << std::endl;
 
   //------------------------ simulated tracks
@@ -93,7 +91,6 @@ void PixelTrackVal::analyze(const edm::Event &ev, const edm::EventSetup &es) {
   }
 
   for (unsigned int idx = 0; idx < tracks.size(); idx++) {
-
     const reco::Track *it = &tracks[idx];
     TH1 *h = static_cast<TH1 *>(hList.FindObject("h_Nan"));
     h->Fill(1., edm::isNotFinite(it->momentum().x()) * 1.);
@@ -105,8 +102,7 @@ void PixelTrackVal::analyze(const edm::Event &ev, const edm::EventSetup &es) {
     for (int i = 0; i != 3; i++) {
       for (int j = i; j != 3; j++) {
         index++;
-        static_cast<TH1 *>(hList.FindObject("h_Nan"))
-            ->Fill(index * 1., edm::isNotFinite(it->covariance(i, j)) * 1.);
+        static_cast<TH1 *>(hList.FindObject("h_Nan"))->Fill(index * 1., edm::isNotFinite(it->covariance(i, j)) * 1.);
         if (edm::isNotFinite(it->covariance(i, j)))
           problem = true;
         // in addition, diagonal element must be positive
@@ -120,12 +116,10 @@ void PixelTrackVal::analyze(const edm::Event &ev, const edm::EventSetup &es) {
       std::cout << " *** PROBLEM **" << std::endl;
 
     if (verbose_ > 0) {
-      std::cout << "\tmomentum: " << tracks[idx].momentum()
-                << "\tPT: " << tracks[idx].pt() << std::endl;
-      std::cout << "\tvertex: " << tracks[idx].vertex()
-                << "\tTIP: " << tracks[idx].d0() << " +- "
-                << tracks[idx].d0Error() << "\tZ0: " << tracks[idx].dz()
-                << " +- " << tracks[idx].dzError() << std::endl;
+      std::cout << "\tmomentum: " << tracks[idx].momentum() << "\tPT: " << tracks[idx].pt() << std::endl;
+      std::cout << "\tvertex: " << tracks[idx].vertex() << "\tTIP: " << tracks[idx].d0() << " +- "
+                << tracks[idx].d0Error() << "\tZ0: " << tracks[idx].dz() << " +- " << tracks[idx].dzError()
+                << std::endl;
       std::cout << "\tcharge: " << tracks[idx].charge() << std::endl;
     }
   }
@@ -160,12 +154,10 @@ void PixelTrackVal::analyze(const edm::Event &ev, const edm::EventSetup &es) {
     if ((*p).vertIndex() != 0)
       continue;
 
-    math::XYZVector mom_gen((*p).momentum().x(), (*p).momentum().y(),
-                            (*p).momentum().z());
+    math::XYZVector mom_gen((*p).momentum().x(), (*p).momentum().y(), (*p).momentum().z());
     float phi_gen = (*p).momentum().phi();
     //    float pt_gen = (*p).momentum().Pt();
-    float pt_gen = sqrt((*p).momentum().x() * (*p).momentum().x() +
-                        (*p).momentum().y() * (*p).momentum().y());
+    float pt_gen = sqrt((*p).momentum().x() * (*p).momentum().x() + (*p).momentum().y() * (*p).momentum().y());
     float eta_gen = (*p).momentum().eta();
     math::XYZTLorentzVectorD vtx((*simVtcs)[p->vertIndex()].position().x(),
                                  (*simVtcs)[p->vertIndex()].position().y(),
@@ -199,12 +191,10 @@ void PixelTrackVal::analyze(const edm::Event &ev, const edm::EventSetup &es) {
       if (fabs(deta) < 0.3 && fabs(dphi) < 0.3)
         static_cast<TH1 *>(hList.FindObject("h_dR"))->Fill(dR);
       if (fabs(deta) < detaMax && dR < dRMax) {
-        static_cast<TH1 *>(hList.FindObject("h_Pt"))
-            ->Fill((pt_gen - pt_rec) / pt_gen);
+        static_cast<TH1 *>(hList.FindObject("h_Pt"))->Fill((pt_gen - pt_rec) / pt_gen);
         static_cast<TH1 *>(hList.FindObject("h_TIP"))->Fill(it->d0());
         static_cast<TH1 *>(hList.FindObject("h_VtxZ"))->Fill(dz);
-        static_cast<TH1 *>(hList.FindObject("h_VtxZ_Pull"))
-            ->Fill(fabs(dz / it->dzError()));
+        static_cast<TH1 *>(hList.FindObject("h_VtxZ_Pull"))->Fill(fabs(dz / it->dzError()));
       }
     }
   }

--- a/Validation/RecoPixelVertexing/test/PixelVertexVal.cc
+++ b/Validation/RecoPixelVertexing/test/PixelVertexVal.cc
@@ -52,16 +52,15 @@ private:
 
 PixelVertexVal::PixelVertexVal(const edm::ParameterSet &conf)
     : verbose_(conf.getUntrackedParameter<unsigned int>("Verbosity",
-                                                        0)) // How noisy?
+                                                        0))  // How noisy?
       ,
-      file_(conf.getUntrackedParameter<std::string>("HistoFile",
-                                                    "pixelVertexHistos.root")),
-      h(), trackCollectionToken_(consumes<reco::TrackCollection>(edm::InputTag(
-               conf.getParameter<std::string>("TrackCollection")))),
-      vertexCollectionToken_(consumes<reco::VertexCollection>(
-          edm::InputTag(conf.getParameter<std::string>("VertexCollection")))),
-      simVertexContainerToken_(consumes<edm::SimVertexContainer>(
-          conf.getParameter<edm::InputTag>("simG4"))) {
+      file_(conf.getUntrackedParameter<std::string>("HistoFile", "pixelVertexHistos.root")),
+      h(),
+      trackCollectionToken_(
+          consumes<reco::TrackCollection>(edm::InputTag(conf.getParameter<std::string>("TrackCollection")))),
+      vertexCollectionToken_(
+          consumes<reco::VertexCollection>(edm::InputTag(conf.getParameter<std::string>("VertexCollection")))),
+      simVertexContainerToken_(consumes<edm::SimVertexContainer>(conf.getParameter<edm::InputTag>("simG4"))) {
   edm::LogInfo("PixelVertexVal") << " CTOR";
 }
 
@@ -133,8 +132,7 @@ void PixelVertexVal::analyze(const edm::Event &ev, const edm::EventSetup &es) {
     h["h_ResZ"]->Fill(dz);
     h["h_PullZ"]->Fill(dz / pv.zError());
 
-    for (reco::Vertex::trackRef_iterator it = pv.tracks_begin();
-         it != pv.tracks_end(); it++) {
+    for (reco::Vertex::trackRef_iterator it = pv.tracks_begin(); it != pv.tracks_end(); it++) {
       //    for (reco::Vertex::track_iterator it=pv.tracks_begin(); it !=
       //    pv.tracks_end(); it++) { for (reco::TrackRefVector::iterator
       //    it=pv.tracks_begin(); it != pv.tracks_end(); it++) {
@@ -146,8 +144,7 @@ void PixelVertexVal::analyze(const edm::Event &ev, const edm::EventSetup &es) {
 
 void PixelVertexVal::endJob() {
   TFile rootFile(file_.c_str(), "RECREATE");
-  for (std::map<std::string, TH1 *>::const_iterator ih = h.begin();
-       ih != h.end(); ++ih) {
+  for (std::map<std::string, TH1 *>::const_iterator ih = h.begin(); ih != h.end(); ++ih) {
     TH1 *histo = (*ih).second;
     histo->Write();
     delete histo;

--- a/Validation/SiPixelPhase1DigisV/interface/SiPixelPhase1DigisV.h
+++ b/Validation/SiPixelPhase1DigisV/interface/SiPixelPhase1DigisV.h
@@ -1,4 +1,4 @@
-#ifndef SiPixelPhase1DigisV_h // Can we use #pragma once?
+#ifndef SiPixelPhase1DigisV_h  // Can we use #pragma once?
 #define SiPixelPhase1DigisV_h
 // -*- C++ -*-
 //
@@ -19,12 +19,12 @@
 class SiPixelPhase1DigisV : public SiPixelPhase1Base {
   // List of quantities to be plotted.
   enum {
-    ADC,    // digi ADC readouts
-    NDIGIS, // number of digis per event and module
-    ROW,    // number of digis per row
-    COLUMN, // number of digis per column
+    ADC,     // digi ADC readouts
+    NDIGIS,  // number of digis per event and module
+    ROW,     // number of digis per row
+    COLUMN,  // number of digis per column
 
-    MAX_HIST // a sentinel that gives the number of quantities (not a plot).
+    MAX_HIST  // a sentinel that gives the number of quantities (not a plot).
   };
 
 public:
@@ -38,10 +38,10 @@ private:
 
 class SiPixelPhase1DigisHarvesterV : public SiPixelPhase1Harvester {
   enum {
-    ADC,    // digi ADC readouts
-    NDIGIS, // number of digis per event and module
-    ROW,    // number of digis per row
-    COLUMN, // number of digis per column
+    ADC,     // digi ADC readouts
+    NDIGIS,  // number of digis per event and module
+    ROW,     // number of digis per row
+    COLUMN,  // number of digis per column
 
     MAX_HIST
   };

--- a/Validation/SiPixelPhase1DigisV/src/SiPixelPhase1DigisHarvesterV.cc
+++ b/Validation/SiPixelPhase1DigisV/src/SiPixelPhase1DigisHarvesterV.cc
@@ -10,8 +10,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "Validation/SiPixelPhase1DigisV/interface/SiPixelPhase1DigisV.h"
 
-SiPixelPhase1DigisHarvesterV::SiPixelPhase1DigisHarvesterV(
-    const edm::ParameterSet &iConfig)
+SiPixelPhase1DigisHarvesterV::SiPixelPhase1DigisHarvesterV(const edm::ParameterSet &iConfig)
     : SiPixelPhase1Harvester(iConfig) {}
 
 DEFINE_FWK_MODULE(SiPixelPhase1DigisHarvesterV);

--- a/Validation/SiPixelPhase1DigisV/src/SiPixelPhase1DigisV.cc
+++ b/Validation/SiPixelPhase1DigisV/src/SiPixelPhase1DigisV.cc
@@ -20,15 +20,11 @@
 // DQM Stuff
 #include "DQMServices/Core/interface/MonitorElement.h"
 
-SiPixelPhase1DigisV::SiPixelPhase1DigisV(const edm::ParameterSet &iConfig)
-    : SiPixelPhase1Base(iConfig) {
-  srcToken_ = consumes<edm::DetSetVector<PixelDigi>>(
-      iConfig.getParameter<edm::InputTag>("src"));
+SiPixelPhase1DigisV::SiPixelPhase1DigisV(const edm::ParameterSet &iConfig) : SiPixelPhase1Base(iConfig) {
+  srcToken_ = consumes<edm::DetSetVector<PixelDigi>>(iConfig.getParameter<edm::InputTag>("src"));
 }
 
-void SiPixelPhase1DigisV::analyze(const edm::Event &iEvent,
-                                  const edm::EventSetup &iSetup) {
-
+void SiPixelPhase1DigisV::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   edm::Handle<edm::DetSetVector<PixelDigi>> input;
   iEvent.getByToken(srcToken_, input);
   if (!input.isValid())
@@ -38,7 +34,7 @@ void SiPixelPhase1DigisV::analyze(const edm::Event &iEvent,
   for (it = input->begin(); it != input->end(); ++it) {
     for (PixelDigi const &digi : *it) {
       histo[ADC].fill((double)digi.adc(), DetId(it->detId()), &iEvent);
-      histo[NDIGIS].fill(DetId(it->detId()), &iEvent); // count
+      histo[NDIGIS].fill(DetId(it->detId()), &iEvent);  // count
       histo[ROW].fill((double)digi.row(), DetId(it->detId()), &iEvent);
       histo[COLUMN].fill((double)digi.column(), DetId(it->detId()), &iEvent);
     }

--- a/Validation/SiPixelPhase1HitsV/interface/SiPixelPhase1HitsV.h
+++ b/Validation/SiPixelPhase1HitsV/interface/SiPixelPhase1HitsV.h
@@ -15,7 +15,7 @@
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 
 namespace reco {
-class TrackToTrackingParticleAssociator;
+  class TrackToTrackingParticleAssociator;
 }
 
 class SiPixelPhase1HitsV : public SiPixelPhase1Base {
@@ -45,8 +45,7 @@ private:
 
   edm::EDGetTokenT<edm::View<reco::Track>> tracksToken_;
   edm::EDGetTokenT<TrackingParticleCollection> tpToken_;
-  edm::EDGetTokenT<reco::TrackToTrackingParticleAssociator>
-      trackAssociatorByHitsToken_;
+  edm::EDGetTokenT<reco::TrackToTrackingParticleAssociator> trackAssociatorByHitsToken_;
 };
 
 #endif

--- a/Validation/SiPixelPhase1HitsV/src/SiPixelPhase1HitsV.cc
+++ b/Validation/SiPixelPhase1HitsV/src/SiPixelPhase1HitsV.cc
@@ -25,27 +25,17 @@
 
 SiPixelPhase1HitsV::SiPixelPhase1HitsV(const edm::ParameterSet &iConfig)
     : SiPixelPhase1Base(iConfig),
-      pixelBarrelLowToken_(consumes<edm::PSimHitContainer>(
-          iConfig.getParameter<edm::InputTag>("pixBarrelLowSrc"))),
-      pixelBarrelHighToken_(consumes<edm::PSimHitContainer>(
-          iConfig.getParameter<edm::InputTag>("pixBarrelHighSrc"))),
-      pixelForwardLowToken_(consumes<edm::PSimHitContainer>(
-          iConfig.getParameter<edm::InputTag>("pixForwardLowSrc"))),
-      pixelForwardHighToken_(consumes<edm::PSimHitContainer>(
-          iConfig.getParameter<edm::InputTag>("pixForwardHighSrc"))),
+      pixelBarrelLowToken_(consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("pixBarrelLowSrc"))),
+      pixelBarrelHighToken_(consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("pixBarrelHighSrc"))),
+      pixelForwardLowToken_(consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("pixForwardLowSrc"))),
+      pixelForwardHighToken_(consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("pixForwardHighSrc"))),
 
-      tracksToken_(consumes<edm::View<reco::Track>>(
-          iConfig.getParameter<edm::InputTag>("tracksTag"))),
-      tpToken_(consumes<TrackingParticleCollection>(
-          iConfig.getParameter<edm::InputTag>("tpTag"))),
-      trackAssociatorByHitsToken_(
-          consumes<reco::TrackToTrackingParticleAssociator>(
-              iConfig.getParameter<edm::InputTag>(
-                  "trackAssociatorByHitsTag"))) {}
+      tracksToken_(consumes<edm::View<reco::Track>>(iConfig.getParameter<edm::InputTag>("tracksTag"))),
+      tpToken_(consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("tpTag"))),
+      trackAssociatorByHitsToken_(consumes<reco::TrackToTrackingParticleAssociator>(
+          iConfig.getParameter<edm::InputTag>("trackAssociatorByHitsTag"))) {}
 
-void SiPixelPhase1HitsV::analyze(const edm::Event &iEvent,
-                                 const edm::EventSetup &iSetup) {
-
+void SiPixelPhase1HitsV::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   edm::Handle<edm::PSimHitContainer> barrelLowInput;
   iEvent.getByToken(pixelBarrelLowToken_, barrelLowInput);
   if (!barrelLowInput.isValid())
@@ -217,18 +207,16 @@ void SiPixelPhase1HitsV::analyze(const edm::Event &iEvent,
   if (!theHitsAssociator.isValid()) {
     throw cms::Exception("NO VALID HIT ASSOCIATOR");
   }
-  reco::TrackToTrackingParticleAssociator const *associatorByHits =
-      theHitsAssociator.product();
+  reco::TrackToTrackingParticleAssociator const *associatorByHits = theHitsAssociator.product();
 
   if (TPCollectionH.isValid() && trackCollectionH.isValid()) {
-    reco::RecoToSimCollection const &p =
-        associatorByHits->associateRecoToSim(trackCollectionH, TPCollectionH);
+    reco::RecoToSimCollection const &p = associatorByHits->associateRecoToSim(trackCollectionH, TPCollectionH);
 
     for (edm::View<reco::Track>::size_type i = 0; i < tC.size(); ++i) {
       edm::RefToBase<reco::Track> track(trackCollectionH, i);
       //      const reco::Track& t = *track;
-      auto id = DetId(track->innerDetId()); // histo manager requires a det ID,
-                                            // use innermost ID for ease
+      auto id = DetId(track->innerDetId());  // histo manager requires a det ID,
+                                             // use innermost ID for ease
 
       auto iter = p.find(track);
       histo[EFFICIENCY_TRACK].fill(iter != p.end() ? 1 : 0, id, &iEvent);

--- a/Validation/SiPixelPhase1TrackClustersV/src/SiPixelPhase1TrackClustersV.cc
+++ b/Validation/SiPixelPhase1TrackClustersV/src/SiPixelPhase1TrackClustersV.cc
@@ -22,18 +22,13 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryStateCombiner.h"
 
-SiPixelPhase1TrackClustersV::SiPixelPhase1TrackClustersV(
-    const edm::ParameterSet &iConfig)
+SiPixelPhase1TrackClustersV::SiPixelPhase1TrackClustersV(const edm::ParameterSet &iConfig)
     : SiPixelPhase1Base(iConfig) {
-  clustersToken_ = consumes<edmNew::DetSetVector<SiPixelCluster>>(
-      iConfig.getParameter<edm::InputTag>("clusters"));
-  tracksToken_ = consumes<reco::TrackCollection>(
-      iConfig.getParameter<edm::InputTag>("tracks"));
+  clustersToken_ = consumes<edmNew::DetSetVector<SiPixelCluster>>(iConfig.getParameter<edm::InputTag>("clusters"));
+  tracksToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
 }
 
-void SiPixelPhase1TrackClustersV::analyze(const edm::Event &iEvent,
-                                          const edm::EventSetup &iSetup) {
-
+void SiPixelPhase1TrackClustersV::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // get geometry
   edm::ESHandle<TrackerGeometry> tracker;
   iSetup.get<TrackerDigiGeometryRecord>().get(tracker);

--- a/Validation/SiPixelPhase1TrackingParticleV/interface/SiPixelPhase1TrackingParticleV.h
+++ b/Validation/SiPixelPhase1TrackingParticleV/interface/SiPixelPhase1TrackingParticleV.h
@@ -15,7 +15,7 @@
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 
 namespace reco {
-class TrackToTrackingParticleAssociator;
+  class TrackToTrackingParticleAssociator;
 }
 
 class SiPixelPhase1TrackingParticleV : public SiPixelPhase1Base {

--- a/Validation/TrackerDigis/interface/SiPixelDigiValid.h
+++ b/Validation/TrackerDigis/interface/SiPixelDigiValid.h
@@ -11,22 +11,21 @@
 #include <string>
 
 namespace edm {
-template <class T> class DetSetVector;
+  template <class T>
+  class DetSetVector;
 }
 class PixelDigi;
 class DQMStore;
 class MonitorElement;
 
 class SiPixelDigiValid : public DQMEDAnalyzer {
-
 public:
   SiPixelDigiValid(const edm::ParameterSet &ps);
   ~SiPixelDigiValid() override;
 
 protected:
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
-  void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &run,
-                      const edm::EventSetup &es) override;
+  void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &run, const edm::EventSetup &es) override;
   void endJob(void) override;
 
 private:
@@ -261,8 +260,7 @@ private:
   MonitorElement *meNdigiZmDisk2PerPanel2_;
 
   DQMStore *dbe_;
-  edm::EDGetTokenT<edm::DetSetVector<PixelDigi>>
-      edmDetSetVector_PixelDigi_Token_;
+  edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> edmDetSetVector_PixelDigi_Token_;
   edm::ESHandle<GeometricSearchTracker> tracker;
 };
 #endif

--- a/Validation/TrackerDigis/interface/SiStripDigiValid.h
+++ b/Validation/TrackerDigis/interface/SiStripDigiValid.h
@@ -8,22 +8,21 @@
 #include <string>
 
 namespace edm {
-template <class T> class DetSetVector;
+  template <class T>
+  class DetSetVector;
 }
 class SiStripDigi;
 class DQMStore;
 class MonitorElement;
 
 class SiStripDigiValid : public DQMEDAnalyzer {
-
 public:
   SiStripDigiValid(const edm::ParameterSet &ps);
   ~SiStripDigiValid() override;
 
 protected:
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
-  void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &run,
-                      const edm::EventSetup &es) override;
+  void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &run, const edm::EventSetup &es) override;
   void endJob(void) override;
 
 private:
@@ -172,8 +171,7 @@ private:
   DQMStore *dbe_;
   bool runStandalone;
   std::string outputFile_;
-  edm::EDGetTokenT<edm::DetSetVector<SiStripDigi>>
-      edmDetSetVector_SiStripDigi_Token_;
+  edm::EDGetTokenT<edm::DetSetVector<SiStripDigi>> edmDetSetVector_SiStripDigi_Token_;
 };
 
 #endif

--- a/Validation/TrackerDigis/plugins/SiPixelDigiValid.cc
+++ b/Validation/TrackerDigis/plugins/SiPixelDigiValid.cc
@@ -24,446 +24,252 @@
 // using namespace edm;
 
 SiPixelDigiValid::SiPixelDigiValid(const edm::ParameterSet &ps)
-    : outputFile_(ps.getUntrackedParameter<std::string>("outputFile",
-                                                        "pixeldigihisto.root")),
-      runStandalone(ps.getParameter<bool>("runStandalone")), dbe_(nullptr),
-      edmDetSetVector_PixelDigi_Token_(consumes<edm::DetSetVector<PixelDigi>>(
-          ps.getParameter<edm::InputTag>("src"))) {}
+    : outputFile_(ps.getUntrackedParameter<std::string>("outputFile", "pixeldigihisto.root")),
+      runStandalone(ps.getParameter<bool>("runStandalone")),
+      dbe_(nullptr),
+      edmDetSetVector_PixelDigi_Token_(consumes<edm::DetSetVector<PixelDigi>>(ps.getParameter<edm::InputTag>("src"))) {}
 
 SiPixelDigiValid::~SiPixelDigiValid() {}
 
-void SiPixelDigiValid::bookHistograms(DQMStore::IBooker &ibooker,
-                                      const edm::Run &run,
-                                      const edm::EventSetup &es) {
+void SiPixelDigiValid::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &run, const edm::EventSetup &es) {
   dbe_ = edm::Service<DQMStore>().operator->();
   es.get<TrackerRecoGeometryRecord>().get(tracker);
 
   if (dbe_) {
     ibooker.setCurrentFolder("TrackerDigisV/TrackerDigis/Pixel");
 
-    meDigiMultiLayer1Ring1_ = ibooker.book1D("digimulti_layer1ring1",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer1Ring2_ = ibooker.book1D("digimulti_layer1ring2",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer1Ring3_ = ibooker.book1D("digimulti_layer1ring3",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer1Ring4_ = ibooker.book1D("digimulti_layer1ring4",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer1Ring5_ = ibooker.book1D("digimulti_layer1ring5",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer1Ring6_ = ibooker.book1D("digimulti_layer1ring6",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer1Ring7_ = ibooker.book1D("digimulti_layer1ring7",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer1Ring8_ = ibooker.book1D("digimulti_layer1ring8",
-                                             "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer1Ring1_ = ibooker.book1D("digimulti_layer1ring1", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer1Ring2_ = ibooker.book1D("digimulti_layer1ring2", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer1Ring3_ = ibooker.book1D("digimulti_layer1ring3", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer1Ring4_ = ibooker.book1D("digimulti_layer1ring4", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer1Ring5_ = ibooker.book1D("digimulti_layer1ring5", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer1Ring6_ = ibooker.book1D("digimulti_layer1ring6", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer1Ring7_ = ibooker.book1D("digimulti_layer1ring7", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer1Ring8_ = ibooker.book1D("digimulti_layer1ring8", "Digi Multiplicity ", 30, 0., 30.);
 
-    meDigiMultiLayer2Ring1_ = ibooker.book1D("digimulti_layer2ring1",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer2Ring2_ = ibooker.book1D("digimulti_layer2ring2",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer2Ring3_ = ibooker.book1D("digimulti_layer2ring3",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer2Ring4_ = ibooker.book1D("digimulti_layer2ring4",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer2Ring5_ = ibooker.book1D("digimulti_layer2ring5",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer2Ring6_ = ibooker.book1D("digimulti_layer2ring6",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer2Ring7_ = ibooker.book1D("digimulti_layer2ring7",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer2Ring8_ = ibooker.book1D("digimulti_layer2ring8",
-                                             "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer2Ring1_ = ibooker.book1D("digimulti_layer2ring1", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer2Ring2_ = ibooker.book1D("digimulti_layer2ring2", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer2Ring3_ = ibooker.book1D("digimulti_layer2ring3", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer2Ring4_ = ibooker.book1D("digimulti_layer2ring4", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer2Ring5_ = ibooker.book1D("digimulti_layer2ring5", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer2Ring6_ = ibooker.book1D("digimulti_layer2ring6", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer2Ring7_ = ibooker.book1D("digimulti_layer2ring7", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer2Ring8_ = ibooker.book1D("digimulti_layer2ring8", "Digi Multiplicity ", 30, 0., 30.);
 
-    meDigiMultiLayer3Ring1_ = ibooker.book1D("digimulti_layer3ring1",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer3Ring2_ = ibooker.book1D("digimulti_layer3ring2",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer3Ring3_ = ibooker.book1D("digimulti_layer3ring3",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer3Ring4_ = ibooker.book1D("digimulti_layer3ring4",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer3Ring5_ = ibooker.book1D("digimulti_layer3ring5",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer3Ring6_ = ibooker.book1D("digimulti_layer3ring6",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer3Ring7_ = ibooker.book1D("digimulti_layer3ring7",
-                                             "Digi Multiplicity ", 30, 0., 30.);
-    meDigiMultiLayer3Ring8_ = ibooker.book1D("digimulti_layer3ring8",
-                                             "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer3Ring1_ = ibooker.book1D("digimulti_layer3ring1", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer3Ring2_ = ibooker.book1D("digimulti_layer3ring2", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer3Ring3_ = ibooker.book1D("digimulti_layer3ring3", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer3Ring4_ = ibooker.book1D("digimulti_layer3ring4", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer3Ring5_ = ibooker.book1D("digimulti_layer3ring5", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer3Ring6_ = ibooker.book1D("digimulti_layer3ring6", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer3Ring7_ = ibooker.book1D("digimulti_layer3ring7", "Digi Multiplicity ", 30, 0., 30.);
+    meDigiMultiLayer3Ring8_ = ibooker.book1D("digimulti_layer3ring8", "Digi Multiplicity ", 30, 0., 30.);
 
     /////Barrel
-    meAdcLayer1Ring1_ =
-        ibooker.book1D("adc_layer1ring1", "Digi charge", 50, 0., 300.);
-    meAdcLayer1Ring2_ =
-        ibooker.book1D("adc_layer1ring2", "Digi charge", 50, 0., 300.);
-    meAdcLayer1Ring3_ =
-        ibooker.book1D("adc_layer1ring3", "Digi charge", 50, 0., 300.);
-    meAdcLayer1Ring4_ =
-        ibooker.book1D("adc_layer1ring4", "Digi charge", 50, 0., 300.);
-    meAdcLayer1Ring5_ =
-        ibooker.book1D("adc_layer1ring5", "Digi charge", 50, 0., 300.);
-    meAdcLayer1Ring6_ =
-        ibooker.book1D("adc_layer1ring6", "Digi charge", 50, 0., 300.);
-    meAdcLayer1Ring7_ =
-        ibooker.book1D("adc_layer1ring7", "Digi charge", 50, 0., 300.);
-    meAdcLayer1Ring8_ =
-        ibooker.book1D("adc_layer1ring8", "Digi charge", 50, 0., 300.);
+    meAdcLayer1Ring1_ = ibooker.book1D("adc_layer1ring1", "Digi charge", 50, 0., 300.);
+    meAdcLayer1Ring2_ = ibooker.book1D("adc_layer1ring2", "Digi charge", 50, 0., 300.);
+    meAdcLayer1Ring3_ = ibooker.book1D("adc_layer1ring3", "Digi charge", 50, 0., 300.);
+    meAdcLayer1Ring4_ = ibooker.book1D("adc_layer1ring4", "Digi charge", 50, 0., 300.);
+    meAdcLayer1Ring5_ = ibooker.book1D("adc_layer1ring5", "Digi charge", 50, 0., 300.);
+    meAdcLayer1Ring6_ = ibooker.book1D("adc_layer1ring6", "Digi charge", 50, 0., 300.);
+    meAdcLayer1Ring7_ = ibooker.book1D("adc_layer1ring7", "Digi charge", 50, 0., 300.);
+    meAdcLayer1Ring8_ = ibooker.book1D("adc_layer1ring8", "Digi charge", 50, 0., 300.);
 
-    meRowLayer1Ring1_ =
-        ibooker.book1D("row_layer1ring1", "Digi row", 50, 0., 200.);
-    meRowLayer1Ring2_ =
-        ibooker.book1D("row_layer1ring2", "Digi row", 50, 0., 200.);
-    meRowLayer1Ring3_ =
-        ibooker.book1D("row_layer1ring3", "Digi row", 50, 0., 200.);
-    meRowLayer1Ring4_ =
-        ibooker.book1D("row_layer1ring4", "Digi row", 50, 0., 200.);
-    meRowLayer1Ring5_ =
-        ibooker.book1D("row_layer1ring5", "Digi row", 50, 0., 200.);
-    meRowLayer1Ring6_ =
-        ibooker.book1D("row_layer1ring6", "Digi row", 50, 0., 200.);
-    meRowLayer1Ring7_ =
-        ibooker.book1D("row_layer1ring7", "Digi row", 50, 0., 200.);
-    meRowLayer1Ring8_ =
-        ibooker.book1D("row_layer1ring8", "Digi row", 50, 0., 200.);
+    meRowLayer1Ring1_ = ibooker.book1D("row_layer1ring1", "Digi row", 50, 0., 200.);
+    meRowLayer1Ring2_ = ibooker.book1D("row_layer1ring2", "Digi row", 50, 0., 200.);
+    meRowLayer1Ring3_ = ibooker.book1D("row_layer1ring3", "Digi row", 50, 0., 200.);
+    meRowLayer1Ring4_ = ibooker.book1D("row_layer1ring4", "Digi row", 50, 0., 200.);
+    meRowLayer1Ring5_ = ibooker.book1D("row_layer1ring5", "Digi row", 50, 0., 200.);
+    meRowLayer1Ring6_ = ibooker.book1D("row_layer1ring6", "Digi row", 50, 0., 200.);
+    meRowLayer1Ring7_ = ibooker.book1D("row_layer1ring7", "Digi row", 50, 0., 200.);
+    meRowLayer1Ring8_ = ibooker.book1D("row_layer1ring8", "Digi row", 50, 0., 200.);
 
-    meColLayer1Ring1_ =
-        ibooker.book1D("col_layer1ring1", "Digi column", 50, 0., 500.);
-    meColLayer1Ring2_ =
-        ibooker.book1D("col_layer1ring2", "Digi column", 50, 0., 500.);
-    meColLayer1Ring3_ =
-        ibooker.book1D("col_layer1ring3", "Digi column", 50, 0., 500.);
-    meColLayer1Ring4_ =
-        ibooker.book1D("col_layer1ring4", "Digi column", 50, 0., 500.);
-    meColLayer1Ring5_ =
-        ibooker.book1D("col_layer1ring5", "Digi column", 50, 0., 500.);
-    meColLayer1Ring6_ =
-        ibooker.book1D("col_layer1ring6", "Digi column", 50, 0., 500.);
-    meColLayer1Ring7_ =
-        ibooker.book1D("col_layer1ring7", "Digi column", 50, 0., 500.);
-    meColLayer1Ring8_ =
-        ibooker.book1D("col_layer1ring8", "Digi column", 50, 0., 500.);
+    meColLayer1Ring1_ = ibooker.book1D("col_layer1ring1", "Digi column", 50, 0., 500.);
+    meColLayer1Ring2_ = ibooker.book1D("col_layer1ring2", "Digi column", 50, 0., 500.);
+    meColLayer1Ring3_ = ibooker.book1D("col_layer1ring3", "Digi column", 50, 0., 500.);
+    meColLayer1Ring4_ = ibooker.book1D("col_layer1ring4", "Digi column", 50, 0., 500.);
+    meColLayer1Ring5_ = ibooker.book1D("col_layer1ring5", "Digi column", 50, 0., 500.);
+    meColLayer1Ring6_ = ibooker.book1D("col_layer1ring6", "Digi column", 50, 0., 500.);
+    meColLayer1Ring7_ = ibooker.book1D("col_layer1ring7", "Digi column", 50, 0., 500.);
+    meColLayer1Ring8_ = ibooker.book1D("col_layer1ring8", "Digi column", 50, 0., 500.);
 
-    meAdcLayer2Ring1_ =
-        ibooker.book1D("adc_layer2ring1", "Digi charge", 50, 0., 300.);
-    meAdcLayer2Ring2_ =
-        ibooker.book1D("adc_layer2ring2", "Digi charge", 50, 0., 300.);
-    meAdcLayer2Ring3_ =
-        ibooker.book1D("adc_layer2ring3", "Digi charge", 50, 0., 300.);
-    meAdcLayer2Ring4_ =
-        ibooker.book1D("adc_layer2ring4", "Digi charge", 50, 0., 300.);
-    meAdcLayer2Ring5_ =
-        ibooker.book1D("adc_layer2ring5", "Digi charge", 50, 0., 300.);
-    meAdcLayer2Ring6_ =
-        ibooker.book1D("adc_layer2ring6", "Digi charge", 50, 0., 300.);
-    meAdcLayer2Ring7_ =
-        ibooker.book1D("adc_layer2ring7", "Digi charge", 50, 0., 300.);
-    meAdcLayer2Ring8_ =
-        ibooker.book1D("adc_layer2ring8", "Digi charge", 50, 0., 300.);
+    meAdcLayer2Ring1_ = ibooker.book1D("adc_layer2ring1", "Digi charge", 50, 0., 300.);
+    meAdcLayer2Ring2_ = ibooker.book1D("adc_layer2ring2", "Digi charge", 50, 0., 300.);
+    meAdcLayer2Ring3_ = ibooker.book1D("adc_layer2ring3", "Digi charge", 50, 0., 300.);
+    meAdcLayer2Ring4_ = ibooker.book1D("adc_layer2ring4", "Digi charge", 50, 0., 300.);
+    meAdcLayer2Ring5_ = ibooker.book1D("adc_layer2ring5", "Digi charge", 50, 0., 300.);
+    meAdcLayer2Ring6_ = ibooker.book1D("adc_layer2ring6", "Digi charge", 50, 0., 300.);
+    meAdcLayer2Ring7_ = ibooker.book1D("adc_layer2ring7", "Digi charge", 50, 0., 300.);
+    meAdcLayer2Ring8_ = ibooker.book1D("adc_layer2ring8", "Digi charge", 50, 0., 300.);
 
-    meRowLayer2Ring1_ =
-        ibooker.book1D("row_layer2ring1", "Digi row", 50, 0., 200.);
-    meRowLayer2Ring2_ =
-        ibooker.book1D("row_layer2ring2", "Digi row", 50, 0., 200.);
-    meRowLayer2Ring3_ =
-        ibooker.book1D("row_layer2ring3", "Digi row", 50, 0., 200.);
-    meRowLayer2Ring4_ =
-        ibooker.book1D("row_layer2ring4", "Digi row", 50, 0., 200.);
-    meRowLayer2Ring5_ =
-        ibooker.book1D("row_layer2ring5", "Digi row", 50, 0., 200.);
-    meRowLayer2Ring6_ =
-        ibooker.book1D("row_layer2ring6", "Digi row", 50, 0., 200.);
-    meRowLayer2Ring7_ =
-        ibooker.book1D("row_layer2ring7", "Digi row", 50, 0., 200.);
-    meRowLayer2Ring8_ =
-        ibooker.book1D("row_layer2ring8", "Digi row", 50, 0., 200.);
+    meRowLayer2Ring1_ = ibooker.book1D("row_layer2ring1", "Digi row", 50, 0., 200.);
+    meRowLayer2Ring2_ = ibooker.book1D("row_layer2ring2", "Digi row", 50, 0., 200.);
+    meRowLayer2Ring3_ = ibooker.book1D("row_layer2ring3", "Digi row", 50, 0., 200.);
+    meRowLayer2Ring4_ = ibooker.book1D("row_layer2ring4", "Digi row", 50, 0., 200.);
+    meRowLayer2Ring5_ = ibooker.book1D("row_layer2ring5", "Digi row", 50, 0., 200.);
+    meRowLayer2Ring6_ = ibooker.book1D("row_layer2ring6", "Digi row", 50, 0., 200.);
+    meRowLayer2Ring7_ = ibooker.book1D("row_layer2ring7", "Digi row", 50, 0., 200.);
+    meRowLayer2Ring8_ = ibooker.book1D("row_layer2ring8", "Digi row", 50, 0., 200.);
 
-    meColLayer2Ring1_ =
-        ibooker.book1D("col_layer2ring1", "Digi column", 50, 0., 500.);
-    meColLayer2Ring2_ =
-        ibooker.book1D("col_layer2ring2", "Digi column", 50, 0., 500.);
-    meColLayer2Ring3_ =
-        ibooker.book1D("col_layer2ring3", "Digi column", 50, 0., 500.);
-    meColLayer2Ring4_ =
-        ibooker.book1D("col_layer2ring4", "Digi column", 50, 0., 500.);
-    meColLayer2Ring5_ =
-        ibooker.book1D("col_layer2ring5", "Digi column", 50, 0., 500.);
-    meColLayer2Ring6_ =
-        ibooker.book1D("col_layer2ring6", "Digi column", 50, 0., 500.);
-    meColLayer2Ring7_ =
-        ibooker.book1D("col_layer2ring7", "Digi column", 50, 0., 500.);
-    meColLayer2Ring8_ =
-        ibooker.book1D("col_layer2ring8", "Digi column", 50, 0., 500.);
+    meColLayer2Ring1_ = ibooker.book1D("col_layer2ring1", "Digi column", 50, 0., 500.);
+    meColLayer2Ring2_ = ibooker.book1D("col_layer2ring2", "Digi column", 50, 0., 500.);
+    meColLayer2Ring3_ = ibooker.book1D("col_layer2ring3", "Digi column", 50, 0., 500.);
+    meColLayer2Ring4_ = ibooker.book1D("col_layer2ring4", "Digi column", 50, 0., 500.);
+    meColLayer2Ring5_ = ibooker.book1D("col_layer2ring5", "Digi column", 50, 0., 500.);
+    meColLayer2Ring6_ = ibooker.book1D("col_layer2ring6", "Digi column", 50, 0., 500.);
+    meColLayer2Ring7_ = ibooker.book1D("col_layer2ring7", "Digi column", 50, 0., 500.);
+    meColLayer2Ring8_ = ibooker.book1D("col_layer2ring8", "Digi column", 50, 0., 500.);
 
-    meAdcLayer3Ring1_ =
-        ibooker.book1D("adc_layer3ring1", "Digi charge", 50, 0., 300.);
-    meAdcLayer3Ring2_ =
-        ibooker.book1D("adc_layer3ring2", "Digi charge", 50, 0., 300.);
-    meAdcLayer3Ring3_ =
-        ibooker.book1D("adc_layer3ring3", "Digi charge", 50, 0., 300.);
-    meAdcLayer3Ring4_ =
-        ibooker.book1D("adc_layer3ring4", "Digi charge", 50, 0., 300.);
-    meAdcLayer3Ring5_ =
-        ibooker.book1D("adc_layer3ring5", "Digi charge", 50, 0., 300.);
-    meAdcLayer3Ring6_ =
-        ibooker.book1D("adc_layer3ring6", "Digi charge", 50, 0., 300.);
-    meAdcLayer3Ring7_ =
-        ibooker.book1D("adc_layer3ring7", "Digi charge", 50, 0., 300.);
-    meAdcLayer3Ring8_ =
-        ibooker.book1D("adc_layer3ring8", "Digi charge", 50, 0., 300.);
+    meAdcLayer3Ring1_ = ibooker.book1D("adc_layer3ring1", "Digi charge", 50, 0., 300.);
+    meAdcLayer3Ring2_ = ibooker.book1D("adc_layer3ring2", "Digi charge", 50, 0., 300.);
+    meAdcLayer3Ring3_ = ibooker.book1D("adc_layer3ring3", "Digi charge", 50, 0., 300.);
+    meAdcLayer3Ring4_ = ibooker.book1D("adc_layer3ring4", "Digi charge", 50, 0., 300.);
+    meAdcLayer3Ring5_ = ibooker.book1D("adc_layer3ring5", "Digi charge", 50, 0., 300.);
+    meAdcLayer3Ring6_ = ibooker.book1D("adc_layer3ring6", "Digi charge", 50, 0., 300.);
+    meAdcLayer3Ring7_ = ibooker.book1D("adc_layer3ring7", "Digi charge", 50, 0., 300.);
+    meAdcLayer3Ring8_ = ibooker.book1D("adc_layer3ring8", "Digi charge", 50, 0., 300.);
 
-    meRowLayer3Ring1_ =
-        ibooker.book1D("row_layer3ring1", "Digi row", 50, 0., 200.);
-    meRowLayer3Ring2_ =
-        ibooker.book1D("row_layer3ring2", "Digi row", 50, 0., 200.);
-    meRowLayer3Ring3_ =
-        ibooker.book1D("row_layer3ring3", "Digi row", 50, 0., 200.);
-    meRowLayer3Ring4_ =
-        ibooker.book1D("row_layer3ring4", "Digi row", 50, 0., 200.);
-    meRowLayer3Ring5_ =
-        ibooker.book1D("row_layer3ring5", "Digi row", 50, 0., 200.);
-    meRowLayer3Ring6_ =
-        ibooker.book1D("row_layer3ring6", "Digi row", 50, 0., 200.);
-    meRowLayer3Ring7_ =
-        ibooker.book1D("row_layer3ring7", "Digi row", 50, 0., 200.);
-    meRowLayer3Ring8_ =
-        ibooker.book1D("row_layer3ring8", "Digi row", 50, 0., 200.);
+    meRowLayer3Ring1_ = ibooker.book1D("row_layer3ring1", "Digi row", 50, 0., 200.);
+    meRowLayer3Ring2_ = ibooker.book1D("row_layer3ring2", "Digi row", 50, 0., 200.);
+    meRowLayer3Ring3_ = ibooker.book1D("row_layer3ring3", "Digi row", 50, 0., 200.);
+    meRowLayer3Ring4_ = ibooker.book1D("row_layer3ring4", "Digi row", 50, 0., 200.);
+    meRowLayer3Ring5_ = ibooker.book1D("row_layer3ring5", "Digi row", 50, 0., 200.);
+    meRowLayer3Ring6_ = ibooker.book1D("row_layer3ring6", "Digi row", 50, 0., 200.);
+    meRowLayer3Ring7_ = ibooker.book1D("row_layer3ring7", "Digi row", 50, 0., 200.);
+    meRowLayer3Ring8_ = ibooker.book1D("row_layer3ring8", "Digi row", 50, 0., 200.);
 
-    meColLayer3Ring1_ =
-        ibooker.book1D("col_layer3ring1", "Digi column", 50, 0., 500.);
-    meColLayer3Ring2_ =
-        ibooker.book1D("col_layer3ring2", "Digi column", 50, 0., 500.);
-    meColLayer3Ring3_ =
-        ibooker.book1D("col_layer3ring3", "Digi column", 50, 0., 500.);
-    meColLayer3Ring4_ =
-        ibooker.book1D("col_layer3ring4", "Digi column", 50, 0., 500.);
-    meColLayer3Ring5_ =
-        ibooker.book1D("col_layer3ring5", "Digi column", 50, 0., 500.);
-    meColLayer3Ring6_ =
-        ibooker.book1D("col_layer3ring6", "Digi column", 50, 0., 500.);
-    meColLayer3Ring7_ =
-        ibooker.book1D("col_layer3ring7", "Digi column", 50, 0., 500.);
-    meColLayer3Ring8_ =
-        ibooker.book1D("col_layer3ring8", "Digi column", 50, 0., 500.);
+    meColLayer3Ring1_ = ibooker.book1D("col_layer3ring1", "Digi column", 50, 0., 500.);
+    meColLayer3Ring2_ = ibooker.book1D("col_layer3ring2", "Digi column", 50, 0., 500.);
+    meColLayer3Ring3_ = ibooker.book1D("col_layer3ring3", "Digi column", 50, 0., 500.);
+    meColLayer3Ring4_ = ibooker.book1D("col_layer3ring4", "Digi column", 50, 0., 500.);
+    meColLayer3Ring5_ = ibooker.book1D("col_layer3ring5", "Digi column", 50, 0., 500.);
+    meColLayer3Ring6_ = ibooker.book1D("col_layer3ring6", "Digi column", 50, 0., 500.);
+    meColLayer3Ring7_ = ibooker.book1D("col_layer3ring7", "Digi column", 50, 0., 500.);
+    meColLayer3Ring8_ = ibooker.book1D("col_layer3ring8", "Digi column", 50, 0., 500.);
 
     meDigiMultiLayer1Ladders_ =
-        ibooker.bookProfile("digi_layer1_ladders", "Digi Num. per ladder", 22,
-                            0.0, 21.0, 100, 0.0, 100);
+        ibooker.bookProfile("digi_layer1_ladders", "Digi Num. per ladder", 22, 0.0, 21.0, 100, 0.0, 100);
     meDigiMultiLayer2Ladders_ =
-        ibooker.bookProfile("digi_layer2_ladders", "Digi Num. per ladder", 34,
-                            0.0, 32.0, 100, 0.0, 100);
+        ibooker.bookProfile("digi_layer2_ladders", "Digi Num. per ladder", 34, 0.0, 32.0, 100, 0.0, 100);
     meDigiMultiLayer3Ladders_ =
-        ibooker.bookProfile("digi_layer3_ladders", "Digi Num. per ladder", 46,
-                            0.0, 45.0, 100, 0.0, 100);
+        ibooker.bookProfile("digi_layer3_ladders", "Digi Num. per ladder", 46, 0.0, 45.0, 100, 0.0, 100);
 
     // Forward Pixel
     /* ZMinus Side 1st Disk */
-    meAdcZmDisk1Panel1Plaq1_ = ibooker.book1D("adc_zm_disk1_panel1_plaq1",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZmDisk1Panel1Plaq2_ = ibooker.book1D("adc_zm_disk1_panel1_plaq2",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZmDisk1Panel1Plaq3_ = ibooker.book1D("adc_zm_disk1_panel1_plaq3",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZmDisk1Panel1Plaq4_ = ibooker.book1D("adc_zm_disk1_panel1_plaq4",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZmDisk1Panel2Plaq1_ = ibooker.book1D("adc_zm_disk1_panel2_plaq1",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZmDisk1Panel2Plaq2_ = ibooker.book1D("adc_zm_disk1_panel2_plaq2",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZmDisk1Panel2Plaq3_ = ibooker.book1D("adc_zm_disk1_panel2_plaq3",
-                                              "Digi charge", 50, 0., 300.);
+    meAdcZmDisk1Panel1Plaq1_ = ibooker.book1D("adc_zm_disk1_panel1_plaq1", "Digi charge", 50, 0., 300.);
+    meAdcZmDisk1Panel1Plaq2_ = ibooker.book1D("adc_zm_disk1_panel1_plaq2", "Digi charge", 50, 0., 300.);
+    meAdcZmDisk1Panel1Plaq3_ = ibooker.book1D("adc_zm_disk1_panel1_plaq3", "Digi charge", 50, 0., 300.);
+    meAdcZmDisk1Panel1Plaq4_ = ibooker.book1D("adc_zm_disk1_panel1_plaq4", "Digi charge", 50, 0., 300.);
+    meAdcZmDisk1Panel2Plaq1_ = ibooker.book1D("adc_zm_disk1_panel2_plaq1", "Digi charge", 50, 0., 300.);
+    meAdcZmDisk1Panel2Plaq2_ = ibooker.book1D("adc_zm_disk1_panel2_plaq2", "Digi charge", 50, 0., 300.);
+    meAdcZmDisk1Panel2Plaq3_ = ibooker.book1D("adc_zm_disk1_panel2_plaq3", "Digi charge", 50, 0., 300.);
 
-    meRowZmDisk1Panel1Plaq1_ =
-        ibooker.book1D("row_zm_disk1_panel1_plaq1", "Digi row", 50, 0., 100.);
-    meRowZmDisk1Panel1Plaq2_ =
-        ibooker.book1D("row_zm_disk1_panel1_plaq2", "Digi row", 50, 0., 200.);
-    meRowZmDisk1Panel1Plaq3_ =
-        ibooker.book1D("row_zm_disk1_panel1_plaq3", "Digi row", 50, 0., 200.);
-    meRowZmDisk1Panel1Plaq4_ =
-        ibooker.book1D("row_zm_disk1_panel1_plaq4", "Digi row", 50, 0., 100.);
-    meRowZmDisk1Panel2Plaq1_ =
-        ibooker.book1D("row_zm_disk1_panel2_plaq1", "Digi row", 50, 0., 200.);
-    meRowZmDisk1Panel2Plaq2_ =
-        ibooker.book1D("row_zm_disk1_panel2_plaq2", "Digi row", 50, 0., 200.);
-    meRowZmDisk1Panel2Plaq3_ =
-        ibooker.book1D("row_zm_disk1_panel2_plaq3", "Digi row", 50, 0., 200.);
+    meRowZmDisk1Panel1Plaq1_ = ibooker.book1D("row_zm_disk1_panel1_plaq1", "Digi row", 50, 0., 100.);
+    meRowZmDisk1Panel1Plaq2_ = ibooker.book1D("row_zm_disk1_panel1_plaq2", "Digi row", 50, 0., 200.);
+    meRowZmDisk1Panel1Plaq3_ = ibooker.book1D("row_zm_disk1_panel1_plaq3", "Digi row", 50, 0., 200.);
+    meRowZmDisk1Panel1Plaq4_ = ibooker.book1D("row_zm_disk1_panel1_plaq4", "Digi row", 50, 0., 100.);
+    meRowZmDisk1Panel2Plaq1_ = ibooker.book1D("row_zm_disk1_panel2_plaq1", "Digi row", 50, 0., 200.);
+    meRowZmDisk1Panel2Plaq2_ = ibooker.book1D("row_zm_disk1_panel2_plaq2", "Digi row", 50, 0., 200.);
+    meRowZmDisk1Panel2Plaq3_ = ibooker.book1D("row_zm_disk1_panel2_plaq3", "Digi row", 50, 0., 200.);
 
-    meColZmDisk1Panel1Plaq1_ = ibooker.book1D("col_zm_disk1_panel1_plaq1",
-                                              "Digi column", 50, 0., 150.);
-    meColZmDisk1Panel1Plaq2_ = ibooker.book1D("col_zm_disk1_panel1_plaq2",
-                                              "Digi column", 50, 0., 200.);
-    meColZmDisk1Panel1Plaq3_ = ibooker.book1D("col_zm_disk1_panel1_plaq3",
-                                              "Digi column", 50, 0., 250.);
-    meColZmDisk1Panel1Plaq4_ = ibooker.book1D("col_zm_disk1_panel1_plaq4",
-                                              "Digi column", 50, 0., 300.);
-    meColZmDisk1Panel2Plaq1_ = ibooker.book1D("col_zm_disk1_panel2_plaq1",
-                                              "Digi column", 50, 0., 200.);
-    meColZmDisk1Panel2Plaq2_ = ibooker.book1D("col_zm_disk1_panel2_plaq2",
-                                              "Digi column", 50, 0., 250.);
-    meColZmDisk1Panel2Plaq3_ = ibooker.book1D("col_zm_disk1_panel2_plaq3",
-                                              "Digi column", 50, 0., 300.);
-    meNdigiZmDisk1PerPanel1_ = ibooker.book1D(
-        "digi_zm_disk1_panel1", "Digi Num. Panel1 Of 1st Disk In ZMinus Side ",
-        30, 0., 30.);
-    meNdigiZmDisk1PerPanel2_ = ibooker.book1D(
-        "digi_zm_disk1_panel2", "Digi Num. Panel2 Of 1st Disk In ZMinus Side ",
-        30, 0., 30.);
+    meColZmDisk1Panel1Plaq1_ = ibooker.book1D("col_zm_disk1_panel1_plaq1", "Digi column", 50, 0., 150.);
+    meColZmDisk1Panel1Plaq2_ = ibooker.book1D("col_zm_disk1_panel1_plaq2", "Digi column", 50, 0., 200.);
+    meColZmDisk1Panel1Plaq3_ = ibooker.book1D("col_zm_disk1_panel1_plaq3", "Digi column", 50, 0., 250.);
+    meColZmDisk1Panel1Plaq4_ = ibooker.book1D("col_zm_disk1_panel1_plaq4", "Digi column", 50, 0., 300.);
+    meColZmDisk1Panel2Plaq1_ = ibooker.book1D("col_zm_disk1_panel2_plaq1", "Digi column", 50, 0., 200.);
+    meColZmDisk1Panel2Plaq2_ = ibooker.book1D("col_zm_disk1_panel2_plaq2", "Digi column", 50, 0., 250.);
+    meColZmDisk1Panel2Plaq3_ = ibooker.book1D("col_zm_disk1_panel2_plaq3", "Digi column", 50, 0., 300.);
+    meNdigiZmDisk1PerPanel1_ =
+        ibooker.book1D("digi_zm_disk1_panel1", "Digi Num. Panel1 Of 1st Disk In ZMinus Side ", 30, 0., 30.);
+    meNdigiZmDisk1PerPanel2_ =
+        ibooker.book1D("digi_zm_disk1_panel2", "Digi Num. Panel2 Of 1st Disk In ZMinus Side ", 30, 0., 30.);
 
     /* ZMius Side 2nd disk */
-    meAdcZmDisk2Panel1Plaq1_ = ibooker.book1D("adc_zm_disk2_panel1_plaq1",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZmDisk2Panel1Plaq2_ = ibooker.book1D("adc_zm_disk2_panel1_plaq2",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZmDisk2Panel1Plaq3_ = ibooker.book1D("adc_zm_disk2_panel1_plaq3",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZmDisk2Panel1Plaq4_ = ibooker.book1D("adc_zm_disk2_panel1_plaq4",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZmDisk2Panel2Plaq1_ = ibooker.book1D("adc_zm_disk2_panel2_plaq1",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZmDisk2Panel2Plaq2_ = ibooker.book1D("adc_zm_disk2_panel2_plaq2",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZmDisk2Panel2Plaq3_ = ibooker.book1D("adc_zm_disk2_panel2_plaq3",
-                                              "Digi charge", 50, 0., 300.);
+    meAdcZmDisk2Panel1Plaq1_ = ibooker.book1D("adc_zm_disk2_panel1_plaq1", "Digi charge", 50, 0., 300.);
+    meAdcZmDisk2Panel1Plaq2_ = ibooker.book1D("adc_zm_disk2_panel1_plaq2", "Digi charge", 50, 0., 300.);
+    meAdcZmDisk2Panel1Plaq3_ = ibooker.book1D("adc_zm_disk2_panel1_plaq3", "Digi charge", 50, 0., 300.);
+    meAdcZmDisk2Panel1Plaq4_ = ibooker.book1D("adc_zm_disk2_panel1_plaq4", "Digi charge", 50, 0., 300.);
+    meAdcZmDisk2Panel2Plaq1_ = ibooker.book1D("adc_zm_disk2_panel2_plaq1", "Digi charge", 50, 0., 300.);
+    meAdcZmDisk2Panel2Plaq2_ = ibooker.book1D("adc_zm_disk2_panel2_plaq2", "Digi charge", 50, 0., 300.);
+    meAdcZmDisk2Panel2Plaq3_ = ibooker.book1D("adc_zm_disk2_panel2_plaq3", "Digi charge", 50, 0., 300.);
 
-    meRowZmDisk2Panel1Plaq1_ =
-        ibooker.book1D("row_zm_disk2_panel1_plaq1", "Digi row", 50, 0., 100.);
-    meRowZmDisk2Panel1Plaq2_ =
-        ibooker.book1D("row_zm_disk2_panel1_plaq2", "Digi row", 50, 0., 200.);
-    meRowZmDisk2Panel1Plaq3_ =
-        ibooker.book1D("row_zm_disk2_panel1_plaq3", "Digi row", 50, 0., 200.);
-    meRowZmDisk2Panel1Plaq4_ =
-        ibooker.book1D("row_zm_disk2_panel1_plaq4", "Digi row", 50, 0., 100.);
-    meRowZmDisk2Panel2Plaq1_ =
-        ibooker.book1D("row_zm_disk2_panel2_plaq1", "Digi row", 50, 0., 200.);
-    meRowZmDisk2Panel2Plaq2_ =
-        ibooker.book1D("row_zm_disk2_panel2_plaq2", "Digi row", 50, 0., 200.);
-    meRowZmDisk2Panel2Plaq3_ =
-        ibooker.book1D("row_zm_disk2_panel2_plaq3", "Digi row", 50, 0., 200.);
+    meRowZmDisk2Panel1Plaq1_ = ibooker.book1D("row_zm_disk2_panel1_plaq1", "Digi row", 50, 0., 100.);
+    meRowZmDisk2Panel1Plaq2_ = ibooker.book1D("row_zm_disk2_panel1_plaq2", "Digi row", 50, 0., 200.);
+    meRowZmDisk2Panel1Plaq3_ = ibooker.book1D("row_zm_disk2_panel1_plaq3", "Digi row", 50, 0., 200.);
+    meRowZmDisk2Panel1Plaq4_ = ibooker.book1D("row_zm_disk2_panel1_plaq4", "Digi row", 50, 0., 100.);
+    meRowZmDisk2Panel2Plaq1_ = ibooker.book1D("row_zm_disk2_panel2_plaq1", "Digi row", 50, 0., 200.);
+    meRowZmDisk2Panel2Plaq2_ = ibooker.book1D("row_zm_disk2_panel2_plaq2", "Digi row", 50, 0., 200.);
+    meRowZmDisk2Panel2Plaq3_ = ibooker.book1D("row_zm_disk2_panel2_plaq3", "Digi row", 50, 0., 200.);
 
-    meColZmDisk2Panel1Plaq1_ = ibooker.book1D("col_zm_disk2_panel1_plaq1",
-                                              "Digi Column", 50, 0., 150.);
-    meColZmDisk2Panel1Plaq2_ = ibooker.book1D("col_zm_disk2_panel1_plaq2",
-                                              "Digi Column", 50, 0., 200.);
-    meColZmDisk2Panel1Plaq3_ = ibooker.book1D("col_zm_disk2_panel1_plaq3",
-                                              "Digi Column", 50, 0., 250.);
-    meColZmDisk2Panel1Plaq4_ = ibooker.book1D("col_zm_disk2_panel1_plaq4",
-                                              "Digi Column", 50, 0., 300.);
-    meColZmDisk2Panel2Plaq1_ = ibooker.book1D("col_zm_disk2_panel2_plaq1",
-                                              "Digi Column", 50, 0., 200.);
-    meColZmDisk2Panel2Plaq2_ = ibooker.book1D("col_zm_disk2_panel2_plaq2",
-                                              "Digi Column", 50, 0., 250.);
-    meColZmDisk2Panel2Plaq3_ = ibooker.book1D("col_zm_disk2_panel2_plaq3",
-                                              "Digi Column", 50, 0., 300.);
-    meNdigiZmDisk2PerPanel1_ = ibooker.book1D(
-        "digi_zm_disk2_panel1", "Digi Num. Panel1 Of 2nd Disk In ZMinus Side ",
-        30, 0., 30.);
-    meNdigiZmDisk2PerPanel2_ = ibooker.book1D(
-        "digi_zm_disk2_panel2", "Digi Num. Panel2 Of 2nd Disk In ZMinus Side ",
-        30, 0., 30.);
+    meColZmDisk2Panel1Plaq1_ = ibooker.book1D("col_zm_disk2_panel1_plaq1", "Digi Column", 50, 0., 150.);
+    meColZmDisk2Panel1Plaq2_ = ibooker.book1D("col_zm_disk2_panel1_plaq2", "Digi Column", 50, 0., 200.);
+    meColZmDisk2Panel1Plaq3_ = ibooker.book1D("col_zm_disk2_panel1_plaq3", "Digi Column", 50, 0., 250.);
+    meColZmDisk2Panel1Plaq4_ = ibooker.book1D("col_zm_disk2_panel1_plaq4", "Digi Column", 50, 0., 300.);
+    meColZmDisk2Panel2Plaq1_ = ibooker.book1D("col_zm_disk2_panel2_plaq1", "Digi Column", 50, 0., 200.);
+    meColZmDisk2Panel2Plaq2_ = ibooker.book1D("col_zm_disk2_panel2_plaq2", "Digi Column", 50, 0., 250.);
+    meColZmDisk2Panel2Plaq3_ = ibooker.book1D("col_zm_disk2_panel2_plaq3", "Digi Column", 50, 0., 300.);
+    meNdigiZmDisk2PerPanel1_ =
+        ibooker.book1D("digi_zm_disk2_panel1", "Digi Num. Panel1 Of 2nd Disk In ZMinus Side ", 30, 0., 30.);
+    meNdigiZmDisk2PerPanel2_ =
+        ibooker.book1D("digi_zm_disk2_panel2", "Digi Num. Panel2 Of 2nd Disk In ZMinus Side ", 30, 0., 30.);
 
     /* ZPlus Side 1st Disk */
-    meAdcZpDisk1Panel1Plaq1_ = ibooker.book1D("adc_zp_disk1_panel1_plaq1",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZpDisk1Panel1Plaq2_ = ibooker.book1D("adc_zp_disk1_panel1_plaq2",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZpDisk1Panel1Plaq3_ = ibooker.book1D("adc_zp_disk1_panel1_plaq3",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZpDisk1Panel1Plaq4_ = ibooker.book1D("adc_zp_disk1_panel1_plaq4",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZpDisk1Panel2Plaq1_ = ibooker.book1D("adc_zp_disk1_panel2_plaq1",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZpDisk1Panel2Plaq2_ = ibooker.book1D("adc_zp_disk1_panel2_plaq2",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZpDisk1Panel2Plaq3_ = ibooker.book1D("adc_zp_disk1_panel2_plaq3",
-                                              "Digi charge", 50, 0., 300.);
+    meAdcZpDisk1Panel1Plaq1_ = ibooker.book1D("adc_zp_disk1_panel1_plaq1", "Digi charge", 50, 0., 300.);
+    meAdcZpDisk1Panel1Plaq2_ = ibooker.book1D("adc_zp_disk1_panel1_plaq2", "Digi charge", 50, 0., 300.);
+    meAdcZpDisk1Panel1Plaq3_ = ibooker.book1D("adc_zp_disk1_panel1_plaq3", "Digi charge", 50, 0., 300.);
+    meAdcZpDisk1Panel1Plaq4_ = ibooker.book1D("adc_zp_disk1_panel1_plaq4", "Digi charge", 50, 0., 300.);
+    meAdcZpDisk1Panel2Plaq1_ = ibooker.book1D("adc_zp_disk1_panel2_plaq1", "Digi charge", 50, 0., 300.);
+    meAdcZpDisk1Panel2Plaq2_ = ibooker.book1D("adc_zp_disk1_panel2_plaq2", "Digi charge", 50, 0., 300.);
+    meAdcZpDisk1Panel2Plaq3_ = ibooker.book1D("adc_zp_disk1_panel2_plaq3", "Digi charge", 50, 0., 300.);
 
-    meRowZpDisk1Panel1Plaq1_ =
-        ibooker.book1D("row_zp_disk1_panel1_plaq1", "Digi row", 50, 0., 100.);
-    meRowZpDisk1Panel1Plaq2_ =
-        ibooker.book1D("row_zp_disk1_panel1_plaq2", "Digi row", 50, 0., 200.);
-    meRowZpDisk1Panel1Plaq3_ =
-        ibooker.book1D("row_zp_disk1_panel1_plaq3", "Digi row", 50, 0., 200.);
-    meRowZpDisk1Panel1Plaq4_ =
-        ibooker.book1D("row_zp_disk1_panel1_plaq4", "Digi row", 50, 0., 100.);
-    meRowZpDisk1Panel2Plaq1_ =
-        ibooker.book1D("row_zp_disk1_panel2_plaq1", "Digi row", 50, 0., 200.);
-    meRowZpDisk1Panel2Plaq2_ =
-        ibooker.book1D("row_zp_disk1_panel2_plaq2", "Digi row", 50, 0., 200.);
-    meRowZpDisk1Panel2Plaq3_ =
-        ibooker.book1D("row_zp_disk1_panel2_plaq3", "Digi row", 50, 0., 200.);
+    meRowZpDisk1Panel1Plaq1_ = ibooker.book1D("row_zp_disk1_panel1_plaq1", "Digi row", 50, 0., 100.);
+    meRowZpDisk1Panel1Plaq2_ = ibooker.book1D("row_zp_disk1_panel1_plaq2", "Digi row", 50, 0., 200.);
+    meRowZpDisk1Panel1Plaq3_ = ibooker.book1D("row_zp_disk1_panel1_plaq3", "Digi row", 50, 0., 200.);
+    meRowZpDisk1Panel1Plaq4_ = ibooker.book1D("row_zp_disk1_panel1_plaq4", "Digi row", 50, 0., 100.);
+    meRowZpDisk1Panel2Plaq1_ = ibooker.book1D("row_zp_disk1_panel2_plaq1", "Digi row", 50, 0., 200.);
+    meRowZpDisk1Panel2Plaq2_ = ibooker.book1D("row_zp_disk1_panel2_plaq2", "Digi row", 50, 0., 200.);
+    meRowZpDisk1Panel2Plaq3_ = ibooker.book1D("row_zp_disk1_panel2_plaq3", "Digi row", 50, 0., 200.);
 
-    meColZpDisk1Panel1Plaq1_ = ibooker.book1D("col_zp_disk1_panel1_plaq1",
-                                              "Digi Column", 50, 0., 150.);
-    meColZpDisk1Panel1Plaq2_ = ibooker.book1D("col_zp_disk1_panel1_plaq2",
-                                              "Digi column", 50, 0., 200.);
-    meColZpDisk1Panel1Plaq3_ = ibooker.book1D("col_zp_disk1_panel1_plaq3",
-                                              "Digi column", 50, 0., 250.);
-    meColZpDisk1Panel1Plaq4_ = ibooker.book1D("col_zp_disk1_panel1_plaq4",
-                                              "Digi column", 50, 0., 300.);
-    meColZpDisk1Panel2Plaq1_ = ibooker.book1D("col_zp_disk1_panel2_plaq1",
-                                              "Digi column", 50, 0., 200.);
-    meColZpDisk1Panel2Plaq2_ = ibooker.book1D("col_zp_disk1_panel2_plaq2",
-                                              "Digi column", 50, 0., 250.);
-    meColZpDisk1Panel2Plaq3_ = ibooker.book1D("col_zp_disk1_panel2_plaq3",
-                                              "Digi column", 50, 0., 300.);
-    meNdigiZpDisk1PerPanel1_ = ibooker.book1D(
-        "digi_zp_disk1_panel1", "Digi Num. Panel1 Of 1st Disk In ZPlus Side ",
-        30, 0., 30.);
-    meNdigiZpDisk1PerPanel2_ = ibooker.book1D(
-        "digi_zp_disk1_panel2", "Digi Num. Panel2 Of 1st Disk In ZPlus Side ",
-        30, 0., 30.);
+    meColZpDisk1Panel1Plaq1_ = ibooker.book1D("col_zp_disk1_panel1_plaq1", "Digi Column", 50, 0., 150.);
+    meColZpDisk1Panel1Plaq2_ = ibooker.book1D("col_zp_disk1_panel1_plaq2", "Digi column", 50, 0., 200.);
+    meColZpDisk1Panel1Plaq3_ = ibooker.book1D("col_zp_disk1_panel1_plaq3", "Digi column", 50, 0., 250.);
+    meColZpDisk1Panel1Plaq4_ = ibooker.book1D("col_zp_disk1_panel1_plaq4", "Digi column", 50, 0., 300.);
+    meColZpDisk1Panel2Plaq1_ = ibooker.book1D("col_zp_disk1_panel2_plaq1", "Digi column", 50, 0., 200.);
+    meColZpDisk1Panel2Plaq2_ = ibooker.book1D("col_zp_disk1_panel2_plaq2", "Digi column", 50, 0., 250.);
+    meColZpDisk1Panel2Plaq3_ = ibooker.book1D("col_zp_disk1_panel2_plaq3", "Digi column", 50, 0., 300.);
+    meNdigiZpDisk1PerPanel1_ =
+        ibooker.book1D("digi_zp_disk1_panel1", "Digi Num. Panel1 Of 1st Disk In ZPlus Side ", 30, 0., 30.);
+    meNdigiZpDisk1PerPanel2_ =
+        ibooker.book1D("digi_zp_disk1_panel2", "Digi Num. Panel2 Of 1st Disk In ZPlus Side ", 30, 0., 30.);
 
     /* ZPlus Side 2nd disk */
-    meAdcZpDisk2Panel1Plaq1_ = ibooker.book1D("adc_zp_disk2_panel1_plaq1",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZpDisk2Panel1Plaq2_ = ibooker.book1D("adc_zp_disk2_panel1_plaq2",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZpDisk2Panel1Plaq3_ = ibooker.book1D("adc_zp_disk2_panel1_plaq3",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZpDisk2Panel1Plaq4_ = ibooker.book1D("adc_zp_disk2_panel1_plaq4",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZpDisk2Panel2Plaq1_ = ibooker.book1D("adc_zp_disk2_panel2_plaq1",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZpDisk2Panel2Plaq2_ = ibooker.book1D("adc_zp_disk2_panel2_plaq2",
-                                              "Digi charge", 50, 0., 300.);
-    meAdcZpDisk2Panel2Plaq3_ = ibooker.book1D("adc_zp_disk2_panel2_plaq3",
-                                              "Digi charge", 50, 0., 300.);
+    meAdcZpDisk2Panel1Plaq1_ = ibooker.book1D("adc_zp_disk2_panel1_plaq1", "Digi charge", 50, 0., 300.);
+    meAdcZpDisk2Panel1Plaq2_ = ibooker.book1D("adc_zp_disk2_panel1_plaq2", "Digi charge", 50, 0., 300.);
+    meAdcZpDisk2Panel1Plaq3_ = ibooker.book1D("adc_zp_disk2_panel1_plaq3", "Digi charge", 50, 0., 300.);
+    meAdcZpDisk2Panel1Plaq4_ = ibooker.book1D("adc_zp_disk2_panel1_plaq4", "Digi charge", 50, 0., 300.);
+    meAdcZpDisk2Panel2Plaq1_ = ibooker.book1D("adc_zp_disk2_panel2_plaq1", "Digi charge", 50, 0., 300.);
+    meAdcZpDisk2Panel2Plaq2_ = ibooker.book1D("adc_zp_disk2_panel2_plaq2", "Digi charge", 50, 0., 300.);
+    meAdcZpDisk2Panel2Plaq3_ = ibooker.book1D("adc_zp_disk2_panel2_plaq3", "Digi charge", 50, 0., 300.);
 
-    meRowZpDisk2Panel1Plaq1_ =
-        ibooker.book1D("row_zp_disk2_panel1_plaq1", "Digi row", 10, 0., 100.);
-    meRowZpDisk2Panel1Plaq2_ =
-        ibooker.book1D("row_zp_disk2_panel1_plaq2", "Digi row", 10, 0., 200.);
-    meRowZpDisk2Panel1Plaq3_ =
-        ibooker.book1D("row_zp_disk2_panel1_plaq3", "Digi row", 10, 0., 200.);
-    meRowZpDisk2Panel1Plaq4_ =
-        ibooker.book1D("row_zp_disk2_panel1_plaq4", "Digi row", 10, 0., 100.);
-    meRowZpDisk2Panel2Plaq1_ =
-        ibooker.book1D("row_zp_disk2_panel2_plaq1", "Digi row", 10, 0., 200.);
-    meRowZpDisk2Panel2Plaq2_ =
-        ibooker.book1D("row_zp_disk2_panel2_plaq2", "Digi row", 10, 0., 200.);
-    meRowZpDisk2Panel2Plaq3_ =
-        ibooker.book1D("row_zp_disk2_panel2_plaq3", "Digi row", 10, 0., 200.);
+    meRowZpDisk2Panel1Plaq1_ = ibooker.book1D("row_zp_disk2_panel1_plaq1", "Digi row", 10, 0., 100.);
+    meRowZpDisk2Panel1Plaq2_ = ibooker.book1D("row_zp_disk2_panel1_plaq2", "Digi row", 10, 0., 200.);
+    meRowZpDisk2Panel1Plaq3_ = ibooker.book1D("row_zp_disk2_panel1_plaq3", "Digi row", 10, 0., 200.);
+    meRowZpDisk2Panel1Plaq4_ = ibooker.book1D("row_zp_disk2_panel1_plaq4", "Digi row", 10, 0., 100.);
+    meRowZpDisk2Panel2Plaq1_ = ibooker.book1D("row_zp_disk2_panel2_plaq1", "Digi row", 10, 0., 200.);
+    meRowZpDisk2Panel2Plaq2_ = ibooker.book1D("row_zp_disk2_panel2_plaq2", "Digi row", 10, 0., 200.);
+    meRowZpDisk2Panel2Plaq3_ = ibooker.book1D("row_zp_disk2_panel2_plaq3", "Digi row", 10, 0., 200.);
 
-    meColZpDisk2Panel1Plaq1_ = ibooker.book1D("col_zp_disk2_panel1_plaq1",
-                                              "Digi column", 50, 0., 150.);
-    meColZpDisk2Panel1Plaq2_ = ibooker.book1D("col_zp_disk2_panel1_plaq2",
-                                              "Digi column", 50, 0., 200.);
-    meColZpDisk2Panel1Plaq3_ = ibooker.book1D("col_zp_disk2_panel1_plaq3",
-                                              "Digi column", 50, 0., 250.);
-    meColZpDisk2Panel1Plaq4_ = ibooker.book1D("col_zp_disk2_panel1_plaq4",
-                                              "Digi column", 50, 0., 300.);
-    meColZpDisk2Panel2Plaq1_ = ibooker.book1D("col_zp_disk2_panel2_plaq1",
-                                              "Digi column", 50, 0., 200.);
-    meColZpDisk2Panel2Plaq2_ = ibooker.book1D("col_zp_disk2_panel2_plaq2",
-                                              "Digi column", 50, 0., 250.);
-    meColZpDisk2Panel2Plaq3_ = ibooker.book1D("col_zp_disk2_panel2_plaq3",
-                                              "Digi column", 50, 0., 300.);
-    meNdigiZpDisk2PerPanel1_ = ibooker.book1D(
-        "digi_zp_disk2_panel1", "Digi Num. Panel1 Of 2nd Disk In ZPlus Side ",
-        30, 0., 30.);
-    meNdigiZpDisk2PerPanel2_ = ibooker.book1D(
-        "digi_zp_disk2_panel2", "Digi Num. Panel2 Of 2nd Disk In ZPlus Side ",
-        30, 0., 30.);
+    meColZpDisk2Panel1Plaq1_ = ibooker.book1D("col_zp_disk2_panel1_plaq1", "Digi column", 50, 0., 150.);
+    meColZpDisk2Panel1Plaq2_ = ibooker.book1D("col_zp_disk2_panel1_plaq2", "Digi column", 50, 0., 200.);
+    meColZpDisk2Panel1Plaq3_ = ibooker.book1D("col_zp_disk2_panel1_plaq3", "Digi column", 50, 0., 250.);
+    meColZpDisk2Panel1Plaq4_ = ibooker.book1D("col_zp_disk2_panel1_plaq4", "Digi column", 50, 0., 300.);
+    meColZpDisk2Panel2Plaq1_ = ibooker.book1D("col_zp_disk2_panel2_plaq1", "Digi column", 50, 0., 200.);
+    meColZpDisk2Panel2Plaq2_ = ibooker.book1D("col_zp_disk2_panel2_plaq2", "Digi column", 50, 0., 250.);
+    meColZpDisk2Panel2Plaq3_ = ibooker.book1D("col_zp_disk2_panel2_plaq3", "Digi column", 50, 0., 300.);
+    meNdigiZpDisk2PerPanel1_ =
+        ibooker.book1D("digi_zp_disk2_panel1", "Digi Num. Panel1 Of 2nd Disk In ZPlus Side ", 30, 0., 30.);
+    meNdigiZpDisk2PerPanel2_ =
+        ibooker.book1D("digi_zp_disk2_panel2", "Digi Num. Panel2 Of 2nd Disk In ZPlus Side ", 30, 0., 30.);
   }
 }
 
@@ -550,10 +356,9 @@ void SiPixelDigiValid::analyze(const edm::Event &e, const edm::EventSetup &c) {
     edm::DetSet<PixelDigi>::const_iterator iter;
 
     if (detId.subdetId() == PixelSubdetector::PixelBarrel) {
-
-      unsigned int layer = tTopo->pxbLayer(id);   // Layer:1,2,3.
-      unsigned int ladder = tTopo->pxbLadder(id); // Ladeer: 1-20, 32, 44.
-      unsigned int zindex = tTopo->pxbModule(id); // Z-index: 1-8.
+      unsigned int layer = tTopo->pxbLayer(id);    // Layer:1,2,3.
+      unsigned int ladder = tTopo->pxbLadder(id);  // Ladeer: 1-20, 32, 44.
+      unsigned int zindex = tTopo->pxbModule(id);  // Z-index: 1-8.
       // LogInfo("SiPixelDigiValid")<<"Barrel:: Layer="<<layer<<"
       // Ladder="<<ladder<<" zindex="<<zindex;
       for (iter = begin; iter != end; iter++) {
@@ -707,7 +512,7 @@ void SiPixelDigiValid::analyze(const edm::Event &e, const edm::EventSetup &c) {
       }
     }
 
-    if (detId.subdetId() == PixelSubdetector::PixelEndcap) { // Endcap
+    if (detId.subdetId() == PixelSubdetector::PixelEndcap) {  // Endcap
 
       unsigned int side = tTopo->pxfSide(id);
       unsigned int disk = tTopo->pxfDisk(id);
@@ -884,11 +689,11 @@ void SiPixelDigiValid::analyze(const edm::Event &e, const edm::EventSetup &c) {
           }
           ++ndigiZpDisk2PerPanel2[blade - 1];
         }
-      } // iterating the digi
+      }  // iterating the digi
 
-    } // Endcap
+    }  // Endcap
 
-  } // end for loop
+  }  // end for loop
 
   meDigiMultiLayer1Ring1_->Fill(ndigiperRingLayer1[0]);
   meDigiMultiLayer1Ring2_->Fill(ndigiperRingLayer1[1]);

--- a/Validation/TrackerDigis/plugins/SiStripDigiValid.cc
+++ b/Validation/TrackerDigis/plugins/SiStripDigiValid.cc
@@ -22,18 +22,15 @@
 #include "Validation/TrackerDigis/interface/SiStripDigiValid.h"
 
 SiStripDigiValid::SiStripDigiValid(const edm::ParameterSet &ps)
-    : dbe_(nullptr), runStandalone(ps.getParameter<bool>("runStandalone")),
-      outputFile_(ps.getUntrackedParameter<std::string>("outputFile",
-                                                        "stripdigihisto.root")),
+    : dbe_(nullptr),
+      runStandalone(ps.getParameter<bool>("runStandalone")),
+      outputFile_(ps.getUntrackedParameter<std::string>("outputFile", "stripdigihisto.root")),
       edmDetSetVector_SiStripDigi_Token_(
-          consumes<edm::DetSetVector<SiStripDigi>>(
-              ps.getParameter<edm::InputTag>("src"))) {}
+          consumes<edm::DetSetVector<SiStripDigi>>(ps.getParameter<edm::InputTag>("src"))) {}
 
 SiStripDigiValid::~SiStripDigiValid() {}
 
-void SiStripDigiValid::bookHistograms(DQMStore::IBooker &ibooker,
-                                      const edm::Run &run,
-                                      const edm::EventSetup &es) {
+void SiStripDigiValid::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &run, const edm::EventSetup &es) {
   dbe_ = edm::Service<DQMStore>().operator->();
 
   if (dbe_) {
@@ -43,102 +40,70 @@ void SiStripDigiValid::bookHistograms(DQMStore::IBooker &ibooker,
       Char_t histo[200];
       // Z Plus Side
       sprintf(histo, "adc_tib_layer1_extmodule%d_zp", i + 1);
-      meAdcTIBLayer1Extzp_[i] =
-          ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
+      meAdcTIBLayer1Extzp_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "adc_tib_layer1_intmodule%d_zp", i + 1);
-      meAdcTIBLayer1Intzp_[i] =
-          ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
+      meAdcTIBLayer1Intzp_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "adc_tib_layer2_extmodule%d_zp", i + 1);
-      meAdcTIBLayer2Extzp_[i] =
-          ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
+      meAdcTIBLayer2Extzp_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "adc_tib_layer2_intmodule%d_zp", i + 1);
-      meAdcTIBLayer2Intzp_[i] =
-          ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
+      meAdcTIBLayer2Intzp_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "adc_tib_layer3_extmodule%d_zp", i + 1);
-      meAdcTIBLayer3Extzp_[i] =
-          ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
+      meAdcTIBLayer3Extzp_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "adc_tib_layer3_intmodule%d_zp", i + 1);
-      meAdcTIBLayer3Intzp_[i] =
-          ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
+      meAdcTIBLayer3Intzp_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "adc_tib_layer4_extmodule%d_zp", i + 1);
-      meAdcTIBLayer4Extzp_[i] =
-          ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
+      meAdcTIBLayer4Extzp_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "adc_tib_layer4_intmodule%d_zp", i + 1);
-      meAdcTIBLayer4Intzp_[i] =
-          ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
+      meAdcTIBLayer4Intzp_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "strip_tib_layer1_extmodule%d_zp", i + 1);
-      meStripTIBLayer1Extzp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIBLayer1Extzp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tib_layer1_intmodule%d_zp", i + 1);
-      meStripTIBLayer1Intzp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIBLayer1Intzp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tib_layer2_extmodule%d_zp", i + 1);
-      meStripTIBLayer2Extzp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIBLayer2Extzp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tib_layer2_intmodule%d_zp", i + 1);
-      meStripTIBLayer2Intzp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIBLayer2Intzp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tib_layer3_extmodule%d_zp", i + 1);
-      meStripTIBLayer3Extzp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIBLayer3Extzp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tib_layer3_intmodule%d_zp", i + 1);
-      meStripTIBLayer3Intzp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIBLayer3Intzp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tib_layer4_extmodule%d_zp", i + 1);
-      meStripTIBLayer4Extzp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIBLayer4Extzp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tib_layer4_intmodule%d_zp", i + 1);
-      meStripTIBLayer4Intzp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIBLayer4Intzp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       //  Z Minus Side
       sprintf(histo, "adc_tib_layer1_extmodule%d_zm", i + 1);
-      meAdcTIBLayer1Extzm_[i] =
-          ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
+      meAdcTIBLayer1Extzm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "adc_tib_layer1_intmodule%d_zm", i + 1);
-      meAdcTIBLayer1Intzm_[i] =
-          ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
+      meAdcTIBLayer1Intzm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "adc_tib_layer2_extmodule%d_zm", i + 1);
-      meAdcTIBLayer2Extzm_[i] =
-          ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
+      meAdcTIBLayer2Extzm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "adc_tib_layer2_intmodule%d_zm", i + 1);
-      meAdcTIBLayer2Intzm_[i] =
-          ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
+      meAdcTIBLayer2Intzm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "adc_tib_layer3_extmodule%d_zm", i + 1);
-      meAdcTIBLayer3Extzm_[i] =
-          ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
+      meAdcTIBLayer3Extzm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "adc_tib_layer3_intmodule%d_zm", i + 1);
-      meAdcTIBLayer3Intzm_[i] =
-          ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
+      meAdcTIBLayer3Intzm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "adc_tib_layer4_extmodule%d_zm", i + 1);
-      meAdcTIBLayer4Extzm_[i] =
-          ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
+      meAdcTIBLayer4Extzm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "adc_tib_layer4_intmodule%d_zm", i + 1);
-      meAdcTIBLayer4Intzm_[i] =
-          ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
+      meAdcTIBLayer4Intzm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "strip_tib_layer1_extmodule%d_zm", i + 1);
-      meStripTIBLayer1Extzm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIBLayer1Extzm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tib_layer1_intmodule%d_zm", i + 1);
-      meStripTIBLayer1Intzm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIBLayer1Intzm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tib_layer2_extmodule%d_zm", i + 1);
-      meStripTIBLayer2Extzm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIBLayer2Extzm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tib_layer2_intmodule%d_zm", i + 1);
-      meStripTIBLayer2Intzm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIBLayer2Intzm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tib_layer3_extmodule%d_zm", i + 1);
-      meStripTIBLayer3Extzm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIBLayer3Extzm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tib_layer3_intmodule%d_zm", i + 1);
-      meStripTIBLayer3Intzm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIBLayer3Intzm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tib_layer4_extmodule%d_zm", i + 1);
-      meStripTIBLayer4Extzm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIBLayer4Extzm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tib_layer4_intmodule%d_zm", i + 1);
-      meStripTIBLayer4Intzm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIBLayer4Intzm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
     }
 
     for (int i = 0; i < 6; i++) {
@@ -147,64 +112,52 @@ void SiStripDigiValid::bookHistograms(DQMStore::IBooker &ibooker,
       sprintf(histo, "adc_tob_layer1_module%d_zp", i + 1);
       meAdcTOBLayer1zp_[i] = ibooker.book1D(histo, "Digis ADC", 10, 0., 300.);
       sprintf(histo, "strip_tob_layer1_module%d_zp", i + 1);
-      meStripTOBLayer1zp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTOBLayer1zp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "adc_tob_layer2_module%d_zp", i + 1);
       meAdcTOBLayer2zp_[i] = ibooker.book1D(histo, "Digis ADC", 10, 0., 300.);
       sprintf(histo, "strip_tob_layer2_module%d_zp", i + 1);
-      meStripTOBLayer2zp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTOBLayer2zp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "adc_tob_layer3_module%d_zp", i + 1);
       meAdcTOBLayer3zp_[i] = ibooker.book1D(histo, "Digis ADC", 10, 0., 300.);
       sprintf(histo, "strip_tob_layer3_module%d_zp", i + 1);
-      meStripTOBLayer3zp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTOBLayer3zp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "adc_tob_layer4_module%d_zp", i + 1);
       meAdcTOBLayer4zp_[i] = ibooker.book1D(histo, "Digis ADC", 10, 0., 300.);
       sprintf(histo, "strip_tob_layer4_module%d_zp", i + 1);
-      meStripTOBLayer4zp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTOBLayer4zp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "adc_tob_layer5_module%d_zp", i + 1);
       meAdcTOBLayer5zp_[i] = ibooker.book1D(histo, "Digis ADC", 10, 0., 300.);
       sprintf(histo, "strip_tob_layer5_module%d_zp", i + 1);
-      meStripTOBLayer5zp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTOBLayer5zp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "adc_tob_layer6_module%d_zp", i + 1);
       meAdcTOBLayer6zp_[i] = ibooker.book1D(histo, "Digis ADC", 10, 0., 300.);
       sprintf(histo, "strip_tob_layer6_module%d_zp", i + 1);
-      meStripTOBLayer6zp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTOBLayer6zp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       // Z Minus Side
       sprintf(histo, "adc_tob_layer1_module%d_zm", i + 1);
       meAdcTOBLayer1zm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "strip_tob_layer1_module%d_zm", i + 1);
-      meStripTOBLayer1zm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTOBLayer1zm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "adc_tob_layer2_module%d_zm", i + 1);
       meAdcTOBLayer2zm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "strip_tob_layer2_module%d_zm", i + 1);
-      meStripTOBLayer2zm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTOBLayer2zm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "adc_tob_layer3_module%d_zm", i + 1);
       meAdcTOBLayer3zm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "strip_tob_layer3_module%d_zm", i + 1);
-      meStripTOBLayer3zm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTOBLayer3zm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "adc_tob_layer4_module%d_zm", i + 1);
       meAdcTOBLayer4zm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "strip_tob_layer4_module%d_zm", i + 1);
-      meStripTOBLayer4zm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTOBLayer4zm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "adc_tob_layer5_module%d_zm", i + 1);
       meAdcTOBLayer5zm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "strip_tob_layer5_module%d_zm", i + 1);
-      meStripTOBLayer5zm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTOBLayer5zm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "adc_tob_layer6_module%d_zm", i + 1);
       meAdcTOBLayer6zm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "strip_tob_layer6_module%d_zm", i + 1);
-      meStripTOBLayer6zm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTOBLayer6zm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
     }
 
     for (int i = 0; i < 3; i++) {
@@ -217,14 +170,11 @@ void SiStripDigiValid::bookHistograms(DQMStore::IBooker &ibooker,
       sprintf(histo, "adc_tid_wheel3_ring%d_zp", i + 1);
       meAdcTIDWheel3zp_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "strip_tid_wheel1_ring%d_zp", i + 1);
-      meStripTIDWheel1zp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIDWheel1zp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tid_wheel2_ring%d_zp", i + 1);
-      meStripTIDWheel2zp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIDWheel2zp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tid_wheel3_ring%d_zp", i + 1);
-      meStripTIDWheel3zp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIDWheel3zp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       // Z minus Side
       sprintf(histo, "adc_tid_wheel1_ring%d_zm", i + 1);
       meAdcTIDWheel1zm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
@@ -233,14 +183,11 @@ void SiStripDigiValid::bookHistograms(DQMStore::IBooker &ibooker,
       sprintf(histo, "adc_tid_wheel3_ring%d_zm", i + 1);
       meAdcTIDWheel3zm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "strip_tid_wheel1_ring%d_zm", i + 1);
-      meStripTIDWheel1zm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIDWheel1zm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tid_wheel2_ring%d_zm", i + 1);
-      meStripTIDWheel2zm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIDWheel2zm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tid_wheel3_ring%d_zm", i + 1);
-      meStripTIDWheel3zm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTIDWheel3zm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
     }
 
     for (int i = 0; i < 7; i++) {
@@ -253,14 +200,11 @@ void SiStripDigiValid::bookHistograms(DQMStore::IBooker &ibooker,
       sprintf(histo, "adc_tec_wheel3_ring%d_zp", i + 1);
       meAdcTECWheel3zp_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "strip_tec_wheel1_ring%d_zp", i + 1);
-      meStripTECWheel1zp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTECWheel1zp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tec_wheel2_ring%d_zp", i + 1);
-      meStripTECWheel2zp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTECWheel2zp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tec_wheel3_ring%d_zp", i + 1);
-      meStripTECWheel3zp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTECWheel3zp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
 
       // Z Minus Side
       sprintf(histo, "adc_tec_wheel1_ring%d_zm", i + 1);
@@ -270,14 +214,11 @@ void SiStripDigiValid::bookHistograms(DQMStore::IBooker &ibooker,
       sprintf(histo, "adc_tec_wheel3_ring%d_zm", i + 1);
       meAdcTECWheel3zm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "strip_tec_wheel1_ring%d_zm", i + 1);
-      meStripTECWheel1zm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTECWheel1zm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tec_wheel2_ring%d_zm", i + 1);
-      meStripTECWheel2zm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTECWheel2zm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tec_wheel3_ring%d_zm", i + 1);
-      meStripTECWheel3zm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTECWheel3zm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
     }
 
     for (int i = 0; i < 6; i++) {
@@ -290,14 +231,11 @@ void SiStripDigiValid::bookHistograms(DQMStore::IBooker &ibooker,
       sprintf(histo, "adc_tec_wheel6_ring%d_zp", i + 1);
       meAdcTECWheel6zp_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "strip_tec_wheel4_ring%d_zp", i + 1);
-      meStripTECWheel4zp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTECWheel4zp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tec_wheel5_ring%d_zp", i + 1);
-      meStripTECWheel5zp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTECWheel5zp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tec_wheel6_ring%d_zp", i + 1);
-      meStripTECWheel6zp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTECWheel6zp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
 
       // Z Minus Side
       sprintf(histo, "adc_tec_wheel4_ring%d_zm", i + 1);
@@ -307,14 +245,11 @@ void SiStripDigiValid::bookHistograms(DQMStore::IBooker &ibooker,
       sprintf(histo, "adc_tec_wheel6_ring%d_zm", i + 1);
       meAdcTECWheel6zm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "strip_tec_wheel4_ring%d_zm", i + 1);
-      meStripTECWheel4zm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTECWheel4zm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tec_wheel5_ring%d_zm", i + 1);
-      meStripTECWheel5zm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTECWheel5zm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tec_wheel6_ring%d_zm", i + 1);
-      meStripTECWheel6zm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTECWheel6zm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
     }
 
     for (int i = 0; i < 5; i++) {
@@ -325,11 +260,9 @@ void SiStripDigiValid::bookHistograms(DQMStore::IBooker &ibooker,
       sprintf(histo, "adc_tec_wheel8_ring%d_zp", i + 1);
       meAdcTECWheel8zp_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "strip_tec_wheel7_ring%d_zp", i + 1);
-      meStripTECWheel7zp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTECWheel7zp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tec_wheel8_ring%d_zp", i + 1);
-      meStripTECWheel8zp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTECWheel8zp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
 
       // Z Minus Side
       sprintf(histo, "adc_tec_wheel7_ring%d_zm", i + 1);
@@ -337,11 +270,9 @@ void SiStripDigiValid::bookHistograms(DQMStore::IBooker &ibooker,
       sprintf(histo, "adc_tec_wheel8_ring%d_zm", i + 1);
       meAdcTECWheel8zm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "strip_tec_wheel7_ring%d_zm", i + 1);
-      meStripTECWheel7zm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTECWheel7zm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
       sprintf(histo, "strip_tec_wheel8_ring%d_zm", i + 1);
-      meStripTECWheel8zm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTECWheel8zm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
     }
 
     for (int i = 0; i < 4; i++) {
@@ -350,55 +281,45 @@ void SiStripDigiValid::bookHistograms(DQMStore::IBooker &ibooker,
       sprintf(histo, "adc_tec_wheel9_ring%d_zp", i + 1);
       meAdcTECWheel9zp_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "strip_tec_wheel9_ring%d_zp", i + 1);
-      meStripTECWheel9zp_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTECWheel9zp_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
 
       // Z Minus Side
       sprintf(histo, "adc_tec_wheel9_ring%d_zm", i + 1);
       meAdcTECWheel9zm_[i] = ibooker.book1D(histo, "Digis ADC", 50, 0., 300.);
       sprintf(histo, "strip_tec_wheel9_ring%d_zm", i + 1);
-      meStripTECWheel9zm_[i] =
-          ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
+      meStripTECWheel9zm_[i] = ibooker.book1D(histo, "Digis Strip Num.", 200, 0., 800.);
     }
 
     for (int i = 0; i < 4; i++) {
       Char_t histo[200];
       sprintf(histo, "ndigi_tib_layer_%d_zm", i + 1);
-      meNDigiTIBLayerzm_[i] =
-          ibooker.book1D(histo, "Digi Multiplicity", 100, 0., 500.);
+      meNDigiTIBLayerzm_[i] = ibooker.book1D(histo, "Digi Multiplicity", 100, 0., 500.);
       sprintf(histo, "ndigi_tib_layer_%d_zp", i + 1);
-      meNDigiTIBLayerzp_[i] =
-          ibooker.book1D(histo, "Digi Multiplicity", 100, 0., 500.);
+      meNDigiTIBLayerzp_[i] = ibooker.book1D(histo, "Digi Multiplicity", 100, 0., 500.);
     }
 
     for (int i = 0; i < 6; i++) {
       Char_t histo[200];
       sprintf(histo, "ndigi_tob_layer_%d_zm", i + 1);
-      meNDigiTOBLayerzm_[i] =
-          ibooker.book1D(histo, "Digi Multiplicity", 100, 0., 500.);
+      meNDigiTOBLayerzm_[i] = ibooker.book1D(histo, "Digi Multiplicity", 100, 0., 500.);
       sprintf(histo, "ndigi_tob_layer_%d_zp", i + 1);
-      meNDigiTOBLayerzp_[i] =
-          ibooker.book1D(histo, "Digi Multiplicity", 100, 0., 500.);
+      meNDigiTOBLayerzp_[i] = ibooker.book1D(histo, "Digi Multiplicity", 100, 0., 500.);
     }
 
     for (int i = 0; i < 3; i++) {
       Char_t histo[200];
       sprintf(histo, "ndigi_tid_wheel_%d_zm", i + 1);
-      meNDigiTIDWheelzm_[i] =
-          ibooker.book1D(histo, "Digi Multiplicity", 100, 0., 500.);
+      meNDigiTIDWheelzm_[i] = ibooker.book1D(histo, "Digi Multiplicity", 100, 0., 500.);
       sprintf(histo, "ndigi_tid_wheel_%d_zp", i + 1);
-      meNDigiTIDWheelzp_[i] =
-          ibooker.book1D(histo, "Digi Multiplicity", 100, 0., 500.);
+      meNDigiTIDWheelzp_[i] = ibooker.book1D(histo, "Digi Multiplicity", 100, 0., 500.);
     }
 
     for (int i = 0; i < 9; i++) {
       Char_t histo[200];
       sprintf(histo, "ndigi_tec_wheel_%d_zm", i + 1);
-      meNDigiTECWheelzm_[i] =
-          ibooker.book1D(histo, "Digi Multiplicity", 100, 0., 500.);
+      meNDigiTECWheelzm_[i] = ibooker.book1D(histo, "Digi Multiplicity", 100, 0., 500.);
       sprintf(histo, "ndigi_tec_wheel_%d_zp", i + 1);
-      meNDigiTECWheelzp_[i] =
-          ibooker.book1D(histo, "Digi Multiplicity", 100, 0., 500.);
+      meNDigiTECWheelzp_[i] = ibooker.book1D(histo, "Digi Multiplicity", 100, 0., 500.);
     }
   }
 }
@@ -464,8 +385,7 @@ void SiStripDigiValid::analyze(const edm::Event &e, const edm::EventSetup &c) {
     edm::DetSet<SiStripDigi>::const_iterator iter;
 
     if (detId.subdetId() == StripSubdetector::TIB) {
-
-      for (iter = begin; iter != end; iter++) { // loop digis
+      for (iter = begin; iter != end; iter++) {  // loop digis
         if (tTopo->tibStringInfo(id)[0] == 1) {
           ++ndigilayertibzm[tTopo->tibLayer(id) - 1];
           if (tTopo->tibLayer(id) == 1) {
@@ -706,8 +626,7 @@ void SiStripDigiValid::analyze(const edm::Event &e, const edm::EventSetup &c) {
       }
     }
     if (detId.subdetId() == StripSubdetector::TOB) {
-
-      for (iter = begin; iter != end; iter++) { // loop digis
+      for (iter = begin; iter != end; iter++) {  // loop digis
         if (tTopo->tobRodInfo(id)[0] == 1) {
           ++ndigilayertobzm[tTopo->tobLayer(id) - 1];
           if (tTopo->tobLayer(id) == 1) {
@@ -1030,7 +949,6 @@ void SiStripDigiValid::analyze(const edm::Event &e, const edm::EventSetup &c) {
     }
 
     if (detId.subdetId() == StripSubdetector::TID) {
-
       for (iter = begin; iter != end; iter++) {
         if (tTopo->tidSide(id) == 1) {
           ++ndigiwheeltidzm[tTopo->tidWheel(id) - 1];
@@ -1125,7 +1043,6 @@ void SiStripDigiValid::analyze(const edm::Event &e, const edm::EventSetup &c) {
       }
     }
     if (detId.subdetId() == StripSubdetector::TEC) {
-
       for (iter = begin; iter != end; iter++) {
         if (tTopo->tecSide(id) == 1) {
           ++ndigiwheelteczm[tTopo->tecWheel(id) - 1];

--- a/Validation/TrackerHits/interface/TrackerHitAnalyzer.h
+++ b/Validation/TrackerHits/interface/TrackerHitAnalyzer.h
@@ -22,7 +22,6 @@ class DQMStore;
 class MonitorElement;
 
 class TrackerHitAnalyzer : public DQMEDAnalyzer {
-
 public:
   /// Constructor
   TrackerHitAnalyzer(const edm::ParameterSet &ps);
@@ -31,8 +30,7 @@ public:
   ~TrackerHitAnalyzer() override;
 
 protected:
-  void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &run,
-                      const edm::EventSetup &es) override;
+  void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &run, const edm::EventSetup &es) override;
 
   /// Analyze
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
@@ -45,18 +43,12 @@ protected:
 private:
   bool verbose_;
 
-  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_pxlBrlLow_Token_,
-      edmPSimHitContainer_pxlBrlHigh_Token_;
-  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_pxlFwdLow_Token_,
-      edmPSimHitContainer_pxlFwdHigh_Token_;
-  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTIBLow_Token_,
-      edmPSimHitContainer_siTIBHigh_Token_;
-  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTOBLow_Token_,
-      edmPSimHitContainer_siTOBHigh_Token_;
-  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTIDLow_Token_,
-      edmPSimHitContainer_siTIDHigh_Token_;
-  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTECLow_Token_,
-      edmPSimHitContainer_siTECHigh_Token_;
+  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_pxlBrlLow_Token_, edmPSimHitContainer_pxlBrlHigh_Token_;
+  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_pxlFwdLow_Token_, edmPSimHitContainer_pxlFwdHigh_Token_;
+  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTIBLow_Token_, edmPSimHitContainer_siTIBHigh_Token_;
+  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTOBLow_Token_, edmPSimHitContainer_siTOBHigh_Token_;
+  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTIDLow_Token_, edmPSimHitContainer_siTIDHigh_Token_;
+  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTECLow_Token_, edmPSimHitContainer_siTECHigh_Token_;
   edm::EDGetTokenT<edm::SimTrackContainer> edmSimTrackContainerToken_;
 
   DQMStore *fDBE;

--- a/Validation/TrackerHits/interface/TrackerHitProducer.h
+++ b/Validation/TrackerHits/interface/TrackerHitProducer.h
@@ -14,12 +14,11 @@
 #include <vector>
 
 namespace edm {
-class HepMCProduct;
+  class HepMCProduct;
 }
 class PTrackerSimHit;
 
 class TrackerHitProducer : public edm::EDProducer {
-
 public:
   typedef std::vector<float> FloatVector;
   typedef std::vector<int> IntegerVector;
@@ -55,18 +54,12 @@ private:
   edm::EDGetTokenT<edm::HepMCProduct> edmHepMCProductToken_;
   edm::EDGetTokenT<edm::SimVertexContainer> edmSimVertexContainerToken_;
   edm::EDGetTokenT<edm::SimTrackContainer> edmSimTrackContainerToken_;
-  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_pxlBrlLow_Token_,
-      edmPSimHitContainer_pxlBrlHigh_Token_;
-  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_pxlFwdLow_Token_,
-      edmPSimHitContainer_pxlFwdHigh_Token_;
-  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTIBLow_Token_,
-      edmPSimHitContainer_siTIBHigh_Token_;
-  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTOBLow_Token_,
-      edmPSimHitContainer_siTOBHigh_Token_;
-  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTIDLow_Token_,
-      edmPSimHitContainer_siTIDHigh_Token_;
-  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTECLow_Token_,
-      edmPSimHitContainer_siTECHigh_Token_;
+  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_pxlBrlLow_Token_, edmPSimHitContainer_pxlBrlHigh_Token_;
+  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_pxlFwdLow_Token_, edmPSimHitContainer_pxlFwdHigh_Token_;
+  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTIBLow_Token_, edmPSimHitContainer_siTIBHigh_Token_;
+  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTOBLow_Token_, edmPSimHitContainer_siTOBHigh_Token_;
+  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTIDLow_Token_, edmPSimHitContainer_siTIDHigh_Token_;
+  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTECLow_Token_, edmPSimHitContainer_siTECHigh_Token_;
 
   // G4MC info
   FloatVector G4VtxX;
@@ -106,6 +99,6 @@ private:
   std::string fName;
   std::string label;
 
-}; // end class declaration
+};  // end class declaration
 
 #endif

--- a/Validation/TrackerHits/src/TrackerHitAnalyzer.cc
+++ b/Validation/TrackerHits/src/TrackerHitAnalyzer.cc
@@ -40,41 +40,38 @@
 
 TrackerHitAnalyzer::TrackerHitAnalyzer(const edm::ParameterSet &ps)
     : verbose_(ps.getUntrackedParameter<bool>("Verbosity", false)),
-      edmPSimHitContainer_pxlBrlLow_Token_(consumes<edm::PSimHitContainer>(
-          ps.getParameter<edm::InputTag>("PxlBrlLowSrc"))),
-      edmPSimHitContainer_pxlBrlHigh_Token_(consumes<edm::PSimHitContainer>(
-          ps.getParameter<edm::InputTag>("PxlBrlHighSrc"))),
-      edmPSimHitContainer_pxlFwdLow_Token_(consumes<edm::PSimHitContainer>(
-          ps.getParameter<edm::InputTag>("PxlFwdLowSrc"))),
-      edmPSimHitContainer_pxlFwdHigh_Token_(consumes<edm::PSimHitContainer>(
-          ps.getParameter<edm::InputTag>("PxlFwdHighSrc"))),
-      edmPSimHitContainer_siTIBLow_Token_(consumes<edm::PSimHitContainer>(
-          ps.getParameter<edm::InputTag>("SiTIBLowSrc"))),
-      edmPSimHitContainer_siTIBHigh_Token_(consumes<edm::PSimHitContainer>(
-          ps.getParameter<edm::InputTag>("SiTIBHighSrc"))),
-      edmPSimHitContainer_siTOBLow_Token_(consumes<edm::PSimHitContainer>(
-          ps.getParameter<edm::InputTag>("SiTOBLowSrc"))),
-      edmPSimHitContainer_siTOBHigh_Token_(consumes<edm::PSimHitContainer>(
-          ps.getParameter<edm::InputTag>("SiTOBHighSrc"))),
-      edmPSimHitContainer_siTIDLow_Token_(consumes<edm::PSimHitContainer>(
-          ps.getParameter<edm::InputTag>("SiTIDLowSrc"))),
-      edmPSimHitContainer_siTIDHigh_Token_(consumes<edm::PSimHitContainer>(
-          ps.getParameter<edm::InputTag>("SiTIDHighSrc"))),
-      edmPSimHitContainer_siTECLow_Token_(consumes<edm::PSimHitContainer>(
-          ps.getParameter<edm::InputTag>("SiTECLowSrc"))),
-      edmPSimHitContainer_siTECHigh_Token_(consumes<edm::PSimHitContainer>(
-          ps.getParameter<edm::InputTag>("SiTECHighSrc"))),
-      edmSimTrackContainerToken_(consumes<edm::SimTrackContainer>(
-          ps.getParameter<edm::InputTag>("G4TrkSrc"))),
-      fDBE(nullptr), conf_(ps),
+      edmPSimHitContainer_pxlBrlLow_Token_(
+          consumes<edm::PSimHitContainer>(ps.getParameter<edm::InputTag>("PxlBrlLowSrc"))),
+      edmPSimHitContainer_pxlBrlHigh_Token_(
+          consumes<edm::PSimHitContainer>(ps.getParameter<edm::InputTag>("PxlBrlHighSrc"))),
+      edmPSimHitContainer_pxlFwdLow_Token_(
+          consumes<edm::PSimHitContainer>(ps.getParameter<edm::InputTag>("PxlFwdLowSrc"))),
+      edmPSimHitContainer_pxlFwdHigh_Token_(
+          consumes<edm::PSimHitContainer>(ps.getParameter<edm::InputTag>("PxlFwdHighSrc"))),
+      edmPSimHitContainer_siTIBLow_Token_(
+          consumes<edm::PSimHitContainer>(ps.getParameter<edm::InputTag>("SiTIBLowSrc"))),
+      edmPSimHitContainer_siTIBHigh_Token_(
+          consumes<edm::PSimHitContainer>(ps.getParameter<edm::InputTag>("SiTIBHighSrc"))),
+      edmPSimHitContainer_siTOBLow_Token_(
+          consumes<edm::PSimHitContainer>(ps.getParameter<edm::InputTag>("SiTOBLowSrc"))),
+      edmPSimHitContainer_siTOBHigh_Token_(
+          consumes<edm::PSimHitContainer>(ps.getParameter<edm::InputTag>("SiTOBHighSrc"))),
+      edmPSimHitContainer_siTIDLow_Token_(
+          consumes<edm::PSimHitContainer>(ps.getParameter<edm::InputTag>("SiTIDLowSrc"))),
+      edmPSimHitContainer_siTIDHigh_Token_(
+          consumes<edm::PSimHitContainer>(ps.getParameter<edm::InputTag>("SiTIDHighSrc"))),
+      edmPSimHitContainer_siTECLow_Token_(
+          consumes<edm::PSimHitContainer>(ps.getParameter<edm::InputTag>("SiTECLowSrc"))),
+      edmPSimHitContainer_siTECHigh_Token_(
+          consumes<edm::PSimHitContainer>(ps.getParameter<edm::InputTag>("SiTECHighSrc"))),
+      edmSimTrackContainerToken_(consumes<edm::SimTrackContainer>(ps.getParameter<edm::InputTag>("G4TrkSrc"))),
+      fDBE(nullptr),
+      conf_(ps),
       runStandalone(ps.getParameter<bool>("runStandalone")),
-      fOutputFile(ps.getUntrackedParameter<std::string>(
-          "outputFile", "TrackerHitHisto.root")),
+      fOutputFile(ps.getUntrackedParameter<std::string>("outputFile", "TrackerHitHisto.root")),
       pixelOutput(ps.getParameter<bool>("pixelOutput")) {}
 
-void TrackerHitAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
-                                        const edm::Run &run,
-                                        const edm::EventSetup &es) {
+void TrackerHitAnalyzer::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &run, const edm::EventSetup &es) {
   ////// booking histograms
   fDBE = edm::Service<DQMStore>().operator->();
 
@@ -106,24 +103,18 @@ void TrackerHitAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
     int nbin = 5000;
 
     ibooker.setCurrentFolder("TrackerHitsV/TrackerHit/");
-    htofeta = ibooker.book2D("tof_eta", "Time of flight vs eta", nbin, -3.0,
-                             3.0, 200, -100, 100);
-    htofphi = ibooker.book2D("tof_phi", "Time of flight vs phi", nbin, -180,
-                             180, 200, -100, 100);
-    htofr = ibooker.book2D("tof_r", "Time of flight vs r", nbin, 0, 300, 200,
-                           -100, 100);
-    htofz = ibooker.book2D("tof_z", "Time of flight vs z", nbin, -280, 280, 200,
-                           -100, 100);
+    htofeta = ibooker.book2D("tof_eta", "Time of flight vs eta", nbin, -3.0, 3.0, 200, -100, 100);
+    htofphi = ibooker.book2D("tof_phi", "Time of flight vs phi", nbin, -180, 180, 200, -100, 100);
+    htofr = ibooker.book2D("tof_r", "Time of flight vs r", nbin, 0, 300, 200, -100, 100);
+    htofz = ibooker.book2D("tof_z", "Time of flight vs z", nbin, -280, 280, 200, -100, 100);
 
     const float E2NEL = 1.;
 
-    const char *Region[] = {"005",  "051",  "115",  "152",  "225",  "253",
-                            "-050", "-105", "-151", "-215", "-252", "-325"};
+    const char *Region[] = {"005", "051", "115", "152", "225", "253", "-050", "-105", "-151", "-215", "-252", "-325"};
     nbin = 200;
 
     // Energy loss histograms
     for (int i = 0; i < 12; i++) {
-
       sprintf(htitle1, "Energy loss in TIB %s", Region[i]);
       sprintf(htitle2, "Energy loss in TOB %s", Region[i]);
       sprintf(htitle3, "Energy loss in TID %s", Region[i]);
@@ -163,7 +154,6 @@ void TrackerHitAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
     const float low[] = {-0.03, -0.03, -0.02, -0.03, -0.03, -0.03};
 
     for (int i = 0; i < 12; i++) {
-
       sprintf(htitle1, "Entryx-Exitx in TIB %s", Region[i]);
       sprintf(htitle2, "Entryx-Exitx in TOB %s", Region[i]);
       sprintf(htitle3, "Entryx-Exitx in TID %s", Region[i]);
@@ -202,7 +192,6 @@ void TrackerHitAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
     const float low0[] = {-0.05, -0.06, -0.03, -0.03, -0.03, -0.03};
 
     for (int i = 0; i < 12; i++) {
-
       sprintf(htitle1, "Entryy-Exity in TIB %s", Region[i]);
       sprintf(htitle2, "Entryy-Exity in TOB %s", Region[i]);
       sprintf(htitle3, "Entryy-Exity in TID %s", Region[i]);
@@ -241,7 +230,6 @@ void TrackerHitAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
     const float low1[] = {0., 0., 0., 0., 0., 0.};
 
     for (int i = 0; i < 12; i++) {
-
       sprintf(htitle1, "abs(Entryz-Exitz) in TIB %s", Region[i]);
       sprintf(htitle2, "abs(Entryz-Exitz) in TOB %s", Region[i]);
       sprintf(htitle3, "abs(Entryz-Exitz) in TID %s", Region[i]);
@@ -280,7 +268,6 @@ void TrackerHitAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
     const float low2[] = {-3.2, -5.0, -5.5, -6.2, -0.85, -0.5};
 
     for (int i = 0; i < 12; i++) {
-
       sprintf(htitle1, "Localx in TIB %s", Region[i]);
       sprintf(htitle2, "Localx in TOB %s", Region[i]);
       sprintf(htitle3, "Localx in TID %s", Region[i]);
@@ -319,7 +306,6 @@ void TrackerHitAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
     const float low3[] = {-6.0, -10., -5.6, -10.5, -3.4, -0.52};
 
     for (int i = 0; i < 12; i++) {
-
       sprintf(htitle1, "Localy in TIB %s", Region[i]);
       sprintf(htitle2, "Localy in TOB %s", Region[i]);
       sprintf(htitle3, "Localy in TID %s", Region[i]);
@@ -373,11 +359,8 @@ void TrackerHitAnalyzer::endJob() {
   }
 }
 
-void TrackerHitAnalyzer::analyze(const edm::Event &e,
-                                 const edm::EventSetup &c) {
-
-  edm::LogInfo("EventInfo")
-      << " Run = " << e.id().run() << " Event = " << e.id().event();
+void TrackerHitAnalyzer::analyze(const edm::Event &e, const edm::EventSetup &c) {
+  edm::LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();
 
   // iterator to access containers
   edm::PSimHitContainer::const_iterator itHit;
@@ -388,16 +371,14 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
   edm::Handle<edm::PSimHitContainer> PxlBrlLowContainer;
   e.getByToken(edmPSimHitContainer_pxlBrlLow_Token_, PxlBrlLowContainer);
   if (!PxlBrlLowContainer.isValid()) {
-    edm::LogError("TrackerHitAnalyzer::analyze")
-        << "Unable to find TrackerHitsPixelBarrelLowTof in event!";
+    edm::LogError("TrackerHitAnalyzer::analyze") << "Unable to find TrackerHitsPixelBarrelLowTof in event!";
     return;
   }
   // extract high container
   edm::Handle<edm::PSimHitContainer> PxlBrlHighContainer;
   e.getByToken(edmPSimHitContainer_pxlBrlHigh_Token_, PxlBrlHighContainer);
   if (!PxlBrlHighContainer.isValid()) {
-    edm::LogError("TrackerHitAnalyzer::analyze")
-        << "Unable to find TrackerHitsPixelBarrelHighTof in event!";
+    edm::LogError("TrackerHitAnalyzer::analyze") << "Unable to find TrackerHitsPixelBarrelHighTof in event!";
     return;
   }
   /////////////////////////////////
@@ -407,16 +388,14 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
   edm::Handle<edm::PSimHitContainer> PxlFwdLowContainer;
   e.getByToken(edmPSimHitContainer_pxlFwdLow_Token_, PxlFwdLowContainer);
   if (!PxlFwdLowContainer.isValid()) {
-    edm::LogError("TrackerHitAnalyzer::analyze")
-        << "Unable to find TrackerHitsPixelEndcapLowTof in event!";
+    edm::LogError("TrackerHitAnalyzer::analyze") << "Unable to find TrackerHitsPixelEndcapLowTof in event!";
     return;
   }
   // extract high container
   edm::Handle<edm::PSimHitContainer> PxlFwdHighContainer;
   e.getByToken(edmPSimHitContainer_pxlFwdHigh_Token_, PxlFwdHighContainer);
   if (!PxlFwdHighContainer.isValid()) {
-    edm::LogError("TrackerHitAnalyzer::analyze")
-        << "Unable to find TrackerHitsPixelEndcapHighTof in event!";
+    edm::LogError("TrackerHitAnalyzer::analyze") << "Unable to find TrackerHitsPixelEndcapHighTof in event!";
     return;
   }
   ///////////////////////////////////
@@ -426,8 +405,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
   edm::Handle<edm::PSimHitContainer> SiTIBLowContainer;
   e.getByToken(edmPSimHitContainer_siTIBLow_Token_, SiTIBLowContainer);
   if (!SiTIBLowContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::analyze")
-        << "Unable to find TrackerHitsTIBLowTof in event!";
+    edm::LogError("TrackerHitProducer::analyze") << "Unable to find TrackerHitsTIBLowTof in event!";
     return;
   }
   //////////////////////////////////
@@ -435,8 +413,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
   edm::Handle<edm::PSimHitContainer> SiTIBHighContainer;
   e.getByToken(edmPSimHitContainer_siTIBHigh_Token_, SiTIBHighContainer);
   if (!SiTIBHighContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::analyze")
-        << "Unable to find TrackerHitsTIBHighTof in event!";
+    edm::LogError("TrackerHitProducer::analyze") << "Unable to find TrackerHitsTIBHighTof in event!";
     return;
   }
   ///////////////////////////////////
@@ -446,8 +423,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
   edm::Handle<edm::PSimHitContainer> SiTOBLowContainer;
   e.getByToken(edmPSimHitContainer_siTOBLow_Token_, SiTOBLowContainer);
   if (!SiTOBLowContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::analyze")
-        << "Unable to find TrackerHitsTOBLowTof in event!";
+    edm::LogError("TrackerHitProducer::analyze") << "Unable to find TrackerHitsTOBLowTof in event!";
     return;
   }
   //////////////////////////////////
@@ -455,8 +431,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
   edm::Handle<edm::PSimHitContainer> SiTOBHighContainer;
   e.getByToken(edmPSimHitContainer_siTOBHigh_Token_, SiTOBHighContainer);
   if (!SiTOBHighContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::analyze")
-        << "Unable to find TrackerHitsTOBHighTof in event!";
+    edm::LogError("TrackerHitProducer::analyze") << "Unable to find TrackerHitsTOBHighTof in event!";
     return;
   }
 
@@ -467,8 +442,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
   edm::Handle<edm::PSimHitContainer> SiTIDLowContainer;
   e.getByToken(edmPSimHitContainer_siTIDLow_Token_, SiTIDLowContainer);
   if (!SiTIDLowContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::analyze")
-        << "Unable to find TrackerHitsTIDLowTof in event!";
+    edm::LogError("TrackerHitProducer::analyze") << "Unable to find TrackerHitsTIDLowTof in event!";
     return;
   }
   //////////////////////////////////
@@ -476,8 +450,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
   edm::Handle<edm::PSimHitContainer> SiTIDHighContainer;
   e.getByToken(edmPSimHitContainer_siTIDHigh_Token_, SiTIDHighContainer);
   if (!SiTIDHighContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::analyze")
-        << "Unable to find TrackerHitsTIDHighTof in event!";
+    edm::LogError("TrackerHitProducer::analyze") << "Unable to find TrackerHitsTIDHighTof in event!";
     return;
   }
   ///////////////////////////////////
@@ -487,8 +460,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
   edm::Handle<edm::PSimHitContainer> SiTECLowContainer;
   e.getByToken(edmPSimHitContainer_siTECLow_Token_, SiTECLowContainer);
   if (!SiTECLowContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::analyze")
-        << "Unable to find TrackerHitsTECLowTof in event!";
+    edm::LogError("TrackerHitProducer::analyze") << "Unable to find TrackerHitsTECLowTof in event!";
     return;
   }
   //////////////////////////////////
@@ -496,8 +468,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
   edm::Handle<edm::PSimHitContainer> SiTECHighContainer;
   e.getByToken(edmPSimHitContainer_siTECHigh_Token_, SiTECHighContainer);
   if (!SiTECHighContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::analyze")
-        << "Unable to find TrackerHitsTECHighTof in event!";
+    edm::LogError("TrackerHitProducer::analyze") << "Unable to find TrackerHitsTECHighTof in event!";
     return;
   }
 
@@ -508,8 +479,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
   edm::Handle<edm::SimTrackContainer> G4TrkContainer;
   e.getByToken(edmSimTrackContainerToken_, G4TrkContainer);
   if (!G4TrkContainer.isValid()) {
-    edm::LogError("TrackerHitAnalyzer::analyze")
-        << "Unable to find SimTrack in event!";
+    edm::LogError("TrackerHitAnalyzer::analyze") << "Unable to find SimTrack in event!";
     return;
   }
 
@@ -520,18 +490,14 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
 
   int ir = -100;
   edm::SimTrackContainer::const_iterator itTrk;
-  for (itTrk = G4TrkContainer->begin(); itTrk != G4TrkContainer->end();
-       ++itTrk) {
-
+  for (itTrk = G4TrkContainer->begin(); itTrk != G4TrkContainer->end(); ++itTrk) {
     //    std::cout << "itTrk = "<< itTrk << std::endl;
     double eta = 0, p = 0;
-    const CLHEP::HepLorentzVector &G4Trk =
-        CLHEP::HepLorentzVector(itTrk->momentum().x(), itTrk->momentum().y(),
-                                itTrk->momentum().z(), itTrk->momentum().e());
+    const CLHEP::HepLorentzVector &G4Trk = CLHEP::HepLorentzVector(
+        itTrk->momentum().x(), itTrk->momentum().y(), itTrk->momentum().z(), itTrk->momentum().e());
     p = sqrt(G4Trk[0] * G4Trk[0] + G4Trk[1] * G4Trk[1] + G4Trk[2] * G4Trk[2]);
     if (p == 0)
-      edm::LogError("TrackerHitAnalyzer::analyze")
-          << "TrackerTest::INFO: Primary has p = 0 ";
+      edm::LogError("TrackerHitAnalyzer::analyze") << "TrackerTest::INFO: Primary has p = 0 ";
     else {
       double costheta = G4Trk[2] / p;
       double theta = acos(TMath::Min(TMath::Max(costheta, -1.), 1.));
@@ -575,8 +541,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
   // If Phase 1, do not run - will run in new Phase 1 module
 
   if (pixelOutput) {
-    for (itHit = PxlBrlLowContainer->begin();
-         itHit != PxlBrlLowContainer->end(); ++itHit) {
+    for (itHit = PxlBrlLowContainer->begin(); itHit != PxlBrlLowContainer->end(); ++itHit) {
       DetId detid = DetId(itHit->detUnitId());
       const GeomDetUnit *det = (const GeomDetUnit *)tracker->idToDetUnit(detid);
       GlobalPoint gpos = det->toGlobal(itHit->localPosition());
@@ -588,13 +553,11 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
       h5e[ir]->Fill(itHit->energyLoss());
       h5ex[ir]->Fill(itHit->entryPoint().x() - itHit->exitPoint().x());
       h5ey[ir]->Fill(itHit->entryPoint().y() - itHit->exitPoint().y());
-      h5ez[ir]->Fill(
-          std::fabs(itHit->entryPoint().z() - itHit->exitPoint().z()));
+      h5ez[ir]->Fill(std::fabs(itHit->entryPoint().z() - itHit->exitPoint().z()));
       h5lx[ir]->Fill(itHit->localPosition().x());
       h5ly[ir]->Fill(itHit->localPosition().y());
     }
-    for (itHit = PxlBrlHighContainer->begin();
-         itHit != PxlBrlHighContainer->end(); ++itHit) {
+    for (itHit = PxlBrlHighContainer->begin(); itHit != PxlBrlHighContainer->end(); ++itHit) {
       DetId detid = DetId(itHit->detUnitId());
       const GeomDetUnit *det = (const GeomDetUnit *)tracker->idToDetUnit(detid);
       GlobalPoint gpos = det->toGlobal(itHit->localPosition());
@@ -606,13 +569,11 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
       h5e[ir]->Fill(itHit->energyLoss());
       h5ex[ir]->Fill(itHit->entryPoint().x() - itHit->exitPoint().x());
       h5ey[ir]->Fill(itHit->entryPoint().y() - itHit->exitPoint().y());
-      h5ez[ir]->Fill(
-          std::fabs(itHit->entryPoint().z() - itHit->exitPoint().z()));
+      h5ez[ir]->Fill(std::fabs(itHit->entryPoint().z() - itHit->exitPoint().z()));
       h5lx[ir]->Fill(itHit->localPosition().x());
       h5ly[ir]->Fill(itHit->localPosition().y());
     }
-    for (itHit = PxlFwdLowContainer->begin();
-         itHit != PxlFwdLowContainer->end(); ++itHit) {
+    for (itHit = PxlFwdLowContainer->begin(); itHit != PxlFwdLowContainer->end(); ++itHit) {
       DetId detid = DetId(itHit->detUnitId());
       const GeomDetUnit *det = (const GeomDetUnit *)tracker->idToDetUnit(detid);
       GlobalPoint gpos = det->toGlobal(itHit->localPosition());
@@ -624,13 +585,11 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
       h6e[ir]->Fill(itHit->energyLoss());
       h6ex[ir]->Fill(itHit->entryPoint().x() - itHit->exitPoint().x());
       h6ey[ir]->Fill(itHit->entryPoint().y() - itHit->exitPoint().y());
-      h6ez[ir]->Fill(
-          std::fabs(itHit->entryPoint().z() - itHit->exitPoint().z()));
+      h6ez[ir]->Fill(std::fabs(itHit->entryPoint().z() - itHit->exitPoint().z()));
       h6lx[ir]->Fill(itHit->localPosition().x());
       h6ly[ir]->Fill(itHit->localPosition().y());
     }
-    for (itHit = PxlFwdHighContainer->begin();
-         itHit != PxlFwdHighContainer->end(); ++itHit) {
+    for (itHit = PxlFwdHighContainer->begin(); itHit != PxlFwdHighContainer->end(); ++itHit) {
       DetId detid = DetId(itHit->detUnitId());
       const GeomDetUnit *det = (const GeomDetUnit *)tracker->idToDetUnit(detid);
       GlobalPoint gpos = det->toGlobal(itHit->localPosition());
@@ -642,8 +601,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
       h6e[ir]->Fill(itHit->energyLoss());
       h6ex[ir]->Fill(itHit->entryPoint().x() - itHit->exitPoint().x());
       h6ey[ir]->Fill(itHit->entryPoint().y() - itHit->exitPoint().y());
-      h6ez[ir]->Fill(
-          std::fabs(itHit->entryPoint().z() - itHit->exitPoint().z()));
+      h6ez[ir]->Fill(std::fabs(itHit->entryPoint().z() - itHit->exitPoint().z()));
       h6lx[ir]->Fill(itHit->localPosition().x());
       h6ly[ir]->Fill(itHit->localPosition().y());
     }
@@ -651,8 +609,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
   ///////////////////////////////
   // get TIB information
   ///////////////////////////////
-  for (itHit = SiTIBLowContainer->begin(); itHit != SiTIBLowContainer->end();
-       ++itHit) {
+  for (itHit = SiTIBLowContainer->begin(); itHit != SiTIBLowContainer->end(); ++itHit) {
     DetId detid = DetId(itHit->detUnitId());
     const GeomDetUnit *det = (const GeomDetUnit *)tracker->idToDetUnit(detid);
     GlobalPoint gpos = det->toGlobal(itHit->localPosition());
@@ -668,8 +625,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
     h1lx[ir]->Fill(itHit->localPosition().x());
     h1ly[ir]->Fill(itHit->localPosition().y());
   }
-  for (itHit = SiTIBHighContainer->begin(); itHit != SiTIBHighContainer->end();
-       ++itHit) {
+  for (itHit = SiTIBHighContainer->begin(); itHit != SiTIBHighContainer->end(); ++itHit) {
     DetId detid = DetId(itHit->detUnitId());
     const GeomDetUnit *det = (const GeomDetUnit *)tracker->idToDetUnit(detid);
     GlobalPoint gpos = det->toGlobal(itHit->localPosition());
@@ -688,8 +644,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
   ///////////////////////////////
   // get TOB information
   ///////////////////////////////
-  for (itHit = SiTOBLowContainer->begin(); itHit != SiTOBLowContainer->end();
-       ++itHit) {
+  for (itHit = SiTOBLowContainer->begin(); itHit != SiTOBLowContainer->end(); ++itHit) {
     DetId detid = DetId(itHit->detUnitId());
     const GeomDetUnit *det = (const GeomDetUnit *)tracker->idToDetUnit(detid);
     GlobalPoint gpos = det->toGlobal(itHit->localPosition());
@@ -705,8 +660,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
     h2lx[ir]->Fill(itHit->localPosition().x());
     h2ly[ir]->Fill(itHit->localPosition().y());
   }
-  for (itHit = SiTOBHighContainer->begin(); itHit != SiTOBHighContainer->end();
-       ++itHit) {
+  for (itHit = SiTOBHighContainer->begin(); itHit != SiTOBHighContainer->end(); ++itHit) {
     DetId detid = DetId(itHit->detUnitId());
     const GeomDetUnit *det = (const GeomDetUnit *)tracker->idToDetUnit(detid);
     GlobalPoint gpos = det->toGlobal(itHit->localPosition());
@@ -725,8 +679,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
   ///////////////////////////////
   // get TID information
   ///////////////////////////////
-  for (itHit = SiTIDLowContainer->begin(); itHit != SiTIDLowContainer->end();
-       ++itHit) {
+  for (itHit = SiTIDLowContainer->begin(); itHit != SiTIDLowContainer->end(); ++itHit) {
     DetId detid = DetId(itHit->detUnitId());
     const GeomDetUnit *det = (const GeomDetUnit *)tracker->idToDetUnit(detid);
     GlobalPoint gpos = det->toGlobal(itHit->localPosition());
@@ -742,8 +695,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
     h3lx[ir]->Fill(itHit->localPosition().x());
     h3ly[ir]->Fill(itHit->localPosition().y());
   }
-  for (itHit = SiTIDHighContainer->begin(); itHit != SiTIDHighContainer->end();
-       ++itHit) {
+  for (itHit = SiTIDHighContainer->begin(); itHit != SiTIDHighContainer->end(); ++itHit) {
     DetId detid = DetId(itHit->detUnitId());
     const GeomDetUnit *det = (const GeomDetUnit *)tracker->idToDetUnit(detid);
     GlobalPoint gpos = det->toGlobal(itHit->localPosition());
@@ -762,8 +714,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
   ///////////////////////////////
   // get TEC information
   ///////////////////////////////
-  for (itHit = SiTECLowContainer->begin(); itHit != SiTECLowContainer->end();
-       ++itHit) {
+  for (itHit = SiTECLowContainer->begin(); itHit != SiTECLowContainer->end(); ++itHit) {
     DetId detid = DetId(itHit->detUnitId());
     const GeomDetUnit *det = (const GeomDetUnit *)tracker->idToDetUnit(detid);
     GlobalPoint gpos = det->toGlobal(itHit->localPosition());
@@ -779,8 +730,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event &e,
     h4lx[ir]->Fill(itHit->localPosition().x());
     h4ly[ir]->Fill(itHit->localPosition().y());
   }
-  for (itHit = SiTECHighContainer->begin(); itHit != SiTECHighContainer->end();
-       ++itHit) {
+  for (itHit = SiTECHighContainer->begin(); itHit != SiTECHighContainer->end(); ++itHit) {
     DetId detid = DetId(itHit->detUnitId());
     const GeomDetUnit *det = (const GeomDetUnit *)tracker->idToDetUnit(detid);
     GlobalPoint gpos = det->toGlobal(itHit->localPosition());

--- a/Validation/TrackerHits/src/TrackerHitProducer.cc
+++ b/Validation/TrackerHits/src/TrackerHitProducer.cc
@@ -34,46 +34,43 @@
 #include <memory>
 
 TrackerHitProducer::TrackerHitProducer(const edm::ParameterSet &iPSet)
-    : getAllProvenances(
-          iPSet.getParameter<edm::ParameterSet>("ProvenanceLookup")
-              .getUntrackedParameter<bool>("GetAllProvenances", false)),
-      printProvenanceInfo(
-          iPSet.getParameter<edm::ParameterSet>("ProvenanceLookup")
-              .getUntrackedParameter<bool>("PrintProvenanceInfo", false)),
-      verbosity(iPSet.getUntrackedParameter<int>("Verbosity", 0)), count(0),
-      nRawGenPart(0), config_(iPSet),
-      edmHepMCProductToken_(consumes<edm::HepMCProduct>(edm::InputTag(
-          iPSet.getUntrackedParameter<std::string>("HepMCProductLabel",
-                                                   "source"),
-          iPSet.getUntrackedParameter<std::string>("HepMCInputInstance", "")))),
-      edmSimVertexContainerToken_(consumes<edm::SimVertexContainer>(
-          iPSet.getParameter<edm::InputTag>("G4VtxSrc"))),
-      edmSimTrackContainerToken_(consumes<edm::SimTrackContainer>(
-          iPSet.getParameter<edm::InputTag>("G4TrkSrc"))),
-      edmPSimHitContainer_pxlBrlLow_Token_(consumes<edm::PSimHitContainer>(
-          iPSet.getParameter<edm::InputTag>("PxlBrlLowSrc"))),
-      edmPSimHitContainer_pxlBrlHigh_Token_(consumes<edm::PSimHitContainer>(
-          iPSet.getParameter<edm::InputTag>("PxlBrlHighSrc"))),
-      edmPSimHitContainer_pxlFwdLow_Token_(consumes<edm::PSimHitContainer>(
-          iPSet.getParameter<edm::InputTag>("PxlFwdLowSrc"))),
-      edmPSimHitContainer_pxlFwdHigh_Token_(consumes<edm::PSimHitContainer>(
-          iPSet.getParameter<edm::InputTag>("PxlFwdHighSrc"))),
-      edmPSimHitContainer_siTIBLow_Token_(consumes<edm::PSimHitContainer>(
-          iPSet.getParameter<edm::InputTag>("SiTIBLowSrc"))),
-      edmPSimHitContainer_siTIBHigh_Token_(consumes<edm::PSimHitContainer>(
-          iPSet.getParameter<edm::InputTag>("SiTIBHighSrc"))),
-      edmPSimHitContainer_siTOBLow_Token_(consumes<edm::PSimHitContainer>(
-          iPSet.getParameter<edm::InputTag>("SiTOBLowSrc"))),
-      edmPSimHitContainer_siTOBHigh_Token_(consumes<edm::PSimHitContainer>(
-          iPSet.getParameter<edm::InputTag>("SiTOBHighSrc"))),
-      edmPSimHitContainer_siTIDLow_Token_(consumes<edm::PSimHitContainer>(
-          iPSet.getParameter<edm::InputTag>("SiTIDLowSrc"))),
-      edmPSimHitContainer_siTIDHigh_Token_(consumes<edm::PSimHitContainer>(
-          iPSet.getParameter<edm::InputTag>("SiTIDHighSrc"))),
-      edmPSimHitContainer_siTECLow_Token_(consumes<edm::PSimHitContainer>(
-          iPSet.getParameter<edm::InputTag>("SiTECLowSrc"))),
-      edmPSimHitContainer_siTECHigh_Token_(consumes<edm::PSimHitContainer>(
-          iPSet.getParameter<edm::InputTag>("SiTECHighSrc"))),
+    : getAllProvenances(iPSet.getParameter<edm::ParameterSet>("ProvenanceLookup")
+                            .getUntrackedParameter<bool>("GetAllProvenances", false)),
+      printProvenanceInfo(iPSet.getParameter<edm::ParameterSet>("ProvenanceLookup")
+                              .getUntrackedParameter<bool>("PrintProvenanceInfo", false)),
+      verbosity(iPSet.getUntrackedParameter<int>("Verbosity", 0)),
+      count(0),
+      nRawGenPart(0),
+      config_(iPSet),
+      edmHepMCProductToken_(consumes<edm::HepMCProduct>(
+          edm::InputTag(iPSet.getUntrackedParameter<std::string>("HepMCProductLabel", "source"),
+                        iPSet.getUntrackedParameter<std::string>("HepMCInputInstance", "")))),
+      edmSimVertexContainerToken_(consumes<edm::SimVertexContainer>(iPSet.getParameter<edm::InputTag>("G4VtxSrc"))),
+      edmSimTrackContainerToken_(consumes<edm::SimTrackContainer>(iPSet.getParameter<edm::InputTag>("G4TrkSrc"))),
+      edmPSimHitContainer_pxlBrlLow_Token_(
+          consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("PxlBrlLowSrc"))),
+      edmPSimHitContainer_pxlBrlHigh_Token_(
+          consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("PxlBrlHighSrc"))),
+      edmPSimHitContainer_pxlFwdLow_Token_(
+          consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("PxlFwdLowSrc"))),
+      edmPSimHitContainer_pxlFwdHigh_Token_(
+          consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("PxlFwdHighSrc"))),
+      edmPSimHitContainer_siTIBLow_Token_(
+          consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTIBLowSrc"))),
+      edmPSimHitContainer_siTIBHigh_Token_(
+          consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTIBHighSrc"))),
+      edmPSimHitContainer_siTOBLow_Token_(
+          consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTOBLowSrc"))),
+      edmPSimHitContainer_siTOBHigh_Token_(
+          consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTOBHighSrc"))),
+      edmPSimHitContainer_siTIDLow_Token_(
+          consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTIDLowSrc"))),
+      edmPSimHitContainer_siTIDHigh_Token_(
+          consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTIDHighSrc"))),
+      edmPSimHitContainer_siTECLow_Token_(
+          consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTECLowSrc"))),
+      edmPSimHitContainer_siTECHigh_Token_(
+          consumes<edm::PSimHitContainer>(iPSet.getParameter<edm::InputTag>("SiTECHighSrc"))),
       fName(iPSet.getUntrackedParameter<std::string>("Name", "")),
       label(iPSet.getParameter<std::string>("Label")) {
   // use value of first digit to determine default output level (inclusive)
@@ -93,41 +90,29 @@ TrackerHitProducer::TrackerHitProducer(const edm::ParameterSet &iPSet)
         << "    Label     =" << label << "\n"
         << "    GetProv   =" << getAllProvenances << "\n"
         << "    PrintProv =" << printProvenanceInfo << "\n"
-        << "    PxlBrlLowSrc  = "
-        << iPSet.getParameter<edm::InputTag>("PxlBrlLowSrc").label() << ":"
+        << "    PxlBrlLowSrc  = " << iPSet.getParameter<edm::InputTag>("PxlBrlLowSrc").label() << ":"
         << iPSet.getParameter<edm::InputTag>("PxlBrlLowSrc").instance() << "\n"
-        << "    PxlBrlHighSrc = "
-        << iPSet.getParameter<edm::InputTag>("PxlBrlHighSrc").label() << ":"
+        << "    PxlBrlHighSrc = " << iPSet.getParameter<edm::InputTag>("PxlBrlHighSrc").label() << ":"
         << iPSet.getParameter<edm::InputTag>("PxlBrlHighSrc").instance() << "\n"
-        << "    PxlFwdLowSrc  = "
-        << iPSet.getParameter<edm::InputTag>("PxlFwdLowSrc").label() << ":"
+        << "    PxlFwdLowSrc  = " << iPSet.getParameter<edm::InputTag>("PxlFwdLowSrc").label() << ":"
         << iPSet.getParameter<edm::InputTag>("PxlFwdLowSrc").instance() << "\n"
-        << "    PxlFwdHighSrc = "
-        << iPSet.getParameter<edm::InputTag>("PxlFwdHighSrc").label() << ":"
+        << "    PxlFwdHighSrc = " << iPSet.getParameter<edm::InputTag>("PxlFwdHighSrc").label() << ":"
         << iPSet.getParameter<edm::InputTag>("PxlFwdHighSrc").instance() << "\n"
-        << "    SiTIBLowSrc   = "
-        << iPSet.getParameter<edm::InputTag>("SiTIBLowSrc").label() << ":"
+        << "    SiTIBLowSrc   = " << iPSet.getParameter<edm::InputTag>("SiTIBLowSrc").label() << ":"
         << iPSet.getParameter<edm::InputTag>("SiTIBLowSrc").instance() << "\n"
-        << "    SiTIBHighSrc  = "
-        << iPSet.getParameter<edm::InputTag>("SiTIBHighSrc").label() << ":"
+        << "    SiTIBHighSrc  = " << iPSet.getParameter<edm::InputTag>("SiTIBHighSrc").label() << ":"
         << iPSet.getParameter<edm::InputTag>("SiTIBHighSrc").instance() << "\n"
-        << "    SiTOBLowSrc   = "
-        << iPSet.getParameter<edm::InputTag>("SiTOBLowSrc").label() << ":"
+        << "    SiTOBLowSrc   = " << iPSet.getParameter<edm::InputTag>("SiTOBLowSrc").label() << ":"
         << iPSet.getParameter<edm::InputTag>("SiTOBLowSrc").instance() << "\n"
-        << "    SiTOBHighSrc  = "
-        << iPSet.getParameter<edm::InputTag>("SiTOBHighSrc").label() << ":"
+        << "    SiTOBHighSrc  = " << iPSet.getParameter<edm::InputTag>("SiTOBHighSrc").label() << ":"
         << iPSet.getParameter<edm::InputTag>("SiTOBHighSrc").instance() << "\n"
-        << "    SiTIDLowSrc   = "
-        << iPSet.getParameter<edm::InputTag>("SiTIDLowSrc").label() << ":"
+        << "    SiTIDLowSrc   = " << iPSet.getParameter<edm::InputTag>("SiTIDLowSrc").label() << ":"
         << iPSet.getParameter<edm::InputTag>("SiTIDLowSrc").instance() << "\n"
-        << "    SiTIDHighSrc  = "
-        << iPSet.getParameter<edm::InputTag>("SiTIDHighSrc").label() << ":"
+        << "    SiTIDHighSrc  = " << iPSet.getParameter<edm::InputTag>("SiTIDHighSrc").label() << ":"
         << iPSet.getParameter<edm::InputTag>("SiTIDHighSrc").instance() << "\n"
-        << "    SiTECLowSrc   = "
-        << iPSet.getParameter<edm::InputTag>("SiTECLowSrc").label() << ":"
+        << "    SiTECLowSrc   = " << iPSet.getParameter<edm::InputTag>("SiTECLowSrc").label() << ":"
         << iPSet.getParameter<edm::InputTag>("SiTECLowSrc").instance() << "\n"
-        << "    SiTECHighSrc  = "
-        << iPSet.getParameter<edm::InputTag>("SiTECHighSrc").label() << ":"
+        << "    SiTECHighSrc  = " << iPSet.getParameter<edm::InputTag>("SiTECHighSrc").label() << ":"
         << iPSet.getParameter<edm::InputTag>("SiTECHighSrc").instance() << "\n"
         << "===============================\n";
   }
@@ -144,13 +129,11 @@ void TrackerHitProducer::beginJob() {
 
 void TrackerHitProducer::endJob() {
   if (verbosity > 0)
-    edm::LogInfo("TrackerHitProducer::endJob")
-        << "Terminating having processed" << count << "events.";
+    edm::LogInfo("TrackerHitProducer::endJob") << "Terminating having processed" << count << "events.";
   return;
 }
 
-void TrackerHitProducer::produce(edm::Event &iEvent,
-                                 const edm::EventSetup &iSetup) {
+void TrackerHitProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // keep track of number of events processed
   ++count;
 
@@ -163,9 +146,8 @@ void TrackerHitProducer::produce(edm::Event &iEvent,
   // iSetup.get<edm::SetupRecord>().get(pSetup);
 
   if (verbosity > 0) {
-    edm::LogInfo("TrackerHitProducer::produce")
-        << "Processing run" << nrun << ","
-        << "event " << nevt;
+    edm::LogInfo("TrackerHitProducer::produce") << "Processing run" << nrun << ","
+                                                << "event " << nevt;
   }
 
   // clear event holders
@@ -173,13 +155,11 @@ void TrackerHitProducer::produce(edm::Event &iEvent,
 
   // look at information available in the event
   if (getAllProvenances) {
-
     std::vector<const edm::StableProvenance *> AllProv;
     iEvent.getAllStableProvenance(AllProv);
 
     if (verbosity > 0)
-      edm::LogInfo("TrackerHitProducer::produce")
-          << "Number of Provenances =" << AllProv.size();
+      edm::LogInfo("TrackerHitProducer::produce") << "Number of Provenances =" << AllProv.size();
 
     if (printProvenanceInfo && (verbosity > 0)) {
       TString eventout("\nProvenance info:\n");
@@ -211,8 +191,7 @@ void TrackerHitProducer::produce(edm::Event &iEvent,
   fillTrk(iEvent, iSetup);
 
   if (verbosity > 0)
-    edm::LogInfo("TrackerHitProducer::produce")
-        << "Done gathering data from event.";
+    edm::LogInfo("TrackerHitProducer::produce") << "Done gathering data from event.";
 
   // produce object to put into event
   std::unique_ptr<PTrackerSimHit> pOut(new PTrackerSimHit);
@@ -234,7 +213,6 @@ void TrackerHitProducer::produce(edm::Event &iEvent,
 
 //==================fill and store functions================================
 void TrackerHitProducer::fillG4MC(edm::Event &iEvent) {
-
   TString eventout;
   if (verbosity > 0)
     eventout = "\nGathering info:";
@@ -245,8 +223,7 @@ void TrackerHitProducer::fillG4MC(edm::Event &iEvent) {
   edm::Handle<edm::HepMCProduct> HepMCEvt_;
   iEvent.getByToken(edmHepMCProductToken_, HepMCEvt_);
   if (!HepMCEvt_.isValid()) {
-    edm::LogError("TrackerHitProducer::fillG4MC")
-        << "Unable to find HepMCProduct in event!";
+    edm::LogError("TrackerHitProducer::fillG4MC") << "Unable to find HepMCProduct in event!";
     return;
   }
   const HepMC::GenEvent *MCEvt = HepMCEvt_->GetEvent();
@@ -263,25 +240,21 @@ void TrackerHitProducer::fillG4MC(edm::Event &iEvent) {
   edm::Handle<edm::SimVertexContainer> G4VtxContainer;
   iEvent.getByToken(edmSimVertexContainerToken_, G4VtxContainer);
   if (!G4VtxContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::fillG4MC")
-        << "Unable to find SimVertex in event!";
+    edm::LogError("TrackerHitProducer::fillG4MC") << "Unable to find SimVertex in event!";
     return;
   }
   int i = 0;
   edm::SimVertexContainer::const_iterator itVtx;
-  for (itVtx = G4VtxContainer->begin(); itVtx != G4VtxContainer->end();
-       ++itVtx) {
-
+  for (itVtx = G4VtxContainer->begin(); itVtx != G4VtxContainer->end(); ++itVtx) {
     ++i;
 
-    const CLHEP::HepLorentzVector &G4Vtx =
-        CLHEP::HepLorentzVector(itVtx->position().x(), itVtx->position().y(),
-                                itVtx->position().z(), itVtx->position().e());
-    G4VtxX.push_back(G4Vtx[0] / micrometer); // cm from code -> micrometer
-                                             // *10000
-    G4VtxY.push_back(G4Vtx[1] / micrometer); // cm from code -> micrometer
-                                             // *10000
-    G4VtxZ.push_back(G4Vtx[2] / millimeter); // cm from code -> millimeter *10
+    const CLHEP::HepLorentzVector &G4Vtx = CLHEP::HepLorentzVector(
+        itVtx->position().x(), itVtx->position().y(), itVtx->position().z(), itVtx->position().e());
+    G4VtxX.push_back(G4Vtx[0] / micrometer);  // cm from code -> micrometer
+                                              // *10000
+    G4VtxY.push_back(G4Vtx[1] / micrometer);  // cm from code -> micrometer
+                                              // *10000
+    G4VtxZ.push_back(G4Vtx[2] / millimeter);  // cm from code -> millimeter *10
   }
 
   if (verbosity > 1) {
@@ -295,26 +268,20 @@ void TrackerHitProducer::fillG4MC(edm::Event &iEvent) {
   edm::Handle<edm::SimTrackContainer> G4TrkContainer;
   iEvent.getByToken(edmSimTrackContainerToken_, G4TrkContainer);
   if (!G4TrkContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::fillG4MC")
-        << "Unable to find SimTrack in event!";
+    edm::LogError("TrackerHitProducer::fillG4MC") << "Unable to find SimTrack in event!";
     return;
   }
   i = 0;
   edm::SimTrackContainer::const_iterator itTrk;
-  for (itTrk = G4TrkContainer->begin(); itTrk != G4TrkContainer->end();
-       ++itTrk) {
-
+  for (itTrk = G4TrkContainer->begin(); itTrk != G4TrkContainer->end(); ++itTrk) {
     ++i;
 
     double etaInit = 0, phiInit = 0, pInit = 0;
-    const CLHEP::HepLorentzVector &G4Trk =
-        CLHEP::HepLorentzVector(itTrk->momentum().x(), itTrk->momentum().y(),
-                                itTrk->momentum().z(), itTrk->momentum().e());
-    pInit =
-        sqrt(G4Trk[0] * G4Trk[0] + G4Trk[1] * G4Trk[1] + G4Trk[2] * G4Trk[2]);
+    const CLHEP::HepLorentzVector &G4Trk = CLHEP::HepLorentzVector(
+        itTrk->momentum().x(), itTrk->momentum().y(), itTrk->momentum().z(), itTrk->momentum().e());
+    pInit = sqrt(G4Trk[0] * G4Trk[0] + G4Trk[1] * G4Trk[1] + G4Trk[2] * G4Trk[2]);
     if (pInit == 0)
-      edm::LogError("TrackerHitProducer::fillG4MC")
-          << "TrackerTest::INFO: Primary has p = 0 ";
+      edm::LogError("TrackerHitProducer::fillG4MC") << "TrackerTest::INFO: Primary has p = 0 ";
     else {
       double costheta = G4Trk[2] / pInit;
       double theta = acos(TMath::Min(TMath::Max(costheta, -1.), 1.));
@@ -323,8 +290,8 @@ void TrackerHitProducer::fillG4MC(edm::Event &iEvent) {
       if (G4Trk[0] != 0 || G4Trk[1] != 0)
         phiInit = atan2(G4Trk[1], G4Trk[0]);
     }
-    G4TrkPt.push_back(sqrt(G4Trk[0] * G4Trk[0] + G4Trk[1] * G4Trk[1])); // GeV
-    G4TrkE.push_back(G4Trk[3]);                                         // GeV
+    G4TrkPt.push_back(sqrt(G4Trk[0] * G4Trk[0] + G4Trk[1] * G4Trk[1]));  // GeV
+    G4TrkE.push_back(G4Trk[3]);                                          // GeV
     G4TrkEta.push_back(etaInit);
     G4TrkPhi.push_back(phiInit);
   }
@@ -341,7 +308,6 @@ void TrackerHitProducer::fillG4MC(edm::Event &iEvent) {
 }
 
 void TrackerHitProducer::storeG4MC(PTrackerSimHit &product) {
-
   if (verbosity > 2) {
     TString eventout("\nnRawGenPart        = ");
     eventout += nRawGenPart;
@@ -370,7 +336,7 @@ void TrackerHitProducer::storeG4MC(PTrackerSimHit &product) {
       eventout += ")";
     }
     edm::LogInfo("TrackerHitProducer::storeG4MC") << eventout;
-  } // end verbose output
+  }  // end verbose output
 
   product.putRawGenPart(nRawGenPart);
   product.putG4Vtx(G4VtxX, G4VtxY, G4VtxZ);
@@ -379,8 +345,7 @@ void TrackerHitProducer::storeG4MC(PTrackerSimHit &product) {
   return;
 }
 
-void TrackerHitProducer::fillTrk(edm::Event &iEvent,
-                                 const edm::EventSetup &iSetup) {
+void TrackerHitProducer::fillTrk(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   TString eventout;
   int sysID = 0;
   if (verbosity > 0)
@@ -398,8 +363,7 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> PxlBrlLowContainer;
   iEvent.getByToken(edmPSimHitContainer_pxlBrlLow_Token_, PxlBrlLowContainer);
   if (!PxlBrlLowContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::fillTrk")
-        << "Unable to find TrackerHitsPixelBarrelLowTof in event!";
+    edm::LogError("TrackerHitProducer::fillTrk") << "Unable to find TrackerHitsPixelBarrelLowTof in event!";
     return;
   }
 
@@ -407,10 +371,9 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
   //  theHits.insert(theHits.end(),PxlBrlLowContainer->begin(),
   //             PxlBrlLowContainer->end());
 
-  sysID = 100; // TrackerHitsPixelBarrelLowTof
+  sysID = 100;  // TrackerHitsPixelBarrelLowTof
   int j = 0;
-  for (itHit = PxlBrlLowContainer->begin(); itHit != PxlBrlLowContainer->end();
-       ++itHit) {
+  for (itHit = PxlBrlLowContainer->begin(); itHit != PxlBrlLowContainer->end(); ++itHit) {
     //  for (itHit = theHits.begin(); itHit != theHits.end(); ++itHit) {
 
     // gather necessary information
@@ -443,11 +406,10 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
     HitsEloss.push_back(itHit->energyLoss());
     HitsToF.push_back(itHit->tof());
 
-  } // end loop through PxlBrl Hits
+  }  // end loop through PxlBrl Hits
 
   if (verbosity > 1) {
-    eventout +=
-        "\n          Number of Pixel Barrel Low TOF Hits collected:     ";
+    eventout += "\n          Number of Pixel Barrel Low TOF Hits collected:     ";
     eventout += j;
   }
 
@@ -457,16 +419,13 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> PxlBrlHighContainer;
   iEvent.getByToken(edmPSimHitContainer_pxlBrlHigh_Token_, PxlBrlHighContainer);
   if (!PxlBrlHighContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::fillTrk")
-        << "Unable to find TrackerHitsPixelBarrelHighTof in event!";
+    edm::LogError("TrackerHitProducer::fillTrk") << "Unable to find TrackerHitsPixelBarrelHighTof in event!";
     return;
   }
 
-  sysID = 200; // TrackerHitsPixelBarrelHighTof
+  sysID = 200;  // TrackerHitsPixelBarrelHighTof
   j = 0;
-  for (itHit = PxlBrlHighContainer->begin();
-       itHit != PxlBrlHighContainer->end(); ++itHit) {
-
+  for (itHit = PxlBrlHighContainer->begin(); itHit != PxlBrlHighContainer->end(); ++itHit) {
     // gather necessary information
     ++j;
     HitsSysID.push_back(sysID);
@@ -497,11 +456,10 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
     HitsEloss.push_back(itHit->energyLoss());
     HitsToF.push_back(itHit->tof());
 
-  } // end loop through PxlBrl Hits
+  }  // end loop through PxlBrl Hits
 
   if (verbosity > 1) {
-    eventout +=
-        "\n          Number of Pixel Barrel High TOF Hits collected:     ";
+    eventout += "\n          Number of Pixel Barrel High TOF Hits collected:     ";
     eventout += j;
   }
 
@@ -512,16 +470,13 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> PxlFwdLowContainer;
   iEvent.getByToken(edmPSimHitContainer_pxlFwdLow_Token_, PxlFwdLowContainer);
   if (!PxlFwdLowContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::fillTrk")
-        << "Unable to find TrackerHitsPixelEndcapLowTof in event!";
+    edm::LogError("TrackerHitProducer::fillTrk") << "Unable to find TrackerHitsPixelEndcapLowTof in event!";
     return;
   }
 
-  sysID = 300; // TrackerHitsPixelEndcapLowTof
+  sysID = 300;  // TrackerHitsPixelEndcapLowTof
   j = 0;
-  for (itHit = PxlFwdLowContainer->begin(); itHit != PxlFwdLowContainer->end();
-       ++itHit) {
-
+  for (itHit = PxlFwdLowContainer->begin(); itHit != PxlFwdLowContainer->end(); ++itHit) {
     // gather necessary information
     ++j;
     HitsSysID.push_back(sysID);
@@ -552,11 +507,10 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
     HitsEloss.push_back(itHit->energyLoss());
     HitsToF.push_back(itHit->tof());
 
-  } // end loop through PxlFwd Hits
+  }  // end loop through PxlFwd Hits
 
   if (verbosity > 1) {
-    eventout +=
-        "\n          Number of Pixel Forward Low TOF Hits collected:     ";
+    eventout += "\n          Number of Pixel Forward Low TOF Hits collected:     ";
     eventout += j;
   }
 
@@ -564,16 +518,13 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> PxlFwdHighContainer;
   iEvent.getByToken(edmPSimHitContainer_pxlFwdHigh_Token_, PxlFwdHighContainer);
   if (!PxlFwdHighContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::fillTrk")
-        << "Unable to find TrackerHitsPixelEndcapHighTof in event!";
+    edm::LogError("TrackerHitProducer::fillTrk") << "Unable to find TrackerHitsPixelEndcapHighTof in event!";
     return;
   }
 
-  sysID = 400; // TrackerHitsPixelEndcapHighTof
+  sysID = 400;  // TrackerHitsPixelEndcapHighTof
   j = 0;
-  for (itHit = PxlFwdHighContainer->begin();
-       itHit != PxlFwdHighContainer->end(); ++itHit) {
-
+  for (itHit = PxlFwdHighContainer->begin(); itHit != PxlFwdHighContainer->end(); ++itHit) {
     // gather necessary information
     ++j;
     HitsSysID.push_back(sysID);
@@ -604,11 +555,10 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
     HitsEloss.push_back(itHit->energyLoss());
     HitsToF.push_back(itHit->tof());
 
-  } // end loop through PxlFwd Hits
+  }  // end loop through PxlFwd Hits
 
   if (verbosity > 1) {
-    eventout +=
-        "\n          Number of Pixel Forward High TOF Hits collected:     ";
+    eventout += "\n          Number of Pixel Forward High TOF Hits collected:     ";
     eventout += j;
   }
 
@@ -619,16 +569,13 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> SiTIBLowContainer;
   iEvent.getByToken(edmPSimHitContainer_siTIBLow_Token_, SiTIBLowContainer);
   if (!SiTIBLowContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::fillTrk")
-        << "Unable to find TrackerHitsTIBLowTof in event!";
+    edm::LogError("TrackerHitProducer::fillTrk") << "Unable to find TrackerHitsTIBLowTof in event!";
     return;
   }
 
-  sysID = 10; // TrackerHitsTIBLowTof
+  sysID = 10;  // TrackerHitsTIBLowTof
   j = 0;
-  for (itHit = SiTIBLowContainer->begin(); itHit != SiTIBLowContainer->end();
-       ++itHit) {
-
+  for (itHit = SiTIBLowContainer->begin(); itHit != SiTIBLowContainer->end(); ++itHit) {
     // gather necessary information
     ++j;
     HitsSysID.push_back(sysID);
@@ -659,7 +606,7 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
     HitsEloss.push_back(itHit->energyLoss());
     HitsToF.push_back(itHit->tof());
 
-  } // end loop through PxlFwd Hits
+  }  // end loop through PxlFwd Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of TIB low TOF Hits collected:     ";
@@ -670,16 +617,13 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> SiTIBHighContainer;
   iEvent.getByToken(edmPSimHitContainer_siTIBHigh_Token_, SiTIBHighContainer);
   if (!SiTIBHighContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::fillTrk")
-        << "Unable to find TrackerHitsTIBHighTof in event!";
+    edm::LogError("TrackerHitProducer::fillTrk") << "Unable to find TrackerHitsTIBHighTof in event!";
     return;
   }
 
-  sysID = 20; // TrackerHitsTIBHighTof
+  sysID = 20;  // TrackerHitsTIBHighTof
   j = 0;
-  for (itHit = SiTIBHighContainer->begin(); itHit != SiTIBHighContainer->end();
-       ++itHit) {
-
+  for (itHit = SiTIBHighContainer->begin(); itHit != SiTIBHighContainer->end(); ++itHit) {
     // gather necessary information
     ++j;
     HitsSysID.push_back(sysID);
@@ -710,7 +654,7 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
     HitsEloss.push_back(itHit->energyLoss());
     HitsToF.push_back(itHit->tof());
 
-  } // end loop through PxlFwd Hits
+  }  // end loop through PxlFwd Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of TIB high TOF Hits collected:     ";
@@ -724,16 +668,13 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> SiTOBLowContainer;
   iEvent.getByToken(edmPSimHitContainer_siTOBLow_Token_, SiTOBLowContainer);
   if (!SiTOBLowContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::fillTrk")
-        << "Unable to find TrackerHitsTOBLowTof in event!";
+    edm::LogError("TrackerHitProducer::fillTrk") << "Unable to find TrackerHitsTOBLowTof in event!";
     return;
   }
 
-  sysID = 30; // TrackerHitsTOBLowTof
+  sysID = 30;  // TrackerHitsTOBLowTof
   j = 0;
-  for (itHit = SiTOBLowContainer->begin(); itHit != SiTOBLowContainer->end();
-       ++itHit) {
-
+  for (itHit = SiTOBLowContainer->begin(); itHit != SiTOBLowContainer->end(); ++itHit) {
     // gather necessary information
     ++j;
     HitsSysID.push_back(sysID);
@@ -764,7 +705,7 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
     HitsEloss.push_back(itHit->energyLoss());
     HitsToF.push_back(itHit->tof());
 
-  } // end loop through PxlFwd Hits
+  }  // end loop through PxlFwd Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of TOB low TOF Hits collected:     ";
@@ -775,16 +716,13 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> SiTOBHighContainer;
   iEvent.getByToken(edmPSimHitContainer_siTOBHigh_Token_, SiTOBHighContainer);
   if (!SiTOBHighContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::fillTrk")
-        << "Unable to find TrackerHitsTOBHighTof in event!";
+    edm::LogError("TrackerHitProducer::fillTrk") << "Unable to find TrackerHitsTOBHighTof in event!";
     return;
   }
 
-  sysID = 40; // TrackerHitsTOBHighTof
+  sysID = 40;  // TrackerHitsTOBHighTof
   j = 0;
-  for (itHit = SiTOBHighContainer->begin(); itHit != SiTOBHighContainer->end();
-       ++itHit) {
-
+  for (itHit = SiTOBHighContainer->begin(); itHit != SiTOBHighContainer->end(); ++itHit) {
     // gather necessary information
     ++j;
     HitsSysID.push_back(sysID);
@@ -815,7 +753,7 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
     HitsEloss.push_back(itHit->energyLoss());
     HitsToF.push_back(itHit->tof());
 
-  } // end loop through SiTOB Hits
+  }  // end loop through SiTOB Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of TOB high TOF Hits collected:     ";
@@ -829,16 +767,13 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> SiTIDLowContainer;
   iEvent.getByToken(edmPSimHitContainer_siTIDLow_Token_, SiTIDLowContainer);
   if (!SiTIDLowContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::fillTrk")
-        << "Unable to find TrackerHitsTIDLowTof in event!";
+    edm::LogError("TrackerHitProducer::fillTrk") << "Unable to find TrackerHitsTIDLowTof in event!";
     return;
   }
 
-  sysID = 50; // TrackerHitsTIDLowTof
+  sysID = 50;  // TrackerHitsTIDLowTof
   j = 0;
-  for (itHit = SiTIDLowContainer->begin(); itHit != SiTIDLowContainer->end();
-       ++itHit) {
-
+  for (itHit = SiTIDLowContainer->begin(); itHit != SiTIDLowContainer->end(); ++itHit) {
     // gather necessary information
     ++j;
     HitsSysID.push_back(sysID);
@@ -869,7 +804,7 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
     HitsEloss.push_back(itHit->energyLoss());
     HitsToF.push_back(itHit->tof());
 
-  } // end loop through SiTID Hits
+  }  // end loop through SiTID Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of TID low TOF Hits collected:     ";
@@ -880,16 +815,13 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> SiTIDHighContainer;
   iEvent.getByToken(edmPSimHitContainer_siTIDHigh_Token_, SiTIDHighContainer);
   if (!SiTIDHighContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::fillTrk")
-        << "Unable to find TrackerHitsTIDHighTof in event!";
+    edm::LogError("TrackerHitProducer::fillTrk") << "Unable to find TrackerHitsTIDHighTof in event!";
     return;
   }
 
-  sysID = 60; // TrackerHitsTIDHighTof
+  sysID = 60;  // TrackerHitsTIDHighTof
   j = 0;
-  for (itHit = SiTIDHighContainer->begin(); itHit != SiTIDHighContainer->end();
-       ++itHit) {
-
+  for (itHit = SiTIDHighContainer->begin(); itHit != SiTIDHighContainer->end(); ++itHit) {
     // gather necessary information
     ++j;
     HitsSysID.push_back(sysID);
@@ -920,7 +852,7 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
     HitsEloss.push_back(itHit->energyLoss());
     HitsToF.push_back(itHit->tof());
 
-  } // end loop through SiTID Hits
+  }  // end loop through SiTID Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of TID high TOF Hits collected:     ";
@@ -934,16 +866,13 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> SiTECLowContainer;
   iEvent.getByToken(edmPSimHitContainer_siTECLow_Token_, SiTECLowContainer);
   if (!SiTECLowContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::fillTrk")
-        << "Unable to find TrackerHitsTECLowTof in event!";
+    edm::LogError("TrackerHitProducer::fillTrk") << "Unable to find TrackerHitsTECLowTof in event!";
     return;
   }
 
-  sysID = 70; // TrackerHitsTECLowTof
+  sysID = 70;  // TrackerHitsTECLowTof
   j = 0;
-  for (itHit = SiTECLowContainer->begin(); itHit != SiTECLowContainer->end();
-       ++itHit) {
-
+  for (itHit = SiTECLowContainer->begin(); itHit != SiTECLowContainer->end(); ++itHit) {
     // gather necessary information
     ++j;
     HitsSysID.push_back(sysID);
@@ -974,7 +903,7 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
     HitsEloss.push_back(itHit->energyLoss());
     HitsToF.push_back(itHit->tof());
 
-  } // end loop through SiTEC Hits
+  }  // end loop through SiTEC Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of TEC low TOF Hits collected:     ";
@@ -985,15 +914,12 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
   edm::Handle<edm::PSimHitContainer> SiTECHighContainer;
   iEvent.getByToken(edmPSimHitContainer_siTECHigh_Token_, SiTECHighContainer);
   if (!SiTECHighContainer.isValid()) {
-    edm::LogError("TrackerHitProducer::fillTrk")
-        << "Unable to find TrackerHitsTECHighTof in event!";
+    edm::LogError("TrackerHitProducer::fillTrk") << "Unable to find TrackerHitsTECHighTof in event!";
     return;
   }
-  sysID = 80; // TrackerHitsTECHighTof
+  sysID = 80;  // TrackerHitsTECHighTof
   j = 0;
-  for (itHit = SiTECHighContainer->begin(); itHit != SiTECHighContainer->end();
-       ++itHit) {
-
+  for (itHit = SiTECHighContainer->begin(); itHit != SiTECHighContainer->end(); ++itHit) {
     // gather necessary information
     ++j;
     HitsSysID.push_back(sysID);
@@ -1024,7 +950,7 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
     HitsEloss.push_back(itHit->energyLoss());
     HitsToF.push_back(itHit->tof());
 
-  } // end loop through SiTEC Hits
+  }  // end loop through SiTEC Hits
 
   if (verbosity > 1) {
     eventout += "\n          Number of TEC high TOF Hits collected:     ";
@@ -1038,7 +964,6 @@ void TrackerHitProducer::fillTrk(edm::Event &iEvent,
 }
 
 void TrackerHitProducer::storeTrk(PTrackerSimHit &product) {
-
   /*
     if (verbosity > 2) {
       TString eventout("\nnPxlBrlHits        = ");
@@ -1096,10 +1021,28 @@ void TrackerHitProducer::storeTrk(PTrackerSimHit &product) {
       edm::LogInfo("TrackerHitProducer::storeTrk") << eventout;
     } // end verbose output
   */
-  product.putHits(HitsSysID, HitsDuID, HitsTkID, HitsProT, HitsParT, HitsP,
-                  HitsLpX, HitsLpY, HitsLpZ, HitsLdX, HitsLdY, HitsLdZ,
-                  HitsLdTheta, HitsLdPhi, HitsExPx, HitsExPy, HitsExPz,
-                  HitsEnPx, HitsEnPy, HitsEnPz, HitsEloss, HitsToF);
+  product.putHits(HitsSysID,
+                  HitsDuID,
+                  HitsTkID,
+                  HitsProT,
+                  HitsParT,
+                  HitsP,
+                  HitsLpX,
+                  HitsLpY,
+                  HitsLpZ,
+                  HitsLdX,
+                  HitsLdY,
+                  HitsLdZ,
+                  HitsLdTheta,
+                  HitsLdPhi,
+                  HitsExPx,
+                  HitsExPy,
+                  HitsExPz,
+                  HitsEnPx,
+                  HitsEnPy,
+                  HitsEnPz,
+                  HitsEloss,
+                  HitsToF);
 
   return;
 }

--- a/Validation/TrackingMCTruth/interface/TrackingTruthValid.h
+++ b/Validation/TrackingMCTruth/interface/TrackingTruthValid.h
@@ -22,8 +22,7 @@ public:
 
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
-  void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &run,
-                      const edm::EventSetup &es) override;
+  void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &run, const edm::EventSetup &es) override;
   void endJob() override;
 
 private:

--- a/Validation/TrackingMCTruth/plugins/TrackingTruthValid.cc
+++ b/Validation/TrackingMCTruth/plugins/TrackingTruthValid.cc
@@ -29,63 +29,53 @@ typedef TrackingVertex::g4v_iterator g4v_iterator;
 
 TrackingTruthValid::TrackingTruthValid(const edm::ParameterSet &conf)
     : runStandalone(conf.getParameter<bool>("runStandalone")),
-      outputFile(conf.getParameter<std::string>("outputFile")), dbe_(nullptr),
-      vec_TrackingParticle_Token_(consumes<TrackingParticleCollection>(
-          conf.getParameter<edm::InputTag>("src"))) {}
+      outputFile(conf.getParameter<std::string>("outputFile")),
+      dbe_(nullptr),
+      vec_TrackingParticle_Token_(consumes<TrackingParticleCollection>(conf.getParameter<edm::InputTag>("src"))) {}
 
-void TrackingTruthValid::bookHistograms(DQMStore::IBooker &ibooker,
-                                        const edm::Run &run,
-                                        const edm::EventSetup &es) {
+void TrackingTruthValid::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &run, const edm::EventSetup &es) {
   dbe_ = edm::Service<DQMStore>().operator->();
   ibooker.setCurrentFolder("Tracking/TrackingMCTruth/TrackingParticle");
 
   meTPMass = ibooker.book1D("TPMass", "Tracking Particle Mass", 100, -1, +5.);
-  meTPCharge =
-      ibooker.book1D("TPCharge", "Tracking Particle Charge", 10, -5, 5);
+  meTPCharge = ibooker.book1D("TPCharge", "Tracking Particle Charge", 10, -5, 5);
   meTPId = ibooker.book1D("TPId", "Tracking Particle Id", 500, -5000, 5000);
   meTPProc = ibooker.book1D("TPProc", "Tracking Particle Proc", 20, -0.5, 19.5);
-  meTPAllHits = ibooker.book1D("TPAllHits", "Tracking Particle All Hits", 200,
-                               -0.5, 199.5);
-  meTPMatchedHits = ibooker.book1D(
-      "TPMatchedHits", "Tracking Particle Matched Hits", 100, -0.5, 99.5);
+  meTPAllHits = ibooker.book1D("TPAllHits", "Tracking Particle All Hits", 200, -0.5, 199.5);
+  meTPMatchedHits = ibooker.book1D("TPMatchedHits", "Tracking Particle Matched Hits", 100, -0.5, 99.5);
   meTPPt = ibooker.book1D("TPPt", "Tracking Particle Pt", 100, 0, 100.);
   meTPEta = ibooker.book1D("TPEta", "Tracking Particle Eta", 100, -7., 7.);
   meTPPhi = ibooker.book1D("TPPhi", "Tracking Particle Phi", 100, -4., 4);
-  meTPVtxX =
-      ibooker.book1D("TPVtxX", "Tracking Particle VtxX", 100, -100, 100.);
-  meTPVtxY =
-      ibooker.book1D("TPVtxY", "Tracking Particle VtxY", 100, -100, 100.);
-  meTPVtxZ =
-      ibooker.book1D("TPVtxZ", "Tracking Particle VtxZ", 100, -100, 100.);
+  meTPVtxX = ibooker.book1D("TPVtxX", "Tracking Particle VtxX", 100, -100, 100.);
+  meTPVtxY = ibooker.book1D("TPVtxY", "Tracking Particle VtxY", 100, -100, 100.);
+  meTPVtxZ = ibooker.book1D("TPVtxZ", "Tracking Particle VtxZ", 100, -100, 100.);
   meTPtip = ibooker.book1D("TPtip", "Tracking Particle tip", 100, 0, 1000.);
   meTPlip = ibooker.book1D("TPlip", "Tracking Particle lip", 100, 0, 100.);
 
   // Prepare Axes Labels for Processes
-  meTPProc->setBinLabel(1, "Undefined");             // value =  0
-  meTPProc->setBinLabel(2, "Unknown");               // value =  1
-  meTPProc->setBinLabel(3, "Primary");               // value =  2
-  meTPProc->setBinLabel(4, "Hadronic");              // value =  3
-  meTPProc->setBinLabel(5, "Decay");                 // value =  4
-  meTPProc->setBinLabel(6, "Compton");               // value =  5
-  meTPProc->setBinLabel(7, "Annihilation");          // value =  6
-  meTPProc->setBinLabel(8, "EIoni");                 // value =  7
-  meTPProc->setBinLabel(9, "HIoni");                 // value =  8
-  meTPProc->setBinLabel(10, "MuIoni");               // value =  9
-  meTPProc->setBinLabel(11, "Photon");               // value = 10
-  meTPProc->setBinLabel(12, "MuPairProd");           // value = 11
-  meTPProc->setBinLabel(13, "Conversions");          // value = 12
-  meTPProc->setBinLabel(14, "EBrem");                // value = 13
-  meTPProc->setBinLabel(15, "SynchrotronRadiation"); // value = 14
-  meTPProc->setBinLabel(16, "MuBrem");               // value = 15
-  meTPProc->setBinLabel(17, "MuNucl");               // value = 16
+  meTPProc->setBinLabel(1, "Undefined");              // value =  0
+  meTPProc->setBinLabel(2, "Unknown");                // value =  1
+  meTPProc->setBinLabel(3, "Primary");                // value =  2
+  meTPProc->setBinLabel(4, "Hadronic");               // value =  3
+  meTPProc->setBinLabel(5, "Decay");                  // value =  4
+  meTPProc->setBinLabel(6, "Compton");                // value =  5
+  meTPProc->setBinLabel(7, "Annihilation");           // value =  6
+  meTPProc->setBinLabel(8, "EIoni");                  // value =  7
+  meTPProc->setBinLabel(9, "HIoni");                  // value =  8
+  meTPProc->setBinLabel(10, "MuIoni");                // value =  9
+  meTPProc->setBinLabel(11, "Photon");                // value = 10
+  meTPProc->setBinLabel(12, "MuPairProd");            // value = 11
+  meTPProc->setBinLabel(13, "Conversions");           // value = 12
+  meTPProc->setBinLabel(14, "EBrem");                 // value = 13
+  meTPProc->setBinLabel(15, "SynchrotronRadiation");  // value = 14
+  meTPProc->setBinLabel(16, "MuBrem");                // value = 15
+  meTPProc->setBinLabel(17, "MuNucl");                // value = 16
   meTPProc->setBinLabel(18, "");
   meTPProc->setBinLabel(19, "");
   meTPProc->setBinLabel(20, "");
 }
 
-void TrackingTruthValid::analyze(const edm::Event &event,
-                                 const edm::EventSetup &c) {
-
+void TrackingTruthValid::analyze(const edm::Event &event, const edm::EventSetup &c) {
   edm::Handle<TrackingParticleCollection> TruthTrackContainer;
   //  edm::Handle<TrackingVertexCollection>    TruthVertexContainer;
 
@@ -94,8 +84,7 @@ void TrackingTruthValid::analyze(const edm::Event &event,
   const TrackingParticleCollection *tPC = TruthTrackContainer.product();
 
   // Loop over TrackingParticle's
-  for (TrackingParticleCollection::const_iterator t = tPC->begin();
-       t != tPC->end(); ++t) {
+  for (TrackingParticleCollection::const_iterator t = tPC->begin(); t != tPC->end(); ++t) {
     // if(t -> trackerPSimHit().size() ==0) cout << " Track with 0 SimHit " <<
     // endl;
 
@@ -156,7 +145,7 @@ void TrackingTruthValid::analyze(const edm::Event &event,
       std::cout << "\t Muon: "    << t->muonPSimHit().size()    << std::endl;
       std::cout << (*t) << std::endl;
     */
-  } // End loop over TrackingParticle
+  }  // End loop over TrackingParticle
 
   // Loop over TrackingVertex's
   /*


### PR DESCRIPTION

Applying code-format for CMSSW category dqm.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/187//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Fixes the code-formats suggested by #26619 (see #26686)
