### PR TITLE
Running code-format for simulation

### DIFF
--- a/DataFormats/SiStripDetId/interface/SiStripDetId.h
+++ b/DataFormats/SiStripDetId/interface/SiStripDetId.h
@@ -15,7 +15,6 @@ std::ostream &operator<<(std::ostream &, const SiStripDetId &);
     @brief Detector identifier class for the strip tracker.
 */
 class SiStripDetId : public DetId {
-
 public:
   // ---------- Constructors, enumerated types ----------
 
@@ -35,23 +34,7 @@ public:
   enum SubDetector { UNKNOWN = 0, TIB = 3, TID = 4, TOB = 5, TEC = 6 };
 
   /** Enumerated type for tracker module geometries. */
-  enum ModuleGeometry {
-    UNKNOWNGEOMETRY,
-    IB1,
-    IB2,
-    OB1,
-    OB2,
-    W1A,
-    W2A,
-    W3A,
-    W1B,
-    W2B,
-    W3B,
-    W4,
-    W5,
-    W6,
-    W7
-  };
+  enum ModuleGeometry { UNKNOWNGEOMETRY, IB1, IB2, OB1, OB2, W1A, W2A, W3A, W1B, W2B, W3B, W4, W5, W6, W7 };
 
   // ---------- Common methods ----------
 
@@ -76,8 +59,7 @@ public:
   // ---------- Constructors that set "reserved" field ----------
 
   /** Construct from a raw value and set "reserved" field. */
-  SiStripDetId(const uint32_t &raw_id, const uint16_t &reserved)
-      : DetId(raw_id) {
+  SiStripDetId(const uint32_t &raw_id, const uint16_t &reserved) : DetId(raw_id) {
     id_ &= (~static_cast<uint32_t>(reservedMask_ << reservedStartBit_));
     id_ |= ((reserved & reservedMask_) << reservedStartBit_);
   }
@@ -86,8 +68,7 @@ public:
   //
 
   /** Construct from generic DetId and set "reserved" field. */
-  SiStripDetId(const DetId &det_id, const uint16_t &reserved)
-      : DetId(det_id.rawId()) {
+  SiStripDetId(const DetId &det_id, const uint16_t &reserved) : DetId(det_id.rawId()) {
     id_ &= (~static_cast<uint32_t>(reservedMask_ << reservedStartBit_));
     id_ |= ((reserved & reservedMask_) << reservedStartBit_);
   }
@@ -125,51 +106,51 @@ SiStripDetId::SubDetector SiStripDetId::subDetector() const {
 SiStripDetId::ModuleGeometry SiStripDetId::moduleGeometry() const {
   SiStripDetId::ModuleGeometry geometry = UNKNOWNGEOMETRY;
   switch (subDetector()) {
-  case TIB:
-    geometry = int((id_ >> layerStartBit_) & layerMask_) < 3 ? IB1 : IB2;
-    break;
-  case TOB:
-    geometry = int((id_ >> layerStartBit_) & layerMask_) < 5 ? OB2 : OB1;
-    break;
-  case TID:
-    switch ((id_ >> ringStartBitTID_) & ringMaskTID_) {
-    case 1:
-      geometry = W1A;
+    case TIB:
+      geometry = int((id_ >> layerStartBit_) & layerMask_) < 3 ? IB1 : IB2;
       break;
-    case 2:
-      geometry = W2A;
+    case TOB:
+      geometry = int((id_ >> layerStartBit_) & layerMask_) < 5 ? OB2 : OB1;
       break;
-    case 3:
-      geometry = W3A;
+    case TID:
+      switch ((id_ >> ringStartBitTID_) & ringMaskTID_) {
+        case 1:
+          geometry = W1A;
+          break;
+        case 2:
+          geometry = W2A;
+          break;
+        case 3:
+          geometry = W3A;
+          break;
+      }
       break;
-    }
-    break;
-  case TEC:
-    switch ((id_ >> ringStartBitTEC_) & ringMaskTEC_) {
-    case 1:
-      geometry = W1B;
-      break;
-    case 2:
-      geometry = W2B;
-      break;
-    case 3:
-      geometry = W3B;
-      break;
-    case 4:
-      geometry = W4;
-      break;
-    case 5:
-      geometry = W5;
-      break;
-    case 6:
-      geometry = W6;
-      break;
-    case 7:
-      geometry = W7;
-      break;
-    }
-  case UNKNOWN:
-  default:;
+    case TEC:
+      switch ((id_ >> ringStartBitTEC_) & ringMaskTEC_) {
+        case 1:
+          geometry = W1B;
+          break;
+        case 2:
+          geometry = W2B;
+          break;
+        case 3:
+          geometry = W3B;
+          break;
+        case 4:
+          geometry = W4;
+          break;
+        case 5:
+          geometry = W5;
+          break;
+        case 6:
+          geometry = W6;
+          break;
+        case 7:
+          geometry = W7;
+          break;
+      }
+    case UNKNOWN:
+    default:;
   }
   return geometry;
 }
@@ -179,9 +160,7 @@ uint32_t SiStripDetId::glued() const {
   return (testId == 0) ? 0 : (id_ - testId);
 }
 
-uint32_t SiStripDetId::stereo() const {
-  return (((id_ >> sterStartBit_) & sterMask_) == 1) ? 1 : 0;
-}
+uint32_t SiStripDetId::stereo() const { return (((id_ >> sterStartBit_) & sterMask_) == 1) ? 1 : 0; }
 
 uint32_t SiStripDetId::partnerDetId() const {
   uint32_t testId = (id_ >> sterStartBit_) & sterMask_;
@@ -197,8 +176,6 @@ uint32_t SiStripDetId::partnerDetId() const {
 
 double SiStripDetId::stripLength() const { return 0.; }
 
-uint16_t SiStripDetId::reserved() const {
-  return static_cast<uint16_t>((id_ >> reservedStartBit_) & reservedMask_);
-}
+uint16_t SiStripDetId::reserved() const { return static_cast<uint16_t>((id_ >> reservedStartBit_) & reservedMask_); }
 
-#endif // DataFormats_SiStripDetId_SiStripDetId_h
+#endif  // DataFormats_SiStripDetId_SiStripDetId_h

--- a/DataFormats/SiStripDetId/interface/SiStripSubStructure.h
+++ b/DataFormats/SiStripDetId/interface/SiStripSubStructure.h
@@ -26,41 +26,37 @@
 class TrackerTopology;
 
 namespace SiStripSubStructure {
-void getTIBDetectors(
-    const std::vector<uint32_t> &inputDetRawIds, // INPUT
-    std::vector<uint32_t> &tibDetRawIds,         // OUTPUT
-    const TrackerTopology *trackerTopology,      // TrackerTopology
-    uint32_t layer = 0,   // SELECTION: layer = 1..4, 0(ALL)
-    uint32_t bkw_frw = 0, // bkw_frw = 1(TIB-), 2(TIB+) 0(ALL)
-    uint32_t int_ext = 0, // int_ext = 1 (internal), 2(external), 0(ALL)
-    uint32_t string = 0); // string = 1..N, 0(ALL)
+  void getTIBDetectors(const std::vector<uint32_t> &inputDetRawIds,  // INPUT
+                       std::vector<uint32_t> &tibDetRawIds,          // OUTPUT
+                       const TrackerTopology *trackerTopology,       // TrackerTopology
+                       uint32_t layer = 0,                           // SELECTION: layer = 1..4, 0(ALL)
+                       uint32_t bkw_frw = 0,                         // bkw_frw = 1(TIB-), 2(TIB+) 0(ALL)
+                       uint32_t int_ext = 0,                         // int_ext = 1 (internal), 2(external), 0(ALL)
+                       uint32_t string = 0);                         // string = 1..N, 0(ALL)
 
-void getTIDDetectors(
-    const std::vector<uint32_t> &inputDetRawIds, // INPUT
-    std::vector<uint32_t> &tidDetRawIds,         // OUTPUT
-    const TrackerTopology *trackerTopology,      // TrackerTopology
-    uint32_t side = 0,  // SELECTION: side = 1(back), 2(front), 0(ALL)
-    uint32_t wheel = 0, // wheel = 1..3, 0(ALL)
-    uint32_t ring = 0,  // ring  = 1..3, 0(ALL)
-    uint32_t ster = 0); // ster = 1(stereo), else (nonstereo), 0(ALL)
+  void getTIDDetectors(const std::vector<uint32_t> &inputDetRawIds,  // INPUT
+                       std::vector<uint32_t> &tidDetRawIds,          // OUTPUT
+                       const TrackerTopology *trackerTopology,       // TrackerTopology
+                       uint32_t side = 0,                            // SELECTION: side = 1(back), 2(front), 0(ALL)
+                       uint32_t wheel = 0,                           // wheel = 1..3, 0(ALL)
+                       uint32_t ring = 0,                            // ring  = 1..3, 0(ALL)
+                       uint32_t ster = 0);                           // ster = 1(stereo), else (nonstereo), 0(ALL)
 
-void getTOBDetectors(
-    const std::vector<uint32_t> &inputDetRawIds, // INPUT
-    std::vector<uint32_t> &tobDetRawIds,         // OUTPUT
-    const TrackerTopology *trackerTopology,      // TrackerTopology
-    uint32_t layer = 0,   // SELECTION: layer = 1..6, 0(ALL)
-    uint32_t bkw_frw = 0, // bkw_frw = 1(TOB-) 2(TOB+) 0(everything)
-    uint32_t rod = 0);    // rod = 1..N, 0(ALL)
+  void getTOBDetectors(const std::vector<uint32_t> &inputDetRawIds,  // INPUT
+                       std::vector<uint32_t> &tobDetRawIds,          // OUTPUT
+                       const TrackerTopology *trackerTopology,       // TrackerTopology
+                       uint32_t layer = 0,                           // SELECTION: layer = 1..6, 0(ALL)
+                       uint32_t bkw_frw = 0,                         // bkw_frw = 1(TOB-) 2(TOB+) 0(everything)
+                       uint32_t rod = 0);                            // rod = 1..N, 0(ALL)
 
-void getTECDetectors(
-    const std::vector<uint32_t> &inputDetRawIds, // INPUT
-    std::vector<uint32_t> &tecDetRawIds,         // OUTPUT
-    const TrackerTopology *trackerTopology,      // TrackerTopology
-    uint32_t side = 0,          // SELECTION: side = 1(TEC-), 2(TEC+),  0(ALL)
-    uint32_t wheel = 0,         // wheel = 1..9, 0(ALL)
-    uint32_t petal_bkw_frw = 0, // petal_bkw_frw = 1(backward) 2(forward) 0(all)
-    uint32_t petal = 0,         // petal = 1..8, 0(ALL)
-    uint32_t ring = 0,          // ring = 1..7, 0(ALL)
-    uint32_t ster = 0);         // ster = 1(sterero), else(nonstereo), 0(ALL)
-};                              // namespace SiStripSubStructure
+  void getTECDetectors(const std::vector<uint32_t> &inputDetRawIds,  // INPUT
+                       std::vector<uint32_t> &tecDetRawIds,          // OUTPUT
+                       const TrackerTopology *trackerTopology,       // TrackerTopology
+                       uint32_t side = 0,                            // SELECTION: side = 1(TEC-), 2(TEC+),  0(ALL)
+                       uint32_t wheel = 0,                           // wheel = 1..9, 0(ALL)
+                       uint32_t petal_bkw_frw = 0,                   // petal_bkw_frw = 1(backward) 2(forward) 0(all)
+                       uint32_t petal = 0,                           // petal = 1..8, 0(ALL)
+                       uint32_t ring = 0,                            // ring = 1..7, 0(ALL)
+                       uint32_t ster = 0);                           // ster = 1(sterero), else(nonstereo), 0(ALL)
+};                                                                   // namespace SiStripSubStructure
 #endif

--- a/DataFormats/SiStripDetId/src/SiStripDetId.cc
+++ b/DataFormats/SiStripDetId/src/SiStripDetId.cc
@@ -3,11 +3,10 @@
 
 std::ostream &operator<<(std::ostream &os, const SiStripDetId &id) {
   return os << "[SiStripDetId::print]" << std::endl
-            << " rawId       : 0x" << std::hex << std::setfill('0')
-            << std::setw(8) << id.rawId() << std::dec << std::endl
-            << " bits[0:24]  : " << std::hex << std::setfill('0')
-            << std::setw(8) << (0x01FFFFFF & id.rawId()) << std::dec
+            << " rawId       : 0x" << std::hex << std::setfill('0') << std::setw(8) << id.rawId() << std::dec
             << std::endl
+            << " bits[0:24]  : " << std::hex << std::setfill('0') << std::setw(8) << (0x01FFFFFF & id.rawId())
+            << std::dec << std::endl
             << " Detector    : " << id.det() << std::endl
             << " SubDetector : " << id.subdetId() << std::endl
             << " reserved    : " << id.reserved();

--- a/DataFormats/SiStripDetId/src/SiStripSubStructure.cc
+++ b/DataFormats/SiStripDetId/src/SiStripSubStructure.cc
@@ -15,79 +15,88 @@
 
 #include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 
-void SiStripSubStructure::getTIBDetectors(
-    const std::vector<uint32_t> &inputDetRawIds,
-    std::vector<uint32_t> &tibDetRawIds, const TrackerTopology *tTopo,
-    uint32_t rq_layer, uint32_t rq_bkw_frw, uint32_t rq_int_ext,
-    uint32_t rq_string) {
-  std::copy_if(
-      std::begin(inputDetRawIds), std::end(inputDetRawIds),
-      std::back_inserter(tibDetRawIds),
-      [tTopo, rq_layer, rq_bkw_frw, rq_int_ext, rq_string](DetId det) {
-        return ((StripSubdetector::TIB == det.subdetId())
-                // check if TIB is from the ones requested
-                // take everything if default value is 0
-                && ((rq_layer == 0) || (rq_layer == tTopo->tibLayer(det))) &&
-                ((rq_bkw_frw == 0) || (rq_bkw_frw == tTopo->tibSide(det))) &&
-                ((rq_int_ext == 0) || (rq_int_ext == tTopo->tibOrder(det))) &&
-                ((rq_string == 0) || (rq_string == tTopo->tibString(det))));
-      });
-}
-
-void SiStripSubStructure::getTIDDetectors(
-    const std::vector<uint32_t> &inputDetRawIds,
-    std::vector<uint32_t> &tidDetRawIds, const TrackerTopology *tTopo,
-    uint32_t rq_side, uint32_t rq_wheel, uint32_t rq_ring, uint32_t rq_ster) {
-  std::copy_if(std::begin(inputDetRawIds), std::end(inputDetRawIds),
-               std::back_inserter(tidDetRawIds),
-               [tTopo, rq_side, rq_wheel, rq_ring, rq_ster](DetId det) {
-                 return (
-                     (StripSubdetector::TID == det.subdetId())
-                     // check if TID is from the ones requested
-                     // take everything if default value is 0
-                     && ((rq_side == 0) || (rq_side == tTopo->tidSide(det))) &&
-                     ((rq_wheel == 0) || (rq_wheel == tTopo->tidWheel(det))) &&
-                     ((rq_ring == 0) || (rq_ring == tTopo->tidRing(det))) &&
-                     ((rq_ster == 0) || (rq_ster == tTopo->tidStereo(det))));
+void SiStripSubStructure::getTIBDetectors(const std::vector<uint32_t> &inputDetRawIds,
+                                          std::vector<uint32_t> &tibDetRawIds,
+                                          const TrackerTopology *tTopo,
+                                          uint32_t rq_layer,
+                                          uint32_t rq_bkw_frw,
+                                          uint32_t rq_int_ext,
+                                          uint32_t rq_string) {
+  std::copy_if(std::begin(inputDetRawIds),
+               std::end(inputDetRawIds),
+               std::back_inserter(tibDetRawIds),
+               [tTopo, rq_layer, rq_bkw_frw, rq_int_ext, rq_string](DetId det) {
+                 return ((StripSubdetector::TIB == det.subdetId())
+                         // check if TIB is from the ones requested
+                         // take everything if default value is 0
+                         && ((rq_layer == 0) || (rq_layer == tTopo->tibLayer(det))) &&
+                         ((rq_bkw_frw == 0) || (rq_bkw_frw == tTopo->tibSide(det))) &&
+                         ((rq_int_ext == 0) || (rq_int_ext == tTopo->tibOrder(det))) &&
+                         ((rq_string == 0) || (rq_string == tTopo->tibString(det))));
                });
 }
 
-void SiStripSubStructure::getTOBDetectors(
-    const std::vector<uint32_t> &inputDetRawIds,
-    std::vector<uint32_t> &tobDetRawIds, const TrackerTopology *tTopo,
-    uint32_t rq_layer, uint32_t rq_bkw_frw, uint32_t rq_rod) {
-  std::copy_if(
-      std::begin(inputDetRawIds), std::end(inputDetRawIds),
-      std::back_inserter(tobDetRawIds),
-      [tTopo, rq_layer, rq_bkw_frw, rq_rod](DetId det) {
-        return ((StripSubdetector::TOB == det.subdetId())
-                // check if TOB is from the ones requested
-                // take everything if default value is 0
-                && ((rq_layer == 0) || (rq_layer == tTopo->tobLayer(det))) &&
-                ((rq_bkw_frw == 0) || (rq_bkw_frw == tTopo->tobSide(det))) &&
-                ((rq_rod == 0) || (rq_rod == tTopo->tobRod(det))));
-      });
+void SiStripSubStructure::getTIDDetectors(const std::vector<uint32_t> &inputDetRawIds,
+                                          std::vector<uint32_t> &tidDetRawIds,
+                                          const TrackerTopology *tTopo,
+                                          uint32_t rq_side,
+                                          uint32_t rq_wheel,
+                                          uint32_t rq_ring,
+                                          uint32_t rq_ster) {
+  std::copy_if(std::begin(inputDetRawIds),
+               std::end(inputDetRawIds),
+               std::back_inserter(tidDetRawIds),
+               [tTopo, rq_side, rq_wheel, rq_ring, rq_ster](DetId det) {
+                 return ((StripSubdetector::TID == det.subdetId())
+                         // check if TID is from the ones requested
+                         // take everything if default value is 0
+                         && ((rq_side == 0) || (rq_side == tTopo->tidSide(det))) &&
+                         ((rq_wheel == 0) || (rq_wheel == tTopo->tidWheel(det))) &&
+                         ((rq_ring == 0) || (rq_ring == tTopo->tidRing(det))) &&
+                         ((rq_ster == 0) || (rq_ster == tTopo->tidStereo(det))));
+               });
 }
 
-void SiStripSubStructure::getTECDetectors(
-    const std::vector<uint32_t> &inputDetRawIds,
-    std::vector<uint32_t> &tecDetRawIds, const TrackerTopology *tTopo,
-    uint32_t rq_side, uint32_t rq_wheel, uint32_t rq_petal_bkw_frw,
-    uint32_t rq_petal, uint32_t rq_ring, uint32_t rq_ster) {
-  std::copy_if(
-      std::begin(inputDetRawIds), std::end(inputDetRawIds),
-      std::back_inserter(tecDetRawIds),
-      [tTopo, rq_side, rq_wheel, rq_petal_bkw_frw, rq_petal, rq_ring,
-       rq_ster](DetId det) {
-        return ((StripSubdetector::TEC == det.subdetId())
-                // check if TEC is from the ones requested
-                // take everything if default value is 0
-                && ((rq_side == 0) || (rq_side == tTopo->tecSide(det))) &&
-                ((rq_wheel == 0) || (rq_wheel == tTopo->tecWheel(det))) &&
-                ((rq_petal_bkw_frw == 0) ||
-                 (rq_petal_bkw_frw - 1 == tTopo->tecOrder(det))) &&
-                ((rq_petal == 0) || (rq_petal == tTopo->tecPetalNumber(det))) &&
-                ((rq_ring == 0) || (rq_ring == tTopo->tecRing(det))) &&
-                ((rq_ster == 0) || (rq_ster == tTopo->tecStereo(det))));
-      });
+void SiStripSubStructure::getTOBDetectors(const std::vector<uint32_t> &inputDetRawIds,
+                                          std::vector<uint32_t> &tobDetRawIds,
+                                          const TrackerTopology *tTopo,
+                                          uint32_t rq_layer,
+                                          uint32_t rq_bkw_frw,
+                                          uint32_t rq_rod) {
+  std::copy_if(std::begin(inputDetRawIds),
+               std::end(inputDetRawIds),
+               std::back_inserter(tobDetRawIds),
+               [tTopo, rq_layer, rq_bkw_frw, rq_rod](DetId det) {
+                 return ((StripSubdetector::TOB == det.subdetId())
+                         // check if TOB is from the ones requested
+                         // take everything if default value is 0
+                         && ((rq_layer == 0) || (rq_layer == tTopo->tobLayer(det))) &&
+                         ((rq_bkw_frw == 0) || (rq_bkw_frw == tTopo->tobSide(det))) &&
+                         ((rq_rod == 0) || (rq_rod == tTopo->tobRod(det))));
+               });
+}
+
+void SiStripSubStructure::getTECDetectors(const std::vector<uint32_t> &inputDetRawIds,
+                                          std::vector<uint32_t> &tecDetRawIds,
+                                          const TrackerTopology *tTopo,
+                                          uint32_t rq_side,
+                                          uint32_t rq_wheel,
+                                          uint32_t rq_petal_bkw_frw,
+                                          uint32_t rq_petal,
+                                          uint32_t rq_ring,
+                                          uint32_t rq_ster) {
+  std::copy_if(std::begin(inputDetRawIds),
+               std::end(inputDetRawIds),
+               std::back_inserter(tecDetRawIds),
+               [tTopo, rq_side, rq_wheel, rq_petal_bkw_frw, rq_petal, rq_ring, rq_ster](DetId det) {
+                 return ((StripSubdetector::TEC == det.subdetId())
+                         // check if TEC is from the ones requested
+                         // take everything if default value is 0
+                         && ((rq_side == 0) || (rq_side == tTopo->tecSide(det))) &&
+                         ((rq_wheel == 0) || (rq_wheel == tTopo->tecWheel(det))) &&
+                         ((rq_petal_bkw_frw == 0) || (rq_petal_bkw_frw - 1 == tTopo->tecOrder(det))) &&
+                         ((rq_petal == 0) || (rq_petal == tTopo->tecPetalNumber(det))) &&
+                         ((rq_ring == 0) || (rq_ring == tTopo->tecRing(det))) &&
+                         ((rq_ster == 0) || (rq_ster == tTopo->tecStereo(det))));
+               });
 }

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloDigiCollectionSorter.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloDigiCollectionSorter.h
@@ -18,7 +18,8 @@ public:
   CaloDigiCollectionSorter(int bin) : theMaxBin(bin) {}
 
   /// embedded class to be used as a sort predicate
-  template <class T> class CaloDigiSortByMaxBin {
+  template <class T>
+  class CaloDigiSortByMaxBin {
   public:
     CaloDigiSortByMaxBin(int bin) : theMaxBin(bin) {}
 

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloHitAnalyzer.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloHitAnalyzer.h
@@ -20,7 +20,8 @@ class CaloVHitFilter;
 
 class CaloHitAnalyzer {
 public:
-  CaloHitAnalyzer(const std::string &name, double hitEnergyThreshold,
+  CaloHitAnalyzer(const std::string &name,
+                  double hitEnergyThreshold,
                   const CaloVSimParameterMap *parameterMap,
                   const CaloVHitFilter *filter = nullptr);
 

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
@@ -20,7 +20,7 @@
 */
 
 namespace CLHEP {
-class HepRandomEngine;
+  class HepRandomEngine;
 }
 
 class CaloVShape;
@@ -36,10 +36,8 @@ public:
   // get this from somewhere external
   enum { BUNCHSPACE = 25 };
 
-  CaloHitResponse(const CaloVSimParameterMap *parameterMap,
-                  const CaloVShape *shape);
-  CaloHitResponse(const CaloVSimParameterMap *parameterMap,
-                  const CaloShapes *shapes);
+  CaloHitResponse(const CaloVSimParameterMap *parameterMap, const CaloVShape *shape);
+  CaloHitResponse(const CaloVSimParameterMap *parameterMap, const CaloShapes *shapes);
 
   /// doesn't delete the pointers passed in
   virtual ~CaloHitResponse();
@@ -59,8 +57,7 @@ public:
   virtual void finalizeHits(CLHEP::HepRandomEngine *) {}
 
   /// Complete cell digitization.
-  virtual void run(const MixCollection<PCaloHit> &hits,
-                   CLHEP::HepRandomEngine *);
+  virtual void run(const MixCollection<PCaloHit> &hits, CLHEP::HepRandomEngine *);
 
   /// process a single SimHit
   virtual void add(const PCaloHit &hit, CLHEP::HepRandomEngine *);
@@ -73,14 +70,10 @@ public:
   void setHitFilter(const CaloVHitFilter *filter) { theHitFilter = filter; }
 
   /// If you want to correct hits, for attenuation or delay, set this.
-  void setHitCorrection(const CaloVHitCorrection *hitCorrection) {
-    theHitCorrection = hitCorrection;
-  }
+  void setHitCorrection(const CaloVHitCorrection *hitCorrection) { theHitCorrection = hitCorrection; }
 
   /// if you want to correct the photoelectrons
-  void setPECorrection(const CaloVPECorrection *peCorrection) {
-    thePECorrection = peCorrection;
-  }
+  void setPECorrection(const CaloVPECorrection *peCorrection) { thePECorrection = peCorrection; }
 
   /// frees up memory
   void clear() { theAnalogSignalMap.clear(); }
@@ -89,12 +82,12 @@ public:
   void addHit(const PCaloHit *hit, CaloSamples &frame) const;
 
   /// creates the signal corresponding to this hit
-  virtual CaloSamples makeAnalogSignal(const PCaloHit &inputHit,
-                                       CLHEP::HepRandomEngine *) const;
+  virtual CaloSamples makeAnalogSignal(const PCaloHit &inputHit, CLHEP::HepRandomEngine *) const;
 
   /// finds the amplitude contribution from this hit, applying
   /// photostatistics, if needed.  Results are in photoelectrons
-  double analogSignalAmplitude(const DetId &id, float energy,
+  double analogSignalAmplitude(const DetId &id,
+                               float energy,
                                const CaloSimParameters &parameters,
                                CLHEP::HepRandomEngine *) const;
 
@@ -112,9 +105,7 @@ public:
   double timeOfFlight(const DetId &detId) const;
 
   /// setting the phase shift for asynchronous trigger (e.g. test beams)
-  void setPhaseShift(const double &thePhaseShift) {
-    thePhaseShift_ = thePhaseShift;
-  }
+  void setPhaseShift(const double &thePhaseShift) { thePhaseShift_ = thePhaseShift; }
 
   /// check if crossing is within bunch range:
 

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloShapes.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloShapes.h
@@ -11,10 +11,7 @@ public:
   CaloShapes() : theShape(nullptr) {}
   // doesn't take ownership of the pointer
   CaloShapes(const CaloVShape *shape) : theShape(shape) {}
-  virtual const CaloVShape *shape(const DetId &detId,
-                                  bool precise = false) const {
-    return theShape;
-  }
+  virtual const CaloVShape *shape(const DetId &detId, bool precise = false) const { return theShape; }
   virtual ~CaloShapes() = default;
 
 private:

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloSimParameters.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloSimParameters.h
@@ -15,9 +15,13 @@ class CaloSimParameters {
 public:
   // note: sampling factor not used
   CaloSimParameters(double simHitToPhotoelectrons,
-                    double photoelectronsToAnalog, double samplingFactor,
-                    double timePhase, int readoutFrameSize, int binOfMaximum,
-                    bool doPhotostatistics, bool syncPhase = true);
+                    double photoelectronsToAnalog,
+                    double samplingFactor,
+                    double timePhase,
+                    int readoutFrameSize,
+                    int binOfMaximum,
+                    bool doPhotostatistics,
+                    bool syncPhase = true);
 
   CaloSimParameters(const edm::ParameterSet &p, bool skipPe2Fc = false);
 
@@ -28,15 +32,11 @@ public:
   /// and converts to photoelectrons
   /// probably should make everything virtual, but this is enough for HCAL
   double simHitToPhotoelectrons() const { return simHitToPhotoelectrons_; }
-  virtual double simHitToPhotoelectrons(const DetId &) const {
-    return simHitToPhotoelectrons_;
-  }
+  virtual double simHitToPhotoelectrons(const DetId &) const { return simHitToPhotoelectrons_; }
 
   /// the factor which goes from photoelectrons to whatever gets read by ADCs
   double photoelectronsToAnalog() const { return photoelectronsToAnalog_; }
-  virtual double photoelectronsToAnalog(const DetId &detId) const {
-    return photoelectronsToAnalog_;
-  }
+  virtual double photoelectronsToAnalog(const DetId &detId) const { return photoelectronsToAnalog_; }
 
   /// the adjustment you need to apply to get the signal where you want it
   double timePhase() const { return timePhase_; }

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h
@@ -15,16 +15,18 @@
 #include <vector>
 
 namespace CLHEP {
-class HepRandomEngine;
+  class HepRandomEngine;
 }
 
-template <class Traits> class CaloTDigitizerDefaultRun {
+template <class Traits>
+class CaloTDigitizerDefaultRun {
 public:
   typedef typename Traits::ElectronicsSim ElectronicsSim;
   typedef typename Traits::Digi Digi;
   typedef typename Traits::DigiCollection DigiCollection;
 
-  void operator()(DigiCollection &output, CLHEP::HepRandomEngine *engine,
+  void operator()(DigiCollection &output,
+                  CLHEP::HepRandomEngine *engine,
                   CaloSamples *analogSignal,
                   std::vector<DetId>::const_iterator idItr,
                   ElectronicsSim *theElectronicsSim) {
@@ -36,8 +38,7 @@ public:
 
 // second parameter changes the operation of run() slightly (default value for
 // old-style with edm::SortedCollection instead of edm::DataFrameContainer)
-template <class Traits,
-          template <class> class runHelper = CaloTDigitizerDefaultRun>
+template <class Traits, template <class> class runHelper = CaloTDigitizerDefaultRun>
 class CaloTDigitizer {
 public:
   /// these are the types that need to be defined in the Traits
@@ -47,11 +48,13 @@ public:
   typedef typename Traits::Digi Digi;
   typedef typename Traits::DigiCollection DigiCollection;
 
-  CaloTDigitizer(CaloHitResponse *hitResponse, ElectronicsSim *electronicsSim,
-                 bool addNoise)
-      : theHitResponse(hitResponse), theNoiseSignalGenerator(nullptr),
-        theElectronicsSim(electronicsSim), theDetIds(nullptr),
-        addNoise_(addNoise), debugCS_(false) {}
+  CaloTDigitizer(CaloHitResponse *hitResponse, ElectronicsSim *electronicsSim, bool addNoise)
+      : theHitResponse(hitResponse),
+        theNoiseSignalGenerator(nullptr),
+        theElectronicsSim(electronicsSim),
+        theDetIds(nullptr),
+        addNoise_(addNoise),
+        debugCS_(false) {}
 
   /// doesn't delete the pointers passed in
   ~CaloTDigitizer() {}
@@ -63,20 +66,15 @@ public:
   }
   void setDetIds(const std::vector<DetId> &detIds) { theDetIds = &detIds; }
 
-  void setNoiseSignalGenerator(CaloVNoiseSignalGenerator *generator) {
-    theNoiseSignalGenerator = generator;
-  }
+  void setNoiseSignalGenerator(CaloVNoiseSignalGenerator *generator) { theNoiseSignalGenerator = generator; }
 
   void setDebugCaloSamples(bool debug) { debugCS_ = debug; }
 
   const CaloSamplesCollection &getCaloSamples() const { return csColl_; }
 
-  void add(const std::vector<PCaloHit> &hits, int bunchCrossing,
-           CLHEP::HepRandomEngine *engine) {
+  void add(const std::vector<PCaloHit> &hits, int bunchCrossing, CLHEP::HepRandomEngine *engine) {
     if (theHitResponse->withinBunchRange(bunchCrossing)) {
-      for (std::vector<PCaloHit>::const_iterator it = hits.begin(),
-                                                 itEnd = hits.end();
-           it != itEnd; ++it) {
+      for (std::vector<PCaloHit>::const_iterator it = hits.begin(), itEnd = hits.end(); it != itEnd; ++it) {
         theHitResponse->add(*it, engine);
       }
     }
@@ -101,8 +99,7 @@ public:
     theElectronicsSim->newEvent(engine);
 
     // reserve space for how many digis we expect
-    int nDigisExpected =
-        addNoise_ ? theDetIds->size() : theHitResponse->nSignals();
+    int nDigisExpected = addNoise_ ? theDetIds->size() : theHitResponse->nSignals();
     output.reserve(nDigisExpected);
     if (debugCS_) {
       csColl_.clear();
@@ -111,8 +108,7 @@ public:
     }
 
     // make a raw digi for evey cell
-    for (std::vector<DetId>::const_iterator idItr = theDetIds->begin();
-         idItr != theDetIds->end(); ++idItr) {
+    for (std::vector<DetId>::const_iterator idItr = theDetIds->begin(); idItr != theDetIds->end(); ++idItr) {
       CaloSamples *analogSignal = theHitResponse->findSignal(*idItr);
       if (analogSignal && debugCS_)
         csColl_.push_back(*analogSignal);
@@ -125,8 +121,7 @@ public:
         needToDeleteSignal = true;
       }
       if (analogSignal != nullptr) {
-        runAnalogToDigital(output, engine, analogSignal, idItr,
-                           theElectronicsSim);
+        runAnalogToDigital(output, engine, analogSignal, idItr, theElectronicsSim);
         if (needToDeleteSignal)
           delete analogSignal;
       }
@@ -141,10 +136,9 @@ public:
     // noise signals need to be in units of photoelectrons.  Fractional is OK
     theNoiseSignalGenerator->fillEvent(engine);
     theNoiseSignalGenerator->getNoiseSignals(noiseSignals);
-    for (std::vector<CaloSamples>::const_iterator
-             signalItr = noiseSignals.begin(),
-             signalEnd = noiseSignals.end();
-         signalItr != signalEnd; ++signalItr) {
+    for (std::vector<CaloSamples>::const_iterator signalItr = noiseSignals.begin(), signalEnd = noiseSignals.end();
+         signalItr != signalEnd;
+         ++signalItr) {
       theHitResponse->add(*signalItr);
     }
   }

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloVHitCorrection.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloVHitCorrection.h
@@ -4,7 +4,7 @@
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
 
 namespace CLHEP {
-class HepRandomEngine;
+  class HepRandomEngine;
 }
 
 class CaloVHitCorrection {

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloVNoiseSignalGenerator.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloVNoiseSignalGenerator.h
@@ -5,7 +5,7 @@
 #include <vector>
 
 namespace CLHEP {
-class HepRandomEngine;
+  class HepRandomEngine;
 }
 
 class CaloVNoiseSignalGenerator {
@@ -16,11 +16,9 @@ public:
   ///  fill theNoiseSignals with one event's worth of noise, in units of pe
   void fillEvent(CLHEP::HepRandomEngine *);
 
-  void fillEvent(); // don't need random engine for some tasks
+  void fillEvent();  // don't need random engine for some tasks
 
-  void getNoiseSignals(std::vector<CaloSamples> &noiseSignals) {
-    noiseSignals = theNoiseSignals;
-  }
+  void getNoiseSignals(std::vector<CaloSamples> &noiseSignals) { noiseSignals = theNoiseSignals; }
 
   bool contains(const DetId &detId) const;
 

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloVPECorrection.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloVPECorrection.h
@@ -8,14 +8,13 @@
 #include "DataFormats/DetId/interface/DetId.h"
 
 namespace CLHEP {
-class HepRandomEngine;
+  class HepRandomEngine;
 }
 
 class CaloVPECorrection {
 public:
   virtual ~CaloVPECorrection() {}
-  virtual double correctPE(const DetId &detId, double npe,
-                           CLHEP::HepRandomEngine *) const = 0;
+  virtual double correctPE(const DetId &detId, double npe, CLHEP::HepRandomEngine *) const = 0;
 };
 
 #endif

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloValidationStatistics.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloValidationStatistics.h
@@ -11,8 +11,7 @@
 
 class CaloValidationStatistics {
 public:
-  CaloValidationStatistics(std::string name, float expectedMean,
-                           float expectedRMS);
+  CaloValidationStatistics(std::string name, float expectedMean, float expectedRMS);
   /// prints to LogInfo upon destruction
   ~CaloValidationStatistics();
 
@@ -43,7 +42,6 @@ private:
   int n_;
 };
 
-std::ostream &operator<<(std::ostream &os,
-                         const CaloValidationStatistics &stat);
+std::ostream &operator<<(std::ostream &os, const CaloValidationStatistics &stat);
 
 #endif

--- a/SimCalorimetry/CaloSimAlgos/src/CaloCachedShapeIntegrator.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloCachedShapeIntegrator.cc
@@ -1,6 +1,6 @@
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloCachedShapeIntegrator.h"
 
-const int NBINS = 281; // 256, plus 25 before
+const int NBINS = 281;  // 256, plus 25 before
 
 CaloCachedShapeIntegrator::CaloCachedShapeIntegrator(const CaloVShape *aShape)
     : v_(NBINS, 0.), timeToRise_(aShape->timeToRise()) {

--- a/SimCalorimetry/CaloSimAlgos/src/CaloHitAnalyzer.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloHitAnalyzer.cc
@@ -11,9 +11,12 @@ CaloHitAnalyzer::CaloHitAnalyzer(const std::string &name,
                                  double hitEnergyThreshold,
                                  const CaloVSimParameterMap *parameterMap,
                                  const CaloVHitFilter *filter)
-    : hitEnergySumMap_(), hitEnergyThreshold_(hitEnergyThreshold),
-      simParameterMap_(parameterMap), hitFilter_(filter),
-      summary_(name, 1., 0.), noiseHits_(0) {}
+    : hitEnergySumMap_(),
+      hitEnergyThreshold_(hitEnergyThreshold),
+      simParameterMap_(parameterMap),
+      hitFilter_(filter),
+      summary_(name, 1., 0.),
+      noiseHits_(0) {}
 
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 void CaloHitAnalyzer::fillHits(MixCollection<PCaloHit> &hits) {

--- a/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
@@ -18,20 +18,34 @@
 
 #include <iostream>
 
-CaloHitResponse::CaloHitResponse(const CaloVSimParameterMap *parametersMap,
-                                 const CaloVShape *shape)
-    : theAnalogSignalMap(), theParameterMap(parametersMap), theShapes(nullptr),
-      theShape(shape), theHitCorrection(nullptr), thePECorrection(nullptr),
-      theHitFilter(nullptr), theGeometry(nullptr), theMinBunch(-10),
-      theMaxBunch(10), thePhaseShift_(1.), storePrecise(false),
+CaloHitResponse::CaloHitResponse(const CaloVSimParameterMap *parametersMap, const CaloVShape *shape)
+    : theAnalogSignalMap(),
+      theParameterMap(parametersMap),
+      theShapes(nullptr),
+      theShape(shape),
+      theHitCorrection(nullptr),
+      thePECorrection(nullptr),
+      theHitFilter(nullptr),
+      theGeometry(nullptr),
+      theMinBunch(-10),
+      theMaxBunch(10),
+      thePhaseShift_(1.),
+      storePrecise(false),
       ignoreTime(false) {}
 
-CaloHitResponse::CaloHitResponse(const CaloVSimParameterMap *parametersMap,
-                                 const CaloShapes *shapes)
-    : theAnalogSignalMap(), theParameterMap(parametersMap), theShapes(shapes),
-      theShape(nullptr), theHitCorrection(nullptr), thePECorrection(nullptr),
-      theHitFilter(nullptr), theGeometry(nullptr), theMinBunch(-10),
-      theMaxBunch(10), thePhaseShift_(1.), storePrecise(false),
+CaloHitResponse::CaloHitResponse(const CaloVSimParameterMap *parametersMap, const CaloShapes *shapes)
+    : theAnalogSignalMap(),
+      theParameterMap(parametersMap),
+      theShapes(shapes),
+      theShape(nullptr),
+      theHitCorrection(nullptr),
+      thePECorrection(nullptr),
+      theHitFilter(nullptr),
+      theGeometry(nullptr),
+      theMinBunch(-10),
+      theMaxBunch(10),
+      thePhaseShift_(1.),
+      storePrecise(false),
       ignoreTime(false) {}
 
 CaloHitResponse::~CaloHitResponse() {}
@@ -41,14 +55,11 @@ void CaloHitResponse::setBunchRange(int minBunch, int maxBunch) {
   theMaxBunch = maxBunch;
 }
 
-void CaloHitResponse::run(const MixCollection<PCaloHit> &hits,
-                          CLHEP::HepRandomEngine *engine) {
-
-  for (MixCollection<PCaloHit>::MixItr hitItr = hits.begin();
-       hitItr != hits.end(); ++hitItr) {
+void CaloHitResponse::run(const MixCollection<PCaloHit> &hits, CLHEP::HepRandomEngine *engine) {
+  for (MixCollection<PCaloHit>::MixItr hitItr = hits.begin(); hitItr != hits.end(); ++hitItr) {
     if (withinBunchRange(hitItr.bunch())) {
       add(*hitItr, engine);
-    } // loop over hits
+    }  // loop over hits
   }
 }
 
@@ -62,8 +73,7 @@ void CaloHitResponse::add(const PCaloHit &hit, CLHEP::HepRandomEngine *engine) {
   if (theHitFilter == nullptr || theHitFilter->accepts(hit)) {
     LogDebug("CaloHitResponse") << hit;
     CaloSamples signal(makeAnalogSignal(hit, engine));
-    bool keep(
-        keepBlank()); // here we  check for blank signal if not keeping them
+    bool keep(keepBlank());  // here we  check for blank signal if not keeping them
     if (!keep) {
       const unsigned int size(signal.size());
       if (0 != size) {
@@ -89,14 +99,10 @@ void CaloHitResponse::add(const CaloSamples &signal) {
   }
 }
 
-CaloSamples
-CaloHitResponse::makeAnalogSignal(const PCaloHit &hit,
-                                  CLHEP::HepRandomEngine *engine) const {
-
+CaloSamples CaloHitResponse::makeAnalogSignal(const PCaloHit &hit, CLHEP::HepRandomEngine *engine) const {
   DetId detId(hit.id());
   const CaloSimParameters &parameters = theParameterMap->simParameters(detId);
-  double signal =
-      analogSignalAmplitude(detId, hit.energy(), parameters, engine);
+  double signal = analogSignalAmplitude(detId, hit.energy(), parameters, engine);
 
   double time = hit.time();
   double tof = timeOfFlight(detId);
@@ -112,9 +118,8 @@ CaloHitResponse::makeAnalogSignal(const PCaloHit &hit,
     shape = theShapes->shape(detId, storePrecise);
   }
   // assume bins count from zero, go for center of bin
-  const double tzero =
-      (shape->timeToRise() + parameters.timePhase() - jitter -
-       BUNCHSPACE * (parameters.binOfMaximum() - thePhaseShift_));
+  const double tzero = (shape->timeToRise() + parameters.timePhase() - jitter -
+                        BUNCHSPACE * (parameters.binOfMaximum() - thePhaseShift_));
   double binTime = tzero;
 
   CaloSamples result(makeBlankSignal(detId));
@@ -139,11 +144,10 @@ CaloHitResponse::makeAnalogSignal(const PCaloHit &hit,
   return result;
 }
 
-double
-CaloHitResponse::analogSignalAmplitude(const DetId &detId, float energy,
-                                       const CaloSimParameters &parameters,
-                                       CLHEP::HepRandomEngine *engine) const {
-
+double CaloHitResponse::analogSignalAmplitude(const DetId &detId,
+                                              float energy,
+                                              const CaloSimParameters &parameters,
+                                              CLHEP::HepRandomEngine *engine) const {
   // OK, the "energy" in the hit could be a real energy, deposited energy,
   // or pe count.  This factor converts to photoelectrons
   // GMA Smeared in photon production it self
@@ -170,8 +174,7 @@ CaloSamples *CaloHitResponse::findSignal(const DetId &detId) {
 
 CaloSamples CaloHitResponse::makeBlankSignal(const DetId &detId) const {
   const CaloSimParameters &parameters = theParameterMap->simParameters(detId);
-  int preciseSize(storePrecise ? parameters.readoutFrameSize() * BUNCHSPACE
-                               : 0);
+  int preciseSize(storePrecise ? parameters.readoutFrameSize() * BUNCHSPACE : 0);
   CaloSamples result(detId, parameters.readoutFrameSize(), preciseSize);
   result.setPresamples(parameters.binOfMaximum() - 1);
   if (storePrecise)
@@ -184,18 +187,15 @@ double CaloHitResponse::timeOfFlight(const DetId &detId) const {
   // Take the whole CaloGeometry and find the right subdet
   double result = 0.;
   if (theGeometry == nullptr) {
-    edm::LogWarning("CaloHitResponse")
-        << "No Calo Geometry set, so no time of flight correction";
+    edm::LogWarning("CaloHitResponse") << "No Calo Geometry set, so no time of flight correction";
   } else {
-    auto cellGeometry =
-        theGeometry->getSubdetectorGeometry(detId)->getGeometry(detId);
+    auto cellGeometry = theGeometry->getSubdetectorGeometry(detId)->getGeometry(detId);
     if (cellGeometry == nullptr) {
-      edm::LogWarning("CaloHitResponse")
-          << "No Calo cell found for ID" << detId.rawId()
-          << " so no time-of-flight subtraction will be done";
+      edm::LogWarning("CaloHitResponse") << "No Calo cell found for ID" << detId.rawId()
+                                         << " so no time-of-flight subtraction will be done";
     } else {
       double distance = cellGeometry->getPosition().mag();
-      result = distance * cm / c_light; // Units of c_light: mm/ns
+      result = distance * cm / c_light;  // Units of c_light: mm/ns
     }
   }
   return result;

--- a/SimCalorimetry/CaloSimAlgos/src/CaloShapeIntegrator.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloShapeIntegrator.cc
@@ -1,7 +1,6 @@
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloShapeIntegrator.h"
 
-CaloShapeIntegrator::CaloShapeIntegrator(const CaloVShape *aShape)
-    : m_shape(aShape) {}
+CaloShapeIntegrator::CaloShapeIntegrator(const CaloVShape *aShape) : m_shape(aShape) {}
 
 CaloShapeIntegrator::~CaloShapeIntegrator() {}
 

--- a/SimCalorimetry/CaloSimAlgos/src/CaloSimParameters.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloSimParameters.cc
@@ -4,13 +4,19 @@
 
 CaloSimParameters::CaloSimParameters(double simHitToPhotoelectrons,
                                      double photoelectronsToAnalog,
-                                     double samplingFactor, double timePhase,
-                                     int readoutFrameSize, int binOfMaximum,
-                                     bool doPhotostatistics, bool syncPhase)
+                                     double samplingFactor,
+                                     double timePhase,
+                                     int readoutFrameSize,
+                                     int binOfMaximum,
+                                     bool doPhotostatistics,
+                                     bool syncPhase)
     : simHitToPhotoelectrons_(simHitToPhotoelectrons),
-      photoelectronsToAnalog_(photoelectronsToAnalog), timePhase_(timePhase),
-      readoutFrameSize_(readoutFrameSize), binOfMaximum_(binOfMaximum),
-      doPhotostatistics_(doPhotostatistics), syncPhase_(syncPhase) {}
+      photoelectronsToAnalog_(photoelectronsToAnalog),
+      timePhase_(timePhase),
+      readoutFrameSize_(readoutFrameSize),
+      binOfMaximum_(binOfMaximum),
+      doPhotostatistics_(doPhotostatistics),
+      syncPhase_(syncPhase) {}
 
 CaloSimParameters::CaloSimParameters(const edm::ParameterSet &p, bool skipPe2Fc)
     : simHitToPhotoelectrons_(p.getParameter<double>("simHitToPhotoelectrons")),
@@ -25,11 +31,9 @@ CaloSimParameters::CaloSimParameters(const edm::ParameterSet &p, bool skipPe2Fc)
     photoelectronsToAnalog_ = p.getParameter<double>("photoelectronsToAnalog");
   } else if (p.existsAs<std::vector<double>>("photoelectronsToAnalog")) {
     // just take the first one
-    photoelectronsToAnalog_ =
-        p.getParameter<std::vector<double>>("photoelectronsToAnalog").at(0);
+    photoelectronsToAnalog_ = p.getParameter<std::vector<double>>("photoelectronsToAnalog").at(0);
   } else if (!skipPe2Fc) {
-    throw cms::Exception("CaloSimParameters")
-        << "Cannot find parameter photoelectronsToAnalog";
+    throw cms::Exception("CaloSimParameters") << "Cannot find parameter photoelectronsToAnalog";
   }
   // some subsystems may not want this at all
 }
@@ -37,10 +41,8 @@ CaloSimParameters::CaloSimParameters(const edm::ParameterSet &p, bool skipPe2Fc)
 std::ostream &operator<<(std::ostream &os, const CaloSimParameters &p) {
   DetId dummy(0);
   os << "CALO SIM PARAMETERS" << std::endl;
-  os << p.simHitToPhotoelectrons(dummy) << " pe per SimHit energy "
-     << std::endl;
-  os << p.photoelectronsToAnalog() << " Analog signal to be digitized per pe"
-     << std::endl;
+  os << p.simHitToPhotoelectrons(dummy) << " pe per SimHit energy " << std::endl;
+  os << p.photoelectronsToAnalog() << " Analog signal to be digitized per pe" << std::endl;
   os << " Incident energy / SimHit Energy " << std::endl;
   return os;
 }

--- a/SimCalorimetry/CaloSimAlgos/src/CaloVNoiseSignalGenerator.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloVNoiseSignalGenerator.cc
@@ -2,8 +2,7 @@
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloVNoiseSignalGenerator.h"
 #include <iostream>
 
-CaloVNoiseSignalGenerator::CaloVNoiseSignalGenerator()
-    : theNoiseSignals(), theDetIds() {}
+CaloVNoiseSignalGenerator::CaloVNoiseSignalGenerator() : theNoiseSignals(), theDetIds() {}
 
 void CaloVNoiseSignalGenerator::fillEvent(CLHEP::HepRandomEngine *engine) {
   theDetIds.clear();
@@ -17,8 +16,7 @@ void CaloVNoiseSignalGenerator::fillEvent() {
   fillDetIds();
 }
 
-void CaloVNoiseSignalGenerator::setNoiseSignals(
-    const std::vector<CaloSamples> &noiseSignals) {
+void CaloVNoiseSignalGenerator::setNoiseSignals(const std::vector<CaloSamples> &noiseSignals) {
   theNoiseSignals = noiseSignals;
 }
 
@@ -28,10 +26,8 @@ bool CaloVNoiseSignalGenerator::contains(const DetId &detId) const {
 
 void CaloVNoiseSignalGenerator::fillDetIds() {
   theDetIds.reserve(theNoiseSignals.size());
-  for (std::vector<CaloSamples>::const_iterator sampleItr =
-           theNoiseSignals.begin();
-       sampleItr != theNoiseSignals.end(); ++sampleItr) {
-
+  for (std::vector<CaloSamples>::const_iterator sampleItr = theNoiseSignals.begin(); sampleItr != theNoiseSignals.end();
+       ++sampleItr) {
     theDetIds.push_back(sampleItr->id().rawId());
   }
   edm::sort_all(theDetIds);

--- a/SimCalorimetry/CaloSimAlgos/src/CaloValidationStatistics.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloValidationStatistics.cc
@@ -3,15 +3,17 @@
 #include <cmath>
 #include <iostream>
 
-CaloValidationStatistics::CaloValidationStatistics(std::string name,
-                                                   float expectedMean,
-                                                   float expectedRMS)
-    : name_(name), expectedMean_(expectedMean), expectedRMS_(expectedRMS),
-      sum_(0.), sumOfSquares_(0.), weightedSum_(0.), sumOfWeights_(0.), n_(0) {}
+CaloValidationStatistics::CaloValidationStatistics(std::string name, float expectedMean, float expectedRMS)
+    : name_(name),
+      expectedMean_(expectedMean),
+      expectedRMS_(expectedRMS),
+      sum_(0.),
+      sumOfSquares_(0.),
+      weightedSum_(0.),
+      sumOfWeights_(0.),
+      n_(0) {}
 
-CaloValidationStatistics::~CaloValidationStatistics() {
-  edm::LogInfo("CaloValidationStatistics") << *this;
-}
+CaloValidationStatistics::~CaloValidationStatistics() { edm::LogInfo("CaloValidationStatistics") << *this; }
 
 void CaloValidationStatistics::addEntry(float value, float weight) {
   sum_ += value;
@@ -29,12 +31,9 @@ float CaloValidationStatistics::RMS() const {
   return std::sqrt(numerator / denominator);
 }
 
-float CaloValidationStatistics::weightedMean() const {
-  return weightedSum_ / sumOfWeights_;
-}
+float CaloValidationStatistics::weightedMean() const { return weightedSum_ / sumOfWeights_; }
 
-std::ostream &operator<<(std::ostream &os,
-                         const CaloValidationStatistics &stat) {
+std::ostream &operator<<(std::ostream &os, const CaloValidationStatistics &stat) {
   os << "OVAL " << stat.name() << " entries:" << stat.nEntries();
   if (stat.nEntries() > 0) {
     os << " Mean: " << stat.mean() << " (expect " << stat.expectedMean() << ")";

--- a/SimCalorimetry/EcalTestBeamAlgos/interface/EcalTBReadout.h
+++ b/SimCalorimetry/EcalTestBeamAlgos/interface/EcalTBReadout.h
@@ -28,22 +28,22 @@ public:
   void findTTlist(const int &crysId, const EcalTrigTowerConstituentsMap &etmap);
 
   /// read only the digis from the selected TT
-  void readOut(const EBDigiCollection &input, EBDigiCollection &output,
-               const EcalTrigTowerConstituentsMap &etmap);
+  void readOut(const EBDigiCollection &input, EBDigiCollection &output, const EcalTrigTowerConstituentsMap &etmap);
 
   /// read only the digis from the selected TT
-  void readOut(const EEDigiCollection &input, EEDigiCollection &output,
-               const EcalTrigTowerConstituentsMap &etmap);
+  void readOut(const EEDigiCollection &input, EEDigiCollection &output, const EcalTrigTowerConstituentsMap &etmap);
 
   /// master function to be called once per event
   void performReadout(edm::Event &event,
                       const EcalTrigTowerConstituentsMap &theTTmap,
-                      const EBDigiCollection &input, EBDigiCollection &output);
+                      const EBDigiCollection &input,
+                      EBDigiCollection &output);
 
   /// master function to be called once per event
   void performReadout(edm::Event &event,
                       const EcalTrigTowerConstituentsMap &theTTmap,
-                      const EEDigiCollection &input, EEDigiCollection &output);
+                      const EEDigiCollection &input,
+                      EEDigiCollection &output);
 
 private:
   int theTargetCrystal_;

--- a/SimCalorimetry/EcalTestBeamAlgos/src/EcalTBReadout.cc
+++ b/SimCalorimetry/EcalTestBeamAlgos/src/EcalTBReadout.cc
@@ -6,15 +6,12 @@
 #include "SimCalorimetry/EcalTestBeamAlgos/interface/EcalTBReadout.h"
 #include "SimDataFormats/EcalTestBeam/interface/PEcalTBInfo.h"
 
-EcalTBReadout::EcalTBReadout(const std::string theEcalTBInfoLabel)
-    : ecalTBInfoLabel_(theEcalTBInfoLabel) {
+EcalTBReadout::EcalTBReadout(const std::string theEcalTBInfoLabel) : ecalTBInfoLabel_(theEcalTBInfoLabel) {
   theTargetCrystal_ = -1;
   theTTlist_.reserve(1);
 }
 
-void EcalTBReadout::findTTlist(const int &crysId,
-                               const EcalTrigTowerConstituentsMap &etmap) {
-
+void EcalTBReadout::findTTlist(const int &crysId, const EcalTrigTowerConstituentsMap &etmap) {
   // search for the TT involved in the NCRYMATRIX x NCRYMATRIX
   // around the target crystal if a new target, otherwise use
   // the list already filled
@@ -44,8 +41,7 @@ void EcalTBReadout::findTTlist(const int &crysId,
     ++ncount;
   }
   if (!found) {
-    throw cms::Exception("ObjectNotFound",
-                         "Ecal TB target crystal not found in geometry");
+    throw cms::Exception("ObjectNotFound", "Ecal TB target crystal not found in geometry");
     return;
   }
   theTargetCrystal_ = theTargetId.ic();
@@ -56,11 +52,8 @@ void EcalTBReadout::findTTlist(const int &crysId,
   int myEta = theTargetId.ieta();
   int myPhi = theTargetId.iphi();
 
-  for (int icrysEta = (myEta - (NCRYMATRIX - 1) / 2);
-       icrysEta <= (myEta + (NCRYMATRIX - 1) / 2); ++icrysEta) {
-    for (int icrysPhi = (myPhi - (NCRYMATRIX - 1) / 2);
-         icrysPhi <= (myPhi + (NCRYMATRIX - 1) / 2); ++icrysPhi) {
-
+  for (int icrysEta = (myEta - (NCRYMATRIX - 1) / 2); icrysEta <= (myEta + (NCRYMATRIX - 1) / 2); ++icrysEta) {
+    for (int icrysPhi = (myPhi - (NCRYMATRIX - 1) / 2); icrysPhi <= (myPhi + (NCRYMATRIX - 1) / 2); ++icrysPhi) {
       /// loop on all the valid DetId and search for the good ones
 
       EBDetId thisEBdetid;
@@ -80,22 +73,16 @@ void EcalTBReadout::findTTlist(const int &crysId,
       }
 
       if (found) {
-
         EcalTrigTowerDetId thisTTdetId = etmap.towerOf(thisEBdetid);
 
-        LogDebug("EcalDigi")
-            << "Crystal to be readout: sequential id = " << thisEBdetid.ic()
-            << " eta = " << icrysEta << " phi = " << icrysPhi
-            << " from TT = " << thisTTdetId;
+        LogDebug("EcalDigi") << "Crystal to be readout: sequential id = " << thisEBdetid.ic() << " eta = " << icrysEta
+                             << " phi = " << icrysPhi << " from TT = " << thisTTdetId;
 
-        if (theTTlist_.empty() ||
-            (theTTlist_.size() == 1 && theTTlist_[0] != thisTTdetId)) {
+        if (theTTlist_.empty() || (theTTlist_.size() == 1 && theTTlist_[0] != thisTTdetId)) {
           theTTlist_.push_back(thisTTdetId);
         } else {
-          std::vector<EcalTrigTowerDetId>::iterator ttFound =
-              find(theTTlist_.begin(), theTTlist_.end(), thisTTdetId);
-          if (theTTlist_.size() > 1 && ttFound == theTTlist_.end() &&
-              *(theTTlist_.end()) != thisTTdetId) {
+          std::vector<EcalTrigTowerDetId>::iterator ttFound = find(theTTlist_.begin(), theTTlist_.end(), thisTTdetId);
+          if (theTTlist_.size() > 1 && ttFound == theTTlist_.end() && *(theTTlist_.end()) != thisTTdetId) {
             theTTlist_.push_back(thisTTdetId);
           }
         }
@@ -132,14 +119,12 @@ void EcalTBReadout::readOut(const EBDigiCollection &input,
     EBDataFrame ebdf = input[digis];
 
     EcalTrigTowerDetId thisTTdetId = etmap.towerOf(ebdf.id());
-    std::vector<EcalTrigTowerDetId>::iterator ttFound =
-        find(theTTlist_.begin(), theTTlist_.end(), thisTTdetId);
+    std::vector<EcalTrigTowerDetId>::iterator ttFound = find(theTTlist_.begin(), theTTlist_.end(), thisTTdetId);
 
     if ((ttFound != theTTlist_.end()) || *(theTTlist_.end()) == thisTTdetId) {
       output.push_back(ebdf.id());
       EBDataFrame ebdf2(output.back());
-      std::copy(ebdf.frame().begin(), ebdf.frame().end(),
-                ebdf2.frame().begin());
+      std::copy(ebdf.frame().begin(), ebdf.frame().end(), ebdf2.frame().begin());
     }
   }
 }
@@ -152,14 +137,12 @@ void EcalTBReadout::readOut(const EEDigiCollection &input,
 
     EcalTrigTowerDetId thisTTdetId(etmap.towerOf(eedf.id()));
 
-    std::vector<EcalTrigTowerDetId>::iterator ttFound(
-        find(theTTlist_.begin(), theTTlist_.end(), thisTTdetId));
+    std::vector<EcalTrigTowerDetId>::iterator ttFound(find(theTTlist_.begin(), theTTlist_.end(), thisTTdetId));
 
     if ((ttFound != theTTlist_.end()) || *(theTTlist_.end()) == thisTTdetId) {
       output.push_back(eedf.id());
       EEDataFrame eedf2(output.back());
-      std::copy(eedf.frame().begin(), eedf.frame().end(),
-                eedf2.frame().begin());
+      std::copy(eedf.frame().begin(), eedf.frame().end(), eedf2.frame().begin());
     }
   }
 }
@@ -189,7 +172,6 @@ void EcalTBReadout::performReadout(edm::Event &event,
                                    const EcalTrigTowerConstituentsMap &theTTmap,
                                    const EEDigiCollection &input,
                                    EEDigiCollection &output) {
-
   // TB readout
   // step 1: get the target crystal index
 

--- a/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
+++ b/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
@@ -24,30 +24,26 @@
 class PEcalTBInfo;
 
 namespace edm {
-class StreamID;
-class ConsumesCollector;
-} // namespace edm
+  class StreamID;
+  class ConsumesCollector;
+}  // namespace edm
 
 namespace CLHEP {
-class HepRandomEngine;
+  class HepRandomEngine;
 }
 
 class HcalTBDigiProducer : public DigiAccumulatorMixMod {
 public:
-  explicit HcalTBDigiProducer(const edm::ParameterSet &ps,
-                              edm::ProducerBase &mixMod,
-                              edm::ConsumesCollector &iC);
+  explicit HcalTBDigiProducer(const edm::ParameterSet &ps, edm::ProducerBase &mixMod, edm::ConsumesCollector &iC);
   ~HcalTBDigiProducer() override;
 
   void initializeEvent(edm::Event const &e, edm::EventSetup const &c) override;
   void accumulate(edm::Event const &e, edm::EventSetup const &c) override;
-  void accumulate(PileUpEventPrincipal const &e, edm::EventSetup const &c,
-                  edm::StreamID const &) override;
+  void accumulate(PileUpEventPrincipal const &e, edm::EventSetup const &c, edm::StreamID const &) override;
   void finalizeEvent(edm::Event &e, edm::EventSetup const &c) override;
 
 private:
-  void accumulateCaloHits(edm::Handle<std::vector<PCaloHit>> const &hits,
-                          int bunchCrossing);
+  void accumulateCaloHits(edm::Handle<std::vector<PCaloHit>> const &hits, int bunchCrossing);
 
   /// fills the vectors for each subdetector
   void sortHits(const edm::PCaloHitContainer &hits);

--- a/SimCalorimetry/HcalTestBeam/interface/HcalTBSimParameterMap.h
+++ b/SimCalorimetry/HcalTestBeam/interface/HcalTBSimParameterMap.h
@@ -6,7 +6,6 @@
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalSimParameters.h"
 
 class HcalTBSimParameterMap : public CaloVSimParameterMap {
-
 public:
   /// hardcoded default parameters
   HcalTBSimParameterMap();

--- a/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
+++ b/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
@@ -25,14 +25,17 @@ HcalTBDigiProducer::HcalTBDigiProducer(const edm::ParameterSet &ps,
     : theParameterMap(new HcalTBSimParameterMap(ps)),
       theHcalShape(new HcalShape()),
       theHcalIntegratedShape(new CaloShapeIntegrator(theHcalShape)),
-      theHBHEResponse(
-          new CaloHitResponse(theParameterMap, theHcalIntegratedShape)),
-      theHOResponse(
-          new CaloHitResponse(theParameterMap, theHcalIntegratedShape)),
-      theAmplifier(nullptr), theCoderFactory(nullptr),
-      theElectronicsSim(nullptr), theTimeSlewSim(nullptr),
-      theHBHEDigitizer(nullptr), theHODigitizer(nullptr), theHBHEHits(),
-      theHOHits(), thisPhaseShift(0) {
+      theHBHEResponse(new CaloHitResponse(theParameterMap, theHcalIntegratedShape)),
+      theHOResponse(new CaloHitResponse(theParameterMap, theHcalIntegratedShape)),
+      theAmplifier(nullptr),
+      theCoderFactory(nullptr),
+      theElectronicsSim(nullptr),
+      theTimeSlewSim(nullptr),
+      theHBHEDigitizer(nullptr),
+      theHODigitizer(nullptr),
+      theHBHEHits(),
+      theHOHits(),
+      thisPhaseShift(0) {
   std::string const instance("simHcalDigis");
   mixMod.produces<HBHEDigiCollection>(instance);
   mixMod.produces<HODigiCollection>(instance);
@@ -47,11 +50,10 @@ HcalTBDigiProducer::HcalTBDigiProducer(const edm::ParameterSet &ps,
 
   bool doNoise = ps.getParameter<bool>("doNoise");
   bool dummy1 = false;
-  bool dummy2 = false; // extra arguments for premixing
+  bool dummy2 = false;  // extra arguments for premixing
   theAmplifier = new HcalAmplifier(theParameterMap, doNoise, dummy1, dummy2);
   theCoderFactory = new HcalCoderFactory(HcalCoderFactory::DB);
-  theElectronicsSim =
-      new HcalElectronicsSim(theAmplifier, theCoderFactory, dummy1);
+  theElectronicsSim = new HcalElectronicsSim(theAmplifier, theCoderFactory, dummy1);
 
   double minFCToDelay = ps.getParameter<double>("minFCToDelay");
   bool doTimeSlew = ps.getParameter<bool>("doTimeSlew");
@@ -63,16 +65,13 @@ HcalTBDigiProducer::HcalTBDigiProducer(const edm::ParameterSet &ps,
     theAmplifier->setTimeSlewSim(theTimeSlewSim);
   }
 
-  theHBHEDigitizer =
-      new HBHEDigitizer(theHBHEResponse, theElectronicsSim, doNoise);
+  theHBHEDigitizer = new HBHEDigitizer(theHBHEResponse, theElectronicsSim, doNoise);
   theHODigitizer = new HODigitizer(theHOResponse, theElectronicsSim, doNoise);
 
   tunePhaseShift = ps.getUntrackedParameter<double>("tunePhaseShiftTB", 1.);
-  ecalTBInfoLabel = ps.getUntrackedParameter<std::string>("EcalTBInfoLabel",
-                                                          "SimEcalTBG4Object");
-  edm::LogInfo("HcalSim") << "HcalTBDigiProducer initialized with doNoise = "
-                          << doNoise << ", doTimeSlew = " << doTimeSlew
-                          << " and doPhaseShift = " << doPhaseShift
+  ecalTBInfoLabel = ps.getUntrackedParameter<std::string>("EcalTBInfoLabel", "SimEcalTBG4Object");
+  edm::LogInfo("HcalSim") << "HcalTBDigiProducer initialized with doNoise = " << doNoise
+                          << ", doTimeSlew = " << doTimeSlew << " and doPhaseShift = " << doPhaseShift
                           << " tunePhasShift = " << tunePhaseShift;
 
   if (doPhaseShift) {
@@ -81,7 +80,6 @@ HcalTBDigiProducer::HcalTBDigiProducer(const edm::ParameterSet &ps,
 }
 
 HcalTBDigiProducer::~HcalTBDigiProducer() {
-
   if (theHBHEDigitizer)
     delete theHBHEDigitizer;
   if (theHODigitizer)
@@ -106,8 +104,7 @@ HcalTBDigiProducer::~HcalTBDigiProducer() {
     delete theTimeSlewSim;
 }
 
-void HcalTBDigiProducer::initializeEvent(edm::Event const &e,
-                                         edm::EventSetup const &eventSetup) {
+void HcalTBDigiProducer::initializeEvent(edm::Event const &e, edm::EventSetup const &eventSetup) {
   // get the appropriate gains, noises, & widths for this event
   edm::ESHandle<HcalDbService> conditions;
   eventSetup.get<HcalDbRecord>().get(conditions);
@@ -124,7 +121,6 @@ void HcalTBDigiProducer::initializeEvent(edm::Event const &e,
   theHBHEHits.clear();
   theHOHits.clear();
   if (doPhaseShift) {
-
     edm::Handle<PEcalTBInfo> theEcalTBInfo;
     e.getByLabel(ecalTBInfoLabel, theEcalTBInfo);
     thisPhaseShift = theEcalTBInfo->phaseShift();
@@ -145,9 +141,7 @@ void HcalTBDigiProducer::initializeEvent(edm::Event const &e,
   theHODigitizer->initializeHits();
 }
 
-void HcalTBDigiProducer::accumulateCaloHits(
-    edm::Handle<std::vector<PCaloHit>> const &hcalHandle, int bunchCrossing) {
-
+void HcalTBDigiProducer::accumulateCaloHits(edm::Handle<std::vector<PCaloHit>> const &hcalHandle, int bunchCrossing) {
   LogDebug("HcalSim") << "HcalTBDigiProducer::accumulate trying to get SimHit";
 
   if (hcalHandle.isValid()) {
@@ -158,8 +152,7 @@ void HcalTBDigiProducer::accumulateCaloHits(
   }
 }
 
-void HcalTBDigiProducer::accumulate(edm::Event const &e,
-                                    edm::EventSetup const &) {
+void HcalTBDigiProducer::accumulate(edm::Event const &e, edm::EventSetup const &) {
   // Step A: Get Inputs, and accumulate digis
 
   edm::InputTag hcalTag("g4SimHits", "HcalHits");
@@ -181,32 +174,27 @@ void HcalTBDigiProducer::accumulate(PileUpEventPrincipal const &e,
   accumulateCaloHits(hcalHandle, e.bunchCrossing());
 }
 
-void HcalTBDigiProducer::finalizeEvent(edm::Event &e,
-                                       const edm::EventSetup &eventSetup) {
+void HcalTBDigiProducer::finalizeEvent(edm::Event &e, const edm::EventSetup &eventSetup) {
   // Step B: Create empty output
   std::unique_ptr<HBHEDigiCollection> hbheResult(new HBHEDigiCollection());
   std::unique_ptr<HODigiCollection> hoResult(new HODigiCollection());
   LogDebug("HcalSim") << "HcalTBDigiProducer::produce Empty collection created";
   // Step C: Invoke the algorithm, getting back outputs.
   theHBHEDigitizer->run(*hbheResult, randomEngine_);
-  edm::LogInfo("HcalSim") << "HcalTBDigiProducer: HBHE digis : "
-                          << hbheResult->size();
+  edm::LogInfo("HcalSim") << "HcalTBDigiProducer: HBHE digis : " << hbheResult->size();
   theHODigitizer->run(*hoResult, randomEngine_);
-  edm::LogInfo("HcalSim") << "HcalTBDigiProducer: HO digis   : "
-                          << hoResult->size();
+  edm::LogInfo("HcalSim") << "HcalTBDigiProducer: HO digis   : " << hoResult->size();
 
   // Step D: Put outputs into event
   std::string const instance("simHcalDigis");
   e.put(std::move(hbheResult), instance);
   e.put(std::move(hoResult), instance);
 
-  randomEngine_ = nullptr; // to prevent access outside event
+  randomEngine_ = nullptr;  // to prevent access outside event
 }
 
 void HcalTBDigiProducer::sortHits(const edm::PCaloHitContainer &hits) {
-
-  for (edm::PCaloHitContainer::const_iterator hitItr = hits.begin();
-       hitItr != hits.end(); ++hitItr) {
+  for (edm::PCaloHitContainer::const_iterator hitItr = hits.begin(); hitItr != hits.end(); ++hitItr) {
     HcalSubdetector subdet = HcalDetId(hitItr->id()).subdet();
     if (subdet == HcalBarrel || subdet == HcalEndcap) {
       theHBHEHits.push_back(*hitItr);
@@ -219,7 +207,6 @@ void HcalTBDigiProducer::sortHits(const edm::PCaloHitContainer &hits) {
 }
 
 void HcalTBDigiProducer::checkGeometry(const edm::EventSetup &eventSetup) {
-
   // TODO find a way to avoid doing this every event
   edm::ESHandle<CaloGeometry> geometry;
   eventSetup.get<CaloGeometryRecord>().get(geometry);
@@ -234,15 +221,13 @@ void HcalTBDigiProducer::checkGeometry(const edm::EventSetup &eventSetup) {
 }
 
 void HcalTBDigiProducer::updateGeometry() {
-
   theHBHEResponse->setGeometry(theGeometry);
   theHOResponse->setGeometry(theGeometry);
 
   // Get cells for HB and HE
   hbheCells.clear();
   hbheCells = theGeometry->getValidDetIds(DetId::Hcal, HcalBarrel);
-  std::vector<DetId> heCells =
-      theGeometry->getValidDetIds(DetId::Hcal, HcalEndcap);
+  std::vector<DetId> heCells = theGeometry->getValidDetIds(DetId::Hcal, HcalEndcap);
   // combine HB & HE
   hbheCells.insert(hbheCells.end(), heCells.begin(), heCells.end());
 
@@ -250,8 +235,7 @@ void HcalTBDigiProducer::updateGeometry() {
   hoCells.clear();
   hoCells = theGeometry->getValidDetIds(DetId::Hcal, HcalOuter);
 
-  edm::LogInfo("HcalSim") << "HcalTBDigiProducer update Geometry with "
-                          << hbheCells.size() << " cells in HB/HE and "
+  edm::LogInfo("HcalSim") << "HcalTBDigiProducer update Geometry with " << hbheCells.size() << " cells in HB/HE and "
                           << hoCells.size() << " cells in HO";
 
   theHBHEDigitizer->setDetIds(hbheCells);
@@ -261,7 +245,6 @@ void HcalTBDigiProducer::updateGeometry() {
 }
 
 void HcalTBDigiProducer::setPhaseShift(const DetId &detId) {
-
   const CaloSimParameters &parameters = theParameterMap->simParameters(detId);
   if (!parameters.syncPhase()) {
     int myDet = detId.subdetId();

--- a/SimCalorimetry/HcalTestBeam/src/HcalTBSimParameterMap.cc
+++ b/SimCalorimetry/HcalTestBeam/src/HcalTBSimParameterMap.cc
@@ -4,12 +4,9 @@
 #include "SimCalorimetry/HcalTestBeam/interface/HcalTBSimParameterMap.h"
 
 HcalTBSimParameterMap::HcalTBSimParameterMap()
-    : theHBParameters(2000., 117, 5, 10, 5, true, false, 1,
-                      std::vector<double>(16, 117.), 10.),
-      theHEParameters(2000., 178, 5, 10, 5, true, false, 16,
-                      std::vector<double>(16, 178.), 10.),
-      theHOParameters(4000., 217, 5, 10, 5, true, false, 1,
-                      std::vector<double>(16, 217.), 5.) {}
+    : theHBParameters(2000., 117, 5, 10, 5, true, false, 1, std::vector<double>(16, 117.), 10.),
+      theHEParameters(2000., 178, 5, 10, 5, true, false, 16, std::vector<double>(16, 178.), 10.),
+      theHOParameters(4000., 217, 5, 10, 5, true, false, 1, std::vector<double>(16, 217.), 5.) {}
 
 /*
   CaloSimParameters(double photomultiplierGain, double amplifierGain,
@@ -28,8 +25,7 @@ HcalTBSimParameterMap::HcalTBSimParameterMap(const edm::ParameterSet &p)
           p.getUntrackedParameter<bool>("doPhotostatisticsTB", true),
           p.getUntrackedParameter<bool>("syncPhaseTB", true),
           p.getUntrackedParameter<int>("firstRingTBHB", 1),
-          p.getUntrackedParameter<std::vector<double>>(
-              "samplingFactorsTBHB", std::vector<double>(16, 117.)),
+          p.getUntrackedParameter<std::vector<double>>("samplingFactorsTBHB", std::vector<double>(16, 117.)),
           p.getUntrackedParameter<double>("sipmTauTBHB", 10.)),
       theHEParameters(
           p.getUntrackedParameter<double>("photomultiplierGainTBHE", 2000.),
@@ -40,8 +36,7 @@ HcalTBSimParameterMap::HcalTBSimParameterMap(const edm::ParameterSet &p)
           p.getUntrackedParameter<bool>("doPhotostatisticsTB", true),
           p.getUntrackedParameter<bool>("syncPhaseTB", true),
           p.getUntrackedParameter<int>("firstRingTBHE", 16),
-          p.getUntrackedParameter<std::vector<double>>(
-              "samplingFactorsTBHE", std::vector<double>(16, 178.)),
+          p.getUntrackedParameter<std::vector<double>>("samplingFactorsTBHE", std::vector<double>(16, 178.)),
           p.getUntrackedParameter<double>("sipmTauTBHE", 10.)),
       theHOParameters(
           p.getUntrackedParameter<double>("photomultiplierGainTBHE", 4000.),
@@ -52,12 +47,10 @@ HcalTBSimParameterMap::HcalTBSimParameterMap(const edm::ParameterSet &p)
           p.getUntrackedParameter<bool>("doPhotostatisticsTB", true),
           p.getUntrackedParameter<bool>("syncPhaseTB", true),
           p.getUntrackedParameter<int>("firstRingTBHO", 1),
-          p.getUntrackedParameter<std::vector<double>>(
-              "samplingFactorsTBHO", std::vector<double>(16, 217.)),
+          p.getUntrackedParameter<std::vector<double>>("samplingFactorsTBHO", std::vector<double>(16, 217.)),
           p.getUntrackedParameter<double>("sipmTauTBHO", 5.)) {}
 
-const CaloSimParameters &
-HcalTBSimParameterMap::simParameters(const DetId &detId) const {
+const CaloSimParameters &HcalTBSimParameterMap::simParameters(const DetId &detId) const {
   HcalDetId hcalDetId(detId);
   if (hcalDetId.subdet() == HcalBarrel) {
     return theHBParameters;

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalRealisticZS.cc
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalRealisticZS.cc
@@ -11,7 +11,6 @@
 
 HcalRealisticZS::HcalRealisticZS(edm::ParameterSet const &conf)
     : inputLabel_(conf.getParameter<std::string>("digiLabel")) {
-
   bool markAndPass = conf.getParameter<bool>("markAndPass");
   bool useInstanceLabels = conf.getParameter<bool>("useInstanceLabels");
 
@@ -19,16 +18,15 @@ HcalRealisticZS::HcalRealisticZS(edm::ParameterSet const &conf)
   tok_hbhe_ = consumes<HBHEDigiCollection>(edm::InputTag(inputLabel_));
   tok_ho_ = consumes<HODigiCollection>(edm::InputTag(inputLabel_));
   tok_hf_ = consumes<HFDigiCollection>(edm::InputTag(inputLabel_));
-  tok_hfQIE10_ = consumes<QIE10DigiCollection>(edm::InputTag(
-      inputLabel_, useInstanceLabels ? "HFQIE10DigiCollection" : ""));
-  tok_hbheQIE11_ = consumes<QIE11DigiCollection>(edm::InputTag(
-      inputLabel_, useInstanceLabels ? "HBHEQIE11DigiCollection" : ""));
+  tok_hfQIE10_ =
+      consumes<QIE10DigiCollection>(edm::InputTag(inputLabel_, useInstanceLabels ? "HFQIE10DigiCollection" : ""));
+  tok_hbheQIE11_ =
+      consumes<QIE11DigiCollection>(edm::InputTag(inputLabel_, useInstanceLabels ? "HBHEQIE11DigiCollection" : ""));
 
   std::vector<int> tmp = conf.getParameter<std::vector<int>>("HBregion");
 
   if (tmp[0] < 0 || tmp[0] > 9 || tmp[1] < 0 || tmp[1] > 9 || tmp[0] > tmp[1]) {
-    edm::LogError("HcalZeroSuppression")
-        << "ZS(HB) region error: " << tmp[0] << ":" << tmp[1];
+    edm::LogError("HcalZeroSuppression") << "ZS(HB) region error: " << tmp[0] << ":" << tmp[1];
     tmp[0] = 0;
     tmp[1] = 9;
   }
@@ -37,8 +35,7 @@ HcalRealisticZS::HcalRealisticZS(edm::ParameterSet const &conf)
 
   tmp = conf.getParameter<std::vector<int>>("HEregion");
   if (tmp[0] < 0 || tmp[0] > 9 || tmp[1] < 0 || tmp[1] > 9 || tmp[0] > tmp[1]) {
-    edm::LogError("HcalZeroSuppression")
-        << "ZS(HE) region error: " << tmp[0] << ":" << tmp[1];
+    edm::LogError("HcalZeroSuppression") << "ZS(HE) region error: " << tmp[0] << ":" << tmp[1];
     tmp[0] = 0;
     tmp[1] = 9;
   }
@@ -46,8 +43,7 @@ HcalRealisticZS::HcalRealisticZS(edm::ParameterSet const &conf)
 
   tmp = conf.getParameter<std::vector<int>>("HOregion");
   if (tmp[0] < 0 || tmp[0] > 9 || tmp[1] < 0 || tmp[1] > 9 || tmp[0] > tmp[1]) {
-    edm::LogError("HcalZeroSuppression")
-        << "ZS(HO) region error: " << tmp[0] << ":" << tmp[1];
+    edm::LogError("HcalZeroSuppression") << "ZS(HO) region error: " << tmp[0] << ":" << tmp[1];
     tmp[0] = 0;
     tmp[1] = 9;
   }
@@ -55,8 +51,7 @@ HcalRealisticZS::HcalRealisticZS(edm::ParameterSet const &conf)
 
   tmp = conf.getParameter<std::vector<int>>("HFregion");
   if (tmp[0] < 0 || tmp[0] > 9 || tmp[1] < 0 || tmp[1] > 9 || tmp[0] > tmp[1]) {
-    edm::LogError("HcalZeroSuppression")
-        << "ZS(HF) region error: " << tmp[0] << ":" << tmp[1];
+    edm::LogError("HcalZeroSuppression") << "ZS(HF) region error: " << tmp[0] << ":" << tmp[1];
     tmp[0] = 0;
     tmp[1] = 9;
   }
@@ -66,17 +61,18 @@ HcalRealisticZS::HcalRealisticZS(edm::ParameterSet const &conf)
   // HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
   // which means that channel-by-channel ZS thresholds from DB will NOT be used
   if (conf.getParameter<int>("useConfigZSvalues")) {
-
-    algo_.reset(new HcalZSAlgoRealistic(
-        markAndPass, conf.getParameter<int>("HBlevel"),
-        conf.getParameter<int>("HElevel"), conf.getParameter<int>("HOlevel"),
-        conf.getParameter<int>("HFlevel"), HBsearchTS, HEsearchTS, HOsearchTS,
-        HFsearchTS));
+    algo_.reset(new HcalZSAlgoRealistic(markAndPass,
+                                        conf.getParameter<int>("HBlevel"),
+                                        conf.getParameter<int>("HElevel"),
+                                        conf.getParameter<int>("HOlevel"),
+                                        conf.getParameter<int>("HFlevel"),
+                                        HBsearchTS,
+                                        HEsearchTS,
+                                        HOsearchTS,
+                                        HFsearchTS));
 
   } else {
-
-    algo_.reset(new HcalZSAlgoRealistic(markAndPass, HBsearchTS, HEsearchTS,
-                                        HOsearchTS, HFsearchTS));
+    algo_.reset(new HcalZSAlgoRealistic(markAndPass, HBsearchTS, HEsearchTS, HOsearchTS, HFsearchTS));
   }
 
   produces<HBHEDigiCollection>();
@@ -88,9 +84,7 @@ HcalRealisticZS::HcalRealisticZS(edm::ParameterSet const &conf)
 
 HcalRealisticZS::~HcalRealisticZS() { algo_->clearDbService(); }
 
-void HcalRealisticZS::produce(edm::Event &e,
-                              const edm::EventSetup &eventSetup) {
-
+void HcalRealisticZS::produce(edm::Event &e, const edm::EventSetup &eventSetup) {
   edm::Handle<HBHEDigiCollection> hbhe;
   edm::Handle<HODigiCollection> ho;
   edm::Handle<HFDigiCollection> hf;
@@ -122,10 +116,8 @@ void HcalRealisticZS::produce(edm::Event &e,
   // create empty output
   std::unique_ptr<HBHEDigiCollection> zs_hbheUpgrade(new HBHEDigiCollection);
   std::unique_ptr<HFDigiCollection> zs_hfUpgrade(new HFDigiCollection);
-  std::unique_ptr<QIE10DigiCollection> zs_hfQIE10(
-      new QIE10DigiCollection(hfQIE10->samples()));
-  std::unique_ptr<QIE11DigiCollection> zs_hbheQIE11(
-      new QIE11DigiCollection(hbheQIE11->samples()));
+  std::unique_ptr<QIE10DigiCollection> zs_hfQIE10(new QIE10DigiCollection(hfQIE10->samples()));
+  std::unique_ptr<QIE11DigiCollection> zs_hbheQIE11(new QIE11DigiCollection(hbheQIE11->samples()));
 
   // run the algorithm
   algo_->suppress(*(hbhe.product()), *zs_hbhe);
@@ -134,17 +126,14 @@ void HcalRealisticZS::produce(edm::Event &e,
   algo_->suppress(*(hfQIE10.product()), *zs_hfQIE10);
   algo_->suppress(*(hbheQIE11.product()), *zs_hbheQIE11);
 
-  edm::LogInfo("HcalZeroSuppression")
-      << "Suppression (HBHE) input " << hbhe->size() << " digis, output "
-      << zs_hbhe->size() << " digis"
-      << " (HO) input " << ho->size() << " digis, output " << zs_ho->size()
-      << " digis"
-      << " (HF) input " << hf->size() << " digis, output " << zs_hf->size()
-      << " digis"
-      << " (HFQIE10) input " << hfQIE10->size() << " digis, output "
-      << zs_hfQIE10->size() << " digis"
-      << " (HBHEQIE11) input " << hbheQIE11->size() << " digis, output "
-      << zs_hbheQIE11->size() << " digis";
+  edm::LogInfo("HcalZeroSuppression") << "Suppression (HBHE) input " << hbhe->size() << " digis, output "
+                                      << zs_hbhe->size() << " digis"
+                                      << " (HO) input " << ho->size() << " digis, output " << zs_ho->size() << " digis"
+                                      << " (HF) input " << hf->size() << " digis, output " << zs_hf->size() << " digis"
+                                      << " (HFQIE10) input " << hfQIE10->size() << " digis, output "
+                                      << zs_hfQIE10->size() << " digis"
+                                      << " (HBHEQIE11) input " << hbheQIE11->size() << " digis, output "
+                                      << zs_hbheQIE11->size() << " digis";
 
   // return result
   e.put(std::move(zs_hbhe));

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalSimpleAmplitudeZS.cc
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalSimpleAmplitudeZS.cc
@@ -15,61 +15,56 @@ using namespace std;
 
 HcalSimpleAmplitudeZS::HcalSimpleAmplitudeZS(edm::ParameterSet const &conf)
     : inputLabel_(conf.getParameter<std::string>("digiLabel")) {
-
   // register for data access
   tok_hbhe_ = consumes<HBHEDigiCollection>(edm::InputTag(inputLabel_));
   tok_ho_ = consumes<HODigiCollection>(edm::InputTag(inputLabel_));
   tok_hf_ = consumes<HFDigiCollection>(edm::InputTag(inputLabel_));
-  tok_hfQIE10_ = consumes<QIE10DigiCollection>(
-      edm::InputTag(inputLabel_, "HFQIE10DigiCollection"));
-  tok_hbheQIE11_ = consumes<QIE11DigiCollection>(
-      edm::InputTag(inputLabel_, "HBHEQIE11DigiCollection"));
+  tok_hfQIE10_ = consumes<QIE10DigiCollection>(edm::InputTag(inputLabel_, "HFQIE10DigiCollection"));
+  tok_hbheQIE11_ = consumes<QIE11DigiCollection>(edm::InputTag(inputLabel_, "HBHEQIE11DigiCollection"));
 
-  const edm::ParameterSet &psHBHE =
-      conf.getParameter<edm::ParameterSet>("hbhe");
+  const edm::ParameterSet &psHBHE = conf.getParameter<edm::ParameterSet>("hbhe");
   bool markAndPass = psHBHE.getParameter<bool>("markAndPass");
-  hbhe_ = std::unique_ptr<HcalZSAlgoEnergy>(
-      new HcalZSAlgoEnergy(markAndPass, psHBHE.getParameter<int>("level"),
-                           psHBHE.getParameter<int>("firstSample"),
-                           psHBHE.getParameter<int>("samplesToAdd"),
-                           psHBHE.getParameter<bool>("twoSided")));
+  hbhe_ = std::unique_ptr<HcalZSAlgoEnergy>(new HcalZSAlgoEnergy(markAndPass,
+                                                                 psHBHE.getParameter<int>("level"),
+                                                                 psHBHE.getParameter<int>("firstSample"),
+                                                                 psHBHE.getParameter<int>("samplesToAdd"),
+                                                                 psHBHE.getParameter<bool>("twoSided")));
   produces<HBHEDigiCollection>();
-  hbheQIE11_ = std::unique_ptr<HcalZSAlgoEnergy>(
-      new HcalZSAlgoEnergy(markAndPass, psHBHE.getParameter<int>("level"),
-                           psHBHE.getParameter<int>("firstSample"),
-                           psHBHE.getParameter<int>("samplesToAdd"),
-                           psHBHE.getParameter<bool>("twoSided")));
+  hbheQIE11_ = std::unique_ptr<HcalZSAlgoEnergy>(new HcalZSAlgoEnergy(markAndPass,
+                                                                      psHBHE.getParameter<int>("level"),
+                                                                      psHBHE.getParameter<int>("firstSample"),
+                                                                      psHBHE.getParameter<int>("samplesToAdd"),
+                                                                      psHBHE.getParameter<bool>("twoSided")));
   produces<QIE11DigiCollection>("HBHEQIE11DigiCollection");
 
   const edm::ParameterSet &psHO = conf.getParameter<edm::ParameterSet>("ho");
   markAndPass = psHO.getParameter<bool>("markAndPass");
-  ho_ = std::unique_ptr<HcalZSAlgoEnergy>(
-      new HcalZSAlgoEnergy(markAndPass, psHO.getParameter<int>("level"),
-                           psHO.getParameter<int>("firstSample"),
-                           psHO.getParameter<int>("samplesToAdd"),
-                           psHO.getParameter<bool>("twoSided")));
+  ho_ = std::unique_ptr<HcalZSAlgoEnergy>(new HcalZSAlgoEnergy(markAndPass,
+                                                               psHO.getParameter<int>("level"),
+                                                               psHO.getParameter<int>("firstSample"),
+                                                               psHO.getParameter<int>("samplesToAdd"),
+                                                               psHO.getParameter<bool>("twoSided")));
   produces<HODigiCollection>();
 
   const edm::ParameterSet &psHF = conf.getParameter<edm::ParameterSet>("hf");
   markAndPass = psHF.getParameter<bool>("markAndPass");
-  hf_ = std::unique_ptr<HcalZSAlgoEnergy>(
-      new HcalZSAlgoEnergy(markAndPass, psHF.getParameter<int>("level"),
-                           psHF.getParameter<int>("firstSample"),
-                           psHF.getParameter<int>("samplesToAdd"),
-                           psHF.getParameter<bool>("twoSided")));
+  hf_ = std::unique_ptr<HcalZSAlgoEnergy>(new HcalZSAlgoEnergy(markAndPass,
+                                                               psHF.getParameter<int>("level"),
+                                                               psHF.getParameter<int>("firstSample"),
+                                                               psHF.getParameter<int>("samplesToAdd"),
+                                                               psHF.getParameter<bool>("twoSided")));
   produces<HFDigiCollection>();
-  hfQIE10_ = std::unique_ptr<HcalZSAlgoEnergy>(
-      new HcalZSAlgoEnergy(markAndPass, psHF.getParameter<int>("level"),
-                           psHF.getParameter<int>("firstSample"),
-                           psHF.getParameter<int>("samplesToAdd"),
-                           psHF.getParameter<bool>("twoSided")));
+  hfQIE10_ = std::unique_ptr<HcalZSAlgoEnergy>(new HcalZSAlgoEnergy(markAndPass,
+                                                                    psHF.getParameter<int>("level"),
+                                                                    psHF.getParameter<int>("firstSample"),
+                                                                    psHF.getParameter<int>("samplesToAdd"),
+                                                                    psHF.getParameter<bool>("twoSided")));
   produces<QIE10DigiCollection>("HFQIE10DigiCollection");
 }
 
 HcalSimpleAmplitudeZS::~HcalSimpleAmplitudeZS() {}
 
-void HcalSimpleAmplitudeZS::produce(edm::Event &e,
-                                    const edm::EventSetup &eventSetup) {
+void HcalSimpleAmplitudeZS::produce(edm::Event &e, const edm::EventSetup &eventSetup) {
   // get conditions
   edm::ESHandle<HcalDbService> conditions;
   eventSetup.get<HcalDbRecord>().get(conditions);
@@ -84,9 +79,8 @@ void HcalSimpleAmplitudeZS::produce(edm::Event &e,
     // run the algorithm
     hbhe_->suppress(*(digi.product()), *zs);
 
-    edm::LogInfo("HcalZeroSuppression")
-        << "Suppression (HBHE) input " << digi->size() << " digis, output "
-        << zs->size() << " digis";
+    edm::LogInfo("HcalZeroSuppression") << "Suppression (HBHE) input " << digi->size() << " digis, output "
+                                        << zs->size() << " digis";
 
     // return result
     e.put(std::move(zs));
@@ -102,9 +96,8 @@ void HcalSimpleAmplitudeZS::produce(edm::Event &e,
     // run the algorithm
     ho_->suppress(*(digi.product()), *zs);
 
-    edm::LogInfo("HcalZeroSuppression")
-        << "Suppression (HO) input " << digi->size() << " digis, output "
-        << zs->size() << " digis";
+    edm::LogInfo("HcalZeroSuppression") << "Suppression (HO) input " << digi->size() << " digis, output " << zs->size()
+                                        << " digis";
 
     // return result
     e.put(std::move(zs));
@@ -120,9 +113,8 @@ void HcalSimpleAmplitudeZS::produce(edm::Event &e,
     // run the algorithm
     hf_->suppress(*(digi.product()), *zs);
 
-    edm::LogInfo("HcalZeroSuppression")
-        << "Suppression (HF) input " << digi->size() << " digis, output "
-        << zs->size() << " digis";
+    edm::LogInfo("HcalZeroSuppression") << "Suppression (HF) input " << digi->size() << " digis, output " << zs->size()
+                                        << " digis";
 
     // return result
     e.put(std::move(zs));
@@ -134,14 +126,12 @@ void HcalSimpleAmplitudeZS::produce(edm::Event &e,
     e.getByToken(tok_hfQIE10_, digi);
 
     // create empty output
-    std::unique_ptr<QIE10DigiCollection> zs(
-        new QIE10DigiCollection(digi->samples()));
+    std::unique_ptr<QIE10DigiCollection> zs(new QIE10DigiCollection(digi->samples()));
     // run the algorithm
     hfQIE10_->suppress(*(digi.product()), *zs);
 
-    edm::LogInfo("HcalZeroSuppression")
-        << "Suppression (HFQIE10) input " << digi->size() << " digis, output "
-        << zs->size() << " digis";
+    edm::LogInfo("HcalZeroSuppression") << "Suppression (HFQIE10) input " << digi->size() << " digis, output "
+                                        << zs->size() << " digis";
 
     // return result
     e.put(std::move(zs), "HFQIE10DigiCollection");
@@ -153,14 +143,12 @@ void HcalSimpleAmplitudeZS::produce(edm::Event &e,
     e.getByToken(tok_hbheQIE11_, digi);
 
     // create empty output
-    std::unique_ptr<QIE11DigiCollection> zs(
-        new QIE11DigiCollection(digi->samples()));
+    std::unique_ptr<QIE11DigiCollection> zs(new QIE11DigiCollection(digi->samples()));
     // run the algorithm
     hbheQIE11_->suppress(*(digi.product()), *zs);
 
-    edm::LogInfo("HcalZeroSuppression")
-        << "Suppression (HBHEQIE11) input " << digi->size() << " digis, output "
-        << zs->size() << " digis";
+    edm::LogInfo("HcalZeroSuppression") << "Suppression (HBHEQIE11) input " << digi->size() << " digis, output "
+                                        << zs->size() << " digis";
 
     // return result
     e.put(std::move(zs), "HBHEQIE11DigiCollection");

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoEnergy.cc
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoEnergy.cc
@@ -4,75 +4,67 @@
 #include "HcalZSAlgoEnergy.h"
 #include <iostream>
 
-HcalZSAlgoEnergy::HcalZSAlgoEnergy(bool mp, int level, int start, int samples,
-                                   bool twosided)
-    : HcalZeroSuppressionAlgo(mp), threshold_(level), firstsample_(start),
-      samplecount_(samples), twosided_(twosided) {}
+HcalZSAlgoEnergy::HcalZSAlgoEnergy(bool mp, int level, int start, int samples, bool twosided)
+    : HcalZeroSuppressionAlgo(mp), threshold_(level), firstsample_(start), samplecount_(samples), twosided_(twosided) {}
 
 namespace ZSEnergy_impl {
 
-template <class DIGI>
-bool keepMe(const HcalDbService &db, const DIGI &inp, int threshold,
-            int firstSample, int samples, bool twosided) {
-  bool keepIt = false;
-  const HcalQIECoder *channelCoder = db.getHcalCoder(inp.id());
-  const HcalQIEShape *shape = db.getHcalShape(channelCoder);
+  template <class DIGI>
+  bool keepMe(const HcalDbService &db, const DIGI &inp, int threshold, int firstSample, int samples, bool twosided) {
+    bool keepIt = false;
+    const HcalQIECoder *channelCoder = db.getHcalCoder(inp.id());
+    const HcalQIEShape *shape = db.getHcalShape(channelCoder);
 
-  // determine average pedestal for channel
-  float pedsum = 0, pedave = 0, offset = 0, slope = 0;
-  const HcalPedestal *ped = db.getPedestal(inp.id());
-  for (int j = 0; j < 4; j++) {
-    pedave += ped->getValue(j) / 4.0;
-    offset += channelCoder->charge(*shape, 0, j) / 4.0;
-    slope += channelCoder->charge(*shape, 1, j) / 4.0;
-  }
-  slope -= offset;
-  pedave -= offset;
-  pedave /= slope;
+    // determine average pedestal for channel
+    float pedsum = 0, pedave = 0, offset = 0, slope = 0;
+    const HcalPedestal *ped = db.getPedestal(inp.id());
+    for (int j = 0; j < 4; j++) {
+      pedave += ped->getValue(j) / 4.0;
+      offset += channelCoder->charge(*shape, 0, j) / 4.0;
+      slope += channelCoder->charge(*shape, 1, j) / 4.0;
+    }
+    slope -= offset;
+    pedave -= offset;
+    pedave /= slope;
 
-  int sum = 0;
+    int sum = 0;
 
-  for (int j = 0; j < samples && j + firstSample < (int)inp.size(); j++) {
-    sum += inp[j + firstSample].adc();
-    pedsum += pedave;
-  }
-  //    int presum=sum;
-  sum -= (int)(pedsum);
+    for (int j = 0; j < samples && j + firstSample < (int)inp.size(); j++) {
+      sum += inp[j + firstSample].adc();
+      pedsum += pedave;
+    }
+    //    int presum=sum;
+    sum -= (int)(pedsum);
 
-  if (sum >= threshold)
-    keepIt = true;
-  else if (sum <= (-threshold) && twosided)
-    keepIt = true;
-  /*
+    if (sum >= threshold)
+      keepIt = true;
+    else if (sum <= (-threshold) && twosided)
+      keepIt = true;
+    /*
     else
    std::cout << inp.id() << " " << sum << ":" << presum << " " << threshold
     << " " << pedsum << " " << pedave
     << " " << offset << " " << slope
     << std::endl;
   */
-  return keepIt;
-}
-} // namespace ZSEnergy_impl
+    return keepIt;
+  }
+}  // namespace ZSEnergy_impl
 
 bool HcalZSAlgoEnergy::shouldKeep(const HBHEDataFrame &digi) const {
-  return ZSEnergy_impl::keepMe<HBHEDataFrame>(
-      *db_, digi, threshold_, firstsample_, samplecount_, twosided_);
+  return ZSEnergy_impl::keepMe<HBHEDataFrame>(*db_, digi, threshold_, firstsample_, samplecount_, twosided_);
 }
 bool HcalZSAlgoEnergy::shouldKeep(const HODataFrame &digi) const {
-  return ZSEnergy_impl::keepMe<HODataFrame>(
-      *db_, digi, threshold_, firstsample_, samplecount_, twosided_);
+  return ZSEnergy_impl::keepMe<HODataFrame>(*db_, digi, threshold_, firstsample_, samplecount_, twosided_);
 }
 bool HcalZSAlgoEnergy::shouldKeep(const HFDataFrame &digi) const {
-  return ZSEnergy_impl::keepMe<HFDataFrame>(
-      *db_, digi, threshold_, firstsample_, samplecount_, twosided_);
+  return ZSEnergy_impl::keepMe<HFDataFrame>(*db_, digi, threshold_, firstsample_, samplecount_, twosided_);
 }
 bool HcalZSAlgoEnergy::shouldKeep(const QIE10DataFrame &digi) const {
-  return ZSEnergy_impl::keepMe<QIE10DataFrame>(
-      *db_, digi, threshold_, firstsample_, samplecount_, twosided_);
+  return ZSEnergy_impl::keepMe<QIE10DataFrame>(*db_, digi, threshold_, firstsample_, samplecount_, twosided_);
 }
 bool HcalZSAlgoEnergy::shouldKeep(const QIE11DataFrame &digi) const {
-  return ZSEnergy_impl::keepMe<QIE11DataFrame>(
-      *db_, digi, threshold_, firstsample_, samplecount_, twosided_);
+  return ZSEnergy_impl::keepMe<QIE11DataFrame>(*db_, digi, threshold_, firstsample_, samplecount_, twosided_);
 }
 
 void HcalZSAlgoEnergy::prepare(const HcalDbService *db) { db_ = db; }

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoEnergy.h
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoEnergy.h
@@ -16,8 +16,7 @@
  */
 class HcalZSAlgoEnergy : public HcalZeroSuppressionAlgo {
 public:
-  HcalZSAlgoEnergy(bool markAndPass, int level, int start, int samples,
-                   bool twosided);
+  HcalZSAlgoEnergy(bool markAndPass, int level, int start, int samples, bool twosided);
   ~HcalZSAlgoEnergy() override = default;
   void prepare(const HcalDbService *db);
   void done();

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoRealistic.cc
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoRealistic.cc
@@ -1,15 +1,23 @@
 #include "HcalZSAlgoRealistic.h"
 #include <iostream>
 
-HcalZSAlgoRealistic::HcalZSAlgoRealistic(bool mp, int levelHB, int levelHE,
-                                         int levelHO, int levelHF,
+HcalZSAlgoRealistic::HcalZSAlgoRealistic(bool mp,
+                                         int levelHB,
+                                         int levelHE,
+                                         int levelHO,
+                                         int levelHF,
                                          std::pair<int, int> HBsearchTS,
                                          std::pair<int, int> HEsearchTS,
                                          std::pair<int, int> HOsearchTS,
                                          std::pair<int, int> HFsearchTS)
-    : HcalZeroSuppressionAlgo(mp), thresholdHB_(levelHB), thresholdHE_(levelHE),
-      thresholdHO_(levelHO), thresholdHF_(levelHF), HBsearchTS_(HBsearchTS),
-      HEsearchTS_(HEsearchTS), HOsearchTS_(HOsearchTS),
+    : HcalZeroSuppressionAlgo(mp),
+      thresholdHB_(levelHB),
+      thresholdHE_(levelHE),
+      thresholdHO_(levelHO),
+      thresholdHF_(levelHF),
+      HBsearchTS_(HBsearchTS),
+      HEsearchTS_(HEsearchTS),
+      HOsearchTS_(HOsearchTS),
       HFsearchTS_(HFsearchTS) {
   usingDBvalues = false;
 }
@@ -19,8 +27,10 @@ HcalZSAlgoRealistic::HcalZSAlgoRealistic(bool mp,
                                          std::pair<int, int> HEsearchTS,
                                          std::pair<int, int> HOsearchTS,
                                          std::pair<int, int> HFsearchTS)
-    : HcalZeroSuppressionAlgo(mp), HBsearchTS_(HBsearchTS),
-      HEsearchTS_(HEsearchTS), HOsearchTS_(HOsearchTS),
+    : HcalZeroSuppressionAlgo(mp),
+      HBsearchTS_(HBsearchTS),
+      HEsearchTS_(HEsearchTS),
+      HOsearchTS_(HOsearchTS),
       HFsearchTS_(HFsearchTS) {
   thresholdHB_ = -1;
   thresholdHE_ = -1;
@@ -30,8 +40,7 @@ HcalZSAlgoRealistic::HcalZSAlgoRealistic(bool mp,
 }
 
 template <class Digi>
-bool HcalZSAlgoRealistic::keepMe(const Digi &inp, int start, int finish,
-                                 int threshold, uint32_t zsmask) const {
+bool HcalZSAlgoRealistic::keepMe(const Digi &inp, int start, int finish, int threshold, uint32_t zsmask) const {
   if ((usingDBvalues) && (threshold < 0) && (m_dbService != nullptr)) {
     threshold = (m_dbService->getHcalZSThreshold(inp.id()))->getValue();
   }
@@ -49,10 +58,8 @@ bool HcalZSAlgoRealistic::keepMe(const Digi &inp, int start, int finish,
 // zs mask not used for QIE10,11
 
 template <>
-bool HcalZSAlgoRealistic::keepMe<QIE10DataFrame>(const QIE10DataFrame &inp,
-                                                 int start, int finish,
-                                                 int threshold,
-                                                 uint32_t zsmask) const {
+bool HcalZSAlgoRealistic::keepMe<QIE10DataFrame>(
+    const QIE10DataFrame &inp, int start, int finish, int threshold, uint32_t zsmask) const {
   if ((usingDBvalues) && (threshold < 0) && (m_dbService != nullptr)) {
     threshold = (m_dbService->getHcalZSThreshold(inp.id()))->getValue();
   }
@@ -66,10 +73,8 @@ bool HcalZSAlgoRealistic::keepMe<QIE10DataFrame>(const QIE10DataFrame &inp,
 }
 
 template <>
-bool HcalZSAlgoRealistic::keepMe<QIE11DataFrame>(const QIE11DataFrame &inp,
-                                                 int start, int finish,
-                                                 int threshold,
-                                                 uint32_t zsmask) const {
+bool HcalZSAlgoRealistic::keepMe<QIE11DataFrame>(
+    const QIE11DataFrame &inp, int start, int finish, int threshold, uint32_t zsmask) const {
   if ((usingDBvalues) && (threshold < 0) && (m_dbService != nullptr)) {
     threshold = (m_dbService->getHcalZSThreshold(inp.id()))->getValue();
   }

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoRealistic.h
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoRealistic.h
@@ -14,12 +14,17 @@
  */
 class HcalZSAlgoRealistic : public HcalZeroSuppressionAlgo {
 public:
-  HcalZSAlgoRealistic(bool markAndPass, std::pair<int, int> HBsearchTS,
+  HcalZSAlgoRealistic(bool markAndPass,
+                      std::pair<int, int> HBsearchTS,
                       std::pair<int, int> HEsearchTS,
                       std::pair<int, int> HOsearchTS,
                       std::pair<int, int> HFsearchTS);
-  HcalZSAlgoRealistic(bool markAndPass, int levelHB, int levelHE, int levelHO,
-                      int levelHF, std::pair<int, int> HBsearchTS,
+  HcalZSAlgoRealistic(bool markAndPass,
+                      int levelHB,
+                      int levelHE,
+                      int levelHO,
+                      int levelHF,
+                      std::pair<int, int> HBsearchTS,
                       std::pair<int, int> HEsearchTS,
                       std::pair<int, int> HOsearchTS,
                       std::pair<int, int> HFsearchTS);
@@ -39,8 +44,7 @@ private:
   int thresholdHB_, thresholdHE_, thresholdHO_, thresholdHF_;
   std::pair<int, int> HBsearchTS_, HEsearchTS_, HOsearchTS_, HFsearchTS_;
   template <class Digi>
-  bool keepMe(const Digi &inp, int start, int finish, int threshold,
-              uint32_t zsmask) const;
+  bool keepMe(const Digi &inp, int start, int finish, int threshold, uint32_t zsmask) const;
 };
 
 #endif

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZeroSuppressionAlgo.cc
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZeroSuppressionAlgo.cc
@@ -1,11 +1,8 @@
 #include "HcalZeroSuppressionAlgo.h"
 
-HcalZeroSuppressionAlgo::HcalZeroSuppressionAlgo(bool mp) : m_markAndPass(mp) {
-  m_dbService = nullptr;
-}
+HcalZeroSuppressionAlgo::HcalZeroSuppressionAlgo(bool mp) : m_markAndPass(mp) { m_dbService = nullptr; }
 
-void HcalZeroSuppressionAlgo::suppress(const HBHEDigiCollection &input,
-                                       HBHEDigiCollection &output) {
+void HcalZeroSuppressionAlgo::suppress(const HBHEDigiCollection &input, HBHEDigiCollection &output) {
   HBHEDigiCollection::const_iterator i;
 
   for (i = input.begin(); i != input.end(); ++i) {
@@ -25,8 +22,7 @@ void HcalZeroSuppressionAlgo::suppress(const HBHEDigiCollection &input,
   }
 }
 
-void HcalZeroSuppressionAlgo::suppress(const HFDigiCollection &input,
-                                       HFDigiCollection &output) {
+void HcalZeroSuppressionAlgo::suppress(const HFDigiCollection &input, HFDigiCollection &output) {
   HFDigiCollection::const_iterator i;
 
   for (i = input.begin(); i != input.end(); ++i) {
@@ -46,8 +42,7 @@ void HcalZeroSuppressionAlgo::suppress(const HFDigiCollection &input,
   }
 }
 
-void HcalZeroSuppressionAlgo::suppress(const HODigiCollection &input,
-                                       HODigiCollection &output) {
+void HcalZeroSuppressionAlgo::suppress(const HODigiCollection &input, HODigiCollection &output) {
   HODigiCollection::const_iterator i;
 
   for (i = input.begin(); i != input.end(); ++i) {
@@ -67,10 +62,8 @@ void HcalZeroSuppressionAlgo::suppress(const HODigiCollection &input,
   }
 }
 
-void HcalZeroSuppressionAlgo::suppress(const QIE10DigiCollection &input,
-                                       QIE10DigiCollection &output) {
-  for (QIE10DigiCollection::const_iterator i = input.begin(); i != input.end();
-       ++i) {
+void HcalZeroSuppressionAlgo::suppress(const QIE10DigiCollection &input, QIE10DigiCollection &output) {
+  for (QIE10DigiCollection::const_iterator i = input.begin(); i != input.end(); ++i) {
     QIE10DataFrame df(*i);
     if (shouldKeep(df)) {
       if (!m_markAndPass) {
@@ -86,10 +79,8 @@ void HcalZeroSuppressionAlgo::suppress(const QIE10DigiCollection &input,
   }
 }
 
-void HcalZeroSuppressionAlgo::suppress(const QIE11DigiCollection &input,
-                                       QIE11DigiCollection &output) {
-  for (QIE11DigiCollection::const_iterator i = input.begin(); i != input.end();
-       ++i) {
+void HcalZeroSuppressionAlgo::suppress(const QIE11DigiCollection &input, QIE11DigiCollection &output) {
+  for (QIE11DigiCollection::const_iterator i = input.begin(); i != input.end(); ++i) {
     QIE11DataFrame df(*i);
     if (shouldKeep(df)) {
       if (!m_markAndPass) {

--- a/SimDataFormats/Associations/interface/MuonToTrackingParticleAssociator.h
+++ b/SimDataFormats/Associations/interface/MuonToTrackingParticleAssociator.h
@@ -12,42 +12,37 @@
 #include <memory>
 
 namespace reco {
-class MuonToTrackingParticleAssociator {
-
-public:
-  MuonToTrackingParticleAssociator() = default;
-  ~MuonToTrackingParticleAssociator() = default;
+  class MuonToTrackingParticleAssociator {
+  public:
+    MuonToTrackingParticleAssociator() = default;
+    ~MuonToTrackingParticleAssociator() = default;
 #ifndef __GCCXML__
-  MuonToTrackingParticleAssociator(
-      std::unique_ptr<MuonToTrackingParticleAssociatorBaseImpl>);
+    MuonToTrackingParticleAssociator(std::unique_ptr<MuonToTrackingParticleAssociatorBaseImpl>);
 #endif
-  MuonToTrackingParticleAssociator(MuonToTrackingParticleAssociator &&) =
-      default;
-  MuonToTrackingParticleAssociator &
-  operator=(MuonToTrackingParticleAssociator &&) = default;
+    MuonToTrackingParticleAssociator(MuonToTrackingParticleAssociator &&) = default;
+    MuonToTrackingParticleAssociator &operator=(MuonToTrackingParticleAssociator &&) = default;
 
-  void associateMuons(
-      MuonToSimCollection &recoToSim, SimToMuonCollection &simToReco,
-      const edm::RefToBaseVector<reco::Muon> &muons, MuonTrackType type,
-      const edm::RefVector<TrackingParticleCollection> &tpColl) const {
-    impl_->associateMuons(recoToSim, simToReco, muons, type, tpColl);
-  }
-  void
-  associateMuons(MuonToSimCollection &recoToSim, SimToMuonCollection &simToReco,
-                 const edm::Handle<edm::View<reco::Muon>> &muons,
-                 MuonTrackType type,
-                 const edm::Handle<TrackingParticleCollection> &tpColl) const {
-    impl_->associateMuons(recoToSim, simToReco, muons, type, tpColl);
-  }
+    void associateMuons(MuonToSimCollection &recoToSim,
+                        SimToMuonCollection &simToReco,
+                        const edm::RefToBaseVector<reco::Muon> &muons,
+                        MuonTrackType type,
+                        const edm::RefVector<TrackingParticleCollection> &tpColl) const {
+      impl_->associateMuons(recoToSim, simToReco, muons, type, tpColl);
+    }
+    void associateMuons(MuonToSimCollection &recoToSim,
+                        SimToMuonCollection &simToReco,
+                        const edm::Handle<edm::View<reco::Muon>> &muons,
+                        MuonTrackType type,
+                        const edm::Handle<TrackingParticleCollection> &tpColl) const {
+      impl_->associateMuons(recoToSim, simToReco, muons, type, tpColl);
+    }
 
-private:
-  MuonToTrackingParticleAssociator(const MuonToTrackingParticleAssociator &) =
-      delete;
-  MuonToTrackingParticleAssociator &
-  operator=(const MuonToTrackingParticleAssociator &) = delete;
+  private:
+    MuonToTrackingParticleAssociator(const MuonToTrackingParticleAssociator &) = delete;
+    MuonToTrackingParticleAssociator &operator=(const MuonToTrackingParticleAssociator &) = delete;
 
-  std::unique_ptr<MuonToTrackingParticleAssociatorBaseImpl const> impl_;
-};
-} // namespace reco
+    std::unique_ptr<MuonToTrackingParticleAssociatorBaseImpl const> impl_;
+  };
+}  // namespace reco
 
 #endif

--- a/SimDataFormats/Associations/interface/MuonToTrackingParticleAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/MuonToTrackingParticleAssociatorBaseImpl.h
@@ -9,22 +9,23 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 
 namespace reco {
-class MuonToTrackingParticleAssociatorBaseImpl {
+  class MuonToTrackingParticleAssociatorBaseImpl {
+  public:
+    MuonToTrackingParticleAssociatorBaseImpl();
+    virtual ~MuonToTrackingParticleAssociatorBaseImpl();
 
-public:
-  MuonToTrackingParticleAssociatorBaseImpl();
-  virtual ~MuonToTrackingParticleAssociatorBaseImpl();
+    virtual void associateMuons(MuonToSimCollection &recoToSim,
+                                SimToMuonCollection &simToReco,
+                                const edm::RefToBaseVector<reco::Muon> &muons,
+                                MuonTrackType type,
+                                const edm::RefVector<TrackingParticleCollection> &tpColl) const = 0;
 
-  virtual void associateMuons(
-      MuonToSimCollection &recoToSim, SimToMuonCollection &simToReco,
-      const edm::RefToBaseVector<reco::Muon> &muons, MuonTrackType type,
-      const edm::RefVector<TrackingParticleCollection> &tpColl) const = 0;
-
-  virtual void associateMuons(
-      MuonToSimCollection &recoToSim, SimToMuonCollection &simToReco,
-      const edm::Handle<edm::View<reco::Muon>> &muons, MuonTrackType type,
-      const edm::Handle<TrackingParticleCollection> &tpColl) const = 0;
-};
-} // namespace reco
+    virtual void associateMuons(MuonToSimCollection &recoToSim,
+                                SimToMuonCollection &simToReco,
+                                const edm::Handle<edm::View<reco::Muon>> &muons,
+                                MuonTrackType type,
+                                const edm::Handle<TrackingParticleCollection> &tpColl) const = 0;
+  };
+}  // namespace reco
 
 #endif

--- a/SimDataFormats/Associations/interface/MuonTrackType.h
+++ b/SimDataFormats/Associations/interface/MuonTrackType.h
@@ -25,23 +25,18 @@
 #include <vector>
 
 namespace reco {
-enum MuonTrackType { InnerTk, OuterTk, GlobalTk, Segments, GlbOrTrk };
+  enum MuonTrackType { InnerTk, OuterTk, GlobalTk, Segments, GlbOrTrk };
 
-struct RefToBaseSort {
-  template <typename T>
-  bool operator()(const edm::RefToBase<T> &r1,
-                  const edm::RefToBase<T> &r2) const {
-    return (r1.id() == r2.id() ? r1.key() < r2.key() : r1.id() < r2.id());
-  }
-};
-typedef std::map<edm::RefToBase<reco::Muon>,
-                 std::vector<std::pair<TrackingParticleRef, double>>,
-                 RefToBaseSort>
-    MuonToSimCollection;
-typedef std::map<TrackingParticleRef,
-                 std::vector<std::pair<edm::RefToBase<reco::Muon>, double>>>
-    SimToMuonCollection;
+  struct RefToBaseSort {
+    template <typename T>
+    bool operator()(const edm::RefToBase<T> &r1, const edm::RefToBase<T> &r2) const {
+      return (r1.id() == r2.id() ? r1.key() < r2.key() : r1.id() < r2.id());
+    }
+  };
+  typedef std::map<edm::RefToBase<reco::Muon>, std::vector<std::pair<TrackingParticleRef, double>>, RefToBaseSort>
+      MuonToSimCollection;
+  typedef std::map<TrackingParticleRef, std::vector<std::pair<edm::RefToBase<reco::Muon>, double>>> SimToMuonCollection;
 
-} // namespace reco
+}  // namespace reco
 
 #endif

--- a/SimDataFormats/Associations/interface/TrackToGenParticleAssociator.h
+++ b/SimDataFormats/Associations/interface/TrackToGenParticleAssociator.h
@@ -24,63 +24,54 @@
 // be the first in the output map.
 
 namespace reco {
-typedef edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-    reco::GenParticleCollection, edm::View<reco::Track>, double>>
-    GenToRecoCollection;
-typedef edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-    edm::View<reco::Track>, reco::GenParticleCollection, double>>
-    RecoToGenCollection;
+  typedef edm::AssociationMap<
+      edm::OneToManyWithQualityGeneric<reco::GenParticleCollection, edm::View<reco::Track>, double>>
+      GenToRecoCollection;
+  typedef edm::AssociationMap<
+      edm::OneToManyWithQualityGeneric<edm::View<reco::Track>, reco::GenParticleCollection, double>>
+      RecoToGenCollection;
 
-class TrackToGenParticleAssociator {
-
-public:
-  /// Constructor
-  TrackToGenParticleAssociator() = default;
+  class TrackToGenParticleAssociator {
+  public:
+    /// Constructor
+    TrackToGenParticleAssociator() = default;
 #ifndef __GCCXML__
-  TrackToGenParticleAssociator(
-      std::unique_ptr<reco::TrackToGenParticleAssociatorBaseImpl>);
+    TrackToGenParticleAssociator(std::unique_ptr<reco::TrackToGenParticleAssociatorBaseImpl>);
 #endif
-  ~TrackToGenParticleAssociator() = default;
-  TrackToGenParticleAssociator(TrackToGenParticleAssociator &&) = default;
-  TrackToGenParticleAssociator &
-  operator=(TrackToGenParticleAssociator &&) = default;
+    ~TrackToGenParticleAssociator() = default;
+    TrackToGenParticleAssociator(TrackToGenParticleAssociator &&) = default;
+    TrackToGenParticleAssociator &operator=(TrackToGenParticleAssociator &&) = default;
 
-  /// Association Sim To Reco with Collections (Gen Particle version)
-  reco::RecoToGenCollection associateRecoToGen(
-      const edm::RefToBaseVector<reco::Track> &tracks,
-      const edm::RefVector<reco::GenParticleCollection> &gens) const {
-    return m_impl->associateRecoToGen(tracks, gens);
-  }
-  /// Association Sim To Reco with Collections (Gen Particle version)
-  reco::GenToRecoCollection associateGenToReco(
-      const edm::RefToBaseVector<reco::Track> &tracks,
-      const edm::RefVector<reco::GenParticleCollection> &gens) const {
-    return m_impl->associateGenToReco(tracks, gens);
-  }
+    /// Association Sim To Reco with Collections (Gen Particle version)
+    reco::RecoToGenCollection associateRecoToGen(const edm::RefToBaseVector<reco::Track> &tracks,
+                                                 const edm::RefVector<reco::GenParticleCollection> &gens) const {
+      return m_impl->associateRecoToGen(tracks, gens);
+    }
+    /// Association Sim To Reco with Collections (Gen Particle version)
+    reco::GenToRecoCollection associateGenToReco(const edm::RefToBaseVector<reco::Track> &tracks,
+                                                 const edm::RefVector<reco::GenParticleCollection> &gens) const {
+      return m_impl->associateGenToReco(tracks, gens);
+    }
 
-  /// compare reco to sim the handle of reco::Track and GenParticle collections
-  reco::RecoToGenCollection associateRecoToGen(
-      const edm::Handle<edm::View<reco::Track>> &tCH,
-      const edm::Handle<reco::GenParticleCollection> &tPCH) const {
-    return m_impl->associateRecoToGen(tCH, tPCH);
-  }
+    /// compare reco to sim the handle of reco::Track and GenParticle collections
+    reco::RecoToGenCollection associateRecoToGen(const edm::Handle<edm::View<reco::Track>> &tCH,
+                                                 const edm::Handle<reco::GenParticleCollection> &tPCH) const {
+      return m_impl->associateRecoToGen(tCH, tPCH);
+    }
 
-  /// compare reco to sim the handle of reco::Track and GenParticle collections
-  reco::GenToRecoCollection associateGenToReco(
-      const edm::Handle<edm::View<reco::Track>> &tCH,
-      const edm::Handle<reco::GenParticleCollection> &tPCH) const {
-    return m_impl->associateGenToReco(tCH, tPCH);
-  }
+    /// compare reco to sim the handle of reco::Track and GenParticle collections
+    reco::GenToRecoCollection associateGenToReco(const edm::Handle<edm::View<reco::Track>> &tCH,
+                                                 const edm::Handle<reco::GenParticleCollection> &tPCH) const {
+      return m_impl->associateGenToReco(tCH, tPCH);
+    }
 
-private:
-  TrackToGenParticleAssociator(const TrackToGenParticleAssociator &) =
-      delete; // stop default
+  private:
+    TrackToGenParticleAssociator(const TrackToGenParticleAssociator &) = delete;  // stop default
 
-  const TrackToGenParticleAssociator &
-  operator=(const TrackToGenParticleAssociator &) = delete; // stop default
+    const TrackToGenParticleAssociator &operator=(const TrackToGenParticleAssociator &) = delete;  // stop default
 
-  std::unique_ptr<TrackToGenParticleAssociatorBaseImpl> m_impl;
-};
-} // namespace reco
+    std::unique_ptr<TrackToGenParticleAssociatorBaseImpl> m_impl;
+  };
+}  // namespace reco
 
 #endif

--- a/SimDataFormats/Associations/interface/TrackToGenParticleAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/TrackToGenParticleAssociatorBaseImpl.h
@@ -18,47 +18,43 @@
 #include "SimDataFormats/Associations/interface/TrackToGenParticleAssociatorBaseImpl.h"
 
 namespace reco {
-typedef edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-    reco::GenParticleCollection, edm::View<reco::Track>, double>>
-    GenToRecoCollection;
-typedef edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-    edm::View<reco::Track>, reco::GenParticleCollection, double>>
-    RecoToGenCollection;
+  typedef edm::AssociationMap<
+      edm::OneToManyWithQualityGeneric<reco::GenParticleCollection, edm::View<reco::Track>, double>>
+      GenToRecoCollection;
+  typedef edm::AssociationMap<
+      edm::OneToManyWithQualityGeneric<edm::View<reco::Track>, reco::GenParticleCollection, double>>
+      RecoToGenCollection;
 
-class TrackToGenParticleAssociatorBaseImpl {
+  class TrackToGenParticleAssociatorBaseImpl {
+  public:
+    /// Constructor
+    TrackToGenParticleAssociatorBaseImpl();
+    virtual ~TrackToGenParticleAssociatorBaseImpl();
 
-public:
-  /// Constructor
-  TrackToGenParticleAssociatorBaseImpl();
-  virtual ~TrackToGenParticleAssociatorBaseImpl();
+    /// Association Sim To Reco with Collections (Gen Particle version)
+    virtual reco::RecoToGenCollection associateRecoToGen(
+        const edm::RefToBaseVector<reco::Track> &tracks,
+        const edm::RefVector<reco::GenParticleCollection> &gens) const = 0;
 
-  /// Association Sim To Reco with Collections (Gen Particle version)
-  virtual reco::RecoToGenCollection associateRecoToGen(
-      const edm::RefToBaseVector<reco::Track> &tracks,
-      const edm::RefVector<reco::GenParticleCollection> &gens) const = 0;
+    /// Association Sim To Reco with Collections (Gen Particle version)
+    virtual reco::GenToRecoCollection associateGenToReco(
+        const edm::RefToBaseVector<reco::Track> &tracks,
+        const edm::RefVector<reco::GenParticleCollection> &gens) const = 0;
 
-  /// Association Sim To Reco with Collections (Gen Particle version)
-  virtual reco::GenToRecoCollection associateGenToReco(
-      const edm::RefToBaseVector<reco::Track> &tracks,
-      const edm::RefVector<reco::GenParticleCollection> &gens) const = 0;
+    /// compare reco to sim the handle of reco::Track and GenParticle collections
+    virtual reco::RecoToGenCollection associateRecoToGen(
+        const edm::Handle<edm::View<reco::Track>> &tCH, const edm::Handle<reco::GenParticleCollection> &tPCH) const = 0;
 
-  /// compare reco to sim the handle of reco::Track and GenParticle collections
-  virtual reco::RecoToGenCollection associateRecoToGen(
-      const edm::Handle<edm::View<reco::Track>> &tCH,
-      const edm::Handle<reco::GenParticleCollection> &tPCH) const = 0;
+    /// compare reco to sim the handle of reco::Track and GenParticle collections
+    virtual reco::GenToRecoCollection associateGenToReco(
+        const edm::Handle<edm::View<reco::Track>> &tCH, const edm::Handle<reco::GenParticleCollection> &tPCH) const = 0;
 
-  /// compare reco to sim the handle of reco::Track and GenParticle collections
-  virtual reco::GenToRecoCollection associateGenToReco(
-      const edm::Handle<edm::View<reco::Track>> &tCH,
-      const edm::Handle<reco::GenParticleCollection> &tPCH) const = 0;
+  private:
+    TrackToGenParticleAssociatorBaseImpl(const TrackToGenParticleAssociatorBaseImpl &) = delete;  // stop default
 
-private:
-  TrackToGenParticleAssociatorBaseImpl(
-      const TrackToGenParticleAssociatorBaseImpl &) = delete; // stop default
-
-  const TrackToGenParticleAssociatorBaseImpl &operator=(
-      const TrackToGenParticleAssociatorBaseImpl &) = delete; // stop default
-};
-} // namespace reco
+    const TrackToGenParticleAssociatorBaseImpl &operator=(const TrackToGenParticleAssociatorBaseImpl &) =
+        delete;  // stop default
+  };
+}  // namespace reco
 
 #endif

--- a/SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h
+++ b/SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h
@@ -34,101 +34,88 @@
 
 namespace reco {
 
-typedef edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-    TrackingParticleCollection, edm::View<TrajectorySeed>, double>>
-    SimToRecoCollectionSeed;
-typedef edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-    edm::View<TrajectorySeed>, TrackingParticleCollection, double>>
-    RecoToSimCollectionSeed;
+  typedef edm::AssociationMap<
+      edm::OneToManyWithQualityGeneric<TrackingParticleCollection, edm::View<TrajectorySeed>, double>>
+      SimToRecoCollectionSeed;
+  typedef edm::AssociationMap<
+      edm::OneToManyWithQualityGeneric<edm::View<TrajectorySeed>, TrackingParticleCollection, double>>
+      RecoToSimCollectionSeed;
 
-typedef edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-    TrackingParticleCollection, TrackCandidateCollection, double>>
-    SimToRecoCollectionTCandidate;
-typedef edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-    TrajectorySeedCollection, TrackCandidateCollection, double>>
-    RecoToSimCollectionTCandidate;
+  typedef edm::AssociationMap<
+      edm::OneToManyWithQualityGeneric<TrackingParticleCollection, TrackCandidateCollection, double>>
+      SimToRecoCollectionTCandidate;
+  typedef edm::AssociationMap<
+      edm::OneToManyWithQualityGeneric<TrajectorySeedCollection, TrackCandidateCollection, double>>
+      RecoToSimCollectionTCandidate;
 
-class TrackToTrackingParticleAssociator {
-
-public:
+  class TrackToTrackingParticleAssociator {
+  public:
 #ifndef __GCCXML__
-  TrackToTrackingParticleAssociator(
-      std::unique_ptr<reco::TrackToTrackingParticleAssociatorBaseImpl>);
+    TrackToTrackingParticleAssociator(std::unique_ptr<reco::TrackToTrackingParticleAssociatorBaseImpl>);
 #endif
-  TrackToTrackingParticleAssociator() = default;
-  TrackToTrackingParticleAssociator(TrackToTrackingParticleAssociator &&) =
-      default;
-  TrackToTrackingParticleAssociator &
-  operator=(TrackToTrackingParticleAssociator &&) = default;
-  ~TrackToTrackingParticleAssociator() = default;
+    TrackToTrackingParticleAssociator() = default;
+    TrackToTrackingParticleAssociator(TrackToTrackingParticleAssociator &&) = default;
+    TrackToTrackingParticleAssociator &operator=(TrackToTrackingParticleAssociator &&) = default;
+    ~TrackToTrackingParticleAssociator() = default;
 
-  // ---------- const member functions ---------------------
-  /// compare reco to sim the handle of reco::Track and TrackingParticle
-  /// collections
-  reco::RecoToSimCollection associateRecoToSim(
-      const edm::Handle<edm::View<reco::Track>> &tCH,
-      const edm::Handle<TrackingParticleCollection> &tPCH) const {
-    return m_impl->associateRecoToSim(tCH, tPCH);
-  }
+    // ---------- const member functions ---------------------
+    /// compare reco to sim the handle of reco::Track and TrackingParticle
+    /// collections
+    reco::RecoToSimCollection associateRecoToSim(const edm::Handle<edm::View<reco::Track>> &tCH,
+                                                 const edm::Handle<TrackingParticleCollection> &tPCH) const {
+      return m_impl->associateRecoToSim(tCH, tPCH);
+    }
 
-  /// compare reco to sim the handle of reco::Track and TrackingParticle
-  /// collections
-  reco::SimToRecoCollection associateSimToReco(
-      const edm::Handle<edm::View<reco::Track>> &tCH,
-      const edm::Handle<TrackingParticleCollection> &tPCH) const {
-    return m_impl->associateSimToReco(tCH, tPCH);
-  }
+    /// compare reco to sim the handle of reco::Track and TrackingParticle
+    /// collections
+    reco::SimToRecoCollection associateSimToReco(const edm::Handle<edm::View<reco::Track>> &tCH,
+                                                 const edm::Handle<TrackingParticleCollection> &tPCH) const {
+      return m_impl->associateSimToReco(tCH, tPCH);
+    }
 
-  /// Association Reco To Sim with Collections
-  reco::RecoToSimCollection associateRecoToSim(
-      const edm::RefToBaseVector<reco::Track> &tc,
-      const edm::RefVector<TrackingParticleCollection> &tpc) const {
-    return m_impl->associateRecoToSim(tc, tpc);
-  }
+    /// Association Reco To Sim with Collections
+    reco::RecoToSimCollection associateRecoToSim(const edm::RefToBaseVector<reco::Track> &tc,
+                                                 const edm::RefVector<TrackingParticleCollection> &tpc) const {
+      return m_impl->associateRecoToSim(tc, tpc);
+    }
 
-  /// Association Sim To Reco with Collections
-  reco::SimToRecoCollection associateSimToReco(
-      const edm::RefToBaseVector<reco::Track> &tc,
-      const edm::RefVector<TrackingParticleCollection> &tpc) const {
-    return m_impl->associateSimToReco(tc, tpc);
-  }
+    /// Association Sim To Reco with Collections
+    reco::SimToRecoCollection associateSimToReco(const edm::RefToBaseVector<reco::Track> &tc,
+                                                 const edm::RefVector<TrackingParticleCollection> &tpc) const {
+      return m_impl->associateSimToReco(tc, tpc);
+    }
 
-  // TrajectorySeed
-  reco::RecoToSimCollectionSeed
-  associateRecoToSim(const edm::Handle<edm::View<TrajectorySeed>> &ts,
-                     const edm::Handle<TrackingParticleCollection> &tpc) const {
-    return m_impl->associateRecoToSim(ts, tpc);
-  }
+    // TrajectorySeed
+    reco::RecoToSimCollectionSeed associateRecoToSim(const edm::Handle<edm::View<TrajectorySeed>> &ts,
+                                                     const edm::Handle<TrackingParticleCollection> &tpc) const {
+      return m_impl->associateRecoToSim(ts, tpc);
+    }
 
-  reco::SimToRecoCollectionSeed
-  associateSimToReco(const edm::Handle<edm::View<TrajectorySeed>> &ts,
-                     const edm::Handle<TrackingParticleCollection> &tpc) const {
-    return m_impl->associateSimToReco(ts, tpc);
-  }
+    reco::SimToRecoCollectionSeed associateSimToReco(const edm::Handle<edm::View<TrajectorySeed>> &ts,
+                                                     const edm::Handle<TrackingParticleCollection> &tpc) const {
+      return m_impl->associateSimToReco(ts, tpc);
+    }
 
-  // TrackCandidate
-  reco::RecoToSimCollectionTCandidate
-  associateRecoToSim(const edm::Handle<TrackCandidateCollection> &tc,
-                     const edm::Handle<TrackingParticleCollection> &tpc) const {
-    return m_impl->associateRecoToSim(tc, tpc);
-  }
+    // TrackCandidate
+    reco::RecoToSimCollectionTCandidate associateRecoToSim(const edm::Handle<TrackCandidateCollection> &tc,
+                                                           const edm::Handle<TrackingParticleCollection> &tpc) const {
+      return m_impl->associateRecoToSim(tc, tpc);
+    }
 
-  reco::SimToRecoCollectionTCandidate
-  associateSimToReco(const edm::Handle<TrackCandidateCollection> &tc,
-                     const edm::Handle<TrackingParticleCollection> &tpc) const {
-    return m_impl->associateSimToReco(tc, tpc);
-  }
+    reco::SimToRecoCollectionTCandidate associateSimToReco(const edm::Handle<TrackCandidateCollection> &tc,
+                                                           const edm::Handle<TrackingParticleCollection> &tpc) const {
+      return m_impl->associateSimToReco(tc, tpc);
+    }
 
-private:
-  TrackToTrackingParticleAssociator(const TrackToTrackingParticleAssociator &) =
-      delete; // stop default
+  private:
+    TrackToTrackingParticleAssociator(const TrackToTrackingParticleAssociator &) = delete;  // stop default
 
-  const TrackToTrackingParticleAssociator &
-  operator=(const TrackToTrackingParticleAssociator &) = delete; // stop default
+    const TrackToTrackingParticleAssociator &operator=(const TrackToTrackingParticleAssociator &) =
+        delete;  // stop default
 
-  // ---------- member data --------------------------------
-  std::unique_ptr<TrackToTrackingParticleAssociatorBaseImpl> m_impl;
-};
-} // namespace reco
+    // ---------- member data --------------------------------
+    std::unique_ptr<TrackToTrackingParticleAssociatorBaseImpl> m_impl;
+  };
+}  // namespace reco
 
 #endif

--- a/SimDataFormats/Associations/interface/TrackToTrackingParticleAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/TrackToTrackingParticleAssociatorBaseImpl.h
@@ -16,66 +16,58 @@
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 
 namespace reco {
-typedef edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-    TrackingParticleCollection, edm::View<TrajectorySeed>, double>>
-    SimToRecoCollectionSeed;
-typedef edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-    edm::View<TrajectorySeed>, TrackingParticleCollection, double>>
-    RecoToSimCollectionSeed;
+  typedef edm::AssociationMap<
+      edm::OneToManyWithQualityGeneric<TrackingParticleCollection, edm::View<TrajectorySeed>, double>>
+      SimToRecoCollectionSeed;
+  typedef edm::AssociationMap<
+      edm::OneToManyWithQualityGeneric<edm::View<TrajectorySeed>, TrackingParticleCollection, double>>
+      RecoToSimCollectionSeed;
 
-typedef edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-    TrackingParticleCollection, TrackCandidateCollection, double>>
-    SimToRecoCollectionTCandidate;
-typedef edm::AssociationMap<edm::OneToManyWithQualityGeneric<
-    TrajectorySeedCollection, TrackCandidateCollection, double>>
-    RecoToSimCollectionTCandidate;
+  typedef edm::AssociationMap<
+      edm::OneToManyWithQualityGeneric<TrackingParticleCollection, TrackCandidateCollection, double>>
+      SimToRecoCollectionTCandidate;
+  typedef edm::AssociationMap<
+      edm::OneToManyWithQualityGeneric<TrajectorySeedCollection, TrackCandidateCollection, double>>
+      RecoToSimCollectionTCandidate;
 
-class TrackToTrackingParticleAssociatorBaseImpl {
-public:
-  /// Constructor
-  TrackToTrackingParticleAssociatorBaseImpl();
-  /// Destructor
-  virtual ~TrackToTrackingParticleAssociatorBaseImpl();
+  class TrackToTrackingParticleAssociatorBaseImpl {
+  public:
+    /// Constructor
+    TrackToTrackingParticleAssociatorBaseImpl();
+    /// Destructor
+    virtual ~TrackToTrackingParticleAssociatorBaseImpl();
 
-  /// compare reco to sim the handle of reco::Track and TrackingParticle
-  /// collections
-  virtual reco::RecoToSimCollection
-  associateRecoToSim(const edm::Handle<edm::View<reco::Track>> &tCH,
-                     const edm::Handle<TrackingParticleCollection> &tPCH) const;
+    /// compare reco to sim the handle of reco::Track and TrackingParticle
+    /// collections
+    virtual reco::RecoToSimCollection associateRecoToSim(const edm::Handle<edm::View<reco::Track>> &tCH,
+                                                         const edm::Handle<TrackingParticleCollection> &tPCH) const;
 
-  /// compare reco to sim the handle of reco::Track and TrackingParticle
-  /// collections
-  virtual reco::SimToRecoCollection
-  associateSimToReco(const edm::Handle<edm::View<reco::Track>> &tCH,
-                     const edm::Handle<TrackingParticleCollection> &tPCH) const;
+    /// compare reco to sim the handle of reco::Track and TrackingParticle
+    /// collections
+    virtual reco::SimToRecoCollection associateSimToReco(const edm::Handle<edm::View<reco::Track>> &tCH,
+                                                         const edm::Handle<TrackingParticleCollection> &tPCH) const;
 
-  /// Association Reco To Sim with Collections
-  virtual reco::RecoToSimCollection associateRecoToSim(
-      const edm::RefToBaseVector<reco::Track> &tc,
-      const edm::RefVector<TrackingParticleCollection> &tpc) const = 0;
-  /// Association Sim To Reco with Collections
-  virtual reco::SimToRecoCollection associateSimToReco(
-      const edm::RefToBaseVector<reco::Track> &tc,
-      const edm::RefVector<TrackingParticleCollection> &tpc) const = 0;
+    /// Association Reco To Sim with Collections
+    virtual reco::RecoToSimCollection associateRecoToSim(
+        const edm::RefToBaseVector<reco::Track> &tc, const edm::RefVector<TrackingParticleCollection> &tpc) const = 0;
+    /// Association Sim To Reco with Collections
+    virtual reco::SimToRecoCollection associateSimToReco(
+        const edm::RefToBaseVector<reco::Track> &tc, const edm::RefVector<TrackingParticleCollection> &tpc) const = 0;
 
-  // TrajectorySeed
-  virtual reco::RecoToSimCollectionSeed
-  associateRecoToSim(const edm::Handle<edm::View<TrajectorySeed>> &,
-                     const edm::Handle<TrackingParticleCollection> &) const;
+    // TrajectorySeed
+    virtual reco::RecoToSimCollectionSeed associateRecoToSim(const edm::Handle<edm::View<TrajectorySeed>> &,
+                                                             const edm::Handle<TrackingParticleCollection> &) const;
 
-  virtual reco::SimToRecoCollectionSeed
-  associateSimToReco(const edm::Handle<edm::View<TrajectorySeed>> &,
-                     const edm::Handle<TrackingParticleCollection> &) const;
+    virtual reco::SimToRecoCollectionSeed associateSimToReco(const edm::Handle<edm::View<TrajectorySeed>> &,
+                                                             const edm::Handle<TrackingParticleCollection> &) const;
 
-  // TrackCandidate
-  virtual reco::RecoToSimCollectionTCandidate
-  associateRecoToSim(const edm::Handle<TrackCandidateCollection> &,
-                     const edm::Handle<TrackingParticleCollection> &) const;
+    // TrackCandidate
+    virtual reco::RecoToSimCollectionTCandidate associateRecoToSim(
+        const edm::Handle<TrackCandidateCollection> &, const edm::Handle<TrackingParticleCollection> &) const;
 
-  virtual reco::SimToRecoCollectionTCandidate
-  associateSimToReco(const edm::Handle<TrackCandidateCollection> &,
-                     const edm::Handle<TrackingParticleCollection> &) const;
-};
-} // namespace reco
+    virtual reco::SimToRecoCollectionTCandidate associateSimToReco(
+        const edm::Handle<TrackCandidateCollection> &, const edm::Handle<TrackingParticleCollection> &) const;
+  };
+}  // namespace reco
 
 #endif

--- a/SimDataFormats/Associations/interface/VertexAssociation.h
+++ b/SimDataFormats/Associations/interface/VertexAssociation.h
@@ -10,12 +10,10 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
 
 namespace reco {
-typedef edm::AssociationMap<edm::OneToManyWithQuality<
-    TrackingVertexCollection, edm::View<reco::Vertex>, double>>
-    VertexSimToRecoCollection;
-typedef edm::AssociationMap<edm::OneToManyWithQuality<
-    edm::View<reco::Vertex>, TrackingVertexCollection, double>>
-    VertexRecoToSimCollection;
-} // namespace reco
+  typedef edm::AssociationMap<edm::OneToManyWithQuality<TrackingVertexCollection, edm::View<reco::Vertex>, double>>
+      VertexSimToRecoCollection;
+  typedef edm::AssociationMap<edm::OneToManyWithQuality<edm::View<reco::Vertex>, TrackingVertexCollection, double>>
+      VertexRecoToSimCollection;
+}  // namespace reco
 
 #endif

--- a/SimDataFormats/Associations/interface/VertexToTrackingVertexAssociator.h
+++ b/SimDataFormats/Associations/interface/VertexToTrackingVertexAssociator.h
@@ -6,46 +6,40 @@
 #include "SimDataFormats/Associations/interface/VertexToTrackingVertexAssociatorBaseImpl.h"
 
 namespace reco {
-class VertexToTrackingVertexAssociator {
-public:
+  class VertexToTrackingVertexAssociator {
+  public:
 #ifndef __GCCXML__
-  VertexToTrackingVertexAssociator(
-      std::unique_ptr<reco::VertexToTrackingVertexAssociatorBaseImpl>);
+    VertexToTrackingVertexAssociator(std::unique_ptr<reco::VertexToTrackingVertexAssociatorBaseImpl>);
 #endif
-  VertexToTrackingVertexAssociator() = default;
-  VertexToTrackingVertexAssociator(VertexToTrackingVertexAssociator &&) =
-      default;
-  VertexToTrackingVertexAssociator &
-  operator=(VertexToTrackingVertexAssociator &&) = default;
-  ~VertexToTrackingVertexAssociator() = default;
+    VertexToTrackingVertexAssociator() = default;
+    VertexToTrackingVertexAssociator(VertexToTrackingVertexAssociator &&) = default;
+    VertexToTrackingVertexAssociator &operator=(VertexToTrackingVertexAssociator &&) = default;
+    ~VertexToTrackingVertexAssociator() = default;
 
-  // ---------- const member functions ---------------------
-  /// compare reco to sim the handle of reco::Vertex and TrackingVertex
-  /// collections
-  reco::VertexRecoToSimCollection
-  associateRecoToSim(const edm::Handle<edm::View<reco::Vertex>> &vCH,
-                     const edm::Handle<TrackingVertexCollection> &tVCH) const {
-    return m_impl->associateRecoToSim(vCH, tVCH);
-  }
+    // ---------- const member functions ---------------------
+    /// compare reco to sim the handle of reco::Vertex and TrackingVertex
+    /// collections
+    reco::VertexRecoToSimCollection associateRecoToSim(const edm::Handle<edm::View<reco::Vertex>> &vCH,
+                                                       const edm::Handle<TrackingVertexCollection> &tVCH) const {
+      return m_impl->associateRecoToSim(vCH, tVCH);
+    }
 
-  /// compare reco to sim the handle of reco::Vertex and TrackingVertex
-  /// collections
-  reco::VertexSimToRecoCollection
-  associateSimToReco(const edm::Handle<edm::View<reco::Vertex>> &vCH,
-                     const edm::Handle<TrackingVertexCollection> &tVCH) const {
-    return m_impl->associateSimToReco(vCH, tVCH);
-  }
+    /// compare reco to sim the handle of reco::Vertex and TrackingVertex
+    /// collections
+    reco::VertexSimToRecoCollection associateSimToReco(const edm::Handle<edm::View<reco::Vertex>> &vCH,
+                                                       const edm::Handle<TrackingVertexCollection> &tVCH) const {
+      return m_impl->associateSimToReco(vCH, tVCH);
+    }
 
-private:
-  VertexToTrackingVertexAssociator(const VertexToTrackingVertexAssociator &) =
-      delete; // stop default
+  private:
+    VertexToTrackingVertexAssociator(const VertexToTrackingVertexAssociator &) = delete;  // stop default
 
-  const VertexToTrackingVertexAssociator &
-  operator=(const VertexToTrackingVertexAssociator &) = delete; // stop default
+    const VertexToTrackingVertexAssociator &operator=(const VertexToTrackingVertexAssociator &) =
+        delete;  // stop default
 
-  // ---------- member data --------------------------------
-  std::unique_ptr<VertexToTrackingVertexAssociatorBaseImpl> m_impl;
-};
-} // namespace reco
+    // ---------- member data --------------------------------
+    std::unique_ptr<VertexToTrackingVertexAssociatorBaseImpl> m_impl;
+  };
+}  // namespace reco
 
 #endif

--- a/SimDataFormats/Associations/interface/VertexToTrackingVertexAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/VertexToTrackingVertexAssociatorBaseImpl.h
@@ -5,25 +5,23 @@
 #include "SimDataFormats/Associations/interface/VertexAssociation.h"
 
 namespace reco {
-class VertexToTrackingVertexAssociatorBaseImpl {
-public:
-  /// Constructor
-  VertexToTrackingVertexAssociatorBaseImpl();
-  /// Destructor
-  virtual ~VertexToTrackingVertexAssociatorBaseImpl();
+  class VertexToTrackingVertexAssociatorBaseImpl {
+  public:
+    /// Constructor
+    VertexToTrackingVertexAssociatorBaseImpl();
+    /// Destructor
+    virtual ~VertexToTrackingVertexAssociatorBaseImpl();
 
-  /// compare reco to sim the handle of reco::Vertex and TrackingVertex
-  /// collections
-  virtual reco::VertexRecoToSimCollection associateRecoToSim(
-      const edm::Handle<edm::View<reco::Vertex>> &vCH,
-      const edm::Handle<TrackingVertexCollection> &tVCH) const = 0;
+    /// compare reco to sim the handle of reco::Vertex and TrackingVertex
+    /// collections
+    virtual reco::VertexRecoToSimCollection associateRecoToSim(
+        const edm::Handle<edm::View<reco::Vertex>> &vCH, const edm::Handle<TrackingVertexCollection> &tVCH) const = 0;
 
-  /// compare reco to sim the handle of reco::Vertex and TrackingVertex
-  /// collections
-  virtual reco::VertexSimToRecoCollection associateSimToReco(
-      const edm::Handle<edm::View<reco::Vertex>> &vCH,
-      const edm::Handle<TrackingVertexCollection> &tVCH) const = 0;
-};
-} // namespace reco
+    /// compare reco to sim the handle of reco::Vertex and TrackingVertex
+    /// collections
+    virtual reco::VertexSimToRecoCollection associateSimToReco(
+        const edm::Handle<edm::View<reco::Vertex>> &vCH, const edm::Handle<TrackingVertexCollection> &tVCH) const = 0;
+  };
+}  // namespace reco
 
 #endif

--- a/SimDataFormats/Associations/src/MuonToTrackingParticleAssociatorBaseImpl.cc
+++ b/SimDataFormats/Associations/src/MuonToTrackingParticleAssociatorBaseImpl.cc
@@ -26,8 +26,6 @@
 //
 // constructors and destructor
 //
-reco::MuonToTrackingParticleAssociatorBaseImpl::
-    MuonToTrackingParticleAssociatorBaseImpl() {}
+reco::MuonToTrackingParticleAssociatorBaseImpl::MuonToTrackingParticleAssociatorBaseImpl() {}
 
-reco::MuonToTrackingParticleAssociatorBaseImpl::
-    ~MuonToTrackingParticleAssociatorBaseImpl() {}
+reco::MuonToTrackingParticleAssociatorBaseImpl::~MuonToTrackingParticleAssociatorBaseImpl() {}

--- a/SimDataFormats/Associations/src/TrackToGenParticleAssociatorBaseImpl.cc
+++ b/SimDataFormats/Associations/src/TrackToGenParticleAssociatorBaseImpl.cc
@@ -26,8 +26,6 @@
 //
 // constructors and destructor
 //
-reco::TrackToGenParticleAssociatorBaseImpl::
-    TrackToGenParticleAssociatorBaseImpl() {}
+reco::TrackToGenParticleAssociatorBaseImpl::TrackToGenParticleAssociatorBaseImpl() {}
 
-reco::TrackToGenParticleAssociatorBaseImpl::
-    ~TrackToGenParticleAssociatorBaseImpl() {}
+reco::TrackToGenParticleAssociatorBaseImpl::~TrackToGenParticleAssociatorBaseImpl() {}

--- a/SimDataFormats/Associations/src/TrackToTrackingParticleAssociatorBaseImpl.cc
+++ b/SimDataFormats/Associations/src/TrackToTrackingParticleAssociatorBaseImpl.cc
@@ -26,19 +26,15 @@
 //
 // constructors and destructor
 //
-reco::TrackToTrackingParticleAssociatorBaseImpl::
-    TrackToTrackingParticleAssociatorBaseImpl() {}
+reco::TrackToTrackingParticleAssociatorBaseImpl::TrackToTrackingParticleAssociatorBaseImpl() {}
 
-reco::TrackToTrackingParticleAssociatorBaseImpl::
-    ~TrackToTrackingParticleAssociatorBaseImpl() {}
+reco::TrackToTrackingParticleAssociatorBaseImpl::~TrackToTrackingParticleAssociatorBaseImpl() {}
 
 //
 // const member functions
 //
-reco::RecoToSimCollection
-reco::TrackToTrackingParticleAssociatorBaseImpl::associateRecoToSim(
-    const edm::Handle<edm::View<reco::Track>> &tCH,
-    const edm::Handle<TrackingParticleCollection> &tPCH) const {
+reco::RecoToSimCollection reco::TrackToTrackingParticleAssociatorBaseImpl::associateRecoToSim(
+    const edm::Handle<edm::View<reco::Track>> &tCH, const edm::Handle<TrackingParticleCollection> &tPCH) const {
   edm::RefToBaseVector<reco::Track> tc;
   for (unsigned int j = 0; j < tCH->size(); j++)
     tc.push_back(tCH->refAt(j));
@@ -52,10 +48,8 @@ reco::TrackToTrackingParticleAssociatorBaseImpl::associateRecoToSim(
 
 /// compare reco to sim the handle of reco::Track and TrackingParticle
 /// collections
-reco::SimToRecoCollection
-reco::TrackToTrackingParticleAssociatorBaseImpl::associateSimToReco(
-    const edm::Handle<edm::View<reco::Track>> &tCH,
-    const edm::Handle<TrackingParticleCollection> &tPCH) const {
+reco::SimToRecoCollection reco::TrackToTrackingParticleAssociatorBaseImpl::associateSimToReco(
+    const edm::Handle<edm::View<reco::Track>> &tCH, const edm::Handle<TrackingParticleCollection> &tPCH) const {
   edm::RefToBaseVector<reco::Track> tc;
   for (unsigned int j = 0; j < tCH->size(); j++)
     tc.push_back(tCH->refAt(j));
@@ -68,35 +62,27 @@ reco::TrackToTrackingParticleAssociatorBaseImpl::associateSimToReco(
 }
 
 // TrajectorySeed
-reco::RecoToSimCollectionSeed
-reco::TrackToTrackingParticleAssociatorBaseImpl::associateRecoToSim(
-    const edm::Handle<edm::View<TrajectorySeed>> &,
-    const edm::Handle<TrackingParticleCollection> &) const {
+reco::RecoToSimCollectionSeed reco::TrackToTrackingParticleAssociatorBaseImpl::associateRecoToSim(
+    const edm::Handle<edm::View<TrajectorySeed>> &, const edm::Handle<TrackingParticleCollection> &) const {
   reco::RecoToSimCollectionSeed empty;
   return empty;
 }
 
-reco::SimToRecoCollectionSeed
-reco::TrackToTrackingParticleAssociatorBaseImpl::associateSimToReco(
-    const edm::Handle<edm::View<TrajectorySeed>> &,
-    const edm::Handle<TrackingParticleCollection> &) const {
+reco::SimToRecoCollectionSeed reco::TrackToTrackingParticleAssociatorBaseImpl::associateSimToReco(
+    const edm::Handle<edm::View<TrajectorySeed>> &, const edm::Handle<TrackingParticleCollection> &) const {
   reco::SimToRecoCollectionSeed empty;
   return empty;
 }
 
 // TrackCandidate
-reco::RecoToSimCollectionTCandidate
-reco::TrackToTrackingParticleAssociatorBaseImpl::associateRecoToSim(
-    const edm::Handle<TrackCandidateCollection> &,
-    const edm::Handle<TrackingParticleCollection> &) const {
+reco::RecoToSimCollectionTCandidate reco::TrackToTrackingParticleAssociatorBaseImpl::associateRecoToSim(
+    const edm::Handle<TrackCandidateCollection> &, const edm::Handle<TrackingParticleCollection> &) const {
   reco::RecoToSimCollectionTCandidate empty;
   return empty;
 }
 
-reco::SimToRecoCollectionTCandidate
-reco::TrackToTrackingParticleAssociatorBaseImpl::associateSimToReco(
-    const edm::Handle<TrackCandidateCollection> &,
-    const edm::Handle<TrackingParticleCollection> &) const {
+reco::SimToRecoCollectionTCandidate reco::TrackToTrackingParticleAssociatorBaseImpl::associateSimToReco(
+    const edm::Handle<TrackCandidateCollection> &, const edm::Handle<TrackingParticleCollection> &) const {
   reco::SimToRecoCollectionTCandidate empty;
   return empty;
 }

--- a/SimDataFormats/Associations/src/VertexToTrackingVertexAssociatorBaseImpl.cc
+++ b/SimDataFormats/Associations/src/VertexToTrackingVertexAssociatorBaseImpl.cc
@@ -1,7 +1,5 @@
 #include "SimDataFormats/Associations/interface/VertexToTrackingVertexAssociatorBaseImpl.h"
 
-reco::VertexToTrackingVertexAssociatorBaseImpl::
-    VertexToTrackingVertexAssociatorBaseImpl() {}
+reco::VertexToTrackingVertexAssociatorBaseImpl::VertexToTrackingVertexAssociatorBaseImpl() {}
 
-reco::VertexToTrackingVertexAssociatorBaseImpl::
-    ~VertexToTrackingVertexAssociatorBaseImpl() {}
+reco::VertexToTrackingVertexAssociatorBaseImpl::~VertexToTrackingVertexAssociatorBaseImpl() {}

--- a/SimDataFormats/Associations/src/classes.h
+++ b/SimDataFormats/Associations/src/classes.h
@@ -8,20 +8,20 @@
 #include "SimDataFormats/Associations/interface/VertexToTrackingVertexAssociator.h"
 
 namespace SimDataFormats_Associations {
-struct SimDataFormats_Associations {
-  // add 'dummy' Wrapper variable for each class type you put into the Event
-  edm::Wrapper<reco::TrackToTrackingParticleAssociator> dummy1;
-  edm::Wrapper<reco::TrackToGenParticleAssociator> dummy2;
-  edm::Wrapper<reco::MuonToTrackingParticleAssociator> dummy3;
+  struct SimDataFormats_Associations {
+    // add 'dummy' Wrapper variable for each class type you put into the Event
+    edm::Wrapper<reco::TrackToTrackingParticleAssociator> dummy1;
+    edm::Wrapper<reco::TrackToGenParticleAssociator> dummy2;
+    edm::Wrapper<reco::MuonToTrackingParticleAssociator> dummy3;
 
-  edm::Wrapper<reco::VertexToTrackingVertexAssociator> dummy4;
+    edm::Wrapper<reco::VertexToTrackingVertexAssociator> dummy4;
 
-  reco::VertexSimToRecoCollection vstrc;
-  reco::VertexSimToRecoCollection::const_iterator vstrci;
-  edm::Wrapper<reco::VertexSimToRecoCollection> wvstrc;
+    reco::VertexSimToRecoCollection vstrc;
+    reco::VertexSimToRecoCollection::const_iterator vstrci;
+    edm::Wrapper<reco::VertexSimToRecoCollection> wvstrc;
 
-  reco::VertexRecoToSimCollection vrtsc;
-  reco::VertexRecoToSimCollection::const_iterator vrtsci;
-  edm::Wrapper<reco::VertexRecoToSimCollection> wvrtsci;
-};
-} // namespace SimDataFormats_Associations
+    reco::VertexRecoToSimCollection vrtsc;
+    reco::VertexRecoToSimCollection::const_iterator vrtsci;
+    edm::Wrapper<reco::VertexRecoToSimCollection> wvrtsci;
+  };
+}  // namespace SimDataFormats_Associations

--- a/SimDataFormats/CaloAnalysis/interface/CaloParticle.h
+++ b/SimDataFormats/CaloAnalysis/interface/CaloParticle.h
@@ -17,11 +17,11 @@ class CaloParticle {
   friend std::ostream &operator<<(std::ostream &s, CaloParticle const &tp);
 
 public:
-  typedef int Charge;                             ///< electric charge type
-  typedef math::XYZTLorentzVectorD LorentzVector; ///< Lorentz vector
-  typedef math::PtEtaPhiMLorentzVector PolarLorentzVector; ///< Lorentz vector
-  typedef math::XYZPointD Point;   ///< point in the space
-  typedef math::XYZVectorD Vector; ///< point in the space
+  typedef int Charge;                                       ///< electric charge type
+  typedef math::XYZTLorentzVectorD LorentzVector;           ///< Lorentz vector
+  typedef math::PtEtaPhiMLorentzVector PolarLorentzVector;  ///< Lorentz vector
+  typedef math::XYZPointD Point;                            ///< point in the space
+  typedef math::XYZVectorD Vector;                          ///< point in the space
 
   /// reference to reco::GenParticle
   typedef reco::GenParticleRefVector::iterator genp_iterator;
@@ -31,7 +31,7 @@ public:
   CaloParticle();
 
   CaloParticle(const SimTrack &simtrk);
-  CaloParticle(EncodedEventId eventID, uint32_t particleID); // for PU
+  CaloParticle(EncodedEventId eventID, uint32_t particleID);  // for PU
 
   // destructor
   ~CaloParticle();
@@ -56,9 +56,7 @@ public:
   uint64_t particleId() const { return particleId_; }
 
   // Setters for G4 and reco::GenParticle
-  void addGenParticle(const reco::GenParticleRef &ref) {
-    genParticles_.push_back(ref);
-  }
+  void addGenParticle(const reco::GenParticleRef &ref) { genParticles_.push_back(ref); }
   void addSimCluster(const SimClusterRef &ref) { simClusters_.push_back(ref); }
   void addG4Track(const SimTrack &t) { g4Tracks_.push_back(t); }
   /// iterators
@@ -70,9 +68,7 @@ public:
   sc_iterator simCluster_end() const { return simClusters_.end(); }
 
   // Getters for Embd and Sim Tracks
-  const reco::GenParticleRefVector &genParticles() const {
-    return genParticles_;
-  }
+  const reco::GenParticleRefVector &genParticles() const { return genParticles_; }
   const SimClusterRefVector &simClusters() const { return simClusters_; }
   // Only for clusters from the signal vertex
   const std::vector<SimTrack> &g4Tracks() const { return g4Tracks_; }
@@ -156,11 +152,9 @@ public:
    *
    * Returns status() from the first gen particle, or -99 if there are no gen
    * particles attached. */
-  int status() const {
-    return genParticles_.empty() ? -99 : (*genParticles_[0]).status();
-  }
+  int status() const { return genParticles_.empty() ? -99 : (*genParticles_[0]).status(); }
 
-  static const unsigned int longLivedTag; ///< long lived flag
+  static const unsigned int longLivedTag;  ///< long lived flag
 
   /// is long lived?
   bool longLived() const { return status() & longLivedTag; }
@@ -210,4 +204,4 @@ private:
   SimClusterRefVector simClusters_;
 };
 
-#endif // SimDataFormats_CaloParticle_H
+#endif  // SimDataFormats_CaloParticle_H

--- a/SimDataFormats/CaloAnalysis/interface/SimCluster.h
+++ b/SimDataFormats/CaloAnalysis/interface/SimCluster.h
@@ -30,11 +30,11 @@ class SimCluster {
   friend std::ostream &operator<<(std::ostream &s, SimCluster const &tp);
 
 public:
-  typedef int Charge;                             ///< electric charge type
-  typedef math::XYZTLorentzVectorD LorentzVector; ///< Lorentz vector
-  typedef math::PtEtaPhiMLorentzVector PolarLorentzVector; ///< Lorentz vector
-  typedef math::XYZPointD Point;   ///< point in the space
-  typedef math::XYZVectorD Vector; ///< point in the space
+  typedef int Charge;                                       ///< electric charge type
+  typedef math::XYZTLorentzVectorD LorentzVector;           ///< Lorentz vector
+  typedef math::PtEtaPhiMLorentzVector PolarLorentzVector;  ///< Lorentz vector
+  typedef math::XYZPointD Point;                            ///< point in the space
+  typedef math::XYZVectorD Vector;                          ///< point in the space
 
   /// reference to reco::GenParticle
   typedef reco::GenParticleRefVector::iterator genp_iterator;
@@ -43,7 +43,7 @@ public:
   SimCluster();
 
   SimCluster(const SimTrack &simtrk);
-  SimCluster(EncodedEventId eventID, uint32_t particleID); // for PU
+  SimCluster(EncodedEventId eventID, uint32_t particleID);  // for PU
 
   // destructor
   ~SimCluster();
@@ -68,9 +68,7 @@ public:
   uint64_t particleId() const { return particleId_; }
 
   // Setters for G4 and reco::GenParticle
-  void addGenParticle(const reco::GenParticleRef &ref) {
-    genParticles_.push_back(ref);
-  }
+  void addGenParticle(const reco::GenParticleRef &ref) { genParticles_.push_back(ref); }
   void addG4Track(const SimTrack &t) { g4Tracks_.push_back(t); }
   /// iterators
   genp_iterator genParticle_begin() const { return genParticles_.begin(); }
@@ -79,9 +77,7 @@ public:
   g4t_iterator g4Track_end() const { return g4Tracks_.end(); }
 
   // Getters for Embd and Sim Tracks
-  const reco::GenParticleRefVector &genParticles() const {
-    return genParticles_;
-  }
+  const reco::GenParticleRefVector &genParticles() const { return genParticles_; }
   // Only for clusters from the signal vertex
   const std::vector<SimTrack> &g4Tracks() const { return g4Tracks_; }
 
@@ -162,11 +158,9 @@ public:
    *
    * Returns status() from the first gen particle, or -99 if there are no gen
    * particles attached. */
-  int status() const {
-    return genParticles_.empty() ? -99 : (*genParticles_[0]).status();
-  }
+  int status() const { return genParticles_.empty() ? -99 : (*genParticles_[0]).status(); }
 
-  static const unsigned int longLivedTag; ///< long lived flag
+  static const unsigned int longLivedTag;  ///< long lived flag
 
   /// is long lived?
   bool longLived() const { return status() & longLivedTag; }
@@ -220,4 +214,4 @@ private:
   reco::GenParticleRefVector genParticles_;
 };
 
-#endif // SimDataFormats_SimCluster_H
+#endif  // SimDataFormats_SimCluster_H

--- a/SimDataFormats/CaloAnalysis/src/CaloParticle.cc
+++ b/SimDataFormats/CaloAnalysis/src/CaloParticle.cc
@@ -16,8 +16,8 @@ CaloParticle::CaloParticle(const SimTrack &simtrk) {
   addG4Track(simtrk);
   event_ = simtrk.eventId();
   particleId_ = simtrk.trackId();
-  theMomentum_.SetPxPyPzE(simtrk.momentum().px(), simtrk.momentum().py(),
-                          simtrk.momentum().pz(), simtrk.momentum().E());
+  theMomentum_.SetPxPyPzE(
+      simtrk.momentum().px(), simtrk.momentum().py(), simtrk.momentum().pz(), simtrk.momentum().E());
 }
 
 CaloParticle::CaloParticle(EncodedEventId eventID, uint32_t particleID) {
@@ -29,27 +29,22 @@ CaloParticle::~CaloParticle() {}
 
 std::ostream &operator<<(std::ostream &s, CaloParticle const &tp) {
   s << "Calo Particle:" << std::endl;
-  s << "CP momentum, q, ID, & Event #: " << tp.p4() << " " << tp.charge() << " "
-    << tp.pdgId() << " " << tp.eventId().bunchCrossing() << "."
-    << tp.eventId().event() << std::endl;
+  s << "CP momentum, q, ID, & Event #: " << tp.p4() << " " << tp.charge() << " " << tp.pdgId() << " "
+    << tp.eventId().bunchCrossing() << "." << tp.eventId().event() << std::endl;
 
-  for (CaloParticle::genp_iterator hepT = tp.genParticle_begin();
-       hepT != tp.genParticle_end(); ++hepT) {
+  for (CaloParticle::genp_iterator hepT = tp.genParticle_begin(); hepT != tp.genParticle_end(); ++hepT) {
     s << " HepMC Track Momentum " << (*hepT)->momentum().rho() << std::endl;
   }
 
-  for (CaloParticle::g4t_iterator g4T = tp.g4Track_begin();
-       g4T != tp.g4Track_end(); ++g4T) {
+  for (CaloParticle::g4t_iterator g4T = tp.g4Track_begin(); g4T != tp.g4Track_end(); ++g4T) {
     s << " Geant Track Momentum  " << g4T->momentum() << std::endl;
-    s << " Geant Track ID & type " << g4T->trackId() << " " << g4T->type()
-      << std::endl;
+    s << " Geant Track ID & type " << g4T->trackId() << " " << g4T->type() << std::endl;
     if (g4T->type() != tp.pdgId()) {
       s << " Mismatch b/t CaloParticle and Geant types" << std::endl;
     }
   }
   s << "SimClusters in this CaloParticle: " << std::endl;
-  for (auto itr = tp.simClusters_.begin(); itr != tp.simClusters_.end();
-       ++itr) {
+  for (auto itr = tp.simClusters_.begin(); itr != tp.simClusters_.end(); ++itr) {
     s << **itr;
   }
   s << std::endl;

--- a/SimDataFormats/CaloAnalysis/src/SimCluster.cc
+++ b/SimDataFormats/CaloAnalysis/src/SimCluster.cc
@@ -17,8 +17,8 @@ SimCluster::SimCluster(const SimTrack &simtrk) {
   event_ = simtrk.eventId();
   particleId_ = simtrk.trackId();
 
-  theMomentum_.SetPxPyPzE(simtrk.momentum().px(), simtrk.momentum().py(),
-                          simtrk.momentum().pz(), simtrk.momentum().E());
+  theMomentum_.SetPxPyPzE(
+      simtrk.momentum().px(), simtrk.momentum().py(), simtrk.momentum().pz(), simtrk.momentum().E());
 }
 
 SimCluster::SimCluster(EncodedEventId eventID, uint32_t particleID) {
@@ -29,26 +29,21 @@ SimCluster::SimCluster(EncodedEventId eventID, uint32_t particleID) {
 SimCluster::~SimCluster() {}
 
 std::ostream &operator<<(std::ostream &s, SimCluster const &tp) {
-  s << "CP momentum, q, ID, & Event #: " << tp.p4() << " " << tp.charge() << " "
-    << tp.pdgId() << " " << tp.eventId().bunchCrossing() << "."
-    << tp.eventId().event() << std::endl;
+  s << "CP momentum, q, ID, & Event #: " << tp.p4() << " " << tp.charge() << " " << tp.pdgId() << " "
+    << tp.eventId().bunchCrossing() << "." << tp.eventId().event() << std::endl;
 
-  for (SimCluster::genp_iterator hepT = tp.genParticle_begin();
-       hepT != tp.genParticle_end(); ++hepT) {
+  for (SimCluster::genp_iterator hepT = tp.genParticle_begin(); hepT != tp.genParticle_end(); ++hepT) {
     s << " HepMC Track Momentum " << (*hepT)->momentum().rho() << std::endl;
   }
 
-  for (SimCluster::g4t_iterator g4T = tp.g4Track_begin();
-       g4T != tp.g4Track_end(); ++g4T) {
+  for (SimCluster::g4t_iterator g4T = tp.g4Track_begin(); g4T != tp.g4Track_end(); ++g4T) {
     s << " Geant Track Momentum  " << g4T->momentum() << std::endl;
-    s << " Geant Track ID & type " << g4T->trackId() << " " << g4T->type()
-      << std::endl;
+    s << " Geant Track ID & type " << g4T->trackId() << " " << g4T->type() << std::endl;
     if (g4T->type() != tp.pdgId()) {
       s << " Mismatch b/t SimCluster and Geant types" << std::endl;
     }
   }
-  s << " # of cells = " << tp.hits_.size() << ", effective cells = "
-    << std::accumulate(tp.fractions_.begin(), tp.fractions_.end(), 0.f)
-    << std::endl;
+  s << " # of cells = " << tp.hits_.size()
+    << ", effective cells = " << std::accumulate(tp.fractions_.begin(), tp.fractions_.end(), 0.f) << std::endl;
   return s;
 }

--- a/SimDataFormats/CaloAnalysis/src/classes.h
+++ b/SimDataFormats/CaloAnalysis/src/classes.h
@@ -4,23 +4,23 @@
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
 
 namespace SimDataFormats {
-namespace CaloAnalysis {
-SimCluster sc;
-SimClusterCollection vsc;
-edm::Wrapper<SimClusterCollection> wvsc;
+  namespace CaloAnalysis {
+    SimCluster sc;
+    SimClusterCollection vsc;
+    edm::Wrapper<SimClusterCollection> wvsc;
 
-SimClusterRef scr;
-SimClusterRefVector scrv;
-SimClusterRefProd scrp;
-SimClusterContainer scc;
+    SimClusterRef scr;
+    SimClusterRefVector scrv;
+    SimClusterRefProd scrp;
+    SimClusterContainer scc;
 
-CaloParticle cp;
-CaloParticleCollection vcp;
-edm::Wrapper<CaloParticleCollection> wvcp;
+    CaloParticle cp;
+    CaloParticleCollection vcp;
+    edm::Wrapper<CaloParticleCollection> wvcp;
 
-CaloParticleRef cpr;
-CaloParticleRefVector cprv;
-CaloParticleRefProd cprp;
-CaloParticleContainer cpc;
-} // namespace CaloAnalysis
-} // namespace SimDataFormats
+    CaloParticleRef cpr;
+    CaloParticleRefVector cprv;
+    CaloParticleRefProd cprp;
+    CaloParticleContainer cpc;
+  }  // namespace CaloAnalysis
+}  // namespace SimDataFormats

--- a/SimG4CMS/EcalTestBeam/interface/EcalTBH4BeamSD.h
+++ b/SimG4CMS/EcalTestBeam/interface/EcalTBH4BeamSD.h
@@ -18,10 +18,11 @@
 class EcalBaseNumber;
 
 class EcalTBH4BeamSD : public CaloSD {
-
 public:
-  EcalTBH4BeamSD(const std::string &, const DDCompactView &,
-                 const SensitiveDetectorCatalog &, edm::ParameterSet const &,
+  EcalTBH4BeamSD(const std::string &,
+                 const DDCompactView &,
+                 const SensitiveDetectorCatalog &,
+                 edm::ParameterSet const &,
                  const SimTrackManager *);
   ~EcalTBH4BeamSD() override;
   uint32_t setDetUnitId(const G4Step *step) override;
@@ -39,4 +40,4 @@ private:
   EcalBaseNumber theBaseNumber;
 };
 
-#endif // EcalTBH4BeamSD_h
+#endif  // EcalTBH4BeamSD_h

--- a/SimG4CMS/EcalTestBeam/interface/EcalTBH4Trigger.h
+++ b/SimG4CMS/EcalTestBeam/interface/EcalTBH4Trigger.h
@@ -44,10 +44,10 @@ class EndOfRun;
 class EndOfEvent;
 class EndOfTrack;
 
-#define OBSERVES(type)                                                         \
-public                                                                         \
+#define OBSERVES(type) \
+public                 \
   Observer<const type *>
-#define UPDATEH4(type)                                                         \
+#define UPDATEH4(type) \
   void update(const type *) {}
 class EcalTBH4Trigger : public SimWatcher,
                         // OBSERVES(DDDWorld),
@@ -61,7 +61,6 @@ class EcalTBH4Trigger : public SimWatcher,
 //,
 // OBSERVES(EndOfTrack)
 {
-
 public:
   EcalTBH4Trigger(const edm::ParameterSet &pSet)
       : m_verbose(pSet.getUntrackedParameter<bool>("verbose", false)),
@@ -93,8 +92,7 @@ public:
   //  UPDATEH4(BeginOfTrack)
   void update(const G4Step *iStep) override {
     if (trigEvents_ >= 0 && nTriggeredEvents_ >= trigEvents_)
-      throw SimG4Exception(
-          "Number of needed trigger events reached in ECALTBH4");
+      throw SimG4Exception("Number of needed trigger events reached in ECALTBH4");
 
     const G4StepPoint *pre = iStep->GetPreStepPoint();
     const G4StepPoint *post = iStep->GetPostStepPoint();
@@ -104,8 +102,7 @@ public:
       // Get name and copy numbers
       if (touch->GetHistoryDepth() > 0) {
         for (int ii = 0; ii <= touch->GetHistoryDepth(); ii++) {
-          std::cout << "EcalTBH4::Level " << ii << ": "
-                    << touch->GetVolume(ii)->GetName() << "["
+          std::cout << "EcalTBH4::Level " << ii << ": " << touch->GetVolume(ii)->GetName() << "["
                     << touch->GetReplicaNumber(ii) << "]";
         }
       }
@@ -113,30 +110,23 @@ public:
       const G4Track *theTrack = iStep->GetTrack();
       const G4ThreeVector &pos = post->GetPosition();
       std::cout << "( " << pos.x() << "," << pos.y() << "," << pos.z() << ") ";
-      std::cout << " released energy (MeV) "
-                << iStep->GetTotalEnergyDeposit() / CLHEP::MeV;
+      std::cout << " released energy (MeV) " << iStep->GetTotalEnergyDeposit() / CLHEP::MeV;
       if (theTrack) {
         const G4ThreeVector mom = theTrack->GetMomentum();
-        std::cout << " track length (cm) "
-                  << theTrack->GetTrackLength() / CLHEP::cm << " particle type "
-                  << theTrack->GetDefinition()->GetParticleName()
-                  << " momentum "
-                  << "( " << mom.x() << "," << mom.y() << "," << mom.z()
-                  << ") ";
+        std::cout << " track length (cm) " << theTrack->GetTrackLength() / CLHEP::cm << " particle type "
+                  << theTrack->GetDefinition()->GetParticleName() << " momentum "
+                  << "( " << mom.x() << "," << mom.y() << "," << mom.z() << ") ";
         if (theTrack->GetCreatorProcess()) {
-          std::cout << " created by "
-                    << theTrack->GetCreatorProcess()->GetProcessName();
+          std::cout << " created by " << theTrack->GetCreatorProcess()->GetProcessName();
         }
       }
       if (post->GetPhysicalVolume()) {
-        std::cout << " " << pre->GetPhysicalVolume()->GetName() << "->"
-                  << post->GetPhysicalVolume()->GetName();
+        std::cout << " " << pre->GetPhysicalVolume()->GetName() << "->" << post->GetPhysicalVolume()->GetName();
       }
       std::cout << std::endl;
     }
 
     if (post && post->GetPhysicalVolume()) {
-
       if (!m_passedTrg1 && post->GetPhysicalVolume()->GetName() == "TRG1")
         m_passedTrg1 = true;
       if (!m_passedTrg3 && post->GetPhysicalVolume()->GetName() == "TRG3")
@@ -147,9 +137,8 @@ public:
         m_passedTrg5 = true;
       if (!m_passedTrg6 && post->GetPhysicalVolume()->GetName() == "TRG6")
         m_passedTrg6 = true;
-      if (post->GetPhysicalVolume()->GetName() ==
-          "CMSSE")                           // Exiting TBH4BeamLine
-        if (!(m_passedTrg1 && m_passedTrg6)) // Trigger defined as Trg4 && Trg6
+      if (post->GetPhysicalVolume()->GetName() == "CMSSE")  // Exiting TBH4BeamLine
+        if (!(m_passedTrg1 && m_passedTrg6))                // Trigger defined as Trg4 && Trg6
           throw SimG4Exception("Event is not triggered by ECALTBH4");
     }
 

--- a/SimG4CMS/EcalTestBeam/interface/TBHodoActiveVolumeRawInfoProducer.h
+++ b/SimG4CMS/EcalTestBeam/interface/TBHodoActiveVolumeRawInfoProducer.h
@@ -24,7 +24,6 @@
 #include "TBDataFormats/EcalTBObjects/interface/EcalTBHodoscopeRawInfo.h"
 
 class TBHodoActiveVolumeRawInfoProducer : public edm::stream::EDProducer<> {
-
 public:
   /// Constructor
   explicit TBHodoActiveVolumeRawInfoProducer(const edm::ParameterSet &ps);

--- a/SimG4CMS/EcalTestBeam/plugins/EcalTBMCInfoProducer.cc
+++ b/SimG4CMS/EcalTestBeam/plugins/EcalTBMCInfoProducer.cc
@@ -20,13 +20,10 @@ using namespace std;
 using namespace cms;
 
 EcalTBMCInfoProducer::EcalTBMCInfoProducer(const edm::ParameterSet &ps) {
-
   produces<PEcalTBInfo>();
 
-  edm::FileInPath CrystalMapFile =
-      ps.getParameter<edm::FileInPath>("CrystalMapFile");
-  GenVtxToken =
-      consumes<edm::HepMCProduct>(edm::InputTag("moduleLabelVtx", "source"));
+  edm::FileInPath CrystalMapFile = ps.getParameter<edm::FileInPath>("CrystalMapFile");
+  GenVtxToken = consumes<edm::HepMCProduct>(edm::InputTag("moduleLabelVtx", "source"));
   double fMinEta = ps.getParameter<double>("MinEta");
   double fMaxEta = ps.getParameter<double>("MaxEta");
   double fMinPhi = ps.getParameter<double>("MinPhi");
@@ -51,15 +48,13 @@ EcalTBMCInfoProducer::EcalTBMCInfoProducer(const edm::ParameterSet &ps) {
       deltaEta = fabs(beamEta - eta);
       deltaPhi = fabs(beamPhi - phi);
       crysNumber = cryIndex;
-    } else if (fabs(beamEta - eta) < deltaEta &&
-               fabs(beamPhi - phi) > deltaPhi) {
+    } else if (fabs(beamEta - eta) < deltaEta && fabs(beamPhi - phi) > deltaPhi) {
       if (fabs(beamPhi - phi) < 0.017) {
         deltaEta = fabs(beamEta - eta);
         deltaPhi = fabs(beamPhi - phi);
         crysNumber = cryIndex;
       }
-    } else if (fabs(beamEta - eta) > deltaEta &&
-               fabs(beamPhi - phi) < deltaPhi) {
+    } else if (fabs(beamEta - eta) > deltaEta && fabs(beamPhi - phi) < deltaPhi) {
       if (fabs(beamEta - eta) < 0.017) {
         deltaEta = fabs(beamEta - eta);
         deltaPhi = fabs(beamPhi - phi);
@@ -68,14 +63,13 @@ EcalTBMCInfoProducer::EcalTBMCInfoProducer(const edm::ParameterSet &ps) {
     }
   }
 
-  edm::LogInfo("EcalTBInfo")
-      << "Initialize TB MC ECAL info producer with parameters: \n"
-      << "Crystal map file:  " << CrystalMapFile << "\n"
-      << "Beam average eta = " << beamEta << "\n"
-      << "Beam average phi = " << beamPhi << "\n"
-      << "Corresponding to crystal number = " << crysNumber << "\n"
-      << "Beam X offset =    " << beamXoff << "\n"
-      << "Beam Y offset =    " << beamYoff;
+  edm::LogInfo("EcalTBInfo") << "Initialize TB MC ECAL info producer with parameters: \n"
+                             << "Crystal map file:  " << CrystalMapFile << "\n"
+                             << "Beam average eta = " << beamEta << "\n"
+                             << "Beam average phi = " << beamPhi << "\n"
+                             << "Corresponding to crystal number = " << crysNumber << "\n"
+                             << "Beam X offset =    " << beamXoff << "\n"
+                             << "Beam Y offset =    " << beamYoff;
 
   // rotation matrix to move from the CMS reference frame to the test beam one
 
@@ -96,18 +90,16 @@ EcalTBMCInfoProducer::EcalTBMCInfoProducer(const edm::ParameterSet &ps) {
   // random number
   edm::Service<edm::RandomNumberGenerator> rng;
   if (!rng.isAvailable()) {
-    throw cms::Exception("Configuration")
-        << "EcalTBMCInfoProducer requires the RandomNumberGeneratorService\n"
-           "which is not present in the configuration file.  You must add the "
-           "service\n"
-           "in the configuration file or remove the modules that require it.";
+    throw cms::Exception("Configuration") << "EcalTBMCInfoProducer requires the RandomNumberGeneratorService\n"
+                                             "which is not present in the configuration file.  You must add the "
+                                             "service\n"
+                                             "in the configuration file or remove the modules that require it.";
   }
 }
 
 EcalTBMCInfoProducer::~EcalTBMCInfoProducer() { delete theTestMap; }
 
-void EcalTBMCInfoProducer::produce(edm::Event &event,
-                                   const edm::EventSetup &eventSetup) {
+void EcalTBMCInfoProducer::produce(edm::Event &event, const edm::EventSetup &eventSetup) {
   edm::Service<edm::RandomNumberGenerator> rng;
   CLHEP::HepRandomEngine *engine = &rng->getEngine(event.streamID());
 
@@ -131,17 +123,14 @@ void EcalTBMCInfoProducer::produce(edm::Event &event,
   const HepMC::GenEvent *Evt = GenEvt->GetEvent();
   HepMC::GenEvent::vertex_const_iterator Vtx = Evt->vertices_begin();
 
-  math::XYZPoint eventCMSVertex((*Vtx)->position().x(), (*Vtx)->position().y(),
-                                (*Vtx)->position().z());
+  math::XYZPoint eventCMSVertex((*Vtx)->position().x(), (*Vtx)->position().y(), (*Vtx)->position().z());
 
-  LogDebug("EcalTBInfo") << "Generated vertex position = " << eventCMSVertex.x()
-                         << " " << eventCMSVertex.y() << " "
+  LogDebug("EcalTBInfo") << "Generated vertex position = " << eventCMSVertex.x() << " " << eventCMSVertex.y() << " "
                          << eventCMSVertex.z();
 
   math::XYZPoint eventTBVertex = (*fromCMStoTB) * eventCMSVertex;
 
-  LogDebug("EcalTBInfo") << "Rotated vertex position   = " << eventTBVertex.x()
-                         << " " << eventTBVertex.y() << " "
+  LogDebug("EcalTBInfo") << "Rotated vertex position   = " << eventTBVertex.x() << " " << eventTBVertex.y() << " "
                          << eventTBVertex.z();
 
   partXhodo = eventTBVertex.x();

--- a/SimG4CMS/EcalTestBeam/plugins/FakeTBEventHeaderProducer.cc
+++ b/SimG4CMS/EcalTestBeam/plugins/FakeTBEventHeaderProducer.cc
@@ -10,17 +10,14 @@
 using namespace cms;
 using namespace std;
 
-FakeTBEventHeaderProducer::FakeTBEventHeaderProducer(
-    const edm::ParameterSet &ps) {
-  ecalTBInfo_ = consumes<PEcalTBInfo>(
-      edm::InputTag("EcalTBInfoLabel", "SimEcalTBG4Object"));
+FakeTBEventHeaderProducer::FakeTBEventHeaderProducer(const edm::ParameterSet &ps) {
+  ecalTBInfo_ = consumes<PEcalTBInfo>(edm::InputTag("EcalTBInfoLabel", "SimEcalTBG4Object"));
   produces<EcalTBEventHeader>();
 }
 
 FakeTBEventHeaderProducer::~FakeTBEventHeaderProducer() {}
 
-void FakeTBEventHeaderProducer::produce(edm::Event &event,
-                                        const edm::EventSetup &eventSetup) {
+void FakeTBEventHeaderProducer::produce(edm::Event &event, const edm::EventSetup &eventSetup) {
   unique_ptr<EcalTBEventHeader> product(new EcalTBEventHeader());
 
   // get the vertex information from the event
@@ -31,8 +28,7 @@ void FakeTBEventHeaderProducer::produce(edm::Event &event,
   if (EcalTBInfo.isValid()) {
     theEcalTBInfo = EcalTBInfo.product();
   } else {
-    edm::LogError("FakeTBEventHeaderProducer")
-        << "Error! can't get the product PEcalTBInfo";
+    edm::LogError("FakeTBEventHeaderProducer") << "Error! can't get the product PEcalTBInfo";
   }
 
   if (!theEcalTBInfo) {
@@ -45,8 +41,7 @@ void FakeTBEventHeaderProducer::produce(edm::Event &event,
   product->setRunNumber(event.id().run());
   product->setBurstNumber(1);
   product->setTriggerMask(0x1);
-  product->setCrystalInBeam(
-      EBDetId(1, theEcalTBInfo->nCrystal(), EBDetId::SMCRYSTALMODE));
+  product->setCrystalInBeam(EBDetId(1, theEcalTBInfo->nCrystal(), EBDetId::SMCRYSTALMODE));
 
   //   LogDebug("FakeTBHeader") << (*product);
   //   LogDebug("FakeTBHeader") << (*product).eventType();

--- a/SimG4CMS/EcalTestBeam/plugins/FakeTBHodoscopeRawInfoProducer.cc
+++ b/SimG4CMS/EcalTestBeam/plugins/FakeTBHodoscopeRawInfoProducer.cc
@@ -9,23 +9,16 @@
 using namespace cms;
 using namespace std;
 
-FakeTBHodoscopeRawInfoProducer::FakeTBHodoscopeRawInfoProducer(
-    const edm::ParameterSet &ps) {
-
-  ecalTBInfo_ = consumes<PEcalTBInfo>(
-      edm::InputTag("EcalTBInfoLabel", "SimEcalTBG4Object"));
+FakeTBHodoscopeRawInfoProducer::FakeTBHodoscopeRawInfoProducer(const edm::ParameterSet &ps) {
+  ecalTBInfo_ = consumes<PEcalTBInfo>(edm::InputTag("EcalTBInfoLabel", "SimEcalTBG4Object"));
   produces<EcalTBHodoscopeRawInfo>();
 
   theTBHodoGeom_ = new EcalTBHodoscopeGeometry();
 }
 
-FakeTBHodoscopeRawInfoProducer::~FakeTBHodoscopeRawInfoProducer() {
+FakeTBHodoscopeRawInfoProducer::~FakeTBHodoscopeRawInfoProducer() { delete theTBHodoGeom_; }
 
-  delete theTBHodoGeom_;
-}
-
-void FakeTBHodoscopeRawInfoProducer::produce(
-    edm::Event &event, const edm::EventSetup &eventSetup) {
+void FakeTBHodoscopeRawInfoProducer::produce(edm::Event &event, const edm::EventSetup &eventSetup) {
   unique_ptr<EcalTBHodoscopeRawInfo> product(new EcalTBHodoscopeRawInfo());
 
   // get the vertex information from the event
@@ -47,13 +40,11 @@ void FakeTBHodoscopeRawInfoProducer::produce(
   product->setPlanes(nPlanes);
 
   for (int iPlane = 0; iPlane < nPlanes; ++iPlane) {
-
     float theCoord = (float)partXhodo;
     if (iPlane == 1 || iPlane == 3)
       theCoord = (float)partYhodo;
 
-    vector<int> firedChannels =
-        theTBHodoGeom_->getFiredFibresInPlane(theCoord, iPlane);
+    vector<int> firedChannels = theTBHodoGeom_->getFiredFibresInPlane(theCoord, iPlane);
     unsigned int nChannels = firedChannels.size();
 
     EcalTBHodoscopePlaneRawHits planeHit(nChannels);

--- a/SimG4CMS/EcalTestBeam/plugins/TBHodoActiveVolumeRawInfoProducer.cc
+++ b/SimG4CMS/EcalTestBeam/plugins/TBHodoActiveVolumeRawInfoProducer.cc
@@ -11,11 +11,8 @@
 using namespace cms;
 using namespace std;
 
-TBHodoActiveVolumeRawInfoProducer::TBHodoActiveVolumeRawInfoProducer(
-    const edm::ParameterSet &ps) {
-
-  m_EcalToken = consumes<edm::PCaloHitContainer>(
-      edm::InputTag("g4SimHits", "EcalTBH4BeamHits"));
+TBHodoActiveVolumeRawInfoProducer::TBHodoActiveVolumeRawInfoProducer(const edm::ParameterSet &ps) {
+  m_EcalToken = consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits", "EcalTBH4BeamHits"));
   produces<EcalTBHodoscopeRawInfo>();
 
   theTBHodoGeom_ = new EcalTBHodoscopeGeometry();
@@ -23,12 +20,9 @@ TBHodoActiveVolumeRawInfoProducer::TBHodoActiveVolumeRawInfoProducer(
   myThreshold = 0.05E-3;
 }
 
-TBHodoActiveVolumeRawInfoProducer::~TBHodoActiveVolumeRawInfoProducer() {
-  delete theTBHodoGeom_;
-}
+TBHodoActiveVolumeRawInfoProducer::~TBHodoActiveVolumeRawInfoProducer() { delete theTBHodoGeom_; }
 
-void TBHodoActiveVolumeRawInfoProducer::produce(
-    edm::Event &event, const edm::EventSetup &eventSetup) {
+void TBHodoActiveVolumeRawInfoProducer::produce(edm::Event &event, const edm::EventSetup &eventSetup) {
   unique_ptr<EcalTBHodoscopeRawInfo> product(new EcalTBHodoscopeRawInfo());
 
   // caloHit container
@@ -70,8 +64,7 @@ void TBHodoActiveVolumeRawInfoProducer::produce(
       firedChannels[iPlane][iFiber] = 0.;
     }
   }
-  for (std::map<unsigned int, double>::const_iterator itmap = energyMap.begin();
-       itmap != energyMap.end(); ++itmap) {
+  for (std::map<unsigned int, double>::const_iterator itmap = energyMap.begin(); itmap != energyMap.end(); ++itmap) {
     if ((*itmap).second > myThreshold) {
       HodoscopeDetId myHodoDetId = HodoscopeDetId((*itmap).first);
       firedChannels[myHodoDetId.planeId()][myHodoDetId.fibrId()] = true;

--- a/SimG4CMS/EcalTestBeam/src/EcalTBH4BeamSD.cc
+++ b/SimG4CMS/EcalTestBeam/src/EcalTBH4BeamSD.cc
@@ -25,9 +25,7 @@ EcalTBH4BeamSD::EcalTBH4BeamSD(const std::string &name,
                                edm::ParameterSet const &p,
                                const SimTrackManager *manager)
     : CaloSD(name, cpv, clg, p, manager), numberingScheme(nullptr) {
-
-  edm::ParameterSet m_EcalTBH4BeamSD =
-      p.getParameter<edm::ParameterSet>("EcalTBH4BeamSD");
+  edm::ParameterSet m_EcalTBH4BeamSD = p.getParameter<edm::ParameterSet>("EcalTBH4BeamSD");
   useBirk = m_EcalTBH4BeamSD.getParameter<bool>("UseBirkLaw");
   birk1 = m_EcalTBH4BeamSD.getParameter<double>("BirkC1") * (g / (MeV * cm2));
   birk2 = m_EcalTBH4BeamSD.getParameter<double>("BirkC2");
@@ -35,21 +33,17 @@ EcalTBH4BeamSD::EcalTBH4BeamSD(const std::string &name,
 
   EcalNumberingScheme *scheme = nullptr;
   if (name == "EcalTBH4BeamHits") {
-    scheme =
-        dynamic_cast<EcalNumberingScheme *>(new EcalHodoscopeNumberingScheme());
+    scheme = dynamic_cast<EcalNumberingScheme *>(new EcalHodoscopeNumberingScheme());
   } else {
-    edm::LogWarning("EcalTBSim")
-        << "EcalTBH4BeamSD: ReadoutName not supported\n";
+    edm::LogWarning("EcalTBSim") << "EcalTBH4BeamSD: ReadoutName not supported\n";
   }
 
   if (scheme)
     setNumberingScheme(scheme);
-  edm::LogInfo("EcalTBSim")
-      << "Constructing a EcalTBH4BeamSD  with name " << GetName();
-  edm::LogInfo("EcalTBSim")
-      << "EcalTBH4BeamSD:: Use of Birks law is set to  " << useBirk
-      << "        with three constants kB = " << birk1 << ", C1 = " << birk2
-      << ", C2 = " << birk3;
+  edm::LogInfo("EcalTBSim") << "Constructing a EcalTBH4BeamSD  with name " << GetName();
+  edm::LogInfo("EcalTBSim") << "EcalTBH4BeamSD:: Use of Birks law is set to  " << useBirk
+                            << "        with three constants kB = " << birk1 << ", C1 = " << birk2
+                            << ", C2 = " << birk3;
 }
 
 EcalTBH4BeamSD::~EcalTBH4BeamSD() {
@@ -58,31 +52,25 @@ EcalTBH4BeamSD::~EcalTBH4BeamSD() {
 }
 
 double EcalTBH4BeamSD::getEnergyDeposit(const G4Step *aStep) {
-
   // take into account light collection curve for crystals
   double weight = 1.;
   if (useBirk)
     weight *= getAttenuation(aStep, birk1, birk2, birk3);
   double edep = aStep->GetTotalEnergyDeposit() * weight;
-  LogDebug("EcalTBSim")
-      << "EcalTBH4BeamSD:: "
-      << aStep->GetPreStepPoint()->GetPhysicalVolume()->GetName()
-      << " Light Collection Efficiency " << weight
-      << " Weighted Energy Deposit " << edep / MeV << " MeV";
+  LogDebug("EcalTBSim") << "EcalTBH4BeamSD:: " << aStep->GetPreStepPoint()->GetPhysicalVolume()->GetName()
+                        << " Light Collection Efficiency " << weight << " Weighted Energy Deposit " << edep / MeV
+                        << " MeV";
   return edep;
 }
 
 uint32_t EcalTBH4BeamSD::setDetUnitId(const G4Step *aStep) {
   getBaseNumber(aStep);
-  return (numberingScheme == nullptr
-              ? 0
-              : numberingScheme->getUnitID(theBaseNumber));
+  return (numberingScheme == nullptr ? 0 : numberingScheme->getUnitID(theBaseNumber));
 }
 
 void EcalTBH4BeamSD::setNumberingScheme(EcalNumberingScheme *scheme) {
   if (scheme != nullptr) {
-    edm::LogInfo("EcalTBSim")
-        << "EcalTBH4BeamSD: updates numbering scheme for " << GetName() << "\n";
+    edm::LogInfo("EcalTBSim") << "EcalTBH4BeamSD: updates numbering scheme for " << GetName() << "\n";
     if (numberingScheme)
       delete numberingScheme;
     numberingScheme = scheme;
@@ -90,7 +78,6 @@ void EcalTBH4BeamSD::setNumberingScheme(EcalNumberingScheme *scheme) {
 }
 
 void EcalTBH4BeamSD::getBaseNumber(const G4Step *aStep) {
-
   theBaseNumber.reset();
   const G4VTouchable *touch = aStep->GetPreStepPoint()->GetTouchable();
   int theSize = touch->GetHistoryDepth() + 1;
@@ -99,11 +86,9 @@ void EcalTBH4BeamSD::getBaseNumber(const G4Step *aStep) {
   // Get name and copy numbers
   if (theSize > 1) {
     for (int ii = 0; ii < theSize; ii++) {
-      theBaseNumber.addLevel(touch->GetVolume(ii)->GetName(),
-                             touch->GetReplicaNumber(ii));
-      LogDebug("EcalTBSim") << "EcalTBH4BeamSD::getBaseNumber(): Adding level "
-                            << ii << ": " << touch->GetVolume(ii)->GetName()
-                            << "[" << touch->GetReplicaNumber(ii) << "]";
+      theBaseNumber.addLevel(touch->GetVolume(ii)->GetName(), touch->GetReplicaNumber(ii));
+      LogDebug("EcalTBSim") << "EcalTBH4BeamSD::getBaseNumber(): Adding level " << ii << ": "
+                            << touch->GetVolume(ii)->GetName() << "[" << touch->GetReplicaNumber(ii) << "]";
     }
   }
 }

--- a/SimG4CMS/EcalTestBeam/test/testFromCMStoTB.cpp
+++ b/SimG4CMS/EcalTestBeam/test/testFromCMStoTB.cpp
@@ -11,10 +11,7 @@
 
 using namespace std;
 
-void computeRotation(double &myTheta, double &myPhi,
-                     ROOT::Math::Rotation3D &CMStoTB,
-                     ROOT::Math::Rotation3D &TBtoCMS) {
-
+void computeRotation(double &myTheta, double &myPhi, ROOT::Math::Rotation3D &CMStoTB, ROOT::Math::Rotation3D &TBtoCMS) {
   // rotation matrix to move from the CMS reference frame to the test beam one
 
   ROOT::Math::Rotation3D *fromCMStoTB = new ROOT::Math::Rotation3D();
@@ -33,8 +30,7 @@ void computeRotation(double &myTheta, double &myPhi,
   (*fromCMStoTB) *= (*r2);
   (*fromCMStoTB) *= (*r1);
 
-  cout << "Rotation matrix from CMS to test beam frame = " << (*fromCMStoTB)
-       << "built from: \n"
+  cout << "Rotation matrix from CMS to test beam frame = " << (*fromCMStoTB) << "built from: \n"
        << " the rotation of " << angle1 << " around Z " << (*r1) << "\n"
        << " the rotation of " << angle2 << " around X " << (*r2) << "\n"
        << " the rotation of " << angle3 << " around Z " << (*r3) << std::endl;
@@ -50,8 +46,7 @@ void computeRotation(double &myTheta, double &myPhi,
   (*fromTBtoCMS) *= (*r12);
   (*fromTBtoCMS) *= (*r13);
 
-  cout << "Rotation matrix from test beam to CMS frame = " << (*fromTBtoCMS)
-       << "built from: \n"
+  cout << "Rotation matrix from test beam to CMS frame = " << (*fromTBtoCMS) << "built from: \n"
        << " the rotation of " << angle13 << " around Z " << (*r13) << "\n"
        << " the rotation of " << angle12 << " around X " << (*r12) << "\n"
        << " the rotation of " << angle11 << " around Z " << (*r11) << std::endl;
@@ -71,7 +66,6 @@ void computeRotation(double &myTheta, double &myPhi,
 }
 
 void checkTotalRotation(double &myTheta, double &myPhi) {
-
   // rotation matrix to move from the CMS reference frame to the test beam one
 
   double xx = -cos(myTheta) * cos(myPhi);
@@ -86,11 +80,9 @@ void checkTotalRotation(double &myTheta, double &myPhi) {
   double zy = sin(myTheta) * sin(myPhi);
   double zz = cos(myTheta);
 
-  ROOT::Math::Rotation3D *fromCMStoTB =
-      new ROOT::Math::Rotation3D(xx, xy, xz, yx, yy, yz, zx, zy, zz);
+  ROOT::Math::Rotation3D *fromCMStoTB = new ROOT::Math::Rotation3D(xx, xy, xz, yx, yy, yz, zx, zy, zz);
 
-  cout << "Total rotation matrix from CMS to test beam frame = "
-       << (*fromCMStoTB) << endl;
+  cout << "Total rotation matrix from CMS to test beam frame = " << (*fromCMStoTB) << endl;
 
   // rotation matrix to move from the test beam reference frame to the CMS one
 
@@ -106,11 +98,9 @@ void checkTotalRotation(double &myTheta, double &myPhi) {
   zy = 0.;
   zz = cos(myTheta);
 
-  ROOT::Math::Rotation3D *fromTBtoCMS =
-      new ROOT::Math::Rotation3D(xx, xy, xz, yx, yy, yz, zx, zy, zz);
+  ROOT::Math::Rotation3D *fromTBtoCMS = new ROOT::Math::Rotation3D(xx, xy, xz, yx, yy, yz, zx, zy, zz);
 
-  cout << "Total rotation matrix from test beam to CMS frame = "
-       << (*fromTBtoCMS) << endl;
+  cout << "Total rotation matrix from test beam to CMS frame = " << (*fromTBtoCMS) << endl;
 
   ROOT::Math::Rotation3D test = (*fromCMStoTB) * (*fromTBtoCMS);
 
@@ -118,7 +108,6 @@ void checkTotalRotation(double &myTheta, double &myPhi) {
 }
 
 int main() {
-
   // (eta,phi) for a crystal
 
   double myMod = 1.;
@@ -147,7 +136,6 @@ int main() {
 
   for (int ieta = -1; ieta <= 1; ++ieta) {
     for (int iphi = -1; iphi <= 1; ++iphi) {
-
       newTheta = myTheta + (double)ieta;
       newPhi = myPhi + (double)iphi;
 
@@ -158,22 +146,18 @@ int main() {
 
       cout << "\n ieta = " << ieta << " iphi = " << iphi << endl;
       cout << "\n From CMS to TB \n" << endl;
-      cout << "Input vector  = " << test
-           << " corresponding to theta = " << newTheta << " phi = " << newPhi
-           << endl;
+      cout << "Input vector  = " << test << " corresponding to theta = " << newTheta << " phi = " << newPhi << endl;
 
       math::XYZPoint testrot = (*CMStoTB) * test;
 
-      cout << "Output vector = " << testrot
-           << " corresponding to theta = " << testrot.theta()
+      cout << "Output vector = " << testrot << " corresponding to theta = " << testrot.theta()
            << " phi = " << testrot.phi() << endl;
 
       cout << "\n From TB to CMS \n" << endl;
 
       math::XYZPoint thistest = (*TBtoCMS) * testrot;
 
-      cout << "Output vector = " << thistest
-           << " corresponding to theta = " << thistest.theta()
+      cout << "Output vector = " << thistest << " corresponding to theta = " << thistest.theta()
            << " phi = " << thistest.phi() << endl;
       cout << "\n===========================================\n" << endl;
     }
@@ -183,7 +167,6 @@ int main() {
 
   for (int ix = -1; ix <= 1; ++ix) {
     for (int iy = -1; iy <= 1; ++iy) {
-
       xx = (double)ix * 0.01;
       yy = (double)iy * 0.01;
       zz = 1.;
@@ -195,8 +178,7 @@ int main() {
 
       math::XYZPoint testrot = (*TBtoCMS) * test;
 
-      cout << "Output vector = " << testrot
-           << " corresponding to theta = " << testrot.theta()
+      cout << "Output vector = " << testrot << " corresponding to theta = " << testrot.theta()
            << " phi = " << testrot.phi() << endl;
 
       cout << "\n From CMS to TB \n" << endl;

--- a/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
+++ b/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
@@ -17,7 +17,7 @@
 #endif
 
 #include <iterator>
-#include <numeric> // for std::accumulate
+#include <numeric>  // for std::accumulate
 #include <unordered_map>
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -57,10 +57,10 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 namespace {
-using Index_t = unsigned;
-using Barcode_t = int;
-const std::string messageCategoryGraph_("CaloTruthAccumulatorGraphProducer");
-} // namespace
+  using Index_t = unsigned;
+  using Barcode_t = int;
+  const std::string messageCategoryGraph_("CaloTruthAccumulatorGraphProducer");
+}  // namespace
 
 using boost::add_edge;
 using boost::adjacency_list;
@@ -102,8 +102,7 @@ using boost::vertex_name_t;
 
 */
 struct EdgeProperty {
-  EdgeProperty(const SimTrack *t, int h, int c)
-      : simTrack(t), simHits(h), cumulative_simHits(c) {}
+  EdgeProperty(const SimTrack *t, int h, int c) : simTrack(t), simHits(h), cumulative_simHits(c) {}
   const SimTrack *simTrack;
   int simHits;
   int cumulative_simHits;
@@ -111,55 +110,45 @@ struct EdgeProperty {
 
 struct VertexProperty {
   VertexProperty() : simTrack(nullptr), cumulative_simHits(0) {}
-  VertexProperty(const SimTrack *t, int c)
-      : simTrack(t), cumulative_simHits(c) {}
+  VertexProperty(const SimTrack *t, int c) : simTrack(t), cumulative_simHits(c) {}
   VertexProperty(const VertexProperty &other)
-      : simTrack(other.simTrack), cumulative_simHits(other.cumulative_simHits) {
-  }
+      : simTrack(other.simTrack), cumulative_simHits(other.cumulative_simHits) {}
   const SimTrack *simTrack;
   int cumulative_simHits;
 };
 
 using EdgeParticleClustersProperty = property<edge_weight_t, EdgeProperty>;
 using VertexMotherParticleProperty = property<vertex_name_t, VertexProperty>;
-using DecayChain =
-    adjacency_list<listS, vecS, directedS, VertexMotherParticleProperty,
-                   EdgeParticleClustersProperty>;
+using DecayChain = adjacency_list<listS, vecS, directedS, VertexMotherParticleProperty, EdgeParticleClustersProperty>;
 
 class CaloTruthAccumulator : public DigiAccumulatorMixMod {
 public:
-  explicit CaloTruthAccumulator(const edm::ParameterSet &config,
-                                edm::ProducerBase &mixMod,
-                                edm::ConsumesCollector &iC);
+  explicit CaloTruthAccumulator(const edm::ParameterSet &config, edm::ProducerBase &mixMod, edm::ConsumesCollector &iC);
 
 private:
-  void initializeEvent(const edm::Event &event,
-                       const edm::EventSetup &setup) override;
-  void accumulate(const edm::Event &event,
-                  const edm::EventSetup &setup) override;
-  void accumulate(const PileUpEventPrincipal &event,
-                  const edm::EventSetup &setup, edm::StreamID const &) override;
+  void initializeEvent(const edm::Event &event, const edm::EventSetup &setup) override;
+  void accumulate(const edm::Event &event, const edm::EventSetup &setup) override;
+  void accumulate(const PileUpEventPrincipal &event, const edm::EventSetup &setup, edm::StreamID const &) override;
   void finalizeEvent(edm::Event &event, const edm::EventSetup &setup) override;
-  void beginLuminosityBlock(edm::LuminosityBlock const &lumi,
-                            edm::EventSetup const &setup) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const &lumi, edm::EventSetup const &setup) override;
 
   /** @brief Both forms of accumulate() delegate to this templated method. */
   template <class T>
-  void accumulateEvent(const T &event, const edm::EventSetup &setup,
+  void accumulateEvent(const T &event,
+                       const edm::EventSetup &setup,
                        const edm::Handle<edm::HepMCProduct> &hepMCproduct);
 
   /** @brief Fills the supplied vector with pointers to the SimHits, checking
    * for bad modules if required */
   template <class T>
-  void fillSimHits(
-      std::vector<std::pair<DetId, const PCaloHit *>> &returnValue,
-      std::unordered_map<int, std::map<int, float>> &simTrackDetIdEnergyMap,
-      const T &event, const edm::EventSetup &setup);
+  void fillSimHits(std::vector<std::pair<DetId, const PCaloHit *>> &returnValue,
+                   std::unordered_map<int, std::map<int, float>> &simTrackDetIdEnergyMap,
+                   const T &event,
+                   const edm::EventSetup &setup);
 
   const std::string messageCategory_;
 
-  std::unordered_map<Index_t, float>
-      m_detIdToTotalSimEnergy; // keep track of cell normalizations
+  std::unordered_map<Index_t, float> m_detIdToTotalSimEnergy;  // keep track of cell normalizations
   std::unordered_multimap<Barcode_t, Index_t> m_simHitBarcodeToIndex;
 
   /** The maximum bunch crossing BEFORE the signal crossing to create
@@ -222,177 +211,160 @@ private:
 /* Graph utility functions */
 
 namespace {
-template <typename Edge, typename Graph, typename Visitor>
-void accumulateSimHits_edge(Edge &e, const Graph &g, Visitor *v) {
-  auto const edge_property = get(edge_weight, g, e);
-  v->total_simHits += edge_property.simHits;
-  IfLogDebug(DEBUG, messageCategoryGraph_)
-      << " Examining edges " << e << " --> particle "
-      << edge_property.simTrack->type() << "("
-      << edge_property.simTrack->trackId() << ")"
-      << " with SimClusters: " << edge_property.simHits
-      << " Accumulated SimClusters: " << v->total_simHits << std::endl;
-}
-template <typename Vertex, typename Graph>
-void print_vertex(Vertex &u, const Graph &g) {
-  auto const vertex_property = get(vertex_name, g, u);
-  IfLogDebug(DEBUG, messageCategoryGraph_) << " At " << u;
-  // The Mother of all vertices has **no** SimTrack associated.
-  if (vertex_property.simTrack)
+  template <typename Edge, typename Graph, typename Visitor>
+  void accumulateSimHits_edge(Edge &e, const Graph &g, Visitor *v) {
+    auto const edge_property = get(edge_weight, g, e);
+    v->total_simHits += edge_property.simHits;
     IfLogDebug(DEBUG, messageCategoryGraph_)
-        << " [" << vertex_property.simTrack->type() << "]"
-        << "(" << vertex_property.simTrack->trackId() << ")";
-  IfLogDebug(DEBUG, messageCategoryGraph_) << std::endl;
-}
+        << " Examining edges " << e << " --> particle " << edge_property.simTrack->type() << "("
+        << edge_property.simTrack->trackId() << ")"
+        << " with SimClusters: " << edge_property.simHits << " Accumulated SimClusters: " << v->total_simHits
+        << std::endl;
+  }
+  template <typename Vertex, typename Graph>
+  void print_vertex(Vertex &u, const Graph &g) {
+    auto const vertex_property = get(vertex_name, g, u);
+    IfLogDebug(DEBUG, messageCategoryGraph_) << " At " << u;
+    // The Mother of all vertices has **no** SimTrack associated.
+    if (vertex_property.simTrack)
+      IfLogDebug(DEBUG, messageCategoryGraph_) << " [" << vertex_property.simTrack->type() << "]"
+                                               << "(" << vertex_property.simTrack->trackId() << ")";
+    IfLogDebug(DEBUG, messageCategoryGraph_) << std::endl;
+  }
 
 // Graphviz output functions will only be generated in DEBUG mode
 #if DEBUG
-std::string graphviz_vertex(const VertexProperty &v) {
-  std::ostringstream oss;
-  oss << "{id: " << (v.simTrack ? v.simTrack->trackId() : 0)
-      << ",\\ntype: " << (v.simTrack ? v.simTrack->type() : 0)
-      << ",\\nchits: " << v.cumulative_simHits << "}";
-  return oss.str();
-}
+  std::string graphviz_vertex(const VertexProperty &v) {
+    std::ostringstream oss;
+    oss << "{id: " << (v.simTrack ? v.simTrack->trackId() : 0) << ",\\ntype: " << (v.simTrack ? v.simTrack->type() : 0)
+        << ",\\nchits: " << v.cumulative_simHits << "}";
+    return oss.str();
+  }
 
-std::string graphviz_edge(const EdgeProperty &e) {
-  std::ostringstream oss;
-  oss << "[" << (e.simTrack ? e.simTrack->trackId() : 0) << ","
-      << (e.simTrack ? e.simTrack->type() : 0) << "," << e.simHits << ","
-      << e.cumulative_simHits << "]";
-  return oss.str();
-}
+  std::string graphviz_edge(const EdgeProperty &e) {
+    std::ostringstream oss;
+    oss << "[" << (e.simTrack ? e.simTrack->trackId() : 0) << "," << (e.simTrack ? e.simTrack->type() : 0) << ","
+        << e.simHits << "," << e.cumulative_simHits << "]";
+    return oss.str();
+  }
 #endif
 
-class SimHitsAccumulator_dfs_visitor : public boost::default_dfs_visitor {
-public:
-  int total_simHits = 0;
-  template <typename Edge, typename Graph>
-  void examine_edge(Edge e, const Graph &g) {
-    accumulateSimHits_edge(e, g, this);
-  }
-  template <typename Edge, typename Graph>
-  void finish_edge(Edge e, const Graph &g) {
-    auto const edge_property = get(edge_weight, g, e);
-    auto src = source(e, g);
-    auto trg = target(e, g);
-    auto cumulative = edge_property.simHits +
-                      get(vertex_name, g, trg).cumulative_simHits +
-                      (get(vertex_name, g, src).simTrack
-                           ? get(vertex_name, g, src).cumulative_simHits
-                           : 0); // when we hit the root vertex we have to stop
-                                 // adding back its contribution.
-    auto const src_vertex_property = get(vertex_name, g, src);
-    put(get(vertex_name, const_cast<Graph &>(g)), src,
-        VertexProperty(src_vertex_property.simTrack, cumulative));
-    put(get(edge_weight, const_cast<Graph &>(g)), e,
-        EdgeProperty(edge_property.simTrack, edge_property.simHits,
-                     cumulative));
-    IfLogDebug(DEBUG, messageCategoryGraph_)
-        << " Finished edge: " << e
-        << " Track id: " << get(edge_weight, g, e).simTrack->trackId()
-        << " has accumulated " << cumulative << " hits" << std::endl;
-    IfLogDebug(DEBUG, messageCategoryGraph_)
-        << " SrcVtx: " << src << "\t" << get(vertex_name, g, src).simTrack
-        << "\t" << get(vertex_name, g, src).cumulative_simHits << std::endl;
-    IfLogDebug(DEBUG, messageCategoryGraph_)
-        << " TrgVtx: " << trg << "\t" << get(vertex_name, g, trg).simTrack
-        << "\t" << get(vertex_name, g, trg).cumulative_simHits << std::endl;
-  }
-};
-
-using Selector = std::function<bool(EdgeProperty &)>;
-
-class CaloParticle_dfs_visitor : public boost::default_dfs_visitor {
-public:
-  CaloParticle_dfs_visitor(
-      CaloTruthAccumulator::OutputCollections &output,
-      CaloTruthAccumulator::calo_particles &caloParticles,
-      std::unordered_multimap<Barcode_t, Index_t> &simHitBarcodeToIndex,
-      std::unordered_map<int, std::map<int, float>> &simTrackDetIdEnergyMap,
-      Selector selector)
-      : output_(output), caloParticles_(caloParticles),
-        simHitBarcodeToIndex_(simHitBarcodeToIndex),
-        simTrackDetIdEnergyMap_(simTrackDetIdEnergyMap), selector_(selector) {}
-  template <typename Vertex, typename Graph>
-  void discover_vertex(Vertex u, const Graph &g) {
-    // If we reach the vertex 0, it means that we are backtracking with respect
-    // to the first generation of stable particles: simply return;
-    //    if (u == 0) return;
-    print_vertex(u, g);
-    auto const vertex_property = get(vertex_name, g, u);
-    if (!vertex_property.simTrack)
-      return;
-    auto trackIdx = vertex_property.simTrack->trackId();
-    IfLogDebug(DEBUG, messageCategoryGraph_)
-        << " Found " << simHitBarcodeToIndex_.count(trackIdx)
-        << " associated simHits" << std::endl;
-    if (simHitBarcodeToIndex_.count(trackIdx)) {
-      output_.pSimClusters->emplace_back(*vertex_property.simTrack);
-      auto &simcluster = output_.pSimClusters->back();
-      std::unordered_map<uint32_t, float> acc_energy;
-      for (auto const &hit_and_energy : simTrackDetIdEnergyMap_[trackIdx]) {
-        acc_energy[hit_and_energy.first] += hit_and_energy.second;
-      }
-      for (auto const &hit_and_energy : acc_energy) {
-        simcluster.addRecHitAndFraction(hit_and_energy.first,
-                                        hit_and_energy.second);
-      }
+  class SimHitsAccumulator_dfs_visitor : public boost::default_dfs_visitor {
+  public:
+    int total_simHits = 0;
+    template <typename Edge, typename Graph>
+    void examine_edge(Edge e, const Graph &g) {
+      accumulateSimHits_edge(e, g, this);
     }
-  }
-  template <typename Edge, typename Graph>
-  void examine_edge(Edge e, const Graph &g) {
-    auto src = source(e, g);
-    auto vertex_property = get(vertex_name, g, src);
-    if (src == 0 or (vertex_property.simTrack == nullptr)) {
-      auto edge_property = get(edge_weight, g, e);
+    template <typename Edge, typename Graph>
+    void finish_edge(Edge e, const Graph &g) {
+      auto const edge_property = get(edge_weight, g, e);
+      auto src = source(e, g);
+      auto trg = target(e, g);
+      auto cumulative = edge_property.simHits + get(vertex_name, g, trg).cumulative_simHits +
+                        (get(vertex_name, g, src).simTrack ? get(vertex_name, g, src).cumulative_simHits
+                                                           : 0);  // when we hit the root vertex we have to stop
+                                                                  // adding back its contribution.
+      auto const src_vertex_property = get(vertex_name, g, src);
+      put(get(vertex_name, const_cast<Graph &>(g)), src, VertexProperty(src_vertex_property.simTrack, cumulative));
+      put(get(edge_weight, const_cast<Graph &>(g)),
+          e,
+          EdgeProperty(edge_property.simTrack, edge_property.simHits, cumulative));
       IfLogDebug(DEBUG, messageCategoryGraph_)
-          << "Considering CaloParticle: " << edge_property.simTrack->trackId();
-      if (selector_(edge_property)) {
-        IfLogDebug(DEBUG, messageCategoryGraph_)
-            << "Adding CaloParticle: " << edge_property.simTrack->trackId();
-        output_.pCaloParticles->emplace_back(*(edge_property.simTrack));
-        caloParticles_.sc_start_.push_back(output_.pSimClusters->size());
+          << " Finished edge: " << e << " Track id: " << get(edge_weight, g, e).simTrack->trackId()
+          << " has accumulated " << cumulative << " hits" << std::endl;
+      IfLogDebug(DEBUG, messageCategoryGraph_) << " SrcVtx: " << src << "\t" << get(vertex_name, g, src).simTrack
+                                               << "\t" << get(vertex_name, g, src).cumulative_simHits << std::endl;
+      IfLogDebug(DEBUG, messageCategoryGraph_) << " TrgVtx: " << trg << "\t" << get(vertex_name, g, trg).simTrack
+                                               << "\t" << get(vertex_name, g, trg).cumulative_simHits << std::endl;
+    }
+  };
+
+  using Selector = std::function<bool(EdgeProperty &)>;
+
+  class CaloParticle_dfs_visitor : public boost::default_dfs_visitor {
+  public:
+    CaloParticle_dfs_visitor(CaloTruthAccumulator::OutputCollections &output,
+                             CaloTruthAccumulator::calo_particles &caloParticles,
+                             std::unordered_multimap<Barcode_t, Index_t> &simHitBarcodeToIndex,
+                             std::unordered_map<int, std::map<int, float>> &simTrackDetIdEnergyMap,
+                             Selector selector)
+        : output_(output),
+          caloParticles_(caloParticles),
+          simHitBarcodeToIndex_(simHitBarcodeToIndex),
+          simTrackDetIdEnergyMap_(simTrackDetIdEnergyMap),
+          selector_(selector) {}
+    template <typename Vertex, typename Graph>
+    void discover_vertex(Vertex u, const Graph &g) {
+      // If we reach the vertex 0, it means that we are backtracking with respect
+      // to the first generation of stable particles: simply return;
+      //    if (u == 0) return;
+      print_vertex(u, g);
+      auto const vertex_property = get(vertex_name, g, u);
+      if (!vertex_property.simTrack)
+        return;
+      auto trackIdx = vertex_property.simTrack->trackId();
+      IfLogDebug(DEBUG, messageCategoryGraph_)
+          << " Found " << simHitBarcodeToIndex_.count(trackIdx) << " associated simHits" << std::endl;
+      if (simHitBarcodeToIndex_.count(trackIdx)) {
+        output_.pSimClusters->emplace_back(*vertex_property.simTrack);
+        auto &simcluster = output_.pSimClusters->back();
+        std::unordered_map<uint32_t, float> acc_energy;
+        for (auto const &hit_and_energy : simTrackDetIdEnergyMap_[trackIdx]) {
+          acc_energy[hit_and_energy.first] += hit_and_energy.second;
+        }
+        for (auto const &hit_and_energy : acc_energy) {
+          simcluster.addRecHitAndFraction(hit_and_energy.first, hit_and_energy.second);
+        }
       }
     }
-  }
-
-  template <typename Edge, typename Graph>
-  void finish_edge(Edge e, const Graph &g) {
-    auto src = source(e, g);
-    auto vertex_property = get(vertex_name, g, src);
-    if (src == 0 or (vertex_property.simTrack == nullptr)) {
-      auto edge_property = get(edge_weight, g, e);
-      if (selector_(edge_property)) {
-        caloParticles_.sc_stop_.push_back(output_.pSimClusters->size());
+    template <typename Edge, typename Graph>
+    void examine_edge(Edge e, const Graph &g) {
+      auto src = source(e, g);
+      auto vertex_property = get(vertex_name, g, src);
+      if (src == 0 or (vertex_property.simTrack == nullptr)) {
+        auto edge_property = get(edge_weight, g, e);
+        IfLogDebug(DEBUG, messageCategoryGraph_) << "Considering CaloParticle: " << edge_property.simTrack->trackId();
+        if (selector_(edge_property)) {
+          IfLogDebug(DEBUG, messageCategoryGraph_) << "Adding CaloParticle: " << edge_property.simTrack->trackId();
+          output_.pCaloParticles->emplace_back(*(edge_property.simTrack));
+          caloParticles_.sc_start_.push_back(output_.pSimClusters->size());
+        }
       }
     }
-  }
 
-private:
-  CaloTruthAccumulator::OutputCollections &output_;
-  CaloTruthAccumulator::calo_particles &caloParticles_;
-  std::unordered_multimap<Barcode_t, Index_t> &simHitBarcodeToIndex_;
-  std::unordered_map<int, std::map<int, float>> &simTrackDetIdEnergyMap_;
-  Selector selector_;
-};
-} // namespace
+    template <typename Edge, typename Graph>
+    void finish_edge(Edge e, const Graph &g) {
+      auto src = source(e, g);
+      auto vertex_property = get(vertex_name, g, src);
+      if (src == 0 or (vertex_property.simTrack == nullptr)) {
+        auto edge_property = get(edge_weight, g, e);
+        if (selector_(edge_property)) {
+          caloParticles_.sc_stop_.push_back(output_.pSimClusters->size());
+        }
+      }
+    }
+
+  private:
+    CaloTruthAccumulator::OutputCollections &output_;
+    CaloTruthAccumulator::calo_particles &caloParticles_;
+    std::unordered_multimap<Barcode_t, Index_t> &simHitBarcodeToIndex_;
+    std::unordered_map<int, std::map<int, float>> &simTrackDetIdEnergyMap_;
+    Selector selector_;
+  };
+}  // namespace
 
 CaloTruthAccumulator::CaloTruthAccumulator(const edm::ParameterSet &config,
                                            edm::ProducerBase &mixMod,
                                            edm::ConsumesCollector &iC)
     : messageCategory_("CaloTruthAccumulator"),
-      maximumPreviousBunchCrossing_(
-          config.getParameter<unsigned int>("maximumPreviousBunchCrossing")),
-      maximumSubsequentBunchCrossing_(
-          config.getParameter<unsigned int>("maximumSubsequentBunchCrossing")),
+      maximumPreviousBunchCrossing_(config.getParameter<unsigned int>("maximumPreviousBunchCrossing")),
+      maximumSubsequentBunchCrossing_(config.getParameter<unsigned int>("maximumSubsequentBunchCrossing")),
       simTrackLabel_(config.getParameter<edm::InputTag>("simTrackCollection")),
-      simVertexLabel_(
-          config.getParameter<edm::InputTag>("simVertexCollection")),
-      collectionTags_(), genParticleLabel_(config.getParameter<edm::InputTag>(
-                             "genParticleCollection")),
-      hepMCproductLabel_(
-          config.getParameter<edm::InputTag>("HepMCProductLabel")),
+      simVertexLabel_(config.getParameter<edm::InputTag>("simVertexCollection")),
+      collectionTags_(),
+      genParticleLabel_(config.getParameter<edm::InputTag>("genParticleCollection")),
+      hepMCproductLabel_(config.getParameter<edm::InputTag>("HepMCProductLabel")),
       minEnergy_(config.getParameter<double>("MinEnergy")),
       maxPseudoRapidity_(config.getParameter<double>("MaxPseudoRapidity")),
       premixStage1_(config.getParameter<bool>("premixStage1")),
@@ -400,8 +372,7 @@ CaloTruthAccumulator::CaloTruthAccumulator(const edm::ParameterSet &config,
   mixMod.produces<SimClusterCollection>("MergedCaloTruth");
   mixMod.produces<CaloParticleCollection>("MergedCaloTruth");
   if (premixStage1_) {
-    mixMod.produces<std::vector<std::pair<unsigned int, float>>>(
-        "MergedCaloTruth");
+    mixMod.produces<std::vector<std::pair<unsigned int, float>>>("MergedCaloTruth");
   }
 
   iC.consumes<std::vector<SimTrack>>(simTrackLabel_);
@@ -411,15 +382,11 @@ CaloTruthAccumulator::CaloTruthAccumulator(const edm::ParameterSet &config,
   iC.consumes<std::vector<int>>(hepMCproductLabel_);
 
   // Fill the collection tags
-  const edm::ParameterSet &simHitCollectionConfig =
-      config.getParameterSet("simHitCollections");
-  std::vector<std::string> parameterNames =
-      simHitCollectionConfig.getParameterNames();
+  const edm::ParameterSet &simHitCollectionConfig = config.getParameterSet("simHitCollections");
+  std::vector<std::string> parameterNames = simHitCollectionConfig.getParameterNames();
 
   for (auto const &parameterName : parameterNames) {
-    std::vector<edm::InputTag> tags =
-        simHitCollectionConfig.getParameter<std::vector<edm::InputTag>>(
-            parameterName);
+    std::vector<edm::InputTag> tags = simHitCollectionConfig.getParameter<std::vector<edm::InputTag>>(parameterName);
     collectionTags_.insert(collectionTags_.end(), tags.begin(), tags.end());
   }
 
@@ -428,31 +395,26 @@ CaloTruthAccumulator::CaloTruthAccumulator(const edm::ParameterSet &config,
   }
 }
 
-void CaloTruthAccumulator::beginLuminosityBlock(
-    edm::LuminosityBlock const &iLumiBlock, const edm::EventSetup &iSetup) {
+void CaloTruthAccumulator::beginLuminosityBlock(edm::LuminosityBlock const &iLumiBlock, const edm::EventSetup &iSetup) {
   edm::ESHandle<CaloGeometry> geom;
   iSetup.get<CaloGeometryRecord>().get(geom);
-  const HGCalGeometry *eegeom = nullptr, *fhgeom = nullptr,
-                      *bhgeomnew = nullptr;
+  const HGCalGeometry *eegeom = nullptr, *fhgeom = nullptr, *bhgeomnew = nullptr;
   const HcalGeometry *bhgeom = nullptr;
 
-  eegeom = static_cast<const HGCalGeometry *>(geom->getSubdetectorGeometry(
-      DetId::HGCalEE, ForwardSubdetector::ForwardEmpty));
+  eegeom = static_cast<const HGCalGeometry *>(
+      geom->getSubdetectorGeometry(DetId::HGCalEE, ForwardSubdetector::ForwardEmpty));
   // check if it's the new geometry
   if (eegeom) {
     geometryType_ = 1;
-    fhgeom = static_cast<const HGCalGeometry *>(geom->getSubdetectorGeometry(
-        DetId::HGCalHSi, ForwardSubdetector::ForwardEmpty));
-    bhgeomnew = static_cast<const HGCalGeometry *>(geom->getSubdetectorGeometry(
-        DetId::HGCalHSc, ForwardSubdetector::ForwardEmpty));
+    fhgeom = static_cast<const HGCalGeometry *>(
+        geom->getSubdetectorGeometry(DetId::HGCalHSi, ForwardSubdetector::ForwardEmpty));
+    bhgeomnew = static_cast<const HGCalGeometry *>(
+        geom->getSubdetectorGeometry(DetId::HGCalHSc, ForwardSubdetector::ForwardEmpty));
   } else {
     geometryType_ = 0;
-    eegeom = static_cast<const HGCalGeometry *>(
-        geom->getSubdetectorGeometry(DetId::Forward, HGCEE));
-    fhgeom = static_cast<const HGCalGeometry *>(
-        geom->getSubdetectorGeometry(DetId::Forward, HGCHEF));
-    bhgeom = static_cast<const HcalGeometry *>(
-        geom->getSubdetectorGeometry(DetId::Hcal, HcalEndcap));
+    eegeom = static_cast<const HGCalGeometry *>(geom->getSubdetectorGeometry(DetId::Forward, HGCEE));
+    fhgeom = static_cast<const HGCalGeometry *>(geom->getSubdetectorGeometry(DetId::Forward, HGCHEF));
+    bhgeom = static_cast<const HcalGeometry *>(geom->getSubdetectorGeometry(DetId::Hcal, HcalEndcap));
   }
   hgtopo_[0] = &(eegeom->topology());
   hgtopo_[1] = &(fhgeom->topology());
@@ -468,8 +430,7 @@ void CaloTruthAccumulator::beginLuminosityBlock(
     hcddd_ = bhgeom->topology().dddConstants();
 }
 
-void CaloTruthAccumulator::initializeEvent(edm::Event const &event,
-                                           edm::EventSetup const &setup) {
+void CaloTruthAccumulator::initializeEvent(edm::Event const &event, edm::EventSetup const &setup) {
   output_.pSimClusters.reset(new SimClusterCollection());
   output_.pCaloParticles.reset(new CaloParticleCollection());
 
@@ -483,40 +444,32 @@ void CaloTruthAccumulator::initializeEvent(edm::Event const &event,
     to get a handle to) which is only implemented for container-like objects
     like std::vector but not for edm::HepMCProduct!
 */
-void CaloTruthAccumulator::accumulate(edm::Event const &event,
-                                      edm::EventSetup const &setup) {
+void CaloTruthAccumulator::accumulate(edm::Event const &event, edm::EventSetup const &setup) {
   edm::Handle<edm::HepMCProduct> hepmc;
   event.getByLabel(hepMCproductLabel_, hepmc);
 
-  edm::LogInfo(messageCategory_)
-      << " CaloTruthAccumulator::accumulate (signal)";
+  edm::LogInfo(messageCategory_) << " CaloTruthAccumulator::accumulate (signal)";
   accumulateEvent(event, setup, hepmc);
 }
 
 void CaloTruthAccumulator::accumulate(PileUpEventPrincipal const &event,
                                       edm::EventSetup const &setup,
                                       edm::StreamID const &) {
-  if (event.bunchCrossing() >=
-          -static_cast<int>(maximumPreviousBunchCrossing_) &&
-      event.bunchCrossing() <=
-          static_cast<int>(maximumSubsequentBunchCrossing_)) {
+  if (event.bunchCrossing() >= -static_cast<int>(maximumPreviousBunchCrossing_) &&
+      event.bunchCrossing() <= static_cast<int>(maximumSubsequentBunchCrossing_)) {
     // simply create empty handle as we do not have a HepMCProduct in PU anyway
     edm::Handle<edm::HepMCProduct> hepmc;
-    edm::LogInfo(messageCategory_)
-        << " CaloTruthAccumulator::accumulate (pileup) bunchCrossing="
-        << event.bunchCrossing();
+    edm::LogInfo(messageCategory_) << " CaloTruthAccumulator::accumulate (pileup) bunchCrossing="
+                                   << event.bunchCrossing();
     accumulateEvent(event, setup, hepmc);
   } else {
-    edm::LogInfo(messageCategory_)
-        << "Skipping pileup event for bunch crossing " << event.bunchCrossing();
+    edm::LogInfo(messageCategory_) << "Skipping pileup event for bunch crossing " << event.bunchCrossing();
   }
 }
 
-void CaloTruthAccumulator::finalizeEvent(edm::Event &event,
-                                         edm::EventSetup const &setup) {
-  edm::LogInfo(messageCategory_)
-      << "Adding " << output_.pSimClusters->size() << " SimParticles and "
-      << output_.pCaloParticles->size() << " CaloParticles to the event.";
+void CaloTruthAccumulator::finalizeEvent(edm::Event &event, edm::EventSetup const &setup) {
+  edm::LogInfo(messageCategory_) << "Adding " << output_.pSimClusters->size() << " SimParticles and "
+                                 << output_.pCaloParticles->size() << " CaloParticles to the event.";
 
   // We need to normalize the hits and energies into hits and fractions (since
   // we have looped over all pileup events)
@@ -524,11 +477,9 @@ void CaloTruthAccumulator::finalizeEvent(edm::Event &event,
   // fractions in stage2
 
   if (premixStage1_) {
-    auto totalEnergies =
-        std::make_unique<std::vector<std::pair<unsigned int, float>>>();
+    auto totalEnergies = std::make_unique<std::vector<std::pair<unsigned int, float>>>();
     totalEnergies->reserve(m_detIdToTotalSimEnergy.size());
-    std::copy(m_detIdToTotalSimEnergy.begin(), m_detIdToTotalSimEnergy.end(),
-              std::back_inserter(*totalEnergies));
+    std::copy(m_detIdToTotalSimEnergy.begin(), m_detIdToTotalSimEnergy.end(), std::back_inserter(*totalEnergies));
     std::sort(totalEnergies->begin(), totalEnergies->end());
     event.put(std::move(totalEnergies), "MergedCaloTruth");
   } else {
@@ -542,8 +493,7 @@ void CaloTruthAccumulator::finalizeEvent(edm::Event &event,
           fraction = hAndE.second / totalenergy;
         else
           edm::LogWarning(messageCategory_)
-              << "TotalSimEnergy for hit " << hAndE.first
-              << " is 0! The fraction for this hit cannot be computed.";
+              << "TotalSimEnergy for hit " << hAndE.first << " is 0! The fraction for this hit cannot be computed.";
         sc.addRecHitAndFraction(hAndE.first, fraction);
       }
     }
@@ -555,8 +505,7 @@ void CaloTruthAccumulator::finalizeEvent(edm::Event &event,
   // now fill the calo particles
   for (unsigned i = 0; i < output_.pCaloParticles->size(); ++i) {
     auto &cp = (*output_.pCaloParticles)[i];
-    for (unsigned j = m_caloParticles.sc_start_[i];
-         j < m_caloParticles.sc_stop_[i]; ++j) {
+    for (unsigned j = m_caloParticles.sc_start_[i]; j < m_caloParticles.sc_stop_[i]; ++j) {
       edm::Ref<SimClusterCollection> ref(scHandle, j);
       cp.addSimCluster(ref);
     }
@@ -571,10 +520,9 @@ void CaloTruthAccumulator::finalizeEvent(edm::Event &event,
 }
 
 template <class T>
-void CaloTruthAccumulator::accumulateEvent(
-    const T &event, const edm::EventSetup &setup,
-    const edm::Handle<edm::HepMCProduct> &hepMCproduct) {
-
+void CaloTruthAccumulator::accumulateEvent(const T &event,
+                                           const edm::EventSetup &setup,
+                                           const edm::Handle<edm::HepMCProduct> &hepMCproduct) {
   edm::Handle<std::vector<reco::GenParticle>> hGenParticles;
   edm::Handle<std::vector<int>> hGenParticleIndices;
 
@@ -602,8 +550,7 @@ void CaloTruthAccumulator::accumulateEvent(
 
   IfLogDebug(DEBUG, messageCategory_) << " TRACKS" << std::endl;
   for (auto const &t : tracks) {
-    IfLogDebug(DEBUG, messageCategory_)
-        << " " << idx << "\t" << t.trackId() << "\t" << t << std::endl;
+    IfLogDebug(DEBUG, messageCategory_) << " " << idx << "\t" << t.trackId() << "\t" << t << std::endl;
     trackid_to_track_index[t.trackId()] = idx;
     idx++;
   }
@@ -639,8 +586,7 @@ void CaloTruthAccumulator::accumulateEvent(
   std::vector<int> collapsed_vertices(vertices.size(), 0);
   IfLogDebug(DEBUG, messageCategory_) << " VERTICES" << std::endl;
   for (auto const &v : vertices) {
-    IfLogDebug(DEBUG, messageCategory_)
-        << " " << idx++ << "\t" << v << std::endl;
+    IfLogDebug(DEBUG, messageCategory_) << " " << idx++ << "\t" << v << std::endl;
     if (v.parentIndex() != -1) {
       auto trk_idx = trackid_to_track_index[v.parentIndex()];
       auto origin_vtx = tracks[trk_idx].vertIndex();
@@ -654,9 +600,9 @@ void CaloTruthAccumulator::accumulateEvent(
       // Perform the actual vertex collapsing, if needed.
       if (collapsed_vertices[origin_vtx])
         origin_vtx = collapsed_vertices[origin_vtx];
-      add_edge(origin_vtx, v.vertexId(),
-               EdgeProperty(&tracks[trk_idx],
-                            simTrackDetIdEnergyMap[v.parentIndex()].size(), 0),
+      add_edge(origin_vtx,
+               v.vertexId(),
+               EdgeProperty(&tracks[trk_idx], simTrackDetIdEnergyMap[v.parentIndex()].size(), 0),
                decay);
       used_sim_tracks[trk_idx] = v.vertexId();
     }
@@ -672,11 +618,8 @@ void CaloTruthAccumulator::accumulateEvent(
       // Perform the actual vertex collapsing, if needed.
       if (collapsed_vertices[origin_vtx])
         origin_vtx = collapsed_vertices[origin_vtx];
-      add_edge(origin_vtx, offset,
-               EdgeProperty(&tracks[i],
-                            simTrackDetIdEnergyMap[tracks[i].trackId()].size(),
-                            0),
-               decay);
+      add_edge(
+          origin_vtx, offset, EdgeProperty(&tracks[i], simTrackDetIdEnergyMap[tracks[i].trackId()].size(), 0), decay);
       // The properties for "fake" vertices associated to stable particles have
       // to be set inside this loop, since they do not belong to the vertices
       // collection and would be skipped by that loop (coming next)
@@ -689,45 +632,43 @@ void CaloTruthAccumulator::accumulateEvent(
       // Skip collapsed_vertices
       if (collapsed_vertices[v.vertexId()])
         continue;
-      put(vertexMothersProp, v.vertexId(),
-          VertexProperty(&tracks[trackid_to_track_index[v.parentIndex()]], 0));
+      put(vertexMothersProp, v.vertexId(), VertexProperty(&tracks[trackid_to_track_index[v.parentIndex()]], 0));
     }
   }
   SimHitsAccumulator_dfs_visitor vis;
   depth_first_search(decay, visitor(vis));
   CaloParticle_dfs_visitor caloParticleCreator(
-      output_, m_caloParticles, m_simHitBarcodeToIndex, simTrackDetIdEnergyMap,
+      output_,
+      m_caloParticles,
+      m_simHitBarcodeToIndex,
+      simTrackDetIdEnergyMap,
       [&](EdgeProperty &edge_property) -> bool {
         // Apply selection on SimTracks in order to promote them to be
         // CaloParticles. The function returns TRUE if the particle satisfies
         // the selection, FALSE otherwise. Therefore the correct logic to select
         // the particle is to ask for TRUE as return value.
-        return (edge_property.cumulative_simHits != 0 and
-                !edge_property.simTrack->noGenpart() and
+        return (edge_property.cumulative_simHits != 0 and !edge_property.simTrack->noGenpart() and
                 edge_property.simTrack->momentum().E() > minEnergy_ and
-                std::abs(edge_property.simTrack->momentum().Eta()) <
-                    maxPseudoRapidity_);
+                std::abs(edge_property.simTrack->momentum().Eta()) < maxPseudoRapidity_);
       });
   depth_first_search(decay, visitor(caloParticleCreator));
 
 #if DEBUG
-  boost::write_graphviz(std::cout, decay,
-                        make_label_writer(make_transform_value_property_map(
-                            &graphviz_vertex, get(vertex_name, decay))),
-                        make_label_writer(make_transform_value_property_map(
-                            &graphviz_edge, get(edge_weight, decay))));
+  boost::write_graphviz(std::cout,
+                        decay,
+                        make_label_writer(make_transform_value_property_map(&graphviz_vertex, get(vertex_name, decay))),
+                        make_label_writer(make_transform_value_property_map(&graphviz_edge, get(edge_weight, decay))));
 #endif
 }
 
 template <class T>
-void CaloTruthAccumulator::fillSimHits(
-    std::vector<std::pair<DetId, const PCaloHit *>> &returnValue,
-    std::unordered_map<int, std::map<int, float>> &simTrackDetIdEnergyMap,
-    const T &event, const edm::EventSetup &setup) {
+void CaloTruthAccumulator::fillSimHits(std::vector<std::pair<DetId, const PCaloHit *>> &returnValue,
+                                       std::unordered_map<int, std::map<int, float>> &simTrackDetIdEnergyMap,
+                                       const T &event,
+                                       const edm::EventSetup &setup) {
   for (auto const &collectionTag : collectionTags_) {
     edm::Handle<std::vector<PCaloHit>> hSimHits;
-    const bool isHcal =
-        (collectionTag.instance().find("HcalHits") != std::string::npos);
+    const bool isHcal = (collectionTag.instance().find("HcalHits") != std::string::npos);
     event.getByLabel(collectionTag, hSimHits);
     for (auto const &simHit : *hSimHits) {
       DetId id(0);
@@ -741,18 +682,15 @@ void CaloTruthAccumulator::fillSimHits(
           id = hid;
       } else {
         int subdet, layer, cell, sec, subsec, zp;
-        HGCalTestNumbering::unpackHexagonIndex(simId, subdet, zp, layer, sec,
-                                               subsec, cell);
+        HGCalTestNumbering::unpackHexagonIndex(simId, subdet, zp, layer, sec, subsec, cell);
         const HGCalDDDConstants *ddd = hgddd_[subdet - 3];
-        std::pair<int, int> recoLayerCell = ddd->simToReco(
-            cell, layer, sec, hgtopo_[subdet - 3]->detectorType());
+        std::pair<int, int> recoLayerCell = ddd->simToReco(cell, layer, sec, hgtopo_[subdet - 3]->detectorType());
         cell = recoLayerCell.first;
         layer = recoLayerCell.second;
         // skip simhits with bad barcodes or non-existant layers
         if (layer == -1 || simHit.geantTrackId() == 0)
           continue;
-        id = HGCalDetId((ForwardSubdetector)subdet, zp, layer, subsec, sec,
-                        cell);
+        id = HGCalDetId((ForwardSubdetector)subdet, zp, layer, subsec, sec, cell);
       }
 
       if (DetId(0) == id)
@@ -760,12 +698,11 @@ void CaloTruthAccumulator::fillSimHits(
 
       uint32_t detId = id.rawId();
       returnValue.emplace_back(id, &simHit);
-      simTrackDetIdEnergyMap[simHit.geantTrackId()][id.rawId()] +=
-          simHit.energy();
+      simTrackDetIdEnergyMap[simHit.geantTrackId()][id.rawId()] += simHit.energy();
 
       m_detIdToTotalSimEnergy[detId] += simHit.energy();
     }
-  } // end of loop over InputTags
+  }  // end of loop over InputTags
 }
 
 // Register with the framework

--- a/SimGeneral/CaloAnalysis/plugins/PreMixingCaloParticleWorker.cc
+++ b/SimGeneral/CaloAnalysis/plugins/PreMixingCaloParticleWorker.cc
@@ -16,25 +16,21 @@
 
 class PreMixingCaloParticleWorker : public PreMixingWorker {
 public:
-  PreMixingCaloParticleWorker(const edm::ParameterSet &ps,
-                              edm::ProducerBase &producer,
-                              edm::ConsumesCollector &&iC);
+  PreMixingCaloParticleWorker(const edm::ParameterSet &ps, edm::ProducerBase &producer, edm::ConsumesCollector &&iC);
   ~PreMixingCaloParticleWorker() override = default;
 
-  void initializeEvent(edm::Event const &iEvent,
-                       edm::EventSetup const &iSetup) override;
-  void addSignals(edm::Event const &iEvent,
-                  edm::EventSetup const &iSetup) override;
-  void addPileups(PileUpEventPrincipal const &pep,
-                  edm::EventSetup const &iSetup) override;
-  void put(edm::Event &iEvent, edm::EventSetup const &iSetup,
-           std::vector<PileupSummaryInfo> const &ps, int bunchSpacing) override;
+  void initializeEvent(edm::Event const &iEvent, edm::EventSetup const &iSetup) override;
+  void addSignals(edm::Event const &iEvent, edm::EventSetup const &iSetup) override;
+  void addPileups(PileUpEventPrincipal const &pep, edm::EventSetup const &iSetup) override;
+  void put(edm::Event &iEvent,
+           edm::EventSetup const &iSetup,
+           std::vector<PileupSummaryInfo> const &ps,
+           int bunchSpacing) override;
 
 private:
   using EnergyMap = std::vector<std::pair<unsigned, float>>;
 
-  void add(const SimClusterCollection &clusters,
-           const CaloParticleCollection &particles, const EnergyMap &energyMap);
+  void add(const SimClusterCollection &clusters, const CaloParticleCollection &particles, const EnergyMap &energyMap);
 
   edm::EDGetTokenT<SimClusterCollection> sigClusterToken_;
   edm::EDGetTokenT<CaloParticleCollection> sigParticleToken_;
@@ -50,36 +46,29 @@ private:
   SimClusterRefProd clusterRef_;
 };
 
-PreMixingCaloParticleWorker::PreMixingCaloParticleWorker(
-    const edm::ParameterSet &ps, edm::ProducerBase &producer,
-    edm::ConsumesCollector &&iC)
-    : sigClusterToken_(iC.consumes<SimClusterCollection>(
-          ps.getParameter<edm::InputTag>("labelSig"))),
-      sigParticleToken_(iC.consumes<CaloParticleCollection>(
-          ps.getParameter<edm::InputTag>("labelSig"))),
-      sigEnergyToken_(
-          iC.consumes<EnergyMap>(ps.getParameter<edm::InputTag>("labelSig"))),
+PreMixingCaloParticleWorker::PreMixingCaloParticleWorker(const edm::ParameterSet &ps,
+                                                         edm::ProducerBase &producer,
+                                                         edm::ConsumesCollector &&iC)
+    : sigClusterToken_(iC.consumes<SimClusterCollection>(ps.getParameter<edm::InputTag>("labelSig"))),
+      sigParticleToken_(iC.consumes<CaloParticleCollection>(ps.getParameter<edm::InputTag>("labelSig"))),
+      sigEnergyToken_(iC.consumes<EnergyMap>(ps.getParameter<edm::InputTag>("labelSig"))),
       particlePileInputTag_(ps.getParameter<edm::InputTag>("pileInputTag")),
       particleCollectionDM_(ps.getParameter<std::string>("collectionDM")) {
   producer.produces<SimClusterCollection>(particleCollectionDM_);
   producer.produces<CaloParticleCollection>(particleCollectionDM_);
 }
 
-void PreMixingCaloParticleWorker::initializeEvent(
-    edm::Event const &iEvent, edm::EventSetup const &iSetup) {
+void PreMixingCaloParticleWorker::initializeEvent(edm::Event const &iEvent, edm::EventSetup const &iSetup) {
   newClusters_ = std::make_unique<SimClusterCollection>();
   newParticles_ = std::make_unique<CaloParticleCollection>();
 
   // need RefProds in order to re-key the CaloParticle->SimCluster refs
   // TODO: try to remove const_cast, requires making Event non-const in
   // BMixingModule::initializeEvent
-  clusterRef_ =
-      const_cast<edm::Event &>(iEvent).getRefBeforePut<SimClusterCollection>(
-          particleCollectionDM_);
+  clusterRef_ = const_cast<edm::Event &>(iEvent).getRefBeforePut<SimClusterCollection>(particleCollectionDM_);
 }
 
-void PreMixingCaloParticleWorker::addSignals(edm::Event const &iEvent,
-                                             edm::EventSetup const &iSetup) {
+void PreMixingCaloParticleWorker::addSignals(edm::Event const &iEvent, edm::EventSetup const &iSetup) {
   edm::Handle<SimClusterCollection> clusters;
   iEvent.getByToken(sigClusterToken_, clusters);
 
@@ -94,8 +83,7 @@ void PreMixingCaloParticleWorker::addSignals(edm::Event const &iEvent,
   }
 }
 
-void PreMixingCaloParticleWorker::addPileups(PileUpEventPrincipal const &pep,
-                                             edm::EventSetup const &iSetup) {
+void PreMixingCaloParticleWorker::addPileups(PileUpEventPrincipal const &pep, edm::EventSetup const &iSetup) {
   edm::Handle<SimClusterCollection> clusters;
   pep.getByLabel(particlePileInputTag_, clusters);
 
@@ -117,8 +105,7 @@ void PreMixingCaloParticleWorker::add(const SimClusterCollection &clusters,
 
   // Copy SimClusters
   newClusters_->reserve(newClusters_->size() + clusters.size());
-  std::copy(clusters.begin(), clusters.end(),
-            std::back_inserter(*newClusters_));
+  std::copy(clusters.begin(), clusters.end(), std::back_inserter(*newClusters_));
 
   // Copy CaloParticles
   newParticles_->reserve(newParticles_->size() + particles.size());
@@ -129,8 +116,7 @@ void PreMixingCaloParticleWorker::add(const SimClusterCollection &clusters,
     // re-key the refs to SimClusters
     particle.clearSimClusters();
     for (const auto &ref : p.simClusters()) {
-      particle.addSimCluster(
-          SimClusterRef(clusterRef_, startingIndex + ref.index()));
+      particle.addSimCluster(SimClusterRef(clusterRef_, startingIndex + ref.index()));
     }
   }
 
@@ -154,8 +140,7 @@ void PreMixingCaloParticleWorker::put(edm::Event &iEvent,
         fraction = hAndE.second / totalenergy;
       else
         edm::LogWarning("PreMixingParticleWorker")
-            << "TotalSimEnergy for hit " << hAndE.first
-            << " is 0! The fraction for this hit cannot be computed.";
+            << "TotalSimEnergy for hit " << hAndE.first << " is 0! The fraction for this hit cannot be computed.";
       sc.addRecHitAndFraction(hAndE.first, fraction);
     }
   }

--- a/SimRomanPot/SimFP420/interface/AmplitudeSegmentFP420.h
+++ b/SimRomanPot/SimFP420/interface/AmplitudeSegmentFP420.h
@@ -10,8 +10,7 @@ class AmplitudeSegmentFP420 {
 public:
   AmplitudeSegmentFP420() : _pos(0, 0, 0), _sigma(0), _amplitude(0) {}
 
-  AmplitudeSegmentFP420(float x, float y, float z, float s, float a = 1.0)
-      : _pos(x, y, z), _sigma(s), _amplitude(a) {}
+  AmplitudeSegmentFP420(float x, float y, float z, float s, float a = 1.0) : _pos(x, y, z), _sigma(s), _amplitude(a) {}
 
   const G4ThreeVector &position() const { return _pos; }
   float x() const { return _pos.x(); }

--- a/SimRomanPot/SimFP420/interface/CDrifterFP420.h
+++ b/SimRomanPot/SimFP420/interface/CDrifterFP420.h
@@ -15,8 +15,7 @@ public:
 
   virtual ~CDrifterFP420() {}
 
-  virtual collection_type drift(const ionization_type &, const G4ThreeVector &,
-                                const int &) = 0;
+  virtual collection_type drift(const ionization_type &, const G4ThreeVector &, const int &) = 0;
   //  virtual collection_type drift (const ionization_type, const
   //  G4ThreeVector&) = 0;
 };

--- a/SimRomanPot/SimFP420/interface/ChargeDividerFP420.h
+++ b/SimRomanPot/SimFP420/interface/ChargeDividerFP420.h
@@ -12,26 +12,24 @@
 
 class ChargeDividerFP420 : public CDividerFP420 {
 public:
-  explicit ChargeDividerFP420(double pit, double az420, double azD2,
-                              double azD3, int);
+  explicit ChargeDividerFP420(double pit, double az420, double azD2, double azD3, int);
 
   ~ChargeDividerFP420() override;
 
   //  CDividerFP420::ionization_type divide(const SimHit&, const StripDet& det);
-  CDividerFP420::ionization_type divide(const PSimHit &,
-                                        const double &) override;
+  CDividerFP420::ionization_type divide(const PSimHit &, const double &) override;
 
 private:
-  double pitchcur; // is really moduleThickness here !!!
-  double z420;     // dist between centers of 1st and 2nd stations
-  double zD2;      // dist between centers of 1st and 2nd stations
-  double zD3;      // dist between centers of 1st and 3rd stations
+  double pitchcur;  // is really moduleThickness here !!!
+  double z420;      // dist between centers of 1st and 2nd stations
+  double zD2;       // dist between centers of 1st and 2nd stations
+  double zD3;       // dist between centers of 1st and 3rd stations
 
   float PeakShape(const PSimHit &);
   float DeconvolutionShape(const PSimHit &);
   float TimeResponse(const PSimHit &);
-  void fluctuateEloss(int particleId, float momentum, float eloss, float length,
-                      int NumberOfSegmentation, float elossVector[]);
+  void fluctuateEloss(
+      int particleId, float momentum, float eloss, float length, int NumberOfSegmentation, float elossVector[]);
   //  static SimpleConfigurable<bool> peakMode;
   bool peakMode;
   bool decoMode;

--- a/SimRomanPot/SimFP420/interface/ChargeDrifterFP420.h
+++ b/SimRomanPot/SimFP420/interface/ChargeDrifterFP420.h
@@ -6,15 +6,13 @@
 
 class ChargeDrifterFP420 : public CDrifterFP420 {
 public:
-  ChargeDrifterFP420(double, double, double, double, double, double, double,
-                     double, double, int);
+  ChargeDrifterFP420(double, double, double, double, double, double, double, double, double, int);
   CDrifterFP420::collection_type drift(const CDrifterFP420::ionization_type &,
                                        const G4ThreeVector &,
                                        const int &) override;
 
 private:
-  AmplitudeSegmentFP420 drift(const EnergySegmentFP420 &, const G4ThreeVector &,
-                              const int &);
+  AmplitudeSegmentFP420 drift(const EnergySegmentFP420 &, const G4ThreeVector &, const int &);
 
   double modulePath;
   double constTe;

--- a/SimRomanPot/SimFP420/interface/DigitizerFP420.h
+++ b/SimRomanPot/SimFP420/interface/DigitizerFP420.h
@@ -29,31 +29,30 @@
 #include <vector>
 
 namespace cms {
-class DigitizerFP420 : public edm::one::EDProducer<> {
-public:
-  explicit DigitizerFP420(const edm::ParameterSet &conf);
+  class DigitizerFP420 : public edm::one::EDProducer<> {
+  public:
+    explicit DigitizerFP420(const edm::ParameterSet &conf);
 
-  ~DigitizerFP420() override;
+    ~DigitizerFP420() override;
 
-  void produce(edm::Event &e, const edm::EventSetup &c) override;
+    void produce(edm::Event &e, const edm::EventSetup &c) override;
 
-private:
-  typedef std::vector<std::string> vstring;
-  typedef std::map<unsigned int, std::vector<PSimHit>, std::less<unsigned int>>
-      simhit_map;
-  typedef simhit_map::iterator simhit_map_iterator;
-  simhit_map SimHitMap;
+  private:
+    typedef std::vector<std::string> vstring;
+    typedef std::map<unsigned int, std::vector<PSimHit>, std::less<unsigned int>> simhit_map;
+    typedef simhit_map::iterator simhit_map_iterator;
+    simhit_map SimHitMap;
 
-  edm::ParameterSet conf_;
-  vstring trackerContainers;
+    edm::ParameterSet conf_;
+    vstring trackerContainers;
 
-  FP420DigiMain *stripDigitizer_;
-  int numStrips; // number of strips in the module
+    FP420DigiMain *stripDigitizer_;
+    int numStrips;  // number of strips in the module
 
-  int dn0, sn0, pn0, rn0, verbosity;
+    int dn0, sn0, pn0, rn0, verbosity;
 
-  std::vector<HDigiFP420> collector;
-};
-} // namespace cms
+    std::vector<HDigiFP420> collector;
+  };
+}  // namespace cms
 
 #endif

--- a/SimRomanPot/SimFP420/interface/EnergySegmentFP420.h
+++ b/SimRomanPot/SimFP420/interface/EnergySegmentFP420.h
@@ -11,14 +11,12 @@ class EnergySegmentFP420 {
 public:
   EnergySegmentFP420() : _energy(0), _position(0, 0, 0) {}
 
-  EnergySegmentFP420(float energy, float x, float y, float z)
-      : _energy(energy), _position(x, y, z) {}
+  EnergySegmentFP420(float energy, float x, float y, float z) : _energy(energy), _position(x, y, z) {}
 
   //      EnergySegmentFP420(float energy, G4ThreeVector position):
   //	_energy(energy),_position(position){}
 
-  EnergySegmentFP420(float energy, Local3DPoint position)
-      : _energy(energy), _position(position) {}
+  EnergySegmentFP420(float energy, Local3DPoint position) : _energy(energy), _position(position) {}
 
   float x() const { return _position.x(); }
   float y() const { return _position.y(); }

--- a/SimRomanPot/SimFP420/interface/FP420DigiMain.h
+++ b/SimRomanPot/SimFP420/interface/FP420DigiMain.h
@@ -43,8 +43,7 @@ public:
   // Runs the algorithm
   //  void run(const std::vector<PSimHit*> &input, DigiCollectionFP420
   //  &output,StripGeomDetUnit *det,GlobalVector);
-  std::vector<HDigiFP420> run(const std::vector<PSimHit> &input,
-                              const G4ThreeVector &, unsigned int);
+  std::vector<HDigiFP420> run(const std::vector<PSimHit> &input, const G4ThreeVector &, unsigned int);
   // vector <HDigiFP420>  run(const std::vector<PSimHit> &input, G4ThreeVector,
   // unsigned int, int);
 
@@ -55,56 +54,56 @@ private:
   edm::ParameterSet conf_;
   // Const Parameters needed by:
   //-- primary ionization
-  int NumberOfSegments, verbosity, xytype; //
+  int NumberOfSegments, verbosity, xytype;  //
   // go from Geant energy GeV to number of electrons
 
   //-- drift
-  float Sigma0;   //=0.0007  // Charge diffusion in microns for 300 micron Si
-  float Thick300; //=0.0300cm     or = 0.300 mm  - define 300microns for
-                  // normalization
+  float Sigma0;    //=0.0007  // Charge diffusion in microns for 300 micron Si
+  float Thick300;  //=0.0300cm     or = 0.300 mm  - define 300microns for
+                   // normalization
 
   //-- induce_signal
-  float ClusterWidth; // Gaussian charge cutoff width in sigma units
+  float ClusterWidth;  // Gaussian charge cutoff width in sigma units
   // Should be rather called CutoffWidth?
 
   //-- make_digis
-  float theElectronPerADC; // Gain, number of electrons per adc count.   =  3600
+  float theElectronPerADC;  // Gain, number of electrons per adc count.   =  3600
   double thez420;
   double thezD2;
   double thezD3;
-  float ENC;                  // Equivalent noise charge   = 50
-  int theAdcFullScale;        // Saturation count, 255=8bit.   = 35000
-  float theNoiseInElectrons;  // Noise (RMS) in units of electrons.  = 500
-  float theStripThreshold;    // Strip threshold in units of noise.  = 5
-  float theStripThresholdInE; // Strip noise in electorns.  = 2500
+  float ENC;                   // Equivalent noise charge   = 50
+  int theAdcFullScale;         // Saturation count, 255=8bit.   = 35000
+  float theNoiseInElectrons;   // Noise (RMS) in units of electrons.  = 500
+  float theStripThreshold;     // Strip threshold in units of noise.  = 5
+  float theStripThresholdInE;  // Strip noise in electorns.  = 2500
   //  bool peakMode; //  = false;
-  bool noNoise;        //  = false;
-  bool addNoisyPixels; //  = true ;
+  bool noNoise;         //  = false;
+  bool addNoisyPixels;  //  = true ;
   bool theApplyTofCut;
 
   float elossCut;
   double tofCut;
-  float theThreshold; // ADC threshold   = 2
+  float theThreshold;  // ADC threshold   = 2
 
-  double pitchX;  // pitchX
-  double pitchY;  // pitchY
-  double pitch;   // pitch automatic
-  double pitchXW; // pitchX
-  double pitchYW; // pitchY
-  double pitchW;  // pitch automatic
+  double pitchX;   // pitchX
+  double pitchY;   // pitchY
+  double pitch;    // pitch automatic
+  double pitchXW;  // pitchX
+  double pitchYW;  // pitchY
+  double pitchW;   // pitch automatic
 
-  double ldriftX; // ldriftX
-  double ldriftY; // ldriftY
-  double ldrift;  // ldrift automatic
+  double ldriftX;  // ldriftX
+  double ldriftY;  // ldriftY
+  double ldrift;   // ldrift automatic
 
-  double depletionVoltage; //  =   25.0       !depletion voltage [V]
-  double appliedVoltage;   //  =   45.0       !bias voltage      [V]
-  double chargeMobility;   //  = 480.0  !holes    mobility [cm**2/V/sec] p-side;
-                           //  = 1350.0 !electron mobility - n-side
-  double temperature;      //  =
-  bool noDiffusion;        //  =   true
-  double chargeDistributionRMS; //  =  5
-                                /*
+  double depletionVoltage;       //  =   25.0       !depletion voltage [V]
+  double appliedVoltage;         //  =   45.0       !bias voltage      [V]
+  double chargeMobility;         //  = 480.0  !holes    mobility [cm**2/V/sec] p-side;
+                                 //  = 1350.0 !electron mobility - n-side
+  double temperature;            //  =
+  bool noDiffusion;              //  =   true
+  double chargeDistributionRMS;  //  =  5
+                                 /*
                                     DH     =   12.3       !diffusion const for holes     [cm**2/sec]
                                     DE     =   34.6       !diffusion const for electrons [cm**2/sec]
                               
@@ -156,39 +155,38 @@ private:
   ZeroSuppressFP420 *theZSuppressFP420;
   DigiConverterFP420 *theDConverterFP420;
 
-  int theStripsInChip; // num of columns per APV (for strip ineff.)
+  int theStripsInChip;  // num of columns per APV (for strip ineff.)
 
-  int numStripsX;  // number of Xstrips in the module
-  int numStripsY;  // number of Ystrips in the module
-  int numStrips;   // number of strips in the module
-  int numStripsXW; // number of Xstrips in the module
-  int numStripsYW; // number of Ystrips in the module
-  int numStripsW;  // number of strips in the module
+  int numStripsX;   // number of Xstrips in the module
+  int numStripsY;   // number of Ystrips in the module
+  int numStrips;    // number of strips in the module
+  int numStripsXW;  // number of Xstrips in the module
+  int numStripsYW;  // number of Ystrips in the module
+  int numStripsW;   // number of strips in the module
 
   //  int numStripsMax;    // max number of strips in the module
-  float moduleThickness; // plate thickness
+  float moduleThickness;  // plate thickness
 
-  void push_digis(const DigitalMapType &, const HitToDigisMapType &,
-                  const PileUpFP420::signal_map_type &);
+  void push_digis(const DigitalMapType &, const HitToDigisMapType &, const PileUpFP420::signal_map_type &);
 
   //-- calibration smearing
-  bool doMissCalibrate;    // Switch on the calibration smearing
-  float theGainSmearing;   // The sigma of the gain fluctuation (around 1)
-  float theOffsetSmearing; // The sigma of the offset fluct. (around 0)
+  bool doMissCalibrate;     // Switch on the calibration smearing
+  float theGainSmearing;    // The sigma of the gain fluctuation (around 1)
+  float theOffsetSmearing;  // The sigma of the offset fluct. (around 0)
 
   // The PDTable
   //  HepPDTable *particleTable;
 
   //-- charge fluctuation
-  double tMax; // The delta production cut, should be as in OSCAR = 30keV
-               //                                           cmsim = 100keV
+  double tMax;  // The delta production cut, should be as in OSCAR = 30keV
+                //                                           cmsim = 100keV
   // The eloss fluctuation class from G4. Is the right place?
-  LandauFP420 fluctuate;              //
-  GaussNoiseProducerFP420 *theNoiser; //
-  std::vector<const PSimHit *> ss;    // ss - pointers to hit info of PSimHit
+  LandauFP420 fluctuate;               //
+  GaussNoiseProducerFP420 *theNoiser;  //
+  std::vector<const PSimHit *> ss;     // ss - pointers to hit info of PSimHit
 
-  void fluctuateEloss(int particleId, float momentum, float eloss, float length,
-                      int NumberOfSegments, float elossVector[]);
+  void fluctuateEloss(
+      int particleId, float momentum, float eloss, float length, int NumberOfSegments, float elossVector[]);
 
   //  std::vector<HDigiFP420> internal_coll; //empty vector of HDigiFP420 used
   //  in digitize // AZ

--- a/SimRomanPot/SimFP420/interface/GNoiseFP420.h
+++ b/SimRomanPot/SimFP420/interface/GNoiseFP420.h
@@ -9,7 +9,6 @@ public:
   // GNoiseFP420(int,float,float);
   virtual ~GNoiseFP420() {}
 
-  virtual PileUpFP420::signal_map_type
-  addNoise(const PileUpFP420::signal_map_type &) = 0;
+  virtual PileUpFP420::signal_map_type addNoise(const PileUpFP420::signal_map_type &) = 0;
 };
 #endif

--- a/SimRomanPot/SimFP420/interface/GaussNoiseFP420.h
+++ b/SimRomanPot/SimFP420/interface/GaussNoiseFP420.h
@@ -8,8 +8,7 @@ class GaussNoiseFP420 : public GNoiseFP420 {
 public:
   // GaussNoiseFP420(int,float,float,bool);
   GaussNoiseFP420(int ns, float nrms, float th, bool aNpixel, int verbosity);
-  PileUpFP420::signal_map_type
-  addNoise(const PileUpFP420::signal_map_type &) override;
+  PileUpFP420::signal_map_type addNoise(const PileUpFP420::signal_map_type &) override;
   void setNumPixels(int in) { numPixels = in; }
   void setThreshold(float in) { threshold = in; }
 

--- a/SimRomanPot/SimFP420/interface/GaussNoiseProducerFP420.h
+++ b/SimRomanPot/SimFP420/interface/GaussNoiseProducerFP420.h
@@ -4,13 +4,11 @@
 #include <map>
 
 class GaussNoiseProducerFP420 {
-
 public:
   GaussNoiseProducerFP420() {}
   ~GaussNoiseProducerFP420() {}
 
-  void generate(int NumberOfchannels, float threshold, float noiseRMS,
-                std::map<int, float, std::less<int>> &theMap);
+  void generate(int NumberOfchannels, float threshold, float noiseRMS, std::map<int, float, std::less<int>> &theMap);
 };
 
 #endif

--- a/SimRomanPot/SimFP420/interface/HitDigitizerFP420.h
+++ b/SimRomanPot/SimFP420/interface/HitDigitizerFP420.h
@@ -20,8 +20,7 @@ public:
   // HitDigitizerFP420(const edm::ParameterSet& conf, const ElectrodGeomDetUnit
   // *det); HitDigitizerFP420(float in, float inp, float inpx, float inpy,float
   // ild,float ildx,float ildy);
-  HitDigitizerFP420(float in, float ild, float ildx, float ildy, float in0,
-                    float in2, float in3, int verbosity);
+  HitDigitizerFP420(float in, float ild, float ildx, float ildy, float in0, float in2, float in3, int verbosity);
   // HitDigitizerFP420(float in, float inp, float inpx, float inpy);
 
   ~HitDigitizerFP420();
@@ -47,8 +46,7 @@ public:
   // IChargeFP420* getInduceChargeOnElectrods(){return theIChargeFP420;}
 
   //  hit_map_type processHit(const PSimHit&, G4ThreeVector, int, int, double);
-  hit_map_type processHit(const PSimHit &, const G4ThreeVector &, int, int,
-                          double, int, double, double, int);
+  hit_map_type processHit(const PSimHit &, const G4ThreeVector &, int, int, double, int, double, double, int);
 
 private:
   CDividerFP420 *theCDividerFP420;
@@ -71,7 +69,7 @@ private:
 
   //  typedef GloballyPositioned<double>      Frame;  //  AZ
 
-  float tanLorentzAnglePerTesla; // Lorentz angle tangent per Tesla
+  float tanLorentzAnglePerTesla;  // Lorentz angle tangent per Tesla
 };
 
 #endif

--- a/SimRomanPot/SimFP420/interface/IChargeFP420.h
+++ b/SimRomanPot/SimFP420/interface/IChargeFP420.h
@@ -11,7 +11,6 @@ public:
   typedef std::map<int, float, std::less<int>> hit_map_type;
 
   virtual ~IChargeFP420() {}
-  virtual hit_map_type induce(const CDrifterFP420::collection_type &, int,
-                              double, int, double, int, int) = 0;
+  virtual hit_map_type induce(const CDrifterFP420::collection_type &, int, double, int, double, int, int) = 0;
 };
 #endif

--- a/SimRomanPot/SimFP420/interface/InduceChargeFP420.h
+++ b/SimRomanPot/SimFP420/interface/InduceChargeFP420.h
@@ -16,9 +16,12 @@ public:
   //
   //
   IChargeFP420::hit_map_type induce(const CDrifterFP420::collection_type &,
-                                    int numStrips, double localPitch,
-                                    int numStripsW, double localPitchW,
-                                    int xytype, int verbosity) override;
+                                    int numStrips,
+                                    double localPitch,
+                                    int numStripsW,
+                                    double localPitchW,
+                                    int xytype,
+                                    int verbosity) override;
   //
   //
 private:

--- a/SimRomanPot/SimFP420/interface/LandauFP420.h
+++ b/SimRomanPot/SimFP420/interface/LandauFP420.h
@@ -56,9 +56,8 @@ public:
 
   // momentum in MeV/c, mass in MeV, tmax (delta cut) in MeV,
   // length in mm, meanLoss eloss in MeV.
-  double SampleFluctuations(const double momentum, const double mass,
-                            double &tmax, const double length,
-                            const double meanLoss);
+  double SampleFluctuations(
+      const double momentum, const double mass, double &tmax, const double length, const double meanLoss);
 
   // G4double Dispersion(    const G4Material*,
   //                        const G4DynamicParticle*,

--- a/SimRomanPot/SimFP420/interface/PileUpFP420.h
+++ b/SimRomanPot/SimFP420/interface/PileUpFP420.h
@@ -8,19 +8,15 @@ class SimHit;
 
 // Class which takes the responses from each SimHit and piles-up them.
 class PileUpFP420 {
-
 public:
   typedef float Amplitude;
   typedef std::map<int, Amplitude, std::less<int>> signal_map_type;
-  typedef std::map<int, std::vector<std::pair<const PSimHit *, Amplitude>>,
-                   std::less<int>>
-      HitToDigisMapType;
+  typedef std::map<int, std::vector<std::pair<const PSimHit *, Amplitude>>, std::less<int>> HitToDigisMapType;
 
   virtual ~PileUpFP420() {}
 
   PileUpFP420() { reset(); }
-  virtual void add(const HitDigitizerFP420::hit_map_type &, const PSimHit &hit,
-                   int);
+  virtual void add(const HitDigitizerFP420::hit_map_type &, const PSimHit &hit, int);
   void reset() {
     resetLink();
     resetSignal();

--- a/SimRomanPot/SimFP420/interface/ZeroSuppressFP420.h
+++ b/SimRomanPot/SimFP420/interface/ZeroSuppressFP420.h
@@ -13,8 +13,7 @@ public:
   /* calculates the lower and high signal thresholds using the noise */
   void initParams(const edm::ParameterSet &conf_);
 
-  ZSuppressFP420::DigitalMapType zeroSuppress(const DigitalMapType &,
-                                              int) override;
+  ZSuppressFP420::DigitalMapType zeroSuppress(const DigitalMapType &, int) override;
 
   ZSuppressFP420::DigitalMapType trkFEDclusterizer(const DigitalMapType &, int);
 

--- a/SimRomanPot/SimFP420/plugins/DigitizerFP420.cc
+++ b/SimRomanPot/SimFP420/plugins/DigitizerFP420.cc
@@ -59,87 +59,81 @@
 using namespace std;
 
 namespace cms {
-DigitizerFP420::DigitizerFP420(const edm::ParameterSet &conf)
-    : conf_(conf), stripDigitizer_(new FP420DigiMain(conf)) {
+  DigitizerFP420::DigitizerFP420(const edm::ParameterSet &conf)
+      : conf_(conf), stripDigitizer_(new FP420DigiMain(conf)) {
+    std::string alias(conf.getParameter<std::string>("@module_label"));
 
-  std::string alias(conf.getParameter<std::string>("@module_label"));
+    //  produces<edm::DetSetVector<HDigiFP420> >().setBranchAlias( alias );
+    //  produces<edm::DetSetVector<HDigiFP420SimLink> >().setBranchAlias ( alias +
+    //  "hDigiFP420SimLink");
+    produces<DigiCollectionFP420>().setBranchAlias(alias);
 
-  //  produces<edm::DetSetVector<HDigiFP420> >().setBranchAlias( alias );
-  //  produces<edm::DetSetVector<HDigiFP420SimLink> >().setBranchAlias ( alias +
-  //  "hDigiFP420SimLink");
-  produces<DigiCollectionFP420>().setBranchAlias(alias);
+    trackerContainers.clear();
+    trackerContainers = conf.getParameter<std::vector<std::string>>("ROUList");
 
-  trackerContainers.clear();
-  trackerContainers = conf.getParameter<std::vector<std::string>>("ROUList");
+    verbosity = conf_.getUntrackedParameter<int>("VerbosityLevel");
+    dn0 = conf_.getParameter<int>("NumberFP420Detectors");
+    sn0 = conf_.getParameter<int>("NumberFP420Stations");
+    pn0 = conf_.getParameter<int>("NumberFP420SPlanes");
+    rn0 = 7;
+    // rn0 = 3;
 
-  verbosity = conf_.getUntrackedParameter<int>("VerbosityLevel");
-  dn0 = conf_.getParameter<int>("NumberFP420Detectors");
-  sn0 = conf_.getParameter<int>("NumberFP420Stations");
-  pn0 = conf_.getParameter<int>("NumberFP420SPlanes");
-  rn0 = 7;
-  // rn0 = 3;
+    //  produces<DigiCollectionFP420>();
 
-  //  produces<DigiCollectionFP420>();
+    //  produces<StripDigiCollection>();
+    //   produces<HDigiFP420>();
+    //  produces<edm::DetSetVector<HDigiFP420> >().setBranchAlias( alias );
 
-  //  produces<StripDigiCollection>();
-  //   produces<HDigiFP420>();
-  //  produces<edm::DetSetVector<HDigiFP420> >().setBranchAlias( alias );
+    //  produces<DigiCollectionFP420>();
+    // produces<DigiCollectionFP420>("HDigiFP420");
 
-  //  produces<DigiCollectionFP420>();
-  // produces<DigiCollectionFP420>("HDigiFP420");
+    //  produces<edm::DigiCollectionFP420>();
 
-  //  produces<edm::DigiCollectionFP420>();
+    //   produces<edm::DetSetVector<DigiCollectionFP420> >();
 
-  //   produces<edm::DetSetVector<DigiCollectionFP420> >();
-
-  if (verbosity > 0) {
-    std::cout << "Creating a DigitizerFP420" << std::endl;
-    std::cout << "DigitizerFP420: dn0=" << dn0 << " sn0=" << sn0
-              << " pn0=" << pn0 << " rn0=" << rn0 << std::endl;
-    std::cout << "DigitizerFP420:trackerContainers.size()="
-              << trackerContainers.size() << std::endl;
+    if (verbosity > 0) {
+      std::cout << "Creating a DigitizerFP420" << std::endl;
+      std::cout << "DigitizerFP420: dn0=" << dn0 << " sn0=" << sn0 << " pn0=" << pn0 << " rn0=" << rn0 << std::endl;
+      std::cout << "DigitizerFP420:trackerContainers.size()=" << trackerContainers.size() << std::endl;
+    }
   }
-}
 
-// Virtual destructor needed.
-DigitizerFP420::~DigitizerFP420() {
-  if (verbosity > 0) {
-    std::cout << "Destroying a DigitizerFP420" << std::endl;
+  // Virtual destructor needed.
+  DigitizerFP420::~DigitizerFP420() {
+    if (verbosity > 0) {
+      std::cout << "Destroying a DigitizerFP420" << std::endl;
+    }
+    delete stripDigitizer_;
   }
-  delete stripDigitizer_;
-}
-//  void DigitizerFP420::produce(PSimHitCollection *   theCAFI,
-//  DigiCollectionFP420 & output) {
-void DigitizerFP420::produce(edm::Event &iEvent,
-                             const edm::EventSetup &iSetup) {
-  // be lazy and include the appropriate namespaces
-  using namespace edm;
-  using namespace std;
+  //  void DigitizerFP420::produce(PSimHitCollection *   theCAFI,
+  //  DigiCollectionFP420 & output) {
+  void DigitizerFP420::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+    // be lazy and include the appropriate namespaces
+    using namespace edm;
+    using namespace std;
 
-  if (verbosity > 0) {
-    std::cout << " ===" << std::endl;
-    std::cout << " ============== DigitizerFP420: start   produce= "
-              << std::endl;
-    std::cout << " ===" << std::endl;
-  }
-  // Get input
-  //    std::cout << "DigitizerFP420 start produce" << std::endl;
-  //  edm::ESHandle < ParticleDataTable > pdt;
-  //  iSetup.getData( pdt );
+    if (verbosity > 0) {
+      std::cout << " ===" << std::endl;
+      std::cout << " ============== DigitizerFP420: start   produce= " << std::endl;
+      std::cout << " ===" << std::endl;
+    }
+    // Get input
+    //    std::cout << "DigitizerFP420 start produce" << std::endl;
+    //  edm::ESHandle < ParticleDataTable > pdt;
+    //  iSetup.getData( pdt );
 
-  // Step A: Get Inputs for allTrackerHits
+    // Step A: Get Inputs for allTrackerHits
 
-  edm::Handle<CrossingFrame<PSimHit>> cf_simhit;
-  std::vector<const CrossingFrame<PSimHit> *> cf_simhitvec;
-  for (uint32_t i = 0; i < trackerContainers.size(); i++) {
-    iEvent.getByLabel("mix", trackerContainers[i], cf_simhit);
-    cf_simhitvec.push_back(cf_simhit.product());
-  }
-  std::unique_ptr<MixCollection<PSimHit>> allTrackerHits(
-      new MixCollection<PSimHit>(cf_simhitvec));
+    edm::Handle<CrossingFrame<PSimHit>> cf_simhit;
+    std::vector<const CrossingFrame<PSimHit> *> cf_simhitvec;
+    for (uint32_t i = 0; i < trackerContainers.size(); i++) {
+      iEvent.getByLabel("mix", trackerContainers[i], cf_simhit);
+      cf_simhitvec.push_back(cf_simhit.product());
+    }
+    std::unique_ptr<MixCollection<PSimHit>> allTrackerHits(new MixCollection<PSimHit>(cf_simhitvec));
 
-  // use instead of the previous
-  /*
+    // use instead of the previous
+    /*
         std::cout <<" ============== DigitizerFP420: start loop           1   "
      << std::endl; edm::Handle<CrossingFrame<PSimHit> > xFrame; std::cout <<"
      ============== DigitizerFP420: start loop           2   " << std::endl;
@@ -150,107 +144,100 @@ void DigitizerFP420::produce(edm::Event &iEvent,
      DigitizerFP420: start loop           4   " << std::endl;
   */
 
-  // Loop on PSimHit
+    // Loop on PSimHit
 
-  ///////////////////////////////////////////////////////////////////////
-  // Step C: create empty output collection
-  std::unique_ptr<DigiCollectionFP420> output(new DigiCollectionFP420);
-  //  std::unique_ptr<edm::DetSetVector<HDigiFP420> > outputfinal(new
-  //  edm::DetSetVector<HDigiFP420>(output) );
-  //  std::unique_ptr<edm::DetSetVector<HDigiFP420> > outputfinal(new
-  //  edm::DetSetVector<HDigiFP420>(output) );
-  //  std::unique_ptr<edm::DetSetVector<HDigiFP420SimLink> > outputlink(new
-  //  edm::DetSetVector<HDigiFP420SimLink>(output) );
+    ///////////////////////////////////////////////////////////////////////
+    // Step C: create empty output collection
+    std::unique_ptr<DigiCollectionFP420> output(new DigiCollectionFP420);
+    //  std::unique_ptr<edm::DetSetVector<HDigiFP420> > outputfinal(new
+    //  edm::DetSetVector<HDigiFP420>(output) );
+    //  std::unique_ptr<edm::DetSetVector<HDigiFP420> > outputfinal(new
+    //  edm::DetSetVector<HDigiFP420>(output) );
+    //  std::unique_ptr<edm::DetSetVector<HDigiFP420SimLink> > outputlink(new
+    //  edm::DetSetVector<HDigiFP420SimLink>(output) );
 
-  SimHitMap.clear();
+    SimHitMap.clear();
 
-  // ==================================
-  if (verbosity > 0) {
-    std::cout << " ===" << std::endl;
-    std::cout << " ============== DigitizerFP420: MixCollection treatment= "
-              << std::endl;
-    std::cout << " ===" << std::endl;
-  }
+    // ==================================
+    if (verbosity > 0) {
+      std::cout << " ===" << std::endl;
+      std::cout << " ============== DigitizerFP420: MixCollection treatment= " << std::endl;
+      std::cout << " ===" << std::endl;
+    }
 
-  MixCollection<PSimHit>::iterator isim;
-  for (isim = allTrackerHits->begin(); isim != allTrackerHits->end(); isim++) {
-    unsigned int unitID = (*isim).detUnitId();
-    int det, zside, sector, zmodule;
-    FP420NumberingScheme::unpackFP420Index(unitID, det, zside, sector, zmodule);
-    // below, the continues plane index should be (for even different sensor
-    // index zside)
-    //	unsigned int intindex = packMYIndex(rn0, pn0, sn0, det, zside, sector,
-    // zmodule);
-    unsigned int intindex = FP420NumberingScheme::packMYIndex(
-        rn0, pn0, sn0, det, zside, sector, zmodule);
-    //	int zScale=(rn0-1), sScale = (rn0-1)*(pn0-1), dScale =
-    //(rn0-1)*(pn0-1)*(sn0-1); 	unsigned int intindex = dScale*(det -
-    // 1)+sScale*(sector - 1)+zScale*(zmodule - 1)+zside;
+    MixCollection<PSimHit>::iterator isim;
+    for (isim = allTrackerHits->begin(); isim != allTrackerHits->end(); isim++) {
+      unsigned int unitID = (*isim).detUnitId();
+      int det, zside, sector, zmodule;
+      FP420NumberingScheme::unpackFP420Index(unitID, det, zside, sector, zmodule);
+      // below, the continues plane index should be (for even different sensor
+      // index zside)
+      //	unsigned int intindex = packMYIndex(rn0, pn0, sn0, det, zside, sector,
+      // zmodule);
+      unsigned int intindex = FP420NumberingScheme::packMYIndex(rn0, pn0, sn0, det, zside, sector, zmodule);
+      //	int zScale=(rn0-1), sScale = (rn0-1)*(pn0-1), dScale =
+      //(rn0-1)*(pn0-1)*(sn0-1); 	unsigned int intindex = dScale*(det -
+      // 1)+sScale*(sector - 1)+zScale*(zmodule - 1)+zside;
+
+      if (verbosity > 0) {
+        double losenergy = (*isim).energyLoss();
+        std::cout << " ===" << std::endl;
+        std::cout << " ============== DigitizerFP420:  losenergy= " << losenergy << std::endl;
+        std::cout << " === for intindex = " << intindex << std::endl;
+      }
+      // does not matter which index is used: intindex or unitID - mainly to
+      // collect hits under every index
+      SimHitMap[intindex].push_back((*isim));
+      // for development later one( cal be used another index):
+      //	SimHitMap[unitID].push_back((*isim));
+    }
+    //============================================================================================================================
 
     if (verbosity > 0) {
-      double losenergy = (*isim).energyLoss();
       std::cout << " ===" << std::endl;
-      std::cout << " ============== DigitizerFP420:  losenergy= " << losenergy
-                << std::endl;
-      std::cout << " === for intindex = " << intindex << std::endl;
+      std::cout << " ============== DigitizerFP420: put zero to container " << std::endl;
+      std::cout << " ===" << std::endl;
     }
-    // does not matter which index is used: intindex or unitID - mainly to
-    // collect hits under every index
-    SimHitMap[intindex].push_back((*isim));
-    // for development later one( cal be used another index):
-    //	SimHitMap[unitID].push_back((*isim));
-  }
-  //============================================================================================================================
+    //    put zero to container info from the beginning (important! because not
+    //    any detID is updated with coming of new event     !!!!!!
+    // clean info of container from previous event
+    for (int det = 1; det < dn0; det++) {
+      for (int sector = 1; sector < sn0; sector++) {
+        for (int zmodule = 1; zmodule < pn0; zmodule++) {
+          for (int zside = 1; zside < rn0; zside++) {
+            // intindex is a continues numbering of FP420
+            unsigned int detID = FP420NumberingScheme::packMYIndex(rn0, pn0, sn0, det, zside, sector, zmodule);
+            // int zScale=(rn0-1), sScale = (rn0-1)*(pn0-1), dScale =
+            // (rn0-1)*(pn0-1)*(sn0-1); unsigned int detID = dScale*(det -
+            // 1)+sScale*(sector - 1)+zScale*(zmodule - 1)+zside;
+            std::vector<HDigiFP420> collector;
+            collector.clear();
+            DigiCollectionFP420::Range inputRange;
+            inputRange.first = collector.begin();
+            inputRange.second = collector.end();
+            output->putclear(inputRange, detID);
+          }  // for
+        }    // for
+      }      // for
+    }        // for
+    //                                                                                                                      !!!!!!
+    // if we want to keep Digi container/Collection for one event uncomment the
+    // line below and vice versa
+    output->clear();  // container_.clear() --> start from the beginning of the
+                      // container
 
-  if (verbosity > 0) {
-    std::cout << " ===" << std::endl;
-    std::cout << " ============== DigitizerFP420: put zero to container "
-              << std::endl;
-    std::cout << " ===" << std::endl;
-  }
-  //    put zero to container info from the beginning (important! because not
-  //    any detID is updated with coming of new event     !!!!!!
-  // clean info of container from previous event
-  for (int det = 1; det < dn0; det++) {
-    for (int sector = 1; sector < sn0; sector++) {
-      for (int zmodule = 1; zmodule < pn0; zmodule++) {
-        for (int zside = 1; zside < rn0; zside++) {
-          // intindex is a continues numbering of FP420
-          unsigned int detID = FP420NumberingScheme::packMYIndex(
-              rn0, pn0, sn0, det, zside, sector, zmodule);
-          // int zScale=(rn0-1), sScale = (rn0-1)*(pn0-1), dScale =
-          // (rn0-1)*(pn0-1)*(sn0-1); unsigned int detID = dScale*(det -
-          // 1)+sScale*(sector - 1)+zScale*(zmodule - 1)+zside;
-          std::vector<HDigiFP420> collector;
-          collector.clear();
-          DigiCollectionFP420::Range inputRange;
-          inputRange.first = collector.begin();
-          inputRange.second = collector.end();
-          output->putclear(inputRange, detID);
-        } // for
-      }   // for
-    }     // for
-  }       // for
-  //                                                                                                                      !!!!!!
-  // if we want to keep Digi container/Collection for one event uncomment the
-  // line below and vice versa
-  output->clear(); // container_.clear() --> start from the beginning of the
-                   // container
+    //============================================================================================================================================
 
-  //============================================================================================================================================
+    if (verbosity > 0) {
+      std::cout << " ===" << std::endl;
+      std::cout << " ============== DigitizerFP420: start loop over det iu " << std::endl;
+      std::cout << " ============== DigitizerFP420: SimHitMap.size()= " << SimHitMap.size() << std::endl;
+      std::cout << " ===" << std::endl;
+    }
+    bool first = true;
 
-  if (verbosity > 0) {
-    std::cout << " ===" << std::endl;
-    std::cout << " ============== DigitizerFP420: start loop over det iu "
-              << std::endl;
-    std::cout << " ============== DigitizerFP420: SimHitMap.size()= "
-              << SimHitMap.size() << std::endl;
-    std::cout << " ===" << std::endl;
-  }
-  bool first = true;
-
-  /////for development later one
-  /*
+    /////for development later one
+    /*
   if(verbosity>0) std::cout <<"=======  DigitizerFP420:  SimHitMap size = " <<
   SimHitMap.size() << std::endl; for(unsigned int i = 0; i < SimHitMap.size();
   i++ ) {
@@ -269,66 +256,58 @@ void DigitizerFP420::produce(edm::Event &iEvent,
     }
   }
 */
-  ////////////////////////
-  //============================================================================================================================================
-  // new:   <------
-  for (unsigned int i = 0; i < SimHitMap.size(); i++) {
-    vector<PSimHit>::const_iterator simHitIter = SimHitMap[i].begin();
-    vector<PSimHit>::const_iterator simHitIterEnd = SimHitMap[i].end();
-    for (; simHitIter != simHitIterEnd; ++simHitIter) {
-      const PSimHit ihit = *simHitIter;
-      unsigned int unitID = ihit.detUnitId();
-      if (verbosity > 0 || verbosity == -50)
-        std::cout << " ====== DigitizerFP420: unitID= " << unitID
-                  << "Hit number i=  " << i << std::endl;
-      int det, zside, sector, zmodule;
-      FP420NumberingScheme::unpackFP420Index(unitID, det, zside, sector,
-                                             zmodule);
+    ////////////////////////
+    //============================================================================================================================================
+    // new:   <------
+    for (unsigned int i = 0; i < SimHitMap.size(); i++) {
+      vector<PSimHit>::const_iterator simHitIter = SimHitMap[i].begin();
+      vector<PSimHit>::const_iterator simHitIterEnd = SimHitMap[i].end();
+      for (; simHitIter != simHitIterEnd; ++simHitIter) {
+        const PSimHit ihit = *simHitIter;
+        unsigned int unitID = ihit.detUnitId();
+        if (verbosity > 0 || verbosity == -50)
+          std::cout << " ====== DigitizerFP420: unitID= " << unitID << "Hit number i=  " << i << std::endl;
+        int det, zside, sector, zmodule;
+        FP420NumberingScheme::unpackFP420Index(unitID, det, zside, sector, zmodule);
 
-      unsigned int iu = FP420NumberingScheme::packMYIndex(
-          rn0, pn0, sn0, det, zside, sector, zmodule);
-      if (verbosity > 0 || verbosity == -50)
-        std::cout << "for Hits iu = " << iu << " sector = " << sector
-                  << " zmodule = " << zmodule << " zside = " << zside
-                  << "  det=" << det << std::endl;
-      //   int zScale=(rn0-1), sScale = (rn0-1)*(pn0-1), dScale =
-      //   (rn0-1)*(pn0-1)*(sn0-1);
-      //  unsigned int iu = dScale*(det - 1)+sScale*(sector - 1)+zScale*(zmodule
-      //  - 1)+zside;
+        unsigned int iu = FP420NumberingScheme::packMYIndex(rn0, pn0, sn0, det, zside, sector, zmodule);
+        if (verbosity > 0 || verbosity == -50)
+          std::cout << "for Hits iu = " << iu << " sector = " << sector << " zmodule = " << zmodule
+                    << " zside = " << zside << "  det=" << det << std::endl;
+        //   int zScale=(rn0-1), sScale = (rn0-1)*(pn0-1), dScale =
+        //   (rn0-1)*(pn0-1)*(sn0-1);
+        //  unsigned int iu = dScale*(det - 1)+sScale*(sector - 1)+zScale*(zmodule
+        //  - 1)+zside;
 
-      if (verbosity > 0) {
-        unsigned int index =
-            FP420NumberingScheme::packFP420Index(det, zside, sector, zmodule);
-        std::cout << " DigitizerFP420:       index = " << index
-                  << " iu = " << iu << std::endl;
-      }
+        if (verbosity > 0) {
+          unsigned int index = FP420NumberingScheme::packFP420Index(det, zside, sector, zmodule);
+          std::cout << " DigitizerFP420:       index = " << index << " iu = " << iu << std::endl;
+        }
 
-      //    GlobalVector bfield=pSetup->inTesla((*iu)->surface().position());
-      //      CLHEP::Hep3Vector Bfieldloc=bfield();
-      G4ThreeVector bfield(0., 0., 0.0);
-      //	G4ThreeVector bfield(  0.5,  0.5,  1.0  );
+        //    GlobalVector bfield=pSetup->inTesla((*iu)->surface().position());
+        //      CLHEP::Hep3Vector Bfieldloc=bfield();
+        G4ThreeVector bfield(0., 0., 0.0);
+        //	G4ThreeVector bfield(  0.5,  0.5,  1.0  );
 
-      if (verbosity > 0) {
-        std::cout << " ===" << std::endl;
-        std::cout << " ============== DigitizerFP420:  call run for iu= " << iu
-                  << std::endl;
-        std::cout << " ===" << std::endl;
-      }
-      collector.clear();
+        if (verbosity > 0) {
+          std::cout << " ===" << std::endl;
+          std::cout << " ============== DigitizerFP420:  call run for iu= " << iu << std::endl;
+          std::cout << " ===" << std::endl;
+        }
+        collector.clear();
 
-      collector = stripDigitizer_->run(SimHitMap[iu], bfield,
-                                       iu); // stripDigitizer_.run...  return
-      //						 ,sScale
+        collector = stripDigitizer_->run(SimHitMap[iu], bfield,
+                                         iu);  // stripDigitizer_.run...  return
+        //						 ,sScale
 
-      if (verbosity > 0) {
-        std::cout << " ===" << std::endl;
-        std::cout << " ===" << std::endl;
-        std::cout << "=======  DigitizerFP420:  collector size = "
-                  << collector.size() << std::endl;
-        std::cout << " ===" << std::endl;
-        std::cout << " ===" << std::endl;
-      }
-      /*
+        if (verbosity > 0) {
+          std::cout << " ===" << std::endl;
+          std::cout << " ===" << std::endl;
+          std::cout << "=======  DigitizerFP420:  collector size = " << collector.size() << std::endl;
+          std::cout << " ===" << std::endl;
+          std::cout << " ===" << std::endl;
+        }
+        /*
 
       std::vector<HDigiFP420> collector;
       collector.clear();
@@ -337,41 +316,41 @@ void DigitizerFP420::produce(edm::Event &iEvent,
       inputRange.second = collector.end();
       output->putclear(inputRange,detID);
       */
-      if (!collector.empty()) {
-        if (verbosity > 0) {
-          std::cout << "         ============= DigitizerFP420:collector "
-                       "start!!!!!!!!!!!!!!"
-                    << std::endl;
-        }
-        DigiCollectionFP420::Range outputRange;
-        outputRange.first = collector.begin();
-        outputRange.second = collector.end();
+        if (!collector.empty()) {
+          if (verbosity > 0) {
+            std::cout << "         ============= DigitizerFP420:collector "
+                         "start!!!!!!!!!!!!!!"
+                      << std::endl;
+          }
+          DigiCollectionFP420::Range outputRange;
+          outputRange.first = collector.begin();
+          outputRange.second = collector.end();
 
-        if (first) {
-          // use it only if ClusterCollectionFP420 is the ClusterCollection of
-          // one event, otherwise, do not use (loose 1st cl. of 1st event only)
-          first = false;
-          unsigned int detID0 = 0;
-          output->put(outputRange, detID0); // !!! put into adress 0 for detID
-                                            // which will not be used never
-        }                                   // if ( first )
+          if (first) {
+            // use it only if ClusterCollectionFP420 is the ClusterCollection of
+            // one event, otherwise, do not use (loose 1st cl. of 1st event only)
+            first = false;
+            unsigned int detID0 = 0;
+            output->put(outputRange, detID0);  // !!! put into adress 0 for detID
+                                               // which will not be used never
+          }                                    // if ( first )
 
-        // put !!!
-        output->put(outputRange, iu);
+          // put !!!
+          output->put(outputRange, iu);
 
-      } // if(collector.size()>0
+        }  // if(collector.size()>0
 
-      //   }   // for
-      // }   // for
-      //	}   // for
-      // }   // for
+        //   }   // for
+        // }   // for
+        //	}   // for
+        // }   // for
 
-    } // for
-  }   // for
+      }  // for
+    }    // for
 
-  // END
+    // END
 
-  /*
+    /*
   if(verbosity>0) {
     std::vector<HDigiFP420> theAllDigis;
     theAllDigis.clear();
@@ -393,88 +372,77 @@ void DigitizerFP420::produce(edm::Event &iEvent,
     }// for
   }
 */
-  if (verbosity == -50) {
-    //     check of access to the collector:
-    for (int det = 1; det < dn0; det++) {
-      for (int sector = 1; sector < sn0; sector++) {
-        for (int zmodule = 1; zmodule < pn0; zmodule++) {
-          for (int zside = 1; zside < rn0; zside++) {
-            unsigned int iu = FP420NumberingScheme::packMYIndex(
-                rn0, pn0, sn0, det, zside, sector, zmodule);
-            int layer = FP420NumberingScheme::unpackLayerIndex(rn0, zside);
-            int orient = FP420NumberingScheme::unpackOrientation(rn0, zside);
-            std::cout << "****DigitizerFP420:check2" << std::endl;
-            //	std::cout <<" iu = " << iu <<" sector = " << sector <<" zmodule
-            //= " << zmodule <<" zside = " << zside << "  det=" << det <<
-            // std::endl; 	std::cout <<" layer = " << layer <<" orient = "
-            // << orient << std::endl;
-            int newdet, newzside, newsector, newzmodule;
-            FP420NumberingScheme::unpackMYIndex(
-                iu, rn0, pn0, sn0, newdet, newzside, newsector, newzmodule);
-            std::cout << " newdet = " << newdet << " newsector = " << newsector
-                      << " newzmodule = " << newzmodule
-                      << " newzside = " << newzside << std::endl;
+    if (verbosity == -50) {
+      //     check of access to the collector:
+      for (int det = 1; det < dn0; det++) {
+        for (int sector = 1; sector < sn0; sector++) {
+          for (int zmodule = 1; zmodule < pn0; zmodule++) {
+            for (int zside = 1; zside < rn0; zside++) {
+              unsigned int iu = FP420NumberingScheme::packMYIndex(rn0, pn0, sn0, det, zside, sector, zmodule);
+              int layer = FP420NumberingScheme::unpackLayerIndex(rn0, zside);
+              int orient = FP420NumberingScheme::unpackOrientation(rn0, zside);
+              std::cout << "****DigitizerFP420:check2" << std::endl;
+              //	std::cout <<" iu = " << iu <<" sector = " << sector <<" zmodule
+              //= " << zmodule <<" zside = " << zside << "  det=" << det <<
+              // std::endl; 	std::cout <<" layer = " << layer <<" orient = "
+              // << orient << std::endl;
+              int newdet, newzside, newsector, newzmodule;
+              FP420NumberingScheme::unpackMYIndex(iu, rn0, pn0, sn0, newdet, newzside, newsector, newzmodule);
+              std::cout << " newdet = " << newdet << " newsector = " << newsector << " newzmodule = " << newzmodule
+                        << " newzside = " << newzside << std::endl;
 
-            collector.clear();
-            DigiCollectionFP420::Range outputRange;
-            //	outputRange = output->get(iu);
-            outputRange = output->get(iu);
+              collector.clear();
+              DigiCollectionFP420::Range outputRange;
+              //	outputRange = output->get(iu);
+              outputRange = output->get(iu);
 
-            // fill output in collector vector (for may be sorting? or other
-            // checks)
-            std::vector<HDigiFP420> collector;
-            //  collector.clear();
-            DigiCollectionFP420::ContainerIterator sort_begin =
-                outputRange.first;
-            DigiCollectionFP420::ContainerIterator sort_end =
-                outputRange.second;
-            for (; sort_begin != sort_end; ++sort_begin) {
-              collector.push_back(*sort_begin);
-            } // for
+              // fill output in collector vector (for may be sorting? or other
+              // checks)
+              std::vector<HDigiFP420> collector;
+              //  collector.clear();
+              DigiCollectionFP420::ContainerIterator sort_begin = outputRange.first;
+              DigiCollectionFP420::ContainerIterator sort_end = outputRange.second;
+              for (; sort_begin != sort_end; ++sort_begin) {
+                collector.push_back(*sort_begin);
+              }  // for
               //  std::sort(collector.begin(),collector.end());
-            std::cout << " ===" << std::endl;
-            std::cout << "======  collector size = " << collector.size()
-                      << std::endl;
-            if (!collector.empty()) {
-              std::cout << " iu = " << iu << " sector = " << sector
-                        << " zmodule = " << zmodule << " zside = " << zside
-                        << "  det=" << det << " layer = " << layer
-                        << " orient = " << orient << std::endl;
               std::cout << " ===" << std::endl;
-            }
-            vector<HDigiFP420>::const_iterator simHitIter = collector.begin();
-            vector<HDigiFP420>::const_iterator simHitIterEnd = collector.end();
-            for (; simHitIter != simHitIterEnd; ++simHitIter) {
-              const HDigiFP420 istrip = *simHitIter;
-              std::cout << " strip number=" << istrip.strip()
-                        << "  adc=" << istrip.adc() << std::endl;
-              std::cout << " channel =" << istrip.channel() << " V "
-                        << istrip.stripV() << " VW " << istrip.stripVW()
-                        << std::endl;
-              std::cout << " ===" << std::endl;
-              std::cout << " ===" << std::endl;
-              std::cout
-                  << " ==================================================="
-                  << std::endl;
-            }
+              std::cout << "======  collector size = " << collector.size() << std::endl;
+              if (!collector.empty()) {
+                std::cout << " iu = " << iu << " sector = " << sector << " zmodule = " << zmodule
+                          << " zside = " << zside << "  det=" << det << " layer = " << layer << " orient = " << orient
+                          << std::endl;
+                std::cout << " ===" << std::endl;
+              }
+              vector<HDigiFP420>::const_iterator simHitIter = collector.begin();
+              vector<HDigiFP420>::const_iterator simHitIterEnd = collector.end();
+              for (; simHitIter != simHitIterEnd; ++simHitIter) {
+                const HDigiFP420 istrip = *simHitIter;
+                std::cout << " strip number=" << istrip.strip() << "  adc=" << istrip.adc() << std::endl;
+                std::cout << " channel =" << istrip.channel() << " V " << istrip.stripV() << " VW " << istrip.stripVW()
+                          << std::endl;
+                std::cout << " ===" << std::endl;
+                std::cout << " ===" << std::endl;
+                std::cout << " ===================================================" << std::endl;
+              }
 
-            //==================================
+              //==================================
 
-          } // for
-        }   // for
-      }     // for
-    }       // for
+            }  // for
+          }    // for
+        }      // for
+      }        // for
 
-    //     end of check of access to the strip collection
+      //     end of check of access to the strip collection
 
-  } // if(verbosity
+    }  // if(verbosity
 
-  // Step D: write output to file
-  if (verbosity > 0) {
-    std::cout << "DigitizerFP420 recoutput" << std::endl;
-  }
-  // Step D: write output to file
-  iEvent.put(std::move(output));
-} // produce
+    // Step D: write output to file
+    if (verbosity > 0) {
+      std::cout << "DigitizerFP420 recoutput" << std::endl;
+    }
+    // Step D: write output to file
+    iEvent.put(std::move(output));
+  }  // produce
 
-} // namespace cms
+}  // namespace cms

--- a/SimRomanPot/SimFP420/src/ChargeDividerFP420.cc
+++ b/SimRomanPot/SimFP420/src/ChargeDividerFP420.cc
@@ -18,42 +18,38 @@ using namespace std;
 
 // DigitizerFP420::DigitizerFP420(const edm::ParameterSet&
 // conf):conf_(conf),stripDigitizer_(new FP420DigiMain(conf))
-ChargeDividerFP420::ChargeDividerFP420(double pit, double az420, double azD2,
-                                       double azD3, int ver) {
-
+ChargeDividerFP420::ChargeDividerFP420(double pit, double az420, double azD2, double azD3, int ver) {
   verbosity = ver;
   //                           pit - is really moduleThickness here !!!
   if (verbosity > 0) {
     std::cout << "ChargeDividerFP420.h: constructor" << std::endl;
-    std::cout << "peakMode = " << peakMode
-              << "fluctuateCharge=   " << fluctuateCharge
-              << "chargedivisionsPerHit = " << chargedivisionsPerHit
-              << "deltaCut=   " << deltaCut << std::endl;
+    std::cout << "peakMode = " << peakMode << "fluctuateCharge=   " << fluctuateCharge
+              << "chargedivisionsPerHit = " << chargedivisionsPerHit << "deltaCut=   " << deltaCut << std::endl;
   }
 
   // Run APV in peak instead of deconvolution mode, which degrades the time
   // resolution
   //  peakMode=true ; //     APVpeakmode
-  peakMode = false; //  peakMode=true -->  APVconvolutionmode
-  decoMode = false; //  decoMode=true -->  deconvolution mode
+  peakMode = false;  //  peakMode=true -->  APVconvolutionmode
+  decoMode = false;  //  decoMode=true -->  deconvolution mode
   // Enable interstrip Landau fluctuations within a cluster.
   fluctuateCharge = true;
 
   // Number of segments per strip into which charge is divided during
   // simulation. If large the precision of simulation improves.
-  chargedivisionsPerHit = 10; // = or =20
+  chargedivisionsPerHit = 10;  // = or =20
 
   // delta cutoff in MeV, has to be same as in OSCAR (0.120425 MeV corresponding
   // // to 100um range for electrons)
   // SimpleConfigurable<double>  ChargeDividerFP420::deltaCut(0.120425,
-  deltaCut = 0.120425; //  DeltaProductionCut
+  deltaCut = 0.120425;  //  DeltaProductionCut
 
-  pitchcur = pit; // pitchcur - is really moduleThickness here !!!
+  pitchcur = pit;  // pitchcur - is really moduleThickness here !!!
 
   // but position before Stations:
-  z420 = az420; // dist between centers of 1st and 2nd stations
-  zD2 = azD2;   // dist between centers of 1st and 2nd stations
-  zD3 = azD3;   // dist between centers of 1st and 3rd stations
+  z420 = az420;  // dist between centers of 1st and 2nd stations
+  zD2 = azD2;    // dist between centers of 1st and 2nd stations
+  zD3 = azD3;    // dist between centers of 1st and 3rd stations
 
   //                                                                                                                           .
   //                                                                                                                           .
@@ -63,9 +59,7 @@ ChargeDividerFP420::ChargeDividerFP420(double pit, double az420, double azD2,
   //                   8*13.3+ 2*6 = 118.4 center .
   //                                                                                                                           .
   // zStationBegPos[0] = -150. - (118.4+10.)/2 + z420; // 10. -arbitrary
-  zStationBegPos[0] =
-      -40. +
-      z420; // 5 superplanes per station 79.7mm: -40.- left edge of Station
+  zStationBegPos[0] = -40. + z420;  // 5 superplanes per station 79.7mm: -40.- left edge of Station
   zStationBegPos[1] = zStationBegPos[0] + zD2;
   zStationBegPos[2] = zStationBegPos[0] + zD3;
   zStationBegPos[3] = zStationBegPos[0] + 2 * zD3;
@@ -77,8 +71,7 @@ ChargeDividerFP420::~ChargeDividerFP420() {
   //    std::cout << "Destroying a ChargeDividerFP420" << std::endl;
   //  }
 }
-CDividerFP420::ionization_type
-ChargeDividerFP420::divide(const PSimHit &hit, const double &pitchcur) {
+CDividerFP420::ionization_type ChargeDividerFP420::divide(const PSimHit &hit, const double &pitchcur) {
   // !!!
   //                                       pitchcur - is really moduleThickness
   //                                       here !!!
@@ -94,16 +87,13 @@ ChargeDividerFP420::divide(const PSimHit &hit, const double &pitchcur) {
   // direction/direction.mag() - cosines of direction
 
   if (verbosity > 0) {
-    std::cout << " CDividerFP420::ChargeDividerFP420:divide: direction= "
-              << direction << std::endl;
-    std::cout << " CDividerFP420::ChargeDividerFP420:divide: direction.mag = "
-              << direction.mag() << std::endl;
+    std::cout << " CDividerFP420::ChargeDividerFP420:divide: direction= " << direction << std::endl;
+    std::cout << " CDividerFP420::ChargeDividerFP420:divide: direction.mag = " << direction.mag() << std::endl;
     std::cout << " obtained as ExitLocalP = " << hit.exitPoint() << "  -  "
               << "  EntryLocalP = " << hit.entryPoint() << std::endl;
     std::cout << "  pitchcur= " << pitchcur << std::endl;
     std::cout << "  peakMode = " << peakMode << "  decoMode = " << decoMode
-              << "  fluctuateCharge=   " << fluctuateCharge
-              << "  chargedivisionsPerHit = " << chargedivisionsPerHit
+              << "  fluctuateCharge=   " << fluctuateCharge << "  chargedivisionsPerHit = " << chargedivisionsPerHit
               << "  deltaCut=   " << deltaCut << std::endl;
   }
 
@@ -114,19 +104,17 @@ ChargeDividerFP420::divide(const PSimHit &hit, const double &pitchcur) {
       //    (int)(1+chargedivisionsPerHit*fabs(direction.z())/pitchcur); //
       //    equidistant in Z, but why?
 
-      (int)(1 + chargedivisionsPerHit * direction.mag() /
-                    pitchcur); // equidistant over hit path
+      (int)(1 + chargedivisionsPerHit * direction.mag() / pitchcur);  // equidistant over hit path
 
   if (verbosity > 0) {
     std::cout << "NumberOfSegmentation= " << NumberOfSegmentation << std::endl;
   }
 
-  float eLoss = hit.energyLoss(); // Eloss in GeV
+  float eLoss = hit.energyLoss();  // Eloss in GeV
   //  float eLoss = hit.getEnergyLoss();  // Eloss in GeV
 
   if (verbosity > 0) {
-    std::cout << "CDividerFP420::ChargeDividerFP420:divide: eLoss=  " << eLoss
-              << std::endl;
+    std::cout << "CDividerFP420::ChargeDividerFP420:divide: eLoss=  " << eLoss << std::endl;
   }
 
   //
@@ -135,8 +123,7 @@ ChargeDividerFP420::divide(const PSimHit &hit, const double &pitchcur) {
   //     (DeconvolutionShape)
   float decSignal = TimeResponse(hit);
   if (verbosity > 0) {
-    std::cout << "CDividerFP420::ChargeDividerFP420:divide: decSignal=  "
-              << decSignal << std::endl;
+    std::cout << "CDividerFP420::ChargeDividerFP420:divide: decSignal=  " << decSignal << std::endl;
   }
 
   ionization_type _ionization_points;
@@ -158,47 +145,41 @@ ChargeDividerFP420::divide(const PSimHit &hit, const double &pitchcur) {
     //    float momentum = hit.getPabs();
     int pid = hit.particleType();
     float momentum = hit.pabs();
-    float length = direction.mag(); // length or (size of path) of the hit;
+    float length = direction.mag();  // length or (size of path) of the hit;
 
     if (verbosity > 0) {
-      std::cout << "pid= " << pid << "momentum= " << momentum
-                << "eLoss= " << eLoss << "length= " << length << std::endl;
+      std::cout << "pid= " << pid << "momentum= " << momentum << "eLoss= " << eLoss << "length= " << length
+                << std::endl;
     }
-    fluctuateEloss(pid, momentum, eLoss, length, NumberOfSegmentation,
-                   eLossVector);
+    fluctuateEloss(pid, momentum, eLoss, length, NumberOfSegmentation, eLossVector);
   }
 
   for (int i = 0; i != NumberOfSegmentation; ++i) {
     if (fluctuateCharge) {
       energy = eLossVector[i] * decSignal / eLoss;
-      EnergySegmentFP420 edu(
-          energy,
-          hit.entryPoint() +
-              float((i + 0.5) / NumberOfSegmentation) *
-                  direction); // take energy value from vector eLossVector
+      EnergySegmentFP420 edu(energy,
+                             hit.entryPoint() + float((i + 0.5) / NumberOfSegmentation) *
+                                                    direction);  // take energy value from vector eLossVector
       //   EnergySegmentFP420
       //   edu(energy,hit.getEntryLocalP()+float((i+0.5)/NumberOfSegmentation)*direction);//take
       //   energy value from vector eLossVector
-      _ionization_points[i] = edu; // save
+      _ionization_points[i] = edu;  // save
     } else {
       energy = decSignal / float(NumberOfSegmentation);
-      EnergySegmentFP420 edu(energy,
-                             hit.entryPoint() +
-                                 float((i + 0.5) / NumberOfSegmentation) *
-                                     direction); // take energy value from eLoss
-                                                 // average over n.segments
+      EnergySegmentFP420 edu(
+          energy,
+          hit.entryPoint() + float((i + 0.5) / NumberOfSegmentation) * direction);  // take energy value from eLoss
+                                                                                    // average over n.segments
       // EnergySegmentFP420
       // edu(energy,hit.getEntryLocalP()+float((i+0.5)/NumberOfSegmentation)*direction);//take
       // energy value from eLoss average over n.segments
-      _ionization_points[i] = edu; // save
+      _ionization_points[i] = edu;  // save
     }
   }
 
   if (verbosity > 0) {
-    std::cout << "CDividerFP420::ChargeDividerFP420:divide:  !!!  RESULT !!!"
-              << std::endl;
-    std::cout << " _ionization_points size = " << _ionization_points.size()
-              << std::endl;
+    std::cout << "CDividerFP420::ChargeDividerFP420:divide:  !!!  RESULT !!!" << std::endl;
+    std::cout << " _ionization_points size = " << _ionization_points.size() << std::endl;
     for (unsigned int i = 0; i < _ionization_points.size(); ++i) {
       std::cout << " eLossVector[i] i = " << i << eLossVector[i] << std::endl;
     }
@@ -208,24 +189,22 @@ ChargeDividerFP420::divide(const PSimHit &hit, const double &pitchcur) {
   return _ionization_points;
 }
 
-void ChargeDividerFP420::fluctuateEloss(int pid, float particleMomentum,
-                                        float eloss, float length,
-                                        int NumberOfSegs, float elossVector[]) {
-
+void ChargeDividerFP420::fluctuateEloss(
+    int pid, float particleMomentum, float eloss, float length, int NumberOfSegs, float elossVector[]) {
   if (verbosity > 0) {
-    std::cout << "fluctuateEloss: eloss=  " << eloss << "length=  " << length
-              << "NumberOfSegs=  " << NumberOfSegs << std::endl;
+    std::cout << "fluctuateEloss: eloss=  " << eloss << "length=  " << length << "NumberOfSegs=  " << NumberOfSegs
+              << std::endl;
   }
 
   //  double particleMass = 139.57; // Mass in MeV, Assume pion
-  double particleMass = 938.271; // Mass in MeV, Assume proton   ----  AZ
+  double particleMass = 938.271;  // Mass in MeV, Assume proton   ----  AZ
   //  if( particleTable->getParticleData(pid) ) {  // Get mass from the PDTable
   //    particleMass = 1000. * particleTable->getParticleData(pid)->mass();
   //    //Conv. GeV to MeV
   //  }
   pid = abs(pid);
   if (pid == 11)
-    particleMass = 0.511; // Mass in MeV
+    particleMass = 0.511;  // Mass in MeV
   else if (pid == 13)
     particleMass = 105.658;
   else if (pid == 211)
@@ -237,10 +216,9 @@ void ChargeDividerFP420::fluctuateEloss(int pid, float particleMomentum,
   // Generate charge fluctuations.
   float de = 0.;
   float sum = 0.;
-  double segmentEloss = (1000. * eloss) / NumberOfSegs; // eloss in MeV
+  double segmentEloss = (1000. * eloss) / NumberOfSegs;  // eloss in MeV
   if (verbosity > 0) {
-    std::cout << "segmentLength=  " << segmentLength
-              << "segmentEloss=  " << segmentEloss << std::endl;
+    std::cout << "segmentLength=  " << segmentLength << "segmentEloss=  " << segmentEloss << std::endl;
   }
 
   for (int i = 0; i < NumberOfSegs; ++i) {
@@ -251,10 +229,11 @@ void ChargeDividerFP420::fluctuateEloss(int pid, float particleMomentum,
     //    redefined inside, so fix it.
     double deltaCutoff = deltaCut;
     de = fluctuate.SampleFluctuations(double(particleMomentum * 1000.),
-                                      particleMass, deltaCutoff,
+                                      particleMass,
+                                      deltaCutoff,
                                       double(segmentLength),
                                       segmentEloss) /
-         1000.; // convert to GeV
+         1000.;  // convert to GeV
     elossVector[i] = de;
     sum += de;
   }
@@ -262,12 +241,12 @@ void ChargeDividerFP420::fluctuateEloss(int pid, float particleMomentum,
   if (verbosity > 0) {
     std::cout << "sum=  " << sum << std::endl;
   }
-  if (sum > 0.) { // If fluctuations give eloss>0.
+  if (sum > 0.) {  // If fluctuations give eloss>0.
     // Rescale to the same total eloss
     float ratio = eloss / sum;
     for (int ii = 0; ii < NumberOfSegs; ++ii)
       elossVector[ii] = ratio * elossVector[ii];
-  } else { // If fluctuations gives 0 eloss
+  } else {  // If fluctuations gives 0 eloss
     float averageEloss = eloss / NumberOfSegs;
     for (int ii = 0; ii < NumberOfSegs; ++ii)
       elossVector[ii] = averageEloss;
@@ -277,24 +256,18 @@ void ChargeDividerFP420::fluctuateEloss(int pid, float particleMomentum,
 
 float ChargeDividerFP420::TimeResponse(const PSimHit &hit) {
   if (peakMode) {
-
     if (verbosity > 0) {
-      std::cout << "ChargeDividerFP420:TimeResponse: call of PeakShape"
-                << std::endl;
+      std::cout << "ChargeDividerFP420:TimeResponse: call of PeakShape" << std::endl;
     }
     return this->PeakShape(hit);
   } else if (decoMode) {
-
     if (verbosity > 0) {
-      std::cout << "ChargeDividerFP420:TimeResponse: call of DeconvolutionShape"
-                << std::endl;
+      std::cout << "ChargeDividerFP420:TimeResponse: call of DeconvolutionShape" << std::endl;
     }
     return this->DeconvolutionShape(hit);
   } else {
-
     if (verbosity > 0) {
-      std::cout << "ChargeDividerFP420:TimeResponse: no any  Shape"
-                << std::endl;
+      std::cout << "ChargeDividerFP420:TimeResponse: no any  Shape" << std::endl;
     }
     //    return hit.getEnergyLoss();
     return hit.energyLoss();
@@ -331,13 +304,12 @@ float ChargeDividerFP420::PeakShape(const PSimHit &hit) {
   //  float dist = hit.getEntryLocalP().mag();
   float dist = (zStationBegPos[sector - 1] - 420000.) / costheta;
   //  float dist     = (zStationBegPos[sector-1] - hit.getVz()) / costheta;
-  dist = dist / 10.; // mm  --> cm as light velocity = 30 cm/ns
+  dist = dist / 10.;  // mm  --> cm as light velocity = 30 cm/ns
 
   if (verbosity > 0) {
     std::cout << "sector=" << sector << std::endl;
     std::cout << "zmodule=" << zmodule << std::endl;
-    std::cout << "zStationBegPos[sector-1]=" << zStationBegPos[sector - 1]
-              << std::endl;
+    std::cout << "zStationBegPos[sector-1]=" << zStationBegPos[sector - 1] << std::endl;
     std::cout << "RRR=" << RRR << std::endl;
     std::cout << "costheta=" << costheta << std::endl;
     std::cout << "unitID=" << unitID << std::endl;
@@ -347,7 +319,7 @@ float ChargeDividerFP420::PeakShape(const PSimHit &hit) {
   }
 
   // Time when read out relative to time hit produced.
-  float t0 = dist / 30.; // light velocity = 30 cm/ns
+  float t0 = dist / 30.;  // light velocity = 30 cm/ns
   float SigmaShape = 52.17;
   //  float tofNorm = (hit.getTof() - t0)/SigmaShape;
   float tofNorm = (hit.tof() - t0) / SigmaShape;
@@ -362,11 +334,8 @@ float ChargeDividerFP420::PeakShape(const PSimHit &hit) {
     std::cout << "tofNorm=" << tofNorm << std::endl;
     std::cout << "1 + readTimeNorm=" << 1 + readTimeNorm << std::endl;
     std::cout << "hit.getEnergyLoss()=" << hit.energyLoss() << std::endl;
-    std::cout << "(1 + readTimeNorm)*exp(-readTimeNorm)="
-              << (1 + readTimeNorm) * exp(-readTimeNorm) << std::endl;
-    std::cout << "return="
-              << hit.energyLoss() * (1 + readTimeNorm) * exp(-readTimeNorm)
-              << std::endl;
+    std::cout << "(1 + readTimeNorm)*exp(-readTimeNorm)=" << (1 + readTimeNorm) * exp(-readTimeNorm) << std::endl;
+    std::cout << "return=" << hit.energyLoss() * (1 + readTimeNorm) * exp(-readTimeNorm) << std::endl;
   }
   if (1 + readTimeNorm > 0) {
     //    return hit.energyLoss()*(1 + readTimeNorm)*exp(-readTimeNorm);
@@ -407,13 +376,12 @@ float ChargeDividerFP420::DeconvolutionShape(const PSimHit &hit) {
   //  float dist = hit.getEntryLocalP().mag();
   float dist = (zStationBegPos[sector - 1] - 420000.) / costheta;
   //  float dist     = (zStationBegPos[sector-1] - hit.getVz()) / costheta;
-  dist = dist / 10.; // mm  --> cm as light velocity = 30 cm/ns
+  dist = dist / 10.;  // mm  --> cm as light velocity = 30 cm/ns
 
   if (verbosity > 0) {
     std::cout << "sector=" << sector << std::endl;
     std::cout << "zmodule=" << zmodule << std::endl;
-    std::cout << "zStationBegPos[sector-1]=" << zStationBegPos[sector - 1]
-              << std::endl;
+    std::cout << "zStationBegPos[sector-1]=" << zStationBegPos[sector - 1] << std::endl;
     std::cout << "RRR=" << RRR << std::endl;
     std::cout << "costheta=" << costheta << std::endl;
     std::cout << "unitID=" << unitID << std::endl;
@@ -422,7 +390,7 @@ float ChargeDividerFP420::DeconvolutionShape(const PSimHit &hit) {
     std::cout << "dist found =" << dist << std::endl;
   }
 
-  float t0 = dist / 30.; // light velocity = 30 cm/ns
+  float t0 = dist / 30.;  // light velocity = 30 cm/ns
   float SigmaShape = 12.;
   // fun/pl 1*exp(-0.5*((0.1/30-x)/0.1)**2) 0. 0.08
   //  float SigmaShape = 22.;
@@ -434,17 +402,13 @@ float ChargeDividerFP420::DeconvolutionShape(const PSimHit &hit) {
   //  return hit.energyLoss()*exp(-0.5*readTimeNorm*readTimeNorm);
 
   if (verbosity > 0) {
-    std::cout << "ChargeDividerFP420:DeconvolutionShape::dist=" << dist
-              << std::endl;
+    std::cout << "ChargeDividerFP420:DeconvolutionShape::dist=" << dist << std::endl;
     std::cout << "t0=" << t0 << std::endl;
     std::cout << "hit.getTof()=" << hit.tof() << std::endl;
     std::cout << "tofNorm=" << tofNorm << std::endl;
     std::cout << "hit.getEnergyLoss()=" << hit.energyLoss() << std::endl;
-    std::cout << "exp(-0.5*readTimeNorm*readTimeNorm)="
-              << exp(-0.5 * readTimeNorm * readTimeNorm) << std::endl;
-    std::cout << "return="
-              << hit.energyLoss() * exp(-0.5 * readTimeNorm * readTimeNorm)
-              << std::endl;
+    std::cout << "exp(-0.5*readTimeNorm*readTimeNorm)=" << exp(-0.5 * readTimeNorm * readTimeNorm) << std::endl;
+    std::cout << "return=" << hit.energyLoss() * exp(-0.5 * readTimeNorm * readTimeNorm) << std::endl;
   }
   return hit.energyLoss() * exp(-0.5 * readTimeNorm * readTimeNorm);
   //  return hit.getEnergyLoss();

--- a/SimRomanPot/SimFP420/src/ChargeDrifterFP420.cc
+++ b/SimRomanPot/SimFP420/src/ChargeDrifterFP420.cc
@@ -7,17 +7,15 @@
 #include "SimRomanPot/SimFP420/interface/ChargeDrifterFP420.h"
 using namespace std;
 
-ChargeDrifterFP420::ChargeDrifterFP420(double mt, double tn, double dc,
-                                       double tm, double cdr, double dv,
-                                       double av, double ptx, double pty,
-                                       int verbosity) {
+ChargeDrifterFP420::ChargeDrifterFP420(
+    double mt, double tn, double dc, double tm, double cdr, double dv, double av, double ptx, double pty, int verbosity) {
   //
   //
   verbo = verbosity;
   modulePath = mt;
   constTe = tn;
   constDe = dc;
-  temperature = tm; // keep just in case
+  temperature = tm;  // keep just in case
   startT0 = cdr;
   depV = dv;
   appV = av;
@@ -30,17 +28,15 @@ ChargeDrifterFP420::ChargeDrifterFP420(double mt, double tn, double dc,
   //      edm::LogInfo("ChargeDrifterFP420") << "call constructor";
   if (verbo > 0) {
     std::cout << "ChargeDrifterFP420: call constructor" << std::endl;
-    std::cout << "ldriftcurrX= " << ldriftcurrX
-              << "ldriftcurrY= " << ldriftcurrY << std::endl;
-    std::cout << "modulePath= " << modulePath << "constTe= " << constTe
-              << std::endl;
+    std::cout << "ldriftcurrX= " << ldriftcurrX << "ldriftcurrY= " << ldriftcurrY << std::endl;
+    std::cout << "modulePath= " << modulePath << "constTe= " << constTe << std::endl;
     std::cout << "ChargeDrifterFP420:----------------------" << std::endl;
   }
 }
 
-CDrifterFP420::collection_type
-ChargeDrifterFP420::drift(const CDrifterFP420::ionization_type &ion,
-                          const G4ThreeVector &driftDir, const int &xytype) {
+CDrifterFP420::collection_type ChargeDrifterFP420::drift(const CDrifterFP420::ionization_type &ion,
+                                                         const G4ThreeVector &driftDir,
+                                                         const int &xytype) {
   //
   //
   if (verbo > 0) {
@@ -83,12 +79,11 @@ AmplitudeSegmentFP420 ChargeDrifterFP420::drift(const EnergySegmentFP420 &edu,
                  "====== "
               << std::endl;
     std::cout << "ChargeDrifterFP420: xytype= " << xytype << std::endl;
-    std::cout << "constTe= " << constTe << "ldriftcurrX= " << ldriftcurrX
-              << "ldriftcurrY= " << ldriftcurrY << std::endl;
-    std::cout << "1currX = " << currX << "  1currY = " << currY
-              << "  1currZ = " << currZ << std::endl;
-    std::cout << "drift.x() = " << drift.x() << "  drift.y() = " << drift.y()
-              << "  drift.z() = " << drift.z() << std::endl;
+    std::cout << "constTe= " << constTe << "ldriftcurrX= " << ldriftcurrX << "ldriftcurrY= " << ldriftcurrY
+              << std::endl;
+    std::cout << "1currX = " << currX << "  1currY = " << currY << "  1currZ = " << currZ << std::endl;
+    std::cout << "drift.x() = " << drift.x() << "  drift.y() = " << drift.y() << "  drift.z() = " << drift.z()
+              << std::endl;
   }
 
   // Yglobal Xlocal:
@@ -102,19 +97,15 @@ AmplitudeSegmentFP420 ChargeDrifterFP420::drift(const EnergySegmentFP420 &edu,
     tanShiftAngleZ = drift.z() / drift.x();
 
     //    pathValue = fabs(sliX-ldriftcurrX*int(sliX/ldriftcurrX));
-    pathValue = fabs(sliX) -
-                int(fabs(sliX / (2 * ldriftcurrX)) + 0.5) * (2 * ldriftcurrX);
+    pathValue = fabs(sliX) - int(fabs(sliX / (2 * ldriftcurrX)) + 0.5) * (2 * ldriftcurrX);
     pathValue = fabs(pathValue);
     pathFraction = pathValue / ldriftcurrX;
     if (verbo > 0) {
       std::cout << "==================================" << std::endl;
-      std::cout << "fabs(sliX)= " << fabs(sliX)
-                << "ldriftcurrX= " << ldriftcurrX << std::endl;
-      std::cout << "fabs(sliX/(2*ldriftcurrX))+0.5= "
-                << fabs(sliX / (2 * ldriftcurrX)) + 0.5 << std::endl;
+      std::cout << "fabs(sliX)= " << fabs(sliX) << "ldriftcurrX= " << ldriftcurrX << std::endl;
+      std::cout << "fabs(sliX/(2*ldriftcurrX))+0.5= " << fabs(sliX / (2 * ldriftcurrX)) + 0.5 << std::endl;
       std::cout << "int(fabs(sliX/(2*ldriftcurrX))+0.5)*(2*ldriftcurrX)= "
-                << int(fabs(sliX / (2 * ldriftcurrX)) + 0.5) * (2 * ldriftcurrX)
-                << std::endl;
+                << int(fabs(sliX / (2 * ldriftcurrX)) + 0.5) * (2 * ldriftcurrX) << std::endl;
       std::cout << "pathValue= " << pathValue << std::endl;
       std::cout << "pathFraction= " << pathFraction << std::endl;
       std::cout << "==================================" << std::endl;
@@ -123,9 +114,9 @@ AmplitudeSegmentFP420 ChargeDrifterFP420::drift(const EnergySegmentFP420 &edu,
     pathFraction = pathFraction > 0. ? pathFraction : 0.;
     pathFraction = pathFraction < 1. ? pathFraction : 1.;
 
-    yDriftDueToField // Drift along Y due to BField
+    yDriftDueToField  // Drift along Y due to BField
         = pathValue * tanShiftAngleY;
-    zDriftDueToField // Drift along Z due to BField
+    zDriftDueToField  // Drift along Z due to BField
         = pathValue * tanShiftAngleZ;
     // will define Y and Z ccordinates (E along X)
     currY = sliY + yDriftDueToField;
@@ -139,8 +130,7 @@ AmplitudeSegmentFP420 ChargeDrifterFP420::drift(const EnergySegmentFP420 &edu,
     tanShiftAngleZ = drift.z() / drift.y();
 
     // pathValue = fabs(sliY-ldriftcurrY*int(sliY/ldriftcurrY));
-    pathValue = fabs(sliY) -
-                int(fabs(sliY / (2 * ldriftcurrY)) + 0.5) * (2 * ldriftcurrY);
+    pathValue = fabs(sliY) - int(fabs(sliY / (2 * ldriftcurrY)) + 0.5) * (2 * ldriftcurrY);
     pathValue = fabs(pathValue);
     pathFraction = pathValue / ldriftcurrY;
     //
@@ -148,27 +138,23 @@ AmplitudeSegmentFP420 ChargeDrifterFP420::drift(const EnergySegmentFP420 &edu,
 
     if (verbo > 0) {
       std::cout << "==================================" << std::endl;
-      std::cout << "fabs(sliY)= " << fabs(sliY)
-                << "ldriftcurrY= " << ldriftcurrY << std::endl;
-      std::cout << "fabs(sliY/(2*ldriftcurrY))+0.5= "
-                << fabs(sliY / (2 * ldriftcurrY)) + 0.5 << std::endl;
+      std::cout << "fabs(sliY)= " << fabs(sliY) << "ldriftcurrY= " << ldriftcurrY << std::endl;
+      std::cout << "fabs(sliY/(2*ldriftcurrY))+0.5= " << fabs(sliY / (2 * ldriftcurrY)) + 0.5 << std::endl;
       std::cout << "int(fabs(sliY/(2*ldriftcurrY))+0.5)*(2*ldriftcurrY)= "
-                << int(fabs(sliY / (2 * ldriftcurrY)) + 0.5) * (2 * ldriftcurrY)
-                << std::endl;
+                << int(fabs(sliY / (2 * ldriftcurrY)) + 0.5) * (2 * ldriftcurrY) << std::endl;
       std::cout << "pathValue= " << pathValue << std::endl;
       std::cout << "pathFraction= " << pathFraction << std::endl;
       std::cout << "==================================" << std::endl;
     }
 
     if (pathFraction < 0. || pathFraction > 1.)
-      std::cout << "ChargeDrifterFP420: ERROR:pathFraction=" << pathFraction
-                << std::endl;
+      std::cout << "ChargeDrifterFP420: ERROR:pathFraction=" << pathFraction << std::endl;
     pathFraction = pathFraction > 0. ? pathFraction : 0.;
     pathFraction = pathFraction < 1. ? pathFraction : 1.;
-    xDriftDueToField // Drift along X due to BField
+    xDriftDueToField  // Drift along X due to BField
         = pathValue * tanShiftAngleX;
     //      = (ldriftcurrY-sliY)*tanShiftAngleX;
-    zDriftDueToField // Drift along Z due to BField
+    zDriftDueToField  // Drift along Z due to BField
         = pathValue * tanShiftAngleZ;
     // will define X and Z ccordinates (E along Y)
     currX = sliX + xDriftDueToField;
@@ -196,52 +182,34 @@ AmplitudeSegmentFP420 ChargeDrifterFP420::drift(const EnergySegmentFP420 &edu,
   //  <<log(1.-2*depV*pathFraction/(depV+appV))  << std::endl;
   double bbb = 1. - 2 * depV * pathFraction / (depV + appV);
   if (bbb < 0.)
-    std::cout
-        << "ChargeDrifterFP420:ERROR: check your Voltage for log(bbb) bbb="
-        << bbb << std::endl;
+    std::cout << "ChargeDrifterFP420:ERROR: check your Voltage for log(bbb) bbb=" << bbb << std::endl;
   double driftTime = -constTe * log(bbb) + startT0;
   //    log(1.-2*depV*pathFraction/(depV+appV)) + startT0;
   // since no magnetic field the Sigma_x, Sigma_y are the same =  sigma
   // !!!!!!!!!!!!!!!!!
-  double sigma =
-      sqrt(2. * constDe * driftTime *
-           100.); //  * 100.  - since constDe is [cm2/sec], but i want [mm2/sec]
+  double sigma = sqrt(2. * constDe * driftTime * 100.);  //  * 100.  - since constDe is [cm2/sec], but i want [mm2/sec]
 
   //  std::cout << "ChargeDrifterFP420: driftTime=  " << driftTime << "
   //  pathFraction=  " << pathFraction << "  constTe=  " << constTe << "  sigma=
   //  " << sigma << std::endl;
   if (verbo > 0) {
-    std::cout << "ChargeDrifterFP420: drift: xytype=" << xytype
-              << "pathFraction=" << pathFraction << std::endl;
-    std::cout << "  constTe= " << constTe << "  driftTime = " << driftTime
-              << " startT0  = " << startT0 << std::endl;
-    std::cout << " log = " << log(1. - 2 * depV * pathFraction / (depV + appV))
-              << std::endl;
-    std::cout << " negativ inside log = "
-              << -2 * depV * pathFraction / (depV + appV) << std::endl;
+    std::cout << "ChargeDrifterFP420: drift: xytype=" << xytype << "pathFraction=" << pathFraction << std::endl;
+    std::cout << "  constTe= " << constTe << "  driftTime = " << driftTime << " startT0  = " << startT0 << std::endl;
+    std::cout << " log = " << log(1. - 2 * depV * pathFraction / (depV + appV)) << std::endl;
+    std::cout << " negativ inside log = " << -2 * depV * pathFraction / (depV + appV) << std::endl;
     std::cout << " constDe = " << constDe << "  sigma = " << sigma << std::endl;
 
-    std::cout << "ChargeDrifterFP420: drift: xytype=" << xytype
-              << "pathValue=" << pathValue << std::endl;
-    std::cout << " tanShiftAngleX = " << tanShiftAngleX
-              << "  tanShiftAngleY = " << tanShiftAngleY
+    std::cout << "ChargeDrifterFP420: drift: xytype=" << xytype << "pathValue=" << pathValue << std::endl;
+    std::cout << " tanShiftAngleX = " << tanShiftAngleX << "  tanShiftAngleY = " << tanShiftAngleY
               << "  tanShiftAngleZ = " << tanShiftAngleZ << std::endl;
-    std::cout << "sliX = " << sliX << "  sliY = " << sliY << "  sliZ = " << sliZ
-              << std::endl;
-    std::cout << "pathFraction = " << pathFraction
-              << "  driftTime = " << driftTime << std::endl;
+    std::cout << "sliX = " << sliX << "  sliY = " << sliY << "  sliZ = " << sliZ << std::endl;
+    std::cout << "pathFraction = " << pathFraction << "  driftTime = " << driftTime << std::endl;
     std::cout << "sigma = " << sigma << std::endl;
-    std::cout << "xDriftDueToField = " << xDriftDueToField
-              << "  yDriftDueToField = " << yDriftDueToField
+    std::cout << "xDriftDueToField = " << xDriftDueToField << "  yDriftDueToField = " << yDriftDueToField
               << "  zDriftDueToField = " << zDriftDueToField << std::endl;
-    std::cout << "2currX = " << currX << "  2currY = " << currY
-              << "  2currZ = " << currZ << std::endl;
-    std::cout
-        << "ChargeDrifterFP420: drift; finally, rETURN AmplitudeSlimentFP420"
-        << std::endl;
-    std::cout
-        << "==================================================================="
-        << std::endl;
+    std::cout << "2currX = " << currX << "  2currY = " << currY << "  2currZ = " << currZ << std::endl;
+    std::cout << "ChargeDrifterFP420: drift; finally, rETURN AmplitudeSlimentFP420" << std::endl;
+    std::cout << "===================================================================" << std::endl;
     std::cout << " (edu).energy()= " << (edu).energy() << std::endl;
     std::cout << "==" << std::endl;
   }

--- a/SimRomanPot/SimFP420/src/DigiConverterFP420.cc
+++ b/SimRomanPot/SimFP420/src/DigiConverterFP420.cc
@@ -7,7 +7,6 @@
 #include "SimRomanPot/SimFP420/interface/DigiConverterFP420.h"
 
 DigiConverterFP420::DigiConverterFP420(float in, int verbosity) {
-
   electronperADC = in;
   verbos = verbosity;
 
@@ -26,31 +25,24 @@ DigiConverterFP420::DigiConverterFP420(float in, int verbosity) {
   //      std::cout << "theMaxADC= "<< theMaxADC  << std::endl; // = 1023
   if (verbos > 0) {
     std::cout << " ***DigiConverterFP420: constructor" << std::endl;
-    std::cout << "with known electronperADC =  " << electronperADC
-              << "the adcBits =  " << adcBits << "  theMaxADC=  " << theMaxADC
-              << "for known defaultBits=  " << defaultBits
+    std::cout << "with known electronperADC =  " << electronperADC << "the adcBits =  " << adcBits
+              << "  theMaxADC=  " << theMaxADC << "for known defaultBits=  " << defaultBits
               << " largestBits=  " << largestBits << std::endl;
   }
 }
 
-DConverterFP420::DigitalMapType
-DigiConverterFP420::convert(const signal_map_type &analogSignal) {
-
+DConverterFP420::DigitalMapType DigiConverterFP420::convert(const signal_map_type &analogSignal) {
   DConverterFP420::DigitalMapType _temp;
 
-  for (signal_map_type::const_iterator i = analogSignal.begin();
-       i != analogSignal.end(); i++) {
-
+  for (signal_map_type::const_iterator i = analogSignal.begin(); i != analogSignal.end(); i++) {
     // convert analog amplitude to digital, means integer number simulating ADC
     // digitization!
     // with truncation check
     int adc = convert((*i).second);
 
     if (verbos > 0) {
-      std::cout << " ***DigiConverterFP420: convert: after truncation "
-                << std::endl;
-      std::cout << "adc =  " << adc << " (*i).first =  " << (*i).first
-                << std::endl;
+      std::cout << " ***DigiConverterFP420: convert: after truncation " << std::endl;
+      std::cout << "adc =  " << adc << " (*i).first =  " << (*i).first << std::endl;
     }
     if (adc > 0)
       _temp.insert(_temp.end(), DigitalMapType::value_type((*i).first, adc));
@@ -60,12 +52,10 @@ DigiConverterFP420::convert(const signal_map_type &analogSignal) {
 }
 
 int DigiConverterFP420::truncate(float in_adc) {
-
   int adc = int(in_adc);
   if (verbos > 0) {
     std::cout << " ***DigiConverterFP420: truncate" << std::endl;
-    std::cout << "if adc =  " << adc << "bigger theMaxADC =  " << theMaxADC
-              << " adc=theMaxADC !!!" << std::endl;
+    std::cout << "if adc =  " << adc << "bigger theMaxADC =  " << theMaxADC << " adc=theMaxADC !!!" << std::endl;
   }
   if (adc > theMaxADC)
     adc = theMaxADC;

--- a/SimRomanPot/SimFP420/src/FP420DigiMain.cc
+++ b/SimRomanPot/SimFP420/src/FP420DigiMain.cc
@@ -44,84 +44,79 @@ FP420DigiMain::FP420DigiMain(const edm::ParameterSet &conf) : conf_(conf) {
   // rn0              = 3; // number of sensors in superlayer
   xytype = 2;
 
-  edm::LogInfo("SimRomanPotSimFP420")
-      << "theApplyTofCut=" << theApplyTofCut << " tofCut=" << tofCut << "\n"
-      << "FP420DigiMain theElectronPerADC=" << theElectronPerADC
-      << " theThreshold=" << theThreshold << " noNoise=" << noNoise;
+  edm::LogInfo("SimRomanPotSimFP420") << "theApplyTofCut=" << theApplyTofCut << " tofCut=" << tofCut << "\n"
+                                      << "FP420DigiMain theElectronPerADC=" << theElectronPerADC
+                                      << " theThreshold=" << theThreshold << " noNoise=" << noNoise;
 
   // X (or Y)define type of sensor (xytype=1 or 2 used to derive it: 1-Y, 2-X)
   // for every type there is normal pixel size=0.05 and Wide 0.400 mm
-  Thick300 = 0.300; // = 0.300 mm  normalized to 300micron Silicon
+  Thick300 = 0.300;  // = 0.300 mm  normalized to 300micron Silicon
   // ENC= 2160.;             //          EquivalentNoiseCharge300um = 2160. +
   // other sources of noise
-  ENC = 960.; //          EquivalentNoiseCharge300um = 2160. + other sources of
-              //          noise
+  ENC = 960.;  //          EquivalentNoiseCharge300um = 2160. + other sources of
+               //          noise
 
-  ldriftX = 0.050;         // in mm(xytype=1)
-  ldriftY = 0.050;         // in mm(xytype=2)
-  moduleThickness = 0.250; // mm(xytype=1)(xytype=2)
+  ldriftX = 0.050;          // in mm(xytype=1)
+  ldriftY = 0.050;          // in mm(xytype=2)
+  moduleThickness = 0.250;  // mm(xytype=1)(xytype=2)
 
-  pitchY = 0.050; // in mm(xytype=1)
-  pitchX = 0.050; // in mm(xytype=2)
+  pitchY = 0.050;  // in mm(xytype=1)
+  pitchX = 0.050;  // in mm(xytype=2)
   // numStripsY = 200;        // Y plate number of strips:200*0.050=10mm
   // (xytype=1) numStripsX = 400;        // X plate number of
   // strips:400*0.050=20mm (xytype=2)
-  numStripsY = 144; // Y plate number of strips:144*0.050=7.2mm (xytype=1)
-  numStripsX = 160; // X plate number of strips:160*0.050=8.0mm (xytype=2)
+  numStripsY = 144;  // Y plate number of strips:144*0.050=7.2mm (xytype=1)
+  numStripsX = 160;  // X plate number of strips:160*0.050=8.0mm (xytype=2)
 
-  pitchYW = 0.400; // in mm(xytype=1)
-  pitchXW = 0.400; // in mm(xytype=2)
+  pitchYW = 0.400;  // in mm(xytype=1)
+  pitchXW = 0.400;  // in mm(xytype=2)
   // numStripsYW = 50;        // Y plate number of W strips:50 *0.400=20mm
   // (xytype=1) - W have ortogonal projection numStripsXW = 25;        // X
   // plate number of W strips:25 *0.400=10mm (xytype=2) - W have ortogonal
   // projection
-  numStripsYW = 20; // Y plate number of W strips:20 *0.400=8.0mm (xytype=1) - W
-                    // have ortogonal projection
-  numStripsXW = 18; // X plate number of W strips:18 *0.400=7.2mm (xytype=2) - W
-                    // have ortogonal projection
+  numStripsYW = 20;  // Y plate number of W strips:20 *0.400=8.0mm (xytype=1) - W
+                     // have ortogonal projection
+  numStripsXW = 18;  // X plate number of W strips:18 *0.400=7.2mm (xytype=2) - W
+                     // have ortogonal projection
 
   //  tofCut = 1350.;           // Cut on the particle TOF range  = 1380 - 1500
-  elossCut = 0.00003; // Cut on the particle TOF   = 100 or 50
+  elossCut = 0.00003;  // Cut on the particle TOF   = 100 or 50
 
-  edm::LogInfo("SimRomanPotSimFP420")
-      << "FP420DigiMain moduleThickness=" << moduleThickness;
+  edm::LogInfo("SimRomanPotSimFP420") << "FP420DigiMain moduleThickness=" << moduleThickness;
 
   float noiseRMS = ENC * moduleThickness / Thick300;
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Y:
   if (xytype == 1) {
-    numStrips = numStripsY; // Y plate number of strips:200*0.050=10mm -->
-                            // 100*0.100=10mm
+    numStrips = numStripsY;  // Y plate number of strips:200*0.050=10mm -->
+                             // 100*0.100=10mm
     pitch = pitchY;
-    ldrift = ldriftX; // because drift is in local coordinates which 90 degree
-                      // rotated ( for correct timeNormalization & noiseRMS
-                      // calculations)
-    numStripsW = numStripsYW; // Y plate number of strips:200*0.050=10mm -->
-                              // 100*0.100=10mm
+    ldrift = ldriftX;          // because drift is in local coordinates which 90 degree
+                               // rotated ( for correct timeNormalization & noiseRMS
+                               // calculations)
+    numStripsW = numStripsYW;  // Y plate number of strips:200*0.050=10mm -->
+                               // 100*0.100=10mm
     pitchW = pitchYW;
   }
   // X:
   if (xytype == 2) {
-    numStrips = numStripsX; // X plate number of strips:400*0.050=20mm -->
-                            // 200*0.100=20mm
+    numStrips = numStripsX;  // X plate number of strips:400*0.050=20mm -->
+                             // 200*0.100=20mm
     pitch = pitchX;
-    ldrift = ldriftY; // because drift is in local coordinates which 90 degree
-                      // rotated ( for correct timeNormalization & noiseRMS
-                      // calculations)
-    numStripsW = numStripsXW; // X plate number of strips:400*0.050=20mm -->
-                              // 200*0.100=20mm
+    ldrift = ldriftY;          // because drift is in local coordinates which 90 degree
+                               // rotated ( for correct timeNormalization & noiseRMS
+                               // calculations)
+    numStripsW = numStripsXW;  // X plate number of strips:400*0.050=20mm -->
+                               // 200*0.100=20mm
     pitchW = pitchXW;
   }
 
   theHitDigitizerFP420 =
-      new HitDigitizerFP420(moduleThickness, ldrift, ldriftY, ldriftX, thez420,
-                            thezD2, thezD3, verbosity);
+      new HitDigitizerFP420(moduleThickness, ldrift, ldriftY, ldriftX, thez420, thezD2, thezD3, verbosity);
   int numPixels = numStrips * numStripsW;
-  theGNoiseFP420 = new GaussNoiseFP420(numPixels, noiseRMS, theThreshold,
-                                       addNoisyPixels, verbosity);
-  theZSuppressFP420 =
-      new ZeroSuppressFP420(conf_, noiseRMS / theElectronPerADC);
+  theGNoiseFP420 = new GaussNoiseFP420(numPixels, noiseRMS, theThreshold, addNoisyPixels, verbosity);
+  theZSuppressFP420 = new ZeroSuppressFP420(conf_, noiseRMS / theElectronPerADC);
   thePileUpFP420 = new PileUpFP420();
   theDConverterFP420 = new DigiConverterFP420(theElectronPerADC, verbosity);
 
@@ -139,10 +134,7 @@ FP420DigiMain::~FP420DigiMain() {
 //  Run the algorithm
 //  ------------------
 
-vector<HDigiFP420> FP420DigiMain::run(const std::vector<PSimHit> &input,
-                                      const G4ThreeVector &bfield,
-                                      unsigned int iu) {
-
+vector<HDigiFP420> FP420DigiMain::run(const std::vector<PSimHit> &input, const G4ThreeVector &bfield, unsigned int iu) {
   thePileUpFP420->reset();
   bool first = true;
 
@@ -153,7 +145,6 @@ vector<HDigiFP420> FP420DigiMain::run(const std::vector<PSimHit> &input,
   std::vector<PSimHit>::const_iterator simHitIter = input.begin();
   std::vector<PSimHit>::const_iterator simHitIterEnd = input.end();
   for (; simHitIter != simHitIterEnd; ++simHitIter) {
-
     const PSimHit ihit = *simHitIter;
 
     if (first) {
@@ -167,46 +158,37 @@ vector<HDigiFP420> FP420DigiMain::run(const std::vector<PSimHit> &input,
 
     if (verbosity > 1) {
       unsigned int unitID = ihit.detUnitId();
-      std::cout << " *******FP420DigiMain:                           intindex= "
-                << iu << std::endl;
-      std::cout << " tof= " << tof << "  EnergyLoss= " << losenergy
-                << "  pabs= " << ihit.pabs() << std::endl;
-      std::cout << " EntryLocalP x= " << ihit.entryPoint().x()
-                << " EntryLocalP y= " << ihit.entryPoint().y() << std::endl;
-      std::cout << " ExitLocalP x= " << ihit.exitPoint().x()
-                << " ExitLocalP y= " << ihit.exitPoint().y() << std::endl;
-      std::cout << " EntryLocalP z= " << ihit.entryPoint().z()
-                << " ExitLocalP z= " << ihit.exitPoint().z() << std::endl;
-      std::cout << " unitID= " << unitID << "  xytype= " << xytype
-                << " particleType= " << ihit.particleType()
+      std::cout << " *******FP420DigiMain:                           intindex= " << iu << std::endl;
+      std::cout << " tof= " << tof << "  EnergyLoss= " << losenergy << "  pabs= " << ihit.pabs() << std::endl;
+      std::cout << " EntryLocalP x= " << ihit.entryPoint().x() << " EntryLocalP y= " << ihit.entryPoint().y()
+                << std::endl;
+      std::cout << " ExitLocalP x= " << ihit.exitPoint().x() << " ExitLocalP y= " << ihit.exitPoint().y() << std::endl;
+      std::cout << " EntryLocalP z= " << ihit.entryPoint().z() << " ExitLocalP z= " << ihit.exitPoint().z()
+                << std::endl;
+      std::cout << " unitID= " << unitID << "  xytype= " << xytype << " particleType= " << ihit.particleType()
                 << " trackId= " << ihit.trackId() << std::endl;
       //    std::cout << " det= " << det << " sector= " << sector << "  zmodule=
       //    " << zmodule << std::endl;
       std::cout << "  bfield= " << bfield << std::endl;
     }
     if (verbosity > 0) {
-      std::cout
-          << " *******FP420DigiMain:                           theApplyTofCut= "
-          << theApplyTofCut << std::endl;
-      std::cout << " tof= " << tof << "  EnergyLoss= " << losenergy
-                << "  pabs= " << ihit.pabs() << std::endl;
+      std::cout << " *******FP420DigiMain:                           theApplyTofCut= " << theApplyTofCut << std::endl;
+      std::cout << " tof= " << tof << "  EnergyLoss= " << losenergy << "  pabs= " << ihit.pabs() << std::endl;
       std::cout << " particleType= " << ihit.particleType() << std::endl;
     }
 
-    if ((!(theApplyTofCut) ||
-         (theApplyTofCut && abs(tof) > tofCut && abs(tof) < (tofCut + 200.))) &&
+    if ((!(theApplyTofCut) || (theApplyTofCut && abs(tof) > tofCut && abs(tof) < (tofCut + 200.))) &&
         losenergy > elossCut) {
       if (verbosity > 0)
         std::cout << " inside tof: OK " << std::endl;
 
       HitDigitizerFP420::hit_map_type _temp = theHitDigitizerFP420->processHit(
-          ihit, bfield, xytype, numStrips, pitch, numStripsW, pitchW,
-          moduleThickness, verbosity);
+          ihit, bfield, xytype, numStrips, pitch, numStripsW, pitchW, moduleThickness, verbosity);
 
       thePileUpFP420->add(_temp, ihit, verbosity);
     }
     // main part end (AZ)
-  } // for
+  }  // for
   // main loop end (AZ)
 
   PileUpFP420::signal_map_type theSignal = thePileUpFP420->dumpSignal();
@@ -222,11 +204,9 @@ vector<HDigiFP420> FP420DigiMain::run(const std::vector<PSimHit> &input,
   }
   digis.clear();
 
-  push_digis(theZSuppressFP420->zeroSuppress(
-                 theDConverterFP420->convert(afterNoise), verbosity),
-             theLink, afterNoise);
+  push_digis(theZSuppressFP420->zeroSuppress(theDConverterFP420->convert(afterNoise), verbosity), theLink, afterNoise);
 
-  return digis; // to HDigiFP420
+  return digis;  // to HDigiFP420
 }
 
 void FP420DigiMain::push_digis(const DigitalMapType &dm,
@@ -234,15 +214,13 @@ void FP420DigiMain::push_digis(const DigitalMapType &dm,
                                const PileUpFP420::signal_map_type &afterNoise) {
   //
   if (verbosity > 0) {
-    std::cout << " ****FP420DigiMain: push_digis start: do for loop dm.size()="
-              << dm.size() << std::endl;
+    std::cout << " ****FP420DigiMain: push_digis start: do for loop dm.size()=" << dm.size() << std::endl;
   }
 
   digis.reserve(50);
   digis.clear();
   //   link_coll.clear();
   for (DigitalMapType::const_iterator i = dm.begin(); i != dm.end(); i++) {
-
     // Load digis
     // push to digis the content of first and second words of HDigiFP420 vector
     // for every strip pointer (*i)
@@ -250,10 +228,8 @@ void FP420DigiMain::push_digis(const DigitalMapType &dm,
     ndigis++;
     // very useful check:
     if (verbosity > 0) {
-      std::cout << " ****FP420DigiMain:push_digis:  ndigis = " << ndigis
-                << std::endl;
-      std::cout << "push_digis: strip  = " << (*i).first
-                << "  adc = " << (*i).second << std::endl;
+      std::cout << " ****FP420DigiMain:push_digis:  ndigis = " << ndigis << std::endl;
+      std::cout << "push_digis: strip  = " << (*i).first << "  adc = " << (*i).second << std::endl;
     }
   }
 
@@ -261,16 +237,15 @@ void FP420DigiMain::push_digis(const DigitalMapType &dm,
 
   // reworked to access the fraction of amplitude per simhit
 
-  for (HitToDigisMapType::const_iterator mi = htd.begin(); mi != htd.end();
-       mi++) {
+  for (HitToDigisMapType::const_iterator mi = htd.begin(); mi != htd.end(); mi++) {
     //
     if (dm.find((*mi).first) != dm.end()) {
       // --- For each channel, sum up the signals from a simtrack
       //
       map<const PSimHit *, Amplitude> totalAmplitudePerSimHit;
-      for (std::vector<std::pair<const PSimHit *, Amplitude>>::const_iterator
-               simul = (*mi).second.begin();
-           simul != (*mi).second.end(); simul++) {
+      for (std::vector<std::pair<const PSimHit *, Amplitude>>::const_iterator simul = (*mi).second.begin();
+           simul != (*mi).second.end();
+           simul++) {
         totalAmplitudePerSimHit[(*simul).first] += (*simul).second;
       }
       /*
@@ -299,6 +274,6 @@ void FP420DigiMain::push_digis(const DigitalMapType &dm,
       }//for
       */
       //
-    } // if
-  }   // for
+    }  // if
+  }    // for
 }

--- a/SimRomanPot/SimFP420/src/GaussNoiseFP420.cc
+++ b/SimRomanPot/SimFP420/src/GaussNoiseFP420.cc
@@ -8,14 +8,10 @@
 #include "SimRomanPot/SimFP420/interface/GaussNoiseFP420.h"
 #include "SimRomanPot/SimFP420/interface/GaussNoiseProducerFP420.h"
 
-GaussNoiseFP420::GaussNoiseFP420(int ns, float nrms, float th, bool aNpixel,
-                                 int verbosity)
-    : numPixels(ns), noiseRMS(nrms), threshold(th), addNoisyPixels(aNpixel),
-      verbosi(verbosity) {}
+GaussNoiseFP420::GaussNoiseFP420(int ns, float nrms, float th, bool aNpixel, int verbosity)
+    : numPixels(ns), noiseRMS(nrms), threshold(th), addNoisyPixels(aNpixel), verbosi(verbosity) {}
 
-PileUpFP420::signal_map_type
-GaussNoiseFP420::addNoise(const PileUpFP420::signal_map_type &in) {
-
+PileUpFP420::signal_map_type GaussNoiseFP420::addNoise(const PileUpFP420::signal_map_type &in) {
   PileUpFP420::signal_map_type _signal;
 
   // Add noise on non-hit pixels
@@ -25,18 +21,15 @@ GaussNoiseFP420::addNoise(const PileUpFP420::signal_map_type &in) {
 
   GaussNoiseProducerFP420 gen;
   gen.generate(numPixels, threshold, noiseRMS,
-               generatedNoise); // threshold is thePixelThreshold
+               generatedNoise);  // threshold is thePixelThreshold
 
   // noise for channels with signal:
   // ----------------------------
 
-  for (PileUpFP420::signal_map_type::const_iterator si = in.begin();
-       si != in.end(); si++) {
-
+  for (PileUpFP420::signal_map_type::const_iterator si = in.begin(); si != in.end(); si++) {
     if (verbosi > 0) {
       std::cout << " ***GaussNoiseFP420:  before noise:" << std::endl;
-      std::cout << " for si->first=  " << si->first
-                << "    _signal[si->first]=  " << _signal[si->first]
+      std::cout << " for si->first=  " << si->first << "    _signal[si->first]=  " << _signal[si->first]
                 << "        si->second=      " << si->second << std::endl;
     }
     // define Gaussian noise centered at 0. with sigma = noiseRMS:
@@ -46,22 +39,20 @@ GaussNoiseFP420::addNoise(const PileUpFP420::signal_map_type &in) {
     _signal[si->first] = si->second + noise;
 
     if (verbosi > 0) {
-      std::cout << " ***GaussNoiseFP420: after noise added  = " << noise
-                << std::endl;
-      std::cout << "after noise added the _signal[si->first]=  "
-                << _signal[si->first] << std::endl;
+      std::cout << " ***GaussNoiseFP420: after noise added  = " << noise << std::endl;
+      std::cout << "after noise added the _signal[si->first]=  " << _signal[si->first] << std::endl;
     }
   }
 
   //                                                                                                    //
-  if (addNoisyPixels) { // Option to skip noise in non-hit pixels
+  if (addNoisyPixels) {  // Option to skip noise in non-hit pixels
     // Noise on the other channels:
     typedef std::map<int, float, std::less<int>>::iterator MI;
     for (MI p = generatedNoise.begin(); p != generatedNoise.end(); p++) {
       if (_signal[(*p).first] == 0) {
         _signal[(*p).first] += (*p).second;
       }
-    } // for(MI
+    }  // for(MI
   }
 
   // or:

--- a/SimRomanPot/SimFP420/src/GaussNoiseProducerFP420.cc
+++ b/SimRomanPot/SimFP420/src/GaussNoiseProducerFP420.cc
@@ -15,10 +15,10 @@
 extern "C" float freq_(const float &x);
 extern "C" float gausin_(const float &x);
 
-void GaussNoiseProducerFP420::generate(
-    int NumberOfchannels, float threshold, float noiseRMS,
-    std::map<int, float, std::less<int>> &theMap) {
-
+void GaussNoiseProducerFP420::generate(int NumberOfchannels,
+                                       float threshold,
+                                       float noiseRMS,
+                                       std::map<int, float, std::less<int>> &theMap) {
   // estimale mean number of noisy channels with amplidudes above $AdcThreshold$
 
   // Gauss is centered at 0 with sigma=1
@@ -37,8 +37,7 @@ void GaussNoiseProducerFP420::generate(
   // with known probability higher threshold compute number of noisy channels
   // distributed in Poisson:
   float meanNumberOfNoisyChannels = probabilityLeft * NumberOfchannels;
-  int numberOfNoisyChannels =
-      CLHEP::RandPoisson::shoot(meanNumberOfNoisyChannels);
+  int numberOfNoisyChannels = CLHEP::RandPoisson::shoot(meanNumberOfNoisyChannels);
 
   // draw noise at random according to Gaussian tail
 
@@ -47,7 +46,6 @@ void GaussNoiseProducerFP420::generate(
 
   float lowLimit = threshold * noiseRMS;
   for (int i = 0; i < numberOfNoisyChannels; i++) {
-
     // Find a random channel number
     int theChannelNumber = (int)CLHEP::RandFlat::shootInt(NumberOfchannels);
 

--- a/SimRomanPot/SimFP420/src/HitDigitizerFP420.cc
+++ b/SimRomanPot/SimFP420/src/HitDigitizerFP420.cc
@@ -26,9 +26,8 @@ using namespace std;
 // HitDigitizerFP420::HitDigitizerFP420(float in,float inp,float inpx,float
 // inpy){ HitDigitizerFP420::HitDigitizerFP420(float in,float inp,float
 // inpx,float inpy,float ild,float ildx,float ildy){
-HitDigitizerFP420::HitDigitizerFP420(float in, float ild, float ildx,
-                                     float ildy, float in0, float in2,
-                                     float in3, int verbosity) {
+HitDigitizerFP420::HitDigitizerFP420(
+    float in, float ild, float ildx, float ildy, float in0, float in2, float in3, int verbosity) {
   moduleThickness = in;
   double bz420 = in0;
   double bzD2 = in2;
@@ -44,43 +43,40 @@ HitDigitizerFP420::HitDigitizerFP420(float in, float ild, float ildx,
   //
 
   // theCDividerFP420 = new ChargeDividerFP420(pitch);
-  theCDividerFP420 =
-      new ChargeDividerFP420(moduleThickness, bz420, bzD2, bzD3, verbosity);
+  theCDividerFP420 = new ChargeDividerFP420(moduleThickness, bz420, bzD2, bzD3, verbosity);
 
-  depletionVoltage = 20.0; //
-  appliedVoltage = 25.0; //  a bit bigger than depletionVoltage to have positive
-                         //  value A for logA, A=1-2*Tfract.*Vd/(Vd+Vb)
+  depletionVoltage = 20.0;  //
+  appliedVoltage = 25.0;    //  a bit bigger than depletionVoltage to have positive
+                            //  value A for logA, A=1-2*Tfract.*Vd/(Vd+Vb)
 
   //  chargeMobility=480.0;//  = 480.0  !holes    mobility [cm**2/V/sec] p-side;
   //  = 1350.0 !electron mobility - n-side
-  chargeMobility = 1350.0; //  = 480.0  !holes    mobility [cm**2/V/sec] p-side;
-                           //  = 1350.0 !electron mobility - n-side
+  chargeMobility = 1350.0;  //  = 480.0  !holes    mobility [cm**2/V/sec] p-side;
+                            //  = 1350.0 !electron mobility - n-side
   // temperature=297.; // 24 C degree +273 = 297 ---->diffusion const for
   // electrons= (1.38E-23/1.6E-19)*1350.0*297=34.6
   //  diffusion const for holes  =   12.3   [cm**2/sec]
-  temperature = 263.; // -10  C degree +273 = 263 ---->diffusion const for
-                      // electrons= (1.38E-23/1.6E-19)*1350.0*263=30.6
+  temperature = 263.;  // -10  C degree +273 = 263 ---->diffusion const for
+                       // electrons= (1.38E-23/1.6E-19)*1350.0*263=30.6
   double diffusionConstant = CBOLTZ / e_SI * chargeMobility * temperature;
   // noDiffusion=true; // true if no Diffusion
-  noDiffusion = false; // false if Diffusion
+  noDiffusion = false;  // false if Diffusion
   if (noDiffusion)
     diffusionConstant *= 1.0e-3;
 
   chargeDistributionRMS = 6.5e-10;
 
   // arbitrary:
-  tanLorentzAnglePerTesla = 0.; //  try =0.106 if B field exist
+  tanLorentzAnglePerTesla = 0.;  //  try =0.106 if B field exist
 
   //    double timeNormalisation =
   //    pow(moduleThickness,2)/(2.*depletionVoltage*chargeMobility); double
   //    timeNormalisation = pow(pitch,2)/(2.*depletionVoltage*chargeMobility);
 
-  double timeNormalisation =
-      pow(ldrift, 2) / (2. * depletionVoltage * chargeMobility); //
+  double timeNormalisation = pow(ldrift, 2) / (2. * depletionVoltage * chargeMobility);  //
   // double timeNormalisation =
   // pow(ldrift,2)/(2.*depletionVoltage*chargeMobility);//
-  timeNormalisation =
-      timeNormalisation * 0.01; // because ldrift in [mm] but mu_e in [cm2/V/sec
+  timeNormalisation = timeNormalisation * 0.01;  // because ldrift in [mm] but mu_e in [cm2/V/sec
 
   //      double timeNormalisation =
   //      pow(pitch/2.,2)/(2.*depletionVoltage*chargeMobility);// i entered
@@ -89,28 +85,30 @@ HitDigitizerFP420::HitDigitizerFP420(float in, float ild, float ildx,
   //      expression for timeNormalisation the real distance of charge
   //      collection must be, so use pitch/2.   !
 
-  double clusterWidth = 5.;  // was = 3
-  gevperelectron = 3.61e-09; //     double GevPerElectron = 3.61e-09
+  double clusterWidth = 5.;   // was = 3
+  gevperelectron = 3.61e-09;  //     double GevPerElectron = 3.61e-09
 
   // GevPerElectron AZ:average deposited energy per e-h pair [keV]??? =0.0036
   if (verbosity > 0) {
-    std::cout << "HitDigitizerFP420: constructor ldrift= " << ldrift
-              << std::endl;
+    std::cout << "HitDigitizerFP420: constructor ldrift= " << ldrift << std::endl;
     std::cout << "ldriftY= " << ldriftY << "ldriftX= " << ldriftX << std::endl;
-    std::cout << "depletionVoltage" << depletionVoltage << "appliedVoltage"
-              << appliedVoltage << "chargeMobility" << chargeMobility
-              << "temperature" << temperature << "diffusionConstant"
-              << diffusionConstant << "chargeDistributionRMS"
-              << chargeDistributionRMS << "moduleThickness" << moduleThickness
-              << "timeNormalisation" << timeNormalisation << "gevperelectron"
-              << gevperelectron << std::endl;
+    std::cout << "depletionVoltage" << depletionVoltage << "appliedVoltage" << appliedVoltage << "chargeMobility"
+              << chargeMobility << "temperature" << temperature << "diffusionConstant" << diffusionConstant
+              << "chargeDistributionRMS" << chargeDistributionRMS << "moduleThickness" << moduleThickness
+              << "timeNormalisation" << timeNormalisation << "gevperelectron" << gevperelectron << std::endl;
   }
   // ndif
 
-  theCDrifterFP420 = new ChargeDrifterFP420(
-      moduleThickness, timeNormalisation, diffusionConstant, temperature,
-      chargeDistributionRMS, depletionVoltage, appliedVoltage, ldriftX, ldriftY,
-      verbosity);
+  theCDrifterFP420 = new ChargeDrifterFP420(moduleThickness,
+                                            timeNormalisation,
+                                            diffusionConstant,
+                                            temperature,
+                                            chargeDistributionRMS,
+                                            depletionVoltage,
+                                            appliedVoltage,
+                                            ldriftX,
+                                            ldriftY,
+                                            verbosity);
   //					pitchX,
   //					pitchY);
 
@@ -125,12 +123,15 @@ HitDigitizerFP420::~HitDigitizerFP420() {
 
 // HitDigitizerFP420::hit_map_type HitDigitizerFP420::processHit(const PSimHit&
 // hit, G4ThreeVector bfield, int xytype,int numStrips, double pitch){
-HitDigitizerFP420::hit_map_type
-HitDigitizerFP420::processHit(const PSimHit &hit, const G4ThreeVector &bfield,
-                              int xytype, int numStrips, double pitch,
-                              int numStripsW, double pitchW,
-                              double moduleThickness, int verbosity) {
-
+HitDigitizerFP420::hit_map_type HitDigitizerFP420::processHit(const PSimHit &hit,
+                                                              const G4ThreeVector &bfield,
+                                                              int xytype,
+                                                              int numStrips,
+                                                              double pitch,
+                                                              int numStripsW,
+                                                              double pitchW,
+                                                              double moduleThickness,
+                                                              int verbosity) {
   // use chargePosition just for cross-check in "induce" method
   // hit center in 3D-detector r.f.
 
@@ -149,8 +150,7 @@ HitDigitizerFP420::processHit(const PSimHit &hit, const G4ThreeVector &bfield,
     // and local Y are collinear
     //     chargePosition  = int(fabs(middle.x()/pitch + 0.5*numStrips + 1.));//
     //     charge in strip coord
-    chargePosition = 0.5 * (numStrips) +
-                     middlex / pitch; // charge in strip coord 0 - numStrips-1
+    chargePosition = 0.5 * (numStrips) + middlex / pitch;  // charge in strip coord 0 - numStrips-1
 
   }
   // X:
@@ -163,15 +163,12 @@ HitDigitizerFP420::processHit(const PSimHit &hit, const G4ThreeVector &bfield,
     // local and global reference frames are rotated in 90 degree, so global X
     // and local Y are collinear
     //     chargePosition  = int(fabs(middle.y()/pitch + 0.5*numStrips + 1.));
-    chargePosition = 0.5 * (numStrips) +
-                     middley / pitch; // charge in strip coord 0 - numStrips-1
+    chargePosition = 0.5 * (numStrips) + middley / pitch;  // charge in strip coord 0 - numStrips-1
 
     //  std::cout << " chargePosition    SiHitDi... = " << chargePosition <<
     //  std::endl;
   } else {
-    std::cout
-        << "================================================================"
-        << std::endl;
+    std::cout << "================================================================" << std::endl;
     std::cout << "****   HitDigitizerFP420:  !!!  ERROR: you have not to be "
                  "here !!!  xytype="
               << xytype << std::endl;
@@ -182,10 +179,9 @@ HitDigitizerFP420::processHit(const PSimHit &hit, const G4ThreeVector &bfield,
   }
   //   if(chargePosition > numStrips || chargePosition<1) {
   if (chargePosition > numStrips || chargePosition < 0) {
-    std::cout
-        << "****   HitDigitizerFP420:  !!!  ERROR: check correspondence of XY "
-           "detector dimensions in XML and here !!! chargePosition = "
-        << chargePosition << std::endl;
+    std::cout << "****   HitDigitizerFP420:  !!!  ERROR: check correspondence of XY "
+                 "detector dimensions in XML and here !!! chargePosition = "
+              << chargePosition << std::endl;
     //     break;
   }
 
@@ -194,10 +190,8 @@ HitDigitizerFP420::processHit(const PSimHit &hit, const G4ThreeVector &bfield,
                  "input: xytype="
               << xytype << " numStrips=  " << numStrips << " pitch=  " << pitch
               << " Calculated chargePosition=  " << chargePosition << std::endl;
-    std::cout << "The middle of hit point on input was: middlex =  " << middlex
-              << std::endl;
-    std::cout << "The middle of hit point on input was: middley =  " << middley
-              << std::endl;
+    std::cout << "The middle of hit point on input was: middlex =  " << middlex << std::endl;
+    std::cout << "The middle of hit point on input was: middley =  " << middley << std::endl;
     //  std::cout << "For checks: hit point Entry =  " << hit.getEntry() <<
     //  std::endl;
     std::cout << " ======   ****   HitDigitizerFP420:processHit:   start  "
@@ -209,8 +203,7 @@ HitDigitizerFP420::processHit(const PSimHit &hit, const G4ThreeVector &bfield,
   //
 
   //   CDrifterFP420::ionization_type ion = theCDividerFP420->divide(hit,pitch);
-  CDrifterFP420::ionization_type ion =
-      theCDividerFP420->divide(hit, moduleThickness);
+  CDrifterFP420::ionization_type ion = theCDividerFP420->divide(hit, moduleThickness);
   //
   // Compute the drift direction for this det
   //
@@ -218,8 +211,7 @@ HitDigitizerFP420::processHit(const PSimHit &hit, const G4ThreeVector &bfield,
   //  G4ThreeVector driftDir = DriftDirection(&det,bfield);
   G4ThreeVector driftDir = DriftDirection(bfield, xytype, verbosity);
   if (verbosity > 0) {
-    std::cout << " ======   ****   HitDigitizerFP420:processHit: driftDir= "
-              << driftDir << std::endl;
+    std::cout << " ======   ****   HitDigitizerFP420:processHit: driftDir= " << driftDir << std::endl;
     std::cout << " ======   ****   HitDigitizerFP420:processHit:  start   "
                  "induce , CDrifterFP420   drift   "
               << std::endl;
@@ -230,16 +222,13 @@ HitDigitizerFP420::processHit(const PSimHit &hit, const G4ThreeVector &bfield,
   //  }  else
   //
 
-  return theIChargeFP420->induce(theCDrifterFP420->drift(ion, driftDir, xytype),
-                                 numStrips, pitch, numStripsW, pitchW, xytype,
-                                 verbosity);
+  return theIChargeFP420->induce(
+      theCDrifterFP420->drift(ion, driftDir, xytype), numStrips, pitch, numStripsW, pitchW, xytype, verbosity);
 
   //
 }
 
-G4ThreeVector HitDigitizerFP420::DriftDirection(const G4ThreeVector &_bfield,
-                                                int xytype, int verbosity) {
-
+G4ThreeVector HitDigitizerFP420::DriftDirection(const G4ThreeVector &_bfield, int xytype, int verbosity) {
   // LOCAL hit: exchange xytype:  1 <-> 2
 
   //  Frame detFrame(_detp->surface().position(),_detp->surface().rotation());
@@ -259,7 +248,7 @@ G4ThreeVector HitDigitizerFP420::DriftDirection(const G4ThreeVector &_bfield,
   // global Y or localX
   // E field is in Xlocal direction with change vector to opposite
   if (xytype == 2) {
-    dir_x = 1.; // E field in Xlocal direction
+    dir_x = 1.;  // E field in Xlocal direction
     dir_y = +tanLorentzAnglePerTesla * Bfield.z();
     dir_z = -tanLorentzAnglePerTesla * Bfield.y();
   }
@@ -267,14 +256,13 @@ G4ThreeVector HitDigitizerFP420::DriftDirection(const G4ThreeVector &_bfield,
   // E field is in Ylocal direction with change vector to opposite
   else if (xytype == 1) {
     dir_x = +tanLorentzAnglePerTesla * Bfield.z();
-    dir_y = 1.; // E field in Ylocal direction
+    dir_y = 1.;  // E field in Ylocal direction
     dir_z = -tanLorentzAnglePerTesla * Bfield.x();
   } else {
     dir_x = 0.;
     dir_y = 0.;
     dir_z = 0.;
-    std::cout << "HitDigitizerFP420: ERROR - wrong xytype=" << xytype
-              << std::endl;
+    std::cout << "HitDigitizerFP420: ERROR - wrong xytype=" << xytype << std::endl;
   }
 
   //  G4ThreeVector theDriftDirection = LocalVector(dir_x,dir_y,dir_z);
@@ -282,8 +270,7 @@ G4ThreeVector HitDigitizerFP420::DriftDirection(const G4ThreeVector &_bfield,
   // Local3DPoint
   // EntryPo(aHit->getEntry().x(),aHit->getEntry().y(),aHit->getEntry().z());
   if (verbosity > 0) {
-    std::cout << "HitDigitizerFP420:DriftDirection tanLorentzAnglePerTesla= "
-              << tanLorentzAnglePerTesla << std::endl;
+    std::cout << "HitDigitizerFP420:DriftDirection tanLorentzAnglePerTesla= " << tanLorentzAnglePerTesla << std::endl;
     std::cout << "HitDigitizerFP420:DriftDirection The drift direction in "
                  "local coordinate is "
               << theDriftDirection << std::endl;

--- a/SimRomanPot/SimFP420/src/InduceChargeFP420.cc
+++ b/SimRomanPot/SimFP420/src/InduceChargeFP420.cc
@@ -11,13 +11,15 @@
 using namespace std;
 
 static const float capacitive_coupling[2] = {.80, .10};
-static const float FiducialXYZ[3] = {
-    3.6, 4., 0.250}; // dX/2, dY/2,dZ -- mm fiducial dimension of Si plate
+static const float FiducialXYZ[3] = {3.6, 4., 0.250};  // dX/2, dY/2,dZ -- mm fiducial dimension of Si plate
 
-IChargeFP420::hit_map_type InduceChargeFP420::induce(
-    const CDrifterFP420::collection_type &_collection_points, int numStrips,
-    double localPitch, int numStripsW, double localPitchW, int xytype,
-    int verbosity) {
+IChargeFP420::hit_map_type InduceChargeFP420::induce(const CDrifterFP420::collection_type &_collection_points,
+                                                     int numStrips,
+                                                     double localPitch,
+                                                     int numStripsW,
+                                                     double localPitchW,
+                                                     int xytype,
+                                                     int verbosity) {
   signalCoupling.clear();
   signalCoupling.push_back(capacitive_coupling[0]);
   signalCoupling.push_back(capacitive_coupling[1]);
@@ -32,67 +34,51 @@ IChargeFP420::hit_map_type InduceChargeFP420::induce(
   // map to store pixel integrals in the x and in the y directions
   std::map<int, float, less<int>> x, y;
 
-  for (CDrifterFP420::collection_type::const_iterator sp =
-           _collection_points.begin();
-       sp != _collection_points.end(); sp++) {
-
-    float chargePositionW = -1.; // charge in strip coord in Wide pixel
-    float chargePosition = -1.;  // charge in strip coord
+  for (CDrifterFP420::collection_type::const_iterator sp = _collection_points.begin(); sp != _collection_points.end();
+       sp++) {
+    float chargePositionW = -1.;  // charge in strip coord in Wide pixel
+    float chargePosition = -1.;   // charge in strip coord
 
     // define chargePosition
-    G4ThreeVector Position3D = (*sp).position(); // charge in strip coord
+    G4ThreeVector Position3D = (*sp).position();  // charge in strip coord
 
     if (verbosity > 0) {
       std::cout << " =============================*InduceChargeFP420:induce:"
                    "Position3D= "
                 << Position3D << std::endl;
       std::cout << " localPitch= " << localPitch << std::endl;
-      std::cout << " xytype= " << xytype << " numStrips= " << numStrips
-                << std::endl;
+      std::cout << " xytype= " << xytype << " numStrips= " << numStrips << std::endl;
     }
 
     // is slice still inside fiducial volume of the plate? if not ->  put slice
     // energy to zero.
-    if (abs(Position3D.x()) < FiducialXYZ[0] &&
-        abs(Position3D.y()) < FiducialXYZ[1]) {
+    if (abs(Position3D.x()) < FiducialXYZ[0] && abs(Position3D.y()) < FiducialXYZ[1]) {
       if (abs(Position3D.z()) < FiducialXYZ[2]) {
       } else {
         //	(*sp).amplitude() == 0.;
-        std::cout
-            << " *InduceChargeFP420:Z slice outside the plate: Position3D= "
-            << Position3D << std::endl;
+        std::cout << " *InduceChargeFP420:Z slice outside the plate: Position3D= " << Position3D << std::endl;
       }
     } else {
       //      (*sp).amplitude() == 0.;
-      std::cout
-          << " *InduceChargeFP420:XY slice outside the plate: Position3D= "
-          << Position3D << std::endl;
+      std::cout << " *InduceChargeFP420:XY slice outside the plate: Position3D= " << Position3D << std::endl;
     }
 
     // chargePosition - still local coordinates, so exchange x and y due to 90
     // degree rotation Yglobal::
     if (xytype == 1) {
       // =
-      chargePosition =
-          0.5 * numStrips +
-          Position3D.x() / localPitch; // charge in strip coord. in l.r.f
-                                       // starting at edge of plate
-      chargePositionW =
-          0.5 * numStripsW +
-          Position3D.y() / localPitchW; // charge in strip coord. in l.r.f
-                                        // starting at edge of plate
+      chargePosition = 0.5 * numStrips + Position3D.x() / localPitch;     // charge in strip coord. in l.r.f
+                                                                          // starting at edge of plate
+      chargePositionW = 0.5 * numStripsW + Position3D.y() / localPitchW;  // charge in strip coord. in l.r.f
+                                                                          // starting at edge of plate
     }
     // X:
     else if (xytype == 2) {
       // =
-      chargePosition =
-          0.5 * numStrips +
-          Position3D.y() / localPitch; // charge in strip coord. in l.r.f
-                                       // starting at edge of plate
-      chargePositionW =
-          0.5 * numStripsW +
-          Position3D.x() / localPitchW; // charge in strip coord. in l.r.f
-                                        // starting at edge of plate
+      chargePosition = 0.5 * numStrips + Position3D.y() / localPitch;     // charge in strip coord. in l.r.f
+                                                                          // starting at edge of plate
+      chargePositionW = 0.5 * numStripsW + Position3D.x() / localPitchW;  // charge in strip coord. in l.r.f
+                                                                          // starting at edge of plate
     } else {
       std::cout << "**** InduceChargeFP420:  !!!  ERROR: you have not to be "
                    "here !!!  xytype="
@@ -105,14 +91,13 @@ IChargeFP420::hit_map_type InduceChargeFP420::induce(
         std::cout << "===================================**** "
                      "InduceChargeFP420: xytype= "
                   << xytype << std::endl;
-        std::cout << "  chargePositionW= " << chargePositionW
-                  << "  chargePosition= " << chargePosition << std::endl;
+        std::cout << "  chargePositionW= " << chargePositionW << "  chargePosition= " << chargePosition << std::endl;
         std::cout << "Position3D= " << Position3D << std::endl;
       }
     }
 
-    float chargeSpread = (*sp).sigma() / localPitch;   // sigma in strip pitches
-    float chargeSpreadW = (*sp).sigma() / localPitchW; // sigma in strip pitches
+    float chargeSpread = (*sp).sigma() / localPitch;    // sigma in strip pitches
+    float chargeSpreadW = (*sp).sigma() / localPitchW;  // sigma in strip pitches
 
     // Define strips intervals along x: check edge condition
 
@@ -127,21 +112,13 @@ IChargeFP420::hit_map_type InduceChargeFP420::induce(
     stripRightW = (numStripsW > stripRightW ? stripRightW : numStripsW - 1);
 
     if (verbosity > 1) {
-      std::cout << " Position3D =  " << Position3D
-                << "amplitude=" << (*sp).amplitude() << std::endl;
-      std::cout << " MaxChargeSpread= " << clusterWidth * chargeSpread
-                << " sigma= " << (*sp).sigma() << std::endl;
-      std::cout << "*** numStrips= " << numStrips
-                << " localPitch= " << localPitch << "xytype=" << xytype
-                << std::endl;
-      std::cout << " chargePosition= " << chargePosition
-                << " chargeSpread= " << chargeSpread << std::endl;
-      std::cout << " stripLeft= " << stripLeft << " stripRight= " << stripRight
-                << std::endl;
-      std::cout << " chargePositionW= " << chargePositionW
-                << " chargeSpreadW= " << chargeSpreadW << std::endl;
-      std::cout << " stripLeftW= " << stripLeftW
-                << " stripRightW= " << stripRightW << std::endl;
+      std::cout << " Position3D =  " << Position3D << "amplitude=" << (*sp).amplitude() << std::endl;
+      std::cout << " MaxChargeSpread= " << clusterWidth * chargeSpread << " sigma= " << (*sp).sigma() << std::endl;
+      std::cout << "*** numStrips= " << numStrips << " localPitch= " << localPitch << "xytype=" << xytype << std::endl;
+      std::cout << " chargePosition= " << chargePosition << " chargeSpread= " << chargeSpread << std::endl;
+      std::cout << " stripLeft= " << stripLeft << " stripRight= " << stripRight << std::endl;
+      std::cout << " chargePositionW= " << chargePositionW << " chargeSpreadW= " << chargeSpreadW << std::endl;
+      std::cout << " stripLeftW= " << stripLeftW << " stripRightW= " << stripRightW << std::endl;
     }
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     /// X
@@ -152,16 +129,14 @@ IChargeFP420::hit_map_type InduceChargeFP420::induce(
         lowerBound = 0.;
       else {
         gsl_sf_result result;
-        int status =
-            gsl_sf_erf_Q_e((i - chargePosition) / chargeSpread, &result);
+        int status = gsl_sf_erf_Q_e((i - chargePosition) / chargeSpread, &result);
         if (status != 0)
           std::cerr << "InduceChargeFP420::could not compute gaussian tail "
                        "probability for the threshold chosen"
                     << std::endl;
         lowerBound = 1. - result.val;
         if (verbosity > 0) {
-          std::cout << "go to left: i=  " << i << "lowerBound=" << lowerBound
-                    << std::endl;
+          std::cout << "go to left: i=  " << i << "lowerBound=" << lowerBound << std::endl;
         }
       }
 
@@ -170,8 +145,7 @@ IChargeFP420::hit_map_type InduceChargeFP420::induce(
         upperBound = 1.;
       else {
         gsl_sf_result result;
-        int status =
-            gsl_sf_erf_Q_e((i - chargePosition + 1) / chargeSpread, &result);
+        int status = gsl_sf_erf_Q_e((i - chargePosition + 1) / chargeSpread, &result);
         if (status != 0)
           std::cerr << "InduceChargeFP420::could not compute gaussian tail "
                        "probability for the threshold chosen"
@@ -179,30 +153,23 @@ IChargeFP420::hit_map_type InduceChargeFP420::induce(
         upperBound = 1. - result.val;
 
         if (verbosity > 0) {
-          std::cout << "go to right: i=  " << i << "upperBound=" << upperBound
-                    << std::endl;
+          std::cout << "go to right: i=  " << i << "upperBound=" << upperBound << std::endl;
         }
       }
 
       double totalIntegrationRange = upperBound - lowerBound;
-      x[i] = totalIntegrationRange; // save strip integral
+      x[i] = totalIntegrationRange;  // save strip integral
 
       if (totalIntegrationRange <= 0.)
-        std::cout << " upperBound= " << upperBound
-                  << " lowerBound= " << lowerBound << std::endl;
+        std::cout << " upperBound= " << upperBound << " lowerBound= " << lowerBound << std::endl;
       if (verbosity == -30) {
-        std::cout
-            << " *InduceChargeFP420:====================================X i =  "
-            << i << std::endl;
-        std::cout << " upperBound= " << upperBound
-                  << " lowerBound= " << lowerBound << std::endl;
-        std::cout << " totalIntegrationRange= " << totalIntegrationRange
-                  << std::endl;
-        std::cout << " *InduceChargeFP420:==================================== "
-                  << std::endl;
+        std::cout << " *InduceChargeFP420:====================================X i =  " << i << std::endl;
+        std::cout << " upperBound= " << upperBound << " lowerBound= " << lowerBound << std::endl;
+        std::cout << " totalIntegrationRange= " << totalIntegrationRange << std::endl;
+        std::cout << " *InduceChargeFP420:==================================== " << std::endl;
       }
 
-    } // for
+    }  // for
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     /// XW=Y
     for (int i = stripLeftW; i <= stripRightW; i++) {
@@ -212,8 +179,7 @@ IChargeFP420::hit_map_type InduceChargeFP420::induce(
         lowerBoundW = 0.;
       else {
         gsl_sf_result result;
-        int status =
-            gsl_sf_erf_Q_e((i - chargePositionW) / chargeSpreadW, &result);
+        int status = gsl_sf_erf_Q_e((i - chargePositionW) / chargeSpreadW, &result);
         if (status != 0)
           std::cerr << "InduceChargeFP420::W could not compute gaussian tail "
                        "probability for the threshold chosen"
@@ -221,8 +187,7 @@ IChargeFP420::hit_map_type InduceChargeFP420::induce(
         lowerBoundW = 1. - result.val;
 
         if (verbosity > 0) {
-          std::cout << "go to left: i=  " << i << "lowerBoundW=" << lowerBoundW
-                    << std::endl;
+          std::cout << "go to left: i=  " << i << "lowerBoundW=" << lowerBoundW << std::endl;
         }
       }
 
@@ -231,8 +196,7 @@ IChargeFP420::hit_map_type InduceChargeFP420::induce(
         upperBoundW = 1.;
       else {
         gsl_sf_result result;
-        int status =
-            gsl_sf_erf_Q_e((i - chargePositionW + 1) / chargeSpreadW, &result);
+        int status = gsl_sf_erf_Q_e((i - chargePositionW + 1) / chargeSpreadW, &result);
         if (status != 0)
           std::cerr << "InduceChargeFP420::W could not compute gaussian tail "
                        "probability for the threshold chosen"
@@ -240,28 +204,21 @@ IChargeFP420::hit_map_type InduceChargeFP420::induce(
         upperBoundW = 1. - result.val;
 
         if (verbosity > 0) {
-          std::cout << "go to right: i=  " << i << "upperBoundW=" << upperBoundW
-                    << std::endl;
+          std::cout << "go to right: i=  " << i << "upperBoundW=" << upperBoundW << std::endl;
         }
       }
 
       double totalIntegrationRange = upperBoundW - lowerBoundW;
-      y[i] = totalIntegrationRange; // save W strip integral
+      y[i] = totalIntegrationRange;  // save W strip integral
 
       if (totalIntegrationRange <= 0.)
-        std::cout << " upperBoundW= " << upperBoundW
-                  << " lowerBoundW= " << lowerBoundW << std::endl;
+        std::cout << " upperBoundW= " << upperBoundW << " lowerBoundW= " << lowerBoundW << std::endl;
 
       if (verbosity == -30) {
-        std::cout
-            << " *InduceChargeFP420:====================================XW  i= "
-            << i << std::endl;
-        std::cout << " upperBoundW= " << upperBoundW
-                  << " lowerBoundW= " << lowerBoundW << std::endl;
-        std::cout << " totalIntegrationRange= " << totalIntegrationRange
-                  << std::endl;
-        std::cout << " *InduceChargeFP420:==================================== "
-                  << std::endl;
+        std::cout << " *InduceChargeFP420:====================================XW  i= " << i << std::endl;
+        std::cout << " upperBoundW= " << upperBoundW << " lowerBoundW= " << lowerBoundW << std::endl;
+        std::cout << " totalIntegrationRange= " << totalIntegrationRange << std::endl;
+        std::cout << " *InduceChargeFP420:==================================== " << std::endl;
       }
     }
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -279,31 +236,23 @@ IChargeFP420::hit_map_type InduceChargeFP420::induce(
 */
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     if (verbosity > 1) {
-      std::cout
-          << "InduceChargeFP420:   "
-             "*************************************************************** "
-          << std::endl;
-      std::cout << " numStripsW= " << numStripsW << " numStrips= " << numStrips
+      std::cout << "InduceChargeFP420:   "
+                   "*************************************************************** "
                 << std::endl;
-      std::cout << " nSignalCoupling= " << nSignalCoupling
-                << " xytype= " << xytype << std::endl;
-      std::cout << " stripLeftW= " << stripLeftW
-                << " stripRightW= " << stripRightW << std::endl;
-      std::cout << " stripLeft= " << stripLeft << " stripRight= " << stripRight
-                << std::endl;
+      std::cout << " numStripsW= " << numStripsW << " numStrips= " << numStrips << std::endl;
+      std::cout << " nSignalCoupling= " << nSignalCoupling << " xytype= " << xytype << std::endl;
+      std::cout << " stripLeftW= " << stripLeftW << " stripRightW= " << stripRightW << std::endl;
+      std::cout << " stripLeft= " << stripLeft << " stripRight= " << stripRight << std::endl;
     }
     // Get the 2D charge integrals by folding x and y strips
-    for (int iy = stripLeftW; iy <= stripRightW;
-         iy++) { // loop over Wide y index
-      for (int ix = stripLeft; ix <= stripRight; ix++) { // loop over x index
+    for (int iy = stripLeftW; iy <= stripRightW; iy++) {  // loop over Wide y index
+      for (int ix = stripLeft; ix <= stripRight; ix++) {  // loop over x index
         for (int k = -nSignalCoupling + 1; k <= nSignalCoupling - 1; k++) {
           if (ix + k >= 0 && ix + k < numStrips) {
-            float ChargeFraction = signalCoupling[abs(k)] *
-                                   (x[ix] * y[iy] / geVperElectron) *
-                                   (*sp).amplitude();
+            float ChargeFraction = signalCoupling[abs(k)] * (x[ix] * y[iy] / geVperElectron) * (*sp).amplitude();
             if (ChargeFraction > 0.) {
               //  int chan = PixelDigi::pixelToChannel( ix, iy);  // Get index
-              int chan = iy * numStrips + (ix + k); // Get index
+              int chan = iy * numStrips + (ix + k);  // Get index
 
               //    if(k==0 ){
               // 	std::cout << "InduceChargeFP420: chan= " << chan <<
@@ -315,30 +264,25 @@ IChargeFP420::hit_map_type InduceChargeFP420::induce(
                   std::cout << "InduceChargeFP420:                             "
                                "                 chan= "
                             << chan << std::endl;
-                  std::cout << "ix= " << ix << "iy= " << iy << "k= " << k
-                            << "ChargeFraction= " << ChargeFraction
+                  std::cout << "ix= " << ix << "iy= " << iy << "k= " << k << "ChargeFraction= " << ChargeFraction
                             << std::endl;
-                  std::cout << "hit_signal[chan]= " << hit_signal[chan]
-                            << "geVperElectron= " << geVperElectron
+                  std::cout << "hit_signal[chan]= " << hit_signal[chan] << "geVperElectron= " << geVperElectron
                             << std::endl;
-                  std::cout
-                      << "signalCoupling[abs(k)]= " << signalCoupling[abs(k)]
-                      << "x[ix]= " << x[ix] << "y[iy]= " << y[iy]
-                      << "(*sp).amplitude()= " << (*sp).amplitude()
-                      << std::endl;
+                  std::cout << "signalCoupling[abs(k)]= " << signalCoupling[abs(k)] << "x[ix]= " << x[ix]
+                            << "y[iy]= " << y[iy] << "(*sp).amplitude()= " << (*sp).amplitude() << std::endl;
                 }
               }
               // Load the amplitude:
               hit_signal[chan] += ChargeFraction;
-            } // endif ChargeFraction
-          }   // endif ix+k
+            }  // endif ChargeFraction
+          }    // endif ix+k
           else {
             // std::cout << "WARNING:                         ix+k =" << ix+k <<
             // std::endl;
-          } // endif ix+k
-        }   // endfor k
-      }     // endfor ix
-    }       // endfor iy
+          }  // endif ix+k
+        }    // endfor k
+      }      // endfor ix
+    }        // endfor iy
 
     if (verbosity > 0) {
       std::cout << "==========================================================="
@@ -346,11 +290,10 @@ IChargeFP420::hit_map_type InduceChargeFP420::induce(
                 << std::endl;
     }
 
-  } // for loop on ions (*sp)
+  }  // for loop on ions (*sp)
 
   if (verbosity > 0) {
-    std::cout << "end of InduceChargeFP420============================= "
-              << std::endl;
+    std::cout << "end of InduceChargeFP420============================= " << std::endl;
   }
 
   return hit_signal;

--- a/SimRomanPot/SimFP420/src/LandauFP420.cc
+++ b/SimRomanPot/SimFP420/src/LandauFP420.cc
@@ -65,24 +65,27 @@ using namespace std;
 // for silicon.
 LandauFP420::LandauFP420()
     : minNumberInteractionsBohr(10.0),
-      theBohrBeta2(50.0 * keV / proton_mass_c2), minLoss(0.000001 * eV),
-      problim(0.01), alim(10.), nmaxCont1(4), nmaxCont2(16) {
+      theBohrBeta2(50.0 * keV / proton_mass_c2),
+      minLoss(0.000001 * eV),
+      problim(0.01),
+      alim(10.),
+      nmaxCont1(4),
+      nmaxCont2(16) {
   sumalim = -log(problim);
 
-  chargeSquare = 1.; // Assume all particles have charge 1
+  chargeSquare = 1.;  // Assume all particles have charge 1
   // Taken from Geant4 printout, HARDWIRED for Silicon.
-  ipotFluct =
-      0.0001736; // material->GetIonisation()->GetMeanExcitationEnergy();
-  electronDensity = 6.797E+20; // material->GetElectronDensity();
-  f1Fluct = 0.8571;            // material->GetIonisation()->GetF1fluct();
-  f2Fluct = 0.1429;            // material->GetIonisation()->GetF2fluct();
-  e1Fluct = 0.000116;          // material->GetIonisation()->GetEnergy1fluct();
-  e2Fluct = 0.00196;           // material->GetIonisation()->GetEnergy2fluct();
-  e1LogFluct = -9.063;   // material->GetIonisation()->GetLogEnergy1fluct();
-  e2LogFluct = -6.235;   // material->GetIonisation()->GetLogEnergy2fluct();
-  rateFluct = 0.4;       // material->GetIonisation()->GetRateionexcfluct();
-  ipotLogFluct = -8.659; // material->GetIonisation()->GetLogMeanExcEnergy();
-  e0 = 1.E-5;            // material->GetIonisation()->GetEnergy0fluct();
+  ipotFluct = 0.0001736;        // material->GetIonisation()->GetMeanExcitationEnergy();
+  electronDensity = 6.797E+20;  // material->GetElectronDensity();
+  f1Fluct = 0.8571;             // material->GetIonisation()->GetF1fluct();
+  f2Fluct = 0.1429;             // material->GetIonisation()->GetF2fluct();
+  e1Fluct = 0.000116;           // material->GetIonisation()->GetEnergy1fluct();
+  e2Fluct = 0.00196;            // material->GetIonisation()->GetEnergy2fluct();
+  e1LogFluct = -9.063;          // material->GetIonisation()->GetLogEnergy1fluct();
+  e2LogFluct = -6.235;          // material->GetIonisation()->GetLogEnergy2fluct();
+  rateFluct = 0.4;              // material->GetIonisation()->GetRateionexcfluct();
+  ipotLogFluct = -8.659;        // material->GetIonisation()->GetLogMeanExcEnergy();
+  e0 = 1.E-5;                   // material->GetIonisation()->GetEnergy0fluct();
 }
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 LandauFP420::~LandauFP420() {}
@@ -90,9 +93,8 @@ LandauFP420::~LandauFP420() {}
 // The main dedx fluctuation routine.
 // Arguments: momentum in MeV/c, mass in MeV, delta ray cut (tmax) in
 // MeV, silicon thickness in mm, mean eloss in MeV.
-double LandauFP420::SampleFluctuations(const double momentum, const double mass,
-                                       double &tmax, const double length,
-                                       const double meanLoss) {
+double LandauFP420::SampleFluctuations(
+    const double momentum, const double mass, double &tmax, const double length, const double meanLoss) {
   //  calculate actual loss from the mean loss
   //  The model used to get the fluctuation is essentially the same
   // as in Glandz in Geant3.
@@ -102,7 +104,7 @@ double LandauFP420::SampleFluctuations(const double momentum, const double mass,
     return meanLoss;
 
   // if(dp->GetDefinition() != particle) {
-  particleMass = mass; // dp->GetMass();
+  particleMass = mass;  // dp->GetMass();
   // G4double q     = dp->GetCharge();
   // chargeSquare   = q*q;
   //}
@@ -115,10 +117,8 @@ double LandauFP420::SampleFluctuations(const double momentum, const double mass,
   // Validity range for delta electron cross section
   double loss, siga;
   // Gaussian fluctuation
-  if (meanLoss >= minNumberInteractionsBohr * tmax ||
-      tmax <= ipotFluct * minNumberInteractionsBohr) {
-    siga = (1.0 / beta2 - 0.5) * twopi_mc2_rcl2 * tmax * length *
-           electronDensity * chargeSquare;
+  if (meanLoss >= minNumberInteractionsBohr * tmax || tmax <= ipotFluct * minNumberInteractionsBohr) {
+    siga = (1.0 / beta2 - 0.5) * twopi_mc2_rcl2 * tmax * length * electronDensity * chargeSquare;
     siga = sqrt(siga);
     do {
       // loss = G4RandGauss::shoot(meanLoss,siga);
@@ -155,7 +155,7 @@ double LandauFP420::SampleFluctuations(const double momentum, const double mass,
 
   loss = 0.;
 
-  if (suma < sumalim) // very small Step
+  if (suma < sumalim)  // very small Step
   {
     // e0 = material->GetIonisation()->GetEnergy0fluct();//Hardwired in const
     if (tmax == ipotFluct) {
@@ -204,7 +204,7 @@ double LandauFP420::SampleFluctuations(const double momentum, const double mass,
     }
   }
 
-  else // not so small Step
+  else  // not so small Step
   {
     // excitation type 1
     if (a1 > alim) {
@@ -252,8 +252,7 @@ double LandauFP420::SampleFluctuations(const double momentum, const double mass,
           sa = float(nmaxCont1) * rfac;
           na = CLHEP::RandGaussQ::shoot(namean, sa);
           if (na > 0.) {
-            alfa = w1 * float(nmaxCont2 + p3) /
-                   (w1 * float(nmaxCont2) + float(p3));
+            alfa = w1 * float(nmaxCont2 + p3) / (w1 * float(nmaxCont2) + float(p3));
             alfa1 = alfa * log(alfa) / (alfa - 1.);
             ea = na * ipotFluct * alfa1;
             sea = ipotFluct * sqrt(na * (alfa - alfa1 * alfa1));

--- a/SimRomanPot/SimFP420/src/PileUpFP420.cc
+++ b/SimRomanPot/SimFP420/src/PileUpFP420.cc
@@ -10,33 +10,23 @@
 #include "SimRomanPot/SimFP420/interface/PileUpFP420.h"
 //#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
-void PileUpFP420::add(const HitDigitizerFP420::hit_map_type &in,
-                      const PSimHit &hit, int verbosity) {
-
+void PileUpFP420::add(const HitDigitizerFP420::hit_map_type &in, const PSimHit &hit, int verbosity) {
   if (verbosity > 0) {
-    std::cout
-        << " ==========================****PileUpFP420: add start       = "
-        << std::endl;
+    std::cout << " ==========================****PileUpFP420: add start       = " << std::endl;
   }
-  for (HitDigitizerFP420::hit_map_type::const_iterator im = in.begin();
-       im != in.end(); im++) {
-
+  for (HitDigitizerFP420::hit_map_type::const_iterator im = in.begin(); im != in.end(); im++) {
     theMap[(*im).first] += Amplitude((*im).second);
 
-    theMapLink[(*im).first].push_back(
-        std::pair<const PSimHit *, Amplitude>(&hit, Amplitude((*im).second)));
+    theMapLink[(*im).first].push_back(std::pair<const PSimHit *, Amplitude>(&hit, Amplitude((*im).second)));
 
     if (verbosity > 0) {
-      std::cout << "*********** Amplitude((*im).first)  = "
-                << Amplitude((*im).first) << std::endl;
-      std::cout << " Amplitude((*im).second)  = " << Amplitude((*im).second)
-                << std::endl;
+      std::cout << "*********** Amplitude((*im).first)  = " << Amplitude((*im).first) << std::endl;
+      std::cout << " Amplitude((*im).second)  = " << Amplitude((*im).second) << std::endl;
     }
-  } // for loop
+  }  // for loop
 
   if (verbosity > 0) {
-    std::cout << " ==========================****PileUpFP420: add end       = "
-              << std::endl;
+    std::cout << " ==========================****PileUpFP420: add end       = " << std::endl;
   }
 }
 void PileUpFP420::resetSignal() { theMap.clear(); }

--- a/SimRomanPot/SimFP420/src/ZeroSuppressFP420.cc
+++ b/SimRomanPot/SimFP420/src/ZeroSuppressFP420.cc
@@ -7,15 +7,13 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimRomanPot/SimFP420/interface/ZeroSuppressFP420.h"
 
-ZeroSuppressFP420::ZeroSuppressFP420(const edm::ParameterSet &conf, float noise)
-    : conf_(conf), theNumFEDalgos(4) {
+ZeroSuppressFP420::ZeroSuppressFP420(const edm::ParameterSet &conf, float noise) : conf_(conf), theNumFEDalgos(4) {
   noiseInAdc = noise;
   initParams(conf_);
   verbosity = conf_.getUntrackedParameter<int>("VerbosityLevel");
   // initParams();
   if (verbosity > 0) {
-    std::cout << "ZeroSuppressFP420: constructor: noiseInAdc=  " << noiseInAdc
-              << std::endl;
+    std::cout << "ZeroSuppressFP420: constructor: noiseInAdc=  " << noiseInAdc << std::endl;
   }
 }
 
@@ -27,12 +25,9 @@ ZeroSuppressFP420::ZeroSuppressFP420(const edm::ParameterSet &conf, float noise)
 
 void ZeroSuppressFP420::initParams(edm::ParameterSet const &conf_) {
   verbosity = conf_.getUntrackedParameter<int>("VerbosityLevel");
-  algoConf = conf_.getParameter<int>(
-      "FedFP420Algorithm"); // FedFP420Algorithm: =1  (,2,3,4)
-  lowthreshConf = conf_.getParameter<double>(
-      "FedFP420LowThreshold"); // FedFP420LowThreshold  =3.
-  highthreshConf = conf_.getParameter<double>(
-      "FedFP420HighThreshold"); // FedFP420HighThreshold  =4.
+  algoConf = conf_.getParameter<int>("FedFP420Algorithm");               // FedFP420Algorithm: =1  (,2,3,4)
+  lowthreshConf = conf_.getParameter<double>("FedFP420LowThreshold");    // FedFP420LowThreshold  =3.
+  highthreshConf = conf_.getParameter<double>("FedFP420HighThreshold");  // FedFP420HighThreshold  =4.
 
   /*
    * There are four possible algorithms, the default of which (4)
@@ -47,45 +42,36 @@ void ZeroSuppressFP420::initParams(edm::ParameterSet const &conf_) {
   theFEDhighThresh = highthreshConf * noiseInAdc;
 
   if (verbosity > 0) {
-    std::cout << "ZeroSuppressFP420: initParams: !!!  theFEDalgorithm=  "
-              << theFEDalgorithm << std::endl;
-    std::cout << " lowthreshConf=  " << lowthreshConf
-              << " highthreshConf=  " << highthreshConf
-              << " theFEDlowThresh=  " << theFEDlowThresh
-              << " theFEDhighThresh=  " << theFEDhighThresh << std::endl;
+    std::cout << "ZeroSuppressFP420: initParams: !!!  theFEDalgorithm=  " << theFEDalgorithm << std::endl;
+    std::cout << " lowthreshConf=  " << lowthreshConf << " highthreshConf=  " << highthreshConf
+              << " theFEDlowThresh=  " << theFEDlowThresh << " theFEDhighThresh=  " << theFEDhighThresh << std::endl;
   }
 
   // Check zero suppress algorithm
   if (theFEDalgorithm < 1 || theFEDalgorithm > theNumFEDalgos) {
-    edm::LogError("FP420DigiInfo")
-        << "ZeroSuppressFP420 FATAL ERROR: Unknown zero suppress algorithm "
-        << theFEDalgorithm;
+    edm::LogError("FP420DigiInfo") << "ZeroSuppressFP420 FATAL ERROR: Unknown zero suppress algorithm "
+                                   << theFEDalgorithm;
     exit(1);
   }
 
   // Check thresholds
   if (theFEDlowThresh > theFEDhighThresh) {
-    edm::LogError("FP420DigiInfo")
-        << "ZeroSuppressFP420 FATAL ERROR: Low threshold exceeds high "
-           "threshold: "
-        << theFEDlowThresh << " > " << theFEDhighThresh;
+    edm::LogError("FP420DigiInfo") << "ZeroSuppressFP420 FATAL ERROR: Low threshold exceeds high "
+                                      "threshold: "
+                                   << theFEDlowThresh << " > " << theFEDhighThresh;
     exit(2);
   }
 }
 
-ZSuppressFP420::DigitalMapType
-ZeroSuppressFP420::zeroSuppress(const DigitalMapType &notZeroSuppressedMap,
-                                int vrb) {
+ZSuppressFP420::DigitalMapType ZeroSuppressFP420::zeroSuppress(const DigitalMapType &notZeroSuppressedMap, int vrb) {
   return trkFEDclusterizer(notZeroSuppressedMap, vrb);
   if (vrb > 0) {
-    std::cout << "zeroSuppress: return trkFEDclusterizer(notZeroSuppressedMap)"
-              << std::endl;
+    std::cout << "zeroSuppress: return trkFEDclusterizer(notZeroSuppressedMap)" << std::endl;
   }
 }
 
 // This performs the zero suppression
-ZSuppressFP420::DigitalMapType
-ZeroSuppressFP420::trkFEDclusterizer(const DigitalMapType &in, int vrb) {
+ZSuppressFP420::DigitalMapType ZeroSuppressFP420::trkFEDclusterizer(const DigitalMapType &in, int vrb) {
   const std::string s2("ZeroSuppressFP420::trkFEDclusterizer1");
 
   DigitalMapType selectedSignal;
@@ -96,15 +82,13 @@ ZeroSuppressFP420::trkFEDclusterizer(const DigitalMapType &in, int vrb) {
   }
 
   for (i = in.begin(); i != in.end(); i++) {
-
     // Find adc values for neighbouring strips
     int strip = i->first;
     int adc = i->second;
     iPrev = in.find(strip - 1);
     iNext = in.find(strip + 1);
     if (vrb > 0) {
-      std::cout << "Inside For loop trkFEDclusterizer: strip= " << strip
-                << " adc= " << adc << std::endl;
+      std::cout << "Inside For loop trkFEDclusterizer: strip= " << strip << " adc= " << adc << std::endl;
     }
     // Set values for channels just outside module to infinity.
     // This is to avoid losing channels at the edges,
@@ -122,8 +106,7 @@ ZeroSuppressFP420::trkFEDclusterizer(const DigitalMapType &in, int vrb) {
       adcNext = iNext->second;
     int adcMaxNeigh = std::max(adcPrev, adcNext);
     if (vrb > 0) {
-      std::cout << "adcPrev= " << adcPrev << " adcNext= " << adcNext
-                << " adcMaxNeigh= " << adcMaxNeigh << std::endl;
+      std::cout << "adcPrev= " << adcPrev << " adcNext= " << adcNext << " adcMaxNeigh= " << adcMaxNeigh << std::endl;
     }
 
     // Find adc values for next neighbouring channes
@@ -142,58 +125,43 @@ ZeroSuppressFP420::trkFEDclusterizer(const DigitalMapType &in, int vrb) {
       adcNext2 = iNext2->second;
 
     if (vrb > 0) {
-      std::cout << "adcPrev2= " << adcPrev2 << " adcNext2= " << adcNext2
-                << std::endl;
-      std::cout << "To be accepted or not?  adc= " << adc
-                << " >= theFEDlowThresh=" << theFEDlowThresh << std::endl;
+      std::cout << "adcPrev2= " << adcPrev2 << " adcNext2= " << adcNext2 << std::endl;
+      std::cout << "To be accepted or not?  adc= " << adc << " >= theFEDlowThresh=" << theFEDlowThresh << std::endl;
     }
     // Decide if this channel should be accepted.
     bool accept = false;
     switch (theFEDalgorithm) {
+      case 1:
+        accept = (adc >= theFEDlowThresh);
+        break;
 
-    case 1:
-      accept = (adc >= theFEDlowThresh);
-      break;
+      case 2:
+        accept = (adc >= theFEDhighThresh || (adc >= theFEDlowThresh && adcMaxNeigh >= theFEDlowThresh));
+        break;
 
-    case 2:
-      accept = (adc >= theFEDhighThresh ||
-                (adc >= theFEDlowThresh && adcMaxNeigh >= theFEDlowThresh));
-      break;
+      case 3:
+        accept = (adc >= theFEDhighThresh || (adc >= theFEDlowThresh && adcMaxNeigh >= theFEDhighThresh));
+        break;
 
-    case 3:
-      accept = (adc >= theFEDhighThresh ||
-                (adc >= theFEDlowThresh && adcMaxNeigh >= theFEDhighThresh));
-      break;
-
-    case 4:
-      accept =
-          ((adc >= theFEDhighThresh) || // Test for adc>highThresh (same as
-                                        // algorithm 2)
-           ((adc >=
-             theFEDlowThresh) && // Test for adc>lowThresh, with neighbour
-                                 // adc>lowThresh (same as algorithm 2)
-            (adcMaxNeigh >= theFEDlowThresh)) ||
-           ((adc < theFEDlowThresh) && // Test for adc<lowThresh
-            (((adcPrev >=
-               theFEDhighThresh) && // with both neighbours>highThresh
-              (adcNext >= theFEDhighThresh)) ||
-             ((adcPrev >=
-               theFEDhighThresh) && // OR with previous neighbour>highThresh and
-              (adcNext >=
-               theFEDlowThresh) && // both the next neighbours>lowThresh
-              (adcNext2 >= theFEDlowThresh)) ||
-             ((adcNext >=
-               theFEDhighThresh) && // OR with next neighbour>highThresh and
-              (adcPrev >=
-               theFEDlowThresh) && // both the previous neighbours>lowThresh
-              (adcPrev2 >= theFEDlowThresh)) ||
-             ((adcNext >=
-               theFEDlowThresh) && // OR with both next neighbours>lowThresh and
-              (adcNext2 >=
-               theFEDlowThresh) && // both the previous neighbours>lowThresh
-              (adcPrev >= theFEDlowThresh) &&
-              (adcPrev2 >= theFEDlowThresh)))));
-      break;
+      case 4:
+        accept = ((adc >= theFEDhighThresh) ||  // Test for adc>highThresh (same as
+                                                // algorithm 2)
+                  ((adc >= theFEDlowThresh) &&  // Test for adc>lowThresh, with neighbour
+                                                // adc>lowThresh (same as algorithm 2)
+                   (adcMaxNeigh >= theFEDlowThresh)) ||
+                  ((adc < theFEDlowThresh) &&          // Test for adc<lowThresh
+                   (((adcPrev >= theFEDhighThresh) &&  // with both neighbours>highThresh
+                     (adcNext >= theFEDhighThresh)) ||
+                    ((adcPrev >= theFEDhighThresh) &&  // OR with previous neighbour>highThresh and
+                     (adcNext >= theFEDlowThresh) &&   // both the next neighbours>lowThresh
+                     (adcNext2 >= theFEDlowThresh)) ||
+                    ((adcNext >= theFEDhighThresh) &&  // OR with next neighbour>highThresh and
+                     (adcPrev >= theFEDlowThresh) &&   // both the previous neighbours>lowThresh
+                     (adcPrev2 >= theFEDlowThresh)) ||
+                    ((adcNext >= theFEDlowThresh) &&   // OR with both next neighbours>lowThresh and
+                     (adcNext2 >= theFEDlowThresh) &&  // both the previous neighbours>lowThresh
+                     (adcPrev >= theFEDlowThresh) && (adcPrev2 >= theFEDlowThresh)))));
+        break;
     }
 
     /*
@@ -206,15 +174,13 @@ ZeroSuppressFP420::trkFEDclusterizer(const DigitalMapType &in, int vrb) {
       selectedSignal[strip] = adc;
 
       if (vrb > 0) {
-        std::cout << "selected strips = " << strip << " adc= " << adc
-                  << std::endl;
+        std::cout << "selected strips = " << strip << " adc= " << adc << std::endl;
       }
     }
   }
 
   if (vrb > 0) {
-    std::cout << "last line of trkFEDclusterizer: return selectedSignal"
-              << std::endl;
+    std::cout << "last line of trkFEDclusterizer: return selectedSignal" << std::endl;
   }
   return selectedSignal;
 }

--- a/SimTracker/Common/interface/SiG4UniversalFluctuation.h
+++ b/SimTracker/Common/interface/SiG4UniversalFluctuation.h
@@ -19,7 +19,7 @@
 #define SiG4UniversalFluctuation_h
 
 namespace CLHEP {
-class HepRandomEngine;
+  class HepRandomEngine;
 }
 
 class SiG4UniversalFluctuation {
@@ -30,14 +30,16 @@ public:
 
   // momentum in MeV/c, mass in MeV, tmax (delta cut) in MeV,
   // length in mm, meanLoss eloss in MeV.
-  double SampleFluctuations(const double momentum, const double mass,
-                            double &tmax, const double length,
-                            const double meanLoss, CLHEP::HepRandomEngine *);
+  double SampleFluctuations(const double momentum,
+                            const double mass,
+                            double &tmax,
+                            const double length,
+                            const double meanLoss,
+                            CLHEP::HepRandomEngine *);
 
 private:
   // hide assignment operator
-  SiG4UniversalFluctuation &
-  operator=(const SiG4UniversalFluctuation &right) = delete;
+  SiG4UniversalFluctuation &operator=(const SiG4UniversalFluctuation &right) = delete;
   SiG4UniversalFluctuation(const SiG4UniversalFluctuation &) = delete;
 
   double particleMass;

--- a/SimTracker/Common/interface/SimHitInfoForLinks.h
+++ b/SimTracker/Common/interface/SimHitInfoForLinks.h
@@ -11,16 +11,12 @@
 
 class SimHitInfoForLinks {
 public:
-  explicit SimHitInfoForLinks(PSimHit const *hitp, size_t hitindex,
-                              unsigned int tofbin)
-      : eventId_(hitp->eventId()), trackIds_(1, hitp->trackId()),
-        hitIndex_(hitindex), tofBin_(tofbin) {}
+  explicit SimHitInfoForLinks(PSimHit const *hitp, size_t hitindex, unsigned int tofbin)
+      : eventId_(hitp->eventId()), trackIds_(1, hitp->trackId()), hitIndex_(hitindex), tofBin_(tofbin) {}
 
   const EncodedEventId &eventId() const { return eventId_; }
   const std::vector<unsigned int> &trackIds() const { return trackIds_; }
-  std::vector<unsigned int> &trackIds() {
-    return trackIds_;
-  } // needed ATM in phase2 digitizer
+  std::vector<unsigned int> &trackIds() { return trackIds_; }  // needed ATM in phase2 digitizer
   unsigned int trackId() const { return trackIds_[0]; }
   size_t hitIndex() const { return hitIndex_; }
   unsigned int tofBin() const { return tofBin_; }

--- a/SimTracker/Common/interface/SimHitSelectorFromDB.h
+++ b/SimTracker/Common/interface/SimHitSelectorFromDB.h
@@ -9,16 +9,14 @@
 #include <vector>
 
 class SimHitSelectorFromDB {
-
 public:
   SimHitSelectorFromDB();
   ~SimHitSelectorFromDB(){};
 
   //  std::vector<PSimHit> getSimHit(std::unique_ptr<MixCollection<PSimHit>
   //  >&,std::map<uint32_t, std::vector<int> >& );
-  std::vector<std::pair<const PSimHit *, int>>
-  getSimHit(std::unique_ptr<MixCollection<PSimHit>> &,
-            std::map<uint32_t, std::vector<int>> &);
+  std::vector<std::pair<const PSimHit *, int>> getSimHit(std::unique_ptr<MixCollection<PSimHit>> &,
+                                                         std::map<uint32_t, std::vector<int>> &);
 
 private:
   //  std::vector<PSimHit> theNewSimHitList;

--- a/SimTracker/Common/interface/TrackingParticleSelector.h
+++ b/SimTracker/Common/interface/TrackingParticleSelector.h
@@ -14,47 +14,58 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 
 class TrackingParticleSelector {
-
 public:
   TrackingParticleSelector() {}
-  TrackingParticleSelector(double ptMin, double ptMax, double minRapidity,
-                           double maxRapidity, double tip, double lip,
-                           int minHit, bool signalOnly, bool intimeOnly,
-                           bool chargedOnly, bool stableOnly,
+  TrackingParticleSelector(double ptMin,
+                           double ptMax,
+                           double minRapidity,
+                           double maxRapidity,
+                           double tip,
+                           double lip,
+                           int minHit,
+                           bool signalOnly,
+                           bool intimeOnly,
+                           bool chargedOnly,
+                           bool stableOnly,
                            const std::vector<int> &pdgId = std::vector<int>(),
-                           double minPhi = -3.2, double maxPhi = 3.2)
-      : ptMin2_(ptMin * ptMin), ptMax2_(ptMax * ptMax),
-        minRapidity_(minRapidity), maxRapidity_(maxRapidity),
-        meanPhi_((minPhi + maxPhi) / 2.), rangePhi_((maxPhi - minPhi) / 2.),
-        tip2_(tip * tip), lip_(lip), minHit_(minHit), signalOnly_(signalOnly),
-        intimeOnly_(intimeOnly), chargedOnly_(chargedOnly),
-        stableOnly_(stableOnly), pdgId_(pdgId) {
+                           double minPhi = -3.2,
+                           double maxPhi = 3.2)
+      : ptMin2_(ptMin * ptMin),
+        ptMax2_(ptMax * ptMax),
+        minRapidity_(minRapidity),
+        maxRapidity_(maxRapidity),
+        meanPhi_((minPhi + maxPhi) / 2.),
+        rangePhi_((maxPhi - minPhi) / 2.),
+        tip2_(tip * tip),
+        lip_(lip),
+        minHit_(minHit),
+        signalOnly_(signalOnly),
+        intimeOnly_(intimeOnly),
+        chargedOnly_(chargedOnly),
+        stableOnly_(stableOnly),
+        pdgId_(pdgId) {
     if (minPhi >= maxPhi) {
       throw cms::Exception("Configuration")
-          << "TrackingParticleSelector: minPhi (" << minPhi
-          << ") must be smaller than maxPhi (" << maxPhi
+          << "TrackingParticleSelector: minPhi (" << minPhi << ") must be smaller than maxPhi (" << maxPhi
           << "). The range is constructed from minPhi to maxPhi around their "
              "average.";
     }
     if (minPhi >= M_PI) {
-      throw cms::Exception("Configuration")
-          << "TrackingParticleSelector: minPhi (" << minPhi
-          << ") must be smaller than PI. The range is constructed from minPhi "
-             "to maxPhi around their average.";
+      throw cms::Exception("Configuration") << "TrackingParticleSelector: minPhi (" << minPhi
+                                            << ") must be smaller than PI. The range is constructed from minPhi "
+                                               "to maxPhi around their average.";
     }
     if (maxPhi <= -M_PI) {
-      throw cms::Exception("Configuration")
-          << "TrackingParticleSelector: maxPhi (" << maxPhi
-          << ") must be larger than -PI. The range is constructed from minPhi "
-             "to maxPhi around their average.";
+      throw cms::Exception("Configuration") << "TrackingParticleSelector: maxPhi (" << maxPhi
+                                            << ") must be larger than -PI. The range is constructed from minPhi "
+                                               "to maxPhi around their average.";
     }
   }
 
   /// Operator() performs the selection: e.g. if (tPSelector(tp)) {...}
   bool operator()(const TrackingParticle &tp) const {
     // signal only means no PU particles
-    if (signalOnly_ &&
-        !(tp.eventId().bunchCrossing() == 0 && tp.eventId().event() == 0))
+    if (signalOnly_ && !(tp.eventId().bunchCrossing() == 0 && tp.eventId().event() == 0))
       return false;
     // intime only means no OOT PU particles
     if (intimeOnly_ && !(tp.eventId().bunchCrossing() == 0))
@@ -74,23 +85,19 @@ public:
     }
 
     if (chargedOnly_ && tp.charge() == 0)
-      return false; // select only if charge!=0
+      return false;  // select only if charge!=0
 
     // select only stable particles
     if (stableOnly_) {
-      for (TrackingParticle::genp_iterator j = tp.genParticle_begin();
-           j != tp.genParticle_end(); ++j) {
+      for (TrackingParticle::genp_iterator j = tp.genParticle_begin(); j != tp.genParticle_end(); ++j) {
         if (j->get() == nullptr || j->get()->status() != 1) {
           return false;
         }
       }
       // test for remaining unstabled due to lack of genparticle pointer
-      if (tp.status() == -99 &&
-          (std::abs(pdgid) != 11 && std::abs(pdgid) != 13 &&
-           std::abs(pdgid) != 211 && std::abs(pdgid) != 321 &&
-           std::abs(pdgid) != 2212 && std::abs(pdgid) != 3112 &&
-           std::abs(pdgid) != 3222 && std::abs(pdgid) != 3312 &&
-           std::abs(pdgid) != 3334))
+      if (tp.status() == -99 && (std::abs(pdgid) != 11 && std::abs(pdgid) != 13 && std::abs(pdgid) != 211 &&
+                                 std::abs(pdgid) != 321 && std::abs(pdgid) != 2212 && std::abs(pdgid) != 3112 &&
+                                 std::abs(pdgid) != 3222 && std::abs(pdgid) != 3312 && std::abs(pdgid) != 3334))
         return false;
     }
 
@@ -106,11 +113,9 @@ public:
       double pt2 = tp.p4().perp2();
       return pt2 >= ptMin2_ && pt2 <= ptMax2_;
     };
-    return (tp.numberOfTrackerLayers() >= minHit_ && ptOk(tp) && etaOk(tp) &&
-            phiOk(tp) &&
-            std::abs(tp.vertex().z()) <=
-                lip_ && // vertex last to avoid to load it if not striclty
-                        // necessary...
+    return (tp.numberOfTrackerLayers() >= minHit_ && ptOk(tp) && etaOk(tp) && phiOk(tp) &&
+            std::abs(tp.vertex().z()) <= lip_ &&  // vertex last to avoid to load it if not striclty
+                                                  // necessary...
             tp.vertex().perp2() <= tip2_);
   }
 
@@ -135,30 +140,33 @@ private:
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 namespace reco {
-namespace modules {
+  namespace modules {
 
-template <> struct ParameterAdapter<TrackingParticleSelector> {
-  static TrackingParticleSelector make(const edm::ParameterSet &cfg,
-                                       edm::ConsumesCollector &iC) {
-    return make(cfg);
-  }
+    template <>
+    struct ParameterAdapter<TrackingParticleSelector> {
+      static TrackingParticleSelector make(const edm::ParameterSet &cfg, edm::ConsumesCollector &iC) {
+        return make(cfg);
+      }
 
-  static TrackingParticleSelector make(const edm::ParameterSet &cfg) {
-    return TrackingParticleSelector(
-        cfg.getParameter<double>("ptMin"), cfg.getParameter<double>("ptMax"),
-        cfg.getParameter<double>("minRapidity"),
-        cfg.getParameter<double>("maxRapidity"),
-        cfg.getParameter<double>("tip"), cfg.getParameter<double>("lip"),
-        cfg.getParameter<int>("minHit"), cfg.getParameter<bool>("signalOnly"),
-        cfg.getParameter<bool>("intimeOnly"),
-        cfg.getParameter<bool>("chargedOnly"),
-        cfg.getParameter<bool>("stableOnly"),
-        cfg.getParameter<std::vector<int>>("pdgId"),
-        cfg.getParameter<double>("minPhi"), cfg.getParameter<double>("maxPhi"));
-  }
-};
+      static TrackingParticleSelector make(const edm::ParameterSet &cfg) {
+        return TrackingParticleSelector(cfg.getParameter<double>("ptMin"),
+                                        cfg.getParameter<double>("ptMax"),
+                                        cfg.getParameter<double>("minRapidity"),
+                                        cfg.getParameter<double>("maxRapidity"),
+                                        cfg.getParameter<double>("tip"),
+                                        cfg.getParameter<double>("lip"),
+                                        cfg.getParameter<int>("minHit"),
+                                        cfg.getParameter<bool>("signalOnly"),
+                                        cfg.getParameter<bool>("intimeOnly"),
+                                        cfg.getParameter<bool>("chargedOnly"),
+                                        cfg.getParameter<bool>("stableOnly"),
+                                        cfg.getParameter<std::vector<int>>("pdgId"),
+                                        cfg.getParameter<double>("minPhi"),
+                                        cfg.getParameter<double>("maxPhi"));
+      }
+    };
 
-} // namespace modules
-} // namespace reco
+  }  // namespace modules
+}  // namespace reco
 
 #endif

--- a/SimTracker/Common/src/SiG4UniversalFluctuation.cc
+++ b/SimTracker/Common/src/SiG4UniversalFluctuation.cc
@@ -17,25 +17,28 @@ using namespace std;
 
 SiG4UniversalFluctuation::SiG4UniversalFluctuation()
     : minNumberInteractionsBohr(10.0),
-      theBohrBeta2(50.0 * keV / proton_mass_c2), minLoss(10. * eV),
-      problim(5.e-3), alim(10.), nmaxCont1(4.), nmaxCont2(16.) {
+      theBohrBeta2(50.0 * keV / proton_mass_c2),
+      minLoss(10. * eV),
+      problim(5.e-3),
+      alim(10.),
+      nmaxCont1(4.),
+      nmaxCont2(16.) {
   sumalim = -log(problim);
 
   // Add these definitions d.k.
-  chargeSquare = 1.; // Assume all particles have charge 1
+  chargeSquare = 1.;  // Assume all particles have charge 1
   // Taken from Geant4 printout, HARDWIRED for Silicon.
-  ipotFluct =
-      0.0001736; // material->GetIonisation()->GetMeanExcitationEnergy();
-  electronDensity = 6.797E+20; // material->GetElectronDensity();
-  f1Fluct = 0.8571;            // material->GetIonisation()->GetF1fluct();
-  f2Fluct = 0.1429;            // material->GetIonisation()->GetF2fluct();
-  e1Fluct = 0.000116;          // material->GetIonisation()->GetEnergy1fluct();
-  e2Fluct = 0.00196;           // material->GetIonisation()->GetEnergy2fluct();
-  e1LogFluct = -9.063;   // material->GetIonisation()->GetLogEnergy1fluct();
-  e2LogFluct = -6.235;   // material->GetIonisation()->GetLogEnergy2fluct();
-  rateFluct = 0.4;       // material->GetIonisation()->GetRateionexcfluct();
-  ipotLogFluct = -8.659; // material->GetIonisation()->GetLogMeanExcEnergy();
-  e0 = 1.E-5;            // material->GetIonisation()->GetEnergy0fluct();
+  ipotFluct = 0.0001736;        // material->GetIonisation()->GetMeanExcitationEnergy();
+  electronDensity = 6.797E+20;  // material->GetElectronDensity();
+  f1Fluct = 0.8571;             // material->GetIonisation()->GetF1fluct();
+  f2Fluct = 0.1429;             // material->GetIonisation()->GetF2fluct();
+  e1Fluct = 0.000116;           // material->GetIonisation()->GetEnergy1fluct();
+  e2Fluct = 0.00196;            // material->GetIonisation()->GetEnergy2fluct();
+  e1LogFluct = -9.063;          // material->GetIonisation()->GetLogEnergy1fluct();
+  e2LogFluct = -6.235;          // material->GetIonisation()->GetLogEnergy2fluct();
+  rateFluct = 0.4;              // material->GetIonisation()->GetRateionexcfluct();
+  ipotLogFluct = -8.659;        // material->GetIonisation()->GetLogMeanExcEnergy();
+  e0 = 1.E-5;                   // material->GetIonisation()->GetEnergy0fluct();
 
   // cout << " init new fluct +++++++++++++++++++++++++++++++++++++++++"<<endl;
 }
@@ -47,9 +50,12 @@ SiG4UniversalFluctuation::SiG4UniversalFluctuation()
 
 SiG4UniversalFluctuation::~SiG4UniversalFluctuation() {}
 
-double SiG4UniversalFluctuation::SampleFluctuations(
-    const double momentum, const double mass, double &tmax, const double length,
-    const double meanLoss, CLHEP::HepRandomEngine *engine) {
+double SiG4UniversalFluctuation::SampleFluctuations(const double momentum,
+                                                    const double mass,
+                                                    double &tmax,
+                                                    const double length,
+                                                    const double meanLoss,
+                                                    CLHEP::HepRandomEngine *engine) {
   // Calculate actual loss from the mean loss.
   // The model used to get the fluctuations is essentially the same
   // as in Glandz in Geant3 (Cern program library W5013, phys332).
@@ -71,14 +77,11 @@ double SiG4UniversalFluctuation::SampleFluctuations(
   // for heavy particles only and conditions
   // for Gauusian fluct. has been changed
   //
-  if ((particleMass > electron_mass_c2) &&
-      (meanLoss >= minNumberInteractionsBohr * tmax)) {
+  if ((particleMass > electron_mass_c2) && (meanLoss >= minNumberInteractionsBohr * tmax)) {
     double massrate = electron_mass_c2 / particleMass;
-    double tmaxkine = 2. * electron_mass_c2 * beta2 * gam2 /
-                      (1. + massrate * (2. * gam + massrate));
+    double tmaxkine = 2. * electron_mass_c2 * beta2 * gam2 / (1. + massrate * (2. * gam + massrate));
     if (tmaxkine <= 2. * tmax) {
-      siga = (1.0 / beta2 - 0.5) * twopi_mc2_rcl2 * tmax * length *
-             electronDensity * chargeSquare;
+      siga = (1.0 / beta2 - 0.5) * twopi_mc2_rcl2 * tmax * length * electronDensity * chargeSquare;
       siga = sqrt(siga);
       double twomeanLoss = meanLoss + meanLoss;
       if (twomeanLoss < siga) {
@@ -118,8 +121,7 @@ double SiG4UniversalFluctuation::SampleFluctuations(
 
   // added
   if (tmax > ipotFluct) {
-    a3 = rate * meanLoss * (tmax - ipotFluct) /
-         (ipotFluct * tmax * vdt::fast_log(w1));
+    a3 = rate * meanLoss * (tmax - ipotFluct) / (ipotFluct * tmax * vdt::fast_log(w1));
   }
   double suma = a1 + a2 + a3;
 

--- a/SimTracker/Common/src/SimHitSelectorFromDB.cc
+++ b/SimTracker/Common/src/SimHitSelectorFromDB.cc
@@ -5,13 +5,11 @@ SimHitSelectorFromDB::SimHitSelectorFromDB() : theNewSimHitList(0) {}
 // std::vector<PSimHit>
 // SimHitSelectorFromDB::getSimHit(std::unique_ptr<MixCollection<PSimHit> >&
 // simhit,
-std::vector<std::pair<const PSimHit *, int>>
-SimHitSelectorFromDB::getSimHit(std::unique_ptr<MixCollection<PSimHit>> &simhit,
-                                std::map<uint32_t, std::vector<int>> &detId) {
+std::vector<std::pair<const PSimHit *, int>> SimHitSelectorFromDB::getSimHit(
+    std::unique_ptr<MixCollection<PSimHit>> &simhit, std::map<uint32_t, std::vector<int>> &detId) {
   theNewSimHitList.clear();
   int counter = 0;
-  for (MixCollection<PSimHit>::iterator it = simhit->begin();
-       it != simhit->end(); it++) {
+  for (MixCollection<PSimHit>::iterator it = simhit->begin(); it != simhit->end(); it++) {
     counter++;
     if (!detId.empty()) {
       uint32_t tkid = (*it).detUnitId();

--- a/TrackPropagation/Geant4e/interface/ConvertFromToCLHEP.h
+++ b/TrackPropagation/Geant4e/interface/ConvertFromToCLHEP.h
@@ -21,132 +21,123 @@
  */
 
 namespace TrackPropagation {
-/**
+  /**
  Convert a CMS GlobalPoint to a CLHEP HepGeom::Point3D<double>
  CMS uses cm while Geant4 uses mm. This is taken into account in the
  conversion.
  */
 
-inline HepGeom::Point3D<double> globalPointToHepPoint3D(const GlobalPoint &r) {
-  return HepGeom::Point3D<double>(r.x() * cm, r.y() * cm, r.z() * cm);
-}
+  inline HepGeom::Point3D<double> globalPointToHepPoint3D(const GlobalPoint &r) {
+    return HepGeom::Point3D<double>(r.x() * cm, r.y() * cm, r.z() * cm);
+  }
 
-/** Convert a CLHEP HepGeom::Point3D<double>  to a CMS GlobalPoint
+  /** Convert a CLHEP HepGeom::Point3D<double>  to a CMS GlobalPoint
  CMS uses cms while Geant4 uses mm. This is taken into account in the
  conversion.
  */
-inline GlobalPoint hepPoint3DToGlobalPoint(const HepGeom::Point3D<double> &r) {
-  return GlobalPoint(r.x() / cm, r.y() / cm, r.z() / cm);
-}
+  inline GlobalPoint hepPoint3DToGlobalPoint(const HepGeom::Point3D<double> &r) {
+    return GlobalPoint(r.x() / cm, r.y() / cm, r.z() / cm);
+  }
 
-/** Convert a G4double representing a scaler measure ( e.g. Track length ) to
+  /** Convert a G4double representing a scaler measure ( e.g. Track length ) to
  the CMS convention, which is using mm
  */
-inline double g4doubleToCmsDouble(const G4double &d) { return d / cm; }
+  inline double g4doubleToCmsDouble(const G4double &d) { return d / cm; }
 
-/** Convert a CMS GlobalVector to a CLHEP HepGeom::Normal3D<double>
+  /** Convert a CMS GlobalVector to a CLHEP HepGeom::Normal3D<double>
  CMS uses GeV while G4 uses MeV
  */
-inline HepGeom::Normal3D<double>
-globalVectorToHepNormal3D(const GlobalVector &p) {
-  return HepGeom::Normal3D<double>(p.x(), p.y(), p.z());
-}
+  inline HepGeom::Normal3D<double> globalVectorToHepNormal3D(const GlobalVector &p) {
+    return HepGeom::Normal3D<double>(p.x(), p.y(), p.z());
+  }
 
-/** Convert a CLHEP HepGeom::Normal3D<double>  to a CMS GlobalVector
+  /** Convert a CLHEP HepGeom::Normal3D<double>  to a CMS GlobalVector
  CMS uses GeV while G4 uses MeV
  */
-inline GlobalVector
-hepNormal3DToGlobalVector(const HepGeom::Normal3D<double> &p) {
-  return GlobalVector(p.x(), p.y(), p.z());
-}
+  inline GlobalVector hepNormal3DToGlobalVector(const HepGeom::Normal3D<double> &p) {
+    return GlobalVector(p.x(), p.y(), p.z());
+  }
 
-/** Convert a CMS GlobalVector to a CLHEP CLHEP::Hep3Vector
+  /** Convert a CMS GlobalVector to a CLHEP CLHEP::Hep3Vector
  */
-inline CLHEP::Hep3Vector globalVectorToHep3Vector(const GlobalVector &p) {
-  return CLHEP::Hep3Vector(p.x(), p.y(), p.z());
-}
+  inline CLHEP::Hep3Vector globalVectorToHep3Vector(const GlobalVector &p) {
+    return CLHEP::Hep3Vector(p.x(), p.y(), p.z());
+  }
 
-/** Convert a CLHEP CLHEP::Hep3Vector to a CMS GlobalVector
+  /** Convert a CLHEP CLHEP::Hep3Vector to a CMS GlobalVector
  */
-inline GlobalVector hep3VectorToGlobalVector(const CLHEP::Hep3Vector &p) {
-  return GlobalVector(p.x(), p.y(), p.z());
-}
+  inline GlobalVector hep3VectorToGlobalVector(const CLHEP::Hep3Vector &p) { return GlobalVector(p.x(), p.y(), p.z()); }
 
-/** Convert a CMS GlobalPoint to a CLHEP CLHEP::Hep3Vector
+  /** Convert a CMS GlobalPoint to a CLHEP CLHEP::Hep3Vector
  CMS uses cm while Geant4 uses mm. This is taken into account in the
  conversion.
  */
-inline CLHEP::Hep3Vector globalPointToHep3Vector(const GlobalPoint &r) {
-  return CLHEP::Hep3Vector(r.x() * cm, r.y() * cm, r.z() * cm);
-}
+  inline CLHEP::Hep3Vector globalPointToHep3Vector(const GlobalPoint &r) {
+    return CLHEP::Hep3Vector(r.x() * cm, r.y() * cm, r.z() * cm);
+  }
 
-/** Convert a CLHEP CLHEP::Hep3Vector to a CMS GlobalPoint
+  /** Convert a CLHEP CLHEP::Hep3Vector to a CMS GlobalPoint
  CMS uses cm while Geant4 uses mm. This is taken into account in the
  conversion.
  */
-inline GlobalPoint hep3VectorToGlobalPoint(const CLHEP::Hep3Vector &v) {
-  return GlobalPoint(v.x() / cm, v.y() / cm, v.z() / cm);
-}
+  inline GlobalPoint hep3VectorToGlobalPoint(const CLHEP::Hep3Vector &v) {
+    return GlobalPoint(v.x() / cm, v.y() / cm, v.z() / cm);
+  }
 
-/** Convert a CMS TkRotation<float> to a CLHEP
+  /** Convert a CMS TkRotation<float> to a CLHEP
  * CLHEP::HepRotation=G4RotationMatrix
  */
-inline CLHEP::HepRotation
-tkRotationFToHepRotation(const TkRotation<float> &tkr) {
-  return CLHEP::HepRotation(CLHEP::Hep3Vector(tkr.xx(), tkr.yx(), tkr.zx()),
-                            CLHEP::Hep3Vector(tkr.xy(), tkr.yy(), tkr.zy()),
-                            CLHEP::Hep3Vector(tkr.xz(), tkr.yz(), tkr.zz()));
-}
+  inline CLHEP::HepRotation tkRotationFToHepRotation(const TkRotation<float> &tkr) {
+    return CLHEP::HepRotation(CLHEP::Hep3Vector(tkr.xx(), tkr.yx(), tkr.zx()),
+                              CLHEP::Hep3Vector(tkr.xy(), tkr.yy(), tkr.zy()),
+                              CLHEP::Hep3Vector(tkr.xz(), tkr.yz(), tkr.zz()));
+  }
 
-/** Convert a CLHEP CLHEP::Hep3Vector to a CMS GlobalPoint
+  /** Convert a CLHEP CLHEP::Hep3Vector to a CMS GlobalPoint
  */
-inline TkRotation<float> hepRotationToTkRotationF(const CLHEP::HepRotation &r) {
-  return TkRotation<float>(r.xx(), r.xy(), r.xz(), r.yx(), r.yy(), r.yz(),
-                           r.zx(), r.zy(), r.zz());
-}
+  inline TkRotation<float> hepRotationToTkRotationF(const CLHEP::HepRotation &r) {
+    return TkRotation<float>(r.xx(), r.xy(), r.xz(), r.yx(), r.yy(), r.yz(), r.zx(), r.zy(), r.zz());
+  }
 
-/** Convert a G4 Trajectory Error Matrix to the CMS Algebraic Sym Matrix
+  /** Convert a G4 Trajectory Error Matrix to the CMS Algebraic Sym Matrix
  CMS uses q/p as first parameter, G4 uses 1/p
  */
 
-inline AlgebraicSymMatrix55
-g4ErrorTrajErrToAlgebraicSymMatrix55(const G4ErrorTrajErr &e, const int q) {
-  assert(q != 0);
-  // From DataFormats/CLHEP/interface/Migration.h
-  // typedef ROOT::Math::SMatrix<double,5,5,ROOT::Math::MatRepSym<double,5> >
-  // AlgebraicSymMatrix55;
-  AlgebraicSymMatrix55 m55;
-  for (unsigned int i = 0; i < 5; i++)
-    for (unsigned int j = 0; j < 5; j++) {
-      m55(i, j) = e(i + 1, j + 1);
-      if (i == 0)
-        m55(i, j) = double(q) * m55(i, j);
-      if (j == 0)
-        m55(i, j) = double(q) * m55(i, j);
-    }
-  return m55;
-}
+  inline AlgebraicSymMatrix55 g4ErrorTrajErrToAlgebraicSymMatrix55(const G4ErrorTrajErr &e, const int q) {
+    assert(q != 0);
+    // From DataFormats/CLHEP/interface/Migration.h
+    // typedef ROOT::Math::SMatrix<double,5,5,ROOT::Math::MatRepSym<double,5> >
+    // AlgebraicSymMatrix55;
+    AlgebraicSymMatrix55 m55;
+    for (unsigned int i = 0; i < 5; i++)
+      for (unsigned int j = 0; j < 5; j++) {
+        m55(i, j) = e(i + 1, j + 1);
+        if (i == 0)
+          m55(i, j) = double(q) * m55(i, j);
+        if (j == 0)
+          m55(i, j) = double(q) * m55(i, j);
+      }
+    return m55;
+  }
 
-/** Convert a CMS Algebraic Sym Matrix (for curv error) to a G4 Trajectory Error
+  /** Convert a CMS Algebraic Sym Matrix (for curv error) to a G4 Trajectory Error
  * Matrix
  */
-inline G4ErrorTrajErr
-algebraicSymMatrix55ToG4ErrorTrajErr(const AlgebraicSymMatrix55 &e,
-                                     const int q) {
-  assert(q != 0);
-  G4ErrorTrajErr g4err(5, 1);
-  for (unsigned int i = 0; i < 5; i++)
-    for (unsigned int j = 0; j < 5; j++) {
-      g4err(i + 1, j + 1) = e(i, j);
+  inline G4ErrorTrajErr algebraicSymMatrix55ToG4ErrorTrajErr(const AlgebraicSymMatrix55 &e, const int q) {
+    assert(q != 0);
+    G4ErrorTrajErr g4err(5, 1);
+    for (unsigned int i = 0; i < 5; i++)
+      for (unsigned int j = 0; j < 5; j++) {
+        g4err(i + 1, j + 1) = e(i, j);
 
-      if (i == 0)
-        g4err(i + 1, j + 1) = g4err(i + 1, j + 1) * double(q);
-      if (j == 0)
-        g4err(i + 1, j + 1) = g4err(i + 1, j + 1) * double(q);
-    }
-  return g4err;
-}
+        if (i == 0)
+          g4err(i + 1, j + 1) = g4err(i + 1, j + 1) * double(q);
+        if (j == 0)
+          g4err(i + 1, j + 1) = g4err(i + 1, j + 1) * double(q);
+      }
+    return g4err;
+  }
 
-} // namespace TrackPropagation
+}  // namespace TrackPropagation
 
 #endif

--- a/TrackPropagation/Geant4e/interface/Geant4ePropagator.h
+++ b/TrackPropagation/Geant4e/interface/Geant4ePropagator.h
@@ -18,7 +18,6 @@
  */
 
 class Geant4ePropagator : public Propagator {
-
 public:
   /** Constructor. Takes as arguments:
    *  * The magnetic field
@@ -63,24 +62,19 @@ public:
    *  All of these method calls are internally mapped to
    */
 
-  std::pair<TrajectoryStateOnSurface, double>
-  propagateWithPath(const FreeTrajectoryState &, const Plane &) const override;
+  std::pair<TrajectoryStateOnSurface, double> propagateWithPath(const FreeTrajectoryState &,
+                                                                const Plane &) const override;
 
-  std::pair<TrajectoryStateOnSurface, double>
-  propagateWithPath(const FreeTrajectoryState &,
-                    const Cylinder &) const override;
+  std::pair<TrajectoryStateOnSurface, double> propagateWithPath(const FreeTrajectoryState &,
+                                                                const Cylinder &) const override;
 
-  std::pair<TrajectoryStateOnSurface, double>
-  propagateWithPath(const TrajectoryStateOnSurface &,
-                    const Plane &) const override;
+  std::pair<TrajectoryStateOnSurface, double> propagateWithPath(const TrajectoryStateOnSurface &,
+                                                                const Plane &) const override;
 
-  std::pair<TrajectoryStateOnSurface, double>
-  propagateWithPath(const TrajectoryStateOnSurface &,
-                    const Cylinder &) const override;
+  std::pair<TrajectoryStateOnSurface, double> propagateWithPath(const TrajectoryStateOnSurface &,
+                                                                const Cylinder &) const override;
 
-  Geant4ePropagator *clone() const override {
-    return new Geant4ePropagator(*this);
-  }
+  Geant4ePropagator *clone() const override { return new Geant4ePropagator(*this); }
 
   const MagneticField *magneticField() const override { return theField; }
 
@@ -101,9 +95,7 @@ private:
   // Transform a CMS Reco detector surface into a Geant4 Target for the error
   // propagation
   template <class SurfaceType>
-  ErrorTargetPair
-  transformToG4SurfaceTarget(const SurfaceType &pDest,
-                             bool moveTargetToEndOfSurface) const;
+  ErrorTargetPair transformToG4SurfaceTarget(const SurfaceType &pDest, bool moveTargetToEndOfSurface) const;
 
   // generates the Geant4 name for a particle from the
   // string stored in theParticleName ( set via constructor )
@@ -119,15 +111,15 @@ private:
   //
   // returns TSOS after the propagation and the path length
   template <class SurfaceType>
-  std::pair<TrajectoryStateOnSurface, double>
-  propagateGeneric(const FreeTrajectoryState &ftsStart,
-                   const SurfaceType &pDest) const;
+  std::pair<TrajectoryStateOnSurface, double> propagateGeneric(const FreeTrajectoryState &ftsStart,
+                                                               const SurfaceType &pDest) const;
 
   // saves the Geant4 propagation direction (Forward or Backward) in the
   // provided variable reference mode and returns true if the propagation
   // direction could be set
   template <class SurfaceType>
-  bool configurePropagation(G4ErrorMode &mode, SurfaceType const &pDest,
+  bool configurePropagation(G4ErrorMode &mode,
+                            SurfaceType const &pDest,
                             GlobalPoint const &cmsInitPos,
                             GlobalVector const &cmsInitMom) const;
 
@@ -136,7 +128,8 @@ private:
   // configurePropagation and provides specific implementations for Plane and
   // Cylinder classes
   template <class SurfaceType>
-  bool configureAnyPropagation(G4ErrorMode &mode, SurfaceType const &pDest,
+  bool configureAnyPropagation(G4ErrorMode &mode,
+                               SurfaceType const &pDest,
                                GlobalPoint const &cmsInitPos,
                                GlobalVector const &cmsInitMom) const;
 

--- a/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.cc
+++ b/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.cc
@@ -13,8 +13,7 @@
 
 using namespace edm;
 
-GeantPropagatorESProducer::GeantPropagatorESProducer(
-    const edm::ParameterSet &p) {
+GeantPropagatorESProducer::GeantPropagatorESProducer(const edm::ParameterSet &p) {
   std::string myname = p.getParameter<std::string>("ComponentName");
   pset_ = p;
   setWhatProduced(this, myname);
@@ -22,9 +21,7 @@ GeantPropagatorESProducer::GeantPropagatorESProducer(
 
 GeantPropagatorESProducer::~GeantPropagatorESProducer() {}
 
-std::unique_ptr<Propagator>
-GeantPropagatorESProducer::produce(const TrackingComponentsRecord &iRecord) {
-
+std::unique_ptr<Propagator> GeantPropagatorESProducer::produce(const TrackingComponentsRecord &iRecord) {
   ESHandle<MagneticField> magfield;
   iRecord.getRecord<IdealMagneticFieldRecord>().get(magfield);
 

--- a/TrackPropagation/Geant4e/test/Geant4ePropagatorAnalyzer.cc
+++ b/TrackPropagation/Geant4e/test/Geant4ePropagatorAnalyzer.cc
@@ -2,7 +2,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/MakerMacros.h" //For define_fwk_module
+#include "FWCore/Framework/interface/MakerMacros.h"  //For define_fwk_module
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -56,7 +56,6 @@ using namespace std;
 enum testMuChamberType { DT, RPC, CSC };
 
 class Geant4ePropagatorAnalyzer : public edm::EDAnalyzer {
-
 public:
   explicit Geant4ePropagatorAnalyzer(const edm::ParameterSet &);
   ~Geant4ePropagatorAnalyzer() override {}
@@ -65,7 +64,8 @@ public:
   void endJob() override;
   void beginJob() override;
   void iterateOverHits(edm::Handle<edm::PSimHitContainer> simHits,
-                       testMuChamberType muonChamberType, unsigned int trkIndex,
+                       testMuChamberType muonChamberType,
+                       unsigned int trkIndex,
                        const FreeTrajectoryState &ftsTrack);
 
 protected:
@@ -76,9 +76,9 @@ protected:
   // std::auto_ptr<sim::FieldBuilder> theFieldBuilder;
 
   // Geometry
-  edm::ESHandle<DTGeometry> theDTGeomESH;   // DTs
-  edm::ESHandle<RPCGeometry> theRPCGeomESH; // RPC
-  edm::ESHandle<CSCGeometry> theCSCGeomESH; // CSC
+  edm::ESHandle<DTGeometry> theDTGeomESH;    // DTs
+  edm::ESHandle<RPCGeometry> theRPCGeomESH;  // RPC
+  edm::ESHandle<CSCGeometry> theCSCGeomESH;  // CSC
 
   // Station that we want to study. -1 for all
   int fStudyStation;
@@ -133,12 +133,12 @@ protected:
   edm::InputTag G4TrkSrc_;
 };
 
-Geant4ePropagatorAnalyzer::Geant4ePropagatorAnalyzer(
-    const edm::ParameterSet &iConfig)
-    : theRun(-1), theEvent(-1), thePropagator(nullptr),
+Geant4ePropagatorAnalyzer::Geant4ePropagatorAnalyzer(const edm::ParameterSet &iConfig)
+    : theRun(-1),
+      theEvent(-1),
+      thePropagator(nullptr),
       G4VtxSrc_(iConfig.getParameter<edm::InputTag>("G4VtxSrc")),
       G4TrkSrc_(iConfig.getParameter<edm::InputTag>("G4TrkSrc")) {
-
   // debug_ = iConfig.getParameter<bool>("debug");
   fStudyStation = iConfig.getParameter<int>("StudyStation");
 
@@ -150,95 +150,86 @@ Geant4ePropagatorAnalyzer::Geant4ePropagatorAnalyzer(
   //
 
   // Output ROOT file
-  theRootFile = new TFile(iConfig.getParameter<std::string>("RootFile").c_str(),
-                          "recreate");
+  theRootFile = new TFile(iConfig.getParameter<std::string>("RootFile").c_str(), "recreate");
 
   // Distance between Sim Hit and associated Layer
-  fDistanceSHLayer =
-      new TH1F("fDistanceSHLayer", "Distance(sim hit - layer)", 200, -1, 1);
+  fDistanceSHLayer = new TH1F("fDistanceSHLayer", "Distance(sim hit - layer)", 200, -1, 1);
 
   // Distance between simhit and extrapolation
   fDistance = new TH1F("fDistance", "Distance(sim hit - extrap)", 150, 0, 300);
   // Distance between simhit and extrapolation
-  fDistanceSt[0] = new TH1F(
-      "fDistance_St1", "Distance(sim hit - extrap) for station 1", 150, 0, 300);
-  fDistanceSt[1] = new TH1F(
-      "fDistance_St2", "Distance(sim hit - extrap) for station 2", 150, 0, 300);
-  fDistanceSt[2] = new TH1F(
-      "fDistance_St3", "Distance(sim hit - extrap) for station 3", 150, 0, 300);
-  fDistanceSt[3] = new TH1F(
-      "fDistance_St4", "Distance(sim hit - extrap) for station 4", 150, 0, 300);
+  fDistanceSt[0] = new TH1F("fDistance_St1", "Distance(sim hit - extrap) for station 1", 150, 0, 300);
+  fDistanceSt[1] = new TH1F("fDistance_St2", "Distance(sim hit - extrap) for station 2", 150, 0, 300);
+  fDistanceSt[2] = new TH1F("fDistance_St3", "Distance(sim hit - extrap) for station 3", 150, 0, 300);
+  fDistanceSt[3] = new TH1F("fDistance_St4", "Distance(sim hit - extrap) for station 4", 150, 0, 300);
 
   // Simulated hits
   fHitR = new TH1F("fHitR", "R^{sim hit}", 300, 400, 1000);
   fHitRho = new TH1F("fHitRho", "#rho^{sim hit}", 300, 400, 1000);
   fHitEta = new TH1F("fHitEta", "#eta^{sim hit}", 100, -0.1, 0.1);
-  fHitPhi = new TH1F("fHitPhi", "#varphi^{sim hit}", 160,
-                     fBeamCenter - fBeamInterval, fBeamCenter + fBeamInterval);
-  fHitPhi1L =
-      new TH1F("fHitPhi1L", "#varphi^{sim hit} for 1st layer", 160,
-               fBeamCenter - fBeamInterval, fBeamCenter + fBeamInterval);
+  fHitPhi = new TH1F("fHitPhi", "#varphi^{sim hit}", 160, fBeamCenter - fBeamInterval, fBeamCenter + fBeamInterval);
+  fHitPhi1L = new TH1F(
+      "fHitPhi1L", "#varphi^{sim hit} for 1st layer", 160, fBeamCenter - fBeamInterval, fBeamCenter + fBeamInterval);
 
-  fHitRVsPhi =
-      new TH2F("fHitRVsPhi", "R vs. #varphi for sim hits", 60, 400, 1000, 80,
-               fBeamCenter - fBeamInterval, fBeamCenter + fBeamInterval);
+  fHitRVsPhi = new TH2F("fHitRVsPhi",
+                        "R vs. #varphi for sim hits",
+                        60,
+                        400,
+                        1000,
+                        80,
+                        fBeamCenter - fBeamInterval,
+                        fBeamCenter + fBeamInterval);
 
   // Position of layers
   fLayerR = new TH1F("fLayerR", "R^{layer}", 300, 400, 1000);
   fLayerRho = new TH1F("fLayerRho", "#rho^{layer}", 300, 400, 1000);
   fLayerEta = new TH1F("fLayerEta", "#eta^{layer}", 100, -0.1, 0.1);
-  fLayerPhi =
-      new TH1F("fLayerPhi", "#varphi^{layer}", 160, fBeamCenter - fBeamInterval,
-               fBeamCenter + fBeamInterval);
-  fLayerRVsPhi =
-      new TH2F("fLayerRVsPhi", "R vs. #varphi for layers", 60, 400, 1000, 80,
-               fBeamCenter - fBeamInterval, fBeamCenter + fBeamInterval);
+  fLayerPhi = new TH1F("fLayerPhi", "#varphi^{layer}", 160, fBeamCenter - fBeamInterval, fBeamCenter + fBeamInterval);
+  fLayerRVsPhi = new TH2F("fLayerRVsPhi",
+                          "R vs. #varphi for layers",
+                          60,
+                          400,
+                          1000,
+                          80,
+                          fBeamCenter - fBeamInterval,
+                          fBeamCenter + fBeamInterval);
 
   // Extrapolated hits
   fExtrapR = new TH1F("fExtrapR", "R^{extrap. hit}", 300, 400, 1000);
   fExtrapRho = new TH1F("fExtrapRho", "#rho^{extrap. hit}", 300, 400, 1000);
   fExtrapEta = new TH1F("fExtrapEta", "#eta^{extrap. hit}", 100, -0.1, 0.1);
   fExtrapPhi =
-      new TH1F("fExtrapPhi", "#varphi^{extrap. hit}", 160,
-               fBeamCenter - fBeamInterval, fBeamCenter + fBeamInterval);
+      new TH1F("fExtrapPhi", "#varphi^{extrap. hit}", 160, fBeamCenter - fBeamInterval, fBeamCenter + fBeamInterval);
 
-  fExtrapRVsPhi =
-      new TH2F("fExtrapRVsPhi", "R vs. #varphi for extrap. hits", 60, 400, 1000,
-               80, fBeamCenter - fBeamInterval, fBeamCenter + fBeamInterval);
+  fExtrapRVsPhi = new TH2F("fExtrapRVsPhi",
+                           "R vs. #varphi for extrap. hits",
+                           60,
+                           400,
+                           1000,
+                           80,
+                           fBeamCenter - fBeamInterval,
+                           fBeamCenter + fBeamInterval);
 
   // Distances
-  fDeltaRo =
-      new TH1F("fDeltaRo", "#Delta(#rho^{sim}, #rho^{extrap})", 100, 0, 200);
-  fDeltaEta =
-      new TH1F("fDeltaEta", "#Delta(#eta^{sim}, #eta^{extrap})", 100, -1, 1);
-  fDeltaPhi = new TH1F("fDeltaPhi", "#Delta(#varphi^{sim}, #varphi^{extrap})",
-                       120, -30, 30);
+  fDeltaRo = new TH1F("fDeltaRo", "#Delta(#rho^{sim}, #rho^{extrap})", 100, 0, 200);
+  fDeltaEta = new TH1F("fDeltaEta", "#Delta(#eta^{sim}, #eta^{extrap})", 100, -1, 1);
+  fDeltaPhi = new TH1F("fDeltaPhi", "#Delta(#varphi^{sim}, #varphi^{extrap})", 120, -30, 30);
 
   // Studies on Phi
-  fStationPosPhi =
-      new TH1F("fStationPosPhi", "Station with positive #varphi", 6, -0.5, 5.5);
-  fSectorPosPhi =
-      new TH1F("fSectorPosPhi", "Sector with positive #varphi", 6, -0.5, 5.5);
-  fSLayerPosPhi = new TH1F("fSLayerPosPhi", "Superlayer with positive #varphi",
-                           6, -0.5, 5.5);
-  fLayerPosPhi =
-      new TH1F("fLayerPosPhi", "Layer with positive #varphi", 6, -0.5, 5.5);
-  fStationNegPhi =
-      new TH1F("fStationNegPhi", "Station with negative #varphi", 6, -0.5, 5.5);
-  fSectorNegPhi =
-      new TH1F("fSectorNegPhi", "Sector with negative #varphi", 6, -0.5, 5.5);
-  fSLayerNegPhi = new TH1F("fSLayerNegPhi", "Superlayer with negative #varphi",
-                           6, -0.5, 5.5);
-  fLayerNegPhi =
-      new TH1F("fLayerNegPhi", "Layer with negative #varphi", 6, -0.5, 5.5);
+  fStationPosPhi = new TH1F("fStationPosPhi", "Station with positive #varphi", 6, -0.5, 5.5);
+  fSectorPosPhi = new TH1F("fSectorPosPhi", "Sector with positive #varphi", 6, -0.5, 5.5);
+  fSLayerPosPhi = new TH1F("fSLayerPosPhi", "Superlayer with positive #varphi", 6, -0.5, 5.5);
+  fLayerPosPhi = new TH1F("fLayerPosPhi", "Layer with positive #varphi", 6, -0.5, 5.5);
+  fStationNegPhi = new TH1F("fStationNegPhi", "Station with negative #varphi", 6, -0.5, 5.5);
+  fSectorNegPhi = new TH1F("fSectorNegPhi", "Sector with negative #varphi", 6, -0.5, 5.5);
+  fSLayerNegPhi = new TH1F("fSLayerNegPhi", "Superlayer with negative #varphi", 6, -0.5, 5.5);
+  fLayerNegPhi = new TH1F("fLayerNegPhi", "Layer with negative #varphi", 6, -0.5, 5.5);
 
   //
   ///////////////////////////////////////////////////////////////////////////////////
 }
 
-void Geant4ePropagatorAnalyzer::beginJob() {
-  LogDebug("Geant4e") << "Nothing done in beginJob...";
-}
+void Geant4ePropagatorAnalyzer::beginJob() { LogDebug("Geant4e") << "Nothing done in beginJob..."; }
 
 void Geant4ePropagatorAnalyzer::endJob() {
   fDistanceSHLayer->Write();
@@ -283,9 +274,7 @@ void Geant4ePropagatorAnalyzer::endJob() {
   //  TimingReport::current()->dump(std::cout);
 }
 
-void Geant4ePropagatorAnalyzer::analyze(const edm::Event &iEvent,
-                                        const edm::EventSetup &iSetup) {
-
+void Geant4ePropagatorAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
 
   LogDebug("Geant4e") << "Starting analyze...";
@@ -296,8 +285,7 @@ void Geant4ePropagatorAnalyzer::analyze(const edm::Event &iEvent,
   iSetup.get<IdealMagneticFieldRecord>().get(bField);
   if (bField.isValid())
     LogDebug("Geant4e") << "G4e -- Magnetic field is valid. Value in (0,0,0): "
-                        << bField->inTesla(GlobalPoint(0, 0, 0)).mag()
-                        << " Tesla";
+                        << bField->inTesla(GlobalPoint(0, 0, 0)).mag() << " Tesla";
   else
     LogError("Geant4e") << "G4e -- NO valid Magnetic field";
 
@@ -320,8 +308,8 @@ void Geant4ePropagatorAnalyzer::analyze(const edm::Event &iEvent,
   // Run/Event information
   theRun = (int)iEvent.id().run();
   theEvent = (int)iEvent.id().event();
-  LogDebug("Geant4e") << "G4e -- Begin for run/event ==" << theRun << "/"
-                      << theEvent << " ---------------------------------";
+  LogDebug("Geant4e") << "G4e -- Begin for run/event ==" << theRun << "/" << theEvent
+                      << " ---------------------------------";
 
   ///////////////////////////////////////
   // Initialise the propagator
@@ -383,13 +371,11 @@ void Geant4ePropagatorAnalyzer::analyze(const edm::Event &iEvent,
   // DEBUG
   unsigned int counter = 0;
   // DEBUG
-  for (SimTrackContainer::const_iterator simTracksIt = simTracks->begin();
-       simTracksIt != simTracks->end(); simTracksIt++) {
-
+  for (SimTrackContainer::const_iterator simTracksIt = simTracks->begin(); simTracksIt != simTracks->end();
+       simTracksIt++) {
     // DEBUG
     counter++;
-    LogDebug("Geant4e") << "G4e -- Iterating over " << counter
-                        << "rd track. Number: " << simTracksIt->genpartIndex()
+    LogDebug("Geant4e") << "G4e -- Iterating over " << counter << "rd track. Number: " << simTracksIt->genpartIndex()
                         << "------------------";
     // DEBUG
 
@@ -411,22 +397,16 @@ void Geant4ePropagatorAnalyzer::analyze(const edm::Event &iEvent,
       LogDebug("Geant4e") << "Found a muon track " << trkPDG;
 
     //- Get momentum, but only use tracks with P > 2 GeV
-    GlobalVector p3T =
-        TrackPropagation::hep3VectorToGlobalVector(CLHEP::Hep3Vector(
-            simTracksIt->momentum().x(), simTracksIt->momentum().y(),
-            simTracksIt->momentum().z()));
+    GlobalVector p3T = TrackPropagation::hep3VectorToGlobalVector(
+        CLHEP::Hep3Vector(simTracksIt->momentum().x(), simTracksIt->momentum().y(), simTracksIt->momentum().z()));
     if (p3T.perp() < 2.) {
       LogDebug("Geant4e") << "Track PT is too low: " << p3T.perp();
       continue;
     } else {
-      LogDebug("Geant4e") << "*** Phi (rad): " << p3T.phi() << " - Phi(deg)"
-                          << p3T.phi().degrees();
+      LogDebug("Geant4e") << "*** Phi (rad): " << p3T.phi() << " - Phi(deg)" << p3T.phi().degrees();
       LogDebug("Geant4e") << "Track PT is enough.";
-      LogDebug("Geant4e") << "Track P.: " << p3T
-                          << "\nTrack P.: PT=" << p3T.perp()
-                          << "\tEta=" << p3T.eta()
-                          << "\tPhi=" << p3T.phi().degrees()
-                          << "--> Rad: Phi=" << p3T.phi();
+      LogDebug("Geant4e") << "Track P.: " << p3T << "\nTrack P.: PT=" << p3T.perp() << "\tEta=" << p3T.eta()
+                          << "\tPhi=" << p3T.phi().degrees() << "--> Rad: Phi=" << p3T.phi();
     }
 
     //- Vertex fixes the starting point
@@ -436,14 +416,11 @@ void Geant4ePropagatorAnalyzer::analyze(const edm::Event &iEvent,
       LogDebug("Geant4e") << "Track with no vertex, defaulting to (0,0,0)";
     else
       // seems to be stored in mm --> convert to cm
-      r3T = TrackPropagation::hep3VectorToGlobalPoint(
-          CLHEP::Hep3Vector((*simVertices)[vtxInd].position().x(),
-                            (*simVertices)[vtxInd].position().y(),
-                            (*simVertices)[vtxInd].position().z()));
+      r3T = TrackPropagation::hep3VectorToGlobalPoint(CLHEP::Hep3Vector((*simVertices)[vtxInd].position().x(),
+                                                                        (*simVertices)[vtxInd].position().y(),
+                                                                        (*simVertices)[vtxInd].position().z()));
 
-    LogDebug("Geant4e") << "Init point: " << r3T
-                        << "\nInit point Ro=" << r3T.perp()
-                        << "\tEta=" << r3T.eta()
+    LogDebug("Geant4e") << "Init point: " << r3T << "\nInit point Ro=" << r3T.perp() << "\tEta=" << r3T.eta()
                         << "\tPhi=" << r3T.phi().degrees();
 
     //- Charge
@@ -471,14 +448,13 @@ void Geant4ePropagatorAnalyzer::analyze(const edm::Event &iEvent,
     //- Iterate over Sim Hits in CSC and check propagation
     // iterateOverHits(simHitsCSC, CSC, trkInd, ftsTrack);
 
-  } // <-- for over sim tracks
+  }  // <-- for over sim tracks
 }
 
-void Geant4ePropagatorAnalyzer::iterateOverHits(
-    edm::Handle<edm::PSimHitContainer> simHits,
-    testMuChamberType muonChamberType, unsigned int trkIndex,
-    const FreeTrajectoryState &ftsTrack) {
-
+void Geant4ePropagatorAnalyzer::iterateOverHits(edm::Handle<edm::PSimHitContainer> simHits,
+                                                testMuChamberType muonChamberType,
+                                                unsigned int trkIndex,
+                                                const FreeTrajectoryState &ftsTrack) {
   using namespace edm;
 
   if (muonChamberType == DT)
@@ -488,14 +464,11 @@ void Geant4ePropagatorAnalyzer::iterateOverHits(
   else if (muonChamberType == CSC)
     LogDebug("Geant4e") << "G4e -- Iterating over CSC hits...";
 
-  for (PSimHitContainer::const_iterator simHitIt = simHits->begin();
-       simHitIt != simHits->end(); simHitIt++) {
-
+  for (PSimHitContainer::const_iterator simHitIt = simHits->begin(); simHitIt != simHits->end(); simHitIt++) {
     ///////////////
     // Skip if this hit does not belong to the track
     if (simHitIt->trackId() != trkIndex) {
-      LogDebug("Geant4e") << "Hit (in tr " << simHitIt->trackId()
-                          << ") does not belong to track " << trkIndex;
+      LogDebug("Geant4e") << "Hit (in tr " << simHitIt->trackId() << ") does not belong to track " << trkIndex;
       continue;
     }
 
@@ -508,20 +481,18 @@ void Geant4ePropagatorAnalyzer::iterateOverHits(
       LogDebug("Geant4e") << "Associated track is not a muon: " << trkPDG;
       continue;
     }
-    LogDebug("Geant4e") << "G4e -- Found a hit corresponding to a muon "
-                        << trkPDG;
+    LogDebug("Geant4e") << "G4e -- Found a hit corresponding to a muon " << trkPDG;
 
     //////////////////////////////////////////////////////////
     // Build the surface. This is different for DT, RPC, CSC
     // const GeomDetUnit* layer = 0;
     const GeomDet *layer = nullptr;
     // * DT
-    DTWireId *wIdDT = nullptr; // For DT holds the information about the chamber
+    DTWireId *wIdDT = nullptr;  // For DT holds the information about the chamber
     if (muonChamberType == DT) {
       wIdDT = new DTWireId(simHitIt->detUnitId());
       int station = wIdDT->station();
-      LogDebug("Geant4e") << "G4e -- DT Chamber. Station: " << station
-                          << ". DetId: " << wIdDT->layerId();
+      LogDebug("Geant4e") << "G4e -- DT Chamber. Station: " << station << ". DetId: " << wIdDT->layerId();
 
       if (fStudyStation != -1 && fStudyStation != station)
         continue;
@@ -572,34 +543,29 @@ void Geant4ePropagatorAnalyzer::iterateOverHits(
     GlobalPoint posHit = surf.toGlobal(simHitIt->localPosition());
     Point3DBase<float, GlobalTag> surfpos = surf.position();
     LogDebug("Geant4e") << "G4e -- Layer position: " << surfpos << " cm"
-                        << "\nG4e --                   Ro=" << surfpos.perp()
-                        << "\tEta=" << surfpos.eta()
+                        << "\nG4e --                   Ro=" << surfpos.perp() << "\tEta=" << surfpos.eta()
                         << "\tPhi=" << surfpos.phi().degrees() << "deg";
     LogDebug("Geant4e") << "G4e -- Sim Hit position: " << posHit << " cm"
-                        << "\nG4e --                   Ro=" << posHit.perp()
-                        << "\tEta=" << posHit.eta()
+                        << "\nG4e --                   Ro=" << posHit.perp() << "\tEta=" << posHit.eta()
                         << "\tPhi=" << posHit.phi().degrees() << "deg"
                         << "\t localpos=" << simHitIt->localPosition();
 
     const Plane *bp = dynamic_cast<const Plane *>(&surf);
     if (bp != nullptr) {
       Float_t distance = bp->localZ(posHit);
-      LogDebug("Geant4e") << "\nG4e -- Distance from plane to sim hit: "
-                          << distance << "cm";
+      LogDebug("Geant4e") << "\nG4e -- Distance from plane to sim hit: " << distance << "cm";
       fDistanceSHLayer->Fill(distance);
     } else {
       LogWarning("Geant4e") << "G4e -- Layer is not a Plane!!!";
       fDistanceSHLayer->Fill(-1);
     }
 
-    LogDebug("Geant4e") << "Sim Hit Momentum PT=" << p3Hit.perp()
-                        << "\tEta=" << p3Hit.eta()
+    LogDebug("Geant4e") << "Sim Hit Momentum PT=" << p3Hit.perp() << "\tEta=" << p3Hit.eta()
                         << "\tPhi=" << p3Hit.phi().degrees() << "deg";
 
     /////////////////////////////////////////
     // Propagate: Need to explicetely
-    TrajectoryStateOnSurface tSOSDest =
-        thePropagator->propagate(ftsTrack, surf);
+    TrajectoryStateOnSurface tSOSDest = thePropagator->propagate(ftsTrack, surf);
 
     /////////////////////
     // Get hit position and extrapolation position to compare
@@ -613,20 +579,15 @@ void Geant4ePropagatorAnalyzer::iterateOverHits(
     float simhitphi = posHit.phi().degrees();
     float layerphi = surfpos.phi().degrees();
     float extrapphi = posExtrap.phi().degrees();
-    LogDebug("Geant4e")
-        << "G4e -- Difference between hit and final position: " << distance
-        << " cm\n"
-        << "G4e -- Transversal difference between hit and final position: "
-        << posDistance.perp() << " cm.";
-    LogDebug("Geant4e") << "G4e -- Extrapolated position:" << posExtrap
-                        << " cm\n"
-                        << "G4e --       (Rho, eta, phi): (" << posExtrap.perp()
-                        << " cm, " << posExtrap.eta() << ", " << extrapphi
-                        << " deg)";
+    LogDebug("Geant4e") << "G4e -- Difference between hit and final position: " << distance << " cm\n"
+                        << "G4e -- Transversal difference between hit and final position: " << posDistance.perp()
+                        << " cm.";
+    LogDebug("Geant4e") << "G4e -- Extrapolated position:" << posExtrap << " cm\n"
+                        << "G4e --       (Rho, eta, phi): (" << posExtrap.perp() << " cm, " << posExtrap.eta() << ", "
+                        << extrapphi << " deg)";
     LogDebug("Geant4e") << "G4e --          Hit position: " << posHit << " cm\n"
-                        << "G4e --       (Rho, eta, phi): (" << posHit.perp()
-                        << " cm, " << posHit.eta() << ", " << simhitphi
-                        << " deg)";
+                        << "G4e --       (Rho, eta, phi): (" << posHit.perp() << " cm, " << posHit.eta() << ", "
+                        << simhitphi << " deg)";
 
     fDistance->Fill(distance);
     fDistanceSt[wIdDT->station() - 1]->Fill(distance);
@@ -671,7 +632,7 @@ void Geant4ePropagatorAnalyzer::iterateOverHits(
       delete wIdDT;
     }
 
-  } //<== For over simhits
+  }  //<== For over simhits
 }
 
 // define this as a plug-in


### PR DESCRIPTION

Applying code-format for CMSSW category simulation.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/189//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Fixes the code-formats suggested by #26623 (see #26686)
