### PR TITLE
Running code-format for dqm

### DIFF
--- a/DQM/EcalCommon/interface/DQWorker.h
+++ b/DQM/EcalCommon/interface/DQWorker.h
@@ -13,105 +13,99 @@
 #include "tbb/concurrent_unordered_map.h"
 
 namespace edm {
-class Run;
-class LuminosityBlock;
-class Event;
-class EventSetup;
-class ParameterSet;
-class ParameterSetDescription;
-} // namespace edm
+  class Run;
+  class LuminosityBlock;
+  class Event;
+  class EventSetup;
+  class ParameterSet;
+  class ParameterSetDescription;
+}  // namespace edm
 
 namespace ecaldqm {
 
-class WorkerFactoryStore;
+  class WorkerFactoryStore;
 
-class DQWorker {
-  friend class WorkerFactoryStore;
+  class DQWorker {
+    friend class WorkerFactoryStore;
 
-private:
-  struct Timestamp {
-    time_t now;
-    edm::RunNumber_t iRun;
-    edm::LuminosityBlockNumber_t iLumi;
-    edm::EventNumber_t iEvt;
-    Timestamp() : now(0), iRun(0), iLumi(0), iEvt(0) {}
+  private:
+    struct Timestamp {
+      time_t now;
+      edm::RunNumber_t iRun;
+      edm::LuminosityBlockNumber_t iLumi;
+      edm::EventNumber_t iEvt;
+      Timestamp() : now(0), iRun(0), iLumi(0), iEvt(0) {}
+    };
+
+  protected:
+    void setVerbosity(int _verbosity) { verbosity_ = _verbosity; }
+    void initialize(std::string const &_name, edm::ParameterSet const &);
+
+    virtual void setME(edm::ParameterSet const &);
+    virtual void setSource(edm::ParameterSet const &) {}  // for clients
+    virtual void setParams(edm::ParameterSet const &) {}
+
+  public:
+    DQWorker();
+    virtual ~DQWorker() noexcept(false);
+
+    static void fillDescriptions(edm::ParameterSetDescription &_desc);
+
+    virtual void beginRun(edm::Run const &, edm::EventSetup const &) {}
+    virtual void endRun(edm::Run const &, edm::EventSetup const &) {}
+
+    virtual void beginLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) {}
+    virtual void endLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) {}
+
+    virtual void bookMEs(DQMStore::IBooker &);
+    virtual void releaseMEs();
+
+    void setTime(time_t _t) { timestamp_.now = _t; }
+    void setRunNumber(edm::RunNumber_t _r) { timestamp_.iRun = _r; }
+    void setLumiNumber(edm::LuminosityBlockNumber_t _l) { timestamp_.iLumi = _l; }
+    void setEventNumber(edm::EventNumber_t _e) { timestamp_.iEvt = _e; }
+
+    std::string const &getName() const { return name_; }
+    bool onlineMode() const { return onlineMode_; }
+
+  protected:
+    void print_(std::string const &, int = 0) const;
+
+    std::string name_;
+    MESetCollection MEs_;
+    bool booked_;
+
+    Timestamp timestamp_;
+    int verbosity_;
+
+    // common parameters
+    bool onlineMode_;
+    bool willConvertToEDM_;
   };
 
-protected:
-  void setVerbosity(int _verbosity) { verbosity_ = _verbosity; }
-  void initialize(std::string const &_name, edm::ParameterSet const &);
+  typedef DQWorker *(*WorkerFactory)();
 
-  virtual void setME(edm::ParameterSet const &);
-  virtual void setSource(edm::ParameterSet const &) {} // for clients
-  virtual void setParams(edm::ParameterSet const &) {}
+  // to be instantiated after the implementation of each worker module
+  class WorkerFactoryStore {
+  public:
+    template <typename Worker>
+    struct Registration {
+      Registration(std::string const &_name) {
+        WorkerFactoryStore::singleton()->registerFactory(_name, []() -> DQWorker * { return new Worker(); });
+      }
+    };
 
-public:
-  DQWorker();
-  virtual ~DQWorker() noexcept(false);
+    void registerFactory(std::string const &_name, WorkerFactory _f) { workerFactories_[_name] = _f; }
+    DQWorker *getWorker(std::string const &, int, edm::ParameterSet const &, edm::ParameterSet const &) const;
 
-  static void fillDescriptions(edm::ParameterSetDescription &_desc);
+    static WorkerFactoryStore *singleton();
 
-  virtual void beginRun(edm::Run const &, edm::EventSetup const &) {}
-  virtual void endRun(edm::Run const &, edm::EventSetup const &) {}
-
-  virtual void beginLuminosityBlock(edm::LuminosityBlock const &,
-                                    edm::EventSetup const &) {}
-  virtual void endLuminosityBlock(edm::LuminosityBlock const &,
-                                  edm::EventSetup const &) {}
-
-  virtual void bookMEs(DQMStore::IBooker &);
-  virtual void releaseMEs();
-
-  void setTime(time_t _t) { timestamp_.now = _t; }
-  void setRunNumber(edm::RunNumber_t _r) { timestamp_.iRun = _r; }
-  void setLumiNumber(edm::LuminosityBlockNumber_t _l) { timestamp_.iLumi = _l; }
-  void setEventNumber(edm::EventNumber_t _e) { timestamp_.iEvt = _e; }
-
-  std::string const &getName() const { return name_; }
-  bool onlineMode() const { return onlineMode_; }
-
-protected:
-  void print_(std::string const &, int = 0) const;
-
-  std::string name_;
-  MESetCollection MEs_;
-  bool booked_;
-
-  Timestamp timestamp_;
-  int verbosity_;
-
-  // common parameters
-  bool onlineMode_;
-  bool willConvertToEDM_;
-};
-
-typedef DQWorker *(*WorkerFactory)();
-
-// to be instantiated after the implementation of each worker module
-class WorkerFactoryStore {
-public:
-  template <typename Worker> struct Registration {
-    Registration(std::string const &_name) {
-      WorkerFactoryStore::singleton()->registerFactory(
-          _name, []() -> DQWorker * { return new Worker(); });
-    }
+  private:
+    tbb::concurrent_unordered_map<std::string, WorkerFactory> workerFactories_;
   };
 
-  void registerFactory(std::string const &_name, WorkerFactory _f) {
-    workerFactories_[_name] = _f;
-  }
-  DQWorker *getWorker(std::string const &, int, edm::ParameterSet const &,
-                      edm::ParameterSet const &) const;
+}  // namespace ecaldqm
 
-  static WorkerFactoryStore *singleton();
-
-private:
-  tbb::concurrent_unordered_map<std::string, WorkerFactory> workerFactories_;
-};
-
-} // namespace ecaldqm
-
-#define DEFINE_ECALDQM_WORKER(TYPE)                                            \
-  WorkerFactoryStore::Registration<TYPE> ecaldqm##TYPE##Registration(#TYPE)
+#define DEFINE_ECALDQM_WORKER(TYPE) WorkerFactoryStore::Registration<TYPE> ecaldqm##TYPE##Registration(#TYPE)
 
 #endif

--- a/DQM/EcalCommon/interface/EcalDQMCommonUtils.h
+++ b/DQM/EcalCommon/interface/EcalDQMCommonUtils.h
@@ -23,169 +23,168 @@
 
 namespace ecaldqm {
 
-enum SMName {
-  kEEm07,
-  kEEm08,
-  kEEm09,
-  kEEm01,
-  kEEm02,
-  kEEm03,
-  kEEm04,
-  kEEm05,
-  kEEm06,
-  kEBm01,
-  kEBm02,
-  kEBm03,
-  kEBm04,
-  kEBm05,
-  kEBm06,
-  kEBm07,
-  kEBm08,
-  kEBm09,
-  kEBm10,
-  kEBm11,
-  kEBm12,
-  kEBm13,
-  kEBm14,
-  kEBm15,
-  kEBm16,
-  kEBm17,
-  kEBm18,
-  kEBp01,
-  kEBp02,
-  kEBp03,
-  kEBp04,
-  kEBp05,
-  kEBp06,
-  kEBp07,
-  kEBp08,
-  kEBp09,
-  kEBp10,
-  kEBp11,
-  kEBp12,
-  kEBp13,
-  kEBp14,
-  kEBp15,
-  kEBp16,
-  kEBp17,
-  kEBp18,
-  kEEp07,
-  kEEp08,
-  kEEp09,
-  kEEp01,
-  kEEp02,
-  kEEp03,
-  kEEp04,
-  kEEp05,
-  kEEp06,
-  kEEmLow = kEEm07,
-  kEEmHigh = kEEm06,
-  kEEpLow = kEEp07,
-  kEEpHigh = kEEp06,
-  kEBmLow = kEBm01,
-  kEBmHigh = kEBm18,
-  kEBpLow = kEBp01,
-  kEBpHigh = kEBp18
-};
+  enum SMName {
+    kEEm07,
+    kEEm08,
+    kEEm09,
+    kEEm01,
+    kEEm02,
+    kEEm03,
+    kEEm04,
+    kEEm05,
+    kEEm06,
+    kEBm01,
+    kEBm02,
+    kEBm03,
+    kEBm04,
+    kEBm05,
+    kEBm06,
+    kEBm07,
+    kEBm08,
+    kEBm09,
+    kEBm10,
+    kEBm11,
+    kEBm12,
+    kEBm13,
+    kEBm14,
+    kEBm15,
+    kEBm16,
+    kEBm17,
+    kEBm18,
+    kEBp01,
+    kEBp02,
+    kEBp03,
+    kEBp04,
+    kEBp05,
+    kEBp06,
+    kEBp07,
+    kEBp08,
+    kEBp09,
+    kEBp10,
+    kEBp11,
+    kEBp12,
+    kEBp13,
+    kEBp14,
+    kEBp15,
+    kEBp16,
+    kEBp17,
+    kEBp18,
+    kEEp07,
+    kEEp08,
+    kEEp09,
+    kEEp01,
+    kEEp02,
+    kEEp03,
+    kEEp04,
+    kEEp05,
+    kEEp06,
+    kEEmLow = kEEm07,
+    kEEmHigh = kEEm06,
+    kEEpLow = kEEp07,
+    kEEpHigh = kEEp06,
+    kEBmLow = kEBm01,
+    kEBmHigh = kEBm18,
+    kEBpLow = kEBp01,
+    kEBpHigh = kEBp18
+  };
 
-enum Constants {
-  nDCC = 54,
-  nEBDCC = 36,
-  nEEDCC = 18,
-  nDCCMEM = 44,
-  nEEDCCMEM = 8,
+  enum Constants {
+    nDCC = 54,
+    nEBDCC = 36,
+    nEEDCC = 18,
+    nDCCMEM = 44,
+    nEEDCCMEM = 8,
 
-  nTTOuter = 16,
-  nTTInner = 28,
-  // These lines set the number of TriggerTowers in "outer" and "inner" TCCs,
-  // where "outer" := closer to the barrel. These constants are used in
-  // setting the binning. There are 16 trigger towers per TCC for "outer" TCCs,
-  // and 24 per TCC for "inner" TCCs (but the numbering is from 0 to 27, so
-  // 28 bins are required).
+    nTTOuter = 16,
+    nTTInner = 28,
+    // These lines set the number of TriggerTowers in "outer" and "inner" TCCs,
+    // where "outer" := closer to the barrel. These constants are used in
+    // setting the binning. There are 16 trigger towers per TCC for "outer" TCCs,
+    // and 24 per TCC for "inner" TCCs (but the numbering is from 0 to 27, so
+    // 28 bins are required).
 
-  nTCC = 108,
-  kEEmTCCLow = 0,
-  kEEmTCCHigh = 35,
-  kEEpTCCLow = 72,
-  kEEpTCCHigh = 107,
-  kEBTCCLow = 36,
-  kEBTCCHigh = 71,
+    nTCC = 108,
+    kEEmTCCLow = 0,
+    kEEmTCCHigh = 35,
+    kEEpTCCLow = 72,
+    kEEpTCCHigh = 107,
+    kEBTCCLow = 36,
+    kEBTCCHigh = 71,
 
-  nChannels = EBDetId::kSizeForDenseIndexing + EEDetId::kSizeForDenseIndexing,
-  nTowers =
-      EcalTrigTowerDetId::kEBTotalTowers + EcalScDetId::kSizeForDenseIndexing
-};
+    nChannels = EBDetId::kSizeForDenseIndexing + EEDetId::kSizeForDenseIndexing,
+    nTowers = EcalTrigTowerDetId::kEBTotalTowers + EcalScDetId::kSizeForDenseIndexing
+  };
 
-extern std::vector<unsigned> const memDCC;
+  extern std::vector<unsigned> const memDCC;
 
-extern double const etaBound;
+  extern double const etaBound;
 
-// returns DCC ID (1 - 54)
-unsigned dccId(DetId const &);
-unsigned dccId(EcalElectronicsId const &);
+  // returns DCC ID (1 - 54)
+  unsigned dccId(DetId const &);
+  unsigned dccId(EcalElectronicsId const &);
 
-unsigned memDCCId(unsigned);    // convert from dccId skipping DCCs without MEM
-unsigned memDCCIndex(unsigned); // reverse conversion
+  unsigned memDCCId(unsigned);     // convert from dccId skipping DCCs without MEM
+  unsigned memDCCIndex(unsigned);  // reverse conversion
 
-// returns TCC ID (1 - 108)
-unsigned tccId(DetId const &);
-unsigned tccId(EcalElectronicsId const &);
+  // returns TCC ID (1 - 108)
+  unsigned tccId(DetId const &);
+  unsigned tccId(EcalElectronicsId const &);
 
-// returns the data tower id - pass only
-unsigned towerId(DetId const &);
-unsigned towerId(EcalElectronicsId const &);
+  // returns the data tower id - pass only
+  unsigned towerId(DetId const &);
+  unsigned towerId(EcalElectronicsId const &);
 
-unsigned ttId(DetId const &);
-unsigned ttId(EcalElectronicsId const &);
+  unsigned ttId(DetId const &);
+  unsigned ttId(EcalElectronicsId const &);
 
-unsigned rtHalf(DetId const &);
+  unsigned rtHalf(DetId const &);
 
-std::pair<unsigned, unsigned> innerTCCs(unsigned);
-std::pair<unsigned, unsigned> outerTCCs(unsigned);
+  std::pair<unsigned, unsigned> innerTCCs(unsigned);
+  std::pair<unsigned, unsigned> outerTCCs(unsigned);
 
-std::vector<DetId> scConstituents(EcalScDetId const &);
+  std::vector<DetId> scConstituents(EcalScDetId const &);
 
-EcalPnDiodeDetId pnForCrystal(DetId const &, char);
+  EcalPnDiodeDetId pnForCrystal(DetId const &, char);
 
-unsigned dccId(std::string const &);
-std::string smName(unsigned);
+  unsigned dccId(std::string const &);
+  std::string smName(unsigned);
 
-int zside(DetId const &);
+  int zside(DetId const &);
 
-double eta(EBDetId const &);
-double eta(EEDetId const &);
-double phi(EBDetId const &);
-double phi(EEDetId const &);
-double phi(EcalTrigTowerDetId const &);
-double phi(double);
+  double eta(EBDetId const &);
+  double eta(EEDetId const &);
+  double phi(EBDetId const &);
+  double phi(EEDetId const &);
+  double phi(EcalTrigTowerDetId const &);
+  double phi(double);
 
-bool isForward(DetId const &);
+  bool isForward(DetId const &);
 
-bool isCrystalId(DetId const &);
-bool isSingleChannelId(DetId const &);
-bool isEcalScDetId(DetId const &);
-bool isEndcapTTId(DetId const &);
+  bool isCrystalId(DetId const &);
+  bool isSingleChannelId(DetId const &);
+  bool isEcalScDetId(DetId const &);
+  bool isEndcapTTId(DetId const &);
 
-unsigned nCrystals(unsigned);
-unsigned nSuperCrystals(unsigned);
+  unsigned nCrystals(unsigned);
+  unsigned nSuperCrystals(unsigned);
 
-bool ccuExists(unsigned, unsigned);
+  bool ccuExists(unsigned, unsigned);
 
-bool checkElectronicsMap(bool = true);
-EcalElectronicsMapping const *getElectronicsMap();
-void setElectronicsMap(EcalElectronicsMapping const *);
+  bool checkElectronicsMap(bool = true);
+  EcalElectronicsMapping const *getElectronicsMap();
+  void setElectronicsMap(EcalElectronicsMapping const *);
 
-bool checkTrigTowerMap(bool = true);
-EcalTrigTowerConstituentsMap const *getTrigTowerMap();
-void setTrigTowerMap(EcalTrigTowerConstituentsMap const *);
+  bool checkTrigTowerMap(bool = true);
+  EcalTrigTowerConstituentsMap const *getTrigTowerMap();
+  void setTrigTowerMap(EcalTrigTowerConstituentsMap const *);
 
-bool checkGeometry(bool = true);
-CaloGeometry const *getGeometry();
-void setGeometry(CaloGeometry const *);
+  bool checkGeometry(bool = true);
+  CaloGeometry const *getGeometry();
+  void setGeometry(CaloGeometry const *);
 
-bool checkTopology(bool = true);
-CaloTopology const *getTopology();
-void setTopology(CaloTopology const *);
-} // namespace ecaldqm
+  bool checkTopology(bool = true);
+  CaloTopology const *getTopology();
+  void setTopology(CaloTopology const *);
+}  // namespace ecaldqm
 
 #endif

--- a/DQM/EcalCommon/interface/EcalDQMonitor.h
+++ b/DQM/EcalCommon/interface/EcalDQMonitor.h
@@ -10,57 +10,54 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace edm {
-class ParameterSet;
-class Run;
-class LuminosityBlock;
-class EventSetup;
-} // namespace edm
+  class ParameterSet;
+  class Run;
+  class LuminosityBlock;
+  class EventSetup;
+}  // namespace edm
 
 namespace ecaldqm {
-class EcalDQMonitor {
-public:
-  EcalDQMonitor(edm::ParameterSet const &);
-  virtual ~EcalDQMonitor() noexcept(false);
+  class EcalDQMonitor {
+  public:
+    EcalDQMonitor(edm::ParameterSet const &);
+    virtual ~EcalDQMonitor() noexcept(false);
 
-  static void fillDescriptions(edm::ParameterSetDescription &);
+    static void fillDescriptions(edm::ParameterSetDescription &);
 
-protected:
-  void ecaldqmGetSetupObjects(edm::EventSetup const &);
-  void ecaldqmBeginRun(edm::Run const &, edm::EventSetup const &);
-  void ecaldqmEndRun(edm::Run const &, edm::EventSetup const &);
-  void ecaldqmBeginLuminosityBlock(edm::LuminosityBlock const &,
-                                   edm::EventSetup const &);
-  void ecaldqmEndLuminosityBlock(edm::LuminosityBlock const &,
-                                 edm::EventSetup const &);
+  protected:
+    void ecaldqmGetSetupObjects(edm::EventSetup const &);
+    void ecaldqmBeginRun(edm::Run const &, edm::EventSetup const &);
+    void ecaldqmEndRun(edm::Run const &, edm::EventSetup const &);
+    void ecaldqmBeginLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &);
+    void ecaldqmEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &);
+
+    template <typename FuncOnWorker>
+    void executeOnWorkers_(FuncOnWorker,
+                           std::string const &,
+                           std::string const & = "",
+                           int = 1);  // loop over workers and capture exceptions
+
+    std::vector<DQWorker *> workers_;
+    std::string const moduleName_;
+    int const verbosity_;
+  };
 
   template <typename FuncOnWorker>
-  void executeOnWorkers_(FuncOnWorker, std::string const &,
-                         std::string const & = "",
-                         int = 1); // loop over workers and capture exceptions
-
-  std::vector<DQWorker *> workers_;
-  std::string const moduleName_;
-  int const verbosity_;
-};
-
-template <typename FuncOnWorker>
-void EcalDQMonitor::executeOnWorkers_(FuncOnWorker _func,
-                                      std::string const &_context,
-                                      std::string const &_message /* = ""*/,
-                                      int _verbThreshold /* = 1*/) {
-  std::for_each(workers_.begin(), workers_.end(), [&](DQWorker *worker) {
-    if (verbosity_ > _verbThreshold && !_message.empty())
-      edm::LogInfo("EcalDQM")
-          << moduleName_ << ": " << _message << " @ " << worker->getName();
-    try {
-      _func(worker);
-    } catch (std::exception &) {
-      edm::LogError("EcalDQM") << moduleName_ << ": Exception in " << _context
-                               << " @ " << worker->getName();
-      throw;
-    }
-  });
-}
-} // namespace ecaldqm
+  void EcalDQMonitor::executeOnWorkers_(FuncOnWorker _func,
+                                        std::string const &_context,
+                                        std::string const &_message /* = ""*/,
+                                        int _verbThreshold /* = 1*/) {
+    std::for_each(workers_.begin(), workers_.end(), [&](DQWorker *worker) {
+      if (verbosity_ > _verbThreshold && !_message.empty())
+        edm::LogInfo("EcalDQM") << moduleName_ << ": " << _message << " @ " << worker->getName();
+      try {
+        _func(worker);
+      } catch (std::exception &) {
+        edm::LogError("EcalDQM") << moduleName_ << ": Exception in " << _context << " @ " << worker->getName();
+        throw;
+      }
+    });
+  }
+}  // namespace ecaldqm
 
 #endif

--- a/DQM/EcalCommon/interface/EcalMEFormatter.h
+++ b/DQM/EcalCommon/interface/EcalMEFormatter.h
@@ -14,7 +14,8 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions &);
 
 private:
-  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &,
+  void dqmEndLuminosityBlock(DQMStore::IBooker &,
+                             DQMStore::IGetter &,
                              edm::LuminosityBlock const &,
                              edm::EventSetup const &) override;
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;

--- a/DQM/EcalCommon/interface/EcalMonitorPrescaler.h
+++ b/DQM/EcalCommon/interface/EcalMonitorPrescaler.h
@@ -15,16 +15,7 @@ public:
   bool filter(edm::Event &, edm::EventSetup const &) override;
 
 private:
-  enum Prescalers {
-    kPhysics,
-    kCosmics,
-    kCalibration,
-    kLaser,
-    kLed,
-    kTestPulse,
-    kPedestal,
-    nPrescalers
-  };
+  enum Prescalers { kPhysics, kCosmics, kCalibration, kLaser, kLed, kTestPulse, kPedestal, nPrescalers };
 
   static uint32_t filterBits_[nPrescalers];
 
@@ -33,4 +24,4 @@ private:
   std::pair<unsigned, unsigned> prescalers_[nPrescalers];
 };
 
-#endif // EcalMonitorPrescaler_H
+#endif  // EcalMonitorPrescaler_H

--- a/DQM/EcalCommon/interface/FEFlags.h
+++ b/DQM/EcalCommon/interface/FEFlags.h
@@ -3,28 +3,28 @@
 
 namespace ecaldqm {
 
-// partially taken from
-// EventFilter/EcalRawToDigi/interface/DCCRawDataDefinitions.h
-enum FEFlags {
-  Enabled = 0,
-  Disabled = 1,
-  Timeout = 2,
-  HeaderError = 3,
-  ChannelId = 4,
-  LinkError = 5,
-  BlockSize = 6,
-  Suppressed = 7,
-  FIFOFull = 8,
-  L1ADesync = 9,
-  BXDesync = 10,
-  L1ABXDesync = 11,
-  FIFOFullL1ADesync = 12,
-  HParity = 13,
-  VParity = 14,
-  ForcedZS = 15,
-  nFEFlags = 16
-};
+  // partially taken from
+  // EventFilter/EcalRawToDigi/interface/DCCRawDataDefinitions.h
+  enum FEFlags {
+    Enabled = 0,
+    Disabled = 1,
+    Timeout = 2,
+    HeaderError = 3,
+    ChannelId = 4,
+    LinkError = 5,
+    BlockSize = 6,
+    Suppressed = 7,
+    FIFOFull = 8,
+    L1ADesync = 9,
+    BXDesync = 10,
+    L1ABXDesync = 11,
+    FIFOFullL1ADesync = 12,
+    HParity = 13,
+    VParity = 14,
+    ForcedZS = 15,
+    nFEFlags = 16
+  };
 
-} // namespace ecaldqm
+}  // namespace ecaldqm
 
 #endif

--- a/DQM/EcalCommon/interface/MESet.h
+++ b/DQM/EcalCommon/interface/MESet.h
@@ -17,364 +17,337 @@
 #include "boost/ptr_container/ptr_map.hpp"
 
 namespace ecaldqm {
-/*
+  /*
   class MESet
   Base class for MonitorElement wrappers
   Interface between ME bins and DetId
 */
 
-class StatusManager;
+  class StatusManager;
 
-class MESet {
-public:
-  typedef std::map<std::string, std::string> PathReplacements;
+  class MESet {
+  public:
+    typedef std::map<std::string, std::string> PathReplacements;
 
-  MESet();
-  MESet(std::string const &, binning::ObjectType, binning::BinningType,
-        MonitorElement::Kind);
-  MESet(MESet const &);
-  virtual ~MESet();
+    MESet();
+    MESet(std::string const &, binning::ObjectType, binning::BinningType, MonitorElement::Kind);
+    MESet(MESet const &);
+    virtual ~MESet();
 
-  virtual MESet &operator=(MESet const &);
+    virtual MESet &operator=(MESet const &);
 
-  virtual MESet *clone(std::string const & = "") const;
+    virtual MESet *clone(std::string const & = "") const;
 
-  virtual void book(DQMStore::IBooker &) {}
-  virtual bool retrieve(DQMStore::IGetter &, std::string * = nullptr) const {
-    return false;
-  }
-  virtual void clear() const;
+    virtual void book(DQMStore::IBooker &) {}
+    virtual bool retrieve(DQMStore::IGetter &, std::string * = nullptr) const { return false; }
+    virtual void clear() const;
 
-  virtual void fill(DetId const &, double = 1., double = 1., double = 1.) {}
-  virtual void fill(EcalElectronicsId const &, double = 1., double = 1.,
-                    double = 1.) {}
-  virtual void fill(int, double = 1., double = 1., double = 1.) {}
-  virtual void fill(double, double = 1., double = 1.) {}
+    virtual void fill(DetId const &, double = 1., double = 1., double = 1.) {}
+    virtual void fill(EcalElectronicsId const &, double = 1., double = 1., double = 1.) {}
+    virtual void fill(int, double = 1., double = 1., double = 1.) {}
+    virtual void fill(double, double = 1., double = 1.) {}
 
-  virtual void setBinContent(DetId const &, double) {}
-  virtual void setBinContent(EcalElectronicsId const &, double) {}
-  virtual void setBinContent(int, double) {}
-  virtual void setBinContent(DetId const &, int, double) {}
-  virtual void setBinContent(EcalElectronicsId const &, int, double) {}
-  virtual void setBinContent(int, int, double) {}
+    virtual void setBinContent(DetId const &, double) {}
+    virtual void setBinContent(EcalElectronicsId const &, double) {}
+    virtual void setBinContent(int, double) {}
+    virtual void setBinContent(DetId const &, int, double) {}
+    virtual void setBinContent(EcalElectronicsId const &, int, double) {}
+    virtual void setBinContent(int, int, double) {}
 
-  virtual void setBinError(DetId const &, double) {}
-  virtual void setBinError(EcalElectronicsId const &, double) {}
-  virtual void setBinError(int, double) {}
-  virtual void setBinError(DetId const &, int, double) {}
-  virtual void setBinError(EcalElectronicsId const &, int, double) {}
-  virtual void setBinError(int, int, double) {}
+    virtual void setBinError(DetId const &, double) {}
+    virtual void setBinError(EcalElectronicsId const &, double) {}
+    virtual void setBinError(int, double) {}
+    virtual void setBinError(DetId const &, int, double) {}
+    virtual void setBinError(EcalElectronicsId const &, int, double) {}
+    virtual void setBinError(int, int, double) {}
 
-  virtual void setBinEntries(DetId const &, double) {}
-  virtual void setBinEntries(EcalElectronicsId const &, double) {}
-  virtual void setBinEntries(int, double) {}
-  virtual void setBinEntries(DetId const &, int, double) {}
-  virtual void setBinEntries(EcalElectronicsId const &, int, double) {}
-  virtual void setBinEntries(int, int, double) {}
+    virtual void setBinEntries(DetId const &, double) {}
+    virtual void setBinEntries(EcalElectronicsId const &, double) {}
+    virtual void setBinEntries(int, double) {}
+    virtual void setBinEntries(DetId const &, int, double) {}
+    virtual void setBinEntries(EcalElectronicsId const &, int, double) {}
+    virtual void setBinEntries(int, int, double) {}
 
-  virtual double getBinContent(DetId const &, int = 0) const { return 0.; }
-  virtual double getBinContent(EcalElectronicsId const &, int = 0) const {
-    return 0.;
-  }
-  virtual double getBinContent(int, int = 0) const { return 0.; }
+    virtual double getBinContent(DetId const &, int = 0) const { return 0.; }
+    virtual double getBinContent(EcalElectronicsId const &, int = 0) const { return 0.; }
+    virtual double getBinContent(int, int = 0) const { return 0.; }
 
-  virtual double getBinError(DetId const &, int = 0) const { return 0.; }
-  virtual double getBinError(EcalElectronicsId const &, int = 0) const {
-    return 0.;
-  }
-  virtual double getBinError(int, int = 0) const { return 0.; }
+    virtual double getBinError(DetId const &, int = 0) const { return 0.; }
+    virtual double getBinError(EcalElectronicsId const &, int = 0) const { return 0.; }
+    virtual double getBinError(int, int = 0) const { return 0.; }
 
-  virtual double getBinEntries(DetId const &, int = 0) const { return 0.; }
-  virtual double getBinEntries(EcalElectronicsId const &, int = 0) const {
-    return 0.;
-  }
-  virtual double getBinEntries(int, int = 0) const { return 0.; }
+    virtual double getBinEntries(DetId const &, int = 0) const { return 0.; }
+    virtual double getBinEntries(EcalElectronicsId const &, int = 0) const { return 0.; }
+    virtual double getBinEntries(int, int = 0) const { return 0.; }
 
-  // title, axis
-  virtual void setAxisTitle(std::string const &, int = 1);
+    // title, axis
+    virtual void setAxisTitle(std::string const &, int = 1);
 
-  virtual void reset(double = 0., double = 0., double = 0.);
-  virtual void resetAll(double = 0., double = 0., double = 0.);
+    virtual void reset(double = 0., double = 0., double = 0.);
+    virtual void resetAll(double = 0., double = 0., double = 0.);
 
-  virtual bool maskMatches(DetId const &, uint32_t,
-                           StatusManager const *) const;
+    virtual bool maskMatches(DetId const &, uint32_t, StatusManager const *) const;
 
-  virtual std::string const &getPath() const { return path_; }
-  binning::ObjectType getObjType() const { return otype_; }
-  binning::BinningType getBinType() const { return btype_; }
-  MonitorElement::Kind getKind() const { return kind_; }
-  bool isActive() const { return active_; } // booked or retrieved
-  virtual bool isVariableBinning() const { return false; }
-  virtual MonitorElement const *getME(unsigned _iME) const {
-    return (_iME < mes_.size() ? mes_[_iME] : nullptr);
-  }
-  virtual MonitorElement *getME(unsigned _iME) {
-    return (_iME < mes_.size() ? mes_[_iME] : nullptr);
-  }
-  virtual void softReset();
-  virtual void recoverStats();
+    virtual std::string const &getPath() const { return path_; }
+    binning::ObjectType getObjType() const { return otype_; }
+    binning::BinningType getBinType() const { return btype_; }
+    MonitorElement::Kind getKind() const { return kind_; }
+    bool isActive() const { return active_; }  // booked or retrieved
+    virtual bool isVariableBinning() const { return false; }
+    virtual MonitorElement const *getME(unsigned _iME) const { return (_iME < mes_.size() ? mes_[_iME] : nullptr); }
+    virtual MonitorElement *getME(unsigned _iME) { return (_iME < mes_.size() ? mes_[_iME] : nullptr); }
+    virtual void softReset();
+    virtual void recoverStats();
 
-  std::string formPath(PathReplacements const &) const;
+    std::string formPath(PathReplacements const &) const;
 
-  void setLumiFlag() { lumiFlag_ = true; };
-  bool getLumiFlag() const { return lumiFlag_; }
-  void setBatchMode() { batchMode_ = true; }
-  bool getBatchMode() const { return batchMode_; }
+    void setLumiFlag() { lumiFlag_ = true; };
+    bool getLumiFlag() const { return lumiFlag_; }
+    void setBatchMode() { batchMode_ = true; }
+    bool getBatchMode() const { return batchMode_; }
 
-protected:
-  virtual void fill_(unsigned, int, double);
-  virtual void fill_(unsigned, int, double, double);
-  virtual void fill_(unsigned, double, double, double);
-
-  virtual void checkME_(unsigned _iME) const {
-    if (!getME(_iME)) {
-      std::stringstream ss;
-      ss << "ME does not exist at index " << _iME;
-      throw_(ss.str());
-    }
-  }
-
-  void throw_(std::string const &_message) const {
-    throw cms::Exception("EcalDQM") << path_ << ": " << _message;
-  }
-
-  mutable std::vector<MonitorElement *> mes_;
-
-  mutable std::string path_;
-  binning::ObjectType otype_;
-  binning::BinningType btype_;
-  MonitorElement::Kind kind_;
-  bool lumiFlag_;  // when true, histograms will be saved every lumi section
-                   // (default false)
-  bool batchMode_; // when true, histograms are not GUI-ready (default false)
-
-  mutable bool active_;
-
-public:
-  struct ConstBin {
   protected:
-    MESet const *meSet_;
+    virtual void fill_(unsigned, int, double);
+    virtual void fill_(unsigned, int, double, double);
+    virtual void fill_(unsigned, double, double, double);
+
+    virtual void checkME_(unsigned _iME) const {
+      if (!getME(_iME)) {
+        std::stringstream ss;
+        ss << "ME does not exist at index " << _iME;
+        throw_(ss.str());
+      }
+    }
+
+    void throw_(std::string const &_message) const { throw cms::Exception("EcalDQM") << path_ << ": " << _message; }
+
+    mutable std::vector<MonitorElement *> mes_;
+
+    mutable std::string path_;
+    binning::ObjectType otype_;
+    binning::BinningType btype_;
+    MonitorElement::Kind kind_;
+    bool lumiFlag_;   // when true, histograms will be saved every lumi section
+                      // (default false)
+    bool batchMode_;  // when true, histograms are not GUI-ready (default false)
+
+    mutable bool active_;
 
   public:
-    unsigned iME;
-    int iBin;
-    binning::ObjectType otype;
+    struct ConstBin {
+    protected:
+      MESet const *meSet_;
 
-    ConstBin() : meSet_(nullptr), iME(-1), iBin(-1), otype(binning::nObjType) {}
-    ConstBin(MESet const &, unsigned = 0, int = 1);
-    ConstBin(ConstBin const &_orig)
-        : meSet_(_orig.meSet_), iME(_orig.iME), iBin(_orig.iBin),
-          otype(_orig.otype) {}
-    ConstBin &operator=(ConstBin const &);
-    bool operator==(ConstBin const &_rhs) const {
-      return meSet_ != nullptr && meSet_ == _rhs.meSet_ && iME == _rhs.iME &&
-             iBin == _rhs.iBin;
-    }
-    bool isChannel() const {
-      if (meSet_)
-        return binning::isValidIdBin(otype, meSet_->getBinType(), iME, iBin);
-      else
-        return false;
-    }
-    uint32_t getId() const {
-      if (meSet_)
-        return binning::idFromBin(otype, meSet_->getBinType(), iME, iBin);
-      else
-        return 0;
-    }
-    double getBinContent() const {
-      if (meSet_ && iME != unsigned(-1))
-        return meSet_->getME(iME)->getBinContent(iBin);
-      else
-        return 0.;
-    }
-    double getBinError() const {
-      if (meSet_ && iME != unsigned(-1))
-        return meSet_->getME(iME)->getBinError(iBin);
-      else
-        return 0.;
-    }
-    double getBinEntries() const {
-      if (meSet_ && iME != unsigned(-1))
-        return meSet_->getME(iME)->getBinEntries(iBin);
-      else
-        return 0.;
-    }
-    MonitorElement const *getME() const {
-      if (meSet_ && iME != unsigned(-1))
-        return meSet_->getME(iME);
-      else
-        return nullptr;
-    }
-    void setMESet(MESet const &_meSet) { meSet_ = &_meSet; }
-    MESet const *getMESet() const { return meSet_; }
-  };
+    public:
+      unsigned iME;
+      int iBin;
+      binning::ObjectType otype;
 
-  struct Bin : public ConstBin {
-  protected:
-    MESet *meSet_;
+      ConstBin() : meSet_(nullptr), iME(-1), iBin(-1), otype(binning::nObjType) {}
+      ConstBin(MESet const &, unsigned = 0, int = 1);
+      ConstBin(ConstBin const &_orig) : meSet_(_orig.meSet_), iME(_orig.iME), iBin(_orig.iBin), otype(_orig.otype) {}
+      ConstBin &operator=(ConstBin const &);
+      bool operator==(ConstBin const &_rhs) const {
+        return meSet_ != nullptr && meSet_ == _rhs.meSet_ && iME == _rhs.iME && iBin == _rhs.iBin;
+      }
+      bool isChannel() const {
+        if (meSet_)
+          return binning::isValidIdBin(otype, meSet_->getBinType(), iME, iBin);
+        else
+          return false;
+      }
+      uint32_t getId() const {
+        if (meSet_)
+          return binning::idFromBin(otype, meSet_->getBinType(), iME, iBin);
+        else
+          return 0;
+      }
+      double getBinContent() const {
+        if (meSet_ && iME != unsigned(-1))
+          return meSet_->getME(iME)->getBinContent(iBin);
+        else
+          return 0.;
+      }
+      double getBinError() const {
+        if (meSet_ && iME != unsigned(-1))
+          return meSet_->getME(iME)->getBinError(iBin);
+        else
+          return 0.;
+      }
+      double getBinEntries() const {
+        if (meSet_ && iME != unsigned(-1))
+          return meSet_->getME(iME)->getBinEntries(iBin);
+        else
+          return 0.;
+      }
+      MonitorElement const *getME() const {
+        if (meSet_ && iME != unsigned(-1))
+          return meSet_->getME(iME);
+        else
+          return nullptr;
+      }
+      void setMESet(MESet const &_meSet) { meSet_ = &_meSet; }
+      MESet const *getMESet() const { return meSet_; }
+    };
 
-  public:
-    Bin() : ConstBin(), meSet_(nullptr) {}
-    Bin(MESet &_set, unsigned _iME = 0, int _iBin = 1)
-        : ConstBin(_set, _iME, _iBin), meSet_(&_set) {}
-    Bin(Bin const &_orig) : ConstBin(_orig), meSet_(_orig.meSet_) {}
-    ConstBin &operator=(Bin const &_rhs) {
-      bool wasNull(ConstBin::meSet_ == nullptr);
-      ConstBin::operator=(_rhs);
-      if (wasNull)
-        meSet_ = _rhs.meSet_;
-      return *this;
-    }
-    void fill(double _w = 1.) {
-      if (meSet_)
-        meSet_->fill_(iME, iBin, _w);
-    }
-    void fill(double _y, double _w = 1.) {
-      if (meSet_)
-        meSet_->fill_(iME, iBin, _y, _w);
-    }
-    void setBinContent(double _content) {
-      if (meSet_ && iME != unsigned(-1))
-        meSet_->getME(iME)->setBinContent(iBin, _content);
-    }
-    void setBinError(double _error) {
-      if (meSet_ && iME != unsigned(-1))
-        meSet_->getME(iME)->setBinError(iBin, _error);
-    }
-    void setBinEntries(double _entries) {
-      if (meSet_ && iME != unsigned(-1))
-        meSet_->getME(iME)->setBinEntries(iBin, _entries);
-    }
-    MonitorElement *getME() const {
-      if (meSet_ && iME != unsigned(-1))
-        return meSet_->getME(iME);
-      else
-        return nullptr;
-    }
-    void setMESet(MESet &_meSet) {
-      ConstBin::meSet_ = &_meSet;
-      meSet_ = &_meSet;
-    }
-    MESet *getMESet() const { return meSet_; }
-  };
+    struct Bin : public ConstBin {
+    protected:
+      MESet *meSet_;
 
-  /* const_iterator
+    public:
+      Bin() : ConstBin(), meSet_(nullptr) {}
+      Bin(MESet &_set, unsigned _iME = 0, int _iBin = 1) : ConstBin(_set, _iME, _iBin), meSet_(&_set) {}
+      Bin(Bin const &_orig) : ConstBin(_orig), meSet_(_orig.meSet_) {}
+      ConstBin &operator=(Bin const &_rhs) {
+        bool wasNull(ConstBin::meSet_ == nullptr);
+        ConstBin::operator=(_rhs);
+        if (wasNull)
+          meSet_ = _rhs.meSet_;
+        return *this;
+      }
+      void fill(double _w = 1.) {
+        if (meSet_)
+          meSet_->fill_(iME, iBin, _w);
+      }
+      void fill(double _y, double _w = 1.) {
+        if (meSet_)
+          meSet_->fill_(iME, iBin, _y, _w);
+      }
+      void setBinContent(double _content) {
+        if (meSet_ && iME != unsigned(-1))
+          meSet_->getME(iME)->setBinContent(iBin, _content);
+      }
+      void setBinError(double _error) {
+        if (meSet_ && iME != unsigned(-1))
+          meSet_->getME(iME)->setBinError(iBin, _error);
+      }
+      void setBinEntries(double _entries) {
+        if (meSet_ && iME != unsigned(-1))
+          meSet_->getME(iME)->setBinEntries(iBin, _entries);
+      }
+      MonitorElement *getME() const {
+        if (meSet_ && iME != unsigned(-1))
+          return meSet_->getME(iME);
+        else
+          return nullptr;
+      }
+      void setMESet(MESet &_meSet) {
+        ConstBin::meSet_ = &_meSet;
+        meSet_ = &_meSet;
+      }
+      MESet *getMESet() const { return meSet_; }
+    };
+
+    /* const_iterator
      iterates over bins
      supports automatic transition between MEs in the same set
      underflow -> bin == 0 overflow -> bin == -1
   */
-  struct const_iterator {
-    const_iterator() : bin_() {}
-    const_iterator(MESet const &_meSet, unsigned _iME = 0, int _iBin = 1)
-        : bin_(_meSet, _iME, _iBin) {}
-    const_iterator(MESet const &, DetId const &);
-    const_iterator(const_iterator const &_orig) : bin_(_orig.bin_) {}
-    const_iterator &operator=(const_iterator const &_rhs) {
-      bin_ = _rhs.bin_;
-      return *this;
-    }
-    bool operator==(const_iterator const &_rhs) const {
-      return bin_ == _rhs.bin_;
-    }
-    bool operator!=(const_iterator const &_rhs) const {
-      return !(bin_ == _rhs.bin_);
-    }
-    ConstBin const *operator->() const { return &bin_; }
-    const_iterator &operator++();
-    const_iterator &toNextChannel();
-    bool up();
-    bool down();
-    bool left();
-    bool right();
+    struct const_iterator {
+      const_iterator() : bin_() {}
+      const_iterator(MESet const &_meSet, unsigned _iME = 0, int _iBin = 1) : bin_(_meSet, _iME, _iBin) {}
+      const_iterator(MESet const &, DetId const &);
+      const_iterator(const_iterator const &_orig) : bin_(_orig.bin_) {}
+      const_iterator &operator=(const_iterator const &_rhs) {
+        bin_ = _rhs.bin_;
+        return *this;
+      }
+      bool operator==(const_iterator const &_rhs) const { return bin_ == _rhs.bin_; }
+      bool operator!=(const_iterator const &_rhs) const { return !(bin_ == _rhs.bin_); }
+      ConstBin const *operator->() const { return &bin_; }
+      const_iterator &operator++();
+      const_iterator &toNextChannel();
+      bool up();
+      bool down();
+      bool left();
+      bool right();
 
-  protected:
-    ConstBin bin_;
+    protected:
+      ConstBin bin_;
+    };
+
+    struct iterator : public const_iterator {
+      iterator() : const_iterator(), bin_() {}
+      iterator(MESet &_meSet, unsigned _iME = 0, int _iBin = 1) : const_iterator(_meSet, _iME, _iBin), bin_(_meSet) {
+        bin_.ConstBin::operator=(const_iterator::bin_);
+      }
+      iterator(MESet &_meSet, DetId const &_id) : const_iterator(_meSet, _id), bin_(_meSet) {
+        bin_.ConstBin::operator=(const_iterator::bin_);
+      }
+      iterator(iterator const &_orig) : const_iterator(_orig), bin_(_orig.bin_) {}
+      iterator &operator=(const_iterator const &_rhs) {
+        const_iterator::operator=(_rhs);
+        bin_.ConstBin::operator=(const_iterator::bin_);
+        return *this;
+      }
+      Bin *operator->() { return &bin_; }
+      Bin const *operator->() const { return &bin_; }
+      const_iterator &operator++() {
+        const_iterator::operator++();
+        bin_.ConstBin::operator=(const_iterator::bin_);
+        return *this;
+      }
+      const_iterator &toNextChannel() {
+        const_iterator::toNextChannel();
+        bin_.ConstBin::operator=(const_iterator::bin_);
+        return *this;
+      }
+      bool up() {
+        bool res(const_iterator::up());
+        bin_.ConstBin::operator=(const_iterator::bin_);
+        return res;
+      }
+      bool down() {
+        bool res(const_iterator::down());
+        bin_.ConstBin::operator=(const_iterator::bin_);
+        return res;
+      }
+      bool left() {
+        bool res(const_iterator::left());
+        bin_.ConstBin::operator=(const_iterator::bin_);
+        return res;
+      }
+      bool right() {
+        bool res(const_iterator::right());
+        bin_.ConstBin::operator=(const_iterator::bin_);
+        return res;
+      }
+
+    private:
+      Bin bin_;
+    };
+
+    virtual const_iterator begin() const { return const_iterator(*this); }
+
+    virtual const_iterator end() const { return const_iterator(*this, -1, -1); }
+
+    virtual const_iterator beginChannel() const {
+      const_iterator itr(*this, 0, 0);
+      return itr.toNextChannel();
+    }
+
+    virtual iterator begin() { return iterator(*this); }
+
+    virtual iterator end() { return iterator(*this, -1, -1); }
+
+    virtual iterator beginChannel() {
+      iterator itr(*this, 0, 0);
+      itr.toNextChannel();
+      return itr;
+    }
   };
 
-  struct iterator : public const_iterator {
-    iterator() : const_iterator(), bin_() {}
-    iterator(MESet &_meSet, unsigned _iME = 0, int _iBin = 1)
-        : const_iterator(_meSet, _iME, _iBin), bin_(_meSet) {
-      bin_.ConstBin::operator=(const_iterator::bin_);
-    }
-    iterator(MESet &_meSet, DetId const &_id)
-        : const_iterator(_meSet, _id), bin_(_meSet) {
-      bin_.ConstBin::operator=(const_iterator::bin_);
-    }
-    iterator(iterator const &_orig) : const_iterator(_orig), bin_(_orig.bin_) {}
-    iterator &operator=(const_iterator const &_rhs) {
-      const_iterator::operator=(_rhs);
-      bin_.ConstBin::operator=(const_iterator::bin_);
-      return *this;
-    }
-    Bin *operator->() { return &bin_; }
-    Bin const *operator->() const { return &bin_; }
-    const_iterator &operator++() {
-      const_iterator::operator++();
-      bin_.ConstBin::operator=(const_iterator::bin_);
-      return *this;
-    }
-    const_iterator &toNextChannel() {
-      const_iterator::toNextChannel();
-      bin_.ConstBin::operator=(const_iterator::bin_);
-      return *this;
-    }
-    bool up() {
-      bool res(const_iterator::up());
-      bin_.ConstBin::operator=(const_iterator::bin_);
-      return res;
-    }
-    bool down() {
-      bool res(const_iterator::down());
-      bin_.ConstBin::operator=(const_iterator::bin_);
-      return res;
-    }
-    bool left() {
-      bool res(const_iterator::left());
-      bin_.ConstBin::operator=(const_iterator::bin_);
-      return res;
-    }
-    bool right() {
-      bool res(const_iterator::right());
-      bin_.ConstBin::operator=(const_iterator::bin_);
-      return res;
-    }
-
-  private:
-    Bin bin_;
-  };
-
-  virtual const_iterator begin() const { return const_iterator(*this); }
-
-  virtual const_iterator end() const { return const_iterator(*this, -1, -1); }
-
-  virtual const_iterator beginChannel() const {
-    const_iterator itr(*this, 0, 0);
-    return itr.toNextChannel();
-  }
-
-  virtual iterator begin() { return iterator(*this); }
-
-  virtual iterator end() { return iterator(*this, -1, -1); }
-
-  virtual iterator beginChannel() {
-    iterator itr(*this, 0, 0);
-    itr.toNextChannel();
-    return itr;
-  }
-};
-
-} // namespace ecaldqm
+}  // namespace ecaldqm
 
 namespace boost {
-template <>
-inline ecaldqm::MESet *new_clone<ecaldqm::MESet>(ecaldqm::MESet const &);
-template <> void delete_clone<ecaldqm::MESet>(ecaldqm::MESet const *);
-} // namespace boost
+  template <>
+  inline ecaldqm::MESet *new_clone<ecaldqm::MESet>(ecaldqm::MESet const &);
+  template <>
+  void delete_clone<ecaldqm::MESet>(ecaldqm::MESet const *);
+}  // namespace boost
 
 namespace ecaldqm {
-typedef boost::ptr_map<std::string, MESet> MESetCollection;
+  typedef boost::ptr_map<std::string, MESet> MESetCollection;
 }
 
 #endif

--- a/DQM/EcalCommon/interface/MESetBinningUtils.h
+++ b/DQM/EcalCommon/interface/MESetBinningUtils.h
@@ -8,174 +8,176 @@
 class DetId;
 class EcalElectronicsId;
 namespace edm {
-class ParameterSet;
-class ParameterSetDescription;
-} // namespace edm
+  class ParameterSet;
+  class ParameterSetDescription;
+}  // namespace edm
 
 namespace ecaldqm {
-namespace binning {
-enum ObjectType {
-  kEB,
-  kEE,
-  kEEm,
-  kEEp,
-  kSM,
-  kEBSM,
-  kEESM,
-  kSMMEM,
-  kEBSMMEM,
-  kEESMMEM,
-  kEcal,
-  kMEM,
-  kEBMEM,
-  kEEMEM,
-  kEcal2P,
-  kEcal3P,
-  kEE2P,
-  kMEM2P,
-  kChannel,
-  nObjType
-};
+  namespace binning {
+    enum ObjectType {
+      kEB,
+      kEE,
+      kEEm,
+      kEEp,
+      kSM,
+      kEBSM,
+      kEESM,
+      kSMMEM,
+      kEBSMMEM,
+      kEESMMEM,
+      kEcal,
+      kMEM,
+      kEBMEM,
+      kEEMEM,
+      kEcal2P,
+      kEcal3P,
+      kEE2P,
+      kMEM2P,
+      kChannel,
+      nObjType
+    };
 
-enum BinningType {
-  kCrystal,
-  kTriggerTower,
-  kSuperCrystal,
-  kPseudoStrip,
-  kTCC,
-  kDCC,
-  kProjEta,
-  kProjPhi,
-  kRCT,
-  kUser,
-  kReport,
-  kTrend,
-  nBinType
-};
+    enum BinningType {
+      kCrystal,
+      kTriggerTower,
+      kSuperCrystal,
+      kPseudoStrip,
+      kTCC,
+      kDCC,
+      kProjEta,
+      kProjPhi,
+      kRCT,
+      kUser,
+      kReport,
+      kTrend,
+      nBinType
+    };
 
-enum Constants {
-  nPresetBinnings = kRCT + 1,
+    enum Constants {
+      nPresetBinnings = kRCT + 1,
 
-  nEBSMEta = 85,
-  nEBSMPhi = 20,
-  nEESMX = 40,
-  nEESMXRed = 30, // for EE+-01&05&09
-  nEESMXExt = 45, // for EE+-02&08
-  nEESMY = 40,
-  nEESMYRed = 35, // for EE+-03&07
+      nEBSMEta = 85,
+      nEBSMPhi = 20,
+      nEESMX = 40,
+      nEESMXRed = 30,  // for EE+-01&05&09
+      nEESMXExt = 45,  // for EE+-02&08
+      nEESMY = 40,
+      nEESMYRed = 35,  // for EE+-03&07
 
-  nEBEtaBins = 34,
-  nEEEtaBins = 20,
-  nPhiBins = 36
-};
+      nEBEtaBins = 34,
+      nEEEtaBins = 20,
+      nPhiBins = 36
+    };
 
-struct AxisSpecs {
-  int nbins;
-  float low, high;
-  float *edges;
-  std::string *labels;
-  std::string title;
-  AxisSpecs()
-      : nbins(0), low(0.), high(0.), edges(nullptr), labels(nullptr),
-        title("") {}
-  AxisSpecs(AxisSpecs const &_specs)
-      : nbins(_specs.nbins), low(_specs.low), high(_specs.high), edges(nullptr),
-        labels(nullptr), title(_specs.title) {
-    if (_specs.edges) {
-      edges = new float[nbins + 1];
-      for (int i(0); i <= nbins; i++)
-        edges[i] = _specs.edges[i];
-    }
-    if (_specs.labels) {
-      labels = new std::string[nbins];
-      for (int i(0); i < nbins; i++)
-        labels[i] = _specs.labels[i];
-    }
-  }
-  AxisSpecs &operator=(AxisSpecs const &_rhs) {
-    if (edges) {
-      delete[] edges;
-      edges = nullptr;
-    }
-    if (labels) {
-      delete[] labels;
-      labels = nullptr;
-    }
-    nbins = _rhs.nbins;
-    low = _rhs.low;
-    high = _rhs.high;
-    title = _rhs.title;
-    if (_rhs.edges) {
-      edges = new float[nbins + 1];
-      for (int i(0); i <= nbins; i++)
-        edges[i] = _rhs.edges[i];
-    }
-    if (_rhs.labels) {
-      labels = new std::string[nbins];
-      for (int i(0); i < nbins; i++)
-        labels[i] = _rhs.labels[i];
-    }
-    return *this;
-  }
-  ~AxisSpecs() {
-    delete[] edges;
-    delete[] labels;
-  }
-};
+    struct AxisSpecs {
+      int nbins;
+      float low, high;
+      float *edges;
+      std::string *labels;
+      std::string title;
+      AxisSpecs() : nbins(0), low(0.), high(0.), edges(nullptr), labels(nullptr), title("") {}
+      AxisSpecs(AxisSpecs const &_specs)
+          : nbins(_specs.nbins),
+            low(_specs.low),
+            high(_specs.high),
+            edges(nullptr),
+            labels(nullptr),
+            title(_specs.title) {
+        if (_specs.edges) {
+          edges = new float[nbins + 1];
+          for (int i(0); i <= nbins; i++)
+            edges[i] = _specs.edges[i];
+        }
+        if (_specs.labels) {
+          labels = new std::string[nbins];
+          for (int i(0); i < nbins; i++)
+            labels[i] = _specs.labels[i];
+        }
+      }
+      AxisSpecs &operator=(AxisSpecs const &_rhs) {
+        if (edges) {
+          delete[] edges;
+          edges = nullptr;
+        }
+        if (labels) {
+          delete[] labels;
+          labels = nullptr;
+        }
+        nbins = _rhs.nbins;
+        low = _rhs.low;
+        high = _rhs.high;
+        title = _rhs.title;
+        if (_rhs.edges) {
+          edges = new float[nbins + 1];
+          for (int i(0); i <= nbins; i++)
+            edges[i] = _rhs.edges[i];
+        }
+        if (_rhs.labels) {
+          labels = new std::string[nbins];
+          for (int i(0); i < nbins; i++)
+            labels[i] = _rhs.labels[i];
+        }
+        return *this;
+      }
+      ~AxisSpecs() {
+        delete[] edges;
+        delete[] labels;
+      }
+    };
 
-AxisSpecs getBinning(ObjectType, BinningType, bool, int, unsigned);
+    AxisSpecs getBinning(ObjectType, BinningType, bool, int, unsigned);
 
-int findBin1D(ObjectType, BinningType, DetId const &);
-int findBin1D(ObjectType, BinningType, EcalElectronicsId const &);
-int findBin1D(ObjectType, BinningType, int);
+    int findBin1D(ObjectType, BinningType, DetId const &);
+    int findBin1D(ObjectType, BinningType, EcalElectronicsId const &);
+    int findBin1D(ObjectType, BinningType, int);
 
-int findBin2D(ObjectType, BinningType, DetId const &);
-int findBin2D(ObjectType, BinningType, EcalElectronicsId const &);
-int findBin2D(ObjectType, BinningType, int);
+    int findBin2D(ObjectType, BinningType, DetId const &);
+    int findBin2D(ObjectType, BinningType, EcalElectronicsId const &);
+    int findBin2D(ObjectType, BinningType, int);
 
-unsigned findPlotIndex(ObjectType, DetId const &);
-unsigned findPlotIndex(ObjectType, EcalElectronicsId const &);
-unsigned findPlotIndex(ObjectType, int, BinningType _btype = kDCC);
+    unsigned findPlotIndex(ObjectType, DetId const &);
+    unsigned findPlotIndex(ObjectType, EcalElectronicsId const &);
+    unsigned findPlotIndex(ObjectType, int, BinningType _btype = kDCC);
 
-ObjectType getObject(ObjectType, unsigned);
+    ObjectType getObject(ObjectType, unsigned);
 
-unsigned getNObjects(ObjectType);
+    unsigned getNObjects(ObjectType);
 
-bool isValidIdBin(ObjectType, BinningType, unsigned, int);
+    bool isValidIdBin(ObjectType, BinningType, unsigned, int);
 
-std::string channelName(uint32_t, BinningType _btype = kDCC);
+    std::string channelName(uint32_t, BinningType _btype = kDCC);
 
-uint32_t idFromName(std::string const &);
-uint32_t idFromBin(ObjectType, BinningType, unsigned, int);
+    uint32_t idFromName(std::string const &);
+    uint32_t idFromBin(ObjectType, BinningType, unsigned, int);
 
-AxisSpecs formAxis(edm::ParameterSet const &);
-void fillAxisDescriptions(edm::ParameterSetDescription &);
+    AxisSpecs formAxis(edm::ParameterSet const &);
+    void fillAxisDescriptions(edm::ParameterSetDescription &);
 
-ObjectType translateObjectType(std::string const &);
-BinningType translateBinningType(std::string const &);
-MonitorElement::Kind translateKind(std::string const &);
+    ObjectType translateObjectType(std::string const &);
+    BinningType translateBinningType(std::string const &);
+    MonitorElement::Kind translateKind(std::string const &);
 
-/* Functions used only internally within binning namespace */
+    /* Functions used only internally within binning namespace */
 
-// used for SM binnings
-int xlow_(int);
-int ylow_(int);
+    // used for SM binnings
+    int xlow_(int);
+    int ylow_(int);
 
-AxisSpecs getBinningEB_(BinningType, bool, int);
-AxisSpecs getBinningEE_(BinningType, bool, int, int);
-AxisSpecs getBinningSM_(BinningType, bool, unsigned, int);
-AxisSpecs getBinningSMMEM_(BinningType, bool, unsigned, int);
-AxisSpecs getBinningEcal_(BinningType, bool, int);
-AxisSpecs getBinningMEM_(BinningType, bool, int, int);
+    AxisSpecs getBinningEB_(BinningType, bool, int);
+    AxisSpecs getBinningEE_(BinningType, bool, int, int);
+    AxisSpecs getBinningSM_(BinningType, bool, unsigned, int);
+    AxisSpecs getBinningSMMEM_(BinningType, bool, unsigned, int);
+    AxisSpecs getBinningEcal_(BinningType, bool, int);
+    AxisSpecs getBinningMEM_(BinningType, bool, int, int);
 
-int findBinCrystal_(ObjectType, DetId const &, int = -1);
-int findBinCrystal_(ObjectType, EcalElectronicsId const &);
-int findBinTriggerTower_(ObjectType, DetId const &);
-int findBinPseudoStrip_(ObjectType, DetId const &);
-int findBinRCT_(ObjectType, DetId const &);
-int findBinSuperCrystal_(ObjectType, DetId const &, int = -1);
-int findBinSuperCrystal_(ObjectType, EcalElectronicsId const &);
-} // namespace binning
-} // namespace ecaldqm
+    int findBinCrystal_(ObjectType, DetId const &, int = -1);
+    int findBinCrystal_(ObjectType, EcalElectronicsId const &);
+    int findBinTriggerTower_(ObjectType, DetId const &);
+    int findBinPseudoStrip_(ObjectType, DetId const &);
+    int findBinRCT_(ObjectType, DetId const &);
+    int findBinSuperCrystal_(ObjectType, DetId const &, int = -1);
+    int findBinSuperCrystal_(ObjectType, EcalElectronicsId const &);
+  }  // namespace binning
+}  // namespace ecaldqm
 
 #endif

--- a/DQM/EcalCommon/interface/MESetDet0D.h
+++ b/DQM/EcalCommon/interface/MESetDet0D.h
@@ -4,43 +4,34 @@
 #include "MESetEcal.h"
 
 namespace ecaldqm {
-/* class MESetDet0D
+  /* class MESetDet0D
    subdetector-based MonitorElement wrapper
    represents single float MEs (DQM_KIND_REAL)
    fill = setBinContent
 */
 
-class MESetDet0D : public MESetEcal {
-public:
-  MESetDet0D(std::string const &, binning::ObjectType, binning::BinningType,
-             MonitorElement::Kind);
-  MESetDet0D(MESetDet0D const &);
-  ~MESetDet0D() override;
+  class MESetDet0D : public MESetEcal {
+  public:
+    MESetDet0D(std::string const &, binning::ObjectType, binning::BinningType, MonitorElement::Kind);
+    MESetDet0D(MESetDet0D const &);
+    ~MESetDet0D() override;
 
-  MESet *clone(std::string const & = "") const override;
+    MESet *clone(std::string const & = "") const override;
 
-  void fill(DetId const &, double, double = 0., double = 0.) override;
-  void fill(EcalElectronicsId const &, double, double = 0.,
-            double = 0.) override;
-  void fill(int, double, double = 0., double = 0.) override;
+    void fill(DetId const &, double, double = 0., double = 0.) override;
+    void fill(EcalElectronicsId const &, double, double = 0., double = 0.) override;
+    void fill(int, double, double = 0., double = 0.) override;
 
-  void setBinContent(DetId const &_id, int, double _value) override {
-    fill(_id, _value);
-  }
-  void setBinContent(EcalElectronicsId const &_id, int,
-                     double _value) override {
-    fill(_id, _value);
-  }
-  void setBinContent(int _dcctccid, int, double _value) override {
-    fill(_dcctccid, _value);
-  }
+    void setBinContent(DetId const &_id, int, double _value) override { fill(_id, _value); }
+    void setBinContent(EcalElectronicsId const &_id, int, double _value) override { fill(_id, _value); }
+    void setBinContent(int _dcctccid, int, double _value) override { fill(_dcctccid, _value); }
 
-  double getBinContent(DetId const &, int = 0) const override;
-  double getBinContent(EcalElectronicsId const &, int = 0) const override;
-  double getBinContent(int, int = 0) const override;
+    double getBinContent(DetId const &, int = 0) const override;
+    double getBinContent(EcalElectronicsId const &, int = 0) const override;
+    double getBinContent(int, int = 0) const override;
 
-  void reset(double = 0., double = 0., double = 0.) override;
-};
-} // namespace ecaldqm
+    void reset(double = 0., double = 0., double = 0.) override;
+  };
+}  // namespace ecaldqm
 
 #endif

--- a/DQM/EcalCommon/interface/MESetDet1D.h
+++ b/DQM/EcalCommon/interface/MESetDet1D.h
@@ -4,70 +4,72 @@
 #include "MESetEcal.h"
 
 namespace ecaldqm {
-/*
+  /*
   class MESetDet1D
   channel ID-based MonitorElement wrapper
   channel id <-> x axis bin
 */
 
-class MESetDet1D : public MESetEcal {
-public:
-  MESetDet1D(std::string const &, binning::ObjectType, binning::BinningType,
-             MonitorElement::Kind, binning::AxisSpecs const * = nullptr);
-  MESetDet1D(MESetDet1D const &);
-  ~MESetDet1D() override;
+  class MESetDet1D : public MESetEcal {
+  public:
+    MESetDet1D(std::string const &,
+               binning::ObjectType,
+               binning::BinningType,
+               MonitorElement::Kind,
+               binning::AxisSpecs const * = nullptr);
+    MESetDet1D(MESetDet1D const &);
+    ~MESetDet1D() override;
 
-  MESet *clone(std::string const & = "") const override;
+    MESet *clone(std::string const & = "") const override;
 
-  void book(DQMStore::IBooker &) override;
+    void book(DQMStore::IBooker &) override;
 
-  void fill(DetId const &, double = 1., double = 1., double = 0.) override;
-  void fill(EcalElectronicsId const &, double = 1., double = 1.,
-            double = 0.) override;
-  void fill(int, double = 1., double = 1., double = 0.) override;
+    void fill(DetId const &, double = 1., double = 1., double = 0.) override;
+    void fill(EcalElectronicsId const &, double = 1., double = 1., double = 0.) override;
+    void fill(int, double = 1., double = 1., double = 0.) override;
 
-  void setBinContent(DetId const &, double) override;
-  void setBinContent(EcalElectronicsId const &, double) override;
-  void setBinContent(int, double) override;
-  void setBinContent(DetId const &, int, double) override;
-  void setBinContent(EcalElectronicsId const &, int, double) override;
-  void setBinContent(int, int, double) override;
+    void setBinContent(DetId const &, double) override;
+    void setBinContent(EcalElectronicsId const &, double) override;
+    void setBinContent(int, double) override;
+    void setBinContent(DetId const &, int, double) override;
+    void setBinContent(EcalElectronicsId const &, int, double) override;
+    void setBinContent(int, int, double) override;
 
-  void setBinError(DetId const &, double) override;
-  void setBinError(EcalElectronicsId const &, double) override;
-  void setBinError(int, double) override;
-  void setBinError(DetId const &, int, double) override;
-  void setBinError(EcalElectronicsId const &, int, double) override;
-  void setBinError(int, int, double) override;
+    void setBinError(DetId const &, double) override;
+    void setBinError(EcalElectronicsId const &, double) override;
+    void setBinError(int, double) override;
+    void setBinError(DetId const &, int, double) override;
+    void setBinError(EcalElectronicsId const &, int, double) override;
+    void setBinError(int, int, double) override;
 
-  void setBinEntries(DetId const &, double) override;
-  void setBinEntries(EcalElectronicsId const &, double) override;
-  void setBinEntries(int, double) override;
-  void setBinEntries(DetId const &, int, double) override;
-  void setBinEntries(EcalElectronicsId const &, int, double) override;
-  void setBinEntries(int, int, double) override;
+    void setBinEntries(DetId const &, double) override;
+    void setBinEntries(EcalElectronicsId const &, double) override;
+    void setBinEntries(int, double) override;
+    void setBinEntries(DetId const &, int, double) override;
+    void setBinEntries(EcalElectronicsId const &, int, double) override;
+    void setBinEntries(int, int, double) override;
 
-  double getBinContent(DetId const &, int = 0) const override;
-  double getBinContent(EcalElectronicsId const &, int = 0) const override;
-  double getBinContent(int, int = 0) const override;
+    double getBinContent(DetId const &, int = 0) const override;
+    double getBinContent(EcalElectronicsId const &, int = 0) const override;
+    double getBinContent(int, int = 0) const override;
 
-  double getBinError(DetId const &, int = 0) const override;
-  double getBinError(EcalElectronicsId const &, int = 0) const override;
-  double getBinError(int, int = 0) const override;
+    double getBinError(DetId const &, int = 0) const override;
+    double getBinError(EcalElectronicsId const &, int = 0) const override;
+    double getBinError(int, int = 0) const override;
 
-  double getBinEntries(DetId const &, int = 0) const override;
-  double getBinEntries(EcalElectronicsId const &, int = 0) const override;
-  double getBinEntries(int, int = 0) const override;
+    double getBinEntries(DetId const &, int = 0) const override;
+    double getBinEntries(EcalElectronicsId const &, int = 0) const override;
+    double getBinEntries(int, int = 0) const override;
 
-  int findBin(DetId const &) const;
-  int findBin(EcalElectronicsId const &) const;
-  int findBin(int) const;
-  int findBin(DetId const &, double, double = 0.) const override;
-  int findBin(EcalElectronicsId const &, double, double = 0.) const override;
-  int findBin(int, double, double = 0.) const override;
+    int findBin(DetId const &) const;
+    int findBin(EcalElectronicsId const &) const;
+    int findBin(int) const;
+    int findBin(DetId const &, double, double = 0.) const override;
+    int findBin(EcalElectronicsId const &, double, double = 0.) const override;
+    int findBin(int, double, double = 0.) const override;
 
-  void reset(double = 0., double = 0., double = 0.) override;
-};
-} // namespace ecaldqm
+    void reset(double = 0., double = 0., double = 0.) override;
+  };
+}  // namespace ecaldqm
 
 #endif

--- a/DQM/EcalCommon/interface/MESetDet2D.h
+++ b/DQM/EcalCommon/interface/MESetDet2D.h
@@ -4,69 +4,71 @@
 #include "MESetEcal.h"
 
 namespace ecaldqm {
-/* class MESetDet2D
+  /* class MESetDet2D
    channel ID-based MonitorElement wrapper
    channel id <-> 2D cell
 */
-class MESetDet2D : public MESetEcal {
-public:
-  MESetDet2D(std::string const &, binning::ObjectType, binning::BinningType,
-             MonitorElement::Kind, binning::AxisSpecs const * = nullptr);
-  MESetDet2D(MESetDet2D const &);
-  ~MESetDet2D() override;
+  class MESetDet2D : public MESetEcal {
+  public:
+    MESetDet2D(std::string const &,
+               binning::ObjectType,
+               binning::BinningType,
+               MonitorElement::Kind,
+               binning::AxisSpecs const * = nullptr);
+    MESetDet2D(MESetDet2D const &);
+    ~MESetDet2D() override;
 
-  MESet *clone(std::string const & = "") const override;
+    MESet *clone(std::string const & = "") const override;
 
-  void book(DQMStore::IBooker &) override;
+    void book(DQMStore::IBooker &) override;
 
-  void fill(DetId const &, double = 1., double = 0., double = 0.) override;
-  void fill(EcalElectronicsId const &, double = 1., double = 0.,
-            double = 0.) override;
-  void fill(int, double = 1., double = 1., double = 1.) override;
+    void fill(DetId const &, double = 1., double = 0., double = 0.) override;
+    void fill(EcalElectronicsId const &, double = 1., double = 0., double = 0.) override;
+    void fill(int, double = 1., double = 1., double = 1.) override;
 
-  using MESetEcal::setBinContent;
-  void setBinContent(DetId const &, double) override;
-  void setBinContent(EcalElectronicsId const &, double) override;
-  void setBinContent(int, double) override;
+    using MESetEcal::setBinContent;
+    void setBinContent(DetId const &, double) override;
+    void setBinContent(EcalElectronicsId const &, double) override;
+    void setBinContent(int, double) override;
 
-  using MESetEcal::setBinError;
-  void setBinError(DetId const &, double) override;
-  void setBinError(EcalElectronicsId const &, double) override;
-  void setBinError(int, double) override;
+    using MESetEcal::setBinError;
+    void setBinError(DetId const &, double) override;
+    void setBinError(EcalElectronicsId const &, double) override;
+    void setBinError(int, double) override;
 
-  using MESetEcal::setBinEntries;
-  void setBinEntries(DetId const &, double) override;
-  void setBinEntries(EcalElectronicsId const &, double) override;
-  void setBinEntries(int, double) override;
+    using MESetEcal::setBinEntries;
+    void setBinEntries(DetId const &, double) override;
+    void setBinEntries(EcalElectronicsId const &, double) override;
+    void setBinEntries(int, double) override;
 
-  using MESetEcal::getBinContent;
-  double getBinContent(DetId const &, int = 0) const override;
-  double getBinContent(EcalElectronicsId const &, int = 0) const override;
-  double getBinContent(int, int = 0) const override;
+    using MESetEcal::getBinContent;
+    double getBinContent(DetId const &, int = 0) const override;
+    double getBinContent(EcalElectronicsId const &, int = 0) const override;
+    double getBinContent(int, int = 0) const override;
 
-  using MESetEcal::getBinError;
-  double getBinError(DetId const &, int = 0) const override;
-  double getBinError(EcalElectronicsId const &, int = 0) const override;
-  double getBinError(int, int = 0) const override;
+    using MESetEcal::getBinError;
+    double getBinError(DetId const &, int = 0) const override;
+    double getBinError(EcalElectronicsId const &, int = 0) const override;
+    double getBinError(int, int = 0) const override;
 
-  using MESetEcal::getBinEntries;
-  double getBinEntries(DetId const &, int = 0) const override;
-  double getBinEntries(EcalElectronicsId const &, int = 0) const override;
-  double getBinEntries(int, int) const override;
+    using MESetEcal::getBinEntries;
+    double getBinEntries(DetId const &, int = 0) const override;
+    double getBinEntries(EcalElectronicsId const &, int = 0) const override;
+    double getBinEntries(int, int) const override;
 
-  using MESetEcal::findBin;
-  int findBin(DetId const &) const;
-  int findBin(EcalElectronicsId const &) const;
+    using MESetEcal::findBin;
+    int findBin(DetId const &) const;
+    int findBin(EcalElectronicsId const &) const;
 
-  void reset(double = 0., double = 0., double = 0.) override;
+    void reset(double = 0., double = 0., double = 0.) override;
 
-  void softReset() override;
+    void softReset() override;
 
-protected:
-  void fill_(unsigned, int, double) override;
-  void fill_(unsigned, int, double, double) override;
-  void fill_(unsigned, double, double, double) override;
-};
-} // namespace ecaldqm
+  protected:
+    void fill_(unsigned, int, double) override;
+    void fill_(unsigned, int, double, double) override;
+    void fill_(unsigned, double, double, double) override;
+  };
+}  // namespace ecaldqm
 
 #endif

--- a/DQM/EcalCommon/interface/MESetEcal.h
+++ b/DQM/EcalCommon/interface/MESetEcal.h
@@ -5,78 +5,81 @@
 
 namespace ecaldqm {
 
-/* class MESetEcal
+  /* class MESetEcal
    implements plot <-> detector part relationship
    base class for channel-binned histograms
    MESetEcal is only filled given an object identifier and a bin (channel id
    does not give a bin)
 */
 
-class MESetEcal : public MESet {
-public:
-  MESetEcal(std::string const &, binning::ObjectType, binning::BinningType,
-            MonitorElement::Kind, unsigned,
-            binning::AxisSpecs const * = nullptr,
-            binning::AxisSpecs const * = nullptr,
-            binning::AxisSpecs const * = nullptr);
-  MESetEcal(MESetEcal const &);
-  ~MESetEcal() override;
+  class MESetEcal : public MESet {
+  public:
+    MESetEcal(std::string const &,
+              binning::ObjectType,
+              binning::BinningType,
+              MonitorElement::Kind,
+              unsigned,
+              binning::AxisSpecs const * = nullptr,
+              binning::AxisSpecs const * = nullptr,
+              binning::AxisSpecs const * = nullptr);
+    MESetEcal(MESetEcal const &);
+    ~MESetEcal() override;
 
-  MESet &operator=(MESet const &) override;
+    MESet &operator=(MESet const &) override;
 
-  MESet *clone(std::string const & = "") const override;
+    MESet *clone(std::string const & = "") const override;
 
-  void book(DQMStore::IBooker &) override;
-  bool retrieve(DQMStore::IGetter &, std::string * = nullptr) const override;
+    void book(DQMStore::IBooker &) override;
+    bool retrieve(DQMStore::IGetter &, std::string * = nullptr) const override;
 
-  void fill(DetId const &, double = 1., double = 1., double = 1.) override;
-  void fill(EcalElectronicsId const &, double = 1., double = 1.,
-            double = 1.) override;
-  void fill(int, double = 1., double = 1., double = 1.) override;
-  void fill(double, double = 1., double = 1.) override;
+    void fill(DetId const &, double = 1., double = 1., double = 1.) override;
+    void fill(EcalElectronicsId const &, double = 1., double = 1., double = 1.) override;
+    void fill(int, double = 1., double = 1., double = 1.) override;
+    void fill(double, double = 1., double = 1.) override;
 
-  void setBinContent(DetId const &, int, double) override;
-  void setBinContent(EcalElectronicsId const &, int, double) override;
-  void setBinContent(int, int, double) override;
+    void setBinContent(DetId const &, int, double) override;
+    void setBinContent(EcalElectronicsId const &, int, double) override;
+    void setBinContent(int, int, double) override;
 
-  void setBinError(DetId const &, int, double) override;
-  void setBinError(EcalElectronicsId const &, int, double) override;
-  void setBinError(int, int, double) override;
+    void setBinError(DetId const &, int, double) override;
+    void setBinError(EcalElectronicsId const &, int, double) override;
+    void setBinError(int, int, double) override;
 
-  void setBinEntries(DetId const &, int, double) override;
-  void setBinEntries(EcalElectronicsId const &, int, double) override;
-  void setBinEntries(int, int, double) override;
+    void setBinEntries(DetId const &, int, double) override;
+    void setBinEntries(EcalElectronicsId const &, int, double) override;
+    void setBinEntries(int, int, double) override;
 
-  double getBinContent(DetId const &, int) const override;
-  double getBinContent(EcalElectronicsId const &, int) const override;
-  double getBinContent(int, int) const override;
+    double getBinContent(DetId const &, int) const override;
+    double getBinContent(EcalElectronicsId const &, int) const override;
+    double getBinContent(int, int) const override;
 
-  double getBinError(DetId const &, int) const override;
-  double getBinError(EcalElectronicsId const &, int) const override;
-  double getBinError(int, int) const override;
+    double getBinError(DetId const &, int) const override;
+    double getBinError(EcalElectronicsId const &, int) const override;
+    double getBinError(int, int) const override;
 
-  double getBinEntries(DetId const &, int) const override;
-  double getBinEntries(EcalElectronicsId const &, int) const override;
-  double getBinEntries(int, int) const override;
+    double getBinEntries(DetId const &, int) const override;
+    double getBinEntries(EcalElectronicsId const &, int) const override;
+    double getBinEntries(int, int) const override;
 
-  virtual int findBin(DetId const &, double, double = 0.) const;
-  virtual int findBin(EcalElectronicsId const &, double, double = 0.) const;
-  virtual int findBin(int, double, double = 0.) const;
+    virtual int findBin(DetId const &, double, double = 0.) const;
+    virtual int findBin(EcalElectronicsId const &, double, double = 0.) const;
+    virtual int findBin(int, double, double = 0.) const;
 
-  bool isVariableBinning() const override;
+    bool isVariableBinning() const override;
 
-  std::vector<std::string> generatePaths() const;
+    std::vector<std::string> generatePaths() const;
 
-protected:
-  unsigned logicalDimensions_;
-  binning::AxisSpecs const *xaxis_;
-  binning::AxisSpecs const *yaxis_;
-  binning::AxisSpecs const *zaxis_;
+  protected:
+    unsigned logicalDimensions_;
+    binning::AxisSpecs const *xaxis_;
+    binning::AxisSpecs const *yaxis_;
+    binning::AxisSpecs const *zaxis_;
 
-private:
-  template <class Bookable> void doBook_(Bookable &);
-};
+  private:
+    template <class Bookable>
+    void doBook_(Bookable &);
+  };
 
-} // namespace ecaldqm
+}  // namespace ecaldqm
 
 #endif

--- a/DQM/EcalCommon/interface/MESetMulti.h
+++ b/DQM/EcalCommon/interface/MESetMulti.h
@@ -4,178 +4,132 @@
 #include "MESet.h"
 
 namespace ecaldqm {
-/* class MESetMulti
+  /* class MESetMulti
    wrapper for a set of MESets
    limit() filters out unused MESets
    use() method sets the MESet to be used
 */
 
-class MESetMulti : public MESet {
-public:
-  typedef std::map<std::string, std::vector<std::string>> ReplCandidates;
+  class MESetMulti : public MESet {
+  public:
+    typedef std::map<std::string, std::vector<std::string>> ReplCandidates;
 
-  MESetMulti(MESet const &, ReplCandidates const &);
-  MESetMulti(MESetMulti const &);
-  ~MESetMulti() override;
+    MESetMulti(MESet const &, ReplCandidates const &);
+    MESetMulti(MESetMulti const &);
+    ~MESetMulti() override;
 
-  MESet &operator=(MESet const &) override;
+    MESet &operator=(MESet const &) override;
 
-  MESet *clone(std::string const & = "") const override;
+    MESet *clone(std::string const & = "") const override;
 
-  void book(DQMStore::IBooker &) override;
-  bool retrieve(DQMStore::IGetter &, std::string * = nullptr) const override;
-  void clear() const override;
+    void book(DQMStore::IBooker &) override;
+    bool retrieve(DQMStore::IGetter &, std::string * = nullptr) const override;
+    void clear() const override;
 
-  void fill(DetId const &_id, double _xyw = 1., double _yw = 1.,
-            double _w = 1.) override {
-    current_->fill(_id, _xyw, _yw, _w);
-  }
-  void fill(EcalElectronicsId const &_id, double _xyw = 1., double _yw = 1.,
-            double _w = 1.) override {
-    current_->fill(_id, _xyw, _yw, _w);
-  }
-  void fill(int _dcctccid, double _xyw = 1., double _yw = 1.,
-            double _w = 1.) override {
-    current_->fill(_dcctccid, _xyw, _yw, _w);
-  }
-  void fill(double _x, double _yw = 1., double _w = 1.) override {
-    current_->fill(_x, _yw, _w);
-  }
+    void fill(DetId const &_id, double _xyw = 1., double _yw = 1., double _w = 1.) override {
+      current_->fill(_id, _xyw, _yw, _w);
+    }
+    void fill(EcalElectronicsId const &_id, double _xyw = 1., double _yw = 1., double _w = 1.) override {
+      current_->fill(_id, _xyw, _yw, _w);
+    }
+    void fill(int _dcctccid, double _xyw = 1., double _yw = 1., double _w = 1.) override {
+      current_->fill(_dcctccid, _xyw, _yw, _w);
+    }
+    void fill(double _x, double _yw = 1., double _w = 1.) override { current_->fill(_x, _yw, _w); }
 
-  void setBinContent(DetId const &_id, double _content) override {
-    current_->setBinContent(_id, _content);
-  }
-  void setBinContent(EcalElectronicsId const &_id, double _content) override {
-    current_->setBinContent(_id, _content);
-  }
-  void setBinContent(int _dcctccid, double _content) override {
-    current_->setBinContent(_dcctccid, _content);
-  }
-  void setBinContent(DetId const &_id, int _bin, double _content) override {
-    current_->setBinContent(_id, _bin, _content);
-  }
-  void setBinContent(EcalElectronicsId const &_id, int _bin,
-                     double _content) override {
-    current_->setBinContent(_id, _bin, _content);
-  }
-  void setBinContent(int _dcctccid, int _bin, double _content) override {
-    current_->setBinContent(_dcctccid, _bin, _content);
-  }
+    void setBinContent(DetId const &_id, double _content) override { current_->setBinContent(_id, _content); }
+    void setBinContent(EcalElectronicsId const &_id, double _content) override {
+      current_->setBinContent(_id, _content);
+    }
+    void setBinContent(int _dcctccid, double _content) override { current_->setBinContent(_dcctccid, _content); }
+    void setBinContent(DetId const &_id, int _bin, double _content) override {
+      current_->setBinContent(_id, _bin, _content);
+    }
+    void setBinContent(EcalElectronicsId const &_id, int _bin, double _content) override {
+      current_->setBinContent(_id, _bin, _content);
+    }
+    void setBinContent(int _dcctccid, int _bin, double _content) override {
+      current_->setBinContent(_dcctccid, _bin, _content);
+    }
 
-  void setBinError(DetId const &_id, double _error) override {
-    current_->setBinError(_id, _error);
-  }
-  void setBinError(EcalElectronicsId const &_id, double _error) override {
-    current_->setBinError(_id, _error);
-  }
-  void setBinError(int _dcctccid, double _error) override {
-    current_->setBinError(_dcctccid, _error);
-  }
-  void setBinError(DetId const &_id, int _bin, double _error) override {
-    current_->setBinError(_id, _bin, _error);
-  }
-  void setBinError(EcalElectronicsId const &_id, int _bin,
-                   double _error) override {
-    current_->setBinError(_id, _bin, _error);
-  }
-  void setBinError(int _dcctccid, int _bin, double _error) override {
-    current_->setBinError(_dcctccid, _bin, _error);
-  }
+    void setBinError(DetId const &_id, double _error) override { current_->setBinError(_id, _error); }
+    void setBinError(EcalElectronicsId const &_id, double _error) override { current_->setBinError(_id, _error); }
+    void setBinError(int _dcctccid, double _error) override { current_->setBinError(_dcctccid, _error); }
+    void setBinError(DetId const &_id, int _bin, double _error) override { current_->setBinError(_id, _bin, _error); }
+    void setBinError(EcalElectronicsId const &_id, int _bin, double _error) override {
+      current_->setBinError(_id, _bin, _error);
+    }
+    void setBinError(int _dcctccid, int _bin, double _error) override {
+      current_->setBinError(_dcctccid, _bin, _error);
+    }
 
-  void setBinEntries(DetId const &_id, double _entries) override {
-    current_->setBinEntries(_id, _entries);
-  }
-  void setBinEntries(EcalElectronicsId const &_id, double _entries) override {
-    current_->setBinEntries(_id, _entries);
-  }
-  void setBinEntries(int _dcctccid, double _entries) override {
-    current_->setBinEntries(_dcctccid, _entries);
-  }
-  void setBinEntries(DetId const &_id, int _bin, double _entries) override {
-    current_->setBinEntries(_id, _bin, _entries);
-  }
-  void setBinEntries(EcalElectronicsId const &_id, int _bin,
-                     double _entries) override {
-    current_->setBinEntries(_id, _bin, _entries);
-  }
-  void setBinEntries(int _dcctccid, int _bin, double _entries) override {
-    current_->setBinEntries(_dcctccid, _bin, _entries);
-  }
+    void setBinEntries(DetId const &_id, double _entries) override { current_->setBinEntries(_id, _entries); }
+    void setBinEntries(EcalElectronicsId const &_id, double _entries) override {
+      current_->setBinEntries(_id, _entries);
+    }
+    void setBinEntries(int _dcctccid, double _entries) override { current_->setBinEntries(_dcctccid, _entries); }
+    void setBinEntries(DetId const &_id, int _bin, double _entries) override {
+      current_->setBinEntries(_id, _bin, _entries);
+    }
+    void setBinEntries(EcalElectronicsId const &_id, int _bin, double _entries) override {
+      current_->setBinEntries(_id, _bin, _entries);
+    }
+    void setBinEntries(int _dcctccid, int _bin, double _entries) override {
+      current_->setBinEntries(_dcctccid, _bin, _entries);
+    }
 
-  double getBinContent(DetId const &_id, int _bin = 0) const override {
-    return current_->getBinContent(_id, _bin);
-  }
-  double getBinContent(EcalElectronicsId const &_id,
-                       int _bin = 0) const override {
-    return current_->getBinContent(_id, _bin);
-  }
-  double getBinContent(int _dcctccid, int _bin = 0) const override {
-    return current_->getBinContent(_dcctccid, _bin);
-  }
+    double getBinContent(DetId const &_id, int _bin = 0) const override { return current_->getBinContent(_id, _bin); }
+    double getBinContent(EcalElectronicsId const &_id, int _bin = 0) const override {
+      return current_->getBinContent(_id, _bin);
+    }
+    double getBinContent(int _dcctccid, int _bin = 0) const override {
+      return current_->getBinContent(_dcctccid, _bin);
+    }
 
-  double getBinError(DetId const &_id, int _bin = 0) const override {
-    return current_->getBinError(_id, _bin);
-  }
-  double getBinError(EcalElectronicsId const &_id,
-                     int _bin = 0) const override {
-    return current_->getBinError(_id, _bin);
-  }
-  double getBinError(int _dcctccid, int _bin = 0) const override {
-    return current_->getBinError(_dcctccid, _bin);
-  }
+    double getBinError(DetId const &_id, int _bin = 0) const override { return current_->getBinError(_id, _bin); }
+    double getBinError(EcalElectronicsId const &_id, int _bin = 0) const override {
+      return current_->getBinError(_id, _bin);
+    }
+    double getBinError(int _dcctccid, int _bin = 0) const override { return current_->getBinError(_dcctccid, _bin); }
 
-  double getBinEntries(DetId const &_id, int _bin = 0) const override {
-    return current_->getBinEntries(_id, _bin);
-  }
-  double getBinEntries(EcalElectronicsId const &_id,
-                       int _bin = 0) const override {
-    return current_->getBinEntries(_id, _bin);
-  }
-  double getBinEntries(int _dcctccid, int _bin = 0) const override {
-    return current_->getBinEntries(_dcctccid, _bin);
-  }
+    double getBinEntries(DetId const &_id, int _bin = 0) const override { return current_->getBinEntries(_id, _bin); }
+    double getBinEntries(EcalElectronicsId const &_id, int _bin = 0) const override {
+      return current_->getBinEntries(_id, _bin);
+    }
+    double getBinEntries(int _dcctccid, int _bin = 0) const override {
+      return current_->getBinEntries(_dcctccid, _bin);
+    }
 
-  void reset(double = 0., double = 0., double = 0.) override;
-  void resetAll(double = 0., double = 0., double = 0.) override;
+    void reset(double = 0., double = 0., double = 0.) override;
+    void resetAll(double = 0., double = 0., double = 0.) override;
 
-  bool maskMatches(DetId const &_id, uint32_t _mask,
-                   StatusManager const *_statusManager) const override {
-    return current_ && current_->maskMatches(_id, _mask, _statusManager);
-  }
+    bool maskMatches(DetId const &_id, uint32_t _mask, StatusManager const *_statusManager) const override {
+      return current_ && current_->maskMatches(_id, _mask, _statusManager);
+    }
 
-  bool isVariableBinning() const override {
-    return current_->isVariableBinning();
-  }
+    bool isVariableBinning() const override { return current_->isVariableBinning(); }
 
-  std::string const &getPath() const override { return current_->getPath(); }
-  MonitorElement const *getME(unsigned _iME) const override {
-    return current_->getME(_iME);
-  }
-  MonitorElement *getME(unsigned _iME) override {
-    return current_->getME(_iME);
-  }
+    std::string const &getPath() const override { return current_->getPath(); }
+    MonitorElement const *getME(unsigned _iME) const override { return current_->getME(_iME); }
+    MonitorElement *getME(unsigned _iME) override { return current_->getME(_iME); }
 
-  void use(unsigned) const;
-  MESet *getCurrent() const { return current_; }
-  unsigned getMultiplicity() const { return sets_.size(); }
-  unsigned getIndex(PathReplacements const &) const;
+    void use(unsigned) const;
+    MESet *getCurrent() const { return current_; }
+    unsigned getMultiplicity() const { return sets_.size(); }
+    unsigned getIndex(PathReplacements const &) const;
 
-  const_iterator begin() const override { return const_iterator(*current_); }
-  const_iterator end() const override {
-    return const_iterator(*current_, -1, -1);
-  }
-  const_iterator beginChannel() const override {
-    return current_->beginChannel();
-  }
-  iterator begin() override { return iterator(*current_); }
-  iterator end() override { return iterator(*current_, -1, -1); }
-  iterator beginChannel() override { return current_->beginChannel(); }
+    const_iterator begin() const override { return const_iterator(*current_); }
+    const_iterator end() const override { return const_iterator(*current_, -1, -1); }
+    const_iterator beginChannel() const override { return current_->beginChannel(); }
+    iterator begin() override { return iterator(*current_); }
+    iterator end() override { return iterator(*current_, -1, -1); }
+    iterator beginChannel() override { return current_->beginChannel(); }
 
-protected:
-  mutable MESet *current_;
-  std::vector<MESet *> sets_;
-  ReplCandidates replCandidates_;
-};
-} // namespace ecaldqm
+  protected:
+    mutable MESet *current_;
+    std::vector<MESet *> sets_;
+    ReplCandidates replCandidates_;
+  };
+}  // namespace ecaldqm
 
 #endif

--- a/DQM/EcalCommon/interface/MESetNonObject.h
+++ b/DQM/EcalCommon/interface/MESetNonObject.h
@@ -4,47 +4,50 @@
 #include "MESet.h"
 
 namespace ecaldqm {
-class MESetNonObject : public MESet {
-public:
-  MESetNonObject(std::string const &, binning::ObjectType, binning::BinningType,
-                 MonitorElement::Kind, binning::AxisSpecs const * = nullptr,
-                 binning::AxisSpecs const * = nullptr,
-                 binning::AxisSpecs const * = nullptr);
-  MESetNonObject(MESetNonObject const &);
-  ~MESetNonObject() override;
+  class MESetNonObject : public MESet {
+  public:
+    MESetNonObject(std::string const &,
+                   binning::ObjectType,
+                   binning::BinningType,
+                   MonitorElement::Kind,
+                   binning::AxisSpecs const * = nullptr,
+                   binning::AxisSpecs const * = nullptr,
+                   binning::AxisSpecs const * = nullptr);
+    MESetNonObject(MESetNonObject const &);
+    ~MESetNonObject() override;
 
-  MESet &operator=(MESet const &) override;
+    MESet &operator=(MESet const &) override;
 
-  MESet *clone(std::string const & = "") const override;
+    MESet *clone(std::string const & = "") const override;
 
-  void book(DQMStore::IBooker &) override;
-  bool retrieve(DQMStore::IGetter &, std::string * = nullptr) const override;
+    void book(DQMStore::IBooker &) override;
+    bool retrieve(DQMStore::IGetter &, std::string * = nullptr) const override;
 
-  void fill(double, double = 1., double = 1.) override;
+    void fill(double, double = 1., double = 1.) override;
 
-  void setBinContent(int, double) override;
+    void setBinContent(int, double) override;
 
-  void setBinError(int, double) override;
+    void setBinError(int, double) override;
 
-  void setBinEntries(int, double) override;
+    void setBinEntries(int, double) override;
 
-  double getBinContent(int, int = 0) const override;
+    double getBinContent(int, int = 0) const override;
 
-  double getFloatValue() const;
+    double getFloatValue() const;
 
-  double getBinError(int, int = 0) const override;
+    double getBinError(int, int = 0) const override;
 
-  double getBinEntries(int, int = 0) const override;
+    double getBinEntries(int, int = 0) const override;
 
-  int findBin(double, double = 0.) const;
+    int findBin(double, double = 0.) const;
 
-  bool isVariableBinning() const override;
+    bool isVariableBinning() const override;
 
-protected:
-  binning::AxisSpecs const *xaxis_;
-  binning::AxisSpecs const *yaxis_;
-  binning::AxisSpecs const *zaxis_;
-};
-} // namespace ecaldqm
+  protected:
+    binning::AxisSpecs const *xaxis_;
+    binning::AxisSpecs const *yaxis_;
+    binning::AxisSpecs const *zaxis_;
+  };
+}  // namespace ecaldqm
 
 #endif

--- a/DQM/EcalCommon/interface/MESetProjection.h
+++ b/DQM/EcalCommon/interface/MESetProjection.h
@@ -5,42 +5,44 @@
 
 namespace ecaldqm {
 
-/* class MESetProjection
+  /* class MESetProjection
    MonitorElement wrapper for projection type 1D MEs
 */
 
-class MESetProjection : public MESetEcal {
-public:
-  MESetProjection(std::string const &, binning::ObjectType,
-                  binning::BinningType, MonitorElement::Kind,
-                  binning::AxisSpecs const * = nullptr);
-  MESetProjection(MESetProjection const &);
-  ~MESetProjection() override;
+  class MESetProjection : public MESetEcal {
+  public:
+    MESetProjection(std::string const &,
+                    binning::ObjectType,
+                    binning::BinningType,
+                    MonitorElement::Kind,
+                    binning::AxisSpecs const * = nullptr);
+    MESetProjection(MESetProjection const &);
+    ~MESetProjection() override;
 
-  MESet *clone(std::string const & = "") const override;
+    MESet *clone(std::string const & = "") const override;
 
-  void fill(DetId const &, double = 1., double = 0., double = 0.) override;
-  void fill(int, double = 1., double = 1., double = 0.) override;
-  void fill(double, double = 1., double = 0.) override;
+    void fill(DetId const &, double = 1., double = 0., double = 0.) override;
+    void fill(int, double = 1., double = 1., double = 0.) override;
+    void fill(double, double = 1., double = 0.) override;
 
-  using MESetEcal::setBinContent;
-  void setBinContent(DetId const &, double) override;
+    using MESetEcal::setBinContent;
+    void setBinContent(DetId const &, double) override;
 
-  using MESetEcal::setBinError;
-  void setBinError(DetId const &, double) override;
+    using MESetEcal::setBinError;
+    void setBinError(DetId const &, double) override;
 
-  using MESetEcal::setBinEntries;
-  void setBinEntries(DetId const &, double) override;
+    using MESetEcal::setBinEntries;
+    void setBinEntries(DetId const &, double) override;
 
-  using MESetEcal::getBinContent;
-  double getBinContent(DetId const &, int = 0) const override;
+    using MESetEcal::getBinContent;
+    double getBinContent(DetId const &, int = 0) const override;
 
-  using MESetEcal::getBinError;
-  double getBinError(DetId const &, int = 0) const override;
+    using MESetEcal::getBinError;
+    double getBinError(DetId const &, int = 0) const override;
 
-  using MESetEcal::getBinEntries;
-  double getBinEntries(DetId const &, int = 0) const override;
-};
-} // namespace ecaldqm
+    using MESetEcal::getBinEntries;
+    double getBinEntries(DetId const &, int = 0) const override;
+  };
+}  // namespace ecaldqm
 
 #endif

--- a/DQM/EcalCommon/interface/MESetTrend.h
+++ b/DQM/EcalCommon/interface/MESetTrend.h
@@ -4,52 +4,54 @@
 #include "MESetEcal.h"
 
 namespace ecaldqm {
-/* class MESetTrend
+  /* class MESetTrend
    time on xaxis
    channel id is used to identify the plot
 */
 
-class MESetTrend : public MESetEcal {
-public:
-  MESetTrend(std::string const &, binning::ObjectType, binning::BinningType,
-             MonitorElement::Kind, binning::AxisSpecs const * = nullptr,
-             binning::AxisSpecs const * = nullptr);
-  MESetTrend(MESetTrend const &);
-  ~MESetTrend() override {}
+  class MESetTrend : public MESetEcal {
+  public:
+    MESetTrend(std::string const &,
+               binning::ObjectType,
+               binning::BinningType,
+               MonitorElement::Kind,
+               binning::AxisSpecs const * = nullptr,
+               binning::AxisSpecs const * = nullptr);
+    MESetTrend(MESetTrend const &);
+    ~MESetTrend() override {}
 
-  MESet &operator=(MESet const &) override;
+    MESet &operator=(MESet const &) override;
 
-  MESet *clone(std::string const & = "") const override;
+    MESet *clone(std::string const & = "") const override;
 
-  void book(DQMStore::IBooker &) override;
+    void book(DQMStore::IBooker &) override;
 
-  void fill(DetId const &, double, double = 1., double = 1.) override;
-  void fill(EcalElectronicsId const &, double, double = 1.,
-            double = 1.) override;
-  void fill(int, double, double = 1., double = 1.) override;
-  void fill(double, double = 1., double = 1.) override;
+    void fill(DetId const &, double, double = 1., double = 1.) override;
+    void fill(EcalElectronicsId const &, double, double = 1., double = 1.) override;
+    void fill(int, double, double = 1., double = 1.) override;
+    void fill(double, double = 1., double = 1.) override;
 
-  int findBin(DetId const &, double, double = 0.) const override;
-  int findBin(EcalElectronicsId const &, double, double = 0.) const override;
-  int findBin(int, double, double = 0.) const override;
-  int findBin(double, double = 0.) const;
+    int findBin(DetId const &, double, double = 0.) const override;
+    int findBin(EcalElectronicsId const &, double, double = 0.) const override;
+    int findBin(int, double, double = 0.) const override;
+    int findBin(double, double = 0.) const;
 
-  bool isVariableBinning() const override { return true; }
+    bool isVariableBinning() const override { return true; }
 
-  void setMinutely() { minutely_ = true; }
-  void setShiftAxis() { shiftAxis_ = true; }
-  void setCumulative();
-  bool isMinutely() const { return minutely_; }
-  bool canShiftAxis() const { return shiftAxis_; }
-  bool isCumulative() const { return currentBin_ > 0; }
+    void setMinutely() { minutely_ = true; }
+    void setShiftAxis() { shiftAxis_ = true; }
+    void setCumulative();
+    bool isMinutely() const { return minutely_; }
+    bool canShiftAxis() const { return shiftAxis_; }
+    bool isCumulative() const { return currentBin_ > 0; }
 
-private:
-  bool shift_(unsigned);
+  private:
+    bool shift_(unsigned);
 
-  bool minutely_;  // if true, bins in minutes instead of lumis
-  bool shiftAxis_; // if true, shift x values
-  int currentBin_; // only used for cumulative case
-};
-} // namespace ecaldqm
+    bool minutely_;   // if true, bins in minutes instead of lumis
+    bool shiftAxis_;  // if true, shift x values
+    int currentBin_;  // only used for cumulative case
+  };
+}  // namespace ecaldqm
 
 #endif

--- a/DQM/EcalCommon/interface/MESetUtils.h
+++ b/DQM/EcalCommon/interface/MESetUtils.h
@@ -7,13 +7,13 @@
 #include <string>
 
 namespace edm {
-class ParameterSet;
-class ParameterSetDescription;
-} // namespace edm
+  class ParameterSet;
+  class ParameterSetDescription;
+}  // namespace edm
 
 namespace ecaldqm {
-MESet *createMESet(edm::ParameterSet const &);
-void fillMESetDescriptions(edm::ParameterSetDescription &);
-} // namespace ecaldqm
+  MESet *createMESet(edm::ParameterSet const &);
+  void fillMESetDescriptions(edm::ParameterSetDescription &);
+}  // namespace ecaldqm
 
 #endif

--- a/DQM/EcalCommon/interface/StatusManager.h
+++ b/DQM/EcalCommon/interface/StatusManager.h
@@ -11,23 +11,23 @@
 
 namespace ecaldqm {
 
-class StatusManager {
-public:
-  StatusManager();
-  ~StatusManager() {}
+  class StatusManager {
+  public:
+    StatusManager();
+    ~StatusManager() {}
 
-  void readFromStream(std::istream &);
-  void readFromObj(EcalDQMChannelStatus const &, EcalDQMTowerStatus const &);
-  void writeToStream(std::ostream &) const;
-  void writeToObj(EcalDQMChannelStatus &, EcalDQMTowerStatus &) const;
+    void readFromStream(std::istream &);
+    void readFromObj(EcalDQMChannelStatus const &, EcalDQMTowerStatus const &);
+    void writeToStream(std::ostream &) const;
+    void writeToObj(EcalDQMChannelStatus &, EcalDQMTowerStatus &) const;
 
-  uint32_t getStatus(uint32_t) const;
+    uint32_t getStatus(uint32_t) const;
 
-private:
-  std::map<std::string, uint32_t> dictionary_;
-  std::map<uint32_t, uint32_t> status_;
-};
+  private:
+    std::map<std::string, uint32_t> dictionary_;
+    std::map<uint32_t, uint32_t> status_;
+  };
 
-} // namespace ecaldqm
+}  // namespace ecaldqm
 
 #endif

--- a/DQM/EcalCommon/plugins/EcalMEFormatter.cc
+++ b/DQM/EcalCommon/plugins/EcalMEFormatter.cc
@@ -10,8 +10,7 @@
 
 #include <limits>
 
-EcalMEFormatter::EcalMEFormatter(edm::ParameterSet const &_ps)
-    : DQMEDHarvester(), ecaldqm::DQWorker() {
+EcalMEFormatter::EcalMEFormatter(edm::ParameterSet const &_ps) : DQMEDHarvester(), ecaldqm::DQWorker() {
   initialize("EcalMEFormatter", _ps);
   setME(_ps.getUntrackedParameterSet("MEs"));
   verbosity_ = _ps.getUntrackedParameter<int>("verbosity", 0);
@@ -33,28 +32,22 @@ void EcalMEFormatter::dqmEndLuminosityBlock(DQMStore::IBooker &,
   format_(_igetter, true);
 }
 
-void EcalMEFormatter::dqmEndJob(DQMStore::IBooker &,
-                                DQMStore::IGetter &_igetter) {
-  format_(_igetter, false);
-}
+void EcalMEFormatter::dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &_igetter) { format_(_igetter, false); }
 
 void EcalMEFormatter::format_(DQMStore::IGetter &_igetter, bool _checkLumi) {
   std::string failedPath;
 
-  for (ecaldqm::MESetCollection::iterator mItr(MEs_.begin());
-       mItr != MEs_.end(); ++mItr) {
+  for (ecaldqm::MESetCollection::iterator mItr(MEs_.begin()); mItr != MEs_.end(); ++mItr) {
     if (_checkLumi && !mItr->second->getLumiFlag())
       continue;
     mItr->second->clear();
     if (!mItr->second->retrieve(_igetter, &failedPath)) {
       if (verbosity_ > 0)
-        edm::LogWarning("EcalDQM")
-            << "Could not find ME " << mItr->first << "@" << failedPath;
+        edm::LogWarning("EcalDQM") << "Could not find ME " << mItr->first << "@" << failedPath;
       continue;
     }
     if (verbosity_ > 1)
-      edm::LogInfo("EcalDQM")
-          << "Retrieved " << mItr->first << " from DQMStore";
+      edm::LogInfo("EcalDQM") << "Retrieved " << mItr->first << " from DQMStore";
 
     if (dynamic_cast<ecaldqm::MESetDet2D *>(mItr->second))
       formatDet2D_(*mItr->second);

--- a/DQM/EcalCommon/plugins/EcalMonitorPrescaler.cc
+++ b/DQM/EcalCommon/plugins/EcalMonitorPrescaler.cc
@@ -10,104 +10,65 @@
 #include <cmath>
 #include <iostream>
 
-uint32_t EcalMonitorPrescaler::filterBits_[EcalMonitorPrescaler::nPrescalers] =
-    {
-        (1 << EcalDCCHeaderBlock::MTCC) |
-            (1 << EcalDCCHeaderBlock::PHYSICS_GLOBAL) |
-            (1 << EcalDCCHeaderBlock::PHYSICS_LOCAL), // kPhysics
-        (1 << EcalDCCHeaderBlock::COSMIC) |
-            (1 << EcalDCCHeaderBlock::COSMICS_GLOBAL) |
-            (1 << EcalDCCHeaderBlock::COSMICS_LOCAL), // kCosmics
-        (1 << EcalDCCHeaderBlock::LASER_STD) |
-            (1 << EcalDCCHeaderBlock::LASER_GAP) |
-            (1 << EcalDCCHeaderBlock::LED_STD) |
-            (1 << EcalDCCHeaderBlock::LED_GAP) |
-            (1 << EcalDCCHeaderBlock::PEDESTAL_STD) |
-            (1 << EcalDCCHeaderBlock::PEDESTAL_GAP) |
-            (1 << EcalDCCHeaderBlock::TESTPULSE_MGPA) |
-            (1 << EcalDCCHeaderBlock::TESTPULSE_GAP) |
-            (1 << EcalDCCHeaderBlock::PEDESTAL_OFFSET_SCAN), // kCalibration
-        (1 << EcalDCCHeaderBlock::LASER_STD) |
-            (1 << EcalDCCHeaderBlock::LASER_GAP), // kLaser
-        (1 << EcalDCCHeaderBlock::LED_STD) |
-            (1 << EcalDCCHeaderBlock::LED_GAP), // kLed
-        (1 << EcalDCCHeaderBlock::TESTPULSE_MGPA) |
-            (1 << EcalDCCHeaderBlock::TESTPULSE_GAP), // kTestPulse
-        (1 << EcalDCCHeaderBlock::PEDESTAL_STD) |
-            (1 << EcalDCCHeaderBlock::PEDESTAL_GAP) |
-            (1 << EcalDCCHeaderBlock::PEDESTAL_OFFSET_SCAN) // kPedestal
+uint32_t EcalMonitorPrescaler::filterBits_[EcalMonitorPrescaler::nPrescalers] = {
+    (1 << EcalDCCHeaderBlock::MTCC) | (1 << EcalDCCHeaderBlock::PHYSICS_GLOBAL) |
+        (1 << EcalDCCHeaderBlock::PHYSICS_LOCAL),  // kPhysics
+    (1 << EcalDCCHeaderBlock::COSMIC) | (1 << EcalDCCHeaderBlock::COSMICS_GLOBAL) |
+        (1 << EcalDCCHeaderBlock::COSMICS_LOCAL),  // kCosmics
+    (1 << EcalDCCHeaderBlock::LASER_STD) | (1 << EcalDCCHeaderBlock::LASER_GAP) | (1 << EcalDCCHeaderBlock::LED_STD) |
+        (1 << EcalDCCHeaderBlock::LED_GAP) | (1 << EcalDCCHeaderBlock::PEDESTAL_STD) |
+        (1 << EcalDCCHeaderBlock::PEDESTAL_GAP) | (1 << EcalDCCHeaderBlock::TESTPULSE_MGPA) |
+        (1 << EcalDCCHeaderBlock::TESTPULSE_GAP) | (1 << EcalDCCHeaderBlock::PEDESTAL_OFFSET_SCAN),  // kCalibration
+    (1 << EcalDCCHeaderBlock::LASER_STD) | (1 << EcalDCCHeaderBlock::LASER_GAP),                     // kLaser
+    (1 << EcalDCCHeaderBlock::LED_STD) | (1 << EcalDCCHeaderBlock::LED_GAP),                         // kLed
+    (1 << EcalDCCHeaderBlock::TESTPULSE_MGPA) | (1 << EcalDCCHeaderBlock::TESTPULSE_GAP),            // kTestPulse
+    (1 << EcalDCCHeaderBlock::PEDESTAL_STD) | (1 << EcalDCCHeaderBlock::PEDESTAL_GAP) |
+        (1 << EcalDCCHeaderBlock::PEDESTAL_OFFSET_SCAN)  // kPedestal
 };
 
 EcalMonitorPrescaler::EcalMonitorPrescaler(edm::ParameterSet const &_ps)
-    : EcalRawDataCollection_(consumes<EcalRawDataCollection>(
-          _ps.getParameter<edm::InputTag>("EcalRawDataCollection"))) {
+    : EcalRawDataCollection_(
+          consumes<EcalRawDataCollection>(_ps.getParameter<edm::InputTag>("EcalRawDataCollection"))) {
   for (unsigned iP(0); iP != nPrescalers; ++iP)
     prescalers_[iP].first = 0;
 
-  prescalers_[kPhysics].second =
-      _ps.getUntrackedParameter<unsigned>("physics", -1);
-  prescalers_[kCosmics].second =
-      _ps.getUntrackedParameter<unsigned>("cosmics", -1);
-  prescalers_[kCalibration].second =
-      _ps.getUntrackedParameter<unsigned>("calibration", -1);
+  prescalers_[kPhysics].second = _ps.getUntrackedParameter<unsigned>("physics", -1);
+  prescalers_[kCosmics].second = _ps.getUntrackedParameter<unsigned>("cosmics", -1);
+  prescalers_[kCalibration].second = _ps.getUntrackedParameter<unsigned>("calibration", -1);
   prescalers_[kLaser].second = _ps.getUntrackedParameter<unsigned>("laser", -1);
   prescalers_[kLed].second = _ps.getUntrackedParameter<unsigned>("led", -1);
-  prescalers_[kTestPulse].second =
-      _ps.getUntrackedParameter<unsigned>("testPulse", -1);
-  prescalers_[kPedestal].second =
-      _ps.getUntrackedParameter<unsigned>("pedestal", -1);
+  prescalers_[kTestPulse].second = _ps.getUntrackedParameter<unsigned>("testPulse", -1);
+  prescalers_[kPedestal].second = _ps.getUntrackedParameter<unsigned>("pedestal", -1);
 
   // Backward compatibility
-  prescalers_[kPhysics].second =
-      std::min(prescalers_[kPhysics].second,
-               (unsigned int)(_ps.getUntrackedParameter<int>(
-                   "occupancyPrescaleFactor", -1)));
-  prescalers_[kPhysics].second =
-      std::min(prescalers_[kPhysics].second,
-               (unsigned int)(_ps.getUntrackedParameter<int>(
-                   "integrityPrescaleFactor", -1)));
-  prescalers_[kCosmics].second =
-      std::min(prescalers_[kCosmics].second,
-               (unsigned int)(_ps.getUntrackedParameter<int>(
-                   "cosmicPrescaleFactor", -1)));
-  prescalers_[kLaser].second = std::min(
-      prescalers_[kLaser].second, (unsigned int)(_ps.getUntrackedParameter<int>(
-                                      "laserPrescaleFactor", -1)));
-  prescalers_[kLed].second = std::min(
-      prescalers_[kLed].second,
-      (unsigned int)(_ps.getUntrackedParameter<int>("ledPrescaleFactor", -1)));
+  prescalers_[kPhysics].second = std::min(
+      prescalers_[kPhysics].second, (unsigned int)(_ps.getUntrackedParameter<int>("occupancyPrescaleFactor", -1)));
+  prescalers_[kPhysics].second = std::min(
+      prescalers_[kPhysics].second, (unsigned int)(_ps.getUntrackedParameter<int>("integrityPrescaleFactor", -1)));
+  prescalers_[kCosmics].second = std::min(prescalers_[kCosmics].second,
+                                          (unsigned int)(_ps.getUntrackedParameter<int>("cosmicPrescaleFactor", -1)));
+  prescalers_[kLaser].second =
+      std::min(prescalers_[kLaser].second, (unsigned int)(_ps.getUntrackedParameter<int>("laserPrescaleFactor", -1)));
+  prescalers_[kLed].second =
+      std::min(prescalers_[kLed].second, (unsigned int)(_ps.getUntrackedParameter<int>("ledPrescaleFactor", -1)));
+  prescalers_[kPedestal].second = std::min(
+      prescalers_[kPedestal].second, (unsigned int)(_ps.getUntrackedParameter<int>("pedestalPrescaleFactor", -1)));
   prescalers_[kPedestal].second =
       std::min(prescalers_[kPedestal].second,
-               (unsigned int)(_ps.getUntrackedParameter<int>(
-                   "pedestalPrescaleFactor", -1)));
+               (unsigned int)(_ps.getUntrackedParameter<int>("pedestalonlinePrescaleFactor", -1)));
+  prescalers_[kTestPulse].second = std::min(
+      prescalers_[kTestPulse].second, (unsigned int)(_ps.getUntrackedParameter<int>("testpulsePrescaleFactor", -1)));
   prescalers_[kPedestal].second =
       std::min(prescalers_[kPedestal].second,
-               (unsigned int)(_ps.getUntrackedParameter<int>(
-                   "pedestalonlinePrescaleFactor", -1)));
-  prescalers_[kTestPulse].second =
-      std::min(prescalers_[kTestPulse].second,
-               (unsigned int)(_ps.getUntrackedParameter<int>(
-                   "testpulsePrescaleFactor", -1)));
-  prescalers_[kPedestal].second =
-      std::min(prescalers_[kPedestal].second,
-               (unsigned int)(_ps.getUntrackedParameter<int>(
-                   "pedestaloffsetPrescaleFactor", -1)));
-  prescalers_[kPhysics].second =
-      std::min(prescalers_[kPhysics].second,
-               (unsigned int)(_ps.getUntrackedParameter<int>(
-                   "triggertowerPrescaleFactor", -1)));
-  prescalers_[kPhysics].second =
-      std::min(prescalers_[kPhysics].second,
-               (unsigned int)(_ps.getUntrackedParameter<int>(
-                   "timingPrescaleFactor", -1)));
-  prescalers_[kPhysics].second =
-      std::min(prescalers_[kPhysics].second,
-               (unsigned int)(_ps.getUntrackedParameter<int>(
-                   "physicsPrescaleFactor", -1)));
-  prescalers_[kPhysics].second =
-      std::min(prescalers_[kPhysics].second,
-               (unsigned int)(_ps.getUntrackedParameter<int>(
-                   "clusterPrescaleFactor", -1)));
+               (unsigned int)(_ps.getUntrackedParameter<int>("pedestaloffsetPrescaleFactor", -1)));
+  prescalers_[kPhysics].second = std::min(
+      prescalers_[kPhysics].second, (unsigned int)(_ps.getUntrackedParameter<int>("triggertowerPrescaleFactor", -1)));
+  prescalers_[kPhysics].second = std::min(prescalers_[kPhysics].second,
+                                          (unsigned int)(_ps.getUntrackedParameter<int>("timingPrescaleFactor", -1)));
+  prescalers_[kPhysics].second = std::min(prescalers_[kPhysics].second,
+                                          (unsigned int)(_ps.getUntrackedParameter<int>("physicsPrescaleFactor", -1)));
+  prescalers_[kPhysics].second = std::min(prescalers_[kPhysics].second,
+                                          (unsigned int)(_ps.getUntrackedParameter<int>("clusterPrescaleFactor", -1)));
 }
 
 EcalMonitorPrescaler::~EcalMonitorPrescaler() {}
@@ -121,19 +82,16 @@ bool EcalMonitorPrescaler::filter(edm::Event &_event, edm::EventSetup const &) {
   edm::Handle<EcalRawDataCollection> dcchs;
 
   if (!_event.getByToken(EcalRawDataCollection_, dcchs)) {
-    edm::LogWarning("EcalMonitorPrescaler")
-        << "EcalRawDataCollection not available";
+    edm::LogWarning("EcalMonitorPrescaler") << "EcalRawDataCollection not available";
     return false;
   }
 
   uint32_t eventBits(0);
-  for (EcalRawDataCollection::const_iterator dcchItr(dcchs->begin());
-       dcchItr != dcchs->end(); ++dcchItr)
+  for (EcalRawDataCollection::const_iterator dcchItr(dcchs->begin()); dcchItr != dcchs->end(); ++dcchItr)
     eventBits |= (1 << dcchItr->getRunType());
 
   for (unsigned iP(0); iP != nPrescalers; ++iP) {
-    if ((eventBits & filterBits_[iP]) != 0 &&
-        ++prescalers_[iP].first % prescalers_[iP].second == 0)
+    if ((eventBits & filterBits_[iP]) != 0 && ++prescalers_[iP].first % prescalers_[iP].second == 0)
       return true;
   }
 

--- a/DQM/EcalCommon/src/DQWorker.cc
+++ b/DQM/EcalCommon/src/DQWorker.cc
@@ -10,96 +10,91 @@
 #include "DataFormats/Provenance/interface/EventID.h"
 
 namespace ecaldqm {
-DQWorker::DQWorker()
-    : name_(""), MEs_(), booked_(false), timestamp_(), verbosity_(0),
-      onlineMode_(false), willConvertToEDM_(true) {}
+  DQWorker::DQWorker()
+      : name_(""), MEs_(), booked_(false), timestamp_(), verbosity_(0), onlineMode_(false), willConvertToEDM_(true) {}
 
-DQWorker::~DQWorker() noexcept(false) {}
+  DQWorker::~DQWorker() noexcept(false) {}
 
-/*static*/
-void DQWorker::fillDescriptions(edm::ParameterSetDescription &_desc) {
-  _desc.addUntracked<bool>("onlineMode", false);
-  _desc.addUntracked<bool>("willConvertToEDM", true);
+  /*static*/
+  void DQWorker::fillDescriptions(edm::ParameterSetDescription &_desc) {
+    _desc.addUntracked<bool>("onlineMode", false);
+    _desc.addUntracked<bool>("willConvertToEDM", true);
 
-  edm::ParameterSetDescription meParameters;
-  edm::ParameterSetDescription meNodeParameters;
-  fillMESetDescriptions(meNodeParameters);
-  meParameters.addNode(edm::ParameterWildcard<edm::ParameterSetDescription>(
-      "*", edm::RequireZeroOrMore, false, meNodeParameters));
-  _desc.addUntracked("MEs", meParameters);
+    edm::ParameterSetDescription meParameters;
+    edm::ParameterSetDescription meNodeParameters;
+    fillMESetDescriptions(meNodeParameters);
+    meParameters.addNode(
+        edm::ParameterWildcard<edm::ParameterSetDescription>("*", edm::RequireZeroOrMore, false, meNodeParameters));
+    _desc.addUntracked("MEs", meParameters);
 
-  edm::ParameterSetDescription workerParameters;
-  workerParameters.setUnknown();
-  _desc.addUntracked("params", workerParameters);
-}
+    edm::ParameterSetDescription workerParameters;
+    workerParameters.setUnknown();
+    _desc.addUntracked("params", workerParameters);
+  }
 
-void DQWorker::initialize(std::string const &_name,
-                          edm::ParameterSet const &_commonParams) {
-  name_ = _name;
-  onlineMode_ = _commonParams.getUntrackedParameter<bool>("onlineMode");
-  willConvertToEDM_ =
-      _commonParams.getUntrackedParameter<bool>("willConvertToEDM");
-}
+  void DQWorker::initialize(std::string const &_name, edm::ParameterSet const &_commonParams) {
+    name_ = _name;
+    onlineMode_ = _commonParams.getUntrackedParameter<bool>("onlineMode");
+    willConvertToEDM_ = _commonParams.getUntrackedParameter<bool>("willConvertToEDM");
+  }
 
-void DQWorker::setME(edm::ParameterSet const &_meParams) {
-  std::vector<std::string> const &MENames(_meParams.getParameterNames());
+  void DQWorker::setME(edm::ParameterSet const &_meParams) {
+    std::vector<std::string> const &MENames(_meParams.getParameterNames());
 
-  for (unsigned iME(0); iME != MENames.size(); iME++) {
-    std::string name(MENames[iME]);
-    edm::ParameterSet const &params(_meParams.getUntrackedParameterSet(name));
+    for (unsigned iME(0); iME != MENames.size(); iME++) {
+      std::string name(MENames[iME]);
+      edm::ParameterSet const &params(_meParams.getUntrackedParameterSet(name));
 
-    if (!onlineMode_ && params.getUntrackedParameter<bool>("online"))
-      continue;
+      if (!onlineMode_ && params.getUntrackedParameter<bool>("online"))
+        continue;
 
-    try {
-      MEs_.insert(name, createMESet(params));
-    } catch (std::exception &) {
-      edm::LogError("EcalDQM")
-          << "Exception caught while constructing MESet " << name;
-      throw;
+      try {
+        MEs_.insert(name, createMESet(params));
+      } catch (std::exception &) {
+        edm::LogError("EcalDQM") << "Exception caught while constructing MESet " << name;
+        throw;
+      }
     }
   }
-}
 
-void DQWorker::releaseMEs() {
-  for (MESetCollection::iterator mItr(MEs_.begin()); mItr != MEs_.end(); ++mItr)
-    mItr->second->clear();
-  booked_ = false;
-}
+  void DQWorker::releaseMEs() {
+    for (MESetCollection::iterator mItr(MEs_.begin()); mItr != MEs_.end(); ++mItr)
+      mItr->second->clear();
+    booked_ = false;
+  }
 
-void DQWorker::bookMEs(DQMStore::IBooker &_booker) {
-  if (booked_)
-    return;
-  for (MESetCollection::iterator mItr(MEs_.begin()); mItr != MEs_.end(); ++mItr)
-    mItr->second->book(_booker);
-  booked_ = true;
-}
+  void DQWorker::bookMEs(DQMStore::IBooker &_booker) {
+    if (booked_)
+      return;
+    for (MESetCollection::iterator mItr(MEs_.begin()); mItr != MEs_.end(); ++mItr)
+      mItr->second->book(_booker);
+    booked_ = true;
+  }
 
-void DQWorker::print_(std::string const &_message,
-                      int _threshold /* = 0*/) const {
-  if (verbosity_ > _threshold)
-    edm::LogInfo("EcalDQM") << name_ << ": " << _message;
-}
+  void DQWorker::print_(std::string const &_message, int _threshold /* = 0*/) const {
+    if (verbosity_ > _threshold)
+      edm::LogInfo("EcalDQM") << name_ << ": " << _message;
+  }
 
-DQWorker *
-WorkerFactoryStore::getWorker(std::string const &_name, int _verbosity,
-                              edm::ParameterSet const &_commonParams,
-                              edm::ParameterSet const &_workerParams) const {
-  DQWorker *worker(workerFactories_.at(_name)());
-  worker->setVerbosity(_verbosity);
-  worker->initialize(_name, _commonParams);
-  worker->setME(_workerParams.getUntrackedParameterSet("MEs"));
-  if (_workerParams.existsAs<edm::ParameterSet>("sources", false))
-    worker->setSource(_workerParams.getUntrackedParameterSet("sources"));
-  if (_workerParams.existsAs<edm::ParameterSet>("params", false))
-    worker->setParams(_workerParams.getUntrackedParameterSet("params"));
-  return worker;
-}
+  DQWorker *WorkerFactoryStore::getWorker(std::string const &_name,
+                                          int _verbosity,
+                                          edm::ParameterSet const &_commonParams,
+                                          edm::ParameterSet const &_workerParams) const {
+    DQWorker *worker(workerFactories_.at(_name)());
+    worker->setVerbosity(_verbosity);
+    worker->initialize(_name, _commonParams);
+    worker->setME(_workerParams.getUntrackedParameterSet("MEs"));
+    if (_workerParams.existsAs<edm::ParameterSet>("sources", false))
+      worker->setSource(_workerParams.getUntrackedParameterSet("sources"));
+    if (_workerParams.existsAs<edm::ParameterSet>("params", false))
+      worker->setParams(_workerParams.getUntrackedParameterSet("params"));
+    return worker;
+  }
 
-/*static*/
-WorkerFactoryStore *WorkerFactoryStore::singleton() {
-  static WorkerFactoryStore workerFactoryStore;
-  return &workerFactoryStore;
-}
+  /*static*/
+  WorkerFactoryStore *WorkerFactoryStore::singleton() {
+    static WorkerFactoryStore workerFactoryStore;
+    return &workerFactoryStore;
+  }
 
-} // namespace ecaldqm
+}  // namespace ecaldqm

--- a/DQM/EcalCommon/src/EcalDQMCommonUtils.cc
+++ b/DQM/EcalCommon/src/EcalDQMCommonUtils.cc
@@ -5,436 +5,413 @@
 #include <mutex>
 
 namespace ecaldqm {
-unsigned memarr[] = {
-    kEEm07, kEEm08, kEEm02, kEEm03, kEBm01, kEBm02, kEBm03, kEBm04, kEBm05,
-    kEBm06, kEBm07, kEBm08, kEBm09, kEBm10, kEBm11, kEBm12, kEBm13, kEBm14,
-    kEBm15, kEBm16, kEBm17, kEBm18, kEBp01, kEBp02, kEBp03, kEBp04, kEBp05,
-    kEBp06, kEBp07, kEBp08, kEBp09, kEBp10, kEBp11, kEBp12, kEBp13, kEBp14,
-    kEBp15, kEBp16, kEBp17, kEBp18, kEEp07, kEEp08, kEEp02, kEEp03};
-const std::vector<unsigned> memDCC(memarr, memarr + 44);
+  unsigned memarr[] = {kEEm07, kEEm08, kEEm02, kEEm03, kEBm01, kEBm02, kEBm03, kEBm04, kEBm05, kEBm06, kEBm07,
+                       kEBm08, kEBm09, kEBm10, kEBm11, kEBm12, kEBm13, kEBm14, kEBm15, kEBm16, kEBm17, kEBm18,
+                       kEBp01, kEBp02, kEBp03, kEBp04, kEBp05, kEBp06, kEBp07, kEBp08, kEBp09, kEBp10, kEBp11,
+                       kEBp12, kEBp13, kEBp14, kEBp15, kEBp16, kEBp17, kEBp18, kEEp07, kEEp08, kEEp02, kEEp03};
+  const std::vector<unsigned> memDCC(memarr, memarr + 44);
 
-const double etaBound(1.479);
+  const double etaBound(1.479);
 
-unsigned dccId(const DetId &_id) {
-  EcalElectronicsMapping const *map(getElectronicsMap());
+  unsigned dccId(const DetId &_id) {
+    EcalElectronicsMapping const *map(getElectronicsMap());
 
-  unsigned subdet(_id.subdetId());
+    unsigned subdet(_id.subdetId());
 
-  if (subdet == EcalBarrel)
-    return map->DCCid(EBDetId(_id));
-  else if (subdet == EcalTriggerTower)
-    return map->DCCid(EcalTrigTowerDetId(_id));
-  else if (subdet == EcalEndcap) {
-    if (isEcalScDetId(_id))
-      return map->getDCCandSC(EcalScDetId(_id)).first;
-    else
-      return map->getElectronicsId(EEDetId(_id)).dccId();
-  } else if (subdet == EcalLaserPnDiode)
-    return EcalPnDiodeDetId(_id).iDCCId();
+    if (subdet == EcalBarrel)
+      return map->DCCid(EBDetId(_id));
+    else if (subdet == EcalTriggerTower)
+      return map->DCCid(EcalTrigTowerDetId(_id));
+    else if (subdet == EcalEndcap) {
+      if (isEcalScDetId(_id))
+        return map->getDCCandSC(EcalScDetId(_id)).first;
+      else
+        return map->getElectronicsId(EEDetId(_id)).dccId();
+    } else if (subdet == EcalLaserPnDiode)
+      return EcalPnDiodeDetId(_id).iDCCId();
 
-  throw cms::Exception("InvalidDetId")
-      << "EcalDQMCommonUtils::dccId(" << _id.rawId() << ")" << std::endl;
+    throw cms::Exception("InvalidDetId") << "EcalDQMCommonUtils::dccId(" << _id.rawId() << ")" << std::endl;
 
-  return 0;
-}
-
-unsigned dccId(const EcalElectronicsId &_id) { return _id.dccId(); }
-
-unsigned memDCCId(unsigned _index) {
-  // for DCCs with no MEM - map the index in an array of DCCs with no MEM to the
-  // DCC ID
-  if (_index >= memDCC.size())
     return 0;
-  return memDCC.at(_index) + 1;
-}
-
-unsigned memDCCIndex(unsigned _dccid) {
-  std::vector<unsigned>::const_iterator itr(
-      std::find(memDCC.begin(), memDCC.end(), _dccid - 1));
-  if (itr == memDCC.end())
-    return -1;
-
-  return (itr - memDCC.begin());
-}
-
-unsigned tccId(const DetId &_id) {
-  EcalElectronicsMapping const *map(getElectronicsMap());
-
-  unsigned subdet(_id.subdetId());
-
-  if (subdet == EcalBarrel)
-    return map->TCCid(EBDetId(_id));
-  else if (subdet == EcalTriggerTower)
-    return map->TCCid(EcalTrigTowerDetId(_id));
-  else if (subdet == EcalEndcap) {
-    if (isEcalScDetId(_id))
-      return 0; // incompatible
-    else
-      return map->getTriggerElectronicsId(EEDetId(_id)).tccId();
   }
 
-  throw cms::Exception("InvalidDetId")
-      << "EcalDQMCommonUtils::tccId(" << uint32_t(_id) << ")" << std::endl;
+  unsigned dccId(const EcalElectronicsId &_id) { return _id.dccId(); }
 
-  return 0;
-}
-
-unsigned tccId(const EcalElectronicsId &_id) {
-  return getElectronicsMap()->getTriggerElectronicsId(_id).tccId();
-}
-
-unsigned towerId(const DetId &_id) {
-  unsigned subdet(_id.subdetId());
-
-  if (subdet == EcalBarrel)
-    return EBDetId(_id).tower().iTT();
-  else if (subdet == EcalTriggerTower)
-    return EcalTrigTowerDetId(_id).iTT();
-  else if (subdet == EcalEndcap) {
-    if (isEcalScDetId(_id))
-      return getElectronicsMap()->getDCCandSC(EcalScDetId(_id)).second;
-    else
-      return getElectronicsMap()->getElectronicsId(EEDetId(_id)).towerId();
+  unsigned memDCCId(unsigned _index) {
+    // for DCCs with no MEM - map the index in an array of DCCs with no MEM to the
+    // DCC ID
+    if (_index >= memDCC.size())
+      return 0;
+    return memDCC.at(_index) + 1;
   }
 
-  throw cms::Exception("InvalidDetId")
-      << "EcalDQMCommonUtils::towerId(" << std::hex << uint32_t(_id) << ")"
-      << std::endl;
+  unsigned memDCCIndex(unsigned _dccid) {
+    std::vector<unsigned>::const_iterator itr(std::find(memDCC.begin(), memDCC.end(), _dccid - 1));
+    if (itr == memDCC.end())
+      return -1;
 
-  return 0;
-}
-
-unsigned towerId(const EcalElectronicsId &_id) { return _id.towerId(); }
-
-unsigned ttId(const DetId &_id) {
-  unsigned subdet(_id.subdetId());
-
-  if (subdet == EcalBarrel)
-    return EBDetId(_id).tower().iTT();
-  else if (subdet == EcalTriggerTower)
-    return getElectronicsMap()->iTT(EcalTrigTowerDetId(_id));
-  else if (subdet == EcalEndcap && !isEcalScDetId(_id))
-    return getElectronicsMap()->getTriggerElectronicsId(_id).ttId();
-
-  throw cms::Exception("InvalidDetId")
-      << "EcalDQMCommonUtils::ttId(" << std::hex << uint32_t(_id) << ")"
-      << std::endl;
-
-  return 0;
-}
-
-unsigned ttId(const EcalElectronicsId &_id) {
-  return getElectronicsMap()->getTriggerElectronicsId(_id).ttId();
-}
-
-unsigned rtHalf(DetId const &_id) {
-  if (_id.subdetId() == EcalBarrel) {
-    int ic(EBDetId(_id).ic());
-    if ((ic - 1) / 20 > 4 && (ic - 1) % 20 < 10)
-      return 1;
-  } else {
-    unsigned iDCC(dccId(_id) - 1);
-    if ((iDCC == kEEm05 || iDCC == kEEp05) && EEDetId(_id).ix() > 50)
-      return 1;
+    return (itr - memDCC.begin());
   }
 
-  return 0;
-}
+  unsigned tccId(const DetId &_id) {
+    EcalElectronicsMapping const *map(getElectronicsMap());
 
-std::pair<unsigned, unsigned> innerTCCs(unsigned _dccId) {
-  int iDCC(_dccId - 1);
-  std::pair<unsigned, unsigned> res;
-  if (iDCC <= kEEmHigh) {
-    res.first = (iDCC - kEEmLow) * 2;
-    if (res.first == 0)
-      res.first = 18;
-    res.second = (iDCC - kEEmLow) * 2 + 1;
-  } else if (iDCC < -kEBpHigh)
-    res.first = res.second = _dccId + 27;
-  else {
-    res.first = (iDCC - kEEpLow) * 2 + 90;
-    if (res.first == 90)
-      res.first = 108;
-    res.second = (iDCC - kEEpLow) * 2 + 91;
+    unsigned subdet(_id.subdetId());
+
+    if (subdet == EcalBarrel)
+      return map->TCCid(EBDetId(_id));
+    else if (subdet == EcalTriggerTower)
+      return map->TCCid(EcalTrigTowerDetId(_id));
+    else if (subdet == EcalEndcap) {
+      if (isEcalScDetId(_id))
+        return 0;  // incompatible
+      else
+        return map->getTriggerElectronicsId(EEDetId(_id)).tccId();
+    }
+
+    throw cms::Exception("InvalidDetId") << "EcalDQMCommonUtils::tccId(" << uint32_t(_id) << ")" << std::endl;
+
+    return 0;
   }
 
-  return res;
-}
+  unsigned tccId(const EcalElectronicsId &_id) { return getElectronicsMap()->getTriggerElectronicsId(_id).tccId(); }
 
-std::pair<unsigned, unsigned> outerTCCs(unsigned _dccId) {
-  int iDCC(_dccId - 1);
-  std::pair<unsigned, unsigned> res;
-  if (iDCC <= kEEmHigh) {
-    res.first = (iDCC - kEEmLow) * 2 + 18;
-    if (res.first == 18)
-      res.first = 36;
-    res.second = (iDCC - kEEmLow) * 2 + 19;
-  } else if (iDCC <= kEBpHigh)
-    res.first = res.second = _dccId + 27;
-  else {
-    res.first = (iDCC - kEEpLow) * 2 + 72;
-    if (res.first == 72)
-      res.first = 90;
-    res.second = (iDCC - kEEpLow) * 2 + 73;
+  unsigned towerId(const DetId &_id) {
+    unsigned subdet(_id.subdetId());
+
+    if (subdet == EcalBarrel)
+      return EBDetId(_id).tower().iTT();
+    else if (subdet == EcalTriggerTower)
+      return EcalTrigTowerDetId(_id).iTT();
+    else if (subdet == EcalEndcap) {
+      if (isEcalScDetId(_id))
+        return getElectronicsMap()->getDCCandSC(EcalScDetId(_id)).second;
+      else
+        return getElectronicsMap()->getElectronicsId(EEDetId(_id)).towerId();
+    }
+
+    throw cms::Exception("InvalidDetId") << "EcalDQMCommonUtils::towerId(" << std::hex << uint32_t(_id) << ")"
+                                         << std::endl;
+
+    return 0;
   }
 
-  return res;
-}
+  unsigned towerId(const EcalElectronicsId &_id) { return _id.towerId(); }
 
-std::vector<DetId> scConstituents(EcalScDetId const &_scid) {
-  std::vector<DetId> res;
+  unsigned ttId(const DetId &_id) {
+    unsigned subdet(_id.subdetId());
 
-  int ixbase((_scid.ix() - 1) * 5);
-  int iybase((_scid.iy() - 1) * 5);
+    if (subdet == EcalBarrel)
+      return EBDetId(_id).tower().iTT();
+    else if (subdet == EcalTriggerTower)
+      return getElectronicsMap()->iTT(EcalTrigTowerDetId(_id));
+    else if (subdet == EcalEndcap && !isEcalScDetId(_id))
+      return getElectronicsMap()->getTriggerElectronicsId(_id).ttId();
 
-  for (int ix(1); ix <= 5; ++ix) {
-    for (int iy(1); iy <= 5; ++iy) {
-      if (EEDetId::validDetId(ixbase + ix, iybase + iy, _scid.zside()))
-        res.push_back(EEDetId(ixbase + ix, iybase + iy, _scid.zside()));
+    throw cms::Exception("InvalidDetId") << "EcalDQMCommonUtils::ttId(" << std::hex << uint32_t(_id) << ")"
+                                         << std::endl;
+
+    return 0;
+  }
+
+  unsigned ttId(const EcalElectronicsId &_id) { return getElectronicsMap()->getTriggerElectronicsId(_id).ttId(); }
+
+  unsigned rtHalf(DetId const &_id) {
+    if (_id.subdetId() == EcalBarrel) {
+      int ic(EBDetId(_id).ic());
+      if ((ic - 1) / 20 > 4 && (ic - 1) % 20 < 10)
+        return 1;
+    } else {
+      unsigned iDCC(dccId(_id) - 1);
+      if ((iDCC == kEEm05 || iDCC == kEEp05) && EEDetId(_id).ix() > 50)
+        return 1;
+    }
+
+    return 0;
+  }
+
+  std::pair<unsigned, unsigned> innerTCCs(unsigned _dccId) {
+    int iDCC(_dccId - 1);
+    std::pair<unsigned, unsigned> res;
+    if (iDCC <= kEEmHigh) {
+      res.first = (iDCC - kEEmLow) * 2;
+      if (res.first == 0)
+        res.first = 18;
+      res.second = (iDCC - kEEmLow) * 2 + 1;
+    } else if (iDCC < -kEBpHigh)
+      res.first = res.second = _dccId + 27;
+    else {
+      res.first = (iDCC - kEEpLow) * 2 + 90;
+      if (res.first == 90)
+        res.first = 108;
+      res.second = (iDCC - kEEpLow) * 2 + 91;
+    }
+
+    return res;
+  }
+
+  std::pair<unsigned, unsigned> outerTCCs(unsigned _dccId) {
+    int iDCC(_dccId - 1);
+    std::pair<unsigned, unsigned> res;
+    if (iDCC <= kEEmHigh) {
+      res.first = (iDCC - kEEmLow) * 2 + 18;
+      if (res.first == 18)
+        res.first = 36;
+      res.second = (iDCC - kEEmLow) * 2 + 19;
+    } else if (iDCC <= kEBpHigh)
+      res.first = res.second = _dccId + 27;
+    else {
+      res.first = (iDCC - kEEpLow) * 2 + 72;
+      if (res.first == 72)
+        res.first = 90;
+      res.second = (iDCC - kEEpLow) * 2 + 73;
+    }
+
+    return res;
+  }
+
+  std::vector<DetId> scConstituents(EcalScDetId const &_scid) {
+    std::vector<DetId> res;
+
+    int ixbase((_scid.ix() - 1) * 5);
+    int iybase((_scid.iy() - 1) * 5);
+
+    for (int ix(1); ix <= 5; ++ix) {
+      for (int iy(1); iy <= 5; ++iy) {
+        if (EEDetId::validDetId(ixbase + ix, iybase + iy, _scid.zside()))
+          res.push_back(EEDetId(ixbase + ix, iybase + iy, _scid.zside()));
+      }
+    }
+
+    return res;
+  }
+
+  int zside(const DetId &_id) {
+    uint32_t rawId(_id);
+
+    switch (_id.subdetId()) {
+      case EcalBarrel:
+        return (((rawId >> 16) & 0x1) == 1 ? 1 : -1);
+      case EcalEndcap:
+        return (((rawId >> 14) & 0x1) == 1 ? 1 : -1);
+      case EcalTriggerTower:
+        return (((rawId >> 15) & 0x1) == 1 ? 1 : -1);
+      case EcalLaserPnDiode:
+        return (((rawId >> 4) & 0x7f) > kEBpLow ? 1 : -1);
+      default:
+        throw cms::Exception("InvalidDetId")
+            << "EcalDQMCommonUtils::zside(" << std::hex << uint32_t(_id) << ")" << std::endl;
+    }
+
+    return 0;
+  }
+
+  double eta(const EBDetId &_ebid) {
+    return _ebid.approxEta() + (_ebid.zside() < 0 ? 0.5 : -0.5) * EBDetId::crystalUnitToEta;
+  }
+
+  double eta(const EEDetId &_id) { return getGeometry()->getPosition(_id).eta(); }
+
+  double phi(EBDetId const &_ebid) {
+    const double degToRad(0.0174533);
+    return (_ebid.iphi() - 10.5) * degToRad;
+  }
+
+  double phi(EEDetId const &_eeid) {
+    const double degToRad(0.0174533);
+    double p(std::atan2(_eeid.ix() - 50.5, _eeid.iy() - 50.5));
+    if (p < -10. * degToRad)
+      p += 360. * degToRad;
+    return p;
+  }
+
+  double phi(EcalTrigTowerDetId const &_ttid) {
+    const double degToRad(0.0174533);
+    double p((_ttid.iphi() - 0.5) * 5. * degToRad);
+    if (p > 350. * degToRad)
+      p -= 360. * degToRad;
+    return p;
+  }
+
+  double phi(double _phi) {
+    const double degToRad(0.0174533);
+    if (_phi < -10. * degToRad)
+      _phi += 360. * degToRad;
+    return _phi;
+  }
+
+  bool isForward(DetId const &_id) {
+    // the numbers here roughly corresponds to a cut at |eta| > 2.2
+    // cf hepwww.rl.ac.uk/CMSecal/Dee-layout.html
+    if (_id.subdetId() != EcalEndcap)
+      return false;
+    if (isEcalScDetId(_id)) {
+      EcalScDetId scid(_id);
+      return (scid.ix() - 10) * (scid.ix() - 10) + (scid.iy() - 10) * (scid.iy() - 10) < 25.;
+    } else {
+      EEDetId eeid(_id);
+      return (eeid.ix() - 50) * (eeid.ix() - 50) + (eeid.iy() - 50) * (eeid.iy() - 50) < 625.;
     }
   }
 
-  return res;
-}
-
-int zside(const DetId &_id) {
-  uint32_t rawId(_id);
-
-  switch (_id.subdetId()) {
-  case EcalBarrel:
-    return (((rawId >> 16) & 0x1) == 1 ? 1 : -1);
-  case EcalEndcap:
-    return (((rawId >> 14) & 0x1) == 1 ? 1 : -1);
-  case EcalTriggerTower:
-    return (((rawId >> 15) & 0x1) == 1 ? 1 : -1);
-  case EcalLaserPnDiode:
-    return (((rawId >> 4) & 0x7f) > kEBpLow ? 1 : -1);
-  default:
-    throw cms::Exception("InvalidDetId")
-        << "EcalDQMCommonUtils::zside(" << std::hex << uint32_t(_id) << ")"
-        << std::endl;
+  bool isCrystalId(const DetId &_id) {
+    return (_id.det() == DetId::Ecal) &&
+           ((_id.subdetId() == EcalBarrel) || ((_id.subdetId() == EcalEndcap) && (((_id.rawId() >> 15) & 0x1) == 0)));
   }
 
-  return 0;
-}
-
-double eta(const EBDetId &_ebid) {
-  return _ebid.approxEta() +
-         (_ebid.zside() < 0 ? 0.5 : -0.5) * EBDetId::crystalUnitToEta;
-}
-
-double eta(const EEDetId &_id) { return getGeometry()->getPosition(_id).eta(); }
-
-double phi(EBDetId const &_ebid) {
-  const double degToRad(0.0174533);
-  return (_ebid.iphi() - 10.5) * degToRad;
-}
-
-double phi(EEDetId const &_eeid) {
-  const double degToRad(0.0174533);
-  double p(std::atan2(_eeid.ix() - 50.5, _eeid.iy() - 50.5));
-  if (p < -10. * degToRad)
-    p += 360. * degToRad;
-  return p;
-}
-
-double phi(EcalTrigTowerDetId const &_ttid) {
-  const double degToRad(0.0174533);
-  double p((_ttid.iphi() - 0.5) * 5. * degToRad);
-  if (p > 350. * degToRad)
-    p -= 360. * degToRad;
-  return p;
-}
-
-double phi(double _phi) {
-  const double degToRad(0.0174533);
-  if (_phi < -10. * degToRad)
-    _phi += 360. * degToRad;
-  return _phi;
-}
-
-bool isForward(DetId const &_id) {
-  // the numbers here roughly corresponds to a cut at |eta| > 2.2
-  // cf hepwww.rl.ac.uk/CMSecal/Dee-layout.html
-  if (_id.subdetId() != EcalEndcap)
-    return false;
-  if (isEcalScDetId(_id)) {
-    EcalScDetId scid(_id);
-    return (scid.ix() - 10) * (scid.ix() - 10) +
-               (scid.iy() - 10) * (scid.iy() - 10) <
-           25.;
-  } else {
-    EEDetId eeid(_id);
-    return (eeid.ix() - 50) * (eeid.ix() - 50) +
-               (eeid.iy() - 50) * (eeid.iy() - 50) <
-           625.;
+  bool isSingleChannelId(const DetId &_id) {
+    return (_id.det() == DetId::Ecal) && (isCrystalId(_id) || (_id.subdetId() == EcalLaserPnDiode));
   }
-}
 
-bool isCrystalId(const DetId &_id) {
-  return (_id.det() == DetId::Ecal) && ((_id.subdetId() == EcalBarrel) ||
-                                        ((_id.subdetId() == EcalEndcap) &&
-                                         (((_id.rawId() >> 15) & 0x1) == 0)));
-}
+  bool isEcalScDetId(const DetId &_id) {
+    return (_id.det() == DetId::Ecal) && ((_id.subdetId() == EcalEndcap) && ((_id.rawId() >> 15) & 0x1));
+  }
 
-bool isSingleChannelId(const DetId &_id) {
-  return (_id.det() == DetId::Ecal) &&
-         (isCrystalId(_id) || (_id.subdetId() == EcalLaserPnDiode));
-}
+  bool isEndcapTTId(const DetId &_id) {
+    return (_id.det() == DetId::Ecal) && ((_id.subdetId() == EcalTriggerTower) && (((_id.rawId() >> 7) & 0x7f) > 17));
+  }
 
-bool isEcalScDetId(const DetId &_id) {
-  return (_id.det() == DetId::Ecal) &&
-         ((_id.subdetId() == EcalEndcap) && ((_id.rawId() >> 15) & 0x1));
-}
+  unsigned dccId(std::string const &_smName) {
+    unsigned smNumber(std::atoi(_smName.substr(3).c_str()));
 
-bool isEndcapTTId(const DetId &_id) {
-  return (_id.det() == DetId::Ecal) && ((_id.subdetId() == EcalTriggerTower) &&
-                                        (((_id.rawId() >> 7) & 0x7f) > 17));
-}
-
-unsigned dccId(std::string const &_smName) {
-  unsigned smNumber(std::atoi(_smName.substr(3).c_str()));
-
-  if (_smName.find("EE-") == 0)
-    return kEEmLow + 1 + ((smNumber + 2) % 9);
-  else if (_smName.find("EB-") == 0)
-    return kEBmLow + 1 + smNumber;
-  else if (_smName.find("EB+") == 0)
-    return kEBpLow + 1 + smNumber;
-  else if (_smName.find("EE+") == 0)
-    return kEEpLow + 1 + ((smNumber + 2) % 9);
-  else
-    return 0;
-}
-
-std::string smName(unsigned _dccId) {
-  std::stringstream ss;
-
-  unsigned iSM(_dccId - 1);
-
-  if (iSM <= kEEmHigh)
-    ss << "EE-" << std::setw(2) << std::setfill('0')
-       << (((iSM - kEEmLow + 6) % 9) + 1);
-  else if (iSM <= kEBmHigh)
-    ss << "EB-" << std::setw(2) << std::setfill('0') << (iSM - kEBmLow + 1);
-  else if (iSM <= kEBpHigh)
-    ss << "EB+" << std::setw(2) << std::setfill('0') << (iSM - kEBpLow + 1);
-  else if (iSM <= kEEpHigh)
-    ss << "EE+" << std::setw(2) << std::setfill('0')
-       << (((iSM - kEEpLow + 6) % 9) + 1);
-
-  return ss.str();
-}
-
-// numbers from CalibCalorimetry/EcalLaserAnalyzer/src/MEEEGeom.cc
-unsigned EEPnDCC(unsigned _dee, unsigned _ab) {
-  switch (_dee) {
-  case 1: // EE+F -> FEDs 649-653/0
-    if (_ab == 0)
-      return 50;
+    if (_smName.find("EE-") == 0)
+      return kEEmLow + 1 + ((smNumber + 2) % 9);
+    else if (_smName.find("EB-") == 0)
+      return kEBmLow + 1 + smNumber;
+    else if (_smName.find("EB+") == 0)
+      return kEBpLow + 1 + smNumber;
+    else if (_smName.find("EE+") == 0)
+      return kEEpLow + 1 + ((smNumber + 2) % 9);
     else
-      return 51;
-  case 2: // EE+N -> FEDs 646-648, 653/1, 654
-    if (_ab == 0)
-      return 47;
-    else
-      return 46;
-  case 3: // EE-N -> FEDs 601-603, 608/1, 609
-    if (_ab == 0)
-      return 1;
-    else
-      return 2;
-  case 4: // EE-F -> FEDs 604-608/0
-    if (_ab == 0)
-      return 5;
-    else
-      return 6;
-  default:
-    return 0;
+      return 0;
   }
-}
 
-unsigned nCrystals(unsigned _dccId) {
-  unsigned iSM(_dccId - 1);
+  std::string smName(unsigned _dccId) {
+    std::stringstream ss;
 
-  if (iSM >= kEBmLow && iSM <= kEBpHigh)
-    return 1700;
+    unsigned iSM(_dccId - 1);
 
-  switch (iSM) {
-  case kEEm05:
-  case kEEp05:
-    return 810;
-  case kEEm07:
-  case kEEm03:
-  case kEEp07:
-  case kEEp03:
-    return 830;
-  case kEEm09:
-  case kEEm01:
-  case kEEp09:
-  case kEEp01:
-    return 815;
-  case kEEm08:
-  case kEEm02:
-  case kEEp08:
-  case kEEp02:
-    return 791;
-  case kEEm04:
-  case kEEm06:
-  case kEEp04:
-  case kEEp06:
-    return 821;
-  default:
-    return 0;
+    if (iSM <= kEEmHigh)
+      ss << "EE-" << std::setw(2) << std::setfill('0') << (((iSM - kEEmLow + 6) % 9) + 1);
+    else if (iSM <= kEBmHigh)
+      ss << "EB-" << std::setw(2) << std::setfill('0') << (iSM - kEBmLow + 1);
+    else if (iSM <= kEBpHigh)
+      ss << "EB+" << std::setw(2) << std::setfill('0') << (iSM - kEBpLow + 1);
+    else if (iSM <= kEEpHigh)
+      ss << "EE+" << std::setw(2) << std::setfill('0') << (((iSM - kEEpLow + 6) % 9) + 1);
+
+    return ss.str();
   }
-}
 
-unsigned nSuperCrystals(unsigned _dccId) {
-  unsigned iSM(_dccId - 1);
-
-  if (iSM >= kEBmLow && iSM <= kEBpHigh)
-    return 68;
-
-  switch (iSM) {
-  case kEEm05:
-  case kEEp05:
-    return 41;
-  case kEEm07:
-  case kEEm03:
-  case kEEp07:
-  case kEEp03:
-    return 34;
-  case kEEm09:
-  case kEEm01:
-  case kEEm04:
-  case kEEm06:
-  case kEEp09:
-  case kEEp01:
-  case kEEp04:
-  case kEEp06:
-    return 33;
-  case kEEm08:
-  case kEEm02:
-  case kEEp08:
-  case kEEp02:
-    return 32;
-  default:
-    return 0;
+  // numbers from CalibCalorimetry/EcalLaserAnalyzer/src/MEEEGeom.cc
+  unsigned EEPnDCC(unsigned _dee, unsigned _ab) {
+    switch (_dee) {
+      case 1:  // EE+F -> FEDs 649-653/0
+        if (_ab == 0)
+          return 50;
+        else
+          return 51;
+      case 2:  // EE+N -> FEDs 646-648, 653/1, 654
+        if (_ab == 0)
+          return 47;
+        else
+          return 46;
+      case 3:  // EE-N -> FEDs 601-603, 608/1, 609
+        if (_ab == 0)
+          return 1;
+        else
+          return 2;
+      case 4:  // EE-F -> FEDs 604-608/0
+        if (_ab == 0)
+          return 5;
+        else
+          return 6;
+      default:
+        return 0;
+    }
   }
-}
 
-bool ccuExists(unsigned _dccId, unsigned _towerId) {
-  if (_towerId == 69 || _towerId == 70)
-    return true;
-  else if ((_dccId == 8 || _dccId == 53) && _towerId >= 18 && _towerId <= 24)
-    return false;
-  else if (_dccId <= kEEmHigh + 1 || _dccId >= kEEpLow + 1)
-    return _towerId <= nSuperCrystals(_dccId);
-  else
-    return _towerId <= 68;
-}
+  unsigned nCrystals(unsigned _dccId) {
+    unsigned iSM(_dccId - 1);
 
-/*
+    if (iSM >= kEBmLow && iSM <= kEBpHigh)
+      return 1700;
+
+    switch (iSM) {
+      case kEEm05:
+      case kEEp05:
+        return 810;
+      case kEEm07:
+      case kEEm03:
+      case kEEp07:
+      case kEEp03:
+        return 830;
+      case kEEm09:
+      case kEEm01:
+      case kEEp09:
+      case kEEp01:
+        return 815;
+      case kEEm08:
+      case kEEm02:
+      case kEEp08:
+      case kEEp02:
+        return 791;
+      case kEEm04:
+      case kEEm06:
+      case kEEp04:
+      case kEEp06:
+        return 821;
+      default:
+        return 0;
+    }
+  }
+
+  unsigned nSuperCrystals(unsigned _dccId) {
+    unsigned iSM(_dccId - 1);
+
+    if (iSM >= kEBmLow && iSM <= kEBpHigh)
+      return 68;
+
+    switch (iSM) {
+      case kEEm05:
+      case kEEp05:
+        return 41;
+      case kEEm07:
+      case kEEm03:
+      case kEEp07:
+      case kEEp03:
+        return 34;
+      case kEEm09:
+      case kEEm01:
+      case kEEm04:
+      case kEEm06:
+      case kEEp09:
+      case kEEp01:
+      case kEEp04:
+      case kEEp06:
+        return 33;
+      case kEEm08:
+      case kEEm02:
+      case kEEp08:
+      case kEEp02:
+        return 32;
+      default:
+        return 0;
+    }
+  }
+
+  bool ccuExists(unsigned _dccId, unsigned _towerId) {
+    if (_towerId == 69 || _towerId == 70)
+      return true;
+    else if ((_dccId == 8 || _dccId == 53) && _towerId >= 18 && _towerId <= 24)
+      return false;
+    else if (_dccId <= kEEmHigh + 1 || _dccId >= kEEpLow + 1)
+      return _towerId <= nSuperCrystals(_dccId);
+    else
+      return _towerId <= 68;
+  }
+
+  /*
   Note on concurrency compatibility:
   Call to getters bellow must always happen after
   EcalDQMonitor::ecaldqmGetSetupObjects or equivalent.
@@ -443,90 +420,89 @@ bool ccuExists(unsigned _dccId, unsigned _towerId) {
   thread-safe.
 */
 
-std::mutex mapMutex;
-EcalElectronicsMapping const *electronicsMap(nullptr);
-EcalTrigTowerConstituentsMap const *trigtowerMap(nullptr);
-CaloGeometry const *geometry(nullptr);
-CaloTopology const *topology(nullptr);
+  std::mutex mapMutex;
+  EcalElectronicsMapping const *electronicsMap(nullptr);
+  EcalTrigTowerConstituentsMap const *trigtowerMap(nullptr);
+  CaloGeometry const *geometry(nullptr);
+  CaloTopology const *topology(nullptr);
 
-bool checkElectronicsMap(bool _throw /* = true*/) {
-  std::lock_guard<std::mutex> lock(mapMutex);
-  if (electronicsMap)
-    return true;
-  if (_throw)
-    throw cms::Exception("InvalidCall") << "ElectronicsMapping not initialized";
-  return false;
-}
+  bool checkElectronicsMap(bool _throw /* = true*/) {
+    std::lock_guard<std::mutex> lock(mapMutex);
+    if (electronicsMap)
+      return true;
+    if (_throw)
+      throw cms::Exception("InvalidCall") << "ElectronicsMapping not initialized";
+    return false;
+  }
 
-EcalElectronicsMapping const *getElectronicsMap() {
-  if (!electronicsMap)
-    checkElectronicsMap();
-  return electronicsMap;
-}
+  EcalElectronicsMapping const *getElectronicsMap() {
+    if (!electronicsMap)
+      checkElectronicsMap();
+    return electronicsMap;
+  }
 
-void setElectronicsMap(EcalElectronicsMapping const *_map) {
-  std::lock_guard<std::mutex> lock(mapMutex);
-  electronicsMap = _map;
-}
+  void setElectronicsMap(EcalElectronicsMapping const *_map) {
+    std::lock_guard<std::mutex> lock(mapMutex);
+    electronicsMap = _map;
+  }
 
-bool checkTrigTowerMap(bool _throw /* = true*/) {
-  std::lock_guard<std::mutex> lock(mapMutex);
-  if (trigtowerMap)
-    return true;
-  if (_throw)
-    throw cms::Exception("InvalidCall")
-        << "TrigTowerConstituentsMap not initialized";
-  return false;
-}
+  bool checkTrigTowerMap(bool _throw /* = true*/) {
+    std::lock_guard<std::mutex> lock(mapMutex);
+    if (trigtowerMap)
+      return true;
+    if (_throw)
+      throw cms::Exception("InvalidCall") << "TrigTowerConstituentsMap not initialized";
+    return false;
+  }
 
-EcalTrigTowerConstituentsMap const *getTrigTowerMap() {
-  if (!trigtowerMap)
-    checkTrigTowerMap();
-  return trigtowerMap;
-}
+  EcalTrigTowerConstituentsMap const *getTrigTowerMap() {
+    if (!trigtowerMap)
+      checkTrigTowerMap();
+    return trigtowerMap;
+  }
 
-void setTrigTowerMap(EcalTrigTowerConstituentsMap const *_map) {
-  std::lock_guard<std::mutex> lock(mapMutex);
-  trigtowerMap = _map;
-}
+  void setTrigTowerMap(EcalTrigTowerConstituentsMap const *_map) {
+    std::lock_guard<std::mutex> lock(mapMutex);
+    trigtowerMap = _map;
+  }
 
-bool checkGeometry(bool _throw /* = true*/) {
-  std::lock_guard<std::mutex> lock(mapMutex);
-  if (geometry)
-    return true;
-  if (_throw)
-    throw cms::Exception("InvalidCall") << "CaloGeometry not initialized";
-  return false;
-}
+  bool checkGeometry(bool _throw /* = true*/) {
+    std::lock_guard<std::mutex> lock(mapMutex);
+    if (geometry)
+      return true;
+    if (_throw)
+      throw cms::Exception("InvalidCall") << "CaloGeometry not initialized";
+    return false;
+  }
 
-CaloGeometry const *getGeometry() {
-  if (!geometry)
-    checkGeometry();
-  return geometry;
-}
+  CaloGeometry const *getGeometry() {
+    if (!geometry)
+      checkGeometry();
+    return geometry;
+  }
 
-void setGeometry(CaloGeometry const *_geom) {
-  std::lock_guard<std::mutex> lock(mapMutex);
-  geometry = _geom;
-}
+  void setGeometry(CaloGeometry const *_geom) {
+    std::lock_guard<std::mutex> lock(mapMutex);
+    geometry = _geom;
+  }
 
-bool checkTopology(bool _throw /* = true*/) {
-  std::lock_guard<std::mutex> lock(mapMutex);
-  if (topology)
-    return true;
-  if (_throw)
-    throw cms::Exception("InvalidCall") << "CaloTopology not initialized";
-  return false;
-}
+  bool checkTopology(bool _throw /* = true*/) {
+    std::lock_guard<std::mutex> lock(mapMutex);
+    if (topology)
+      return true;
+    if (_throw)
+      throw cms::Exception("InvalidCall") << "CaloTopology not initialized";
+    return false;
+  }
 
-CaloTopology const *getTopology() {
-  if (!topology)
-    checkTopology();
-  return topology;
-}
+  CaloTopology const *getTopology() {
+    if (!topology)
+      checkTopology();
+    return topology;
+  }
 
-void setTopology(CaloTopology const *_geom) {
-  std::lock_guard<std::mutex> lock(mapMutex);
-  topology = _geom;
-}
-} // namespace ecaldqm
+  void setTopology(CaloTopology const *_geom) {
+    std::lock_guard<std::mutex> lock(mapMutex);
+    topology = _geom;
+  }
+}  // namespace ecaldqm

--- a/DQM/EcalCommon/src/EcalDQMCommonUtils2.cc
+++ b/DQM/EcalCommon/src/EcalDQMCommonUtils2.cc
@@ -7,1472 +7,1072 @@
 #include "CalibCalorimetry/EcalLaserAnalyzer/interface/MEEEGeom.h"
 
 namespace ecaldqm {
-EcalPnDiodeDetId pnForCrystal(DetId const &_id, char _ab) {
-  bool pnA(_ab == 'a' || _ab == 'A');
+  EcalPnDiodeDetId pnForCrystal(DetId const &_id, char _ab) {
+    bool pnA(_ab == 'a' || _ab == 'A');
 
-  if (!isCrystalId(_id))
-    return EcalPnDiodeDetId(0);
-
-  if (_id.subdetId() == EcalBarrel) {
-    EBDetId ebid(_id);
-    int lmmod(MEEBGeom::lmmod(ebid.ieta(), ebid.iphi()));
-
-    switch (dccId(_id)) {
-    case 10:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 10, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 10, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 10, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 10, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 10, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 10, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 10, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 10, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 10, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 10, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 10, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 10, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 10, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 10, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 10, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 10, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 10, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 10, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 11:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 11, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 11, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 11, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 11, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 11, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 11, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 11, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 11, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 11, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 11, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 11, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 11, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 11, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 11, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 11, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 11, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 11, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 11, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 12:
-      switch (lmmod) {
-      case 1:
-        return /*pnA ? EcalPnDiodeDetId(EcalBarrel, 12, 1) :*/ EcalPnDiodeDetId(
-            EcalBarrel, 12, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 12, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 12, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 12, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 12, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 12, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 12, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 12, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 12, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 12, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 12, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 12, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 12, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 12, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 12, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 12, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 12, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 13:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 13, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 13, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 13, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 13, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 13, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 13, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 13, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 13, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 13, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 13, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 13, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 13, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 13, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 13, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 13, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 13, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 13, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 13, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 14:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 14, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 14, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 14, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 14, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 14, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 14, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 14, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 14, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 14, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 14, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 14, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 14, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 14, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 14, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 14, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 14, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 14, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 14, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 15:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 15, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 15, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 15, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 15, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 15, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 15, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 15, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 15, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 15, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 15, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 15, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 15, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 15, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 15, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 15, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 15, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 15, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 15, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 16:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 16, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 16, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 16, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 16, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 16, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 16, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 16, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 16, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 16, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 16, 8);
-      case 6:
-        return pnA ? /*EcalPnDiodeDetId(EcalBarrel, 16, 4)*/ EcalPnDiodeDetId(
-                         EcalBarrel, 16, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 16, 9);
-      case 7:
-        return /*pnA ? EcalPnDiodeDetId(EcalBarrel, 16, 4) :*/ EcalPnDiodeDetId(
-            EcalBarrel, 16, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 16, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 16, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 16, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 16, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 17:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 17, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 17, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 17, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 17, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 17, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 17, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 17, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 17, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 17, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 17, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 17, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 17, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 17, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 17, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 17, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 17, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 17, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 17, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 18:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 18, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 18, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 18, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 18, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 18, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 18, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 18, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 18, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 18, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 18, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 18, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 18, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 18, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 18, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 18, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 18, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 18, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 18, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 19:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 19, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 19, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 19, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 19, 8);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 19, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 19, 8);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 19, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 19, 7);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 19, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 19, 7);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 19, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 19, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 19, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 19, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 19, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 19, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 19, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 19, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 20:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 20, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 20, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 20, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 20, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 20, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 20, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 20, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 20, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 20, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 20, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 20, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 20, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 20, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 20, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 20, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 20, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 20, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 20, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 21:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 21, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 21, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 21, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 21, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 21, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 21, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 21, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 21, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 21, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 21, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 21, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 21, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 21, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 21, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 21, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 21, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 21, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 21, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 22:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 22, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 22, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 22, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 22, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 22, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 22, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 22, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 22, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 22, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 22, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 22, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 22, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 22, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 22, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 22, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 22, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 22, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 22, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 23:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 23, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 23, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 23, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 23, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 23, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 23, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 23, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 23, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 23, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 23, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 23, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 23, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 23, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 23, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 23, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 23, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 23, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 23, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 24:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 24, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 24, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 24, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 24, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 24, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 24, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 24, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 24, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 24, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 24, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 24, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 24, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 24, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 24, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 24, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 24, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 24, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 24, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 25:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 25, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 25, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 25, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 25, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 25, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 25, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 25, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 25, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 25, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 25, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 25, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 25, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 25, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 25, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 25, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 25, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 25, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 25, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 26:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 26, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 26, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 26, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 26, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 26, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 26, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 26, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 26, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 26, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 26, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 26, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 26, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 26, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 26, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 26, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 26, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 26, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 26, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 27:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 27, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 27, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 27, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 27, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 27, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 27, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 27, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 27, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 27, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 27, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 27, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 27, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 27, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 27, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 27, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 27, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 27, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 27, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 28:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 28, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 28, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 28, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 28, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 28, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 28, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 28, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 28, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 28, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 28, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 28, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 28, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 28, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 28, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 28, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 28, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 28, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 28, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 29:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 29, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 29, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 29, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 29, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 29, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 29, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 29, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 29, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 29, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 29, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 29, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 29, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 29, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 29, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 29, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 29, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 29, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 29, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 30:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 30, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 30, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 30, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 30, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 30, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 30, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 30, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 30, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 30, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 30, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 30, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 30, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 30, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 30, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 30, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 30, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 30, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 30, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 31:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 31, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 31, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 31, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 31, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 31, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 31, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 31, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 31, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 31, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 31, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 31, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 31, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 31, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 31, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 31, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 31, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 31, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 31, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 32:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 32, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 32, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 32, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 32, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 32, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 32, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 32, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 32, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 32, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 32, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 32, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 32, 10);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 32, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 32, 10);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 32, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 32, 9);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 32, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 32, 9);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 33:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 33, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 33, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 33, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 33, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 33, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 33, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 33, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 33, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 33, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 33, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 33, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 33, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 33, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 33, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 33, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 33, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 33, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 33, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 34:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 34, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 34, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 34, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 34, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 34, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 34, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 34, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 34, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 34, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 34, 8);
-      case 6:
-        return pnA ? /*EcalPnDiodeDetId(EcalBarrel, 34, 4)*/ EcalPnDiodeDetId(
-                         EcalBarrel, 34, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 34, 9);
-      case 7:
-        return /*pnA ? EcalPnDiodeDetId(EcalBarrel, 34, 4) :*/ EcalPnDiodeDetId(
-            EcalBarrel, 34, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 34, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 34, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 34, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 34, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 35:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 35, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 35, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 35, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 35, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 35, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 35, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 35, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 35, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 35, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 35, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 35, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 35, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 35, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 35, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 35, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 35, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 35, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 35, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 36:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 36, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 36, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 36, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 36, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 36, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 36, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 36, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 36, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 36, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 36, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 36, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 36, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 36, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 36, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 36, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 36, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 36, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 36, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 37:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 37, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 37, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 37, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 37, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 37, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 37, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 37, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 37, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 37, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 37, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 37, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 37, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 37, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 37, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 37, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 37, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 37, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 37, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 38:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 38, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 38, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 38, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 38, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 38, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 38, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 38, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 38, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 38, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 38, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 38, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 38, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 38, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 38, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 38, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 38, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 38, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 38, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 39:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 39, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 39, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 39, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 39, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 39, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 39, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 39, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 39, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 39, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 39, 8);
-      case 6:
-        return pnA ? /*EcalPnDiodeDetId(EcalBarrel, 39, 4)*/ EcalPnDiodeDetId(
-                         EcalBarrel, 39, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 39, 9);
-      case 7:
-        return /*pnA ? EcalPnDiodeDetId(EcalBarrel, 39, 4) :*/ EcalPnDiodeDetId(
-            EcalBarrel, 39, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 39, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 39, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 39, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 39, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 40:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 40, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 40, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 40, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 40, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 40, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 40, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 40, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 40, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 40, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 40, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 40, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 40, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 40, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 40, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 40, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 40, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 40, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 40, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 41:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 41, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 41, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 41, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 41, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 41, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 41, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 41, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 41, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 41, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 41, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 41, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 41, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 41, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 41, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 41, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 41, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 41, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 41, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 42:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 42, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 42, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 42, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 42, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 42, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 42, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 42, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 42, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 42, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 42, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 42, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 42, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 42, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 42, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 42, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 42, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 42, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 42, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 43:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 43, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 43, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 43, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 43, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 43, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 43, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 43, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 43, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 43, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 43, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 43, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 43, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 43, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 43, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 43, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 43, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 43, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 43, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 44:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 44, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 44, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 44, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 44, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 44, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 44, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 44, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 44, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 44, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 44, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 44, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 44, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 44, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 44, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 44, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 44, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 44, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 44, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    case 45:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 45, 1)
-                   : EcalPnDiodeDetId(EcalBarrel, 45, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 45, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 45, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 45, 2)
-                   : EcalPnDiodeDetId(EcalBarrel, 45, 7);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 45, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 45, 8);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 45, 3)
-                   : EcalPnDiodeDetId(EcalBarrel, 45, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 45, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 45, 9);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 45, 4)
-                   : EcalPnDiodeDetId(EcalBarrel, 45, 9);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 45, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 45, 10);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalBarrel, 45, 5)
-                   : EcalPnDiodeDetId(EcalBarrel, 45, 10);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-      break;
-    default:
+    if (!isCrystalId(_id))
       return EcalPnDiodeDetId(0);
-    }
 
-  } else {
-    EcalScDetId scid(EEDetId(_id).sc());
-    int ix(scid.ix());
-    int iy(scid.iy());
-    int dee(MEEEGeom::dee(ix, iy, scid.zside()));
-    int lmmod(MEEEGeom::lmmod(ix, iy));
+    if (_id.subdetId() == EcalBarrel) {
+      EBDetId ebid(_id);
+      int lmmod(MEEBGeom::lmmod(ebid.ieta(), ebid.iphi()));
 
-    switch (dee) {
-    case 1:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 1)
-                   : EcalPnDiodeDetId(EcalEndcap, 50, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 2)
-                   : EcalPnDiodeDetId(EcalEndcap, 50, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 3)
-                   : EcalPnDiodeDetId(EcalEndcap, 50, 8);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 4)
-                   : EcalPnDiodeDetId(EcalEndcap, 50, 9);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 3)
-                   : EcalPnDiodeDetId(EcalEndcap, 50, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 1)
-                   : EcalPnDiodeDetId(EcalEndcap, 50, 6);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 2)
-                   : EcalPnDiodeDetId(EcalEndcap, 50, 7);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 4)
-                   : EcalPnDiodeDetId(EcalEndcap, 50, 9);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 6)
-                   : EcalPnDiodeDetId(EcalEndcap, 50, 1);
-      case 10:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 7)
-                   : EcalPnDiodeDetId(EcalEndcap, 50, 2);
-      case 11:
-        return /*pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 8) :*/ EcalPnDiodeDetId(
-            EcalEndcap, 50, 3);
-      case 12:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 9)
-                   : EcalPnDiodeDetId(EcalEndcap, 50, 4);
-      case 13:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 10)
-                   : EcalPnDiodeDetId(EcalEndcap, 50, 5);
-      case 14:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 8)
-                   : EcalPnDiodeDetId(EcalEndcap, 50, 3);
-      case 15:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 6)
-                   : EcalPnDiodeDetId(EcalEndcap, 50, 1);
-      case 16:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 7)
-                   : EcalPnDiodeDetId(EcalEndcap, 50, 2);
-      case 17:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 10)
-                   : EcalPnDiodeDetId(EcalEndcap, 50, 5);
-      case 18:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 5)
-                   : EcalPnDiodeDetId(EcalEndcap, 50, 10);
-      case 19:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 9)
-                   : EcalPnDiodeDetId(EcalEndcap, 50, 4);
-      default:
-        return EcalPnDiodeDetId(0);
+      switch (dccId(_id)) {
+        case 10:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 10, 1) : EcalPnDiodeDetId(EcalBarrel, 10, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 10, 2) : EcalPnDiodeDetId(EcalBarrel, 10, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 10, 2) : EcalPnDiodeDetId(EcalBarrel, 10, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 10, 3) : EcalPnDiodeDetId(EcalBarrel, 10, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 10, 3) : EcalPnDiodeDetId(EcalBarrel, 10, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 10, 4) : EcalPnDiodeDetId(EcalBarrel, 10, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 10, 4) : EcalPnDiodeDetId(EcalBarrel, 10, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 10, 5) : EcalPnDiodeDetId(EcalBarrel, 10, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 10, 5) : EcalPnDiodeDetId(EcalBarrel, 10, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 11:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 11, 1) : EcalPnDiodeDetId(EcalBarrel, 11, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 11, 2) : EcalPnDiodeDetId(EcalBarrel, 11, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 11, 2) : EcalPnDiodeDetId(EcalBarrel, 11, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 11, 3) : EcalPnDiodeDetId(EcalBarrel, 11, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 11, 3) : EcalPnDiodeDetId(EcalBarrel, 11, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 11, 4) : EcalPnDiodeDetId(EcalBarrel, 11, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 11, 4) : EcalPnDiodeDetId(EcalBarrel, 11, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 11, 5) : EcalPnDiodeDetId(EcalBarrel, 11, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 11, 5) : EcalPnDiodeDetId(EcalBarrel, 11, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 12:
+          switch (lmmod) {
+            case 1:
+              return /*pnA ? EcalPnDiodeDetId(EcalBarrel, 12, 1) :*/ EcalPnDiodeDetId(EcalBarrel, 12, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 12, 2) : EcalPnDiodeDetId(EcalBarrel, 12, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 12, 2) : EcalPnDiodeDetId(EcalBarrel, 12, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 12, 3) : EcalPnDiodeDetId(EcalBarrel, 12, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 12, 3) : EcalPnDiodeDetId(EcalBarrel, 12, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 12, 4) : EcalPnDiodeDetId(EcalBarrel, 12, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 12, 4) : EcalPnDiodeDetId(EcalBarrel, 12, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 12, 5) : EcalPnDiodeDetId(EcalBarrel, 12, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 12, 5) : EcalPnDiodeDetId(EcalBarrel, 12, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 13:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 13, 1) : EcalPnDiodeDetId(EcalBarrel, 13, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 13, 2) : EcalPnDiodeDetId(EcalBarrel, 13, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 13, 2) : EcalPnDiodeDetId(EcalBarrel, 13, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 13, 3) : EcalPnDiodeDetId(EcalBarrel, 13, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 13, 3) : EcalPnDiodeDetId(EcalBarrel, 13, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 13, 4) : EcalPnDiodeDetId(EcalBarrel, 13, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 13, 4) : EcalPnDiodeDetId(EcalBarrel, 13, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 13, 5) : EcalPnDiodeDetId(EcalBarrel, 13, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 13, 5) : EcalPnDiodeDetId(EcalBarrel, 13, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 14:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 14, 1) : EcalPnDiodeDetId(EcalBarrel, 14, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 14, 2) : EcalPnDiodeDetId(EcalBarrel, 14, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 14, 2) : EcalPnDiodeDetId(EcalBarrel, 14, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 14, 3) : EcalPnDiodeDetId(EcalBarrel, 14, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 14, 3) : EcalPnDiodeDetId(EcalBarrel, 14, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 14, 4) : EcalPnDiodeDetId(EcalBarrel, 14, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 14, 4) : EcalPnDiodeDetId(EcalBarrel, 14, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 14, 5) : EcalPnDiodeDetId(EcalBarrel, 14, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 14, 5) : EcalPnDiodeDetId(EcalBarrel, 14, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 15:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 15, 1) : EcalPnDiodeDetId(EcalBarrel, 15, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 15, 2) : EcalPnDiodeDetId(EcalBarrel, 15, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 15, 2) : EcalPnDiodeDetId(EcalBarrel, 15, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 15, 3) : EcalPnDiodeDetId(EcalBarrel, 15, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 15, 3) : EcalPnDiodeDetId(EcalBarrel, 15, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 15, 4) : EcalPnDiodeDetId(EcalBarrel, 15, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 15, 4) : EcalPnDiodeDetId(EcalBarrel, 15, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 15, 5) : EcalPnDiodeDetId(EcalBarrel, 15, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 15, 5) : EcalPnDiodeDetId(EcalBarrel, 15, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 16:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 16, 1) : EcalPnDiodeDetId(EcalBarrel, 16, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 16, 2) : EcalPnDiodeDetId(EcalBarrel, 16, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 16, 2) : EcalPnDiodeDetId(EcalBarrel, 16, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 16, 3) : EcalPnDiodeDetId(EcalBarrel, 16, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 16, 3) : EcalPnDiodeDetId(EcalBarrel, 16, 8);
+            case 6:
+              return pnA ? /*EcalPnDiodeDetId(EcalBarrel, 16, 4)*/ EcalPnDiodeDetId(EcalBarrel, 16, 1)
+                         : EcalPnDiodeDetId(EcalBarrel, 16, 9);
+            case 7:
+              return /*pnA ? EcalPnDiodeDetId(EcalBarrel, 16, 4) :*/ EcalPnDiodeDetId(EcalBarrel, 16, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 16, 5) : EcalPnDiodeDetId(EcalBarrel, 16, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 16, 5) : EcalPnDiodeDetId(EcalBarrel, 16, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 17:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 17, 1) : EcalPnDiodeDetId(EcalBarrel, 17, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 17, 2) : EcalPnDiodeDetId(EcalBarrel, 17, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 17, 2) : EcalPnDiodeDetId(EcalBarrel, 17, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 17, 3) : EcalPnDiodeDetId(EcalBarrel, 17, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 17, 3) : EcalPnDiodeDetId(EcalBarrel, 17, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 17, 4) : EcalPnDiodeDetId(EcalBarrel, 17, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 17, 4) : EcalPnDiodeDetId(EcalBarrel, 17, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 17, 5) : EcalPnDiodeDetId(EcalBarrel, 17, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 17, 5) : EcalPnDiodeDetId(EcalBarrel, 17, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 18:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 18, 1) : EcalPnDiodeDetId(EcalBarrel, 18, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 18, 2) : EcalPnDiodeDetId(EcalBarrel, 18, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 18, 2) : EcalPnDiodeDetId(EcalBarrel, 18, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 18, 3) : EcalPnDiodeDetId(EcalBarrel, 18, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 18, 3) : EcalPnDiodeDetId(EcalBarrel, 18, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 18, 4) : EcalPnDiodeDetId(EcalBarrel, 18, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 18, 4) : EcalPnDiodeDetId(EcalBarrel, 18, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 18, 5) : EcalPnDiodeDetId(EcalBarrel, 18, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 18, 5) : EcalPnDiodeDetId(EcalBarrel, 18, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 19:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 19, 1) : EcalPnDiodeDetId(EcalBarrel, 19, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 19, 2) : EcalPnDiodeDetId(EcalBarrel, 19, 8);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 19, 2) : EcalPnDiodeDetId(EcalBarrel, 19, 8);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 19, 3) : EcalPnDiodeDetId(EcalBarrel, 19, 7);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 19, 3) : EcalPnDiodeDetId(EcalBarrel, 19, 7);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 19, 4) : EcalPnDiodeDetId(EcalBarrel, 19, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 19, 4) : EcalPnDiodeDetId(EcalBarrel, 19, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 19, 5) : EcalPnDiodeDetId(EcalBarrel, 19, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 19, 5) : EcalPnDiodeDetId(EcalBarrel, 19, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 20:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 20, 1) : EcalPnDiodeDetId(EcalBarrel, 20, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 20, 2) : EcalPnDiodeDetId(EcalBarrel, 20, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 20, 2) : EcalPnDiodeDetId(EcalBarrel, 20, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 20, 3) : EcalPnDiodeDetId(EcalBarrel, 20, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 20, 3) : EcalPnDiodeDetId(EcalBarrel, 20, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 20, 4) : EcalPnDiodeDetId(EcalBarrel, 20, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 20, 4) : EcalPnDiodeDetId(EcalBarrel, 20, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 20, 5) : EcalPnDiodeDetId(EcalBarrel, 20, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 20, 5) : EcalPnDiodeDetId(EcalBarrel, 20, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 21:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 21, 1) : EcalPnDiodeDetId(EcalBarrel, 21, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 21, 2) : EcalPnDiodeDetId(EcalBarrel, 21, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 21, 2) : EcalPnDiodeDetId(EcalBarrel, 21, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 21, 3) : EcalPnDiodeDetId(EcalBarrel, 21, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 21, 3) : EcalPnDiodeDetId(EcalBarrel, 21, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 21, 4) : EcalPnDiodeDetId(EcalBarrel, 21, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 21, 4) : EcalPnDiodeDetId(EcalBarrel, 21, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 21, 5) : EcalPnDiodeDetId(EcalBarrel, 21, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 21, 5) : EcalPnDiodeDetId(EcalBarrel, 21, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 22:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 22, 1) : EcalPnDiodeDetId(EcalBarrel, 22, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 22, 2) : EcalPnDiodeDetId(EcalBarrel, 22, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 22, 2) : EcalPnDiodeDetId(EcalBarrel, 22, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 22, 3) : EcalPnDiodeDetId(EcalBarrel, 22, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 22, 3) : EcalPnDiodeDetId(EcalBarrel, 22, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 22, 4) : EcalPnDiodeDetId(EcalBarrel, 22, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 22, 4) : EcalPnDiodeDetId(EcalBarrel, 22, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 22, 5) : EcalPnDiodeDetId(EcalBarrel, 22, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 22, 5) : EcalPnDiodeDetId(EcalBarrel, 22, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 23:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 23, 1) : EcalPnDiodeDetId(EcalBarrel, 23, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 23, 2) : EcalPnDiodeDetId(EcalBarrel, 23, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 23, 2) : EcalPnDiodeDetId(EcalBarrel, 23, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 23, 3) : EcalPnDiodeDetId(EcalBarrel, 23, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 23, 3) : EcalPnDiodeDetId(EcalBarrel, 23, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 23, 4) : EcalPnDiodeDetId(EcalBarrel, 23, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 23, 4) : EcalPnDiodeDetId(EcalBarrel, 23, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 23, 5) : EcalPnDiodeDetId(EcalBarrel, 23, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 23, 5) : EcalPnDiodeDetId(EcalBarrel, 23, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 24:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 24, 1) : EcalPnDiodeDetId(EcalBarrel, 24, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 24, 2) : EcalPnDiodeDetId(EcalBarrel, 24, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 24, 2) : EcalPnDiodeDetId(EcalBarrel, 24, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 24, 3) : EcalPnDiodeDetId(EcalBarrel, 24, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 24, 3) : EcalPnDiodeDetId(EcalBarrel, 24, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 24, 4) : EcalPnDiodeDetId(EcalBarrel, 24, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 24, 4) : EcalPnDiodeDetId(EcalBarrel, 24, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 24, 5) : EcalPnDiodeDetId(EcalBarrel, 24, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 24, 5) : EcalPnDiodeDetId(EcalBarrel, 24, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 25:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 25, 2) : EcalPnDiodeDetId(EcalBarrel, 25, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 25, 1) : EcalPnDiodeDetId(EcalBarrel, 25, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 25, 1) : EcalPnDiodeDetId(EcalBarrel, 25, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 25, 3) : EcalPnDiodeDetId(EcalBarrel, 25, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 25, 3) : EcalPnDiodeDetId(EcalBarrel, 25, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 25, 4) : EcalPnDiodeDetId(EcalBarrel, 25, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 25, 4) : EcalPnDiodeDetId(EcalBarrel, 25, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 25, 5) : EcalPnDiodeDetId(EcalBarrel, 25, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 25, 5) : EcalPnDiodeDetId(EcalBarrel, 25, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 26:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 26, 1) : EcalPnDiodeDetId(EcalBarrel, 26, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 26, 2) : EcalPnDiodeDetId(EcalBarrel, 26, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 26, 2) : EcalPnDiodeDetId(EcalBarrel, 26, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 26, 3) : EcalPnDiodeDetId(EcalBarrel, 26, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 26, 3) : EcalPnDiodeDetId(EcalBarrel, 26, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 26, 4) : EcalPnDiodeDetId(EcalBarrel, 26, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 26, 4) : EcalPnDiodeDetId(EcalBarrel, 26, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 26, 5) : EcalPnDiodeDetId(EcalBarrel, 26, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 26, 5) : EcalPnDiodeDetId(EcalBarrel, 26, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 27:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 27, 1) : EcalPnDiodeDetId(EcalBarrel, 27, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 27, 2) : EcalPnDiodeDetId(EcalBarrel, 27, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 27, 2) : EcalPnDiodeDetId(EcalBarrel, 27, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 27, 3) : EcalPnDiodeDetId(EcalBarrel, 27, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 27, 3) : EcalPnDiodeDetId(EcalBarrel, 27, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 27, 4) : EcalPnDiodeDetId(EcalBarrel, 27, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 27, 4) : EcalPnDiodeDetId(EcalBarrel, 27, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 27, 5) : EcalPnDiodeDetId(EcalBarrel, 27, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 27, 5) : EcalPnDiodeDetId(EcalBarrel, 27, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 28:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 28, 1) : EcalPnDiodeDetId(EcalBarrel, 28, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 28, 2) : EcalPnDiodeDetId(EcalBarrel, 28, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 28, 2) : EcalPnDiodeDetId(EcalBarrel, 28, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 28, 3) : EcalPnDiodeDetId(EcalBarrel, 28, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 28, 3) : EcalPnDiodeDetId(EcalBarrel, 28, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 28, 4) : EcalPnDiodeDetId(EcalBarrel, 28, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 28, 4) : EcalPnDiodeDetId(EcalBarrel, 28, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 28, 5) : EcalPnDiodeDetId(EcalBarrel, 28, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 28, 5) : EcalPnDiodeDetId(EcalBarrel, 28, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 29:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 29, 1) : EcalPnDiodeDetId(EcalBarrel, 29, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 29, 2) : EcalPnDiodeDetId(EcalBarrel, 29, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 29, 2) : EcalPnDiodeDetId(EcalBarrel, 29, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 29, 3) : EcalPnDiodeDetId(EcalBarrel, 29, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 29, 3) : EcalPnDiodeDetId(EcalBarrel, 29, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 29, 4) : EcalPnDiodeDetId(EcalBarrel, 29, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 29, 4) : EcalPnDiodeDetId(EcalBarrel, 29, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 29, 5) : EcalPnDiodeDetId(EcalBarrel, 29, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 29, 5) : EcalPnDiodeDetId(EcalBarrel, 29, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 30:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 30, 1) : EcalPnDiodeDetId(EcalBarrel, 30, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 30, 2) : EcalPnDiodeDetId(EcalBarrel, 30, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 30, 2) : EcalPnDiodeDetId(EcalBarrel, 30, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 30, 3) : EcalPnDiodeDetId(EcalBarrel, 30, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 30, 3) : EcalPnDiodeDetId(EcalBarrel, 30, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 30, 4) : EcalPnDiodeDetId(EcalBarrel, 30, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 30, 4) : EcalPnDiodeDetId(EcalBarrel, 30, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 30, 5) : EcalPnDiodeDetId(EcalBarrel, 30, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 30, 5) : EcalPnDiodeDetId(EcalBarrel, 30, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 31:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 31, 1) : EcalPnDiodeDetId(EcalBarrel, 31, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 31, 2) : EcalPnDiodeDetId(EcalBarrel, 31, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 31, 2) : EcalPnDiodeDetId(EcalBarrel, 31, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 31, 3) : EcalPnDiodeDetId(EcalBarrel, 31, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 31, 3) : EcalPnDiodeDetId(EcalBarrel, 31, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 31, 4) : EcalPnDiodeDetId(EcalBarrel, 31, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 31, 4) : EcalPnDiodeDetId(EcalBarrel, 31, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 31, 5) : EcalPnDiodeDetId(EcalBarrel, 31, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 31, 5) : EcalPnDiodeDetId(EcalBarrel, 31, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 32:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 32, 1) : EcalPnDiodeDetId(EcalBarrel, 32, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 32, 2) : EcalPnDiodeDetId(EcalBarrel, 32, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 32, 2) : EcalPnDiodeDetId(EcalBarrel, 32, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 32, 3) : EcalPnDiodeDetId(EcalBarrel, 32, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 32, 3) : EcalPnDiodeDetId(EcalBarrel, 32, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 32, 5) : EcalPnDiodeDetId(EcalBarrel, 32, 10);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 32, 5) : EcalPnDiodeDetId(EcalBarrel, 32, 10);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 32, 4) : EcalPnDiodeDetId(EcalBarrel, 32, 9);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 32, 4) : EcalPnDiodeDetId(EcalBarrel, 32, 9);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 33:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 33, 1) : EcalPnDiodeDetId(EcalBarrel, 33, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 33, 2) : EcalPnDiodeDetId(EcalBarrel, 33, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 33, 2) : EcalPnDiodeDetId(EcalBarrel, 33, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 33, 3) : EcalPnDiodeDetId(EcalBarrel, 33, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 33, 3) : EcalPnDiodeDetId(EcalBarrel, 33, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 33, 4) : EcalPnDiodeDetId(EcalBarrel, 33, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 33, 4) : EcalPnDiodeDetId(EcalBarrel, 33, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 33, 5) : EcalPnDiodeDetId(EcalBarrel, 33, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 33, 5) : EcalPnDiodeDetId(EcalBarrel, 33, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 34:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 34, 1) : EcalPnDiodeDetId(EcalBarrel, 34, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 34, 2) : EcalPnDiodeDetId(EcalBarrel, 34, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 34, 2) : EcalPnDiodeDetId(EcalBarrel, 34, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 34, 3) : EcalPnDiodeDetId(EcalBarrel, 34, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 34, 3) : EcalPnDiodeDetId(EcalBarrel, 34, 8);
+            case 6:
+              return pnA ? /*EcalPnDiodeDetId(EcalBarrel, 34, 4)*/ EcalPnDiodeDetId(EcalBarrel, 34, 1)
+                         : EcalPnDiodeDetId(EcalBarrel, 34, 9);
+            case 7:
+              return /*pnA ? EcalPnDiodeDetId(EcalBarrel, 34, 4) :*/ EcalPnDiodeDetId(EcalBarrel, 34, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 34, 5) : EcalPnDiodeDetId(EcalBarrel, 34, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 34, 5) : EcalPnDiodeDetId(EcalBarrel, 34, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 35:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 35, 1) : EcalPnDiodeDetId(EcalBarrel, 35, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 35, 2) : EcalPnDiodeDetId(EcalBarrel, 35, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 35, 2) : EcalPnDiodeDetId(EcalBarrel, 35, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 35, 3) : EcalPnDiodeDetId(EcalBarrel, 35, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 35, 3) : EcalPnDiodeDetId(EcalBarrel, 35, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 35, 4) : EcalPnDiodeDetId(EcalBarrel, 35, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 35, 4) : EcalPnDiodeDetId(EcalBarrel, 35, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 35, 5) : EcalPnDiodeDetId(EcalBarrel, 35, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 35, 5) : EcalPnDiodeDetId(EcalBarrel, 35, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 36:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 36, 1) : EcalPnDiodeDetId(EcalBarrel, 36, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 36, 2) : EcalPnDiodeDetId(EcalBarrel, 36, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 36, 2) : EcalPnDiodeDetId(EcalBarrel, 36, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 36, 3) : EcalPnDiodeDetId(EcalBarrel, 36, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 36, 3) : EcalPnDiodeDetId(EcalBarrel, 36, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 36, 4) : EcalPnDiodeDetId(EcalBarrel, 36, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 36, 4) : EcalPnDiodeDetId(EcalBarrel, 36, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 36, 5) : EcalPnDiodeDetId(EcalBarrel, 36, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 36, 5) : EcalPnDiodeDetId(EcalBarrel, 36, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 37:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 37, 1) : EcalPnDiodeDetId(EcalBarrel, 37, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 37, 2) : EcalPnDiodeDetId(EcalBarrel, 37, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 37, 2) : EcalPnDiodeDetId(EcalBarrel, 37, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 37, 3) : EcalPnDiodeDetId(EcalBarrel, 37, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 37, 3) : EcalPnDiodeDetId(EcalBarrel, 37, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 37, 4) : EcalPnDiodeDetId(EcalBarrel, 37, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 37, 4) : EcalPnDiodeDetId(EcalBarrel, 37, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 37, 5) : EcalPnDiodeDetId(EcalBarrel, 37, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 37, 5) : EcalPnDiodeDetId(EcalBarrel, 37, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 38:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 38, 1) : EcalPnDiodeDetId(EcalBarrel, 38, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 38, 2) : EcalPnDiodeDetId(EcalBarrel, 38, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 38, 2) : EcalPnDiodeDetId(EcalBarrel, 38, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 38, 3) : EcalPnDiodeDetId(EcalBarrel, 38, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 38, 3) : EcalPnDiodeDetId(EcalBarrel, 38, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 38, 4) : EcalPnDiodeDetId(EcalBarrel, 38, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 38, 4) : EcalPnDiodeDetId(EcalBarrel, 38, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 38, 5) : EcalPnDiodeDetId(EcalBarrel, 38, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 38, 5) : EcalPnDiodeDetId(EcalBarrel, 38, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 39:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 39, 1) : EcalPnDiodeDetId(EcalBarrel, 39, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 39, 2) : EcalPnDiodeDetId(EcalBarrel, 39, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 39, 2) : EcalPnDiodeDetId(EcalBarrel, 39, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 39, 3) : EcalPnDiodeDetId(EcalBarrel, 39, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 39, 3) : EcalPnDiodeDetId(EcalBarrel, 39, 8);
+            case 6:
+              return pnA ? /*EcalPnDiodeDetId(EcalBarrel, 39, 4)*/ EcalPnDiodeDetId(EcalBarrel, 39, 1)
+                         : EcalPnDiodeDetId(EcalBarrel, 39, 9);
+            case 7:
+              return /*pnA ? EcalPnDiodeDetId(EcalBarrel, 39, 4) :*/ EcalPnDiodeDetId(EcalBarrel, 39, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 39, 5) : EcalPnDiodeDetId(EcalBarrel, 39, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 39, 5) : EcalPnDiodeDetId(EcalBarrel, 39, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 40:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 40, 1) : EcalPnDiodeDetId(EcalBarrel, 40, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 40, 2) : EcalPnDiodeDetId(EcalBarrel, 40, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 40, 2) : EcalPnDiodeDetId(EcalBarrel, 40, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 40, 3) : EcalPnDiodeDetId(EcalBarrel, 40, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 40, 3) : EcalPnDiodeDetId(EcalBarrel, 40, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 40, 4) : EcalPnDiodeDetId(EcalBarrel, 40, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 40, 4) : EcalPnDiodeDetId(EcalBarrel, 40, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 40, 5) : EcalPnDiodeDetId(EcalBarrel, 40, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 40, 5) : EcalPnDiodeDetId(EcalBarrel, 40, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 41:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 41, 1) : EcalPnDiodeDetId(EcalBarrel, 41, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 41, 2) : EcalPnDiodeDetId(EcalBarrel, 41, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 41, 2) : EcalPnDiodeDetId(EcalBarrel, 41, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 41, 3) : EcalPnDiodeDetId(EcalBarrel, 41, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 41, 3) : EcalPnDiodeDetId(EcalBarrel, 41, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 41, 4) : EcalPnDiodeDetId(EcalBarrel, 41, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 41, 4) : EcalPnDiodeDetId(EcalBarrel, 41, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 41, 5) : EcalPnDiodeDetId(EcalBarrel, 41, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 41, 5) : EcalPnDiodeDetId(EcalBarrel, 41, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 42:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 42, 1) : EcalPnDiodeDetId(EcalBarrel, 42, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 42, 2) : EcalPnDiodeDetId(EcalBarrel, 42, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 42, 2) : EcalPnDiodeDetId(EcalBarrel, 42, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 42, 3) : EcalPnDiodeDetId(EcalBarrel, 42, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 42, 3) : EcalPnDiodeDetId(EcalBarrel, 42, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 42, 4) : EcalPnDiodeDetId(EcalBarrel, 42, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 42, 4) : EcalPnDiodeDetId(EcalBarrel, 42, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 42, 5) : EcalPnDiodeDetId(EcalBarrel, 42, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 42, 5) : EcalPnDiodeDetId(EcalBarrel, 42, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 43:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 43, 1) : EcalPnDiodeDetId(EcalBarrel, 43, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 43, 2) : EcalPnDiodeDetId(EcalBarrel, 43, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 43, 2) : EcalPnDiodeDetId(EcalBarrel, 43, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 43, 3) : EcalPnDiodeDetId(EcalBarrel, 43, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 43, 3) : EcalPnDiodeDetId(EcalBarrel, 43, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 43, 4) : EcalPnDiodeDetId(EcalBarrel, 43, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 43, 4) : EcalPnDiodeDetId(EcalBarrel, 43, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 43, 5) : EcalPnDiodeDetId(EcalBarrel, 43, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 43, 5) : EcalPnDiodeDetId(EcalBarrel, 43, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 44:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 44, 1) : EcalPnDiodeDetId(EcalBarrel, 44, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 44, 2) : EcalPnDiodeDetId(EcalBarrel, 44, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 44, 2) : EcalPnDiodeDetId(EcalBarrel, 44, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 44, 3) : EcalPnDiodeDetId(EcalBarrel, 44, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 44, 3) : EcalPnDiodeDetId(EcalBarrel, 44, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 44, 4) : EcalPnDiodeDetId(EcalBarrel, 44, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 44, 4) : EcalPnDiodeDetId(EcalBarrel, 44, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 44, 5) : EcalPnDiodeDetId(EcalBarrel, 44, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 44, 5) : EcalPnDiodeDetId(EcalBarrel, 44, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        case 45:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 45, 1) : EcalPnDiodeDetId(EcalBarrel, 45, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 45, 2) : EcalPnDiodeDetId(EcalBarrel, 45, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 45, 2) : EcalPnDiodeDetId(EcalBarrel, 45, 7);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 45, 3) : EcalPnDiodeDetId(EcalBarrel, 45, 8);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 45, 3) : EcalPnDiodeDetId(EcalBarrel, 45, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 45, 4) : EcalPnDiodeDetId(EcalBarrel, 45, 9);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 45, 4) : EcalPnDiodeDetId(EcalBarrel, 45, 9);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 45, 5) : EcalPnDiodeDetId(EcalBarrel, 45, 10);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalBarrel, 45, 5) : EcalPnDiodeDetId(EcalBarrel, 45, 10);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+          break;
+        default:
+          return EcalPnDiodeDetId(0);
       }
-    case 2:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 1)
-                   : EcalPnDiodeDetId(EcalEndcap, 46, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 2)
-                   : EcalPnDiodeDetId(EcalEndcap, 46, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 3)
-                   : EcalPnDiodeDetId(EcalEndcap, 46, 8);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 4)
-                   : EcalPnDiodeDetId(EcalEndcap, 46, 9);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 3)
-                   : EcalPnDiodeDetId(EcalEndcap, 46, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 1)
-                   : EcalPnDiodeDetId(EcalEndcap, 46, 6);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 2)
-                   : EcalPnDiodeDetId(EcalEndcap, 46, 7);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 4)
-                   : EcalPnDiodeDetId(EcalEndcap, 46, 9);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 6)
-                   : EcalPnDiodeDetId(EcalEndcap, 46, 1);
-      case 10:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 7)
-                   : EcalPnDiodeDetId(EcalEndcap, 46, 2);
-      case 11:
-        return /*pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 8) :*/ EcalPnDiodeDetId(
-            EcalEndcap, 46, 3);
-      case 12:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 9)
-                   : EcalPnDiodeDetId(EcalEndcap, 46, 4);
-      case 13:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 10)
-                   : EcalPnDiodeDetId(EcalEndcap, 46, 5);
-      case 14:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 8)
-                   : EcalPnDiodeDetId(EcalEndcap, 46, 3);
-      case 15:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 6)
-                   : EcalPnDiodeDetId(EcalEndcap, 46, 1);
-      case 16:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 7)
-                   : EcalPnDiodeDetId(EcalEndcap, 46, 2);
-      case 17:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 10)
-                   : EcalPnDiodeDetId(EcalEndcap, 46, 5);
-      case 18:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 5)
-                   : EcalPnDiodeDetId(EcalEndcap, 46, 10);
-      case 19:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 9)
-                   : EcalPnDiodeDetId(EcalEndcap, 46, 4);
-      default:
-        return EcalPnDiodeDetId(0);
+
+    } else {
+      EcalScDetId scid(EEDetId(_id).sc());
+      int ix(scid.ix());
+      int iy(scid.iy());
+      int dee(MEEEGeom::dee(ix, iy, scid.zside()));
+      int lmmod(MEEEGeom::lmmod(ix, iy));
+
+      switch (dee) {
+        case 1:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 1) : EcalPnDiodeDetId(EcalEndcap, 50, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 2) : EcalPnDiodeDetId(EcalEndcap, 50, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 3) : EcalPnDiodeDetId(EcalEndcap, 50, 8);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 4) : EcalPnDiodeDetId(EcalEndcap, 50, 9);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 3) : EcalPnDiodeDetId(EcalEndcap, 50, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 1) : EcalPnDiodeDetId(EcalEndcap, 50, 6);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 2) : EcalPnDiodeDetId(EcalEndcap, 50, 7);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 4) : EcalPnDiodeDetId(EcalEndcap, 50, 9);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 6) : EcalPnDiodeDetId(EcalEndcap, 50, 1);
+            case 10:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 7) : EcalPnDiodeDetId(EcalEndcap, 50, 2);
+            case 11:
+              return /*pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 8) :*/ EcalPnDiodeDetId(EcalEndcap, 50, 3);
+            case 12:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 9) : EcalPnDiodeDetId(EcalEndcap, 50, 4);
+            case 13:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 10) : EcalPnDiodeDetId(EcalEndcap, 50, 5);
+            case 14:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 8) : EcalPnDiodeDetId(EcalEndcap, 50, 3);
+            case 15:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 6) : EcalPnDiodeDetId(EcalEndcap, 50, 1);
+            case 16:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 7) : EcalPnDiodeDetId(EcalEndcap, 50, 2);
+            case 17:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 10) : EcalPnDiodeDetId(EcalEndcap, 50, 5);
+            case 18:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 5) : EcalPnDiodeDetId(EcalEndcap, 50, 10);
+            case 19:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 51, 9) : EcalPnDiodeDetId(EcalEndcap, 50, 4);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+        case 2:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 1) : EcalPnDiodeDetId(EcalEndcap, 46, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 2) : EcalPnDiodeDetId(EcalEndcap, 46, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 3) : EcalPnDiodeDetId(EcalEndcap, 46, 8);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 4) : EcalPnDiodeDetId(EcalEndcap, 46, 9);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 3) : EcalPnDiodeDetId(EcalEndcap, 46, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 1) : EcalPnDiodeDetId(EcalEndcap, 46, 6);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 2) : EcalPnDiodeDetId(EcalEndcap, 46, 7);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 4) : EcalPnDiodeDetId(EcalEndcap, 46, 9);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 6) : EcalPnDiodeDetId(EcalEndcap, 46, 1);
+            case 10:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 7) : EcalPnDiodeDetId(EcalEndcap, 46, 2);
+            case 11:
+              return /*pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 8) :*/ EcalPnDiodeDetId(EcalEndcap, 46, 3);
+            case 12:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 9) : EcalPnDiodeDetId(EcalEndcap, 46, 4);
+            case 13:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 10) : EcalPnDiodeDetId(EcalEndcap, 46, 5);
+            case 14:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 8) : EcalPnDiodeDetId(EcalEndcap, 46, 3);
+            case 15:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 6) : EcalPnDiodeDetId(EcalEndcap, 46, 1);
+            case 16:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 7) : EcalPnDiodeDetId(EcalEndcap, 46, 2);
+            case 17:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 10) : EcalPnDiodeDetId(EcalEndcap, 46, 5);
+            case 18:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 5) : EcalPnDiodeDetId(EcalEndcap, 46, 10);
+            case 19:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 47, 9) : EcalPnDiodeDetId(EcalEndcap, 46, 4);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+        case 3:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 1) : EcalPnDiodeDetId(EcalEndcap, 1, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 2) : EcalPnDiodeDetId(EcalEndcap, 1, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 3) : EcalPnDiodeDetId(EcalEndcap, 1, 8);
+            case 4:
+              return /*pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 4) :*/ EcalPnDiodeDetId(EcalEndcap, 1, 9);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 3) : EcalPnDiodeDetId(EcalEndcap, 1, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 1) : EcalPnDiodeDetId(EcalEndcap, 1, 6);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 2) : EcalPnDiodeDetId(EcalEndcap, 1, 7);
+            case 8:
+              return /*pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 4) :*/ EcalPnDiodeDetId(EcalEndcap, 1, 9);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 6) : EcalPnDiodeDetId(EcalEndcap, 1, 1);
+            case 10:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 7) : EcalPnDiodeDetId(EcalEndcap, 1, 2);
+            case 11:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 8) : EcalPnDiodeDetId(EcalEndcap, 1, 3);
+            case 12:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 9) : EcalPnDiodeDetId(EcalEndcap, 1, 4);
+            case 13:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 10) : EcalPnDiodeDetId(EcalEndcap, 1, 5);
+            case 14:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 8) : EcalPnDiodeDetId(EcalEndcap, 1, 3);
+            case 15:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 6) : EcalPnDiodeDetId(EcalEndcap, 1, 1);
+            case 16:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 7) : EcalPnDiodeDetId(EcalEndcap, 1, 2);
+            case 17:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 10) : EcalPnDiodeDetId(EcalEndcap, 1, 5);
+            case 18:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 5) : EcalPnDiodeDetId(EcalEndcap, 1, 10);
+            case 19:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 9) : EcalPnDiodeDetId(EcalEndcap, 1, 4);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+        case 4:
+          switch (lmmod) {
+            case 1:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 1) : EcalPnDiodeDetId(EcalEndcap, 5, 6);
+            case 2:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 2) : EcalPnDiodeDetId(EcalEndcap, 5, 7);
+            case 3:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 3) : EcalPnDiodeDetId(EcalEndcap, 5, 8);
+            case 4:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 4) : EcalPnDiodeDetId(EcalEndcap, 5, 9);
+            case 5:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 3) : EcalPnDiodeDetId(EcalEndcap, 5, 8);
+            case 6:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 1) : EcalPnDiodeDetId(EcalEndcap, 5, 6);
+            case 7:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 2) : EcalPnDiodeDetId(EcalEndcap, 5, 7);
+            case 8:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 4) : EcalPnDiodeDetId(EcalEndcap, 5, 9);
+            case 9:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 6) : EcalPnDiodeDetId(EcalEndcap, 5, 1);
+            case 10:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 7) : EcalPnDiodeDetId(EcalEndcap, 5, 2);
+            case 11:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 8) : EcalPnDiodeDetId(EcalEndcap, 5, 3);
+            case 12:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 9) : EcalPnDiodeDetId(EcalEndcap, 5, 4);
+            case 13:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 10) : EcalPnDiodeDetId(EcalEndcap, 5, 5);
+            case 14:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 8) : EcalPnDiodeDetId(EcalEndcap, 5, 3);
+            case 15:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 6) : EcalPnDiodeDetId(EcalEndcap, 5, 1);
+            case 16:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 7) : EcalPnDiodeDetId(EcalEndcap, 5, 2);
+            case 17:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 10) : EcalPnDiodeDetId(EcalEndcap, 5, 5);
+            case 18:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 5) : EcalPnDiodeDetId(EcalEndcap, 5, 10);
+            case 19:
+              return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 9) : EcalPnDiodeDetId(EcalEndcap, 5, 4);
+            default:
+              return EcalPnDiodeDetId(0);
+          }
+        default:
+          return EcalPnDiodeDetId(0);
       }
-    case 3:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 1)
-                   : EcalPnDiodeDetId(EcalEndcap, 1, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 2)
-                   : EcalPnDiodeDetId(EcalEndcap, 1, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 3)
-                   : EcalPnDiodeDetId(EcalEndcap, 1, 8);
-      case 4:
-        return /*pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 4) :*/ EcalPnDiodeDetId(
-            EcalEndcap, 1, 9);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 3)
-                   : EcalPnDiodeDetId(EcalEndcap, 1, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 1)
-                   : EcalPnDiodeDetId(EcalEndcap, 1, 6);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 2)
-                   : EcalPnDiodeDetId(EcalEndcap, 1, 7);
-      case 8:
-        return /*pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 4) :*/ EcalPnDiodeDetId(
-            EcalEndcap, 1, 9);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 6)
-                   : EcalPnDiodeDetId(EcalEndcap, 1, 1);
-      case 10:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 7)
-                   : EcalPnDiodeDetId(EcalEndcap, 1, 2);
-      case 11:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 8)
-                   : EcalPnDiodeDetId(EcalEndcap, 1, 3);
-      case 12:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 9)
-                   : EcalPnDiodeDetId(EcalEndcap, 1, 4);
-      case 13:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 10)
-                   : EcalPnDiodeDetId(EcalEndcap, 1, 5);
-      case 14:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 8)
-                   : EcalPnDiodeDetId(EcalEndcap, 1, 3);
-      case 15:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 6)
-                   : EcalPnDiodeDetId(EcalEndcap, 1, 1);
-      case 16:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 7)
-                   : EcalPnDiodeDetId(EcalEndcap, 1, 2);
-      case 17:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 10)
-                   : EcalPnDiodeDetId(EcalEndcap, 1, 5);
-      case 18:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 5)
-                   : EcalPnDiodeDetId(EcalEndcap, 1, 10);
-      case 19:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 2, 9)
-                   : EcalPnDiodeDetId(EcalEndcap, 1, 4);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-    case 4:
-      switch (lmmod) {
-      case 1:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 1)
-                   : EcalPnDiodeDetId(EcalEndcap, 5, 6);
-      case 2:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 2)
-                   : EcalPnDiodeDetId(EcalEndcap, 5, 7);
-      case 3:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 3)
-                   : EcalPnDiodeDetId(EcalEndcap, 5, 8);
-      case 4:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 4)
-                   : EcalPnDiodeDetId(EcalEndcap, 5, 9);
-      case 5:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 3)
-                   : EcalPnDiodeDetId(EcalEndcap, 5, 8);
-      case 6:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 1)
-                   : EcalPnDiodeDetId(EcalEndcap, 5, 6);
-      case 7:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 2)
-                   : EcalPnDiodeDetId(EcalEndcap, 5, 7);
-      case 8:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 4)
-                   : EcalPnDiodeDetId(EcalEndcap, 5, 9);
-      case 9:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 6)
-                   : EcalPnDiodeDetId(EcalEndcap, 5, 1);
-      case 10:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 7)
-                   : EcalPnDiodeDetId(EcalEndcap, 5, 2);
-      case 11:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 8)
-                   : EcalPnDiodeDetId(EcalEndcap, 5, 3);
-      case 12:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 9)
-                   : EcalPnDiodeDetId(EcalEndcap, 5, 4);
-      case 13:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 10)
-                   : EcalPnDiodeDetId(EcalEndcap, 5, 5);
-      case 14:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 8)
-                   : EcalPnDiodeDetId(EcalEndcap, 5, 3);
-      case 15:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 6)
-                   : EcalPnDiodeDetId(EcalEndcap, 5, 1);
-      case 16:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 7)
-                   : EcalPnDiodeDetId(EcalEndcap, 5, 2);
-      case 17:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 10)
-                   : EcalPnDiodeDetId(EcalEndcap, 5, 5);
-      case 18:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 5)
-                   : EcalPnDiodeDetId(EcalEndcap, 5, 10);
-      case 19:
-        return pnA ? EcalPnDiodeDetId(EcalEndcap, 6, 9)
-                   : EcalPnDiodeDetId(EcalEndcap, 5, 4);
-      default:
-        return EcalPnDiodeDetId(0);
-      }
-    default:
-      return EcalPnDiodeDetId(0);
     }
   }
-}
 
-} // namespace ecaldqm
+}  // namespace ecaldqm

--- a/DQM/EcalCommon/src/EcalDQMonitor.cc
+++ b/DQM/EcalCommon/src/EcalDQMonitor.cc
@@ -18,135 +18,125 @@
 #include <sstream>
 
 namespace ecaldqm {
-EcalDQMonitor::EcalDQMonitor(edm::ParameterSet const &_ps)
-    : workers_(),
-      moduleName_(_ps.getUntrackedParameter<std::string>("moduleName")),
-      verbosity_(_ps.getUntrackedParameter<int>("verbosity")) {
-  std::vector<std::string> workerNames(
-      _ps.getUntrackedParameter<std::vector<std::string>>("workers"));
-  edm::ParameterSet const &workerParams(
-      _ps.getUntrackedParameterSet("workerParameters"));
-  edm::ParameterSet const &commonParams(
-      _ps.getUntrackedParameterSet("commonParameters"));
+  EcalDQMonitor::EcalDQMonitor(edm::ParameterSet const &_ps)
+      : workers_(),
+        moduleName_(_ps.getUntrackedParameter<std::string>("moduleName")),
+        verbosity_(_ps.getUntrackedParameter<int>("verbosity")) {
+    std::vector<std::string> workerNames(_ps.getUntrackedParameter<std::vector<std::string>>("workers"));
+    edm::ParameterSet const &workerParams(_ps.getUntrackedParameterSet("workerParameters"));
+    edm::ParameterSet const &commonParams(_ps.getUntrackedParameterSet("commonParameters"));
 
-  std::for_each(
-      workerNames.begin(), workerNames.end(), [&](std::string const &name) {
-        if (verbosity_ > 0)
-          edm::LogInfo("EcalDQM")
-              << moduleName_ << ": Setting up " << name << std::endl;
-        try {
-          DQWorker *worker(WorkerFactoryStore::singleton()->getWorker(
-              name, verbosity_, commonParams,
-              workerParams.getUntrackedParameterSet(name)));
+    std::for_each(workerNames.begin(), workerNames.end(), [&](std::string const &name) {
+      if (verbosity_ > 0)
+        edm::LogInfo("EcalDQM") << moduleName_ << ": Setting up " << name << std::endl;
+      try {
+        DQWorker *worker(WorkerFactoryStore::singleton()->getWorker(
+            name, verbosity_, commonParams, workerParams.getUntrackedParameterSet(name)));
+        if (worker->onlineMode())
+          worker->setTime(time(nullptr));
+        workers_.push_back(worker);
+      } catch (std::exception &) {
+        edm::LogError("EcalDQM") << "Worker " << name << " not defined";
+        throw;
+      }
+    });
+  }
+
+  EcalDQMonitor::~EcalDQMonitor() noexcept(false) {
+    if (verbosity_ > 2)
+      edm::LogInfo("EcalDQM") << moduleName_ << ": Deleting workers";
+
+    executeOnWorkers_([](DQWorker *worker) { delete worker; }, "Dtor");
+  }
+
+  /*static*/
+  void EcalDQMonitor::fillDescriptions(edm::ParameterSetDescription &_desc) {
+    _desc.addUntracked<std::string>("moduleName", "Ecal Monitor Module");
+    _desc.addUntracked<std::vector<std::string>>("workers");
+    _desc.addUntracked<int>("verbosity", 0);
+
+    edm::ParameterSetDescription commonParameters;
+    commonParameters.addUntracked<bool>("onlineMode", false);
+    commonParameters.addUntracked<bool>("willConvertToEDM", true);
+    _desc.addUntracked("commonParameters", commonParameters);
+  }
+
+  void EcalDQMonitor::ecaldqmGetSetupObjects(edm::EventSetup const &_es) {
+    // NB: a more minimal solution may rely on ESWatchers
+    //    but then here the cost is rather minimal
+    // set up electronicsMap in EcalDQMCommonUtils
+    edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
+    _es.get<EcalMappingRcd>().get(elecMapHandle);
+    setElectronicsMap(elecMapHandle.product());
+
+    // set up trigTowerMap in EcalDQMCommonUtils
+    edm::ESHandle<EcalTrigTowerConstituentsMap> ttMapHandle;
+    _es.get<IdealGeometryRecord>().get(ttMapHandle);
+    setTrigTowerMap(ttMapHandle.product());
+
+    edm::ESHandle<CaloGeometry> geomHandle;
+    _es.get<CaloGeometryRecord>().get(geomHandle);
+    setGeometry(geomHandle.product());
+
+    // set up trigTowerMap in EcalDQMCommonUtils
+    edm::ESHandle<CaloTopology> topoHandle;
+    _es.get<CaloTopologyRecord>().get(topoHandle);
+    setTopology(topoHandle.product());
+  }
+
+  void EcalDQMonitor::ecaldqmBeginRun(edm::Run const &_run, edm::EventSetup const &_es) {
+    executeOnWorkers_(
+        [&_run, &_es](DQWorker *worker) {
           if (worker->onlineMode())
             worker->setTime(time(nullptr));
-          workers_.push_back(worker);
-        } catch (std::exception &) {
-          edm::LogError("EcalDQM") << "Worker " << name << " not defined";
-          throw;
-        }
-      });
-}
+          worker->setRunNumber(_run.run());
+          worker->beginRun(_run, _es);
+        },
+        "beginRun");
 
-EcalDQMonitor::~EcalDQMonitor() noexcept(false) {
-  if (verbosity_ > 2)
-    edm::LogInfo("EcalDQM") << moduleName_ << ": Deleting workers";
+    if (verbosity_ > 0)
+      edm::LogInfo("EcalDQM") << moduleName_ << "::ecaldqmBeginRun";
+  }
 
-  executeOnWorkers_([](DQWorker *worker) { delete worker; }, "Dtor");
-}
+  void EcalDQMonitor::ecaldqmEndRun(edm::Run const &_run, edm::EventSetup const &_es) {
+    executeOnWorkers_(
+        [&_run, &_es](DQWorker *worker) {
+          if (worker->onlineMode())
+            worker->setTime(time(nullptr));
+          worker->setRunNumber(_run.run());
+          worker->endRun(_run, _es);
+        },
+        "endRun");
 
-/*static*/
-void EcalDQMonitor::fillDescriptions(edm::ParameterSetDescription &_desc) {
-  _desc.addUntracked<std::string>("moduleName", "Ecal Monitor Module");
-  _desc.addUntracked<std::vector<std::string>>("workers");
-  _desc.addUntracked<int>("verbosity", 0);
+    if (verbosity_ > 0)
+      edm::LogInfo("EcalDQM") << moduleName_ << "::ecaldqmEndRun";
+  }
 
-  edm::ParameterSetDescription commonParameters;
-  commonParameters.addUntracked<bool>("onlineMode", false);
-  commonParameters.addUntracked<bool>("willConvertToEDM", true);
-  _desc.addUntracked("commonParameters", commonParameters);
-}
+  void EcalDQMonitor::ecaldqmBeginLuminosityBlock(edm::LuminosityBlock const &_lumi, edm::EventSetup const &_es) {
+    executeOnWorkers_(
+        [&_lumi, &_es](DQWorker *worker) {
+          if (worker->onlineMode())
+            worker->setTime(time(nullptr));
+          worker->setLumiNumber(_lumi.luminosityBlock());
+          worker->beginLuminosityBlock(_lumi, _es);
+        },
+        "beginLumi");
 
-void EcalDQMonitor::ecaldqmGetSetupObjects(edm::EventSetup const &_es) {
-  // NB: a more minimal solution may rely on ESWatchers
-  //    but then here the cost is rather minimal
-  // set up electronicsMap in EcalDQMCommonUtils
-  edm::ESHandle<EcalElectronicsMapping> elecMapHandle;
-  _es.get<EcalMappingRcd>().get(elecMapHandle);
-  setElectronicsMap(elecMapHandle.product());
+    if (verbosity_ > 1)
+      edm::LogInfo("EcalDQM") << moduleName_ << "::ecaldqmBeginLuminosityBlock";
+  }
 
-  // set up trigTowerMap in EcalDQMCommonUtils
-  edm::ESHandle<EcalTrigTowerConstituentsMap> ttMapHandle;
-  _es.get<IdealGeometryRecord>().get(ttMapHandle);
-  setTrigTowerMap(ttMapHandle.product());
+  void EcalDQMonitor::ecaldqmEndLuminosityBlock(edm::LuminosityBlock const &_lumi, edm::EventSetup const &_es) {
+    executeOnWorkers_(
+        [&_lumi, &_es](DQWorker *worker) {
+          if (worker->onlineMode())
+            worker->setTime(time(nullptr));
+          worker->setLumiNumber(_lumi.luminosityBlock());
+          worker->endLuminosityBlock(_lumi, _es);
+        },
+        "endLumi");
 
-  edm::ESHandle<CaloGeometry> geomHandle;
-  _es.get<CaloGeometryRecord>().get(geomHandle);
-  setGeometry(geomHandle.product());
-
-  // set up trigTowerMap in EcalDQMCommonUtils
-  edm::ESHandle<CaloTopology> topoHandle;
-  _es.get<CaloTopologyRecord>().get(topoHandle);
-  setTopology(topoHandle.product());
-}
-
-void EcalDQMonitor::ecaldqmBeginRun(edm::Run const &_run,
-                                    edm::EventSetup const &_es) {
-  executeOnWorkers_(
-      [&_run, &_es](DQWorker *worker) {
-        if (worker->onlineMode())
-          worker->setTime(time(nullptr));
-        worker->setRunNumber(_run.run());
-        worker->beginRun(_run, _es);
-      },
-      "beginRun");
-
-  if (verbosity_ > 0)
-    edm::LogInfo("EcalDQM") << moduleName_ << "::ecaldqmBeginRun";
-}
-
-void EcalDQMonitor::ecaldqmEndRun(edm::Run const &_run,
-                                  edm::EventSetup const &_es) {
-  executeOnWorkers_(
-      [&_run, &_es](DQWorker *worker) {
-        if (worker->onlineMode())
-          worker->setTime(time(nullptr));
-        worker->setRunNumber(_run.run());
-        worker->endRun(_run, _es);
-      },
-      "endRun");
-
-  if (verbosity_ > 0)
-    edm::LogInfo("EcalDQM") << moduleName_ << "::ecaldqmEndRun";
-}
-
-void EcalDQMonitor::ecaldqmBeginLuminosityBlock(
-    edm::LuminosityBlock const &_lumi, edm::EventSetup const &_es) {
-  executeOnWorkers_(
-      [&_lumi, &_es](DQWorker *worker) {
-        if (worker->onlineMode())
-          worker->setTime(time(nullptr));
-        worker->setLumiNumber(_lumi.luminosityBlock());
-        worker->beginLuminosityBlock(_lumi, _es);
-      },
-      "beginLumi");
-
-  if (verbosity_ > 1)
-    edm::LogInfo("EcalDQM") << moduleName_ << "::ecaldqmBeginLuminosityBlock";
-}
-
-void EcalDQMonitor::ecaldqmEndLuminosityBlock(edm::LuminosityBlock const &_lumi,
-                                              edm::EventSetup const &_es) {
-  executeOnWorkers_(
-      [&_lumi, &_es](DQWorker *worker) {
-        if (worker->onlineMode())
-          worker->setTime(time(nullptr));
-        worker->setLumiNumber(_lumi.luminosityBlock());
-        worker->endLuminosityBlock(_lumi, _es);
-      },
-      "endLumi");
-
-  if (verbosity_ > 2)
-    edm::LogInfo("EcalDQM") << moduleName_ << "::ecaldqmEndLuminosityBlock";
-}
-} // namespace ecaldqm
+    if (verbosity_ > 2)
+      edm::LogInfo("EcalDQM") << moduleName_ << "::ecaldqmEndLuminosityBlock";
+  }
+}  // namespace ecaldqm

--- a/DQM/EcalCommon/src/MESet.cc
+++ b/DQM/EcalCommon/src/MESet.cc
@@ -11,521 +11,510 @@
 #include "TString.h"
 
 namespace ecaldqm {
-MESet::MESet()
-    : mes_(0), path_(""), otype_(binning::nObjType), btype_(binning::nBinType),
-      kind_(MonitorElement::DQM_KIND_INVALID), lumiFlag_(false),
-      batchMode_(false), active_(false) {}
+  MESet::MESet()
+      : mes_(0),
+        path_(""),
+        otype_(binning::nObjType),
+        btype_(binning::nBinType),
+        kind_(MonitorElement::DQM_KIND_INVALID),
+        lumiFlag_(false),
+        batchMode_(false),
+        active_(false) {}
 
-MESet::MESet(std::string const &_path, binning::ObjectType _otype,
-             binning::BinningType _btype, MonitorElement::Kind _kind)
-    : mes_(0), path_(_path), otype_(_otype), btype_(_btype), kind_(_kind),
-      lumiFlag_(false), batchMode_(false), active_(false) {
-  if (path_.empty() || path_.find("/") == std::string::npos ||
-      (otype_ != binning::kChannel && path_.find("/") == path_.size() - 1))
-    throw_(_path + " cannot be used for ME path name");
+  MESet::MESet(std::string const &_path,
+               binning::ObjectType _otype,
+               binning::BinningType _btype,
+               MonitorElement::Kind _kind)
+      : mes_(0),
+        path_(_path),
+        otype_(_otype),
+        btype_(_btype),
+        kind_(_kind),
+        lumiFlag_(false),
+        batchMode_(false),
+        active_(false) {
+    if (path_.empty() || path_.find("/") == std::string::npos ||
+        (otype_ != binning::kChannel && path_.find("/") == path_.size() - 1))
+      throw_(_path + " cannot be used for ME path name");
 
-  switch (kind_) {
-  case MonitorElement::DQM_KIND_REAL:
-  case MonitorElement::DQM_KIND_TH1F:
-  case MonitorElement::DQM_KIND_TPROFILE:
-  case MonitorElement::DQM_KIND_TH2F:
-  case MonitorElement::DQM_KIND_TPROFILE2D:
-    break;
-  default:
-    throw_("Unsupported MonitorElement kind");
+    switch (kind_) {
+      case MonitorElement::DQM_KIND_REAL:
+      case MonitorElement::DQM_KIND_TH1F:
+      case MonitorElement::DQM_KIND_TPROFILE:
+      case MonitorElement::DQM_KIND_TH2F:
+      case MonitorElement::DQM_KIND_TPROFILE2D:
+        break;
+      default:
+        throw_("Unsupported MonitorElement kind");
+    }
   }
-}
 
-MESet::MESet(MESet const &_orig)
-    : mes_(_orig.mes_), path_(_orig.path_), otype_(_orig.otype_),
-      btype_(_orig.btype_), kind_(_orig.kind_), lumiFlag_(_orig.lumiFlag_),
-      batchMode_(_orig.batchMode_), active_(_orig.active_) {}
+  MESet::MESet(MESet const &_orig)
+      : mes_(_orig.mes_),
+        path_(_orig.path_),
+        otype_(_orig.otype_),
+        btype_(_orig.btype_),
+        kind_(_orig.kind_),
+        lumiFlag_(_orig.lumiFlag_),
+        batchMode_(_orig.batchMode_),
+        active_(_orig.active_) {}
 
-MESet::~MESet() {}
+  MESet::~MESet() {}
 
-MESet &MESet::operator=(MESet const &_rhs) {
-  mes_ = _rhs.mes_;
-  path_ = _rhs.path_;
-  otype_ = _rhs.otype_;
-  btype_ = _rhs.btype_;
-  kind_ = _rhs.kind_;
-  active_ = _rhs.active_;
+  MESet &MESet::operator=(MESet const &_rhs) {
+    mes_ = _rhs.mes_;
+    path_ = _rhs.path_;
+    otype_ = _rhs.otype_;
+    btype_ = _rhs.btype_;
+    kind_ = _rhs.kind_;
+    active_ = _rhs.active_;
 
-  return *this;
-}
+    return *this;
+  }
 
-MESet *MESet::clone(std::string const &_path /* = ""*/) const {
-  std::string path(path_);
-  if (!_path.empty())
-    path_ = _path;
-  MESet *copy(new MESet(*this));
-  path_ = path;
-  return copy;
-}
+  MESet *MESet::clone(std::string const &_path /* = ""*/) const {
+    std::string path(path_);
+    if (!_path.empty())
+      path_ = _path;
+    MESet *copy(new MESet(*this));
+    path_ = path;
+    return copy;
+  }
 
-void MESet::clear() const {
-  active_ = false;
-  mes_.clear();
-}
+  void MESet::clear() const {
+    active_ = false;
+    mes_.clear();
+  }
 
-void MESet::setAxisTitle(std::string const &_title, int _axis /* = 1*/) {
-  if (!active_)
-    return;
+  void MESet::setAxisTitle(std::string const &_title, int _axis /* = 1*/) {
+    if (!active_)
+      return;
 
-  unsigned nME(mes_.size());
-  for (unsigned iME(0); iME < nME; iME++)
-    mes_[iME]->setAxisTitle(_title, _axis);
-}
-
-void MESet::reset(double _content /* = 0.*/, double _err /* = 0.*/,
-                  double _entries /* = 0.*/) {
-  if (!active_)
-    return;
-
-  resetAll(_content, _err, _entries);
-}
-
-void MESet::resetAll(double _content /* = 0.*/, double _err /* = 0.*/,
-                     double _entries /* = 0.*/) {
-  if (!active_)
-    return;
-
-  unsigned nME(mes_.size());
-
-  if (kind_ == MonitorElement::DQM_KIND_REAL) {
+    unsigned nME(mes_.size());
     for (unsigned iME(0); iME < nME; iME++)
-      mes_[iME]->Fill(_content);
-    return;
+      mes_[iME]->setAxisTitle(_title, _axis);
   }
 
-  bool simple(true);
-  if (_content != 0. || _err != 0. || _entries != 0.)
-    simple = false;
+  void MESet::reset(double _content /* = 0.*/, double _err /* = 0.*/, double _entries /* = 0.*/) {
+    if (!active_)
+      return;
 
-  for (unsigned iME(0); iME < nME; iME++) {
-    TH1 *h(mes_[iME]->getTH1());
-    h->Reset();
-    if (simple)
-      continue;
+    resetAll(_content, _err, _entries);
+  }
 
-    int nbinsX(h->GetNbinsX());
-    int nbinsY(h->GetNbinsY());
-    double entries(0.);
-    for (int ix(1); ix <= nbinsX; ix++) {
-      for (int iy(1); iy <= nbinsY; iy++) {
-        int bin(h->GetBin(ix, iy));
-        h->SetBinContent(bin, _content);
-        h->SetBinError(bin, _err);
-        if (kind_ == MonitorElement::DQM_KIND_TPROFILE) {
-          static_cast<TProfile *>(h)->SetBinEntries(bin, _entries);
-          entries += _entries;
-        } else if (kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
-          static_cast<TProfile2D *>(h)->SetBinEntries(bin, _entries);
-          entries += _entries;
-        }
-      }
+  void MESet::resetAll(double _content /* = 0.*/, double _err /* = 0.*/, double _entries /* = 0.*/) {
+    if (!active_)
+      return;
+
+    unsigned nME(mes_.size());
+
+    if (kind_ == MonitorElement::DQM_KIND_REAL) {
+      for (unsigned iME(0); iME < nME; iME++)
+        mes_[iME]->Fill(_content);
+      return;
     }
-    if (entries == 0.)
-      entries = _entries;
-    h->SetEntries(_entries);
-  }
-}
 
-std::string
-MESet::formPath(std::map<std::string, std::string> const &_replacements) const {
-  TString path(path_);
+    bool simple(true);
+    if (_content != 0. || _err != 0. || _entries != 0.)
+      simple = false;
 
-  for (typename MESet::PathReplacements::const_iterator repItr(
-           _replacements.begin());
-       repItr != _replacements.end(); ++repItr) {
-    TString pattern("\\%\\(");
-    pattern += repItr->first;
-    pattern += "\\)s";
+    for (unsigned iME(0); iME < nME; iME++) {
+      TH1 *h(mes_[iME]->getTH1());
+      h->Reset();
+      if (simple)
+        continue;
 
-    TPRegexp re(pattern);
-
-    re.Substitute(path, repItr->second, "g");
-  }
-
-  return path.Data();
-}
-
-bool MESet::maskMatches(DetId const &_id, uint32_t _mask,
-                        StatusManager const *_statusManager) const {
-  if (!_statusManager)
-    return false;
-
-  if ((_statusManager->getStatus(_id.rawId()) & _mask) != 0)
-    return true;
-
-  int subdet(_id.subdetId());
-
-  bool searchNeighborsInTower(btype_ == binning::kTriggerTower ||
-                              btype_ == binning::kSuperCrystal);
-
-  // turn off masking for good channel for the time being
-  // update the RenderPlugin then enable again
-
-  switch (subdet) {
-  case EcalBarrel: // this is a DetId for single crystal in barrel
-  {
-    EBDetId ebId(_id);
-    EcalTrigTowerDetId ttId(ebId.tower());
-    if ((_statusManager->getStatus(ttId.rawId()) & _mask) != 0)
-      return true;
-
-    if (searchNeighborsInTower) {
-      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttId));
-      for (std::vector<DetId>::iterator idItr(ids.begin()); idItr != ids.end();
-           ++idItr)
-        if ((_statusManager->getStatus(idItr->rawId()) & _mask) != 0)
-          return true;
-    }
-  } break;
-
-  case EcalEndcap:
-    if (isEcalScDetId(_id)) {
-      EcalScDetId scId(_id);
-      for (int ix(1); ix <= 5; ix++) {
-        for (int iy(1); iy <= 5; iy++) {
-          int iix((scId.ix() - 1) * 5 + ix);
-          int iiy((scId.iy() - 1) * 5 + iy);
-          if (!EEDetId::validDetId(iix, iiy, scId.zside()))
-            continue;
-          if ((_statusManager->getStatus(
-                   EEDetId(iix, iiy, scId.zside()).rawId()) &
-               _mask) != 0)
-            return true;
-        }
-      }
-    } else {
-      EEDetId eeId(_id);
-      EcalScDetId scId(eeId.sc());
-      if ((_statusManager->getStatus(scId.rawId()) & _mask) != 0)
-        return true;
-
-      if (searchNeighborsInTower) {
-        for (int ix(1); ix <= 5; ix++) {
-          for (int iy(1); iy <= 5; iy++) {
-            int iix((scId.ix() - 1) * 5 + ix);
-            int iiy((scId.iy() - 1) * 5 + iy);
-            if (!EEDetId::validDetId(iix, iiy, scId.zside()))
-              continue;
-            if ((_statusManager->getStatus(
-                     EEDetId(iix, iiy, scId.zside()).rawId()) &
-                 _mask) != 0)
-              return true;
+      int nbinsX(h->GetNbinsX());
+      int nbinsY(h->GetNbinsY());
+      double entries(0.);
+      for (int ix(1); ix <= nbinsX; ix++) {
+        for (int iy(1); iy <= nbinsY; iy++) {
+          int bin(h->GetBin(ix, iy));
+          h->SetBinContent(bin, _content);
+          h->SetBinError(bin, _err);
+          if (kind_ == MonitorElement::DQM_KIND_TPROFILE) {
+            static_cast<TProfile *>(h)->SetBinEntries(bin, _entries);
+            entries += _entries;
+          } else if (kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
+            static_cast<TProfile2D *>(h)->SetBinEntries(bin, _entries);
+            entries += _entries;
           }
         }
       }
+      if (entries == 0.)
+        entries = _entries;
+      h->SetEntries(_entries);
     }
-    break;
-
-  case EcalTriggerTower: {
-    EcalTrigTowerDetId ttId(_id);
-    std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttId));
-    for (std::vector<DetId>::iterator idItr(ids.begin()); idItr != ids.end();
-         ++idItr)
-      if ((_statusManager->getStatus(idItr->rawId()) & _mask) != 0)
-        return true;
-  } break;
-
-  default:
-    break;
   }
 
-  return false;
-}
+  std::string MESet::formPath(std::map<std::string, std::string> const &_replacements) const {
+    TString path(path_);
 
-void MESet::softReset() {
-  if (!active_)
-    return;
+    for (typename MESet::PathReplacements::const_iterator repItr(_replacements.begin()); repItr != _replacements.end();
+         ++repItr) {
+      TString pattern("\\%\\(");
+      pattern += repItr->first;
+      pattern += "\\)s";
 
-  DQMStore &store(*edm::Service<DQMStore>());
+      TPRegexp re(pattern);
 
-  for (unsigned iME(0); iME < mes_.size(); ++iME)
-    store.softReset(mes_[iME]);
-}
+      re.Substitute(path, repItr->second, "g");
+    }
 
-void MESet::recoverStats() {
-  if (!active_)
-    return;
-
-  DQMStore &store(*edm::Service<DQMStore>());
-
-  for (unsigned iME(0); iME < mes_.size(); ++iME)
-    store.disableSoftReset(mes_[iME]);
-}
-
-void MESet::fill_(unsigned _iME, int _bin, double _w) {
-  if (kind_ == MonitorElement::DQM_KIND_REAL)
-    return;
-
-  MonitorElement *me(mes_[_iME]);
-  if (!me)
-    return;
-
-  TH1 *h(me->getTH1());
-
-  int nbinsX(h->GetNbinsX());
-
-  double x(h->GetXaxis()->GetBinCenter(_bin % (nbinsX + 2)));
-
-  if (kind_ == MonitorElement::DQM_KIND_TH1F ||
-      kind_ == MonitorElement::DQM_KIND_TPROFILE)
-    me->Fill(x, _w);
-  else {
-    double y(h->GetYaxis()->GetBinCenter(_bin / (nbinsX + 2)));
-    me->Fill(x, y, _w);
+    return path.Data();
   }
-}
 
-void MESet::fill_(unsigned _iME, int _bin, double _y, double _w) {
-  if (kind_ != MonitorElement::DQM_KIND_TH2F &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return;
+  bool MESet::maskMatches(DetId const &_id, uint32_t _mask, StatusManager const *_statusManager) const {
+    if (!_statusManager)
+      return false;
 
-  MonitorElement *me(mes_[_iME]);
-  if (!me)
-    return;
+    if ((_statusManager->getStatus(_id.rawId()) & _mask) != 0)
+      return true;
 
-  TH1 *h(me->getTH1());
+    int subdet(_id.subdetId());
 
-  int nbinsX(h->GetNbinsX());
+    bool searchNeighborsInTower(btype_ == binning::kTriggerTower || btype_ == binning::kSuperCrystal);
 
-  double x(h->GetXaxis()->GetBinCenter(_bin % (nbinsX + 2)));
-  me->Fill(x, _y, _w);
-}
+    // turn off masking for good channel for the time being
+    // update the RenderPlugin then enable again
 
-void MESet::fill_(unsigned _iME, double _x, double _wy, double _w) {
-  MonitorElement *me(mes_[_iME]);
-  if (!me)
-    return;
+    switch (subdet) {
+      case EcalBarrel:  // this is a DetId for single crystal in barrel
+      {
+        EBDetId ebId(_id);
+        EcalTrigTowerDetId ttId(ebId.tower());
+        if ((_statusManager->getStatus(ttId.rawId()) & _mask) != 0)
+          return true;
 
-  if (kind_ == MonitorElement::DQM_KIND_REAL)
-    me->Fill(_x);
-  else if (kind_ == MonitorElement::DQM_KIND_TH1F ||
-           kind_ == MonitorElement::DQM_KIND_TPROFILE)
-    me->Fill(_x, _wy);
-  else
-    me->Fill(_x, _wy, _w);
-}
+        if (searchNeighborsInTower) {
+          std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttId));
+          for (std::vector<DetId>::iterator idItr(ids.begin()); idItr != ids.end(); ++idItr)
+            if ((_statusManager->getStatus(idItr->rawId()) & _mask) != 0)
+              return true;
+        }
+      } break;
 
-MESet::ConstBin::ConstBin(MESet const &_meSet, unsigned _iME /* = 0*/,
-                          int _iBin /* = 1*/)
-    : meSet_(&_meSet), iME(_iME), iBin(_iBin), otype(binning::nObjType) {
-  if (iME == unsigned(-1))
-    return;
+      case EcalEndcap:
+        if (isEcalScDetId(_id)) {
+          EcalScDetId scId(_id);
+          for (int ix(1); ix <= 5; ix++) {
+            for (int iy(1); iy <= 5; iy++) {
+              int iix((scId.ix() - 1) * 5 + ix);
+              int iiy((scId.iy() - 1) * 5 + iy);
+              if (!EEDetId::validDetId(iix, iiy, scId.zside()))
+                continue;
+              if ((_statusManager->getStatus(EEDetId(iix, iiy, scId.zside()).rawId()) & _mask) != 0)
+                return true;
+            }
+          }
+        } else {
+          EEDetId eeId(_id);
+          EcalScDetId scId(eeId.sc());
+          if ((_statusManager->getStatus(scId.rawId()) & _mask) != 0)
+            return true;
 
-  // current internal bin numbering scheme does not allow 1D histograms
-  // (overflow & underflow in each y)
-  MonitorElement::Kind kind(meSet_->getKind());
-  //    if(kind != MonitorElement::DQM_KIND_TH1F && kind !=
-  //    MonitorElement::DQM_KIND_TPROFILE &&
-  if (kind != MonitorElement::DQM_KIND_TH2F &&
-      kind != MonitorElement::DQM_KIND_TPROFILE2D)
-    throw cms::Exception("InvalidOperation")
-        << "MESet::ConstBin::Ctor: const_iterator only available for MESet of "
-           "2D histograms";
+          if (searchNeighborsInTower) {
+            for (int ix(1); ix <= 5; ix++) {
+              for (int iy(1); iy <= 5; iy++) {
+                int iix((scId.ix() - 1) * 5 + ix);
+                int iiy((scId.iy() - 1) * 5 + iy);
+                if (!EEDetId::validDetId(iix, iiy, scId.zside()))
+                  continue;
+                if ((_statusManager->getStatus(EEDetId(iix, iiy, scId.zside()).rawId()) & _mask) != 0)
+                  return true;
+              }
+            }
+          }
+        }
+        break;
 
-  MonitorElement const *me(meSet_->getME(iME));
+      case EcalTriggerTower: {
+        EcalTrigTowerDetId ttId(_id);
+        std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttId));
+        for (std::vector<DetId>::iterator idItr(ids.begin()); idItr != ids.end(); ++idItr)
+          if ((_statusManager->getStatus(idItr->rawId()) & _mask) != 0)
+            return true;
+      } break;
 
-  if (!me)
-    throw cms::Exception("InvalidOperation")
-        << "MESet::ConstBin::Ctor: ME " << iME << " does not exist for MESet "
-        << meSet_->getPath();
+      default:
+        break;
+    }
 
-  if (iBin == 1 && (kind == MonitorElement::DQM_KIND_TH2F ||
-                    kind == MonitorElement::DQM_KIND_TPROFILE2D))
-    iBin = me->getNbinsX() + 3;
+    return false;
+  }
 
-  otype = binning::getObject(meSet_->getObjType(), iME);
-}
+  void MESet::softReset() {
+    if (!active_)
+      return;
 
-MESet::ConstBin &MESet::ConstBin::operator=(ConstBin const &_rhs) {
-  if (meSet_->getObjType() != _rhs.meSet_->getObjType() ||
-      meSet_->getBinType() != _rhs.meSet_->getBinType())
-    throw cms::Exception("IncompatibleAssignment")
-        << "Iterator of otype " << _rhs.meSet_->getObjType() << " and btype "
-        << _rhs.meSet_->getBinType() << " to otype " << meSet_->getObjType()
-        << " and btype " << meSet_->getBinType() << " ("
-        << _rhs.meSet_->getPath() << " to " << meSet_->getPath() << ")";
+    DQMStore &store(*edm::Service<DQMStore>());
 
-  iME = _rhs.iME;
-  iBin = _rhs.iBin;
-  otype = _rhs.otype;
+    for (unsigned iME(0); iME < mes_.size(); ++iME)
+      store.softReset(mes_[iME]);
+  }
 
-  return *this;
-}
+  void MESet::recoverStats() {
+    if (!active_)
+      return;
 
-MESet::const_iterator::const_iterator(MESet const &_meSet, DetId const &_id)
-    : bin_() {
-  binning::ObjectType otype(_meSet.getObjType());
-  unsigned iME(binning::findPlotIndex(otype, _id));
-  if (iME == unsigned(-1))
-    return;
+    DQMStore &store(*edm::Service<DQMStore>());
 
-  binning::BinningType btype(_meSet.getBinType());
-  int bin(binning::findBin2D(otype, btype, _id));
-  if (bin == 0)
-    return;
+    for (unsigned iME(0); iME < mes_.size(); ++iME)
+      store.disableSoftReset(mes_[iME]);
+  }
 
-  bin_.setMESet(_meSet);
-  bin_.iME = iME;
-  bin_.iBin = bin;
-  bin_.otype = otype;
-}
+  void MESet::fill_(unsigned _iME, int _bin, double _w) {
+    if (kind_ == MonitorElement::DQM_KIND_REAL)
+      return;
 
-MESet::const_iterator &MESet::const_iterator::operator++() {
-  unsigned &iME(bin_.iME);
-  MESet const *meSet(bin_.getMESet());
+    MonitorElement *me(mes_[_iME]);
+    if (!me)
+      return;
 
-  if (iME == unsigned(-1))
+    TH1 *h(me->getTH1());
+
+    int nbinsX(h->GetNbinsX());
+
+    double x(h->GetXaxis()->GetBinCenter(_bin % (nbinsX + 2)));
+
+    if (kind_ == MonitorElement::DQM_KIND_TH1F || kind_ == MonitorElement::DQM_KIND_TPROFILE)
+      me->Fill(x, _w);
+    else {
+      double y(h->GetYaxis()->GetBinCenter(_bin / (nbinsX + 2)));
+      me->Fill(x, y, _w);
+    }
+  }
+
+  void MESet::fill_(unsigned _iME, int _bin, double _y, double _w) {
+    if (kind_ != MonitorElement::DQM_KIND_TH2F && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return;
+
+    MonitorElement *me(mes_[_iME]);
+    if (!me)
+      return;
+
+    TH1 *h(me->getTH1());
+
+    int nbinsX(h->GetNbinsX());
+
+    double x(h->GetXaxis()->GetBinCenter(_bin % (nbinsX + 2)));
+    me->Fill(x, _y, _w);
+  }
+
+  void MESet::fill_(unsigned _iME, double _x, double _wy, double _w) {
+    MonitorElement *me(mes_[_iME]);
+    if (!me)
+      return;
+
+    if (kind_ == MonitorElement::DQM_KIND_REAL)
+      me->Fill(_x);
+    else if (kind_ == MonitorElement::DQM_KIND_TH1F || kind_ == MonitorElement::DQM_KIND_TPROFILE)
+      me->Fill(_x, _wy);
+    else
+      me->Fill(_x, _wy, _w);
+  }
+
+  MESet::ConstBin::ConstBin(MESet const &_meSet, unsigned _iME /* = 0*/, int _iBin /* = 1*/)
+      : meSet_(&_meSet), iME(_iME), iBin(_iBin), otype(binning::nObjType) {
+    if (iME == unsigned(-1))
+      return;
+
+    // current internal bin numbering scheme does not allow 1D histograms
+    // (overflow & underflow in each y)
+    MonitorElement::Kind kind(meSet_->getKind());
+    //    if(kind != MonitorElement::DQM_KIND_TH1F && kind !=
+    //    MonitorElement::DQM_KIND_TPROFILE &&
+    if (kind != MonitorElement::DQM_KIND_TH2F && kind != MonitorElement::DQM_KIND_TPROFILE2D)
+      throw cms::Exception("InvalidOperation") << "MESet::ConstBin::Ctor: const_iterator only available for MESet of "
+                                                  "2D histograms";
+
+    MonitorElement const *me(meSet_->getME(iME));
+
+    if (!me)
+      throw cms::Exception("InvalidOperation")
+          << "MESet::ConstBin::Ctor: ME " << iME << " does not exist for MESet " << meSet_->getPath();
+
+    if (iBin == 1 && (kind == MonitorElement::DQM_KIND_TH2F || kind == MonitorElement::DQM_KIND_TPROFILE2D))
+      iBin = me->getNbinsX() + 3;
+
+    otype = binning::getObject(meSet_->getObjType(), iME);
+  }
+
+  MESet::ConstBin &MESet::ConstBin::operator=(ConstBin const &_rhs) {
+    if (meSet_->getObjType() != _rhs.meSet_->getObjType() || meSet_->getBinType() != _rhs.meSet_->getBinType())
+      throw cms::Exception("IncompatibleAssignment")
+          << "Iterator of otype " << _rhs.meSet_->getObjType() << " and btype " << _rhs.meSet_->getBinType()
+          << " to otype " << meSet_->getObjType() << " and btype " << meSet_->getBinType() << " ("
+          << _rhs.meSet_->getPath() << " to " << meSet_->getPath() << ")";
+
+    iME = _rhs.iME;
+    iBin = _rhs.iBin;
+    otype = _rhs.otype;
+
     return *this;
-
-  int &bin(bin_.iBin);
-  binning::ObjectType &otype(bin_.otype);
-
-  MonitorElement::Kind kind(meSet->getKind());
-  MonitorElement const *me(meSet->getME(iME));
-
-  int nbinsX(me->getNbinsX());
-
-  ++bin;
-  if (bin == 1) {
-    iME = 0;
-    me = meSet->getME(iME);
-    nbinsX = me->getNbinsX();
-    if (kind == MonitorElement::DQM_KIND_TH2F ||
-        kind == MonitorElement::DQM_KIND_TPROFILE2D)
-      bin = nbinsX + 3;
-    otype = binning::getObject(meSet->getObjType(), iME);
   }
 
-  if (bin % (nbinsX + 2) == nbinsX + 1) {
-    if (kind == MonitorElement::DQM_KIND_TH1F ||
-        kind == MonitorElement::DQM_KIND_TPROFILE ||
-        bin / (nbinsX + 2) == me->getNbinsY()) {
-      iME += 1;
+  MESet::const_iterator::const_iterator(MESet const &_meSet, DetId const &_id) : bin_() {
+    binning::ObjectType otype(_meSet.getObjType());
+    unsigned iME(binning::findPlotIndex(otype, _id));
+    if (iME == unsigned(-1))
+      return;
+
+    binning::BinningType btype(_meSet.getBinType());
+    int bin(binning::findBin2D(otype, btype, _id));
+    if (bin == 0)
+      return;
+
+    bin_.setMESet(_meSet);
+    bin_.iME = iME;
+    bin_.iBin = bin;
+    bin_.otype = otype;
+  }
+
+  MESet::const_iterator &MESet::const_iterator::operator++() {
+    unsigned &iME(bin_.iME);
+    MESet const *meSet(bin_.getMESet());
+
+    if (iME == unsigned(-1))
+      return *this;
+
+    int &bin(bin_.iBin);
+    binning::ObjectType &otype(bin_.otype);
+
+    MonitorElement::Kind kind(meSet->getKind());
+    MonitorElement const *me(meSet->getME(iME));
+
+    int nbinsX(me->getNbinsX());
+
+    ++bin;
+    if (bin == 1) {
+      iME = 0;
       me = meSet->getME(iME);
-      if (!me) {
-        iME = unsigned(-1);
-        bin = -1;
-        otype = binning::nObjType;
-      } else {
-        nbinsX = me->getNbinsX();
-        if (kind == MonitorElement::DQM_KIND_TH2F ||
-            kind == MonitorElement::DQM_KIND_TPROFILE2D)
-          bin = nbinsX + 3;
-        else
-          bin = 1;
+      nbinsX = me->getNbinsX();
+      if (kind == MonitorElement::DQM_KIND_TH2F || kind == MonitorElement::DQM_KIND_TPROFILE2D)
+        bin = nbinsX + 3;
+      otype = binning::getObject(meSet->getObjType(), iME);
+    }
 
-        otype = binning::getObject(meSet->getObjType(), iME);
-      }
-    } else
-      bin += 2;
+    if (bin % (nbinsX + 2) == nbinsX + 1) {
+      if (kind == MonitorElement::DQM_KIND_TH1F || kind == MonitorElement::DQM_KIND_TPROFILE ||
+          bin / (nbinsX + 2) == me->getNbinsY()) {
+        iME += 1;
+        me = meSet->getME(iME);
+        if (!me) {
+          iME = unsigned(-1);
+          bin = -1;
+          otype = binning::nObjType;
+        } else {
+          nbinsX = me->getNbinsX();
+          if (kind == MonitorElement::DQM_KIND_TH2F || kind == MonitorElement::DQM_KIND_TPROFILE2D)
+            bin = nbinsX + 3;
+          else
+            bin = 1;
+
+          otype = binning::getObject(meSet->getObjType(), iME);
+        }
+      } else
+        bin += 2;
+    }
+
+    return *this;
   }
 
-  return *this;
-}
+  MESet::const_iterator &MESet::const_iterator::toNextChannel() {
+    if (!bin_.getMESet())
+      return *this;
+    do
+      operator++();
+    while (bin_.iME != unsigned(-1) && !bin_.isChannel());
 
-MESet::const_iterator &MESet::const_iterator::toNextChannel() {
-  if (!bin_.getMESet())
     return *this;
-  do
-    operator++();
-  while (bin_.iME != unsigned(-1) && !bin_.isChannel());
+  }
 
-  return *this;
-}
+  bool MESet::const_iterator::up() {
+    MESet const *meSet(bin_.getMESet());
+    if (bin_.iME == unsigned(-1) || bin_.iBin < 1)
+      return false;
 
-bool MESet::const_iterator::up() {
-  MESet const *meSet(bin_.getMESet());
-  if (bin_.iME == unsigned(-1) || bin_.iBin < 1)
-    return false;
+    MonitorElement::Kind kind(meSet->getKind());
+    if (kind != MonitorElement::DQM_KIND_TH2F && kind != MonitorElement::DQM_KIND_TPROFILE2D)
+      return false;
 
-  MonitorElement::Kind kind(meSet->getKind());
-  if (kind != MonitorElement::DQM_KIND_TH2F &&
-      kind != MonitorElement::DQM_KIND_TPROFILE2D)
-    return false;
+    MonitorElement const *me(meSet->getME(bin_.iME));
 
-  MonitorElement const *me(meSet->getME(bin_.iME));
+    if (bin_.iBin / (me->getNbinsX() + 2) >= me->getNbinsY())
+      return false;
 
-  if (bin_.iBin / (me->getNbinsX() + 2) >= me->getNbinsY())
-    return false;
+    bin_.iBin += me->getNbinsX() + 2;
 
-  bin_.iBin += me->getNbinsX() + 2;
+    return true;
+  }
 
-  return true;
-}
+  bool MESet::const_iterator::down() {
+    MESet const *meSet(bin_.getMESet());
+    if (bin_.iME == unsigned(-1) || bin_.iBin < 1)
+      return false;
 
-bool MESet::const_iterator::down() {
-  MESet const *meSet(bin_.getMESet());
-  if (bin_.iME == unsigned(-1) || bin_.iBin < 1)
-    return false;
+    MonitorElement::Kind kind(meSet->getKind());
+    if (kind != MonitorElement::DQM_KIND_TH2F && kind != MonitorElement::DQM_KIND_TPROFILE2D)
+      return false;
 
-  MonitorElement::Kind kind(meSet->getKind());
-  if (kind != MonitorElement::DQM_KIND_TH2F &&
-      kind != MonitorElement::DQM_KIND_TPROFILE2D)
-    return false;
+    MonitorElement const *me(meSet->getME(bin_.iME));
 
-  MonitorElement const *me(meSet->getME(bin_.iME));
+    if (bin_.iBin / (me->getNbinsX() + 2) <= 1)
+      return false;
 
-  if (bin_.iBin / (me->getNbinsX() + 2) <= 1)
-    return false;
+    bin_.iBin -= me->getNbinsX() + 2;
 
-  bin_.iBin -= me->getNbinsX() + 2;
+    return true;
+  }
 
-  return true;
-}
+  bool MESet::const_iterator::left() {
+    MESet const *meSet(bin_.getMESet());
+    if (bin_.iME == unsigned(-1) || bin_.iBin < 1)
+      return false;
 
-bool MESet::const_iterator::left() {
-  MESet const *meSet(bin_.getMESet());
-  if (bin_.iME == unsigned(-1) || bin_.iBin < 1)
-    return false;
+    MonitorElement::Kind kind(meSet->getKind());
+    if (kind != MonitorElement::DQM_KIND_TH2F && kind != MonitorElement::DQM_KIND_TPROFILE2D)
+      return false;
 
-  MonitorElement::Kind kind(meSet->getKind());
-  if (kind != MonitorElement::DQM_KIND_TH2F &&
-      kind != MonitorElement::DQM_KIND_TPROFILE2D)
-    return false;
+    MonitorElement const *me(meSet->getME(bin_.iME));
 
-  MonitorElement const *me(meSet->getME(bin_.iME));
+    if (bin_.iBin % (me->getNbinsX() + 2) <= 1)
+      return false;
 
-  if (bin_.iBin % (me->getNbinsX() + 2) <= 1)
-    return false;
+    bin_.iBin -= 1;
 
-  bin_.iBin -= 1;
+    return true;
+  }
 
-  return true;
-}
+  bool MESet::const_iterator::right() {
+    MESet const *meSet(bin_.getMESet());
+    if (bin_.iME == unsigned(-1) || bin_.iBin < 1)
+      return false;
 
-bool MESet::const_iterator::right() {
-  MESet const *meSet(bin_.getMESet());
-  if (bin_.iME == unsigned(-1) || bin_.iBin < 1)
-    return false;
+    MonitorElement::Kind kind(meSet->getKind());
+    if (kind != MonitorElement::DQM_KIND_TH2F && kind != MonitorElement::DQM_KIND_TPROFILE2D)
+      return false;
 
-  MonitorElement::Kind kind(meSet->getKind());
-  if (kind != MonitorElement::DQM_KIND_TH2F &&
-      kind != MonitorElement::DQM_KIND_TPROFILE2D)
-    return false;
+    MonitorElement const *me(meSet->getME(bin_.iME));
 
-  MonitorElement const *me(meSet->getME(bin_.iME));
+    if (bin_.iBin % (me->getNbinsX() + 2) >= me->getNbinsX())
+      return false;
 
-  if (bin_.iBin % (me->getNbinsX() + 2) >= me->getNbinsX())
-    return false;
+    bin_.iBin += 1;
 
-  bin_.iBin += 1;
-
-  return true;
-}
-} // namespace ecaldqm
+    return true;
+  }
+}  // namespace ecaldqm
 
 namespace boost {
-template <>
-inline ecaldqm::MESet *new_clone<ecaldqm::MESet>(ecaldqm::MESet const &_s) {
-  return _s.clone();
-}
-template <> void delete_clone<ecaldqm::MESet>(ecaldqm::MESet const *_s) {
-  checked_delete(_s);
-}
-} // namespace boost
+  template <>
+  inline ecaldqm::MESet *new_clone<ecaldqm::MESet>(ecaldqm::MESet const &_s) {
+    return _s.clone();
+  }
+  template <>
+  void delete_clone<ecaldqm::MESet>(ecaldqm::MESet const *_s) {
+    checked_delete(_s);
+  }
+}  // namespace boost

--- a/DQM/EcalCommon/src/MESetBinningUtils.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils.cc
@@ -9,977 +9,930 @@
 #include "TPRegexp.h"
 
 namespace ecaldqm {
-namespace binning {
-AxisSpecs getBinning(ObjectType _otype, BinningType _btype, bool _isMap,
-                     int _axis, unsigned _iME) {
-  if (_otype >= nObjType || _btype >= unsigned(nPresetBinnings))
-    return AxisSpecs(); // you are on your own
+  namespace binning {
+    AxisSpecs getBinning(ObjectType _otype, BinningType _btype, bool _isMap, int _axis, unsigned _iME) {
+      if (_otype >= nObjType || _btype >= unsigned(nPresetBinnings))
+        return AxisSpecs();  // you are on your own
 
-  switch (_otype) {
-  case kEB:
-    return getBinningEB_(_btype, _isMap, _axis);
-  case kEE:
-    return getBinningEE_(_btype, _isMap, 0, _axis);
-  case kEEm:
-    return getBinningEE_(_btype, _isMap, -1, _axis);
-  case kEEp:
-    return getBinningEE_(_btype, _isMap, 1, _axis);
-  case kSM:
-    return getBinningSM_(_btype, _isMap, _iME, _axis);
-  case kEBSM:
-    return getBinningSM_(_btype, _isMap, _iME + 9, _axis);
-  case kEESM:
-    if (_iME <= kEEmHigh)
-      return getBinningSM_(_btype, _isMap, _iME, _axis);
-    else
-      return getBinningSM_(_btype, _isMap, _iME + nEBDCC, _axis);
-  case kSMMEM:
-    return getBinningSMMEM_(_btype, _isMap, _iME, _axis);
-  case kEBSMMEM:
-    return getBinningSMMEM_(_btype, _isMap, _iME + nEEDCCMEM / 2, _axis);
-  case kEESMMEM:
-    if (_iME <= kEEmHigh)
-      return getBinningSMMEM_(_btype, _isMap, _iME, _axis);
-    else
-      return getBinningSMMEM_(_btype, _isMap, _iME + nEBDCC, _axis);
-  case kEcal:
-    return getBinningEcal_(_btype, _isMap, _axis);
-  case kMEM:
-    return getBinningMEM_(_btype, _isMap, -1, _axis);
-  case kEBMEM:
-    return getBinningMEM_(_btype, _isMap, EcalBarrel, _axis);
-  case kEEMEM:
-    return getBinningMEM_(_btype, _isMap, EcalEndcap, _axis);
-  default:
-    return AxisSpecs();
-  }
-}
+      switch (_otype) {
+        case kEB:
+          return getBinningEB_(_btype, _isMap, _axis);
+        case kEE:
+          return getBinningEE_(_btype, _isMap, 0, _axis);
+        case kEEm:
+          return getBinningEE_(_btype, _isMap, -1, _axis);
+        case kEEp:
+          return getBinningEE_(_btype, _isMap, 1, _axis);
+        case kSM:
+          return getBinningSM_(_btype, _isMap, _iME, _axis);
+        case kEBSM:
+          return getBinningSM_(_btype, _isMap, _iME + 9, _axis);
+        case kEESM:
+          if (_iME <= kEEmHigh)
+            return getBinningSM_(_btype, _isMap, _iME, _axis);
+          else
+            return getBinningSM_(_btype, _isMap, _iME + nEBDCC, _axis);
+        case kSMMEM:
+          return getBinningSMMEM_(_btype, _isMap, _iME, _axis);
+        case kEBSMMEM:
+          return getBinningSMMEM_(_btype, _isMap, _iME + nEEDCCMEM / 2, _axis);
+        case kEESMMEM:
+          if (_iME <= kEEmHigh)
+            return getBinningSMMEM_(_btype, _isMap, _iME, _axis);
+          else
+            return getBinningSMMEM_(_btype, _isMap, _iME + nEBDCC, _axis);
+        case kEcal:
+          return getBinningEcal_(_btype, _isMap, _axis);
+        case kMEM:
+          return getBinningMEM_(_btype, _isMap, -1, _axis);
+        case kEBMEM:
+          return getBinningMEM_(_btype, _isMap, EcalBarrel, _axis);
+        case kEEMEM:
+          return getBinningMEM_(_btype, _isMap, EcalEndcap, _axis);
+        default:
+          return AxisSpecs();
+      }
+    }
 
-int findBin1D(ObjectType _otype, BinningType _btype, const DetId &_id) {
-  switch (_otype) {
-  case kSM:
-  case kEBSM:
-  case kEESM:
-    if (_btype == kSuperCrystal)
-      return towerId(_id);
-    else if (_btype == kTriggerTower) {
-      unsigned tccid(tccId(_id));
-      if (tccid <= 36 || tccid >= 73) { // EE
-        unsigned bin(ttId(_id));
-        bool outer((tccid >= 19 && tccid <= 36) ||
-                   (tccid >= 73 && tccid <= 90));
-        // For the following, the constants nTTInner and nTTOuter are defined in
-        // EcalDQMCommonUtils.h.
-        if (outer)
-          bin += 2 * nTTInner; // For outer TCCs, sets bin number to increment
-        // by twice the number of TTs in inner TCCs, because numbering of bins
-        // is in the order (inner1, inner2, outer1, outer2).
-        // ("inner"" := closer to the beam)
-        bin += (tccid % 2) *
-               (outer ? nTTOuter : nTTInner); // Yields x-axis bin number
-        // in the format above; TTs in even-numbered TCCs are filled in inner1
-        // or outer1, and those in odd-numbered TCC are filled in inner2 and
-        // outer2.
-        return bin;
-      } else
-        return ttId(_id);
-    } else
-      break;
-  case kEcal:
-    if (_btype == kDCC)
-      return dccId(_id);
-    else if (_btype == kTCC)
-      return tccId(_id);
-    else
-      break;
-  case kEB:
-    if (_btype == kDCC)
-      return dccId(_id) - 9;
-    else if (_btype == kTCC)
-      return tccId(_id) - 36;
-    else
-      break;
-  case kEEm:
-    if (_btype == kDCC)
-      return dccId(_id);
-    else if (_btype == kTCC)
-      return tccId(_id);
-    else
-      break;
-  case kEEp:
-    if (_btype == kDCC)
-      return dccId(_id) - 45;
-    else if (_btype == kTCC)
-      return tccId(_id) - 72;
-    else
-      break;
-  case kEE:
-    if (_btype == kDCC) {
-      int bin(dccId(_id));
-      if (bin >= 46)
-        bin -= 36;
-      return bin;
-    } else if (_btype == kTCC) {
-      int bin(tccId(_id));
-      if (bin >= 72)
-        bin -= 36;
-      return bin;
-    } else
-      break;
-  case kSMMEM:
-  case kEBSMMEM:
-  case kEESMMEM:
-    if (_btype == kCrystal)
-      return EcalPnDiodeDetId(_id).iPnId();
-    else
-      break;
-  default:
-    break;
-  }
+    int findBin1D(ObjectType _otype, BinningType _btype, const DetId &_id) {
+      switch (_otype) {
+        case kSM:
+        case kEBSM:
+        case kEESM:
+          if (_btype == kSuperCrystal)
+            return towerId(_id);
+          else if (_btype == kTriggerTower) {
+            unsigned tccid(tccId(_id));
+            if (tccid <= 36 || tccid >= 73) {  // EE
+              unsigned bin(ttId(_id));
+              bool outer((tccid >= 19 && tccid <= 36) || (tccid >= 73 && tccid <= 90));
+              // For the following, the constants nTTInner and nTTOuter are defined in
+              // EcalDQMCommonUtils.h.
+              if (outer)
+                bin += 2 * nTTInner;  // For outer TCCs, sets bin number to increment
+              // by twice the number of TTs in inner TCCs, because numbering of bins
+              // is in the order (inner1, inner2, outer1, outer2).
+              // ("inner"" := closer to the beam)
+              bin += (tccid % 2) * (outer ? nTTOuter : nTTInner);  // Yields x-axis bin number
+              // in the format above; TTs in even-numbered TCCs are filled in inner1
+              // or outer1, and those in odd-numbered TCC are filled in inner2 and
+              // outer2.
+              return bin;
+            } else
+              return ttId(_id);
+          } else
+            break;
+        case kEcal:
+          if (_btype == kDCC)
+            return dccId(_id);
+          else if (_btype == kTCC)
+            return tccId(_id);
+          else
+            break;
+        case kEB:
+          if (_btype == kDCC)
+            return dccId(_id) - 9;
+          else if (_btype == kTCC)
+            return tccId(_id) - 36;
+          else
+            break;
+        case kEEm:
+          if (_btype == kDCC)
+            return dccId(_id);
+          else if (_btype == kTCC)
+            return tccId(_id);
+          else
+            break;
+        case kEEp:
+          if (_btype == kDCC)
+            return dccId(_id) - 45;
+          else if (_btype == kTCC)
+            return tccId(_id) - 72;
+          else
+            break;
+        case kEE:
+          if (_btype == kDCC) {
+            int bin(dccId(_id));
+            if (bin >= 46)
+              bin -= 36;
+            return bin;
+          } else if (_btype == kTCC) {
+            int bin(tccId(_id));
+            if (bin >= 72)
+              bin -= 36;
+            return bin;
+          } else
+            break;
+        case kSMMEM:
+        case kEBSMMEM:
+        case kEESMMEM:
+          if (_btype == kCrystal)
+            return EcalPnDiodeDetId(_id).iPnId();
+          else
+            break;
+        default:
+          break;
+      }
 
-  return 0;
-}
+      return 0;
+    }
 
-int findBin1D(ObjectType _otype, BinningType _btype,
-              const EcalElectronicsId &_id) {
-  switch (_otype) {
-  case kSM:
-  case kEBSM:
-  case kEESM:
-    if (_btype == kSuperCrystal)
-      return towerId(_id);
-    else if (_btype == kTriggerTower) {
-      unsigned tccid(tccId(_id));
-      if (tccid <= 36 || tccid >= 73) { // EE
-        unsigned bin(ttId(_id));
-        bool outer((tccid >= 19 && tccid <= 36) ||
-                   (tccid >= 73 && tccid <= 90));
-        // For the following, the constants nTTInner and nTTOuter are defined in
-        // EcalDQMCommonUtils.h.
-        if (outer)
-          bin += 2 * nTTInner; // For outer TCCs, sets bin number to increment
-        // by twice the number of TTs in inner TCCs, because numbering of bins
-        // is in the order (inner1, inner2, outer1, outer2).
-        // ("inner"" := closer to the beam)
-        bin += (tccid % 2) *
-               (outer ? nTTOuter : nTTInner); // Yields x-axis bin number
-        // in the format above; TTs in even-numbered TCCs are filled in inner1
-        // or outer1, and those in odd-numbered TCC are filled in inner2 and
-        // outer2.
-        return bin;
-      } else
-        return ttId(_id);
-    } else
-      break;
-  case kEcal:
-    if (_btype == kDCC)
-      return dccId(_id);
-    else if (_btype == kTCC)
-      return tccId(_id);
-    else
-      break;
-  case kEB:
-    if (_btype == kDCC)
-      return dccId(_id) - 9;
-    else if (_btype == kTCC)
-      return tccId(_id) - 36;
-    else
-      break;
-  case kEEm:
-    if (_btype == kDCC)
-      return dccId(_id);
-    else if (_btype == kTCC)
-      return tccId(_id);
-    else
-      break;
-  case kEEp:
-    if (_btype == kDCC)
-      return dccId(_id) - 45;
-    else if (_btype == kTCC)
-      return tccId(_id) - 72;
-    else
-      break;
-  case kEE:
-    if (_btype == kDCC) {
-      int bin(dccId(_id));
-      if (bin >= 46)
-        bin -= 36;
-      return bin;
-    } else if (_btype == kTCC) {
-      int bin(tccId(_id));
-      if (bin >= 72)
-        bin -= 36;
-      return bin;
-    } else
-      break;
-  default:
-    break;
-  }
+    int findBin1D(ObjectType _otype, BinningType _btype, const EcalElectronicsId &_id) {
+      switch (_otype) {
+        case kSM:
+        case kEBSM:
+        case kEESM:
+          if (_btype == kSuperCrystal)
+            return towerId(_id);
+          else if (_btype == kTriggerTower) {
+            unsigned tccid(tccId(_id));
+            if (tccid <= 36 || tccid >= 73) {  // EE
+              unsigned bin(ttId(_id));
+              bool outer((tccid >= 19 && tccid <= 36) || (tccid >= 73 && tccid <= 90));
+              // For the following, the constants nTTInner and nTTOuter are defined in
+              // EcalDQMCommonUtils.h.
+              if (outer)
+                bin += 2 * nTTInner;  // For outer TCCs, sets bin number to increment
+              // by twice the number of TTs in inner TCCs, because numbering of bins
+              // is in the order (inner1, inner2, outer1, outer2).
+              // ("inner"" := closer to the beam)
+              bin += (tccid % 2) * (outer ? nTTOuter : nTTInner);  // Yields x-axis bin number
+              // in the format above; TTs in even-numbered TCCs are filled in inner1
+              // or outer1, and those in odd-numbered TCC are filled in inner2 and
+              // outer2.
+              return bin;
+            } else
+              return ttId(_id);
+          } else
+            break;
+        case kEcal:
+          if (_btype == kDCC)
+            return dccId(_id);
+          else if (_btype == kTCC)
+            return tccId(_id);
+          else
+            break;
+        case kEB:
+          if (_btype == kDCC)
+            return dccId(_id) - 9;
+          else if (_btype == kTCC)
+            return tccId(_id) - 36;
+          else
+            break;
+        case kEEm:
+          if (_btype == kDCC)
+            return dccId(_id);
+          else if (_btype == kTCC)
+            return tccId(_id);
+          else
+            break;
+        case kEEp:
+          if (_btype == kDCC)
+            return dccId(_id) - 45;
+          else if (_btype == kTCC)
+            return tccId(_id) - 72;
+          else
+            break;
+        case kEE:
+          if (_btype == kDCC) {
+            int bin(dccId(_id));
+            if (bin >= 46)
+              bin -= 36;
+            return bin;
+          } else if (_btype == kTCC) {
+            int bin(tccId(_id));
+            if (bin >= 72)
+              bin -= 36;
+            return bin;
+          } else
+            break;
+        default:
+          break;
+      }
 
-  return 0;
-}
+      return 0;
+    }
 
-int findBin1D(ObjectType _otype, BinningType _btype, int _dcctccid) {
-  if (_otype == kEcal && _btype == kDCC)
-    return _dcctccid;
-  else if (_otype == kEcal && _btype == kTCC)
-    return _dcctccid;
-  if (_otype == kEB && _btype == kDCC)
-    return _dcctccid - 9;
-  else if (_otype == kEB && _btype == kTCC)
-    return _dcctccid - 36;
-  else if (_otype == kEEm && _btype == kDCC)
-    return _dcctccid;
-  else if (_otype == kEEm && _btype == kTCC)
-    return _dcctccid;
-  else if (_otype == kEEp && _btype == kDCC)
-    return _dcctccid - 45;
-  else if (_otype == kEEp && _btype == kTCC)
-    return _dcctccid - 72;
-  else if (_otype == kEE && _btype == kDCC)
-    return _dcctccid <= 9 ? _dcctccid : _dcctccid - 36;
-  else if (_otype == kEE && _btype == kTCC)
-    return _dcctccid <= 36 ? _dcctccid : _dcctccid - 36;
+    int findBin1D(ObjectType _otype, BinningType _btype, int _dcctccid) {
+      if (_otype == kEcal && _btype == kDCC)
+        return _dcctccid;
+      else if (_otype == kEcal && _btype == kTCC)
+        return _dcctccid;
+      if (_otype == kEB && _btype == kDCC)
+        return _dcctccid - 9;
+      else if (_otype == kEB && _btype == kTCC)
+        return _dcctccid - 36;
+      else if (_otype == kEEm && _btype == kDCC)
+        return _dcctccid;
+      else if (_otype == kEEm && _btype == kTCC)
+        return _dcctccid;
+      else if (_otype == kEEp && _btype == kDCC)
+        return _dcctccid - 45;
+      else if (_otype == kEEp && _btype == kTCC)
+        return _dcctccid - 72;
+      else if (_otype == kEE && _btype == kDCC)
+        return _dcctccid <= 9 ? _dcctccid : _dcctccid - 36;
+      else if (_otype == kEE && _btype == kTCC)
+        return _dcctccid <= 36 ? _dcctccid : _dcctccid - 36;
 
-  return 0;
-}
+      return 0;
+    }
 
-int findBin2D(ObjectType _otype, BinningType _btype, const DetId &_id) {
-  if (_otype >= nObjType || _btype >= unsigned(nPresetBinnings))
-    return 0;
+    int findBin2D(ObjectType _otype, BinningType _btype, const DetId &_id) {
+      if (_otype >= nObjType || _btype >= unsigned(nPresetBinnings))
+        return 0;
 
-  switch (_btype) {
-  case kCrystal:
-    return findBinCrystal_(_otype, _id);
-    break;
-  case kTriggerTower:
-    return findBinTriggerTower_(_otype, _id);
-    break;
-  case kSuperCrystal:
-    return findBinSuperCrystal_(_otype, _id);
-    break;
-  case kPseudoStrip:
-    return findBinPseudoStrip_(_otype, _id);
-    break;
-  case kRCT:
-    return findBinRCT_(_otype, _id);
-    break;
-  default:
-    return 0;
-  }
-}
-
-int findBin2D(ObjectType _otype, BinningType _btype,
-              const EcalElectronicsId &_id) {
-  if (_otype >= nObjType || _btype >= unsigned(nPresetBinnings))
-    return 0;
-
-  switch (_btype) {
-  case kCrystal:
-    return findBinCrystal_(_otype, _id);
-    break;
-  case kSuperCrystal:
-    return findBinSuperCrystal_(_otype, _id);
-    break;
-  default:
-    return 0;
-  }
-}
-
-int findBin2D(ObjectType _otype, BinningType _btype, int _dccid) {
-  if (_otype != kEcal || _btype != kDCC)
-    return 0;
-
-  int nbinsX(9);
-  unsigned iDCC(_dccid - 1);
-  int xbin(0);
-  if (iDCC <= kEEmHigh || iDCC >= kEEpLow)
-    xbin = (iDCC + 6) % nbinsX + 1;
-  else
-    xbin = iDCC % nbinsX + 1;
-  int ybin(6 - iDCC / nbinsX);
-
-  return (nbinsX + 2) * ybin + xbin;
-}
-
-unsigned findPlotIndex(ObjectType _otype, const DetId &_id) {
-  if (getNObjects(_otype) == 1)
-    return 0;
-
-  switch (_otype) {
-  case kEcal3P:
-    if (_id.subdetId() == EcalBarrel)
-      return 1;
-    else if (_id.subdetId() == EcalEndcap && zside(_id) > 0)
-      return 2;
-    else if (_id.subdetId() == EcalTriggerTower) {
-      if (!isEndcapTTId(_id))
-        return 1;
-      else {
-        if (zside(_id) > 0)
-          return 2;
-        else
+      switch (_btype) {
+        case kCrystal:
+          return findBinCrystal_(_otype, _id);
+          break;
+        case kTriggerTower:
+          return findBinTriggerTower_(_otype, _id);
+          break;
+        case kSuperCrystal:
+          return findBinSuperCrystal_(_otype, _id);
+          break;
+        case kPseudoStrip:
+          return findBinPseudoStrip_(_otype, _id);
+          break;
+        case kRCT:
+          return findBinRCT_(_otype, _id);
+          break;
+        default:
           return 0;
       }
-    } else
-      return 0;
-
-  case kEcal2P:
-    if (_id.subdetId() == EcalBarrel)
-      return 1;
-    else if (_id.subdetId() == EcalTriggerTower && !isEndcapTTId(_id))
-      return 1;
-    else
-      return 0;
-
-  case kEE2P:
-    if (zside(_id) > 0)
-      return 1;
-    else
-      return 0;
-
-  case kMEM2P:
-    if (_id.subdetId() == EcalLaserPnDiode) {
-      unsigned iDCC(dccId(_id) - 1);
-      if (iDCC >= kEBmLow && iDCC <= kEBpHigh)
-        return 1;
-      else
-        return 0;
-    } else
-      return -1;
-
-  default:
-    return findPlotIndex(_otype, dccId(_id));
-  }
-}
-
-unsigned findPlotIndex(ObjectType _otype, const EcalElectronicsId &_id) {
-  if (getNObjects(_otype) == 1)
-    return 0;
-
-  return findPlotIndex(_otype, _id.dccId());
-}
-
-unsigned findPlotIndex(ObjectType _otype, int _dcctccid,
-                       BinningType _btype /* = kDCC*/) {
-  if (getNObjects(_otype) == 1)
-    return 0;
-
-  int iSM(_dcctccid - 1);
-
-  switch (_otype) {
-  case kSM:
-    if (_btype == kPseudoStrip) {
-      iSM = iSM <= kEEmTCCHigh
-                ? (iSM + 1) % 18 / 2
-                : iSM >= kEEpTCCLow ? (iSM + 1 - 72) % 18 / 2 + 45
-                                    : (iSM + 1) - kEEmTCCHigh;
-      return iSM;
-    } else
-      return iSM;
-
-  case kEBSM:
-    return iSM - 9;
-
-  case kEESM:
-    if (iSM <= kEEmHigh)
-      return iSM;
-    else
-      return iSM - nEBDCC;
-
-  case kSMMEM:
-    return memDCCIndex(_dcctccid);
-
-  case kEBSMMEM:
-    return memDCCIndex(_dcctccid) - nEEDCCMEM / 2;
-
-  case kEESMMEM:
-    if (iSM <= kEEmHigh)
-      return memDCCIndex(_dcctccid);
-    else
-      return memDCCIndex(_dcctccid) - nEBDCC;
-
-  case kEcal2P:
-    if (_btype == kDCC) {
-      if (iSM <= kEEmHigh || iSM >= kEEpLow)
-        return 0;
-      else
-        return 1;
-    } else if (_btype == kTCC) {
-      if (iSM <= kEEmTCCHigh || iSM >= kEEpTCCLow)
-        return 0;
-      else
-        return 1;
-    } else {
-      if (iSM == EcalBarrel - 1)
-        return 1;
-      else
-        return 0;
     }
 
-  case kEcal3P:
-    if (_btype == kDCC) {
-      if (iSM <= kEEmHigh)
+    int findBin2D(ObjectType _otype, BinningType _btype, const EcalElectronicsId &_id) {
+      if (_otype >= nObjType || _btype >= unsigned(nPresetBinnings))
         return 0;
-      else if (iSM <= kEBpHigh)
-        return 1;
-      else
-        return 2;
-    } else if (_btype == kTCC) {
-      if (iSM <= kEEmTCCHigh)
-        return 0;
-      else if (iSM <= kEBTCCHigh)
-        return 1;
-      else
-        return 2;
-    } else {
-      if (iSM == -EcalEndcap - 1)
-        return 0;
-      else if (iSM == EcalBarrel - 1)
-        return 1;
-      else
-        return 2;
-    }
 
-  case kEE2P:
-    if (_btype == kDCC) {
-      if (iSM >= kEEpLow)
-        return 1;
-      else
-        return 0;
-    } else {
-      if (iSM >= kEEpTCCLow)
-        return 1;
-      else
-        return 0;
-    }
-
-  case kMEM2P:
-    if (_btype == kDCC) {
-      if (iSM <= kEEmHigh || iSM >= kEEpLow)
-        return 0;
-      else
-        return 1;
-    } else if (_btype == kTCC)
-      return -1;
-    else {
-      if (iSM == kEB)
-        return 1;
-      else
-        return 0;
-    }
-  default:
-    return -1;
-  }
-}
-
-ObjectType getObject(ObjectType _otype, unsigned _iObj) {
-  switch (_otype) {
-  case kEcal3P:
-    switch (_iObj) {
-    case 0:
-      return kEEm;
-    case 1:
-      return kEB;
-    case 2:
-      return kEEp;
-    default:
-      return nObjType;
-    }
-  case kEcal2P:
-    switch (_iObj) {
-    case 0:
-      return kEE;
-    case 1:
-      return kEB;
-    default:
-      return nObjType;
-    }
-  case kEE2P:
-    switch (_iObj) {
-    case 0:
-      return kEEm;
-    case 1:
-      return kEEp;
-    default:
-      return nObjType;
-    }
-  case kMEM2P:
-    switch (_iObj) {
-    case 0:
-      return kEEMEM;
-    case 1:
-      return kEBMEM;
-    default:
-      return nObjType;
-    }
-  default:
-    return _otype;
-  }
-}
-
-unsigned getNObjects(ObjectType _otype) {
-  switch (_otype) {
-  case kSM:
-    return nDCC;
-  case kEBSM:
-    return nEBDCC;
-  case kEESM:
-    return nEEDCC;
-  case kSMMEM:
-    return nDCCMEM;
-  case kEBSMMEM:
-    return nEBDCC;
-  case kEESMMEM:
-    return nEEDCCMEM;
-  case kEcal2P:
-    return 2;
-  case kEcal3P:
-    return 3;
-  case kEE2P:
-    return 2;
-  case kMEM2P:
-    return 2;
-  default:
-    return 1;
-  }
-}
-
-bool isValidIdBin(ObjectType _otype, BinningType _btype, unsigned _iME,
-                  int _bin) {
-  if (_otype == kEEm || _otype == kEEp) {
-    if (_btype == kCrystal || _btype == kTriggerTower)
-      return EEDetId::validDetId(_bin % 102, _bin / 102, 1);
-    else if (_btype == kSuperCrystal)
-      return EcalScDetId::validDetId(_bin % 22, _bin / 22, 1);
-  } else if (_otype == kEE) {
-    if (_btype == kCrystal || _btype == kTriggerTower) {
-      int ix(_bin % 202);
-      if (ix > 100)
-        ix = (ix - 100) % 101;
-      return EEDetId::validDetId(ix, _bin / 202, 1);
-    } else if (_btype == kSuperCrystal) {
-      int ix(_bin % 42);
-      if (ix > 20)
-        ix = (ix - 20) % 21;
-      return EcalScDetId::validDetId(ix, _bin / 42, 1);
-    }
-  } else if (_otype == kSM || _otype == kEESM) {
-    unsigned iSM(_iME);
-    if (_otype == kEESM && iSM > kEEmHigh)
-      iSM += nEBDCC;
-
-    if (iSM >= kEBmLow && iSM <= kEBpHigh)
-      return true;
-
-    if (_btype == kCrystal || _btype == kTriggerTower) {
-      int nX(nEESMX);
-      if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
-        nX = nEESMXExt;
-      if (iSM == kEEm01 || iSM == kEEm05 || iSM == kEEm09 || iSM == kEEp01 ||
-          iSM == kEEp05 || iSM == kEEp09)
-        nX = nEESMXRed;
-      int ix(_bin % (nX + 2) + xlow_(iSM));
-      int iy(_bin / (nX + 2) + ylow_(iSM));
-      int z(iSM <= kEEmHigh ? -1 : 1);
-      return EEDetId::validDetId(ix, iy, 1) &&
-             iSM == dccId(EEDetId(ix, iy, z)) - 1;
-    } else if (_btype == kSuperCrystal) {
-      int nX(nEESMX / 5);
-      if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
-        nX = nEESMXExt / 5;
-      if (iSM == kEEm01 || iSM == kEEm05 || iSM == kEEm09 || iSM == kEEp01 ||
-          iSM == kEEp05 || iSM == kEEp09)
-        nX = nEESMXRed / 5;
-      int ix(_bin % (nX + 2) + xlow_(iSM) / 5);
-      int iy(_bin / (nX + 2) + ylow_(iSM) / 5);
-      int z(iSM <= kEEmHigh ? -1 : 1);
-      return EcalScDetId::validDetId(ix, iy, z) &&
-             iSM == dccId(EcalScDetId(ix, iy, z)) - 1;
-    }
-  }
-
-  return true;
-}
-
-std::string channelName(uint32_t _rawId, BinningType _btype /* = kDCC*/) {
-  // assume the following IDs for respective binning types:
-  // Crystal: EcalElectronicsId
-  // TriggerTower: EcalTriggerElectronicsId (pstrip and channel ignored)
-  // SuperCrystal: EcalElectronicsId (strip and crystal ignored)
-  // TCC: TCC ID
-  // DCC: DCC ID
-
-  std::stringstream ss;
-
-  switch (_btype) {
-  case kCrystal: {
-    // EB-03 DCC 12 CCU 12 strip 3 xtal 1 (EB ieta -13 iphi 60) (TCC 39 TT 12
-    // pstrip 3 chan 1)
-    EcalElectronicsId eid(_rawId);
-    if (eid.towerId() >= 69)
-      ss << smName(eid.dccId()) << " DCC " << eid.dccId() << " CCU "
-         << eid.towerId() << " PN " << eid.xtalId();
-    else {
-      ss << smName(eid.dccId()) << " DCC " << eid.dccId() << " CCU "
-         << eid.towerId() << " strip " << eid.stripId() << " xtal "
-         << eid.xtalId();
-
-      if (eid.dccId() >= kEBmLow + 1 && eid.dccId() <= kEBpHigh + 1) {
-        EBDetId ebid(getElectronicsMap()->getDetId(eid));
-        ss << " (EB ieta " << std::showpos << ebid.ieta() << std::noshowpos
-           << " iphi " << ebid.iphi() << ")";
-      } else {
-        EEDetId eeid(getElectronicsMap()->getDetId(eid));
-        ss << " (EE ix " << eeid.ix() << " iy " << eeid.iy() << ")";
+      switch (_btype) {
+        case kCrystal:
+          return findBinCrystal_(_otype, _id);
+          break;
+        case kSuperCrystal:
+          return findBinSuperCrystal_(_otype, _id);
+          break;
+        default:
+          return 0;
       }
-      EcalTriggerElectronicsId teid(
-          getElectronicsMap()->getTriggerElectronicsId(eid));
-      ss << " (TCC " << teid.tccId() << " TT " << teid.ttId() << " pstrip "
-         << teid.pseudoStripId() << " chan " << teid.channelId() << ")";
-      break;
     }
-  }
-  case kTriggerTower: {
-    // EB-03 DCC 12 TCC 18 TT 3
-    EcalTriggerElectronicsId teid(_rawId);
-    EcalElectronicsId eid(getElectronicsMap()->getElectronicsId(teid));
-    ss << smName(eid.dccId()) << " DCC " << eid.dccId() << " TCC "
-       << teid.tccId() << " TT " << teid.ttId();
-    break;
-  }
-  case kSuperCrystal: {
-    // EB-03 DCC 12 CCU 18 (EBTT ieta -13 iphi 60)
-    EcalElectronicsId eid(_rawId);
-    ss << smName(eid.dccId()) << " DCC " << eid.dccId() << " CCU "
-       << eid.towerId();
-    if (eid.dccId() >= kEBmLow + 1 && eid.dccId() <= kEBpHigh + 1) {
-      EcalTrigTowerDetId ttid(
-          EBDetId(getElectronicsMap()->getDetId(eid)).tower());
-      ss << " (EBTT ieta " << std::showpos << ttid.ieta() << std::noshowpos
-         << " iphi " << ttid.iphi() << ")";
-    } else {
-      EcalScDetId scid(EEDetId(getElectronicsMap()->getDetId(eid)).sc());
-      ss << " (EESC ix " << scid.ix() << " iy " << scid.iy() << ")";
-    }
-    break;
-  }
-  case kTCC: {
-    // EB-03 TCC 12
-    int tccid(_rawId - nDCC);
-    int dccid(getElectronicsMap()->DCCid(
-        getElectronicsMap()->getTrigTowerDetId(tccid, 1)));
-    ss << smName(dccid) << " TCC " << (_rawId - nDCC);
-    break;
-  }
-  case kDCC:
-    ss << smName(_rawId);
-    break;
-  default:
-    break;
-  }
 
-  return ss.str();
-}
+    int findBin2D(ObjectType _otype, BinningType _btype, int _dccid) {
+      if (_otype != kEcal || _btype != kDCC)
+        return 0;
 
-uint32_t idFromName(std::string const &_name) {
-  TString name(_name);
-  TPRegexp re("(EB|EE)([+-][0-9][0-9])(?: TCC ([0-9]+)| DCC ([0-9]+) (CCU|TCC) "
-              "([0-9]+)(?: (TT|strip|PN) ([0-9]+)(?: xtal ([0-9]+)|)|)|)");
-  //            1      2                       3             4        5 6 7 8 9
-  uint32_t rawId(0);
-
-  TObjArray *matches(re.MatchS(name));
-  matches->SetOwner(true);
-  if (matches->GetEntries() == 0)
-    return 0;
-  else if (matches->GetEntries() == 3) {
-    TString subdet(static_cast<TObjString *>(matches->At(1))->GetString());
-    if (subdet == "EB") {
-      int dccid(static_cast<TObjString *>(matches->At(2))->GetString().Atoi());
-      unsigned offset(0);
-      if (dccid < 0) {
-        dccid *= -1;
-        offset = kEEmLow;
-      } else
-        offset = kEEpLow;
-      rawId = (dccid + 2) % 9 + 1 + offset;
-    } else {
-      int dccid(static_cast<TObjString *>(matches->At(2))->GetString().Atoi());
-      if (dccid < 0)
-        dccid *= -1;
+      int nbinsX(9);
+      unsigned iDCC(_dccid - 1);
+      int xbin(0);
+      if (iDCC <= kEEmHigh || iDCC >= kEEpLow)
+        xbin = (iDCC + 6) % nbinsX + 1;
       else
-        dccid += 18;
-      rawId = kEBmLow + dccid;
+        xbin = iDCC % nbinsX + 1;
+      int ybin(6 - iDCC / nbinsX);
+
+      return (nbinsX + 2) * ybin + xbin;
     }
-  } else if (matches->GetEntries() == 4)
-    rawId =
-        static_cast<TObjString *>(matches->At(3))->GetString().Atoi() + nDCC;
-  else {
-    TString subtype(static_cast<TObjString *>(matches->At(5))->GetString());
-    if (subtype == "TCC") {
-      int tccid(static_cast<TObjString *>(matches->At(6))->GetString().Atoi());
-      int ttid(static_cast<TObjString *>(matches->At(8))->GetString().Atoi());
-      rawId = EcalTriggerElectronicsId(tccid, ttid, 1, 1).rawId();
-    } else {
-      int dccid(static_cast<TObjString *>(matches->At(4))->GetString().Atoi());
-      int towerid(
-          static_cast<TObjString *>(matches->At(6))->GetString().Atoi());
-      if (matches->GetEntries() == 7)
-        rawId = EcalElectronicsId(dccid, towerid, 1, 1).rawId();
-      else {
-        TString chType(static_cast<TObjString *>(matches->At(7))->GetString());
-        int stripOrPNid(
-            static_cast<TObjString *>(matches->At(8))->GetString().Atoi());
-        if (chType == "PN")
-          rawId = EcalElectronicsId(dccid, towerid, 1, stripOrPNid).rawId();
-        else if (chType == "strip") {
-          int xtalid(
-              static_cast<TObjString *>(matches->At(9))->GetString().Atoi());
-          rawId =
-              EcalElectronicsId(dccid, towerid, stripOrPNid, xtalid).rawId();
+
+    unsigned findPlotIndex(ObjectType _otype, const DetId &_id) {
+      if (getNObjects(_otype) == 1)
+        return 0;
+
+      switch (_otype) {
+        case kEcal3P:
+          if (_id.subdetId() == EcalBarrel)
+            return 1;
+          else if (_id.subdetId() == EcalEndcap && zside(_id) > 0)
+            return 2;
+          else if (_id.subdetId() == EcalTriggerTower) {
+            if (!isEndcapTTId(_id))
+              return 1;
+            else {
+              if (zside(_id) > 0)
+                return 2;
+              else
+                return 0;
+            }
+          } else
+            return 0;
+
+        case kEcal2P:
+          if (_id.subdetId() == EcalBarrel)
+            return 1;
+          else if (_id.subdetId() == EcalTriggerTower && !isEndcapTTId(_id))
+            return 1;
+          else
+            return 0;
+
+        case kEE2P:
+          if (zside(_id) > 0)
+            return 1;
+          else
+            return 0;
+
+        case kMEM2P:
+          if (_id.subdetId() == EcalLaserPnDiode) {
+            unsigned iDCC(dccId(_id) - 1);
+            if (iDCC >= kEBmLow && iDCC <= kEBpHigh)
+              return 1;
+            else
+              return 0;
+          } else
+            return -1;
+
+        default:
+          return findPlotIndex(_otype, dccId(_id));
+      }
+    }
+
+    unsigned findPlotIndex(ObjectType _otype, const EcalElectronicsId &_id) {
+      if (getNObjects(_otype) == 1)
+        return 0;
+
+      return findPlotIndex(_otype, _id.dccId());
+    }
+
+    unsigned findPlotIndex(ObjectType _otype, int _dcctccid, BinningType _btype /* = kDCC*/) {
+      if (getNObjects(_otype) == 1)
+        return 0;
+
+      int iSM(_dcctccid - 1);
+
+      switch (_otype) {
+        case kSM:
+          if (_btype == kPseudoStrip) {
+            iSM = iSM <= kEEmTCCHigh ? (iSM + 1) % 18 / 2
+                                     : iSM >= kEEpTCCLow ? (iSM + 1 - 72) % 18 / 2 + 45 : (iSM + 1) - kEEmTCCHigh;
+            return iSM;
+          } else
+            return iSM;
+
+        case kEBSM:
+          return iSM - 9;
+
+        case kEESM:
+          if (iSM <= kEEmHigh)
+            return iSM;
+          else
+            return iSM - nEBDCC;
+
+        case kSMMEM:
+          return memDCCIndex(_dcctccid);
+
+        case kEBSMMEM:
+          return memDCCIndex(_dcctccid) - nEEDCCMEM / 2;
+
+        case kEESMMEM:
+          if (iSM <= kEEmHigh)
+            return memDCCIndex(_dcctccid);
+          else
+            return memDCCIndex(_dcctccid) - nEBDCC;
+
+        case kEcal2P:
+          if (_btype == kDCC) {
+            if (iSM <= kEEmHigh || iSM >= kEEpLow)
+              return 0;
+            else
+              return 1;
+          } else if (_btype == kTCC) {
+            if (iSM <= kEEmTCCHigh || iSM >= kEEpTCCLow)
+              return 0;
+            else
+              return 1;
+          } else {
+            if (iSM == EcalBarrel - 1)
+              return 1;
+            else
+              return 0;
+          }
+
+        case kEcal3P:
+          if (_btype == kDCC) {
+            if (iSM <= kEEmHigh)
+              return 0;
+            else if (iSM <= kEBpHigh)
+              return 1;
+            else
+              return 2;
+          } else if (_btype == kTCC) {
+            if (iSM <= kEEmTCCHigh)
+              return 0;
+            else if (iSM <= kEBTCCHigh)
+              return 1;
+            else
+              return 2;
+          } else {
+            if (iSM == -EcalEndcap - 1)
+              return 0;
+            else if (iSM == EcalBarrel - 1)
+              return 1;
+            else
+              return 2;
+          }
+
+        case kEE2P:
+          if (_btype == kDCC) {
+            if (iSM >= kEEpLow)
+              return 1;
+            else
+              return 0;
+          } else {
+            if (iSM >= kEEpTCCLow)
+              return 1;
+            else
+              return 0;
+          }
+
+        case kMEM2P:
+          if (_btype == kDCC) {
+            if (iSM <= kEEmHigh || iSM >= kEEpLow)
+              return 0;
+            else
+              return 1;
+          } else if (_btype == kTCC)
+            return -1;
+          else {
+            if (iSM == kEB)
+              return 1;
+            else
+              return 0;
+          }
+        default:
+          return -1;
+      }
+    }
+
+    ObjectType getObject(ObjectType _otype, unsigned _iObj) {
+      switch (_otype) {
+        case kEcal3P:
+          switch (_iObj) {
+            case 0:
+              return kEEm;
+            case 1:
+              return kEB;
+            case 2:
+              return kEEp;
+            default:
+              return nObjType;
+          }
+        case kEcal2P:
+          switch (_iObj) {
+            case 0:
+              return kEE;
+            case 1:
+              return kEB;
+            default:
+              return nObjType;
+          }
+        case kEE2P:
+          switch (_iObj) {
+            case 0:
+              return kEEm;
+            case 1:
+              return kEEp;
+            default:
+              return nObjType;
+          }
+        case kMEM2P:
+          switch (_iObj) {
+            case 0:
+              return kEEMEM;
+            case 1:
+              return kEBMEM;
+            default:
+              return nObjType;
+          }
+        default:
+          return _otype;
+      }
+    }
+
+    unsigned getNObjects(ObjectType _otype) {
+      switch (_otype) {
+        case kSM:
+          return nDCC;
+        case kEBSM:
+          return nEBDCC;
+        case kEESM:
+          return nEEDCC;
+        case kSMMEM:
+          return nDCCMEM;
+        case kEBSMMEM:
+          return nEBDCC;
+        case kEESMMEM:
+          return nEEDCCMEM;
+        case kEcal2P:
+          return 2;
+        case kEcal3P:
+          return 3;
+        case kEE2P:
+          return 2;
+        case kMEM2P:
+          return 2;
+        default:
+          return 1;
+      }
+    }
+
+    bool isValidIdBin(ObjectType _otype, BinningType _btype, unsigned _iME, int _bin) {
+      if (_otype == kEEm || _otype == kEEp) {
+        if (_btype == kCrystal || _btype == kTriggerTower)
+          return EEDetId::validDetId(_bin % 102, _bin / 102, 1);
+        else if (_btype == kSuperCrystal)
+          return EcalScDetId::validDetId(_bin % 22, _bin / 22, 1);
+      } else if (_otype == kEE) {
+        if (_btype == kCrystal || _btype == kTriggerTower) {
+          int ix(_bin % 202);
+          if (ix > 100)
+            ix = (ix - 100) % 101;
+          return EEDetId::validDetId(ix, _bin / 202, 1);
+        } else if (_btype == kSuperCrystal) {
+          int ix(_bin % 42);
+          if (ix > 20)
+            ix = (ix - 20) % 21;
+          return EcalScDetId::validDetId(ix, _bin / 42, 1);
         }
-        // case "TT" is already taken care of
+      } else if (_otype == kSM || _otype == kEESM) {
+        unsigned iSM(_iME);
+        if (_otype == kEESM && iSM > kEEmHigh)
+          iSM += nEBDCC;
+
+        if (iSM >= kEBmLow && iSM <= kEBpHigh)
+          return true;
+
+        if (_btype == kCrystal || _btype == kTriggerTower) {
+          int nX(nEESMX);
+          if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
+            nX = nEESMXExt;
+          if (iSM == kEEm01 || iSM == kEEm05 || iSM == kEEm09 || iSM == kEEp01 || iSM == kEEp05 || iSM == kEEp09)
+            nX = nEESMXRed;
+          int ix(_bin % (nX + 2) + xlow_(iSM));
+          int iy(_bin / (nX + 2) + ylow_(iSM));
+          int z(iSM <= kEEmHigh ? -1 : 1);
+          return EEDetId::validDetId(ix, iy, 1) && iSM == dccId(EEDetId(ix, iy, z)) - 1;
+        } else if (_btype == kSuperCrystal) {
+          int nX(nEESMX / 5);
+          if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
+            nX = nEESMXExt / 5;
+          if (iSM == kEEm01 || iSM == kEEm05 || iSM == kEEm09 || iSM == kEEp01 || iSM == kEEp05 || iSM == kEEp09)
+            nX = nEESMXRed / 5;
+          int ix(_bin % (nX + 2) + xlow_(iSM) / 5);
+          int iy(_bin / (nX + 2) + ylow_(iSM) / 5);
+          int z(iSM <= kEEmHigh ? -1 : 1);
+          return EcalScDetId::validDetId(ix, iy, z) && iSM == dccId(EcalScDetId(ix, iy, z)) - 1;
+        }
       }
+
+      return true;
     }
-  }
 
-  delete matches;
+    std::string channelName(uint32_t _rawId, BinningType _btype /* = kDCC*/) {
+      // assume the following IDs for respective binning types:
+      // Crystal: EcalElectronicsId
+      // TriggerTower: EcalTriggerElectronicsId (pstrip and channel ignored)
+      // SuperCrystal: EcalElectronicsId (strip and crystal ignored)
+      // TCC: TCC ID
+      // DCC: DCC ID
 
-  return rawId;
-}
+      std::stringstream ss;
 
-uint32_t idFromBin(ObjectType _otype, BinningType _btype, unsigned _iME,
-                   int _bin) {
-  if (_otype == kEB) {
-    if (_btype == kCrystal) {
-      int ieta(_bin / 362 - 86);
-      if (ieta >= 0)
-        ++ieta;
-      return EBDetId(ieta, _bin % 362);
-    } else if (_btype == kTriggerTower || _btype == kSuperCrystal) {
-      int ieta(_bin / 74 - 17);
-      int z(1);
-      if (ieta <= 0) {
-        z = -1;
-        ieta = -ieta + 1;
+      switch (_btype) {
+        case kCrystal: {
+          // EB-03 DCC 12 CCU 12 strip 3 xtal 1 (EB ieta -13 iphi 60) (TCC 39 TT 12
+          // pstrip 3 chan 1)
+          EcalElectronicsId eid(_rawId);
+          if (eid.towerId() >= 69)
+            ss << smName(eid.dccId()) << " DCC " << eid.dccId() << " CCU " << eid.towerId() << " PN " << eid.xtalId();
+          else {
+            ss << smName(eid.dccId()) << " DCC " << eid.dccId() << " CCU " << eid.towerId() << " strip "
+               << eid.stripId() << " xtal " << eid.xtalId();
+
+            if (eid.dccId() >= kEBmLow + 1 && eid.dccId() <= kEBpHigh + 1) {
+              EBDetId ebid(getElectronicsMap()->getDetId(eid));
+              ss << " (EB ieta " << std::showpos << ebid.ieta() << std::noshowpos << " iphi " << ebid.iphi() << ")";
+            } else {
+              EEDetId eeid(getElectronicsMap()->getDetId(eid));
+              ss << " (EE ix " << eeid.ix() << " iy " << eeid.iy() << ")";
+            }
+            EcalTriggerElectronicsId teid(getElectronicsMap()->getTriggerElectronicsId(eid));
+            ss << " (TCC " << teid.tccId() << " TT " << teid.ttId() << " pstrip " << teid.pseudoStripId() << " chan "
+               << teid.channelId() << ")";
+            break;
+          }
+        }
+        case kTriggerTower: {
+          // EB-03 DCC 12 TCC 18 TT 3
+          EcalTriggerElectronicsId teid(_rawId);
+          EcalElectronicsId eid(getElectronicsMap()->getElectronicsId(teid));
+          ss << smName(eid.dccId()) << " DCC " << eid.dccId() << " TCC " << teid.tccId() << " TT " << teid.ttId();
+          break;
+        }
+        case kSuperCrystal: {
+          // EB-03 DCC 12 CCU 18 (EBTT ieta -13 iphi 60)
+          EcalElectronicsId eid(_rawId);
+          ss << smName(eid.dccId()) << " DCC " << eid.dccId() << " CCU " << eid.towerId();
+          if (eid.dccId() >= kEBmLow + 1 && eid.dccId() <= kEBpHigh + 1) {
+            EcalTrigTowerDetId ttid(EBDetId(getElectronicsMap()->getDetId(eid)).tower());
+            ss << " (EBTT ieta " << std::showpos << ttid.ieta() << std::noshowpos << " iphi " << ttid.iphi() << ")";
+          } else {
+            EcalScDetId scid(EEDetId(getElectronicsMap()->getDetId(eid)).sc());
+            ss << " (EESC ix " << scid.ix() << " iy " << scid.iy() << ")";
+          }
+          break;
+        }
+        case kTCC: {
+          // EB-03 TCC 12
+          int tccid(_rawId - nDCC);
+          int dccid(getElectronicsMap()->DCCid(getElectronicsMap()->getTrigTowerDetId(tccid, 1)));
+          ss << smName(dccid) << " TCC " << (_rawId - nDCC);
+          break;
+        }
+        case kDCC:
+          ss << smName(_rawId);
+          break;
+        default:
+          break;
       }
-      return EcalTrigTowerDetId(z, EcalBarrel, ieta, (_bin % 74 + 69) % 72 + 1);
-    }
-  } else if (_otype == kEEm || _otype == kEEp) {
-    int z(_otype == kEEm ? -1 : 1);
-    if (_btype == kCrystal || _btype == kTriggerTower)
-      return EEDetId(_bin % 102, _bin / 102, z).rawId();
-    else if (_btype == kSuperCrystal)
-      return EcalScDetId(_bin % 22, _bin / 22, z).rawId();
-  } else if (_otype == kEE) {
-    if (_btype == kCrystal || _btype == kTriggerTower) {
-      int ix(_bin % 202);
-      int z(ix > 100 ? 1 : -1);
-      if (z > 0)
-        ix = (ix - 100) % 101;
-      return EEDetId(ix, _bin / 202, z).rawId();
-    } else if (_btype == kSuperCrystal) {
-      int ix(_bin % 42);
-      int z(ix > 20 ? 1 : -1);
-      if (z > 0)
-        ix = (ix - 20) % 21;
-      return EcalScDetId(ix, _bin / 42, z).rawId();
-    }
-  } else if (_otype == kSM || _otype == kEBSM || _otype == kEESM) {
-    unsigned iSM(_iME);
-    if (_otype == kEBSM)
-      iSM += 9;
-    else if (_otype == kEESM && iSM > kEEmHigh)
-      iSM += nEBDCC;
 
-    int z(iSM <= kEBmHigh ? -1 : 1);
+      return ss.str();
+    }
 
-    if ((iSM >= kEBmLow && iSM <= kEBmHigh) ||
-        (iSM >= kEBpLow && iSM <= kEBpHigh)) {
-      if (_btype == kCrystal) {
-        int iphi(((iSM - 9) % 18) * 20 + (z < 0 ? _bin / 87 : 21 - _bin / 87));
-        int ieta((_bin % 87) * z);
-        return EBDetId(ieta, iphi).rawId();
-      } else if (_btype == kTriggerTower || _btype == kSuperCrystal) {
-        int iphi(
-            (((iSM - 9) % 18) * 4 + (z < 0 ? _bin / 19 : 5 - _bin / 19) + 69) %
-                72 +
-            1);
-        int ieta(_bin % 19);
-        return EcalTrigTowerDetId(z, EcalBarrel, ieta, iphi).rawId();
+    uint32_t idFromName(std::string const &_name) {
+      TString name(_name);
+      TPRegexp re(
+          "(EB|EE)([+-][0-9][0-9])(?: TCC ([0-9]+)| DCC ([0-9]+) (CCU|TCC) "
+          "([0-9]+)(?: (TT|strip|PN) ([0-9]+)(?: xtal ([0-9]+)|)|)|)");
+      //            1      2                       3             4        5 6 7 8 9
+      uint32_t rawId(0);
+
+      TObjArray *matches(re.MatchS(name));
+      matches->SetOwner(true);
+      if (matches->GetEntries() == 0)
+        return 0;
+      else if (matches->GetEntries() == 3) {
+        TString subdet(static_cast<TObjString *>(matches->At(1))->GetString());
+        if (subdet == "EB") {
+          int dccid(static_cast<TObjString *>(matches->At(2))->GetString().Atoi());
+          unsigned offset(0);
+          if (dccid < 0) {
+            dccid *= -1;
+            offset = kEEmLow;
+          } else
+            offset = kEEpLow;
+          rawId = (dccid + 2) % 9 + 1 + offset;
+        } else {
+          int dccid(static_cast<TObjString *>(matches->At(2))->GetString().Atoi());
+          if (dccid < 0)
+            dccid *= -1;
+          else
+            dccid += 18;
+          rawId = kEBmLow + dccid;
+        }
+      } else if (matches->GetEntries() == 4)
+        rawId = static_cast<TObjString *>(matches->At(3))->GetString().Atoi() + nDCC;
+      else {
+        TString subtype(static_cast<TObjString *>(matches->At(5))->GetString());
+        if (subtype == "TCC") {
+          int tccid(static_cast<TObjString *>(matches->At(6))->GetString().Atoi());
+          int ttid(static_cast<TObjString *>(matches->At(8))->GetString().Atoi());
+          rawId = EcalTriggerElectronicsId(tccid, ttid, 1, 1).rawId();
+        } else {
+          int dccid(static_cast<TObjString *>(matches->At(4))->GetString().Atoi());
+          int towerid(static_cast<TObjString *>(matches->At(6))->GetString().Atoi());
+          if (matches->GetEntries() == 7)
+            rawId = EcalElectronicsId(dccid, towerid, 1, 1).rawId();
+          else {
+            TString chType(static_cast<TObjString *>(matches->At(7))->GetString());
+            int stripOrPNid(static_cast<TObjString *>(matches->At(8))->GetString().Atoi());
+            if (chType == "PN")
+              rawId = EcalElectronicsId(dccid, towerid, 1, stripOrPNid).rawId();
+            else if (chType == "strip") {
+              int xtalid(static_cast<TObjString *>(matches->At(9))->GetString().Atoi());
+              rawId = EcalElectronicsId(dccid, towerid, stripOrPNid, xtalid).rawId();
+            }
+            // case "TT" is already taken care of
+          }
+        }
       }
-    } else {
-      if (_btype == kCrystal || _btype == kTriggerTower) {
-        int nX(nEESMX);
-        if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
-          nX = nEESMXExt;
-        if (iSM == kEEm01 || iSM == kEEm05 || iSM == kEEm09 || iSM == kEEp01 ||
-            iSM == kEEp05 || iSM == kEEp09)
-          nX = nEESMXRed;
-        return EEDetId(_bin % (nX + 2) + xlow_(iSM),
-                       _bin / (nX + 2) + ylow_(iSM), z)
-            .rawId();
-      } else if (_btype == kSuperCrystal) {
-        int nX(nEESMX / 5);
-        if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
-          nX = nEESMXExt / 5;
-        if (iSM == kEEm01 || iSM == kEEm05 || iSM == kEEm09 || iSM == kEEp01 ||
-            iSM == kEEp05 || iSM == kEEp09)
-          nX = nEESMXRed / 5;
-        return EcalScDetId(_bin % (nX + 2) + xlow_(iSM) / 5,
-                           _bin / (nX + 2) + ylow_(iSM) / 5, z)
-            .rawId();
+
+      delete matches;
+
+      return rawId;
+    }
+
+    uint32_t idFromBin(ObjectType _otype, BinningType _btype, unsigned _iME, int _bin) {
+      if (_otype == kEB) {
+        if (_btype == kCrystal) {
+          int ieta(_bin / 362 - 86);
+          if (ieta >= 0)
+            ++ieta;
+          return EBDetId(ieta, _bin % 362);
+        } else if (_btype == kTriggerTower || _btype == kSuperCrystal) {
+          int ieta(_bin / 74 - 17);
+          int z(1);
+          if (ieta <= 0) {
+            z = -1;
+            ieta = -ieta + 1;
+          }
+          return EcalTrigTowerDetId(z, EcalBarrel, ieta, (_bin % 74 + 69) % 72 + 1);
+        }
+      } else if (_otype == kEEm || _otype == kEEp) {
+        int z(_otype == kEEm ? -1 : 1);
+        if (_btype == kCrystal || _btype == kTriggerTower)
+          return EEDetId(_bin % 102, _bin / 102, z).rawId();
+        else if (_btype == kSuperCrystal)
+          return EcalScDetId(_bin % 22, _bin / 22, z).rawId();
+      } else if (_otype == kEE) {
+        if (_btype == kCrystal || _btype == kTriggerTower) {
+          int ix(_bin % 202);
+          int z(ix > 100 ? 1 : -1);
+          if (z > 0)
+            ix = (ix - 100) % 101;
+          return EEDetId(ix, _bin / 202, z).rawId();
+        } else if (_btype == kSuperCrystal) {
+          int ix(_bin % 42);
+          int z(ix > 20 ? 1 : -1);
+          if (z > 0)
+            ix = (ix - 20) % 21;
+          return EcalScDetId(ix, _bin / 42, z).rawId();
+        }
+      } else if (_otype == kSM || _otype == kEBSM || _otype == kEESM) {
+        unsigned iSM(_iME);
+        if (_otype == kEBSM)
+          iSM += 9;
+        else if (_otype == kEESM && iSM > kEEmHigh)
+          iSM += nEBDCC;
+
+        int z(iSM <= kEBmHigh ? -1 : 1);
+
+        if ((iSM >= kEBmLow && iSM <= kEBmHigh) || (iSM >= kEBpLow && iSM <= kEBpHigh)) {
+          if (_btype == kCrystal) {
+            int iphi(((iSM - 9) % 18) * 20 + (z < 0 ? _bin / 87 : 21 - _bin / 87));
+            int ieta((_bin % 87) * z);
+            return EBDetId(ieta, iphi).rawId();
+          } else if (_btype == kTriggerTower || _btype == kSuperCrystal) {
+            int iphi((((iSM - 9) % 18) * 4 + (z < 0 ? _bin / 19 : 5 - _bin / 19) + 69) % 72 + 1);
+            int ieta(_bin % 19);
+            return EcalTrigTowerDetId(z, EcalBarrel, ieta, iphi).rawId();
+          }
+        } else {
+          if (_btype == kCrystal || _btype == kTriggerTower) {
+            int nX(nEESMX);
+            if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
+              nX = nEESMXExt;
+            if (iSM == kEEm01 || iSM == kEEm05 || iSM == kEEm09 || iSM == kEEp01 || iSM == kEEp05 || iSM == kEEp09)
+              nX = nEESMXRed;
+            return EEDetId(_bin % (nX + 2) + xlow_(iSM), _bin / (nX + 2) + ylow_(iSM), z).rawId();
+          } else if (_btype == kSuperCrystal) {
+            int nX(nEESMX / 5);
+            if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
+              nX = nEESMXExt / 5;
+            if (iSM == kEEm01 || iSM == kEEm05 || iSM == kEEm09 || iSM == kEEp01 || iSM == kEEp05 || iSM == kEEp09)
+              nX = nEESMXRed / 5;
+            return EcalScDetId(_bin % (nX + 2) + xlow_(iSM) / 5, _bin / (nX + 2) + ylow_(iSM) / 5, z).rawId();
+          }
+        }
       }
+
+      return 0;
     }
-  }
 
-  return 0;
-}
+    AxisSpecs formAxis(edm::ParameterSet const &_axisParams) {
+      AxisSpecs axis;
 
-AxisSpecs formAxis(edm::ParameterSet const &_axisParams) {
-  AxisSpecs axis;
+      if (_axisParams.existsAs<std::vector<double>>("edges", false)) {
+        std::vector<double> const &vEdges(_axisParams.getUntrackedParameter<std::vector<double>>("edges"));
+        axis.nbins = vEdges.size() - 1;
+        axis.edges = new float[vEdges.size()];
+        std::copy(vEdges.begin(), vEdges.end(), axis.edges);
+      } else {
+        axis.nbins = _axisParams.getUntrackedParameter<int>("nbins");
+        axis.low = _axisParams.getUntrackedParameter<double>("low");
+        bool highSet(_axisParams.existsAs<double>("high", false));
+        bool perBinSet(_axisParams.existsAs<double>("unitsPerBin", false));
+        if (highSet) {
+          if (perBinSet)
+            edm::LogWarning("EcalDQM") << "Maximum and bin width both set in an axis; using the former";
+          axis.high = _axisParams.getUntrackedParameter<double>("high");
+        } else if (perBinSet)
+          axis.high = axis.low + _axisParams.getUntrackedParameter<double>("unitsPerBin") * axis.nbins;
+        else
+          axis.high = 0.;
+      }
 
-  if (_axisParams.existsAs<std::vector<double>>("edges", false)) {
-    std::vector<double> const &vEdges(
-        _axisParams.getUntrackedParameter<std::vector<double>>("edges"));
-    axis.nbins = vEdges.size() - 1;
-    axis.edges = new float[vEdges.size()];
-    std::copy(vEdges.begin(), vEdges.end(), axis.edges);
-  } else {
-    axis.nbins = _axisParams.getUntrackedParameter<int>("nbins");
-    axis.low = _axisParams.getUntrackedParameter<double>("low");
-    bool highSet(_axisParams.existsAs<double>("high", false));
-    bool perBinSet(_axisParams.existsAs<double>("unitsPerBin", false));
-    if (highSet) {
-      if (perBinSet)
-        edm::LogWarning("EcalDQM")
-            << "Maximum and bin width both set in an axis; using the former";
-      axis.high = _axisParams.getUntrackedParameter<double>("high");
-    } else if (perBinSet)
-      axis.high =
-          axis.low +
-          _axisParams.getUntrackedParameter<double>("unitsPerBin") * axis.nbins;
-    else
-      axis.high = 0.;
-  }
+      if (_axisParams.existsAs<std::vector<std::string>>("labels", false)) {
+        std::vector<std::string> const &labels(_axisParams.getUntrackedParameter<std::vector<std::string>>("labels"));
+        if (int(labels.size()) == axis.nbins) {
+          axis.labels = new std::string[axis.nbins];
+          for (int iB(0); iB != axis.nbins; ++iB)
+            axis.labels[iB] = labels[iB];
+        }
+      }
 
-  if (_axisParams.existsAs<std::vector<std::string>>("labels", false)) {
-    std::vector<std::string> const &labels(
-        _axisParams.getUntrackedParameter<std::vector<std::string>>("labels"));
-    if (int(labels.size()) == axis.nbins) {
-      axis.labels = new std::string[axis.nbins];
-      for (int iB(0); iB != axis.nbins; ++iB)
-        axis.labels[iB] = labels[iB];
+      axis.title = _axisParams.getUntrackedParameter<std::string>("title");
+
+      return axis;
     }
-  }
 
-  axis.title = _axisParams.getUntrackedParameter<std::string>("title");
+    void fillAxisDescriptions(edm::ParameterSetDescription &_desc) {
+      _desc.addUntracked<std::string>("title", "");
+      _desc.addUntracked<int>("nbins", 0);
+      _desc.addUntracked<double>("low", 0.);
+      _desc.addOptionalNode(edm::ParameterDescription<double>("high", 0., false) ^
+                                edm::ParameterDescription<double>("unitsPerBin", 0., false),
+                            false);
+      _desc.addOptionalUntracked<std::vector<double>>("edges");
+      _desc.addOptionalUntracked<std::vector<std::string>>("labels");
+    }
 
-  return axis;
-}
+    ObjectType translateObjectType(std::string const &_otypeName) {
+      if (_otypeName == "EB")
+        return kEB;
+      else if (_otypeName == "EE")
+        return kEE;
+      else if (_otypeName == "EEm")
+        return kEEm;
+      else if (_otypeName == "EEp")
+        return kEEp;
+      else if (_otypeName == "SM")
+        return kSM;
+      else if (_otypeName == "EBSM")
+        return kEBSM;
+      else if (_otypeName == "EESM")
+        return kEESM;
+      else if (_otypeName == "SMMEM")
+        return kSMMEM;
+      else if (_otypeName == "EBSMMEM")
+        return kEBSMMEM;
+      else if (_otypeName == "EESMMEM")
+        return kEESMMEM;
+      else if (_otypeName == "Ecal")
+        return kEcal;
+      else if (_otypeName == "MEM")
+        return kMEM;
+      else if (_otypeName == "EBMEM")
+        return kEBMEM;
+      else if (_otypeName == "EEMEM")
+        return kEEMEM;
+      else if (_otypeName == "Ecal2P")
+        return kEcal2P;
+      else if (_otypeName == "Ecal3P")
+        return kEcal3P;
+      else if (_otypeName == "EE2P")
+        return kEE2P;
+      else if (_otypeName == "MEM2P")
+        return kMEM2P;
+      else if (_otypeName == "Channel")
+        return kChannel;
+      else if (_otypeName == "None")
+        return nObjType;
 
-void fillAxisDescriptions(edm::ParameterSetDescription &_desc) {
-  _desc.addUntracked<std::string>("title", "");
-  _desc.addUntracked<int>("nbins", 0);
-  _desc.addUntracked<double>("low", 0.);
-  _desc.addOptionalNode(
-      edm::ParameterDescription<double>("high", 0., false) ^
-          edm::ParameterDescription<double>("unitsPerBin", 0., false),
-      false);
-  _desc.addOptionalUntracked<std::vector<double>>("edges");
-  _desc.addOptionalUntracked<std::vector<std::string>>("labels");
-}
+      throw cms::Exception("InvalidConfiguration") << "No object type " << _otypeName << " defined";
+    }
 
-ObjectType translateObjectType(std::string const &_otypeName) {
-  if (_otypeName == "EB")
-    return kEB;
-  else if (_otypeName == "EE")
-    return kEE;
-  else if (_otypeName == "EEm")
-    return kEEm;
-  else if (_otypeName == "EEp")
-    return kEEp;
-  else if (_otypeName == "SM")
-    return kSM;
-  else if (_otypeName == "EBSM")
-    return kEBSM;
-  else if (_otypeName == "EESM")
-    return kEESM;
-  else if (_otypeName == "SMMEM")
-    return kSMMEM;
-  else if (_otypeName == "EBSMMEM")
-    return kEBSMMEM;
-  else if (_otypeName == "EESMMEM")
-    return kEESMMEM;
-  else if (_otypeName == "Ecal")
-    return kEcal;
-  else if (_otypeName == "MEM")
-    return kMEM;
-  else if (_otypeName == "EBMEM")
-    return kEBMEM;
-  else if (_otypeName == "EEMEM")
-    return kEEMEM;
-  else if (_otypeName == "Ecal2P")
-    return kEcal2P;
-  else if (_otypeName == "Ecal3P")
-    return kEcal3P;
-  else if (_otypeName == "EE2P")
-    return kEE2P;
-  else if (_otypeName == "MEM2P")
-    return kMEM2P;
-  else if (_otypeName == "Channel")
-    return kChannel;
-  else if (_otypeName == "None")
-    return nObjType;
+    BinningType translateBinningType(std::string const &_btypeName) {
+      if (_btypeName == "Crystal")
+        return kCrystal;
+      else if (_btypeName == "TriggerTower")
+        return kTriggerTower;
+      else if (_btypeName == "SuperCrystal")
+        return kSuperCrystal;
+      else if (_btypeName == "PseudoStrip")
+        return kPseudoStrip;
+      else if (_btypeName == "TCC")
+        return kTCC;
+      else if (_btypeName == "DCC")
+        return kDCC;
+      else if (_btypeName == "ProjEta")
+        return kProjEta;
+      else if (_btypeName == "ProjPhi")
+        return kProjPhi;
+      else if (_btypeName == "RCT")
+        return kRCT;
+      else if (_btypeName == "User")
+        return kUser;
+      else if (_btypeName == "Report")
+        return kReport;
+      else if (_btypeName == "Trend")
+        return kTrend;
 
-  throw cms::Exception("InvalidConfiguration")
-      << "No object type " << _otypeName << " defined";
-}
+      throw cms::Exception("InvalidConfiguration") << "No binning type " << _btypeName << " defined";
+    }
 
-BinningType translateBinningType(std::string const &_btypeName) {
-  if (_btypeName == "Crystal")
-    return kCrystal;
-  else if (_btypeName == "TriggerTower")
-    return kTriggerTower;
-  else if (_btypeName == "SuperCrystal")
-    return kSuperCrystal;
-  else if (_btypeName == "PseudoStrip")
-    return kPseudoStrip;
-  else if (_btypeName == "TCC")
-    return kTCC;
-  else if (_btypeName == "DCC")
-    return kDCC;
-  else if (_btypeName == "ProjEta")
-    return kProjEta;
-  else if (_btypeName == "ProjPhi")
-    return kProjPhi;
-  else if (_btypeName == "RCT")
-    return kRCT;
-  else if (_btypeName == "User")
-    return kUser;
-  else if (_btypeName == "Report")
-    return kReport;
-  else if (_btypeName == "Trend")
-    return kTrend;
-
-  throw cms::Exception("InvalidConfiguration")
-      << "No binning type " << _btypeName << " defined";
-}
-
-MonitorElement::Kind translateKind(std::string const &_kindName) {
-  if (_kindName == "REAL")
-    return MonitorElement::DQM_KIND_REAL;
-  else if (_kindName == "TH1F")
-    return MonitorElement::DQM_KIND_TH1F;
-  else if (_kindName == "TProfile")
-    return MonitorElement::DQM_KIND_TPROFILE;
-  else if (_kindName == "TH2F")
-    return MonitorElement::DQM_KIND_TH2F;
-  else if (_kindName == "TProfile2D")
-    return MonitorElement::DQM_KIND_TPROFILE2D;
-  else
-    return MonitorElement::DQM_KIND_INVALID;
-}
-} // namespace binning
-} // namespace ecaldqm
+    MonitorElement::Kind translateKind(std::string const &_kindName) {
+      if (_kindName == "REAL")
+        return MonitorElement::DQM_KIND_REAL;
+      else if (_kindName == "TH1F")
+        return MonitorElement::DQM_KIND_TH1F;
+      else if (_kindName == "TProfile")
+        return MonitorElement::DQM_KIND_TPROFILE;
+      else if (_kindName == "TH2F")
+        return MonitorElement::DQM_KIND_TH2F;
+      else if (_kindName == "TProfile2D")
+        return MonitorElement::DQM_KIND_TPROFILE2D;
+      else
+        return MonitorElement::DQM_KIND_INVALID;
+    }
+  }  // namespace binning
+}  // namespace ecaldqm

--- a/DQM/EcalCommon/src/MESetBinningUtils2.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils2.cc
@@ -9,756 +9,738 @@
 #include "TMath.h"
 
 namespace ecaldqm {
-namespace binning {
-int xlow_(int _iSM) {
-  switch (_iSM) {
-  case kEEm01:
-  case kEEp01:
-    return 20;
-  case kEEm02:
-  case kEEp02:
-    return 0;
-  case kEEm03:
-  case kEEp03:
-    return 0;
-  case kEEm04:
-  case kEEp04:
-    return 5;
-  case kEEm05:
-  case kEEp05:
-    return 35;
-  case kEEm06:
-  case kEEp06:
-    return 55;
-  case kEEm07:
-  case kEEp07:
-    return 60;
-  case kEEm08:
-  case kEEp08:
-    return 55;
-  case kEEm09:
-  case kEEp09:
-    return 50;
-  default:
-    break;
-  }
+  namespace binning {
+    int xlow_(int _iSM) {
+      switch (_iSM) {
+        case kEEm01:
+        case kEEp01:
+          return 20;
+        case kEEm02:
+        case kEEp02:
+          return 0;
+        case kEEm03:
+        case kEEp03:
+          return 0;
+        case kEEm04:
+        case kEEp04:
+          return 5;
+        case kEEm05:
+        case kEEp05:
+          return 35;
+        case kEEm06:
+        case kEEp06:
+          return 55;
+        case kEEm07:
+        case kEEp07:
+          return 60;
+        case kEEm08:
+        case kEEp08:
+          return 55;
+        case kEEm09:
+        case kEEp09:
+          return 50;
+        default:
+          break;
+      }
 
-  if (_iSM >= kEBmLow && _iSM <= kEBpHigh)
-    return 0;
+      if (_iSM >= kEBmLow && _iSM <= kEBpHigh)
+        return 0;
 
-  return 0;
-}
-
-int ylow_(int _iSM) {
-  switch (_iSM) {
-  case kEEm01:
-  case kEEp01:
-  case kEEm09:
-  case kEEp09:
-    return 60;
-  case kEEm02:
-  case kEEp02:
-  case kEEm08:
-  case kEEp08:
-    return 50;
-  case kEEm03:
-  case kEEp03:
-  case kEEm07:
-  case kEEp07:
-    return 25;
-  case kEEm04:
-  case kEEp04:
-  case kEEm06:
-  case kEEp06:
-    return 5;
-  case kEEm05:
-  case kEEp05:
-    return 0;
-  default:
-    break;
-  }
-
-  if (_iSM >= kEBmLow && _iSM <= kEBmHigh)
-    return ((_iSM - kEBmLow) % 18) * 20;
-  if (_iSM >= kEBpLow && _iSM <= kEBpHigh)
-    return (-1 - ((_iSM - kEBpLow) % 18)) * 20;
-
-  return 0;
-}
-
-AxisSpecs getBinningEB_(BinningType _btype, bool _isMap, int _axis) {
-  AxisSpecs specs;
-
-  if (!_isMap) {
-    switch (_btype) {
-    case kTCC:
-      specs.nbins = 36;
-      specs.low = 9.;
-      specs.high = 45.;
-      specs.title = "iTCC";
-      break;
-    case kDCC:
-      specs.nbins = 36;
-      specs.low = 9.;
-      specs.high = 45.;
-      break;
-    case kProjEta:
-      specs.nbins = nEBEtaBins;
-      specs.low = -etaBound;
-      specs.high = etaBound;
-      specs.title = "eta";
-      break;
-    case kProjPhi:
-      specs.nbins = nPhiBins;
-      specs.low = -TMath::Pi() / 18.;
-      specs.high = TMath::Pi() * 35. / 18.;
-      specs.title = "phi";
-      break;
-    default:
-      break;
-    }
-  } else {
-    switch (_btype) {
-    case kCrystal:
-      if (_axis == 1)
-        specs.nbins = 360;
-      else if (_axis == 2)
-        specs.nbins = 170;
-      break;
-    case kSuperCrystal:
-    case kTriggerTower:
-    case kPseudoStrip:
-      if (_axis == 1)
-        specs.nbins = 72;
-      else if (_axis == 2)
-        specs.nbins = 34;
-      break;
-    default:
-      return specs;
+      return 0;
     }
 
-    if (_axis == 1) {
-      specs.low = 0.;
-      specs.high = 360.;
-      specs.title = "iphi";
-    } else if (_axis == 2) {
-      specs.low = -85.;
-      specs.high = 85.;
-      specs.title = "ieta";
+    int ylow_(int _iSM) {
+      switch (_iSM) {
+        case kEEm01:
+        case kEEp01:
+        case kEEm09:
+        case kEEp09:
+          return 60;
+        case kEEm02:
+        case kEEp02:
+        case kEEm08:
+        case kEEp08:
+          return 50;
+        case kEEm03:
+        case kEEp03:
+        case kEEm07:
+        case kEEp07:
+          return 25;
+        case kEEm04:
+        case kEEp04:
+        case kEEm06:
+        case kEEp06:
+          return 5;
+        case kEEm05:
+        case kEEp05:
+          return 0;
+        default:
+          break;
+      }
+
+      if (_iSM >= kEBmLow && _iSM <= kEBmHigh)
+        return ((_iSM - kEBmLow) % 18) * 20;
+      if (_iSM >= kEBpLow && _iSM <= kEBpHigh)
+        return (-1 - ((_iSM - kEBpLow) % 18)) * 20;
+
+      return 0;
     }
-  }
 
-  return specs;
-}
+    AxisSpecs getBinningEB_(BinningType _btype, bool _isMap, int _axis) {
+      AxisSpecs specs;
 
-AxisSpecs getBinningEE_(BinningType _btype, bool _isMap, int _zside,
-                        int _axis) {
-  AxisSpecs specs;
-
-  if (!_isMap) {
-    switch (_btype) {
-    case kTCC:
-      specs.nbins = _zside ? 36 : 72;
-      specs.low = 0.;
-      specs.high = _zside ? 36. : 72.;
-      specs.title = "iTCC";
-      break;
-    case kDCC:
-      specs.nbins = _zside ? 9 : 18;
-      specs.low = 0.;
-      specs.high = _zside ? 9. : 18.;
-      break;
-    case kProjEta:
-      if (_zside == 0) {
-        specs.nbins = nEEEtaBins / (3. - etaBound) * 6.;
-        specs.low = -3.;
-        specs.high = 3.;
+      if (!_isMap) {
+        switch (_btype) {
+          case kTCC:
+            specs.nbins = 36;
+            specs.low = 9.;
+            specs.high = 45.;
+            specs.title = "iTCC";
+            break;
+          case kDCC:
+            specs.nbins = 36;
+            specs.low = 9.;
+            specs.high = 45.;
+            break;
+          case kProjEta:
+            specs.nbins = nEBEtaBins;
+            specs.low = -etaBound;
+            specs.high = etaBound;
+            specs.title = "eta";
+            break;
+          case kProjPhi:
+            specs.nbins = nPhiBins;
+            specs.low = -TMath::Pi() / 18.;
+            specs.high = TMath::Pi() * 35. / 18.;
+            specs.title = "phi";
+            break;
+          default:
+            break;
+        }
       } else {
-        specs.nbins = nEEEtaBins;
-        specs.low = _zside < 0 ? -3. : etaBound;
-        specs.high = _zside < 0 ? -etaBound : 3.;
+        switch (_btype) {
+          case kCrystal:
+            if (_axis == 1)
+              specs.nbins = 360;
+            else if (_axis == 2)
+              specs.nbins = 170;
+            break;
+          case kSuperCrystal:
+          case kTriggerTower:
+          case kPseudoStrip:
+            if (_axis == 1)
+              specs.nbins = 72;
+            else if (_axis == 2)
+              specs.nbins = 34;
+            break;
+          default:
+            return specs;
+        }
+
+        if (_axis == 1) {
+          specs.low = 0.;
+          specs.high = 360.;
+          specs.title = "iphi";
+        } else if (_axis == 2) {
+          specs.low = -85.;
+          specs.high = 85.;
+          specs.title = "ieta";
+        }
       }
-      specs.title = "eta";
-      break;
-    case kProjPhi:
-      specs.nbins = nPhiBins;
-      specs.low = -TMath::Pi() / 18.;
-      specs.high = TMath::Pi() * 35. / 18.;
-      specs.title = "phi";
-      break;
-    default:
-      break;
-    }
-  } else {
-    switch (_btype) {
-    case kCrystal:
-    case kTriggerTower:
-    case kPseudoStrip:
-      if (_axis == 1)
-        specs.nbins = _zside ? 100 : 200;
-      if (_axis == 2)
-        specs.nbins = 100;
-      break;
-    case kSuperCrystal:
-      if (_axis == 1)
-        specs.nbins = _zside ? 20 : 40;
-      if (_axis == 2)
-        specs.nbins = 20;
-      break;
-    default:
+
       return specs;
     }
 
-    if (_axis == 1) {
-      specs.low = 0.;
-      specs.high = _zside ? 100. : 200.;
-      specs.title = "ix";
-    } else if (_axis == 2) {
-      specs.low = 0.;
-      specs.high = 100.;
-      specs.title = "iy";
-    }
-  }
+    AxisSpecs getBinningEE_(BinningType _btype, bool _isMap, int _zside, int _axis) {
+      AxisSpecs specs;
 
-  return specs;
-}
+      if (!_isMap) {
+        switch (_btype) {
+          case kTCC:
+            specs.nbins = _zside ? 36 : 72;
+            specs.low = 0.;
+            specs.high = _zside ? 36. : 72.;
+            specs.title = "iTCC";
+            break;
+          case kDCC:
+            specs.nbins = _zside ? 9 : 18;
+            specs.low = 0.;
+            specs.high = _zside ? 9. : 18.;
+            break;
+          case kProjEta:
+            if (_zside == 0) {
+              specs.nbins = nEEEtaBins / (3. - etaBound) * 6.;
+              specs.low = -3.;
+              specs.high = 3.;
+            } else {
+              specs.nbins = nEEEtaBins;
+              specs.low = _zside < 0 ? -3. : etaBound;
+              specs.high = _zside < 0 ? -etaBound : 3.;
+            }
+            specs.title = "eta";
+            break;
+          case kProjPhi:
+            specs.nbins = nPhiBins;
+            specs.low = -TMath::Pi() / 18.;
+            specs.high = TMath::Pi() * 35. / 18.;
+            specs.title = "phi";
+            break;
+          default:
+            break;
+        }
+      } else {
+        switch (_btype) {
+          case kCrystal:
+          case kTriggerTower:
+          case kPseudoStrip:
+            if (_axis == 1)
+              specs.nbins = _zside ? 100 : 200;
+            if (_axis == 2)
+              specs.nbins = 100;
+            break;
+          case kSuperCrystal:
+            if (_axis == 1)
+              specs.nbins = _zside ? 20 : 40;
+            if (_axis == 2)
+              specs.nbins = 20;
+            break;
+          default:
+            return specs;
+        }
 
-AxisSpecs getBinningSM_(BinningType _btype, bool _isMap, unsigned _iObj,
-                        int _axis) {
-  AxisSpecs specs;
+        if (_axis == 1) {
+          specs.low = 0.;
+          specs.high = _zside ? 100. : 200.;
+          specs.title = "ix";
+        } else if (_axis == 2) {
+          specs.low = 0.;
+          specs.high = 100.;
+          specs.title = "iy";
+        }
+      }
 
-  unsigned iSM(_iObj);
-
-  const bool isBarrel(iSM >= kEBmLow && iSM <= kEBpHigh);
-
-  if (!_isMap) {
-    switch (_btype) {
-    case kCrystal:
-      specs.nbins = isBarrel
-                        ? 1700
-                        : getElectronicsMap()->dccConstituents(iSM + 1).size();
-      specs.low = 0.;
-      specs.high = specs.nbins;
-      specs.title = "crystal";
-      break;
-    case kTriggerTower:
-    case kPseudoStrip:
-      specs.nbins =
-          isBarrel ? 68
-                   : (2 * nTTOuter + 2 * nTTInner); // For EE: numbering of bins
-      // is in the order (inner1, inner2, outer1, outer2). ("inner"" := closer
-      // to the beam)
-      specs.low = 1.;
-      specs.high = specs.nbins + specs.low;
-      specs.title = "tower";
-      break;
-    case kSuperCrystal:
-      specs.nbins = isBarrel ? 68 : nSuperCrystals(iSM + 1);
-      specs.low = 1.;
-      specs.high = specs.nbins + specs.low;
-      specs.title = "tower";
-      break;
-    default:
-      break;
-    }
-  } else {
-    int nEEX(nEESMX);
-    int nEEY(nEESMY);
-    if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
-      nEEX = nEESMXExt;
-    if (iSM == kEEm01 || iSM == kEEm05 || iSM == kEEm09 || iSM == kEEp01 ||
-        iSM == kEEp05 || iSM == kEEp09)
-      nEEX = nEESMXRed;
-    if (iSM == kEEm03 || iSM == kEEm07 || iSM == kEEp03 || iSM == kEEp07)
-      nEEY = nEESMYRed;
-
-    switch (_btype) {
-    case kCrystal:
-      if (_axis == 1)
-        specs.nbins = isBarrel ? nEBSMEta : nEEX;
-      else if (_axis == 2)
-        specs.nbins = isBarrel ? nEBSMPhi : nEEY;
-      break;
-    case kTriggerTower:
-    case kPseudoStrip:
-      if (_axis == 1)
-        specs.nbins = isBarrel ? nEBSMEta / 5 : nEEX;
-      else if (_axis == 2)
-        specs.nbins = isBarrel ? nEBSMPhi / 5 : nEEY;
-      break;
-    case kSuperCrystal:
-      if (_axis == 1)
-        specs.nbins = isBarrel ? nEBSMEta / 5 : nEEX / 5;
-      else if (_axis == 2)
-        specs.nbins = isBarrel ? nEBSMPhi / 5 : nEEY / 5;
-      break;
-    default:
       return specs;
     }
 
-    if (_axis == 1) {
-      specs.low = xlow_(iSM);
-      specs.high = specs.low + (isBarrel ? nEBSMEta : nEEX);
-      specs.title = isBarrel ? (iSM < kEBpLow ? "-ieta" : "ieta") : "ix";
-    } else if (_axis == 2) {
-      specs.low = ylow_(iSM);
-      specs.high = specs.low + (isBarrel ? nEBSMPhi : nEEY);
-      specs.title = isBarrel ? "iphi" : "iy";
-    }
-  }
+    AxisSpecs getBinningSM_(BinningType _btype, bool _isMap, unsigned _iObj, int _axis) {
+      AxisSpecs specs;
 
-  return specs;
-}
+      unsigned iSM(_iObj);
 
-AxisSpecs getBinningSMMEM_(BinningType _btype, bool _isMap, unsigned _iObj,
-                           int _axis) {
-  AxisSpecs specs;
+      const bool isBarrel(iSM >= kEBmLow && iSM <= kEBpHigh);
 
-  unsigned iSM(memDCCId(_iObj) - 1);
+      if (!_isMap) {
+        switch (_btype) {
+          case kCrystal:
+            specs.nbins = isBarrel ? 1700 : getElectronicsMap()->dccConstituents(iSM + 1).size();
+            specs.low = 0.;
+            specs.high = specs.nbins;
+            specs.title = "crystal";
+            break;
+          case kTriggerTower:
+          case kPseudoStrip:
+            specs.nbins = isBarrel ? 68 : (2 * nTTOuter + 2 * nTTInner);  // For EE: numbering of bins
+            // is in the order (inner1, inner2, outer1, outer2). ("inner"" := closer
+            // to the beam)
+            specs.low = 1.;
+            specs.high = specs.nbins + specs.low;
+            specs.title = "tower";
+            break;
+          case kSuperCrystal:
+            specs.nbins = isBarrel ? 68 : nSuperCrystals(iSM + 1);
+            specs.low = 1.;
+            specs.high = specs.nbins + specs.low;
+            specs.title = "tower";
+            break;
+          default:
+            break;
+        }
+      } else {
+        int nEEX(nEESMX);
+        int nEEY(nEESMY);
+        if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
+          nEEX = nEESMXExt;
+        if (iSM == kEEm01 || iSM == kEEm05 || iSM == kEEm09 || iSM == kEEp01 || iSM == kEEp05 || iSM == kEEp09)
+          nEEX = nEESMXRed;
+        if (iSM == kEEm03 || iSM == kEEm07 || iSM == kEEp03 || iSM == kEEp07)
+          nEEY = nEESMYRed;
 
-  if (iSM == unsigned(-1) || _btype != kCrystal)
-    return specs;
+        switch (_btype) {
+          case kCrystal:
+            if (_axis == 1)
+              specs.nbins = isBarrel ? nEBSMEta : nEEX;
+            else if (_axis == 2)
+              specs.nbins = isBarrel ? nEBSMPhi : nEEY;
+            break;
+          case kTriggerTower:
+          case kPseudoStrip:
+            if (_axis == 1)
+              specs.nbins = isBarrel ? nEBSMEta / 5 : nEEX;
+            else if (_axis == 2)
+              specs.nbins = isBarrel ? nEBSMPhi / 5 : nEEY;
+            break;
+          case kSuperCrystal:
+            if (_axis == 1)
+              specs.nbins = isBarrel ? nEBSMEta / 5 : nEEX / 5;
+            else if (_axis == 2)
+              specs.nbins = isBarrel ? nEBSMPhi / 5 : nEEY / 5;
+            break;
+          default:
+            return specs;
+        }
 
-  if (_axis == 1) {
-    specs.nbins = 10;
-    specs.low = 0.;
-    specs.high = 10.;
-    if (_isMap)
-      specs.title = "pseudo-strip";
-    else
-      specs.title = "iPN";
-  } else if (_axis == 2) {
-    specs.nbins = 1;
-    specs.low = 0.;
-    specs.high = 5.;
-    specs.title = "channel";
-  }
-
-  return specs;
-}
-
-AxisSpecs getBinningEcal_(BinningType _btype, bool _isMap, int _axis) {
-  AxisSpecs specs;
-
-  if (!_isMap) {
-    switch (_btype) {
-    case kTCC:
-      specs.nbins = 108;
-      specs.low = 0.;
-      specs.high = 108.;
-      specs.title = "iTCC";
-      break;
-    case kDCC:
-      specs.nbins = 54;
-      specs.low = 0.;
-      specs.high = 54.;
-      specs.title = "iDCC";
-      break;
-    case kProjEta:
-      specs.nbins = nEBEtaBins + 2 * nEEEtaBins;
-      specs.edges = new float[specs.nbins + 1];
-      for (int i(0); i <= nEEEtaBins; i++)
-        specs.edges[i] = -3. + (3. - etaBound) / nEEEtaBins * i;
-      for (int i(1); i <= nEBEtaBins; i++)
-        specs.edges[i + nEEEtaBins] =
-            -etaBound + 2. * etaBound / nEBEtaBins * i;
-      for (int i(1); i <= nEEEtaBins; i++)
-        specs.edges[i + nEEEtaBins + nEBEtaBins] =
-            etaBound + (3. - etaBound) / nEEEtaBins * i;
-      specs.title = "eta";
-      break;
-    case kProjPhi:
-      specs.nbins = nPhiBins;
-      specs.low = -TMath::Pi() / 18.;
-      specs.high = TMath::Pi() * 35. / 18.;
-      specs.title = "phi";
-      break;
-    default:
-      break;
-    }
-  } else {
-    switch (_btype) {
-    case kDCC:
-      if (_axis == 1) {
-        specs.nbins = 9;
-        specs.low = 0.;
-        specs.high = 9.;
-      } else if (_axis == 2) {
-        specs.nbins = 6;
-        specs.low = 0.;
-        specs.high = 6.;
+        if (_axis == 1) {
+          specs.low = xlow_(iSM);
+          specs.high = specs.low + (isBarrel ? nEBSMEta : nEEX);
+          specs.title = isBarrel ? (iSM < kEBpLow ? "-ieta" : "ieta") : "ix";
+        } else if (_axis == 2) {
+          specs.low = ylow_(iSM);
+          specs.high = specs.low + (isBarrel ? nEBSMPhi : nEEY);
+          specs.title = isBarrel ? "iphi" : "iy";
+        }
       }
-      break;
-    case kRCT:
+
+      return specs;
+    }
+
+    AxisSpecs getBinningSMMEM_(BinningType _btype, bool _isMap, unsigned _iObj, int _axis) {
+      AxisSpecs specs;
+
+      unsigned iSM(memDCCId(_iObj) - 1);
+
+      if (iSM == unsigned(-1) || _btype != kCrystal)
+        return specs;
+
       if (_axis == 1) {
-        specs.nbins = 64;
-        specs.low = -32.;
-        specs.high = 32.;
-        specs.title = "RCT iEta";
-      } else if (_axis == 2) {
-        specs.nbins = 72;
+        specs.nbins = 10;
         specs.low = 0.;
-        specs.high = 72.;
-        specs.title = "RCT Phi";
+        specs.high = 10.;
+        if (_isMap)
+          specs.title = "pseudo-strip";
+        else
+          specs.title = "iPN";
+      } else if (_axis == 2) {
+        specs.nbins = 1;
+        specs.low = 0.;
+        specs.high = 5.;
+        specs.title = "channel";
       }
-      break;
-    default:
-      break;
+
+      return specs;
     }
-  }
 
-  return specs;
-}
+    AxisSpecs getBinningEcal_(BinningType _btype, bool _isMap, int _axis) {
+      AxisSpecs specs;
 
-AxisSpecs getBinningMEM_(BinningType _btype, bool _isMap, int _subdet,
-                         int _axis) {
-  AxisSpecs specs;
+      if (!_isMap) {
+        switch (_btype) {
+          case kTCC:
+            specs.nbins = 108;
+            specs.low = 0.;
+            specs.high = 108.;
+            specs.title = "iTCC";
+            break;
+          case kDCC:
+            specs.nbins = 54;
+            specs.low = 0.;
+            specs.high = 54.;
+            specs.title = "iDCC";
+            break;
+          case kProjEta:
+            specs.nbins = nEBEtaBins + 2 * nEEEtaBins;
+            specs.edges = new float[specs.nbins + 1];
+            for (int i(0); i <= nEEEtaBins; i++)
+              specs.edges[i] = -3. + (3. - etaBound) / nEEEtaBins * i;
+            for (int i(1); i <= nEBEtaBins; i++)
+              specs.edges[i + nEEEtaBins] = -etaBound + 2. * etaBound / nEBEtaBins * i;
+            for (int i(1); i <= nEEEtaBins; i++)
+              specs.edges[i + nEEEtaBins + nEBEtaBins] = etaBound + (3. - etaBound) / nEEEtaBins * i;
+            specs.title = "eta";
+            break;
+          case kProjPhi:
+            specs.nbins = nPhiBins;
+            specs.low = -TMath::Pi() / 18.;
+            specs.high = TMath::Pi() * 35. / 18.;
+            specs.title = "phi";
+            break;
+          default:
+            break;
+        }
+      } else {
+        switch (_btype) {
+          case kDCC:
+            if (_axis == 1) {
+              specs.nbins = 9;
+              specs.low = 0.;
+              specs.high = 9.;
+            } else if (_axis == 2) {
+              specs.nbins = 6;
+              specs.low = 0.;
+              specs.high = 6.;
+            }
+            break;
+          case kRCT:
+            if (_axis == 1) {
+              specs.nbins = 64;
+              specs.low = -32.;
+              specs.high = 32.;
+              specs.title = "RCT iEta";
+            } else if (_axis == 2) {
+              specs.nbins = 72;
+              specs.low = 0.;
+              specs.high = 72.;
+              specs.title = "RCT Phi";
+            }
+            break;
+          default:
+            break;
+        }
+      }
 
-  if (_btype != kCrystal)
-    return specs;
-
-  int nbins(44);
-  if (_subdet == EcalBarrel)
-    nbins = 36;
-  else if (_subdet == EcalEndcap)
-    nbins = 8;
-
-  if (_axis == 1) {
-    specs.nbins = nbins;
-    specs.low = 0.;
-    specs.high = nbins;
-  } else if (_axis == 2) {
-    specs.nbins = 10;
-    specs.low = 0.;
-    specs.high = 10.;
-    specs.title = "iPN";
-  }
-
-  return specs;
-}
-
-int findBinCrystal_(ObjectType _otype, const DetId &_id, int _iSM /* = -1*/) {
-  int xbin(0), ybin(0);
-  int nbinsX(0);
-  int subdet(_id.subdetId());
-
-  if (subdet == EcalBarrel) {
-    EBDetId ebid(_id);
-    int iphi(ebid.iphi());
-    int ieta(ebid.ieta());
-    switch (_otype) {
-    case kEB:
-      xbin = iphi;
-      ybin = ieta < 0 ? ieta + 86 : ieta + 85;
-      nbinsX = 360;
-      break;
-    case kSM:
-    case kEBSM:
-      xbin = ieta < 0 ? -ieta : ieta;
-      ybin = ieta < 0 ? (iphi - 1) % 20 + 1 : 20 - (iphi - 1) % 20;
-      nbinsX = nEBSMEta;
-      break;
-    default:
-      break;
+      return specs;
     }
-  } else if (subdet == EcalEndcap) {
-    EEDetId eeid(_id);
-    int ix(eeid.ix());
-    int iy(eeid.iy());
-    switch (_otype) {
-    case kEE:
-      xbin = eeid.zside() < 0 ? ix : ix + 100;
-      ybin = iy;
-      nbinsX = 200;
-      break;
-    case kEEm:
-    case kEEp:
-      xbin = ix;
-      ybin = iy;
-      nbinsX = 100;
-      break;
-    case kSM:
-    case kEESM: {
-      int iSM(_iSM >= 0 ? _iSM : dccId(_id) - 1);
-      xbin = ix - xlow_(iSM);
-      ybin = iy - ylow_(iSM);
-      if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
-        nbinsX = nEESMXExt;
-      else if (iSM == kEEm01 || iSM == kEEm05 || iSM == kEEm09 ||
-               iSM == kEEp01 || iSM == kEEp05 || iSM == kEEp09)
-        nbinsX = nEESMXRed;
-      else
-        nbinsX = nEESMX;
-    } break;
-    default:
-      break;
+
+    AxisSpecs getBinningMEM_(BinningType _btype, bool _isMap, int _subdet, int _axis) {
+      AxisSpecs specs;
+
+      if (_btype != kCrystal)
+        return specs;
+
+      int nbins(44);
+      if (_subdet == EcalBarrel)
+        nbins = 36;
+      else if (_subdet == EcalEndcap)
+        nbins = 8;
+
+      if (_axis == 1) {
+        specs.nbins = nbins;
+        specs.low = 0.;
+        specs.high = nbins;
+      } else if (_axis == 2) {
+        specs.nbins = 10;
+        specs.low = 0.;
+        specs.high = 10.;
+        specs.title = "iPN";
+      }
+
+      return specs;
     }
-  } else if (subdet == EcalLaserPnDiode) {
-    EcalPnDiodeDetId pnid(_id);
-    switch (_otype) {
-    case kSMMEM:
-    case kEBSMMEM:
-    case kEESMMEM:
-      xbin = pnid.iPnId();
-      ybin = 1;
-      nbinsX = 10;
-      break;
-    case kMEM:
-      xbin = memDCCIndex(dccId(_id)) + 1;
-      ybin = pnid.iPnId();
-      nbinsX = 44;
-      break;
-    case kEBMEM:
-      xbin = memDCCIndex(dccId(_id)) - 3;
-      ybin = pnid.iPnId();
-      nbinsX = 36;
-      break;
-    case kEEMEM:
-      xbin = memDCCIndex(dccId(_id)) + 1;
-      if (xbin > kEEmHigh + 1)
-        xbin -= 36;
-      ybin = pnid.iPnId();
-      nbinsX = 8;
-      break;
-    default:
-      break;
+
+    int findBinCrystal_(ObjectType _otype, const DetId &_id, int _iSM /* = -1*/) {
+      int xbin(0), ybin(0);
+      int nbinsX(0);
+      int subdet(_id.subdetId());
+
+      if (subdet == EcalBarrel) {
+        EBDetId ebid(_id);
+        int iphi(ebid.iphi());
+        int ieta(ebid.ieta());
+        switch (_otype) {
+          case kEB:
+            xbin = iphi;
+            ybin = ieta < 0 ? ieta + 86 : ieta + 85;
+            nbinsX = 360;
+            break;
+          case kSM:
+          case kEBSM:
+            xbin = ieta < 0 ? -ieta : ieta;
+            ybin = ieta < 0 ? (iphi - 1) % 20 + 1 : 20 - (iphi - 1) % 20;
+            nbinsX = nEBSMEta;
+            break;
+          default:
+            break;
+        }
+      } else if (subdet == EcalEndcap) {
+        EEDetId eeid(_id);
+        int ix(eeid.ix());
+        int iy(eeid.iy());
+        switch (_otype) {
+          case kEE:
+            xbin = eeid.zside() < 0 ? ix : ix + 100;
+            ybin = iy;
+            nbinsX = 200;
+            break;
+          case kEEm:
+          case kEEp:
+            xbin = ix;
+            ybin = iy;
+            nbinsX = 100;
+            break;
+          case kSM:
+          case kEESM: {
+            int iSM(_iSM >= 0 ? _iSM : dccId(_id) - 1);
+            xbin = ix - xlow_(iSM);
+            ybin = iy - ylow_(iSM);
+            if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
+              nbinsX = nEESMXExt;
+            else if (iSM == kEEm01 || iSM == kEEm05 || iSM == kEEm09 || iSM == kEEp01 || iSM == kEEp05 || iSM == kEEp09)
+              nbinsX = nEESMXRed;
+            else
+              nbinsX = nEESMX;
+          } break;
+          default:
+            break;
+        }
+      } else if (subdet == EcalLaserPnDiode) {
+        EcalPnDiodeDetId pnid(_id);
+        switch (_otype) {
+          case kSMMEM:
+          case kEBSMMEM:
+          case kEESMMEM:
+            xbin = pnid.iPnId();
+            ybin = 1;
+            nbinsX = 10;
+            break;
+          case kMEM:
+            xbin = memDCCIndex(dccId(_id)) + 1;
+            ybin = pnid.iPnId();
+            nbinsX = 44;
+            break;
+          case kEBMEM:
+            xbin = memDCCIndex(dccId(_id)) - 3;
+            ybin = pnid.iPnId();
+            nbinsX = 36;
+            break;
+          case kEEMEM:
+            xbin = memDCCIndex(dccId(_id)) + 1;
+            if (xbin > kEEmHigh + 1)
+              xbin -= 36;
+            ybin = pnid.iPnId();
+            nbinsX = 8;
+            break;
+          default:
+            break;
+        }
+      }
+
+      return (nbinsX + 2) * ybin + xbin;
     }
-  }
 
-  return (nbinsX + 2) * ybin + xbin;
-}
+    int findBinCrystal_(ObjectType _otype, EcalElectronicsId const &_id) {
+      return findBinCrystal_(_otype, getElectronicsMap()->getDetId(_id));
+    }
 
-int findBinCrystal_(ObjectType _otype, EcalElectronicsId const &_id) {
-  return findBinCrystal_(_otype, getElectronicsMap()->getDetId(_id));
-}
+    int findBinRCT_(ObjectType _otype, DetId const &_id) {
+      int xbin(0);
+      int ybin(0);
+      int nbinsX(0);
 
-int findBinRCT_(ObjectType _otype, DetId const &_id) {
-  int xbin(0);
-  int ybin(0);
-  int nbinsX(0);
+      EcalTrigTowerDetId ttid(_id);
+      int ieta(ttid.ieta());
+      int iphi((ttid.iphi() + 1) % 72 + 1);
 
-  EcalTrigTowerDetId ttid(_id);
-  int ieta(ttid.ieta());
-  int iphi((ttid.iphi() + 1) % 72 + 1);
-
-  xbin = ieta < 0 ? ieta + 33 : ieta + 32;
-  ybin = iphi;
-  nbinsX = 64;
-
-  return (nbinsX + 2) * ybin + xbin;
-}
-
-int findBinTriggerTower_(ObjectType _otype, DetId const &_id) {
-  int xbin(0);
-  int ybin(0);
-  int nbinsX(0);
-  int subdet(_id.subdetId());
-
-  if ((subdet == EcalTriggerTower && !isEndcapTTId(_id)) ||
-      subdet == EcalBarrel) {
-    EcalTrigTowerDetId ttid;
-    if (subdet == EcalBarrel)
-      ttid = EBDetId(_id).tower();
-    else
-      ttid = _id;
-
-    int ieta(ttid.ieta());
-    int iphi((ttid.iphi() + 1) % 72 + 1);
-    switch (_otype) {
-    case kEB:
-      xbin = iphi;
-      ybin = ieta < 0 ? ieta + 18 : ieta + 17;
-      nbinsX = 72;
-      break;
-    case kSM:
-    case kEBSM:
-      xbin = ieta < 0 ? -ieta : ieta;
-      ybin = ieta < 0 ? (iphi - 1) % 4 + 1 : 4 - (iphi - 1) % 4;
-      nbinsX = 17;
-      break;
-    case kEcal:
       xbin = ieta < 0 ? ieta + 33 : ieta + 32;
-      ybin = iphi > 70 ? iphi - 70 : iphi + 2;
+      ybin = iphi;
       nbinsX = 64;
-    default:
-      break;
+
+      return (nbinsX + 2) * ybin + xbin;
     }
-  } else if (subdet == EcalEndcap) {
-    unsigned tccid(tccId(_id));
-    unsigned iSM(tccid <= 36 ? tccid % 18 / 2 : (tccid - 72) % 18 / 2);
-    return findBinCrystal_(_otype, _id, iSM);
-  }
 
-  return (nbinsX + 2) * ybin + xbin;
-}
+    int findBinTriggerTower_(ObjectType _otype, DetId const &_id) {
+      int xbin(0);
+      int ybin(0);
+      int nbinsX(0);
+      int subdet(_id.subdetId());
 
-int findBinPseudoStrip_(ObjectType _otype, DetId const &_id) {
-
-  int xbin(0);
-  int ybin(0);
-  int nbinsX(0);
-  int subdet(_id.subdetId());
-
-  if ((subdet == EcalTriggerTower && !isEndcapTTId(_id)) ||
-      subdet == EcalBarrel) {
-    return findBinTriggerTower_(_otype, _id);
-  } else if (subdet == EcalEndcap) {
-    unsigned tccid(tccId(_id));
-    unsigned iSM(tccid <= 36 ? tccid % 18 / 2 : (tccid - 72) % 18 / 2);
-    return findBinCrystal_(_otype, _id, iSM);
-  }
-
-  return (nbinsX + 2) * ybin + xbin;
-}
-
-int findBinSuperCrystal_(ObjectType _otype, const DetId &_id,
-                         int _iSM /* -1*/) {
-  int xbin(0);
-  int ybin(0);
-  int nbinsX(0);
-  int subdet(_id.subdetId());
-
-  if (subdet == EcalBarrel) {
-    EBDetId ebid(_id);
-    int iphi(ebid.iphi());
-    int ieta(ebid.ieta());
-    switch (_otype) {
-    case kEB:
-      xbin = (iphi - 1) / 5 + 1;
-      ybin = (ieta < 0 ? ieta + 85 : ieta + 84) / 5 + 1;
-      nbinsX = 72;
-      break;
-    case kSM:
-    case kEBSM:
-      xbin = (ieta < 0 ? -ieta - 1 : ieta - 1) / 5 + 1;
-      ybin = (ieta < 0 ? (iphi - 1) % 20 : 19 - (iphi - 1) % 20) / 5 + 1;
-      nbinsX = nEBSMEta / 5;
-      break;
-    default:
-      break;
-    }
-  } else if (subdet == EcalEndcap) {
-    if (isEcalScDetId(_id)) {
-      EcalScDetId scid(_id);
-      int ix(scid.ix());
-      int iy(scid.iy());
-      switch (_otype) {
-      case kEE: {
-        int zside(scid.zside());
-        xbin = zside < 0 ? ix : ix + 20;
-        ybin = iy;
-        nbinsX = 40;
-      } break;
-      case kEEm:
-      case kEEp:
-        xbin = ix;
-        ybin = iy;
-        nbinsX = 20;
-        break;
-      case kSM:
-      case kEESM: {
-        int iSM(_iSM >= 0 ? _iSM : dccId(_id) - 1);
-        xbin = ix - xlow_(iSM) / 5;
-        ybin = iy - ylow_(iSM) / 5;
-        if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
-          nbinsX = nEESMXExt / 5;
-        else if (iSM == kEEm01 || iSM == kEEm05 || iSM == kEEm09 ||
-                 iSM == kEEp01 || iSM == kEEp05 || iSM == kEEp09)
-          nbinsX = nEESMXRed / 5;
+      if ((subdet == EcalTriggerTower && !isEndcapTTId(_id)) || subdet == EcalBarrel) {
+        EcalTrigTowerDetId ttid;
+        if (subdet == EcalBarrel)
+          ttid = EBDetId(_id).tower();
         else
-          nbinsX = nEESMX / 5;
-      } break;
-      default:
-        break;
+          ttid = _id;
+
+        int ieta(ttid.ieta());
+        int iphi((ttid.iphi() + 1) % 72 + 1);
+        switch (_otype) {
+          case kEB:
+            xbin = iphi;
+            ybin = ieta < 0 ? ieta + 18 : ieta + 17;
+            nbinsX = 72;
+            break;
+          case kSM:
+          case kEBSM:
+            xbin = ieta < 0 ? -ieta : ieta;
+            ybin = ieta < 0 ? (iphi - 1) % 4 + 1 : 4 - (iphi - 1) % 4;
+            nbinsX = 17;
+            break;
+          case kEcal:
+            xbin = ieta < 0 ? ieta + 33 : ieta + 32;
+            ybin = iphi > 70 ? iphi - 70 : iphi + 2;
+            nbinsX = 64;
+          default:
+            break;
+        }
+      } else if (subdet == EcalEndcap) {
+        unsigned tccid(tccId(_id));
+        unsigned iSM(tccid <= 36 ? tccid % 18 / 2 : (tccid - 72) % 18 / 2);
+        return findBinCrystal_(_otype, _id, iSM);
       }
-    } else {
-      EEDetId eeid(_id);
-      int ix(eeid.ix());
-      int iy(eeid.iy());
-      switch (_otype) {
-      case kEE:
-        xbin = (eeid.zside() < 0 ? ix - 1 : ix + 99) / 5 + 1;
-        ybin = (iy - 1) / 5 + 1;
-        nbinsX = 40;
-        break;
-      case kEEm:
-      case kEEp:
-        xbin = (ix - 1) / 5 + 1;
-        ybin = (iy - 1) / 5 + 1;
-        nbinsX = 20;
-        break;
-      case kSM:
-      case kEESM: {
-        int iSM(_iSM >= 0 ? _iSM : dccId(_id) - 1);
-        xbin = (ix - xlow_(iSM) - 1) / 5 + 1;
-        ybin = (iy - ylow_(iSM) - 1) / 5 + 1;
-        if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
-          nbinsX = nEESMXExt / 5;
-        else if (iSM == kEEm01 || iSM == kEEm05 || iSM == kEEm09 ||
-                 iSM == kEEp01 || iSM == kEEp05 || iSM == kEEp09)
-          nbinsX = nEESMXRed / 5;
-        else
-          nbinsX = nEESMX / 5;
-      } break;
-      default:
-        break;
+
+      return (nbinsX + 2) * ybin + xbin;
+    }
+
+    int findBinPseudoStrip_(ObjectType _otype, DetId const &_id) {
+      int xbin(0);
+      int ybin(0);
+      int nbinsX(0);
+      int subdet(_id.subdetId());
+
+      if ((subdet == EcalTriggerTower && !isEndcapTTId(_id)) || subdet == EcalBarrel) {
+        return findBinTriggerTower_(_otype, _id);
+      } else if (subdet == EcalEndcap) {
+        unsigned tccid(tccId(_id));
+        unsigned iSM(tccid <= 36 ? tccid % 18 / 2 : (tccid - 72) % 18 / 2);
+        return findBinCrystal_(_otype, _id, iSM);
       }
+
+      return (nbinsX + 2) * ybin + xbin;
     }
-  } else if (subdet == EcalTriggerTower && !isEndcapTTId(_id)) {
-    EcalTrigTowerDetId ttid(_id);
-    int ieta(ttid.ieta());
-    int iphi((ttid.iphi() + 1) % 72 + 1);
-    switch (_otype) {
-    case kEB:
-      xbin = iphi;
-      ybin = ieta < 0 ? ieta + 18 : ieta + 17;
-      nbinsX = 72;
-      break;
-    case kSM:
-    case kEBSM:
-      xbin = ieta < 0 ? -ieta : ieta;
-      ybin = ieta < 0 ? (iphi - 1) % 4 + 1 : 4 - (iphi - 1) % 4;
-      nbinsX = nEBSMEta / 5;
-      break;
-    default:
-      break;
+
+    int findBinSuperCrystal_(ObjectType _otype, const DetId &_id, int _iSM /* -1*/) {
+      int xbin(0);
+      int ybin(0);
+      int nbinsX(0);
+      int subdet(_id.subdetId());
+
+      if (subdet == EcalBarrel) {
+        EBDetId ebid(_id);
+        int iphi(ebid.iphi());
+        int ieta(ebid.ieta());
+        switch (_otype) {
+          case kEB:
+            xbin = (iphi - 1) / 5 + 1;
+            ybin = (ieta < 0 ? ieta + 85 : ieta + 84) / 5 + 1;
+            nbinsX = 72;
+            break;
+          case kSM:
+          case kEBSM:
+            xbin = (ieta < 0 ? -ieta - 1 : ieta - 1) / 5 + 1;
+            ybin = (ieta < 0 ? (iphi - 1) % 20 : 19 - (iphi - 1) % 20) / 5 + 1;
+            nbinsX = nEBSMEta / 5;
+            break;
+          default:
+            break;
+        }
+      } else if (subdet == EcalEndcap) {
+        if (isEcalScDetId(_id)) {
+          EcalScDetId scid(_id);
+          int ix(scid.ix());
+          int iy(scid.iy());
+          switch (_otype) {
+            case kEE: {
+              int zside(scid.zside());
+              xbin = zside < 0 ? ix : ix + 20;
+              ybin = iy;
+              nbinsX = 40;
+            } break;
+            case kEEm:
+            case kEEp:
+              xbin = ix;
+              ybin = iy;
+              nbinsX = 20;
+              break;
+            case kSM:
+            case kEESM: {
+              int iSM(_iSM >= 0 ? _iSM : dccId(_id) - 1);
+              xbin = ix - xlow_(iSM) / 5;
+              ybin = iy - ylow_(iSM) / 5;
+              if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
+                nbinsX = nEESMXExt / 5;
+              else if (iSM == kEEm01 || iSM == kEEm05 || iSM == kEEm09 || iSM == kEEp01 || iSM == kEEp05 ||
+                       iSM == kEEp09)
+                nbinsX = nEESMXRed / 5;
+              else
+                nbinsX = nEESMX / 5;
+            } break;
+            default:
+              break;
+          }
+        } else {
+          EEDetId eeid(_id);
+          int ix(eeid.ix());
+          int iy(eeid.iy());
+          switch (_otype) {
+            case kEE:
+              xbin = (eeid.zside() < 0 ? ix - 1 : ix + 99) / 5 + 1;
+              ybin = (iy - 1) / 5 + 1;
+              nbinsX = 40;
+              break;
+            case kEEm:
+            case kEEp:
+              xbin = (ix - 1) / 5 + 1;
+              ybin = (iy - 1) / 5 + 1;
+              nbinsX = 20;
+              break;
+            case kSM:
+            case kEESM: {
+              int iSM(_iSM >= 0 ? _iSM : dccId(_id) - 1);
+              xbin = (ix - xlow_(iSM) - 1) / 5 + 1;
+              ybin = (iy - ylow_(iSM) - 1) / 5 + 1;
+              if (iSM == kEEm02 || iSM == kEEm08 || iSM == kEEp02 || iSM == kEEp08)
+                nbinsX = nEESMXExt / 5;
+              else if (iSM == kEEm01 || iSM == kEEm05 || iSM == kEEm09 || iSM == kEEp01 || iSM == kEEp05 ||
+                       iSM == kEEp09)
+                nbinsX = nEESMXRed / 5;
+              else
+                nbinsX = nEESMX / 5;
+            } break;
+            default:
+              break;
+          }
+        }
+      } else if (subdet == EcalTriggerTower && !isEndcapTTId(_id)) {
+        EcalTrigTowerDetId ttid(_id);
+        int ieta(ttid.ieta());
+        int iphi((ttid.iphi() + 1) % 72 + 1);
+        switch (_otype) {
+          case kEB:
+            xbin = iphi;
+            ybin = ieta < 0 ? ieta + 18 : ieta + 17;
+            nbinsX = 72;
+            break;
+          case kSM:
+          case kEBSM:
+            xbin = ieta < 0 ? -ieta : ieta;
+            ybin = ieta < 0 ? (iphi - 1) % 4 + 1 : 4 - (iphi - 1) % 4;
+            nbinsX = nEBSMEta / 5;
+            break;
+          default:
+            break;
+        }
+      }
+
+      return (nbinsX + 2) * ybin + xbin;
     }
-  }
 
-  return (nbinsX + 2) * ybin + xbin;
-}
+    int findBinSuperCrystal_(ObjectType _otype, const EcalElectronicsId &_id) {
+      int xbin(0);
+      int ybin(0);
+      int nbinsX(0);
+      int iDCC(_id.dccId() - 1);
 
-int findBinSuperCrystal_(ObjectType _otype, const EcalElectronicsId &_id) {
-  int xbin(0);
-  int ybin(0);
-  int nbinsX(0);
-  int iDCC(_id.dccId() - 1);
+      if (iDCC >= kEBmLow && iDCC <= kEBpHigh) {
+        unsigned towerid(_id.towerId());
+        bool isEBm(iDCC <= kEBmHigh);
+        switch (_otype) {
+          case kEB:
+            xbin = 4 * ((iDCC - 9) % 18) + (isEBm ? towerid - 1 : 68 - towerid) % 4 + 1;
+            ybin = (towerid - 1) / 4 * (isEBm ? -1 : 1) + (isEBm ? 18 : 17);
+            nbinsX = 72;
+            break;
+          case kSM:
+          case kEBSM:
+            xbin = (towerid - 1) / 4 + 1;
+            ybin = (isEBm ? towerid - 1 : 68 - towerid) % 4 + 1;
+            nbinsX = 17;
+            break;
+          default:
+            break;
+        }
+      } else {
+        return findBinSuperCrystal_(_otype, EEDetId(getElectronicsMap()->getDetId(_id)).sc());
+      }
 
-  if (iDCC >= kEBmLow && iDCC <= kEBpHigh) {
-    unsigned towerid(_id.towerId());
-    bool isEBm(iDCC <= kEBmHigh);
-    switch (_otype) {
-    case kEB:
-      xbin =
-          4 * ((iDCC - 9) % 18) + (isEBm ? towerid - 1 : 68 - towerid) % 4 + 1;
-      ybin = (towerid - 1) / 4 * (isEBm ? -1 : 1) + (isEBm ? 18 : 17);
-      nbinsX = 72;
-      break;
-    case kSM:
-    case kEBSM:
-      xbin = (towerid - 1) / 4 + 1;
-      ybin = (isEBm ? towerid - 1 : 68 - towerid) % 4 + 1;
-      nbinsX = 17;
-      break;
-    default:
-      break;
+      return (nbinsX + 2) * ybin + xbin;
     }
-  } else {
-    return findBinSuperCrystal_(
-        _otype, EEDetId(getElectronicsMap()->getDetId(_id)).sc());
-  }
-
-  return (nbinsX + 2) * ybin + xbin;
-}
-} // namespace binning
-} // namespace ecaldqm
+  }  // namespace binning
+}  // namespace ecaldqm

--- a/DQM/EcalCommon/src/MESetDet0D.cc
+++ b/DQM/EcalCommon/src/MESetDet0D.cc
@@ -1,94 +1,95 @@
 #include "DQM/EcalCommon/interface/MESetDet0D.h"
 
 namespace ecaldqm {
-MESetDet0D::MESetDet0D(std::string const &_fullPath, binning::ObjectType _otype,
-                       binning::BinningType _btype, MonitorElement::Kind _kind)
-    : MESetEcal(_fullPath, _otype, _btype, _kind, 0, nullptr, nullptr) {
-  switch (kind_) {
-  case MonitorElement::DQM_KIND_REAL:
-    break;
-  default:
-    throw_("Unsupported MonitorElement kind");
+  MESetDet0D::MESetDet0D(std::string const &_fullPath,
+                         binning::ObjectType _otype,
+                         binning::BinningType _btype,
+                         MonitorElement::Kind _kind)
+      : MESetEcal(_fullPath, _otype, _btype, _kind, 0, nullptr, nullptr) {
+    switch (kind_) {
+      case MonitorElement::DQM_KIND_REAL:
+        break;
+      default:
+        throw_("Unsupported MonitorElement kind");
+    }
   }
-}
 
-MESetDet0D::MESetDet0D(MESetDet0D const &_orig) : MESetEcal(_orig) {}
+  MESetDet0D::MESetDet0D(MESetDet0D const &_orig) : MESetEcal(_orig) {}
 
-MESetDet0D::~MESetDet0D() {}
+  MESetDet0D::~MESetDet0D() {}
 
-MESet *MESetDet0D::clone(std::string const &_path /* = ""*/) const {
-  std::string path(path_);
-  if (!_path.empty())
-    path_ = _path;
-  MESet *copy(new MESetDet0D(*this));
-  path_ = path;
-  return copy;
-}
+  MESet *MESetDet0D::clone(std::string const &_path /* = ""*/) const {
+    std::string path(path_);
+    if (!_path.empty())
+      path_ = _path;
+    MESet *copy(new MESetDet0D(*this));
+    path_ = path;
+    return copy;
+  }
 
-void MESetDet0D::fill(DetId const &_id, double _value, double, double) {
-  if (!active_)
-    return;
+  void MESetDet0D::fill(DetId const &_id, double _value, double, double) {
+    if (!active_)
+      return;
 
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
 
-  mes_[iME]->Fill(_value);
-}
-
-void MESetDet0D::fill(EcalElectronicsId const &_id, double _value, double,
-                      double) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  mes_[iME]->Fill(_value);
-}
-
-void MESetDet0D::fill(int _dcctccid, double _value, double, double) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
-  checkME_(iME);
-
-  mes_[iME]->Fill(_value);
-}
-
-double MESetDet0D::getBinContent(DetId const &_id, int) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  return mes_[iME]->getFloatValue();
-}
-
-double MESetDet0D::getBinContent(EcalElectronicsId const &_id, int) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  return mes_[iME]->getFloatValue();
-}
-
-double MESetDet0D::getBinContent(int _dcctccid, int) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
-  checkME_(iME);
-
-  return mes_[iME]->getFloatValue();
-}
-
-void MESetDet0D::reset(double _value /* = 0.*/, double, double) {
-  unsigned nME(mes_.size());
-  for (unsigned iME(0); iME < nME; iME++)
     mes_[iME]->Fill(_value);
-}
-} // namespace ecaldqm
+  }
+
+  void MESetDet0D::fill(EcalElectronicsId const &_id, double _value, double, double) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    mes_[iME]->Fill(_value);
+  }
+
+  void MESetDet0D::fill(int _dcctccid, double _value, double, double) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    checkME_(iME);
+
+    mes_[iME]->Fill(_value);
+  }
+
+  double MESetDet0D::getBinContent(DetId const &_id, int) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    return mes_[iME]->getFloatValue();
+  }
+
+  double MESetDet0D::getBinContent(EcalElectronicsId const &_id, int) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    return mes_[iME]->getFloatValue();
+  }
+
+  double MESetDet0D::getBinContent(int _dcctccid, int) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    checkME_(iME);
+
+    return mes_[iME]->getFloatValue();
+  }
+
+  void MESetDet0D::reset(double _value /* = 0.*/, double, double) {
+    unsigned nME(mes_.size());
+    for (unsigned iME(0); iME < nME; iME++)
+      mes_[iME]->Fill(_value);
+  }
+}  // namespace ecaldqm

--- a/DQM/EcalCommon/src/MESetDet1D.cc
+++ b/DQM/EcalCommon/src/MESetDet1D.cc
@@ -4,791 +4,753 @@
 
 namespace ecaldqm {
 
-MESetDet1D::MESetDet1D(std::string const &_fullPath, binning::ObjectType _otype,
-                       binning::BinningType _btype, MonitorElement::Kind _kind,
-                       binning::AxisSpecs const *_yaxis /* = 0*/)
-    : MESetEcal(_fullPath, _otype, _btype, _kind, 1, nullptr, _yaxis, nullptr) {
-  switch (kind_) {
-  case MonitorElement::DQM_KIND_TH1F:
-  case MonitorElement::DQM_KIND_TPROFILE:
-  case MonitorElement::DQM_KIND_TH2F:
-  case MonitorElement::DQM_KIND_TPROFILE2D:
-    break;
-  default:
-    throw_("Unsupported MonitorElement kind");
-  }
-}
-
-MESetDet1D::MESetDet1D(MESetDet1D const &_orig) : MESetEcal(_orig) {}
-
-MESetDet1D::~MESetDet1D() {}
-
-MESet *MESetDet1D::clone(std::string const &_path /* = ""*/) const {
-  std::string path(path_);
-  if (!_path.empty())
-    path_ = _path;
-  MESet *copy(new MESetDet1D(*this));
-  path_ = path;
-  return copy;
-}
-
-void MESetDet1D::book(DQMStore::IBooker &_ibooker) {
-  MESetEcal::book(_ibooker);
-
-  if (btype_ == binning::kDCC) {
-    for (unsigned iME(0); iME < mes_.size(); iME++) {
-      MonitorElement *me(mes_[iME]);
-
-      binning::ObjectType actualObject(binning::getObject(otype_, iME));
-      if (actualObject == binning::kEB) {
-        for (int iBin(1); iBin <= me->getNbinsX(); iBin++)
-          me->setBinLabel(iBin, binning::channelName(iBin + kEBmLow));
-      } else if (actualObject == binning::kEE) {
-        for (int iBin(1); iBin <= me->getNbinsX() / 2; iBin++) {
-          me->setBinLabel(iBin, binning::channelName(iBin));
-          me->setBinLabel(iBin + me->getNbinsX() / 2,
-                          binning::channelName(iBin + 45));
-        }
-      } else if (actualObject == binning::kEEm) {
-        for (int iBin(1); iBin <= me->getNbinsX(); iBin++)
-          me->setBinLabel(iBin, binning::channelName(iBin));
-      } else if (actualObject == binning::kEEp) {
-        for (int iBin(1); iBin <= me->getNbinsX(); iBin++)
-          me->setBinLabel(iBin, binning::channelName(iBin + 45));
-      }
+  MESetDet1D::MESetDet1D(std::string const &_fullPath,
+                         binning::ObjectType _otype,
+                         binning::BinningType _btype,
+                         MonitorElement::Kind _kind,
+                         binning::AxisSpecs const *_yaxis /* = 0*/)
+      : MESetEcal(_fullPath, _otype, _btype, _kind, 1, nullptr, _yaxis, nullptr) {
+    switch (kind_) {
+      case MonitorElement::DQM_KIND_TH1F:
+      case MonitorElement::DQM_KIND_TPROFILE:
+      case MonitorElement::DQM_KIND_TH2F:
+      case MonitorElement::DQM_KIND_TPROFILE2D:
+        break;
+      default:
+        throw_("Unsupported MonitorElement kind");
     }
-  } else if (btype_ == binning::kTriggerTower) {
-    for (unsigned iME(0); iME < mes_.size(); iME++) {
-      MonitorElement *me(mes_[iME]);
+  }
 
-      binning::ObjectType actualObject(binning::getObject(otype_, iME));
-      unsigned dccid(0);
-      if (actualObject == binning::kSM && (iME <= kEEmHigh || iME >= kEEpLow))
-        dccid = iME + 1;
-      else if (actualObject == binning::kEESM)
-        dccid = iME <= kEEmHigh ? iME + 1 : iME + 37;
+  MESetDet1D::MESetDet1D(MESetDet1D const &_orig) : MESetEcal(_orig) {}
 
-      if (dccid > 0) {
-        std::stringstream ss;
-        std::pair<unsigned, unsigned> inner(innerTCCs(iME + 1));
-        std::pair<unsigned, unsigned> outer(outerTCCs(iME + 1));
-        ss << "TCC" << inner.first << " TT1";
-        me->setBinLabel(1, ss.str());
-        ss.str("");
-        ss << "TCC" << inner.second << " TT1";
-        me->setBinLabel(1 + nTTInner, ss.str());
-        ss.str("");
-        ss << "TCC" << outer.first << " TT1";
-        me->setBinLabel(1 + 2 * nTTInner, ss.str());
-        ss.str("");
-        ss << "TCC" << outer.second << " TT1";
-        me->setBinLabel(1 + 2 * nTTInner + nTTOuter, ss.str());
-        // Bins are numbered:
-        // inner1:(1)-->(nTTInner)
-        // inner2:(1+nTTInner)-->(1+nTTInner + nTTInner-1 = 2*nTTInner)
-        // outer1:(1+2*nTTInner)-->(1+2*nTTInner+nTTOuter-1=2*nTTInner+nTTOuter)
-        // outer2:(1+2*nTTInner+nTTOuter)-->(1+2*nTTInner+nTTOuter + nTTOuter-1
-        // = 2*nTTInner+2*nTTOuter)
-        int offset(0);
-        for (int iBin(4); iBin <= (2 * nTTOuter + 2 * nTTInner); iBin += 4) {
-          if (iBin == 4 + nTTInner)
-            offset = nTTInner;
-          else if (iBin == 4 + 2 * nTTInner)
-            offset = 2 * nTTInner;
-          else if (iBin == 4 + 2 * nTTInner + nTTOuter)
-            offset = 2 * nTTInner + nTTOuter;
+  MESetDet1D::~MESetDet1D() {}
+
+  MESet *MESetDet1D::clone(std::string const &_path /* = ""*/) const {
+    std::string path(path_);
+    if (!_path.empty())
+      path_ = _path;
+    MESet *copy(new MESetDet1D(*this));
+    path_ = path;
+    return copy;
+  }
+
+  void MESetDet1D::book(DQMStore::IBooker &_ibooker) {
+    MESetEcal::book(_ibooker);
+
+    if (btype_ == binning::kDCC) {
+      for (unsigned iME(0); iME < mes_.size(); iME++) {
+        MonitorElement *me(mes_[iME]);
+
+        binning::ObjectType actualObject(binning::getObject(otype_, iME));
+        if (actualObject == binning::kEB) {
+          for (int iBin(1); iBin <= me->getNbinsX(); iBin++)
+            me->setBinLabel(iBin, binning::channelName(iBin + kEBmLow));
+        } else if (actualObject == binning::kEE) {
+          for (int iBin(1); iBin <= me->getNbinsX() / 2; iBin++) {
+            me->setBinLabel(iBin, binning::channelName(iBin));
+            me->setBinLabel(iBin + me->getNbinsX() / 2, binning::channelName(iBin + 45));
+          }
+        } else if (actualObject == binning::kEEm) {
+          for (int iBin(1); iBin <= me->getNbinsX(); iBin++)
+            me->setBinLabel(iBin, binning::channelName(iBin));
+        } else if (actualObject == binning::kEEp) {
+          for (int iBin(1); iBin <= me->getNbinsX(); iBin++)
+            me->setBinLabel(iBin, binning::channelName(iBin + 45));
+        }
+      }
+    } else if (btype_ == binning::kTriggerTower) {
+      for (unsigned iME(0); iME < mes_.size(); iME++) {
+        MonitorElement *me(mes_[iME]);
+
+        binning::ObjectType actualObject(binning::getObject(otype_, iME));
+        unsigned dccid(0);
+        if (actualObject == binning::kSM && (iME <= kEEmHigh || iME >= kEEpLow))
+          dccid = iME + 1;
+        else if (actualObject == binning::kEESM)
+          dccid = iME <= kEEmHigh ? iME + 1 : iME + 37;
+
+        if (dccid > 0) {
+          std::stringstream ss;
+          std::pair<unsigned, unsigned> inner(innerTCCs(iME + 1));
+          std::pair<unsigned, unsigned> outer(outerTCCs(iME + 1));
+          ss << "TCC" << inner.first << " TT1";
+          me->setBinLabel(1, ss.str());
           ss.str("");
-          ss << iBin - offset;
-          me->setBinLabel(iBin, ss.str());
+          ss << "TCC" << inner.second << " TT1";
+          me->setBinLabel(1 + nTTInner, ss.str());
+          ss.str("");
+          ss << "TCC" << outer.first << " TT1";
+          me->setBinLabel(1 + 2 * nTTInner, ss.str());
+          ss.str("");
+          ss << "TCC" << outer.second << " TT1";
+          me->setBinLabel(1 + 2 * nTTInner + nTTOuter, ss.str());
+          // Bins are numbered:
+          // inner1:(1)-->(nTTInner)
+          // inner2:(1+nTTInner)-->(1+nTTInner + nTTInner-1 = 2*nTTInner)
+          // outer1:(1+2*nTTInner)-->(1+2*nTTInner+nTTOuter-1=2*nTTInner+nTTOuter)
+          // outer2:(1+2*nTTInner+nTTOuter)-->(1+2*nTTInner+nTTOuter + nTTOuter-1
+          // = 2*nTTInner+2*nTTOuter)
+          int offset(0);
+          for (int iBin(4); iBin <= (2 * nTTOuter + 2 * nTTInner); iBin += 4) {
+            if (iBin == 4 + nTTInner)
+              offset = nTTInner;
+            else if (iBin == 4 + 2 * nTTInner)
+              offset = 2 * nTTInner;
+            else if (iBin == 4 + 2 * nTTInner + nTTOuter)
+              offset = 2 * nTTInner + nTTOuter;
+            ss.str("");
+            ss << iBin - offset;
+            me->setBinLabel(iBin, ss.str());
+          }
         }
       }
     }
   }
-}
 
-void MESetDet1D::fill(DetId const &_id, double _wy /* = 1.*/,
-                      double _w /* = 1.*/, double) {
-  if (!active_)
-    return;
+  void MESetDet1D::fill(DetId const &_id, double _wy /* = 1.*/, double _w /* = 1.*/, double) {
+    if (!active_)
+      return;
 
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
 
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
 
-  if (kind_ == MonitorElement::DQM_KIND_TH2F ||
-      kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
-    fill_(iME, xbin, _wy, _w);
-  else
-    fill_(iME, xbin, _wy);
-}
+    if (kind_ == MonitorElement::DQM_KIND_TH2F || kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
+      fill_(iME, xbin, _wy, _w);
+    else
+      fill_(iME, xbin, _wy);
+  }
 
-void MESetDet1D::fill(EcalElectronicsId const &_id, double _wy /* = 1.*/,
-                      double _w /* = 1.*/, double) {
-  if (!active_)
-    return;
+  void MESetDet1D::fill(EcalElectronicsId const &_id, double _wy /* = 1.*/, double _w /* = 1.*/, double) {
+    if (!active_)
+      return;
 
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
 
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
 
-  if (kind_ == MonitorElement::DQM_KIND_TH2F ||
-      kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
-    fill_(iME, xbin, _wy, _w);
-  else
-    fill_(iME, xbin, _wy);
-}
+    if (kind_ == MonitorElement::DQM_KIND_TH2F || kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
+      fill_(iME, xbin, _wy, _w);
+    else
+      fill_(iME, xbin, _wy);
+  }
 
-void MESetDet1D::fill(int _dcctccid, double _wy /* = 1.*/, double _w /* = 1.*/,
-                      double) {
-  if (!active_)
-    return;
+  void MESetDet1D::fill(int _dcctccid, double _wy /* = 1.*/, double _w /* = 1.*/, double) {
+    if (!active_)
+      return;
 
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
-  checkME_(iME);
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    checkME_(iME);
 
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
 
-  if (kind_ == MonitorElement::DQM_KIND_TH2F ||
-      kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
-    fill_(iME, xbin, _wy, _w);
-  else
-    fill_(iME, xbin, _wy);
-}
+    if (kind_ == MonitorElement::DQM_KIND_TH2F || kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
+      fill_(iME, xbin, _wy, _w);
+    else
+      fill_(iME, xbin, _wy);
+  }
 
-void MESetDet1D::setBinContent(DetId const &_id, double _content) {
-  if (!active_)
-    return;
+  void MESetDet1D::setBinContent(DetId const &_id, double _content) {
+    if (!active_)
+      return;
 
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
 
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-
-  if (kind_ == MonitorElement::DQM_KIND_TH2F ||
-      kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
-    int nbinsY(me->getTH1()->GetNbinsY());
-    for (int iY(1); iY <= nbinsY; iY++)
-      me->setBinContent(xbin, iY, _content);
-  } else
-    me->setBinContent(xbin, _content);
-}
-
-void MESetDet1D::setBinContent(EcalElectronicsId const &_id, double _content) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-
-  if (kind_ == MonitorElement::DQM_KIND_TH2F ||
-      kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
-    int nbinsY(me->getTH1()->GetNbinsY());
-    for (int iY(1); iY <= nbinsY; iY++)
-      me->setBinContent(xbin, iY, _content);
-  } else
-    me->setBinContent(xbin, _content);
-}
-
-void MESetDet1D::setBinContent(int _dcctccid, double _content) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _dcctccid));
-
-  if (kind_ == MonitorElement::DQM_KIND_TH2F ||
-      kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
-    int nbinsY(me->getTH1()->GetNbinsY());
-    for (int iY(1); iY <= nbinsY; iY++)
-      me->setBinContent(xbin, iY, _content);
-  } else
-    me->setBinContent(xbin, _content);
-}
-
-void MESetDet1D::setBinContent(DetId const &_id, int _ybin, double _content) {
-  if (!active_)
-    return;
-  if (kind_ != MonitorElement::DQM_KIND_TH2F &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-  me->setBinContent(xbin, _ybin, _content);
-}
-
-void MESetDet1D::setBinContent(EcalElectronicsId const &_id, int _ybin,
-                               double _content) {
-  if (!active_)
-    return;
-  if (kind_ != MonitorElement::DQM_KIND_TH2F &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-  me->setBinContent(xbin, _ybin, _content);
-}
-
-void MESetDet1D::setBinContent(int _dcctccid, int _ybin, double _content) {
-  if (!active_)
-    return;
-  if (kind_ != MonitorElement::DQM_KIND_TH2F &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _dcctccid));
-  me->setBinContent(xbin, _ybin, _content);
-}
-
-void MESetDet1D::setBinError(DetId const &_id, double _error) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-
-  if (kind_ == MonitorElement::DQM_KIND_TH2F ||
-      kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
-    int nbinsY(me->getTH1()->GetNbinsY());
-    for (int iY(1); iY <= nbinsY; iY++)
-      me->setBinError(xbin, iY, _error);
-  } else
-    me->setBinError(xbin, _error);
-}
-
-void MESetDet1D::setBinError(EcalElectronicsId const &_id, double _error) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-
-  if (kind_ == MonitorElement::DQM_KIND_TH2F ||
-      kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
-    int nbinsY(me->getTH1()->GetNbinsY());
-    for (int iY(1); iY <= nbinsY; iY++)
-      me->setBinError(xbin, iY, _error);
-  } else
-    me->setBinError(xbin, _error);
-}
-
-void MESetDet1D::setBinError(int _dcctccid, double _error) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _dcctccid));
-
-  if (kind_ == MonitorElement::DQM_KIND_TH2F ||
-      kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
-    int nbinsY(me->getTH1()->GetNbinsY());
-    for (int iY(1); iY <= nbinsY; iY++)
-      me->setBinError(xbin, iY, _error);
-  } else
-    me->setBinError(xbin, _error);
-}
-
-void MESetDet1D::setBinError(DetId const &_id, int _ybin, double _error) {
-  if (!active_)
-    return;
-  if (kind_ != MonitorElement::DQM_KIND_TH2F &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-  me->setBinError(xbin, _ybin, _error);
-}
-
-void MESetDet1D::setBinError(EcalElectronicsId const &_id, int _ybin,
-                             double _error) {
-  if (!active_)
-    return;
-  if (kind_ != MonitorElement::DQM_KIND_TH2F &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-  me->setBinError(xbin, _ybin, _error);
-}
-
-void MESetDet1D::setBinError(int _dcctccid, int _ybin, double _error) {
-  if (!active_)
-    return;
-  if (kind_ != MonitorElement::DQM_KIND_TH2F &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _dcctccid));
-  me->setBinError(xbin, _ybin, _error);
-}
-
-void MESetDet1D::setBinEntries(DetId const &_id, double _entries) {
-  if (!active_)
-    return;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-
-  if (kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
-    int nbinsX(me->getTH1()->GetNbinsX());
-    int nbinsY(me->getTH1()->GetNbinsY());
-    for (int iY(1); iY <= nbinsY; iY++)
-      me->setBinEntries((nbinsX + 2) * iY + xbin, _entries);
-  } else
-    me->setBinEntries(xbin, _entries);
-}
-
-void MESetDet1D::setBinEntries(EcalElectronicsId const &_id, double _entries) {
-  if (!active_)
-    return;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-
-  if (kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
-    int nbinsX(me->getTH1()->GetNbinsX());
-    int nbinsY(me->getTH1()->GetNbinsY());
-    for (int iY(1); iY <= nbinsY; iY++)
-      me->setBinEntries((nbinsX + 2) * iY + xbin, _entries);
-  } else
-    me->setBinEntries(xbin, _entries);
-}
-
-void MESetDet1D::setBinEntries(int _dcctccid, double _entries) {
-  if (!active_)
-    return;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _dcctccid));
-
-  if (kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
-    int nbinsX(me->getTH1()->GetNbinsX());
-    int nbinsY(me->getTH1()->GetNbinsY());
-    for (int iY(1); iY <= nbinsY; iY++)
-      me->setBinEntries((nbinsX + 2) * iY + xbin, _entries);
-  } else
-    me->setBinEntries(xbin, _entries);
-}
-
-void MESetDet1D::setBinEntries(DetId const &_id, int _ybin, double _entries) {
-  if (!active_)
-    return;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-  int nbinsX(me->getTH1()->GetNbinsX());
-  me->setBinEntries((nbinsX + 2) * _ybin + xbin, _entries);
-}
-
-void MESetDet1D::setBinEntries(EcalElectronicsId const &_id, int _ybin,
-                               double _entries) {
-  if (!active_)
-    return;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-  int nbinsX(me->getTH1()->GetNbinsX());
-  me->setBinEntries((nbinsX + 2) * _ybin + xbin, _entries);
-}
-
-void MESetDet1D::setBinEntries(int _dcctccid, int _ybin, double _entries) {
-  if (!active_)
-    return;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _dcctccid));
-  int nbinsX(me->getTH1()->GetNbinsX());
-  me->setBinEntries((nbinsX + 2) * _ybin + xbin, _entries);
-}
-
-double MESetDet1D::getBinContent(DetId const &_id, int _ybin /* = 0*/) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-  int nbinsX(me->getTH1()->GetNbinsX());
-
-  return me->getBinContent((nbinsX + 2) * _ybin + xbin);
-}
-
-double MESetDet1D::getBinContent(EcalElectronicsId const &_id,
-                                 int _ybin /* = 0*/) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-  int nbinsX(me->getTH1()->GetNbinsX());
-
-  return me->getBinContent((nbinsX + 2) * _ybin + xbin);
-}
-
-double MESetDet1D::getBinContent(int _dcctccid, int _ybin /* = 0*/) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _dcctccid));
-  int nbinsX(me->getTH1()->GetNbinsX());
-
-  return me->getBinContent((nbinsX + 2) * _ybin + xbin);
-}
-
-double MESetDet1D::getBinError(DetId const &_id, int _ybin /* = 0*/) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-  int nbinsX(me->getTH1()->GetNbinsX());
-
-  return me->getBinError((nbinsX + 2) * _ybin + xbin);
-}
-
-double MESetDet1D::getBinError(EcalElectronicsId const &_id,
-                               int _ybin /* = 0*/) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-  int nbinsX(me->getTH1()->GetNbinsX());
-
-  return me->getBinError((nbinsX + 2) * _ybin + xbin);
-}
-
-double MESetDet1D::getBinError(int _dcctccid, int _ybin /* = 0*/) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _dcctccid));
-  int nbinsX(me->getTH1()->GetNbinsX());
-
-  return me->getBinError((nbinsX + 2) * _ybin + xbin);
-}
-
-double MESetDet1D::getBinEntries(DetId const &_id, int _ybin /* = 0*/) const {
-  if (!active_)
-    return 0.;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-  int nbinsX(me->getTH1()->GetNbinsX());
-
-  return me->getBinEntries((nbinsX + 2) * _ybin + xbin);
-}
-
-double MESetDet1D::getBinEntries(EcalElectronicsId const &_id,
-                                 int _ybin /* = 0*/) const {
-  if (!active_)
-    return 0.;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-  int nbinsX(me->getTH1()->GetNbinsX());
-
-  return me->getBinEntries((nbinsX + 2) * _ybin + xbin);
-}
-
-double MESetDet1D::getBinEntries(int _dcctccid, int _ybin /* = 0*/) const {
-  if (!active_)
-    return 0.;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _dcctccid));
-  int nbinsX(me->getTH1()->GetNbinsX());
-
-  return me->getBinEntries((nbinsX + 2) * _ybin + xbin);
-}
-
-int MESetDet1D::findBin(DetId const &_id) const {
-  if (!active_)
-    return -1;
-  if (kind_ == MonitorElement::DQM_KIND_TPROFILE ||
-      kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
-    return -1;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  return binning::findBin1D(obj, btype_, _id);
-}
-
-int MESetDet1D::findBin(EcalElectronicsId const &_id) const {
-  if (!active_)
-    return -1;
-  if (kind_ == MonitorElement::DQM_KIND_TPROFILE ||
-      kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
-    return -1;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  return binning::findBin1D(obj, btype_, _id);
-}
-
-int MESetDet1D::findBin(int _dcctccid) const {
-  if (!active_)
-    return -1;
-  if (kind_ == MonitorElement::DQM_KIND_TPROFILE ||
-      kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
-    return -1;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  return binning::findBin1D(obj, btype_, _dcctccid);
-}
-
-int MESetDet1D::findBin(DetId const &_id, double _y, double) const {
-  if (!active_)
-    return -1;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return -1;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-  int nbinsX(me->getTH1()->GetNbinsX());
-  return xbin + (nbinsX + 2) * me->getTH1()->GetYaxis()->FindBin(_y);
-}
-
-int MESetDet1D::findBin(EcalElectronicsId const &_id, double _y, double) const {
-  if (!active_)
-    return -1;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return -1;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _id));
-  int nbinsX(me->getTH1()->GetNbinsX());
-  return xbin + (nbinsX + 2) * me->getTH1()->GetYaxis()->FindBin(_y);
-}
-
-int MESetDet1D::findBin(int _dcctccid, double _y, double) const {
-  if (!active_)
-    return -1;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return -1;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-  int xbin(binning::findBin1D(obj, btype_, _dcctccid));
-  int nbinsX(me->getTH1()->GetNbinsX());
-  return xbin + (nbinsX + 2) * me->getTH1()->GetYaxis()->FindBin(_y);
-}
-
-void MESetDet1D::reset(double _content /* = 0.*/, double _err /* = 0.*/,
-                       double _entries /* = 0.*/) {
-  unsigned nME(binning::getNObjects(otype_));
-
-  bool isProfile(kind_ == MonitorElement::DQM_KIND_TPROFILE ||
-                 kind_ == MonitorElement::DQM_KIND_TPROFILE2D);
-  bool is2D(kind_ == MonitorElement::DQM_KIND_TH2F ||
-            kind_ == MonitorElement::DQM_KIND_TPROFILE2D);
-
-  for (unsigned iME(0); iME < nME; iME++) {
     MonitorElement *me(mes_[iME]);
 
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
+
+    if (kind_ == MonitorElement::DQM_KIND_TH2F || kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
+      int nbinsY(me->getTH1()->GetNbinsY());
+      for (int iY(1); iY <= nbinsY; iY++)
+        me->setBinContent(xbin, iY, _content);
+    } else
+      me->setBinContent(xbin, _content);
+  }
+
+  void MESetDet1D::setBinContent(EcalElectronicsId const &_id, double _content) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
+
+    if (kind_ == MonitorElement::DQM_KIND_TH2F || kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
+      int nbinsY(me->getTH1()->GetNbinsY());
+      for (int iY(1); iY <= nbinsY; iY++)
+        me->setBinContent(xbin, iY, _content);
+    } else
+      me->setBinContent(xbin, _content);
+  }
+
+  void MESetDet1D::setBinContent(int _dcctccid, double _content) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+
+    if (kind_ == MonitorElement::DQM_KIND_TH2F || kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
+      int nbinsY(me->getTH1()->GetNbinsY());
+      for (int iY(1); iY <= nbinsY; iY++)
+        me->setBinContent(xbin, iY, _content);
+    } else
+      me->setBinContent(xbin, _content);
+  }
+
+  void MESetDet1D::setBinContent(DetId const &_id, int _ybin, double _content) {
+    if (!active_)
+      return;
+    if (kind_ != MonitorElement::DQM_KIND_TH2F && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
+    me->setBinContent(xbin, _ybin, _content);
+  }
+
+  void MESetDet1D::setBinContent(EcalElectronicsId const &_id, int _ybin, double _content) {
+    if (!active_)
+      return;
+    if (kind_ != MonitorElement::DQM_KIND_TH2F && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
+    me->setBinContent(xbin, _ybin, _content);
+  }
+
+  void MESetDet1D::setBinContent(int _dcctccid, int _ybin, double _content) {
+    if (!active_)
+      return;
+    if (kind_ != MonitorElement::DQM_KIND_TH2F && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+    me->setBinContent(xbin, _ybin, _content);
+  }
+
+  void MESetDet1D::setBinError(DetId const &_id, double _error) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
+
+    if (kind_ == MonitorElement::DQM_KIND_TH2F || kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
+      int nbinsY(me->getTH1()->GetNbinsY());
+      for (int iY(1); iY <= nbinsY; iY++)
+        me->setBinError(xbin, iY, _error);
+    } else
+      me->setBinError(xbin, _error);
+  }
+
+  void MESetDet1D::setBinError(EcalElectronicsId const &_id, double _error) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
+
+    if (kind_ == MonitorElement::DQM_KIND_TH2F || kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
+      int nbinsY(me->getTH1()->GetNbinsY());
+      for (int iY(1); iY <= nbinsY; iY++)
+        me->setBinError(xbin, iY, _error);
+    } else
+      me->setBinError(xbin, _error);
+  }
+
+  void MESetDet1D::setBinError(int _dcctccid, double _error) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+
+    if (kind_ == MonitorElement::DQM_KIND_TH2F || kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
+      int nbinsY(me->getTH1()->GetNbinsY());
+      for (int iY(1); iY <= nbinsY; iY++)
+        me->setBinError(xbin, iY, _error);
+    } else
+      me->setBinError(xbin, _error);
+  }
+
+  void MESetDet1D::setBinError(DetId const &_id, int _ybin, double _error) {
+    if (!active_)
+      return;
+    if (kind_ != MonitorElement::DQM_KIND_TH2F && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
+    me->setBinError(xbin, _ybin, _error);
+  }
+
+  void MESetDet1D::setBinError(EcalElectronicsId const &_id, int _ybin, double _error) {
+    if (!active_)
+      return;
+    if (kind_ != MonitorElement::DQM_KIND_TH2F && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
+    me->setBinError(xbin, _ybin, _error);
+  }
+
+  void MESetDet1D::setBinError(int _dcctccid, int _ybin, double _error) {
+    if (!active_)
+      return;
+    if (kind_ != MonitorElement::DQM_KIND_TH2F && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+    me->setBinError(xbin, _ybin, _error);
+  }
+
+  void MESetDet1D::setBinEntries(DetId const &_id, double _entries) {
+    if (!active_)
+      return;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
+
+    if (kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
+      int nbinsX(me->getTH1()->GetNbinsX());
+      int nbinsY(me->getTH1()->GetNbinsY());
+      for (int iY(1); iY <= nbinsY; iY++)
+        me->setBinEntries((nbinsX + 2) * iY + xbin, _entries);
+    } else
+      me->setBinEntries(xbin, _entries);
+  }
+
+  void MESetDet1D::setBinEntries(EcalElectronicsId const &_id, double _entries) {
+    if (!active_)
+      return;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
+
+    if (kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
+      int nbinsX(me->getTH1()->GetNbinsX());
+      int nbinsY(me->getTH1()->GetNbinsY());
+      for (int iY(1); iY <= nbinsY; iY++)
+        me->setBinEntries((nbinsX + 2) * iY + xbin, _entries);
+    } else
+      me->setBinEntries(xbin, _entries);
+  }
+
+  void MESetDet1D::setBinEntries(int _dcctccid, double _entries) {
+    if (!active_)
+      return;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+
+    if (kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
+      int nbinsX(me->getTH1()->GetNbinsX());
+      int nbinsY(me->getTH1()->GetNbinsY());
+      for (int iY(1); iY <= nbinsY; iY++)
+        me->setBinEntries((nbinsX + 2) * iY + xbin, _entries);
+    } else
+      me->setBinEntries(xbin, _entries);
+  }
+
+  void MESetDet1D::setBinEntries(DetId const &_id, int _ybin, double _entries) {
+    if (!active_)
+      return;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
     int nbinsX(me->getTH1()->GetNbinsX());
-    int nbinsY(me->getTH1()->GetNbinsY());
-    for (int ix(1); ix <= nbinsX; ix++) {
-      for (int iy(1); iy <= nbinsY; iy++) {
-        int bin(is2D ? (nbinsX + 2) * iy + ix : ix);
-        me->setBinContent(bin, _content);
-        me->setBinError(bin, _err);
-        if (isProfile)
-          me->setBinEntries(bin, _entries);
+    me->setBinEntries((nbinsX + 2) * _ybin + xbin, _entries);
+  }
+
+  void MESetDet1D::setBinEntries(EcalElectronicsId const &_id, int _ybin, double _entries) {
+    if (!active_)
+      return;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
+    int nbinsX(me->getTH1()->GetNbinsX());
+    me->setBinEntries((nbinsX + 2) * _ybin + xbin, _entries);
+  }
+
+  void MESetDet1D::setBinEntries(int _dcctccid, int _ybin, double _entries) {
+    if (!active_)
+      return;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+    int nbinsX(me->getTH1()->GetNbinsX());
+    me->setBinEntries((nbinsX + 2) * _ybin + xbin, _entries);
+  }
+
+  double MESetDet1D::getBinContent(DetId const &_id, int _ybin /* = 0*/) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
+    int nbinsX(me->getTH1()->GetNbinsX());
+
+    return me->getBinContent((nbinsX + 2) * _ybin + xbin);
+  }
+
+  double MESetDet1D::getBinContent(EcalElectronicsId const &_id, int _ybin /* = 0*/) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
+    int nbinsX(me->getTH1()->GetNbinsX());
+
+    return me->getBinContent((nbinsX + 2) * _ybin + xbin);
+  }
+
+  double MESetDet1D::getBinContent(int _dcctccid, int _ybin /* = 0*/) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+    int nbinsX(me->getTH1()->GetNbinsX());
+
+    return me->getBinContent((nbinsX + 2) * _ybin + xbin);
+  }
+
+  double MESetDet1D::getBinError(DetId const &_id, int _ybin /* = 0*/) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
+    int nbinsX(me->getTH1()->GetNbinsX());
+
+    return me->getBinError((nbinsX + 2) * _ybin + xbin);
+  }
+
+  double MESetDet1D::getBinError(EcalElectronicsId const &_id, int _ybin /* = 0*/) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
+    int nbinsX(me->getTH1()->GetNbinsX());
+
+    return me->getBinError((nbinsX + 2) * _ybin + xbin);
+  }
+
+  double MESetDet1D::getBinError(int _dcctccid, int _ybin /* = 0*/) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+    int nbinsX(me->getTH1()->GetNbinsX());
+
+    return me->getBinError((nbinsX + 2) * _ybin + xbin);
+  }
+
+  double MESetDet1D::getBinEntries(DetId const &_id, int _ybin /* = 0*/) const {
+    if (!active_)
+      return 0.;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
+    int nbinsX(me->getTH1()->GetNbinsX());
+
+    return me->getBinEntries((nbinsX + 2) * _ybin + xbin);
+  }
+
+  double MESetDet1D::getBinEntries(EcalElectronicsId const &_id, int _ybin /* = 0*/) const {
+    if (!active_)
+      return 0.;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
+    int nbinsX(me->getTH1()->GetNbinsX());
+
+    return me->getBinEntries((nbinsX + 2) * _ybin + xbin);
+  }
+
+  double MESetDet1D::getBinEntries(int _dcctccid, int _ybin /* = 0*/) const {
+    if (!active_)
+      return 0.;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+    int nbinsX(me->getTH1()->GetNbinsX());
+
+    return me->getBinEntries((nbinsX + 2) * _ybin + xbin);
+  }
+
+  int MESetDet1D::findBin(DetId const &_id) const {
+    if (!active_)
+      return -1;
+    if (kind_ == MonitorElement::DQM_KIND_TPROFILE || kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
+      return -1;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    return binning::findBin1D(obj, btype_, _id);
+  }
+
+  int MESetDet1D::findBin(EcalElectronicsId const &_id) const {
+    if (!active_)
+      return -1;
+    if (kind_ == MonitorElement::DQM_KIND_TPROFILE || kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
+      return -1;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    return binning::findBin1D(obj, btype_, _id);
+  }
+
+  int MESetDet1D::findBin(int _dcctccid) const {
+    if (!active_)
+      return -1;
+    if (kind_ == MonitorElement::DQM_KIND_TPROFILE || kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
+      return -1;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    return binning::findBin1D(obj, btype_, _dcctccid);
+  }
+
+  int MESetDet1D::findBin(DetId const &_id, double _y, double) const {
+    if (!active_)
+      return -1;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return -1;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
+    int nbinsX(me->getTH1()->GetNbinsX());
+    return xbin + (nbinsX + 2) * me->getTH1()->GetYaxis()->FindBin(_y);
+  }
+
+  int MESetDet1D::findBin(EcalElectronicsId const &_id, double _y, double) const {
+    if (!active_)
+      return -1;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return -1;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _id));
+    int nbinsX(me->getTH1()->GetNbinsX());
+    return xbin + (nbinsX + 2) * me->getTH1()->GetYaxis()->FindBin(_y);
+  }
+
+  int MESetDet1D::findBin(int _dcctccid, double _y, double) const {
+    if (!active_)
+      return -1;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return -1;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+    int xbin(binning::findBin1D(obj, btype_, _dcctccid));
+    int nbinsX(me->getTH1()->GetNbinsX());
+    return xbin + (nbinsX + 2) * me->getTH1()->GetYaxis()->FindBin(_y);
+  }
+
+  void MESetDet1D::reset(double _content /* = 0.*/, double _err /* = 0.*/, double _entries /* = 0.*/) {
+    unsigned nME(binning::getNObjects(otype_));
+
+    bool isProfile(kind_ == MonitorElement::DQM_KIND_TPROFILE || kind_ == MonitorElement::DQM_KIND_TPROFILE2D);
+    bool is2D(kind_ == MonitorElement::DQM_KIND_TH2F || kind_ == MonitorElement::DQM_KIND_TPROFILE2D);
+
+    for (unsigned iME(0); iME < nME; iME++) {
+      MonitorElement *me(mes_[iME]);
+
+      int nbinsX(me->getTH1()->GetNbinsX());
+      int nbinsY(me->getTH1()->GetNbinsY());
+      for (int ix(1); ix <= nbinsX; ix++) {
+        for (int iy(1); iy <= nbinsY; iy++) {
+          int bin(is2D ? (nbinsX + 2) * iy + ix : ix);
+          me->setBinContent(bin, _content);
+          me->setBinError(bin, _err);
+          if (isProfile)
+            me->setBinEntries(bin, _entries);
+        }
       }
     }
   }
-}
-} // namespace ecaldqm
+}  // namespace ecaldqm

--- a/DQM/EcalCommon/src/MESetDet2D.cc
+++ b/DQM/EcalCommon/src/MESetDet2D.cc
@@ -3,98 +3,129 @@
 #include "DQM/EcalCommon/interface/EcalDQMCommonUtils.h"
 
 namespace ecaldqm {
-MESetDet2D::MESetDet2D(std::string const &_fullPath, binning::ObjectType _otype,
-                       binning::BinningType _btype, MonitorElement::Kind _kind,
-                       binning::AxisSpecs const *_zaxis /* = 0*/)
-    : MESetEcal(_fullPath, _otype, _btype, _kind, 2, nullptr, nullptr, _zaxis) {
-  switch (kind_) {
-  case MonitorElement::DQM_KIND_TH2F:
-  case MonitorElement::DQM_KIND_TPROFILE2D:
-    break;
-  default:
-    throw_("Unsupported MonitorElement kind");
+  MESetDet2D::MESetDet2D(std::string const &_fullPath,
+                         binning::ObjectType _otype,
+                         binning::BinningType _btype,
+                         MonitorElement::Kind _kind,
+                         binning::AxisSpecs const *_zaxis /* = 0*/)
+      : MESetEcal(_fullPath, _otype, _btype, _kind, 2, nullptr, nullptr, _zaxis) {
+    switch (kind_) {
+      case MonitorElement::DQM_KIND_TH2F:
+      case MonitorElement::DQM_KIND_TPROFILE2D:
+        break;
+      default:
+        throw_("Unsupported MonitorElement kind");
+    }
   }
-}
 
-MESetDet2D::MESetDet2D(MESetDet2D const &_orig) : MESetEcal(_orig) {}
+  MESetDet2D::MESetDet2D(MESetDet2D const &_orig) : MESetEcal(_orig) {}
 
-MESetDet2D::~MESetDet2D() {}
+  MESetDet2D::~MESetDet2D() {}
 
-MESet *MESetDet2D::clone(std::string const &_path /* = ""*/) const {
-  std::string path(path_);
-  if (!_path.empty())
-    path_ = _path;
-  MESet *copy(new MESetDet2D(*this));
-  path_ = path;
-  return copy;
-}
+  MESet *MESetDet2D::clone(std::string const &_path /* = ""*/) const {
+    std::string path(path_);
+    if (!_path.empty())
+      path_ = _path;
+    MESet *copy(new MESetDet2D(*this));
+    path_ = path;
+    return copy;
+  }
 
-void MESetDet2D::book(DQMStore::IBooker &_ibooker) {
-  MESetEcal::book(_ibooker);
+  void MESetDet2D::book(DQMStore::IBooker &_ibooker) {
+    MESetEcal::book(_ibooker);
 
-  if (btype_ == binning::kCrystal) {
-    for (unsigned iME(0); iME < mes_.size(); iME++) {
-      MonitorElement *me(mes_[iME]);
+    if (btype_ == binning::kCrystal) {
+      for (unsigned iME(0); iME < mes_.size(); iME++) {
+        MonitorElement *me(mes_[iME]);
 
-      binning::ObjectType actualObject(binning::getObject(otype_, iME));
-      if (actualObject == binning::kMEM) {
-        for (int iBin(1); iBin <= me->getNbinsX(); ++iBin)
-          me->setBinLabel(iBin, binning::channelName(memDCCId(iBin - 1)));
+        binning::ObjectType actualObject(binning::getObject(otype_, iME));
+        if (actualObject == binning::kMEM) {
+          for (int iBin(1); iBin <= me->getNbinsX(); ++iBin)
+            me->setBinLabel(iBin, binning::channelName(memDCCId(iBin - 1)));
+        }
+        if (actualObject == binning::kEBMEM) {
+          for (int iBin(1); iBin <= me->getNbinsX(); ++iBin)
+            me->setBinLabel(iBin, binning::channelName(iBin + kEBmLow));
+        }
+        if (actualObject == binning::kEEMEM) {
+          for (int iBin(1); iBin <= me->getNbinsX() / 2; ++iBin) {
+            me->setBinLabel(iBin, binning::channelName(memDCCId(iBin - 1)));
+            me->setBinLabel(iBin + me->getNbinsX() / 2, binning::channelName(memDCCId(iBin + 39)));
+          }
+        }
       }
-      if (actualObject == binning::kEBMEM) {
-        for (int iBin(1); iBin <= me->getNbinsX(); ++iBin)
-          me->setBinLabel(iBin, binning::channelName(iBin + kEBmLow));
-      }
-      if (actualObject == binning::kEEMEM) {
-        for (int iBin(1); iBin <= me->getNbinsX() / 2; ++iBin) {
-          me->setBinLabel(iBin, binning::channelName(memDCCId(iBin - 1)));
-          me->setBinLabel(iBin + me->getNbinsX() / 2,
-                          binning::channelName(memDCCId(iBin + 39)));
+    } else if (btype_ == binning::kDCC) {
+      for (unsigned iME(0); iME < mes_.size(); iME++) {
+        MonitorElement *me(mes_[iME]);
+
+        binning::ObjectType actualObject(binning::getObject(otype_, iME));
+        if (actualObject == binning::kEcal) {
+          me->setBinLabel(1, "EE", 2);
+          me->setBinLabel(6, "EE", 2);
+          me->setBinLabel(3, "EB", 2);
+          me->setBinLabel(5, "EB", 2);
         }
       }
     }
-  } else if (btype_ == binning::kDCC) {
-    for (unsigned iME(0); iME < mes_.size(); iME++) {
-      MonitorElement *me(mes_[iME]);
 
-      binning::ObjectType actualObject(binning::getObject(otype_, iME));
-      if (actualObject == binning::kEcal) {
-        me->setBinLabel(1, "EE", 2);
-        me->setBinLabel(6, "EE", 2);
-        me->setBinLabel(3, "EB", 2);
-        me->setBinLabel(5, "EB", 2);
+    // To avoid the ambiguity between "content == 0 because the mean is 0" and
+    // "content == 0 because the entry is 0" RenderPlugin must be configured
+    // accordingly
+    if (!batchMode_ && kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
+      resetAll(0., 0., -1.);
+  }
+
+  void MESetDet2D::fill(DetId const &_id, double _w /* = 1.*/, double, double) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    int bin;
+
+    if (btype_ == binning::kRCT) {
+      bin = binning::findBin2D(obj, btype_, _id);
+      fill_(iME, bin, _w);
+    } else {
+      if (isEndcapTTId(_id)) {
+        std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
+        unsigned nId(ids.size());
+        for (unsigned iId(0); iId < nId; iId++) {
+          bin = binning::findBin2D(obj, binning::kTriggerTower, ids[iId]);
+          fill_(iME, bin, _w);
+        }
+      } else {
+        bin = binning::findBin2D(obj, btype_, _id);
+        fill_(iME, bin, _w);
       }
     }
   }
 
-  // To avoid the ambiguity between "content == 0 because the mean is 0" and
-  // "content == 0 because the entry is 0" RenderPlugin must be configured
-  // accordingly
-  if (!batchMode_ && kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
-    resetAll(0., 0., -1.);
-}
+  void MESetDet2D::fill(EcalElectronicsId const &_id, double _w /* = 1.*/, double, double) {
+    if (!active_)
+      return;
 
-void MESetDet2D::fill(DetId const &_id, double _w /* = 1.*/, double, double) {
-  if (!active_)
-    return;
+    unsigned iME(0);
+    if (btype_ == binning::kPseudoStrip)
+      iME = binning::findPlotIndex(otype_, _id.dccId(), binning::kPseudoStrip);
+    else
+      iME = binning::findPlotIndex(otype_, _id);
+    checkME_(iME);
 
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
+    binning::ObjectType obj(binning::getObject(otype_, iME));
 
-  binning::ObjectType obj(binning::getObject(otype_, iME));
+    int bin;
 
-  int bin;
-
-  if (btype_ == binning::kRCT) {
-    bin = binning::findBin2D(obj, btype_, _id);
-    fill_(iME, bin, _w);
-  } else {
-    if (isEndcapTTId(_id)) {
+    if (btype_ == binning::kPseudoStrip) {
+      EcalElectronicsId stid(_id);
       std::vector<DetId> ids(
-          getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
+          getElectronicsMap()->pseudoStripConstituents(stid.dccId(), stid.towerId(), stid.stripId()));
       unsigned nId(ids.size());
       for (unsigned iId(0); iId < nId; iId++) {
-        bin = binning::findBin2D(obj, binning::kTriggerTower, ids[iId]);
+        bin = binning::findBin2D(obj, btype_, ids[iId]);
         fill_(iME, bin, _w);
       }
     } else {
@@ -102,474 +133,434 @@ void MESetDet2D::fill(DetId const &_id, double _w /* = 1.*/, double, double) {
       fill_(iME, bin, _w);
     }
   }
-}
 
-void MESetDet2D::fill(EcalElectronicsId const &_id, double _w /* = 1.*/, double,
-                      double) {
-  if (!active_)
-    return;
+  void MESetDet2D::fill(int _dcctccid, double _w /* = 1.*/, double, double) {
+    if (!active_)
+      return;
 
-  unsigned iME(0);
-  if (btype_ == binning::kPseudoStrip)
-    iME = binning::findPlotIndex(otype_, _id.dccId(), binning::kPseudoStrip);
-  else
-    iME = binning::findPlotIndex(otype_, _id);
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin;
-
-  if (btype_ == binning::kPseudoStrip) {
-    EcalElectronicsId stid(_id);
-    std::vector<DetId> ids(getElectronicsMap()->pseudoStripConstituents(
-        stid.dccId(), stid.towerId(), stid.stripId()));
-    unsigned nId(ids.size());
-    for (unsigned iId(0); iId < nId; iId++) {
-      bin = binning::findBin2D(obj, btype_, ids[iId]);
-      fill_(iME, bin, _w);
-    }
-  } else {
-    bin = binning::findBin2D(obj, btype_, _id);
-    fill_(iME, bin, _w);
-  }
-}
-
-void MESetDet2D::fill(int _dcctccid, double _w /* = 1.*/, double, double) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin(binning::findBin2D(obj, btype_, _dcctccid));
-  fill_(iME, bin, _w);
-}
-
-void MESetDet2D::setBinContent(DetId const &_id, double _content) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin;
-
-  if (isEndcapTTId(_id)) {
-    std::vector<DetId> ids(
-        getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
-    unsigned nId(ids.size());
-    for (unsigned iId(0); iId < nId; iId++) {
-      bin = binning::findBin2D(obj, binning::kTriggerTower, ids[iId]);
-      mes_[iME]->setBinContent(bin, _content);
-    }
-  } else {
-    bin = binning::findBin2D(obj, btype_, _id);
-    mes_[iME]->setBinContent(bin, _content);
-  }
-}
-
-void MESetDet2D::setBinContent(EcalElectronicsId const &_id, double _content) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin(binning::findBin2D(obj, btype_, _id));
-  mes_[iME]->setBinContent(bin, _content);
-}
-
-void MESetDet2D::setBinContent(int _dcctccid, double _content) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin(binning::findBin2D(obj, btype_, _dcctccid));
-  mes_[iME]->setBinContent(bin, _content);
-}
-
-void MESetDet2D::setBinError(DetId const &_id, double _error) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin;
-
-  if (isEndcapTTId(_id)) {
-    std::vector<DetId> ids(
-        getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
-    unsigned nId(ids.size());
-    for (unsigned iId(0); iId < nId; iId++) {
-      bin = binning::findBin2D(obj, binning::kTriggerTower, ids[iId]);
-      mes_[iME]->setBinError(bin, _error);
-    }
-  } else {
-    bin = binning::findBin2D(obj, btype_, _id);
-    mes_[iME]->setBinError(bin, _error);
-  }
-}
-
-void MESetDet2D::setBinError(EcalElectronicsId const &_id, double _error) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin(binning::findBin2D(obj, btype_, _id));
-  mes_[iME]->setBinError(bin, _error);
-}
-
-void MESetDet2D::setBinError(int _dcctccid, double _error) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin(binning::findBin2D(obj, btype_, _dcctccid));
-  mes_[iME]->setBinError(bin, _error);
-}
-
-void MESetDet2D::setBinEntries(DetId const &_id, double _entries) {
-  if (!active_)
-    return;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin;
-
-  if (isEndcapTTId(_id)) {
-    std::vector<DetId> ids(
-        getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
-    unsigned nId(ids.size());
-    for (unsigned iId(0); iId < nId; iId++) {
-      bin = binning::findBin2D(obj, binning::kTriggerTower, ids[iId]);
-      mes_[iME]->setBinEntries(bin, _entries);
-    }
-  } else {
-    bin = binning::findBin2D(obj, btype_, _id);
-    mes_[iME]->setBinEntries(bin, _entries);
-  }
-}
-
-void MESetDet2D::setBinEntries(EcalElectronicsId const &_id, double _entries) {
-  if (!active_)
-    return;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin(binning::findBin2D(obj, btype_, _id));
-  mes_[iME]->setBinEntries(bin, _entries);
-}
-
-void MESetDet2D::setBinEntries(int _dcctccid, double _entries) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin(binning::findBin2D(obj, btype_, _dcctccid));
-  mes_[iME]->setBinEntries(bin, _entries);
-}
-
-double MESetDet2D::getBinContent(DetId const &_id, int) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin;
-
-  if (isEndcapTTId(_id)) {
-    std::vector<DetId> ids(
-        getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
-    bin = binning::findBin2D(obj, binning::kTriggerTower, ids[0]);
-  } else {
-    bin = binning::findBin2D(obj, btype_, _id);
-  }
-
-  return mes_[iME]->getBinContent(bin);
-}
-
-double MESetDet2D::getBinContent(EcalElectronicsId const &_id, int) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin(binning::findBin2D(obj, btype_, _id));
-
-  return mes_[iME]->getBinContent(bin);
-}
-
-double MESetDet2D::getBinContent(int _dcctccid, int) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin(binning::findBin2D(obj, btype_, _dcctccid));
-
-  return mes_[iME]->getBinContent(bin);
-}
-
-double MESetDet2D::getBinError(DetId const &_id, int) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin;
-
-  if (isEndcapTTId(_id)) {
-    std::vector<DetId> ids(
-        getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
-    bin = binning::findBin2D(obj, binning::kTriggerTower, ids[0]);
-  } else {
-    bin = binning::findBin2D(obj, btype_, _id);
-  }
-
-  return mes_[iME]->getBinError(bin);
-}
-
-double MESetDet2D::getBinError(EcalElectronicsId const &_id, int) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin(binning::findBin2D(obj, btype_, _id));
-
-  return mes_[iME]->getBinError(bin);
-}
-
-double MESetDet2D::getBinError(int _dcctccid, int) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin(binning::findBin2D(obj, btype_, _dcctccid));
-
-  return mes_[iME]->getBinError(bin);
-}
-
-double MESetDet2D::getBinEntries(DetId const &_id, int) const {
-  if (!active_)
-    return 0.;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin;
-
-  if (isEndcapTTId(_id)) {
-    std::vector<DetId> ids(
-        getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
-    bin = binning::findBin2D(obj, binning::kTriggerTower, ids[0]);
-  } else {
-    bin = binning::findBin2D(obj, btype_, _id);
-  }
-
-  double entries(mes_[iME]->getBinEntries(bin));
-  if (entries < 0.)
-    return 0.;
-  else
-    return entries;
-}
-
-double MESetDet2D::getBinEntries(EcalElectronicsId const &_id, int) const {
-  if (!active_)
-    return 0.;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin(binning::findBin2D(obj, btype_, _id));
-
-  double entries(mes_[iME]->getBinEntries(bin));
-  if (entries < 0.)
-    return 0.;
-  else
-    return entries;
-}
-
-double MESetDet2D::getBinEntries(int _dcctccid, int) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  int bin(binning::findBin2D(obj, btype_, _dcctccid));
-
-  double entries(mes_[iME]->getBinEntries(bin));
-  if (entries < 0.)
-    return 0.;
-  else
-    return entries;
-}
-
-int MESetDet2D::findBin(DetId const &_id) const {
-  if (!active_)
-    return 0;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  if (isEndcapTTId(_id)) {
-    std::vector<DetId> ids(
-        getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
-    return binning::findBin2D(obj, binning::kTriggerTower, ids[0]);
-  } else
-    return binning::findBin2D(obj, btype_, _id);
-}
-
-int MESetDet2D::findBin(EcalElectronicsId const &_id) const {
-  if (!active_)
-    return 0;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  binning::ObjectType obj(binning::getObject(otype_, iME));
-
-  return binning::findBin2D(obj, btype_, _id);
-}
-
-void MESetDet2D::reset(double _content /* = 0.*/, double _err /* = 0.*/,
-                       double _entries /* = 0.*/) {
-  unsigned nME(binning::getNObjects(otype_));
-
-  bool isProfile(kind_ == MonitorElement::DQM_KIND_TPROFILE2D);
-
-  for (unsigned iME(0); iME < nME; iME++) {
-    MonitorElement *me(mes_[iME]);
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    checkME_(iME);
 
     binning::ObjectType obj(binning::getObject(otype_, iME));
 
-    int nbinsX(me->getTH1()->GetNbinsX());
-    int nbinsY(me->getTH1()->GetNbinsY());
-    for (int ix(1); ix <= nbinsX; ix++) {
-      for (int iy(1); iy <= nbinsY; iy++) {
-        int bin((nbinsX + 2) * iy + ix);
-        if (!binning::isValidIdBin(obj, btype_, iME, bin))
-          continue;
-        me->setBinContent(bin, _content);
-        me->setBinError(bin, _err);
-        if (isProfile)
-          me->setBinEntries(bin, _entries);
+    int bin(binning::findBin2D(obj, btype_, _dcctccid));
+    fill_(iME, bin, _w);
+  }
+
+  void MESetDet2D::setBinContent(DetId const &_id, double _content) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    int bin;
+
+    if (isEndcapTTId(_id)) {
+      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
+      unsigned nId(ids.size());
+      for (unsigned iId(0); iId < nId; iId++) {
+        bin = binning::findBin2D(obj, binning::kTriggerTower, ids[iId]);
+        mes_[iME]->setBinContent(bin, _content);
+      }
+    } else {
+      bin = binning::findBin2D(obj, btype_, _id);
+      mes_[iME]->setBinContent(bin, _content);
+    }
+  }
+
+  void MESetDet2D::setBinContent(EcalElectronicsId const &_id, double _content) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    int bin(binning::findBin2D(obj, btype_, _id));
+    mes_[iME]->setBinContent(bin, _content);
+  }
+
+  void MESetDet2D::setBinContent(int _dcctccid, double _content) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    int bin(binning::findBin2D(obj, btype_, _dcctccid));
+    mes_[iME]->setBinContent(bin, _content);
+  }
+
+  void MESetDet2D::setBinError(DetId const &_id, double _error) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    int bin;
+
+    if (isEndcapTTId(_id)) {
+      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
+      unsigned nId(ids.size());
+      for (unsigned iId(0); iId < nId; iId++) {
+        bin = binning::findBin2D(obj, binning::kTriggerTower, ids[iId]);
+        mes_[iME]->setBinError(bin, _error);
+      }
+    } else {
+      bin = binning::findBin2D(obj, btype_, _id);
+      mes_[iME]->setBinError(bin, _error);
+    }
+  }
+
+  void MESetDet2D::setBinError(EcalElectronicsId const &_id, double _error) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    int bin(binning::findBin2D(obj, btype_, _id));
+    mes_[iME]->setBinError(bin, _error);
+  }
+
+  void MESetDet2D::setBinError(int _dcctccid, double _error) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    int bin(binning::findBin2D(obj, btype_, _dcctccid));
+    mes_[iME]->setBinError(bin, _error);
+  }
+
+  void MESetDet2D::setBinEntries(DetId const &_id, double _entries) {
+    if (!active_)
+      return;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    int bin;
+
+    if (isEndcapTTId(_id)) {
+      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
+      unsigned nId(ids.size());
+      for (unsigned iId(0); iId < nId; iId++) {
+        bin = binning::findBin2D(obj, binning::kTriggerTower, ids[iId]);
+        mes_[iME]->setBinEntries(bin, _entries);
+      }
+    } else {
+      bin = binning::findBin2D(obj, btype_, _id);
+      mes_[iME]->setBinEntries(bin, _entries);
+    }
+  }
+
+  void MESetDet2D::setBinEntries(EcalElectronicsId const &_id, double _entries) {
+    if (!active_)
+      return;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    int bin(binning::findBin2D(obj, btype_, _id));
+    mes_[iME]->setBinEntries(bin, _entries);
+  }
+
+  void MESetDet2D::setBinEntries(int _dcctccid, double _entries) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    int bin(binning::findBin2D(obj, btype_, _dcctccid));
+    mes_[iME]->setBinEntries(bin, _entries);
+  }
+
+  double MESetDet2D::getBinContent(DetId const &_id, int) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    int bin;
+
+    if (isEndcapTTId(_id)) {
+      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
+      bin = binning::findBin2D(obj, binning::kTriggerTower, ids[0]);
+    } else {
+      bin = binning::findBin2D(obj, btype_, _id);
+    }
+
+    return mes_[iME]->getBinContent(bin);
+  }
+
+  double MESetDet2D::getBinContent(EcalElectronicsId const &_id, int) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    int bin(binning::findBin2D(obj, btype_, _id));
+
+    return mes_[iME]->getBinContent(bin);
+  }
+
+  double MESetDet2D::getBinContent(int _dcctccid, int) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    int bin(binning::findBin2D(obj, btype_, _dcctccid));
+
+    return mes_[iME]->getBinContent(bin);
+  }
+
+  double MESetDet2D::getBinError(DetId const &_id, int) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    int bin;
+
+    if (isEndcapTTId(_id)) {
+      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
+      bin = binning::findBin2D(obj, binning::kTriggerTower, ids[0]);
+    } else {
+      bin = binning::findBin2D(obj, btype_, _id);
+    }
+
+    return mes_[iME]->getBinError(bin);
+  }
+
+  double MESetDet2D::getBinError(EcalElectronicsId const &_id, int) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    int bin(binning::findBin2D(obj, btype_, _id));
+
+    return mes_[iME]->getBinError(bin);
+  }
+
+  double MESetDet2D::getBinError(int _dcctccid, int) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    int bin(binning::findBin2D(obj, btype_, _dcctccid));
+
+    return mes_[iME]->getBinError(bin);
+  }
+
+  double MESetDet2D::getBinEntries(DetId const &_id, int) const {
+    if (!active_)
+      return 0.;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    int bin;
+
+    if (isEndcapTTId(_id)) {
+      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
+      bin = binning::findBin2D(obj, binning::kTriggerTower, ids[0]);
+    } else {
+      bin = binning::findBin2D(obj, btype_, _id);
+    }
+
+    double entries(mes_[iME]->getBinEntries(bin));
+    if (entries < 0.)
+      return 0.;
+    else
+      return entries;
+  }
+
+  double MESetDet2D::getBinEntries(EcalElectronicsId const &_id, int) const {
+    if (!active_)
+      return 0.;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    int bin(binning::findBin2D(obj, btype_, _id));
+
+    double entries(mes_[iME]->getBinEntries(bin));
+    if (entries < 0.)
+      return 0.;
+    else
+      return entries;
+  }
+
+  double MESetDet2D::getBinEntries(int _dcctccid, int) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    int bin(binning::findBin2D(obj, btype_, _dcctccid));
+
+    double entries(mes_[iME]->getBinEntries(bin));
+    if (entries < 0.)
+      return 0.;
+    else
+      return entries;
+  }
+
+  int MESetDet2D::findBin(DetId const &_id) const {
+    if (!active_)
+      return 0;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    if (isEndcapTTId(_id)) {
+      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(EcalTrigTowerDetId(_id)));
+      return binning::findBin2D(obj, binning::kTriggerTower, ids[0]);
+    } else
+      return binning::findBin2D(obj, btype_, _id);
+  }
+
+  int MESetDet2D::findBin(EcalElectronicsId const &_id) const {
+    if (!active_)
+      return 0;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    binning::ObjectType obj(binning::getObject(otype_, iME));
+
+    return binning::findBin2D(obj, btype_, _id);
+  }
+
+  void MESetDet2D::reset(double _content /* = 0.*/, double _err /* = 0.*/, double _entries /* = 0.*/) {
+    unsigned nME(binning::getNObjects(otype_));
+
+    bool isProfile(kind_ == MonitorElement::DQM_KIND_TPROFILE2D);
+
+    for (unsigned iME(0); iME < nME; iME++) {
+      MonitorElement *me(mes_[iME]);
+
+      binning::ObjectType obj(binning::getObject(otype_, iME));
+
+      int nbinsX(me->getTH1()->GetNbinsX());
+      int nbinsY(me->getTH1()->GetNbinsY());
+      for (int ix(1); ix <= nbinsX; ix++) {
+        for (int iy(1); iy <= nbinsY; iy++) {
+          int bin((nbinsX + 2) * iy + ix);
+          if (!binning::isValidIdBin(obj, btype_, iME, bin))
+            continue;
+          me->setBinContent(bin, _content);
+          me->setBinError(bin, _err);
+          if (isProfile)
+            me->setBinEntries(bin, _entries);
+        }
       }
     }
   }
-}
 
-void MESetDet2D::softReset() {
-  MESet::softReset();
-  if (!batchMode_ && kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
-    resetAll(0., 0., -1.);
-}
-
-void MESetDet2D::fill_(unsigned _iME, int _bin, double _w) {
-  if (kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
-    MonitorElement *me(mes_.at(_iME));
-    if (me->getBinEntries(_bin) < 0.) {
-      me->setBinContent(_bin, 0.);
-      me->setBinEntries(_bin, 0.);
-      me->getTProfile2D()->SetEntries(me->getTProfile2D()->GetEntries() + 1.);
-    }
+  void MESetDet2D::softReset() {
+    MESet::softReset();
+    if (!batchMode_ && kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
+      resetAll(0., 0., -1.);
   }
 
-  MESet::fill_(_iME, _bin, _w);
-}
-
-void MESetDet2D::fill_(unsigned _iME, int _bin, double _y, double _w) {
-  if (kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
-    MonitorElement *me(mes_.at(_iME));
-    if (me->getBinEntries(_bin) < 0.) {
-      me->setBinContent(_bin, 0.);
-      me->setBinEntries(_bin, 0.);
-      me->getTProfile2D()->SetEntries(me->getTProfile2D()->GetEntries() + 1.);
+  void MESetDet2D::fill_(unsigned _iME, int _bin, double _w) {
+    if (kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
+      MonitorElement *me(mes_.at(_iME));
+      if (me->getBinEntries(_bin) < 0.) {
+        me->setBinContent(_bin, 0.);
+        me->setBinEntries(_bin, 0.);
+        me->getTProfile2D()->SetEntries(me->getTProfile2D()->GetEntries() + 1.);
+      }
     }
+
+    MESet::fill_(_iME, _bin, _w);
   }
 
-  MESet::fill_(_iME, _bin, _y, _w);
-}
-
-void MESetDet2D::fill_(unsigned _iME, double _x, double _wy, double _w) {
-  if (kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
-    MonitorElement *me(mes_.at(_iME));
-    int bin(me->getTProfile2D()->FindBin(_x, _wy));
-    if (me->getBinEntries(bin) < 0.) {
-      me->setBinContent(bin, 0.);
-      me->setBinEntries(bin, 0.);
-      me->getTProfile2D()->SetEntries(me->getTProfile2D()->GetEntries() + 1.);
+  void MESetDet2D::fill_(unsigned _iME, int _bin, double _y, double _w) {
+    if (kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
+      MonitorElement *me(mes_.at(_iME));
+      if (me->getBinEntries(_bin) < 0.) {
+        me->setBinContent(_bin, 0.);
+        me->setBinEntries(_bin, 0.);
+        me->getTProfile2D()->SetEntries(me->getTProfile2D()->GetEntries() + 1.);
+      }
     }
+
+    MESet::fill_(_iME, _bin, _y, _w);
   }
 
-  MESet::fill_(_iME, _x, _wy, _w);
-}
-} // namespace ecaldqm
+  void MESetDet2D::fill_(unsigned _iME, double _x, double _wy, double _w) {
+    if (kind_ == MonitorElement::DQM_KIND_TPROFILE2D) {
+      MonitorElement *me(mes_.at(_iME));
+      int bin(me->getTProfile2D()->FindBin(_x, _wy));
+      if (me->getBinEntries(bin) < 0.) {
+        me->setBinContent(bin, 0.);
+        me->setBinEntries(bin, 0.);
+        me->getTProfile2D()->SetEntries(me->getTProfile2D()->GetEntries() + 1.);
+      }
+    }
+
+    MESet::fill_(_iME, _x, _wy, _w);
+  }
+}  // namespace ecaldqm

--- a/DQM/EcalCommon/src/MESetEcal.cc
+++ b/DQM/EcalCommon/src/MESetEcal.cc
@@ -7,228 +7,229 @@
 #include <sstream>
 
 namespace ecaldqm {
-MESetEcal::MESetEcal(std::string const &_fullPath, binning::ObjectType _otype,
-                     binning::BinningType _btype, MonitorElement::Kind _kind,
-                     unsigned _logicalDimensions,
-                     binning::AxisSpecs const *_xaxis /* = 0*/,
-                     binning::AxisSpecs const *_yaxis /* = 0*/,
-                     binning::AxisSpecs const *_zaxis /* = 0*/)
-    : MESet(_fullPath, _otype, _btype, _kind),
-      logicalDimensions_(_logicalDimensions),
-      xaxis_(_xaxis ? new binning::AxisSpecs(*_xaxis) : nullptr),
-      yaxis_(_yaxis ? new binning::AxisSpecs(*_yaxis) : nullptr),
-      zaxis_(_zaxis ? new binning::AxisSpecs(*_zaxis) : nullptr) {
-  if (btype_ == binning::kUser && ((logicalDimensions_ > 0 && !xaxis_) ||
-                                   (logicalDimensions_ > 1 && !yaxis_)))
-    throw_("Need axis specifications");
-}
-
-MESetEcal::MESetEcal(MESetEcal const &_orig)
-    : MESet(_orig), logicalDimensions_(_orig.logicalDimensions_),
-      xaxis_(_orig.xaxis_ ? new binning::AxisSpecs(*_orig.xaxis_) : nullptr),
-      yaxis_(_orig.yaxis_ ? new binning::AxisSpecs(*_orig.yaxis_) : nullptr),
-      zaxis_(_orig.zaxis_ ? new binning::AxisSpecs(*_orig.zaxis_) : nullptr) {}
-
-MESetEcal::~MESetEcal() {
-  delete xaxis_;
-  delete yaxis_;
-  delete zaxis_;
-}
-
-MESet &MESetEcal::operator=(MESet const &_rhs) {
-  delete xaxis_;
-  delete yaxis_;
-  delete zaxis_;
-  xaxis_ = nullptr;
-  yaxis_ = nullptr;
-  zaxis_ = nullptr;
-
-  MESetEcal const *pRhs(dynamic_cast<MESetEcal const *>(&_rhs));
-  if (pRhs) {
-    logicalDimensions_ = pRhs->logicalDimensions_;
-    if (pRhs->xaxis_)
-      xaxis_ = new binning::AxisSpecs(*pRhs->xaxis_);
-    if (pRhs->yaxis_)
-      yaxis_ = new binning::AxisSpecs(*pRhs->yaxis_);
-    if (pRhs->zaxis_)
-      zaxis_ = new binning::AxisSpecs(*pRhs->zaxis_);
+  MESetEcal::MESetEcal(std::string const &_fullPath,
+                       binning::ObjectType _otype,
+                       binning::BinningType _btype,
+                       MonitorElement::Kind _kind,
+                       unsigned _logicalDimensions,
+                       binning::AxisSpecs const *_xaxis /* = 0*/,
+                       binning::AxisSpecs const *_yaxis /* = 0*/,
+                       binning::AxisSpecs const *_zaxis /* = 0*/)
+      : MESet(_fullPath, _otype, _btype, _kind),
+        logicalDimensions_(_logicalDimensions),
+        xaxis_(_xaxis ? new binning::AxisSpecs(*_xaxis) : nullptr),
+        yaxis_(_yaxis ? new binning::AxisSpecs(*_yaxis) : nullptr),
+        zaxis_(_zaxis ? new binning::AxisSpecs(*_zaxis) : nullptr) {
+    if (btype_ == binning::kUser && ((logicalDimensions_ > 0 && !xaxis_) || (logicalDimensions_ > 1 && !yaxis_)))
+      throw_("Need axis specifications");
   }
-  return MESet::operator=(_rhs);
-}
 
-MESet *MESetEcal::clone(std::string const &_path /* = ""*/) const {
-  std::string path(path_);
-  if (!_path.empty())
-    path_ = _path;
-  MESet *copy(new MESetEcal(*this));
-  path_ = path;
-  return copy;
-}
+  MESetEcal::MESetEcal(MESetEcal const &_orig)
+      : MESet(_orig),
+        logicalDimensions_(_orig.logicalDimensions_),
+        xaxis_(_orig.xaxis_ ? new binning::AxisSpecs(*_orig.xaxis_) : nullptr),
+        yaxis_(_orig.yaxis_ ? new binning::AxisSpecs(*_orig.yaxis_) : nullptr),
+        zaxis_(_orig.zaxis_ ? new binning::AxisSpecs(*_orig.zaxis_) : nullptr) {}
 
-void MESetEcal::book(DQMStore::IBooker &_ibooker) {
-  using namespace std;
+  MESetEcal::~MESetEcal() {
+    delete xaxis_;
+    delete yaxis_;
+    delete zaxis_;
+  }
 
-  clear();
+  MESet &MESetEcal::operator=(MESet const &_rhs) {
+    delete xaxis_;
+    delete yaxis_;
+    delete zaxis_;
+    xaxis_ = nullptr;
+    yaxis_ = nullptr;
+    zaxis_ = nullptr;
 
-  vector<string> mePaths(generatePaths());
-
-  for (unsigned iME(0); iME < mePaths.size(); iME++) {
-    string &path(mePaths[iME]);
-    if (path.find('%') != string::npos)
-      throw_("book() called with incompletely formed path [" + path + "]");
-
-    binning::ObjectType actualObject(binning::getObject(otype_, iME));
-
-    binning::AxisSpecs xaxis, yaxis, zaxis;
-
-    bool isHistogram(logicalDimensions_ > 0);
-    bool isMap(logicalDimensions_ > 1);
-
-    if (isHistogram) {
-
-      if (xaxis_)
-        xaxis = *xaxis_;
-      if (yaxis_)
-        yaxis = *yaxis_;
-      if (zaxis_)
-        zaxis = *zaxis_;
-
-      if (xaxis.nbins == 0) { // uses preset
-        binning::AxisSpecs xdef(
-            binning::getBinning(actualObject, btype_, isMap, 1, iME));
-        if (xaxis.labels ||
-            !xaxis.title.empty()) { // PSet specifies title / label only
-          std::string *labels(xaxis.labels);
-          std::string title(xaxis.title);
-          xaxis = xdef;
-          delete[] xaxis.labels;
-          xaxis.labels = labels;
-          xaxis.title = title;
-        } else
-          xaxis = xdef;
-      }
-
-      if (isMap && yaxis.nbins == 0) {
-        binning::AxisSpecs ydef(
-            binning::getBinning(actualObject, btype_, isMap, 2, iME));
-        if (yaxis.labels ||
-            !yaxis.title.empty()) { // PSet specifies title / label only
-          std::string *labels(yaxis.labels);
-          std::string title(yaxis.title);
-          yaxis = ydef;
-          delete[] yaxis.labels;
-          yaxis.labels = labels;
-          yaxis.title = title;
-        } else
-          yaxis = ydef;
-      }
-
-      if (yaxis.high - yaxis.low < 1.e-10) {
-        yaxis.low = -numeric_limits<double>::max();
-        yaxis.high = numeric_limits<double>::max();
-      }
-
-      if (zaxis.high - zaxis.low < 1.e-10) {
-        zaxis.low = -numeric_limits<double>::max();
-        zaxis.high = numeric_limits<double>::max();
-      }
+    MESetEcal const *pRhs(dynamic_cast<MESetEcal const *>(&_rhs));
+    if (pRhs) {
+      logicalDimensions_ = pRhs->logicalDimensions_;
+      if (pRhs->xaxis_)
+        xaxis_ = new binning::AxisSpecs(*pRhs->xaxis_);
+      if (pRhs->yaxis_)
+        yaxis_ = new binning::AxisSpecs(*pRhs->yaxis_);
+      if (pRhs->zaxis_)
+        zaxis_ = new binning::AxisSpecs(*pRhs->zaxis_);
     }
+    return MESet::operator=(_rhs);
+  }
 
-    size_t slashPos(path.find_last_of('/'));
-    string name(path.substr(slashPos + 1));
-    _ibooker.cd();
-    _ibooker.setCurrentFolder(path.substr(0, slashPos));
+  MESet *MESetEcal::clone(std::string const &_path /* = ""*/) const {
+    std::string path(path_);
+    if (!_path.empty())
+      path_ = _path;
+    MESet *copy(new MESetEcal(*this));
+    path_ = path;
+    return copy;
+  }
 
-    MonitorElement *me(nullptr);
+  void MESetEcal::book(DQMStore::IBooker &_ibooker) {
+    using namespace std;
 
-    switch (kind_) {
-    case MonitorElement::DQM_KIND_REAL:
-      me = _ibooker.bookFloat(name);
+    clear();
 
-      break;
+    vector<string> mePaths(generatePaths());
 
-    case MonitorElement::DQM_KIND_TH1F:
-      if (xaxis.edges)
-        me = _ibooker.book1D(name, name, xaxis.nbins, xaxis.edges);
-      else
-        me = _ibooker.book1D(name, name, xaxis.nbins, xaxis.low, xaxis.high);
+    for (unsigned iME(0); iME < mePaths.size(); iME++) {
+      string &path(mePaths[iME]);
+      if (path.find('%') != string::npos)
+        throw_("book() called with incompletely formed path [" + path + "]");
 
-      break;
+      binning::ObjectType actualObject(binning::getObject(otype_, iME));
 
-    case MonitorElement::DQM_KIND_TPROFILE:
-      if (xaxis.edges) {
-        // DQMStore bookProfile interface uses double* for bin edges
-        double *edges(new double[xaxis.nbins + 1]);
-        std::copy(xaxis.edges, xaxis.edges + xaxis.nbins + 1, edges);
-        me = _ibooker.bookProfile(name, name, xaxis.nbins, edges, yaxis.low,
-                                  yaxis.high, "");
-        delete[] edges;
-      } else
-        me = _ibooker.bookProfile(name, name, xaxis.nbins, xaxis.low,
-                                  xaxis.high, yaxis.low, yaxis.high, "");
+      binning::AxisSpecs xaxis, yaxis, zaxis;
 
-      break;
+      bool isHistogram(logicalDimensions_ > 0);
+      bool isMap(logicalDimensions_ > 1);
 
-    case MonitorElement::DQM_KIND_TH2F:
-      if (xaxis.edges || yaxis.edges) {
-        binning::AxisSpecs *specs[] = {&xaxis, &yaxis};
-        for (int iSpec(0); iSpec < 2; iSpec++) {
-          if (!specs[iSpec]->edges) {
-            specs[iSpec]->edges = new float[specs[iSpec]->nbins + 1];
-            int nbins(specs[iSpec]->nbins);
-            double low(specs[iSpec]->low), high(specs[iSpec]->high);
-            for (int i(0); i < nbins + 1; i++)
-              specs[iSpec]->edges[i] = low + (high - low) / nbins * i;
-          }
+      if (isHistogram) {
+        if (xaxis_)
+          xaxis = *xaxis_;
+        if (yaxis_)
+          yaxis = *yaxis_;
+        if (zaxis_)
+          zaxis = *zaxis_;
+
+        if (xaxis.nbins == 0) {  // uses preset
+          binning::AxisSpecs xdef(binning::getBinning(actualObject, btype_, isMap, 1, iME));
+          if (xaxis.labels || !xaxis.title.empty()) {  // PSet specifies title / label only
+            std::string *labels(xaxis.labels);
+            std::string title(xaxis.title);
+            xaxis = xdef;
+            delete[] xaxis.labels;
+            xaxis.labels = labels;
+            xaxis.title = title;
+          } else
+            xaxis = xdef;
         }
-        me = _ibooker.book2D(name, name, xaxis.nbins, xaxis.edges, yaxis.nbins,
-                             yaxis.edges);
-      } else
-        me = _ibooker.book2D(name, name, xaxis.nbins, xaxis.low, xaxis.high,
-                             yaxis.nbins, yaxis.low, yaxis.high);
 
-      break;
+        if (isMap && yaxis.nbins == 0) {
+          binning::AxisSpecs ydef(binning::getBinning(actualObject, btype_, isMap, 2, iME));
+          if (yaxis.labels || !yaxis.title.empty()) {  // PSet specifies title / label only
+            std::string *labels(yaxis.labels);
+            std::string title(yaxis.title);
+            yaxis = ydef;
+            delete[] yaxis.labels;
+            yaxis.labels = labels;
+            yaxis.title = title;
+          } else
+            yaxis = ydef;
+        }
 
-    case MonitorElement::DQM_KIND_TPROFILE2D:
-      if (zaxis.edges) {
-        zaxis.low = zaxis.edges[0];
-        zaxis.high = zaxis.edges[zaxis.nbins];
-      }
-      if (xaxis.edges || yaxis.edges)
-        throw_("Variable bin size for 2D profile not implemented");
-      me = _ibooker.bookProfile2D(name, name, xaxis.nbins, xaxis.low,
-                                  xaxis.high, yaxis.nbins, yaxis.low,
-                                  yaxis.high, zaxis.low, zaxis.high, "");
+        if (yaxis.high - yaxis.low < 1.e-10) {
+          yaxis.low = -numeric_limits<double>::max();
+          yaxis.high = numeric_limits<double>::max();
+        }
 
-      break;
-
-    default:
-      break;
-    }
-
-    if (!me)
-      throw_("ME could not be booked");
-
-    if (isHistogram) {
-      me->setAxisTitle(xaxis.title, 1);
-      me->setAxisTitle(yaxis.title, 2);
-      if (isMap)
-        me->setAxisTitle(zaxis.title, 3);
-
-      if (xaxis.labels) {
-        for (int iBin(1); iBin <= xaxis.nbins; ++iBin)
-          me->setBinLabel(iBin, xaxis.labels[iBin - 1], 1);
-      }
-      if (yaxis.labels) {
-        for (int iBin(1); iBin <= yaxis.nbins; ++iBin)
-          me->setBinLabel(iBin, yaxis.labels[iBin - 1], 2);
-      }
-      if (zaxis.labels) {
-        for (int iBin(1); iBin <= zaxis.nbins; ++iBin)
-          me->setBinLabel(iBin, zaxis.labels[iBin - 1], 3);
+        if (zaxis.high - zaxis.low < 1.e-10) {
+          zaxis.low = -numeric_limits<double>::max();
+          zaxis.high = numeric_limits<double>::max();
+        }
       }
 
-      /* FIX: In ROOT 6.0.12 bit 20 is used by ROOT (bit 19 was already in use
+      size_t slashPos(path.find_last_of('/'));
+      string name(path.substr(slashPos + 1));
+      _ibooker.cd();
+      _ibooker.setCurrentFolder(path.substr(0, slashPos));
+
+      MonitorElement *me(nullptr);
+
+      switch (kind_) {
+        case MonitorElement::DQM_KIND_REAL:
+          me = _ibooker.bookFloat(name);
+
+          break;
+
+        case MonitorElement::DQM_KIND_TH1F:
+          if (xaxis.edges)
+            me = _ibooker.book1D(name, name, xaxis.nbins, xaxis.edges);
+          else
+            me = _ibooker.book1D(name, name, xaxis.nbins, xaxis.low, xaxis.high);
+
+          break;
+
+        case MonitorElement::DQM_KIND_TPROFILE:
+          if (xaxis.edges) {
+            // DQMStore bookProfile interface uses double* for bin edges
+            double *edges(new double[xaxis.nbins + 1]);
+            std::copy(xaxis.edges, xaxis.edges + xaxis.nbins + 1, edges);
+            me = _ibooker.bookProfile(name, name, xaxis.nbins, edges, yaxis.low, yaxis.high, "");
+            delete[] edges;
+          } else
+            me = _ibooker.bookProfile(name, name, xaxis.nbins, xaxis.low, xaxis.high, yaxis.low, yaxis.high, "");
+
+          break;
+
+        case MonitorElement::DQM_KIND_TH2F:
+          if (xaxis.edges || yaxis.edges) {
+            binning::AxisSpecs *specs[] = {&xaxis, &yaxis};
+            for (int iSpec(0); iSpec < 2; iSpec++) {
+              if (!specs[iSpec]->edges) {
+                specs[iSpec]->edges = new float[specs[iSpec]->nbins + 1];
+                int nbins(specs[iSpec]->nbins);
+                double low(specs[iSpec]->low), high(specs[iSpec]->high);
+                for (int i(0); i < nbins + 1; i++)
+                  specs[iSpec]->edges[i] = low + (high - low) / nbins * i;
+              }
+            }
+            me = _ibooker.book2D(name, name, xaxis.nbins, xaxis.edges, yaxis.nbins, yaxis.edges);
+          } else
+            me = _ibooker.book2D(name, name, xaxis.nbins, xaxis.low, xaxis.high, yaxis.nbins, yaxis.low, yaxis.high);
+
+          break;
+
+        case MonitorElement::DQM_KIND_TPROFILE2D:
+          if (zaxis.edges) {
+            zaxis.low = zaxis.edges[0];
+            zaxis.high = zaxis.edges[zaxis.nbins];
+          }
+          if (xaxis.edges || yaxis.edges)
+            throw_("Variable bin size for 2D profile not implemented");
+          me = _ibooker.bookProfile2D(name,
+                                      name,
+                                      xaxis.nbins,
+                                      xaxis.low,
+                                      xaxis.high,
+                                      yaxis.nbins,
+                                      yaxis.low,
+                                      yaxis.high,
+                                      zaxis.low,
+                                      zaxis.high,
+                                      "");
+
+          break;
+
+        default:
+          break;
+      }
+
+      if (!me)
+        throw_("ME could not be booked");
+
+      if (isHistogram) {
+        me->setAxisTitle(xaxis.title, 1);
+        me->setAxisTitle(yaxis.title, 2);
+        if (isMap)
+          me->setAxisTitle(zaxis.title, 3);
+
+        if (xaxis.labels) {
+          for (int iBin(1); iBin <= xaxis.nbins; ++iBin)
+            me->setBinLabel(iBin, xaxis.labels[iBin - 1], 1);
+        }
+        if (yaxis.labels) {
+          for (int iBin(1); iBin <= yaxis.nbins; ++iBin)
+            me->setBinLabel(iBin, yaxis.labels[iBin - 1], 2);
+        }
+        if (zaxis.labels) {
+          for (int iBin(1); iBin <= zaxis.nbins; ++iBin)
+            me->setBinLabel(iBin, zaxis.labels[iBin - 1], 3);
+        }
+
+        /* FIX: In ROOT 6.0.12 bit 20 is used by ROOT (bit 19 was already in use
       in 6.0.x). Talking with the ROOT team, users should never use SetBit for
       their own purpose since those bits are reserved for ROOT internally. See
       https://github.com/cms-sw/cmssw/issues/21423 for some alternative ways of
@@ -242,451 +243,434 @@ void MESetEcal::book(DQMStore::IBooker &_ibooker) {
       if(isMap) me->getTH1()->SetBit(0x1 << 19);
       */
 
-      // The render plugin requires some metadata in order to set the correct
-      // rendering for each plot. The original solution was to use bits number
-      // 19 to 23 in TH1::fBits, but these were meant for ROOT's internal usage
-      // and eventually started breaking things, see:
-      // https://github.com/cms-sw/cmssw/issues/21423 The current solution is to
-      // use the UniqueID field in the parent TObject, which is expected to work
-      // if there is no TRef pointing to the TObject.
+        // The render plugin requires some metadata in order to set the correct
+        // rendering for each plot. The original solution was to use bits number
+        // 19 to 23 in TH1::fBits, but these were meant for ROOT's internal usage
+        // and eventually started breaking things, see:
+        // https://github.com/cms-sw/cmssw/issues/21423 The current solution is to
+        // use the UniqueID field in the parent TObject, which is expected to work
+        // if there is no TRef pointing to the TObject.
 
-      // To check that indeed there is no such TRef, one can use
-      // TestBit(kIsReferenced), e.g. std::cout << "Need to set unique ID at
-      // path = " << path << "; for this path, TestBit(kIsReferenced) is: " <<
-      // (me->getTH1()->TestBit(kIsReferenced)? "true": "false") << std::endl;
-      // // should always output false for the solution to work
+        // To check that indeed there is no such TRef, one can use
+        // TestBit(kIsReferenced), e.g. std::cout << "Need to set unique ID at
+        // path = " << path << "; for this path, TestBit(kIsReferenced) is: " <<
+        // (me->getTH1()->TestBit(kIsReferenced)? "true": "false") << std::endl;
+        // // should always output false for the solution to work
 
-      // Originally, bit 19 in TH1::fBits was set to isMap, while bits 20-23
-      // contained (actualObject+1). The idea is to make sure that both these
-      // variables are easily recoverable in the render plugin, as in this
-      // solution, where isMap is the last bit.
-      me->getTH1()->SetUniqueID(
-          uint32_t(2 * (actualObject + 1) + (isMap ? 1 : 0)));
+        // Originally, bit 19 in TH1::fBits was set to isMap, while bits 20-23
+        // contained (actualObject+1). The idea is to make sure that both these
+        // variables are easily recoverable in the render plugin, as in this
+        // solution, where isMap is the last bit.
+        me->getTH1()->SetUniqueID(uint32_t(2 * (actualObject + 1) + (isMap ? 1 : 0)));
+      }
+
+      if (lumiFlag_)
+        me->setLumiFlag();
+
+      mes_.push_back(me);
     }
 
-    if (lumiFlag_)
-      me->setLumiFlag();
-
-    mes_.push_back(me);
+    active_ = true;
   }
 
-  active_ = true;
-}
+  bool MESetEcal::retrieve(DQMStore::IGetter &_igetter, std::string *_failedPath /* = 0*/) const {
+    clear();
 
-bool MESetEcal::retrieve(DQMStore::IGetter &_igetter,
-                         std::string *_failedPath /* = 0*/) const {
-  clear();
-
-  std::vector<std::string> mePaths(generatePaths());
-  if (mePaths.empty()) {
-    if (_failedPath)
-      _failedPath->clear();
-    return false;
-  }
-
-  for (unsigned iME(0); iME < mePaths.size(); iME++) {
-    std::string &path(mePaths[iME]);
-    if (path.find('%') != std::string::npos)
-      throw_("retrieve() called with incompletely formed path [" + path + "]");
-
-    MonitorElement *me(_igetter.get(path));
-    if (me)
-      mes_.push_back(me);
-    else {
-      clear();
+    std::vector<std::string> mePaths(generatePaths());
+    if (mePaths.empty()) {
       if (_failedPath)
-        *_failedPath = path;
+        _failedPath->clear();
       return false;
     }
-  }
 
-  active_ = true;
-  return true;
-}
-
-void MESetEcal::fill(DetId const &_id, double _x /* = 1.*/,
-                     double _wy /* = 1.*/, double _w /* = 1.*/) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  fill_(iME, _x, _wy, _w);
-}
-
-void MESetEcal::fill(EcalElectronicsId const &_id, double _x /* = 1.*/,
-                     double _wy /* = 1.*/, double _w /* = 1.*/) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  fill_(iME, _x, _wy, _w);
-}
-
-void MESetEcal::fill(int _dcctccid, double _x /* = 1.*/, double _wy /* = 1.*/,
-                     double _w /* = 1.*/) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
-  checkME_(iME);
-
-  fill_(iME, _x, _wy, _w);
-}
-
-void MESetEcal::fill(double _x, double _wy /* = 1.*/, double _w /* = 1.*/) {
-  if (!active_)
-    return;
-
-  if (mes_.size() != 1)
-    return;
-
-  fill_(0, _x, _wy, _w);
-}
-
-void MESetEcal::setBinContent(DetId const &_id, int _bin, double _content) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  mes_[iME]->setBinContent(_bin, _content);
-}
-
-void MESetEcal::setBinContent(EcalElectronicsId const &_id, int _bin,
-                              double _content) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  mes_[iME]->setBinContent(_bin, _content);
-}
-
-void MESetEcal::setBinContent(int _dcctccid, int _bin, double _content) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
-  checkME_(iME);
-
-  mes_[iME]->setBinContent(_bin, _content);
-}
-
-void MESetEcal::setBinError(DetId const &_id, int _bin, double _error) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  mes_[iME]->setBinError(_bin, _error);
-}
-
-void MESetEcal::setBinError(EcalElectronicsId const &_id, int _bin,
-                            double _error) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  mes_[iME]->setBinError(_bin, _error);
-}
-
-void MESetEcal::setBinError(int _dcctccid, int _bin, double _error) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
-  checkME_(iME);
-
-  mes_[iME]->setBinError(_bin, _error);
-}
-
-void MESetEcal::setBinEntries(DetId const &_id, int _bin, double _entries) {
-  if (!active_)
-    return;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  mes_[iME]->setBinEntries(_bin, _entries);
-}
-
-void MESetEcal::setBinEntries(EcalElectronicsId const &_id, int _bin,
-                              double _entries) {
-  if (!active_)
-    return;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  mes_[iME]->setBinEntries(_bin, _entries);
-}
-
-void MESetEcal::setBinEntries(int _dcctccid, int _bin, double _entries) {
-  if (!active_)
-    return;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
-  checkME_(iME);
-
-  mes_[iME]->setBinEntries(_bin, _entries);
-}
-
-double MESetEcal::getBinContent(DetId const &_id, int _bin) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  return mes_[iME]->getBinContent(_bin);
-}
-
-double MESetEcal::getBinContent(EcalElectronicsId const &_id, int _bin) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  return mes_[iME]->getBinContent(_bin);
-}
-
-double MESetEcal::getBinContent(int _dcctccid, int _bin) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
-  checkME_(iME);
-
-  return mes_[iME]->getBinContent(_bin);
-}
-
-double MESetEcal::getBinError(DetId const &_id, int _bin) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  return mes_[iME]->getBinError(_bin);
-}
-
-double MESetEcal::getBinError(EcalElectronicsId const &_id, int _bin) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  return mes_[iME]->getBinError(_bin);
-}
-
-double MESetEcal::getBinError(int _dcctccid, int _bin) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
-  checkME_(iME);
-
-  return mes_[iME]->getBinError(_bin);
-}
-
-double MESetEcal::getBinEntries(DetId const &_id, int _bin) const {
-  if (!active_)
-    return 0.;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  return mes_[iME]->getBinEntries(_bin);
-}
-
-double MESetEcal::getBinEntries(EcalElectronicsId const &_id, int _bin) const {
-  if (!active_)
-    return 0.;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  return mes_[iME]->getBinEntries(_bin);
-}
-
-double MESetEcal::getBinEntries(int _dcctccid, int _bin) const {
-  if (!active_)
-    return 0.;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
-  checkME_(iME);
-
-  return mes_[iME]->getBinEntries(_bin);
-}
-
-int MESetEcal::findBin(DetId const &_id, double _x, double _y /* = 0.*/) const {
-  if (!active_)
-    return -1;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  return mes_[iME]->getTH1()->FindBin(_x, _y);
-}
-
-int MESetEcal::findBin(EcalElectronicsId const &_id, double _x,
-                       double _y /* = 0.*/) const {
-  if (!active_)
-    return -1;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  return mes_[iME]->getTH1()->FindBin(_x, _y);
-}
-
-int MESetEcal::findBin(int _dcctccid, double _x, double _y /* = 0.*/) const {
-  if (!active_)
-    return -1;
-
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
-  checkME_(iME);
-
-  return mes_[iME]->getTH1()->FindBin(_x, _y);
-}
-
-bool MESetEcal::isVariableBinning() const {
-  return (xaxis_ && xaxis_->edges) || (yaxis_ && yaxis_->edges) ||
-         (zaxis_ && zaxis_->edges);
-}
-
-std::vector<std::string> MESetEcal::generatePaths() const {
-  using namespace std;
-
-  vector<string> paths(0);
-
-  unsigned nME(binning::getNObjects(otype_));
-
-  for (unsigned iME(0); iME < nME; iME++) {
-    binning::ObjectType obj(binning::getObject(otype_, iME));
-
-    string path(path_);
-    map<string, string> replacements;
-
-    switch (obj) {
-    case binning::kEB:
-    case binning::kEBMEM:
-      replacements["subdet"] = "EcalBarrel";
-      replacements["prefix"] = "EB";
-      replacements["suffix"] = "";
-      replacements["subdetshort"] = "EB";
-      replacements["subdetshortsig"] = "EB";
-      replacements["supercrystal"] = "trigger tower";
-      break;
-    case binning::kEE:
-    case binning::kEEMEM:
-      replacements["subdet"] = "EcalEndcap";
-      replacements["prefix"] = "EE";
-      replacements["subdetshort"] = "EE";
-      replacements["subdetshortsig"] = "EE";
-      replacements["supercrystal"] = "super crystal";
-      break;
-    case binning::kEEm:
-      replacements["subdet"] = "EcalEndcap";
-      replacements["prefix"] = "EE";
-      replacements["suffix"] = " EE -";
-      replacements["subdetshort"] = "EE";
-      replacements["subdetshortsig"] = "EEM";
-      replacements["supercrystal"] = "super crystal";
-      break;
-    case binning::kEEp:
-      replacements["subdet"] = "EcalEndcap";
-      replacements["prefix"] = "EE";
-      replacements["suffix"] = " EE +";
-      replacements["subdetshort"] = "EE";
-      replacements["subdetshortsig"] = "EEP";
-      replacements["supercrystal"] = "super crystal";
-      break;
-    case binning::kSM:
-      if (iME <= kEEmHigh || iME >= kEEpLow) {
-        replacements["subdet"] = "EcalEndcap";
-        replacements["prefix"] = "EE";
-        replacements["supercrystal"] = "super crystal";
-      } else {
-        replacements["subdet"] = "EcalBarrel";
-        replacements["prefix"] = "EB";
-        replacements["supercrystal"] = "trigger tower";
+    for (unsigned iME(0); iME < mePaths.size(); iME++) {
+      std::string &path(mePaths[iME]);
+      if (path.find('%') != std::string::npos)
+        throw_("retrieve() called with incompletely formed path [" + path + "]");
+
+      MonitorElement *me(_igetter.get(path));
+      if (me)
+        mes_.push_back(me);
+      else {
+        clear();
+        if (_failedPath)
+          *_failedPath = path;
+        return false;
       }
-      replacements["sm"] = binning::channelName(iME + 1);
-      break;
-    case binning::kEBSM:
-      replacements["subdet"] = "EcalBarrel";
-      replacements["prefix"] = "EB";
-      replacements["sm"] = binning::channelName(iME + kEBmLow + 1);
-      replacements["supercrystal"] = "trigger tower";
-      break;
-    case binning::kEESM:
-      replacements["subdet"] = "EcalEndcap";
-      replacements["prefix"] = "EE";
-      replacements["sm"] =
-          binning::channelName(iME <= kEEmHigh ? iME + 1 : iME + 37);
-      replacements["supercrystal"] = "super crystal";
-      break;
-    case binning::kSMMEM: {
-      unsigned iDCC(memDCCId(iME) - 1);
-      // dccId(unsigned) skips DCCs without MEM
-      if (iDCC <= kEEmHigh || iDCC >= kEEpLow) {
-        replacements["subdet"] = "EcalEndcap";
-        replacements["prefix"] = "EE";
-      } else {
-        replacements["subdet"] = "EcalBarrel";
-        replacements["prefix"] = "EB";
-      }
-      replacements["sm"] = binning::channelName(iDCC + 1);
-    } break;
-    case binning::kEBSMMEM: {
-      unsigned iDCC(memDCCId(iME + 4) - 1);
-      replacements["subdet"] = "EcalBarrel";
-      replacements["prefix"] = "EB";
-      replacements["sm"] = binning::channelName(iDCC + 1);
-    } break;
-    case binning::kEESMMEM: {
-      unsigned iDCC(memDCCId(iME < 4 ? iME : iME + 36) - 1);
-      replacements["subdet"] = "EcalEndcap";
-      replacements["prefix"] = "EE";
-      replacements["sm"] = binning::channelName(iDCC + 1);
-    }
-    default:
-      break;
     }
 
-    paths.push_back(formPath(replacements));
+    active_ = true;
+    return true;
   }
 
-  return paths;
-}
-} // namespace ecaldqm
+  void MESetEcal::fill(DetId const &_id, double _x /* = 1.*/, double _wy /* = 1.*/, double _w /* = 1.*/) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    fill_(iME, _x, _wy, _w);
+  }
+
+  void MESetEcal::fill(EcalElectronicsId const &_id, double _x /* = 1.*/, double _wy /* = 1.*/, double _w /* = 1.*/) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    fill_(iME, _x, _wy, _w);
+  }
+
+  void MESetEcal::fill(int _dcctccid, double _x /* = 1.*/, double _wy /* = 1.*/, double _w /* = 1.*/) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    checkME_(iME);
+
+    fill_(iME, _x, _wy, _w);
+  }
+
+  void MESetEcal::fill(double _x, double _wy /* = 1.*/, double _w /* = 1.*/) {
+    if (!active_)
+      return;
+
+    if (mes_.size() != 1)
+      return;
+
+    fill_(0, _x, _wy, _w);
+  }
+
+  void MESetEcal::setBinContent(DetId const &_id, int _bin, double _content) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    mes_[iME]->setBinContent(_bin, _content);
+  }
+
+  void MESetEcal::setBinContent(EcalElectronicsId const &_id, int _bin, double _content) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    mes_[iME]->setBinContent(_bin, _content);
+  }
+
+  void MESetEcal::setBinContent(int _dcctccid, int _bin, double _content) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    checkME_(iME);
+
+    mes_[iME]->setBinContent(_bin, _content);
+  }
+
+  void MESetEcal::setBinError(DetId const &_id, int _bin, double _error) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    mes_[iME]->setBinError(_bin, _error);
+  }
+
+  void MESetEcal::setBinError(EcalElectronicsId const &_id, int _bin, double _error) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    mes_[iME]->setBinError(_bin, _error);
+  }
+
+  void MESetEcal::setBinError(int _dcctccid, int _bin, double _error) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    checkME_(iME);
+
+    mes_[iME]->setBinError(_bin, _error);
+  }
+
+  void MESetEcal::setBinEntries(DetId const &_id, int _bin, double _entries) {
+    if (!active_)
+      return;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    mes_[iME]->setBinEntries(_bin, _entries);
+  }
+
+  void MESetEcal::setBinEntries(EcalElectronicsId const &_id, int _bin, double _entries) {
+    if (!active_)
+      return;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    mes_[iME]->setBinEntries(_bin, _entries);
+  }
+
+  void MESetEcal::setBinEntries(int _dcctccid, int _bin, double _entries) {
+    if (!active_)
+      return;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    checkME_(iME);
+
+    mes_[iME]->setBinEntries(_bin, _entries);
+  }
+
+  double MESetEcal::getBinContent(DetId const &_id, int _bin) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    return mes_[iME]->getBinContent(_bin);
+  }
+
+  double MESetEcal::getBinContent(EcalElectronicsId const &_id, int _bin) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    return mes_[iME]->getBinContent(_bin);
+  }
+
+  double MESetEcal::getBinContent(int _dcctccid, int _bin) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    checkME_(iME);
+
+    return mes_[iME]->getBinContent(_bin);
+  }
+
+  double MESetEcal::getBinError(DetId const &_id, int _bin) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    return mes_[iME]->getBinError(_bin);
+  }
+
+  double MESetEcal::getBinError(EcalElectronicsId const &_id, int _bin) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    return mes_[iME]->getBinError(_bin);
+  }
+
+  double MESetEcal::getBinError(int _dcctccid, int _bin) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    checkME_(iME);
+
+    return mes_[iME]->getBinError(_bin);
+  }
+
+  double MESetEcal::getBinEntries(DetId const &_id, int _bin) const {
+    if (!active_)
+      return 0.;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    return mes_[iME]->getBinEntries(_bin);
+  }
+
+  double MESetEcal::getBinEntries(EcalElectronicsId const &_id, int _bin) const {
+    if (!active_)
+      return 0.;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    return mes_[iME]->getBinEntries(_bin);
+  }
+
+  double MESetEcal::getBinEntries(int _dcctccid, int _bin) const {
+    if (!active_)
+      return 0.;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    checkME_(iME);
+
+    return mes_[iME]->getBinEntries(_bin);
+  }
+
+  int MESetEcal::findBin(DetId const &_id, double _x, double _y /* = 0.*/) const {
+    if (!active_)
+      return -1;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    return mes_[iME]->getTH1()->FindBin(_x, _y);
+  }
+
+  int MESetEcal::findBin(EcalElectronicsId const &_id, double _x, double _y /* = 0.*/) const {
+    if (!active_)
+      return -1;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    return mes_[iME]->getTH1()->FindBin(_x, _y);
+  }
+
+  int MESetEcal::findBin(int _dcctccid, double _x, double _y /* = 0.*/) const {
+    if (!active_)
+      return -1;
+
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    checkME_(iME);
+
+    return mes_[iME]->getTH1()->FindBin(_x, _y);
+  }
+
+  bool MESetEcal::isVariableBinning() const {
+    return (xaxis_ && xaxis_->edges) || (yaxis_ && yaxis_->edges) || (zaxis_ && zaxis_->edges);
+  }
+
+  std::vector<std::string> MESetEcal::generatePaths() const {
+    using namespace std;
+
+    vector<string> paths(0);
+
+    unsigned nME(binning::getNObjects(otype_));
+
+    for (unsigned iME(0); iME < nME; iME++) {
+      binning::ObjectType obj(binning::getObject(otype_, iME));
+
+      string path(path_);
+      map<string, string> replacements;
+
+      switch (obj) {
+        case binning::kEB:
+        case binning::kEBMEM:
+          replacements["subdet"] = "EcalBarrel";
+          replacements["prefix"] = "EB";
+          replacements["suffix"] = "";
+          replacements["subdetshort"] = "EB";
+          replacements["subdetshortsig"] = "EB";
+          replacements["supercrystal"] = "trigger tower";
+          break;
+        case binning::kEE:
+        case binning::kEEMEM:
+          replacements["subdet"] = "EcalEndcap";
+          replacements["prefix"] = "EE";
+          replacements["subdetshort"] = "EE";
+          replacements["subdetshortsig"] = "EE";
+          replacements["supercrystal"] = "super crystal";
+          break;
+        case binning::kEEm:
+          replacements["subdet"] = "EcalEndcap";
+          replacements["prefix"] = "EE";
+          replacements["suffix"] = " EE -";
+          replacements["subdetshort"] = "EE";
+          replacements["subdetshortsig"] = "EEM";
+          replacements["supercrystal"] = "super crystal";
+          break;
+        case binning::kEEp:
+          replacements["subdet"] = "EcalEndcap";
+          replacements["prefix"] = "EE";
+          replacements["suffix"] = " EE +";
+          replacements["subdetshort"] = "EE";
+          replacements["subdetshortsig"] = "EEP";
+          replacements["supercrystal"] = "super crystal";
+          break;
+        case binning::kSM:
+          if (iME <= kEEmHigh || iME >= kEEpLow) {
+            replacements["subdet"] = "EcalEndcap";
+            replacements["prefix"] = "EE";
+            replacements["supercrystal"] = "super crystal";
+          } else {
+            replacements["subdet"] = "EcalBarrel";
+            replacements["prefix"] = "EB";
+            replacements["supercrystal"] = "trigger tower";
+          }
+          replacements["sm"] = binning::channelName(iME + 1);
+          break;
+        case binning::kEBSM:
+          replacements["subdet"] = "EcalBarrel";
+          replacements["prefix"] = "EB";
+          replacements["sm"] = binning::channelName(iME + kEBmLow + 1);
+          replacements["supercrystal"] = "trigger tower";
+          break;
+        case binning::kEESM:
+          replacements["subdet"] = "EcalEndcap";
+          replacements["prefix"] = "EE";
+          replacements["sm"] = binning::channelName(iME <= kEEmHigh ? iME + 1 : iME + 37);
+          replacements["supercrystal"] = "super crystal";
+          break;
+        case binning::kSMMEM: {
+          unsigned iDCC(memDCCId(iME) - 1);
+          // dccId(unsigned) skips DCCs without MEM
+          if (iDCC <= kEEmHigh || iDCC >= kEEpLow) {
+            replacements["subdet"] = "EcalEndcap";
+            replacements["prefix"] = "EE";
+          } else {
+            replacements["subdet"] = "EcalBarrel";
+            replacements["prefix"] = "EB";
+          }
+          replacements["sm"] = binning::channelName(iDCC + 1);
+        } break;
+        case binning::kEBSMMEM: {
+          unsigned iDCC(memDCCId(iME + 4) - 1);
+          replacements["subdet"] = "EcalBarrel";
+          replacements["prefix"] = "EB";
+          replacements["sm"] = binning::channelName(iDCC + 1);
+        } break;
+        case binning::kEESMMEM: {
+          unsigned iDCC(memDCCId(iME < 4 ? iME : iME + 36) - 1);
+          replacements["subdet"] = "EcalEndcap";
+          replacements["prefix"] = "EE";
+          replacements["sm"] = binning::channelName(iDCC + 1);
+        }
+        default:
+          break;
+      }
+
+      paths.push_back(formPath(replacements));
+    }
+
+    return paths;
+  }
+}  // namespace ecaldqm

--- a/DQM/EcalCommon/src/MESetMulti.cc
+++ b/DQM/EcalCommon/src/MESetMulti.cc
@@ -1,167 +1,158 @@
 #include "DQM/EcalCommon/interface/MESetMulti.h"
 
 namespace ecaldqm {
-MESetMulti::MESetMulti(MESet const &_seed,
-                       ReplCandidates const &_replCandidates)
-    : MESet(_seed), current_(nullptr), sets_(),
-      replCandidates_(_replCandidates) {
-  PathReplacements replacements;
-  std::map<std::string, unsigned> indices;
-  // recursive function to set replacements
-  // indices gives the multi index in each dimension
-  // dimensions are alphanumerically ordered from the use of std::map
-  std::function<bool(typename ReplCandidates::const_iterator &)>
-      setReplacements([&setReplacements, &replacements, &indices,
-                       this](typename ReplCandidates::const_iterator &_rItr) {
-        unsigned &index(indices[_rItr->first]);
-        replacements[_rItr->first] = _rItr->second[index];
-        // one dimension set, go to next
-        ++_rItr;
-        if (_rItr == this->replCandidates_.end()) {
-          // this is the last dimension. Increment the index and retutn to the
-          // first
-          _rItr = this->replCandidates_.begin();
-          ++index;
-        } else if (setReplacements(_rItr))
-          ++index;
+  MESetMulti::MESetMulti(MESet const &_seed, ReplCandidates const &_replCandidates)
+      : MESet(_seed), current_(nullptr), sets_(), replCandidates_(_replCandidates) {
+    PathReplacements replacements;
+    std::map<std::string, unsigned> indices;
+    // recursive function to set replacements
+    // indices gives the multi index in each dimension
+    // dimensions are alphanumerically ordered from the use of std::map
+    std::function<bool(typename ReplCandidates::const_iterator &)> setReplacements(
+        [&setReplacements, &replacements, &indices, this](typename ReplCandidates::const_iterator &_rItr) {
+          unsigned &index(indices[_rItr->first]);
+          replacements[_rItr->first] = _rItr->second[index];
+          // one dimension set, go to next
+          ++_rItr;
+          if (_rItr == this->replCandidates_.end()) {
+            // this is the last dimension. Increment the index and retutn to the
+            // first
+            _rItr = this->replCandidates_.begin();
+            ++index;
+          } else if (setReplacements(_rItr))
+            ++index;
 
-        if (index != _rItr->second.size())
-          return false;
-        // index has counted to the maximum of this dimension, carry over
-        index = 0;
-        return true;
-      });
+          if (index != _rItr->second.size())
+            return false;
+          // index has counted to the maximum of this dimension, carry over
+          index = 0;
+          return true;
+        });
 
-  // [dim0 = 0, dim1 = 0] -> 0, [dim0 = 0, dim1 = 1] -> 1, ...
-  unsigned iM(0);
-  while (true) {
-    replacements.clear();
-    typename ReplCandidates::const_iterator rItr(replCandidates_.begin());
-    bool last(setReplacements(rItr));
-    sets_.push_back(_seed.clone(formPath(replacements)));
-    if (last)
-      break;
-    ++iM;
-  }
-
-  current_ = sets_[0];
-}
-
-MESetMulti::MESetMulti(MESetMulti const &_orig)
-    : MESet(_orig), current_(nullptr), sets_(_orig.sets_.size(), nullptr),
-      replCandidates_(_orig.replCandidates_) {
-  if (sets_.empty())
-    return;
-
-  for (unsigned iS(0); iS < sets_.size(); ++iS) {
-    if (!_orig.sets_[iS])
-      continue;
-    sets_[iS] = _orig.sets_[iS]->clone();
-    if (_orig.sets_[iS] == _orig.current_)
-      current_ = sets_[iS];
-  }
-}
-
-MESetMulti::~MESetMulti() {
-  for (unsigned iS(0); iS < sets_.size(); ++iS)
-    delete sets_[iS];
-}
-
-MESet &MESetMulti::operator=(MESet const &_rhs) {
-  for (unsigned iS(0); iS < sets_.size(); ++iS)
-    delete sets_[iS];
-  sets_.clear();
-  current_ = nullptr;
-
-  MESetMulti const *pRhs(dynamic_cast<MESetMulti const *>(&_rhs));
-  if (pRhs) {
-    sets_.assign(pRhs->sets_.size(), nullptr);
-
-    for (unsigned iS(0); iS < pRhs->sets_.size(); ++iS) {
-      sets_[iS] = pRhs->sets_[iS]->clone();
-      if (pRhs->sets_[iS] == pRhs->current_)
-        current_ = sets_[iS];
+    // [dim0 = 0, dim1 = 0] -> 0, [dim0 = 0, dim1 = 1] -> 1, ...
+    unsigned iM(0);
+    while (true) {
+      replacements.clear();
+      typename ReplCandidates::const_iterator rItr(replCandidates_.begin());
+      bool last(setReplacements(rItr));
+      sets_.push_back(_seed.clone(formPath(replacements)));
+      if (last)
+        break;
+      ++iM;
     }
 
-    replCandidates_ = pRhs->replCandidates_;
+    current_ = sets_[0];
   }
 
-  return MESet::operator=(_rhs);
-}
+  MESetMulti::MESetMulti(MESetMulti const &_orig)
+      : MESet(_orig), current_(nullptr), sets_(_orig.sets_.size(), nullptr), replCandidates_(_orig.replCandidates_) {
+    if (sets_.empty())
+      return;
 
-MESet *MESetMulti::clone(std::string const &_path /* = ""*/) const {
-  std::string path(path_);
-  if (!_path.empty())
-    path_ = _path;
-  MESet *copy(new MESetMulti(*this));
-  path_ = path;
-  return copy;
-}
-
-void MESetMulti::book(DQMStore::IBooker &_ibooker) {
-  for (unsigned iS(0); iS < sets_.size(); ++iS)
-    sets_[iS]->book(_ibooker);
-
-  active_ = true;
-}
-
-bool MESetMulti::retrieve(DQMStore::IGetter &_igetter,
-                          std::string *_failedPath /* = 0*/) const {
-  for (unsigned iS(0); iS < sets_.size(); ++iS)
-    if (!sets_[iS]->retrieve(_igetter, _failedPath))
-      return false;
-
-  active_ = true;
-  return true;
-}
-
-void MESetMulti::clear() const {
-  for (unsigned iS(0); iS < sets_.size(); ++iS)
-    sets_[iS]->clear();
-
-  active_ = false;
-}
-
-void MESetMulti::reset(double _content /* = 0*/, double _error /* = 0.*/,
-                       double _entries /* = 0.*/) {
-  for (unsigned iS(0); iS < sets_.size(); ++iS)
-    sets_[iS]->reset(_content, _error, _entries);
-}
-
-void MESetMulti::resetAll(double _content /* = 0*/, double _error /* = 0.*/,
-                          double _entries /* = 0.*/) {
-  for (unsigned iS(0); iS < sets_.size(); ++iS)
-    sets_[iS]->resetAll(_content, _error, _entries);
-}
-
-void MESetMulti::use(unsigned _iSet) const {
-  if (_iSet >= sets_.size())
-    throw_("MESetMulti index out of range");
-
-  current_ = sets_[_iSet];
-}
-
-unsigned MESetMulti::getIndex(PathReplacements const &_replacements) const {
-  unsigned index(0);
-  unsigned base(1);
-  for (typename ReplCandidates::const_reverse_iterator cItr(
-           replCandidates_.rbegin());
-       cItr != replCandidates_.rend(); ++cItr) {
-    typename PathReplacements::const_iterator rItr(
-        _replacements.find(cItr->first));
-    if (rItr == _replacements.end())
-      throw_(cItr->first + " not given in the key for getIndex");
-    unsigned nC(cItr->second.size());
-    unsigned iR(0);
-    for (; iR != nC; ++iR)
-      if (rItr->second == cItr->second[iR])
-        break;
-    if (iR == nC)
-      throw_(rItr->second + " not found in replacement candidates");
-    index += iR * base;
-    base *= nC;
+    for (unsigned iS(0); iS < sets_.size(); ++iS) {
+      if (!_orig.sets_[iS])
+        continue;
+      sets_[iS] = _orig.sets_[iS]->clone();
+      if (_orig.sets_[iS] == _orig.current_)
+        current_ = sets_[iS];
+    }
   }
 
-  return index;
-}
-} // namespace ecaldqm
+  MESetMulti::~MESetMulti() {
+    for (unsigned iS(0); iS < sets_.size(); ++iS)
+      delete sets_[iS];
+  }
+
+  MESet &MESetMulti::operator=(MESet const &_rhs) {
+    for (unsigned iS(0); iS < sets_.size(); ++iS)
+      delete sets_[iS];
+    sets_.clear();
+    current_ = nullptr;
+
+    MESetMulti const *pRhs(dynamic_cast<MESetMulti const *>(&_rhs));
+    if (pRhs) {
+      sets_.assign(pRhs->sets_.size(), nullptr);
+
+      for (unsigned iS(0); iS < pRhs->sets_.size(); ++iS) {
+        sets_[iS] = pRhs->sets_[iS]->clone();
+        if (pRhs->sets_[iS] == pRhs->current_)
+          current_ = sets_[iS];
+      }
+
+      replCandidates_ = pRhs->replCandidates_;
+    }
+
+    return MESet::operator=(_rhs);
+  }
+
+  MESet *MESetMulti::clone(std::string const &_path /* = ""*/) const {
+    std::string path(path_);
+    if (!_path.empty())
+      path_ = _path;
+    MESet *copy(new MESetMulti(*this));
+    path_ = path;
+    return copy;
+  }
+
+  void MESetMulti::book(DQMStore::IBooker &_ibooker) {
+    for (unsigned iS(0); iS < sets_.size(); ++iS)
+      sets_[iS]->book(_ibooker);
+
+    active_ = true;
+  }
+
+  bool MESetMulti::retrieve(DQMStore::IGetter &_igetter, std::string *_failedPath /* = 0*/) const {
+    for (unsigned iS(0); iS < sets_.size(); ++iS)
+      if (!sets_[iS]->retrieve(_igetter, _failedPath))
+        return false;
+
+    active_ = true;
+    return true;
+  }
+
+  void MESetMulti::clear() const {
+    for (unsigned iS(0); iS < sets_.size(); ++iS)
+      sets_[iS]->clear();
+
+    active_ = false;
+  }
+
+  void MESetMulti::reset(double _content /* = 0*/, double _error /* = 0.*/, double _entries /* = 0.*/) {
+    for (unsigned iS(0); iS < sets_.size(); ++iS)
+      sets_[iS]->reset(_content, _error, _entries);
+  }
+
+  void MESetMulti::resetAll(double _content /* = 0*/, double _error /* = 0.*/, double _entries /* = 0.*/) {
+    for (unsigned iS(0); iS < sets_.size(); ++iS)
+      sets_[iS]->resetAll(_content, _error, _entries);
+  }
+
+  void MESetMulti::use(unsigned _iSet) const {
+    if (_iSet >= sets_.size())
+      throw_("MESetMulti index out of range");
+
+    current_ = sets_[_iSet];
+  }
+
+  unsigned MESetMulti::getIndex(PathReplacements const &_replacements) const {
+    unsigned index(0);
+    unsigned base(1);
+    for (typename ReplCandidates::const_reverse_iterator cItr(replCandidates_.rbegin()); cItr != replCandidates_.rend();
+         ++cItr) {
+      typename PathReplacements::const_iterator rItr(_replacements.find(cItr->first));
+      if (rItr == _replacements.end())
+        throw_(cItr->first + " not given in the key for getIndex");
+      unsigned nC(cItr->second.size());
+      unsigned iR(0);
+      for (; iR != nC; ++iR)
+        if (rItr->second == cItr->second[iR])
+          break;
+      if (iR == nC)
+        throw_(rItr->second + " not found in replacement candidates");
+      index += iR * base;
+      base *= nC;
+    }
+
+    return index;
+  }
+}  // namespace ecaldqm

--- a/DQM/EcalCommon/src/MESetNonObject.cc
+++ b/DQM/EcalCommon/src/MESetNonObject.cc
@@ -1,323 +1,319 @@
 #include "DQM/EcalCommon/interface/MESetNonObject.h"
 
 namespace ecaldqm {
-MESetNonObject::MESetNonObject(std::string const &_fullPath,
-                               binning::ObjectType _otype,
-                               binning::BinningType _btype,
-                               MonitorElement::Kind _kind,
-                               binning::AxisSpecs const *_xaxis /* = 0*/,
-                               binning::AxisSpecs const *_yaxis /* = 0*/,
-                               binning::AxisSpecs const *_zaxis /* = 0*/)
-    : MESet(_fullPath, _otype, _btype, _kind),
-      xaxis_(_xaxis ? new binning::AxisSpecs(*_xaxis) : nullptr),
-      yaxis_(_yaxis ? new binning::AxisSpecs(*_yaxis) : nullptr),
-      zaxis_(_zaxis ? new binning::AxisSpecs(*_zaxis) : nullptr) {}
+  MESetNonObject::MESetNonObject(std::string const &_fullPath,
+                                 binning::ObjectType _otype,
+                                 binning::BinningType _btype,
+                                 MonitorElement::Kind _kind,
+                                 binning::AxisSpecs const *_xaxis /* = 0*/,
+                                 binning::AxisSpecs const *_yaxis /* = 0*/,
+                                 binning::AxisSpecs const *_zaxis /* = 0*/)
+      : MESet(_fullPath, _otype, _btype, _kind),
+        xaxis_(_xaxis ? new binning::AxisSpecs(*_xaxis) : nullptr),
+        yaxis_(_yaxis ? new binning::AxisSpecs(*_yaxis) : nullptr),
+        zaxis_(_zaxis ? new binning::AxisSpecs(*_zaxis) : nullptr) {}
 
-MESetNonObject::MESetNonObject(MESetNonObject const &_orig)
-    : MESet(_orig),
-      xaxis_(_orig.xaxis_ ? new binning::AxisSpecs(*_orig.xaxis_) : nullptr),
-      yaxis_(_orig.yaxis_ ? new binning::AxisSpecs(*_orig.yaxis_) : nullptr),
-      zaxis_(_orig.zaxis_ ? new binning::AxisSpecs(*_orig.zaxis_) : nullptr) {}
+  MESetNonObject::MESetNonObject(MESetNonObject const &_orig)
+      : MESet(_orig),
+        xaxis_(_orig.xaxis_ ? new binning::AxisSpecs(*_orig.xaxis_) : nullptr),
+        yaxis_(_orig.yaxis_ ? new binning::AxisSpecs(*_orig.yaxis_) : nullptr),
+        zaxis_(_orig.zaxis_ ? new binning::AxisSpecs(*_orig.zaxis_) : nullptr) {}
 
-MESetNonObject::~MESetNonObject() {
-  delete xaxis_;
-  delete yaxis_;
-  delete zaxis_;
-}
-
-MESet &MESetNonObject::operator=(MESet const &_rhs) {
-  delete xaxis_;
-  delete yaxis_;
-  delete zaxis_;
-  xaxis_ = nullptr;
-  yaxis_ = nullptr;
-  zaxis_ = nullptr;
-
-  MESetNonObject const *pRhs(dynamic_cast<MESetNonObject const *>(&_rhs));
-  if (pRhs) {
-    if (pRhs->xaxis_)
-      xaxis_ = new binning::AxisSpecs(*pRhs->xaxis_);
-    if (pRhs->yaxis_)
-      yaxis_ = new binning::AxisSpecs(*pRhs->yaxis_);
-    if (pRhs->zaxis_)
-      zaxis_ = new binning::AxisSpecs(*pRhs->zaxis_);
+  MESetNonObject::~MESetNonObject() {
+    delete xaxis_;
+    delete yaxis_;
+    delete zaxis_;
   }
-  return MESet::operator=(_rhs);
-}
 
-MESet *MESetNonObject::clone(std::string const &_path /* = ""*/) const {
-  std::string path(path_);
-  if (!_path.empty())
-    path_ = _path;
-  MESet *copy(new MESetNonObject(*this));
-  path_ = path;
-  return copy;
-}
+  MESet &MESetNonObject::operator=(MESet const &_rhs) {
+    delete xaxis_;
+    delete yaxis_;
+    delete zaxis_;
+    xaxis_ = nullptr;
+    yaxis_ = nullptr;
+    zaxis_ = nullptr;
 
-void MESetNonObject::book(DQMStore::IBooker &_ibooker) {
-  using namespace std;
-
-  clear();
-
-  if (path_.find('%') != string::npos)
-    throw_("book() called with incompletely formed path");
-
-  size_t slashPos(path_.find_last_of('/'));
-  string name(path_.substr(slashPos + 1));
-  _ibooker.setCurrentFolder(path_.substr(0, slashPos));
-
-  MonitorElement *me(nullptr);
-
-  switch (kind_) {
-  case MonitorElement::DQM_KIND_REAL:
-    me = _ibooker.bookFloat(name);
-    break;
-
-  case MonitorElement::DQM_KIND_TH1F: {
-    if (!xaxis_)
-      throw_("No xaxis found for MESetNonObject");
-
-    if (xaxis_->edges)
-      me = _ibooker.book1D(name, name, xaxis_->nbins, xaxis_->edges);
-    else
-      me =
-          _ibooker.book1D(name, name, xaxis_->nbins, xaxis_->low, xaxis_->high);
-  } break;
-
-  case MonitorElement::DQM_KIND_TPROFILE: {
-    if (!xaxis_)
-      throw_("No xaxis found for MESetNonObject");
-
-    double ylow, yhigh;
-    if (!yaxis_) {
-      ylow = -numeric_limits<double>::max();
-      yhigh = numeric_limits<double>::max();
-    } else {
-      ylow = yaxis_->low;
-      yhigh = yaxis_->high;
+    MESetNonObject const *pRhs(dynamic_cast<MESetNonObject const *>(&_rhs));
+    if (pRhs) {
+      if (pRhs->xaxis_)
+        xaxis_ = new binning::AxisSpecs(*pRhs->xaxis_);
+      if (pRhs->yaxis_)
+        yaxis_ = new binning::AxisSpecs(*pRhs->yaxis_);
+      if (pRhs->zaxis_)
+        zaxis_ = new binning::AxisSpecs(*pRhs->zaxis_);
     }
-    if (xaxis_->edges) {
-      // DQMStore bookProfile interface uses double* for bin edges
-      double *edges(new double[xaxis_->nbins + 1]);
-      std::copy(xaxis_->edges, xaxis_->edges + xaxis_->nbins + 1, edges);
-      me = _ibooker.bookProfile(name, name, xaxis_->nbins, edges, ylow, yhigh,
-                                "");
-      delete[] edges;
-    } else
-      me = _ibooker.bookProfile(name, name, xaxis_->nbins, xaxis_->low,
-                                xaxis_->high, ylow, yhigh, "");
-  } break;
+    return MESet::operator=(_rhs);
+  }
 
-  case MonitorElement::DQM_KIND_TH2F: {
-    if (!xaxis_ || !yaxis_)
-      throw_("No x/yaxis found for MESetNonObject");
+  MESet *MESetNonObject::clone(std::string const &_path /* = ""*/) const {
+    std::string path(path_);
+    if (!_path.empty())
+      path_ = _path;
+    MESet *copy(new MESetNonObject(*this));
+    path_ = path;
+    return copy;
+  }
 
-    if (!xaxis_->edges ||
-        !yaxis_->edges) // unlike MESetEcal, if either of X or Y is not set as
-                        // variable, binning will be fixed
-      me = _ibooker.book2D(name, name, xaxis_->nbins, xaxis_->low, xaxis_->high,
-                           yaxis_->nbins, yaxis_->low, yaxis_->high);
-    else
-      me = _ibooker.book2D(name, name, xaxis_->nbins, xaxis_->edges,
-                           yaxis_->nbins, yaxis_->edges);
-  } break;
+  void MESetNonObject::book(DQMStore::IBooker &_ibooker) {
+    using namespace std;
 
-  case MonitorElement::DQM_KIND_TPROFILE2D: {
-    if (!xaxis_ || !yaxis_)
-      throw_("No x/yaxis found for MESetNonObject");
-    if (xaxis_->edges || yaxis_->edges)
-      throw_("Variable bin size for 2D profile not implemented");
+    clear();
 
-    double high(0.), low(0.);
+    if (path_.find('%') != string::npos)
+      throw_("book() called with incompletely formed path");
+
+    size_t slashPos(path_.find_last_of('/'));
+    string name(path_.substr(slashPos + 1));
+    _ibooker.setCurrentFolder(path_.substr(0, slashPos));
+
+    MonitorElement *me(nullptr);
+
+    switch (kind_) {
+      case MonitorElement::DQM_KIND_REAL:
+        me = _ibooker.bookFloat(name);
+        break;
+
+      case MonitorElement::DQM_KIND_TH1F: {
+        if (!xaxis_)
+          throw_("No xaxis found for MESetNonObject");
+
+        if (xaxis_->edges)
+          me = _ibooker.book1D(name, name, xaxis_->nbins, xaxis_->edges);
+        else
+          me = _ibooker.book1D(name, name, xaxis_->nbins, xaxis_->low, xaxis_->high);
+      } break;
+
+      case MonitorElement::DQM_KIND_TPROFILE: {
+        if (!xaxis_)
+          throw_("No xaxis found for MESetNonObject");
+
+        double ylow, yhigh;
+        if (!yaxis_) {
+          ylow = -numeric_limits<double>::max();
+          yhigh = numeric_limits<double>::max();
+        } else {
+          ylow = yaxis_->low;
+          yhigh = yaxis_->high;
+        }
+        if (xaxis_->edges) {
+          // DQMStore bookProfile interface uses double* for bin edges
+          double *edges(new double[xaxis_->nbins + 1]);
+          std::copy(xaxis_->edges, xaxis_->edges + xaxis_->nbins + 1, edges);
+          me = _ibooker.bookProfile(name, name, xaxis_->nbins, edges, ylow, yhigh, "");
+          delete[] edges;
+        } else
+          me = _ibooker.bookProfile(name, name, xaxis_->nbins, xaxis_->low, xaxis_->high, ylow, yhigh, "");
+      } break;
+
+      case MonitorElement::DQM_KIND_TH2F: {
+        if (!xaxis_ || !yaxis_)
+          throw_("No x/yaxis found for MESetNonObject");
+
+        if (!xaxis_->edges || !yaxis_->edges)  // unlike MESetEcal, if either of X or Y is not set as
+                                               // variable, binning will be fixed
+          me = _ibooker.book2D(
+              name, name, xaxis_->nbins, xaxis_->low, xaxis_->high, yaxis_->nbins, yaxis_->low, yaxis_->high);
+        else
+          me = _ibooker.book2D(name, name, xaxis_->nbins, xaxis_->edges, yaxis_->nbins, yaxis_->edges);
+      } break;
+
+      case MonitorElement::DQM_KIND_TPROFILE2D: {
+        if (!xaxis_ || !yaxis_)
+          throw_("No x/yaxis found for MESetNonObject");
+        if (xaxis_->edges || yaxis_->edges)
+          throw_("Variable bin size for 2D profile not implemented");
+
+        double high(0.), low(0.);
+        if (zaxis_) {
+          low = zaxis_->low;
+          high = zaxis_->high;
+        } else {
+          low = -numeric_limits<double>::max();
+          high = numeric_limits<double>::max();
+        }
+
+        me = _ibooker.bookProfile2D(name,
+                                    name,
+                                    xaxis_->nbins,
+                                    xaxis_->low,
+                                    xaxis_->high,
+                                    yaxis_->nbins,
+                                    yaxis_->low,
+                                    yaxis_->high,
+                                    low,
+                                    high,
+                                    "");
+      } break;
+
+      default:
+        throw_("Unsupported MonitorElement kind");
+    }
+
+    if (xaxis_) {
+      me->setAxisTitle(xaxis_->title, 1);
+      if (xaxis_->labels) {
+        for (int iBin(1); iBin <= xaxis_->nbins; ++iBin)
+          me->setBinLabel(iBin, xaxis_->labels[iBin - 1], 1);
+      }
+    }
+    if (yaxis_) {
+      me->setAxisTitle(yaxis_->title, 2);
+      if (yaxis_->labels) {
+        for (int iBin(1); iBin <= yaxis_->nbins; ++iBin)
+          me->setBinLabel(iBin, yaxis_->labels[iBin - 1], 2);
+      }
+    }
     if (zaxis_) {
-      low = zaxis_->low;
-      high = zaxis_->high;
-    } else {
-      low = -numeric_limits<double>::max();
-      high = numeric_limits<double>::max();
+      me->setAxisTitle(zaxis_->title, 3);
+      if (zaxis_->labels) {
+        for (int iBin(1); iBin <= zaxis_->nbins; ++iBin)
+          me->setBinLabel(iBin, zaxis_->labels[iBin - 1], 3);
+      }
     }
 
-    me = _ibooker.bookProfile2D(name, name, xaxis_->nbins, xaxis_->low,
-                                xaxis_->high, yaxis_->nbins, yaxis_->low,
-                                yaxis_->high, low, high, "");
-  } break;
+    if (lumiFlag_)
+      me->setLumiFlag();
 
-  default:
-    throw_("Unsupported MonitorElement kind");
+    mes_.push_back(me);
+
+    active_ = true;
   }
 
-  if (xaxis_) {
-    me->setAxisTitle(xaxis_->title, 1);
-    if (xaxis_->labels) {
-      for (int iBin(1); iBin <= xaxis_->nbins; ++iBin)
-        me->setBinLabel(iBin, xaxis_->labels[iBin - 1], 1);
+  bool MESetNonObject::retrieve(DQMStore::IGetter &_igetter, std::string *_failedPath /* = 0*/) const {
+    mes_.clear();
+
+    MonitorElement *me(_igetter.get(path_));
+    if (!me) {
+      if (_failedPath)
+        *_failedPath = path_;
+      return false;
+    }
+
+    mes_.push_back(me);
+
+    active_ = true;
+    return true;
+  }
+
+  void MESetNonObject::fill(double _x, double _wy /* = 1.*/, double _w /* = 1.*/) {
+    if (!active_)
+      return;
+
+    if (mes_.empty() || !mes_[0])
+      return;
+
+    switch (kind_) {
+      case MonitorElement::DQM_KIND_REAL:
+        mes_[0]->Fill(_x);
+        break;
+      case MonitorElement::DQM_KIND_TH1F:
+      case MonitorElement::DQM_KIND_TPROFILE:
+        mes_[0]->Fill(_x, _wy);
+        break;
+      case MonitorElement::DQM_KIND_TH2F:
+      case MonitorElement::DQM_KIND_TPROFILE2D:
+        mes_[0]->Fill(_x, _wy, _w);
+        break;
+      default:
+        break;
     }
   }
-  if (yaxis_) {
-    me->setAxisTitle(yaxis_->title, 2);
-    if (yaxis_->labels) {
-      for (int iBin(1); iBin <= yaxis_->nbins; ++iBin)
-        me->setBinLabel(iBin, yaxis_->labels[iBin - 1], 2);
-    }
-  }
-  if (zaxis_) {
-    me->setAxisTitle(zaxis_->title, 3);
-    if (zaxis_->labels) {
-      for (int iBin(1); iBin <= zaxis_->nbins; ++iBin)
-        me->setBinLabel(iBin, zaxis_->labels[iBin - 1], 3);
-    }
+
+  void MESetNonObject::setBinContent(int _bin, double _content) {
+    if (!active_)
+      return;
+    if (kind_ == MonitorElement::DQM_KIND_REAL)
+      return;
+
+    if (mes_.empty() || !mes_[0])
+      return;
+
+    mes_[0]->setBinContent(_bin, _content);
   }
 
-  if (lumiFlag_)
-    me->setLumiFlag();
+  void MESetNonObject::setBinError(int _bin, double _error) {
+    if (!active_)
+      return;
+    if (kind_ == MonitorElement::DQM_KIND_REAL)
+      return;
 
-  mes_.push_back(me);
+    if (mes_.empty() || !mes_[0])
+      return;
 
-  active_ = true;
-}
-
-bool MESetNonObject::retrieve(DQMStore::IGetter &_igetter,
-                              std::string *_failedPath /* = 0*/) const {
-  mes_.clear();
-
-  MonitorElement *me(_igetter.get(path_));
-  if (!me) {
-    if (_failedPath)
-      *_failedPath = path_;
-    return false;
+    mes_[0]->setBinError(_bin, _error);
   }
 
-  mes_.push_back(me);
+  void MESetNonObject::setBinEntries(int _bin, double _entries) {
+    if (!active_)
+      return;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return;
 
-  active_ = true;
-  return true;
-}
+    if (mes_.empty() || !mes_[0])
+      return;
 
-void MESetNonObject::fill(double _x, double _wy /* = 1.*/,
-                          double _w /* = 1.*/) {
-  if (!active_)
-    return;
-
-  if (mes_.empty() || !mes_[0])
-    return;
-
-  switch (kind_) {
-  case MonitorElement::DQM_KIND_REAL:
-    mes_[0]->Fill(_x);
-    break;
-  case MonitorElement::DQM_KIND_TH1F:
-  case MonitorElement::DQM_KIND_TPROFILE:
-    mes_[0]->Fill(_x, _wy);
-    break;
-  case MonitorElement::DQM_KIND_TH2F:
-  case MonitorElement::DQM_KIND_TPROFILE2D:
-    mes_[0]->Fill(_x, _wy, _w);
-    break;
-  default:
-    break;
+    mes_[0]->setBinEntries(_bin, _entries);
   }
-}
 
-void MESetNonObject::setBinContent(int _bin, double _content) {
-  if (!active_)
-    return;
-  if (kind_ == MonitorElement::DQM_KIND_REAL)
-    return;
+  double MESetNonObject::getBinContent(int _bin, int) const {
+    if (!active_)
+      return 0.;
+    if (kind_ == MonitorElement::DQM_KIND_REAL)
+      return 0.;
 
-  if (mes_.empty() || !mes_[0])
-    return;
+    if (mes_.empty() || !mes_[0])
+      return 0.;
 
-  mes_[0]->setBinContent(_bin, _content);
-}
+    return mes_[0]->getBinContent(_bin);
+  }
 
-void MESetNonObject::setBinError(int _bin, double _error) {
-  if (!active_)
-    return;
-  if (kind_ == MonitorElement::DQM_KIND_REAL)
-    return;
+  double MESetNonObject::getFloatValue() const {
+    if (kind_ == MonitorElement::DQM_KIND_REAL)
+      return mes_[0]->getFloatValue();
+    else
+      return 0.;
+  }
 
-  if (mes_.empty() || !mes_[0])
-    return;
+  double MESetNonObject::getBinError(int _bin, int) const {
+    if (!active_)
+      return 0.;
+    if (kind_ == MonitorElement::DQM_KIND_REAL)
+      return 0.;
 
-  mes_[0]->setBinError(_bin, _error);
-}
+    if (mes_.empty() || !mes_[0])
+      return 0.;
 
-void MESetNonObject::setBinEntries(int _bin, double _entries) {
-  if (!active_)
-    return;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return;
+    return mes_[0]->getBinError(_bin);
+  }
 
-  if (mes_.empty() || !mes_[0])
-    return;
+  double MESetNonObject::getBinEntries(int _bin, int) const {
+    if (!active_)
+      return 0.;
+    if (kind_ != MonitorElement::DQM_KIND_TPROFILE && kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
+      return 0.;
 
-  mes_[0]->setBinEntries(_bin, _entries);
-}
+    if (mes_.empty() || !mes_[0])
+      return 0.;
 
-double MESetNonObject::getBinContent(int _bin, int) const {
-  if (!active_)
-    return 0.;
-  if (kind_ == MonitorElement::DQM_KIND_REAL)
-    return 0.;
+    return mes_[0]->getBinEntries(_bin);
+  }
 
-  if (mes_.empty() || !mes_[0])
-    return 0.;
+  int MESetNonObject::findBin(double _x, double _y /* = 0.*/) const {
+    if (!active_)
+      return 0;
 
-  return mes_[0]->getBinContent(_bin);
-}
+    if (mes_.empty() || !mes_[0])
+      return 0;
 
-double MESetNonObject::getFloatValue() const {
-  if (kind_ == MonitorElement::DQM_KIND_REAL)
-    return mes_[0]->getFloatValue();
-  else
-    return 0.;
-}
+    if (kind_ == MonitorElement::DQM_KIND_TH1F || kind_ == MonitorElement::DQM_KIND_TPROFILE)
+      return mes_[0]->getTH1()->FindBin(_x);
+    else if (kind_ == MonitorElement::DQM_KIND_TH2F || kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
+      return mes_[0]->getTH1()->FindBin(_x, _y);
+    else
+      return 0;
+  }
 
-double MESetNonObject::getBinError(int _bin, int) const {
-  if (!active_)
-    return 0.;
-  if (kind_ == MonitorElement::DQM_KIND_REAL)
-    return 0.;
-
-  if (mes_.empty() || !mes_[0])
-    return 0.;
-
-  return mes_[0]->getBinError(_bin);
-}
-
-double MESetNonObject::getBinEntries(int _bin, int) const {
-  if (!active_)
-    return 0.;
-  if (kind_ != MonitorElement::DQM_KIND_TPROFILE &&
-      kind_ != MonitorElement::DQM_KIND_TPROFILE2D)
-    return 0.;
-
-  if (mes_.empty() || !mes_[0])
-    return 0.;
-
-  return mes_[0]->getBinEntries(_bin);
-}
-
-int MESetNonObject::findBin(double _x, double _y /* = 0.*/) const {
-  if (!active_)
-    return 0;
-
-  if (mes_.empty() || !mes_[0])
-    return 0;
-
-  if (kind_ == MonitorElement::DQM_KIND_TH1F ||
-      kind_ == MonitorElement::DQM_KIND_TPROFILE)
-    return mes_[0]->getTH1()->FindBin(_x);
-  else if (kind_ == MonitorElement::DQM_KIND_TH2F ||
-           kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
-    return mes_[0]->getTH1()->FindBin(_x, _y);
-  else
-    return 0;
-}
-
-bool MESetNonObject::isVariableBinning() const {
-  return (xaxis_ && xaxis_->edges) || (yaxis_ && yaxis_->edges) ||
-         (zaxis_ && zaxis_->edges);
-}
-} // namespace ecaldqm
+  bool MESetNonObject::isVariableBinning() const {
+    return (xaxis_ && xaxis_->edges) || (yaxis_ && yaxis_->edges) || (zaxis_ && zaxis_->edges);
+  }
+}  // namespace ecaldqm

--- a/DQM/EcalCommon/src/MESetProjection.cc
+++ b/DQM/EcalCommon/src/MESetProjection.cc
@@ -3,460 +3,457 @@
 #include "DQM/EcalCommon/interface/EcalDQMCommonUtils.h"
 
 namespace ecaldqm {
-MESetProjection::MESetProjection(std::string const &_fullPath,
-                                 binning::ObjectType _otype,
-                                 binning::BinningType _btype,
-                                 MonitorElement::Kind _kind,
-                                 binning::AxisSpecs const *_yaxis /* = 0*/)
-    : MESetEcal(_fullPath, _otype, _btype, _kind, 1, nullptr, _yaxis) {
-  switch (kind_) {
-  case MonitorElement::DQM_KIND_TH1F:
-  case MonitorElement::DQM_KIND_TPROFILE:
-    break;
-  default:
-    throw_("Unsupported MonitorElement kind");
-  }
-
-  switch (btype_) {
-  case binning::kProjEta:
-  case binning::kProjPhi:
-    break;
-  default:
-    throw_("Unsupported binning");
-  }
-}
-
-MESetProjection::MESetProjection(MESetProjection const &_orig)
-    : MESetEcal(_orig) {}
-
-MESetProjection::~MESetProjection() {}
-
-MESet *MESetProjection::clone(std::string const &_path /* = ""*/) const {
-  std::string path(path_);
-  if (!_path.empty())
-    path_ = _path;
-  MESet *copy(new MESetProjection(*this));
-  path_ = path;
-  return copy;
-}
-
-void MESetProjection::fill(DetId const &_id, double _w /* = 1.*/, double,
-                           double) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  int subdet(_id.subdetId());
-
-  if (subdet == EcalBarrel) {
-    EBDetId ebid(_id);
-    if (btype_ == binning::kProjEta)
-      fill_(iME, eta(ebid), _w, 0.);
-    else if (btype_ == binning::kProjPhi)
-      fill_(iME, phi(ebid), _w, 0.);
-  } else if (subdet == EcalEndcap) {
-    EEDetId eeid(_id);
-    if (btype_ == binning::kProjEta)
-      fill_(iME, eta(eeid), _w, 0.);
-    if (btype_ == binning::kProjPhi) {
-      fill_(iME, phi(eeid), _w, 0.);
+  MESetProjection::MESetProjection(std::string const &_fullPath,
+                                   binning::ObjectType _otype,
+                                   binning::BinningType _btype,
+                                   MonitorElement::Kind _kind,
+                                   binning::AxisSpecs const *_yaxis /* = 0*/)
+      : MESetEcal(_fullPath, _otype, _btype, _kind, 1, nullptr, _yaxis) {
+    switch (kind_) {
+      case MonitorElement::DQM_KIND_TH1F:
+      case MonitorElement::DQM_KIND_TPROFILE:
+        break;
+      default:
+        throw_("Unsupported MonitorElement kind");
     }
-  } else if (isEndcapTTId(_id)) {
-    EcalTrigTowerDetId ttid(_id);
-    std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
-    unsigned nIds(ids.size());
-    if (btype_ == binning::kProjEta) {
-      for (unsigned iId(0); iId < nIds; iId++)
-        fill_(iME, eta(EEDetId(ids[iId])), _w / nIds, 0.);
-    } else if (btype_ == binning::kProjPhi) {
-      for (unsigned iId(0); iId < nIds; iId++)
-        fill_(iME, phi(EEDetId(ids[iId])), _w / nIds, 0.);
+
+    switch (btype_) {
+      case binning::kProjEta:
+      case binning::kProjPhi:
+        break;
+      default:
+        throw_("Unsupported binning");
     }
-  } else if (subdet == EcalTriggerTower) {
-    EcalTrigTowerDetId ttid(_id);
-    if (btype_ == binning::kProjEta) {
-      int ieta(ttid.ieta());
-      if (ieta < 18 && ieta > 0)
-        fill_(iME, (ieta * 5 - 2.5) * EBDetId::crystalUnitToEta, _w, 0.);
-      else if (ieta > -18 && ieta < 0)
-        fill_(iME, (ieta * 5 + 2.5) * EBDetId::crystalUnitToEta, _w, 0.);
-    } else if (btype_ == binning::kProjPhi)
-      fill_(iME, phi(ttid), _w, 0.);
   }
-}
 
-void MESetProjection::fill(int _subdet, double _x /* = 1.*/,
-                           double _w /* = 1.*/, double) {
-  if (!active_)
-    return;
+  MESetProjection::MESetProjection(MESetProjection const &_orig) : MESetEcal(_orig) {}
 
-  unsigned iME(binning::findPlotIndex(otype_, _subdet, btype_));
-  checkME_(iME);
+  MESetProjection::~MESetProjection() {}
 
-  if (btype_ == binning::kProjPhi)
-    _x = phi(_x);
+  MESet *MESetProjection::clone(std::string const &_path /* = ""*/) const {
+    std::string path(path_);
+    if (!_path.empty())
+      path_ = _path;
+    MESet *copy(new MESetProjection(*this));
+    path_ = path;
+    return copy;
+  }
 
-  mes_[iME]->Fill(_x, _w);
-}
+  void MESetProjection::fill(DetId const &_id, double _w /* = 1.*/, double, double) {
+    if (!active_)
+      return;
 
-void MESetProjection::fill(double _x, double _w /* = 1.*/, double) {
-  if (!active_)
-    return;
-  if (btype_ != binning::kProjEta)
-    return;
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
 
-  unsigned iME;
-  if (_x < -etaBound)
-    iME = 0;
-  else if (_x < etaBound)
-    iME = 1;
-  else
-    iME = 2;
+    int subdet(_id.subdetId());
 
-  if (otype_ == binning::kEcal2P && iME == 2)
-    iME = 0;
-
-  checkME_(iME);
-
-  mes_[iME]->Fill(_x, _w);
-}
-
-void MESetProjection::setBinContent(DetId const &_id, double _content) {
-  if (!active_)
-    return;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  if (isEndcapTTId(_id)) {
-    EcalTrigTowerDetId ttid(_id);
-    std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
-    unsigned nIds(ids.size());
-    std::set<int> bins;
-    if (btype_ == binning::kProjEta) {
-      for (unsigned iId(0); iId < nIds; iId++) {
-        int bin(me->getTH1()->FindBin(eta(EEDetId(ids[iId]))));
-        if (bins.find(bin) != bins.end())
-          continue;
-        me->setBinContent(bin, _content);
+    if (subdet == EcalBarrel) {
+      EBDetId ebid(_id);
+      if (btype_ == binning::kProjEta)
+        fill_(iME, eta(ebid), _w, 0.);
+      else if (btype_ == binning::kProjPhi)
+        fill_(iME, phi(ebid), _w, 0.);
+    } else if (subdet == EcalEndcap) {
+      EEDetId eeid(_id);
+      if (btype_ == binning::kProjEta)
+        fill_(iME, eta(eeid), _w, 0.);
+      if (btype_ == binning::kProjPhi) {
+        fill_(iME, phi(eeid), _w, 0.);
       }
-    } else if (btype_ == binning::kProjPhi) {
-      for (unsigned iId(0); iId < nIds; iId++) {
-        int bin(me->getTH1()->FindBin(phi(EEDetId(ids[iId]))));
-        if (bins.find(bin) != bins.end())
-          continue;
-        me->setBinContent(bin, _content);
+    } else if (isEndcapTTId(_id)) {
+      EcalTrigTowerDetId ttid(_id);
+      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
+      unsigned nIds(ids.size());
+      if (btype_ == binning::kProjEta) {
+        for (unsigned iId(0); iId < nIds; iId++)
+          fill_(iME, eta(EEDetId(ids[iId])), _w / nIds, 0.);
+      } else if (btype_ == binning::kProjPhi) {
+        for (unsigned iId(0); iId < nIds; iId++)
+          fill_(iME, phi(EEDetId(ids[iId])), _w / nIds, 0.);
       }
+    } else if (subdet == EcalTriggerTower) {
+      EcalTrigTowerDetId ttid(_id);
+      if (btype_ == binning::kProjEta) {
+        int ieta(ttid.ieta());
+        if (ieta < 18 && ieta > 0)
+          fill_(iME, (ieta * 5 - 2.5) * EBDetId::crystalUnitToEta, _w, 0.);
+        else if (ieta > -18 && ieta < 0)
+          fill_(iME, (ieta * 5 + 2.5) * EBDetId::crystalUnitToEta, _w, 0.);
+      } else if (btype_ == binning::kProjPhi)
+        fill_(iME, phi(ttid), _w, 0.);
     }
-    return;
   }
 
-  double x(0.);
-  int subdet(_id.subdetId());
-  if (subdet == EcalBarrel) {
-    EBDetId ebid(_id);
-    if (btype_ == binning::kProjEta)
-      x = eta(ebid);
-    else if (btype_ == binning::kProjPhi)
-      x = phi(ebid);
-  } else if (subdet == EcalEndcap) {
-    if (btype_ == binning::kProjEta)
-      x = eta(EEDetId(_id));
-    else if (btype_ == binning::kProjPhi)
-      x = phi(EEDetId(_id));
-  } else if (subdet == EcalTriggerTower) {
-    EcalTrigTowerDetId ttid(_id);
-    if (btype_ == binning::kProjEta) {
-      int ieta(ttid.ieta());
-      if (ieta < 18 && ieta > 0)
-        x = (ieta * 5 - 2.5) * EBDetId::crystalUnitToEta;
-      else if (ieta > -18 && ieta < 0)
-        x = (ieta * 5 + 2.5) * EBDetId::crystalUnitToEta;
-    } else if (btype_ == binning::kProjPhi)
-      x = phi(ttid);
+  void MESetProjection::fill(int _subdet, double _x /* = 1.*/, double _w /* = 1.*/, double) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _subdet, btype_));
+    checkME_(iME);
+
+    if (btype_ == binning::kProjPhi)
+      _x = phi(_x);
+
+    mes_[iME]->Fill(_x, _w);
   }
 
-  int bin(me->getTH1()->FindBin(x));
-  me->setBinContent(bin, _content);
-}
+  void MESetProjection::fill(double _x, double _w /* = 1.*/, double) {
+    if (!active_)
+      return;
+    if (btype_ != binning::kProjEta)
+      return;
 
-void MESetProjection::setBinError(DetId const &_id, double _error) {
-  if (!active_)
-    return;
+    unsigned iME;
+    if (_x < -etaBound)
+      iME = 0;
+    else if (_x < etaBound)
+      iME = 1;
+    else
+      iME = 2;
 
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
+    if (otype_ == binning::kEcal2P && iME == 2)
+      iME = 0;
 
-  MonitorElement *me(mes_[iME]);
+    checkME_(iME);
 
-  if (isEndcapTTId(_id)) {
-    EcalTrigTowerDetId ttid(_id);
-    std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
-    unsigned nIds(ids.size());
-    std::set<int> bins;
-    if (btype_ == binning::kProjEta) {
-      for (unsigned iId(0); iId < nIds; iId++) {
-        int bin(me->getTH1()->FindBin(eta(EEDetId(ids[iId]))));
-        if (bins.find(bin) != bins.end())
-          continue;
-        me->setBinError(bin, _error);
+    mes_[iME]->Fill(_x, _w);
+  }
+
+  void MESetProjection::setBinContent(DetId const &_id, double _content) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    if (isEndcapTTId(_id)) {
+      EcalTrigTowerDetId ttid(_id);
+      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
+      unsigned nIds(ids.size());
+      std::set<int> bins;
+      if (btype_ == binning::kProjEta) {
+        for (unsigned iId(0); iId < nIds; iId++) {
+          int bin(me->getTH1()->FindBin(eta(EEDetId(ids[iId]))));
+          if (bins.find(bin) != bins.end())
+            continue;
+          me->setBinContent(bin, _content);
+        }
+      } else if (btype_ == binning::kProjPhi) {
+        for (unsigned iId(0); iId < nIds; iId++) {
+          int bin(me->getTH1()->FindBin(phi(EEDetId(ids[iId]))));
+          if (bins.find(bin) != bins.end())
+            continue;
+          me->setBinContent(bin, _content);
+        }
       }
-    } else if (btype_ == binning::kProjPhi) {
-      for (unsigned iId(0); iId < nIds; iId++) {
-        int bin(me->getTH1()->FindBin(phi(EEDetId(ids[iId]))));
-        if (bins.find(bin) != bins.end())
-          continue;
-        me->setBinError(bin, _error);
+      return;
+    }
+
+    double x(0.);
+    int subdet(_id.subdetId());
+    if (subdet == EcalBarrel) {
+      EBDetId ebid(_id);
+      if (btype_ == binning::kProjEta)
+        x = eta(ebid);
+      else if (btype_ == binning::kProjPhi)
+        x = phi(ebid);
+    } else if (subdet == EcalEndcap) {
+      if (btype_ == binning::kProjEta)
+        x = eta(EEDetId(_id));
+      else if (btype_ == binning::kProjPhi)
+        x = phi(EEDetId(_id));
+    } else if (subdet == EcalTriggerTower) {
+      EcalTrigTowerDetId ttid(_id);
+      if (btype_ == binning::kProjEta) {
+        int ieta(ttid.ieta());
+        if (ieta < 18 && ieta > 0)
+          x = (ieta * 5 - 2.5) * EBDetId::crystalUnitToEta;
+        else if (ieta > -18 && ieta < 0)
+          x = (ieta * 5 + 2.5) * EBDetId::crystalUnitToEta;
+      } else if (btype_ == binning::kProjPhi)
+        x = phi(ttid);
+    }
+
+    int bin(me->getTH1()->FindBin(x));
+    me->setBinContent(bin, _content);
+  }
+
+  void MESetProjection::setBinError(DetId const &_id, double _error) {
+    if (!active_)
+      return;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    if (isEndcapTTId(_id)) {
+      EcalTrigTowerDetId ttid(_id);
+      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
+      unsigned nIds(ids.size());
+      std::set<int> bins;
+      if (btype_ == binning::kProjEta) {
+        for (unsigned iId(0); iId < nIds; iId++) {
+          int bin(me->getTH1()->FindBin(eta(EEDetId(ids[iId]))));
+          if (bins.find(bin) != bins.end())
+            continue;
+          me->setBinError(bin, _error);
+        }
+      } else if (btype_ == binning::kProjPhi) {
+        for (unsigned iId(0); iId < nIds; iId++) {
+          int bin(me->getTH1()->FindBin(phi(EEDetId(ids[iId]))));
+          if (bins.find(bin) != bins.end())
+            continue;
+          me->setBinError(bin, _error);
+        }
       }
+      return;
     }
-    return;
+
+    double x(0.);
+    int subdet(_id.subdetId());
+    if (subdet == EcalBarrel) {
+      EBDetId ebid(_id);
+      if (btype_ == binning::kProjEta)
+        x = eta(ebid);
+      else if (btype_ == binning::kProjPhi)
+        x = phi(ebid);
+    } else if (subdet == EcalEndcap) {
+      if (btype_ == binning::kProjEta)
+        x = eta(EEDetId(_id));
+      else if (btype_ == binning::kProjPhi)
+        x = phi(EEDetId(_id));
+    } else if (subdet == EcalTriggerTower) {
+      EcalTrigTowerDetId ttid(_id);
+      if (btype_ == binning::kProjEta) {
+        int ieta(ttid.ieta());
+        if (ieta < 18 && ieta > 0)
+          x = (ieta * 5 - 2.5) * EBDetId::crystalUnitToEta;
+        else if (ieta > -18 && ieta < 0)
+          x = (ieta * 5 + 2.5) * EBDetId::crystalUnitToEta;
+      } else if (btype_ == binning::kProjPhi)
+        x = phi(ttid);
+    }
+
+    int bin(me->getTH1()->FindBin(x));
+    me->setBinError(bin, _error);
   }
 
-  double x(0.);
-  int subdet(_id.subdetId());
-  if (subdet == EcalBarrel) {
-    EBDetId ebid(_id);
-    if (btype_ == binning::kProjEta)
-      x = eta(ebid);
-    else if (btype_ == binning::kProjPhi)
-      x = phi(ebid);
-  } else if (subdet == EcalEndcap) {
-    if (btype_ == binning::kProjEta)
-      x = eta(EEDetId(_id));
-    else if (btype_ == binning::kProjPhi)
-      x = phi(EEDetId(_id));
-  } else if (subdet == EcalTriggerTower) {
-    EcalTrigTowerDetId ttid(_id);
-    if (btype_ == binning::kProjEta) {
-      int ieta(ttid.ieta());
-      if (ieta < 18 && ieta > 0)
-        x = (ieta * 5 - 2.5) * EBDetId::crystalUnitToEta;
-      else if (ieta > -18 && ieta < 0)
-        x = (ieta * 5 + 2.5) * EBDetId::crystalUnitToEta;
-    } else if (btype_ == binning::kProjPhi)
-      x = phi(ttid);
-  }
+  void MESetProjection::setBinEntries(DetId const &_id, double _entries) {
+    if (!active_)
+      return;
 
-  int bin(me->getTH1()->FindBin(x));
-  me->setBinError(bin, _error);
-}
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
 
-void MESetProjection::setBinEntries(DetId const &_id, double _entries) {
-  if (!active_)
-    return;
+    MonitorElement *me(mes_[iME]);
 
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  if (isEndcapTTId(_id)) {
-    EcalTrigTowerDetId ttid(_id);
-    std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
-    unsigned nIds(ids.size());
-    std::set<int> bins;
-    if (btype_ == binning::kProjEta) {
-      for (unsigned iId(0); iId < nIds; iId++) {
-        int bin(me->getTH1()->FindBin(eta(EEDetId(ids[iId]))));
-        if (bins.find(bin) != bins.end())
-          continue;
-        me->setBinEntries(bin, _entries);
+    if (isEndcapTTId(_id)) {
+      EcalTrigTowerDetId ttid(_id);
+      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
+      unsigned nIds(ids.size());
+      std::set<int> bins;
+      if (btype_ == binning::kProjEta) {
+        for (unsigned iId(0); iId < nIds; iId++) {
+          int bin(me->getTH1()->FindBin(eta(EEDetId(ids[iId]))));
+          if (bins.find(bin) != bins.end())
+            continue;
+          me->setBinEntries(bin, _entries);
+        }
+      } else if (btype_ == binning::kProjPhi) {
+        for (unsigned iId(0); iId < nIds; iId++) {
+          int bin(me->getTH1()->FindBin(phi(EEDetId(ids[iId]))));
+          if (bins.find(bin) != bins.end())
+            continue;
+          me->setBinEntries(bin, _entries);
+        }
       }
-    } else if (btype_ == binning::kProjPhi) {
-      for (unsigned iId(0); iId < nIds; iId++) {
-        int bin(me->getTH1()->FindBin(phi(EEDetId(ids[iId]))));
-        if (bins.find(bin) != bins.end())
-          continue;
-        me->setBinEntries(bin, _entries);
+      return;
+    }
+
+    double x(0.);
+    int subdet(_id.subdetId());
+    if (subdet == EcalBarrel) {
+      EBDetId ebid(_id);
+      if (btype_ == binning::kProjEta)
+        x = eta(ebid);
+      else if (btype_ == binning::kProjPhi)
+        x = phi(ebid);
+    } else if (subdet == EcalEndcap) {
+      if (btype_ == binning::kProjEta)
+        x = eta(EEDetId(_id));
+      else if (btype_ == binning::kProjPhi)
+        x = phi(EEDetId(_id));
+    } else if (subdet == EcalTriggerTower) {
+      EcalTrigTowerDetId ttid(_id);
+      if (btype_ == binning::kProjEta) {
+        int ieta(ttid.ieta());
+        if (ieta < 18 && ieta > 0)
+          x = (ieta * 5 - 2.5) * EBDetId::crystalUnitToEta;
+        else if (ieta > -18 && ieta < 0)
+          x = (ieta * 5 + 2.5) * EBDetId::crystalUnitToEta;
+      } else if (btype_ == binning::kProjPhi)
+        x = phi(ttid);
+    }
+
+    int bin(me->getTH1()->FindBin(x));
+    me->setBinEntries(bin, _entries);
+  }
+
+  double MESetProjection::getBinContent(DetId const &_id, int) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    if (isEndcapTTId(_id)) {
+      EcalTrigTowerDetId ttid(_id);
+      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
+      if (btype_ == binning::kProjEta) {
+        int bin(me->getTH1()->FindBin(eta(EEDetId(ids[0]))));
+        return me->getBinContent(bin);
+      } else if (btype_ == binning::kProjPhi) {
+        int bin(me->getTH1()->FindBin(phi(EEDetId(ids[0]))));
+        return me->getBinContent(bin);
       }
+      return 0.;
     }
-    return;
-  }
 
-  double x(0.);
-  int subdet(_id.subdetId());
-  if (subdet == EcalBarrel) {
-    EBDetId ebid(_id);
-    if (btype_ == binning::kProjEta)
-      x = eta(ebid);
-    else if (btype_ == binning::kProjPhi)
-      x = phi(ebid);
-  } else if (subdet == EcalEndcap) {
-    if (btype_ == binning::kProjEta)
-      x = eta(EEDetId(_id));
-    else if (btype_ == binning::kProjPhi)
-      x = phi(EEDetId(_id));
-  } else if (subdet == EcalTriggerTower) {
-    EcalTrigTowerDetId ttid(_id);
-    if (btype_ == binning::kProjEta) {
-      int ieta(ttid.ieta());
-      if (ieta < 18 && ieta > 0)
-        x = (ieta * 5 - 2.5) * EBDetId::crystalUnitToEta;
-      else if (ieta > -18 && ieta < 0)
-        x = (ieta * 5 + 2.5) * EBDetId::crystalUnitToEta;
-    } else if (btype_ == binning::kProjPhi)
-      x = phi(ttid);
-  }
-
-  int bin(me->getTH1()->FindBin(x));
-  me->setBinEntries(bin, _entries);
-}
-
-double MESetProjection::getBinContent(DetId const &_id, int) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  if (isEndcapTTId(_id)) {
-    EcalTrigTowerDetId ttid(_id);
-    std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
-    if (btype_ == binning::kProjEta) {
-      int bin(me->getTH1()->FindBin(eta(EEDetId(ids[0]))));
-      return me->getBinContent(bin);
-    } else if (btype_ == binning::kProjPhi) {
-      int bin(me->getTH1()->FindBin(phi(EEDetId(ids[0]))));
-      return me->getBinContent(bin);
+    double x(0.);
+    int subdet(_id.subdetId());
+    if (subdet == EcalBarrel) {
+      EBDetId ebid(_id);
+      if (btype_ == binning::kProjEta)
+        x = eta(ebid);
+      else if (btype_ == binning::kProjPhi)
+        x = phi(ebid);
+    } else if (subdet == EcalEndcap) {
+      if (btype_ == binning::kProjEta)
+        x = eta(EEDetId(_id));
+      else if (btype_ == binning::kProjPhi)
+        x = phi(EEDetId(_id));
+    } else if (subdet == EcalTriggerTower) {
+      EcalTrigTowerDetId ttid(_id);
+      if (btype_ == binning::kProjEta) {
+        int ieta(ttid.ieta());
+        if (ieta < 18 && ieta > 0)
+          x = (ieta * 5 - 2.5) * EBDetId::crystalUnitToEta;
+        else if (ieta > -18 && ieta < 0)
+          x = (ieta * 5 + 2.5) * EBDetId::crystalUnitToEta;
+      } else if (btype_ == binning::kProjPhi)
+        x = phi(ttid);
     }
-    return 0.;
+
+    int bin(me->getTH1()->FindBin(x));
+    return me->getBinContent(bin);
   }
 
-  double x(0.);
-  int subdet(_id.subdetId());
-  if (subdet == EcalBarrel) {
-    EBDetId ebid(_id);
-    if (btype_ == binning::kProjEta)
-      x = eta(ebid);
-    else if (btype_ == binning::kProjPhi)
-      x = phi(ebid);
-  } else if (subdet == EcalEndcap) {
-    if (btype_ == binning::kProjEta)
-      x = eta(EEDetId(_id));
-    else if (btype_ == binning::kProjPhi)
-      x = phi(EEDetId(_id));
-  } else if (subdet == EcalTriggerTower) {
-    EcalTrigTowerDetId ttid(_id);
-    if (btype_ == binning::kProjEta) {
-      int ieta(ttid.ieta());
-      if (ieta < 18 && ieta > 0)
-        x = (ieta * 5 - 2.5) * EBDetId::crystalUnitToEta;
-      else if (ieta > -18 && ieta < 0)
-        x = (ieta * 5 + 2.5) * EBDetId::crystalUnitToEta;
-    } else if (btype_ == binning::kProjPhi)
-      x = phi(ttid);
-  }
+  double MESetProjection::getBinError(DetId const &_id, int) const {
+    if (!active_)
+      return 0.;
 
-  int bin(me->getTH1()->FindBin(x));
-  return me->getBinContent(bin);
-}
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
 
-double MESetProjection::getBinError(DetId const &_id, int) const {
-  if (!active_)
-    return 0.;
+    MonitorElement *me(mes_[iME]);
 
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  if (isEndcapTTId(_id)) {
-    EcalTrigTowerDetId ttid(_id);
-    std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
-    if (btype_ == binning::kProjEta) {
-      int bin(me->getTH1()->FindBin(eta(EEDetId(ids[0]))));
-      return me->getBinError(bin);
-    } else if (btype_ == binning::kProjPhi) {
-      int bin(me->getTH1()->FindBin(phi(EEDetId(ids[0]))));
-      return me->getBinError(bin);
+    if (isEndcapTTId(_id)) {
+      EcalTrigTowerDetId ttid(_id);
+      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
+      if (btype_ == binning::kProjEta) {
+        int bin(me->getTH1()->FindBin(eta(EEDetId(ids[0]))));
+        return me->getBinError(bin);
+      } else if (btype_ == binning::kProjPhi) {
+        int bin(me->getTH1()->FindBin(phi(EEDetId(ids[0]))));
+        return me->getBinError(bin);
+      }
+      return 0.;
     }
-    return 0.;
-  }
 
-  double x(0.);
-  int subdet(_id.subdetId());
-  if (subdet == EcalBarrel) {
-    EBDetId ebid(_id);
-    if (btype_ == binning::kProjEta)
-      x = eta(ebid);
-    else if (btype_ == binning::kProjPhi)
-      x = phi(ebid);
-  } else if (subdet == EcalEndcap) {
-    if (btype_ == binning::kProjEta)
-      x = eta(EEDetId(_id));
-    else if (btype_ == binning::kProjPhi)
-      x = phi(EEDetId(_id));
-  } else if (subdet == EcalTriggerTower) {
-    EcalTrigTowerDetId ttid(_id);
-    if (btype_ == binning::kProjEta) {
-      int ieta(ttid.ieta());
-      if (ieta < 18 && ieta > 0)
-        x = (ieta * 5 - 2.5) * EBDetId::crystalUnitToEta;
-      else if (ieta > -18 && ieta < 0)
-        x = (ieta * 5 + 2.5) * EBDetId::crystalUnitToEta;
-    } else if (btype_ == binning::kProjPhi)
-      x = phi(ttid);
-  }
-
-  int bin(me->getTH1()->FindBin(x));
-  return me->getBinError(bin);
-}
-
-double MESetProjection::getBinEntries(DetId const &_id, int) const {
-  if (!active_)
-    return 0.;
-
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
-
-  MonitorElement *me(mes_[iME]);
-
-  if (isEndcapTTId(_id)) {
-    EcalTrigTowerDetId ttid(_id);
-    std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
-    if (btype_ == binning::kProjEta) {
-      int bin(me->getTH1()->FindBin(eta(EEDetId(ids[0]))));
-      return me->getBinEntries(bin);
-    } else if (btype_ == binning::kProjPhi) {
-      int bin(me->getTH1()->FindBin(phi(EEDetId(ids[0]))));
-      return me->getBinEntries(bin);
+    double x(0.);
+    int subdet(_id.subdetId());
+    if (subdet == EcalBarrel) {
+      EBDetId ebid(_id);
+      if (btype_ == binning::kProjEta)
+        x = eta(ebid);
+      else if (btype_ == binning::kProjPhi)
+        x = phi(ebid);
+    } else if (subdet == EcalEndcap) {
+      if (btype_ == binning::kProjEta)
+        x = eta(EEDetId(_id));
+      else if (btype_ == binning::kProjPhi)
+        x = phi(EEDetId(_id));
+    } else if (subdet == EcalTriggerTower) {
+      EcalTrigTowerDetId ttid(_id);
+      if (btype_ == binning::kProjEta) {
+        int ieta(ttid.ieta());
+        if (ieta < 18 && ieta > 0)
+          x = (ieta * 5 - 2.5) * EBDetId::crystalUnitToEta;
+        else if (ieta > -18 && ieta < 0)
+          x = (ieta * 5 + 2.5) * EBDetId::crystalUnitToEta;
+      } else if (btype_ == binning::kProjPhi)
+        x = phi(ttid);
     }
-    return 0.;
+
+    int bin(me->getTH1()->FindBin(x));
+    return me->getBinError(bin);
   }
 
-  double x(0.);
-  int subdet(_id.subdetId());
-  if (subdet == EcalBarrel) {
-    EBDetId ebid(_id);
-    if (btype_ == binning::kProjEta)
-      x = eta(ebid);
-    else if (btype_ == binning::kProjPhi)
-      x = phi(ebid);
-  } else if (subdet == EcalEndcap) {
-    if (btype_ == binning::kProjEta)
-      x = eta(EEDetId(_id));
-    else if (btype_ == binning::kProjPhi)
-      x = phi(EEDetId(_id));
-  } else if (subdet == EcalTriggerTower) {
-    EcalTrigTowerDetId ttid(_id);
-    if (btype_ == binning::kProjEta) {
-      int ieta(ttid.ieta());
-      if (ieta < 18 && ieta > 0)
-        x = (ieta * 5 - 2.5) * EBDetId::crystalUnitToEta;
-      else if (ieta > -18 && ieta < 0)
-        x = (ieta * 5 + 2.5) * EBDetId::crystalUnitToEta;
-    } else if (btype_ == binning::kProjPhi)
-      x = phi(ttid);
+  double MESetProjection::getBinEntries(DetId const &_id, int) const {
+    if (!active_)
+      return 0.;
+
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
+
+    MonitorElement *me(mes_[iME]);
+
+    if (isEndcapTTId(_id)) {
+      EcalTrigTowerDetId ttid(_id);
+      std::vector<DetId> ids(getTrigTowerMap()->constituentsOf(ttid));
+      if (btype_ == binning::kProjEta) {
+        int bin(me->getTH1()->FindBin(eta(EEDetId(ids[0]))));
+        return me->getBinEntries(bin);
+      } else if (btype_ == binning::kProjPhi) {
+        int bin(me->getTH1()->FindBin(phi(EEDetId(ids[0]))));
+        return me->getBinEntries(bin);
+      }
+      return 0.;
+    }
+
+    double x(0.);
+    int subdet(_id.subdetId());
+    if (subdet == EcalBarrel) {
+      EBDetId ebid(_id);
+      if (btype_ == binning::kProjEta)
+        x = eta(ebid);
+      else if (btype_ == binning::kProjPhi)
+        x = phi(ebid);
+    } else if (subdet == EcalEndcap) {
+      if (btype_ == binning::kProjEta)
+        x = eta(EEDetId(_id));
+      else if (btype_ == binning::kProjPhi)
+        x = phi(EEDetId(_id));
+    } else if (subdet == EcalTriggerTower) {
+      EcalTrigTowerDetId ttid(_id);
+      if (btype_ == binning::kProjEta) {
+        int ieta(ttid.ieta());
+        if (ieta < 18 && ieta > 0)
+          x = (ieta * 5 - 2.5) * EBDetId::crystalUnitToEta;
+        else if (ieta > -18 && ieta < 0)
+          x = (ieta * 5 + 2.5) * EBDetId::crystalUnitToEta;
+      } else if (btype_ == binning::kProjPhi)
+        x = phi(ttid);
+    }
+
+    int bin(me->getTH1()->FindBin(x));
+    return me->getBinEntries(bin);
   }
 
-  int bin(me->getTH1()->FindBin(x));
-  return me->getBinEntries(bin);
-}
-
-} // namespace ecaldqm
+}  // namespace ecaldqm

--- a/DQM/EcalCommon/src/MESetTrend.cc
+++ b/DQM/EcalCommon/src/MESetTrend.cc
@@ -4,399 +4,396 @@
 
 namespace ecaldqm {
 
-MESetTrend::MESetTrend(std::string const &_fullPath, binning::ObjectType _otype,
-                       binning::BinningType _btype, MonitorElement::Kind _kind,
-                       binning::AxisSpecs const *_xaxis /* = 0*/,
-                       binning::AxisSpecs const *_yaxis /* = 0*/)
-    : MESetEcal(_fullPath, _otype, _btype, _kind, 1, _xaxis, _yaxis),
-      minutely_(false), shiftAxis_(false), currentBin_(-1) {
-  switch (kind_) {
-  case MonitorElement::DQM_KIND_TH1F:
-  case MonitorElement::DQM_KIND_TH2F:
-  case MonitorElement::DQM_KIND_TPROFILE:
-  case MonitorElement::DQM_KIND_TPROFILE2D:
-    break;
-  default:
-    throw_("Unsupported MonitorElement kind");
-  }
-}
-
-MESetTrend::MESetTrend(MESetTrend const &_orig)
-    : MESetEcal(_orig), minutely_(_orig.minutely_),
-      shiftAxis_(_orig.shiftAxis_), currentBin_(_orig.currentBin_) {}
-
-MESet &MESetTrend::operator=(MESet const &_rhs) {
-  MESetTrend const *pRhs(dynamic_cast<MESetTrend const *>(&_rhs));
-  if (pRhs) {
-    minutely_ = pRhs->minutely_;
-    shiftAxis_ = pRhs->shiftAxis_;
-    currentBin_ = pRhs->currentBin_;
+  MESetTrend::MESetTrend(std::string const &_fullPath,
+                         binning::ObjectType _otype,
+                         binning::BinningType _btype,
+                         MonitorElement::Kind _kind,
+                         binning::AxisSpecs const *_xaxis /* = 0*/,
+                         binning::AxisSpecs const *_yaxis /* = 0*/)
+      : MESetEcal(_fullPath, _otype, _btype, _kind, 1, _xaxis, _yaxis),
+        minutely_(false),
+        shiftAxis_(false),
+        currentBin_(-1) {
+    switch (kind_) {
+      case MonitorElement::DQM_KIND_TH1F:
+      case MonitorElement::DQM_KIND_TH2F:
+      case MonitorElement::DQM_KIND_TPROFILE:
+      case MonitorElement::DQM_KIND_TPROFILE2D:
+        break;
+      default:
+        throw_("Unsupported MonitorElement kind");
+    }
   }
 
-  return MESetEcal::operator=(_rhs);
-}
+  MESetTrend::MESetTrend(MESetTrend const &_orig)
+      : MESetEcal(_orig), minutely_(_orig.minutely_), shiftAxis_(_orig.shiftAxis_), currentBin_(_orig.currentBin_) {}
 
-MESet *MESetTrend::clone(std::string const &_path /* = ""*/) const {
-  std::string path(path_);
-  if (!_path.empty())
-    path_ = _path;
-  MESet *copy(new MESetTrend(*this));
-  path_ = path;
-  return copy;
-}
+  MESet &MESetTrend::operator=(MESet const &_rhs) {
+    MESetTrend const *pRhs(dynamic_cast<MESetTrend const *>(&_rhs));
+    if (pRhs) {
+      minutely_ = pRhs->minutely_;
+      shiftAxis_ = pRhs->shiftAxis_;
+      currentBin_ = pRhs->currentBin_;
+    }
 
-void MESetTrend::book(DQMStore::IBooker &_ibooker) {
-  binning::AxisSpecs xaxis;
-  if (xaxis_)
-    xaxis = *xaxis_;
-  else {
-    xaxis.nbins = 200;
-    xaxis.low = 0.;
-    xaxis.high = 2000.;
+    return MESetEcal::operator=(_rhs);
   }
 
-  if (minutely_) {
-    time_t localTime(time(nullptr));
-    struct tm timeBuffer;
-    gmtime_r(&localTime, &timeBuffer); // gmtime() is not thread safe
-    unsigned utcTime(mktime(&timeBuffer));
+  MESet *MESetTrend::clone(std::string const &_path /* = ""*/) const {
+    std::string path(path_);
+    if (!_path.empty())
+      path_ = _path;
+    MESet *copy(new MESetTrend(*this));
+    path_ = path;
+    return copy;
+  }
 
-    xaxis.low = utcTime;
+  void MESetTrend::book(DQMStore::IBooker &_ibooker) {
+    binning::AxisSpecs xaxis;
     if (xaxis_)
-      xaxis.high = utcTime + xaxis_->high - xaxis_->low;
-    else
-      xaxis.high = xaxis.low + 200 * 60.;
+      xaxis = *xaxis_;
+    else {
+      xaxis.nbins = 200;
+      xaxis.low = 0.;
+      xaxis.high = 2000.;
+    }
+
+    if (minutely_) {
+      time_t localTime(time(nullptr));
+      struct tm timeBuffer;
+      gmtime_r(&localTime, &timeBuffer);  // gmtime() is not thread safe
+      unsigned utcTime(mktime(&timeBuffer));
+
+      xaxis.low = utcTime;
+      if (xaxis_)
+        xaxis.high = utcTime + xaxis_->high - xaxis_->low;
+      else
+        xaxis.high = xaxis.low + 200 * 60.;
+    }
+
+    binning::AxisSpecs const *xaxisTemp(xaxis_);
+    xaxis_ = &xaxis;
+
+    MESetEcal::book(_ibooker);
+
+    xaxis_ = xaxisTemp;
+
+    if (minutely_) {
+      for (unsigned iME(0); iME < mes_.size(); ++iME)
+        mes_[iME]->getTH1()->GetXaxis()->SetTimeDisplay(1);
+      setAxisTitle("UTC");
+    } else
+      setAxisTitle("LumiSections");
   }
 
-  binning::AxisSpecs const *xaxisTemp(xaxis_);
-  xaxis_ = &xaxis;
+  void MESetTrend::fill(DetId const &_id, double _t, double _wy /* = 1.*/, double _w /* = 1.*/) {
+    if (!active_)
+      return;
 
-  MESetEcal::book(_ibooker);
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
 
-  xaxis_ = xaxisTemp;
+    if (shift_(unsigned(_t)))
+      fill_(iME, _t + 0.5, _wy, _w);
+  }
 
-  if (minutely_) {
-    for (unsigned iME(0); iME < mes_.size(); ++iME)
-      mes_[iME]->getTH1()->GetXaxis()->SetTimeDisplay(1);
-    setAxisTitle("UTC");
-  } else
-    setAxisTitle("LumiSections");
-}
+  void MESetTrend::fill(EcalElectronicsId const &_id, double _t, double _wy /* = 1.*/, double _w /* = 1.*/) {
+    if (!active_)
+      return;
 
-void MESetTrend::fill(DetId const &_id, double _t, double _wy /* = 1.*/,
-                      double _w /* = 1.*/) {
-  if (!active_)
-    return;
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
 
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
+    if (shift_(unsigned(_t)))
+      fill_(iME, _t + 0.5, _wy, _w);
+  }
 
-  if (shift_(unsigned(_t)))
-    fill_(iME, _t + 0.5, _wy, _w);
-}
+  void MESetTrend::fill(int _dcctccid, double _t, double _wy /* = 1.*/, double _w /* = 1.*/) {
+    if (!active_)
+      return;
 
-void MESetTrend::fill(EcalElectronicsId const &_id, double _t,
-                      double _wy /* = 1.*/, double _w /* = 1.*/) {
-  if (!active_)
-    return;
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    checkME_(iME);
 
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
+    if (shift_(unsigned(_t)))
+      fill_(iME, _t + 0.5, _wy, _w);
+  }
 
-  if (shift_(unsigned(_t)))
-    fill_(iME, _t + 0.5, _wy, _w);
-}
+  void MESetTrend::fill(double _t, double _wy /* = 1.*/, double _w /* = 1.*/) {
+    if (!active_)
+      return;
+    if (mes_.size() != 1)
+      throw_("MESet type incompatible");
 
-void MESetTrend::fill(int _dcctccid, double _t, double _wy /* = 1.*/,
-                      double _w /* = 1.*/) {
-  if (!active_)
-    return;
+    if (shift_(unsigned(_t)))
+      fill_(0, _t + 0.5, _wy, _w);
+  }
 
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
-  checkME_(iME);
+  int MESetTrend::findBin(DetId const &_id, double _t, double _y /* = 0.*/) const {
+    if (!active_)
+      return -1;
 
-  if (shift_(unsigned(_t)))
-    fill_(iME, _t + 0.5, _wy, _w);
-}
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
 
-void MESetTrend::fill(double _t, double _wy /* = 1.*/, double _w /* = 1.*/) {
-  if (!active_)
-    return;
-  if (mes_.size() != 1)
-    throw_("MESet type incompatible");
+    return mes_[iME]->getTH1()->FindBin(_t + 0.5, _y);
+  }
 
-  if (shift_(unsigned(_t)))
-    fill_(0, _t + 0.5, _wy, _w);
-}
+  int MESetTrend::findBin(EcalElectronicsId const &_id, double _t, double _y /* = 0.*/) const {
+    if (!active_)
+      return -1;
 
-int MESetTrend::findBin(DetId const &_id, double _t,
-                        double _y /* = 0.*/) const {
-  if (!active_)
-    return -1;
+    unsigned iME(binning::findPlotIndex(otype_, _id));
+    checkME_(iME);
 
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
+    return mes_[iME]->getTH1()->FindBin(_t + 0.5, _y);
+  }
 
-  return mes_[iME]->getTH1()->FindBin(_t + 0.5, _y);
-}
+  int MESetTrend::findBin(int _dcctccid, double _t, double _y /* = 0.*/) const {
+    if (!active_)
+      return -1;
 
-int MESetTrend::findBin(EcalElectronicsId const &_id, double _t,
-                        double _y /* = 0.*/) const {
-  if (!active_)
-    return -1;
+    unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
+    checkME_(iME);
 
-  unsigned iME(binning::findPlotIndex(otype_, _id));
-  checkME_(iME);
+    return mes_[iME]->getTH1()->FindBin(_t + 0.5, _y);
+  }
 
-  return mes_[iME]->getTH1()->FindBin(_t + 0.5, _y);
-}
+  int MESetTrend::findBin(double _t, double _y /* = 0.*/) const {
+    if (!active_)
+      return -1;
+    if (mes_.size() != 1)
+      throw_("MESet type incompatible");
 
-int MESetTrend::findBin(int _dcctccid, double _t, double _y /* = 0.*/) const {
-  if (!active_)
-    return -1;
+    return mes_[0]->getTH1()->FindBin(_t + 0.5, _y);
+  }
 
-  unsigned iME(binning::findPlotIndex(otype_, _dcctccid, btype_));
-  checkME_(iME);
+  void MESetTrend::setCumulative() {
+    if (kind_ == MonitorElement::DQM_KIND_TPROFILE || kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
+      throw_("Cumulative flag set for a profile plot");
+    currentBin_ = 1;
+  }
 
-  return mes_[iME]->getTH1()->FindBin(_t + 0.5, _y);
-}
+  bool MESetTrend::shift_(unsigned _t) {
+    TAxis *tAxis(mes_[0]->getTH1()->GetXaxis());
+    int nbinsX(tAxis->GetNbins());
+    unsigned tLow(tAxis->GetBinLowEdge(1));
+    unsigned tHigh(tAxis->GetBinUpEdge(nbinsX));
 
-int MESetTrend::findBin(double _t, double _y /* = 0.*/) const {
-  if (!active_)
-    return -1;
-  if (mes_.size() != 1)
-    throw_("MESet type incompatible");
+    if (!shiftAxis_)
+      return _t >= tLow && _t < tHigh;
 
-  return mes_[0]->getTH1()->FindBin(_t + 0.5, _y);
-}
+    int dBin(0);
+    int unitsPerBin((tHigh - tLow) / nbinsX);
 
-void MESetTrend::setCumulative() {
-  if (kind_ == MonitorElement::DQM_KIND_TPROFILE ||
-      kind_ == MonitorElement::DQM_KIND_TPROFILE2D)
-    throw_("Cumulative flag set for a profile plot");
-  currentBin_ = 1;
-}
-
-bool MESetTrend::shift_(unsigned _t) {
-  TAxis *tAxis(mes_[0]->getTH1()->GetXaxis());
-  int nbinsX(tAxis->GetNbins());
-  unsigned tLow(tAxis->GetBinLowEdge(1));
-  unsigned tHigh(tAxis->GetBinUpEdge(nbinsX));
-
-  if (!shiftAxis_)
-    return _t >= tLow && _t < tHigh;
-
-  int dBin(0);
-  int unitsPerBin((tHigh - tLow) / nbinsX);
-
-  if (_t >= tLow && _t < tHigh) {
-    if (currentBin_ > 0) {
-      int thisBin(tAxis->FindBin(_t + 0.5));
-      if (thisBin < currentBin_)
-        return false;
-      else if (thisBin > currentBin_) {
-        for (unsigned iME(0); iME < mes_.size(); iME++) {
-          MonitorElement *me(mes_[iME]);
-          int nbinsY(me->getTH1()->GetNbinsY());
-          for (int iy(1); iy <= nbinsY; ++iy) {
-            int orig(me->getTH1()->GetBin(currentBin_, iy));
-            double currentContent(me->getBinContent(orig));
-            double currentError(me->getBinError(orig));
-            for (int ix(currentBin_); ix <= thisBin; ++ix) {
-              int dest(me->getTH1()->GetBin(ix, iy));
-              me->setBinContent(dest, currentContent);
-              me->setBinError(dest, currentError);
+    if (_t >= tLow && _t < tHigh) {
+      if (currentBin_ > 0) {
+        int thisBin(tAxis->FindBin(_t + 0.5));
+        if (thisBin < currentBin_)
+          return false;
+        else if (thisBin > currentBin_) {
+          for (unsigned iME(0); iME < mes_.size(); iME++) {
+            MonitorElement *me(mes_[iME]);
+            int nbinsY(me->getTH1()->GetNbinsY());
+            for (int iy(1); iy <= nbinsY; ++iy) {
+              int orig(me->getTH1()->GetBin(currentBin_, iy));
+              double currentContent(me->getBinContent(orig));
+              double currentError(me->getBinError(orig));
+              for (int ix(currentBin_); ix <= thisBin; ++ix) {
+                int dest(me->getTH1()->GetBin(ix, iy));
+                me->setBinContent(dest, currentContent);
+                me->setBinError(dest, currentError);
+              }
             }
           }
         }
       }
+
+      return true;
+    } else if (_t >= tHigh) {
+      dBin = (_t - tHigh) / unitsPerBin + 1;
+      if (currentBin_ > 0)
+        currentBin_ = nbinsX;
+    } else if (_t < tLow) {
+      if (currentBin_ > 0)
+        return false;  // no going back in time in case of cumulative history
+
+      int maxBin(0);
+
+      for (unsigned iME(0); iME < mes_.size(); iME++) {
+        MonitorElement *me(mes_[iME]);
+
+        bool filled(false);
+        int iMax(nbinsX + 1);
+        while (--iMax > 0 && !filled) {
+          switch (kind_) {
+            case MonitorElement::DQM_KIND_TH1F:
+              if (me->getBinContent(iMax) != 0)
+                filled = true;
+              break;
+            case MonitorElement::DQM_KIND_TPROFILE:
+              if (me->getBinEntries(iMax) != 0)
+                filled = true;
+              break;
+            case MonitorElement::DQM_KIND_TH2F:
+              for (int iy(1); iy <= me->getNbinsY(); iy++) {
+                if (me->getBinContent(me->getTH1()->GetBin(iMax, iy)) != 0) {
+                  filled = true;
+                  break;
+                }
+              }
+              break;
+            case MonitorElement::DQM_KIND_TPROFILE2D:
+              for (int iy(1); iy <= me->getNbinsY(); iy++) {
+                if (me->getBinEntries(me->getTH1()->GetBin(iMax, iy)) != 0) {
+                  filled = true;
+                  break;
+                }
+              }
+              break;
+            default:
+              break;
+          }
+        }
+
+        if (iMax > maxBin)
+          maxBin = iMax;
+      }
+
+      if (_t < tLow - (nbinsX - maxBin) * unitsPerBin)
+        return false;
+
+      dBin = (_t - tLow) / unitsPerBin - 1;
     }
 
-    return true;
-  } else if (_t >= tHigh) {
-    dBin = (_t - tHigh) / unitsPerBin + 1;
-    if (currentBin_ > 0)
-      currentBin_ = nbinsX;
-  } else if (_t < tLow) {
-    if (currentBin_ > 0)
-      return false; // no going back in time in case of cumulative history
+    int start(dBin > 0 ? dBin + 1 : nbinsX + dBin);
+    int end(dBin > 0 ? nbinsX + 1 : 0);
+    int step(dBin > 0 ? 1 : -1);
 
-    int maxBin(0);
+    tLow += dBin * unitsPerBin;
+    tHigh += dBin * unitsPerBin;
 
     for (unsigned iME(0); iME < mes_.size(); iME++) {
       MonitorElement *me(mes_[iME]);
 
-      bool filled(false);
-      int iMax(nbinsX + 1);
-      while (--iMax > 0 && !filled) {
-        switch (kind_) {
-        case MonitorElement::DQM_KIND_TH1F:
-          if (me->getBinContent(iMax) != 0)
-            filled = true;
-          break;
-        case MonitorElement::DQM_KIND_TPROFILE:
-          if (me->getBinEntries(iMax) != 0)
-            filled = true;
-          break;
-        case MonitorElement::DQM_KIND_TH2F:
-          for (int iy(1); iy <= me->getNbinsY(); iy++) {
-            if (me->getBinContent(me->getTH1()->GetBin(iMax, iy)) != 0) {
-              filled = true;
-              break;
+      me->getTH1()->GetXaxis()->SetLimits(tLow, tHigh);
+
+      if ((end - start) / step < 0) {
+        me->Reset();
+        continue;
+      }
+
+      me->setEntries(0.);
+      double entries(0.);
+
+      switch (kind_) {
+        case MonitorElement::DQM_KIND_TH1F: {
+          int ix(start);
+          for (; ix != end; ix += step) {
+            double binContent(me->getBinContent(ix));
+            entries += binContent;
+            me->setBinContent(ix - dBin, binContent);
+            me->setBinError(ix - dBin, me->getBinError(ix));
+          }
+          ix = end - dBin - 1 * step;
+          double lastContent(currentBin_ > 0 ? me->getBinContent(ix) : 0.);
+          double lastError(currentBin_ > 0 ? me->getBinContent(ix) : 0.);
+          for (ix += step; ix != end; ix += step) {
+            me->setBinContent(ix, lastContent);
+            me->setBinError(ix, lastError);
+          }
+        } break;
+        case MonitorElement::DQM_KIND_TPROFILE: {
+          int ix(start);
+          for (; ix != end; ix += step) {
+            double binEntries(me->getBinEntries(ix));
+            double binContent(me->getBinContent(ix));
+            entries += binEntries;
+            me->setBinEntries(ix - dBin, binEntries);
+            me->setBinContent(ix - dBin, binContent * binEntries);
+            if (binEntries > 0) {
+              double rms(me->getBinError(ix) * std::sqrt(binEntries));
+              double sumw2((rms * rms + binContent * binContent) * binEntries);
+              me->setBinError(ix - dBin, std::sqrt(sumw2));
+            } else
+              me->setBinError(ix - dBin, 0.);
+          }
+          ix = end - dBin;
+          for (; ix != end; ix += step) {
+            me->setBinEntries(ix, 0.);
+            me->setBinContent(ix, 0.);
+            me->setBinError(ix, 0.);
+          }
+        } break;
+        case MonitorElement::DQM_KIND_TH2F: {
+          int ix(start);
+          int nbinsY(me->getNbinsY());
+          for (; ix != end; ix += step) {
+            for (int iy(1); iy <= nbinsY; iy++) {
+              int orig(me->getTH1()->GetBin(ix, iy));
+              int dest(me->getTH1()->GetBin(ix - dBin, iy));
+              double binContent(me->getBinContent(orig));
+              entries += binContent;
+              me->setBinContent(dest, binContent);
+              me->setBinError(dest, me->getBinError(orig));
+
+              me->setBinContent(orig, 0.);
+              me->setBinError(orig, 0.);
             }
           }
-          break;
-        case MonitorElement::DQM_KIND_TPROFILE2D:
-          for (int iy(1); iy <= me->getNbinsY(); iy++) {
-            if (me->getBinEntries(me->getTH1()->GetBin(iMax, iy)) != 0) {
-              filled = true;
-              break;
+          ix = end - dBin - 1 * step;
+          std::vector<double> lastContent;
+          std::vector<double> lastError;
+          for (int iy(1); iy <= nbinsY; iy++) {
+            lastContent.push_back(currentBin_ > 0 ? me->getBinContent(ix, iy) : 0.);
+            lastError.push_back(currentBin_ > 0 ? me->getBinError(ix, iy) : 0.);
+          }
+          for (ix += step; ix != end; ix += step) {
+            for (int iy(1); iy <= nbinsY; iy++) {
+              int bin(me->getTH1()->GetBin(ix, iy));
+              me->setBinContent(bin, lastContent[iy - 1]);
+              me->setBinError(bin, lastError[iy - 1]);
             }
           }
-          break;
+        } break;
+        case MonitorElement::DQM_KIND_TPROFILE2D: {
+          int ix(start);
+          int nbinsY(me->getNbinsY());
+          for (; ix != end; ix += step) {
+            for (int iy(1); iy <= nbinsY; iy++) {
+              int orig(me->getTH1()->GetBin(ix, iy));
+              int dest(me->getTH1()->GetBin(ix - dBin, iy));
+              double binEntries(me->getBinEntries(orig));
+              double binContent(me->getBinContent(orig));
+              entries += binEntries;
+              me->setBinEntries(dest, binEntries);
+              me->setBinContent(dest, binContent * binEntries);
+              if (binEntries > 0) {
+                double rms(me->getBinError(orig) * std::sqrt(binEntries));
+                double sumw2((rms * rms + binContent * binContent) * binEntries);
+                me->setBinError(dest, std::sqrt(sumw2));
+              } else
+                me->setBinError(dest, 0.);
+            }
+          }
+          ix = end - dBin;
+          for (; ix != end; ix += step) {
+            for (int iy(1); iy <= nbinsY; iy++) {
+              int bin(me->getTH1()->GetBin(ix, iy));
+              me->setBinEntries(bin, 0.);
+              me->setBinContent(bin, 0.);
+              me->setBinError(bin, 0.);
+            }
+          }
+        } break;
         default:
           break;
-        }
       }
 
-      if (iMax > maxBin)
-        maxBin = iMax;
+      me->setEntries(entries);
     }
 
-    if (_t < tLow - (nbinsX - maxBin) * unitsPerBin)
-      return false;
-
-    dBin = (_t - tLow) / unitsPerBin - 1;
+    return true;
   }
 
-  int start(dBin > 0 ? dBin + 1 : nbinsX + dBin);
-  int end(dBin > 0 ? nbinsX + 1 : 0);
-  int step(dBin > 0 ? 1 : -1);
-
-  tLow += dBin * unitsPerBin;
-  tHigh += dBin * unitsPerBin;
-
-  for (unsigned iME(0); iME < mes_.size(); iME++) {
-    MonitorElement *me(mes_[iME]);
-
-    me->getTH1()->GetXaxis()->SetLimits(tLow, tHigh);
-
-    if ((end - start) / step < 0) {
-      me->Reset();
-      continue;
-    }
-
-    me->setEntries(0.);
-    double entries(0.);
-
-    switch (kind_) {
-    case MonitorElement::DQM_KIND_TH1F: {
-      int ix(start);
-      for (; ix != end; ix += step) {
-        double binContent(me->getBinContent(ix));
-        entries += binContent;
-        me->setBinContent(ix - dBin, binContent);
-        me->setBinError(ix - dBin, me->getBinError(ix));
-      }
-      ix = end - dBin - 1 * step;
-      double lastContent(currentBin_ > 0 ? me->getBinContent(ix) : 0.);
-      double lastError(currentBin_ > 0 ? me->getBinContent(ix) : 0.);
-      for (ix += step; ix != end; ix += step) {
-        me->setBinContent(ix, lastContent);
-        me->setBinError(ix, lastError);
-      }
-    } break;
-    case MonitorElement::DQM_KIND_TPROFILE: {
-      int ix(start);
-      for (; ix != end; ix += step) {
-        double binEntries(me->getBinEntries(ix));
-        double binContent(me->getBinContent(ix));
-        entries += binEntries;
-        me->setBinEntries(ix - dBin, binEntries);
-        me->setBinContent(ix - dBin, binContent * binEntries);
-        if (binEntries > 0) {
-          double rms(me->getBinError(ix) * std::sqrt(binEntries));
-          double sumw2((rms * rms + binContent * binContent) * binEntries);
-          me->setBinError(ix - dBin, std::sqrt(sumw2));
-        } else
-          me->setBinError(ix - dBin, 0.);
-      }
-      ix = end - dBin;
-      for (; ix != end; ix += step) {
-        me->setBinEntries(ix, 0.);
-        me->setBinContent(ix, 0.);
-        me->setBinError(ix, 0.);
-      }
-    } break;
-    case MonitorElement::DQM_KIND_TH2F: {
-      int ix(start);
-      int nbinsY(me->getNbinsY());
-      for (; ix != end; ix += step) {
-        for (int iy(1); iy <= nbinsY; iy++) {
-          int orig(me->getTH1()->GetBin(ix, iy));
-          int dest(me->getTH1()->GetBin(ix - dBin, iy));
-          double binContent(me->getBinContent(orig));
-          entries += binContent;
-          me->setBinContent(dest, binContent);
-          me->setBinError(dest, me->getBinError(orig));
-
-          me->setBinContent(orig, 0.);
-          me->setBinError(orig, 0.);
-        }
-      }
-      ix = end - dBin - 1 * step;
-      std::vector<double> lastContent;
-      std::vector<double> lastError;
-      for (int iy(1); iy <= nbinsY; iy++) {
-        lastContent.push_back(currentBin_ > 0 ? me->getBinContent(ix, iy) : 0.);
-        lastError.push_back(currentBin_ > 0 ? me->getBinError(ix, iy) : 0.);
-      }
-      for (ix += step; ix != end; ix += step) {
-        for (int iy(1); iy <= nbinsY; iy++) {
-          int bin(me->getTH1()->GetBin(ix, iy));
-          me->setBinContent(bin, lastContent[iy - 1]);
-          me->setBinError(bin, lastError[iy - 1]);
-        }
-      }
-    } break;
-    case MonitorElement::DQM_KIND_TPROFILE2D: {
-      int ix(start);
-      int nbinsY(me->getNbinsY());
-      for (; ix != end; ix += step) {
-        for (int iy(1); iy <= nbinsY; iy++) {
-          int orig(me->getTH1()->GetBin(ix, iy));
-          int dest(me->getTH1()->GetBin(ix - dBin, iy));
-          double binEntries(me->getBinEntries(orig));
-          double binContent(me->getBinContent(orig));
-          entries += binEntries;
-          me->setBinEntries(dest, binEntries);
-          me->setBinContent(dest, binContent * binEntries);
-          if (binEntries > 0) {
-            double rms(me->getBinError(orig) * std::sqrt(binEntries));
-            double sumw2((rms * rms + binContent * binContent) * binEntries);
-            me->setBinError(dest, std::sqrt(sumw2));
-          } else
-            me->setBinError(dest, 0.);
-        }
-      }
-      ix = end - dBin;
-      for (; ix != end; ix += step) {
-        for (int iy(1); iy <= nbinsY; iy++) {
-          int bin(me->getTH1()->GetBin(ix, iy));
-          me->setBinEntries(bin, 0.);
-          me->setBinContent(bin, 0.);
-          me->setBinError(bin, 0.);
-        }
-      }
-    } break;
-    default:
-      break;
-    }
-
-    me->setEntries(entries);
-  }
-
-  return true;
-}
-
-} // namespace ecaldqm
+}  // namespace ecaldqm

--- a/DQM/EcalCommon/src/MESetUtils.cc
+++ b/DQM/EcalCommon/src/MESetUtils.cc
@@ -14,164 +14,153 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 namespace ecaldqm {
-MESet *createMESet(edm::ParameterSet const &_MEParam) {
-  std::string path(_MEParam.getUntrackedParameter<std::string>("path"));
-  binning::ObjectType otype(binning::translateObjectType(
-      _MEParam.getUntrackedParameter<std::string>("otype")));
-  binning::BinningType btype(binning::translateBinningType(
-      _MEParam.getUntrackedParameter<std::string>("btype")));
-  MonitorElement::Kind kind(binning::translateKind(
-      _MEParam.getUntrackedParameter<std::string>("kind")));
+  MESet *createMESet(edm::ParameterSet const &_MEParam) {
+    std::string path(_MEParam.getUntrackedParameter<std::string>("path"));
+    binning::ObjectType otype(binning::translateObjectType(_MEParam.getUntrackedParameter<std::string>("otype")));
+    binning::BinningType btype(binning::translateBinningType(_MEParam.getUntrackedParameter<std::string>("btype")));
+    MonitorElement::Kind kind(binning::translateKind(_MEParam.getUntrackedParameter<std::string>("kind")));
 
-  binning::AxisSpecs xaxis, yaxis, zaxis;
-  bool hasXaxis(_MEParam.existsAs<edm::ParameterSet>("xaxis", false));
-  if (hasXaxis)
-    xaxis = binning::formAxis(_MEParam.getUntrackedParameterSet("xaxis"));
-  bool hasYaxis(_MEParam.existsAs<edm::ParameterSet>("yaxis", false));
-  if (hasYaxis)
-    yaxis = binning::formAxis(_MEParam.getUntrackedParameterSet("yaxis"));
-  bool hasZaxis(_MEParam.existsAs<edm::ParameterSet>("zaxis", false));
-  if (hasZaxis)
-    zaxis = binning::formAxis(_MEParam.getUntrackedParameterSet("zaxis"));
+    binning::AxisSpecs xaxis, yaxis, zaxis;
+    bool hasXaxis(_MEParam.existsAs<edm::ParameterSet>("xaxis", false));
+    if (hasXaxis)
+      xaxis = binning::formAxis(_MEParam.getUntrackedParameterSet("xaxis"));
+    bool hasYaxis(_MEParam.existsAs<edm::ParameterSet>("yaxis", false));
+    if (hasYaxis)
+      yaxis = binning::formAxis(_MEParam.getUntrackedParameterSet("yaxis"));
+    bool hasZaxis(_MEParam.existsAs<edm::ParameterSet>("zaxis", false));
+    if (hasZaxis)
+      zaxis = binning::formAxis(_MEParam.getUntrackedParameterSet("zaxis"));
 
-  MESet *set(nullptr);
+    MESet *set(nullptr);
 
-  if (btype == binning::kTrend) {
-    MESetTrend *setTrend(
-        new MESetTrend(path, otype, btype, kind, hasYaxis ? &yaxis : nullptr));
-    if (_MEParam.existsAs<bool>("minutely", false) &&
-        _MEParam.getUntrackedParameter<bool>("minutely"))
-      setTrend->setMinutely();
-    if (_MEParam.existsAs<bool>("cumulative", false) &&
-        _MEParam.getUntrackedParameter<bool>("cumulative"))
-      setTrend->setCumulative();
-    if (_MEParam.existsAs<bool>("shiftAxis", false) &&
-        _MEParam.getUntrackedParameter<bool>("shiftAxis"))
-      setTrend->setShiftAxis();
-    set = setTrend;
-  } else if (otype == binning::nObjType)
-    set = new MESetNonObject(
-        path, otype, btype, kind, hasXaxis ? &xaxis : nullptr,
-        hasYaxis ? &yaxis : nullptr, hasZaxis ? &zaxis : nullptr);
-  else if (otype == binning::kChannel)
+    if (btype == binning::kTrend) {
+      MESetTrend *setTrend(new MESetTrend(path, otype, btype, kind, hasYaxis ? &yaxis : nullptr));
+      if (_MEParam.existsAs<bool>("minutely", false) && _MEParam.getUntrackedParameter<bool>("minutely"))
+        setTrend->setMinutely();
+      if (_MEParam.existsAs<bool>("cumulative", false) && _MEParam.getUntrackedParameter<bool>("cumulative"))
+        setTrend->setCumulative();
+      if (_MEParam.existsAs<bool>("shiftAxis", false) && _MEParam.getUntrackedParameter<bool>("shiftAxis"))
+        setTrend->setShiftAxis();
+      set = setTrend;
+    } else if (otype == binning::nObjType)
+      set = new MESetNonObject(path,
+                               otype,
+                               btype,
+                               kind,
+                               hasXaxis ? &xaxis : nullptr,
+                               hasYaxis ? &yaxis : nullptr,
+                               hasZaxis ? &zaxis : nullptr);
+    else if (otype == binning::kChannel)
 // Class removed until concurrency issue is finalized
 #if 0
       set = new MESetChannel(path, otype, btype, kind);
 #else
-    set = nullptr;
+      set = nullptr;
 #endif
-    else if (btype == binning::kProjEta || btype == binning::kProjPhi) set =
-        new MESetProjection(path, otype, btype, kind,
-                            hasYaxis ? &yaxis : nullptr);
-  else {
-    unsigned logicalDimensions(-1);
-    switch (kind) {
-    case MonitorElement::DQM_KIND_REAL:
-      logicalDimensions = 0;
-      break;
-    case MonitorElement::DQM_KIND_TH1F:
-    case MonitorElement::DQM_KIND_TPROFILE:
-      logicalDimensions = 1;
-      break;
-    case MonitorElement::DQM_KIND_TH2F:
-    case MonitorElement::DQM_KIND_TPROFILE2D:
-      logicalDimensions = 2;
-      break;
-    default:
-      break;
-    }
-
-    // example case: Ecal/TriggerPrimitives/EmulMatching/TrigPrimTask matching
-    // index
-    if (logicalDimensions == 2 && hasYaxis && btype != binning::kUser)
-      logicalDimensions = 1;
-
-    if (logicalDimensions > 2 ||
-        (btype == binning::kReport && logicalDimensions != 0))
-      throw cms::Exception("InvalidConfiguration")
-          << "Cannot create MESet at " << path;
-
-    if (btype == binning::kUser)
-      set = new MESetEcal(path, otype, btype, kind, logicalDimensions,
-                          hasXaxis ? &xaxis : nullptr,
-                          hasYaxis ? &yaxis : nullptr,
-                          hasZaxis ? &zaxis : nullptr);
-    else if (logicalDimensions == 0)
-      set = new MESetDet0D(path, otype, btype, kind);
-    else if (logicalDimensions == 1)
-      set =
-          new MESetDet1D(path, otype, btype, kind, hasYaxis ? &yaxis : nullptr);
-    else if (logicalDimensions == 2)
-      set =
-          new MESetDet2D(path, otype, btype, kind, hasZaxis ? &zaxis : nullptr);
-  }
-
-  if (_MEParam.existsAs<edm::ParameterSet>("multi", false)) {
-    typedef std::vector<std::string> VString;
-
-    edm::ParameterSet const &multiParams(
-        _MEParam.getUntrackedParameterSet("multi"));
-    VString replacementNames(multiParams.getParameterNames());
-    if (replacementNames.empty())
-      throw cms::Exception("InvalidConfiguration")
-          << "0 multiplicity for MESet at " << path;
-
-    MESetMulti::ReplCandidates candidates;
-    for (unsigned iD(0); iD != replacementNames.size(); ++iD) {
-      VString reps;
-      if (multiParams.existsAs<VString>(replacementNames[iD], false))
-        reps = multiParams.getUntrackedParameter<VString>(replacementNames[iD]);
-      else if (multiParams.existsAs<std::vector<int>>(replacementNames[iD],
-                                                      false)) {
-        std::vector<int> repInts(
-            multiParams.getUntrackedParameter<std::vector<int>>(
-                replacementNames[iD]));
-        for (unsigned iR(0); iR != repInts.size(); ++iR)
-          reps.push_back(std::to_string(repInts[iR]));
+      else if (btype == binning::kProjEta || btype == binning::kProjPhi) set =
+          new MESetProjection(path, otype, btype, kind, hasYaxis ? &yaxis : nullptr);
+    else {
+      unsigned logicalDimensions(-1);
+      switch (kind) {
+        case MonitorElement::DQM_KIND_REAL:
+          logicalDimensions = 0;
+          break;
+        case MonitorElement::DQM_KIND_TH1F:
+        case MonitorElement::DQM_KIND_TPROFILE:
+          logicalDimensions = 1;
+          break;
+        case MonitorElement::DQM_KIND_TH2F:
+        case MonitorElement::DQM_KIND_TPROFILE2D:
+          logicalDimensions = 2;
+          break;
+        default:
+          break;
       }
 
-      if (reps.empty())
-        throw cms::Exception("InvalidConfiguration")
-            << "0 multiplicity for MESet at " << path;
+      // example case: Ecal/TriggerPrimitives/EmulMatching/TrigPrimTask matching
+      // index
+      if (logicalDimensions == 2 && hasYaxis && btype != binning::kUser)
+        logicalDimensions = 1;
 
-      candidates[replacementNames[iD]] = reps;
+      if (logicalDimensions > 2 || (btype == binning::kReport && logicalDimensions != 0))
+        throw cms::Exception("InvalidConfiguration") << "Cannot create MESet at " << path;
+
+      if (btype == binning::kUser)
+        set = new MESetEcal(path,
+                            otype,
+                            btype,
+                            kind,
+                            logicalDimensions,
+                            hasXaxis ? &xaxis : nullptr,
+                            hasYaxis ? &yaxis : nullptr,
+                            hasZaxis ? &zaxis : nullptr);
+      else if (logicalDimensions == 0)
+        set = new MESetDet0D(path, otype, btype, kind);
+      else if (logicalDimensions == 1)
+        set = new MESetDet1D(path, otype, btype, kind, hasYaxis ? &yaxis : nullptr);
+      else if (logicalDimensions == 2)
+        set = new MESetDet2D(path, otype, btype, kind, hasZaxis ? &zaxis : nullptr);
     }
-    MESetMulti *multi(new MESetMulti(*set, candidates));
-    delete set;
-    set = multi;
+
+    if (_MEParam.existsAs<edm::ParameterSet>("multi", false)) {
+      typedef std::vector<std::string> VString;
+
+      edm::ParameterSet const &multiParams(_MEParam.getUntrackedParameterSet("multi"));
+      VString replacementNames(multiParams.getParameterNames());
+      if (replacementNames.empty())
+        throw cms::Exception("InvalidConfiguration") << "0 multiplicity for MESet at " << path;
+
+      MESetMulti::ReplCandidates candidates;
+      for (unsigned iD(0); iD != replacementNames.size(); ++iD) {
+        VString reps;
+        if (multiParams.existsAs<VString>(replacementNames[iD], false))
+          reps = multiParams.getUntrackedParameter<VString>(replacementNames[iD]);
+        else if (multiParams.existsAs<std::vector<int>>(replacementNames[iD], false)) {
+          std::vector<int> repInts(multiParams.getUntrackedParameter<std::vector<int>>(replacementNames[iD]));
+          for (unsigned iR(0); iR != repInts.size(); ++iR)
+            reps.push_back(std::to_string(repInts[iR]));
+        }
+
+        if (reps.empty())
+          throw cms::Exception("InvalidConfiguration") << "0 multiplicity for MESet at " << path;
+
+        candidates[replacementNames[iD]] = reps;
+      }
+      MESetMulti *multi(new MESetMulti(*set, candidates));
+      delete set;
+      set = multi;
+    }
+
+    if (!set)
+      throw cms::Exception("InvalidConfiguration") << "MESet " << path << " could not be initialized";
+
+    if (_MEParam.getUntrackedParameter<bool>("perLumi"))
+      set->setLumiFlag();
+
+    return set;
   }
 
-  if (!set)
-    throw cms::Exception("InvalidConfiguration")
-        << "MESet " << path << " could not be initialized";
+  void fillMESetDescriptions(edm::ParameterSetDescription &_desc) {
+    _desc.addUntracked<std::string>("path");
+    _desc.addUntracked<std::string>("kind");
+    _desc.addUntracked<std::string>("otype");
+    _desc.addUntracked<std::string>("btype");
+    _desc.addUntracked<std::string>("description");
+    _desc.addUntracked<bool>("online", false);
+    _desc.addUntracked<bool>("perLumi", false);
+    _desc.addOptionalUntracked<bool>("minutely");
+    _desc.addOptionalUntracked<bool>("cumulative");
+    _desc.addOptionalUntracked<bool>("shiftAxis");
 
-  if (_MEParam.getUntrackedParameter<bool>("perLumi"))
-    set->setLumiFlag();
+    edm::ParameterSetDescription axisParameters;
+    binning::fillAxisDescriptions(axisParameters);
+    _desc.addOptionalUntracked("xaxis", axisParameters);
+    _desc.addOptionalUntracked("yaxis", axisParameters);
+    _desc.addOptionalUntracked("zaxis", axisParameters);
 
-  return set;
-}
-
-void fillMESetDescriptions(edm::ParameterSetDescription &_desc) {
-  _desc.addUntracked<std::string>("path");
-  _desc.addUntracked<std::string>("kind");
-  _desc.addUntracked<std::string>("otype");
-  _desc.addUntracked<std::string>("btype");
-  _desc.addUntracked<std::string>("description");
-  _desc.addUntracked<bool>("online", false);
-  _desc.addUntracked<bool>("perLumi", false);
-  _desc.addOptionalUntracked<bool>("minutely");
-  _desc.addOptionalUntracked<bool>("cumulative");
-  _desc.addOptionalUntracked<bool>("shiftAxis");
-
-  edm::ParameterSetDescription axisParameters;
-  binning::fillAxisDescriptions(axisParameters);
-  _desc.addOptionalUntracked("xaxis", axisParameters);
-  _desc.addOptionalUntracked("yaxis", axisParameters);
-  _desc.addOptionalUntracked("zaxis", axisParameters);
-
-  edm::ParameterSetDescription multiParameters;
-  multiParameters.addWildcardUntracked<std::vector<std::string>>("*");
-  multiParameters.addWildcardUntracked<std::vector<int>>("*");
-  _desc.addOptionalUntracked("multi", multiParameters);
-}
-} // namespace ecaldqm
+    edm::ParameterSetDescription multiParameters;
+    multiParameters.addWildcardUntracked<std::vector<std::string>>("*");
+    multiParameters.addWildcardUntracked<std::vector<int>>("*");
+    _desc.addOptionalUntracked("multi", multiParameters);
+  }
+}  // namespace ecaldqm

--- a/DQM/EcalCommon/src/StatusManager.cc
+++ b/DQM/EcalCommon/src/StatusManager.cc
@@ -17,286 +17,237 @@
 
 namespace ecaldqm {
 
-StatusManager::StatusManager() : dictionary_(), status_() {
-  dictionary_["CH_ID_ERROR"] = 0x1 << EcalDQMStatusHelper::CH_ID_ERROR;
-  dictionary_["CH_GAIN_ZERO_ERROR"] =
-      0x1 << EcalDQMStatusHelper::CH_GAIN_ZERO_ERROR;
-  dictionary_["CH_GAIN_SWITCH_ERROR"] =
-      0x1 << EcalDQMStatusHelper::CH_GAIN_SWITCH_ERROR;
-  dictionary_["TT_ID_ERROR"] = 0x1 << EcalDQMStatusHelper::TT_ID_ERROR;
-  dictionary_["TT_SIZE_ERROR"] = 0x1 << EcalDQMStatusHelper::TT_SIZE_ERROR;
+  StatusManager::StatusManager() : dictionary_(), status_() {
+    dictionary_["CH_ID_ERROR"] = 0x1 << EcalDQMStatusHelper::CH_ID_ERROR;
+    dictionary_["CH_GAIN_ZERO_ERROR"] = 0x1 << EcalDQMStatusHelper::CH_GAIN_ZERO_ERROR;
+    dictionary_["CH_GAIN_SWITCH_ERROR"] = 0x1 << EcalDQMStatusHelper::CH_GAIN_SWITCH_ERROR;
+    dictionary_["TT_ID_ERROR"] = 0x1 << EcalDQMStatusHelper::TT_ID_ERROR;
+    dictionary_["TT_SIZE_ERROR"] = 0x1 << EcalDQMStatusHelper::TT_SIZE_ERROR;
 
-  dictionary_["PEDESTAL_LOW_GAIN_MEAN_ERROR"] =
-      0x1 << EcalDQMStatusHelper::PEDESTAL_LOW_GAIN_MEAN_ERROR;
-  dictionary_["PEDESTAL_MIDDLE_GAIN_MEAN_ERROR"] =
-      0x1 << EcalDQMStatusHelper::PEDESTAL_MIDDLE_GAIN_MEAN_ERROR;
-  dictionary_["PEDESTAL_HIGH_GAIN_MEAN_ERROR"] =
-      0x1 << EcalDQMStatusHelper::PEDESTAL_HIGH_GAIN_MEAN_ERROR;
-  dictionary_["PEDESTAL_LOW_GAIN_RMS_ERROR"] =
-      0x1 << EcalDQMStatusHelper::PEDESTAL_LOW_GAIN_RMS_ERROR;
-  dictionary_["PEDESTAL_MIDDLE_GAIN_RMS_ERROR"] =
-      0x1 << EcalDQMStatusHelper::PEDESTAL_MIDDLE_GAIN_RMS_ERROR;
-  dictionary_["PEDESTAL_HIGH_GAIN_RMS_ERROR"] =
-      0x1 << EcalDQMStatusHelper::PEDESTAL_HIGH_GAIN_RMS_ERROR;
+    dictionary_["PEDESTAL_LOW_GAIN_MEAN_ERROR"] = 0x1 << EcalDQMStatusHelper::PEDESTAL_LOW_GAIN_MEAN_ERROR;
+    dictionary_["PEDESTAL_MIDDLE_GAIN_MEAN_ERROR"] = 0x1 << EcalDQMStatusHelper::PEDESTAL_MIDDLE_GAIN_MEAN_ERROR;
+    dictionary_["PEDESTAL_HIGH_GAIN_MEAN_ERROR"] = 0x1 << EcalDQMStatusHelper::PEDESTAL_HIGH_GAIN_MEAN_ERROR;
+    dictionary_["PEDESTAL_LOW_GAIN_RMS_ERROR"] = 0x1 << EcalDQMStatusHelper::PEDESTAL_LOW_GAIN_RMS_ERROR;
+    dictionary_["PEDESTAL_MIDDLE_GAIN_RMS_ERROR"] = 0x1 << EcalDQMStatusHelper::PEDESTAL_MIDDLE_GAIN_RMS_ERROR;
+    dictionary_["PEDESTAL_HIGH_GAIN_RMS_ERROR"] = 0x1 << EcalDQMStatusHelper::PEDESTAL_HIGH_GAIN_RMS_ERROR;
 
-  dictionary_["PEDESTAL_ONLINE_HIGH_GAIN_MEAN_ERROR"] =
-      0x1 << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_MEAN_ERROR;
-  dictionary_["PEDESTAL_ONLINE_HIGH_GAIN_RMS_ERROR"] =
-      0x1 << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_RMS_ERROR;
+    dictionary_["PEDESTAL_ONLINE_HIGH_GAIN_MEAN_ERROR"] = 0x1
+                                                          << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_MEAN_ERROR;
+    dictionary_["PEDESTAL_ONLINE_HIGH_GAIN_RMS_ERROR"] = 0x1
+                                                         << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_RMS_ERROR;
 
-  dictionary_["TESTPULSE_LOW_GAIN_MEAN_ERROR"] =
-      0x1 << EcalDQMStatusHelper::TESTPULSE_LOW_GAIN_MEAN_ERROR;
-  dictionary_["TESTPULSE_MIDDLE_GAIN_MEAN_ERROR"] =
-      0x1 << EcalDQMStatusHelper::TESTPULSE_MIDDLE_GAIN_MEAN_ERROR;
-  dictionary_["TESTPULSE_HIGH_GAIN_MEAN_ERROR"] =
-      0x1 << EcalDQMStatusHelper::TESTPULSE_HIGH_GAIN_MEAN_ERROR;
-  dictionary_["TESTPULSE_LOW_GAIN_RMS_ERROR"] =
-      0x1 << EcalDQMStatusHelper::TESTPULSE_LOW_GAIN_RMS_ERROR;
-  dictionary_["TESTPULSE_MIDDLE_GAIN_RMS_ERROR"] =
-      0x1 << EcalDQMStatusHelper::TESTPULSE_MIDDLE_GAIN_RMS_ERROR;
-  dictionary_["TESTPULSE_HIGH_GAIN_RMS_ERROR"] =
-      0x1 << EcalDQMStatusHelper::TESTPULSE_HIGH_GAIN_RMS_ERROR;
+    dictionary_["TESTPULSE_LOW_GAIN_MEAN_ERROR"] = 0x1 << EcalDQMStatusHelper::TESTPULSE_LOW_GAIN_MEAN_ERROR;
+    dictionary_["TESTPULSE_MIDDLE_GAIN_MEAN_ERROR"] = 0x1 << EcalDQMStatusHelper::TESTPULSE_MIDDLE_GAIN_MEAN_ERROR;
+    dictionary_["TESTPULSE_HIGH_GAIN_MEAN_ERROR"] = 0x1 << EcalDQMStatusHelper::TESTPULSE_HIGH_GAIN_MEAN_ERROR;
+    dictionary_["TESTPULSE_LOW_GAIN_RMS_ERROR"] = 0x1 << EcalDQMStatusHelper::TESTPULSE_LOW_GAIN_RMS_ERROR;
+    dictionary_["TESTPULSE_MIDDLE_GAIN_RMS_ERROR"] = 0x1 << EcalDQMStatusHelper::TESTPULSE_MIDDLE_GAIN_RMS_ERROR;
+    dictionary_["TESTPULSE_HIGH_GAIN_RMS_ERROR"] = 0x1 << EcalDQMStatusHelper::TESTPULSE_HIGH_GAIN_RMS_ERROR;
 
-  dictionary_["LASER_MEAN_ERROR"] = 0x1
-                                    << EcalDQMStatusHelper::LASER_MEAN_ERROR;
-  dictionary_["LASER_RMS_ERROR"] = 0x1 << EcalDQMStatusHelper::LASER_RMS_ERROR;
-  dictionary_["LASER_TIMING_MEAN_ERROR"] =
-      0x1 << EcalDQMStatusHelper::LASER_TIMING_MEAN_ERROR;
-  dictionary_["LASER_TIMING_RMS_ERROR"] =
-      0x1 << EcalDQMStatusHelper::LASER_TIMING_RMS_ERROR;
+    dictionary_["LASER_MEAN_ERROR"] = 0x1 << EcalDQMStatusHelper::LASER_MEAN_ERROR;
+    dictionary_["LASER_RMS_ERROR"] = 0x1 << EcalDQMStatusHelper::LASER_RMS_ERROR;
+    dictionary_["LASER_TIMING_MEAN_ERROR"] = 0x1 << EcalDQMStatusHelper::LASER_TIMING_MEAN_ERROR;
+    dictionary_["LASER_TIMING_RMS_ERROR"] = 0x1 << EcalDQMStatusHelper::LASER_TIMING_RMS_ERROR;
 
-  dictionary_["LED_MEAN_ERROR"] = 0x1 << EcalDQMStatusHelper::LED_MEAN_ERROR;
-  dictionary_["LED_RMS_ERROR"] = 0x1 << EcalDQMStatusHelper::LED_RMS_ERROR;
-  dictionary_["LED_TIMING_MEAN_ERROR"] =
-      0x1 << EcalDQMStatusHelper::LED_TIMING_MEAN_ERROR;
-  dictionary_["LED_TIMING_RMS_ERROR"] =
-      0x1 << EcalDQMStatusHelper::LED_TIMING_RMS_ERROR;
+    dictionary_["LED_MEAN_ERROR"] = 0x1 << EcalDQMStatusHelper::LED_MEAN_ERROR;
+    dictionary_["LED_RMS_ERROR"] = 0x1 << EcalDQMStatusHelper::LED_RMS_ERROR;
+    dictionary_["LED_TIMING_MEAN_ERROR"] = 0x1 << EcalDQMStatusHelper::LED_TIMING_MEAN_ERROR;
+    dictionary_["LED_TIMING_RMS_ERROR"] = 0x1 << EcalDQMStatusHelper::LED_TIMING_RMS_ERROR;
 
-  dictionary_["STATUS_FLAG_ERROR"] = 0x1
-                                     << EcalDQMStatusHelper::STATUS_FLAG_ERROR;
+    dictionary_["STATUS_FLAG_ERROR"] = 0x1 << EcalDQMStatusHelper::STATUS_FLAG_ERROR;
 
-  dictionary_["PHYSICS_BAD_CHANNEL_WARNING"] =
-      0x1 << EcalDQMStatusHelper::PHYSICS_BAD_CHANNEL_WARNING;
-  dictionary_["PHYSICS_BAD_CHANNEL_ERROR"] =
-      0x1 << EcalDQMStatusHelper::PHYSICS_BAD_CHANNEL_ERROR;
+    dictionary_["PHYSICS_BAD_CHANNEL_WARNING"] = 0x1 << EcalDQMStatusHelper::PHYSICS_BAD_CHANNEL_WARNING;
+    dictionary_["PHYSICS_BAD_CHANNEL_ERROR"] = 0x1 << EcalDQMStatusHelper::PHYSICS_BAD_CHANNEL_ERROR;
 
-  dictionary_["disabled_channel"] =
-      0x1 << EcalDQMStatusHelper::TT_SIZE_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_LOW_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_MIDDLE_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_HIGH_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::TESTPULSE_LOW_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::TESTPULSE_MIDDLE_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::TESTPULSE_HIGH_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::LASER_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::LED_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::PHYSICS_BAD_CHANNEL_WARNING |
-      0x1 << EcalDQMStatusHelper::PHYSICS_BAD_CHANNEL_ERROR;
+    dictionary_["disabled_channel"] =
+        0x1 << EcalDQMStatusHelper::TT_SIZE_ERROR | 0x1 << EcalDQMStatusHelper::PEDESTAL_LOW_GAIN_MEAN_ERROR |
+        0x1 << EcalDQMStatusHelper::PEDESTAL_MIDDLE_GAIN_MEAN_ERROR |
+        0x1 << EcalDQMStatusHelper::PEDESTAL_HIGH_GAIN_MEAN_ERROR |
+        0x1 << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_MEAN_ERROR |
+        0x1 << EcalDQMStatusHelper::TESTPULSE_LOW_GAIN_MEAN_ERROR |
+        0x1 << EcalDQMStatusHelper::TESTPULSE_MIDDLE_GAIN_MEAN_ERROR |
+        0x1 << EcalDQMStatusHelper::TESTPULSE_HIGH_GAIN_MEAN_ERROR | 0x1 << EcalDQMStatusHelper::LASER_MEAN_ERROR |
+        0x1 << EcalDQMStatusHelper::LED_MEAN_ERROR | 0x1 << EcalDQMStatusHelper::PHYSICS_BAD_CHANNEL_WARNING |
+        0x1 << EcalDQMStatusHelper::PHYSICS_BAD_CHANNEL_ERROR;
 
-  dictionary_["dead_channel"] =
-      0x1 << EcalDQMStatusHelper::PEDESTAL_LOW_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_LOW_GAIN_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_MIDDLE_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_MIDDLE_GAIN_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_HIGH_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_HIGH_GAIN_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::TESTPULSE_LOW_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::TESTPULSE_LOW_GAIN_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::TESTPULSE_MIDDLE_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::TESTPULSE_MIDDLE_GAIN_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::TESTPULSE_HIGH_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::TESTPULSE_HIGH_GAIN_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::LASER_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::LASER_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::LASER_TIMING_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::LASER_TIMING_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::LED_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::LED_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::LED_TIMING_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::LED_TIMING_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::PHYSICS_BAD_CHANNEL_WARNING |
-      0x1 << EcalDQMStatusHelper::PHYSICS_BAD_CHANNEL_ERROR;
+    dictionary_["dead_channel"] =
+        0x1 << EcalDQMStatusHelper::PEDESTAL_LOW_GAIN_MEAN_ERROR |
+        0x1 << EcalDQMStatusHelper::PEDESTAL_LOW_GAIN_RMS_ERROR |
+        0x1 << EcalDQMStatusHelper::PEDESTAL_MIDDLE_GAIN_MEAN_ERROR |
+        0x1 << EcalDQMStatusHelper::PEDESTAL_MIDDLE_GAIN_RMS_ERROR |
+        0x1 << EcalDQMStatusHelper::PEDESTAL_HIGH_GAIN_MEAN_ERROR |
+        0x1 << EcalDQMStatusHelper::PEDESTAL_HIGH_GAIN_RMS_ERROR |
+        0x1 << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_MEAN_ERROR |
+        0x1 << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_RMS_ERROR |
+        0x1 << EcalDQMStatusHelper::TESTPULSE_LOW_GAIN_MEAN_ERROR |
+        0x1 << EcalDQMStatusHelper::TESTPULSE_LOW_GAIN_RMS_ERROR |
+        0x1 << EcalDQMStatusHelper::TESTPULSE_MIDDLE_GAIN_MEAN_ERROR |
+        0x1 << EcalDQMStatusHelper::TESTPULSE_MIDDLE_GAIN_RMS_ERROR |
+        0x1 << EcalDQMStatusHelper::TESTPULSE_HIGH_GAIN_MEAN_ERROR |
+        0x1 << EcalDQMStatusHelper::TESTPULSE_HIGH_GAIN_RMS_ERROR | 0x1 << EcalDQMStatusHelper::LASER_MEAN_ERROR |
+        0x1 << EcalDQMStatusHelper::LASER_RMS_ERROR | 0x1 << EcalDQMStatusHelper::LASER_TIMING_MEAN_ERROR |
+        0x1 << EcalDQMStatusHelper::LASER_TIMING_RMS_ERROR | 0x1 << EcalDQMStatusHelper::LED_MEAN_ERROR |
+        0x1 << EcalDQMStatusHelper::LED_RMS_ERROR | 0x1 << EcalDQMStatusHelper::LED_TIMING_MEAN_ERROR |
+        0x1 << EcalDQMStatusHelper::LED_TIMING_RMS_ERROR | 0x1 << EcalDQMStatusHelper::PHYSICS_BAD_CHANNEL_WARNING |
+        0x1 << EcalDQMStatusHelper::PHYSICS_BAD_CHANNEL_ERROR;
 
-  dictionary_["pedestal_problem"] =
-      0x1 << EcalDQMStatusHelper::PEDESTAL_LOW_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_LOW_GAIN_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_MIDDLE_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_MIDDLE_GAIN_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_HIGH_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_HIGH_GAIN_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_RMS_ERROR;
+    dictionary_["pedestal_problem"] = 0x1 << EcalDQMStatusHelper::PEDESTAL_LOW_GAIN_MEAN_ERROR |
+                                      0x1 << EcalDQMStatusHelper::PEDESTAL_LOW_GAIN_RMS_ERROR |
+                                      0x1 << EcalDQMStatusHelper::PEDESTAL_MIDDLE_GAIN_MEAN_ERROR |
+                                      0x1 << EcalDQMStatusHelper::PEDESTAL_MIDDLE_GAIN_RMS_ERROR |
+                                      0x1 << EcalDQMStatusHelper::PEDESTAL_HIGH_GAIN_MEAN_ERROR |
+                                      0x1 << EcalDQMStatusHelper::PEDESTAL_HIGH_GAIN_RMS_ERROR |
+                                      0x1 << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_MEAN_ERROR |
+                                      0x1 << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_RMS_ERROR;
 
-  dictionary_["testpulse_problem"] =
-      0x1 << EcalDQMStatusHelper::TESTPULSE_LOW_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::TESTPULSE_LOW_GAIN_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::TESTPULSE_MIDDLE_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::TESTPULSE_MIDDLE_GAIN_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::TESTPULSE_HIGH_GAIN_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::TESTPULSE_HIGH_GAIN_RMS_ERROR;
+    dictionary_["testpulse_problem"] = 0x1 << EcalDQMStatusHelper::TESTPULSE_LOW_GAIN_MEAN_ERROR |
+                                       0x1 << EcalDQMStatusHelper::TESTPULSE_LOW_GAIN_RMS_ERROR |
+                                       0x1 << EcalDQMStatusHelper::TESTPULSE_MIDDLE_GAIN_MEAN_ERROR |
+                                       0x1 << EcalDQMStatusHelper::TESTPULSE_MIDDLE_GAIN_RMS_ERROR |
+                                       0x1 << EcalDQMStatusHelper::TESTPULSE_HIGH_GAIN_MEAN_ERROR |
+                                       0x1 << EcalDQMStatusHelper::TESTPULSE_HIGH_GAIN_RMS_ERROR;
 
-  dictionary_["laser_problem"] =
-      0x1 << EcalDQMStatusHelper::LASER_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::LASER_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::LASER_TIMING_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::LASER_TIMING_RMS_ERROR;
+    dictionary_["laser_problem"] =
+        0x1 << EcalDQMStatusHelper::LASER_MEAN_ERROR | 0x1 << EcalDQMStatusHelper::LASER_RMS_ERROR |
+        0x1 << EcalDQMStatusHelper::LASER_TIMING_MEAN_ERROR | 0x1 << EcalDQMStatusHelper::LASER_TIMING_RMS_ERROR;
 
-  dictionary_["led_problem"] =
-      0x1 << EcalDQMStatusHelper::LED_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::LED_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::LED_TIMING_MEAN_ERROR |
-      0x1 << EcalDQMStatusHelper::LED_TIMING_RMS_ERROR;
+    dictionary_["led_problem"] =
+        0x1 << EcalDQMStatusHelper::LED_MEAN_ERROR | 0x1 << EcalDQMStatusHelper::LED_RMS_ERROR |
+        0x1 << EcalDQMStatusHelper::LED_TIMING_MEAN_ERROR | 0x1 << EcalDQMStatusHelper::LED_TIMING_RMS_ERROR;
 
-  dictionary_["noise_problem"] =
-      0x1 << EcalDQMStatusHelper::PEDESTAL_LOW_GAIN_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_MIDDLE_GAIN_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_HIGH_GAIN_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_RMS_ERROR |
-      0x1 << EcalDQMStatusHelper::PHYSICS_BAD_CHANNEL_ERROR;
-}
+    dictionary_["noise_problem"] = 0x1 << EcalDQMStatusHelper::PEDESTAL_LOW_GAIN_RMS_ERROR |
+                                   0x1 << EcalDQMStatusHelper::PEDESTAL_MIDDLE_GAIN_RMS_ERROR |
+                                   0x1 << EcalDQMStatusHelper::PEDESTAL_HIGH_GAIN_RMS_ERROR |
+                                   0x1 << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_RMS_ERROR |
+                                   0x1 << EcalDQMStatusHelper::PHYSICS_BAD_CHANNEL_ERROR;
+  }
 
-void StatusManager::readFromStream(std::istream &_input) {
-  TPRegexp linePat("^[ ]*(Crystal|TT|PN)[ ]+(EB[0-9+-]*|EE[0-9+-]*|[0-9]+)[ "
-                   "]+([0-9]+)[ ]([a-zA-Z_]+)");
+  void StatusManager::readFromStream(std::istream &_input) {
+    TPRegexp linePat(
+        "^[ ]*(Crystal|TT|PN)[ ]+(EB[0-9+-]*|EE[0-9+-]*|[0-9]+)[ "
+        "]+([0-9]+)[ ]([a-zA-Z_]+)");
 
-  std::string line;
-  while (true) {
-    std::getline(_input, line);
-    if (!_input.good())
-      break;
+    std::string line;
+    while (true) {
+      std::getline(_input, line);
+      if (!_input.good())
+        break;
 
-    if (!linePat.MatchB(line))
-      continue;
+      if (!linePat.MatchB(line))
+        continue;
 
-    TObjArray *matches(linePat.MatchS(line));
-    TString channelType(matches->At(1)->GetName());
-    TString module(matches->At(2)->GetName());
-    unsigned channel(TString(matches->At(3)->GetName()).Atoi());
-    TString statusName(matches->At(4)->GetName());
-    delete matches;
+      TObjArray *matches(linePat.MatchS(line));
+      TString channelType(matches->At(1)->GetName());
+      TString module(matches->At(2)->GetName());
+      unsigned channel(TString(matches->At(3)->GetName()).Atoi());
+      TString statusName(matches->At(4)->GetName());
+      delete matches;
 
-    std::map<std::string, uint32_t>::const_iterator dItr(
-        dictionary_.find(statusName.Data()));
-    if (dItr == dictionary_.end())
-      continue;
-    uint32_t statusVal(dItr->second);
+      std::map<std::string, uint32_t>::const_iterator dItr(dictionary_.find(statusName.Data()));
+      if (dItr == dictionary_.end())
+        continue;
+      uint32_t statusVal(dItr->second);
 
-    if (channelType == "Crystal") {
-      // module: Subdetector name, channel: dense ID
-      // Store using EBDetId and EEDetId as keys (following
-      // EcalDQMChannelStatus)
+      if (channelType == "Crystal") {
+        // module: Subdetector name, channel: dense ID
+        // Store using EBDetId and EEDetId as keys (following
+        // EcalDQMChannelStatus)
 
-      if (module == "EB") {
-        if (!EBDetId::validDenseIndex(channel))
-          continue;
-        status_.insert(std::pair<uint32_t, uint32_t>(
-            EBDetId::unhashIndex(channel).rawId(), statusVal));
-      } else if (module == "EE") {
-        if (!EEDetId::validDenseIndex(channel))
-          continue;
-        status_.insert(std::pair<uint32_t, uint32_t>(
-            EEDetId::unhashIndex(channel).rawId(), statusVal));
-      }
-    } else if (channelType == "TT") {
-      // module: Supermodule name, channel: RU ID (electronics ID tower)
-      // Store using EcalTrigTowerDetId and EcalScDetId as keys (following
-      // EcalDQMTowerStatus)
-
-      if (module.Contains("EB")) {
-        /* TODO CHECK THIS */
-
-        int iEta((channel - 1) / 4 + 1);
-        int zside(0);
-        int iPhi(0);
-        if (module(3) == '-') {
-          zside = -1;
-          iPhi = (channel - 1) % 4 + 1;
-        } else {
-          zside = 1;
-          iPhi = (68 - channel) % 4 + 1;
+        if (module == "EB") {
+          if (!EBDetId::validDenseIndex(channel))
+            continue;
+          status_.insert(std::pair<uint32_t, uint32_t>(EBDetId::unhashIndex(channel).rawId(), statusVal));
+        } else if (module == "EE") {
+          if (!EEDetId::validDenseIndex(channel))
+            continue;
+          status_.insert(std::pair<uint32_t, uint32_t>(EEDetId::unhashIndex(channel).rawId(), statusVal));
         }
+      } else if (channelType == "TT") {
+        // module: Supermodule name, channel: RU ID (electronics ID tower)
+        // Store using EcalTrigTowerDetId and EcalScDetId as keys (following
+        // EcalDQMTowerStatus)
 
-        status_.insert(std::pair<uint32_t, uint32_t>(
-            EcalTrigTowerDetId(zside, EcalBarrel, iEta, iPhi).rawId(),
-            statusVal));
-      } else if (module.Contains("EE")) {
-        std::vector<EcalScDetId> scIds(getElectronicsMap()->getEcalScDetId(
-            dccId(module.Data()), channel, false));
-        for (unsigned iS(0); iS != scIds.size(); ++iS)
+        if (module.Contains("EB")) {
+          /* TODO CHECK THIS */
+
+          int iEta((channel - 1) / 4 + 1);
+          int zside(0);
+          int iPhi(0);
+          if (module(3) == '-') {
+            zside = -1;
+            iPhi = (channel - 1) % 4 + 1;
+          } else {
+            zside = 1;
+            iPhi = (68 - channel) % 4 + 1;
+          }
+
           status_.insert(
-              std::pair<uint32_t, uint32_t>(scIds[iS].rawId(), statusVal));
+              std::pair<uint32_t, uint32_t>(EcalTrigTowerDetId(zside, EcalBarrel, iEta, iPhi).rawId(), statusVal));
+        } else if (module.Contains("EE")) {
+          std::vector<EcalScDetId> scIds(getElectronicsMap()->getEcalScDetId(dccId(module.Data()), channel, false));
+          for (unsigned iS(0); iS != scIds.size(); ++iS)
+            status_.insert(std::pair<uint32_t, uint32_t>(scIds[iS].rawId(), statusVal));
+        }
+      } else if (channelType == "PN") {
+        // module: DCC ID, channel: iPN
+        // Store using EcalPnDiodeDetId as keys
+        unsigned iDCC(module.Atoi() - 1);
+        int subdet(iDCC <= kEEmHigh || iDCC >= kEEpLow ? EcalEndcap : EcalBarrel);
+        status_.insert(std::pair<uint32_t, uint32_t>(EcalPnDiodeDetId(subdet, iDCC + 1, channel).rawId(), statusVal));
       }
-    } else if (channelType == "PN") {
-      // module: DCC ID, channel: iPN
-      // Store using EcalPnDiodeDetId as keys
-      unsigned iDCC(module.Atoi() - 1);
-      int subdet(iDCC <= kEEmHigh || iDCC >= kEEpLow ? EcalEndcap : EcalBarrel);
-      status_.insert(std::pair<uint32_t, uint32_t>(
-          EcalPnDiodeDetId(subdet, iDCC + 1, channel).rawId(), statusVal));
     }
   }
-}
 
-void StatusManager::readFromObj(EcalDQMChannelStatus const &_channelStatus,
-                                EcalDQMTowerStatus const &_towerStatus) {
-  EcalDQMChannelStatus::Items const &barrelChStatus(
-      _channelStatus.barrelItems());
-  for (unsigned iC(0); iC != EBDetId::kSizeForDenseIndexing; ++iC)
-    status_.insert(std::pair<uint32_t, uint32_t>(
-        EBDetId::unhashIndex(iC).rawId(), barrelChStatus[iC].getStatusCode()));
+  void StatusManager::readFromObj(EcalDQMChannelStatus const &_channelStatus, EcalDQMTowerStatus const &_towerStatus) {
+    EcalDQMChannelStatus::Items const &barrelChStatus(_channelStatus.barrelItems());
+    for (unsigned iC(0); iC != EBDetId::kSizeForDenseIndexing; ++iC)
+      status_.insert(
+          std::pair<uint32_t, uint32_t>(EBDetId::unhashIndex(iC).rawId(), barrelChStatus[iC].getStatusCode()));
 
-  EcalDQMChannelStatus::Items const &endcapChStatus(
-      _channelStatus.endcapItems());
-  for (unsigned iC(0); iC != EEDetId::kSizeForDenseIndexing; ++iC)
-    status_.insert(std::pair<uint32_t, uint32_t>(
-        EEDetId::unhashIndex(iC).rawId(), endcapChStatus[iC].getStatusCode()));
+    EcalDQMChannelStatus::Items const &endcapChStatus(_channelStatus.endcapItems());
+    for (unsigned iC(0); iC != EEDetId::kSizeForDenseIndexing; ++iC)
+      status_.insert(
+          std::pair<uint32_t, uint32_t>(EEDetId::unhashIndex(iC).rawId(), endcapChStatus[iC].getStatusCode()));
 
-  EcalDQMTowerStatus::Items const &barrelTowStatus(_towerStatus.barrelItems());
-  for (unsigned iC(0); iC != EcalTrigTowerDetId::kEBTotalTowers; ++iC)
-    status_.insert(std::pair<uint32_t, uint32_t>(
-        EcalTrigTowerDetId::detIdFromDenseIndex(iC).rawId(),
-        barrelTowStatus[iC].getStatusCode()));
+    EcalDQMTowerStatus::Items const &barrelTowStatus(_towerStatus.barrelItems());
+    for (unsigned iC(0); iC != EcalTrigTowerDetId::kEBTotalTowers; ++iC)
+      status_.insert(std::pair<uint32_t, uint32_t>(EcalTrigTowerDetId::detIdFromDenseIndex(iC).rawId(),
+                                                   barrelTowStatus[iC].getStatusCode()));
 
-  EcalDQMTowerStatus::Items const &endcapTowStatus(_towerStatus.endcapItems());
-  for (unsigned iC(0); iC != EcalScDetId::kSizeForDenseIndexing; ++iC)
-    status_.insert(
-        std::pair<uint32_t, uint32_t>(EcalScDetId::unhashIndex(iC).rawId(),
-                                      endcapTowStatus[iC].getStatusCode()));
-}
-
-void StatusManager::writeToStream(std::ostream &_output) const {}
-
-void StatusManager::writeToObj(EcalDQMChannelStatus &_channelStatus,
-                               EcalDQMTowerStatus &_towerStatus) const {
-  for (unsigned iC(0); iC != EBDetId::kSizeForDenseIndexing; ++iC) {
-    uint32_t key(EBDetId::unhashIndex(iC).rawId());
-    _channelStatus.setValue(key, EcalDQMStatusCode(getStatus(key)));
+    EcalDQMTowerStatus::Items const &endcapTowStatus(_towerStatus.endcapItems());
+    for (unsigned iC(0); iC != EcalScDetId::kSizeForDenseIndexing; ++iC)
+      status_.insert(
+          std::pair<uint32_t, uint32_t>(EcalScDetId::unhashIndex(iC).rawId(), endcapTowStatus[iC].getStatusCode()));
   }
 
-  for (unsigned iC(0); iC != EEDetId::kSizeForDenseIndexing; ++iC) {
-    uint32_t key(EEDetId::unhashIndex(iC).rawId());
-    _channelStatus.setValue(key, EcalDQMStatusCode(getStatus(key)));
+  void StatusManager::writeToStream(std::ostream &_output) const {}
+
+  void StatusManager::writeToObj(EcalDQMChannelStatus &_channelStatus, EcalDQMTowerStatus &_towerStatus) const {
+    for (unsigned iC(0); iC != EBDetId::kSizeForDenseIndexing; ++iC) {
+      uint32_t key(EBDetId::unhashIndex(iC).rawId());
+      _channelStatus.setValue(key, EcalDQMStatusCode(getStatus(key)));
+    }
+
+    for (unsigned iC(0); iC != EEDetId::kSizeForDenseIndexing; ++iC) {
+      uint32_t key(EEDetId::unhashIndex(iC).rawId());
+      _channelStatus.setValue(key, EcalDQMStatusCode(getStatus(key)));
+    }
+
+    for (unsigned iC(0); iC != EcalTrigTowerDetId::kEBTotalTowers; ++iC) {
+      uint32_t key(EcalTrigTowerDetId::detIdFromDenseIndex(iC));
+      _towerStatus.setValue(key, EcalDQMStatusCode(getStatus(key)));
+    }
+
+    for (unsigned iC(0); iC != EcalScDetId::kSizeForDenseIndexing; ++iC) {
+      uint32_t key(EcalScDetId::unhashIndex(iC));
+      _towerStatus.setValue(key, EcalDQMStatusCode(getStatus(key)));
+    }
   }
 
-  for (unsigned iC(0); iC != EcalTrigTowerDetId::kEBTotalTowers; ++iC) {
-    uint32_t key(EcalTrigTowerDetId::detIdFromDenseIndex(iC));
-    _towerStatus.setValue(key, EcalDQMStatusCode(getStatus(key)));
+  uint32_t StatusManager::getStatus(uint32_t _key) const {
+    std::map<uint32_t, uint32_t>::const_iterator itr(status_.find(_key));
+    if (itr == status_.end())
+      return 0;
+    return itr->second;
   }
 
-  for (unsigned iC(0); iC != EcalScDetId::kSizeForDenseIndexing; ++iC) {
-    uint32_t key(EcalScDetId::unhashIndex(iC));
-    _towerStatus.setValue(key, EcalDQMStatusCode(getStatus(key)));
-  }
-}
-
-uint32_t StatusManager::getStatus(uint32_t _key) const {
-  std::map<uint32_t, uint32_t>::const_iterator itr(status_.find(_key));
-  if (itr == status_.end())
-    return 0;
-  return itr->second;
-}
-
-} // namespace ecaldqm
+}  // namespace ecaldqm

--- a/DQM/SiPixelMonitorCluster/interface/SiPixelClusterModule.h
+++ b/DQM/SiPixelMonitorCluster/interface/SiPixelClusterModule.h
@@ -39,7 +39,6 @@
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 
 class SiPixelClusterModule {
-
 public:
   /// Default constructor
   SiPixelClusterModule();
@@ -53,19 +52,32 @@ public:
   typedef edmNew::DetSet<SiPixelCluster>::const_iterator ClusterIterator;
 
   /// Book histograms
-  void book(const edm::ParameterSet &iConfig, const edm::EventSetup &iSetup,
-            DQMStore::IBooker &iBooker, int type = 0, bool twoD = true,
-            bool reducedSet = false, bool isUpgrade = false);
+  void book(const edm::ParameterSet &iConfig,
+            const edm::EventSetup &iSetup,
+            DQMStore::IBooker &iBooker,
+            int type = 0,
+            bool twoD = true,
+            bool reducedSet = false,
+            bool isUpgrade = false);
   /// Fill histograms
   int fill(const edmNew::DetSetVector<SiPixelCluster> &input,
-           const TrackerGeometry *tracker, int *barrelClusterTotal,
-           int *fpixPClusterTotal, int *fpixMClusterTotal,
+           const TrackerGeometry *tracker,
+           int *barrelClusterTotal,
+           int *fpixPClusterTotal,
+           int *fpixMClusterTotal,
            std::vector<MonitorElement *> &layers,
            std::vector<MonitorElement *> &diskspz,
-           std::vector<MonitorElement *> &disksmz, bool modon = true,
-           bool ladon = false, bool layon = false, bool phion = false,
-           bool bladeon = false, bool diskon = false, bool ringon = false,
-           bool twoD = true, bool reducedSet = false, bool smileyon = false,
+           std::vector<MonitorElement *> &disksmz,
+           bool modon = true,
+           bool ladon = false,
+           bool layon = false,
+           bool phion = false,
+           bool bladeon = false,
+           bool diskon = false,
+           bool ringon = false,
+           bool twoD = true,
+           bool reducedSet = false,
+           bool smileyon = false,
            bool isUpgrade = false);
 
 private:

--- a/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSource.h
+++ b/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSource.h
@@ -65,8 +65,7 @@ public:
 
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void dqmBeginRun(const edm::Run &, edm::EventSetup const &) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
   virtual void buildStructure(edm::EventSetup const &);
   virtual void bookMEs(DQMStore::IBooker &, const edm::EventSetup &iSetup);
@@ -89,7 +88,7 @@ private:
   bool ladOn, layOn, phiOn;
   // forward:
   bool ringOn, bladeOn, diskOn;
-  bool smileyOn; // cluster sizeY vs Cluster eta plot
+  bool smileyOn;  // cluster sizeY vs Cluster eta plot
   bool firstRun;
   int lumSec;
   int nLumiSecs;
@@ -112,7 +111,8 @@ private:
   int noOfLayers;
   int noOfDisks;
 
-  void getrococcupancy(DetId detId, const edm::DetSetVector<PixelDigi> &diginp,
+  void getrococcupancy(DetId detId,
+                       const edm::DetSetVector<PixelDigi> &diginp,
                        const TrackerTopology *const tTopo,
                        std::vector<MonitorElement *> const &meinput);
   void getrococcupancye(DetId detId,

--- a/DQM/SiPixelMonitorCluster/src/SiPixelClusterModule.cc
+++ b/DQM/SiPixelMonitorCluster/src/SiPixelClusterModule.cc
@@ -42,14 +42,11 @@
 //
 // Constructors
 //
-SiPixelClusterModule::SiPixelClusterModule()
-    : id_(0), ncols_(416), nrows_(160) {}
+SiPixelClusterModule::SiPixelClusterModule() : id_(0), ncols_(416), nrows_(160) {}
 ///
-SiPixelClusterModule::SiPixelClusterModule(const uint32_t &id)
-    : id_(id), ncols_(416), nrows_(160) {}
+SiPixelClusterModule::SiPixelClusterModule(const uint32_t &id) : id_(id), ncols_(416), nrows_(160) {}
 ///
-SiPixelClusterModule::SiPixelClusterModule(const uint32_t &id, const int &ncols,
-                                           const int &nrows)
+SiPixelClusterModule::SiPixelClusterModule(const uint32_t &id, const int &ncols, const int &nrows)
     : id_(id), ncols_(ncols), nrows_(nrows) {}
 //
 // Destructor
@@ -60,17 +57,17 @@ SiPixelClusterModule::~SiPixelClusterModule() {}
 //
 void SiPixelClusterModule::book(const edm::ParameterSet &iConfig,
                                 const edm::EventSetup &iSetup,
-                                DQMStore::IBooker &iBooker, int type, bool twoD,
-                                bool reducedSet, bool isUpgrade) {
-
+                                DQMStore::IBooker &iBooker,
+                                int type,
+                                bool twoD,
+                                bool reducedSet,
+                                bool isUpgrade) {
   edm::ESHandle<TrackerTopology> tTopoHandle;
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
   pTT = tTopoHandle.product();
 
-  bool barrel =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
-  bool endcap =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
   bool isHalfModule = false;
   if (barrel) {
     isHalfModule = PixelBarrelName(DetId(id_), pTT, isUpgrade).isHalfModule();
@@ -118,8 +115,7 @@ void SiPixelClusterModule::book(const edm::ParameterSet &iConfig,
       meX_->setAxisTitle("Barycenter x-position [row #]", 1);
       // Cluster barycenter Y position
       hid = theHistogramId->setHistoId("y", id_);
-      meY_ =
-          iBooker.book1D(hid, "Cluster barycenter Y (column #)", 500, 0., 500.);
+      meY_ = iBooker.book1D(hid, "Cluster barycenter Y (column #)", 500, 0., 500.);
       meY_->setAxisTitle("Barycenter y-position [column #]", 1);
       // Cluster width on the x-axis
       hid = theHistogramId->setHistoId("sizeX", id_);
@@ -134,19 +130,15 @@ void SiPixelClusterModule::book(const edm::ParameterSet &iConfig,
       hid = theHistogramId->setHistoId("hitmap", id_);
       if (twoD) {
         // 2D hit map
-        mePixClusters_ =
-            iBooker.book2D(hid, "Number of Clusters (1bin=four pixels)", nbinx,
-                           0., float(ncols_), nbiny, 0., float(nrows_));
+        mePixClusters_ = iBooker.book2D(
+            hid, "Number of Clusters (1bin=four pixels)", nbinx, 0., float(ncols_), nbiny, 0., float(nrows_));
         mePixClusters_->setAxisTitle("Columns", 1);
         mePixClusters_->setAxisTitle("Rows", 2);
       } else {
         // projections of hitmap
         mePixClusters_px_ =
-            iBooker.book1D(hid + "_px", "Number of Clusters (1bin=two columns)",
-                           nbinx, 0., float(ncols_));
-        mePixClusters_py_ =
-            iBooker.book1D(hid + "_py", "Number of Clusters (1bin=two rows)",
-                           nbiny, 0., float(nrows_));
+            iBooker.book1D(hid + "_px", "Number of Clusters (1bin=two columns)", nbinx, 0., float(ncols_));
+        mePixClusters_py_ = iBooker.book1D(hid + "_py", "Number of Clusters (1bin=two rows)", nbiny, 0., float(nrows_));
         mePixClusters_px_->setAxisTitle("Columns", 1);
         mePixClusters_py_->setAxisTitle("Rows", 1);
       }
@@ -157,13 +149,10 @@ void SiPixelClusterModule::book(const edm::ParameterSet &iConfig,
   //**
   if (barrel && type == 7) {
     hid = src.label() + "_Barrel";
-    meSizeYvsEtaBarrel_ =
-        iBooker.book2D("sizeYvsEta_" + hid,
-                       "Cluster size along beamline vs. Cluster position #eta",
-                       60, -3., 3., 40, 0., 40.);
+    meSizeYvsEtaBarrel_ = iBooker.book2D(
+        "sizeYvsEta_" + hid, "Cluster size along beamline vs. Cluster position #eta", 60, -3., 3., 40, 0., 40.);
     meSizeYvsEtaBarrel_->setAxisTitle("Cluster #eta", 1);
-    meSizeYvsEtaBarrel_->setAxisTitle(
-        "Cluster size along beamline [number of pixels]", 2);
+    meSizeYvsEtaBarrel_->setAxisTitle("Cluster size along beamline [number of pixels]", 2);
   }
   if (type == 1 && barrel) {
     uint32_t DBladder;
@@ -176,65 +165,57 @@ void SiPixelClusterModule::book(const edm::ParameterSet &iConfig,
     else
       hid += "F";
     // Number of clusters
-    meNClustersLad_ =
-        iBooker.book1D("nclusters_" + hid, "Number of Clusters", 8, 0., 8.);
+    meNClustersLad_ = iBooker.book1D("nclusters_" + hid, "Number of Clusters", 8, 0., 8.);
     meNClustersLad_->setAxisTitle("Number of Clusters", 1);
     // Total cluster charge in MeV
-    meChargeLad_ =
-        iBooker.book1D("charge_" + hid, "Cluster charge", 100, 0., 200.);
+    meChargeLad_ = iBooker.book1D("charge_" + hid, "Cluster charge", 100, 0., 200.);
     meChargeLad_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
-    meSizeLad_ =
-        iBooker.book1D("size_" + hid, "Total cluster size", 30, 0., 30.);
+    meSizeLad_ = iBooker.book1D("size_" + hid, "Total cluster size", 30, 0., 30.);
     meSizeLad_->setAxisTitle("Cluster size [number of pixels]", 1);
     if (!reducedSet) {
       // Lowest cluster row
-      meMinRowLad_ =
-          iBooker.book1D("minrow_" + hid, "Lowest cluster row", 200, 0., 200.);
+      meMinRowLad_ = iBooker.book1D("minrow_" + hid, "Lowest cluster row", 200, 0., 200.);
       meMinRowLad_->setAxisTitle("Lowest cluster row", 1);
       // Highest cluster row
-      meMaxRowLad_ =
-          iBooker.book1D("maxrow_" + hid, "Highest cluster row", 200, 0., 200.);
+      meMaxRowLad_ = iBooker.book1D("maxrow_" + hid, "Highest cluster row", 200, 0., 200.);
       meMaxRowLad_->setAxisTitle("Highest cluster row", 1);
       // Lowest cluster column
-      meMinColLad_ = iBooker.book1D("mincol_" + hid, "Lowest cluster column",
-                                    500, 0., 500.);
+      meMinColLad_ = iBooker.book1D("mincol_" + hid, "Lowest cluster column", 500, 0., 500.);
       meMinColLad_->setAxisTitle("Lowest cluster column", 1);
       // Highest cluster column
-      meMaxColLad_ = iBooker.book1D("maxcol_" + hid, "Highest cluster column",
-                                    500, 0., 500.);
+      meMaxColLad_ = iBooker.book1D("maxcol_" + hid, "Highest cluster column", 500, 0., 500.);
       meMaxColLad_->setAxisTitle("Highest cluster column", 1);
       // Cluster barycenter X position
-      meXLad_ = iBooker.book1D("x_" + hid, "Cluster barycenter X (row #)", 200,
-                               0., 200.);
+      meXLad_ = iBooker.book1D("x_" + hid, "Cluster barycenter X (row #)", 200, 0., 200.);
       meXLad_->setAxisTitle("Barycenter x-position [row #]", 1);
       // Cluster barycenter Y position
-      meYLad_ = iBooker.book1D("y_" + hid, "Cluster barycenter Y (column #)",
-                               500, 0., 500.);
+      meYLad_ = iBooker.book1D("y_" + hid, "Cluster barycenter Y (column #)", 500, 0., 500.);
       meYLad_->setAxisTitle("Barycenter y-position [column #]", 1);
       // Cluster width on the x-axis
-      meSizeXLad_ =
-          iBooker.book1D("sizeX_" + hid, "Cluster x-width (rows)", 10, 0., 10.);
+      meSizeXLad_ = iBooker.book1D("sizeX_" + hid, "Cluster x-width (rows)", 10, 0., 10.);
       meSizeXLad_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
-      meSizeYLad_ = iBooker.book1D("sizeY_" + hid, "Cluster y-width (columns)",
-                                   15, 0., 15.);
+      meSizeYLad_ = iBooker.book1D("sizeY_" + hid, "Cluster y-width (columns)", 15, 0., 15.);
       meSizeYLad_->setAxisTitle("Cluster y-size [columns]", 1);
       if (twoD) {
         // 2D hit map
-        mePixClustersLad_ = iBooker.book2D(
-            "hitmap_" + hid, "Number of Clusters (1bin=four pixels)", nbinx, 0.,
-            float(ncols_), nbiny, 0., float(nrows_));
+        mePixClustersLad_ = iBooker.book2D("hitmap_" + hid,
+                                           "Number of Clusters (1bin=four pixels)",
+                                           nbinx,
+                                           0.,
+                                           float(ncols_),
+                                           nbiny,
+                                           0.,
+                                           float(nrows_));
         mePixClustersLad_->setAxisTitle("Columns", 1);
         mePixClustersLad_->setAxisTitle("Rows", 2);
       } else {
         // projections of hitmap
-        mePixClustersLad_px_ = iBooker.book1D(
-            "hitmap_" + hid + "_px", "Number of Clusters (1bin=two columns)",
-            nbinx, 0., float(ncols_));
-        mePixClustersLad_py_ = iBooker.book1D(
-            "hitmap_" + hid + "_py", "Number of Clusters (1bin=two rows)",
-            nbiny, 0., float(nrows_));
+        mePixClustersLad_px_ =
+            iBooker.book1D("hitmap_" + hid + "_px", "Number of Clusters (1bin=two columns)", nbinx, 0., float(ncols_));
+        mePixClustersLad_py_ =
+            iBooker.book1D("hitmap_" + hid + "_py", "Number of Clusters (1bin=two rows)", nbiny, 0., float(nrows_));
         mePixClustersLad_px_->setAxisTitle("Columns", 1);
         mePixClustersLad_py_->setAxisTitle("Rows", 1);
       }
@@ -242,83 +223,78 @@ void SiPixelClusterModule::book(const edm::ParameterSet &iConfig,
   }
 
   if (type == 2 && barrel) {
-
     uint32_t DBlayer;
     DBlayer = PixelBarrelName(DetId(id_), pTT, isUpgrade).layerName();
     char slayer[80];
     sprintf(slayer, "Layer_%i", DBlayer);
     hid = src.label() + "_" + slayer;
     // Number of clusters
-    meNClustersLay_ =
-        iBooker.book1D("nclusters_" + hid, "Number of Clusters", 8, 0., 8.);
+    meNClustersLay_ = iBooker.book1D("nclusters_" + hid, "Number of Clusters", 8, 0., 8.);
     meNClustersLay_->setAxisTitle("Number of Clusters", 1);
     // Total cluster charge in MeV
-    meChargeLay_ =
-        iBooker.book1D("charge_" + hid, "Cluster charge", 100, 0., 200.);
+    meChargeLay_ = iBooker.book1D("charge_" + hid, "Cluster charge", 100, 0., 200.);
     meChargeLay_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
-    meSizeLay_ =
-        iBooker.book1D("size_" + hid, "Total cluster size", 30, 0., 30.);
+    meSizeLay_ = iBooker.book1D("size_" + hid, "Total cluster size", 30, 0., 30.);
     meSizeLay_->setAxisTitle("Cluster size [in pixels]", 1);
     if (!reducedSet) {
       // Lowest cluster row
-      meMinRowLay_ =
-          iBooker.book1D("minrow_" + hid, "Lowest cluster row", 200, 0., 200.);
+      meMinRowLay_ = iBooker.book1D("minrow_" + hid, "Lowest cluster row", 200, 0., 200.);
       meMinRowLay_->setAxisTitle("Lowest cluster row", 1);
       // Highest cluster row
-      meMaxRowLay_ =
-          iBooker.book1D("maxrow_" + hid, "Highest cluster row", 200, 0., 200.);
+      meMaxRowLay_ = iBooker.book1D("maxrow_" + hid, "Highest cluster row", 200, 0., 200.);
       meMaxRowLay_->setAxisTitle("Highest cluster row", 1);
       // Lowest cluster column
-      meMinColLay_ = iBooker.book1D("mincol_" + hid, "Lowest cluster column",
-                                    500, 0., 500.);
+      meMinColLay_ = iBooker.book1D("mincol_" + hid, "Lowest cluster column", 500, 0., 500.);
       meMinColLay_->setAxisTitle("Lowest cluster column", 1);
       // Highest cluster column
-      meMaxColLay_ = iBooker.book1D("maxcol_" + hid, "Highest cluster column",
-                                    500, 0., 500.);
+      meMaxColLay_ = iBooker.book1D("maxcol_" + hid, "Highest cluster column", 500, 0., 500.);
       meMaxColLay_->setAxisTitle("Highest cluster column", 1);
       // Cluster barycenter X position
-      meXLay_ = iBooker.book1D("x_" + hid, "Cluster barycenter X (row #)", 200,
-                               0., 200.);
+      meXLay_ = iBooker.book1D("x_" + hid, "Cluster barycenter X (row #)", 200, 0., 200.);
       meXLay_->setAxisTitle("Barycenter x-position [row #]", 1);
       // Cluster barycenter Y position
-      meYLay_ = iBooker.book1D("y_" + hid, "Cluster barycenter Y (column #)",
-                               500, 0., 500.);
+      meYLay_ = iBooker.book1D("y_" + hid, "Cluster barycenter Y (column #)", 500, 0., 500.);
       meYLay_->setAxisTitle("Barycenter y-position [column #]", 1);
       // Cluster width on the x-axis
-      meSizeXLay_ =
-          iBooker.book1D("sizeX_" + hid, "Cluster x-width (rows)", 10, 0., 10.);
+      meSizeXLay_ = iBooker.book1D("sizeX_" + hid, "Cluster x-width (rows)", 10, 0., 10.);
       meSizeXLay_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
-      meSizeYLay_ = iBooker.book1D("sizeY_" + hid, "Cluster y-width (columns)",
-                                   15, 0., 15.);
+      meSizeYLay_ = iBooker.book1D("sizeY_" + hid, "Cluster y-width (columns)", 15, 0., 15.);
       meSizeYLay_->setAxisTitle("Cluster y-size [columns]", 1);
       if (twoD) {
         // 2D hit map
         if (isHalfModule) {
-          mePixClustersLay_ = iBooker.book2D(
-              "hitmap_" + hid, "Number of Clusters (1bin=four pixels)", nbinx,
-              0., float(ncols_), 2 * nbiny, 0., float(2 * nrows_));
+          mePixClustersLay_ = iBooker.book2D("hitmap_" + hid,
+                                             "Number of Clusters (1bin=four pixels)",
+                                             nbinx,
+                                             0.,
+                                             float(ncols_),
+                                             2 * nbiny,
+                                             0.,
+                                             float(2 * nrows_));
         } else {
-          mePixClustersLay_ = iBooker.book2D(
-              "hitmap_" + hid, "Number of Clusters (1bin=four pixels)", nbinx,
-              0., float(ncols_), nbiny, 0., float(nrows_));
+          mePixClustersLay_ = iBooker.book2D("hitmap_" + hid,
+                                             "Number of Clusters (1bin=four pixels)",
+                                             nbinx,
+                                             0.,
+                                             float(ncols_),
+                                             nbiny,
+                                             0.,
+                                             float(nrows_));
         }
         mePixClustersLay_->setAxisTitle("Columns", 1);
         mePixClustersLay_->setAxisTitle("Rows", 2);
       } else {
         // projections of hitmap
-        mePixClustersLay_px_ = iBooker.book1D(
-            "hitmap_" + hid + "_px", "Number of Clusters (1bin=two columns)",
-            nbinx, 0., float(ncols_));
+        mePixClustersLay_px_ =
+            iBooker.book1D("hitmap_" + hid + "_px", "Number of Clusters (1bin=two columns)", nbinx, 0., float(ncols_));
         if (isHalfModule) {
           mePixClustersLay_py_ = iBooker.book1D(
-              "hitmap_" + hid + "_py", "Number of Clusters (1bin=two rows)",
-              2 * nbiny, 0., float(2 * nrows_));
+              "hitmap_" + hid + "_py", "Number of Clusters (1bin=two rows)", 2 * nbiny, 0., float(2 * nrows_));
         } else {
-          mePixClustersLay_py_ = iBooker.book1D(
-              "hitmap_" + hid + "_py", "Number of Clusters (1bin=two rows)",
-              nbiny, 0., float(nrows_));
+          mePixClustersLay_py_ =
+              iBooker.book1D("hitmap_" + hid + "_py", "Number of Clusters (1bin=two rows)", nbiny, 0., float(nrows_));
         }
         mePixClustersLay_px_->setAxisTitle("Columns", 1);
         mePixClustersLay_py_->setAxisTitle("Rows", 1);
@@ -332,76 +308,72 @@ void SiPixelClusterModule::book(const edm::ParameterSet &iConfig,
     sprintf(smodule, "Ring_%i", DBmodule);
     hid = src.label() + "_" + smodule;
     // Number of clusters
-    meNClustersPhi_ =
-        iBooker.book1D("nclusters_" + hid, "Number of Clusters", 8, 0., 8.);
+    meNClustersPhi_ = iBooker.book1D("nclusters_" + hid, "Number of Clusters", 8, 0., 8.);
     meNClustersPhi_->setAxisTitle("Number of Clusters", 1);
     // Total cluster charge in MeV
-    meChargePhi_ =
-        iBooker.book1D("charge_" + hid, "Cluster charge", 100, 0., 200.);
+    meChargePhi_ = iBooker.book1D("charge_" + hid, "Cluster charge", 100, 0., 200.);
     meChargePhi_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
-    meSizePhi_ =
-        iBooker.book1D("size_" + hid, "Total cluster size", 30, 0., 30.);
+    meSizePhi_ = iBooker.book1D("size_" + hid, "Total cluster size", 30, 0., 30.);
     meSizePhi_->setAxisTitle("Cluster size [number of pixels]", 1);
     if (!reducedSet) {
       // Lowest cluster row
-      meMinRowPhi_ =
-          iBooker.book1D("minrow_" + hid, "Lowest cluster row", 200, 0., 200.);
+      meMinRowPhi_ = iBooker.book1D("minrow_" + hid, "Lowest cluster row", 200, 0., 200.);
       meMinRowPhi_->setAxisTitle("Lowest cluster row", 1);
       // Highest cluster row
-      meMaxRowPhi_ =
-          iBooker.book1D("maxrow_" + hid, "Highest cluster row", 200, 0., 200.);
+      meMaxRowPhi_ = iBooker.book1D("maxrow_" + hid, "Highest cluster row", 200, 0., 200.);
       meMaxRowPhi_->setAxisTitle("Highest cluster row", 1);
       // Lowest cluster column
-      meMinColPhi_ = iBooker.book1D("mincol_" + hid, "Lowest cluster column",
-                                    500, 0., 500.);
+      meMinColPhi_ = iBooker.book1D("mincol_" + hid, "Lowest cluster column", 500, 0., 500.);
       meMinColPhi_->setAxisTitle("Lowest cluster column", 1);
       // Highest cluster column
-      meMaxColPhi_ = iBooker.book1D("maxcol_" + hid, "Highest cluster column",
-                                    500, 0., 500.);
+      meMaxColPhi_ = iBooker.book1D("maxcol_" + hid, "Highest cluster column", 500, 0., 500.);
       meMaxColPhi_->setAxisTitle("Highest cluster column", 1);
       // Cluster barycenter X position
-      meXPhi_ = iBooker.book1D("x_" + hid, "Cluster barycenter X (row #)", 200,
-                               0., 200.);
+      meXPhi_ = iBooker.book1D("x_" + hid, "Cluster barycenter X (row #)", 200, 0., 200.);
       meXPhi_->setAxisTitle("Barycenter x-position [row #]", 1);
       // Cluster barycenter Y position
-      meYPhi_ = iBooker.book1D("y_" + hid, "Cluster barycenter Y (column #)",
-                               500, 0., 500.);
+      meYPhi_ = iBooker.book1D("y_" + hid, "Cluster barycenter Y (column #)", 500, 0., 500.);
       meYPhi_->setAxisTitle("Barycenter y-position [column #]", 1);
       // Cluster width on the x-axis
-      meSizeXPhi_ =
-          iBooker.book1D("sizeX_" + hid, "Cluster x-width (rows)", 10, 0., 10.);
+      meSizeXPhi_ = iBooker.book1D("sizeX_" + hid, "Cluster x-width (rows)", 10, 0., 10.);
       meSizeXPhi_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
-      meSizeYPhi_ = iBooker.book1D("sizeY_" + hid, "Cluster y-width (columns)",
-                                   15, 0., 15.);
+      meSizeYPhi_ = iBooker.book1D("sizeY_" + hid, "Cluster y-width (columns)", 15, 0., 15.);
       meSizeYPhi_->setAxisTitle("Cluster y-size [columns]", 1);
       if (twoD) {
         // 2D hit map
         if (isHalfModule) {
-          mePixClustersPhi_ = iBooker.book2D(
-              "hitmap_" + hid, "Number of Clusters (1bin=four pixels)", nbinx,
-              0., float(ncols_), 2 * nbiny, 0., float(2 * nrows_));
+          mePixClustersPhi_ = iBooker.book2D("hitmap_" + hid,
+                                             "Number of Clusters (1bin=four pixels)",
+                                             nbinx,
+                                             0.,
+                                             float(ncols_),
+                                             2 * nbiny,
+                                             0.,
+                                             float(2 * nrows_));
         } else {
-          mePixClustersPhi_ = iBooker.book2D(
-              "hitmap_" + hid, "Number of Clusters (1bin=four pixels)", nbinx,
-              0., float(ncols_), nbiny, 0., float(nrows_));
+          mePixClustersPhi_ = iBooker.book2D("hitmap_" + hid,
+                                             "Number of Clusters (1bin=four pixels)",
+                                             nbinx,
+                                             0.,
+                                             float(ncols_),
+                                             nbiny,
+                                             0.,
+                                             float(nrows_));
         }
         mePixClustersPhi_->setAxisTitle("Columns", 1);
         mePixClustersPhi_->setAxisTitle("Rows", 2);
       } else {
         // projections of hitmap
-        mePixClustersPhi_px_ = iBooker.book1D(
-            "hitmap_" + hid + "_px", "Number of Clusters (1bin=two columns)",
-            nbinx, 0., float(ncols_));
+        mePixClustersPhi_px_ =
+            iBooker.book1D("hitmap_" + hid + "_px", "Number of Clusters (1bin=two columns)", nbinx, 0., float(ncols_));
         if (isHalfModule) {
           mePixClustersPhi_py_ = iBooker.book1D(
-              "hitmap_" + hid + "_py", "Number of Clusters (1bin=two rows)",
-              2 * nbiny, 0., float(2 * nrows_));
+              "hitmap_" + hid + "_py", "Number of Clusters (1bin=two rows)", 2 * nbiny, 0., float(2 * nrows_));
         } else {
-          mePixClustersPhi_py_ = iBooker.book1D(
-              "hitmap_" + hid + "_py", "Number of Clusters (1bin=two rows)",
-              nbiny, 0., float(nrows_));
+          mePixClustersPhi_py_ =
+              iBooker.book1D("hitmap_" + hid + "_py", "Number of Clusters (1bin=two rows)", nbiny, 0., float(nrows_));
         }
         mePixClustersPhi_px_->setAxisTitle("Columns", 1);
         mePixClustersPhi_py_->setAxisTitle("Rows", 1);
@@ -417,49 +389,38 @@ void SiPixelClusterModule::book(const edm::ParameterSet &iConfig,
     sprintf(sblade, "Blade_%02i", blade);
     hid = src.label() + "_" + sblade;
     // Number of clusters
-    meNClustersBlade_ =
-        iBooker.book1D("nclusters_" + hid, "Number of Clusters", 8, 0., 8.);
+    meNClustersBlade_ = iBooker.book1D("nclusters_" + hid, "Number of Clusters", 8, 0., 8.);
     meNClustersBlade_->setAxisTitle("Number of Clusters", 1);
     // Total cluster charge in MeV
-    meChargeBlade_ =
-        iBooker.book1D("charge_" + hid, "Cluster charge", 100, 0., 200.);
+    meChargeBlade_ = iBooker.book1D("charge_" + hid, "Cluster charge", 100, 0., 200.);
     meChargeBlade_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
-    meSizeBlade_ =
-        iBooker.book1D("size_" + hid, "Total cluster size", 30, 0., 30.);
+    meSizeBlade_ = iBooker.book1D("size_" + hid, "Total cluster size", 30, 0., 30.);
     meSizeBlade_->setAxisTitle("Cluster size [number of pixels]", 1);
     if (!reducedSet) {
       // Lowest cluster row
-      meMinRowBlade_ =
-          iBooker.book1D("minrow_" + hid, "Lowest cluster row", 200, 0., 200.);
+      meMinRowBlade_ = iBooker.book1D("minrow_" + hid, "Lowest cluster row", 200, 0., 200.);
       meMinRowBlade_->setAxisTitle("Lowest cluster row", 1);
       // Highest cluster row
-      meMaxRowBlade_ =
-          iBooker.book1D("maxrow_" + hid, "Highest cluster row", 200, 0., 200.);
+      meMaxRowBlade_ = iBooker.book1D("maxrow_" + hid, "Highest cluster row", 200, 0., 200.);
       meMaxRowBlade_->setAxisTitle("Highest cluster row", 1);
       // Lowest cluster column
-      meMinColBlade_ = iBooker.book1D("mincol_" + hid, "Lowest cluster column",
-                                      500, 0., 500.);
+      meMinColBlade_ = iBooker.book1D("mincol_" + hid, "Lowest cluster column", 500, 0., 500.);
       meMinColBlade_->setAxisTitle("Lowest cluster column", 1);
       // Highest cluster column
-      meMaxColBlade_ = iBooker.book1D("maxcol_" + hid, "Highest cluster column",
-                                      500, 0., 500.);
+      meMaxColBlade_ = iBooker.book1D("maxcol_" + hid, "Highest cluster column", 500, 0., 500.);
       meMaxColBlade_->setAxisTitle("Highest cluster column", 1);
       // Cluster barycenter X position
-      meXBlade_ = iBooker.book1D("x_" + hid, "Cluster barycenter X (row #)",
-                                 200, 0., 200.);
+      meXBlade_ = iBooker.book1D("x_" + hid, "Cluster barycenter X (row #)", 200, 0., 200.);
       meXBlade_->setAxisTitle("Barycenter x-position [row #]", 1);
       // Cluster barycenter Y position
-      meYBlade_ = iBooker.book1D("y_" + hid, "Cluster barycenter Y (column #)",
-                                 500, 0., 500.);
+      meYBlade_ = iBooker.book1D("y_" + hid, "Cluster barycenter Y (column #)", 500, 0., 500.);
       meYBlade_->setAxisTitle("Barycenter y-position [column #]", 1);
       // Cluster width on the x-axis
-      meSizeXBlade_ =
-          iBooker.book1D("sizeX_" + hid, "Cluster x-width (rows)", 10, 0., 10.);
+      meSizeXBlade_ = iBooker.book1D("sizeX_" + hid, "Cluster x-width (rows)", 10, 0., 10.);
       meSizeXBlade_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
-      meSizeYBlade_ = iBooker.book1D("sizeY_" + hid,
-                                     "Cluster y-width (columns)", 15, 0., 15.);
+      meSizeYBlade_ = iBooker.book1D("sizeY_" + hid, "Cluster y-width (columns)", 15, 0., 15.);
       meSizeYBlade_->setAxisTitle("Cluster y-size [columns]", 1);
     }
   }
@@ -471,49 +432,38 @@ void SiPixelClusterModule::book(const edm::ParameterSet &iConfig,
     sprintf(sdisk, "Disk_%i", disk);
     hid = src.label() + "_" + sdisk;
     // Number of clusters
-    meNClustersDisk_ =
-        iBooker.book1D("nclusters_" + hid, "Number of Clusters", 8, 0., 8.);
+    meNClustersDisk_ = iBooker.book1D("nclusters_" + hid, "Number of Clusters", 8, 0., 8.);
     meNClustersDisk_->setAxisTitle("Number of Clusters", 1);
     // Total cluster charge in MeV
-    meChargeDisk_ =
-        iBooker.book1D("charge_" + hid, "Cluster charge", 100, 0., 200.);
+    meChargeDisk_ = iBooker.book1D("charge_" + hid, "Cluster charge", 100, 0., 200.);
     meChargeDisk_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
-    meSizeDisk_ =
-        iBooker.book1D("size_" + hid, "Total cluster size", 30, 0., 30.);
+    meSizeDisk_ = iBooker.book1D("size_" + hid, "Total cluster size", 30, 0., 30.);
     meSizeDisk_->setAxisTitle("Cluster size [number of pixels]", 1);
     if (!reducedSet) {
       // Lowest cluster row
-      meMinRowDisk_ =
-          iBooker.book1D("minrow_" + hid, "Lowest cluster row", 200, 0., 200.);
+      meMinRowDisk_ = iBooker.book1D("minrow_" + hid, "Lowest cluster row", 200, 0., 200.);
       meMinRowDisk_->setAxisTitle("Lowest cluster row", 1);
       // Highest cluster row
-      meMaxRowDisk_ =
-          iBooker.book1D("maxrow_" + hid, "Highest cluster row", 200, 0., 200.);
+      meMaxRowDisk_ = iBooker.book1D("maxrow_" + hid, "Highest cluster row", 200, 0., 200.);
       meMaxRowDisk_->setAxisTitle("Highest cluster row", 1);
       // Lowest cluster column
-      meMinColDisk_ = iBooker.book1D("mincol_" + hid, "Lowest cluster column",
-                                     500, 0., 500.);
+      meMinColDisk_ = iBooker.book1D("mincol_" + hid, "Lowest cluster column", 500, 0., 500.);
       meMinColDisk_->setAxisTitle("Lowest cluster column", 1);
       // Highest cluster column
-      meMaxColDisk_ = iBooker.book1D("maxcol_" + hid, "Highest cluster column",
-                                     500, 0., 500.);
+      meMaxColDisk_ = iBooker.book1D("maxcol_" + hid, "Highest cluster column", 500, 0., 500.);
       meMaxColDisk_->setAxisTitle("Highest cluster column", 1);
       // Cluster barycenter X position
-      meXDisk_ = iBooker.book1D("x_" + hid, "Cluster barycenter X (row #)", 200,
-                                0., 200.);
+      meXDisk_ = iBooker.book1D("x_" + hid, "Cluster barycenter X (row #)", 200, 0., 200.);
       meXDisk_->setAxisTitle("Barycenter x-position [row #]", 1);
       // Cluster barycenter Y position
-      meYDisk_ = iBooker.book1D("y_" + hid, "Cluster barycenter Y (column #)",
-                                500, 0., 500.);
+      meYDisk_ = iBooker.book1D("y_" + hid, "Cluster barycenter Y (column #)", 500, 0., 500.);
       meYDisk_->setAxisTitle("Barycenter y-position [column #]", 1);
       // Cluster width on the x-axis
-      meSizeXDisk_ =
-          iBooker.book1D("sizeX_" + hid, "Cluster x-width (rows)", 10, 0., 10.);
+      meSizeXDisk_ = iBooker.book1D("sizeX_" + hid, "Cluster x-width (rows)", 10, 0., 10.);
       meSizeXDisk_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
-      meSizeYDisk_ = iBooker.book1D("sizeY_" + hid, "Cluster y-width (columns)",
-                                    15, 0., 15.);
+      meSizeYDisk_ = iBooker.book1D("sizeY_" + hid, "Cluster y-width (columns)", 15, 0., 15.);
       meSizeYDisk_->setAxisTitle("Cluster y-size [columns]", 1);
     }
   }
@@ -528,65 +478,57 @@ void SiPixelClusterModule::book(const edm::ParameterSet &iConfig,
     sprintf(slab, "Panel_%i_Ring_%i", panel, module);
     hid = src.label() + "_" + slab;
     // Number of clusters
-    meNClustersRing_ =
-        iBooker.book1D("nclusters_" + hid, "Number of Clusters", 8, 0., 8.);
+    meNClustersRing_ = iBooker.book1D("nclusters_" + hid, "Number of Clusters", 8, 0., 8.);
     meNClustersRing_->setAxisTitle("Number of Clusters", 1);
     // Total cluster charge in MeV
-    meChargeRing_ =
-        iBooker.book1D("charge_" + hid, "Cluster charge", 100, 0., 200.);
+    meChargeRing_ = iBooker.book1D("charge_" + hid, "Cluster charge", 100, 0., 200.);
     meChargeRing_->setAxisTitle("Charge [kilo electrons]", 1);
     // Total cluster size (in pixels)
-    meSizeRing_ =
-        iBooker.book1D("size_" + hid, "Total cluster size", 30, 0., 30.);
+    meSizeRing_ = iBooker.book1D("size_" + hid, "Total cluster size", 30, 0., 30.);
     meSizeRing_->setAxisTitle("Cluster size [number of pixels]", 1);
     if (!reducedSet) {
       // Lowest cluster row
-      meMinRowRing_ =
-          iBooker.book1D("minrow_" + hid, "Lowest cluster row", 200, 0., 200.);
+      meMinRowRing_ = iBooker.book1D("minrow_" + hid, "Lowest cluster row", 200, 0., 200.);
       meMinRowRing_->setAxisTitle("Lowest cluster row", 1);
       // Highest cluster row
-      meMaxRowRing_ =
-          iBooker.book1D("maxrow_" + hid, "Highest cluster row", 200, 0., 200.);
+      meMaxRowRing_ = iBooker.book1D("maxrow_" + hid, "Highest cluster row", 200, 0., 200.);
       meMaxRowRing_->setAxisTitle("Highest cluster row", 1);
       // Lowest cluster column
-      meMinColRing_ = iBooker.book1D("mincol_" + hid, "Lowest cluster column",
-                                     500, 0., 500.);
+      meMinColRing_ = iBooker.book1D("mincol_" + hid, "Lowest cluster column", 500, 0., 500.);
       meMinColRing_->setAxisTitle("Lowest cluster column", 1);
       // Highest cluster column
-      meMaxColRing_ = iBooker.book1D("maxcol_" + hid, "Highest cluster column",
-                                     500, 0., 500.);
+      meMaxColRing_ = iBooker.book1D("maxcol_" + hid, "Highest cluster column", 500, 0., 500.);
       meMaxColRing_->setAxisTitle("Highest cluster column", 1);
       // Cluster barycenter X position
-      meXRing_ = iBooker.book1D("x_" + hid, "Cluster barycenter X (row #)", 200,
-                                0., 200.);
+      meXRing_ = iBooker.book1D("x_" + hid, "Cluster barycenter X (row #)", 200, 0., 200.);
       meXRing_->setAxisTitle("Barycenter x-position [row #]", 1);
       // Cluster barycenter Y position
-      meYRing_ = iBooker.book1D("y_" + hid, "Cluster barycenter Y (column #)",
-                                500, 0., 500.);
+      meYRing_ = iBooker.book1D("y_" + hid, "Cluster barycenter Y (column #)", 500, 0., 500.);
       meYRing_->setAxisTitle("Barycenter y-position [column #]", 1);
       // Cluster width on the x-axis
-      meSizeXRing_ =
-          iBooker.book1D("sizeX_" + hid, "Cluster x-width (rows)", 10, 0., 10.);
+      meSizeXRing_ = iBooker.book1D("sizeX_" + hid, "Cluster x-width (rows)", 10, 0., 10.);
       meSizeXRing_->setAxisTitle("Cluster x-size [rows]", 1);
       // Cluster width on the y-axis
-      meSizeYRing_ = iBooker.book1D("sizeY_" + hid, "Cluster y-width (columns)",
-                                    15, 0., 15.);
+      meSizeYRing_ = iBooker.book1D("sizeY_" + hid, "Cluster y-width (columns)", 15, 0., 15.);
       meSizeYRing_->setAxisTitle("Cluster y-size [columns]", 1);
       if (twoD) {
         // 2D hit map
-        mePixClustersRing_ = iBooker.book2D(
-            "hitmap_" + hid, "Number of Clusters (1bin=four pixels)", nbinx, 0.,
-            float(ncols_), nbiny, 0., float(nrows_));
+        mePixClustersRing_ = iBooker.book2D("hitmap_" + hid,
+                                            "Number of Clusters (1bin=four pixels)",
+                                            nbinx,
+                                            0.,
+                                            float(ncols_),
+                                            nbiny,
+                                            0.,
+                                            float(nrows_));
         mePixClustersRing_->setAxisTitle("Columns", 1);
         mePixClustersRing_->setAxisTitle("Rows", 2);
       } else {
         // projections of hitmap
-        mePixClustersRing_px_ = iBooker.book1D(
-            "hitmap_" + hid + "_px", "Number of Clusters (1bin=two columns)",
-            nbinx, 0., float(ncols_));
-        mePixClustersRing_py_ = iBooker.book1D(
-            "hitmap_" + hid + "_py", "Number of Clusters (1bin=two rows)",
-            nbiny, 0., float(nrows_));
+        mePixClustersRing_px_ =
+            iBooker.book1D("hitmap_" + hid + "_px", "Number of Clusters (1bin=two columns)", nbinx, 0., float(ncols_));
+        mePixClustersRing_py_ =
+            iBooker.book1D("hitmap_" + hid + "_py", "Number of Clusters (1bin=two rows)", nbiny, 0., float(nrows_));
         mePixClustersRing_px_->setAxisTitle("Columns", 1);
         mePixClustersRing_py_->setAxisTitle("Rows", 1);
       }
@@ -596,27 +538,33 @@ void SiPixelClusterModule::book(const edm::ParameterSet &iConfig,
 //
 // Fill histograms
 //
-int SiPixelClusterModule::fill(
-    const edmNew::DetSetVector<SiPixelCluster> &input,
-    const TrackerGeometry *tracker, int *barrelClusterTotal,
-    int *fpixPClusterTotal, int *fpixMClusterTotal,
-    std::vector<MonitorElement *> &layers,
-    std::vector<MonitorElement *> &diskspz,
-    std::vector<MonitorElement *> &disksmz, bool modon, bool ladon, bool layon,
-    bool phion, bool bladeon, bool diskon, bool ringon, bool twoD,
-    bool reducedSet, bool smileyon, bool isUpgrade) {
+int SiPixelClusterModule::fill(const edmNew::DetSetVector<SiPixelCluster> &input,
+                               const TrackerGeometry *tracker,
+                               int *barrelClusterTotal,
+                               int *fpixPClusterTotal,
+                               int *fpixMClusterTotal,
+                               std::vector<MonitorElement *> &layers,
+                               std::vector<MonitorElement *> &diskspz,
+                               std::vector<MonitorElement *> &disksmz,
+                               bool modon,
+                               bool ladon,
+                               bool layon,
+                               bool phion,
+                               bool bladeon,
+                               bool diskon,
+                               bool ringon,
+                               bool twoD,
+                               bool reducedSet,
+                               bool smileyon,
+                               bool isUpgrade) {
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
 
-  bool barrel =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
-  bool endcap =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
-
-  edmNew::DetSetVector<SiPixelCluster>::const_iterator isearch =
-      input.find(id_); // search  clusters of detid
+  edmNew::DetSetVector<SiPixelCluster>::const_iterator isearch = input.find(id_);  // search  clusters of detid
   unsigned int numberOfClusters = 0;
   unsigned int numberOfFpixClusters = 0;
 
-  if (isearch != input.end()) { // Not an empty iterator
+  if (isearch != input.end()) {  // Not an empty iterator
 
     // Look at clusters now
     edmNew::DetSet<SiPixelCluster>::const_iterator di;
@@ -626,19 +574,18 @@ int SiPixelClusterModule::fill(
         numberOfFpixClusters++;
       if (barrel)
         (*barrelClusterTotal)++;
-      float charge = 0.001 * (di->charge()); // total charge of cluster
-      float x = di->x();                     // barycenter x position
-      float y = di->y();                     // barycenter y position
-      int size = di->size();               // total size of cluster (in pixels)
-      int sizeX = di->sizeX();             // size of cluster in x-direction
-      int sizeY = di->sizeY();             // size of cluster in y-direction
-      int minPixelRow = di->minPixelRow(); // min x index
-      int maxPixelRow = di->maxPixelRow(); // max x index
-      int minPixelCol = di->minPixelCol(); // min y index
-      int maxPixelCol = di->maxPixelCol(); // max y index
+      float charge = 0.001 * (di->charge());  // total charge of cluster
+      float x = di->x();                      // barycenter x position
+      float y = di->y();                      // barycenter y position
+      int size = di->size();                  // total size of cluster (in pixels)
+      int sizeX = di->sizeX();                // size of cluster in x-direction
+      int sizeY = di->sizeY();                // size of cluster in y-direction
+      int minPixelRow = di->minPixelRow();    // min x index
+      int maxPixelRow = di->maxPixelRow();    // max x index
+      int minPixelCol = di->minPixelCol();    // min y index
+      int maxPixelCol = di->maxPixelCol();    // max y index
 
-      const PixelGeomDetUnit *theGeomDet =
-          dynamic_cast<const PixelGeomDetUnit *>(tracker->idToDet(DetId(id_)));
+      const PixelGeomDetUnit *theGeomDet = dynamic_cast<const PixelGeomDetUnit *>(tracker->idToDet(DetId(id_)));
 
       const PixelTopology *topol = &(theGeomDet->specificTopology());
       LocalPoint clustlp = topol->localPosition(MeasurementPoint(x, y));
@@ -649,13 +596,11 @@ int SiPixelClusterModule::fill(
         meSize_->Fill((float)size);
 
       if (barrel) {
-        uint32_t DBlayer =
-            PixelBarrelName(DetId(id_), pTT, isUpgrade).layerName();
+        uint32_t DBlayer = PixelBarrelName(DetId(id_), pTT, isUpgrade).layerName();
         if (!(DBlayer > layers.size()) && (layers[DBlayer - 1]))
           layers[DBlayer - 1]->Fill(clustgp.z(), clustgp.phi());
       } else if (endcap) {
-        uint32_t DBdisk =
-            PixelEndcapName(DetId(id_), pTT, isUpgrade).diskName();
+        uint32_t DBdisk = PixelEndcapName(DetId(id_), pTT, isUpgrade).diskName();
         if (clustgp.z() > 0) {
           (*fpixPClusterTotal)++;
           if (!(DBdisk > diskspz.size()) && (diskspz[DBdisk - 1]))

--- a/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
+++ b/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
@@ -46,7 +46,8 @@ using namespace std;
 using namespace edm;
 
 SiPixelClusterSource::SiPixelClusterSource(const edm::ParameterSet &iConfig)
-    : conf_(iConfig), src_(conf_.getParameter<edm::InputTag>("src")),
+    : conf_(iConfig),
+      src_(conf_.getParameter<edm::InputTag>("src")),
       digisrc_(conf_.getParameter<edm::InputTag>("digisrc")),
       saveFile(conf_.getUntrackedParameter<bool>("saveFile", false)),
       isPIB(conf_.getUntrackedParameter<bool>("isPIB", false)),
@@ -63,16 +64,13 @@ SiPixelClusterSource::SiPixelClusterSource(const edm::ParameterSet &iConfig)
       smileyOn(conf_.getUntrackedParameter<bool>("smileyOn", false)),
       bigEventSize(conf_.getUntrackedParameter<int>("bigEventSize", 100)),
       isUpgrade(conf_.getUntrackedParameter<bool>("isUpgrade", false)),
-      noOfLayers(0), noOfDisks(0) {
-  LogInfo("PixelDQM")
-      << "SiPixelClusterSource::SiPixelClusterSource: Got DQM BackEnd interface"
-      << endl;
+      noOfLayers(0),
+      noOfDisks(0) {
+  LogInfo("PixelDQM") << "SiPixelClusterSource::SiPixelClusterSource: Got DQM BackEnd interface" << endl;
 
   // set Token(-s)
-  srcToken_ = consumes<edmNew::DetSetVector<SiPixelCluster>>(
-      conf_.getParameter<edm::InputTag>("src"));
-  digisrcToken_ = consumes<edm::DetSetVector<PixelDigi>>(
-      conf_.getParameter<edm::InputTag>("digisrc"));
+  srcToken_ = consumes<edmNew::DetSetVector<SiPixelCluster>>(conf_.getParameter<edm::InputTag>("src"));
+  digisrcToken_ = consumes<edm::DetSetVector<PixelDigi>>(conf_.getParameter<edm::InputTag>("digisrc"));
   firstRun = true;
   topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
 }
@@ -80,28 +78,21 @@ SiPixelClusterSource::SiPixelClusterSource(const edm::ParameterSet &iConfig)
 SiPixelClusterSource::~SiPixelClusterSource() {
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
-  LogInfo("PixelDQM")
-      << "SiPixelClusterSource::~SiPixelClusterSource: Destructor" << endl;
+  LogInfo("PixelDQM") << "SiPixelClusterSource::~SiPixelClusterSource: Destructor" << endl;
 
   std::map<uint32_t, SiPixelClusterModule *>::iterator struct_iter;
-  for (struct_iter = thePixelStructure.begin();
-       struct_iter != thePixelStructure.end(); struct_iter++) {
+  for (struct_iter = thePixelStructure.begin(); struct_iter != thePixelStructure.end(); struct_iter++) {
     delete struct_iter->second;
     struct_iter->second = nullptr;
   }
 }
 
-void SiPixelClusterSource::dqmBeginRun(const edm::Run &r,
-                                       const edm::EventSetup &iSetup) {
-  LogInfo("PixelDQM") << " SiPixelClusterSource::beginJob - Initialisation ... "
-                      << std::endl;
-  LogInfo("PixelDQM") << "Mod/Lad/Lay/Phi " << modOn << "/" << ladOn << "/"
-                      << layOn << "/" << phiOn << std::endl;
-  LogInfo("PixelDQM") << "Blade/Disk/Ring" << bladeOn << "/" << diskOn << "/"
-                      << ringOn << std::endl;
+void SiPixelClusterSource::dqmBeginRun(const edm::Run &r, const edm::EventSetup &iSetup) {
+  LogInfo("PixelDQM") << " SiPixelClusterSource::beginJob - Initialisation ... " << std::endl;
+  LogInfo("PixelDQM") << "Mod/Lad/Lay/Phi " << modOn << "/" << ladOn << "/" << layOn << "/" << phiOn << std::endl;
+  LogInfo("PixelDQM") << "Blade/Disk/Ring" << bladeOn << "/" << diskOn << "/" << ringOn << std::endl;
   LogInfo("PixelDQM") << "2DIM IS " << twoDimOn << "\n";
-  LogInfo("PixelDQM") << "Smiley (Cluster sizeY vs. Cluster eta) is "
-                      << smileyOn << "\n";
+  LogInfo("PixelDQM") << "Smiley (Cluster sizeY vs. Cluster eta) is " << smileyOn << "\n";
 
   if (firstRun) {
     eventNo = 0;
@@ -115,9 +106,7 @@ void SiPixelClusterSource::dqmBeginRun(const edm::Run &r,
   }
 }
 
-void SiPixelClusterSource::bookHistograms(DQMStore::IBooker &iBooker,
-                                          edm::Run const &,
-                                          const edm::EventSetup &iSetup) {
+void SiPixelClusterSource::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const &, const edm::EventSetup &iSetup) {
   bookMEs(iBooker, iSetup);
   // Book occupancy maps in global coordinates for all clusters:
   iBooker.setCurrentFolder(topFolderName_ + "/Clusters/OffTrack");
@@ -128,22 +117,19 @@ void SiPixelClusterSource::bookHistograms(DQMStore::IBooker &iBooker,
     ss1 << "position_siPixelClusters_Layer_" << i;
     ss2.str(std::string());
     ss2 << "Clusters Layer" << i << ";Global Z (cm);Global #phi";
-    meClPosLayer.push_back(
-        iBooker.book2D(ss1.str(), ss2.str(), 200, -30., 30., 128, -3.2, 3.2));
+    meClPosLayer.push_back(iBooker.book2D(ss1.str(), ss2.str(), 200, -30., 30., 128, -3.2, 3.2));
   }
   for (int i = 1; i <= noOfDisks; i++) {
     ss1.str(std::string());
     ss1 << "position_siPixelClusters_pz_Disk_" << i;
     ss2.str(std::string());
     ss2 << "Clusters +Z Disk" << i << ";Global X (cm);Global Y (cm)";
-    meClPosDiskpz.push_back(
-        iBooker.book2D(ss1.str(), ss2.str(), 80, -20., 20., 80, -20., 20.));
+    meClPosDiskpz.push_back(iBooker.book2D(ss1.str(), ss2.str(), 80, -20., 20., 80, -20., 20.));
     ss1.str(std::string());
     ss1 << "position_siPixelClusters_mz_Disk_" << i;
     ss2.str(std::string());
     ss2 << "Clusters -Z Disk" << i << ";Global X (cm);Global Y (cm)";
-    meClPosDiskmz.push_back(
-        iBooker.book2D(ss1.str(), ss2.str(), 80, -20., 20., 80, -20., 20.));
+    meClPosDiskmz.push_back(iBooker.book2D(ss1.str(), ss2.str(), 80, -20., 20., 80, -20., 20.));
   }
 
   // Book trend cluster plots for barrel and endcap. Lumisections for offline
@@ -153,8 +139,7 @@ void SiPixelClusterSource::bookHistograms(DQMStore::IBooker &iBooker,
   ss1 << "totalNumberOfClustersProfile_siPixelClusters_Barrel";
   ss2.str(std::string());
   ss2 << "Total number of barrel clusters profile;Lumisection;";
-  meClusBarrelProf =
-      iBooker.bookProfile(ss1.str(), ss2.str(), 2400, 0., 150, 0, 0, "");
+  meClusBarrelProf = iBooker.bookProfile(ss1.str(), ss2.str(), 2400, 0., 150, 0, 0, "");
   meClusBarrelProf->getTH1()->SetCanExtend(TH1::kAllAxes);
 
   iBooker.setCurrentFolder(topFolderName_ + "/Endcap");
@@ -163,16 +148,14 @@ void SiPixelClusterSource::bookHistograms(DQMStore::IBooker &iBooker,
   ss1 << "totalNumberOfClustersProfile_siPixelClusters_FPIX+";
   ss2.str(std::string());
   ss2 << "Total number of FPIX+ clusters profile;Lumisection;";
-  meClusFpixPProf =
-      iBooker.bookProfile(ss1.str(), ss2.str(), 2400, 0., 150, 0, 0, "");
+  meClusFpixPProf = iBooker.bookProfile(ss1.str(), ss2.str(), 2400, 0., 150, 0, 0, "");
   meClusFpixPProf->getTH1()->SetCanExtend(TH1::kAllAxes);
 
   ss1.str(std::string());
   ss1 << "totalNumberOfClustersProfile_siPixelClusters_FPIX-";
   ss2.str(std::string());
   ss2 << "Total number of FPIX- clusters profile;Lumisection;";
-  meClusFpixMProf =
-      iBooker.bookProfile(ss1.str(), ss2.str(), 2400, 0., 150, 0, 0, "");
+  meClusFpixMProf = iBooker.bookProfile(ss1.str(), ss2.str(), 2400, 0., 150, 0, 0, "");
   meClusFpixMProf->getTH1()->SetCanExtend(TH1::kAllAxes);
 
   iBooker.setCurrentFolder(topFolderName_ + "/Barrel");
@@ -204,16 +187,14 @@ void SiPixelClusterSource::bookHistograms(DQMStore::IBooker &iBooker,
     ss1 << "pix_bar Occ_roc_online_" + digisrc_.label() + "_layer_" << i;
     ss2.str(std::string());
     ss2 << "Pixel Barrel Occupancy, ROC level (Online): Layer " << i;
-    meZeroRocBPIX.push_back(
-        iBooker.book2D(ss1.str(), ss2.str(), 72, -4.5, 4.5, ybins, ymin, ymax));
+    meZeroRocBPIX.push_back(iBooker.book2D(ss1.str(), ss2.str(), 72, -4.5, 4.5, ybins, ymin, ymax));
     meZeroRocBPIX.at(i - 1)->setAxisTitle("ROC / Module", 1);
     meZeroRocBPIX.at(i - 1)->setAxisTitle("ROC / Ladder", 2);
   }
 
   iBooker.setCurrentFolder(topFolderName_ + "/Endcap");
-  meZeroRocFPIX = iBooker.book2D("ROC_endcap_occupancy",
-                                 "Pixel Endcap Occupancy, ROC level (Online)",
-                                 72, -4.5, 4.5, 288, -12.5, 12.5);
+  meZeroRocFPIX = iBooker.book2D(
+      "ROC_endcap_occupancy", "Pixel Endcap Occupancy, ROC level (Online)", 72, -4.5, 4.5, 288, -12.5, 12.5);
   meZeroRocFPIX->setBinLabel(1, "Disk-2 Pnl2", 1);
   meZeroRocFPIX->setBinLabel(9, "Disk-2 Pnl1", 1);
   meZeroRocFPIX->setBinLabel(19, "Disk-1 Pnl2", 1);
@@ -229,8 +210,7 @@ void SiPixelClusterSource::bookHistograms(DQMStore::IBooker &iBooker,
 //------------------------------------------------------------------
 // Method called for every event
 //------------------------------------------------------------------
-void SiPixelClusterSource::analyze(const edm::Event &iEvent,
-                                   const edm::EventSetup &iSetup) {
+void SiPixelClusterSource::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   eventNo++;
 
   if (meClPosLayer.at(0) && meClPosLayer.at(0)->getEntries() > 150000) {
@@ -268,16 +248,27 @@ void SiPixelClusterSource::analyze(const edm::Event &iEvent,
   int nEventsFPIXp = 0;
 
   std::map<uint32_t, SiPixelClusterModule *>::iterator struct_iter;
-  for (struct_iter = thePixelStructure.begin();
-       struct_iter != thePixelStructure.end(); struct_iter++) {
-
-    int numberOfFpixClusters =
-        (*struct_iter)
-            .second->fill(*input, tracker, &nEventsBarrel, &nEventsFPIXp,
-                          &nEventsFPIXm, meClPosLayer, meClPosDiskpz,
-                          meClPosDiskmz, modOn, ladOn, layOn, phiOn, bladeOn,
-                          diskOn, ringOn, twoDimOn, reducedSet, smileyOn,
-                          isUpgrade);
+  for (struct_iter = thePixelStructure.begin(); struct_iter != thePixelStructure.end(); struct_iter++) {
+    int numberOfFpixClusters = (*struct_iter)
+                                   .second->fill(*input,
+                                                 tracker,
+                                                 &nEventsBarrel,
+                                                 &nEventsFPIXp,
+                                                 &nEventsFPIXm,
+                                                 meClPosLayer,
+                                                 meClPosDiskpz,
+                                                 meClPosDiskmz,
+                                                 modOn,
+                                                 ladOn,
+                                                 layOn,
+                                                 phiOn,
+                                                 bladeOn,
+                                                 diskOn,
+                                                 ringOn,
+                                                 twoDimOn,
+                                                 reducedSet,
+                                                 smileyOn,
+                                                 isUpgrade);
     nEventFpixClusters = nEventFpixClusters + numberOfFpixClusters;
   }
 
@@ -287,8 +278,7 @@ void SiPixelClusterSource::analyze(const edm::Event &iEvent,
     }
   }
 
-  float trendVar = iEvent.orbitNumber() /
-                   262144.0; // lumisection : seconds - matches strip trend plot
+  float trendVar = iEvent.orbitNumber() / 262144.0;  // lumisection : seconds - matches strip trend plot
 
   meClusBarrelProf->Fill(trendVar, nEventsBarrel);
   meClusFpixPProf->Fill(trendVar, nEventsFPIXp);
@@ -297,9 +287,7 @@ void SiPixelClusterSource::analyze(const edm::Event &iEvent,
   // std::cout<<"nEventFpixClusters: "<<nEventFpixClusters<<" , nLumiSecs:
   // "<<nLumiSecs<<" , nBigEvents: "<<nBigEvents<<std::endl;
 
-  for (TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin();
-       it != pDD->dets().end(); it++) {
-
+  for (TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin(); it != pDD->dets().end(); it++) {
     DetId detId = (*it)->geographicalId();
 
     // fill barrel
@@ -322,7 +310,6 @@ void SiPixelClusterSource::analyze(const edm::Event &iEvent,
 // Build data structure
 //------------------------------------------------------------------
 void SiPixelClusterSource::buildStructure(const edm::EventSetup &iSetup) {
-
   LogInfo("PixelDQM") << " SiPixelClusterSource::buildStructure";
   edm::ESHandle<TrackerGeometry> pDD;
   iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
@@ -331,56 +318,39 @@ void SiPixelClusterSource::buildStructure(const edm::EventSetup &iSetup) {
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology *pTT = tTopoHandle.product();
 
-  LogVerbatim("PixelDQM") << " *** Geometry node for TrackerGeom is  "
-                          << &(*pDD) << std::endl;
-  LogVerbatim("PixelDQM") << " *** I have " << pDD->dets().size()
-                          << " detectors" << std::endl;
-  LogVerbatim("PixelDQM") << " *** I have " << pDD->detTypes().size()
-                          << " types" << std::endl;
+  LogVerbatim("PixelDQM") << " *** Geometry node for TrackerGeom is  " << &(*pDD) << std::endl;
+  LogVerbatim("PixelDQM") << " *** I have " << pDD->dets().size() << " detectors" << std::endl;
+  LogVerbatim("PixelDQM") << " *** I have " << pDD->detTypes().size() << " types" << std::endl;
 
-  for (TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin();
-       it != pDD->dets().end(); it++) {
-
+  for (TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin(); it != pDD->dets().end(); it++) {
     if (dynamic_cast<PixelGeomDetUnit const *>((*it)) != nullptr) {
-
       DetId detId = (*it)->geographicalId();
       const GeomDetUnit *geoUnit = pDD->idToDetUnit(detId);
-      const PixelGeomDetUnit *pixDet =
-          dynamic_cast<const PixelGeomDetUnit *>(geoUnit);
+      const PixelGeomDetUnit *pixDet = dynamic_cast<const PixelGeomDetUnit *>(geoUnit);
       int nrows = (pixDet->specificTopology()).nrows();
       int ncols = (pixDet->specificTopology()).ncolumns();
 
-      if ((detId.subdetId() ==
-           static_cast<int>(PixelSubdetector::PixelBarrel)) ||
-          (detId.subdetId() ==
-           static_cast<int>(PixelSubdetector::PixelEndcap))) {
+      if ((detId.subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) ||
+          (detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap))) {
         uint32_t id = detId();
-        if (detId.subdetId() ==
-            static_cast<int>(PixelSubdetector::PixelBarrel)) {
+        if (detId.subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) {
           if (isPIB)
             continue;
-          LogDebug("PixelDQM")
-              << " ---> Adding Barrel Module " << detId.rawId() << endl;
+          LogDebug("PixelDQM") << " ---> Adding Barrel Module " << detId.rawId() << endl;
           int layer = PixelBarrelName(DetId(id), pTT, isUpgrade).layerName();
           if (layer > noOfLayers)
             noOfLayers = layer;
-          SiPixelClusterModule *theModule =
-              new SiPixelClusterModule(id, ncols, nrows);
-          thePixelStructure.insert(
-              pair<uint32_t, SiPixelClusterModule *>(id, theModule));
-        } else if (detId.subdetId() ==
-                   static_cast<int>(PixelSubdetector::PixelEndcap)) {
-          LogDebug("PixelDQM")
-              << " ---> Adding Endcap Module " << detId.rawId() << endl;
-          PixelEndcapName::HalfCylinder side =
-              PixelEndcapName(DetId(id), pTT, isUpgrade).halfCylinder();
+          SiPixelClusterModule *theModule = new SiPixelClusterModule(id, ncols, nrows);
+          thePixelStructure.insert(pair<uint32_t, SiPixelClusterModule *>(id, theModule));
+        } else if (detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) {
+          LogDebug("PixelDQM") << " ---> Adding Endcap Module " << detId.rawId() << endl;
+          PixelEndcapName::HalfCylinder side = PixelEndcapName(DetId(id), pTT, isUpgrade).halfCylinder();
           int disk = PixelEndcapName(DetId(id), pTT, isUpgrade).diskName();
           if (disk > noOfDisks)
             noOfDisks = disk;
           int blade = PixelEndcapName(DetId(id), pTT, isUpgrade).bladeName();
           int panel = PixelEndcapName(DetId(id), pTT, isUpgrade).pannelName();
-          int module =
-              PixelEndcapName(DetId(id), pTT, isUpgrade).plaquetteName();
+          int module = PixelEndcapName(DetId(id), pTT, isUpgrade).plaquetteName();
           char sside[80];
           sprintf(sside, "HalfCylinder_%i", side);
           char sdisk[80];
@@ -395,127 +365,93 @@ void SiPixelClusterSource::buildStructure(const edm::EventSetup &iSetup) {
           std::string disk_str = sdisk;
           bool mask = side_str.find("HalfCylinder_1") != string::npos ||
                       side_str.find("HalfCylinder_2") != string::npos ||
-                      side_str.find("HalfCylinder_4") != string::npos ||
-                      disk_str.find("Disk_2") != string::npos;
+                      side_str.find("HalfCylinder_4") != string::npos || disk_str.find("Disk_2") != string::npos;
           // clutch to take all of FPIX, but no BPIX:
           mask = false;
           if (isPIB && mask)
             continue;
-          SiPixelClusterModule *theModule =
-              new SiPixelClusterModule(id, ncols, nrows);
-          thePixelStructure.insert(
-              pair<uint32_t, SiPixelClusterModule *>(id, theModule));
+          SiPixelClusterModule *theModule = new SiPixelClusterModule(id, ncols, nrows);
+          thePixelStructure.insert(pair<uint32_t, SiPixelClusterModule *>(id, theModule));
         }
       }
     }
   }
-  LogInfo("PixelDQM") << " *** Pixel Structure Size "
-                      << thePixelStructure.size() << endl;
+  LogInfo("PixelDQM") << " *** Pixel Structure Size " << thePixelStructure.size() << endl;
 }
 //------------------------------------------------------------------
 // Book MEs
 //------------------------------------------------------------------
-void SiPixelClusterSource::bookMEs(DQMStore::IBooker &iBooker,
-                                   const edm::EventSetup &iSetup) {
-
+void SiPixelClusterSource::bookMEs(DQMStore::IBooker &iBooker, const edm::EventSetup &iSetup) {
   // Get DQM interface
   iBooker.setCurrentFolder(topFolderName_);
   char title[256];
-  snprintf(title, 256,
+  snprintf(title,
+           256,
            "Rate of events with >%i FPIX clusters;LumiSection;Rate of large "
            "FPIX events per LS [Hz]",
            bigEventSize);
-  bigFpixClusterEventRate =
-      iBooker.book1D("bigFpixClusterEventRate", title, 5000, 0., 5000.);
+  bigFpixClusterEventRate = iBooker.book1D("bigFpixClusterEventRate", title, 5000, 0., 5000.);
 
   std::map<uint32_t, SiPixelClusterModule *>::iterator struct_iter;
 
   SiPixelFolderOrganizer theSiPixelFolder(false);
 
-  for (struct_iter = thePixelStructure.begin();
-       struct_iter != thePixelStructure.end(); struct_iter++) {
-
+  for (struct_iter = thePixelStructure.begin(); struct_iter != thePixelStructure.end(); struct_iter++) {
     /// Create folder tree and book histograms
     if (modOn) {
-      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 0,
-                                           isUpgrade)) {
-        (*struct_iter)
-            .second->book(conf_, iSetup, iBooker, 0, twoDimOn, reducedSet,
-                          isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 0, isUpgrade)) {
+        (*struct_iter).second->book(conf_, iSetup, iBooker, 0, twoDimOn, reducedSet, isUpgrade);
       } else {
-
         if (!isPIB)
-          throw cms::Exception("LogicError")
-              << "[SiPixelClusterSource::bookMEs] Creation of DQM folder "
-                 "failed";
+          throw cms::Exception("LogicError") << "[SiPixelClusterSource::bookMEs] Creation of DQM folder "
+                                                "failed";
       }
     }
     if (ladOn) {
-      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 1,
-                                           isUpgrade)) {
-        (*struct_iter)
-            .second->book(conf_, iSetup, iBooker, 1, twoDimOn, reducedSet,
-                          isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 1, isUpgrade)) {
+        (*struct_iter).second->book(conf_, iSetup, iBooker, 1, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH LADDER-FOLDER\n";
       }
     }
     if (layOn) {
-      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 2,
-                                           isUpgrade)) {
-        (*struct_iter)
-            .second->book(conf_, iSetup, iBooker, 2, twoDimOn, reducedSet,
-                          isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 2, isUpgrade)) {
+        (*struct_iter).second->book(conf_, iSetup, iBooker, 2, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH LAYER-FOLDER\n";
       }
     }
     if (phiOn) {
-      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 3,
-                                           isUpgrade)) {
-        (*struct_iter)
-            .second->book(conf_, iSetup, iBooker, 3, twoDimOn, reducedSet,
-                          isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 3, isUpgrade)) {
+        (*struct_iter).second->book(conf_, iSetup, iBooker, 3, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH PHI-FOLDER\n";
       }
     }
     if (bladeOn) {
-      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 4,
-                                           isUpgrade)) {
-        (*struct_iter)
-            .second->book(conf_, iSetup, iBooker, 4, twoDimOn, reducedSet,
-                          isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 4, isUpgrade)) {
+        (*struct_iter).second->book(conf_, iSetup, iBooker, 4, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH BLADE-FOLDER\n";
       }
     }
     if (diskOn) {
-      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 5,
-                                           isUpgrade)) {
-        (*struct_iter)
-            .second->book(conf_, iSetup, iBooker, 5, twoDimOn, reducedSet,
-                          isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 5, isUpgrade)) {
+        (*struct_iter).second->book(conf_, iSetup, iBooker, 5, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH DISK-FOLDER\n";
       }
     }
     if (ringOn) {
-      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 6,
-                                           isUpgrade)) {
-        (*struct_iter)
-            .second->book(conf_, iSetup, iBooker, 6, twoDimOn, reducedSet,
-                          isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 6, isUpgrade)) {
+        (*struct_iter).second->book(conf_, iSetup, iBooker, 6, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH RING-FOLDER\n";
       }
     }
     if (smileyOn) {
-      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 7,
-                                           isUpgrade)) {
-        (*struct_iter)
-            .second->book(conf_, iSetup, iBooker, 7, twoDimOn, reducedSet,
-                          isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 7, isUpgrade)) {
+        (*struct_iter).second->book(conf_, iSetup, iBooker, 7, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH BARREL-FOLDER\n";
       }
@@ -523,25 +459,19 @@ void SiPixelClusterSource::bookMEs(DQMStore::IBooker &iBooker,
   }
 }
 
-void SiPixelClusterSource::getrococcupancy(
-    DetId detId, const edm::DetSetVector<PixelDigi> &diginp,
-    const TrackerTopology *const tTopo,
-    std::vector<MonitorElement *> const &meinput) {
-
+void SiPixelClusterSource::getrococcupancy(DetId detId,
+                                           const edm::DetSetVector<PixelDigi> &diginp,
+                                           const TrackerTopology *const tTopo,
+                                           std::vector<MonitorElement *> const &meinput) {
   edm::DetSetVector<PixelDigi>::const_iterator ipxsearch = diginp.find(detId);
   if (ipxsearch != diginp.end()) {
-
     // Look at digis now
     edm::DetSet<PixelDigi>::const_iterator pxdi;
     for (pxdi = ipxsearch->begin(); pxdi != ipxsearch->end(); pxdi++) {
-
-      bool isHalfModule =
-          PixelBarrelName(DetId(detId), tTopo, isUpgrade).isHalfModule();
+      bool isHalfModule = PixelBarrelName(DetId(detId), tTopo, isUpgrade).isHalfModule();
       int DBlayer = PixelBarrelName(DetId(detId), tTopo, isUpgrade).layerName();
-      int DBmodule =
-          PixelBarrelName(DetId(detId), tTopo, isUpgrade).moduleName();
-      int DBladder =
-          PixelBarrelName(DetId(detId), tTopo, isUpgrade).ladderName();
+      int DBmodule = PixelBarrelName(DetId(detId), tTopo, isUpgrade).moduleName();
+      int DBladder = PixelBarrelName(DetId(detId), tTopo, isUpgrade).ladderName();
       int DBshell = PixelBarrelName(DetId(detId), tTopo, isUpgrade).shell();
 
       // add sign to the modules
@@ -557,10 +487,8 @@ void SiPixelClusterSource::getrococcupancy(
 
       float modsign = (float)DBmodule / (abs((float)DBmodule));
       float ladsign = (float)DBladder / (abs((float)DBladder));
-      float rocx = ((float)col / (52. * 8.)) * modsign +
-                   ((float)DBmodule - (modsign)*0.5);
-      float rocy = ((float)row / (80. * 2.)) * ladsign +
-                   ((float)DBladder - (ladsign)*0.5);
+      float rocx = ((float)col / (52. * 8.)) * modsign + ((float)DBmodule - (modsign)*0.5);
+      float rocy = ((float)row / (80. * 2.)) * ladsign + ((float)DBladder - (ladsign)*0.5);
 
       // do the flip where need
       bool flip = false;
@@ -568,11 +496,9 @@ void SiPixelClusterSource::getrococcupancy(
         flip = true;
       }
       if ((flip) && (DBladder > 0)) {
-        if ((((float)DBladder - (ladsign)*0.5) <= rocy) &&
-            (rocy < (float)DBladder)) {
+        if ((((float)DBladder - (ladsign)*0.5) <= rocy) && (rocy < (float)DBladder)) {
           rocy = rocy + ladsign * 0.5;
-        } else if ((((float)DBladder) <= rocy) &&
-                   (rocy < ((float)DBladder + (ladsign)*0.5))) {
+        } else if ((((float)DBladder) <= rocy) && (rocy < ((float)DBladder + (ladsign)*0.5))) {
           rocy = rocy - ladsign * 0.5;
         }
       }
@@ -588,31 +514,26 @@ void SiPixelClusterSource::getrococcupancy(
       }
       if (abs(DBladder) == 1) {
         rocy = rocy + ladsign * 0.5;
-      } // take care of the half module
+      }  // take care of the half module
       meinput[DBlayer - 1]->Fill(rocx, rocy);
-    } // end of looping over pxdi
+    }  // end of looping over pxdi
   }
 }
 
-void SiPixelClusterSource::getrococcupancye(
-    DetId detId, const edmNew::DetSetVector<SiPixelCluster> &clustColl,
-    const TrackerTopology *const pTT, edm::ESHandle<TrackerGeometry> pDD,
-    MonitorElement *meinput) {
-
-  edmNew::DetSetVector<SiPixelCluster>::const_iterator ipxsearch =
-      clustColl.find(detId);
+void SiPixelClusterSource::getrococcupancye(DetId detId,
+                                            const edmNew::DetSetVector<SiPixelCluster> &clustColl,
+                                            const TrackerTopology *const pTT,
+                                            edm::ESHandle<TrackerGeometry> pDD,
+                                            MonitorElement *meinput) {
+  edmNew::DetSetVector<SiPixelCluster>::const_iterator ipxsearch = clustColl.find(detId);
   if (ipxsearch != clustColl.end()) {
-
     // Look at clusters now
     edmNew::DetSet<SiPixelCluster>::const_iterator pxclust;
     for (pxclust = ipxsearch->begin(); pxclust != ipxsearch->end(); pxclust++) {
-
       const GeomDetUnit *geoUnit = pDD->idToDetUnit(detId);
-      const PixelGeomDetUnit *pixDet =
-          dynamic_cast<const PixelGeomDetUnit *>(geoUnit);
+      const PixelGeomDetUnit *pixDet = dynamic_cast<const PixelGeomDetUnit *>(geoUnit);
       const PixelTopology *topol = &(pixDet->specificTopology());
-      LocalPoint clustlp =
-          topol->localPosition(MeasurementPoint(pxclust->x(), pxclust->y()));
+      LocalPoint clustlp = topol->localPosition(MeasurementPoint(pxclust->x(), pxclust->y()));
       GlobalPoint clustgp = geoUnit->surface().toGlobal(clustlp);
 
       float xclust = pxclust->x();
@@ -633,36 +554,28 @@ void SiPixelClusterSource::getrococcupancye(
         pxfdisk = -1. * pxfdisk;
       }
 
-      int clu_sdpx =
-          ((pxfdisk > 0) ? 1 : -1) * (2 * (abs(pxfdisk) - 1) + pxfpanel);
+      int clu_sdpx = ((pxfdisk > 0) ? 1 : -1) * (2 * (abs(pxfdisk) - 1) + pxfpanel);
       int binselx = (pxfpanel == 1 && (pxfmodule == 1 || pxfmodule == 4))
                         ? (pxfmodule == 1)
-                        : ((pxfpanel == 1 && xclust < 80.0) ||
-                           (pxfpanel == 2 && xclust >= 80.0));
+                        : ((pxfpanel == 1 && xclust < 80.0) || (pxfpanel == 2 && xclust >= 80.0));
       int nperpan = 2 * pxfmodule + pxfpanel - 1 + binselx;
-      int clu_roc_binx = ((pxfdisk > 0) ? nperpan : 9 - nperpan) +
-                         (clu_sdpx + 4) * 8 -
-                         2 * ((abs(pxfdisk) == 1) ? pxfdisk : 0);
+      int clu_roc_binx =
+          ((pxfdisk > 0) ? nperpan : 9 - nperpan) + (clu_sdpx + 4) * 8 - 2 * ((abs(pxfdisk) == 1) ? pxfdisk : 0);
 
       int clu_roc_biny = -99.;
       int nrocly = pxfmodule + pxfpanel;
       for (int i = 0; i < nrocly; i++) {
         int j = (pxfdisk < 0) ? i : nrocly - 1 - i;
         if (yclust >= (j * 52.0) && yclust < ((j + 1) * 52.0))
-          clu_roc_biny = 6 - nrocly + 2 * i +
-                         ((pxfblade > 0) ? pxfblade - 1 : pxfblade + 12) * 12 +
-                         1;
+          clu_roc_biny = 6 - nrocly + 2 * i + ((pxfblade > 0) ? pxfblade - 1 : pxfblade + 12) * 12 + 1;
       }
       if (pxfblade > 0) {
         clu_roc_biny = clu_roc_biny + 144;
       }
 
+      meinput->setBinContent(clu_roc_binx, clu_roc_biny, meinput->getBinContent(clu_roc_binx, clu_roc_biny) + 1);
       meinput->setBinContent(
-          clu_roc_binx, clu_roc_biny,
-          meinput->getBinContent(clu_roc_binx, clu_roc_biny) + 1);
-      meinput->setBinContent(
-          clu_roc_binx, clu_roc_biny + 1,
-          meinput->getBinContent(clu_roc_binx, clu_roc_biny + 1) + 1);
+          clu_roc_binx, clu_roc_biny + 1, meinput->getBinContent(clu_roc_binx, clu_roc_biny + 1) + 1);
     }
   }
 }

--- a/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitModule.h
+++ b/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitModule.h
@@ -33,7 +33,6 @@ detector segment (detID)
 #include <boost/cstdint.hpp>
 
 class SiPixelRecHitModule {
-
 public:
   /// Default constructor
   SiPixelRecHitModule();
@@ -45,18 +44,37 @@ public:
   // typedef edm::DetSet<PixelRecHit>::const_iterator  RecHitsIterator;
 
   /// Book histograms
-  void book(const edm::ParameterSet &iConfig, DQMStore::IBooker &iBooker,
-            const edm::EventSetup &iSetup, int type = 0, bool twoD = true,
-            bool reducedSet = false, bool isUpgrade = false);
+  void book(const edm::ParameterSet &iConfig,
+            DQMStore::IBooker &iBooker,
+            const edm::EventSetup &iSetup,
+            int type = 0,
+            bool twoD = true,
+            bool reducedSet = false,
+            bool isUpgrade = false);
   /// Fill histograms
-  void fill(const float &rechit_x, const float &rechit_y, const int &sizeX,
-            const int &sizeY, const float &lerr_x, const float &lerr_y,
-            bool modon = true, bool ladon = false, bool layon = false,
-            bool phion = false, bool bladeon = false, bool diskon = false,
-            bool ringon = false, bool twoD = true, bool reducedSet = false);
-  void nfill(const int &nrec, bool modon = true, bool ladon = false,
-             bool layon = false, bool phion = false, bool bladeon = false,
-             bool diskon = false, bool ringon = false);
+  void fill(const float &rechit_x,
+            const float &rechit_y,
+            const int &sizeX,
+            const int &sizeY,
+            const float &lerr_x,
+            const float &lerr_y,
+            bool modon = true,
+            bool ladon = false,
+            bool layon = false,
+            bool phion = false,
+            bool bladeon = false,
+            bool diskon = false,
+            bool ringon = false,
+            bool twoD = true,
+            bool reducedSet = false);
+  void nfill(const int &nrec,
+             bool modon = true,
+             bool ladon = false,
+             bool layon = false,
+             bool phion = false,
+             bool bladeon = false,
+             bool diskon = false,
+             bool ringon = false);
 
 private:
   uint32_t id_;

--- a/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitSource.h
+++ b/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitSource.h
@@ -57,8 +57,7 @@ public:
   //       typedef edm::DetSet<PixelRecHit>::const_iterator    RecHitIterator;
 
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      const edm::EventSetup &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, const edm::EventSetup &) override;
   void dqmBeginRun(const edm::Run &, edm::EventSetup const &) override;
 
   virtual void buildStructure(edm::EventSetup const &);

--- a/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitModule.cc
+++ b/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitModule.cc
@@ -45,17 +45,17 @@ SiPixelRecHitModule::~SiPixelRecHitModule() {}
 //
 void SiPixelRecHitModule::book(const edm::ParameterSet &iConfig,
                                DQMStore::IBooker &iBooker,
-                               const edm::EventSetup &iSetup, int type,
-                               bool twoD, bool reducedSet, bool isUpgrade) {
-
+                               const edm::EventSetup &iSetup,
+                               int type,
+                               bool twoD,
+                               bool reducedSet,
+                               bool isUpgrade) {
   edm::ESHandle<TrackerTopology> tTopoHandle;
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology *pTT = tTopoHandle.product();
 
-  bool barrel =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
-  bool endcap =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
   bool isHalfModule = false;
 
   if (barrel) {
@@ -124,39 +124,30 @@ void SiPixelRecHitModule::book(const edm::ParameterSet &iConfig,
       hid += "F";
     if (!reducedSet) {
       if (twoD) {
-        meXYPosLad_ = iBooker.book2D("xypos_" + hid, "XY Position", 100, -1., 1,
-                                     100, -4, 4);
+        meXYPosLad_ = iBooker.book2D("xypos_" + hid, "XY Position", 100, -1., 1, 100, -4, 4);
         meXYPosLad_->setAxisTitle("X Position", 1);
         meXYPosLad_->setAxisTitle("Y Position", 2);
       } else {
         // projections of XYPosition
-        meXYPosLad_px_ =
-            iBooker.book1D("xypos_" + hid + "_px", "X Position", 100, -1., 1);
+        meXYPosLad_px_ = iBooker.book1D("xypos_" + hid + "_px", "X Position", 100, -1., 1);
         meXYPosLad_px_->setAxisTitle("X Position", 1);
-        meXYPosLad_py_ =
-            iBooker.book1D("xypos_" + hid + "_py", "Y Position", 100, -4, 4);
+        meXYPosLad_py_ = iBooker.book1D("xypos_" + hid + "_py", "Y Position", 100, -4, 4);
         meXYPosLad_py_->setAxisTitle("Y Position", 1);
       }
     }
-    meClustXLad_ =
-        iBooker.book1D("ClustX_" + hid, "RecHit X size", 10, 0., 10.);
+    meClustXLad_ = iBooker.book1D("ClustX_" + hid, "RecHit X size", 10, 0., 10.);
     meClustXLad_->setAxisTitle("RecHit size X dimension", 1);
-    meClustYLad_ =
-        iBooker.book1D("ClustY_" + hid, "RecHit Y size", 15, 0., 15.);
+    meClustYLad_ = iBooker.book1D("ClustY_" + hid, "RecHit Y size", 15, 0., 15.);
     meClustYLad_->setAxisTitle("RecHit size Y dimension", 1);
-    meErrorXLad_ =
-        iBooker.book1D("ErrorX_" + hid, "RecHit error X", 100, 0., 0.02);
+    meErrorXLad_ = iBooker.book1D("ErrorX_" + hid, "RecHit error X", 100, 0., 0.02);
     meErrorXLad_->setAxisTitle("RecHit error X", 1);
-    meErrorYLad_ =
-        iBooker.book1D("ErrorY_" + hid, "RecHit error Y", 100, 0., 0.02);
+    meErrorYLad_ = iBooker.book1D("ErrorY_" + hid, "RecHit error Y", 100, 0., 0.02);
     meErrorYLad_->setAxisTitle("RecHit error Y", 1);
-    menRecHitsLad_ = iBooker.book1D("nRecHits_" + hid,
-                                    "# of rechits in this module", 8, 0, 8);
+    menRecHitsLad_ = iBooker.book1D("nRecHits_" + hid, "# of rechits in this module", 8, 0, 8);
     menRecHitsLad_->setAxisTitle("number of rechits", 1);
   }
 
   if (type == 2 && barrel) {
-
     uint32_t DBlayer;
     // if (!isUpgrade) { DBlayer = PixelBarrelName(DetId(id_)).layerName(); }
     // else { DBlayer = PixelBarrelNameUpgrade(DetId(id_)).layerName(); }
@@ -167,35 +158,27 @@ void SiPixelRecHitModule::book(const edm::ParameterSet &iConfig,
 
     if (!reducedSet) {
       if (twoD) {
-        meXYPosLay_ = iBooker.book2D("xypos_" + hid, "XY Position", 100, -1., 1,
-                                     100, -4, 4);
+        meXYPosLay_ = iBooker.book2D("xypos_" + hid, "XY Position", 100, -1., 1, 100, -4, 4);
         meXYPosLay_->setAxisTitle("X Position", 1);
         meXYPosLay_->setAxisTitle("Y Position", 2);
       } else {
         // projections of XYPosition
-        meXYPosLay_px_ =
-            iBooker.book1D("xypos_" + hid + "_px", "X Position", 100, -1., 1);
+        meXYPosLay_px_ = iBooker.book1D("xypos_" + hid + "_px", "X Position", 100, -1., 1);
         meXYPosLay_px_->setAxisTitle("X Position", 1);
-        meXYPosLay_py_ =
-            iBooker.book1D("xypos_" + hid + "_py", "Y Position", 100, -4, 4);
+        meXYPosLay_py_ = iBooker.book1D("xypos_" + hid + "_py", "Y Position", 100, -4, 4);
         meXYPosLay_py_->setAxisTitle("Y Position", 1);
       }
     }
 
-    meClustXLay_ =
-        iBooker.book1D("ClustX_" + hid, "RecHit X size", 10, 0., 10.);
+    meClustXLay_ = iBooker.book1D("ClustX_" + hid, "RecHit X size", 10, 0., 10.);
     meClustXLay_->setAxisTitle("RecHit size X dimension", 1);
-    meClustYLay_ =
-        iBooker.book1D("ClustY_" + hid, "RecHit Y size", 15, 0., 15.);
+    meClustYLay_ = iBooker.book1D("ClustY_" + hid, "RecHit Y size", 15, 0., 15.);
     meClustYLay_->setAxisTitle("RecHit size Y dimension", 1);
-    meErrorXLay_ =
-        iBooker.book1D("ErrorX_" + hid, "RecHit error X", 100, 0., 0.02);
+    meErrorXLay_ = iBooker.book1D("ErrorX_" + hid, "RecHit error X", 100, 0., 0.02);
     meErrorXLay_->setAxisTitle("RecHit error X", 1);
-    meErrorYLay_ =
-        iBooker.book1D("ErrorY_" + hid, "RecHit error Y", 100, 0., 0.02);
+    meErrorYLay_ = iBooker.book1D("ErrorY_" + hid, "RecHit error Y", 100, 0., 0.02);
     meErrorYLay_->setAxisTitle("RecHit error Y", 1);
-    menRecHitsLay_ = iBooker.book1D("nRecHits_" + hid,
-                                    "# of rechits in this module", 8, 0, 8);
+    menRecHitsLay_ = iBooker.book1D("nRecHits_" + hid, "# of rechits in this module", 8, 0, 8);
     menRecHitsLay_->setAxisTitle("number of rechits", 1);
   }
 
@@ -210,34 +193,26 @@ void SiPixelRecHitModule::book(const edm::ParameterSet &iConfig,
 
     if (!reducedSet) {
       if (twoD) {
-        meXYPosPhi_ = iBooker.book2D("xypos_" + hid, "XY Position", 100, -1., 1,
-                                     100, -4, 4);
+        meXYPosPhi_ = iBooker.book2D("xypos_" + hid, "XY Position", 100, -1., 1, 100, -4, 4);
         meXYPosPhi_->setAxisTitle("X Position", 1);
         meXYPosPhi_->setAxisTitle("Y Position", 2);
       } else {
         // projections of XYPosition
-        meXYPosPhi_px_ =
-            iBooker.book1D("xypos_" + hid + "_px", "X Position", 100, -1., 1);
+        meXYPosPhi_px_ = iBooker.book1D("xypos_" + hid + "_px", "X Position", 100, -1., 1);
         meXYPosPhi_px_->setAxisTitle("X Position", 1);
-        meXYPosPhi_py_ =
-            iBooker.book1D("xypos_" + hid + "_py", "Y Position", 100, -4, 4);
+        meXYPosPhi_py_ = iBooker.book1D("xypos_" + hid + "_py", "Y Position", 100, -4, 4);
         meXYPosPhi_py_->setAxisTitle("Y Position", 1);
       }
     }
-    meClustXPhi_ =
-        iBooker.book1D("ClustX_" + hid, "RecHit X size", 10, 0., 10.);
+    meClustXPhi_ = iBooker.book1D("ClustX_" + hid, "RecHit X size", 10, 0., 10.);
     meClustXPhi_->setAxisTitle("RecHit size X dimension", 1);
-    meClustYPhi_ =
-        iBooker.book1D("ClustY_" + hid, "RecHit Y size", 15, 0., 15.);
+    meClustYPhi_ = iBooker.book1D("ClustY_" + hid, "RecHit Y size", 15, 0., 15.);
     meClustYPhi_->setAxisTitle("RecHit size Y dimension", 1);
-    meErrorXPhi_ =
-        iBooker.book1D("ErrorX_" + hid, "RecHit error X", 100, 0., 0.02);
+    meErrorXPhi_ = iBooker.book1D("ErrorX_" + hid, "RecHit error X", 100, 0., 0.02);
     meErrorXPhi_->setAxisTitle("RecHit error X", 1);
-    meErrorYPhi_ =
-        iBooker.book1D("ErrorY_" + hid, "RecHit error Y", 100, 0., 0.02);
+    meErrorYPhi_ = iBooker.book1D("ErrorY_" + hid, "RecHit error Y", 100, 0., 0.02);
     meErrorYPhi_->setAxisTitle("RecHit error Y", 1);
-    menRecHitsPhi_ = iBooker.book1D("nRecHits_" + hid,
-                                    "# of rechits in this module", 8, 0, 8);
+    menRecHitsPhi_ = iBooker.book1D("nRecHits_" + hid, "# of rechits in this module", 8, 0, 8);
     menRecHitsPhi_->setAxisTitle("number of rechits", 1);
   }
 
@@ -254,20 +229,15 @@ void SiPixelRecHitModule::book(const edm::ParameterSet &iConfig,
     //     Position",100,-1.,1,100,-4,4); meXYPosBlade_->setAxisTitle("X
     //     Position",1); meXYPosBlade_->setAxisTitle("Y Position",2);
 
-    meClustXBlade_ =
-        iBooker.book1D("ClustX_" + hid, "RecHit X size", 10, 0., 10.);
+    meClustXBlade_ = iBooker.book1D("ClustX_" + hid, "RecHit X size", 10, 0., 10.);
     meClustXBlade_->setAxisTitle("RecHit size X dimension", 1);
-    meClustYBlade_ =
-        iBooker.book1D("ClustY_" + hid, "RecHit Y size", 15, 0., 15.);
+    meClustYBlade_ = iBooker.book1D("ClustY_" + hid, "RecHit Y size", 15, 0., 15.);
     meClustYBlade_->setAxisTitle("RecHit size Y dimension", 1);
-    meErrorXBlade_ =
-        iBooker.book1D("ErrorX_" + hid, "RecHit error X", 100, 0., 0.02);
+    meErrorXBlade_ = iBooker.book1D("ErrorX_" + hid, "RecHit error X", 100, 0., 0.02);
     meErrorXBlade_->setAxisTitle("RecHit error X", 1);
-    meErrorYBlade_ =
-        iBooker.book1D("ErrorY_" + hid, "RecHit error Y", 100, 0., 0.02);
+    meErrorYBlade_ = iBooker.book1D("ErrorY_" + hid, "RecHit error Y", 100, 0., 0.02);
     meErrorYBlade_->setAxisTitle("RecHit error Y", 1);
-    menRecHitsBlade_ = iBooker.book1D("nRecHits_" + hid,
-                                      "# of rechits in this module", 8, 0, 8);
+    menRecHitsBlade_ = iBooker.book1D("nRecHits_" + hid, "# of rechits in this module", 8, 0, 8);
     menRecHitsBlade_->setAxisTitle("number of rechits", 1);
   }
   if (type == 5 && endcap) {
@@ -283,20 +253,15 @@ void SiPixelRecHitModule::book(const edm::ParameterSet &iConfig,
     //     Position",100,-1.,1,100,-4,4); meXYPosDisk_->setAxisTitle("X
     //     Position",1); meXYPosDisk_->setAxisTitle("Y Position",2);
 
-    meClustXDisk_ =
-        iBooker.book1D("ClustX_" + hid, "RecHit X size", 10, 0., 10.);
+    meClustXDisk_ = iBooker.book1D("ClustX_" + hid, "RecHit X size", 10, 0., 10.);
     meClustXDisk_->setAxisTitle("RecHit size X dimension", 1);
-    meClustYDisk_ =
-        iBooker.book1D("ClustY_" + hid, "RecHit Y size", 15, 0., 15.);
+    meClustYDisk_ = iBooker.book1D("ClustY_" + hid, "RecHit Y size", 15, 0., 15.);
     meClustYDisk_->setAxisTitle("RecHit size Y dimension", 1);
-    meErrorXDisk_ =
-        iBooker.book1D("ErrorX_" + hid, "RecHit error X", 100, 0., 0.02);
+    meErrorXDisk_ = iBooker.book1D("ErrorX_" + hid, "RecHit error X", 100, 0., 0.02);
     meErrorXDisk_->setAxisTitle("RecHit error X", 1);
-    meErrorYDisk_ =
-        iBooker.book1D("ErrorY_" + hid, "RecHit error Y", 100, 0., 0.02);
+    meErrorYDisk_ = iBooker.book1D("ErrorY_" + hid, "RecHit error Y", 100, 0., 0.02);
     meErrorYDisk_->setAxisTitle("RecHit error Y", 1);
-    menRecHitsDisk_ = iBooker.book1D("nRecHits_" + hid,
-                                     "# of rechits in this module", 8, 0, 8);
+    menRecHitsDisk_ = iBooker.book1D("nRecHits_" + hid, "# of rechits in this module", 8, 0, 8);
     menRecHitsDisk_->setAxisTitle("number of rechits", 1);
   }
 
@@ -319,51 +284,49 @@ void SiPixelRecHitModule::book(const edm::ParameterSet &iConfig,
 
     if (!reducedSet) {
       if (twoD) {
-        meXYPosRing_ = iBooker.book2D("xypos_" + hid, "XY Position", 100, -1.,
-                                      1, 100, -4, 4);
+        meXYPosRing_ = iBooker.book2D("xypos_" + hid, "XY Position", 100, -1., 1, 100, -4, 4);
         meXYPosRing_->setAxisTitle("X Position", 1);
         meXYPosRing_->setAxisTitle("Y Position", 2);
       } else {
         // projections of XYPosition
-        meXYPosRing_px_ =
-            iBooker.book1D("xypos_" + hid + "_px", "X Position", 100, -1., 1);
+        meXYPosRing_px_ = iBooker.book1D("xypos_" + hid + "_px", "X Position", 100, -1., 1);
         meXYPosRing_px_->setAxisTitle("X Position", 1);
-        meXYPosRing_py_ =
-            iBooker.book1D("xypos_" + hid + "_py", "Y Position", 100, -4, 4);
+        meXYPosRing_py_ = iBooker.book1D("xypos_" + hid + "_py", "Y Position", 100, -4, 4);
         meXYPosRing_py_->setAxisTitle("Y Position", 1);
       }
     }
-    meClustXRing_ =
-        iBooker.book1D("ClustX_" + hid, "RecHit X size", 10, 0., 10.);
+    meClustXRing_ = iBooker.book1D("ClustX_" + hid, "RecHit X size", 10, 0., 10.);
     meClustXRing_->setAxisTitle("RecHit size X dimension", 1);
-    meClustYRing_ =
-        iBooker.book1D("ClustY_" + hid, "RecHit Y size", 15, 0., 15.);
+    meClustYRing_ = iBooker.book1D("ClustY_" + hid, "RecHit Y size", 15, 0., 15.);
     meClustYRing_->setAxisTitle("RecHit size Y dimension", 1);
-    meErrorXRing_ =
-        iBooker.book1D("ErrorX_" + hid, "RecHit error X", 100, 0., 0.02);
+    meErrorXRing_ = iBooker.book1D("ErrorX_" + hid, "RecHit error X", 100, 0., 0.02);
     meErrorXRing_->setAxisTitle("RecHit error X", 1);
-    meErrorYRing_ =
-        iBooker.book1D("ErrorY_" + hid, "RecHit error Y", 100, 0., 0.02);
+    meErrorYRing_ = iBooker.book1D("ErrorY_" + hid, "RecHit error Y", 100, 0., 0.02);
     meErrorYRing_->setAxisTitle("RecHit error Y", 1);
-    menRecHitsRing_ = iBooker.book1D("nRecHits_" + hid,
-                                     "# of rechits in this module", 8, 0, 8);
+    menRecHitsRing_ = iBooker.book1D("nRecHits_" + hid, "# of rechits in this module", 8, 0, 8);
     menRecHitsRing_->setAxisTitle("number of rechits", 1);
   }
 }
 //
 // Fill histograms
 //
-void SiPixelRecHitModule::fill(const float &rechit_x, const float &rechit_y,
-                               const int &sizeX, const int &sizeY,
-                               const float &lerr_x, const float &lerr_y,
-                               bool modon, bool ladon, bool layon, bool phion,
-                               bool bladeon, bool diskon, bool ringon,
-                               bool twoD, bool reducedSet) {
-
-  bool barrel =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
-  bool endcap =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+void SiPixelRecHitModule::fill(const float &rechit_x,
+                               const float &rechit_y,
+                               const int &sizeX,
+                               const int &sizeY,
+                               const float &lerr_x,
+                               const float &lerr_y,
+                               bool modon,
+                               bool ladon,
+                               bool layon,
+                               bool phion,
+                               bool bladeon,
+                               bool diskon,
+                               bool ringon,
+                               bool twoD,
+                               bool reducedSet) {
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
 
   // std::cout << rechit_x << " " << rechit_y << " " << sizeX << " " << sizeY <<
   // std::endl;
@@ -460,14 +423,10 @@ void SiPixelRecHitModule::fill(const float &rechit_x, const float &rechit_y,
   }
 }
 
-void SiPixelRecHitModule::nfill(const int &nrec, bool modon, bool ladon,
-                                bool layon, bool phion, bool bladeon,
-                                bool diskon, bool ringon) {
-
-  bool barrel =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
-  bool endcap =
-      DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
+void SiPixelRecHitModule::nfill(
+    const int &nrec, bool modon, bool ladon, bool layon, bool phion, bool bladeon, bool diskon, bool ringon) {
+  bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
+  bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
 
   // if(modon) menRecHits_->Fill(nrec);
   // barrel

--- a/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitSource.cc
+++ b/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitSource.cc
@@ -49,8 +49,8 @@ using namespace std;
 using namespace edm;
 
 SiPixelRecHitSource::SiPixelRecHitSource(const edm::ParameterSet &iConfig)
-    : conf_(iConfig), src_(consumes<SiPixelRecHitCollection>(
-                          conf_.getParameter<edm::InputTag>("src"))),
+    : conf_(iConfig),
+      src_(consumes<SiPixelRecHitCollection>(conf_.getParameter<edm::InputTag>("src"))),
       saveFile(conf_.getUntrackedParameter<bool>("saveFile", false)),
       isPIB(conf_.getUntrackedParameter<bool>("isPIB", false)),
       slowDown(conf_.getUntrackedParameter<bool>("slowDown", false)),
@@ -65,34 +65,25 @@ SiPixelRecHitSource::SiPixelRecHitSource(const edm::ParameterSet &iConfig)
       diskOn(conf_.getUntrackedParameter<bool>("diskOn", false)),
       isUpgrade(conf_.getUntrackedParameter<bool>("isUpgrade", false)) {
   firstRun = true;
-  LogInfo("PixelDQM")
-      << "SiPixelRecHitSource::SiPixelRecHitSource: Got DQM BackEnd interface"
-      << endl;
+  LogInfo("PixelDQM") << "SiPixelRecHitSource::SiPixelRecHitSource: Got DQM BackEnd interface" << endl;
   topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
 }
 
 SiPixelRecHitSource::~SiPixelRecHitSource() {
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
-  LogInfo("PixelDQM") << "SiPixelRecHitSource::~SiPixelRecHitSource: Destructor"
-                      << endl;
+  LogInfo("PixelDQM") << "SiPixelRecHitSource::~SiPixelRecHitSource: Destructor" << endl;
   std::map<uint32_t, SiPixelRecHitModule *>::iterator struct_iter;
-  for (struct_iter = thePixelStructure.begin();
-       struct_iter != thePixelStructure.end(); struct_iter++) {
+  for (struct_iter = thePixelStructure.begin(); struct_iter != thePixelStructure.end(); struct_iter++) {
     delete struct_iter->second;
     struct_iter->second = nullptr;
   }
 }
 
-void SiPixelRecHitSource::dqmBeginRun(const edm::Run &r,
-                                      const edm::EventSetup &iSetup) {
-
-  LogInfo("PixelDQM") << " SiPixelRecHitSource::beginJob - Initialisation ... "
-                      << std::endl;
-  LogInfo("PixelDQM") << "Mod/Lad/Lay/Phi " << modOn << "/" << ladOn << "/"
-                      << layOn << "/" << phiOn << std::endl;
-  LogInfo("PixelDQM") << "Blade/Disk/Ring" << bladeOn << "/" << diskOn << "/"
-                      << ringOn << std::endl;
+void SiPixelRecHitSource::dqmBeginRun(const edm::Run &r, const edm::EventSetup &iSetup) {
+  LogInfo("PixelDQM") << " SiPixelRecHitSource::beginJob - Initialisation ... " << std::endl;
+  LogInfo("PixelDQM") << "Mod/Lad/Lay/Phi " << modOn << "/" << ladOn << "/" << layOn << "/" << phiOn << std::endl;
+  LogInfo("PixelDQM") << "Blade/Disk/Ring" << bladeOn << "/" << diskOn << "/" << ringOn << std::endl;
   LogInfo("PixelDQM") << "2DIM IS " << twoDimOn << "\n";
 
   if (firstRun) {
@@ -104,17 +95,14 @@ void SiPixelRecHitSource::dqmBeginRun(const edm::Run &r,
   }
 }
 
-void SiPixelRecHitSource::bookHistograms(DQMStore::IBooker &iBooker,
-                                         edm::Run const &,
-                                         const edm::EventSetup &iSetup) {
+void SiPixelRecHitSource::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const &, const edm::EventSetup &iSetup) {
   bookMEs(iBooker, iSetup);
 }
 
 //------------------------------------------------------------------
 // Method called for every event
 //------------------------------------------------------------------
-void SiPixelRecHitSource::analyze(const edm::Event &iEvent,
-                                  const edm::EventSetup &iSetup) {
+void SiPixelRecHitSource::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   eventNo++;
   // cout << eventNo << endl;
   // get input data
@@ -122,8 +110,7 @@ void SiPixelRecHitSource::analyze(const edm::Event &iEvent,
   iEvent.getByToken(src_, recHitColl);
 
   std::map<uint32_t, SiPixelRecHitModule *>::iterator struct_iter;
-  for (struct_iter = thePixelStructure.begin();
-       struct_iter != thePixelStructure.end(); struct_iter++) {
+  for (struct_iter = thePixelStructure.begin(); struct_iter != thePixelStructure.end(); struct_iter++) {
     uint32_t TheID = (*struct_iter).first;
 
     SiPixelRecHitCollection::const_iterator match = recHitColl->find(TheID);
@@ -136,15 +123,11 @@ void SiPixelRecHitSource::analyze(const edm::Event &iEvent,
 
     if (match != recHitColl->end()) {
       SiPixelRecHitCollection::DetSet pixelrechitRange = *match;
-      SiPixelRecHitCollection::DetSet::const_iterator
-          pixelrechitRangeIteratorBegin = pixelrechitRange.begin();
-      SiPixelRecHitCollection::DetSet::const_iterator
-          pixelrechitRangeIteratorEnd = pixelrechitRange.end();
-      SiPixelRecHitCollection::DetSet::const_iterator pixeliter =
-          pixelrechitRangeIteratorBegin;
+      SiPixelRecHitCollection::DetSet::const_iterator pixelrechitRangeIteratorBegin = pixelrechitRange.begin();
+      SiPixelRecHitCollection::DetSet::const_iterator pixelrechitRangeIteratorEnd = pixelrechitRange.end();
+      SiPixelRecHitCollection::DetSet::const_iterator pixeliter = pixelrechitRangeIteratorBegin;
 
       for (; pixeliter != pixelrechitRangeIteratorEnd; pixeliter++) {
-
         rechit_count++;
         // cout << TheID << endl;
         SiPixelRecHit::ClusterRef const &clust = pixeliter->cluster();
@@ -161,15 +144,25 @@ void SiPixelRecHitSource::analyze(const edm::Event &iEvent,
         float lerr_y = sqrt(lerr.yy());
         // std::cout << "errors " << lerr_x << " " << lerr_y << std::endl;
         (*struct_iter)
-            .second->fill(rechit_x, rechit_y, sizeX, sizeY, lerr_x, lerr_y,
-                          modOn, ladOn, layOn, phiOn, bladeOn, diskOn, ringOn,
-                          twoDimOn, reducedSet);
+            .second->fill(rechit_x,
+                          rechit_y,
+                          sizeX,
+                          sizeY,
+                          lerr_x,
+                          lerr_y,
+                          modOn,
+                          ladOn,
+                          layOn,
+                          phiOn,
+                          bladeOn,
+                          diskOn,
+                          ringOn,
+                          twoDimOn,
+                          reducedSet);
       }
     }
     if (rechit_count > 0)
-      (*struct_iter)
-          .second->nfill(rechit_count, modOn, ladOn, layOn, phiOn, bladeOn,
-                         diskOn, ringOn);
+      (*struct_iter).second->nfill(rechit_count, modOn, ladOn, layOn, phiOn, bladeOn, diskOn, ringOn);
   }
 
   // slow down...
@@ -181,7 +174,6 @@ void SiPixelRecHitSource::analyze(const edm::Event &iEvent,
 // Build data structure
 //------------------------------------------------------------------
 void SiPixelRecHitSource::buildStructure(const edm::EventSetup &iSetup) {
-
   LogInfo("PixelDQM") << " SiPixelRecHitSource::buildStructure";
 
   edm::ESHandle<TrackerGeometry> pDD;
@@ -192,50 +184,33 @@ void SiPixelRecHitSource::buildStructure(const edm::EventSetup &iSetup) {
 
   const TrackerTopology *pTT = tTopoHandle.product();
 
-  LogVerbatim("PixelDQM") << " *** Geometry node for TrackerGeom is  "
-                          << &(*pDD) << std::endl;
-  LogVerbatim("PixelDQM") << " *** I have " << pDD->dets().size()
-                          << " detectors" << std::endl;
-  LogVerbatim("PixelDQM") << " *** I have " << pDD->detTypes().size()
-                          << " types" << std::endl;
+  LogVerbatim("PixelDQM") << " *** Geometry node for TrackerGeom is  " << &(*pDD) << std::endl;
+  LogVerbatim("PixelDQM") << " *** I have " << pDD->dets().size() << " detectors" << std::endl;
+  LogVerbatim("PixelDQM") << " *** I have " << pDD->detTypes().size() << " types" << std::endl;
 
-  for (TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin();
-       it != pDD->dets().end(); it++) {
-
+  for (TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin(); it != pDD->dets().end(); it++) {
     if (dynamic_cast<PixelGeomDetUnit const *>((*it)) != nullptr) {
-
       DetId detId = (*it)->geographicalId();
 
-      if ((detId.subdetId() ==
-           static_cast<int>(PixelSubdetector::PixelBarrel)) ||
-          (detId.subdetId() ==
-           static_cast<int>(PixelSubdetector::PixelEndcap))) {
-
+      if ((detId.subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) ||
+          (detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap))) {
         uint32_t id = detId();
 
-        if (detId.subdetId() ==
-            static_cast<int>(PixelSubdetector::PixelBarrel)) {
+        if (detId.subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel)) {
           if (isPIB)
             continue;
-          LogDebug("PixelDQM")
-              << " ---> Adding Barrel Module " << detId.rawId() << endl;
+          LogDebug("PixelDQM") << " ---> Adding Barrel Module " << detId.rawId() << endl;
           SiPixelRecHitModule *theModule = new SiPixelRecHitModule(id);
-          thePixelStructure.insert(
-              pair<uint32_t, SiPixelRecHitModule *>(id, theModule));
+          thePixelStructure.insert(pair<uint32_t, SiPixelRecHitModule *>(id, theModule));
 
-        } else if ((detId.subdetId() ==
-                    static_cast<int>(PixelSubdetector::PixelEndcap))) {
+        } else if ((detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap))) {
+          LogDebug("PixelDQM") << " ---> Adding Endcap Module " << detId.rawId() << endl;
 
-          LogDebug("PixelDQM")
-              << " ---> Adding Endcap Module " << detId.rawId() << endl;
-
-          PixelEndcapName::HalfCylinder side =
-              PixelEndcapName(DetId(id), pTT, isUpgrade).halfCylinder();
+          PixelEndcapName::HalfCylinder side = PixelEndcapName(DetId(id), pTT, isUpgrade).halfCylinder();
           int disk = PixelEndcapName(DetId(id), pTT, isUpgrade).diskName();
           int blade = PixelEndcapName(DetId(id), pTT, isUpgrade).bladeName();
           int panel = PixelEndcapName(DetId(id), pTT, isUpgrade).pannelName();
-          int module =
-              PixelEndcapName(DetId(id), pTT, isUpgrade).plaquetteName();
+          int module = PixelEndcapName(DetId(id), pTT, isUpgrade).plaquetteName();
 
           char sside[80];
           sprintf(sside, "HalfCylinder_%i", side);
@@ -251,104 +226,75 @@ void SiPixelRecHitSource::buildStructure(const edm::EventSetup &iSetup) {
           std::string disk_str = sdisk;
           bool mask = side_str.find("HalfCylinder_1") != string::npos ||
                       side_str.find("HalfCylinder_2") != string::npos ||
-                      side_str.find("HalfCylinder_4") != string::npos ||
-                      disk_str.find("Disk_2") != string::npos;
+                      side_str.find("HalfCylinder_4") != string::npos || disk_str.find("Disk_2") != string::npos;
           if (isPIB && mask)
             continue;
 
           SiPixelRecHitModule *theModule = new SiPixelRecHitModule(id);
-          thePixelStructure.insert(
-              pair<uint32_t, SiPixelRecHitModule *>(id, theModule));
+          thePixelStructure.insert(pair<uint32_t, SiPixelRecHitModule *>(id, theModule));
         }
       }
     }
-  } // FOR_LOOP
+  }  // FOR_LOOP
 
-  LogInfo("PixelDQM") << " *** Pixel Structure Size "
-                      << thePixelStructure.size() << endl;
+  LogInfo("PixelDQM") << " *** Pixel Structure Size " << thePixelStructure.size() << endl;
 }
 //------------------------------------------------------------------
 // Book MEs
 //------------------------------------------------------------------
-void SiPixelRecHitSource::bookMEs(DQMStore::IBooker &iBooker,
-                                  const edm::EventSetup &iSetup) {
-
+void SiPixelRecHitSource::bookMEs(DQMStore::IBooker &iBooker, const edm::EventSetup &iSetup) {
   std::map<uint32_t, SiPixelRecHitModule *>::iterator struct_iter;
 
   SiPixelFolderOrganizer theSiPixelFolder(false);
 
-  for (struct_iter = thePixelStructure.begin();
-       struct_iter != thePixelStructure.end(); struct_iter++) {
-
+  for (struct_iter = thePixelStructure.begin(); struct_iter != thePixelStructure.end(); struct_iter++) {
     /// Create folder tree and book histograms
     if (modOn) {
-      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 0,
-                                           isUpgrade)) {
-        (*struct_iter)
-            .second->book(conf_, iBooker, iSetup, 0, twoDimOn, reducedSet,
-                          isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 0, isUpgrade)) {
+        (*struct_iter).second->book(conf_, iBooker, iSetup, 0, twoDimOn, reducedSet, isUpgrade);
       } else {
         if (!isPIB)
-          throw cms::Exception("LogicError")
-              << "[SiPixelDigiSource::bookMEs] Creation of DQM folder failed";
+          throw cms::Exception("LogicError") << "[SiPixelDigiSource::bookMEs] Creation of DQM folder failed";
       }
     }
     if (ladOn) {
-      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 1,
-                                           isUpgrade)) {
-        (*struct_iter)
-            .second->book(conf_, iBooker, iSetup, 1, twoDimOn, reducedSet,
-                          isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 1, isUpgrade)) {
+        (*struct_iter).second->book(conf_, iBooker, iSetup, 1, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH LADDER-FOLDER\n";
       }
     }
     if (layOn) {
-      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 2,
-                                           isUpgrade)) {
-        (*struct_iter)
-            .second->book(conf_, iBooker, iSetup, 2, twoDimOn, reducedSet,
-                          isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 2, isUpgrade)) {
+        (*struct_iter).second->book(conf_, iBooker, iSetup, 2, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH LAYER-FOLDER\n";
       }
     }
     if (phiOn) {
-      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 3,
-                                           isUpgrade)) {
-        (*struct_iter)
-            .second->book(conf_, iBooker, iSetup, 3, twoDimOn, reducedSet,
-                          isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 3, isUpgrade)) {
+        (*struct_iter).second->book(conf_, iBooker, iSetup, 3, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH PHI-FOLDER\n";
       }
     }
     if (bladeOn) {
-      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 4,
-                                           isUpgrade)) {
-        (*struct_iter)
-            .second->book(conf_, iBooker, iSetup, 4, twoDimOn, reducedSet,
-                          isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 4, isUpgrade)) {
+        (*struct_iter).second->book(conf_, iBooker, iSetup, 4, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH BLADE-FOLDER\n";
       }
     }
     if (diskOn) {
-      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 5,
-                                           isUpgrade)) {
-        (*struct_iter)
-            .second->book(conf_, iBooker, iSetup, 5, twoDimOn, reducedSet,
-                          isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 5, isUpgrade)) {
+        (*struct_iter).second->book(conf_, iBooker, iSetup, 5, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH DISK-FOLDER\n";
       }
     }
     if (ringOn) {
-      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 6,
-                                           isUpgrade)) {
-        (*struct_iter)
-            .second->book(conf_, iBooker, iSetup, 6, twoDimOn, reducedSet,
-                          isUpgrade);
+      if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 6, isUpgrade)) {
+        (*struct_iter).second->book(conf_, iBooker, iSetup, 6, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH RING-FOLDER\n";
       }

--- a/DQM/TrackerCommon/interface/TriggerHelper.h
+++ b/DQM/TrackerCommon/interface/TriggerHelper.h
@@ -32,12 +32,11 @@
 #include <memory>
 
 namespace edm {
-class ConsumesCollector;
-class ParameterSet;
-} // namespace edm
+  class ConsumesCollector;
+  class ParameterSet;
+}  // namespace edm
 
 class TriggerHelper {
-
   // Utility classes
   edm::ESWatcher<AlCaRecoTriggerBitsRcd> *watchDB_;
   std::unique_ptr<L1GtUtils> l1Gt_;
@@ -75,24 +74,20 @@ class TriggerHelper {
 public:
   // Constructors must be called from the ED module's c'tor
   template <typename T>
-  TriggerHelper(const edm::ParameterSet &config, edm::ConsumesCollector &&iC,
-                T &module);
+  TriggerHelper(const edm::ParameterSet &config, edm::ConsumesCollector &&iC, T &module);
 
   template <typename T>
-  TriggerHelper(const edm::ParameterSet &config, edm::ConsumesCollector &iC,
-                T &module);
+  TriggerHelper(const edm::ParameterSet &config, edm::ConsumesCollector &iC, T &module);
 
   ~TriggerHelper();
 
   // Public methods
   bool on() { return on_; }
   bool off() { return (!on_); }
-  void
-  initRun(const edm::Run &run,
-          const edm::EventSetup &setup); // To be called from beginRun() methods
+  void initRun(const edm::Run &run,
+               const edm::EventSetup &setup);  // To be called from beginRun() methods
   bool accept(const edm::Event &event,
-              const edm::EventSetup
-                  &setup); // To be called from analyze/filter() methods
+              const edm::EventSetup &setup);  // To be called from analyze/filter() methods
 
 private:
   // Private methods
@@ -101,40 +96,33 @@ private:
 
   // DCS
   bool acceptDcs(const edm::Event &event);
-  bool acceptDcsPartition(const edm::Handle<DcsStatusCollection> &dcsStatus,
-                          int dcsPartition) const;
+  bool acceptDcsPartition(const edm::Handle<DcsStatusCollection> &dcsStatus, int dcsPartition) const;
 
   // GT status bits
   bool acceptGt(const edm::Event &event);
-  bool acceptGtLogicalExpression(
-      const edm::Handle<L1GlobalTriggerReadoutRecord> &gtReadoutRecord,
-      std::string gtLogicalExpression);
+  bool acceptGtLogicalExpression(const edm::Handle<L1GlobalTriggerReadoutRecord> &gtReadoutRecord,
+                                 std::string gtLogicalExpression);
 
   // L1
   bool acceptL1(const edm::Event &event, const edm::EventSetup &setup);
-  bool acceptL1LogicalExpression(const edm::Event &event,
-                                 std::string l1LogicalExpression);
+  bool acceptL1LogicalExpression(const edm::Event &event, std::string l1LogicalExpression);
 
   // HLT
   bool acceptHlt(const edm::Event &event);
-  bool acceptHltLogicalExpression(
-      const edm::Handle<edm::TriggerResults> &hltTriggerResults,
-      std::string hltLogicalExpression) const;
+  bool acceptHltLogicalExpression(const edm::Handle<edm::TriggerResults> &hltTriggerResults,
+                                  std::string hltLogicalExpression) const;
 
   // Algos
-  std::vector<std::string> expressionsFromDB(const std::string &key,
-                                             const edm::EventSetup &setup);
+  std::vector<std::string> expressionsFromDB(const std::string &key, const edm::EventSetup &setup);
   bool negate(std::string &word) const;
 };
 
 template <typename T>
-TriggerHelper::TriggerHelper(const edm::ParameterSet &config,
-                             edm::ConsumesCollector &&iC, T &module)
+TriggerHelper::TriggerHelper(const edm::ParameterSet &config, edm::ConsumesCollector &&iC, T &module)
     : TriggerHelper(config, iC, module) {}
 
 template <typename T>
-TriggerHelper::TriggerHelper(const edm::ParameterSet &config,
-                             edm::ConsumesCollector &iC, T &module)
+TriggerHelper::TriggerHelper(const edm::ParameterSet &config, edm::ConsumesCollector &iC, T &module)
     : TriggerHelper(config) {
   l1Gt_.reset(new L1GtUtils(config, iC, false, module));
 }

--- a/DQM/TrackerCommon/plugins/DetectorStateFilter.cc
+++ b/DQM/TrackerCommon/plugins/DetectorStateFilter.cc
@@ -14,11 +14,9 @@
 //
 DetectorStateFilter::DetectorStateFilter(const edm::ParameterSet &pset)
     : verbose_(pset.getUntrackedParameter<bool>("DebugOn", false)),
-      detectorType_(
-          pset.getUntrackedParameter<std::string>("DetectorType", "sistrip")),
+      detectorType_(pset.getUntrackedParameter<std::string>("DetectorType", "sistrip")),
       dcsStatusLabel_(consumes<DcsStatusCollection>(
-          pset.getUntrackedParameter<edm::InputTag>(
-              "DcsStatusLabel", edm::InputTag("scalersRawToDigi")))) {
+          pset.getUntrackedParameter<edm::InputTag>("DcsStatusLabel", edm::InputTag("scalersRawToDigi")))) {
   nEvents_ = 0;
   nSelectedEvents_ = 0;
   detectorOn_ = false;
@@ -29,7 +27,6 @@ DetectorStateFilter::DetectorStateFilter(const edm::ParameterSet &pset)
 DetectorStateFilter::~DetectorStateFilter() {}
 
 bool DetectorStateFilter::filter(edm::Event &evt, edm::EventSetup const &es) {
-
   nEvents_++;
   // Check Detector state Only for Real Data and return true for MC
   if (evt.isRealData()) {
@@ -37,47 +34,38 @@ bool DetectorStateFilter::filter(edm::Event &evt, edm::EventSetup const &es) {
     evt.getByToken(dcsStatusLabel_, dcsStatus);
     if (dcsStatus.isValid()) {
       if (detectorType_ == "pixel" && !dcsStatus->empty()) {
-        if ((*dcsStatus)[0].ready(DcsStatus::BPIX) &&
-            (*dcsStatus)[0].ready(DcsStatus::FPIX)) {
+        if ((*dcsStatus)[0].ready(DcsStatus::BPIX) && (*dcsStatus)[0].ready(DcsStatus::FPIX)) {
           detectorOn_ = true;
           nSelectedEvents_++;
         } else
           detectorOn_ = false;
         if (verbose_)
-          std::cout << " Total Events " << nEvents_ << " Selected Events "
-                    << nSelectedEvents_ << " DCS States : "
-                    << " BPix " << (*dcsStatus)[0].ready(DcsStatus::BPIX)
-                    << " FPix " << (*dcsStatus)[0].ready(DcsStatus::FPIX)
-                    << " Detector State " << detectorOn_ << std::endl;
+          std::cout << " Total Events " << nEvents_ << " Selected Events " << nSelectedEvents_ << " DCS States : "
+                    << " BPix " << (*dcsStatus)[0].ready(DcsStatus::BPIX) << " FPix "
+                    << (*dcsStatus)[0].ready(DcsStatus::FPIX) << " Detector State " << detectorOn_ << std::endl;
       } else if (detectorType_ == "sistrip" && !dcsStatus->empty()) {
-        if ((*dcsStatus)[0].ready(DcsStatus::TIBTID) &&
-            (*dcsStatus)[0].ready(DcsStatus::TOB) &&
-            (*dcsStatus)[0].ready(DcsStatus::TECp) &&
-            (*dcsStatus)[0].ready(DcsStatus::TECm)) {
+        if ((*dcsStatus)[0].ready(DcsStatus::TIBTID) && (*dcsStatus)[0].ready(DcsStatus::TOB) &&
+            (*dcsStatus)[0].ready(DcsStatus::TECp) && (*dcsStatus)[0].ready(DcsStatus::TECm)) {
           detectorOn_ = true;
           nSelectedEvents_++;
         } else
           detectorOn_ = false;
         if (verbose_)
-          std::cout << " Total Events " << nEvents_ << " Selected Events "
-                    << nSelectedEvents_ << " DCS States : "
-                    << " TEC- " << (*dcsStatus)[0].ready(DcsStatus::TECm)
-                    << " TEC+ " << (*dcsStatus)[0].ready(DcsStatus::TECp)
-                    << " TIB/TID " << (*dcsStatus)[0].ready(DcsStatus::TIBTID)
-                    << " TOB " << (*dcsStatus)[0].ready(DcsStatus::TOB)
-                    << " Detector States " << detectorOn_ << std::endl;
+          std::cout << " Total Events " << nEvents_ << " Selected Events " << nSelectedEvents_ << " DCS States : "
+                    << " TEC- " << (*dcsStatus)[0].ready(DcsStatus::TECm) << " TEC+ "
+                    << (*dcsStatus)[0].ready(DcsStatus::TECp) << " TIB/TID " << (*dcsStatus)[0].ready(DcsStatus::TIBTID)
+                    << " TOB " << (*dcsStatus)[0].ready(DcsStatus::TOB) << " Detector States " << detectorOn_
+                    << std::endl;
       }
     } else {
-      edm::LogError("DetectorStatusFilter")
-          << "ERROR: DcsStatusCollection not found !";
+      edm::LogError("DetectorStatusFilter") << "ERROR: DcsStatusCollection not found !";
     }
   } else {
     detectorOn_ = true;
     nSelectedEvents_++;
     if (verbose_)
-      std::cout << "Total MC Events " << nEvents_ << " Selected Events "
-                << nSelectedEvents_ << " Detector States " << detectorOn_
-                << std::endl;
+      std::cout << "Total MC Events " << nEvents_ << " Selected Events " << nSelectedEvents_ << " Detector States "
+                << detectorOn_ << std::endl;
   }
   return detectorOn_;
 }

--- a/DQM/TrackerCommon/src/TriggerHelper.cc
+++ b/DQM/TrackerCommon/src/TriggerHelper.cc
@@ -13,10 +13,16 @@
 
 /// To be called from the ED module's c'tor
 TriggerHelper::TriggerHelper(const edm::ParameterSet &config)
-    : watchDB_(nullptr), gtDBKey_(""), l1DBKey_(""), hltDBKey_(""), on_(true),
-      onDcs_(true), onGt_(true), onL1_(true), onHlt_(true),
+    : watchDB_(nullptr),
+      gtDBKey_(""),
+      l1DBKey_(""),
+      hltDBKey_(""),
+      on_(true),
+      onDcs_(true),
+      onGt_(true),
+      onL1_(true),
+      onHlt_(true),
       configError_("CONFIG_ERROR") {
-
   // General switch(es)
   if (config.exists("andOr")) {
     andOr_ = config.getParameter<bool>("andOr");
@@ -40,8 +46,7 @@ TriggerHelper::TriggerHelper(const edm::ParameterSet &config)
     if (config.exists("andOrGt")) {
       andOrGt_ = config.getParameter<bool>("andOrGt");
       gtInputTag_ = config.getParameter<edm::InputTag>("gtInputTag");
-      gtLogicalExpressions_ =
-          config.getParameter<std::vector<std::string>>("gtStatusBits");
+      gtLogicalExpressions_ = config.getParameter<std::vector<std::string>>("gtStatusBits");
       errorReplyGt_ = config.getParameter<bool>("errorReplyGt");
       if (config.exists("gtDBKey"))
         gtDBKey_ = config.getParameter<std::string>("gtDBKey");
@@ -50,8 +55,7 @@ TriggerHelper::TriggerHelper(const edm::ParameterSet &config)
     }
     if (config.exists("andOrL1")) {
       andOrL1_ = config.getParameter<bool>("andOrL1");
-      l1LogicalExpressions_ =
-          config.getParameter<std::vector<std::string>>("l1Algorithms");
+      l1LogicalExpressions_ = config.getParameter<std::vector<std::string>>("l1Algorithms");
       errorReplyL1_ = config.getParameter<bool>("errorReplyL1");
       if (config.exists("l1DBKey"))
         l1DBKey_ = config.getParameter<std::string>("l1DBKey");
@@ -61,8 +65,7 @@ TriggerHelper::TriggerHelper(const edm::ParameterSet &config)
     if (config.exists("andOrHlt")) {
       andOrHlt_ = config.getParameter<bool>("andOrHlt");
       hltInputTag_ = config.getParameter<edm::InputTag>("hltInputTag");
-      hltLogicalExpressions_ =
-          config.getParameter<std::vector<std::string>>("hltPaths");
+      hltLogicalExpressions_ = config.getParameter<std::vector<std::string>>("hltPaths");
       errorReplyHlt_ = config.getParameter<bool>("errorReplyHlt");
       if (config.exists("hltDBKey"))
         hltDBKey_ = config.getParameter<std::string>("hltDBKey");
@@ -78,14 +81,12 @@ TriggerHelper::TriggerHelper(const edm::ParameterSet &config)
 
 /// To be called from d'tors by 'delete'
 TriggerHelper::~TriggerHelper() {
-
   if (on_)
     delete watchDB_;
 }
 
 /// To be called from beginedm::Run() methods
 void TriggerHelper::initRun(const edm::Run &run, const edm::EventSetup &setup) {
-
   // FIXME Can this stay safely in the run loop, or does it need to go to the
   // event loop? Means: Are the event setups identical?
   if (watchDB_->check(setup)) {
@@ -109,15 +110,13 @@ void TriggerHelper::initRun(const edm::Run &run, const edm::EventSetup &setup) {
   hltConfigInit_ = false;
   if (onHlt_) {
     if (hltInputTag_.process().empty()) {
-      edm::LogError("TriggerHelper")
-          << "HLT TriggerResults InputTag \"" << hltInputTag_.encode()
-          << "\" specifies no process";
+      edm::LogError("TriggerHelper") << "HLT TriggerResults InputTag \"" << hltInputTag_.encode()
+                                     << "\" specifies no process";
     } else {
       bool hltChanged(false);
       if (!hltConfig_.init(run, setup, hltInputTag_.process(), hltChanged)) {
-        edm::LogError("TriggerHelper")
-            << "HLT config initialization error with process name \""
-            << hltInputTag_.process() << "\"";
+        edm::LogError("TriggerHelper") << "HLT config initialization error with process name \""
+                                       << hltInputTag_.process() << "\"";
       } else if (hltConfig_.size() <= 0) {
         edm::LogError("TriggerHelper") << "HLT config size error";
       } else
@@ -127,91 +126,81 @@ void TriggerHelper::initRun(const edm::Run &run, const edm::EventSetup &setup) {
 }
 
 /// To be called from analyze/filter() methods
-bool TriggerHelper::accept(const edm::Event &event,
-                           const edm::EventSetup &setup) {
-
+bool TriggerHelper::accept(const edm::Event &event, const edm::EventSetup &setup) {
   if (!on_)
     return true;
 
   // Determine decision
   if (andOr_)
-    return (acceptDcs(event) || acceptGt(event) || acceptL1(event, setup) ||
-            acceptHlt(event));
-  return (acceptDcs(event) && acceptGt(event) && acceptL1(event, setup) &&
-          acceptHlt(event));
+    return (acceptDcs(event) || acceptGt(event) || acceptL1(event, setup) || acceptHlt(event));
+  return (acceptDcs(event) && acceptGt(event) && acceptL1(event, setup) && acceptHlt(event));
 }
 
 bool TriggerHelper::acceptDcs(const edm::Event &event) {
-
   // An empty DCS partitions list acts as switch.
   if (!onDcs_ || dcsPartitions_.empty())
-    return (!andOr_); // logically neutral, depending on base logical connective
+    return (!andOr_);  // logically neutral, depending on base logical connective
 
   // Accessing the DcsStatusCollection
   edm::Handle<DcsStatusCollection> dcsStatus;
   event.getByLabel(dcsInputTag_, dcsStatus);
   if (!dcsStatus.isValid()) {
-    edm::LogError("TriggerHelper")
-        << "DcsStatusCollection product with InputTag \""
-        << dcsInputTag_.encode()
-        << "\" not in event ==> decision: " << errorReplyDcs_;
+    edm::LogError("TriggerHelper") << "DcsStatusCollection product with InputTag \"" << dcsInputTag_.encode()
+                                   << "\" not in event ==> decision: " << errorReplyDcs_;
     return errorReplyDcs_;
   }
 
   // Determine decision of DCS partition combination and return
-  if (andOrDcs_) { // OR combination
-    for (std::vector<int>::const_iterator partitionNumber =
-             dcsPartitions_.begin();
-         partitionNumber != dcsPartitions_.end(); ++partitionNumber) {
+  if (andOrDcs_) {  // OR combination
+    for (std::vector<int>::const_iterator partitionNumber = dcsPartitions_.begin();
+         partitionNumber != dcsPartitions_.end();
+         ++partitionNumber) {
       if (acceptDcsPartition(dcsStatus, *partitionNumber))
         return true;
     }
     return false;
   }
-  for (std::vector<int>::const_iterator partitionNumber =
-           dcsPartitions_.begin();
-       partitionNumber != dcsPartitions_.end(); ++partitionNumber) {
+  for (std::vector<int>::const_iterator partitionNumber = dcsPartitions_.begin();
+       partitionNumber != dcsPartitions_.end();
+       ++partitionNumber) {
     if (!acceptDcsPartition(dcsStatus, *partitionNumber))
       return false;
   }
   return true;
 }
 
-bool TriggerHelper::acceptDcsPartition(
-    const edm::Handle<DcsStatusCollection> &dcsStatus, int dcsPartition) const {
-
+bool TriggerHelper::acceptDcsPartition(const edm::Handle<DcsStatusCollection> &dcsStatus, int dcsPartition) const {
   // Error checks
   switch (dcsPartition) {
-  case DcsStatus::EBp:
-  case DcsStatus::EBm:
-  case DcsStatus::EEp:
-  case DcsStatus::EEm:
-  case DcsStatus::HBHEa:
-  case DcsStatus::HBHEb:
-  case DcsStatus::HBHEc:
-  case DcsStatus::HF:
-  case DcsStatus::HO:
-  case DcsStatus::RPC:
-  case DcsStatus::DT0:
-  case DcsStatus::DTp:
-  case DcsStatus::DTm:
-  case DcsStatus::CSCp:
-  case DcsStatus::CSCm:
-  case DcsStatus::CASTOR:
-  case DcsStatus::TIBTID:
-  case DcsStatus::TOB:
-  case DcsStatus::TECp:
-  case DcsStatus::TECm:
-  case DcsStatus::BPIX:
-  case DcsStatus::FPIX:
-  case DcsStatus::ESp:
-  case DcsStatus::ESm:
-    break;
-  default:
-    edm::LogError("TriggerHelper")
-        << "DCS partition number \"" << dcsPartition
-        << "\" does not exist ==> decision: " << errorReplyDcs_;
-    return errorReplyDcs_;
+    case DcsStatus::EBp:
+    case DcsStatus::EBm:
+    case DcsStatus::EEp:
+    case DcsStatus::EEm:
+    case DcsStatus::HBHEa:
+    case DcsStatus::HBHEb:
+    case DcsStatus::HBHEc:
+    case DcsStatus::HF:
+    case DcsStatus::HO:
+    case DcsStatus::RPC:
+    case DcsStatus::DT0:
+    case DcsStatus::DTp:
+    case DcsStatus::DTm:
+    case DcsStatus::CSCp:
+    case DcsStatus::CSCm:
+    case DcsStatus::CASTOR:
+    case DcsStatus::TIBTID:
+    case DcsStatus::TOB:
+    case DcsStatus::TECp:
+    case DcsStatus::TECm:
+    case DcsStatus::BPIX:
+    case DcsStatus::FPIX:
+    case DcsStatus::ESp:
+    case DcsStatus::ESm:
+      break;
+    default:
+      edm::LogError("TriggerHelper") << "DCS partition number \"" << dcsPartition
+                                     << "\" does not exist ==> decision: " << errorReplyDcs_;
+      return errorReplyDcs_;
   }
 
   // Determine decision
@@ -221,27 +210,23 @@ bool TriggerHelper::acceptDcsPartition(
 /// Does this event fulfill the configured GT status logical expression
 /// combination?
 bool TriggerHelper::acceptGt(const edm::Event &event) {
-
   // An empty GT status bits logical expressions list acts as switch.
   if (!onGt_ || gtLogicalExpressions_.empty())
-    return (!andOr_); // logically neutral, depending on base logical connective
+    return (!andOr_);  // logically neutral, depending on base logical connective
 
   // Accessing the L1GlobalTriggerReadoutRecord
   edm::Handle<L1GlobalTriggerReadoutRecord> gtReadoutRecord;
   event.getByLabel(gtInputTag_, gtReadoutRecord);
   if (!gtReadoutRecord.isValid()) {
-    edm::LogError("TriggerHelper")
-        << "L1GlobalTriggerReadoutRecord product with InputTag \""
-        << gtInputTag_.encode()
-        << "\" not in event ==> decision: " << errorReplyGt_;
+    edm::LogError("TriggerHelper") << "L1GlobalTriggerReadoutRecord product with InputTag \"" << gtInputTag_.encode()
+                                   << "\" not in event ==> decision: " << errorReplyGt_;
     return errorReplyGt_;
   }
 
   // Determine decision of GT status bits logical expression combination and
   // return
-  if (andOrGt_) { // OR combination
-    for (std::vector<std::string>::const_iterator gtLogicalExpression =
-             gtLogicalExpressions_.begin();
+  if (andOrGt_) {  // OR combination
+    for (std::vector<std::string>::const_iterator gtLogicalExpression = gtLogicalExpressions_.begin();
          gtLogicalExpression != gtLogicalExpressions_.end();
          ++gtLogicalExpression) {
       if (acceptGtLogicalExpression(gtReadoutRecord, *gtLogicalExpression))
@@ -249,8 +234,7 @@ bool TriggerHelper::acceptGt(const edm::Event &event) {
     }
     return false;
   }
-  for (std::vector<std::string>::const_iterator gtLogicalExpression =
-           gtLogicalExpressions_.begin();
+  for (std::vector<std::string>::const_iterator gtLogicalExpression = gtLogicalExpressions_.begin();
        gtLogicalExpression != gtLogicalExpressions_.end();
        ++gtLogicalExpression) {
     if (!acceptGtLogicalExpression(gtReadoutRecord, *gtLogicalExpression))
@@ -260,46 +244,37 @@ bool TriggerHelper::acceptGt(const edm::Event &event) {
 }
 
 /// Does this event fulfill this particular GT status bits' logical expression?
-bool TriggerHelper::acceptGtLogicalExpression(
-    const edm::Handle<L1GlobalTriggerReadoutRecord> &gtReadoutRecord,
-    std::string gtLogicalExpression) {
-
+bool TriggerHelper::acceptGtLogicalExpression(const edm::Handle<L1GlobalTriggerReadoutRecord> &gtReadoutRecord,
+                                              std::string gtLogicalExpression) {
   // Check empty std::strings
   if (gtLogicalExpression.empty()) {
-    edm::LogError("TriggerHelper")
-        << "Empty logical expression ==> decision: " << errorReplyGt_;
+    edm::LogError("TriggerHelper") << "Empty logical expression ==> decision: " << errorReplyGt_;
     return errorReplyGt_;
   }
 
   // Negated paths
   bool negExpr(negate(gtLogicalExpression));
   if (negExpr && gtLogicalExpression.empty()) {
-    edm::LogError("TriggerHelper")
-        << "Empty (negated) logical expression ==> decision: " << errorReplyGt_;
+    edm::LogError("TriggerHelper") << "Empty (negated) logical expression ==> decision: " << errorReplyGt_;
     return errorReplyGt_;
   }
 
   // Parse logical expression and determine GT status bit decision
   L1GtLogicParser gtAlgoLogicParser(gtLogicalExpression);
   // Loop over status bits
-  for (size_t iStatusBit = 0;
-       iStatusBit < gtAlgoLogicParser.operandTokenVector().size();
-       ++iStatusBit) {
-    const std::string gtStatusBit(
-        gtAlgoLogicParser.operandTokenVector().at(iStatusBit).tokenName);
+  for (size_t iStatusBit = 0; iStatusBit < gtAlgoLogicParser.operandTokenVector().size(); ++iStatusBit) {
+    const std::string gtStatusBit(gtAlgoLogicParser.operandTokenVector().at(iStatusBit).tokenName);
     // Manipulate status bit decision as stored in the parser
     bool decision;
     // Hard-coded status bits!!!
     if (gtStatusBit == "PhysDecl" || gtStatusBit == "PhysicsDeclared") {
       decision = (gtReadoutRecord->gtFdlWord().physicsDeclared() == 1);
     } else {
-      edm::LogError("TriggerHelper")
-          << "GT status bit \"" << gtStatusBit
-          << "\" is not defined ==> decision: " << errorReplyGt_;
+      edm::LogError("TriggerHelper") << "GT status bit \"" << gtStatusBit
+                                     << "\" is not defined ==> decision: " << errorReplyGt_;
       decision = errorReplyDcs_;
     }
-    gtAlgoLogicParser.operandTokenVector().at(iStatusBit).tokenResult =
-        decision;
+    gtAlgoLogicParser.operandTokenVector().at(iStatusBit).tokenResult = decision;
   }
 
   // Determine decision
@@ -308,20 +283,17 @@ bool TriggerHelper::acceptGtLogicalExpression(
 }
 
 /// Was this event accepted by the configured L1 logical expression combination?
-bool TriggerHelper::acceptL1(const edm::Event &event,
-                             const edm::EventSetup &setup) {
-
+bool TriggerHelper::acceptL1(const edm::Event &event, const edm::EventSetup &setup) {
   // An empty L1 logical expressions list acts as switch.
   if (!onL1_ || l1LogicalExpressions_.empty())
-    return (!andOr_); // logically neutral, depending on base logical connective
+    return (!andOr_);  // logically neutral, depending on base logical connective
 
   // Getting the L1 event setup
-  l1Gt_->retrieveL1EventSetup(setup); // FIXME This can possibly go to initRun()
+  l1Gt_->retrieveL1EventSetup(setup);  // FIXME This can possibly go to initRun()
 
   // Determine decision of L1 logical expression combination and return
-  if (andOrL1_) { // OR combination
-    for (std::vector<std::string>::const_iterator l1LogicalExpression =
-             l1LogicalExpressions_.begin();
+  if (andOrL1_) {  // OR combination
+    for (std::vector<std::string>::const_iterator l1LogicalExpression = l1LogicalExpressions_.begin();
          l1LogicalExpression != l1LogicalExpressions_.end();
          ++l1LogicalExpression) {
       if (acceptL1LogicalExpression(event, *l1LogicalExpression))
@@ -329,8 +301,7 @@ bool TriggerHelper::acceptL1(const edm::Event &event,
     }
     return false;
   }
-  for (std::vector<std::string>::const_iterator l1LogicalExpression =
-           l1LogicalExpressions_.begin();
+  for (std::vector<std::string>::const_iterator l1LogicalExpression = l1LogicalExpressions_.begin();
        l1LogicalExpression != l1LogicalExpressions_.end();
        ++l1LogicalExpression) {
     if (!acceptL1LogicalExpression(event, *l1LogicalExpression))
@@ -341,53 +312,40 @@ bool TriggerHelper::acceptL1(const edm::Event &event,
 
 /// Was this event accepted by this particular L1 algorithms' logical
 /// expression?
-bool TriggerHelper::acceptL1LogicalExpression(const edm::Event &event,
-                                              std::string l1LogicalExpression) {
-
+bool TriggerHelper::acceptL1LogicalExpression(const edm::Event &event, std::string l1LogicalExpression) {
   // Check empty std::strings
   if (l1LogicalExpression.empty()) {
-    edm::LogError("TriggerHelper")
-        << "Empty logical expression ==> decision: " << errorReplyL1_;
+    edm::LogError("TriggerHelper") << "Empty logical expression ==> decision: " << errorReplyL1_;
     return errorReplyL1_;
   }
 
   // Negated logical expression
   bool negExpr(negate(l1LogicalExpression));
   if (negExpr && l1LogicalExpression.empty()) {
-    edm::LogError("TriggerHelper")
-        << "Empty (negated) logical expression ==> decision: " << errorReplyL1_;
+    edm::LogError("TriggerHelper") << "Empty (negated) logical expression ==> decision: " << errorReplyL1_;
     return errorReplyL1_;
   }
 
   // Parse logical expression and determine L1 decision
   L1GtLogicParser l1AlgoLogicParser(l1LogicalExpression);
   // Loop over algorithms
-  for (size_t iAlgorithm = 0;
-       iAlgorithm < l1AlgoLogicParser.operandTokenVector().size();
-       ++iAlgorithm) {
-    const std::string l1AlgoName(
-        l1AlgoLogicParser.operandTokenVector().at(iAlgorithm).tokenName);
+  for (size_t iAlgorithm = 0; iAlgorithm < l1AlgoLogicParser.operandTokenVector().size(); ++iAlgorithm) {
+    const std::string l1AlgoName(l1AlgoLogicParser.operandTokenVector().at(iAlgorithm).tokenName);
     int error(-1);
     const bool decision(l1Gt_->decision(event, l1AlgoName, error));
     // Error checks
     if (error != 0) {
       if (error == 1)
-        edm::LogError("TriggerHelper")
-            << "L1 algorithm \"" << l1AlgoName
-            << "\" does not exist in the L1 menu ==> decision: "
-            << errorReplyL1_;
+        edm::LogError("TriggerHelper") << "L1 algorithm \"" << l1AlgoName
+                                       << "\" does not exist in the L1 menu ==> decision: " << errorReplyL1_;
       else
-        edm::LogError("TriggerHelper")
-            << "L1 algorithm \"" << l1AlgoName << "\" received error code "
-            << error << " from L1GtUtils::decisionBeforeMask ==> decision: "
-            << errorReplyL1_;
-      l1AlgoLogicParser.operandTokenVector().at(iAlgorithm).tokenResult =
-          errorReplyL1_;
+        edm::LogError("TriggerHelper") << "L1 algorithm \"" << l1AlgoName << "\" received error code " << error
+                                       << " from L1GtUtils::decisionBeforeMask ==> decision: " << errorReplyL1_;
+      l1AlgoLogicParser.operandTokenVector().at(iAlgorithm).tokenResult = errorReplyL1_;
       continue;
     }
     // Manipulate algo decision as stored in the parser
-    l1AlgoLogicParser.operandTokenVector().at(iAlgorithm).tokenResult =
-        decision;
+    l1AlgoLogicParser.operandTokenVector().at(iAlgorithm).tokenResult = decision;
   }
 
   // Return decision
@@ -398,15 +356,13 @@ bool TriggerHelper::acceptL1LogicalExpression(const edm::Event &event,
 /// Was this event accepted by the configured HLT logical expression
 /// combination?
 bool TriggerHelper::acceptHlt(const edm::Event &event) {
-
   // An empty HLT logical expressions list acts as switch.
   if (!onHlt_ || hltLogicalExpressions_.empty())
-    return (!andOr_); // logically neutral, depending on base logical connective
+    return (!andOr_);  // logically neutral, depending on base logical connective
 
   // Checking the HLT configuration,
   if (!hltConfigInit_) {
-    edm::LogError("TriggerHelper")
-        << "HLT config error ==> decision: " << errorReplyHlt_;
+    edm::LogError("TriggerHelper") << "HLT config error ==> decision: " << errorReplyHlt_;
     return errorReplyHlt_;
   }
 
@@ -414,16 +370,14 @@ bool TriggerHelper::acceptHlt(const edm::Event &event) {
   edm::Handle<edm::TriggerResults> hltTriggerResults;
   event.getByLabel(hltInputTag_, hltTriggerResults);
   if (!hltTriggerResults.isValid()) {
-    edm::LogError("TriggerHelper")
-        << "TriggerResults product with InputTag \"" << hltInputTag_.encode()
-        << "\" not in event ==> decision: " << errorReplyHlt_;
+    edm::LogError("TriggerHelper") << "TriggerResults product with InputTag \"" << hltInputTag_.encode()
+                                   << "\" not in event ==> decision: " << errorReplyHlt_;
     return errorReplyHlt_;
   }
 
   // Determine decision of HLT logical expression combination and return
-  if (andOrHlt_) { // OR combination
-    for (std::vector<std::string>::const_iterator hltLogicalExpression =
-             hltLogicalExpressions_.begin();
+  if (andOrHlt_) {  // OR combination
+    for (std::vector<std::string>::const_iterator hltLogicalExpression = hltLogicalExpressions_.begin();
          hltLogicalExpression != hltLogicalExpressions_.end();
          ++hltLogicalExpression) {
       if (acceptHltLogicalExpression(hltTriggerResults, *hltLogicalExpression))
@@ -431,8 +385,7 @@ bool TriggerHelper::acceptHlt(const edm::Event &event) {
     }
     return false;
   }
-  for (std::vector<std::string>::const_iterator hltLogicalExpression =
-           hltLogicalExpressions_.begin();
+  for (std::vector<std::string>::const_iterator hltLogicalExpression = hltLogicalExpressions_.begin();
        hltLogicalExpression != hltLogicalExpressions_.end();
        ++hltLogicalExpression) {
     if (!acceptHltLogicalExpression(hltTriggerResults, *hltLogicalExpression))
@@ -442,49 +395,37 @@ bool TriggerHelper::acceptHlt(const edm::Event &event) {
 }
 
 /// Was this event accepted by this particular HLT paths' logical expression?
-bool TriggerHelper::acceptHltLogicalExpression(
-    const edm::Handle<edm::TriggerResults> &hltTriggerResults,
-    std::string hltLogicalExpression) const {
-
+bool TriggerHelper::acceptHltLogicalExpression(const edm::Handle<edm::TriggerResults> &hltTriggerResults,
+                                               std::string hltLogicalExpression) const {
   // Check empty std::strings
   if (hltLogicalExpression.empty()) {
-    edm::LogError("TriggerHelper")
-        << "Empty logical expression ==> decision: " << errorReplyHlt_;
+    edm::LogError("TriggerHelper") << "Empty logical expression ==> decision: " << errorReplyHlt_;
     return errorReplyHlt_;
   }
 
   // Negated paths
   bool negExpr(negate(hltLogicalExpression));
   if (negExpr && hltLogicalExpression.empty()) {
-    edm::LogError("TriggerHelper")
-        << "Empty (negated) logical expression ==> decision: "
-        << errorReplyHlt_;
+    edm::LogError("TriggerHelper") << "Empty (negated) logical expression ==> decision: " << errorReplyHlt_;
     return errorReplyHlt_;
   }
 
   // Parse logical expression and determine HLT decision
   L1GtLogicParser hltAlgoLogicParser(hltLogicalExpression);
   // Loop over paths
-  for (size_t iPath = 0; iPath < hltAlgoLogicParser.operandTokenVector().size();
-       ++iPath) {
-    const std::string hltPathName(
-        hltAlgoLogicParser.operandTokenVector().at(iPath).tokenName);
+  for (size_t iPath = 0; iPath < hltAlgoLogicParser.operandTokenVector().size(); ++iPath) {
+    const std::string hltPathName(hltAlgoLogicParser.operandTokenVector().at(iPath).tokenName);
     const unsigned indexPath(hltConfig_.triggerIndex(hltPathName));
     // Further error checks
     if (indexPath == hltConfig_.size()) {
-      edm::LogError("TriggerHelper")
-          << "HLT path \"" << hltPathName << "\" is not found in process "
-          << hltInputTag_.process() << " ==> decision: " << errorReplyHlt_;
-      hltAlgoLogicParser.operandTokenVector().at(iPath).tokenResult =
-          errorReplyHlt_;
+      edm::LogError("TriggerHelper") << "HLT path \"" << hltPathName << "\" is not found in process "
+                                     << hltInputTag_.process() << " ==> decision: " << errorReplyHlt_;
+      hltAlgoLogicParser.operandTokenVector().at(iPath).tokenResult = errorReplyHlt_;
       continue;
     }
     if (hltTriggerResults->error(indexPath)) {
-      edm::LogError("TriggerHelper")
-          << "HLT path \"" << hltPathName
-          << "\" in error ==> decision: " << errorReplyHlt_;
-      hltAlgoLogicParser.operandTokenVector().at(iPath).tokenResult =
-          errorReplyHlt_;
+      edm::LogError("TriggerHelper") << "HLT path \"" << hltPathName << "\" in error ==> decision: " << errorReplyHlt_;
+      hltAlgoLogicParser.operandTokenVector().at(iPath).tokenResult = errorReplyHlt_;
       continue;
     }
     // Manipulate algo decision as stored in the parser
@@ -498,19 +439,14 @@ bool TriggerHelper::acceptHltLogicalExpression(
 }
 
 /// Reads and returns logical expressions from DB
-std::vector<std::string>
-TriggerHelper::expressionsFromDB(const std::string &key,
-                                 const edm::EventSetup &setup) {
-
+std::vector<std::string> TriggerHelper::expressionsFromDB(const std::string &key, const edm::EventSetup &setup) {
   edm::ESHandle<AlCaRecoTriggerBits> logicalExpressions;
   setup.get<AlCaRecoTriggerBitsRcd>().get(logicalExpressions);
-  const std::map<std::string, std::string> &expressionMap =
-      logicalExpressions->m_alcarecoToTrig;
-  std::map<std::string, std::string>::const_iterator listIter =
-      expressionMap.find(key);
+  const std::map<std::string, std::string> &expressionMap = logicalExpressions->m_alcarecoToTrig;
+  std::map<std::string, std::string>::const_iterator listIter = expressionMap.find(key);
   if (listIter == expressionMap.end()) {
-    edm::LogError("TriggerHelper") << "No logical expressions found under key "
-                                   << key << " in 'AlCaRecoTriggerBitsRcd'";
+    edm::LogError("TriggerHelper") << "No logical expressions found under key " << key
+                                   << " in 'AlCaRecoTriggerBitsRcd'";
     return std::vector<std::string>(1, configError_);
   }
   return logicalExpressions->decompose(listIter->second);
@@ -518,7 +454,6 @@ TriggerHelper::expressionsFromDB(const std::string &key,
 
 /// Checks for negated words
 bool TriggerHelper::negate(std::string &word) const {
-
   bool negate(false);
   if (word.at(0) == '~') {
     negate = true;

--- a/DQMOffline/Alignment/interface/LaserAlignmentT0ProducerDQM.h
+++ b/DQMOffline/Alignment/interface/LaserAlignmentT0ProducerDQM.h
@@ -37,13 +37,11 @@
 #include "Alignment/LaserAlignment/interface/LASGlobalLoop.h"
 
 class LaserAlignmentT0ProducerDQM : public DQMEDAnalyzer {
-
 public:
   explicit LaserAlignmentT0ProducerDQM(const edm::ParameterSet &);
   ~LaserAlignmentT0ProducerDQM() override;
 
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
 private:

--- a/DQMOffline/Alignment/interface/MuonAlignment.h
+++ b/DQMOffline/Alignment/interface/MuonAlignment.h
@@ -51,10 +51,10 @@
 #include "DQMServices/Core/interface/MonitorElement.h"
 
 namespace edm {
-class ParameterSet;
-class EventSetup;
-class InputTag;
-} // namespace edm
+  class ParameterSet;
+  class EventSetup;
+  class InputTag;
+}  // namespace edm
 
 class TH1F;
 
@@ -118,7 +118,8 @@ private:
 
   RecHitVector doMatching(const reco::Track &,
                           edm::Handle<DTRecSegment4DCollection> &,
-                          edm::Handle<CSCSegmentCollection> &, intDVector *,
+                          edm::Handle<CSCSegmentCollection> &,
+                          intDVector *,
                           intDVector *,
                           edm::ESHandle<GlobalTrackingGeometry> &);
 
@@ -132,10 +133,8 @@ private:
   std::string trackRefitterType;
 
   // residual histos residual range
-  double resLocalXRangeStation1, resLocalXRangeStation2, resLocalXRangeStation3,
-      resLocalXRangeStation4;
-  double resLocalYRangeStation1, resLocalYRangeStation2, resLocalYRangeStation3,
-      resLocalYRangeStation4;
+  double resLocalXRangeStation1, resLocalXRangeStation2, resLocalXRangeStation3, resLocalXRangeStation4;
+  double resLocalYRangeStation1, resLocalYRangeStation2, resLocalYRangeStation3, resLocalYRangeStation4;
   double resPhiRange, resThetaRange;
 
   // mean and rms histos ranges

--- a/DQMOffline/Alignment/interface/MuonAlignmentSummary.h
+++ b/DQMOffline/Alignment/interface/MuonAlignmentSummary.h
@@ -24,10 +24,10 @@
 #include "DQMServices/Core/interface/MonitorElement.h"
 
 namespace edm {
-class ParameterSet;
-class EventSetup;
-class InputTag;
-} // namespace edm
+  class ParameterSet;
+  class EventSetup;
+  class InputTag;
+}  // namespace edm
 
 class TH1F;
 
@@ -41,7 +41,7 @@ public:
 
   // Book histograms
   void dqmEndJob(DQMStore::IBooker &,
-                 DQMStore::IGetter &) override; // performed in the endJob
+                 DQMStore::IGetter &) override;  // performed in the endJob
 
 private:
   // ----------member data ---------------------------

--- a/DQMOffline/Alignment/interface/TkAlCaRecoMonitor.h
+++ b/DQMOffline/Alignment/interface/TkAlCaRecoMonitor.h
@@ -35,8 +35,7 @@ public:
   explicit TkAlCaRecoMonitor(const edm::ParameterSet &);
   ~TkAlCaRecoMonitor() override;
 
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
 private:

--- a/DQMOffline/Alignment/src/LaserAlignmentT0ProducerDQM.cc
+++ b/DQMOffline/Alignment/src/LaserAlignmentT0ProducerDQM.cc
@@ -4,9 +4,7 @@
 ///
 ///
 ///
-LaserAlignmentT0ProducerDQM::LaserAlignmentT0ProducerDQM(
-    const edm::ParameterSet &aConfiguration) {
-
+LaserAlignmentT0ProducerDQM::LaserAlignmentT0ProducerDQM(const edm::ParameterSet &aConfiguration) {
   theConfiguration = aConfiguration;
   FillDetectorId();
 }
@@ -19,20 +17,14 @@ LaserAlignmentT0ProducerDQM::~LaserAlignmentT0ProducerDQM() {}
 void LaserAlignmentT0ProducerDQM::bookHistograms(DQMStore::IBooker &iBooker,
                                                  edm::Run const &,
                                                  edm::EventSetup const &) {
-
   // upper and lower treshold for a profile considered showing a signal
-  theLowerAdcThreshold =
-      theConfiguration.getParameter<unsigned int>("LowerAdcThreshold");
-  theUpperAdcThreshold =
-      theConfiguration.getParameter<unsigned int>("UpperAdcThreshold");
+  theLowerAdcThreshold = theConfiguration.getParameter<unsigned int>("LowerAdcThreshold");
+  theUpperAdcThreshold = theConfiguration.getParameter<unsigned int>("UpperAdcThreshold");
 
   // the list of input digi products from the cfg
-  theDigiProducerList =
-      theConfiguration.getParameter<std::vector<edm::ParameterSet>>(
-          "DigiProducerList");
+  theDigiProducerList = theConfiguration.getParameter<std::vector<edm::ParameterSet>>("DigiProducerList");
 
-  std::string folderName =
-      theConfiguration.getParameter<std::string>("FolderName");
+  std::string folderName = theConfiguration.getParameter<std::string>("FolderName");
   iBooker.setCurrentFolder(folderName);
 
   std::string nameAndTitle;
@@ -45,8 +37,7 @@ void LaserAlignmentT0ProducerDQM::bookHistograms(DQMStore::IBooker &iBooker,
   // x: 16 modules (5*TEC-, 6*TIB, 6*TOB, 5*TEC+), all from -z to z
   // y: 8 beams
   nameAndTitle = "NumberOfSignals_AlignmentTubes";
-  nSignalsAT =
-      iBooker.book2D(nameAndTitle, nameAndTitle, 22, 0, 22, nBeams, 0, nBeams);
+  nSignalsAT = iBooker.book2D(nameAndTitle, nameAndTitle, 22, 0, 22, nBeams, 0, nBeams);
   //  nSignalsAT->setAxisTitle( "z-pos", 1 );
   //  nSignalsAT->setAxisTitle( "beam", 2 );
 
@@ -54,21 +45,21 @@ void LaserAlignmentT0ProducerDQM::bookHistograms(DQMStore::IBooker &iBooker,
   for (unsigned int i = 1; i <= 5; ++i) {
     labelBuilder.clear();
     labelBuilder.str("");
-    labelBuilder << "TEC- D" << 5 - i; // TEC-
+    labelBuilder << "TEC- D" << 5 - i;  // TEC-
     nSignalsAT->setBinLabel(i, labelBuilder.str(), 1);
     labelBuilder.clear();
     labelBuilder.str("");
-    labelBuilder << "TEC+ D" << i - 1; // TEC+
+    labelBuilder << "TEC+ D" << i - 1;  // TEC+
     nSignalsAT->setBinLabel(17 + i, labelBuilder.str(), 1);
   }
   for (unsigned int i = 0; i < 6; ++i) {
     labelBuilder.clear();
     labelBuilder.str("");
-    labelBuilder << "TIB" << i; // TIB
+    labelBuilder << "TIB" << i;  // TIB
     nSignalsAT->setBinLabel(6 + i, labelBuilder.str(), 1);
     labelBuilder.clear();
     labelBuilder.str("");
-    labelBuilder << "TOB" << i; // TOB
+    labelBuilder << "TOB" << i;  // TOB
     nSignalsAT->setBinLabel(12 + i, labelBuilder.str(), 1);
   }
 
@@ -76,26 +67,22 @@ void LaserAlignmentT0ProducerDQM::bookHistograms(DQMStore::IBooker &iBooker,
   // x: disk1...disk9 (from inner to outer, so z changes direction!)
   // y: 8 beams
   nameAndTitle = "NumberOfSignals_TEC+R4";
-  nSignalsTECPlusR4 = iBooker.book2D(nameAndTitle, nameAndTitle, nDisks, 0,
-                                     nDisks, nBeams, 0, nBeams);
+  nSignalsTECPlusR4 = iBooker.book2D(nameAndTitle, nameAndTitle, nDisks, 0, nDisks, nBeams, 0, nBeams);
   //  nSignalsTECPlusR4->setAxisTitle( "disk", 1 );
   //  nSignalsTECPlusR4->setAxisTitle( "beam", 2 );
 
   nameAndTitle = "NumberOfSignals_TEC+R6";
-  nSignalsTECPlusR6 = iBooker.book2D(nameAndTitle, nameAndTitle, nDisks, 0,
-                                     nDisks, nBeams, 0, nBeams);
+  nSignalsTECPlusR6 = iBooker.book2D(nameAndTitle, nameAndTitle, nDisks, 0, nDisks, nBeams, 0, nBeams);
   //  nSignalsTECPlusR6->setAxisTitle( "disk", 1 );
   //  nSignalsTECPlusR6->setAxisTitle( "beam", 2 );
 
   nameAndTitle = "NumberOfSignals_TEC-R4";
-  nSignalsTECMinusR4 = iBooker.book2D(nameAndTitle, nameAndTitle, nDisks, 0,
-                                      nDisks, nBeams, 0, nBeams);
+  nSignalsTECMinusR4 = iBooker.book2D(nameAndTitle, nameAndTitle, nDisks, 0, nDisks, nBeams, 0, nBeams);
   //  nSignalsTECMinusR4->setAxisTitle( "disk", 1 );
   //  nSignalsTECMinusR4->setAxisTitle( "beam", 2 );
 
   nameAndTitle = "NumberOfSignals_TEC-R6";
-  nSignalsTECMinusR6 = iBooker.book2D(nameAndTitle, nameAndTitle, nDisks, 0,
-                                      nDisks, nBeams, 0, nBeams);
+  nSignalsTECMinusR6 = iBooker.book2D(nameAndTitle, nameAndTitle, nDisks, 0, nDisks, nBeams, 0, nBeams);
   //  nSignalsTECMinusR6->setAxisTitle( "disk", 1 );
   //  nSignalsTECMinusR6->setAxisTitle( "beam", 2 );
 
@@ -126,25 +113,19 @@ void LaserAlignmentT0ProducerDQM::bookHistograms(DQMStore::IBooker &iBooker,
 ///
 ///
 ///
-void LaserAlignmentT0ProducerDQM::analyze(const edm::Event &aEvent,
-                                          const edm::EventSetup &aSetup) {
-
+void LaserAlignmentT0ProducerDQM::analyze(const edm::Event &aEvent, const edm::EventSetup &aSetup) {
   // loop all input products
-  for (std::vector<edm::ParameterSet>::iterator aDigiProducer =
-           theDigiProducerList.begin();
-       aDigiProducer != theDigiProducerList.end(); ++aDigiProducer) {
-    const std::string digiProducer =
-        aDigiProducer->getParameter<std::string>("DigiProducer");
-    const std::string digiLabel =
-        aDigiProducer->getParameter<std::string>("DigiLabel");
-    const std::string digiType =
-        aDigiProducer->getParameter<std::string>("DigiType");
+  for (std::vector<edm::ParameterSet>::iterator aDigiProducer = theDigiProducerList.begin();
+       aDigiProducer != theDigiProducerList.end();
+       ++aDigiProducer) {
+    const std::string digiProducer = aDigiProducer->getParameter<std::string>("DigiProducer");
+    const std::string digiLabel = aDigiProducer->getParameter<std::string>("DigiLabel");
+    const std::string digiType = aDigiProducer->getParameter<std::string>("DigiType");
 
     // now a distinction of cases: raw or processed digis?
 
     // first we go for raw digis => SiStripRawDigi
     if (digiType == "Raw") {
-
       // retrieve the SiStripRawDigis collection
       edm::Handle<edm::DetSetVector<SiStripRawDigi>> rawDigis;
       aEvent.getByLabel(digiProducer, digiLabel, rawDigis);
@@ -156,7 +137,6 @@ void LaserAlignmentT0ProducerDQM::analyze(const edm::Event &aEvent,
 
     // next we assume "ZeroSuppressed" (non-raw) => SiStripDigi
     else if (digiType == "Processed") {
-
       edm::Handle<edm::DetSetVector<SiStripDigi>> processedDigis;
       aEvent.getByLabel(digiProducer, digiLabel, processedDigis);
 
@@ -168,19 +148,16 @@ void LaserAlignmentT0ProducerDQM::analyze(const edm::Event &aEvent,
     // otherwise we have a problem
     else {
       throw cms::Exception("LaserAlignmentT0ProducerDQM")
-          << " ERROR ** Unknown DigiType: " << digiType
-          << " specified in config." << std::endl;
+          << " ERROR ** Unknown DigiType: " << digiType << " specified in config." << std::endl;
     }
 
-  } // loop all input products
+  }  // loop all input products
 }
 
 ///
 ///
 ///
-void LaserAlignmentT0ProducerDQM::FillFromRawDigis(
-    const edm::DetSetVector<SiStripRawDigi> &aDetSetVector) {
-
+void LaserAlignmentT0ProducerDQM::FillFromRawDigis(const edm::DetSetVector<SiStripRawDigi> &aDetSetVector) {
   LASGlobalLoop moduleLoop;
   int det, ring, beam, disk, pos;
 
@@ -190,7 +167,6 @@ void LaserAlignmentT0ProducerDQM::FillFromRawDigis(
   beam = 0;
   disk = 0;
   do {
-
     bool isAboveThreshold = false;
     bool isExceedThreshold = false;
 
@@ -198,19 +174,16 @@ void LaserAlignmentT0ProducerDQM::FillFromRawDigis(
     const int detRawId = detectorId.GetTECEntry(det, ring, beam, disk);
 
     // search the digis for this raw id
-    edm::DetSetVector<SiStripRawDigi>::const_iterator detSetIter =
-        aDetSetVector.find(detRawId);
+    edm::DetSetVector<SiStripRawDigi>::const_iterator detSetIter = aDetSetVector.find(detRawId);
 
     // raw DetSets may not be missing
     if (detSetIter == aDetSetVector.end()) {
       throw cms::Exception("[LaserAlignmentT0ProducerDQM::FillFromRawDigis]")
-          << " ** ERROR: No raw DetSet found for det: " << detRawId << "."
-          << std::endl;
+          << " ** ERROR: No raw DetSet found for det: " << detRawId << "." << std::endl;
     }
 
     // access single modules' digis
-    edm::DetSet<SiStripRawDigi>::const_iterator digiRangeIterator =
-        detSetIter->data.begin();
+    edm::DetSet<SiStripRawDigi>::const_iterator digiRangeIterator = detSetIter->data.begin();
 
     for (; digiRangeIterator != detSetIter->data.end(); ++digiRangeIterator) {
       const SiStripRawDigi &digi = *digiRangeIterator;
@@ -226,18 +199,17 @@ void LaserAlignmentT0ProducerDQM::FillFromRawDigis(
 
     // if we have signal, fill the histos
     if (isAboveThreshold && !isExceedThreshold) {
-
       // determine the appropriate histogram & bin from the position variables
-      if (det == 0) { // TEC+
+      if (det == 0) {  // TEC+
         if (ring == 0)
-          nSignalsTECPlusR4->Fill(disk, beam); // R4
+          nSignalsTECPlusR4->Fill(disk, beam);  // R4
         else
-          nSignalsTECPlusR6->Fill(disk, beam); // R6
-      } else {                                 // TEC-
+          nSignalsTECPlusR6->Fill(disk, beam);  // R6
+      } else {                                  // TEC-
         if (ring == 0)
-          nSignalsTECMinusR4->Fill(disk, beam); // R4
+          nSignalsTECMinusR4->Fill(disk, beam);  // R4
         else
-          nSignalsTECMinusR6->Fill(disk, beam); // R6
+          nSignalsTECMinusR6->Fill(disk, beam);  // R6
       }
     }
 
@@ -248,7 +220,6 @@ void LaserAlignmentT0ProducerDQM::FillFromRawDigis(
   beam = 0;
   disk = 0;
   do {
-
     bool isAboveThreshold = false;
     bool isExceedThreshold = false;
 
@@ -256,19 +227,16 @@ void LaserAlignmentT0ProducerDQM::FillFromRawDigis(
     const int detRawId = detectorId.GetTEC2TECEntry(det, beam, disk);
 
     // search the digis for this raw id
-    edm::DetSetVector<SiStripRawDigi>::const_iterator detSetIter =
-        aDetSetVector.find(detRawId);
+    edm::DetSetVector<SiStripRawDigi>::const_iterator detSetIter = aDetSetVector.find(detRawId);
 
     // raw DetSets may not be missing
     if (detSetIter == aDetSetVector.end()) {
       throw cms::Exception("[LaserAlignmentT0ProducerDQM::FillFromRawDigis]")
-          << " ** ERROR: No raw DetSet found for det: " << detRawId << "."
-          << std::endl;
+          << " ** ERROR: No raw DetSet found for det: " << detRawId << "." << std::endl;
     }
 
     // access single modules' digis
-    edm::DetSet<SiStripRawDigi>::const_iterator digiRangeIterator =
-        detSetIter->data.begin();
+    edm::DetSet<SiStripRawDigi>::const_iterator digiRangeIterator = detSetIter->data.begin();
 
     for (; digiRangeIterator != detSetIter->data.end(); ++digiRangeIterator) {
       const SiStripRawDigi &digi = *digiRangeIterator;
@@ -284,15 +252,14 @@ void LaserAlignmentT0ProducerDQM::FillFromRawDigis(
 
     // if we have signal, fill the histos
     if (isAboveThreshold && !isExceedThreshold) {
-
       // there is only one histogram for all AT hits
       // but the bin scheme is a little complicated:
       // the TEC(AT) go in the first 5(-) and last 5(+) of 22 bins along x
 
       if (det == 1)
-        nSignalsAT->Fill(4 - disk, beam); // TEC-
+        nSignalsAT->Fill(4 - disk, beam);  // TEC-
       else
-        nSignalsAT->Fill(17 + disk, beam); // TEC+
+        nSignalsAT->Fill(17 + disk, beam);  // TEC+
     }
 
   } while (moduleLoop.TEC2TECLoop(det, beam, disk));
@@ -302,7 +269,6 @@ void LaserAlignmentT0ProducerDQM::FillFromRawDigis(
   beam = 0;
   pos = 0;
   do {
-
     bool isAboveThreshold = false;
     bool isExceedThreshold = false;
 
@@ -310,19 +276,16 @@ void LaserAlignmentT0ProducerDQM::FillFromRawDigis(
     const int detRawId = detectorId.GetTIBTOBEntry(det, beam, pos);
 
     // search the digis for this raw id
-    edm::DetSetVector<SiStripRawDigi>::const_iterator detSetIter =
-        aDetSetVector.find(detRawId);
+    edm::DetSetVector<SiStripRawDigi>::const_iterator detSetIter = aDetSetVector.find(detRawId);
 
     // raw DetSets may not be missing
     if (detSetIter == aDetSetVector.end()) {
       throw cms::Exception("[LaserAlignmentT0ProducerDQM::FillFromRawDigis]")
-          << " ** ERROR: No raw DetSet found for det: " << detRawId << "."
-          << std::endl;
+          << " ** ERROR: No raw DetSet found for det: " << detRawId << "." << std::endl;
     }
 
     // access single modules' digis
-    edm::DetSet<SiStripRawDigi>::const_iterator digiRangeIterator =
-        detSetIter->data.begin();
+    edm::DetSet<SiStripRawDigi>::const_iterator digiRangeIterator = detSetIter->data.begin();
 
     for (; digiRangeIterator != detSetIter->data.end(); ++digiRangeIterator) {
       const SiStripRawDigi &digi = *digiRangeIterator;
@@ -338,15 +301,14 @@ void LaserAlignmentT0ProducerDQM::FillFromRawDigis(
 
     // if we have signal, fill the histos
     if (isAboveThreshold && !isExceedThreshold) {
-
       // there is only one histogram for all AT hits
       // but the bin scheme is a little complicated:
       // the TIB go into bins 6-11, TOB in 12-17
 
       if (det == 2)
-        nSignalsAT->Fill(5 + (5 - pos), beam); // TIB
+        nSignalsAT->Fill(5 + (5 - pos), beam);  // TIB
       else
-        nSignalsAT->Fill(11 + (5 - pos), beam); // TOB
+        nSignalsAT->Fill(11 + (5 - pos), beam);  // TOB
     }
 
   } while (moduleLoop.TIBTOBLoop(det, beam, pos));
@@ -355,9 +317,7 @@ void LaserAlignmentT0ProducerDQM::FillFromRawDigis(
 ///
 ///
 ///
-void LaserAlignmentT0ProducerDQM::FillFromProcessedDigis(
-    const edm::DetSetVector<SiStripDigi> &aDetSetVector) {
-
+void LaserAlignmentT0ProducerDQM::FillFromProcessedDigis(const edm::DetSetVector<SiStripDigi> &aDetSetVector) {
   LASGlobalLoop moduleLoop;
   int det, ring, beam, disk, pos;
 
@@ -367,7 +327,6 @@ void LaserAlignmentT0ProducerDQM::FillFromProcessedDigis(
   beam = 0;
   disk = 0;
   do {
-
     bool isAboveThreshold = false;
     bool isExceedThreshold = false;
 
@@ -375,16 +334,14 @@ void LaserAlignmentT0ProducerDQM::FillFromProcessedDigis(
     const int detRawId = detectorId.GetTECEntry(det, ring, beam, disk);
 
     // search the digis for this raw id
-    edm::DetSetVector<SiStripDigi>::const_iterator detSetIter =
-        aDetSetVector.find(detRawId);
+    edm::DetSetVector<SiStripDigi>::const_iterator detSetIter = aDetSetVector.find(detRawId);
 
     // processed DetSets may be missing (=empty), just skip
     if (detSetIter == aDetSetVector.end())
       continue;
 
     // access single modules' digis
-    edm::DetSet<SiStripDigi>::const_iterator digiRangeIterator =
-        detSetIter->data.begin();
+    edm::DetSet<SiStripDigi>::const_iterator digiRangeIterator = detSetIter->data.begin();
 
     for (; digiRangeIterator != detSetIter->data.end(); ++digiRangeIterator) {
       const SiStripDigi &digi = *digiRangeIterator;
@@ -400,18 +357,17 @@ void LaserAlignmentT0ProducerDQM::FillFromProcessedDigis(
 
     // if we have signal, fill the histos
     if (isAboveThreshold && !isExceedThreshold) {
-
       // determine the appropriate histogram & bin from the position variables
-      if (det == 0) { // TEC+
+      if (det == 0) {  // TEC+
         if (ring == 0)
-          nSignalsTECPlusR4->Fill(disk, beam); // R4
+          nSignalsTECPlusR4->Fill(disk, beam);  // R4
         else
-          nSignalsTECPlusR6->Fill(disk, beam); // R6
-      } else {                                 // TEC-
+          nSignalsTECPlusR6->Fill(disk, beam);  // R6
+      } else {                                  // TEC-
         if (ring == 0)
-          nSignalsTECMinusR4->Fill(disk, beam); // R4
+          nSignalsTECMinusR4->Fill(disk, beam);  // R4
         else
-          nSignalsTECMinusR6->Fill(disk, beam); // R6
+          nSignalsTECMinusR6->Fill(disk, beam);  // R6
       }
     }
 
@@ -422,7 +378,6 @@ void LaserAlignmentT0ProducerDQM::FillFromProcessedDigis(
   beam = 0;
   disk = 0;
   do {
-
     bool isAboveThreshold = false;
     bool isExceedThreshold = false;
 
@@ -430,16 +385,14 @@ void LaserAlignmentT0ProducerDQM::FillFromProcessedDigis(
     const int detRawId = detectorId.GetTEC2TECEntry(det, beam, disk);
 
     // search the digis for this raw id
-    edm::DetSetVector<SiStripDigi>::const_iterator detSetIter =
-        aDetSetVector.find(detRawId);
+    edm::DetSetVector<SiStripDigi>::const_iterator detSetIter = aDetSetVector.find(detRawId);
 
     // processed DetSets may be missing (=empty), just skip
     if (detSetIter == aDetSetVector.end())
       continue;
 
     // access single modules' digis
-    edm::DetSet<SiStripDigi>::const_iterator digiRangeIterator =
-        detSetIter->data.begin();
+    edm::DetSet<SiStripDigi>::const_iterator digiRangeIterator = detSetIter->data.begin();
 
     for (; digiRangeIterator != detSetIter->data.end(); ++digiRangeIterator) {
       const SiStripDigi &digi = *digiRangeIterator;
@@ -455,15 +408,14 @@ void LaserAlignmentT0ProducerDQM::FillFromProcessedDigis(
 
     // if we have signal, fill the histos
     if (isAboveThreshold && !isExceedThreshold) {
-
       // there is only one histogram for all AT hits
       // but the bin scheme is a little complicated:
       // the TEC(AT) go in the first 5(-) and last 5(+) of 22 bins along x
 
       if (det == 1)
-        nSignalsAT->Fill(4 - disk, beam); // TEC-
+        nSignalsAT->Fill(4 - disk, beam);  // TEC-
       else
-        nSignalsAT->Fill(17 + disk, beam); // TEC+
+        nSignalsAT->Fill(17 + disk, beam);  // TEC+
     }
 
   } while (moduleLoop.TEC2TECLoop(det, beam, disk));
@@ -473,7 +425,6 @@ void LaserAlignmentT0ProducerDQM::FillFromProcessedDigis(
   beam = 0;
   pos = 0;
   do {
-
     bool isAboveThreshold = false;
     bool isExceedThreshold = false;
 
@@ -481,16 +432,14 @@ void LaserAlignmentT0ProducerDQM::FillFromProcessedDigis(
     const int detRawId = detectorId.GetTIBTOBEntry(det, beam, pos);
 
     // search the digis for this raw id
-    edm::DetSetVector<SiStripDigi>::const_iterator detSetIter =
-        aDetSetVector.find(detRawId);
+    edm::DetSetVector<SiStripDigi>::const_iterator detSetIter = aDetSetVector.find(detRawId);
 
     // processed DetSets may be missing (=empty), just skip
     if (detSetIter == aDetSetVector.end())
       continue;
 
     // access single modules' digis
-    edm::DetSet<SiStripDigi>::const_iterator digiRangeIterator =
-        detSetIter->data.begin();
+    edm::DetSet<SiStripDigi>::const_iterator digiRangeIterator = detSetIter->data.begin();
 
     for (; digiRangeIterator != detSetIter->data.end(); ++digiRangeIterator) {
       const SiStripDigi &digi = *digiRangeIterator;
@@ -506,15 +455,14 @@ void LaserAlignmentT0ProducerDQM::FillFromProcessedDigis(
 
     // if we have signal, fill the histos
     if (isAboveThreshold && !isExceedThreshold) {
-
       // there is only one histogram for all AT hits
       // but the bin scheme is a little complicated:
       // the TIB go into bins 6-11, TOB in 12-17
 
       if (det == 2)
-        nSignalsAT->Fill(5 + (5 - pos), beam); // TIB
+        nSignalsAT->Fill(5 + (5 - pos), beam);  // TIB
       else
-        nSignalsAT->Fill(11 + (5 - pos), beam); // TOB
+        nSignalsAT->Fill(11 + (5 - pos), beam);  // TOB
     }
 
   } while (moduleLoop.TIBTOBLoop(det, beam, pos));
@@ -528,7 +476,6 @@ void LaserAlignmentT0ProducerDQM::FillFromProcessedDigis(
 /// LaserAlignmentT0ProducerDQM
 ///
 void LaserAlignmentT0ProducerDQM::FillDetectorId(void) {
-
   // these are the detids of the TEC modules hit
   // by the AT as well as the TEC beams
   tecDoubleHitDetId.push_back(470307208);

--- a/DQMOffline/Alignment/src/MuonAlignment.cc
+++ b/DQMOffline/Alignment/src/MuonAlignment.cc
@@ -8,52 +8,38 @@
 #include "DQMOffline/Alignment/interface/MuonAlignment.h"
 
 MuonAlignment::MuonAlignment(const edm::ParameterSet &pSet) {
-
   metname = "MuonAlignment";
 
   LogTrace(metname) << "[MuonAlignment] Constructor called!" << std::endl;
 
   parameters = pSet;
 
-  theMuonCollectionLabel = consumes<reco::TrackCollection>(
-      parameters.getParameter<edm::InputTag>("MuonCollection"));
+  theMuonCollectionLabel = consumes<reco::TrackCollection>(parameters.getParameter<edm::InputTag>("MuonCollection"));
 
-  theRecHits4DTagDT = consumes<DTRecSegment4DCollection>(
-      parameters.getParameter<edm::InputTag>("RecHits4DDTCollectionTag"));
-  theRecHits4DTagCSC = consumes<CSCSegmentCollection>(
-      parameters.getParameter<edm::InputTag>("RecHits4DCSCCollectionTag"));
+  theRecHits4DTagDT =
+      consumes<DTRecSegment4DCollection>(parameters.getParameter<edm::InputTag>("RecHits4DDTCollectionTag"));
+  theRecHits4DTagCSC =
+      consumes<CSCSegmentCollection>(parameters.getParameter<edm::InputTag>("RecHits4DCSCCollectionTag"));
 
-  resLocalXRangeStation1 =
-      parameters.getUntrackedParameter<double>("resLocalXRangeStation1");
-  resLocalXRangeStation2 =
-      parameters.getUntrackedParameter<double>("resLocalXRangeStation2");
-  resLocalXRangeStation3 =
-      parameters.getUntrackedParameter<double>("resLocalXRangeStation3");
-  resLocalXRangeStation4 =
-      parameters.getUntrackedParameter<double>("resLocalXRangeStation4");
-  resLocalYRangeStation1 =
-      parameters.getUntrackedParameter<double>("resLocalYRangeStation1");
-  resLocalYRangeStation2 =
-      parameters.getUntrackedParameter<double>("resLocalYRangeStation2");
-  resLocalYRangeStation3 =
-      parameters.getUntrackedParameter<double>("resLocalYRangeStation3");
-  resLocalYRangeStation4 =
-      parameters.getUntrackedParameter<double>("resLocalYRangeStation4");
+  resLocalXRangeStation1 = parameters.getUntrackedParameter<double>("resLocalXRangeStation1");
+  resLocalXRangeStation2 = parameters.getUntrackedParameter<double>("resLocalXRangeStation2");
+  resLocalXRangeStation3 = parameters.getUntrackedParameter<double>("resLocalXRangeStation3");
+  resLocalXRangeStation4 = parameters.getUntrackedParameter<double>("resLocalXRangeStation4");
+  resLocalYRangeStation1 = parameters.getUntrackedParameter<double>("resLocalYRangeStation1");
+  resLocalYRangeStation2 = parameters.getUntrackedParameter<double>("resLocalYRangeStation2");
+  resLocalYRangeStation3 = parameters.getUntrackedParameter<double>("resLocalYRangeStation3");
+  resLocalYRangeStation4 = parameters.getUntrackedParameter<double>("resLocalYRangeStation4");
   resPhiRange = parameters.getUntrackedParameter<double>("resPhiRange");
   resThetaRange = parameters.getUntrackedParameter<double>("resThetaRange");
 
-  meanPositionRange =
-      parameters.getUntrackedParameter<double>("meanPositionRange");
-  rmsPositionRange =
-      parameters.getUntrackedParameter<double>("rmsPositionRange");
+  meanPositionRange = parameters.getUntrackedParameter<double>("meanPositionRange");
+  rmsPositionRange = parameters.getUntrackedParameter<double>("rmsPositionRange");
   meanAngleRange = parameters.getUntrackedParameter<double>("meanAngleRange");
   rmsAngleRange = parameters.getUntrackedParameter<double>("rmsAngleRange");
 
   nbins = parameters.getUntrackedParameter<unsigned int>("nbins");
-  min1DTrackRecHitSize =
-      parameters.getUntrackedParameter<unsigned int>("min1DTrackRecHitSize");
-  min4DTrackSegmentSize =
-      parameters.getUntrackedParameter<unsigned int>("min4DTrackSegmentSize");
+  min1DTrackRecHitSize = parameters.getUntrackedParameter<unsigned int>("min1DTrackRecHitSize");
+  min4DTrackSegmentSize = parameters.getUntrackedParameter<unsigned int>("min4DTrackSegmentSize");
 
   doDT = parameters.getUntrackedParameter<bool>("doDT");
   doCSC = parameters.getUntrackedParameter<bool>("doCSC");
@@ -69,16 +55,13 @@ MuonAlignment::MuonAlignment(const edm::ParameterSet &pSet) {
 MuonAlignment::~MuonAlignment() {}
 
 void MuonAlignment::beginJob() {
-
   LogTrace(metname) << "[MuonAlignment] Parameters initialization";
 
   if (!(doDT || doCSC)) {
     edm::LogError("MuonAlignment") << " Error!! At least one Muon subsystem "
                                       "(DT or CSC) must be monitorized!!"
                                    << std::endl;
-    edm::LogError("MuonAlignment")
-        << " Please enable doDT or doCSC to True in your python cfg file!!!"
-        << std::endl;
+    edm::LogError("MuonAlignment") << " Please enable doDT or doCSC to True in your python cfg file!!!" << std::endl;
     exit(1);
   }
 
@@ -88,117 +71,125 @@ void MuonAlignment::beginJob() {
     if (doDT) {
       dbe->setCurrentFolder(topFolder.str() + "/DT");
       hLocalPositionDT = dbe->book2D(
-          "hLocalPositionDT",
-          "Local DT position (cm) absolute MEAN residuals;Sector;;cm", 14, 1,
-          15, 40, 0, 40);
+          "hLocalPositionDT", "Local DT position (cm) absolute MEAN residuals;Sector;;cm", 14, 1, 15, 40, 0, 40);
       hLocalAngleDT = dbe->book2D(
-          "hLocalAngleDT",
-          "Local DT angle (rad) absolute MEAN residuals;Sector;;rad", 14, 1, 15,
-          40, 0, 40);
+          "hLocalAngleDT", "Local DT angle (rad) absolute MEAN residuals;Sector;;rad", 14, 1, 15, 40, 0, 40);
       hLocalPositionRmsDT =
-          dbe->book2D("hLocalPositionRmsDT",
-                      "Local DT position (cm) RMS residuals;Sector;;cm", 14, 1,
-                      15, 40, 0, 40);
-      hLocalAngleRmsDT = dbe->book2D(
-          "hLocalAngleRmsDT", "Local DT angle (rad) RMS residuals;Sector;;rad",
-          14, 1, 15, 40, 0, 40);
+          dbe->book2D("hLocalPositionRmsDT", "Local DT position (cm) RMS residuals;Sector;;cm", 14, 1, 15, 40, 0, 40);
+      hLocalAngleRmsDT =
+          dbe->book2D("hLocalAngleRmsDT", "Local DT angle (rad) RMS residuals;Sector;;rad", 14, 1, 15, 40, 0, 40);
 
-      hLocalXMeanDT =
-          dbe->book1D("hLocalXMeanDT",
-                      "Distribution of absolute MEAN Local X (cm) residuals "
-                      "for DT;<X> (cm);number of chambers",
-                      100, 0, meanPositionRange);
+      hLocalXMeanDT = dbe->book1D("hLocalXMeanDT",
+                                  "Distribution of absolute MEAN Local X (cm) residuals "
+                                  "for DT;<X> (cm);number of chambers",
+                                  100,
+                                  0,
+                                  meanPositionRange);
       hLocalXRmsDT = dbe->book1D("hLocalXRmsDT",
                                  "Distribution of RMS Local X (cm) residuals "
                                  "for DT;X RMS (cm);number of chambers",
-                                 100, 0, rmsPositionRange);
-      hLocalYMeanDT =
-          dbe->book1D("hLocalYMeanDT",
-                      "Distribution of absolute MEAN Local Y (cm) residuals "
-                      "for DT;<Y> (cm);number of chambers",
-                      100, 0, meanPositionRange);
+                                 100,
+                                 0,
+                                 rmsPositionRange);
+      hLocalYMeanDT = dbe->book1D("hLocalYMeanDT",
+                                  "Distribution of absolute MEAN Local Y (cm) residuals "
+                                  "for DT;<Y> (cm);number of chambers",
+                                  100,
+                                  0,
+                                  meanPositionRange);
       hLocalYRmsDT = dbe->book1D("hLocalYRmsDT",
                                  "Distribution of RMS Local Y (cm) residuals "
                                  "for DT;Y RMS (cm);number of chambers",
-                                 100, 0, rmsPositionRange);
+                                 100,
+                                 0,
+                                 rmsPositionRange);
 
       hLocalPhiMeanDT = dbe->book1D("hLocalPhiMeanDT",
                                     "Distribution of MEAN #phi (rad) residuals "
                                     "for DT;<#phi>(rad);number of chambers",
-                                    100, -meanAngleRange, meanAngleRange);
+                                    100,
+                                    -meanAngleRange,
+                                    meanAngleRange);
       hLocalPhiRmsDT = dbe->book1D("hLocalPhiRmsDT",
                                    "Distribution of RMS #phi (rad) residuals "
                                    "for DT;#phi RMS (rad);number of chambers",
-                                   100, 0, rmsAngleRange);
-      hLocalThetaMeanDT =
-          dbe->book1D("hLocalThetaMeanDT",
-                      "Distribution of MEAN #theta (rad) residuals for "
-                      "DT;<#theta>(rad);number of chambers",
-                      100, -meanAngleRange, meanAngleRange);
-      hLocalThetaRmsDT =
-          dbe->book1D("hLocalThetaRmsDT",
-                      "Distribution of RMS #theta (rad) residuals for "
-                      "DT;#theta RMS (rad);number of chambers",
-                      100, 0, rmsAngleRange);
+                                   100,
+                                   0,
+                                   rmsAngleRange);
+      hLocalThetaMeanDT = dbe->book1D("hLocalThetaMeanDT",
+                                      "Distribution of MEAN #theta (rad) residuals for "
+                                      "DT;<#theta>(rad);number of chambers",
+                                      100,
+                                      -meanAngleRange,
+                                      meanAngleRange);
+      hLocalThetaRmsDT = dbe->book1D("hLocalThetaRmsDT",
+                                     "Distribution of RMS #theta (rad) residuals for "
+                                     "DT;#theta RMS (rad);number of chambers",
+                                     100,
+                                     0,
+                                     rmsAngleRange);
     }
 
     if (doCSC) {
       dbe->setCurrentFolder(topFolder.str() + "/CSC");
       hLocalPositionCSC = dbe->book2D(
-          "hLocalPositionCSC",
-          "Local CSC position (cm) absolute MEAN residuals;Sector;;cm", 36, 1,
-          37, 40, 0, 40);
+          "hLocalPositionCSC", "Local CSC position (cm) absolute MEAN residuals;Sector;;cm", 36, 1, 37, 40, 0, 40);
       hLocalAngleCSC = dbe->book2D(
-          "hLocalAngleCSC",
-          "Local CSC angle (rad) absolute MEAN residuals;Sector;;rad", 36, 1,
-          37, 40, 0, 40);
+          "hLocalAngleCSC", "Local CSC angle (rad) absolute MEAN residuals;Sector;;rad", 36, 1, 37, 40, 0, 40);
       hLocalPositionRmsCSC =
-          dbe->book2D("hLocalPositionRmsCSC",
-                      "Local CSC position (cm) RMS residuals;Sector;;cm", 36, 1,
-                      37, 40, 0, 40);
+          dbe->book2D("hLocalPositionRmsCSC", "Local CSC position (cm) RMS residuals;Sector;;cm", 36, 1, 37, 40, 0, 40);
       hLocalAngleRmsCSC =
-          dbe->book2D("hLocalAngleRmsCSC",
-                      "Local CSC angle (rad) RMS residuals;Sector;;rad", 36, 1,
-                      37, 40, 0, 40);
+          dbe->book2D("hLocalAngleRmsCSC", "Local CSC angle (rad) RMS residuals;Sector;;rad", 36, 1, 37, 40, 0, 40);
 
-      hLocalXMeanCSC =
-          dbe->book1D("hLocalXMeanCSC",
-                      "Distribution of absolute MEAN Local X (cm) residuals "
-                      "for CSC;<X> (cm);number of chambers",
-                      100, 0, meanPositionRange);
+      hLocalXMeanCSC = dbe->book1D("hLocalXMeanCSC",
+                                   "Distribution of absolute MEAN Local X (cm) residuals "
+                                   "for CSC;<X> (cm);number of chambers",
+                                   100,
+                                   0,
+                                   meanPositionRange);
       hLocalXRmsCSC = dbe->book1D("hLocalXRmsCSC",
                                   "Distribution of RMS Local X (cm) residuals "
                                   "for CSC;X RMS (cm);number of chambers",
-                                  100, 0, rmsPositionRange);
-      hLocalYMeanCSC =
-          dbe->book1D("hLocalYMeanCSC",
-                      "Distribution of absolute MEAN Local Y (cm) residuals "
-                      "for CSC;<Y> (cm);number of chambers",
-                      100, 0, meanPositionRange);
+                                  100,
+                                  0,
+                                  rmsPositionRange);
+      hLocalYMeanCSC = dbe->book1D("hLocalYMeanCSC",
+                                   "Distribution of absolute MEAN Local Y (cm) residuals "
+                                   "for CSC;<Y> (cm);number of chambers",
+                                   100,
+                                   0,
+                                   meanPositionRange);
       hLocalYRmsCSC = dbe->book1D("hLocalYRmsCSC",
                                   "Distribution of RMS Local Y (cm) residuals "
                                   "for CSC;Y RMS (cm);number of chambers",
-                                  100, 0, rmsPositionRange);
+                                  100,
+                                  0,
+                                  rmsPositionRange);
 
-      hLocalPhiMeanCSC =
-          dbe->book1D("hLocalPhiMeanCSC",
-                      "Distribution of absolute MEAN #phi (rad) residuals for "
-                      "CSC;<#phi>(rad);number of chambers",
-                      100, 0, meanAngleRange);
+      hLocalPhiMeanCSC = dbe->book1D("hLocalPhiMeanCSC",
+                                     "Distribution of absolute MEAN #phi (rad) residuals for "
+                                     "CSC;<#phi>(rad);number of chambers",
+                                     100,
+                                     0,
+                                     meanAngleRange);
       hLocalPhiRmsCSC = dbe->book1D("hLocalPhiRmsCSC",
                                     "Distribution of RMS #phi (rad) residuals "
                                     "for CSC;#phi RMS (rad);number of chambers",
-                                    100, 0, rmsAngleRange);
-      hLocalThetaMeanCSC =
-          dbe->book1D("hLocalThetaMeanCSC",
-                      "Distribution of absolute MEAN #theta (rad) residuals "
-                      "for CSC;<#theta>(rad);number of chambers",
-                      100, 0, meanAngleRange);
-      hLocalThetaRmsCSC =
-          dbe->book1D("hLocalThetaRmsCSC",
-                      "Distribution of RMS #theta (rad) residuals for "
-                      "CSC;#theta RMS (rad);number of chambers",
-                      100, 0, rmsAngleRange);
+                                    100,
+                                    0,
+                                    rmsAngleRange);
+      hLocalThetaMeanCSC = dbe->book1D("hLocalThetaMeanCSC",
+                                       "Distribution of absolute MEAN #theta (rad) residuals "
+                                       "for CSC;<#theta>(rad);number of chambers",
+                                       100,
+                                       0,
+                                       meanAngleRange);
+      hLocalThetaRmsCSC = dbe->book1D("hLocalThetaRmsCSC",
+                                      "Distribution of RMS #theta (rad) residuals for "
+                                      "CSC;#theta RMS (rad);number of chambers",
+                                      100,
+                                      0,
+                                      rmsAngleRange);
     }
   }
 
@@ -208,41 +199,35 @@ void MuonAlignment::beginJob() {
 
   // variables for histos ranges
   double rangeX = 0, rangeY = 0;
-  std::string nameOfHistoLocalX, nameOfHistoLocalY, nameOfHistoLocalPhi,
-      nameOfHistoLocalTheta;
+  std::string nameOfHistoLocalX, nameOfHistoLocalY, nameOfHistoLocalPhi, nameOfHistoLocalTheta;
 
   for (int station = -4; station < 5; station++) {
-
     // This piece of code calculates the range of the residuals
     switch (abs(station)) {
-    case 1: {
-      rangeX = resLocalXRangeStation1;
-      rangeY = resLocalYRangeStation1;
-    } break;
-    case 2: {
-      rangeX = resLocalXRangeStation2;
-      rangeY = resLocalYRangeStation2;
-    } break;
-    case 3: {
-      rangeX = resLocalXRangeStation3;
-      rangeY = resLocalYRangeStation3;
-    } break;
-    case 4: {
-      rangeX = resLocalXRangeStation4;
-      rangeY = resLocalYRangeStation4;
-    } break;
-    default:
-      break;
+      case 1: {
+        rangeX = resLocalXRangeStation1;
+        rangeY = resLocalYRangeStation1;
+      } break;
+      case 2: {
+        rangeX = resLocalXRangeStation2;
+        rangeY = resLocalYRangeStation2;
+      } break;
+      case 3: {
+        rangeX = resLocalXRangeStation3;
+        rangeY = resLocalYRangeStation3;
+      } break;
+      case 4: {
+        rangeX = resLocalXRangeStation4;
+        rangeY = resLocalYRangeStation4;
+      } break;
+      default:
+        break;
     }
     if (doDT) {
       if (station > 0) {
-
         for (int wheel = -2; wheel < 3; wheel++) {
-
           for (int sector = 1; sector < 15; sector++) {
-
             if (!((sector == 13 || sector == 14) && station != 4)) {
-
               std::stringstream Wheel;
               Wheel << wheel;
               std::stringstream Station;
@@ -250,54 +235,38 @@ void MuonAlignment::beginJob() {
               std::stringstream Sector;
               Sector << sector;
 
-              nameOfHistoLocalX = "ResidualLocalX_W" + Wheel.str() + "MB" +
-                                  Station.str() + "S" + Sector.str();
-              nameOfHistoLocalPhi = "ResidualLocalPhi_W" + Wheel.str() + "MB" +
-                                    Station.str() + "S" + Sector.str();
-              nameOfHistoLocalTheta = "ResidualLocalTheta_W" + Wheel.str() +
-                                      "MB" + Station.str() + "S" + Sector.str();
-              nameOfHistoLocalY = "ResidualLocalY_W" + Wheel.str() + "MB" +
-                                  Station.str() + "S" + Sector.str();
+              nameOfHistoLocalX = "ResidualLocalX_W" + Wheel.str() + "MB" + Station.str() + "S" + Sector.str();
+              nameOfHistoLocalPhi = "ResidualLocalPhi_W" + Wheel.str() + "MB" + Station.str() + "S" + Sector.str();
+              nameOfHistoLocalTheta = "ResidualLocalTheta_W" + Wheel.str() + "MB" + Station.str() + "S" + Sector.str();
+              nameOfHistoLocalY = "ResidualLocalY_W" + Wheel.str() + "MB" + Station.str() + "S" + Sector.str();
 
-              dbe->setCurrentFolder(topFolder.str() + "/DT/Wheel" +
-                                    Wheel.str() + "/Station" + Station.str() +
+              dbe->setCurrentFolder(topFolder.str() + "/DT/Wheel" + Wheel.str() + "/Station" + Station.str() +
                                     "/Sector" + Sector.str());
 
               // Create ME and push histos into their respective vectors
 
-              MonitorElement *histoLocalX = dbe->book1D(
-                  nameOfHistoLocalX, nameOfHistoLocalX, nbins, -rangeX, rangeX);
+              MonitorElement *histoLocalX = dbe->book1D(nameOfHistoLocalX, nameOfHistoLocalX, nbins, -rangeX, rangeX);
               unitsLocalX.push_back(histoLocalX);
               MonitorElement *histoLocalPhi =
-                  dbe->book1D(nameOfHistoLocalPhi, nameOfHistoLocalPhi, nbins,
-                              -resPhiRange, resPhiRange);
+                  dbe->book1D(nameOfHistoLocalPhi, nameOfHistoLocalPhi, nbins, -resPhiRange, resPhiRange);
               unitsLocalPhi.push_back(histoLocalPhi);
               MonitorElement *histoLocalTheta =
-                  dbe->book1D(nameOfHistoLocalTheta, nameOfHistoLocalTheta,
-                              nbins, -resThetaRange, resThetaRange);
+                  dbe->book1D(nameOfHistoLocalTheta, nameOfHistoLocalTheta, nbins, -resThetaRange, resThetaRange);
               unitsLocalTheta.push_back(histoLocalTheta);
-              MonitorElement *histoLocalY = dbe->book1D(
-                  nameOfHistoLocalY, nameOfHistoLocalY, nbins, -rangeY, rangeY);
+              MonitorElement *histoLocalY = dbe->book1D(nameOfHistoLocalY, nameOfHistoLocalY, nbins, -rangeY, rangeY);
               unitsLocalY.push_back(histoLocalY);
             }
           }
         }
-      } // station>0
-    }   // doDT
+      }  // station>0
+    }    // doDT
 
     if (doCSC) {
       if (station != 0) {
-
         for (int ring = 1; ring < 5; ring++) {
-
           for (int chamber = 1; chamber < 37; chamber++) {
-
-            if (!(((abs(station) == 2 || abs(station) == 3 ||
-                    abs(station) == 4) &&
-                   ring == 1 && chamber > 18) ||
-                  ((abs(station) == 2 || abs(station) == 3 ||
-                    abs(station) == 4) &&
-                   ring > 2))) {
+            if (!(((abs(station) == 2 || abs(station) == 3 || abs(station) == 4) && ring == 1 && chamber > 18) ||
+                  ((abs(station) == 2 || abs(station) == 3 || abs(station) == 4) && ring > 2))) {
               std::stringstream Ring;
               Ring << ring;
               std::stringstream Station;
@@ -305,47 +274,36 @@ void MuonAlignment::beginJob() {
               std::stringstream Chamber;
               Chamber << chamber;
 
-              nameOfHistoLocalX = "ResidualLocalX_ME" + Station.str() + "R" +
-                                  Ring.str() + "C" + Chamber.str();
-              nameOfHistoLocalPhi = "ResidualLocalPhi_ME" + Station.str() +
-                                    "R" + Ring.str() + "C" + Chamber.str();
-              nameOfHistoLocalTheta = "ResidualLocalTheta_ME" + Station.str() +
-                                      "R" + Ring.str() + "C" + Chamber.str();
-              nameOfHistoLocalY = "ResidualLocalY_ME" + Station.str() + "R" +
-                                  Ring.str() + "C" + Chamber.str();
+              nameOfHistoLocalX = "ResidualLocalX_ME" + Station.str() + "R" + Ring.str() + "C" + Chamber.str();
+              nameOfHistoLocalPhi = "ResidualLocalPhi_ME" + Station.str() + "R" + Ring.str() + "C" + Chamber.str();
+              nameOfHistoLocalTheta = "ResidualLocalTheta_ME" + Station.str() + "R" + Ring.str() + "C" + Chamber.str();
+              nameOfHistoLocalY = "ResidualLocalY_ME" + Station.str() + "R" + Ring.str() + "C" + Chamber.str();
 
-              dbe->setCurrentFolder(topFolder.str() + "/CSC/Station" +
-                                    Station.str() + "/Ring" + Ring.str() +
+              dbe->setCurrentFolder(topFolder.str() + "/CSC/Station" + Station.str() + "/Ring" + Ring.str() +
                                     "/Chamber" + Chamber.str());
 
               // Create ME and push histos into their respective vectors
 
-              MonitorElement *histoLocalX = dbe->book1D(
-                  nameOfHistoLocalX, nameOfHistoLocalX, nbins, -rangeX, rangeX);
+              MonitorElement *histoLocalX = dbe->book1D(nameOfHistoLocalX, nameOfHistoLocalX, nbins, -rangeX, rangeX);
               unitsLocalX.push_back(histoLocalX);
               MonitorElement *histoLocalPhi =
-                  dbe->book1D(nameOfHistoLocalPhi, nameOfHistoLocalPhi, nbins,
-                              -resPhiRange, resPhiRange);
+                  dbe->book1D(nameOfHistoLocalPhi, nameOfHistoLocalPhi, nbins, -resPhiRange, resPhiRange);
               unitsLocalPhi.push_back(histoLocalPhi);
               MonitorElement *histoLocalTheta =
-                  dbe->book1D(nameOfHistoLocalTheta, nameOfHistoLocalTheta,
-                              nbins, -resThetaRange, resThetaRange);
+                  dbe->book1D(nameOfHistoLocalTheta, nameOfHistoLocalTheta, nbins, -resThetaRange, resThetaRange);
               unitsLocalTheta.push_back(histoLocalTheta);
-              MonitorElement *histoLocalY = dbe->book1D(
-                  nameOfHistoLocalY, nameOfHistoLocalY, nbins, -rangeY, rangeY);
+              MonitorElement *histoLocalY = dbe->book1D(nameOfHistoLocalY, nameOfHistoLocalY, nbins, -rangeY, rangeY);
               unitsLocalY.push_back(histoLocalY);
             }
           }
         }
-      } // station!=0
-    }   // doCSC
+      }  // station!=0
+    }    // doCSC
 
-  } // loop on stations
+  }  // loop on stations
 }
 
-void MuonAlignment::analyze(const edm::Event &iEvent,
-                            const edm::EventSetup &iSetup) {
-
+void MuonAlignment::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   LogTrace(metname) << "[MuonAlignment] Analysis of event # ";
 
   edm::ESHandle<MagneticField> theMGField;
@@ -355,12 +313,10 @@ void MuonAlignment::analyze(const edm::Event &iEvent,
   iSetup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
 
   edm::ESHandle<Propagator> thePropagatorOpp;
-  iSetup.get<TrackingComponentsRecord>().get("SmartPropagatorOpposite",
-                                             thePropagatorOpp);
+  iSetup.get<TrackingComponentsRecord>().get("SmartPropagatorOpposite", thePropagatorOpp);
 
   edm::ESHandle<Propagator> thePropagatorAlo;
-  iSetup.get<TrackingComponentsRecord>().get("SmartPropagator",
-                                             thePropagatorAlo);
+  iSetup.get<TrackingComponentsRecord>().get("SmartPropagator", thePropagatorAlo);
 
   //	edm::ESHandle<Propagator> thePropagator;
   //  	iSetup.get<TrackingComponentsRecord>().get(
@@ -400,17 +356,14 @@ void MuonAlignment::analyze(const edm::Event &iEvent,
     // reco::TrackRef trackSA = muon;
 
     if (muon->recHitsSize() > (min1DTrackRecHitSize - 1)) {
-
       //      reco::TransientTrack tTrackTR( *trackTR, &*theMGField,
       //      theTrackingGeometry );
       reco::TransientTrack tTrackSA(*muon, &*theMGField, theTrackingGeometry);
 
       // Adapted code for muonCosmics
 
-      Double_t innerPerpSA =
-          tTrackSA.innermostMeasurementState().globalPosition().perp();
-      Double_t outerPerpSA =
-          tTrackSA.outermostMeasurementState().globalPosition().perp();
+      Double_t innerPerpSA = tTrackSA.innermostMeasurementState().globalPosition().perp();
+      Double_t outerPerpSA = tTrackSA.outermostMeasurementState().globalPosition().perp();
 
       TrajectoryStateOnSurface innerTSOS = tTrackSA.outermostMeasurementState();
       //      PropagationDirection propagationDir=alongMomentum;
@@ -418,13 +371,12 @@ void MuonAlignment::analyze(const edm::Event &iEvent,
 
       // Define which kind of reco track is used
       if ((outerPerpSA - innerPerpSA) > 0) {
-
         trackRefitterType = "LHCLike";
         innerTSOS = tTrackSA.innermostMeasurementState();
         thePropagator = thePropagatorAlo.product();
         //	propagationDir = alongMomentum;
 
-      } else { // if ((outerPerpSA-innerPerpSA) < 0 ) {
+      } else {  // if ((outerPerpSA-innerPerpSA) < 0 ) {
 
         trackRefitterType = "CosmicLike";
         innerTSOS = tTrackSA.outermostMeasurementState();
@@ -433,12 +385,10 @@ void MuonAlignment::analyze(const edm::Event &iEvent,
       }
 
       RecHitVector my4DTrack = this->doMatching(
-          *muon, all4DSegmentsDT, all4DSegmentsCSC, &indexCollectionDT,
-          &indexCollectionCSC, theTrackingGeometry);
+          *muon, all4DSegmentsDT, all4DSegmentsCSC, &indexCollectionDT, &indexCollectionCSC, theTrackingGeometry);
 
       // cut in number of segments
       if (my4DTrack.size() > (min4DTrackSegmentSize - 1)) {
-
         // start propagation
         //    TrajectoryStateOnSurface innerTSOS = track.impactPointState();
         //                    TrajectoryStateOnSurface innerTSOS =
@@ -446,26 +396,18 @@ void MuonAlignment::analyze(const edm::Event &iEvent,
 
         // If the state is valid
         if (innerTSOS.isValid()) {
-
           // Loop over Associated segments
-          for (RecHitVector::iterator rechit = my4DTrack.begin();
-               rechit != my4DTrack.end(); ++rechit) {
-
-            const GeomDet *geomDet =
-                theTrackingGeometry->idToDet((*rechit)->geographicalId());
+          for (RecHitVector::iterator rechit = my4DTrack.begin(); rechit != my4DTrack.end(); ++rechit) {
+            const GeomDet *geomDet = theTrackingGeometry->idToDet((*rechit)->geographicalId());
             // Otherwise the propagator could throw an exception
-            const Plane *pDest =
-                dynamic_cast<const Plane *>(&geomDet->surface());
-            const Cylinder *cDest =
-                dynamic_cast<const Cylinder *>(&geomDet->surface());
+            const Plane *pDest = dynamic_cast<const Plane *>(&geomDet->surface());
+            const Cylinder *cDest = dynamic_cast<const Cylinder *>(&geomDet->surface());
 
             if (pDest != nullptr || cDest != nullptr) {
-
               //			 	    Propagator
               //*updatePropagator=thePropagator->clone();
               //				    updatePropagator->setPropagationDirection(propagationDir);
-              TrajectoryStateOnSurface destiny = thePropagator->propagate(
-                  *(innerTSOS.freeState()), geomDet->surface());
+              TrajectoryStateOnSurface destiny = thePropagator->propagate(*(innerTSOS.freeState()), geomDet->surface());
 
               if (!destiny.isValid() || !destiny.hasError())
                 continue;
@@ -479,8 +421,7 @@ void MuonAlignment::analyze(const edm::Event &iEvent,
               int endcap = 0, ring = 0, chamber = 0;
               bool goAhead = (det == 1 && doDT) || (det == 2 && doCSC);
 
-              double residualLocalX = 0, residualLocalPhi = 0,
-                     residualLocalY = 0, residualLocalTheta = 0;
+              double residualLocalX = 0, residualLocalPhi = 0, residualLocalY = 0, residualLocalTheta = 0;
 
               // Fill generic histograms
               // If it's a DT
@@ -490,24 +431,17 @@ void MuonAlignment::analyze(const edm::Event &iEvent,
                 station = myChamber.station();
                 sector = myChamber.sector();
 
-                residualLocalX = (*rechit)->localPosition().x() -
-                                 destiny.localPosition().x();
+                residualLocalX = (*rechit)->localPosition().x() - destiny.localPosition().x();
 
-                residualLocalPhi =
-                    atan2(((RecSegment *)(*rechit))->localDirection().z(),
-                          ((RecSegment *)(*rechit))->localDirection().x()) -
-                    atan2(destiny.localDirection().z(),
-                          destiny.localDirection().x());
+                residualLocalPhi = atan2(((RecSegment *)(*rechit))->localDirection().z(),
+                                         ((RecSegment *)(*rechit))->localDirection().x()) -
+                                   atan2(destiny.localDirection().z(), destiny.localDirection().x());
                 if (station != 4) {
+                  residualLocalY = (*rechit)->localPosition().y() - destiny.localPosition().y();
 
-                  residualLocalY = (*rechit)->localPosition().y() -
-                                   destiny.localPosition().y();
-
-                  residualLocalTheta =
-                      atan2(((RecSegment *)(*rechit))->localDirection().z(),
-                            ((RecSegment *)(*rechit))->localDirection().y()) -
-                      atan2(destiny.localDirection().z(),
-                            destiny.localDirection().y());
+                  residualLocalTheta = atan2(((RecSegment *)(*rechit))->localDirection().z(),
+                                             ((RecSegment *)(*rechit))->localDirection().y()) -
+                                       atan2(destiny.localDirection().z(), destiny.localDirection().y());
                 }
 
               } else if (det == 2 && doCSC) {
@@ -519,34 +453,27 @@ void MuonAlignment::analyze(const edm::Event &iEvent,
                 ring = myChamber.ring();
                 chamber = myChamber.chamber();
 
-                residualLocalX = (*rechit)->localPosition().x() -
-                                 destiny.localPosition().x();
+                residualLocalX = (*rechit)->localPosition().x() - destiny.localPosition().x();
 
-                residualLocalY = (*rechit)->localPosition().y() -
-                                 destiny.localPosition().y();
+                residualLocalY = (*rechit)->localPosition().y() - destiny.localPosition().y();
 
-                residualLocalPhi =
-                    atan2(((RecSegment *)(*rechit))->localDirection().y(),
-                          ((RecSegment *)(*rechit))->localDirection().x()) -
-                    atan2(destiny.localDirection().y(),
-                          destiny.localDirection().x());
+                residualLocalPhi = atan2(((RecSegment *)(*rechit))->localDirection().y(),
+                                         ((RecSegment *)(*rechit))->localDirection().x()) -
+                                   atan2(destiny.localDirection().y(), destiny.localDirection().x());
 
-                residualLocalTheta =
-                    atan2(((RecSegment *)(*rechit))->localDirection().y(),
-                          ((RecSegment *)(*rechit))->localDirection().z()) -
-                    atan2(destiny.localDirection().y(),
-                          destiny.localDirection().z());
+                residualLocalTheta = atan2(((RecSegment *)(*rechit))->localDirection().y(),
+                                           ((RecSegment *)(*rechit))->localDirection().z()) -
+                                     atan2(destiny.localDirection().y(), destiny.localDirection().z());
 
               } else {
-                residualLocalX = 0, residualLocalPhi = 0, residualLocalY = 0,
-                residualLocalTheta = 0;
+                residualLocalX = 0, residualLocalPhi = 0, residualLocalY = 0, residualLocalTheta = 0;
               }
 
               // Fill individual chamber histograms
 
               std::string nameOfHistoLocalX;
 
-              if (det == 1 && doDT) { // DT
+              if (det == 1 && doDT) {  // DT
                 std::stringstream Wheel;
                 Wheel << wheel;
                 std::stringstream Station;
@@ -554,10 +481,9 @@ void MuonAlignment::analyze(const edm::Event &iEvent,
                 std::stringstream Sector;
                 Sector << sector;
 
-                nameOfHistoLocalX = "ResidualLocalX_W" + Wheel.str() + "MB" +
-                                    Station.str() + "S" + Sector.str();
+                nameOfHistoLocalX = "ResidualLocalX_W" + Wheel.str() + "MB" + Station.str() + "S" + Sector.str();
 
-              } else if (det == 2 && doCSC) { // CSC
+              } else if (det == 2 && doCSC) {  // CSC
                 std::stringstream Ring;
                 Ring << ring;
                 std::stringstream Station;
@@ -565,23 +491,19 @@ void MuonAlignment::analyze(const edm::Event &iEvent,
                 std::stringstream Chamber;
                 Chamber << chamber;
 
-                nameOfHistoLocalX = "ResidualLocalX_ME" + Station.str() + "R" +
-                                    Ring.str() + "C" + Chamber.str();
+                nameOfHistoLocalX = "ResidualLocalX_ME" + Station.str() + "R" + Ring.str() + "C" + Chamber.str();
               }
 
               if (goAhead) {
-
                 for (unsigned int i = 0; i < unitsLocalX.size(); i++) {
-
                   if (nameOfHistoLocalX == unitsLocalX[i]->getName()) {
                     position = i;
                     break;
                   }
                 }
 
-                if (trackRefitterType ==
-                    "CosmicLike") { // problem with angle convention in reverse
-                                    // extrapolation
+                if (trackRefitterType == "CosmicLike") {  // problem with angle convention in reverse
+                                                          // extrapolation
                   residualLocalPhi += 3.1416;
                   residualLocalTheta += 3.1416;
                 }
@@ -611,20 +533,19 @@ void MuonAlignment::analyze(const edm::Event &iEvent,
               // delete thePropagator;
 
             } else {
-              edm::LogError("MuonAlignment")
-                  << " Error!! Exception in propagator catched" << std::endl;
+              edm::LogError("MuonAlignment") << " Error!! Exception in propagator catched" << std::endl;
               continue;
             }
 
-          } // loop over my4DTrack
-        }   // TSOS was valid
+          }  // loop over my4DTrack
+        }    // TSOS was valid
 
-      } // cut in at least 4 segments
+      }  // cut in at least 4 segments
 
-    } // end cut in RecHitsSize>36
+    }  // end cut in RecHitsSize>36
     numberOfHits = numberOfHits + countPoints;
     //       } //Muon is GlobalMuon
-  } // loop over Muons
+  }  // loop over Muons
   numberOfTracks = numberOfTracks + countTracks;
 
   //        delete thePropagator;
@@ -634,13 +555,12 @@ void MuonAlignment::analyze(const edm::Event &iEvent,
   // ProductNotFound!!"<<std::endl;
 }
 
-RecHitVector MuonAlignment::doMatching(
-    const reco::Track &staTrack,
-    edm::Handle<DTRecSegment4DCollection> &all4DSegmentsDT,
-    edm::Handle<CSCSegmentCollection> &all4DSegmentsCSC,
-    intDVector *indexCollectionDT, intDVector *indexCollectionCSC,
-    edm::ESHandle<GlobalTrackingGeometry> &theTrackingGeometry) {
-
+RecHitVector MuonAlignment::doMatching(const reco::Track &staTrack,
+                                       edm::Handle<DTRecSegment4DCollection> &all4DSegmentsDT,
+                                       edm::Handle<CSCSegmentCollection> &all4DSegmentsCSC,
+                                       intDVector *indexCollectionDT,
+                                       intDVector *indexCollectionCSC,
+                                       edm::ESHandle<GlobalTrackingGeometry> &theTrackingGeometry) {
   DTRecSegment4DCollection::const_iterator segmentDT;
   CSCSegmentCollection::const_iterator segmentCSC;
 
@@ -649,47 +569,37 @@ RecHitVector MuonAlignment::doMatching(
   RecHitVector my4DTrack;
 
   // Loop over the hits of the track
-  for (unsigned int counter = 0; counter != staTrack.recHitsSize() - 1;
-       counter++) {
-
+  for (unsigned int counter = 0; counter != staTrack.recHitsSize() - 1; counter++) {
     TrackingRecHitRef myRef = staTrack.recHit(counter);
     const TrackingRecHit *rechit = myRef.get();
-    const GeomDet *geomDet =
-        theTrackingGeometry->idToDet(rechit->geographicalId());
+    const GeomDet *geomDet = theTrackingGeometry->idToDet(rechit->geographicalId());
 
     // It's a DT Hit
     if (geomDet->subDetector() == GeomDetEnumerators::DT) {
-
       // Take the layer associated to this hit
       DTLayerId myLayer(rechit->geographicalId().rawId());
 
       int NumberOfDTSegment = 0;
       // Loop over segments
-      for (segmentDT = all4DSegmentsDT->begin();
-           segmentDT != all4DSegmentsDT->end(); ++segmentDT) {
-
+      for (segmentDT = all4DSegmentsDT->begin(); segmentDT != all4DSegmentsDT->end(); ++segmentDT) {
         // By default the chamber associated to this Segment is new
         bool isNewChamber = true;
 
         // Loop over segments already included in the vector of segments in the
         // actual track
-        for (std::vector<int>::iterator positionIt = positionDT.begin();
-             positionIt != positionDT.end(); positionIt++) {
-
+        for (std::vector<int>::iterator positionIt = positionDT.begin(); positionIt != positionDT.end(); positionIt++) {
           // If this segment has been used before isNewChamber = false
           if (NumberOfDTSegment == *positionIt)
             isNewChamber = false;
         }
 
         // Loop over vectors of segments associated to previous tracks
-        for (std::vector<std::vector<int>>::iterator collect =
-                 indexCollectionDT->begin();
-             collect != indexCollectionDT->end(); ++collect) {
-
+        for (std::vector<std::vector<int>>::iterator collect = indexCollectionDT->begin();
+             collect != indexCollectionDT->end();
+             ++collect) {
           // Loop over segments associated to a track
-          for (std::vector<int>::iterator positionIt = (*collect).begin();
-               positionIt != (*collect).end(); positionIt++) {
-
+          for (std::vector<int>::iterator positionIt = (*collect).begin(); positionIt != (*collect).end();
+               positionIt++) {
             // If this segment was used in a previos track then isNewChamber =
             // false
             if (NumberOfDTSegment == *positionIt)
@@ -699,13 +609,10 @@ RecHitVector MuonAlignment::doMatching(
 
         // If the chamber is new
         if (isNewChamber) {
-
           DTChamberId myChamber((*segmentDT).geographicalId().rawId());
           // If the layer of the hit belongs to the chamber of the 4D Segment
-          if (myLayer.wheel() == myChamber.wheel() &&
-              myLayer.station() == myChamber.station() &&
+          if (myLayer.wheel() == myChamber.wheel() && myLayer.station() == myChamber.station() &&
               myLayer.sector() == myChamber.sector()) {
-
             // push position of the segment and tracking rechit
             positionDT.push_back(NumberOfDTSegment);
             my4DTrack.push_back((TrackingRecHit *)&(*segmentDT));
@@ -715,35 +622,29 @@ RecHitVector MuonAlignment::doMatching(
       }
       // In case is a CSC
     } else if (geomDet->subDetector() == GeomDetEnumerators::CSC) {
-
       // Take the layer associated to this hit
       CSCDetId myLayer(rechit->geographicalId().rawId());
 
       int NumberOfCSCSegment = 0;
       // Loop over 4Dsegments
-      for (segmentCSC = all4DSegmentsCSC->begin();
-           segmentCSC != all4DSegmentsCSC->end(); segmentCSC++) {
-
+      for (segmentCSC = all4DSegmentsCSC->begin(); segmentCSC != all4DSegmentsCSC->end(); segmentCSC++) {
         // By default the chamber associated to the segment is new
         bool isNewChamber = true;
 
         // Loop over segments in the current track
-        for (std::vector<int>::iterator positionIt = positionCSC.begin();
-             positionIt != positionCSC.end(); positionIt++) {
-
+        for (std::vector<int>::iterator positionIt = positionCSC.begin(); positionIt != positionCSC.end();
+             positionIt++) {
           // If this segment has been used then newchamber = false
           if (NumberOfCSCSegment == *positionIt)
             isNewChamber = false;
         }
         // Loop over vectors of segments in previous tracks
-        for (std::vector<std::vector<int>>::iterator collect =
-                 indexCollectionCSC->begin();
-             collect != indexCollectionCSC->end(); ++collect) {
-
+        for (std::vector<std::vector<int>>::iterator collect = indexCollectionCSC->begin();
+             collect != indexCollectionCSC->end();
+             ++collect) {
           // Loop over segments in a track
-          for (std::vector<int>::iterator positionIt = (*collect).begin();
-               positionIt != (*collect).end(); positionIt++) {
-
+          for (std::vector<int>::iterator positionIt = (*collect).begin(); positionIt != (*collect).end();
+               positionIt++) {
             // If the segment was used in a previous track isNewChamber = false
             if (NumberOfCSCSegment == *positionIt)
               isNewChamber = false;
@@ -751,7 +652,6 @@ RecHitVector MuonAlignment::doMatching(
         }
         // If the chamber is new
         if (isNewChamber) {
-
           CSCDetId myChamber((*segmentCSC).geographicalId().rawId());
           // If the chambers are the same
           if (myLayer.chamberId() == myChamber.chamberId()) {
@@ -769,28 +669,20 @@ RecHitVector MuonAlignment::doMatching(
   indexCollectionCSC->push_back(positionCSC);
 
   if (trackRefitterType == "CosmicLike") {
-
     std::reverse(my4DTrack.begin(), my4DTrack.end());
   }
   return my4DTrack;
 }
 
 void MuonAlignment::endJob(void) {
-
   LogTrace(metname) << "[MuonAlignment] Saving the histos";
-  bool outputMEsInRootFile =
-      parameters.getParameter<bool>("OutputMEsInRootFile");
-  std::string outputFileName =
-      parameters.getParameter<std::string>("OutputFileName");
+  bool outputMEsInRootFile = parameters.getParameter<bool>("OutputMEsInRootFile");
+  std::string outputFileName = parameters.getParameter<std::string>("OutputFileName");
 
-  edm::LogInfo("MuonAlignment")
-      << "Number of Tracks considered for residuals: " << numberOfTracks
-      << std::endl
-      << std::endl;
-  edm::LogInfo("MuonAlignment")
-      << "Number of Hits considered for residuals: " << numberOfHits
-      << std::endl
-      << std::endl;
+  edm::LogInfo("MuonAlignment") << "Number of Tracks considered for residuals: " << numberOfTracks << std::endl
+                                << std::endl;
+  edm::LogInfo("MuonAlignment") << "Number of Hits considered for residuals: " << numberOfHits << std::endl
+                                << std::endl;
 
   if (doSummary) {
     char binLabel[15];
@@ -804,9 +696,7 @@ void MuonAlignment::endJob(void) {
       return;
 
     for (unsigned int i = 0; i < unitsLocalX.size(); i++) {
-
       if (unitsLocalX[i]->getEntries() != 0) {
-
         TString nameHistoLocalX = unitsLocalX[i]->getName();
 
         TString nameHistoLocalPhi = unitsLocalPhi[i]->getName();
@@ -815,12 +705,11 @@ void MuonAlignment::endJob(void) {
 
         TString nameHistoLocalY = unitsLocalY[i]->getName();
 
-        if (nameHistoLocalX.Contains("MB")) // HistoLocalX DT
+        if (nameHistoLocalX.Contains("MB"))  // HistoLocalX DT
         {
           int wheel, station, sector;
 
-          sscanf(nameHistoLocalX, "ResidualLocalX_W%dMB%1dS%d", &wheel,
-                 &station, &sector);
+          sscanf(nameHistoLocalX, "ResidualLocalX_W%dMB%1dS%d", &wheel, &station, &sector);
 
           Int_t nstation = station - 1;
           Int_t nwheel = wheel + 2;
@@ -839,12 +728,11 @@ void MuonAlignment::endJob(void) {
           hLocalXRmsDT->Fill(Error);
         }
 
-        if (nameHistoLocalX.Contains("ME")) // HistoLocalX CSC
+        if (nameHistoLocalX.Contains("ME"))  // HistoLocalX CSC
         {
           int station, ring, chamber;
 
-          sscanf(nameHistoLocalX, "ResidualLocalX_ME%dR%1dC%d", &station, &ring,
-                 &chamber);
+          sscanf(nameHistoLocalX, "ResidualLocalX_ME%dR%1dC%d", &station, &ring, &chamber);
 
           Double_t Mean = unitsLocalX[i]->getMean();
           Double_t Error = unitsLocalX[i]->getMeanError();
@@ -867,13 +755,11 @@ void MuonAlignment::endJob(void) {
           hLocalXRmsCSC->Fill(Error);
         }
 
-        if (nameHistoLocalTheta.Contains("MB")) // HistoLocalTheta DT
+        if (nameHistoLocalTheta.Contains("MB"))  // HistoLocalTheta DT
         {
-
           int wheel, station, sector;
 
-          sscanf(nameHistoLocalTheta, "ResidualLocalTheta_W%dMB%1dS%d", &wheel,
-                 &station, &sector);
+          sscanf(nameHistoLocalTheta, "ResidualLocalTheta_W%dMB%1dS%d", &wheel, &station, &sector);
 
           if (station != 4) {
             Int_t nstation = station - 1;
@@ -884,8 +770,7 @@ void MuonAlignment::endJob(void) {
 
             Int_t ybin = 2 + nwheel * 8 + nstation * 2;
             hLocalAngleDT->setBinContent(sector, ybin, fabs(Mean));
-            snprintf(binLabel, sizeof(binLabel), "MB%d/%d_#theta", wheel,
-                     station);
+            snprintf(binLabel, sizeof(binLabel), "MB%d/%d_#theta", wheel, station);
             hLocalAngleDT->setBinLabel(ybin, binLabel, 2);
             hLocalAngleRmsDT->setBinContent(sector, ybin, Error);
             hLocalAngleRmsDT->setBinLabel(ybin, binLabel, 2);
@@ -895,13 +780,11 @@ void MuonAlignment::endJob(void) {
           }
         }
 
-        if (nameHistoLocalPhi.Contains("MB")) // HistoLocalPhi DT
+        if (nameHistoLocalPhi.Contains("MB"))  // HistoLocalPhi DT
         {
-
           int wheel, station, sector;
 
-          sscanf(nameHistoLocalPhi, "ResidualLocalPhi_W%dMB%1dS%d", &wheel,
-                 &station, &sector);
+          sscanf(nameHistoLocalPhi, "ResidualLocalPhi_W%dMB%1dS%d", &wheel, &station, &sector);
 
           Int_t nstation = station - 1;
           Int_t nwheel = wheel + 2;
@@ -920,13 +803,11 @@ void MuonAlignment::endJob(void) {
           hLocalPhiRmsDT->Fill(Error);
         }
 
-        if (nameHistoLocalPhi.Contains("ME")) // HistoLocalPhi CSC
+        if (nameHistoLocalPhi.Contains("ME"))  // HistoLocalPhi CSC
         {
-
           int station, ring, chamber;
 
-          sscanf(nameHistoLocalPhi, "ResidualLocalPhi_ME%dR%1dC%d", &station,
-                 &ring, &chamber);
+          sscanf(nameHistoLocalPhi, "ResidualLocalPhi_ME%dR%1dC%d", &station, &ring, &chamber);
 
           Double_t Mean = unitsLocalPhi[i]->getMean();
           Double_t Error = unitsLocalPhi[i]->getMeanError();
@@ -949,13 +830,11 @@ void MuonAlignment::endJob(void) {
           hLocalPhiRmsCSC->Fill(Error);
         }
 
-        if (nameHistoLocalTheta.Contains("ME")) // HistoLocalTheta CSC
+        if (nameHistoLocalTheta.Contains("ME"))  // HistoLocalTheta CSC
         {
-
           int station, ring, chamber;
 
-          sscanf(nameHistoLocalTheta, "ResidualLocalTheta_ME%dR%1dC%d",
-                 &station, &ring, &chamber);
+          sscanf(nameHistoLocalTheta, "ResidualLocalTheta_ME%dR%1dC%d", &station, &ring, &chamber);
 
           Double_t Mean = unitsLocalTheta[i]->getMean();
           Double_t Error = unitsLocalTheta[i]->getMeanError();
@@ -978,13 +857,11 @@ void MuonAlignment::endJob(void) {
           hLocalThetaRmsCSC->Fill(Error);
         }
 
-        if (nameHistoLocalY.Contains("MB")) // HistoLocalY DT
+        if (nameHistoLocalY.Contains("MB"))  // HistoLocalY DT
         {
-
           int wheel, station, sector;
 
-          sscanf(nameHistoLocalY, "ResidualLocalY_W%dMB%1dS%d", &wheel,
-                 &station, &sector);
+          sscanf(nameHistoLocalY, "ResidualLocalY_W%dMB%1dS%d", &wheel, &station, &sector);
 
           if (station != 4) {
             Int_t nstation = station - 1;
@@ -1005,13 +882,11 @@ void MuonAlignment::endJob(void) {
           }
         }
 
-        if (nameHistoLocalY.Contains("ME")) // HistoLocalY CSC
+        if (nameHistoLocalY.Contains("ME"))  // HistoLocalY CSC
         {
-
           int station, ring, chamber;
 
-          sscanf(nameHistoLocalY, "ResidualLocalY_ME%dR%1dC%d", &station, &ring,
-                 &chamber);
+          sscanf(nameHistoLocalY, "ResidualLocalY_ME%dR%1dC%d", &station, &ring, &chamber);
 
           Double_t Mean = unitsLocalY[i]->getMean();
           Double_t Error = unitsLocalY[i]->getMeanError();
@@ -1033,9 +908,9 @@ void MuonAlignment::endJob(void) {
           hLocalYMeanCSC->Fill(fabs(Mean));
           hLocalYRmsCSC->Fill(Error);
         }
-      } // check in # entries
-    }   // loop on vector of histos
-  }     // doSummary
+      }  // check in # entries
+    }    // loop on vector of histos
+  }      // doSummary
 
   if (outputMEsInRootFile) {
     //    dbe->showDirStructure();

--- a/DQMOffline/Alignment/src/MuonAlignmentSummary.cc
+++ b/DQMOffline/Alignment/src/MuonAlignmentSummary.cc
@@ -7,13 +7,10 @@
 #include "DQMOffline/Alignment/interface/MuonAlignmentSummary.h"
 
 MuonAlignmentSummary::MuonAlignmentSummary(const edm::ParameterSet &pSet) {
-
   parameters = pSet;
 
-  meanPositionRange =
-      parameters.getUntrackedParameter<double>("meanPositionRange");
-  rmsPositionRange =
-      parameters.getUntrackedParameter<double>("rmsPositionRange");
+  meanPositionRange = parameters.getUntrackedParameter<double>("meanPositionRange");
+  rmsPositionRange = parameters.getUntrackedParameter<double>("rmsPositionRange");
   meanAngleRange = parameters.getUntrackedParameter<double>("meanAngleRange");
   rmsAngleRange = parameters.getUntrackedParameter<double>("rmsAngleRange");
 
@@ -24,22 +21,18 @@ MuonAlignmentSummary::MuonAlignmentSummary(const edm::ParameterSet &pSet) {
   topFolder << MEFolderName + "Alignment/Muon";
 
   if (!(doDT || doCSC)) {
+    edm::LogError("MuonAlignmentSummary") << " Error!! At least one Muon subsystem (DT or CSC) must be "
+                                             "monitorized!!"
+                                          << std::endl;
     edm::LogError("MuonAlignmentSummary")
-        << " Error!! At least one Muon subsystem (DT or CSC) must be "
-           "monitorized!!"
-        << std::endl;
-    edm::LogError("MuonAlignmentSummary")
-        << " Please enable doDT or doCSC to True in your python cfg file!!!"
-        << std::endl;
+        << " Please enable doDT or doCSC to True in your python cfg file!!!" << std::endl;
     exit(1);
   }
 }
 
 MuonAlignmentSummary::~MuonAlignmentSummary() {}
 
-void MuonAlignmentSummary::dqmEndJob(DQMStore::IBooker &ibooker,
-                                     DQMStore::IGetter &igetter) {
-
+void MuonAlignmentSummary::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
   metname = "MuonAlignmentSummary";
 
   LogTrace(metname) << "[MuonAlignmentSummary] Parameters initialization";
@@ -47,68 +40,72 @@ void MuonAlignmentSummary::dqmEndJob(DQMStore::IBooker &ibooker,
   if (doDT) {
     ibooker.setCurrentFolder(topFolder.str() + "/DT");
     hLocalPositionDT = ibooker.book2D(
-        "hLocalPositionDT",
-        "Local DT position (cm) absolute MEAN residuals;Sector;;cm", 14, 1, 15,
-        40, 0, 40);
+        "hLocalPositionDT", "Local DT position (cm) absolute MEAN residuals;Sector;;cm", 14, 1, 15, 40, 0, 40);
 
     hLocalAngleDT = ibooker.book2D(
-        "hLocalAngleDT",
-        "Local DT angle (rad) absolute MEAN residuals;Sector;;rad", 14, 1, 15,
-        40, 0, 40);
+        "hLocalAngleDT", "Local DT angle (rad) absolute MEAN residuals;Sector;;rad", 14, 1, 15, 40, 0, 40);
 
     hLocalPositionRmsDT =
-        ibooker.book2D("hLocalPositionRmsDT",
-                       "Local DT position (cm) RMS residuals;Sector;;cm", 14, 1,
-                       15, 40, 0, 40);
+        ibooker.book2D("hLocalPositionRmsDT", "Local DT position (cm) RMS residuals;Sector;;cm", 14, 1, 15, 40, 0, 40);
 
-    hLocalAngleRmsDT = ibooker.book2D(
-        "hLocalAngleRmsDT", "Local DT angle (rad) RMS residuals;Sector;;rad",
-        14, 1, 15, 40, 0, 40);
+    hLocalAngleRmsDT =
+        ibooker.book2D("hLocalAngleRmsDT", "Local DT angle (rad) RMS residuals;Sector;;rad", 14, 1, 15, 40, 0, 40);
 
-    hLocalXMeanDT =
-        ibooker.book1D("hLocalXMeanDT",
-                       "Distribution of absolute MEAN Local X (cm) residuals "
-                       "for DT;<X> (cm);number of chambers",
-                       100, 0, meanPositionRange);
+    hLocalXMeanDT = ibooker.book1D("hLocalXMeanDT",
+                                   "Distribution of absolute MEAN Local X (cm) residuals "
+                                   "for DT;<X> (cm);number of chambers",
+                                   100,
+                                   0,
+                                   meanPositionRange);
 
     hLocalXRmsDT = ibooker.book1D("hLocalXRmsDT",
                                   "Distribution of RMS Local X (cm) residuals "
                                   "for DT;X RMS (cm);number of chambers",
-                                  100, 0, rmsPositionRange);
+                                  100,
+                                  0,
+                                  rmsPositionRange);
 
-    hLocalYMeanDT =
-        ibooker.book1D("hLocalYMeanDT",
-                       "Distribution of absolute MEAN Local Y (cm) residuals "
-                       "for DT;<Y> (cm);number of chambers",
-                       100, 0, meanPositionRange);
+    hLocalYMeanDT = ibooker.book1D("hLocalYMeanDT",
+                                   "Distribution of absolute MEAN Local Y (cm) residuals "
+                                   "for DT;<Y> (cm);number of chambers",
+                                   100,
+                                   0,
+                                   meanPositionRange);
 
     hLocalYRmsDT = ibooker.book1D("hLocalYRmsDT",
                                   "Distribution of RMS Local Y (cm) residuals "
                                   "for DT;Y RMS (cm);number of chambers",
-                                  100, 0, rmsPositionRange);
+                                  100,
+                                  0,
+                                  rmsPositionRange);
 
-    hLocalPhiMeanDT =
-        ibooker.book1D("hLocalPhiMeanDT",
-                       "Distribution of absolute MEAN #phi (rad) residuals for "
-                       "DT;<#phi>(rad);number of chambers",
-                       100, 0, meanAngleRange);
+    hLocalPhiMeanDT = ibooker.book1D("hLocalPhiMeanDT",
+                                     "Distribution of absolute MEAN #phi (rad) residuals for "
+                                     "DT;<#phi>(rad);number of chambers",
+                                     100,
+                                     0,
+                                     meanAngleRange);
 
     hLocalPhiRmsDT = ibooker.book1D("hLocalPhiRmsDT",
                                     "Distribution of RMS #phi (rad) residuals "
                                     "for DT;#phi RMS (rad);number of chambers",
-                                    100, 0, rmsAngleRange);
+                                    100,
+                                    0,
+                                    rmsAngleRange);
 
-    hLocalThetaMeanDT =
-        ibooker.book1D("hLocalThetaMeanDT",
-                       "Distribution of absolute MEAN #theta (rad) residuals "
-                       "for DT;<#theta>(rad);number of chambers",
-                       100, 0, meanAngleRange);
+    hLocalThetaMeanDT = ibooker.book1D("hLocalThetaMeanDT",
+                                       "Distribution of absolute MEAN #theta (rad) residuals "
+                                       "for DT;<#theta>(rad);number of chambers",
+                                       100,
+                                       0,
+                                       meanAngleRange);
 
-    hLocalThetaRmsDT =
-        ibooker.book1D("hLocalThetaRmsDT",
-                       "Distribution of RMS #theta (rad) residuals for "
-                       "DT;#theta RMS (rad);number of chambers",
-                       100, 0, rmsAngleRange);
+    hLocalThetaRmsDT = ibooker.book1D("hLocalThetaRmsDT",
+                                      "Distribution of RMS #theta (rad) residuals for "
+                                      "DT;#theta RMS (rad);number of chambers",
+                                      100,
+                                      0,
+                                      rmsAngleRange);
 
     hLocalPositionDT->Reset();
     hLocalAngleDT->Reset();
@@ -125,72 +122,74 @@ void MuonAlignmentSummary::dqmEndJob(DQMStore::IBooker &ibooker,
   }
 
   if (doCSC) {
-
     ibooker.setCurrentFolder(topFolder.str() + "/CSC");
     hLocalPositionCSC = ibooker.book2D(
-        "hLocalPositionCSC",
-        "Local CSC position (cm) absolute MEAN residuals;Sector;;cm", 36, 1, 37,
-        40, 0, 40);
+        "hLocalPositionCSC", "Local CSC position (cm) absolute MEAN residuals;Sector;;cm", 36, 1, 37, 40, 0, 40);
 
     hLocalAngleCSC = ibooker.book2D(
-        "hLocalAngleCSC",
-        "Local CSC angle (rad) absolute MEAN residuals;Sector;;rad", 36, 1, 37,
-        40, 0, 40);
+        "hLocalAngleCSC", "Local CSC angle (rad) absolute MEAN residuals;Sector;;rad", 36, 1, 37, 40, 0, 40);
 
-    hLocalPositionRmsCSC =
-        ibooker.book2D("hLocalPositionRmsCSC",
-                       "Local CSC position (cm) RMS residuals;Sector;;cm", 36,
-                       1, 37, 40, 0, 40);
+    hLocalPositionRmsCSC = ibooker.book2D(
+        "hLocalPositionRmsCSC", "Local CSC position (cm) RMS residuals;Sector;;cm", 36, 1, 37, 40, 0, 40);
 
-    hLocalAngleRmsCSC = ibooker.book2D(
-        "hLocalAngleRmsCSC", "Local CSC angle (rad) RMS residuals;Sector;;rad",
-        36, 1, 37, 40, 0, 40);
+    hLocalAngleRmsCSC =
+        ibooker.book2D("hLocalAngleRmsCSC", "Local CSC angle (rad) RMS residuals;Sector;;rad", 36, 1, 37, 40, 0, 40);
 
-    hLocalXMeanCSC =
-        ibooker.book1D("hLocalXMeanCSC",
-                       "Distribution of absolute MEAN Local X (cm) residuals "
-                       "for CSC;<X> (cm);number of chambers",
-                       100, 0, meanPositionRange);
+    hLocalXMeanCSC = ibooker.book1D("hLocalXMeanCSC",
+                                    "Distribution of absolute MEAN Local X (cm) residuals "
+                                    "for CSC;<X> (cm);number of chambers",
+                                    100,
+                                    0,
+                                    meanPositionRange);
 
     hLocalXRmsCSC = ibooker.book1D("hLocalXRmsCSC",
                                    "Distribution of RMS Local X (cm) residuals "
                                    "for CSC;X RMS (cm);number of chambers",
-                                   100, 0, rmsPositionRange);
+                                   100,
+                                   0,
+                                   rmsPositionRange);
 
-    hLocalYMeanCSC =
-        ibooker.book1D("hLocalYMeanCSC",
-                       "Distribution of absolute MEAN Local Y (cm) residuals "
-                       "for CSC;<Y> (cm);number of chambers",
-                       100, 0, meanPositionRange);
+    hLocalYMeanCSC = ibooker.book1D("hLocalYMeanCSC",
+                                    "Distribution of absolute MEAN Local Y (cm) residuals "
+                                    "for CSC;<Y> (cm);number of chambers",
+                                    100,
+                                    0,
+                                    meanPositionRange);
 
     hLocalYRmsCSC = ibooker.book1D("hLocalYRmsCSC",
                                    "Distribution of RMS Local Y (cm) residuals "
                                    "for CSC;Y RMS (cm);number of chambers",
-                                   100, 0, rmsPositionRange);
+                                   100,
+                                   0,
+                                   rmsPositionRange);
 
-    hLocalPhiMeanCSC =
-        ibooker.book1D("hLocalPhiMeanCSC",
-                       "Distribution of absolute MEAN #phi (rad) residuals for "
-                       "CSC;<#phi>(rad);number of chambers",
-                       100, 0, meanAngleRange);
+    hLocalPhiMeanCSC = ibooker.book1D("hLocalPhiMeanCSC",
+                                      "Distribution of absolute MEAN #phi (rad) residuals for "
+                                      "CSC;<#phi>(rad);number of chambers",
+                                      100,
+                                      0,
+                                      meanAngleRange);
 
-    hLocalPhiRmsCSC =
-        ibooker.book1D("hLocalPhiRmsCSC",
-                       "Distribution of RMS #phi (rad) residuals for CSC;#phi "
-                       "RMS (rad);number of chambers",
-                       100, 0, rmsAngleRange);
+    hLocalPhiRmsCSC = ibooker.book1D("hLocalPhiRmsCSC",
+                                     "Distribution of RMS #phi (rad) residuals for CSC;#phi "
+                                     "RMS (rad);number of chambers",
+                                     100,
+                                     0,
+                                     rmsAngleRange);
 
-    hLocalThetaMeanCSC =
-        ibooker.book1D("hLocalThetaMeanCSC",
-                       "Distribution of absolute MEAN #theta (rad) residuals "
-                       "for CSC;<#theta>(rad);number of chambers",
-                       100, 0, meanAngleRange);
+    hLocalThetaMeanCSC = ibooker.book1D("hLocalThetaMeanCSC",
+                                        "Distribution of absolute MEAN #theta (rad) residuals "
+                                        "for CSC;<#theta>(rad);number of chambers",
+                                        100,
+                                        0,
+                                        meanAngleRange);
 
-    hLocalThetaRmsCSC =
-        ibooker.book1D("hLocalThetaRmsCSC",
-                       "Distribution of RMS #theta (rad) residuals for "
-                       "CSC;#theta RMS (rad);number of chambers",
-                       100, 0, rmsAngleRange);
+    hLocalThetaRmsCSC = ibooker.book1D("hLocalThetaRmsCSC",
+                                       "Distribution of RMS #theta (rad) residuals for "
+                                       "CSC;#theta RMS (rad);number of chambers",
+                                       100,
+                                       0,
+                                       rmsAngleRange);
 
     hLocalPositionCSC->Reset();
     hLocalAngleCSC->Reset();
@@ -213,13 +212,9 @@ void MuonAlignmentSummary::dqmEndJob(DQMStore::IBooker &ibooker,
   for (int station = -4; station < 5; station++) {
     if (doDT) {
       if (station > 0) {
-
         for (int wheel = -2; wheel < 3; wheel++) {
-
           for (int sector = 1; sector < 15; sector++) {
-
             if (!((sector == 13 || sector == 14) && station != 4)) {
-
               std::stringstream Wheel;
               Wheel << wheel;
               std::stringstream Station;
@@ -227,21 +222,16 @@ void MuonAlignmentSummary::dqmEndJob(DQMStore::IBooker &ibooker,
               std::stringstream Sector;
               Sector << sector;
 
-              std::string nameOfHistoLocalX = "ResidualLocalX_W" + Wheel.str() +
-                                              "MB" + Station.str() + "S" +
-                                              Sector.str();
+              std::string nameOfHistoLocalX =
+                  "ResidualLocalX_W" + Wheel.str() + "MB" + Station.str() + "S" + Sector.str();
               std::string nameOfHistoLocalPhi =
-                  "ResidualLocalPhi_W" + Wheel.str() + "MB" + Station.str() +
-                  "S" + Sector.str();
+                  "ResidualLocalPhi_W" + Wheel.str() + "MB" + Station.str() + "S" + Sector.str();
               std::string nameOfHistoLocalTheta =
-                  "ResidualLocalTheta_W" + Wheel.str() + "MB" + Station.str() +
-                  "S" + Sector.str();
-              std::string nameOfHistoLocalY = "ResidualLocalY_W" + Wheel.str() +
-                                              "MB" + Station.str() + "S" +
-                                              Sector.str();
+                  "ResidualLocalTheta_W" + Wheel.str() + "MB" + Station.str() + "S" + Sector.str();
+              std::string nameOfHistoLocalY =
+                  "ResidualLocalY_W" + Wheel.str() + "MB" + Station.str() + "S" + Sector.str();
 
-              std::string path = topFolder.str() + "/DT/Wheel" + Wheel.str() +
-                                 "/Station" + Station.str() + "/Sector" +
+              std::string path = topFolder.str() + "/DT/Wheel" + Wheel.str() + "/Station" + Station.str() + "/Sector" +
                                  Sector.str() + "/";
 
               std::string histo = path + nameOfHistoLocalX;
@@ -250,14 +240,12 @@ void MuonAlignmentSummary::dqmEndJob(DQMStore::IBooker &ibooker,
               Int_t nwheel = wheel + 2;
               MonitorElement *localX = igetter.get(histo);
               if (localX) {
-
                 Double_t Mean = localX->getMean();
                 Double_t Error = localX->getMeanError();
 
                 Int_t ybin = 1 + nwheel * 8 + nstation * 2;
                 hLocalPositionDT->setBinContent(sector, ybin, fabs(Mean));
-                snprintf(binLabel, sizeof(binLabel), "MB%d/%d_X", wheel,
-                         station);
+                snprintf(binLabel, sizeof(binLabel), "MB%d/%d_X", wheel, station);
                 hLocalPositionDT->setBinLabel(ybin, binLabel, 2);
                 hLocalPositionRmsDT->setBinContent(sector, ybin, Error);
                 hLocalPositionRmsDT->setBinLabel(ybin, binLabel, 2);
@@ -271,14 +259,12 @@ void MuonAlignmentSummary::dqmEndJob(DQMStore::IBooker &ibooker,
               histo = path + nameOfHistoLocalPhi;
               MonitorElement *localPhi = igetter.get(histo);
               if (localPhi) {
-
                 Double_t Mean = localPhi->getMean();
                 Double_t Error = localPhi->getMeanError();
 
                 Int_t ybin = 1 + nwheel * 8 + nstation * 2;
                 hLocalAngleDT->setBinContent(sector, ybin, fabs(Mean));
-                snprintf(binLabel, sizeof(binLabel), "MB%d/%d_#phi", wheel,
-                         station);
+                snprintf(binLabel, sizeof(binLabel), "MB%d/%d_#phi", wheel, station);
                 hLocalAngleDT->setBinLabel(ybin, binLabel, 2);
                 hLocalAngleRmsDT->setBinContent(sector, ybin, Error);
                 hLocalAngleRmsDT->setBinLabel(ybin, binLabel, 2);
@@ -290,18 +276,15 @@ void MuonAlignmentSummary::dqmEndJob(DQMStore::IBooker &ibooker,
               }
 
               if (station != 4) {
-
                 histo = path + nameOfHistoLocalY;
                 MonitorElement *localY = igetter.get(histo);
                 if (localY) {
-
                   Double_t Mean = localY->getMean();
                   Double_t Error = localY->getMeanError();
 
                   Int_t ybin = 2 + nwheel * 8 + nstation * 2;
                   hLocalPositionDT->setBinContent(sector, ybin, fabs(Mean));
-                  snprintf(binLabel, sizeof(binLabel), "MB%d/%d_Y", wheel,
-                           station);
+                  snprintf(binLabel, sizeof(binLabel), "MB%d/%d_Y", wheel, station);
                   hLocalPositionDT->setBinLabel(ybin, binLabel, 2);
                   hLocalPositionRmsDT->setBinContent(sector, ybin, Error);
                   hLocalPositionRmsDT->setBinLabel(ybin, binLabel, 2);
@@ -318,8 +301,7 @@ void MuonAlignmentSummary::dqmEndJob(DQMStore::IBooker &ibooker,
 
                   Int_t ybin = 2 + nwheel * 8 + nstation * 2;
                   hLocalAngleDT->setBinContent(sector, ybin, fabs(Mean));
-                  snprintf(binLabel, sizeof(binLabel), "MB%d/%d_#theta", wheel,
-                           station);
+                  snprintf(binLabel, sizeof(binLabel), "MB%d/%d_#theta", wheel, station);
                   hLocalAngleDT->setBinLabel(ybin, binLabel, 2);
                   hLocalAngleRmsDT->setBinContent(sector, ybin, Error);
                   hLocalAngleRmsDT->setBinLabel(ybin, binLabel, 2);
@@ -328,26 +310,19 @@ void MuonAlignmentSummary::dqmEndJob(DQMStore::IBooker &ibooker,
                     hLocalThetaRmsDT->Fill(Error);
                   }
                 }
-              } // station != 4
-            }   // avoid non existing sectors
-          }     // sector
-        }       // wheel
-      }         // station>0
-    }           // doDT
+              }  // station != 4
+            }    // avoid non existing sectors
+          }      // sector
+        }        // wheel
+      }          // station>0
+    }            // doDT
 
     if (doCSC) {
       if (station != 0) {
-
         for (int ring = 1; ring < 5; ring++) {
-
           for (int chamber = 1; chamber < 37; chamber++) {
-
-            if (!(((abs(station) == 2 || abs(station) == 3 ||
-                    abs(station) == 4) &&
-                   ring == 1 && chamber > 18) ||
-                  ((abs(station) == 2 || abs(station) == 3 ||
-                    abs(station) == 4) &&
-                   ring > 2))) {
+            if (!(((abs(station) == 2 || abs(station) == 3 || abs(station) == 4) && ring == 1 && chamber > 18) ||
+                  ((abs(station) == 2 || abs(station) == 3 || abs(station) == 4) && ring > 2))) {
               std::stringstream Ring;
               Ring << ring;
               std::stringstream Station;
@@ -355,22 +330,17 @@ void MuonAlignmentSummary::dqmEndJob(DQMStore::IBooker &ibooker,
               std::stringstream Chamber;
               Chamber << chamber;
 
-              std::string nameOfHistoLocalX = "ResidualLocalX_ME" +
-                                              Station.str() + "R" + Ring.str() +
-                                              "C" + Chamber.str();
+              std::string nameOfHistoLocalX =
+                  "ResidualLocalX_ME" + Station.str() + "R" + Ring.str() + "C" + Chamber.str();
               std::string nameOfHistoLocalPhi =
-                  "ResidualLocalPhi_ME" + Station.str() + "R" + Ring.str() +
-                  "C" + Chamber.str();
+                  "ResidualLocalPhi_ME" + Station.str() + "R" + Ring.str() + "C" + Chamber.str();
               std::string nameOfHistoLocalTheta =
-                  "ResidualLocalTheta_ME" + Station.str() + "R" + Ring.str() +
-                  "C" + Chamber.str();
-              std::string nameOfHistoLocalY = "ResidualLocalY_ME" +
-                                              Station.str() + "R" + Ring.str() +
-                                              "C" + Chamber.str();
+                  "ResidualLocalTheta_ME" + Station.str() + "R" + Ring.str() + "C" + Chamber.str();
+              std::string nameOfHistoLocalY =
+                  "ResidualLocalY_ME" + Station.str() + "R" + Ring.str() + "C" + Chamber.str();
 
-              std::string path = topFolder.str() + "/CSC/Station" +
-                                 Station.str() + "/Ring" + Ring.str() +
-                                 "/Chamber" + Chamber.str() + "/";
+              std::string path = topFolder.str() + "/CSC/Station" + Station.str() + "/Ring" + Ring.str() + "/Chamber" +
+                                 Chamber.str() + "/";
 
               Int_t ybin = abs(station) * 2 + ring;
               if (abs(station) == 1)
@@ -382,14 +352,12 @@ void MuonAlignmentSummary::dqmEndJob(DQMStore::IBooker &ibooker,
               std::string histo = path + nameOfHistoLocalX;
               MonitorElement *localX = igetter.get(histo);
               if (localX) {
-
                 Double_t Mean = localX->getMean();
                 Double_t Error = localX->getMeanError();
 
                 Int_t ybin2 = 2 * ybin - 1;
                 hLocalPositionCSC->setBinContent(chamber, ybin2, fabs(Mean));
-                snprintf(binLabel, sizeof(binLabel), "ME%d/%d_X", station,
-                         ring);
+                snprintf(binLabel, sizeof(binLabel), "ME%d/%d_X", station, ring);
                 hLocalPositionCSC->setBinLabel(ybin2, binLabel, 2);
                 hLocalPositionRmsCSC->setBinContent(chamber, ybin2, Error);
                 hLocalPositionRmsCSC->setBinLabel(ybin2, binLabel, 2);
@@ -402,14 +370,12 @@ void MuonAlignmentSummary::dqmEndJob(DQMStore::IBooker &ibooker,
 
               MonitorElement *localPhi = igetter.get(histo);
               if (localPhi) {
-
                 Double_t Mean = localPhi->getMean();
                 Double_t Error = localPhi->getMeanError();
 
                 Int_t ybin2 = 2 * ybin - 1;
                 hLocalAngleCSC->setBinContent(chamber, ybin2, fabs(Mean));
-                snprintf(binLabel, sizeof(binLabel), "ME%d/%d_#phi", station,
-                         ring);
+                snprintf(binLabel, sizeof(binLabel), "ME%d/%d_#phi", station, ring);
                 hLocalAngleCSC->setBinLabel(ybin2, binLabel, 2);
                 hLocalAngleRmsCSC->setBinContent(chamber, ybin2, Error);
                 hLocalAngleRmsCSC->setBinLabel(ybin2, binLabel, 2);
@@ -421,14 +387,12 @@ void MuonAlignmentSummary::dqmEndJob(DQMStore::IBooker &ibooker,
               histo = path + nameOfHistoLocalTheta;
               MonitorElement *localTheta = igetter.get(histo);
               if (localTheta) {
-
                 Double_t Mean = localTheta->getMean();
                 Double_t Error = localTheta->getMeanError();
 
                 Int_t ybin2 = 2 * ybin;
                 hLocalAngleCSC->setBinContent(chamber, ybin2, fabs(Mean));
-                snprintf(binLabel, sizeof(binLabel), "ME%d/%d_#theta", station,
-                         ring);
+                snprintf(binLabel, sizeof(binLabel), "ME%d/%d_#theta", station, ring);
                 hLocalAngleCSC->setBinLabel(ybin2, binLabel, 2);
                 hLocalAngleRmsCSC->setBinContent(chamber, ybin2, Error);
                 hLocalAngleRmsCSC->setBinLabel(ybin2, binLabel, 2);
@@ -441,14 +405,12 @@ void MuonAlignmentSummary::dqmEndJob(DQMStore::IBooker &ibooker,
 
               MonitorElement *localY = igetter.get(histo);
               if (localY) {
-
                 Double_t Mean = localY->getMean();
                 Double_t Error = localY->getMeanError();
 
                 Int_t ybin2 = 2 * ybin;
                 hLocalPositionCSC->setBinContent(chamber, ybin2, fabs(Mean));
-                snprintf(binLabel, sizeof(binLabel), "ME%d/%d_Y", station,
-                         ring);
+                snprintf(binLabel, sizeof(binLabel), "ME%d/%d_Y", station, ring);
                 hLocalPositionCSC->setBinLabel(ybin2, binLabel, 2);
                 hLocalPositionRmsCSC->setBinContent(chamber, ybin2, Error);
                 hLocalPositionRmsCSC->setBinLabel(ybin2, binLabel, 2);
@@ -457,10 +419,10 @@ void MuonAlignmentSummary::dqmEndJob(DQMStore::IBooker &ibooker,
                   hLocalYRmsCSC->Fill(Error);
                 }
               }
-            } // avoid non existing rings
-          }   // chamber
-        }     // ring
-      }       // station!=0
-    }         // doCSC
-  }           // loop on stations
+            }  // avoid non existing rings
+          }    // chamber
+        }      // ring
+      }        // station!=0
+    }          // doCSC
+  }            // loop on stations
 }

--- a/DQMOffline/Alignment/src/TkAlCaRecoMonitor.cc
+++ b/DQMOffline/Alignment/src/TkAlCaRecoMonitor.cc
@@ -26,21 +26,16 @@
 
 TkAlCaRecoMonitor::TkAlCaRecoMonitor(const edm::ParameterSet &iConfig) {
   conf_ = iConfig;
-  trackProducer_ = consumes<reco::TrackCollection>(
-      conf_.getParameter<edm::InputTag>("TrackProducer"));
-  referenceTrackProducer_ = consumes<reco::TrackCollection>(
-      conf_.getParameter<edm::InputTag>("ReferenceTrackProducer"));
-  jetCollection_ = mayConsume<reco::CaloJetCollection>(
-      conf_.getParameter<edm::InputTag>("CaloJetCollection"));
+  trackProducer_ = consumes<reco::TrackCollection>(conf_.getParameter<edm::InputTag>("TrackProducer"));
+  referenceTrackProducer_ =
+      consumes<reco::TrackCollection>(conf_.getParameter<edm::InputTag>("ReferenceTrackProducer"));
+  jetCollection_ = mayConsume<reco::CaloJetCollection>(conf_.getParameter<edm::InputTag>("CaloJetCollection"));
 }
 
 TkAlCaRecoMonitor::~TkAlCaRecoMonitor() {}
 
-void TkAlCaRecoMonitor::bookHistograms(DQMStore::IBooker &iBooker,
-                                       edm::Run const &,
-                                       edm::EventSetup const &) {
-
-  std::string histname; // for naming the histograms according to algorithm used
+void TkAlCaRecoMonitor::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const &, edm::EventSetup const &) {
+  std::string histname;  // for naming the histograms according to algorithm used
 
   std::string AlgoName = conf_.getParameter<std::string>("AlgoName");
   std::string MEFolderName = conf_.getParameter<std::string>("FolderName");
@@ -62,44 +57,37 @@ void TkAlCaRecoMonitor::bookHistograms(DQMStore::IBooker &iBooker,
 
   if (fillInvariantMass_) {
     histname = "InvariantMass_";
-    invariantMass_ = iBooker.book1D(histname + AlgoName, histname + AlgoName,
-                                    MassBin, MassMin, MassMax);
+    invariantMass_ = iBooker.book1D(histname + AlgoName, histname + AlgoName, MassBin, MassMin, MassMax);
     invariantMass_->setAxisTitle("invariant Mass / GeV");
   } else {
     invariantMass_ = nullptr;
   }
 
-  unsigned int TrackPtPositiveBin =
-      conf_.getParameter<unsigned int>("TrackPtBin");
+  unsigned int TrackPtPositiveBin = conf_.getParameter<unsigned int>("TrackPtBin");
   double TrackPtPositiveMin = conf_.getParameter<double>("TrackPtMin");
   double TrackPtPositiveMax = conf_.getParameter<double>("TrackPtMax");
 
   histname = "TrackPtPositive_";
-  TrackPtPositive_ = iBooker.book1D(histname + AlgoName, histname + AlgoName,
-                                    TrackPtPositiveBin, TrackPtPositiveMin,
-                                    TrackPtPositiveMax);
+  TrackPtPositive_ = iBooker.book1D(
+      histname + AlgoName, histname + AlgoName, TrackPtPositiveBin, TrackPtPositiveMin, TrackPtPositiveMax);
   TrackPtPositive_->setAxisTitle("p_{T} of tracks charge > 0");
 
-  unsigned int TrackPtNegativeBin =
-      conf_.getParameter<unsigned int>("TrackPtBin");
+  unsigned int TrackPtNegativeBin = conf_.getParameter<unsigned int>("TrackPtBin");
   double TrackPtNegativeMin = conf_.getParameter<double>("TrackPtMin");
   double TrackPtNegativeMax = conf_.getParameter<double>("TrackPtMax");
 
   histname = "TrackPtNegative_";
-  TrackPtNegative_ = iBooker.book1D(histname + AlgoName, histname + AlgoName,
-                                    TrackPtNegativeBin, TrackPtNegativeMin,
-                                    TrackPtNegativeMax);
+  TrackPtNegative_ = iBooker.book1D(
+      histname + AlgoName, histname + AlgoName, TrackPtNegativeBin, TrackPtNegativeMin, TrackPtNegativeMax);
   TrackPtNegative_->setAxisTitle("p_{T} of tracks charge < 0");
 
   histname = "TrackQuality_";
-  TrackQuality_ = iBooker.book1D(histname + AlgoName, histname + AlgoName,
-                                 reco::TrackBase::qualitySize, -0.5,
-                                 reco::TrackBase::qualitySize - 0.5);
+  TrackQuality_ = iBooker.book1D(
+      histname + AlgoName, histname + AlgoName, reco::TrackBase::qualitySize, -0.5, reco::TrackBase::qualitySize - 0.5);
   TrackQuality_->setAxisTitle("quality");
   for (int i = 0; i < reco::TrackBase::qualitySize; ++i) {
     TrackQuality_->getTH1()->GetXaxis()->SetBinLabel(
-        i + 1,
-        reco::TrackBase::qualityName(reco::TrackBase::TrackQuality(i)).c_str());
+        i + 1, reco::TrackBase::qualityName(reco::TrackBase::TrackQuality(i)).c_str());
   }
 
   unsigned int SumChargeBin = conf_.getParameter<unsigned int>("SumChargeBin");
@@ -107,91 +95,76 @@ void TkAlCaRecoMonitor::bookHistograms(DQMStore::IBooker &iBooker,
   double SumChargeMax = conf_.getParameter<double>("SumChargeMax");
 
   histname = "SumCharge_";
-  sumCharge_ = iBooker.book1D(histname + AlgoName, histname + AlgoName,
-                              SumChargeBin, SumChargeMin, SumChargeMax);
+  sumCharge_ = iBooker.book1D(histname + AlgoName, histname + AlgoName, SumChargeBin, SumChargeMin, SumChargeMax);
   sumCharge_->setAxisTitle("#SigmaCharge");
 
-  unsigned int TrackCurvatureBin =
-      conf_.getParameter<unsigned int>("TrackCurvatureBin");
+  unsigned int TrackCurvatureBin = conf_.getParameter<unsigned int>("TrackCurvatureBin");
   double TrackCurvatureMin = conf_.getParameter<double>("TrackCurvatureMin");
   double TrackCurvatureMax = conf_.getParameter<double>("TrackCurvatureMax");
 
   histname = "TrackCurvature_";
   TrackCurvature_ =
-      iBooker.book1D(histname + AlgoName, histname + AlgoName,
-                     TrackCurvatureBin, TrackCurvatureMin, TrackCurvatureMax);
+      iBooker.book1D(histname + AlgoName, histname + AlgoName, TrackCurvatureBin, TrackCurvatureMin, TrackCurvatureMax);
   TrackCurvature_->setAxisTitle("#kappa track");
 
   if (runsOnReco_) {
-
     unsigned int JetPtBin = conf_.getParameter<unsigned int>("JetPtBin");
     double JetPtMin = conf_.getParameter<double>("JetPtMin");
     double JetPtMax = conf_.getParameter<double>("JetPtMax");
 
     histname = "JetPt_";
-    jetPt_ = iBooker.book1D(histname + AlgoName, histname + AlgoName, JetPtBin,
-                            JetPtMin, JetPtMax);
+    jetPt_ = iBooker.book1D(histname + AlgoName, histname + AlgoName, JetPtBin, JetPtMin, JetPtMax);
     jetPt_->setAxisTitle("jet p_{T} / GeV");
 
-    unsigned int MinJetDeltaRBin =
-        conf_.getParameter<unsigned int>("MinJetDeltaRBin");
+    unsigned int MinJetDeltaRBin = conf_.getParameter<unsigned int>("MinJetDeltaRBin");
     double MinJetDeltaRMin = conf_.getParameter<double>("MinJetDeltaRMin");
     double MinJetDeltaRMax = conf_.getParameter<double>("MinJetDeltaRMax");
 
     histname = "MinJetDeltaR_";
     minJetDeltaR_ =
-        iBooker.book1D(histname + AlgoName, histname + AlgoName,
-                       MinJetDeltaRBin, MinJetDeltaRMin, MinJetDeltaRMax);
+        iBooker.book1D(histname + AlgoName, histname + AlgoName, MinJetDeltaRBin, MinJetDeltaRMin, MinJetDeltaRMax);
     minJetDeltaR_->setAxisTitle("minimal Jet #DeltaR / rad");
   } else {
     jetPt_ = nullptr;
     minJetDeltaR_ = nullptr;
   }
 
-  unsigned int MinTrackDeltaRBin =
-      conf_.getParameter<unsigned int>("MinTrackDeltaRBin");
+  unsigned int MinTrackDeltaRBin = conf_.getParameter<unsigned int>("MinTrackDeltaRBin");
   double MinTrackDeltaRMin = conf_.getParameter<double>("MinTrackDeltaRMin");
   double MinTrackDeltaRMax = conf_.getParameter<double>("MinTrackDeltaRMax");
 
   histname = "MinTrackDeltaR_";
   minTrackDeltaR_ =
-      iBooker.book1D(histname + AlgoName, histname + AlgoName,
-                     MinTrackDeltaRBin, MinTrackDeltaRMin, MinTrackDeltaRMax);
+      iBooker.book1D(histname + AlgoName, histname + AlgoName, MinTrackDeltaRBin, MinTrackDeltaRMin, MinTrackDeltaRMax);
   minTrackDeltaR_->setAxisTitle("minimal Track #DeltaR / rad");
 
-  unsigned int TrackEfficiencyBin =
-      conf_.getParameter<unsigned int>("TrackEfficiencyBin");
+  unsigned int TrackEfficiencyBin = conf_.getParameter<unsigned int>("TrackEfficiencyBin");
   double TrackEfficiencyMin = conf_.getParameter<double>("TrackEfficiencyMin");
   double TrackEfficiencyMax = conf_.getParameter<double>("TrackEfficiencyMax");
 
   histname = "AlCaRecoTrackEfficiency_";
   AlCaRecoTrackEfficiency_ = iBooker.book1D(
-      histname + AlgoName, histname + AlgoName, TrackEfficiencyBin,
-      TrackEfficiencyMin, TrackEfficiencyMax);
+      histname + AlgoName, histname + AlgoName, TrackEfficiencyBin, TrackEfficiencyMin, TrackEfficiencyMax);
   Labels l_tp, l_rtp;
   labelsForToken(referenceTrackProducer_, l_rtp);
   labelsForToken(trackProducer_, l_tp);
-  AlCaRecoTrackEfficiency_->setAxisTitle("n(" + std::string(l_tp.module) +
-                                         ") / n(" + std::string(l_rtp.module) +
-                                         ")");
+  AlCaRecoTrackEfficiency_->setAxisTitle("n(" + std::string(l_tp.module) + ") / n(" + std::string(l_rtp.module) + ")");
 
-  int zBin = conf_.getParameter<unsigned int>("HitMapsZBin"); // 300
-  double zMax = conf_.getParameter<double>("HitMapZMax");     // 300.0; //cm
+  int zBin = conf_.getParameter<unsigned int>("HitMapsZBin");  // 300
+  double zMax = conf_.getParameter<double>("HitMapZMax");      // 300.0; //cm
 
-  int rBin = conf_.getParameter<unsigned int>("HitMapsRBin"); // 120;
-  double rMax = conf_.getParameter<double>("HitMapRMax");     // 120.0; //cm
+  int rBin = conf_.getParameter<unsigned int>("HitMapsRBin");  // 120;
+  double rMax = conf_.getParameter<double>("HitMapRMax");      // 120.0; //cm
 
   histname = "Hits_ZvsR_";
   double rMin = 0.0;
   if (useSignedR_)
     rMin = -rMax;
 
-  Hits_ZvsR_ = iBooker.book2D(histname + AlgoName, histname + AlgoName, zBin,
-                              -zMax, zMax, rBin, rMin, rMax);
+  Hits_ZvsR_ = iBooker.book2D(histname + AlgoName, histname + AlgoName, zBin, -zMax, zMax, rBin, rMin, rMax);
 
   histname = "Hits_XvsY_";
-  Hits_XvsY_ = iBooker.book2D(histname + AlgoName, histname + AlgoName, rBin,
-                              -rMax, rMax, rBin, -rMax, rMax);
+  Hits_XvsY_ = iBooker.book2D(histname + AlgoName, histname + AlgoName, rBin, -rMax, rMax, rBin, -rMax, rMax);
 
   if (fillRawIdMap_) {
     histname = "Hits_perDetId_";
@@ -201,8 +174,7 @@ void TkAlCaRecoMonitor::bookHistograms(DQMStore::IBooker &iBooker,
     // Hits_perDetId_ = iBooker.book1D(histname+AlgoName, histname+AlgoName,
     // nModules, static_cast<double>(nModules) -0.5,
     // static_cast<double>(nModules) -0.5);
-    Hits_perDetId_ = iBooker.book1D(histname + AlgoName, histname + AlgoName,
-                                    16601, -0.5, 16600.5);
+    Hits_perDetId_ = iBooker.book1D(histname + AlgoName, histname + AlgoName, 16601, -0.5, 16600.5);
     Hits_perDetId_->setAxisTitle("rawId Bins");
 
     //// impossible takes too much memory :(
@@ -219,9 +191,7 @@ void TkAlCaRecoMonitor::bookHistograms(DQMStore::IBooker &iBooker,
 //
 // -- Analyse
 //
-void TkAlCaRecoMonitor::analyze(const edm::Event &iEvent,
-                                const edm::EventSetup &iSetup) {
-
+void TkAlCaRecoMonitor::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   edm::Handle<reco::TrackCollection> trackCollection;
   iEvent.getByToken(trackProducer_, trackCollection);
   if (!trackCollection.isValid()) {
@@ -232,8 +202,7 @@ void TkAlCaRecoMonitor::analyze(const edm::Event &iEvent,
   edm::Handle<reco::TrackCollection> referenceTrackCollection;
   iEvent.getByToken(referenceTrackProducer_, referenceTrackCollection);
   if (!trackCollection.isValid()) {
-    edm::LogError("Alignment")
-        << "invalid reference track-collection encountered!";
+    edm::LogError("Alignment") << "invalid reference track-collection encountered!";
     return;
   }
 
@@ -246,8 +215,7 @@ void TkAlCaRecoMonitor::analyze(const edm::Event &iEvent,
   edm::ESHandle<MagneticField> magneticField;
   iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
   if (!magneticField.isValid()) {
-    edm::LogError("Alignment")
-        << "invalid magnetic field configuration encountered!";
+    edm::LogError("Alignment") << "invalid magnetic field configuration encountered!";
     return;
   }
 
@@ -262,18 +230,15 @@ void TkAlCaRecoMonitor::analyze(const edm::Event &iEvent,
   if (fillRawIdMap_ && binByRawId_.empty())
     this->fillRawIdMap(*geometry);
 
-  AlCaRecoTrackEfficiency_->Fill(
-      static_cast<double>((*trackCollection).size()) /
-      (*referenceTrackCollection).size());
+  AlCaRecoTrackEfficiency_->Fill(static_cast<double>((*trackCollection).size()) / (*referenceTrackCollection).size());
 
   double sumOfCharges = 0;
-  for (reco::TrackCollection::const_iterator track = (*trackCollection).begin();
-       track < (*trackCollection).end(); ++track) {
+  for (reco::TrackCollection::const_iterator track = (*trackCollection).begin(); track < (*trackCollection).end();
+       ++track) {
     double dR = 0;
     if (runsOnReco_) {
-      double minJetDeltaR = 10; // some number > 2pi
-      for (reco::CaloJetCollection::const_iterator itJet = jets->begin();
-           itJet != jets->end(); ++itJet) {
+      double minJetDeltaR = 10;  // some number > 2pi
+      for (reco::CaloJetCollection::const_iterator itJet = jets->begin(); itJet != jets->end(); ++itJet) {
         jetPt_->Fill((*itJet).pt());
         dR = deltaR((*track), (*itJet));
         if ((*itJet).pt() > maxJetPt_ && dR < minJetDeltaR)
@@ -285,10 +250,9 @@ void TkAlCaRecoMonitor::analyze(const edm::Event &iEvent,
       minJetDeltaR_->Fill(minJetDeltaR);
     }
 
-    double minTrackDeltaR = 10; // some number > 2pi
-    for (reco::TrackCollection::const_iterator track2 =
-             (*trackCollection).begin();
-         track2 < (*trackCollection).end(); ++track2) {
+    double minTrackDeltaR = 10;  // some number > 2pi
+    for (reco::TrackCollection::const_iterator track2 = (*trackCollection).begin(); track2 < (*trackCollection).end();
+         ++track2) {
       dR = deltaR((*track), (*track2));
       if (dR < minTrackDeltaR && dR > 1e-6)
         minTrackDeltaR = dR;
@@ -320,30 +284,26 @@ void TkAlCaRecoMonitor::analyze(const edm::Event &iEvent,
   if (fillInvariantMass_) {
     if ((*trackCollection).size() == 2) {
       TLorentzVector track0(
-          (*trackCollection).at(0).px(), (*trackCollection).at(0).py(),
+          (*trackCollection).at(0).px(),
+          (*trackCollection).at(0).py(),
           (*trackCollection).at(0).pz(),
-          sqrt(((*trackCollection).at(0).p() * (*trackCollection).at(0).p()) +
-               daughterMass_ * daughterMass_));
+          sqrt(((*trackCollection).at(0).p() * (*trackCollection).at(0).p()) + daughterMass_ * daughterMass_));
       TLorentzVector track1(
-          (*trackCollection).at(1).px(), (*trackCollection).at(1).py(),
+          (*trackCollection).at(1).px(),
+          (*trackCollection).at(1).py(),
           (*trackCollection).at(1).pz(),
-          sqrt(((*trackCollection).at(1).p() * (*trackCollection).at(1).p()) +
-               daughterMass_ * daughterMass_));
+          sqrt(((*trackCollection).at(1).p() * (*trackCollection).at(1).p()) + daughterMass_ * daughterMass_));
       TLorentzVector mother = track0 + track1;
 
       invariantMass_->Fill(mother.M());
     } else {
-      edm::LogInfo("Alignment")
-          << "wrong number of tracks trackcollection encountered: "
-          << (*trackCollection).size();
+      edm::LogInfo("Alignment") << "wrong number of tracks trackcollection encountered: " << (*trackCollection).size();
     }
   }
 }
 
-void TkAlCaRecoMonitor::fillHitmaps(const reco::Track &track,
-                                    const TrackerGeometry &geometry) {
-  for (trackingRecHit_iterator iHit = track.recHitsBegin();
-       iHit != track.recHitsEnd(); ++iHit) {
+void TkAlCaRecoMonitor::fillHitmaps(const reco::Track &track, const TrackerGeometry &geometry) {
+  for (trackingRecHit_iterator iHit = track.recHitsBegin(); iHit != track.recHitsEnd(); ++iHit) {
     if ((*iHit)->isValid()) {
       const TrackingRecHit *hit = (*iHit);
       const DetId geoId(hit->geographicalId());
@@ -368,16 +328,14 @@ void TkAlCaRecoMonitor::fillHitmaps(const reco::Track &track,
 
 void TkAlCaRecoMonitor::fillRawIdMap(const TrackerGeometry &geometry) {
   std::vector<int> sortedRawIds;
-  for (std::vector<DetId>::const_iterator iDetId =
-           geometry.detUnitIds().begin();
-       iDetId != geometry.detUnitIds().end(); ++iDetId) {
+  for (std::vector<DetId>::const_iterator iDetId = geometry.detUnitIds().begin(); iDetId != geometry.detUnitIds().end();
+       ++iDetId) {
     sortedRawIds.push_back((*iDetId).rawId());
   }
   std::sort(sortedRawIds.begin(), sortedRawIds.end());
 
   int i = 0;
-  for (std::vector<int>::iterator iRawId = sortedRawIds.begin();
-       iRawId != sortedRawIds.end(); ++iRawId) {
+  for (std::vector<int>::iterator iRawId = sortedRawIds.begin(); iRawId != sortedRawIds.end(); ++iRawId) {
     binByRawId_[*iRawId] = i;
     ++i;
   }

--- a/HLTriggerOffline/Exotica/interface/HLTExoticaPlotter.h
+++ b/HLTriggerOffline/Exotica/interface/HLTExoticaPlotter.h
@@ -43,24 +43,30 @@ struct EVTColContainer;
 
 class HLTExoticaPlotter {
 public:
-  HLTExoticaPlotter(const edm::ParameterSet &pset, const std::string &hltPath,
+  HLTExoticaPlotter(const edm::ParameterSet &pset,
+                    const std::string &hltPath,
                     const std::vector<unsigned int> &objectsType);
   ~HLTExoticaPlotter();
   void beginJob();
   void beginRun(const edm::Run &, const edm::EventSetup &);
-  void plotterBookHistos(DQMStore::IBooker &iBooker, const edm::Run &iRun,
-                         const edm::EventSetup &iSetup);
-  void analyze(const bool &isPassTrigger, const std::string &source,
+  void plotterBookHistos(DQMStore::IBooker &iBooker, const edm::Run &iRun, const edm::EventSetup &iSetup);
+  void analyze(const bool &isPassTrigger,
+               const std::string &source,
                const std::vector<reco::LeafCandidate> &matches,
-               std::map<int, double> theSumEt, std::vector<float> &dxys);
+               std::map<int, double> theSumEt,
+               std::vector<float> &dxys);
 
   inline const std::string gethltpath() const { return _hltPath; }
 
 private:
-  void bookHist(DQMStore::IBooker &iBooker, const std::string &source,
-                const std::string &objType, const std::string &variable);
-  void fillHist(const bool &passTrigger, const std::string &source,
-                const std::string &objType, const std::string &var,
+  void bookHist(DQMStore::IBooker &iBooker,
+                const std::string &source,
+                const std::string &objType,
+                const std::string &variable);
+  void fillHist(const bool &passTrigger,
+                const std::string &source,
+                const std::string &objType,
+                const std::string &var,
                 const float &value);
 
   std::string _hltPath;

--- a/HLTriggerOffline/Exotica/interface/HLTExoticaSubAnalysis.h
+++ b/HLTriggerOffline/Exotica/interface/HLTExoticaSubAnalysis.h
@@ -78,14 +78,12 @@ public:
   /// Method to book all relevant histograms in the DQMStore.
   /// Uses the IBooker interface for thread safety.
   /// Intended to be called from master object.
-  void subAnalysisBookHistos(DQMStore::IBooker &iBooker, const edm::Run &iRun,
-                             const edm::EventSetup &iSetup);
+  void subAnalysisBookHistos(DQMStore::IBooker &iBooker, const edm::Run &iRun, const edm::EventSetup &iSetup);
 
   /// Method to fill all relevant histograms.
   /// Notice that we update the EVTColContaner to point to the collections we
   /// want.
-  void analyze(const edm::Event &iEvent, const edm::EventSetup &iEventSetup,
-               EVTColContainer *cols);
+  void analyze(const edm::Event &iEvent, const edm::EventSetup &iEventSetup, EVTColContainer *cols);
 
 private:
   /// Return the objects (muons,electrons,photons,...) needed by a HLT path.
@@ -93,8 +91,7 @@ private:
   /// 3 for PFMET, 4 for PFTau, 5 for Jet.
   /// Notice that this function is really based on a parsing of the name of
   /// the path; any incongruences there may lead to problems.
-  const std::vector<unsigned int>
-  getObjectsType(const std::string &hltpath) const;
+  const std::vector<unsigned int> getObjectsType(const std::string &hltpath) const;
 
   /// Creates the maps that map  which collection should come from which label
   void getNamesOfObjects(const edm::ParameterSet &anpset);
@@ -106,17 +103,18 @@ private:
   void initSelector(const unsigned int &objtype);
   /// This function applies the selectors initialized previously to the objects,
   /// and matches the passing objects to HLT objects.
-  void
-  insertCandidates(const unsigned int &objtype, const EVTColContainer *col,
-                   std::vector<reco::LeafCandidate> *matches,
-                   std::map<int, double> &theSumEt,
-                   std::map<int, std::vector<const reco::Track *>> &trkObjs);
+  void insertCandidates(const unsigned int &objtype,
+                        const EVTColContainer *col,
+                        std::vector<reco::LeafCandidate> *matches,
+                        std::map<int, double> &theSumEt,
+                        std::map<int, std::vector<const reco::Track *>> &trkObjs);
 
   /// The internal functions to book and fill histograms
-  void bookHist(DQMStore::IBooker &iBooker, const std::string &source,
-                const std::string &objType, const std::string &variable);
-  void fillHist(const std::string &source, const std::string &objType,
-                const std::string &variable, const float &value);
+  void bookHist(DQMStore::IBooker &iBooker,
+                const std::string &source,
+                const std::string &objType,
+                const std::string &variable);
+  void fillHist(const std::string &source, const std::string &objType, const std::string &variable, const float &value);
 
   /// Internal, working copy of the PSet passed from above.
   edm::ParameterSet _pset;
@@ -166,8 +164,7 @@ private:
 
   /// The concrete String selectors (use the string cuts introduced
   /// via the config python)
-  std::map<unsigned int, StringCutObjectSelector<reco::GenParticle> *>
-      _genSelectorMap;
+  std::map<unsigned int, StringCutObjectSelector<reco::GenParticle> *> _genSelectorMap;
   StringCutObjectSelector<reco::Muon> *_recMuonSelector;
   StringCutObjectSelector<reco::Track> *_recMuonTrkSelector;
   StringCutObjectSelector<reco::Track> *_recTrackSelector;

--- a/HLTriggerOffline/Exotica/interface/HLTExoticaValidator.h
+++ b/HLTriggerOffline/Exotica/interface/HLTExoticaValidator.h
@@ -42,17 +42,14 @@ public:
 
 protected:
   /// Method called by the framework to book histograms.
-  void bookHistograms(DQMStore::IBooker &iBooker, const edm::Run &iRun,
-                      const edm::EventSetup &iSetup) override;
+  void bookHistograms(DQMStore::IBooker &iBooker, const edm::Run &iRun, const edm::EventSetup &iSetup) override;
 
 private:
   void beginJob() override;
   /// Method called by the framework just before dqmBeginRun()
-  void dqmBeginRun(const edm::Run &iRun,
-                   const edm::EventSetup &iSetup) override;
+  void dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) override;
   /// Method called for each event.
-  void analyze(const edm::Event &iEvent,
-               const edm::EventSetup &iSetup) override;
+  void analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) override;
   void endRun(const edm::Run &iRun, const edm::EventSetup &iSetup) override;
   void endJob() override;
 

--- a/HLTriggerOffline/Exotica/src/EVTColContainer.cc
+++ b/HLTriggerOffline/Exotica/src/EVTColContainer.cc
@@ -85,11 +85,24 @@ struct EVTColContainer {
   const reco::BeamSpot *bs;
 
   EVTColContainer()
-      : nOfCollections(6), nInitialized(0), genParticles(nullptr),
-        muons(nullptr), tracks(nullptr), electrons(nullptr), photons(nullptr),
-        METs(nullptr), pfMETs(nullptr), pfMHTs(nullptr), genMETs(nullptr),
-        caloMETs(nullptr), caloMHTs(nullptr), l1METs(nullptr), pfTaus(nullptr),
-        pfJets(nullptr), caloJets(nullptr), triggerResults(nullptr),
+      : nOfCollections(6),
+        nInitialized(0),
+        genParticles(nullptr),
+        muons(nullptr),
+        tracks(nullptr),
+        electrons(nullptr),
+        photons(nullptr),
+        METs(nullptr),
+        pfMETs(nullptr),
+        pfMHTs(nullptr),
+        genMETs(nullptr),
+        caloMETs(nullptr),
+        caloMHTs(nullptr),
+        l1METs(nullptr),
+        pfTaus(nullptr),
+        pfJets(nullptr),
+        caloJets(nullptr),
+        triggerResults(nullptr),
         bs(nullptr) {}
   ///
   bool isAllInit() { return (nInitialized == nOfCollections); }
@@ -249,10 +262,8 @@ struct EVTColContainer {
     } else if (objtype == EVTColContainer::CALOJET) {
       objTypestr = "CaloJet";
     } else {
-      edm::LogError("ExoticaValidations")
-          << "EVTColContainer::getTypeString, "
-          << "NOT Implemented error (object type id='" << objtype << "')"
-          << std::endl;
+      edm::LogError("ExoticaValidations") << "EVTColContainer::getTypeString, "
+                                          << "NOT Implemented error (object type id='" << objtype << "')" << std::endl;
       ;
     }
 

--- a/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
@@ -16,22 +16,20 @@
 #include <cctype>
 #include <set>
 
-HLTExoticaPlotter::HLTExoticaPlotter(
-    const edm::ParameterSet &pset, const std::string &hltPath,
-    const std::vector<unsigned int> &objectsType)
+HLTExoticaPlotter::HLTExoticaPlotter(const edm::ParameterSet &pset,
+                                     const std::string &hltPath,
+                                     const std::vector<unsigned int> &objectsType)
     : _hltPath(hltPath),
       _hltProcessName(pset.getParameter<std::string>("hltProcessName")),
-      _objectsType(
-          std::set<unsigned int>(objectsType.begin(), objectsType.end())),
+      _objectsType(std::set<unsigned int>(objectsType.begin(), objectsType.end())),
       _nObjects(objectsType.size()),
       _parametersEta(pset.getParameter<std::vector<double>>("parametersEta")),
       _parametersPhi(pset.getParameter<std::vector<double>>("parametersPhi")),
-      _parametersTurnOn(
-          pset.getParameter<std::vector<double>>("parametersTurnOn")),
-      _parametersTurnOnSumEt(
-          pset.getParameter<std::vector<double>>("parametersTurnOnSumEt")),
+      _parametersTurnOn(pset.getParameter<std::vector<double>>("parametersTurnOn")),
+      _parametersTurnOnSumEt(pset.getParameter<std::vector<double>>("parametersTurnOnSumEt")),
       _parametersDxy(pset.getParameter<std::vector<double>>("parametersDxy")),
-      _drop_pt2(false), _drop_pt3(false) {
+      _drop_pt2(false),
+      _drop_pt3(false) {
   if (pset.exists("dropPt2")) {
     _drop_pt2 = pset.getParameter<bool>("dropPt2");
   }
@@ -49,8 +47,7 @@ void HLTExoticaPlotter::plotterBookHistos(DQMStore::IBooker &iBooker,
                                           const edm::Run &iRun,
                                           const edm::EventSetup &iSetup) {
   LogDebug("ExoticaValidation") << "In HLTExoticaPlotter::plotterBookHistos()";
-  for (std::set<unsigned int>::iterator it = _objectsType.begin();
-       it != _objectsType.end(); ++it) {
+  for (std::set<unsigned int>::iterator it = _objectsType.begin(); it != _objectsType.end(); ++it) {
     std::vector<std::string> sources(2);
     sources[0] = "gen";
     sources[1] = "rec";
@@ -61,8 +58,7 @@ void HLTExoticaPlotter::plotterBookHistos(DQMStore::IBooker &iBooker,
       std::string source = sources[i];
 
       if (source == "gen") {
-        if (TString(objTypeStr).Contains("MET") ||
-            TString(objTypeStr).Contains("MHT") ||
+        if (TString(objTypeStr).Contains("MET") || TString(objTypeStr).Contains("MHT") ||
             TString(objTypeStr).Contains("Jet")) {
           continue;
         } else {
@@ -76,14 +72,12 @@ void HLTExoticaPlotter::plotterBookHistos(DQMStore::IBooker &iBooker,
 
           // If the target is electron or muon,
           // we will add Dxy plots.
-          if (*it == EVTColContainer::ELEC || *it == EVTColContainer::MUON ||
-              *it == EVTColContainer::MUTRK) {
+          if (*it == EVTColContainer::ELEC || *it == EVTColContainer::MUON || *it == EVTColContainer::MUTRK) {
             bookHist(iBooker, source, objTypeStr, "Dxy");
           }
         }
-      } else { // reco
-        if (TString(objTypeStr).Contains("MET") ||
-            TString(objTypeStr).Contains("MHT")) {
+      } else {  // reco
+        if (TString(objTypeStr).Contains("MET") || TString(objTypeStr).Contains("MHT")) {
           bookHist(iBooker, source, objTypeStr, "MaxPt1");
           bookHist(iBooker, source, objTypeStr, "SumEt");
         } else {
@@ -97,8 +91,7 @@ void HLTExoticaPlotter::plotterBookHistos(DQMStore::IBooker &iBooker,
 
           // If the target is electron or muon,
           // we will add Dxy plots.
-          if (*it == EVTColContainer::ELEC || *it == EVTColContainer::MUON ||
-              *it == EVTColContainer::MUTRK) {
+          if (*it == EVTColContainer::ELEC || *it == EVTColContainer::MUON || *it == EVTColContainer::MUTRK) {
             bookHist(iBooker, source, objTypeStr, "Dxy");
           }
         }
@@ -119,8 +112,7 @@ void HLTExoticaPlotter::analyze(const bool &isPassTrigger,
 
   std::map<unsigned int, int> countobjects;
   // Initializing the count of the used object
-  for (std::set<unsigned int>::iterator co = _objectsType.begin();
-       co != _objectsType.end(); ++co) {
+  for (std::set<unsigned int>::iterator co = _objectsType.begin(); co != _objectsType.end(); ++co) {
     countobjects[*co] = 0;
   }
 
@@ -147,42 +139,35 @@ void HLTExoticaPlotter::analyze(const bool &isPassTrigger,
     float eta = matches[j].eta();
     float phi = matches[j].phi();
 
-    if (!(TString(objTypeStr).Contains("MET") ||
-          TString(objTypeStr).Contains("MHT"))) {
+    if (!(TString(objTypeStr).Contains("MET") || TString(objTypeStr).Contains("MHT"))) {
       this->fillHist(isPassTrigger, source, objTypeStr, "Eta", eta);
       this->fillHist(isPassTrigger, source, objTypeStr, "Phi", phi);
     } else if (source != "gen") {
       if (theSumEt[objType] >= 0 && countobjects[objType] == 0) {
-        this->fillHist(isPassTrigger, source, objTypeStr, "SumEt",
-                       theSumEt[objType]);
+        this->fillHist(isPassTrigger, source, objTypeStr, "SumEt", theSumEt[objType]);
       }
     }
 
     if (!dxys.empty() &&
-        (objType == EVTColContainer::ELEC || objType == EVTColContainer::MUON ||
-         objType == EVTColContainer::MUTRK))
+        (objType == EVTColContainer::ELEC || objType == EVTColContainer::MUON || objType == EVTColContainer::MUTRK))
       this->fillHist(isPassTrigger, source, objTypeStr, "Dxy", dxys[j]);
 
     if (countobjects[objType] == 0) {
-      if (!(TString(objTypeStr).Contains("MET") ||
-            TString(objTypeStr).Contains("MHT")) ||
-          source != "gen") {
+      if (!(TString(objTypeStr).Contains("MET") || TString(objTypeStr).Contains("MHT")) || source != "gen") {
         this->fillHist(isPassTrigger, source, objTypeStr, "MaxPt1", pt);
       }
       // Filled the high pt ...
       ++(countobjects[objType]);
       ++counttotal;
     } else if (countobjects[objType] == 1 && !_drop_pt2) {
-      if (!(TString(objTypeStr).Contains("MET") ||
-            TString(objTypeStr).Contains("MHT"))) {
+      if (!(TString(objTypeStr).Contains("MET") || TString(objTypeStr).Contains("MHT"))) {
         this->fillHist(isPassTrigger, source, objTypeStr, "MaxPt2", pt);
       }
       // Filled the second high pt ...
       ++(countobjects[objType]);
       ++counttotal;
     } else if (countobjects[objType] == 2 && !_drop_pt3) {
-      if (!(TString(objTypeStr).Contains("MET") ||
-            TString(objTypeStr).Contains("MHT"))) {
+      if (!(TString(objTypeStr).Contains("MET") || TString(objTypeStr).Contains("MHT"))) {
         this->fillHist(isPassTrigger, source, objTypeStr, "MaxPt3", pt);
       }
       // Filled the third highest pt ...
@@ -194,7 +179,7 @@ void HLTExoticaPlotter::analyze(const bool &isPassTrigger,
       }
     }
 
-  } // end loop over matches
+  }  // end loop over matches
 }
 
 void HLTExoticaPlotter::bookHist(DQMStore::IBooker &iBooker,
@@ -223,10 +208,8 @@ void HLTExoticaPlotter::bookHist(DQMStore::IBooker &iBooker,
     double max = _parametersDxy[2];
     h = new TH1F(name.c_str(), title.c_str(), nBins, min, max);
   } else if (variable.find("MaxPt") != std::string::npos) {
-    std::string desc = (variable == "MaxPt1")
-                           ? "Leading"
-                           : (variable == "MaxPt2") ? "Next-to-Leading"
-                                                    : "Next-to-next-to-Leading";
+    std::string desc =
+        (variable == "MaxPt1") ? "Leading" : (variable == "MaxPt2") ? "Next-to-Leading" : "Next-to-next-to-Leading";
     std::string title = "pT of " + desc + " " + sourceUpper + " " + objType +
                         " "
                         "where event pass the " +
@@ -242,10 +225,8 @@ void HLTExoticaPlotter::bookHist(DQMStore::IBooker &iBooker,
 
   else {
     std::string symbol = (variable == "Eta") ? "#eta" : "#phi";
-    std::string title = symbol + " of " + sourceUpper + " " + objType + " " +
-                        "where event pass the " + _hltPath;
-    std::vector<double> params =
-        (variable == "Eta") ? _parametersEta : _parametersPhi;
+    std::string title = symbol + " of " + sourceUpper + " " + objType + " " + "where event pass the " + _hltPath;
+    std::vector<double> params = (variable == "Eta") ? _parametersEta : _parametersPhi;
 
     int nBins = (int)params[0];
     double min = params[1];
@@ -271,9 +252,7 @@ void HLTExoticaPlotter::fillHist(const bool &passTrigger,
   sourceUpper[0] = toupper(sourceUpper[0]);
   std::string name = source + objType + variable + "_" + _hltPath;
 
-  LogDebug("ExoticaValidation")
-      << "In HLTExoticaPlotter::fillHist()" << name << " " << value;
+  LogDebug("ExoticaValidation") << "In HLTExoticaPlotter::fillHist()" << name << " " << value;
   _elements[name]->Fill(value);
-  LogDebug("ExoticaValidation")
-      << "In HLTExoticaPlotter::fillHist()" << name << " worked";
+  LogDebug("ExoticaValidation") << "In HLTExoticaPlotter::fillHist()" << name << " worked";
 }

--- a/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
@@ -25,30 +25,38 @@
 static constexpr int verbose = 0;
 
 /// Constructor
-HLTExoticaSubAnalysis::HLTExoticaSubAnalysis(
-    const edm::ParameterSet &pset, const std::string &analysisname,
-    edm::ConsumesCollector &&consCollector)
-    : _pset(pset), _analysisname(analysisname), _minCandidates(0),
+HLTExoticaSubAnalysis::HLTExoticaSubAnalysis(const edm::ParameterSet &pset,
+                                             const std::string &analysisname,
+                                             edm::ConsumesCollector &&consCollector)
+    : _pset(pset),
+      _analysisname(analysisname),
+      _minCandidates(0),
       _hltProcessName(pset.getParameter<std::string>("hltProcessName")),
       _genParticleLabel(pset.getParameter<std::string>("genParticleLabel")),
       _trigResultsLabel("TriggerResults", "", _hltProcessName),
       _beamSpotLabel(pset.getParameter<std::string>("beamSpotLabel")),
       _parametersEta(pset.getParameter<std::vector<double>>("parametersEta")),
       _parametersPhi(pset.getParameter<std::vector<double>>("parametersPhi")),
-      _parametersTurnOn(
-          pset.getParameter<std::vector<double>>("parametersTurnOn")),
-      _parametersTurnOnSumEt(
-          pset.getParameter<std::vector<double>>("parametersTurnOnSumEt")),
+      _parametersTurnOn(pset.getParameter<std::vector<double>>("parametersTurnOn")),
+      _parametersTurnOnSumEt(pset.getParameter<std::vector<double>>("parametersTurnOnSumEt")),
       _parametersDxy(pset.getParameter<std::vector<double>>("parametersDxy")),
-      _drop_pt2(false), _drop_pt3(false), _recMuonSelector(nullptr),
-      _recMuonTrkSelector(nullptr), _recTrackSelector(nullptr),
-      _recElecSelector(nullptr), _recMETSelector(nullptr),
-      _recPFMETSelector(nullptr), _recPFMHTSelector(nullptr),
-      _genMETSelector(nullptr), _recCaloMETSelector(nullptr),
-      _recCaloMHTSelector(nullptr), _l1METSelector(nullptr),
-      _recPFTauSelector(nullptr), _recPhotonSelector(nullptr),
-      _recPFJetSelector(nullptr), _recCaloJetSelector(nullptr) {
-
+      _drop_pt2(false),
+      _drop_pt3(false),
+      _recMuonSelector(nullptr),
+      _recMuonTrkSelector(nullptr),
+      _recTrackSelector(nullptr),
+      _recElecSelector(nullptr),
+      _recMETSelector(nullptr),
+      _recPFMETSelector(nullptr),
+      _recPFMHTSelector(nullptr),
+      _genMETSelector(nullptr),
+      _recCaloMETSelector(nullptr),
+      _recCaloMHTSelector(nullptr),
+      _l1METSelector(nullptr),
+      _recPFTauSelector(nullptr),
+      _recPhotonSelector(nullptr),
+      _recPFJetSelector(nullptr),
+      _recCaloJetSelector(nullptr) {
   LogDebug("ExoticaValidation") << "In HLTExoticaSubAnalysis::constructor()";
 
   // Specific parameters for this analysis
@@ -59,8 +67,7 @@ HLTExoticaSubAnalysis::HLTExoticaSubAnalysis(
   // The "true" in the beginning of _pset.insert() means
   // "overwrite the parameter if need be".
   if (anpset.exists("parametersTurnOn")) {
-    _parametersTurnOn =
-        anpset.getParameter<std::vector<double>>("parametersTurnOn");
+    _parametersTurnOn = anpset.getParameter<std::vector<double>>("parametersTurnOn");
     _pset.insert(true, "parametersTurnOn", anpset.retrieve("parametersTurnOn"));
   }
   if (anpset.exists("parametersEta")) {
@@ -76,10 +83,8 @@ HLTExoticaSubAnalysis::HLTExoticaSubAnalysis(
     _pset.insert(true, "parametersDxy", anpset.retrieve("parametersDxy"));
   }
   if (anpset.exists("parametersTurnOnSumEt")) {
-    _parametersTurnOnSumEt =
-        anpset.getParameter<std::vector<double>>("parametersTurnOnSumEt");
-    _pset.insert(true, "parametersTurnOnSumEt",
-                 anpset.retrieve("parametersTurnOnSumEt"));
+    _parametersTurnOnSumEt = anpset.getParameter<std::vector<double>>("parametersTurnOnSumEt");
+    _pset.insert(true, "parametersTurnOnSumEt", anpset.retrieve("parametersTurnOnSumEt"));
   }
   if (anpset.exists("dropPt2")) {
     _drop_pt2 = anpset.getParameter<bool>("dropPt2");
@@ -99,9 +104,7 @@ HLTExoticaSubAnalysis::HLTExoticaSubAnalysis(
   this->registerConsumes(consCollector);
 
   // Generic objects: Initialization of basic phase space cuts.
-  for (std::map<unsigned int, edm::InputTag>::const_iterator it =
-           _recLabels.begin();
-       it != _recLabels.end(); ++it) {
+  for (std::map<unsigned int, edm::InputTag>::const_iterator it = _recLabels.begin(); it != _recLabels.end(); ++it) {
     const std::string objStr = EVTColContainer::getTypeString(it->first);
     _genCut[it->first] = pset.getParameter<std::string>(objStr + "_genCut");
     _recCut[it->first] = pset.getParameter<std::string>(objStr + "_recCut");
@@ -109,49 +112,43 @@ HLTExoticaSubAnalysis::HLTExoticaSubAnalysis(
     if (pset.exists(genCutParam)) {
       _genCut_leading[it->first] = pset.getParameter<std::string>(genCutParam);
     } else {
-      _genCut_leading[it->first] = "pt>0"; // no cut
+      _genCut_leading[it->first] = "pt>0";  // no cut
     }
     auto const recCutParam = objStr + "_recCut_leading";
     if (pset.exists(recCutParam)) {
       _recCut_leading[it->first] = pset.getParameter<std::string>(recCutParam);
     } else {
-      _recCut_leading[it->first] = "pt>0"; // no cut
+      _recCut_leading[it->first] = "pt>0";  // no cut
     }
   }
 
   //--- Updating parameters if has to be modified for this particular specific
   // analysis
-  for (std::map<unsigned int, edm::InputTag>::const_iterator it =
-           _recLabels.begin();
-       it != _recLabels.end(); ++it) {
+  for (std::map<unsigned int, edm::InputTag>::const_iterator it = _recLabels.begin(); it != _recLabels.end(); ++it) {
     const std::string objStr = EVTColContainer::getTypeString(it->first);
 
     auto const genCutParam = objStr + "_genCut";
     if (anpset.existsAs<std::string>(genCutParam, false)) {
-      _genCut[it->first] =
-          anpset.getUntrackedParameter<std::string>(genCutParam);
+      _genCut[it->first] = anpset.getUntrackedParameter<std::string>(genCutParam);
     }
 
     auto const recCutParam = objStr + "_recCut";
     if (anpset.existsAs<std::string>(recCutParam, false)) {
-      _recCut[it->first] =
-          anpset.getUntrackedParameter<std::string>(recCutParam);
+      _recCut[it->first] = anpset.getUntrackedParameter<std::string>(recCutParam);
     }
   }
 
   /// Get the vector of paths to check, for this particular analysis.
-  _hltPathsToCheck =
-      anpset.getParameter<std::vector<std::string>>("hltPathsToCheck");
+  _hltPathsToCheck = anpset.getParameter<std::vector<std::string>>("hltPathsToCheck");
   /// Get the minimum candidates, for this particular analysis.
   _minCandidates = anpset.getParameter<unsigned int>("minCandidates");
 
-} /// End Constructor
+}  /// End Constructor
 
 HLTExoticaSubAnalysis::~HLTExoticaSubAnalysis() {
-  for (std::map<unsigned int,
-                StringCutObjectSelector<reco::GenParticle> *>::iterator it =
-           _genSelectorMap.begin();
-       it != _genSelectorMap.end(); ++it) {
+  for (std::map<unsigned int, StringCutObjectSelector<reco::GenParticle> *>::iterator it = _genSelectorMap.begin();
+       it != _genSelectorMap.end();
+       ++it) {
     delete it->second;
     it->second = nullptr;
   }
@@ -195,21 +192,17 @@ void HLTExoticaSubAnalysis::beginJob() {}
 // 2) Make the iBooker from above be known to this class
 // 3) Separate all booking histograms routines in this and any auxiliary classe
 // to be called from bookHistograms() in the container class
-void HLTExoticaSubAnalysis::subAnalysisBookHistos(
-    DQMStore::IBooker &iBooker, const edm::Run &iRun,
-    const edm::EventSetup &iSetup) {
-
-  LogDebug("ExoticaValidation")
-      << "In HLTExoticaSubAnalysis::subAnalysisBookHistos()";
+void HLTExoticaSubAnalysis::subAnalysisBookHistos(DQMStore::IBooker &iBooker,
+                                                  const edm::Run &iRun,
+                                                  const edm::EventSetup &iSetup) {
+  LogDebug("ExoticaValidation") << "In HLTExoticaSubAnalysis::subAnalysisBookHistos()";
 
   // Create the folder structure inside HLT/Exotica
   std::string baseDir = "HLT/Exotica/" + _analysisname + "/";
   iBooker.setCurrentFolder(baseDir);
 
   // Book the gen/reco analysis-dependent histograms (denominators)
-  for (std::map<unsigned int, edm::InputTag>::const_iterator it =
-           _recLabels.begin();
-       it != _recLabels.end(); ++it) {
+  for (std::map<unsigned int, edm::InputTag>::const_iterator it = _recLabels.begin(); it != _recLabels.end(); ++it) {
     const std::string objStr = EVTColContainer::getTypeString(it->first);
     std::vector<std::string> sources(2);
     sources[0] = "gen";
@@ -219,9 +212,7 @@ void HLTExoticaSubAnalysis::subAnalysisBookHistos(
       std::string source = sources[i];
 
       if (source == "gen") {
-        if (TString(objStr).Contains("MET") ||
-            TString(objStr).Contains("MHT") ||
-            TString(objStr).Contains("Jet")) {
+        if (TString(objStr).Contains("MET") || TString(objStr).Contains("MHT") || TString(objStr).Contains("Jet")) {
           continue;
         } else {
           bookHist(iBooker, source, objStr, "MaxPt1");
@@ -234,15 +225,13 @@ void HLTExoticaSubAnalysis::subAnalysisBookHistos(
 
           // If the target is electron or muon,
           // we will add Dxy plots.
-          if (it->first == EVTColContainer::ELEC ||
-              it->first == EVTColContainer::MUON ||
+          if (it->first == EVTColContainer::ELEC || it->first == EVTColContainer::MUON ||
               it->first == EVTColContainer::MUTRK) {
             bookHist(iBooker, source, objStr, "Dxy");
           }
         }
-      } else { // reco
-        if (TString(objStr).Contains("MET") ||
-            TString(objStr).Contains("MHT")) {
+      } else {  // reco
+        if (TString(objStr).Contains("MET") || TString(objStr).Contains("MHT")) {
           bookHist(iBooker, source, objStr, "MaxPt1");
           bookHist(iBooker, source, objStr, "SumEt");
         } else {
@@ -256,29 +245,24 @@ void HLTExoticaSubAnalysis::subAnalysisBookHistos(
 
           // If the target is electron or muon,
           // we will add Dxy plots.
-          if (it->first == EVTColContainer::ELEC ||
-              it->first == EVTColContainer::MUON ||
+          if (it->first == EVTColContainer::ELEC || it->first == EVTColContainer::MUON ||
               it->first == EVTColContainer::MUTRK) {
             bookHist(iBooker, source, objStr, "Dxy");
           }
         }
       }
     }
-  } // closes loop in _recLabels
+  }  // closes loop in _recLabels
 
   // Call the plotterBookHistos() (which books all the path dependent
   // histograms)
-  LogDebug("ExoticaValidation")
-      << "                        number of plotters = " << _plotters.size();
-  for (std::vector<HLTExoticaPlotter>::iterator it = _plotters.begin();
-       it != _plotters.end(); ++it) {
+  LogDebug("ExoticaValidation") << "                        number of plotters = " << _plotters.size();
+  for (std::vector<HLTExoticaPlotter>::iterator it = _plotters.begin(); it != _plotters.end(); ++it) {
     it->plotterBookHistos(iBooker, iRun, iSetup);
   }
 }
 
-void HLTExoticaSubAnalysis::beginRun(const edm::Run &iRun,
-                                     const edm::EventSetup &iSetup) {
-
+void HLTExoticaSubAnalysis::beginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
   LogDebug("ExoticaValidation") << "In HLTExoticaSubAnalysis::beginRun()";
 
   /// Construct the plotters right here.
@@ -287,9 +271,8 @@ void HLTExoticaSubAnalysis::beginRun(const edm::Run &iRun,
   // Initialize the HLT config.
   bool changedConfig(true);
   if (!_hltConfig.init(iRun, iSetup, _hltProcessName, changedConfig)) {
-    edm::LogError("ExoticaValidation")
-        << "HLTExoticaSubAnalysis::constructor(): "
-        << "Initialization of HLTConfigProvider failed!";
+    edm::LogError("ExoticaValidation") << "HLTExoticaSubAnalysis::constructor(): "
+                                       << "Initialization of HLTConfigProvider failed!";
   }
 
   // Parse the input paths to get them if they are in the table and associate
@@ -307,31 +290,26 @@ void HLTExoticaSubAnalysis::beginRun(const edm::Run &iRun,
         found = true;
       }
       if (verbose > 2 && i == 0)
-        LogDebug("ExoticaValidation")
-            << "--- TRIGGER PATH : " << thetriggername;
+        LogDebug("ExoticaValidation") << "--- TRIGGER PATH : " << thetriggername;
     }
 
     // Oh dear, the path we wanted seems to not be available
     if (!found && verbose > 2) {
-      edm::LogWarning("ExoticaValidation")
-          << "HLTExoticaSubAnalysis::constructor(): In " << _analysisname
-          << " subfolder NOT found the path: '" << _hltPathsToCheck[i] << "*'";
+      edm::LogWarning("ExoticaValidation") << "HLTExoticaSubAnalysis::constructor(): In " << _analysisname
+                                           << " subfolder NOT found the path: '" << _hltPathsToCheck[i] << "*'";
     }
-  } // Close loop over paths to check.
+  }  // Close loop over paths to check.
 
   // At this point, _hltpaths contains the names of the paths to check
   // that were found. Let's log it at trace level.
-  LogTrace("ExoticaValidation")
-      << "SubAnalysis: " << _analysisname << "\nHLT Trigger Paths found >>>";
-  for (std::set<std::string>::const_iterator iter = _hltPaths.begin();
-       iter != _hltPaths.end(); ++iter) {
+  LogTrace("ExoticaValidation") << "SubAnalysis: " << _analysisname << "\nHLT Trigger Paths found >>>";
+  for (std::set<std::string>::const_iterator iter = _hltPaths.begin(); iter != _hltPaths.end(); ++iter) {
     LogTrace("ExoticaValidation") << (*iter) << "\n";
   }
 
   // Initialize the plotters (analysers for each trigger path)
   _plotters.clear();
-  for (std::set<std::string>::iterator iPath = _hltPaths.begin();
-       iPath != _hltPaths.end(); ++iPath) {
+  for (std::set<std::string>::iterator iPath = _hltPaths.begin(); iPath != _hltPaths.end(); ++iPath) {
     // Avoiding the dependence of the version number for the trigger paths
     std::string path = *iPath;
     std::string shortpath = path;
@@ -346,9 +324,7 @@ void HLTExoticaSubAnalysis::beginRun(const edm::Run &iRun,
     // const std::vector<unsigned int> objsNeedHLT =
     // this->getObjectsType(shortpath);
     std::vector<unsigned int> objsNeedHLT;
-    for (std::map<unsigned int, edm::InputTag>::iterator it =
-             _recLabels.begin();
-         it != _recLabels.end(); ++it) {
+    for (std::map<unsigned int, edm::InputTag>::iterator it = _recLabels.begin(); it != _recLabels.end(); ++it) {
       objsNeedHLT.push_back(it->first);
     }
 
@@ -387,14 +363,11 @@ void HLTExoticaSubAnalysis::beginRun(const edm::Run &iRun,
     HLTExoticaPlotter analyzer(_pset, shortpath, objsNeedHLT);
     _plotters.push_back(analyzer);
     // counting HLT passed events for debug
-    _triggerCounter.insert(
-        std::map<std::string, int>::value_type(shortpath, 0));
-  } // Okay, at this point we have prepared all the plotters.
+    _triggerCounter.insert(std::map<std::string, int>::value_type(shortpath, 0));
+  }  // Okay, at this point we have prepared all the plotters.
 }
 
-void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent,
-                                    const edm::EventSetup &iSetup,
-                                    EVTColContainer *cols) {
+void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup, EVTColContainer *cols) {
   LogDebug("ExoticaValidation") << "In HLTExoticaSubAnalysis::analyze()";
 
   // Loop over _recLabels to make sure everything is alright.
@@ -422,8 +395,7 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent,
   matchesGen.clear();
   std::vector<reco::LeafCandidate> matchesReco;
   matchesReco.clear();
-  std::map<int, double>
-      theSumEt; // map< pdgId ; SumEt > in order to keep track of the MET type
+  std::map<int, double> theSumEt;  // map< pdgId ; SumEt > in order to keep track of the MET type
   std::map<int, std::vector<const reco::Track *>> trkObjs;
 
   // --- deal with GEN objects first.
@@ -431,8 +403,7 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent,
   // Our definition of "good" is "passes the selector" defined in the config.py
   // Save all the MatchStructs in the "matchesGen" vector.
 
-  for (std::map<unsigned int, edm::InputTag>::iterator it = _recLabels.begin();
-       it != _recLabels.end(); ++it) {
+  for (std::map<unsigned int, edm::InputTag>::iterator it = _recLabels.begin(); it != _recLabels.end(); ++it) {
     // Here we are filling the vector of
     // StringCutObjectSelector<reco::GenParticle> with objects constructed from
     // the strings saved in _genCut. Initialize selectors when first event
@@ -441,14 +412,12 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent,
     // it->first << std::endl;
 
     if (!_genSelectorMap[it->first]) {
-      _genSelectorMap[it->first] =
-          new StringCutObjectSelector<reco::GenParticle>(_genCut[it->first]);
+      _genSelectorMap[it->first] = new StringCutObjectSelector<reco::GenParticle>(_genCut[it->first]);
     }
 
     const std::string objTypeStr = EVTColContainer::getTypeString(it->first);
     // genAnyMET doesn't make sense. No need their matchesGens
-    if (TString(objTypeStr).Contains("MET") ||
-        TString(objTypeStr).Contains("MHT") ||
+    if (TString(objTypeStr).Contains("MET") || TString(objTypeStr).Contains("MHT") ||
         TString(objTypeStr).Contains("Jet"))
       continue;
 
@@ -465,8 +434,7 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent,
         /// We are going to make a fake reco::LeafCandidate, with our
         /// particleType as the pdgId. This is an alternative to the older
         /// implementation with MatchStruct.
-        reco::LeafCandidate v(0, cand->p4(), cand->vertex(), it->first, 0,
-                              true);
+        reco::LeafCandidate v(0, cand->p4(), cand->vertex(), it->first, 0, true);
 
         matchesGen.push_back(v);
       }
@@ -486,8 +454,7 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent,
   // Extraction of the objects candidates
   if (verbose > 0)
     LogDebug("ExoticaValidation") << "-- enter loop over recLabels";
-  for (std::map<unsigned int, edm::InputTag>::iterator it = _recLabels.begin();
-       it != _recLabels.end(); ++it) {
+  for (std::map<unsigned int, edm::InputTag>::iterator it = _recLabels.begin(); it != _recLabels.end(); ++it) {
     // std::cout << "Filling RECO \"matchesReco\" vector for particle kind
     // it->first = "
     //	  << it->first << ", which means " << it->second.label() << std::endl;
@@ -498,9 +465,8 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent,
     // -- Storing the matchesReco
     this->insertCandidates(it->first, cols, &matchesReco, theSumEt, trkObjs);
     if (verbose > 0)
-      LogDebug("ExoticaValidation")
-          << "--- " << EVTColContainer::getTypeString(it->first)
-          << " sumEt=" << theSumEt[it->first];
+      LogDebug("ExoticaValidation") << "--- " << EVTColContainer::getTypeString(it->first)
+                                    << " sumEt=" << theSumEt[it->first];
   }
 
   // std::sort(matchesReco.begin(),
@@ -508,15 +474,12 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent,
   // 	      comparator);
 
   // -- Trigger Results
-  const edm::TriggerNames &trigNames =
-      iEvent.triggerNames(*(cols->triggerResults));
+  const edm::TriggerNames &trigNames = iEvent.triggerNames(*(cols->triggerResults));
 
   // counting HLT passed events for debugging
-  for (std::vector<HLTExoticaPlotter>::iterator an = _plotters.begin();
-       an != _plotters.end(); ++an) {
+  for (std::vector<HLTExoticaPlotter>::iterator an = _plotters.begin(); an != _plotters.end(); ++an) {
     const std::string hltPath = _shortpath2long[an->gethltpath()];
-    const bool ispassTrigger =
-        cols->triggerResults->accept(trigNames.triggerIndex(hltPath));
+    const bool ispassTrigger = cols->triggerResults->accept(trigNames.triggerIndex(hltPath));
     if (ispassTrigger)
       _triggerCounter.find(an->gethltpath())->second++;
   }
@@ -535,9 +498,8 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent,
   ////////////////
   /// GEN CASE ///
   ////////////////
-  if (matchesGen.size() >=
-      _minCandidates) { // FIXME: A bug is potentially here: what about the
-                        // mixed channels?
+  if (matchesGen.size() >= _minCandidates) {  // FIXME: A bug is potentially here: what about the
+                                              // mixed channels?
     // Okay, there are enough candidates. Move on!
 
     // Filling the gen/reco objects (eff-denominators):
@@ -550,9 +512,7 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent,
 
     // Initializing the count of the used objects.
     std::map<unsigned int, int> countobjects;
-    for (std::map<unsigned int, edm::InputTag>::iterator co =
-             _recLabels.begin();
-         co != _recLabels.end(); ++co) {
+    for (std::map<unsigned int, edm::InputTag>::iterator co = _recLabels.begin(); co != _recLabels.end(); ++co) {
       // countobjects->insert(std::pair<unsigned int, int>(co->first, 0));
       countobjects.insert(std::pair<unsigned int, int>(co->first, 0));
     }
@@ -572,10 +532,9 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent,
     for (size_t j = 0; j != matchesGen.size(); ++j) {
       const unsigned int objType = matchesGen[j].pdgId();
       // Cut for the pt-leading object
-      StringCutObjectSelector<reco::LeafCandidate> select(
-          _genCut_leading[objType]);
-      if (!select(matchesGen[j])) { // No interest case
-        isPassedLeadingCut = false; // Will skip the following matchesGen loop
+      StringCutObjectSelector<reco::LeafCandidate> select(_genCut_leading[objType]);
+      if (!select(matchesGen[j])) {  // No interest case
+        isPassedLeadingCut = false;  // Will skip the following matchesGen loop
         matchesGen.clear();
         break;
       }
@@ -622,34 +581,27 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent,
 
       // If the target is electron or muon,
 
-      if (objType == EVTColContainer::MUON ||
-          objType == EVTColContainer::MUTRK ||
-          objType == EVTColContainer::ELEC) {
+      if (objType == EVTColContainer::MUON || objType == EVTColContainer::MUTRK || objType == EVTColContainer::ELEC) {
         const math::XYZPoint &vtx = matchesGen[j].vertex();
         float momphi = matchesGen[j].momentum().phi();
-        float dxyGen = (-(vtx.x() - cols->bs->x0()) * sin(momphi) +
-                        (vtx.y() - cols->bs->y0()) * cos(momphi));
+        float dxyGen = (-(vtx.x() - cols->bs->x0()) * sin(momphi) + (vtx.y() - cols->bs->y0()) * cos(momphi));
         dxys.push_back(dxyGen);
         this->fillHist("gen", objTypeStr, "Dxy", dxyGen);
       }
 
-    } // Closes loop in gen
+    }  // Closes loop in gen
 
     // Calling to the plotters analysis (where the evaluation of the different
     // trigger paths are done)
     // const std::string source = "gen";
-    for (std::vector<HLTExoticaPlotter>::iterator an = _plotters.begin();
-         an != _plotters.end(); ++an) {
+    for (std::vector<HLTExoticaPlotter>::iterator an = _plotters.begin(); an != _plotters.end(); ++an) {
       const std::string hltPath = _shortpath2long[an->gethltpath()];
-      const bool ispassTrigger =
-          cols->triggerResults->accept(trigNames.triggerIndex(hltPath));
-      LogDebug("ExoticaValidation")
-          << "                        preparing to call the plotters analysis";
+      const bool ispassTrigger = cols->triggerResults->accept(trigNames.triggerIndex(hltPath));
+      LogDebug("ExoticaValidation") << "                        preparing to call the plotters analysis";
       an->analyze(ispassTrigger, "gen", matchesGen, theSumEt, dxys);
-      LogDebug("ExoticaValidation")
-          << "                        called the plotter";
+      LogDebug("ExoticaValidation") << "                        called the plotter";
     }
-  } /// Close GEN case
+  }  /// Close GEN case
 
   /////////////////
   /// RECO CASE ///
@@ -657,8 +609,8 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent,
 
   {
     if (matchesReco.size() < _minCandidates)
-      return; // FIXME: A bug is potentially here: what about the mixed
-              // channels?
+      return;  // FIXME: A bug is potentially here: what about the mixed
+               // channels?
 
     // Okay, there are enough candidates. Move on!
 
@@ -673,9 +625,7 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent,
     // std::map<unsigned int, int> * countobjects = new std::map<unsigned int,
     // int>;
     std::map<unsigned int, int> countobjects;
-    for (std::map<unsigned int, edm::InputTag>::iterator co =
-             _recLabels.begin();
-         co != _recLabels.end(); ++co) {
+    for (std::map<unsigned int, edm::InputTag>::iterator co = _recLabels.begin(); co != _recLabels.end(); ++co) {
       countobjects.insert(std::pair<unsigned int, int>(co->first, 0));
     }
 
@@ -701,10 +651,9 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent,
     for (size_t j = 0; j != matchesReco.size(); ++j) {
       const unsigned int objType = matchesReco[j].pdgId();
       // Cut for the pt-leading object
-      StringCutObjectSelector<reco::LeafCandidate> select(
-          _recCut_leading[objType]);
-      if (!select(matchesReco[j])) { // No interest case
-        isPassedLeadingCut = false;  // Will skip the following matchesReco loop
+      StringCutObjectSelector<reco::LeafCandidate> select(_recCut_leading[objType]);
+      if (!select(matchesReco[j])) {  // No interest case
+        isPassedLeadingCut = false;   // Will skip the following matchesReco loop
         matchesReco.clear();
         break;
       }
@@ -722,15 +671,13 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent,
         ++(countobjects[objType]);
         ++counttotal;
       } else if (countobjects[objType] == 1 && !_drop_pt2) {
-        if (!(TString(objTypeStr).Contains("MET") ||
-              TString(objTypeStr).Contains("MHT"))) {
+        if (!(TString(objTypeStr).Contains("MET") || TString(objTypeStr).Contains("MHT"))) {
           this->fillHist("rec", objTypeStr, "MaxPt2", pt);
         }
         ++(countobjects[objType]);
         ++counttotal;
       } else if (countobjects[objType] == 2 && !_drop_pt3) {
-        if (!(TString(objTypeStr).Contains("MET") ||
-              TString(objTypeStr).Contains("MHT"))) {
+        if (!(TString(objTypeStr).Contains("MET") || TString(objTypeStr).Contains("MHT"))) {
           this->fillHist("rec", objTypeStr, "MaxPt3", pt);
         }
         ++(countobjects[objType]);
@@ -749,8 +696,7 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent,
       float eta = matchesReco[j].eta();
       float phi = matchesReco[j].phi();
 
-      if (!(TString(objTypeStr).Contains("MET") ||
-            TString(objTypeStr).Contains("MHT"))) {
+      if (!(TString(objTypeStr).Contains("MET") || TString(objTypeStr).Contains("MHT"))) {
         this->fillHist("rec", objTypeStr, "Eta", eta);
         this->fillHist("rec", objTypeStr, "Phi", phi);
       } else {
@@ -763,7 +709,7 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent,
         dxys.push_back(dxyRec);
       }
 
-    } // Closes loop in reco
+    }  // Closes loop in reco
 
     // LogDebug("ExoticaValidation") << "                        deleting
     // countobjects"; delete countobjects;
@@ -771,36 +717,37 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event &iEvent,
     // Calling to the plotters analysis (where the evaluation of the different
     // trigger paths are done)
     // const std::string source = "reco";
-    for (std::vector<HLTExoticaPlotter>::iterator an = _plotters.begin();
-         an != _plotters.end(); ++an) {
+    for (std::vector<HLTExoticaPlotter>::iterator an = _plotters.begin(); an != _plotters.end(); ++an) {
       const std::string hltPath = _shortpath2long[an->gethltpath()];
-      const bool ispassTrigger =
-          cols->triggerResults->accept(trigNames.triggerIndex(hltPath));
-      LogDebug("ExoticaValidation")
-          << "                        preparing to call the plotters analysis";
+      const bool ispassTrigger = cols->triggerResults->accept(trigNames.triggerIndex(hltPath));
+      LogDebug("ExoticaValidation") << "                        preparing to call the plotters analysis";
       an->analyze(ispassTrigger, "rec", matchesReco, theSumEt, dxys);
-      LogDebug("ExoticaValidation")
-          << "                        called the plotter";
+      LogDebug("ExoticaValidation") << "                        called the plotter";
     }
-  } /// Close RECO case
+  }  /// Close RECO case
 
-} /// closes analyze method
+}  /// closes analyze method
 
 // Return the objects (muons,electrons,photons,...) needed by a hlt path.
-const std::vector<unsigned int>
-HLTExoticaSubAnalysis::getObjectsType(const std::string &hltPath) const {
+const std::vector<unsigned int> HLTExoticaSubAnalysis::getObjectsType(const std::string &hltPath) const {
   LogDebug("ExoticaValidation") << "In HLTExoticaSubAnalysis::getObjectsType()";
 
   static const unsigned int objSize = 15;
-  static const unsigned int objtriggernames[] = {
-      EVTColContainer::MUON,    EVTColContainer::MUTRK,
-      EVTColContainer::TRACK,   EVTColContainer::ELEC,
-      EVTColContainer::PHOTON,  EVTColContainer::MET,
-      EVTColContainer::PFMET,   EVTColContainer::PFMHT,
-      EVTColContainer::GENMET,  EVTColContainer::CALOMET,
-      EVTColContainer::CALOMHT, EVTColContainer::L1MET,
-      EVTColContainer::PFTAU,   EVTColContainer::PFJET,
-      EVTColContainer::CALOJET};
+  static const unsigned int objtriggernames[] = {EVTColContainer::MUON,
+                                                 EVTColContainer::MUTRK,
+                                                 EVTColContainer::TRACK,
+                                                 EVTColContainer::ELEC,
+                                                 EVTColContainer::PHOTON,
+                                                 EVTColContainer::MET,
+                                                 EVTColContainer::PFMET,
+                                                 EVTColContainer::PFMHT,
+                                                 EVTColContainer::GENMET,
+                                                 EVTColContainer::CALOMET,
+                                                 EVTColContainer::CALOMHT,
+                                                 EVTColContainer::L1MET,
+                                                 EVTColContainer::PFTAU,
+                                                 EVTColContainer::PFJET,
+                                                 EVTColContainer::CALOJET};
 
   std::set<unsigned int> objsType;
   // The object to deal has to be entered via the config .py
@@ -820,95 +767,77 @@ HLTExoticaSubAnalysis::getObjectsType(const std::string &hltPath) const {
 
 // Booking the maps: recLabels and genParticle selectors
 void HLTExoticaSubAnalysis::getNamesOfObjects(const edm::ParameterSet &anpset) {
-  LogDebug("ExoticaValidation")
-      << "In HLTExoticaSubAnalysis::getNamesOfObjects()";
+  LogDebug("ExoticaValidation") << "In HLTExoticaSubAnalysis::getNamesOfObjects()";
 
   if (anpset.exists("recMuonLabel")) {
-    _recLabels[EVTColContainer::MUON] =
-        anpset.getParameter<edm::InputTag>("recMuonLabel");
+    _recLabels[EVTColContainer::MUON] = anpset.getParameter<edm::InputTag>("recMuonLabel");
     _genSelectorMap[EVTColContainer::MUON] = nullptr;
   }
   if (anpset.exists("recMuonTrkLabel")) {
-    _recLabels[EVTColContainer::MUTRK] =
-        anpset.getParameter<edm::InputTag>("recMuonTrkLabel");
+    _recLabels[EVTColContainer::MUTRK] = anpset.getParameter<edm::InputTag>("recMuonTrkLabel");
     _genSelectorMap[EVTColContainer::MUTRK] = nullptr;
   }
   if (anpset.exists("recTrackLabel")) {
-    _recLabels[EVTColContainer::TRACK] =
-        anpset.getParameter<edm::InputTag>("recTrackLabel");
+    _recLabels[EVTColContainer::TRACK] = anpset.getParameter<edm::InputTag>("recTrackLabel");
     _genSelectorMap[EVTColContainer::TRACK] = nullptr;
   }
   if (anpset.exists("recElecLabel")) {
-    _recLabels[EVTColContainer::ELEC] =
-        anpset.getParameter<edm::InputTag>("recElecLabel");
+    _recLabels[EVTColContainer::ELEC] = anpset.getParameter<edm::InputTag>("recElecLabel");
     _genSelectorMap[EVTColContainer::ELEC] = nullptr;
   }
   if (anpset.exists("recPhotonLabel")) {
-    _recLabels[EVTColContainer::PHOTON] =
-        anpset.getParameter<edm::InputTag>("recPhotonLabel");
+    _recLabels[EVTColContainer::PHOTON] = anpset.getParameter<edm::InputTag>("recPhotonLabel");
     _genSelectorMap[EVTColContainer::PHOTON] = nullptr;
   }
   if (anpset.exists("recMETLabel")) {
-    _recLabels[EVTColContainer::MET] =
-        anpset.getParameter<edm::InputTag>("recMETLabel");
+    _recLabels[EVTColContainer::MET] = anpset.getParameter<edm::InputTag>("recMETLabel");
     _genSelectorMap[EVTColContainer::MET] = nullptr;
   }
   if (anpset.exists("recPFMETLabel")) {
-    _recLabels[EVTColContainer::PFMET] =
-        anpset.getParameter<edm::InputTag>("recPFMETLabel");
+    _recLabels[EVTColContainer::PFMET] = anpset.getParameter<edm::InputTag>("recPFMETLabel");
     _genSelectorMap[EVTColContainer::PFMET] = nullptr;
   }
   if (anpset.exists("recPFMHTLabel")) {
-    _recLabels[EVTColContainer::PFMHT] =
-        anpset.getParameter<edm::InputTag>("recPFMHTLabel");
+    _recLabels[EVTColContainer::PFMHT] = anpset.getParameter<edm::InputTag>("recPFMHTLabel");
     _genSelectorMap[EVTColContainer::PFMHT] = nullptr;
   }
   if (anpset.exists("genMETLabel")) {
-    _recLabels[EVTColContainer::GENMET] =
-        anpset.getParameter<edm::InputTag>("genMETLabel");
+    _recLabels[EVTColContainer::GENMET] = anpset.getParameter<edm::InputTag>("genMETLabel");
     _genSelectorMap[EVTColContainer::GENMET] = nullptr;
   }
   if (anpset.exists("recCaloMETLabel")) {
-    _recLabels[EVTColContainer::CALOMET] =
-        anpset.getParameter<edm::InputTag>("recCaloMETLabel");
+    _recLabels[EVTColContainer::CALOMET] = anpset.getParameter<edm::InputTag>("recCaloMETLabel");
     _genSelectorMap[EVTColContainer::CALOMET] = nullptr;
   }
   if (anpset.exists("recCaloMHTLabel")) {
-    _recLabels[EVTColContainer::CALOMHT] =
-        anpset.getParameter<edm::InputTag>("recCaloMHTLabel");
+    _recLabels[EVTColContainer::CALOMHT] = anpset.getParameter<edm::InputTag>("recCaloMHTLabel");
     _genSelectorMap[EVTColContainer::CALOMHT] = nullptr;
   }
   if (anpset.exists("hltMETLabel")) {
-    _recLabels[EVTColContainer::CALOMET] =
-        anpset.getParameter<edm::InputTag>("hltMETLabel");
+    _recLabels[EVTColContainer::CALOMET] = anpset.getParameter<edm::InputTag>("hltMETLabel");
     _genSelectorMap[EVTColContainer::CALOMET] = nullptr;
   }
   if (anpset.exists("l1METLabel")) {
-    _recLabels[EVTColContainer::L1MET] =
-        anpset.getParameter<edm::InputTag>("l1METLabel");
+    _recLabels[EVTColContainer::L1MET] = anpset.getParameter<edm::InputTag>("l1METLabel");
     _genSelectorMap[EVTColContainer::L1MET] = nullptr;
   }
   if (anpset.exists("recPFTauLabel")) {
-    _recLabels[EVTColContainer::PFTAU] =
-        anpset.getParameter<edm::InputTag>("recPFTauLabel");
+    _recLabels[EVTColContainer::PFTAU] = anpset.getParameter<edm::InputTag>("recPFTauLabel");
     _genSelectorMap[EVTColContainer::PFTAU] = nullptr;
   }
   if (anpset.exists("recPFJetLabel")) {
-    _recLabels[EVTColContainer::PFJET] =
-        anpset.getParameter<edm::InputTag>("recPFJetLabel");
+    _recLabels[EVTColContainer::PFJET] = anpset.getParameter<edm::InputTag>("recPFJetLabel");
     _genSelectorMap[EVTColContainer::PFJET] = nullptr;
   }
   if (anpset.exists("recCaloJetLabel")) {
-    _recLabels[EVTColContainer::CALOJET] =
-        anpset.getParameter<edm::InputTag>("recCaloJetLabel");
+    _recLabels[EVTColContainer::CALOJET] = anpset.getParameter<edm::InputTag>("recCaloJetLabel");
     _genSelectorMap[EVTColContainer::CALOJET] = nullptr;
   }
 
   if (_recLabels.empty()) {
-    edm::LogError("ExoticaValidation")
-        << "HLTExoticaSubAnalysis::getNamesOfObjects, "
-        << "Not included any object (recMuonLabel, recElecLabel, ...)  "
-        << "in the analysis " << _analysisname;
+    edm::LogError("ExoticaValidation") << "HLTExoticaSubAnalysis::getNamesOfObjects, "
+                                       << "Not included any object (recMuonLabel, recElecLabel, ...)  "
+                                       << "in the analysis " << _analysisname;
     return;
   }
 }
@@ -917,8 +846,7 @@ void HLTExoticaSubAnalysis::getNamesOfObjects(const edm::ParameterSet &anpset) {
 // I have chosen to centralize all consumes() calls here.
 void HLTExoticaSubAnalysis::registerConsumes(edm::ConsumesCollector &iC) {
   // Register that we are getting genParticles
-  _genParticleToken =
-      iC.consumes<reco::GenParticleCollection>(_genParticleLabel);
+  _genParticleToken = iC.consumes<reco::GenParticleCollection>(_genParticleLabel);
 
   // Register that we are getting the trigger results
   _trigResultsToken = iC.consumes<edm::TriggerResults>(_trigResultsLabel);
@@ -930,23 +858,18 @@ void HLTExoticaSubAnalysis::registerConsumes(edm::ConsumesCollector &iC) {
   // Then save the registered token in _tokens.
   // Remember: _recLabels is a map<uint, edm::InputTag>
   // Remember: _tokens    is a map<uint, edm::EDGetToken>
-  LogDebug("ExoticaValidation")
-      << "We have got " << _recLabels.size() << "recLabels";
-  for (std::map<unsigned int, edm::InputTag>::iterator it = _recLabels.begin();
-       it != _recLabels.end(); ++it) {
+  LogDebug("ExoticaValidation") << "We have got " << _recLabels.size() << "recLabels";
+  for (std::map<unsigned int, edm::InputTag>::iterator it = _recLabels.begin(); it != _recLabels.end(); ++it) {
     if (it->first == EVTColContainer::MUON) {
-      edm::EDGetTokenT<reco::MuonCollection> particularToken =
-          iC.consumes<reco::MuonCollection>(it->second);
+      edm::EDGetTokenT<reco::MuonCollection> particularToken = iC.consumes<reco::MuonCollection>(it->second);
       edm::EDGetToken token(particularToken);
       _tokens[it->first] = token;
     } else if (it->first == EVTColContainer::MUTRK) {
-      edm::EDGetTokenT<reco::TrackCollection> particularToken =
-          iC.consumes<reco::TrackCollection>(it->second);
+      edm::EDGetTokenT<reco::TrackCollection> particularToken = iC.consumes<reco::TrackCollection>(it->second);
       edm::EDGetToken token(particularToken);
       _tokens[it->first] = token;
     } else if (it->first == EVTColContainer::TRACK) {
-      edm::EDGetTokenT<reco::TrackCollection> particularToken =
-          iC.consumes<reco::TrackCollection>(it->second);
+      edm::EDGetTokenT<reco::TrackCollection> particularToken = iC.consumes<reco::TrackCollection>(it->second);
       edm::EDGetToken token(particularToken);
       _tokens[it->first] = token;
     } else if (it->first == EVTColContainer::ELEC) {
@@ -955,38 +878,31 @@ void HLTExoticaSubAnalysis::registerConsumes(edm::ConsumesCollector &iC) {
       edm::EDGetToken token(particularToken);
       _tokens[it->first] = token;
     } else if (it->first == EVTColContainer::PHOTON) {
-      edm::EDGetTokenT<reco::PhotonCollection> particularToken =
-          iC.consumes<reco::PhotonCollection>(it->second);
+      edm::EDGetTokenT<reco::PhotonCollection> particularToken = iC.consumes<reco::PhotonCollection>(it->second);
       edm::EDGetToken token(particularToken);
       _tokens[it->first] = token;
     } else if (it->first == EVTColContainer::MET) {
-      edm::EDGetTokenT<reco::METCollection> particularToken =
-          iC.consumes<reco::METCollection>(it->second);
+      edm::EDGetTokenT<reco::METCollection> particularToken = iC.consumes<reco::METCollection>(it->second);
       edm::EDGetToken token(particularToken);
       _tokens[it->first] = token;
     } else if (it->first == EVTColContainer::PFMET) {
-      edm::EDGetTokenT<reco::PFMETCollection> particularToken =
-          iC.consumes<reco::PFMETCollection>(it->second);
+      edm::EDGetTokenT<reco::PFMETCollection> particularToken = iC.consumes<reco::PFMETCollection>(it->second);
       edm::EDGetToken token(particularToken);
       _tokens[it->first] = token;
     } else if (it->first == EVTColContainer::PFMHT) {
-      edm::EDGetTokenT<reco::PFMETCollection> particularToken =
-          iC.consumes<reco::PFMETCollection>(it->second);
+      edm::EDGetTokenT<reco::PFMETCollection> particularToken = iC.consumes<reco::PFMETCollection>(it->second);
       edm::EDGetToken token(particularToken);
       _tokens[it->first] = token;
     } else if (it->first == EVTColContainer::GENMET) {
-      edm::EDGetTokenT<reco::GenMETCollection> particularToken =
-          iC.consumes<reco::GenMETCollection>(it->second);
+      edm::EDGetTokenT<reco::GenMETCollection> particularToken = iC.consumes<reco::GenMETCollection>(it->second);
       edm::EDGetToken token(particularToken);
       _tokens[it->first] = token;
     } else if (it->first == EVTColContainer::CALOMET) {
-      edm::EDGetTokenT<reco::CaloMETCollection> particularToken =
-          iC.consumes<reco::CaloMETCollection>(it->second);
+      edm::EDGetTokenT<reco::CaloMETCollection> particularToken = iC.consumes<reco::CaloMETCollection>(it->second);
       edm::EDGetToken token(particularToken);
       _tokens[it->first] = token;
     } else if (it->first == EVTColContainer::CALOMHT) {
-      edm::EDGetTokenT<reco::CaloMETCollection> particularToken =
-          iC.consumes<reco::CaloMETCollection>(it->second);
+      edm::EDGetTokenT<reco::CaloMETCollection> particularToken = iC.consumes<reco::CaloMETCollection>(it->second);
       edm::EDGetToken token(particularToken);
       _tokens[it->first] = token;
     } else if (it->first == EVTColContainer::L1MET) {
@@ -995,33 +911,27 @@ void HLTExoticaSubAnalysis::registerConsumes(edm::ConsumesCollector &iC) {
       edm::EDGetToken token(particularToken);
       _tokens[it->first] = token;
     } else if (it->first == EVTColContainer::PFTAU) {
-      edm::EDGetTokenT<reco::PFTauCollection> particularToken =
-          iC.consumes<reco::PFTauCollection>(it->second);
+      edm::EDGetTokenT<reco::PFTauCollection> particularToken = iC.consumes<reco::PFTauCollection>(it->second);
       edm::EDGetToken token(particularToken);
       _tokens[it->first] = token;
     } else if (it->first == EVTColContainer::PFJET) {
-      edm::EDGetTokenT<reco::PFJetCollection> particularToken =
-          iC.consumes<reco::PFJetCollection>(it->second);
+      edm::EDGetTokenT<reco::PFJetCollection> particularToken = iC.consumes<reco::PFJetCollection>(it->second);
       edm::EDGetToken token(particularToken);
       _tokens[it->first] = token;
     } else if (it->first == EVTColContainer::CALOJET) {
-      edm::EDGetTokenT<reco::CaloJetCollection> particularToken =
-          iC.consumes<reco::CaloJetCollection>(it->second);
+      edm::EDGetTokenT<reco::CaloJetCollection> particularToken = iC.consumes<reco::CaloJetCollection>(it->second);
       edm::EDGetToken token(particularToken);
       _tokens[it->first] = token;
     } else {
-      edm::LogError("ExoticaValidation")
-          << "HLTExoticaSubAnalysis::registerConsumes"
-          << " NOT IMPLEMENTED (yet) ERROR: '" << it->second.label() << "'";
+      edm::LogError("ExoticaValidation") << "HLTExoticaSubAnalysis::registerConsumes"
+                                         << " NOT IMPLEMENTED (yet) ERROR: '" << it->second.label() << "'";
     }
   }
 }
 
 // Setting the collections of objects in EVTColContainer
-void HLTExoticaSubAnalysis::getHandlesToObjects(const edm::Event &iEvent,
-                                                EVTColContainer *col) {
-  LogDebug("ExoticaValidation")
-      << "In HLTExoticaSubAnalysis::getHandlesToObjects()";
+void HLTExoticaSubAnalysis::getHandlesToObjects(const edm::Event &iEvent, EVTColContainer *col) {
+  LogDebug("ExoticaValidation") << "In HLTExoticaSubAnalysis::getHandlesToObjects()";
 
   if (!col->isCommonInit()) {
     // Extract the trigger results (path info, pass,...)
@@ -1050,8 +960,7 @@ void HLTExoticaSubAnalysis::getHandlesToObjects(const edm::Event &iEvent,
 
   // Loop over the tokens and extract all other objects
   LogDebug("ExoticaValidation") << "We have got " << _tokens.size() << "tokens";
-  for (std::map<unsigned int, edm::EDGetToken>::iterator it = _tokens.begin();
-       it != _tokens.end(); ++it) {
+  for (std::map<unsigned int, edm::EDGetToken>::iterator it = _tokens.begin(); it != _tokens.end(); ++it) {
     if (it->first == EVTColContainer::MUON) {
       edm::Handle<reco::MuonCollection> theHandle;
       iEvent.getByToken(it->second, theHandle);
@@ -1128,9 +1037,8 @@ void HLTExoticaSubAnalysis::getHandlesToObjects(const edm::Event &iEvent,
       if (theHandle.isValid())
         col->set(theHandle.product());
     } else {
-      edm::LogError("ExoticaValidation")
-          << "HLTExoticaSubAnalysis::getHandlesToObjects "
-          << " NOT IMPLEMENTED (yet) ERROR: '" << it->first << "'";
+      edm::LogError("ExoticaValidation") << "HLTExoticaSubAnalysis::getHandlesToObjects "
+                                         << " NOT IMPLEMENTED (yet) ERROR: '" << it->first << "'";
     }
   }
 }
@@ -1180,8 +1088,7 @@ void HLTExoticaSubAnalysis::bookHist(DQMStore::IBooker &iBooker,
   else {
     std::string symbol = (variable == "Eta") ? "#eta" : "#phi";
     std::string title = symbol + " of " + sourceUpper + " " + objType;
-    std::vector<double> params =
-        (variable == "Eta") ? _parametersEta : _parametersPhi;
+    std::vector<double> params = (variable == "Eta") ? _parametersEta : _parametersPhi;
     int nBins = (int)params[0];
     double min = params[1];
     double max = params[2];
@@ -1205,72 +1112,45 @@ void HLTExoticaSubAnalysis::fillHist(const std::string &source,
   sourceUpper[0] = toupper(sourceUpper[0]);
   std::string name = source + objType + variable;
 
-  LogDebug("ExoticaValidation")
-      << "In HLTExoticaSubAnalysis::fillHist() " << name << " " << value;
+  LogDebug("ExoticaValidation") << "In HLTExoticaSubAnalysis::fillHist() " << name << " " << value;
   _elements[name]->Fill(value);
-  LogDebug("ExoticaValidation")
-      << "In HLTExoticaSubAnalysis::fillHist() " << name << " worked";
+  LogDebug("ExoticaValidation") << "In HLTExoticaSubAnalysis::fillHist() " << name << " worked";
 }
 
 // Initialize the selectors
 void HLTExoticaSubAnalysis::initSelector(const unsigned int &objtype) {
-
   LogDebug("ExoticaValidation") << "In HLTExoticaSubAnalysis::initSelector()";
 
   if (objtype == EVTColContainer::MUON && _recMuonSelector == nullptr) {
-    _recMuonSelector =
-        new StringCutObjectSelector<reco::Muon>(_recCut[objtype]);
-  } else if (objtype == EVTColContainer::MUTRK &&
-             _recMuonTrkSelector == nullptr) {
-    _recMuonTrkSelector =
-        new StringCutObjectSelector<reco::Track>(_recCut[objtype]);
-  } else if (objtype == EVTColContainer::TRACK &&
-             _recTrackSelector == nullptr) {
-    _recTrackSelector =
-        new StringCutObjectSelector<reco::Track>(_recCut[objtype]);
+    _recMuonSelector = new StringCutObjectSelector<reco::Muon>(_recCut[objtype]);
+  } else if (objtype == EVTColContainer::MUTRK && _recMuonTrkSelector == nullptr) {
+    _recMuonTrkSelector = new StringCutObjectSelector<reco::Track>(_recCut[objtype]);
+  } else if (objtype == EVTColContainer::TRACK && _recTrackSelector == nullptr) {
+    _recTrackSelector = new StringCutObjectSelector<reco::Track>(_recCut[objtype]);
   } else if (objtype == EVTColContainer::ELEC && _recElecSelector == nullptr) {
-    _recElecSelector =
-        new StringCutObjectSelector<reco::GsfElectron>(_recCut[objtype]);
-  } else if (objtype == EVTColContainer::PHOTON &&
-             _recPhotonSelector == nullptr) {
-    _recPhotonSelector =
-        new StringCutObjectSelector<reco::Photon>(_recCut[objtype]);
+    _recElecSelector = new StringCutObjectSelector<reco::GsfElectron>(_recCut[objtype]);
+  } else if (objtype == EVTColContainer::PHOTON && _recPhotonSelector == nullptr) {
+    _recPhotonSelector = new StringCutObjectSelector<reco::Photon>(_recCut[objtype]);
   } else if (objtype == EVTColContainer::MET && _recMETSelector == nullptr) {
     _recMETSelector = new StringCutObjectSelector<reco::MET>(_recCut[objtype]);
-  } else if (objtype == EVTColContainer::PFMET &&
-             _recPFMETSelector == nullptr) {
-    _recPFMETSelector =
-        new StringCutObjectSelector<reco::PFMET>(_recCut[objtype]);
-  } else if (objtype == EVTColContainer::PFMHT &&
-             _recPFMHTSelector == nullptr) {
-    _recPFMHTSelector =
-        new StringCutObjectSelector<reco::PFMET>(_recCut[objtype]);
+  } else if (objtype == EVTColContainer::PFMET && _recPFMETSelector == nullptr) {
+    _recPFMETSelector = new StringCutObjectSelector<reco::PFMET>(_recCut[objtype]);
+  } else if (objtype == EVTColContainer::PFMHT && _recPFMHTSelector == nullptr) {
+    _recPFMHTSelector = new StringCutObjectSelector<reco::PFMET>(_recCut[objtype]);
   } else if (objtype == EVTColContainer::GENMET && _genMETSelector == nullptr) {
-    _genMETSelector =
-        new StringCutObjectSelector<reco::GenMET>(_recCut[objtype]);
-  } else if (objtype == EVTColContainer::CALOMET &&
-             _recCaloMETSelector == nullptr) {
-    _recCaloMETSelector =
-        new StringCutObjectSelector<reco::CaloMET>(_recCut[objtype]);
-  } else if (objtype == EVTColContainer::CALOMHT &&
-             _recCaloMHTSelector == nullptr) {
-    _recCaloMHTSelector =
-        new StringCutObjectSelector<reco::CaloMET>(_recCut[objtype]);
+    _genMETSelector = new StringCutObjectSelector<reco::GenMET>(_recCut[objtype]);
+  } else if (objtype == EVTColContainer::CALOMET && _recCaloMETSelector == nullptr) {
+    _recCaloMETSelector = new StringCutObjectSelector<reco::CaloMET>(_recCut[objtype]);
+  } else if (objtype == EVTColContainer::CALOMHT && _recCaloMHTSelector == nullptr) {
+    _recCaloMHTSelector = new StringCutObjectSelector<reco::CaloMET>(_recCut[objtype]);
   } else if (objtype == EVTColContainer::L1MET && _l1METSelector == nullptr) {
-    _l1METSelector = new StringCutObjectSelector<l1extra::L1EtMissParticle>(
-        _recCut[objtype]);
-  } else if (objtype == EVTColContainer::PFTAU &&
-             _recPFTauSelector == nullptr) {
-    _recPFTauSelector =
-        new StringCutObjectSelector<reco::PFTau>(_recCut[objtype]);
-  } else if (objtype == EVTColContainer::PFJET &&
-             _recPFJetSelector == nullptr) {
-    _recPFJetSelector =
-        new StringCutObjectSelector<reco::PFJet>(_recCut[objtype]);
-  } else if (objtype == EVTColContainer::CALOJET &&
-             _recCaloJetSelector == nullptr) {
-    _recCaloJetSelector =
-        new StringCutObjectSelector<reco::CaloJet>(_recCut[objtype]);
+    _l1METSelector = new StringCutObjectSelector<l1extra::L1EtMissParticle>(_recCut[objtype]);
+  } else if (objtype == EVTColContainer::PFTAU && _recPFTauSelector == nullptr) {
+    _recPFTauSelector = new StringCutObjectSelector<reco::PFTau>(_recCut[objtype]);
+  } else if (objtype == EVTColContainer::PFJET && _recPFJetSelector == nullptr) {
+    _recPFJetSelector = new StringCutObjectSelector<reco::PFJet>(_recCut[objtype]);
+  } else if (objtype == EVTColContainer::CALOJET && _recCaloJetSelector == nullptr) {
+    _recCaloJetSelector = new StringCutObjectSelector<reco::CaloJet>(_recCut[objtype]);
   }
   /* else
   {
@@ -1279,13 +1159,12 @@ void HLTExoticaSubAnalysis::initSelector(const unsigned int &objtype) {
 }
 
 // Insert the HLT candidates
-void HLTExoticaSubAnalysis::insertCandidates(
-    const unsigned int &objType, const EVTColContainer *cols,
-    std::vector<reco::LeafCandidate> *matches, std::map<int, double> &theSumEt,
-    std::map<int, std::vector<const reco::Track *>> &trkObjs) {
-
-  LogDebug("ExoticaValidation")
-      << "In HLTExoticaSubAnalysis::insertCandidates()";
+void HLTExoticaSubAnalysis::insertCandidates(const unsigned int &objType,
+                                             const EVTColContainer *cols,
+                                             std::vector<reco::LeafCandidate> *matches,
+                                             std::map<int, double> &theSumEt,
+                                             std::map<int, std::vector<const reco::Track *>> &trkObjs) {
+  LogDebug("ExoticaValidation") << "In HLTExoticaSubAnalysis::insertCandidates()";
 
   theSumEt[objType] = -1;
 
@@ -1293,8 +1172,7 @@ void HLTExoticaSubAnalysis::insertCandidates(
     for (size_t i = 0; i < cols->muons->size(); i++) {
       LogDebug("ExoticaValidation") << "Inserting muon " << i;
       if (_recMuonSelector->operator()(cols->muons->at(i))) {
-        reco::LeafCandidate m(0, cols->muons->at(i).p4(),
-                              cols->muons->at(i).vertex(), objType, 0, true);
+        reco::LeafCandidate m(0, cols->muons->at(i).p4(), cols->muons->at(i).vertex(), objType, 0, true);
         matches->push_back(m);
 
         // for making dxy plots
@@ -1308,8 +1186,7 @@ void HLTExoticaSubAnalysis::insertCandidates(
         ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double>> mom4;
         ROOT::Math::XYZVector mom3 = cols->tracks->at(i).momentum();
         mom4.SetXYZT(mom3.x(), mom3.y(), mom3.z(), mom3.r());
-        reco::LeafCandidate m(0, mom4, cols->tracks->at(i).vertex(), objType, 0,
-                              true);
+        reco::LeafCandidate m(0, mom4, cols->tracks->at(i).vertex(), objType, 0, true);
         matches->push_back(m);
 
         // for making dxy plots
@@ -1323,8 +1200,7 @@ void HLTExoticaSubAnalysis::insertCandidates(
         ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double>> mom4;
         ROOT::Math::XYZVector mom3 = cols->tracks->at(i).momentum();
         mom4.SetXYZT(mom3.x(), mom3.y(), mom3.z(), mom3.r());
-        reco::LeafCandidate m(0, mom4, cols->tracks->at(i).vertex(), objType, 0,
-                              true);
+        reco::LeafCandidate m(0, mom4, cols->tracks->at(i).vertex(), objType, 0, true);
         matches->push_back(m);
       }
     }
@@ -1332,9 +1208,7 @@ void HLTExoticaSubAnalysis::insertCandidates(
     for (size_t i = 0; i < cols->electrons->size(); i++) {
       LogDebug("ExoticaValidation") << "Inserting electron " << i;
       if (_recElecSelector->operator()(cols->electrons->at(i))) {
-        reco::LeafCandidate m(0, cols->electrons->at(i).p4(),
-                              cols->electrons->at(i).vertex(), objType, 0,
-                              true);
+        reco::LeafCandidate m(0, cols->electrons->at(i).p4(), cols->electrons->at(i).vertex(), objType, 0, true);
         matches->push_back(m);
 
         // for making dxy plots
@@ -1345,8 +1219,7 @@ void HLTExoticaSubAnalysis::insertCandidates(
     for (size_t i = 0; i < cols->photons->size(); i++) {
       LogDebug("ExoticaValidation") << "Inserting photon " << i;
       if (_recPhotonSelector->operator()(cols->photons->at(i))) {
-        reco::LeafCandidate m(0, cols->photons->at(i).p4(),
-                              cols->photons->at(i).vertex(), objType, 0, true);
+        reco::LeafCandidate m(0, cols->photons->at(i).p4(), cols->photons->at(i).vertex(), objType, 0, true);
         matches->push_back(m);
       }
     }
@@ -1357,8 +1230,7 @@ void HLTExoticaSubAnalysis::insertCandidates(
     for (size_t i = 0; i < cols->pfMETs->size(); i++) {
       LogDebug("ExoticaValidation") << "Inserting PFMET " << i;
       if (_recPFMETSelector->operator()(cols->pfMETs->at(i))) {
-        reco::LeafCandidate m(0, cols->pfMETs->at(i).p4(),
-                              cols->pfMETs->at(i).vertex(), objType, 0, true);
+        reco::LeafCandidate m(0, cols->pfMETs->at(i).p4(), cols->pfMETs->at(i).vertex(), objType, 0, true);
         matches->push_back(m);
         if (i == 0)
           theSumEt[objType] = cols->pfMETs->at(i).sumEt();
@@ -1368,8 +1240,7 @@ void HLTExoticaSubAnalysis::insertCandidates(
     for (size_t i = 0; i < cols->pfMHTs->size(); i++) {
       LogDebug("ExoticaValidation") << "Inserting PFMHT " << i;
       if (_recPFMHTSelector->operator()(cols->pfMHTs->at(i))) {
-        reco::LeafCandidate m(0, cols->pfMHTs->at(i).p4(),
-                              cols->pfMHTs->at(i).vertex(), objType, 0, true);
+        reco::LeafCandidate m(0, cols->pfMHTs->at(i).p4(), cols->pfMHTs->at(i).vertex(), objType, 0, true);
         matches->push_back(m);
         if (i == 0)
           theSumEt[objType] = cols->pfMHTs->at(i).sumEt();
@@ -1379,8 +1250,7 @@ void HLTExoticaSubAnalysis::insertCandidates(
     for (size_t i = 0; i < cols->genMETs->size(); i++) {
       LogDebug("ExoticaValidation") << "Inserting GENMET " << i;
       if (_genMETSelector->operator()(cols->genMETs->at(i))) {
-        reco::LeafCandidate m(0, cols->genMETs->at(i).p4(),
-                              cols->genMETs->at(i).vertex(), objType, 0, true);
+        reco::LeafCandidate m(0, cols->genMETs->at(i).p4(), cols->genMETs->at(i).vertex(), objType, 0, true);
         matches->push_back(m);
         if (i == 0)
           theSumEt[objType] = cols->genMETs->at(i).sumEt();
@@ -1390,8 +1260,7 @@ void HLTExoticaSubAnalysis::insertCandidates(
     for (size_t i = 0; i < cols->caloMETs->size(); i++) {
       LogDebug("ExoticaValidation") << "Inserting CALOMET " << i;
       if (_recCaloMETSelector->operator()(cols->caloMETs->at(i))) {
-        reco::LeafCandidate m(0, cols->caloMETs->at(i).p4(),
-                              cols->caloMETs->at(i).vertex(), objType, 0, true);
+        reco::LeafCandidate m(0, cols->caloMETs->at(i).p4(), cols->caloMETs->at(i).vertex(), objType, 0, true);
         matches->push_back(m);
         if (i == 0)
           theSumEt[objType] = cols->caloMETs->at(i).sumEt();
@@ -1401,8 +1270,7 @@ void HLTExoticaSubAnalysis::insertCandidates(
     for (size_t i = 0; i < cols->caloMHTs->size(); i++) {
       LogDebug("ExoticaValidation") << "Inserting CaloMHT " << i;
       if (_recCaloMHTSelector->operator()(cols->caloMHTs->at(i))) {
-        reco::LeafCandidate m(0, cols->caloMHTs->at(i).p4(),
-                              cols->caloMHTs->at(i).vertex(), objType, 0, true);
+        reco::LeafCandidate m(0, cols->caloMHTs->at(i).p4(), cols->caloMHTs->at(i).vertex(), objType, 0, true);
         matches->push_back(m);
         if (i == 0)
           theSumEt[objType] = cols->caloMHTs->at(i).sumEt();
@@ -1412,8 +1280,7 @@ void HLTExoticaSubAnalysis::insertCandidates(
     for (size_t i = 0; i < cols->l1METs->size(); i++) {
       LogDebug("ExoticaValidation") << "Inserting L1MET " << i;
       if (_l1METSelector->operator()(cols->l1METs->at(i))) {
-        reco::LeafCandidate m(0, cols->l1METs->at(i).p4(),
-                              cols->l1METs->at(i).vertex(), objType, 0, true);
+        reco::LeafCandidate m(0, cols->l1METs->at(i).p4(), cols->l1METs->at(i).vertex(), objType, 0, true);
         matches->push_back(m);
         if (i == 0)
           theSumEt[objType] = cols->l1METs->at(i).etTotal();
@@ -1423,8 +1290,7 @@ void HLTExoticaSubAnalysis::insertCandidates(
     for (size_t i = 0; i < cols->pfTaus->size(); i++) {
       LogDebug("ExoticaValidation") << "Inserting PFtau " << i;
       if (_recPFTauSelector->operator()(cols->pfTaus->at(i))) {
-        reco::LeafCandidate m(0, cols->pfTaus->at(i).p4(),
-                              cols->pfTaus->at(i).vertex(), objType, 0, true);
+        reco::LeafCandidate m(0, cols->pfTaus->at(i).p4(), cols->pfTaus->at(i).vertex(), objType, 0, true);
         matches->push_back(m);
       }
     }
@@ -1432,8 +1298,7 @@ void HLTExoticaSubAnalysis::insertCandidates(
     for (size_t i = 0; i < cols->pfJets->size(); i++) {
       LogDebug("ExoticaValidation") << "Inserting jet " << i;
       if (_recPFJetSelector->operator()(cols->pfJets->at(i))) {
-        reco::LeafCandidate m(0, cols->pfJets->at(i).p4(),
-                              cols->pfJets->at(i).vertex(), objType, 0, true);
+        reco::LeafCandidate m(0, cols->pfJets->at(i).p4(), cols->pfJets->at(i).vertex(), objType, 0, true);
         matches->push_back(m);
       }
     }
@@ -1441,8 +1306,7 @@ void HLTExoticaSubAnalysis::insertCandidates(
     for (size_t i = 0; i < cols->caloJets->size(); i++) {
       LogDebug("ExoticaValidation") << "Inserting jet " << i;
       if (_recCaloJetSelector->operator()(cols->caloJets->at(i))) {
-        reco::LeafCandidate m(0, cols->caloJets->at(i).p4(),
-                              cols->caloJets->at(i).vertex(), objType, 0, true);
+        reco::LeafCandidate m(0, cols->caloJets->at(i).p4(), cols->caloJets->at(i).vertex(), objType, 0, true);
         matches->push_back(m);
       }
     }
@@ -1461,8 +1325,7 @@ void HLTExoticaSubAnalysis::endRun() {
   log << "====================================================================="
          "======"
       << std::endl;
-  log << "          Trigger Results ( " << _analysisname
-      << " )                      " << std::endl;
+  log << "          Trigger Results ( " << _analysisname << " )                      " << std::endl;
   log << "====================================================================="
          "======"
       << std::endl;
@@ -1470,8 +1333,7 @@ void HLTExoticaSubAnalysis::endRun() {
   log << "-------------------:-------------------------------------------------"
          "------"
       << std::endl;
-  for (std::map<std::string, int>::iterator it = _triggerCounter.begin();
-       it != _triggerCounter.end(); ++it) {
+  for (std::map<std::string, int>::iterator it = _triggerCounter.begin(); it != _triggerCounter.end(); ++it) {
     log << std::setw(18) << it->second << " : " << it->first << std::endl;
   }
   log << "====================================================================="

--- a/HLTriggerOffline/Exotica/src/HLTExoticaValidator.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaValidator.cc
@@ -20,10 +20,7 @@
 
 // Constructor
 HLTExoticaValidator::HLTExoticaValidator(const edm::ParameterSet &pset)
-    : _pset(pset),
-      _analysisnames(pset.getParameter<std::vector<std::string>>("analyses")),
-      _collections(nullptr) {
-
+    : _pset(pset), _analysisnames(pset.getParameter<std::vector<std::string>>("analyses")), _collections(nullptr) {
   LogDebug("ExoticaValidation") << "In HLTExoticaValidator::constructor()";
 
   // Prepare the event collections to be used.
@@ -33,8 +30,7 @@ HLTExoticaValidator::HLTExoticaValidator(const edm::ParameterSet &pset)
   // Notice that the constructor takes the full parameter set,
   // the analysis name and the consumesCollector() separately.
   for (size_t i = 0; i < _analysisnames.size(); ++i) {
-    HLTExoticaSubAnalysis analyzer(_pset, _analysisnames.at(i),
-                                   consumesCollector());
+    HLTExoticaSubAnalysis analyzer(_pset, _analysisnames.at(i), consumesCollector());
     _analyzers.push_back(analyzer);
   }
 }
@@ -52,13 +48,11 @@ HLTExoticaValidator::~HLTExoticaValidator() {
 // beginRun() into bookHistograms() and dqmBeginRun() 3) Call
 // subAnalysisBookHistos() for each subAnalysis from inside bookHistograms()
 // *** IMPORTANT *** notice that now dqmBeginRun() runs before bookHistograms()!
-void HLTExoticaValidator::dqmBeginRun(const edm::Run &iRun,
-                                      const edm::EventSetup &iSetup) {
+void HLTExoticaValidator::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
   LogDebug("ExoticaValidation") << "In HLTExoticaValidator::dqmBeginRun()";
 
   // Call the Plotter beginRun (which stores the triggers paths..:)
-  for (std::vector<HLTExoticaSubAnalysis>::iterator iter = _analyzers.begin();
-       iter != _analyzers.end(); ++iter) {
+  for (std::vector<HLTExoticaSubAnalysis>::iterator iter = _analyzers.begin(); iter != _analyzers.end(); ++iter) {
     iter->beginRun(iRun, iSetup);
   }
 }
@@ -66,21 +60,18 @@ void HLTExoticaValidator::dqmBeginRun(const edm::Run &iRun,
 void HLTExoticaValidator::bookHistograms(DQMStore::IBooker &iBooker,
                                          const edm::Run &iRun,
                                          const edm::EventSetup &iSetup) {
-
   LogDebug("ExoticaValidation") << "In HLTExoticaValidator::bookHistograms()";
 
   // Loop over all sub-analyses and book histograms for all of them.
   // For this to work, I think we have to pass the iBooker to each of them.
   // I don't think we have any guarantee that this loop is executed
   // sequentially, but the booking with iBooker itself has such a guarantee.
-  for (std::vector<HLTExoticaSubAnalysis>::iterator iter = _analyzers.begin();
-       iter != _analyzers.end(); ++iter) {
+  for (std::vector<HLTExoticaSubAnalysis>::iterator iter = _analyzers.begin(); iter != _analyzers.end(); ++iter) {
     iter->subAnalysisBookHistos(iBooker, iRun, iSetup);
   }
 }
 
-void HLTExoticaValidator::analyze(const edm::Event &iEvent,
-                                  const edm::EventSetup &iSetup) {
+void HLTExoticaValidator::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   LogDebug("ExoticaValidation") << "In HLTExoticaValidator::analyze()";
 
   // static int eventNumber = 0;
@@ -91,20 +82,15 @@ void HLTExoticaValidator::analyze(const edm::Event &iEvent,
   // Initialize the event collections
   this->_collections->reset();
 
-  for (std::vector<HLTExoticaSubAnalysis>::iterator iter = _analyzers.begin();
-       iter != _analyzers.end(); ++iter) {
+  for (std::vector<HLTExoticaSubAnalysis>::iterator iter = _analyzers.begin(); iter != _analyzers.end(); ++iter) {
     iter->analyze(iEvent, iSetup, this->_collections);
   }
 }
 
-void HLTExoticaValidator::beginJob() {
-  LogDebug("ExoticaValidation") << "In HLTExoticaValidator::beginJob()";
-}
+void HLTExoticaValidator::beginJob() { LogDebug("ExoticaValidation") << "In HLTExoticaValidator::beginJob()"; }
 
-void HLTExoticaValidator::endRun(const edm::Run &iRun,
-                                 const edm::EventSetup &iSetup) {
-  for (std::vector<HLTExoticaSubAnalysis>::iterator iter = _analyzers.begin();
-       iter != _analyzers.end(); ++iter) {
+void HLTExoticaValidator::endRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
+  for (std::vector<HLTExoticaSubAnalysis>::iterator iter = _analyzers.begin(); iter != _analyzers.end(); ++iter) {
     iter->endRun();
   }
 }

--- a/Validation/DTRecHits/interface/DTHitQualityUtils.h
+++ b/Validation/DTRecHits/interface/DTHitQualityUtils.h
@@ -23,36 +23,34 @@ class DTGeometry;
 
 namespace DTHitQualityUtils {
 
-/// Operations
-/// Create a map between the SimHits in a chamber and the corrisponding
-/// MuBarWireId
-std::map<DTWireId, edm::PSimHitContainer>
-mapSimHitsPerWire(const edm::PSimHitContainer &simhits);
-/// Create a map between the Mu SimHits and corresponding MuBarWireId ;
-std::map<DTWireId, const PSimHit *> mapMuSimHitsPerWire(
-    const std::map<DTWireId, edm::PSimHitContainer> &simHitWireMap);
-/// Select the SimHit from a muon in a vector of SimHits
-const PSimHit *findMuSimHit(const edm::PSimHitContainer &hits);
-/// Find Innermost and outermost SimHit from Mu in a SL (they identify a
-/// simulated segment)
-std::pair<const PSimHit *, const PSimHit *>
-findMuSimSegment(const std::map<DTWireId, const PSimHit *> &mapWireAndMuSimHit);
-/// Find direction and position of a segment (in local RF) from outer and inner
-/// mu SimHit in the RF of object Det
-std::pair<LocalVector, LocalPoint> findMuSimSegmentDirAndPos(
-    const std::pair<const PSimHit *, const PSimHit *> &inAndOutSimHit,
-    const DetId detId, const DTGeometry *muonGeom);
-/// Find the angles from a segment direction:
-/// atan(dx/dz) = "phi"   angle in the chamber RF
-/// atan(dy/dz) = "theta" angle in the chamber RF (note: this has opposite sign
-/// in the SLZ RF!)
-std::pair<double, double> findSegmentAlphaAndBeta(const LocalVector &direction);
+  /// Operations
+  /// Create a map between the SimHits in a chamber and the corrisponding
+  /// MuBarWireId
+  std::map<DTWireId, edm::PSimHitContainer> mapSimHitsPerWire(const edm::PSimHitContainer &simhits);
+  /// Create a map between the Mu SimHits and corresponding MuBarWireId ;
+  std::map<DTWireId, const PSimHit *> mapMuSimHitsPerWire(
+      const std::map<DTWireId, edm::PSimHitContainer> &simHitWireMap);
+  /// Select the SimHit from a muon in a vector of SimHits
+  const PSimHit *findMuSimHit(const edm::PSimHitContainer &hits);
+  /// Find Innermost and outermost SimHit from Mu in a SL (they identify a
+  /// simulated segment)
+  std::pair<const PSimHit *, const PSimHit *> findMuSimSegment(
+      const std::map<DTWireId, const PSimHit *> &mapWireAndMuSimHit);
+  /// Find direction and position of a segment (in local RF) from outer and inner
+  /// mu SimHit in the RF of object Det
+  std::pair<LocalVector, LocalPoint> findMuSimSegmentDirAndPos(
+      const std::pair<const PSimHit *, const PSimHit *> &inAndOutSimHit, const DetId detId, const DTGeometry *muonGeom);
+  /// Find the angles from a segment direction:
+  /// atan(dx/dz) = "phi"   angle in the chamber RF
+  /// atan(dy/dz) = "theta" angle in the chamber RF (note: this has opposite sign
+  /// in the SLZ RF!)
+  std::pair<double, double> findSegmentAlphaAndBeta(const LocalVector &direction);
 
-// Set the verbosity level
-extern std::atomic<bool> debug;
+  // Set the verbosity level
+  extern std::atomic<bool> debug;
 
-// Find angle error
-double sigmaAngle(double Angle, double sigma2TanAngle);
+  // Find angle error
+  double sigmaAngle(double Angle, double sigma2TanAngle);
 
-} // namespace DTHitQualityUtils
+}  // namespace DTHitQualityUtils
 #endif

--- a/Validation/DTRecHits/plugins/DT2DSegmentClients.cc
+++ b/Validation/DTRecHits/plugins/DT2DSegmentClients.cc
@@ -16,15 +16,11 @@ DT2DSegmentClients::DT2DSegmentClients(edm::ParameterSet const &pset) {
 
 DT2DSegmentClients::~DT2DSegmentClients() {}
 
-void DT2DSegmentClients::dqmEndJob(DQMStore::IBooker &booker,
-                                   DQMStore::IGetter &getter) {
+void DT2DSegmentClients::dqmEndJob(DQMStore::IBooker &booker, DQMStore::IGetter &getter) {
   MonitorElement *hResPos = getter.get("DT/2DSegments/Res/2D_SuperPhi_hResPos");
-  MonitorElement *hResAngle =
-      getter.get("DT/2DSegments/Res/2D_SuperPhi_hResAngle");
-  MonitorElement *hPullPos =
-      getter.get("DT/2DSegments/Pull/2D_SuperPhi_hPullPos");
-  MonitorElement *hPullAngle =
-      getter.get("DT/2DSegments/Pull/2D_SuperPhi_hPullAngle");
+  MonitorElement *hResAngle = getter.get("DT/2DSegments/Res/2D_SuperPhi_hResAngle");
+  MonitorElement *hPullPos = getter.get("DT/2DSegments/Pull/2D_SuperPhi_hPullPos");
+  MonitorElement *hPullAngle = getter.get("DT/2DSegments/Pull/2D_SuperPhi_hPullAngle");
 
   Tutils util;
   util.drawGFit(hResPos->getTH1(), -0.1, 0.1, -0.1, 0.1);

--- a/Validation/DTRecHits/plugins/DT2DSegmentClients.h
+++ b/Validation/DTRecHits/plugins/DT2DSegmentClients.h
@@ -13,7 +13,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class DT2DSegmentClients : public DQMEDHarvester {
-
 public:
   /// Constructor
   DT2DSegmentClients(const edm::ParameterSet &ps);
@@ -30,4 +29,4 @@ private:
   bool doSLPhi_;
 };
 
-#endif // Validation_DTRecHits_DT2DSegmentClients_h
+#endif  // Validation_DTRecHits_DT2DSegmentClients_h

--- a/Validation/DTRecHits/plugins/DT4DSegmentClients.cc
+++ b/Validation/DTRecHits/plugins/DT4DSegmentClients.cc
@@ -18,81 +18,61 @@ DT4DSegmentClients::DT4DSegmentClients(edm::ParameterSet const &pset) {
 
 DT4DSegmentClients::~DT4DSegmentClients() {}
 
-void DT4DSegmentClients::dqmEndJob(DQMStore::IBooker &booker,
-                                   DQMStore::IGetter &getter) {
-
+void DT4DSegmentClients::dqmEndJob(DQMStore::IBooker &booker, DQMStore::IGetter &getter) {
   MonitorElement *hResAlpha = getter.get("DT/4DSegments/Res/4D_All_hResAlpha");
   MonitorElement *hResBeta = getter.get("DT/4DSegments/Res/4D_All_hResBeta");
   MonitorElement *hResX = getter.get("DT/4DSegments/Res/4D_All_hResX");
   MonitorElement *hResY = getter.get("DT/4DSegments/Res/4D_All_hResY");
-  MonitorElement *hResBetaRZ =
-      getter.get("DT/4DSegments/Res/4D_All_hResBetaRZ");
+  MonitorElement *hResBetaRZ = getter.get("DT/4DSegments/Res/4D_All_hResBetaRZ");
   MonitorElement *hResYRZ = getter.get("DT/4DSegments/Res/4D_All_hResYRZ");
 
-  MonitorElement *hResAlpha_W0 =
-      getter.get("DT/4DSegments/Res/4D_W0_hResAlpha");
+  MonitorElement *hResAlpha_W0 = getter.get("DT/4DSegments/Res/4D_W0_hResAlpha");
   MonitorElement *hResBeta_W0 = getter.get("DT/4DSegments/Res/4D_W0_hResBeta");
   MonitorElement *hResX_W0 = getter.get("DT/4DSegments/Res/4D_W0_hResX");
   MonitorElement *hResY_W0 = getter.get("DT/4DSegments/Res/4D_W0_hResY");
-  MonitorElement *hResBetaRZ_W0 =
-      getter.get("DT/4DSegments/Res/4D_W0_hResBetaRZ");
+  MonitorElement *hResBetaRZ_W0 = getter.get("DT/4DSegments/Res/4D_W0_hResBetaRZ");
   MonitorElement *hResYRZ_W0 = getter.get("DT/4DSegments/Res/4D_W0_hResYRZ");
 
-  MonitorElement *hResAlpha_W1 =
-      getter.get("DT/4DSegments/Res/4D_W1_hResAlpha");
+  MonitorElement *hResAlpha_W1 = getter.get("DT/4DSegments/Res/4D_W1_hResAlpha");
   MonitorElement *hResBeta_W1 = getter.get("DT/4DSegments/Res/4D_W1_hResBeta");
   MonitorElement *hResX_W1 = getter.get("DT/4DSegments/Res/4D_W1_hResX");
   MonitorElement *hResY_W1 = getter.get("DT/4DSegments/Res/4D_W1_hResY");
-  MonitorElement *hResBetaRZ_W1 =
-      getter.get("DT/4DSegments/Res/4D_W1_hResBetaRZ");
+  MonitorElement *hResBetaRZ_W1 = getter.get("DT/4DSegments/Res/4D_W1_hResBetaRZ");
   MonitorElement *hResYRZ_W1 = getter.get("DT/4DSegments/Res/4D_W1_hResYRZ");
 
-  MonitorElement *hResAlpha_W2 =
-      getter.get("DT/4DSegments/Res/4D_W2_hResAlpha");
+  MonitorElement *hResAlpha_W2 = getter.get("DT/4DSegments/Res/4D_W2_hResAlpha");
   MonitorElement *hResBeta_W2 = getter.get("DT/4DSegments/Res/4D_W2_hResBeta");
   MonitorElement *hResX_W2 = getter.get("DT/4DSegments/Res/4D_W2_hResX");
   MonitorElement *hResY_W2 = getter.get("DT/4DSegments/Res/4D_W2_hResY");
-  MonitorElement *hResBetaRZ_W2 =
-      getter.get("DT/4DSegments/Res/4D_W2_hResBetaRZ");
+  MonitorElement *hResBetaRZ_W2 = getter.get("DT/4DSegments/Res/4D_W2_hResBetaRZ");
   MonitorElement *hResYRZ_W2 = getter.get("DT/4DSegments/Res/4D_W2_hResYRZ");
 
-  MonitorElement *hPullAlpha =
-      getter.get("DT/4DSegments/Pull/4D_All_hPullAlpha");
+  MonitorElement *hPullAlpha = getter.get("DT/4DSegments/Pull/4D_All_hPullAlpha");
   MonitorElement *hPullBeta = getter.get("DT/4DSegments/Pull/4D_All_hPullBeta");
   MonitorElement *hPullX = getter.get("DT/4DSegments/Pull/4D_All_hPullX");
   MonitorElement *hPullY = getter.get("DT/4DSegments/Pull/4D_All_hPullY");
-  MonitorElement *hPullBetaRZ =
-      getter.get("DT/4DSegments/Pull/4D_All_hPullBetaRZ");
+  MonitorElement *hPullBetaRZ = getter.get("DT/4DSegments/Pull/4D_All_hPullBetaRZ");
   MonitorElement *hPullYRZ = getter.get("DT/4DSegments/Pull/4D_All_hPullYRZ");
 
-  MonitorElement *hPullAlpha_W0 =
-      getter.get("DT/4DSegments/Pull/4D_W0_hPullAlpha");
-  MonitorElement *hPullBeta_W0 =
-      getter.get("DT/4DSegments/Pull/4D_W0_hPullBeta");
+  MonitorElement *hPullAlpha_W0 = getter.get("DT/4DSegments/Pull/4D_W0_hPullAlpha");
+  MonitorElement *hPullBeta_W0 = getter.get("DT/4DSegments/Pull/4D_W0_hPullBeta");
   MonitorElement *hPullX_W0 = getter.get("DT/4DSegments/Pull/4D_W0_hPullX");
   MonitorElement *hPullY_W0 = getter.get("DT/4DSegments/Pull/4D_W0_hPullY");
-  MonitorElement *hPullBetaRZ_W0 =
-      getter.get("DT/4DSegments/Pull/4D_W0_hPullBetaRZ");
+  MonitorElement *hPullBetaRZ_W0 = getter.get("DT/4DSegments/Pull/4D_W0_hPullBetaRZ");
   MonitorElement *hPullYRZ_W0 = getter.get("DT/4DSegments/Pull/4D_W0_hPullYRZ");
 
-  MonitorElement *hPullAlpha_W1 =
-      getter.get("DT/4DSegments/Pull/4D_W1_hPullAlpha");
-  MonitorElement *hPullBeta_W1 =
-      getter.get("DT/4DSegments/Pull/4D_W1_hPullBeta");
+  MonitorElement *hPullAlpha_W1 = getter.get("DT/4DSegments/Pull/4D_W1_hPullAlpha");
+  MonitorElement *hPullBeta_W1 = getter.get("DT/4DSegments/Pull/4D_W1_hPullBeta");
   MonitorElement *hPullX_W1 = getter.get("DT/4DSegments/Pull/4D_W1_hPullX");
   MonitorElement *hPullY_W1 = getter.get("DT/4DSegments/Pull/4D_W1_hPullY");
-  MonitorElement *hPullBetaRZ_W1 =
-      getter.get("DT/4DSegments/Pull/4D_W1_hPullBetaRZ");
+  MonitorElement *hPullBetaRZ_W1 = getter.get("DT/4DSegments/Pull/4D_W1_hPullBetaRZ");
   MonitorElement *hPullYRZ_W1 = getter.get("DT/4DSegments/Pull/4D_W1_hPullYRZ");
 
-  MonitorElement *hPullAlpha_W2 =
-      getter.get("DT/4DSegments/Pull/4D_W2_hPullAlpha");
-  MonitorElement *hPullBeta_W2 =
-      getter.get("DT/4DSegments/Pull/4D_W2_hPullBeta");
+  MonitorElement *hPullAlpha_W2 = getter.get("DT/4DSegments/Pull/4D_W2_hPullAlpha");
+  MonitorElement *hPullBeta_W2 = getter.get("DT/4DSegments/Pull/4D_W2_hPullBeta");
   MonitorElement *hPullX_W2 = getter.get("DT/4DSegments/Pull/4D_W2_hPullX");
   MonitorElement *hPullY_W2 = getter.get("DT/4DSegments/Pull/4D_W2_hPullY");
-  MonitorElement *hPullBetaRZ_W2 =
-      getter.get("DT/4DSegments/Pull/4D_W2_hPullBetaRZ");
+  MonitorElement *hPullBetaRZ_W2 = getter.get("DT/4DSegments/Pull/4D_W2_hPullBetaRZ");
   MonitorElement *hPullYRZ_W2 = getter.get("DT/4DSegments/Pull/4D_W2_hPullYRZ");
 
   Tutils util;

--- a/Validation/DTRecHits/plugins/DT4DSegmentClients.h
+++ b/Validation/DTRecHits/plugins/DT4DSegmentClients.h
@@ -13,7 +13,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class DT4DSegmentClients : public DQMEDHarvester {
-
 public:
   /// Constructor
   DT4DSegmentClients(const edm::ParameterSet &ps);
@@ -28,4 +27,4 @@ private:
   bool doall_;
 };
 
-#endif // Validation_DTRecHits_DT4DSegmentClients_h
+#endif  // Validation_DTRecHits_DT4DSegmentClients_h

--- a/Validation/DTRecHits/plugins/DTRecHitClients.cc
+++ b/Validation/DTRecHits/plugins/DTRecHitClients.cc
@@ -20,23 +20,18 @@ DTRecHitClients::DTRecHitClients(edm::ParameterSet const &pset) {
 
 DTRecHitClients::~DTRecHitClients() {}
 
-void DTRecHitClients::dqmEndJob(DQMStore::IBooker &booker,
-                                DQMStore::IGetter &getter) {
+void DTRecHitClients::dqmEndJob(DQMStore::IBooker &booker, DQMStore::IGetter &getter) {
   MonitorElement *hRes_S3RPhi = getter.get("DT/1DRecHits/Res/1D_S3RPhi_hRes");
   MonitorElement *hRes_S3RZ = getter.get("DT/1DRecHits/Res/1D_S3RZ_hRes");
   MonitorElement *hRes_S3RZ_W0 = getter.get("DT/1DRecHits/Res/1D_S3RZ_W0_hRes");
   MonitorElement *hRes_S3RZ_W1 = getter.get("DT/1DRecHits/Res/1D_S3RZ_W1_hRes");
   MonitorElement *hRes_S3RZ_W2 = getter.get("DT/1DRecHits/Res/1D_S3RZ_W2_hRes");
 
-  MonitorElement *hPull_S3RPhi =
-      getter.get("DT/1DRecHits/Pull/1D_S3RPhi_hPull");
+  MonitorElement *hPull_S3RPhi = getter.get("DT/1DRecHits/Pull/1D_S3RPhi_hPull");
   MonitorElement *hPull_S3RZ = getter.get("DT/1DRecHits/Pull/1D_S3RZ_hPull");
-  MonitorElement *hPull_S3RZ_W0 =
-      getter.get("DT/1DRecHits/Pull/1D_S3RZ_W0_hPull");
-  MonitorElement *hPull_S3RZ_W1 =
-      getter.get("DT/1DRecHits/Pull/1D_S3RZ_W1_hPull");
-  MonitorElement *hPull_S3RZ_W2 =
-      getter.get("DT/1DRecHits/Pull/1D_S3RZ_W2_hPull");
+  MonitorElement *hPull_S3RZ_W0 = getter.get("DT/1DRecHits/Pull/1D_S3RZ_W0_hPull");
+  MonitorElement *hPull_S3RZ_W1 = getter.get("DT/1DRecHits/Pull/1D_S3RZ_W1_hPull");
+  MonitorElement *hPull_S3RZ_W2 = getter.get("DT/1DRecHits/Pull/1D_S3RZ_W2_hPull");
 
   Tutils util;
   util.drawGFit(hRes_S3RPhi->getTH1(), -0.2, 0.2, -0.1, 0.1);
@@ -81,15 +76,11 @@ void DTRecHitClients::dqmEndJob(DQMStore::IBooker &booker,
     TString name2 = "RZ_W";
     for (long w = 0; w <= 2; ++w) {
       for (long s = 1; s <= 4; ++s) {
-        HEff1DHitHarvest hEff_S1RPhiWS(("S1" + name1 + w + "_St" + s).Data(),
-                                       booker, getter);
-        HEff1DHitHarvest hEff_S3RPhiWS(("S3" + name1 + w + "_St" + s).Data(),
-                                       booker, getter);
+        HEff1DHitHarvest hEff_S1RPhiWS(("S1" + name1 + w + "_St" + s).Data(), booker, getter);
+        HEff1DHitHarvest hEff_S3RPhiWS(("S3" + name1 + w + "_St" + s).Data(), booker, getter);
         if (s != 4) {
-          HEff1DHitHarvest hEff_S1RZWS(("S1" + name2 + w + "_St" + s).Data(),
-                                       booker, getter);
-          HEff1DHitHarvest hEff_S3RZWS(("S3" + name2 + w + "_St" + s).Data(),
-                                       booker, getter);
+          HEff1DHitHarvest hEff_S1RZWS(("S1" + name2 + w + "_St" + s).Data(), booker, getter);
+          HEff1DHitHarvest hEff_S3RZWS(("S3" + name2 + w + "_St" + s).Data(), booker, getter);
         }
       }
     }

--- a/Validation/DTRecHits/plugins/DTRecHitClients.h
+++ b/Validation/DTRecHits/plugins/DTRecHitClients.h
@@ -13,7 +13,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class DTRecHitClients : public DQMEDHarvester {
-
 public:
   /// Constructor
   DTRecHitClients(const edm::ParameterSet &ps);
@@ -33,4 +32,4 @@ private:
   bool doall_;
 };
 
-#endif // Validation_DTRecHits_DTRecHitClients_h
+#endif  // Validation_DTRecHits_DTRecHitClients_h

--- a/Validation/DTRecHits/plugins/DTRecHitQuality.cc
+++ b/Validation/DTRecHits/plugins/DTRecHitQuality.cc
@@ -22,67 +22,55 @@ using namespace std;
 using namespace edm;
 
 namespace dtrechit {
-struct Histograms {
-  std::unique_ptr<HRes1DHit> hRes_S1RPhi;    // RecHits, 1. step, RPh
-  std::unique_ptr<HRes1DHit> hRes_S2RPhi;    // RecHits, 2. step, RPhi
-  std::unique_ptr<HRes1DHit> hRes_S3RPhi;    // RecHits, 3. step, RPhi
-  std::unique_ptr<HRes1DHit> hRes_S1RZ;      // RecHits, 1. step, RZ
-  std::unique_ptr<HRes1DHit> hRes_S2RZ;      // RecHits, 2. step, RZ
-  std::unique_ptr<HRes1DHit> hRes_S3RZ;      // RecHits, 3. step, RZ
-  std::unique_ptr<HRes1DHit> hRes_S1RZ_W0;   // RecHits, 1. step, RZ, wheel 0
-  std::unique_ptr<HRes1DHit> hRes_S2RZ_W0;   // RecHits, 2. step, RZ, wheel 0
-  std::unique_ptr<HRes1DHit> hRes_S3RZ_W0;   // RecHits, 3. step, RZ, wheel 0
-  std::unique_ptr<HRes1DHit> hRes_S1RZ_W1;   // RecHits, 1. step, RZ, wheel +-1
-  std::unique_ptr<HRes1DHit> hRes_S2RZ_W1;   // RecHits, 2. step, RZ, wheel +-1
-  std::unique_ptr<HRes1DHit> hRes_S3RZ_W1;   // RecHits, 3. step, RZ, wheel +-1
-  std::unique_ptr<HRes1DHit> hRes_S1RZ_W2;   // RecHits, 1. step, RZ, wheel +-2
-  std::unique_ptr<HRes1DHit> hRes_S2RZ_W2;   // RecHits, 2. step, RZ, wheel +-2
-  std::unique_ptr<HRes1DHit> hRes_S3RZ_W2;   // RecHits, 3. step, RZ, wheel +-2
-  std::unique_ptr<HRes1DHit> hRes_S1RPhi_W0; // RecHits, 1. step, RPhi, wheel 0
-  std::unique_ptr<HRes1DHit> hRes_S2RPhi_W0; // RecHits, 2. step, RPhi, wheel 0
-  std::unique_ptr<HRes1DHit> hRes_S3RPhi_W0; // RecHits, 3. step, RPhi, wheel 0
-  std::unique_ptr<HRes1DHit>
-      hRes_S1RPhi_W1; // RecHits, 1. step, RPhi, wheel +-1
-  std::unique_ptr<HRes1DHit>
-      hRes_S2RPhi_W1; // RecHits, 2. step, RPhi, wheel +-1
-  std::unique_ptr<HRes1DHit>
-      hRes_S3RPhi_W1; // RecHits, 3. step, RPhi, wheel +-1
-  std::unique_ptr<HRes1DHit>
-      hRes_S1RPhi_W2; // RecHits, 1. step, RPhi, wheel +-2
-  std::unique_ptr<HRes1DHit>
-      hRes_S2RPhi_W2; // RecHits, 2. step, RPhi, wheel +-2
-  std::unique_ptr<HRes1DHit>
-      hRes_S3RPhi_W2; // RecHits, 3. step, RPhi, wheel +-2
-  std::unique_ptr<HRes1DHit>
-      hRes_S3RPhiWS[3][4]; // RecHits, 3. step, by wheel/station
-  std::unique_ptr<HRes1DHit>
-      hRes_S3RZWS[3][4]; // RecHits, 3. step, by wheel/station
+  struct Histograms {
+    std::unique_ptr<HRes1DHit> hRes_S1RPhi;          // RecHits, 1. step, RPh
+    std::unique_ptr<HRes1DHit> hRes_S2RPhi;          // RecHits, 2. step, RPhi
+    std::unique_ptr<HRes1DHit> hRes_S3RPhi;          // RecHits, 3. step, RPhi
+    std::unique_ptr<HRes1DHit> hRes_S1RZ;            // RecHits, 1. step, RZ
+    std::unique_ptr<HRes1DHit> hRes_S2RZ;            // RecHits, 2. step, RZ
+    std::unique_ptr<HRes1DHit> hRes_S3RZ;            // RecHits, 3. step, RZ
+    std::unique_ptr<HRes1DHit> hRes_S1RZ_W0;         // RecHits, 1. step, RZ, wheel 0
+    std::unique_ptr<HRes1DHit> hRes_S2RZ_W0;         // RecHits, 2. step, RZ, wheel 0
+    std::unique_ptr<HRes1DHit> hRes_S3RZ_W0;         // RecHits, 3. step, RZ, wheel 0
+    std::unique_ptr<HRes1DHit> hRes_S1RZ_W1;         // RecHits, 1. step, RZ, wheel +-1
+    std::unique_ptr<HRes1DHit> hRes_S2RZ_W1;         // RecHits, 2. step, RZ, wheel +-1
+    std::unique_ptr<HRes1DHit> hRes_S3RZ_W1;         // RecHits, 3. step, RZ, wheel +-1
+    std::unique_ptr<HRes1DHit> hRes_S1RZ_W2;         // RecHits, 1. step, RZ, wheel +-2
+    std::unique_ptr<HRes1DHit> hRes_S2RZ_W2;         // RecHits, 2. step, RZ, wheel +-2
+    std::unique_ptr<HRes1DHit> hRes_S3RZ_W2;         // RecHits, 3. step, RZ, wheel +-2
+    std::unique_ptr<HRes1DHit> hRes_S1RPhi_W0;       // RecHits, 1. step, RPhi, wheel 0
+    std::unique_ptr<HRes1DHit> hRes_S2RPhi_W0;       // RecHits, 2. step, RPhi, wheel 0
+    std::unique_ptr<HRes1DHit> hRes_S3RPhi_W0;       // RecHits, 3. step, RPhi, wheel 0
+    std::unique_ptr<HRes1DHit> hRes_S1RPhi_W1;       // RecHits, 1. step, RPhi, wheel +-1
+    std::unique_ptr<HRes1DHit> hRes_S2RPhi_W1;       // RecHits, 2. step, RPhi, wheel +-1
+    std::unique_ptr<HRes1DHit> hRes_S3RPhi_W1;       // RecHits, 3. step, RPhi, wheel +-1
+    std::unique_ptr<HRes1DHit> hRes_S1RPhi_W2;       // RecHits, 1. step, RPhi, wheel +-2
+    std::unique_ptr<HRes1DHit> hRes_S2RPhi_W2;       // RecHits, 2. step, RPhi, wheel +-2
+    std::unique_ptr<HRes1DHit> hRes_S3RPhi_W2;       // RecHits, 3. step, RPhi, wheel +-2
+    std::unique_ptr<HRes1DHit> hRes_S3RPhiWS[3][4];  // RecHits, 3. step, by wheel/station
+    std::unique_ptr<HRes1DHit> hRes_S3RZWS[3][4];    // RecHits, 3. step, by wheel/station
 
-  std::unique_ptr<HEff1DHit> hEff_S1RPhi;  // RecHits, 1. step, RPhi
-  std::unique_ptr<HEff1DHit> hEff_S2RPhi;  // RecHits, 2. step, RPhi
-  std::unique_ptr<HEff1DHit> hEff_S3RPhi;  // RecHits, 3. step, RPhi
-  std::unique_ptr<HEff1DHit> hEff_S1RZ;    // RecHits, 1. step, RZ
-  std::unique_ptr<HEff1DHit> hEff_S2RZ;    // RecHits, 2. step, RZ
-  std::unique_ptr<HEff1DHit> hEff_S3RZ;    // RecHits, 3. step, RZ
-  std::unique_ptr<HEff1DHit> hEff_S1RZ_W0; // RecHits, 1. step, RZ, wheel 0
-  std::unique_ptr<HEff1DHit> hEff_S2RZ_W0; // RecHits, 2. step, RZ, wheel 0
-  std::unique_ptr<HEff1DHit> hEff_S3RZ_W0; // RecHits, 3. step, RZ, wheel 0
-  std::unique_ptr<HEff1DHit> hEff_S1RZ_W1; // RecHits, 1. step, RZ, wheel +-1
-  std::unique_ptr<HEff1DHit> hEff_S2RZ_W1; // RecHits, 2. step, RZ, wheel +-1
-  std::unique_ptr<HEff1DHit> hEff_S3RZ_W1; // RecHits, 3. step, RZ, wheel +-1
-  std::unique_ptr<HEff1DHit> hEff_S1RZ_W2; // RecHits, 1. step, RZ, wheel +-2
-  std::unique_ptr<HEff1DHit> hEff_S2RZ_W2; // RecHits, 2. step, RZ, wheel +-2
-  std::unique_ptr<HEff1DHit> hEff_S3RZ_W2; // RecHits, 3. step, RZ, wheel +-2
-  std::unique_ptr<HEff1DHit>
-      hEff_S1RPhiWS[3][4]; // RecHits, 3. step, by wheel/station
-  std::unique_ptr<HEff1DHit>
-      hEff_S3RPhiWS[3][4]; // RecHits, 3. step, by wheel/station
-  std::unique_ptr<HEff1DHit>
-      hEff_S1RZWS[3][4]; // RecHits, 3. step, by wheel/station
-  std::unique_ptr<HEff1DHit>
-      hEff_S3RZWS[3][4]; // RecHits, 3. step, by wheel/station
-};
-} // namespace dtrechit
+    std::unique_ptr<HEff1DHit> hEff_S1RPhi;          // RecHits, 1. step, RPhi
+    std::unique_ptr<HEff1DHit> hEff_S2RPhi;          // RecHits, 2. step, RPhi
+    std::unique_ptr<HEff1DHit> hEff_S3RPhi;          // RecHits, 3. step, RPhi
+    std::unique_ptr<HEff1DHit> hEff_S1RZ;            // RecHits, 1. step, RZ
+    std::unique_ptr<HEff1DHit> hEff_S2RZ;            // RecHits, 2. step, RZ
+    std::unique_ptr<HEff1DHit> hEff_S3RZ;            // RecHits, 3. step, RZ
+    std::unique_ptr<HEff1DHit> hEff_S1RZ_W0;         // RecHits, 1. step, RZ, wheel 0
+    std::unique_ptr<HEff1DHit> hEff_S2RZ_W0;         // RecHits, 2. step, RZ, wheel 0
+    std::unique_ptr<HEff1DHit> hEff_S3RZ_W0;         // RecHits, 3. step, RZ, wheel 0
+    std::unique_ptr<HEff1DHit> hEff_S1RZ_W1;         // RecHits, 1. step, RZ, wheel +-1
+    std::unique_ptr<HEff1DHit> hEff_S2RZ_W1;         // RecHits, 2. step, RZ, wheel +-1
+    std::unique_ptr<HEff1DHit> hEff_S3RZ_W1;         // RecHits, 3. step, RZ, wheel +-1
+    std::unique_ptr<HEff1DHit> hEff_S1RZ_W2;         // RecHits, 1. step, RZ, wheel +-2
+    std::unique_ptr<HEff1DHit> hEff_S2RZ_W2;         // RecHits, 2. step, RZ, wheel +-2
+    std::unique_ptr<HEff1DHit> hEff_S3RZ_W2;         // RecHits, 3. step, RZ, wheel +-2
+    std::unique_ptr<HEff1DHit> hEff_S1RPhiWS[3][4];  // RecHits, 3. step, by wheel/station
+    std::unique_ptr<HEff1DHit> hEff_S3RPhiWS[3][4];  // RecHits, 3. step, by wheel/station
+    std::unique_ptr<HEff1DHit> hEff_S1RZWS[3][4];    // RecHits, 3. step, by wheel/station
+    std::unique_ptr<HEff1DHit> hEff_S3RZWS[3][4];    // RecHits, 3. step, by wheel/station
+  };
+}  // namespace dtrechit
 
 using namespace dtrechit;
 
@@ -93,7 +81,7 @@ using namespace dtrechit;
 // simmetrized one.
 // Set mirrorMinusWheels to avoid this.
 namespace {
-constexpr bool mirrorMinusWheels = true;
+  constexpr bool mirrorMinusWheels = true;
 }
 
 // Constructor
@@ -102,20 +90,16 @@ DTRecHitQuality::DTRecHitQuality(const ParameterSet &pset) {
   debug_ = pset.getUntrackedParameter<bool>("debug");
   // the name of the simhit collection
   simHitLabel_ = pset.getUntrackedParameter<InputTag>("simHitLabel");
-  simHitToken_ = consumes<PSimHitContainer>(
-      pset.getUntrackedParameter<InputTag>("simHitLabel"));
+  simHitToken_ = consumes<PSimHitContainer>(pset.getUntrackedParameter<InputTag>("simHitLabel"));
   // the name of the 1D rec hit collection
   recHitLabel_ = pset.getUntrackedParameter<InputTag>("recHitLabel");
-  recHitToken_ = consumes<DTRecHitCollection>(
-      pset.getUntrackedParameter<InputTag>("recHitLabel"));
+  recHitToken_ = consumes<DTRecHitCollection>(pset.getUntrackedParameter<InputTag>("recHitLabel"));
   // the name of the 2D rec hit collection
   segment2DLabel_ = pset.getUntrackedParameter<InputTag>("segment2DLabel");
-  segment2DToken_ = consumes<DTRecSegment2DCollection>(
-      pset.getUntrackedParameter<InputTag>("segment2DLabel"));
+  segment2DToken_ = consumes<DTRecSegment2DCollection>(pset.getUntrackedParameter<InputTag>("segment2DLabel"));
   // the name of the 4D rec hit collection
   segment4DLabel_ = pset.getUntrackedParameter<InputTag>("segment4DLabel");
-  segment4DToken_ = consumes<DTRecSegment4DCollection>(
-      pset.getUntrackedParameter<InputTag>("segment4DLabel"));
+  segment4DToken_ = consumes<DTRecSegment4DCollection>(pset.getUntrackedParameter<InputTag>("segment4DLabel"));
   // Switches for analysis at various steps
   doStep1_ = pset.getUntrackedParameter<bool>("doStep1", false);
   doStep2_ = pset.getUntrackedParameter<bool>("doStep2", false);
@@ -129,80 +113,66 @@ void DTRecHitQuality::bookHistograms(DQMStore::ConcurrentBooker &booker,
                                      edm::EventSetup const &setup,
                                      Histograms &histograms) const {
   if (doall_ && doStep1_) {
-    histograms.hRes_S1RPhi = std::make_unique<HRes1DHit>(
-        "S1RPhi", booker, true, local_); // RecHits, 1. step, RPhi
-    histograms.hRes_S1RPhi_W0 = std::make_unique<HRes1DHit>(
-        "S1RPhi_W0", booker, true, local_); // RecHits, 1. step, RZ, wheel 0
-    histograms.hRes_S1RPhi_W1 = std::make_unique<HRes1DHit>(
-        "S1RPhi_W1", booker, true, local_); // RecHits, 1. step, RZ, wheel +-1
-    histograms.hRes_S1RPhi_W2 = std::make_unique<HRes1DHit>(
-        "S1RPhi_W2", booker, true, local_); // RecHits, 1. step, RZ, wheel +-2
-    histograms.hRes_S1RZ = std::make_unique<HRes1DHit>(
-        "S1RZ", booker, true, local_); // RecHits, 1. step, RZ
-    histograms.hRes_S1RZ_W0 = std::make_unique<HRes1DHit>(
-        "S1RZ_W0", booker, true, local_); // RecHits, 1. step, RZ, wheel 0
-    histograms.hRes_S1RZ_W1 = std::make_unique<HRes1DHit>(
-        "S1RZ_W1", booker, true, local_); // RecHits, 1. step, RZ, wheel +-1
-    histograms.hRes_S1RZ_W2 = std::make_unique<HRes1DHit>(
-        "S1RZ_W2", booker, true, local_); // RecHits, 1. step, RZ, wheel +-2
-    histograms.hEff_S1RPhi =
-        std::make_unique<HEff1DHit>("S1RPhi", booker); // RecHits, 1. step, RPhi
-    histograms.hEff_S1RZ =
-        std::make_unique<HEff1DHit>("S1RZ", booker); // RecHits, 1. step, RZ
-    histograms.hEff_S1RZ_W0 = std::make_unique<HEff1DHit>(
-        "S1RZ_W0", booker); // RecHits, 1. step, RZ, wheel 0
-    histograms.hEff_S1RZ_W1 = std::make_unique<HEff1DHit>(
-        "S1RZ_W1", booker); // RecHits, 1. step, RZ, wheel +-1
-    histograms.hEff_S1RZ_W2 = std::make_unique<HEff1DHit>(
-        "S1RZ_W2", booker); // RecHits, 1. step, RZ, wheel +-2
+    histograms.hRes_S1RPhi = std::make_unique<HRes1DHit>("S1RPhi", booker, true, local_);  // RecHits, 1. step, RPhi
+    histograms.hRes_S1RPhi_W0 =
+        std::make_unique<HRes1DHit>("S1RPhi_W0", booker, true, local_);  // RecHits, 1. step, RZ, wheel 0
+    histograms.hRes_S1RPhi_W1 =
+        std::make_unique<HRes1DHit>("S1RPhi_W1", booker, true, local_);  // RecHits, 1. step, RZ, wheel +-1
+    histograms.hRes_S1RPhi_W2 =
+        std::make_unique<HRes1DHit>("S1RPhi_W2", booker, true, local_);  // RecHits, 1. step, RZ, wheel +-2
+    histograms.hRes_S1RZ = std::make_unique<HRes1DHit>("S1RZ", booker, true, local_);  // RecHits, 1. step, RZ
+    histograms.hRes_S1RZ_W0 =
+        std::make_unique<HRes1DHit>("S1RZ_W0", booker, true, local_);  // RecHits, 1. step, RZ, wheel 0
+    histograms.hRes_S1RZ_W1 =
+        std::make_unique<HRes1DHit>("S1RZ_W1", booker, true, local_);  // RecHits, 1. step, RZ, wheel +-1
+    histograms.hRes_S1RZ_W2 =
+        std::make_unique<HRes1DHit>("S1RZ_W2", booker, true, local_);          // RecHits, 1. step, RZ, wheel +-2
+    histograms.hEff_S1RPhi = std::make_unique<HEff1DHit>("S1RPhi", booker);    // RecHits, 1. step, RPhi
+    histograms.hEff_S1RZ = std::make_unique<HEff1DHit>("S1RZ", booker);        // RecHits, 1. step, RZ
+    histograms.hEff_S1RZ_W0 = std::make_unique<HEff1DHit>("S1RZ_W0", booker);  // RecHits, 1. step, RZ, wheel 0
+    histograms.hEff_S1RZ_W1 = std::make_unique<HEff1DHit>("S1RZ_W1", booker);  // RecHits, 1. step, RZ, wheel +-1
+    histograms.hEff_S1RZ_W2 = std::make_unique<HEff1DHit>("S1RZ_W2", booker);  // RecHits, 1. step, RZ, wheel +-2
   }
   if (doall_ && doStep2_) {
-    histograms.hRes_S2RPhi = std::make_unique<HRes1DHit>(
-        "S2RPhi", booker, true, local_); // RecHits, 2. step, RPhi
-    histograms.hRes_S2RPhi_W0 = std::make_unique<HRes1DHit>(
-        "S2RPhi_W0", booker, true, local_); // RecHits, 2. step, RPhi, wheel 0
-    histograms.hRes_S2RPhi_W1 = std::make_unique<HRes1DHit>(
-        "S2RPhi_W1", booker, true, local_); // RecHits, 2. step, RPhi, wheel +-1
-    histograms.hRes_S2RPhi_W2 = std::make_unique<HRes1DHit>(
-        "S2RPhi_W2", booker, true, local_); // RecHits, 2. step, RPhi, wheel +-2
-    histograms.hRes_S2RZ = std::make_unique<HRes1DHit>(
-        "S2RZ", booker, true, local_); // RecHits, 2. step, RZ
-    histograms.hRes_S2RZ_W0 = std::make_unique<HRes1DHit>(
-        "S2RZ_W0", booker, true, local_); // RecHits, 2. step, RZ, wheel 0
-    histograms.hRes_S2RZ_W1 = std::make_unique<HRes1DHit>(
-        "S2RZ_W1", booker, true, local_); // RecHits, 2. step, RZ, wheel +-1
-    histograms.hRes_S2RZ_W2 = std::make_unique<HRes1DHit>(
-        "S2RZ_W2", booker, true, local_); // RecHits, 2. step, RZ, wheel +-2
-    histograms.hEff_S2RPhi =
-        std::make_unique<HEff1DHit>("S2RPhi", booker); // RecHits, 2. step, RPhi
-    histograms.hEff_S2RZ_W0 = std::make_unique<HEff1DHit>(
-        "S2RZ_W0", booker); // RecHits, 2. step, RZ, wheel 0
-    histograms.hEff_S2RZ_W1 = std::make_unique<HEff1DHit>(
-        "S2RZ_W1", booker); // RecHits, 2. step, RZ, wheel +-1
-    histograms.hEff_S2RZ_W2 = std::make_unique<HEff1DHit>(
-        "S2RZ_W2", booker); // RecHits, 2. step, RZ, wheel +-2
-    histograms.hEff_S2RZ =
-        std::make_unique<HEff1DHit>("S2RZ", booker); // RecHits, 2. step, RZ
+    histograms.hRes_S2RPhi = std::make_unique<HRes1DHit>("S2RPhi", booker, true, local_);  // RecHits, 2. step, RPhi
+    histograms.hRes_S2RPhi_W0 =
+        std::make_unique<HRes1DHit>("S2RPhi_W0", booker, true, local_);  // RecHits, 2. step, RPhi, wheel 0
+    histograms.hRes_S2RPhi_W1 =
+        std::make_unique<HRes1DHit>("S2RPhi_W1", booker, true, local_);  // RecHits, 2. step, RPhi, wheel +-1
+    histograms.hRes_S2RPhi_W2 =
+        std::make_unique<HRes1DHit>("S2RPhi_W2", booker, true, local_);  // RecHits, 2. step, RPhi, wheel +-2
+    histograms.hRes_S2RZ = std::make_unique<HRes1DHit>("S2RZ", booker, true, local_);  // RecHits, 2. step, RZ
+    histograms.hRes_S2RZ_W0 =
+        std::make_unique<HRes1DHit>("S2RZ_W0", booker, true, local_);  // RecHits, 2. step, RZ, wheel 0
+    histograms.hRes_S2RZ_W1 =
+        std::make_unique<HRes1DHit>("S2RZ_W1", booker, true, local_);  // RecHits, 2. step, RZ, wheel +-1
+    histograms.hRes_S2RZ_W2 =
+        std::make_unique<HRes1DHit>("S2RZ_W2", booker, true, local_);          // RecHits, 2. step, RZ, wheel +-2
+    histograms.hEff_S2RPhi = std::make_unique<HEff1DHit>("S2RPhi", booker);    // RecHits, 2. step, RPhi
+    histograms.hEff_S2RZ_W0 = std::make_unique<HEff1DHit>("S2RZ_W0", booker);  // RecHits, 2. step, RZ, wheel 0
+    histograms.hEff_S2RZ_W1 = std::make_unique<HEff1DHit>("S2RZ_W1", booker);  // RecHits, 2. step, RZ, wheel +-1
+    histograms.hEff_S2RZ_W2 = std::make_unique<HEff1DHit>("S2RZ_W2", booker);  // RecHits, 2. step, RZ, wheel +-2
+    histograms.hEff_S2RZ = std::make_unique<HEff1DHit>("S2RZ", booker);        // RecHits, 2. step, RZ
   }
   if (doStep3_) {
-    histograms.hRes_S3RPhi = std::make_unique<HRes1DHit>(
-        "S3RPhi", booker, doall_, local_); // RecHits, 3. step, RPhi
-    histograms.hRes_S3RPhi_W0 = std::make_unique<HRes1DHit>(
-        "S3RPhi_W0", booker, doall_, local_); // RecHits, 3. step, RPhi, wheel 0
-    histograms.hRes_S3RPhi_W1 = std::make_unique<HRes1DHit>(
-        "S3RPhi_W1", booker, doall_,
-        local_); // RecHits, 3. step, RPhi, wheel +-1
-    histograms.hRes_S3RPhi_W2 = std::make_unique<HRes1DHit>(
-        "S3RPhi_W2", booker, doall_,
-        local_); // RecHits, 3. step, RPhi, wheel +-2
-    histograms.hRes_S3RZ = std::make_unique<HRes1DHit>(
-        "S3RZ", booker, doall_, local_); // RecHits, 3. step, RZ
-    histograms.hRes_S3RZ_W0 = std::make_unique<HRes1DHit>(
-        "S3RZ_W0", booker, doall_, local_); // RecHits, 3. step, RZ, wheel 0
-    histograms.hRes_S3RZ_W1 = std::make_unique<HRes1DHit>(
-        "S3RZ_W1", booker, doall_, local_); // RecHits, 3. step, RZ, wheel +-1
-    histograms.hRes_S3RZ_W2 = std::make_unique<HRes1DHit>(
-        "S3RZ_W2", booker, doall_, local_); // RecHits, 3. step, RZ, wheel +-2
+    histograms.hRes_S3RPhi = std::make_unique<HRes1DHit>("S3RPhi", booker, doall_, local_);  // RecHits, 3. step, RPhi
+    histograms.hRes_S3RPhi_W0 =
+        std::make_unique<HRes1DHit>("S3RPhi_W0", booker, doall_, local_);  // RecHits, 3. step, RPhi, wheel 0
+    histograms.hRes_S3RPhi_W1 = std::make_unique<HRes1DHit>("S3RPhi_W1",
+                                                            booker,
+                                                            doall_,
+                                                            local_);  // RecHits, 3. step, RPhi, wheel +-1
+    histograms.hRes_S3RPhi_W2 = std::make_unique<HRes1DHit>("S3RPhi_W2",
+                                                            booker,
+                                                            doall_,
+                                                            local_);  // RecHits, 3. step, RPhi, wheel +-2
+    histograms.hRes_S3RZ = std::make_unique<HRes1DHit>("S3RZ", booker, doall_, local_);  // RecHits, 3. step, RZ
+    histograms.hRes_S3RZ_W0 =
+        std::make_unique<HRes1DHit>("S3RZ_W0", booker, doall_, local_);  // RecHits, 3. step, RZ, wheel 0
+    histograms.hRes_S3RZ_W1 =
+        std::make_unique<HRes1DHit>("S3RZ_W1", booker, doall_, local_);  // RecHits, 3. step, RZ, wheel +-1
+    histograms.hRes_S3RZ_W2 =
+        std::make_unique<HRes1DHit>("S3RZ_W2", booker, doall_, local_);  // RecHits, 3. step, RZ, wheel +-2
 
     if (local_) {
       // Plots with finer granularity, not to be included in DQM
@@ -210,35 +180,30 @@ void DTRecHitQuality::bookHistograms(DQMStore::ConcurrentBooker &booker,
       TString name2 = "RZ_W";
       for (long w = 0; w <= 2; ++w) {
         for (long s = 1; s <= 4; ++s) {
-          histograms.hRes_S3RPhiWS[w][s - 1] = std::make_unique<HRes1DHit>(
-              ("S3" + name1 + w + "_St" + s).Data(), booker, doall_, local_);
-          histograms.hEff_S1RPhiWS[w][s - 1] = std::make_unique<HEff1DHit>(
-              ("S1" + name1 + w + "_St" + s).Data(), booker);
-          histograms.hEff_S3RPhiWS[w][s - 1] = std::make_unique<HEff1DHit>(
-              ("S3" + name1 + w + "_St" + s).Data(), booker);
+          histograms.hRes_S3RPhiWS[w][s - 1] =
+              std::make_unique<HRes1DHit>(("S3" + name1 + w + "_St" + s).Data(), booker, doall_, local_);
+          histograms.hEff_S1RPhiWS[w][s - 1] =
+              std::make_unique<HEff1DHit>(("S1" + name1 + w + "_St" + s).Data(), booker);
+          histograms.hEff_S3RPhiWS[w][s - 1] =
+              std::make_unique<HEff1DHit>(("S3" + name1 + w + "_St" + s).Data(), booker);
           if (s != 4) {
-            histograms.hRes_S3RZWS[w][s - 1] = std::make_unique<HRes1DHit>(
-                ("S3" + name2 + w + "_St" + s).Data(), booker, doall_, local_);
-            histograms.hEff_S1RZWS[w][s - 1] = std::make_unique<HEff1DHit>(
-                ("S1" + name2 + w + "_St" + s).Data(), booker);
-            histograms.hEff_S3RZWS[w][s - 1] = std::make_unique<HEff1DHit>(
-                ("S3" + name2 + w + "_St" + s).Data(), booker);
+            histograms.hRes_S3RZWS[w][s - 1] =
+                std::make_unique<HRes1DHit>(("S3" + name2 + w + "_St" + s).Data(), booker, doall_, local_);
+            histograms.hEff_S1RZWS[w][s - 1] =
+                std::make_unique<HEff1DHit>(("S1" + name2 + w + "_St" + s).Data(), booker);
+            histograms.hEff_S3RZWS[w][s - 1] =
+                std::make_unique<HEff1DHit>(("S3" + name2 + w + "_St" + s).Data(), booker);
           }
         }
       }
     }
 
     if (doall_) {
-      histograms.hEff_S3RPhi = std::make_unique<HEff1DHit>(
-          "S3RPhi", booker); // RecHits, 3. step, RPhi
-      histograms.hEff_S3RZ =
-          std::make_unique<HEff1DHit>("S3RZ", booker); // RecHits, 3. step, RZ
-      histograms.hEff_S3RZ_W0 = std::make_unique<HEff1DHit>(
-          "S3RZ_W0", booker); // RecHits, 3. step, RZ, wheel 0
-      histograms.hEff_S3RZ_W1 = std::make_unique<HEff1DHit>(
-          "S3RZ_W1", booker); // RecHits, 3. step, RZ, wheel +-1
-      histograms.hEff_S3RZ_W2 = std::make_unique<HEff1DHit>(
-          "S3RZ_W2", booker); // RecHits, 3. step, RZ, wheel +-2
+      histograms.hEff_S3RPhi = std::make_unique<HEff1DHit>("S3RPhi", booker);    // RecHits, 3. step, RPhi
+      histograms.hEff_S3RZ = std::make_unique<HEff1DHit>("S3RZ", booker);        // RecHits, 3. step, RZ
+      histograms.hEff_S3RZ_W0 = std::make_unique<HEff1DHit>("S3RZ_W0", booker);  // RecHits, 3. step, RZ, wheel 0
+      histograms.hEff_S3RZ_W1 = std::make_unique<HEff1DHit>("S3RZ_W1", booker);  // RecHits, 3. step, RZ, wheel +-1
+      histograms.hEff_S3RZ_W2 = std::make_unique<HEff1DHit>("S3RZ_W2", booker);  // RecHits, 3. step, RZ, wheel +-2
     }
   }
 }
@@ -248,8 +213,8 @@ void DTRecHitQuality::dqmAnalyze(edm::Event const &event,
                                  edm::EventSetup const &setup,
                                  Histograms const &histograms) const {
   if (debug_) {
-    cout << "--- [DTRecHitQuality] Analysing Event: #Run: " << event.id().run()
-         << " #Event: " << event.id().event() << endl;
+    cout << "--- [DTRecHitQuality] Analysing Event: #Run: " << event.id().run() << " #Event: " << event.id().event()
+         << endl;
   }
 
   // Get the DT Geometry
@@ -261,8 +226,7 @@ void DTRecHitQuality::dqmAnalyze(edm::Event const &event,
   event.getByToken(simHitToken_, simHits);
 
   // Map simhits per wire
-  map<DTWireId, PSimHitContainer> simHitsPerWire =
-      DTHitQualityUtils::mapSimHitsPerWire(*(simHits.product()));
+  map<DTWireId, PSimHitContainer> simHitsPerWire = DTHitQualityUtils::mapSimHitsPerWire(*(simHits.product()));
 
   //=======================================================================================
   // RecHit analysis at Step 1
@@ -276,8 +240,8 @@ void DTRecHitQuality::dqmAnalyze(edm::Event const &event,
 
     if (!dtRecHits.isValid()) {
       if (debug_) {
-        cout << "[DTRecHitQuality]**Warning: no 1DRechits with label: "
-             << recHitLabel_ << " in this event, skipping!" << endl;
+        cout << "[DTRecHitQuality]**Warning: no 1DRechits with label: " << recHitLabel_ << " in this event, skipping!"
+             << endl;
       }
       return;
     }
@@ -300,8 +264,8 @@ void DTRecHitQuality::dqmAnalyze(edm::Event const &event,
 
     if (!segment2Ds.isValid()) {
       if (debug_) {
-        cout << "[DTRecHitQuality]**Warning: no 2DSegments with label: "
-             << segment2DLabel_ << " in this event, skipping!" << endl;
+        cout << "[DTRecHitQuality]**Warning: no 2DSegments with label: " << segment2DLabel_
+             << " in this event, skipping!" << endl;
       }
 
     } else {
@@ -324,8 +288,8 @@ void DTRecHitQuality::dqmAnalyze(edm::Event const &event,
 
     if (!segment4Ds.isValid()) {
       if (debug_) {
-        cout << "[DTRecHitQuality]**Warning: no 4D Segments with label: "
-             << segment4DLabel_ << " in this event, skipping!" << endl;
+        cout << "[DTRecHitQuality]**Warning: no 4D Segments with label: " << segment4DLabel_
+             << " in this event, skipping!" << endl;
       }
       return;
     }
@@ -388,23 +352,18 @@ map<DTWireId, std::vector<DTRecHit1D>> DTRecHitQuality::map1DRecHitsPerWire(
 }
 
 // Compute SimHit distance from wire (cm)
-float DTRecHitQuality::simHitDistFromWire(const DTLayer *layer,
-                                          const DTWireId &wireId,
-                                          const PSimHit &hit) const {
+float DTRecHitQuality::simHitDistFromWire(const DTLayer *layer, const DTWireId &wireId, const PSimHit &hit) const {
   float xwire = layer->specificTopology().wirePosition(wireId.wire());
   LocalPoint entryP = hit.entryPoint();
   LocalPoint exitP = hit.exitPoint();
   float xEntry = entryP.x() - xwire;
   float xExit = exitP.x() - xwire;
 
-  return fabs(xEntry - (entryP.z() * (xExit - xEntry)) /
-                           (exitP.z() - entryP.z())); // FIXME: check...
+  return fabs(xEntry - (entryP.z() * (xExit - xEntry)) / (exitP.z() - entryP.z()));  // FIXME: check...
 }
 
 // Compute SimHit impact angle (in direction perp to wire), in the SL RF
-float DTRecHitQuality::simHitImpactAngle(const DTLayer *layer,
-                                         const DTWireId &wireId,
-                                         const PSimHit &hit) const {
+float DTRecHitQuality::simHitImpactAngle(const DTLayer *layer, const DTWireId &wireId, const PSimHit &hit) const {
   LocalPoint entryP = hit.entryPoint();
   LocalPoint exitP = hit.exitPoint();
   float theta = (exitP.x() - entryP.x()) / (exitP.z() - entryP.z());
@@ -412,9 +371,7 @@ float DTRecHitQuality::simHitImpactAngle(const DTLayer *layer,
 }
 
 // Compute SimHit distance from FrontEnd
-float DTRecHitQuality::simHitDistFromFE(const DTLayer *layer,
-                                        const DTWireId &wireId,
-                                        const PSimHit &hit) const {
+float DTRecHitQuality::simHitDistFromFE(const DTLayer *layer, const DTWireId &wireId, const PSimHit &hit) const {
   LocalPoint entryP = hit.entryPoint();
   LocalPoint exitP = hit.exitPoint();
   float wireLenght = layer->specificTopology().cellLenght();
@@ -439,33 +396,28 @@ const type *DTRecHitQuality::findBestRecHit(const DTLayer *layer,
       res = fabs(distTmp - simHitDist);
       theBestRecHit = &(*recHit);
     }
-  } // End of loop over RecHits within the cell
+  }  // End of loop over RecHits within the cell
 
   return theBestRecHit;
 }
 
 // Compute the distance from wire (cm) of a hits in a DTRecHit1DPair
-float DTRecHitQuality::recHitDistFromWire(const DTRecHit1DPair &hitPair,
-                                          const DTLayer *layer) const {
+float DTRecHitQuality::recHitDistFromWire(const DTRecHit1DPair &hitPair, const DTLayer *layer) const {
   // Compute the rechit distance from wire
-  return fabs(hitPair.localPosition(DTEnums::Left).x() -
-              hitPair.localPosition(DTEnums::Right).x()) /
-         2.;
+  return fabs(hitPair.localPosition(DTEnums::Left).x() - hitPair.localPosition(DTEnums::Right).x()) / 2.;
 }
 
 // Compute the distance from wire (cm) of a hits in a DTRecHit1D
-float DTRecHitQuality::recHitDistFromWire(const DTRecHit1D &recHit,
-                                          const DTLayer *layer) const {
-  return fabs(recHit.localPosition().x() -
-              layer->specificTopology().wirePosition(recHit.wireId().wire()));
+float DTRecHitQuality::recHitDistFromWire(const DTRecHit1D &recHit, const DTLayer *layer) const {
+  return fabs(recHit.localPosition().x() - layer->specificTopology().wirePosition(recHit.wireId().wire()));
 }
 
 template <typename type>
-void DTRecHitQuality::compute(
-    const DTGeometry *dtGeom,
-    const std::map<DTWireId, std::vector<PSimHit>> &simHitsPerWire,
-    const std::map<DTWireId, std::vector<type>> &recHitsPerWire,
-    Histograms const &histograms, int step) const {
+void DTRecHitQuality::compute(const DTGeometry *dtGeom,
+                              const std::map<DTWireId, std::vector<PSimHit>> &simHitsPerWire,
+                              const std::map<DTWireId, std::vector<type>> &recHitsPerWire,
+                              Histograms const &histograms,
+                              int step) const {
   // Loop over cells with a muon SimHit
   for (const auto &wireAndSHits : simHitsPerWire) {
     DTWireId wireId = wireAndSHits.first;
@@ -481,10 +433,9 @@ void DTRecHitQuality::compute(
     const PSimHit *muSimHit = DTHitQualityUtils::findMuSimHit(simHitsInCell);
     if (muSimHit == nullptr) {
       if (debug_) {
-        cout << "   No mu SimHit in channel: " << wireId << ", skipping! "
-             << endl;
+        cout << "   No mu SimHit in channel: " << wireId << ", skipping! " << endl;
       }
-      continue; // Skip this cell
+      continue;  // Skip this cell
     }
 
     // Find the distance of the simhit from the wire
@@ -496,7 +447,7 @@ void DTRecHitQuality::compute(
                 "cell, skipping!"
              << endl;
       }
-      continue; // Skip this cell
+      continue;  // Skip this cell
     }
     GlobalPoint simHitGlobalPos = layer->toGlobal(muSimHit->localPosition());
 
@@ -512,21 +463,18 @@ void DTRecHitQuality::compute(
     if (recHitsPerWire.find(wireId) == recHitsPerWire.end()) {
       // No RecHit found in this cell
       if (debug_) {
-        cout << "   No RecHit found at Step: " << step << " in cell: " << wireId
-             << endl;
+        cout << "   No RecHit found at Step: " << step << " in cell: " << wireId << endl;
       }
     } else {
       recHitReconstructed = true;
       // vector<type> recHits = (*wireAndRecHits).second;
       const vector<type> &recHits = recHitsPerWire.at(wireId);
       if (debug_) {
-        cout << "   " << recHits.size() << " RecHits, Step " << step
-             << " in channel: " << wireId << endl;
+        cout << "   " << recHits.size() << " RecHits, Step " << step << " in channel: " << wireId << endl;
       }
 
       // Find the best RecHit
-      const type *theBestRecHit =
-          findBestRecHit(layer, wireId, recHits, simHitWireDist);
+      const type *theBestRecHit = findBestRecHit(layer, wireId, recHits, simHitWireDist);
 
       float recHitWireDist = recHitDistFromWire(*theBestRecHit, layer);
       if (debug_) {
@@ -613,10 +561,14 @@ void DTRecHitQuality::compute(
             hRes = histograms.hRes_S3RPhi_W2.get();
           }
           if (local_) {
-            histograms.hRes_S3RPhiWS[abs(wheel)][wireId.station() - 1]->fill(
-                simHitWireDist, simHitTheta, simHitFEDist, recHitWireDist,
-                simHitGlobalPos.eta(), simHitGlobalPos.phi(), recHitErr,
-                wireId.station());
+            histograms.hRes_S3RPhiWS[abs(wheel)][wireId.station() - 1]->fill(simHitWireDist,
+                                                                             simHitTheta,
+                                                                             simHitFEDist,
+                                                                             recHitWireDist,
+                                                                             simHitGlobalPos.eta(),
+                                                                             simHitGlobalPos.phi(),
+                                                                             recHitErr,
+                                                                             wireId.station());
           }
         } else {
           hResTot = histograms.hRes_S3RZ.get();
@@ -630,21 +582,35 @@ void DTRecHitQuality::compute(
             hRes = histograms.hRes_S3RZ_W2.get();
           }
           if (local_) {
-            histograms.hRes_S3RZWS[abs(wheel)][wireId.station() - 1]->fill(
-                simHitWireDist, simHitTheta, simHitFEDist, recHitWireDist,
-                simHitGlobalPos.eta(), simHitGlobalPos.phi(), recHitErr,
-                wireId.station());
+            histograms.hRes_S3RZWS[abs(wheel)][wireId.station() - 1]->fill(simHitWireDist,
+                                                                           simHitTheta,
+                                                                           simHitFEDist,
+                                                                           recHitWireDist,
+                                                                           simHitGlobalPos.eta(),
+                                                                           simHitGlobalPos.phi(),
+                                                                           recHitErr,
+                                                                           wireId.station());
           }
         }
       }
 
       // Fill
-      hRes->fill(simHitWireDist, simHitTheta, simHitFEDist, recHitWireDist,
-                 simHitGlobalPos.eta(), simHitGlobalPos.phi(), recHitErr,
+      hRes->fill(simHitWireDist,
+                 simHitTheta,
+                 simHitFEDist,
+                 recHitWireDist,
+                 simHitGlobalPos.eta(),
+                 simHitGlobalPos.phi(),
+                 recHitErr,
                  wireId.station());
       if (hResTot != nullptr) {
-        hResTot->fill(simHitWireDist, simHitTheta, simHitFEDist, recHitWireDist,
-                      simHitGlobalPos.eta(), simHitGlobalPos.phi(), recHitErr,
+        hResTot->fill(simHitWireDist,
+                      simHitTheta,
+                      simHitFEDist,
+                      recHitWireDist,
+                      simHitGlobalPos.eta(),
+                      simHitGlobalPos.phi(),
+                      recHitErr,
                       wireId.station());
       }
     }
@@ -659,8 +625,7 @@ void DTRecHitQuality::compute(
           hEff = histograms.hEff_S1RPhi.get();
           if (local_) {
             histograms.hEff_S1RPhiWS[abs(wheel)][wireId.station() - 1]->fill(
-                simHitWireDist, simHitGlobalPos.eta(), simHitGlobalPos.phi(),
-                recHitReconstructed);
+                simHitWireDist, simHitGlobalPos.eta(), simHitGlobalPos.phi(), recHitReconstructed);
           }
         } else {
           hEffTot = histograms.hEff_S1RZ.get();
@@ -675,8 +640,7 @@ void DTRecHitQuality::compute(
           }
           if (local_) {
             histograms.hEff_S1RZWS[abs(wheel)][wireId.station() - 1]->fill(
-                simHitWireDist, simHitGlobalPos.eta(), simHitGlobalPos.phi(),
-                recHitReconstructed);
+                simHitWireDist, simHitGlobalPos.eta(), simHitGlobalPos.phi(), recHitReconstructed);
           }
         }
 
@@ -703,8 +667,7 @@ void DTRecHitQuality::compute(
           hEff = histograms.hEff_S3RPhi.get();
           if (local_) {
             histograms.hEff_S3RPhiWS[abs(wheel)][wireId.station() - 1]->fill(
-                simHitWireDist, simHitGlobalPos.eta(), simHitGlobalPos.phi(),
-                recHitReconstructed);
+                simHitWireDist, simHitGlobalPos.eta(), simHitGlobalPos.phi(), recHitReconstructed);
           }
         } else {
           hEffTot = histograms.hEff_S3RZ.get();
@@ -719,17 +682,14 @@ void DTRecHitQuality::compute(
           }
           if (local_) {
             histograms.hEff_S3RZWS[abs(wheel)][wireId.station() - 1]->fill(
-                simHitWireDist, simHitGlobalPos.eta(), simHitGlobalPos.phi(),
-                recHitReconstructed);
+                simHitWireDist, simHitGlobalPos.eta(), simHitGlobalPos.phi(), recHitReconstructed);
           }
         }
       }
       // Fill
-      hEff->fill(simHitWireDist, simHitGlobalPos.eta(), simHitGlobalPos.phi(),
-                 recHitReconstructed);
+      hEff->fill(simHitWireDist, simHitGlobalPos.eta(), simHitGlobalPos.phi(), recHitReconstructed);
       if (hEffTot != nullptr) {
-        hEffTot->fill(simHitWireDist, simHitGlobalPos.eta(),
-                      simHitGlobalPos.phi(), recHitReconstructed);
+        hEffTot->fill(simHitWireDist, simHitGlobalPos.eta(), simHitGlobalPos.phi(), recHitReconstructed);
       }
     }
   }

--- a/Validation/DTRecHits/plugins/DTRecHitQuality.h
+++ b/Validation/DTRecHits/plugins/DTRecHitQuality.h
@@ -29,10 +29,10 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
 namespace edm {
-class ParameterSet;
-class Event;
-class EventSetup;
-} // namespace edm
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
 class PSimHit;
 class DTLayer;
@@ -41,7 +41,7 @@ class DTGeometry;
 class HRes1DHit;
 class HEff1DHit;
 namespace dtrechit {
-struct Histograms;
+  struct Histograms;
 }
 
 class DTRecHitQuality : public DQMGlobalEDAnalyzer<dtrechit::Histograms> {
@@ -51,13 +51,13 @@ public:
 
 private:
   /// Book the DQM plots
-  void bookHistograms(DQMStore::ConcurrentBooker &, edm::Run const &,
+  void bookHistograms(DQMStore::ConcurrentBooker &,
+                      edm::Run const &,
                       edm::EventSetup const &,
                       dtrechit::Histograms &) const override;
 
   /// Perform the real analysis
-  void dqmAnalyze(edm::Event const &, edm::EventSetup const &,
-                  dtrechit::Histograms const &) const override;
+  void dqmAnalyze(edm::Event const &, edm::EventSetup const &, dtrechit::Histograms const &) const override;
 
 private:
   // Switch for debug output
@@ -83,28 +83,22 @@ private:
   bool doall_;
 
   // Return a map between DTRecHit1DPair and wireId
-  std::map<DTWireId, std::vector<DTRecHit1DPair>>
-  map1DRecHitsPerWire(const DTRecHitCollection *dt1DRecHitPairs) const;
+  std::map<DTWireId, std::vector<DTRecHit1DPair>> map1DRecHitsPerWire(const DTRecHitCollection *dt1DRecHitPairs) const;
 
   // Return a map between DTRecHit1D and wireId
-  std::map<DTWireId, std::vector<DTRecHit1D>>
-  map1DRecHitsPerWire(const DTRecSegment2DCollection *segment2Ds) const;
+  std::map<DTWireId, std::vector<DTRecHit1D>> map1DRecHitsPerWire(const DTRecSegment2DCollection *segment2Ds) const;
 
   // Return a map between DTRecHit1D and wireId
-  std::map<DTWireId, std::vector<DTRecHit1D>>
-  map1DRecHitsPerWire(const DTRecSegment4DCollection *segment4Ds) const;
+  std::map<DTWireId, std::vector<DTRecHit1D>> map1DRecHitsPerWire(const DTRecSegment4DCollection *segment4Ds) const;
 
   // Compute SimHit distance from wire (cm)
-  float simHitDistFromWire(const DTLayer *layer, const DTWireId &wireId,
-                           const PSimHit &hit) const;
+  float simHitDistFromWire(const DTLayer *layer, const DTWireId &wireId, const PSimHit &hit) const;
 
   // Compute SimHit impact angle (in direction perp to wire)
-  float simHitImpactAngle(const DTLayer *layer, const DTWireId &wireId,
-                          const PSimHit &hit) const;
+  float simHitImpactAngle(const DTLayer *layer, const DTWireId &wireId, const PSimHit &hit) const;
 
   // Compute SimHit distance from FrontEnd
-  float simHitDistFromFE(const DTLayer *layer, const DTWireId &wireId,
-                         const PSimHit &hit) const;
+  float simHitDistFromFE(const DTLayer *layer, const DTWireId &wireId, const PSimHit &hit) const;
 
   // Find the RecHit closest to the muon SimHit
   //   const DTRecHit1DPair*
@@ -113,16 +107,15 @@ private:
   //               const std::vector<DTRecHit1DPair>& recHits,
   //               const float simHitDist) const;
   template <typename type>
-  const type *findBestRecHit(const DTLayer *layer, const DTWireId &wireId,
+  const type *findBestRecHit(const DTLayer *layer,
+                             const DTWireId &wireId,
                              const std::vector<type> &recHits,
                              float simHitDist) const;
 
   // Compute the distance from wire (cm) of a hits in a DTRecHit1DPair
-  float recHitDistFromWire(const DTRecHit1DPair &hitPair,
-                           const DTLayer *layer) const;
+  float recHitDistFromWire(const DTRecHit1DPair &hitPair, const DTLayer *layer) const;
   // Compute the distance from wire (cm) of a hits in a DTRecHit1D
-  float recHitDistFromWire(const DTRecHit1D &recHit,
-                           const DTLayer *layer) const;
+  float recHitDistFromWire(const DTRecHit1D &recHit, const DTLayer *layer) const;
 
   // Return the error on the measured (cm) coordinate
   float recHitPositionError(const DTRecHit1DPair &recHit) const;
@@ -133,7 +126,8 @@ private:
   void compute(const DTGeometry *dtGeom,
                const std::map<DTWireId, std::vector<PSimHit>> &simHitsPerWire,
                const std::map<DTWireId, std::vector<type>> &recHitsPerWire,
-               dtrechit::Histograms const &histograms, int step) const;
+               dtrechit::Histograms const &histograms,
+               int step) const;
 };
 
-#endif // Validation_DTRecHits_DTRecHitQuality_h
+#endif  // Validation_DTRecHits_DTRecHitQuality_h

--- a/Validation/DTRecHits/plugins/DTSegment2DQuality.cc
+++ b/Validation/DTRecHits/plugins/DTSegment2DQuality.cc
@@ -26,20 +26,20 @@ using namespace std;
 using namespace edm;
 
 namespace dtsegment2d {
-struct Histograms {
-  std::unique_ptr<HRes2DHit> h2DHitRPhi;
-  std::unique_ptr<HRes2DHit> h2DHitRZ;
-  std::unique_ptr<HRes2DHit> h2DHitRZ_W0;
-  std::unique_ptr<HRes2DHit> h2DHitRZ_W1;
-  std::unique_ptr<HRes2DHit> h2DHitRZ_W2;
+  struct Histograms {
+    std::unique_ptr<HRes2DHit> h2DHitRPhi;
+    std::unique_ptr<HRes2DHit> h2DHitRZ;
+    std::unique_ptr<HRes2DHit> h2DHitRZ_W0;
+    std::unique_ptr<HRes2DHit> h2DHitRZ_W1;
+    std::unique_ptr<HRes2DHit> h2DHitRZ_W2;
 
-  std::unique_ptr<HEff2DHit> h2DHitEff_RPhi;
-  std::unique_ptr<HEff2DHit> h2DHitEff_RZ;
-  std::unique_ptr<HEff2DHit> h2DHitEff_RZ_W0;
-  std::unique_ptr<HEff2DHit> h2DHitEff_RZ_W1;
-  std::unique_ptr<HEff2DHit> h2DHitEff_RZ_W2;
-};
-} // namespace dtsegment2d
+    std::unique_ptr<HEff2DHit> h2DHitEff_RPhi;
+    std::unique_ptr<HEff2DHit> h2DHitEff_RZ;
+    std::unique_ptr<HEff2DHit> h2DHitEff_RZ_W0;
+    std::unique_ptr<HEff2DHit> h2DHitEff_RZ_W1;
+    std::unique_ptr<HEff2DHit> h2DHitEff_RZ_W2;
+  };
+}  // namespace dtsegment2d
 
 using namespace dtsegment2d;
 
@@ -50,12 +50,10 @@ DTSegment2DQuality::DTSegment2DQuality(const ParameterSet &pset) {
   DTHitQualityUtils::debug = debug_;
   // the name of the simhit collection
   simHitLabel_ = pset.getUntrackedParameter<InputTag>("simHitLabel");
-  simHitToken_ = consumes<PSimHitContainer>(
-      pset.getUntrackedParameter<InputTag>("simHitLabel"));
+  simHitToken_ = consumes<PSimHitContainer>(pset.getUntrackedParameter<InputTag>("simHitLabel"));
   // the name of the 2D rec hit collection
   segment2DLabel_ = pset.getUntrackedParameter<InputTag>("segment2DLabel");
-  segment2DToken_ = consumes<DTRecSegment2DCollection>(
-      pset.getUntrackedParameter<InputTag>("segment2DLabel"));
+  segment2DToken_ = consumes<DTRecSegment2DCollection>(pset.getUntrackedParameter<InputTag>("segment2DLabel"));
 
   // sigma resolution on position
   sigmaResPos_ = pset.getParameter<double>("sigmaResPos");
@@ -71,15 +69,11 @@ void DTSegment2DQuality::bookHistograms(DQMStore::ConcurrentBooker &booker,
                                         edm::Run const &run,
                                         edm::EventSetup const &setup,
                                         Histograms &histograms) const {
-  histograms.h2DHitRPhi =
-      std::make_unique<HRes2DHit>("RPhi", booker, true, true);
+  histograms.h2DHitRPhi = std::make_unique<HRes2DHit>("RPhi", booker, true, true);
   histograms.h2DHitRZ = std::make_unique<HRes2DHit>("RZ", booker, true, true);
-  histograms.h2DHitRZ_W0 =
-      std::make_unique<HRes2DHit>("RZ_W0", booker, true, true);
-  histograms.h2DHitRZ_W1 =
-      std::make_unique<HRes2DHit>("RZ_W1", booker, true, true);
-  histograms.h2DHitRZ_W2 =
-      std::make_unique<HRes2DHit>("RZ_W2", booker, true, true);
+  histograms.h2DHitRZ_W0 = std::make_unique<HRes2DHit>("RZ_W0", booker, true, true);
+  histograms.h2DHitRZ_W1 = std::make_unique<HRes2DHit>("RZ_W1", booker, true, true);
+  histograms.h2DHitRZ_W2 = std::make_unique<HRes2DHit>("RZ_W2", booker, true, true);
 
   histograms.h2DHitEff_RPhi = std::make_unique<HEff2DHit>("RPhi", booker);
   histograms.h2DHitEff_RZ = std::make_unique<HEff2DHit>("RZ", booker);
@@ -101,14 +95,13 @@ void DTSegment2DQuality::dqmAnalyze(edm::Event const &event,
 
   // Get the SimHit collection from the event
   edm::Handle<PSimHitContainer> simHits;
-  event.getByToken(simHitToken_, simHits); // FIXME: second string to be removed
+  event.getByToken(simHitToken_, simHits);  // FIXME: second string to be removed
 
   // Map simHits by sl
   map<DTSuperLayerId, PSimHitContainer> simHitsPerSl;
   for (const auto &simHit : *simHits) {
     // Create the id of the sl (the simHits in the DT known their wireId)
-    DTSuperLayerId slId =
-        ((DTWireId(simHit.detUnitId())).layerId()).superlayerId();
+    DTSuperLayerId slId = ((DTWireId(simHit.detUnitId())).layerId()).superlayerId();
     // Fill the map
     simHitsPerSl[slId].push_back(simHit);
   }
@@ -119,8 +112,8 @@ void DTSegment2DQuality::dqmAnalyze(edm::Event const &event,
 
   if (not segment2Ds.isValid()) {
     if (debug_) {
-      cout << "[DTSegment2DQuality]**Warning: no 2DSegments with label: "
-           << segment2DLabel_ << " in this event, skipping !" << endl;
+      cout << "[DTSegment2DQuality]**Warning: no 2DSegments with label: " << segment2DLabel_
+           << " in this event, skipping !" << endl;
     }
     return;
   }
@@ -128,32 +121,26 @@ void DTSegment2DQuality::dqmAnalyze(edm::Event const &event,
   // Loop over all superlayers containing a segment
   DTRecSegment2DCollection::id_iterator slId;
   for (slId = segment2Ds->id_begin(); slId != segment2Ds->id_end(); ++slId) {
-
     //------------------------- simHits ---------------------------//
     // Get simHits of each superlayer
     PSimHitContainer simHits = simHitsPerSl[(*slId)];
 
     // Map simhits per wire
-    map<DTWireId, PSimHitContainer> simHitsPerWire =
-        DTHitQualityUtils::mapSimHitsPerWire(simHits);
-    map<DTWireId, const PSimHit *> muSimHitPerWire =
-        DTHitQualityUtils::mapMuSimHitsPerWire(simHitsPerWire);
+    map<DTWireId, PSimHitContainer> simHitsPerWire = DTHitQualityUtils::mapSimHitsPerWire(simHits);
+    map<DTWireId, const PSimHit *> muSimHitPerWire = DTHitQualityUtils::mapMuSimHitsPerWire(simHitsPerWire);
     int nMuSimHit = muSimHitPerWire.size();
     if (nMuSimHit == 0 or nMuSimHit == 1) {
       if (debug_ and nMuSimHit == 1) {
-        cout << "[DTSegment2DQuality] Only " << nMuSimHit
-             << " mu SimHit in this SL, skipping !" << endl;
+        cout << "[DTSegment2DQuality] Only " << nMuSimHit << " mu SimHit in this SL, skipping !" << endl;
       }
-      continue; // If no or only one mu SimHit is found skip this SL
+      continue;  // If no or only one mu SimHit is found skip this SL
     }
     if (debug_) {
-      cout << "=== SL " << (*slId) << " has " << nMuSimHit << " SimHits"
-           << endl;
+      cout << "=== SL " << (*slId) << " has " << nMuSimHit << " SimHits" << endl;
     }
 
     // Find outer and inner mu SimHit to build a segment
-    pair<const PSimHit *, const PSimHit *> inAndOutSimHit =
-        DTHitQualityUtils::findMuSimSegment(muSimHitPerWire);
+    pair<const PSimHit *, const PSimHit *> inAndOutSimHit = DTHitQualityUtils::findMuSimSegment(muSimHitPerWire);
     // Check that outermost and innermost SimHit are not the same
     if (inAndOutSimHit.first == inAndOutSimHit.second) {
       cout << "[DTHitQualityUtils]***Warning: outermost and innermost SimHit "
@@ -164,23 +151,19 @@ void DTSegment2DQuality::dqmAnalyze(edm::Event const &event,
 
     // Find direction and position of the sim Segment in SL RF
     pair<LocalVector, LocalPoint> dirAndPosSimSegm =
-        DTHitQualityUtils::findMuSimSegmentDirAndPos(inAndOutSimHit, (*slId),
-                                                     &(*dtGeom));
+        DTHitQualityUtils::findMuSimSegmentDirAndPos(inAndOutSimHit, (*slId), &(*dtGeom));
 
     LocalVector simSegmLocalDir = dirAndPosSimSegm.first;
     LocalPoint simSegmLocalPos = dirAndPosSimSegm.second;
     if (debug_) {
-      cout << "  Simulated segment:  local direction " << simSegmLocalDir
-           << endl
-           << "                      local position  " << simSegmLocalPos
-           << endl;
+      cout << "  Simulated segment:  local direction " << simSegmLocalDir << endl
+           << "                      local position  " << simSegmLocalPos << endl;
     }
     const DTSuperLayer *superLayer = dtGeom->superLayer(*slId);
     GlobalPoint simSegmGlobalPos = superLayer->toGlobal(simSegmLocalPos);
 
     // Atan(x/z) angle and x position in SL RF
-    float angleSimSeg =
-        DTHitQualityUtils::findSegmentAlphaAndBeta(simSegmLocalDir).first;
+    float angleSimSeg = DTHitQualityUtils::findSegmentAlphaAndBeta(simSegmLocalDir).first;
     float posSimSeg = simSegmLocalPos.x();
     // Position (in eta, phi coordinates) in the global RF
     float etaSimSeg = simSegmGlobalPos.eta();
@@ -206,13 +189,11 @@ void DTSegment2DQuality::dqmAnalyze(edm::Event const &event,
       double deltaAlpha = 99999;
 
       // Loop over the recHits of this slId
-      for (DTRecSegment2DCollection::const_iterator segment2D = range.first;
-           segment2D != range.second; ++segment2D) {
+      for (DTRecSegment2DCollection::const_iterator segment2D = range.first; segment2D != range.second; ++segment2D) {
         // Check the dimension
         if ((*segment2D).dimension() != 2) {
           if (debug_) {
-            cout << "[DTSegment2DQuality]***Error: This is not 2D segment !!!"
-                 << endl;
+            cout << "[DTSegment2DQuality]***Error: This is not 2D segment !!!" << endl;
           }
           abort();
         }
@@ -220,8 +201,7 @@ void DTSegment2DQuality::dqmAnalyze(edm::Event const &event,
         LocalVector recSegDirection = (*segment2D).localDirection();
         LocalPoint recSegPosition = (*segment2D).localPosition();
 
-        float recSegAlpha =
-            DTHitQualityUtils::findSegmentAlphaAndBeta(recSegDirection).first;
+        float recSegAlpha = DTHitQualityUtils::findSegmentAlphaAndBeta(recSegDirection).first;
         if (debug_) {
           cout << "  RecSegment direction: " << recSegDirection << endl
                << "             position : " << recSegPosition << endl
@@ -233,7 +213,7 @@ void DTSegment2DQuality::dqmAnalyze(edm::Event const &event,
           bestRecHit = &(*segment2D);
           bestRecHitFound = true;
         }
-      } // End of Loop over all 2D RecHits
+      }  // End of Loop over all 2D RecHits
 
       if (bestRecHitFound) {
         // Best rechit direction and position in SL RF
@@ -243,9 +223,7 @@ void DTSegment2DQuality::dqmAnalyze(edm::Event const &event,
         LocalError bestRecHitLocalPosErr = bestRecHit->localPositionError();
         LocalError bestRecHitLocalDirErr = bestRecHit->localDirectionError();
 
-        float angleBestRHit =
-            DTHitQualityUtils::findSegmentAlphaAndBeta(bestRecHitLocalDir)
-                .first;
+        float angleBestRHit = DTHitQualityUtils::findSegmentAlphaAndBeta(bestRecHitLocalDir).first;
 
         if (fabs(angleBestRHit - angleSimSeg) < 5 * sigmaResAngle_ and
             fabs(bestRecHitLocalPos.x() - posSimSeg) < 5 * sigmaResPos_) {
@@ -254,12 +232,16 @@ void DTSegment2DQuality::dqmAnalyze(edm::Event const &event,
 
         // Fill Residual histos
         HRes2DHit *hRes = nullptr;
-        if ((*slId).superlayer() == 1 or (*slId).superlayer() == 3) { // RPhi SL
+        if ((*slId).superlayer() == 1 or (*slId).superlayer() == 3) {  // RPhi SL
           hRes = histograms.h2DHitRPhi.get();
-        } else if ((*slId).superlayer() == 2) { // RZ SL
-          histograms.h2DHitRZ->fill(angleSimSeg, angleBestRHit, posSimSeg,
-                                    bestRecHitLocalPos.x(), etaSimSeg,
-                                    phiSimSeg, sqrt(bestRecHitLocalPosErr.xx()),
+        } else if ((*slId).superlayer() == 2) {  // RZ SL
+          histograms.h2DHitRZ->fill(angleSimSeg,
+                                    angleBestRHit,
+                                    posSimSeg,
+                                    bestRecHitLocalPos.x(),
+                                    etaSimSeg,
+                                    phiSimSeg,
+                                    sqrt(bestRecHitLocalPosErr.xx()),
                                     sqrt(bestRecHitLocalDirErr.xx()));
           if (abs((*slId).wheel()) == 0) {
             hRes = histograms.h2DHitRZ_W0.get();
@@ -269,20 +251,23 @@ void DTSegment2DQuality::dqmAnalyze(edm::Event const &event,
             hRes = histograms.h2DHitRZ_W2.get();
           }
         }
-        hRes->fill(angleSimSeg, angleBestRHit, posSimSeg,
-                   bestRecHitLocalPos.x(), etaSimSeg, phiSimSeg,
+        hRes->fill(angleSimSeg,
+                   angleBestRHit,
+                   posSimSeg,
+                   bestRecHitLocalPos.x(),
+                   etaSimSeg,
+                   phiSimSeg,
                    sqrt(bestRecHitLocalPosErr.xx()),
                    sqrt(bestRecHitLocalDirErr.xx()));
       }
-    } // end of if (nsegm != 0)
+    }  // end of if (nsegm != 0)
 
     // Fill Efficiency plot
     HEff2DHit *hEff = nullptr;
-    if ((*slId).superlayer() == 1 or (*slId).superlayer() == 3) { // RPhi SL
+    if ((*slId).superlayer() == 1 or (*slId).superlayer() == 3) {  // RPhi SL
       hEff = histograms.h2DHitEff_RPhi.get();
-    } else if ((*slId).superlayer() == 2) { // RZ SL
-      histograms.h2DHitEff_RZ->fill(etaSimSeg, phiSimSeg, posSimSeg,
-                                    angleSimSeg, recHitFound);
+    } else if ((*slId).superlayer() == 2) {  // RZ SL
+      histograms.h2DHitEff_RZ->fill(etaSimSeg, phiSimSeg, posSimSeg, angleSimSeg, recHitFound);
       if (abs((*slId).wheel()) == 0) {
         hEff = histograms.h2DHitEff_RZ_W0.get();
       } else if (abs((*slId).wheel()) == 1) {
@@ -292,7 +277,7 @@ void DTSegment2DQuality::dqmAnalyze(edm::Event const &event,
       }
     }
     hEff->fill(etaSimSeg, phiSimSeg, posSimSeg, angleSimSeg, recHitFound);
-  } // End of loop over superlayers
+  }  // End of loop over superlayers
 }
 
 // declare this as a framework plugin

--- a/Validation/DTRecHits/plugins/DTSegment2DQuality.h
+++ b/Validation/DTRecHits/plugins/DTSegment2DQuality.h
@@ -19,15 +19,15 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
 namespace edm {
-class ParameterSet;
-class Event;
-class EventSetup;
-} // namespace edm
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
 class HRes2DHit;
 class HEff2DHit;
 namespace dtsegment2d {
-struct Histograms;
+  struct Histograms;
 }
 
 class DTSegment2DQuality : public DQMGlobalEDAnalyzer<dtsegment2d::Histograms> {
@@ -37,13 +37,13 @@ public:
 
 private:
   /// Book the DQM plots
-  void bookHistograms(DQMStore::ConcurrentBooker &, edm::Run const &,
+  void bookHistograms(DQMStore::ConcurrentBooker &,
+                      edm::Run const &,
                       edm::EventSetup const &,
                       dtsegment2d::Histograms &) const override;
 
   /// Perform the real analysis
-  void dqmAnalyze(edm::Event const &, edm::EventSetup const &,
-                  dtsegment2d::Histograms const &) const override;
+  void dqmAnalyze(edm::Event const &, edm::EventSetup const &, dtsegment2d::Histograms const &) const override;
 
 private:
   // Labels to read from event
@@ -62,4 +62,4 @@ private:
   bool debug_;
 };
 
-#endif // Validation_DTRecHits_DTSegment2DQuality_h
+#endif  // Validation_DTRecHits_DTSegment2DQuality_h

--- a/Validation/DTRecHits/plugins/DTSegment2DSLPhiQuality.h
+++ b/Validation/DTRecHits/plugins/DTSegment2DSLPhiQuality.h
@@ -19,32 +19,31 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
 namespace edm {
-class ParameterSet;
-class Event;
-class EventSetup;
-} // namespace edm
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
 class HRes2DHit;
 class HEff2DHit;
 namespace dtsegment2dsl {
-struct Histograms;
+  struct Histograms;
 }
 
-class DTSegment2DSLPhiQuality
-    : public DQMGlobalEDAnalyzer<dtsegment2dsl::Histograms> {
+class DTSegment2DSLPhiQuality : public DQMGlobalEDAnalyzer<dtsegment2dsl::Histograms> {
 public:
   /// Constructor
   DTSegment2DSLPhiQuality(const edm::ParameterSet &pset);
 
 private:
   /// Book the DQM plots
-  void bookHistograms(DQMStore::ConcurrentBooker &, edm::Run const &,
+  void bookHistograms(DQMStore::ConcurrentBooker &,
+                      edm::Run const &,
                       edm::EventSetup const &,
                       dtsegment2dsl::Histograms &) const override;
 
   /// Perform the real analysis
-  void dqmAnalyze(edm::Event const &, edm::EventSetup const &,
-                  dtsegment2dsl::Histograms const &) const override;
+  void dqmAnalyze(edm::Event const &, edm::EventSetup const &, dtsegment2dsl::Histograms const &) const override;
 
 private:
   // Labels to read from event
@@ -66,4 +65,4 @@ private:
   bool debug_;
 };
 
-#endif // Validation_DTRecHits_DTSegment2DSLPhiQuality_h
+#endif  // Validation_DTRecHits_DTSegment2DSLPhiQuality_h

--- a/Validation/DTRecHits/plugins/DTSegment4DQuality.cc
+++ b/Validation/DTRecHits/plugins/DTSegment4DQuality.cc
@@ -26,20 +26,20 @@ using namespace std;
 using namespace edm;
 
 namespace dtsegment4d {
-struct Histograms {
-  std::unique_ptr<HRes4DHit> h4DHit;
-  std::unique_ptr<HRes4DHit> h4DHit_W0;
-  std::unique_ptr<HRes4DHit> h4DHit_W1;
-  std::unique_ptr<HRes4DHit> h4DHit_W2;
-  std::unique_ptr<HRes4DHit> h4DHitWS[3][4];
+  struct Histograms {
+    std::unique_ptr<HRes4DHit> h4DHit;
+    std::unique_ptr<HRes4DHit> h4DHit_W0;
+    std::unique_ptr<HRes4DHit> h4DHit_W1;
+    std::unique_ptr<HRes4DHit> h4DHit_W2;
+    std::unique_ptr<HRes4DHit> h4DHitWS[3][4];
 
-  std::unique_ptr<HEff4DHit> hEff_All;
-  std::unique_ptr<HEff4DHit> hEff_W0;
-  std::unique_ptr<HEff4DHit> hEff_W1;
-  std::unique_ptr<HEff4DHit> hEff_W2;
-  std::unique_ptr<HEff4DHit> hEffWS[3][4];
-};
-} // namespace dtsegment4d
+    std::unique_ptr<HEff4DHit> hEff_All;
+    std::unique_ptr<HEff4DHit> hEff_W0;
+    std::unique_ptr<HEff4DHit> hEff_W1;
+    std::unique_ptr<HEff4DHit> hEff_W2;
+    std::unique_ptr<HEff4DHit> hEffWS[3][4];
+  };
+}  // namespace dtsegment4d
 using namespace dtsegment4d;
 
 // In phi SLs, The dependency on X and angle is specular in positive
@@ -49,7 +49,7 @@ using namespace dtsegment4d;
 // simmetrized one.
 // Set mirrorMinusWheels to avoid this.
 namespace {
-constexpr bool mirrorMinusWheels = true;
+  constexpr bool mirrorMinusWheels = true;
 }
 
 // Constructor
@@ -60,12 +60,10 @@ DTSegment4DQuality::DTSegment4DQuality(const ParameterSet &pset) {
 
   // the name of the simhit collection
   simHitLabel_ = pset.getUntrackedParameter<InputTag>("simHitLabel");
-  simHitToken_ = consumes<PSimHitContainer>(
-      pset.getUntrackedParameter<InputTag>("simHitLabel"));
+  simHitToken_ = consumes<PSimHitContainer>(pset.getUntrackedParameter<InputTag>("simHitLabel"));
   // the name of the 2D rec hit collection
   segment4DLabel_ = pset.getUntrackedParameter<InputTag>("segment4DLabel");
-  segment4DToken_ = consumes<DTRecSegment4DCollection>(
-      pset.getUntrackedParameter<InputTag>("segment4DLabel"));
+  segment4DToken_ = consumes<DTRecSegment4DCollection>(pset.getUntrackedParameter<InputTag>("segment4DLabel"));
 
   // sigma resolution on position
   sigmaResX_ = pset.getParameter<double>("sigmaResX");
@@ -81,14 +79,10 @@ void DTSegment4DQuality::bookHistograms(DQMStore::ConcurrentBooker &booker,
                                         edm::Run const &run,
                                         edm::EventSetup const &setup,
                                         Histograms &histograms) const {
-  histograms.h4DHit =
-      std::make_unique<HRes4DHit>("All", booker, doall_, local_);
-  histograms.h4DHit_W0 =
-      std::make_unique<HRes4DHit>("W0", booker, doall_, local_);
-  histograms.h4DHit_W1 =
-      std::make_unique<HRes4DHit>("W1", booker, doall_, local_);
-  histograms.h4DHit_W2 =
-      std::make_unique<HRes4DHit>("W2", booker, doall_, local_);
+  histograms.h4DHit = std::make_unique<HRes4DHit>("All", booker, doall_, local_);
+  histograms.h4DHit_W0 = std::make_unique<HRes4DHit>("W0", booker, doall_, local_);
+  histograms.h4DHit_W1 = std::make_unique<HRes4DHit>("W1", booker, doall_, local_);
+  histograms.h4DHit_W2 = std::make_unique<HRes4DHit>("W2", booker, doall_, local_);
 
   if (doall_) {
     histograms.hEff_All = std::make_unique<HEff4DHit>("All", booker);
@@ -104,10 +98,8 @@ void DTSegment4DQuality::bookHistograms(DQMStore::ConcurrentBooker &booker,
       for (long s = 1; s <= 4; ++s) {
         // FIXME station 4 is not filled
         TString nameWS = (name + w + "_St" + s);
-        histograms.h4DHitWS[w][s - 1] =
-            std::make_unique<HRes4DHit>(nameWS.Data(), booker, doall_, local_);
-        histograms.hEffWS[w][s - 1] =
-            std::make_unique<HEff4DHit>(nameWS.Data(), booker);
+        histograms.h4DHitWS[w][s - 1] = std::make_unique<HRes4DHit>(nameWS.Data(), booker, doall_, local_);
+        histograms.hEffWS[w][s - 1] = std::make_unique<HEff4DHit>(nameWS.Data(), booker);
       }
     }
   }
@@ -117,7 +109,7 @@ void DTSegment4DQuality::bookHistograms(DQMStore::ConcurrentBooker &booker,
 void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
                                     edm::EventSetup const &setup,
                                     Histograms const &histograms) const {
-  const float epsilon = 5e-5; // numerical accuracy on angles [rad}
+  const float epsilon = 5e-5;  // numerical accuracy on angles [rad}
 
   // Get the DT Geometry
   ESHandle<DTGeometry> dtGeom;
@@ -125,19 +117,16 @@ void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
 
   // Get the SimHit collection from the event
   edm::Handle<PSimHitContainer> simHits;
-  event.getByToken(simHitToken_, simHits); // FIXME: second string to be removed
+  event.getByToken(simHitToken_, simHits);  // FIXME: second string to be removed
 
   // Map simHits by chamber
   map<DTChamberId, PSimHitContainer> simHitsPerCh;
   for (const auto &simHit : *simHits) {
-
     // Consider only muon simhits; the others are not considered elsewhere in
     // this class!
     if (abs(simHit.particleType()) == 13) {
       // Create the id of the chamber (the simHits in the DT known their wireId)
-      DTChamberId chamberId =
-          (((DTWireId(simHit.detUnitId())).layerId()).superlayerId())
-              .chamberId();
+      DTChamberId chamberId = (((DTWireId(simHit.detUnitId())).layerId()).superlayerId()).chamberId();
       // Fill the map
       simHitsPerCh[chamberId].push_back(simHit);
     }
@@ -149,19 +138,18 @@ void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
 
   if (!segment4Ds.isValid()) {
     if (debug_) {
-      cout << "[DTSegment4DQuality]**Warning: no 4D Segments with label: "
-           << segment4DLabel_ << " in this event, skipping!" << endl;
+      cout << "[DTSegment4DQuality]**Warning: no 4D Segments with label: " << segment4DLabel_
+           << " in this event, skipping!" << endl;
     }
     return;
   }
 
   // Loop over all chambers containing a (muon) simhit
   for (auto &simHitsInChamber : simHitsPerCh) {
-
     DTChamberId chamberId = simHitsInChamber.first;
     int station = chamberId.station();
     if (station == 4 && !(local_)) {
-      continue; // use DTSegment2DSLPhiQuality to analyze MB4 performaces in DQM
+      continue;  // use DTSegment2DSLPhiQuality to analyze MB4 performaces in DQM
     }
     int wheel = chamberId.wheel();
 
@@ -171,20 +159,17 @@ void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
 
     // Map simhits per wire
     auto const &simHitsPerWire = DTHitQualityUtils::mapSimHitsPerWire(simHits);
-    auto const &muSimHitPerWire =
-        DTHitQualityUtils::mapMuSimHitsPerWire(simHitsPerWire);
+    auto const &muSimHitPerWire = DTHitQualityUtils::mapMuSimHitsPerWire(simHitsPerWire);
     int nMuSimHit = muSimHitPerWire.size();
-    if (nMuSimHit < 2) { // Skip chamber with less than 2 cells with mu hits
+    if (nMuSimHit < 2) {  // Skip chamber with less than 2 cells with mu hits
       continue;
     }
     if (debug_) {
-      cout << "=== Chamber " << chamberId << " has " << nMuSimHit << " SimHits"
-           << endl;
+      cout << "=== Chamber " << chamberId << " has " << nMuSimHit << " SimHits" << endl;
     }
 
     // Find outer and inner mu SimHit to build a segment
-    pair<const PSimHit *, const PSimHit *> inAndOutSimHit =
-        DTHitQualityUtils::findMuSimSegment(muSimHitPerWire);
+    pair<const PSimHit *, const PSimHit *> inAndOutSimHit = DTHitQualityUtils::findMuSimSegment(muSimHitPerWire);
 
     // Consider only sim segments crossing at least 2 SLs
     if ((DTWireId(inAndOutSimHit.first->detUnitId())).superlayer() ==
@@ -194,8 +179,7 @@ void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
 
     // Find direction and position of the sim Segment in Chamber RF
     pair<LocalVector, LocalPoint> dirAndPosSimSegm =
-        DTHitQualityUtils::findMuSimSegmentDirAndPos(inAndOutSimHit, chamberId,
-                                                     &(*dtGeom));
+        DTHitQualityUtils::findMuSimSegmentDirAndPos(inAndOutSimHit, chamberId, &(*dtGeom));
 
     LocalVector simSegmLocalDir = dirAndPosSimSegm.first;
     LocalPoint simSegmLocalPos = dirAndPosSimSegm.second;
@@ -204,10 +188,8 @@ void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
     GlobalVector simSegmGlobalDir = chamber->toGlobal(simSegmLocalDir);
 
     // phi and theta angle of simulated segment in Chamber RF
-    float alphaSimSeg =
-        DTHitQualityUtils::findSegmentAlphaAndBeta(simSegmLocalDir).first;
-    float betaSimSeg =
-        DTHitQualityUtils::findSegmentAlphaAndBeta(simSegmLocalDir).second;
+    float alphaSimSeg = DTHitQualityUtils::findSegmentAlphaAndBeta(simSegmLocalDir).first;
+    float betaSimSeg = DTHitQualityUtils::findSegmentAlphaAndBeta(simSegmLocalDir).second;
     // x, y position of simulated segment in Chamber RF
     float xSimSeg = simSegmLocalPos.x();
     float ySimSeg = simSegmLocalPos.y();
@@ -218,10 +200,8 @@ void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
     double count_seg = 0;
 
     if (debug_) {
-      cout << "  Simulated segment:  local direction " << simSegmLocalDir
-           << endl
-           << "                      local position  " << simSegmLocalPos
-           << endl
+      cout << "  Simulated segment:  local direction " << simSegmLocalDir << endl
+           << "                      local position  " << simSegmLocalPos << endl
            << "                      alpha           " << alphaSimSeg << endl
            << "                      beta            " << betaSimSeg << endl;
     }
@@ -232,8 +212,7 @@ void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
     DTRecSegment4DCollection::range range = segment4Ds->get(chamberId);
     int nsegm = distance(range.first, range.second);
     if (debug_) {
-      cout << "   Chamber: " << chamberId << " has " << nsegm << " 4D segments"
-           << endl;
+      cout << "   Chamber: " << chamberId << " has " << nsegm << " 4D segments" << endl;
     }
 
     if (nsegm != 0) {
@@ -247,9 +226,7 @@ void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
       double deltaBeta = 99999;
 
       // Loop over the recHits of this chamberId
-      for (DTRecSegment4DCollection::const_iterator segment4D = range.first;
-           segment4D != range.second; ++segment4D) {
-
+      for (DTRecSegment4DCollection::const_iterator segment4D = range.first; segment4D != range.second; ++segment4D) {
         // Consider only segments with both projections
         if (station != 4 && (*segment4D).dimension() != 4) {
           continue;
@@ -258,39 +235,29 @@ void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
         LocalVector recSegDirection = (*segment4D).localDirection();
         LocalPoint recSegPosition = (*segment4D).localPosition();
 
-        pair<double, double> ab =
-            DTHitQualityUtils::findSegmentAlphaAndBeta(recSegDirection);
+        pair<double, double> ab = DTHitQualityUtils::findSegmentAlphaAndBeta(recSegDirection);
         float recSegAlpha = ab.first;
         float recSegBeta = ab.second;
 
         if (debug_) {
-          cout << &(*segment4D) << "  RecSegment direction: " << recSegDirection
-               << endl
-               << "             position : " << (*segment4D).localPosition()
-               << endl
+          cout << &(*segment4D) << "  RecSegment direction: " << recSegDirection << endl
+               << "             position : " << (*segment4D).localPosition() << endl
                << "             alpha    : " << recSegAlpha << endl
                << "             beta     : " << recSegBeta << endl
-               << "             nhits    : "
-               << (*segment4D).phiSegment()->recHits().size() << " "
-               << (((*segment4D).zSegment() != nullptr)
-                       ? (*segment4D).zSegment()->recHits().size()
-                       : 0)
-               << endl;
+               << "             nhits    : " << (*segment4D).phiSegment()->recHits().size() << " "
+               << (((*segment4D).zSegment() != nullptr) ? (*segment4D).zSegment()->recHits().size() : 0) << endl;
         }
 
         float dAlphaRecSim = fabs(recSegAlpha - alphaSimSeg);
         float dBetaRecSim = fabs(recSegBeta - betaSimSeg);
 
         if ((fabs(recSegPosition.x() - simSegmLocalPos.x()) <
-             4) // require rec and sim segments to be ~in the same cell in x
-            &&
-            ((fabs(recSegPosition.y() - simSegmLocalPos.y()) < 4) ||
-             (*segment4D).dimension() <
-                 4)) { // ~in the same cell in y, if segment has the theta view
+             4)  // require rec and sim segments to be ~in the same cell in x
+            && ((fabs(recSegPosition.y() - simSegmLocalPos.y()) < 4) ||
+                (*segment4D).dimension() < 4)) {  // ~in the same cell in y, if segment has the theta view
           ++count_seg;
 
-          if (fabs(dAlphaRecSim - deltaAlpha) <
-              epsilon) { // Numerically equivalent alphas, choose based on beta
+          if (fabs(dAlphaRecSim - deltaAlpha) < epsilon) {  // Numerically equivalent alphas, choose based on beta
             if (dBetaRecSim < deltaBeta) {
               deltaAlpha = dAlphaRecSim;
               deltaBeta = dBetaRecSim;
@@ -304,7 +271,7 @@ void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
           }
         }
 
-      } // End of Loop over all 4D RecHits
+      }  // End of Loop over all 4D RecHits
 
       if (bestRecHit) {
         if (debug_) {
@@ -317,8 +284,7 @@ void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
         LocalError bestRecHitLocalPosErr = bestRecHit->localPositionError();
         LocalError bestRecHitLocalDirErr = bestRecHit->localDirectionError();
 
-        pair<double, double> ab =
-            DTHitQualityUtils::findSegmentAlphaAndBeta(bestRecHitLocalDir);
+        pair<double, double> ab = DTHitQualityUtils::findSegmentAlphaAndBeta(bestRecHitLocalDir);
         float alphaBestRHit = ab.first;
         float betaBestRHit = ab.second;
         // Errors on alpha and beta
@@ -332,10 +298,9 @@ void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
         LocalVector bestRecHitLocalDirRZ;
         LocalError bestRecHitLocalPosErrRZ;
         LocalError bestRecHitLocalDirErrRZ;
-        LocalPoint simSegLocalPosRZ; // FIXME: this is not set for segments with
-                                     // only the phi view.
-        float alphaBestRHitRZ =
-            0; // angle measured in the RZ SL, in its own frame
+        LocalPoint simSegLocalPosRZ;  // FIXME: this is not set for segments with
+                                      // only the phi view.
+        float alphaBestRHitRZ = 0;    // angle measured in the RZ SL, in its own frame
         float alphaSimSegRZ = betaSimSeg;
         if (zedRecSeg) {
           bestRecHitLocalPosRZ = zedRecSeg->localPosition();
@@ -345,29 +310,21 @@ void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
           bestRecHitLocalDirErrRZ = zedRecSeg->localDirectionError();
 
           // angle measured in the RZ SL, in its own frame
-          alphaBestRHitRZ =
-              DTHitQualityUtils::findSegmentAlphaAndBeta(bestRecHitLocalDirRZ)
-                  .first;
+          alphaBestRHitRZ = DTHitQualityUtils::findSegmentAlphaAndBeta(bestRecHitLocalDirRZ).first;
 
           // Get SimSeg position and Direction in rZ SL frame
-          const DTSuperLayer *sl =
-              dtGeom->superLayer(zedRecSeg->superLayerId());
+          const DTSuperLayer *sl = dtGeom->superLayer(zedRecSeg->superLayerId());
           LocalPoint simSegLocalPosRZTmp = sl->toLocal(simSegmGlobalPos);
           LocalVector simSegLocalDirRZ = sl->toLocal(simSegmGlobalDir);
           simSegLocalPosRZ =
-              simSegLocalPosRZTmp +
-              simSegLocalDirRZ *
-                  (-simSegLocalPosRZTmp.z() / (cos(simSegLocalDirRZ.theta())));
-          alphaSimSegRZ =
-              DTHitQualityUtils::findSegmentAlphaAndBeta(simSegLocalDirRZ)
-                  .first;
+              simSegLocalPosRZTmp + simSegLocalDirRZ * (-simSegLocalPosRZTmp.z() / (cos(simSegLocalDirRZ.theta())));
+          alphaSimSegRZ = DTHitQualityUtils::findSegmentAlphaAndBeta(simSegLocalDirRZ).first;
 
           if (debug_) {
-            cout << "RZ SL: recPos " << bestRecHitLocalPosRZ << "recDir "
-                 << bestRecHitLocalDirRZ << "recAlpha " << alphaBestRHitRZ
-                 << endl
-                 << "RZ SL: simPos " << simSegLocalPosRZ << "simDir "
-                 << simSegLocalDirRZ << "simAlpha " << alphaSimSegRZ << endl;
+            cout << "RZ SL: recPos " << bestRecHitLocalPosRZ << "recDir " << bestRecHitLocalDirRZ << "recAlpha "
+                 << alphaBestRHitRZ << endl
+                 << "RZ SL: simPos " << simSegLocalPosRZ << "simDir " << simSegLocalDirRZ << "simAlpha "
+                 << alphaSimSegRZ << endl;
           }
         }
 
@@ -412,51 +369,93 @@ void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
           histo = histograms.h4DHit_W2.get();
         }
 
-        float sigmaAlphaBestRhit = sqrt(DTHitQualityUtils::sigmaAngle(
-            alphaBestRHit, bestRecHitLocalDirErr.xx()));
-        float sigmaBetaBestRhit = sqrt(DTHitQualityUtils::sigmaAngle(
-            betaBestRHit,
-            bestRecHitLocalDirErr.yy())); // FIXME this misses the contribution
-                                          // from uncertainty in extrapolation!
-        float sigmaAlphaBestRhitRZ = sqrt(DTHitQualityUtils::sigmaAngle(
-            alphaBestRHitRZ, bestRecHitLocalDirErrRZ.xx()));
+        float sigmaAlphaBestRhit = sqrt(DTHitQualityUtils::sigmaAngle(alphaBestRHit, bestRecHitLocalDirErr.xx()));
+        float sigmaBetaBestRhit =
+            sqrt(DTHitQualityUtils::sigmaAngle(betaBestRHit,
+                                               bestRecHitLocalDirErr.yy()));  // FIXME this misses the contribution
+                                                                              // from uncertainty in extrapolation!
+        float sigmaAlphaBestRhitRZ = sqrt(DTHitQualityUtils::sigmaAngle(alphaBestRHitRZ, bestRecHitLocalDirErrRZ.xx()));
 
-        histo->fill(alphaSimSeg, alphaBestRHit, betaSimSeg, betaBestRHit,
-                    xSimSeg, bestRecHitLocalPos.x(), ySimSeg,
-                    bestRecHitLocalPos.y(), etaSimSeg, phiSimSeg,
-                    bestRecHitLocalPosRZ.x(), simSegLocalPosRZ.x(),
-                    alphaBestRHitRZ, alphaSimSegRZ, sigmaAlphaBestRhit,
-                    sigmaBetaBestRhit, sqrt(bestRecHitLocalPosErr.xx()),
-                    sqrt(bestRecHitLocalPosErr.yy()), sigmaAlphaBestRhitRZ,
-                    sqrt(bestRecHitLocalPosErrRZ.xx()), nHitPhi, nHitTheta,
-                    t0phi, t0theta);
+        histo->fill(alphaSimSeg,
+                    alphaBestRHit,
+                    betaSimSeg,
+                    betaBestRHit,
+                    xSimSeg,
+                    bestRecHitLocalPos.x(),
+                    ySimSeg,
+                    bestRecHitLocalPos.y(),
+                    etaSimSeg,
+                    phiSimSeg,
+                    bestRecHitLocalPosRZ.x(),
+                    simSegLocalPosRZ.x(),
+                    alphaBestRHitRZ,
+                    alphaSimSegRZ,
+                    sigmaAlphaBestRhit,
+                    sigmaBetaBestRhit,
+                    sqrt(bestRecHitLocalPosErr.xx()),
+                    sqrt(bestRecHitLocalPosErr.yy()),
+                    sigmaAlphaBestRhitRZ,
+                    sqrt(bestRecHitLocalPosErrRZ.xx()),
+                    nHitPhi,
+                    nHitTheta,
+                    t0phi,
+                    t0theta);
 
-        histograms.h4DHit->fill(
-            alphaSimSeg, alphaBestRHit, betaSimSeg, betaBestRHit, xSimSeg,
-            bestRecHitLocalPos.x(), ySimSeg, bestRecHitLocalPos.y(), etaSimSeg,
-            phiSimSeg, bestRecHitLocalPosRZ.x(), simSegLocalPosRZ.x(),
-            alphaBestRHitRZ, alphaSimSegRZ, sigmaAlphaBestRhit,
-            sigmaBetaBestRhit, sqrt(bestRecHitLocalPosErr.xx()),
-            sqrt(bestRecHitLocalPosErr.yy()), sigmaAlphaBestRhitRZ,
-            sqrt(bestRecHitLocalPosErrRZ.xx()), nHitPhi, nHitTheta, t0phi,
-            t0theta);
+        histograms.h4DHit->fill(alphaSimSeg,
+                                alphaBestRHit,
+                                betaSimSeg,
+                                betaBestRHit,
+                                xSimSeg,
+                                bestRecHitLocalPos.x(),
+                                ySimSeg,
+                                bestRecHitLocalPos.y(),
+                                etaSimSeg,
+                                phiSimSeg,
+                                bestRecHitLocalPosRZ.x(),
+                                simSegLocalPosRZ.x(),
+                                alphaBestRHitRZ,
+                                alphaSimSegRZ,
+                                sigmaAlphaBestRhit,
+                                sigmaBetaBestRhit,
+                                sqrt(bestRecHitLocalPosErr.xx()),
+                                sqrt(bestRecHitLocalPosErr.yy()),
+                                sigmaAlphaBestRhitRZ,
+                                sqrt(bestRecHitLocalPosErrRZ.xx()),
+                                nHitPhi,
+                                nHitTheta,
+                                t0phi,
+                                t0theta);
 
         if (local_) {
-          histograms.h4DHitWS[abs(wheel)][station - 1]->fill(
-              alphaSimSeg, alphaBestRHit, betaSimSeg, betaBestRHit, xSimSeg,
-              bestRecHitLocalPos.x(), ySimSeg, bestRecHitLocalPos.y(),
-              etaSimSeg, phiSimSeg, bestRecHitLocalPosRZ.x(),
-              simSegLocalPosRZ.x(), alphaBestRHitRZ, alphaSimSegRZ,
-              sigmaAlphaBestRhit, sigmaBetaBestRhit,
-              sqrt(bestRecHitLocalPosErr.xx()),
-              sqrt(bestRecHitLocalPosErr.yy()), sigmaAlphaBestRhitRZ,
-              sqrt(bestRecHitLocalPosErrRZ.xx()), nHitPhi, nHitTheta, t0phi,
-              t0theta);
+          histograms.h4DHitWS[abs(wheel)][station - 1]->fill(alphaSimSeg,
+                                                             alphaBestRHit,
+                                                             betaSimSeg,
+                                                             betaBestRHit,
+                                                             xSimSeg,
+                                                             bestRecHitLocalPos.x(),
+                                                             ySimSeg,
+                                                             bestRecHitLocalPos.y(),
+                                                             etaSimSeg,
+                                                             phiSimSeg,
+                                                             bestRecHitLocalPosRZ.x(),
+                                                             simSegLocalPosRZ.x(),
+                                                             alphaBestRHitRZ,
+                                                             alphaSimSegRZ,
+                                                             sigmaAlphaBestRhit,
+                                                             sigmaBetaBestRhit,
+                                                             sqrt(bestRecHitLocalPosErr.xx()),
+                                                             sqrt(bestRecHitLocalPosErr.yy()),
+                                                             sigmaAlphaBestRhitRZ,
+                                                             sqrt(bestRecHitLocalPosErrRZ.xx()),
+                                                             nHitPhi,
+                                                             nHitTheta,
+                                                             t0phi,
+                                                             t0theta);
         }
 
-      } // end of if (bestRecHit)
+      }  // end of if (bestRecHit)
 
-    } // end of if (nsegm!= 0)
+    }  // end of if (nsegm!= 0)
 
     // Fill Efficiency plot
     if (doall_) {
@@ -469,18 +468,15 @@ void DTSegment4DQuality::dqmAnalyze(edm::Event const &event,
       } else if (abs(wheel) == 2) {
         heff = histograms.hEff_W2.get();
       }
-      heff->fill(etaSimSeg, phiSimSeg, xSimSeg, ySimSeg, alphaSimSeg,
-                 betaSimSeg, recHitFound, count_seg);
-      histograms.hEff_All->fill(etaSimSeg, phiSimSeg, xSimSeg, ySimSeg,
-                                alphaSimSeg, betaSimSeg, recHitFound,
-                                count_seg);
+      heff->fill(etaSimSeg, phiSimSeg, xSimSeg, ySimSeg, alphaSimSeg, betaSimSeg, recHitFound, count_seg);
+      histograms.hEff_All->fill(
+          etaSimSeg, phiSimSeg, xSimSeg, ySimSeg, alphaSimSeg, betaSimSeg, recHitFound, count_seg);
       if (local_) {
         histograms.hEffWS[abs(wheel)][station - 1]->fill(
-            etaSimSeg, phiSimSeg, xSimSeg, ySimSeg, alphaSimSeg, betaSimSeg,
-            recHitFound, count_seg);
+            etaSimSeg, phiSimSeg, xSimSeg, ySimSeg, alphaSimSeg, betaSimSeg, recHitFound, count_seg);
       }
     }
-  } // End of loop over chambers
+  }  // End of loop over chambers
 }
 
 // declare this as a framework plugin

--- a/Validation/DTRecHits/plugins/DTSegment4DQuality.h
+++ b/Validation/DTRecHits/plugins/DTSegment4DQuality.h
@@ -32,15 +32,15 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
 namespace edm {
-class ParameterSet;
-class Event;
-class EventSetup;
-} // namespace edm
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
 class HRes4DHit;
 class HEff4DHit;
 namespace dtsegment4d {
-struct Histograms;
+  struct Histograms;
 }
 
 class DTSegment4DQuality : public DQMGlobalEDAnalyzer<dtsegment4d::Histograms> {
@@ -50,13 +50,13 @@ public:
 
 private:
   /// Book the DQM plots
-  void bookHistograms(DQMStore::ConcurrentBooker &, edm::Run const &,
+  void bookHistograms(DQMStore::ConcurrentBooker &,
+                      edm::Run const &,
                       edm::EventSetup const &,
                       dtsegment4d::Histograms &) const override;
 
   /// Perform the real analysis
-  void dqmAnalyze(edm::Event const &, edm::EventSetup const &,
-                  dtsegment4d::Histograms const &) const override;
+  void dqmAnalyze(edm::Event const &, edm::EventSetup const &, dtsegment4d::Histograms const &) const override;
 
 private:
   // Labels to read from event

--- a/Validation/DTRecHits/plugins/Histograms.h
+++ b/Validation/DTRecHits/plugins/Histograms.h
@@ -19,8 +19,7 @@
 
 //---------------------------------------------------------------------------------------
 /// Function to fill an efficiency histograms with binomial errors
-inline void divide(MonitorElement *eff, const MonitorElement *numerator,
-                   const MonitorElement *denominator) {
+inline void divide(MonitorElement *eff, const MonitorElement *numerator, const MonitorElement *denominator) {
   TH1 *effH = eff->getTH1();
   TH1 *numH = numerator->getTH1();
   TH1 *denH = denominator->getTH1();
@@ -44,64 +43,47 @@ inline void divide(MonitorElement *eff, const MonitorElement *numerator,
 /// A set of histograms of residuals and pulls for 1D RecHits
 class HRes1DHit {
 public:
-  HRes1DHit(const std::string &name, DQMStore::ConcurrentBooker &booker,
-            bool doall = true, bool local = true) {
+  HRes1DHit(const std::string &name, DQMStore::ConcurrentBooker &booker, bool doall = true, bool local = true) {
     std::string pre = "1D_";
     pre += name;
     doall_ = doall;
     booker.setCurrentFolder("DT/1DRecHits/Res/");
     if (doall) {
-      hDist = booker.book1D(pre + "_hDist", "1D RHit distance from wire", 100,
-                            0, 2.5);
-      hResVsAngle = booker.book2D(pre + "_hResVsAngle",
-                                  "1D RHit residual vs impact angle", 100, -1.2,
-                                  1.2, 100, -0.2, 0.2);
-      hResVsDistFE = booker.book2D(pre + "_hResVsDistFE",
-                                   "1D RHit residual vs FE distance", 100, 0.,
-                                   400., 150, -0.5, 0.5);
+      hDist = booker.book1D(pre + "_hDist", "1D RHit distance from wire", 100, 0, 2.5);
+      hResVsAngle =
+          booker.book2D(pre + "_hResVsAngle", "1D RHit residual vs impact angle", 100, -1.2, 1.2, 100, -0.2, 0.2);
+      hResVsDistFE =
+          booker.book2D(pre + "_hResVsDistFE", "1D RHit residual vs FE distance", 100, 0., 400., 150, -0.5, 0.5);
       booker.setCurrentFolder("DT/1DRecHits/Pull/");
-      hPullVsPos =
-          booker.book2D(pre + "_hPullVsPos", "1D RHit pull vs position", 100, 0,
-                        2.5, 100, -5, 5);
-      hPullVsAngle =
-          booker.book2D(pre + "_hPullVsAngle", "1D RHit pull vs impact angle",
-                        100, -1.2, 1.2, 100, -5, 5);
-      hPullVsDistFE =
-          booker.book2D(pre + "_hPullVsDistFE", "1D RHit pull vs FE distance",
-                        100, 0., 400., 100, -5, 5);
+      hPullVsPos = booker.book2D(pre + "_hPullVsPos", "1D RHit pull vs position", 100, 0, 2.5, 100, -5, 5);
+      hPullVsAngle = booker.book2D(pre + "_hPullVsAngle", "1D RHit pull vs impact angle", 100, -1.2, 1.2, 100, -5, 5);
+      hPullVsDistFE = booker.book2D(pre + "_hPullVsDistFE", "1D RHit pull vs FE distance", 100, 0., 400., 100, -5, 5);
     }
     booker.setCurrentFolder("DT/1DRecHits/Res/");
     hRes = booker.book1D(pre + "_hRes", "1D RHit residual", 300, -0.5, 0.5);
-    hResSt[0] =
-        booker.book1D(pre + "_hResMB1", "1D RHit residual", 300, -0.5, 0.5);
-    hResSt[1] =
-        booker.book1D(pre + "_hResMB2", "1D RHit residual", 300, -0.5, 0.5);
-    hResSt[2] =
-        booker.book1D(pre + "_hResMB3", "1D RHit residual", 300, -0.5, 0.5);
-    hResSt[3] =
-        booker.book1D(pre + "_hResMB4", "1D RHit residual", 300, -0.5, 0.5);
-    hResVsEta = booker.book2D(pre + "_hResVsEta", "1D RHit residual vs eta", 50,
-                              -1.25, 1.25, 150, -0.5, 0.5);
-    hResVsPhi = booker.book2D(pre + "_hResVsPhi", "1D RHit residual vs phi",
-                              100, -3.2, 3.2, 150, -0.5, 0.5);
-    hResVsPos =
-        booker.book2D(pre + "_hResVsPos", "1D RHit residual vs position", 100,
-                      0, 2.5, 150, -0.5, 0.5);
+    hResSt[0] = booker.book1D(pre + "_hResMB1", "1D RHit residual", 300, -0.5, 0.5);
+    hResSt[1] = booker.book1D(pre + "_hResMB2", "1D RHit residual", 300, -0.5, 0.5);
+    hResSt[2] = booker.book1D(pre + "_hResMB3", "1D RHit residual", 300, -0.5, 0.5);
+    hResSt[3] = booker.book1D(pre + "_hResMB4", "1D RHit residual", 300, -0.5, 0.5);
+    hResVsEta = booker.book2D(pre + "_hResVsEta", "1D RHit residual vs eta", 50, -1.25, 1.25, 150, -0.5, 0.5);
+    hResVsPhi = booker.book2D(pre + "_hResVsPhi", "1D RHit residual vs phi", 100, -3.2, 3.2, 150, -0.5, 0.5);
+    hResVsPos = booker.book2D(pre + "_hResVsPos", "1D RHit residual vs position", 100, 0, 2.5, 150, -0.5, 0.5);
 
     booker.setCurrentFolder("DT/1DRecHits/Pull/");
     hPull = booker.book1D(pre + "_hPull", "1D RHit pull", 100, -5, 5);
-    hPullSt[0] =
-        booker.book1D(pre + "_hPullMB1", "1D RHit residual", 100, -5, 5);
-    hPullSt[1] =
-        booker.book1D(pre + "_hPullMB2", "1D RHit residual", 100, -5, 5);
-    hPullSt[2] =
-        booker.book1D(pre + "_hPullMB3", "1D RHit residual", 100, -5, 5);
-    hPullSt[3] =
-        booker.book1D(pre + "_hPullMB4", "1D RHit residual", 100, -5, 5);
+    hPullSt[0] = booker.book1D(pre + "_hPullMB1", "1D RHit residual", 100, -5, 5);
+    hPullSt[1] = booker.book1D(pre + "_hPullMB2", "1D RHit residual", 100, -5, 5);
+    hPullSt[2] = booker.book1D(pre + "_hPullMB3", "1D RHit residual", 100, -5, 5);
+    hPullSt[3] = booker.book1D(pre + "_hPullMB4", "1D RHit residual", 100, -5, 5);
   }
 
-  void fill(float distSimHit, float thetaSimHit, float distFESimHit,
-            float distRecHit, float etaSimHit, float phiSimHit, float errRecHit,
+  void fill(float distSimHit,
+            float thetaSimHit,
+            float distFESimHit,
+            float distRecHit,
+            float etaSimHit,
+            float phiSimHit,
+            float errRecHit,
             int station) {
     // Reso, pull
     float res = distRecHit - distSimHit;
@@ -157,27 +139,16 @@ public:
     pre += name;
     name_ = pre;
     booker.setCurrentFolder("DT/1DRecHits/");
-    hEtaMuSimHit = booker.book1D(pre + "_hEtaMuSimHit",
-                                 "SimHit Eta distribution", 100, -1.5, 1.5);
-    hEtaRecHit =
-        booker.book1D(pre + "_hEtaRecHit",
-                      "SimHit Eta distribution with 1D RecHit", 100, -1.5, 1.5);
-    hPhiMuSimHit = booker.book1D(pre + "_hPhiMuSimHit",
-                                 "SimHit Phi distribution", 100, -M_PI, M_PI);
-    hPhiRecHit = booker.book1D(pre + "_hPhiRecHit",
-                               "SimHit Phi distribution with 1D RecHit", 100,
-                               -M_PI, M_PI);
-    hDistMuSimHit =
-        booker.book1D(pre + "_hDistMuSimHit",
-                      "SimHit Distance from wire distribution", 100, 0, 2.5);
-    hDistRecHit = booker.book1D(
-        pre + "_hDistRecHit",
-        "SimHit Distance from wire distribution with 1D RecHit", 100, 0, 2.5);
+    hEtaMuSimHit = booker.book1D(pre + "_hEtaMuSimHit", "SimHit Eta distribution", 100, -1.5, 1.5);
+    hEtaRecHit = booker.book1D(pre + "_hEtaRecHit", "SimHit Eta distribution with 1D RecHit", 100, -1.5, 1.5);
+    hPhiMuSimHit = booker.book1D(pre + "_hPhiMuSimHit", "SimHit Phi distribution", 100, -M_PI, M_PI);
+    hPhiRecHit = booker.book1D(pre + "_hPhiRecHit", "SimHit Phi distribution with 1D RecHit", 100, -M_PI, M_PI);
+    hDistMuSimHit = booker.book1D(pre + "_hDistMuSimHit", "SimHit Distance from wire distribution", 100, 0, 2.5);
+    hDistRecHit =
+        booker.book1D(pre + "_hDistRecHit", "SimHit Distance from wire distribution with 1D RecHit", 100, 0, 2.5);
   }
 
-  void fill(float distSimHit, float etaSimHit, float phiSimHit,
-            bool fillRecHit) {
-
+  void fill(float distSimHit, float etaSimHit, float phiSimHit, bool fillRecHit) {
     hEtaMuSimHit.fill(etaSimHit);
     hPhiMuSimHit.fill(phiSimHit);
     hDistMuSimHit.fill(distSimHit);
@@ -205,33 +176,23 @@ private:
 /// A set of histograms fo efficiency computation for 1D RecHits (harvesting)
 class HEff1DHitHarvest {
 public:
-  HEff1DHitHarvest(const std::string &name, DQMStore::IBooker &booker,
-                   DQMStore::IGetter &getter) {
+  HEff1DHitHarvest(const std::string &name, DQMStore::IBooker &booker, DQMStore::IGetter &getter) {
     std::string pre = "1D_";
     pre += name;
     name_ = pre;
     booker.setCurrentFolder("DT/1DRecHits/");
-    hEffVsEta = booker.book1D(pre + "_hEffVsEta",
-                              "1D RecHit Efficiency as a function of Eta", 100,
-                              -1.5, 1.5);
-    hEffVsPhi = booker.book1D(pre + "_hEffVsPhi",
-                              "1D RecHit Efficiency as a function of Phi", 100,
-                              -M_PI, M_PI);
-    hEffVsDist = booker.book1D(pre + "_hEffVsDist",
-                               "1D RecHit Efficiency as a function of Dist",
-                               100, 0, 2.5);
+    hEffVsEta = booker.book1D(pre + "_hEffVsEta", "1D RecHit Efficiency as a function of Eta", 100, -1.5, 1.5);
+    hEffVsPhi = booker.book1D(pre + "_hEffVsPhi", "1D RecHit Efficiency as a function of Phi", 100, -M_PI, M_PI);
+    hEffVsDist = booker.book1D(pre + "_hEffVsDist", "1D RecHit Efficiency as a function of Dist", 100, 0, 2.5);
 
     computeEfficiency(getter);
   }
 
   void computeEfficiency(DQMStore::IGetter &getter) {
     std::string pre = "DT/1DRecHits/" + name_;
-    divide(hEffVsEta, getter.get(pre + "_hEtaMuRecHit"),
-           getter.get(pre + "_hEtaMuSimHit"));
-    divide(hEffVsPhi, getter.get(pre + "_hPhiMuRecHit"),
-           getter.get(pre + "_hPhiMuSimHit"));
-    divide(hEffVsDist, getter.get(pre + "_hDistMuRecHit"),
-           getter.get(pre + "_hDistMuSimHit"));
+    divide(hEffVsEta, getter.get(pre + "_hEtaMuRecHit"), getter.get(pre + "_hEtaMuSimHit"));
+    divide(hEffVsPhi, getter.get(pre + "_hPhiMuRecHit"), getter.get(pre + "_hPhiMuSimHit"));
+    divide(hEffVsDist, getter.get(pre + "_hDistMuRecHit"), getter.get(pre + "_hDistMuSimHit"));
   }
 
 private:
@@ -246,68 +207,77 @@ private:
 // Histos of residuals for 2D rechits
 class HRes2DHit {
 public:
-  HRes2DHit(const std::string &name, DQMStore::ConcurrentBooker &booker,
-            bool doall = true, bool local = true) {
+  HRes2DHit(const std::string &name, DQMStore::ConcurrentBooker &booker, bool doall = true, bool local = true) {
     doall_ = doall;
     std::string pre = "2D_";
     pre += name;
     booker.setCurrentFolder("DT/2DSegments/Res/");
     if (doall) {
-      hRecAngle = booker.book1D(
-          pre + "_hRecAngle", "Distribution of Rec segment angles;angle (rad)",
-          100, -1.5, 1.5);
-      hSimAngle = booker.book1D(
-          pre + "_hSimAngle",
-          "Distribution of segment angles from SimHits;angle (rad)", 100, -1.5,
-          1.5);
-      hRecVsSimAngle = booker.book2D(pre + "_hRecVsSimAngle",
-                                     "Rec angle vs sim angle;angle (rad)", 100,
-                                     -1.5, 1.5, 100, -1.5, 1.5);
-      hResAngleVsEta =
-          booker.book2D(pre + "_hResAngleVsEta",
-                        "Residual on 2D segment angle vs Eta; #eta; res (rad)",
-                        100, -2.5, 2.5, 200, -0.2, 0.2);
-      hResAngleVsPhi = booker.book2D(
-          pre + "_hResAngleVsPhi",
-          "Residual on 2D segment angle vs Phi; #phi (rad);res (rad)", 100,
-          -3.2, 3.2, 150, -0.2, 0.2);
-      hResPosVsEta =
-          booker.book2D(pre + "_hResPosVsEta",
-                        "Residual on 2D segment position vs Eta;#eta;res (cm)",
-                        100, -2.5, 2.5, 150, -0.2, 0.2);
-      hResPosVsPhi = booker.book2D(
-          pre + "_hResPosVsPhi",
-          "Residual on 2D segment position vs Phi;#phi (rad);res (cm)", 100,
-          -3.2, 3.2, 150, -0.2, 0.2);
-      hResPosVsResAngle =
-          booker.book2D(pre + "_hResPosVsResAngle",
-                        "Residual on 2D segment position vs Residual on 2D "
-                        "segment angle;angle (rad);res (cm)",
-                        100, -0.3, 0.3, 150, -0.2, 0.2);
+      hRecAngle = booker.book1D(pre + "_hRecAngle", "Distribution of Rec segment angles;angle (rad)", 100, -1.5, 1.5);
+      hSimAngle =
+          booker.book1D(pre + "_hSimAngle", "Distribution of segment angles from SimHits;angle (rad)", 100, -1.5, 1.5);
+      hRecVsSimAngle =
+          booker.book2D(pre + "_hRecVsSimAngle", "Rec angle vs sim angle;angle (rad)", 100, -1.5, 1.5, 100, -1.5, 1.5);
+      hResAngleVsEta = booker.book2D(pre + "_hResAngleVsEta",
+                                     "Residual on 2D segment angle vs Eta; #eta; res (rad)",
+                                     100,
+                                     -2.5,
+                                     2.5,
+                                     200,
+                                     -0.2,
+                                     0.2);
+      hResAngleVsPhi = booker.book2D(pre + "_hResAngleVsPhi",
+                                     "Residual on 2D segment angle vs Phi; #phi (rad);res (rad)",
+                                     100,
+                                     -3.2,
+                                     3.2,
+                                     150,
+                                     -0.2,
+                                     0.2);
+      hResPosVsEta = booker.book2D(
+          pre + "_hResPosVsEta", "Residual on 2D segment position vs Eta;#eta;res (cm)", 100, -2.5, 2.5, 150, -0.2, 0.2);
+      hResPosVsPhi = booker.book2D(pre + "_hResPosVsPhi",
+                                   "Residual on 2D segment position vs Phi;#phi (rad);res (cm)",
+                                   100,
+                                   -3.2,
+                                   3.2,
+                                   150,
+                                   -0.2,
+                                   0.2);
+      hResPosVsResAngle = booker.book2D(pre + "_hResPosVsResAngle",
+                                        "Residual on 2D segment position vs Residual on 2D "
+                                        "segment angle;angle (rad);res (cm)",
+                                        100,
+                                        -0.3,
+                                        0.3,
+                                        150,
+                                        -0.2,
+                                        0.2);
     }
     hResAngle = booker.book1D(
-        pre + "_hResAngle",
-        "Residual on 2D segment angle;angle_{rec}-angle_{sim} (rad)", 50, -0.01,
-        0.01);
+        pre + "_hResAngle", "Residual on 2D segment angle;angle_{rec}-angle_{sim} (rad)", 50, -0.01, 0.01);
     hResPos = booker.book1D(
-        pre + "_hResPos",
-        "Residual on 2D segment position (x at SL center);x_{rec}-x_{sim} (cm)",
-        150, -0.2, 0.2);
+        pre + "_hResPos", "Residual on 2D segment position (x at SL center);x_{rec}-x_{sim} (cm)", 150, -0.2, 0.2);
 
     booker.setCurrentFolder("DT/2DSegments/Pull/");
     hPullAngle = booker.book1D(
-        pre + "_hPullAngle",
-        "Pull on 2D segment angle;(angle_{rec}-angle_{sim})/#sigma (rad)", 150,
-        -5, 5);
+        pre + "_hPullAngle", "Pull on 2D segment angle;(angle_{rec}-angle_{sim})/#sigma (rad)", 150, -5, 5);
     hPullPos = booker.book1D(pre + "_hPullPos",
                              "Pull on 2D segment position (x at SL "
                              "center);(x_{rec}-x_{sim} (cm))/#sigma",
-                             150, -5, 5);
+                             150,
+                             -5,
+                             5);
   }
 
-  void fill(float angleSimSegment, float angleRecSegment, float posSimSegment,
-            float posRecSegment, float etaSimSegment, float phiSimSegment,
-            float sigmaPos, float sigmaAngle) {
+  void fill(float angleSimSegment,
+            float angleRecSegment,
+            float posSimSegment,
+            float posRecSegment,
+            float etaSimSegment,
+            float phiSimSegment,
+            float sigmaPos,
+            float sigmaAngle) {
     float resAngle = angleRecSegment - angleSimSegment;
     hResAngle.fill(resAngle);
     float resPos = posRecSegment - posSimSegment;
@@ -353,32 +323,20 @@ public:
     pre += name;
     name_ = pre;
     booker.setCurrentFolder("DT/2DSegments/");
-    hEtaSimSegm = booker.book1D(pre + "_hEtaSimSegm", "Eta of SimHit segment",
-                                100, -1.5, 1.5);
-    hEtaRecHit = booker.book1D(
-        pre + "_hEtaRecHit",
-        "Eta distribution of SimHit segment with 2D RecHit", 100, -1.5, 1.5);
-    hPhiSimSegm = booker.book1D(pre + "_hPhiSimSegm", "Phi of SimHit segment",
-                                100, -M_PI, M_PI);
-    hPhiRecHit = booker.book1D(
-        pre + "_hPhiRecHit",
-        "Phi distribution of SimHit segment with 2D RecHit", 100, -M_PI, M_PI);
-    hPosSimSegm =
-        booker.book1D(pre + "_hPosSimSegm",
-                      "Position in SL of SimHit segment (cm)", 100, -250, 250);
-    hPosRecHit = booker.book1D(
-        pre + "_hPosRecHit",
-        "Position in SL of SimHit segment with 2D RecHit (cm)", 100, -250, 250);
-    hAngleSimSegm = booker.book1D(pre + "_hAngleSimSegm",
-                                  "Angle of SimHit segment (rad)", 100, -2, 2);
-    hAngleRecHit = booker.book1D(pre + "_hAngleRecHit",
-                                 "Angle of SimHit segment with 2D RecHit (rad)",
-                                 100, -2, 2);
+    hEtaSimSegm = booker.book1D(pre + "_hEtaSimSegm", "Eta of SimHit segment", 100, -1.5, 1.5);
+    hEtaRecHit =
+        booker.book1D(pre + "_hEtaRecHit", "Eta distribution of SimHit segment with 2D RecHit", 100, -1.5, 1.5);
+    hPhiSimSegm = booker.book1D(pre + "_hPhiSimSegm", "Phi of SimHit segment", 100, -M_PI, M_PI);
+    hPhiRecHit =
+        booker.book1D(pre + "_hPhiRecHit", "Phi distribution of SimHit segment with 2D RecHit", 100, -M_PI, M_PI);
+    hPosSimSegm = booker.book1D(pre + "_hPosSimSegm", "Position in SL of SimHit segment (cm)", 100, -250, 250);
+    hPosRecHit =
+        booker.book1D(pre + "_hPosRecHit", "Position in SL of SimHit segment with 2D RecHit (cm)", 100, -250, 250);
+    hAngleSimSegm = booker.book1D(pre + "_hAngleSimSegm", "Angle of SimHit segment (rad)", 100, -2, 2);
+    hAngleRecHit = booker.book1D(pre + "_hAngleRecHit", "Angle of SimHit segment with 2D RecHit (rad)", 100, -2, 2);
   }
 
-  void fill(float etaSimSegm, float phiSimSegm, float posSimSegm,
-            float angleSimSegm, bool fillRecHit) {
-
+  void fill(float etaSimSegm, float phiSimSegm, float posSimSegm, float angleSimSegm, bool fillRecHit) {
     hEtaSimSegm.fill(etaSimSegm);
     hPhiSimSegm.fill(phiSimSegm);
     hPosSimSegm.fill(posSimSegm);
@@ -409,38 +367,26 @@ private:
 // Histos for 2D RecHit efficiency (harvesting)
 class HEff2DHitHarvest {
 public:
-  HEff2DHitHarvest(const std::string &name, DQMStore::IBooker &booker,
-                   DQMStore::IGetter &getter) {
+  HEff2DHitHarvest(const std::string &name, DQMStore::IBooker &booker, DQMStore::IGetter &getter) {
     std::string pre = "2D_";
     pre += name;
     name_ = pre;
     booker.setCurrentFolder("DT/2DSegments/");
-    hEffVsEta = booker.book1D(pre + "_hEffVsEta",
-                              "2D RecHit Efficiency as a function of Eta", 100,
-                              -1.5, 1.5);
-    hEffVsPhi = booker.book1D(pre + "_hEffVsPhi",
-                              "2D RecHit Efficiency as a function of Phi", 100,
-                              -M_PI, M_PI);
-    hEffVsPos = booker.book1D(
-        pre + "_hEffVsPos",
-        "2D RecHit Efficiency as a function of position in SL", 100, -250, 250);
-    hEffVsAngle = booker.book1D(pre + "_hEffVsAngle",
-                                "2D RecHit Efficiency as a function of angle",
-                                100, -2, 2);
+    hEffVsEta = booker.book1D(pre + "_hEffVsEta", "2D RecHit Efficiency as a function of Eta", 100, -1.5, 1.5);
+    hEffVsPhi = booker.book1D(pre + "_hEffVsPhi", "2D RecHit Efficiency as a function of Phi", 100, -M_PI, M_PI);
+    hEffVsPos =
+        booker.book1D(pre + "_hEffVsPos", "2D RecHit Efficiency as a function of position in SL", 100, -250, 250);
+    hEffVsAngle = booker.book1D(pre + "_hEffVsAngle", "2D RecHit Efficiency as a function of angle", 100, -2, 2);
 
     computeEfficiency(getter);
   }
 
   void computeEfficiency(DQMStore::IGetter &getter) {
     std::string pre = "DT/2DSegments/" + name_;
-    divide(hEffVsEta, getter.get(pre + "_hEtaRecHit"),
-           getter.get(pre + "_hEtaSimSegm"));
-    divide(hEffVsPhi, getter.get(pre + "_hPhiRecHit"),
-           getter.get(pre + "_hPhiSimSegm"));
-    divide(hEffVsPos, getter.get(pre + "_hPosRecHit"),
-           getter.get(pre + "_hPosSimSegm"));
-    divide(hEffVsAngle, getter.get(pre + "_hAngleRecHit"),
-           getter.get(pre + "_hAngleSimSegm"));
+    divide(hEffVsEta, getter.get(pre + "_hEtaRecHit"), getter.get(pre + "_hEtaSimSegm"));
+    divide(hEffVsPhi, getter.get(pre + "_hPhiRecHit"), getter.get(pre + "_hPhiSimSegm"));
+    divide(hEffVsPos, getter.get(pre + "_hPosRecHit"), getter.get(pre + "_hPosSimSegm"));
+    divide(hEffVsAngle, getter.get(pre + "_hAngleRecHit"), getter.get(pre + "_hAngleSimSegm"));
   }
 
 private:
@@ -456,8 +402,7 @@ private:
 // Histos of residuals for 4D rechits
 class HRes4DHit {
 public:
-  HRes4DHit(const std::string &name, DQMStore::ConcurrentBooker &booker,
-            bool doall = true, bool local = true)
+  HRes4DHit(const std::string &name, DQMStore::ConcurrentBooker &booker, bool doall = true, bool local = true)
       : local_(local) {
     std::string pre = "4D_";
     pre += name;
@@ -466,245 +411,350 @@ public:
     booker.setCurrentFolder("DT/4DSegments/Res/");
     if (doall) {
       hRecAlpha =
-          booker.book1D(pre + "_hRecAlpha",
-                        "4D RecHit alpha (RPhi) distribution;#alpha^{x} (rad)",
-                        100, -1.5, 1.5);
-      hRecBeta = booker.book1D(pre + "_hRecBeta",
-                               "4D RecHit beta distribution:#alpha^{y} (rad)",
-                               100, -1.5, 1.5);
+          booker.book1D(pre + "_hRecAlpha", "4D RecHit alpha (RPhi) distribution;#alpha^{x} (rad)", 100, -1.5, 1.5);
+      hRecBeta = booker.book1D(pre + "_hRecBeta", "4D RecHit beta distribution:#alpha^{y} (rad)", 100, -1.5, 1.5);
 
       hSimAlpha = booker.book1D(
-          pre + "_hSimAlpha",
-          "4D segment from SimHit alpha (RPhi) distribution;i#alpha^{x} (rad)",
-          100, -1.5, 1.5);
-      hSimBeta = booker.book1D(
-          pre + "_hSimBeta",
-          "4D segment from SimHit beta distribution;#alpha^{y} (rad)", 100,
-          -1.5, 1.5);
-      hRecVsSimAlpha = booker.book2D(
-          pre + "_hRecVsSimAlpha",
-          "4D segment rec alpha {v}s sim alpha (RPhi);#alpha^{x} (rad)", 100,
-          -1.5, 1.5, 100, -1.5, 1.5);
-      hRecVsSimBeta =
-          booker.book2D(pre + "_hRecVsSimBeta",
-                        "4D segment rec beta vs sim beta (RZ);#alpha^{y} (rad)",
-                        100, -1.5, 1.5, 100, -1.5, 1.5);
+          pre + "_hSimAlpha", "4D segment from SimHit alpha (RPhi) distribution;i#alpha^{x} (rad)", 100, -1.5, 1.5);
+      hSimBeta =
+          booker.book1D(pre + "_hSimBeta", "4D segment from SimHit beta distribution;#alpha^{y} (rad)", 100, -1.5, 1.5);
+      hRecVsSimAlpha = booker.book2D(pre + "_hRecVsSimAlpha",
+                                     "4D segment rec alpha {v}s sim alpha (RPhi);#alpha^{x} (rad)",
+                                     100,
+                                     -1.5,
+                                     1.5,
+                                     100,
+                                     -1.5,
+                                     1.5);
+      hRecVsSimBeta = booker.book2D(pre + "_hRecVsSimBeta",
+                                    "4D segment rec beta vs sim beta (RZ);#alpha^{y} (rad)",
+                                    100,
+                                    -1.5,
+                                    1.5,
+                                    100,
+                                    -1.5,
+                                    1.5);
 
-      hResAlphaVsEta =
-          booker.book2D(pre + "_hResAlphaVsEta",
-                        "4D RecHit residual on #alpha_x direction vs "
-                        "eta;#eta;#alpha^{x}_{rec}-#alpha^{x}_{sim} (rad)",
-                        100, -2.5, 2.5, 100, -0.025, 0.025);
-      hResAlphaVsPhi = booker.book2D(
-          pre + "_hResAlphaVsPhi",
-          "4D RecHit residual on #alpha_x direction vs phi (rad);#phi "
-          "(rad);#alpha^{x}_{rec}-#alpha^{x}_{sim} (rad)",
-          100, -3.2, 3.2, 100, -0.025, 0.025);
-      hResBetaVsEta =
-          booker.book2D(pre + "_hResBetaVsEta",
-                        "4D RecHit residual on beta direction vs "
-                        "eta;#eta;#alpha^{y}_{rec}-#alpha^{y}_{sim} (rad)",
-                        100, -2.5, 2.5, 200, -0.2, 0.2);
-      hResBetaVsPhi =
-          booker.book2D(pre + "_hResBetaVsPhi",
-                        "4D RecHit residual on beta direction vs phi;#phi "
-                        "(rad);#alpha^{y}_{rec}-#alpha^{y}_{sim} (rad)",
-                        100, -3.2, 3.2, 200, -0.2, 0.2);
+      hResAlphaVsEta = booker.book2D(pre + "_hResAlphaVsEta",
+                                     "4D RecHit residual on #alpha_x direction vs "
+                                     "eta;#eta;#alpha^{x}_{rec}-#alpha^{x}_{sim} (rad)",
+                                     100,
+                                     -2.5,
+                                     2.5,
+                                     100,
+                                     -0.025,
+                                     0.025);
+      hResAlphaVsPhi = booker.book2D(pre + "_hResAlphaVsPhi",
+                                     "4D RecHit residual on #alpha_x direction vs phi (rad);#phi "
+                                     "(rad);#alpha^{x}_{rec}-#alpha^{x}_{sim} (rad)",
+                                     100,
+                                     -3.2,
+                                     3.2,
+                                     100,
+                                     -0.025,
+                                     0.025);
+      hResBetaVsEta = booker.book2D(pre + "_hResBetaVsEta",
+                                    "4D RecHit residual on beta direction vs "
+                                    "eta;#eta;#alpha^{y}_{rec}-#alpha^{y}_{sim} (rad)",
+                                    100,
+                                    -2.5,
+                                    2.5,
+                                    200,
+                                    -0.2,
+                                    0.2);
+      hResBetaVsPhi = booker.book2D(pre + "_hResBetaVsPhi",
+                                    "4D RecHit residual on beta direction vs phi;#phi "
+                                    "(rad);#alpha^{y}_{rec}-#alpha^{y}_{sim} (rad)",
+                                    100,
+                                    -3.2,
+                                    3.2,
+                                    200,
+                                    -0.2,
+                                    0.2);
 
       hResXVsEta = booker.book2D(pre + "_hResXVsEta",
                                  "4D RecHit residual on position (x) in "
                                  "chamber vs eta;#eta;x_{rec}-x_{sim} (cm)",
-                                 100, -2.5, 2.5, 150, -0.3, 0.3);
-      hResXVsPhi =
-          booker.book2D(pre + "_hResXVsPhi",
-                        "4D RecHit residual on position (x) in chamber vs "
-                        "phi;#phi (rad);x_{rec}-x_{sim} (cm)",
-                        100, -3.2, 3.2, 150, -0.3, 0.3);
+                                 100,
+                                 -2.5,
+                                 2.5,
+                                 150,
+                                 -0.3,
+                                 0.3);
+      hResXVsPhi = booker.book2D(pre + "_hResXVsPhi",
+                                 "4D RecHit residual on position (x) in chamber vs "
+                                 "phi;#phi (rad);x_{rec}-x_{sim} (cm)",
+                                 100,
+                                 -3.2,
+                                 3.2,
+                                 150,
+                                 -0.3,
+                                 0.3);
 
       hResYVsEta = booker.book2D(pre + "_hResYVsEta",
                                  "4D RecHit residual on position (y) in "
                                  "chamber vs eta;#eta;y_{rec}-y_{sim} (cm)",
-                                 100, -2.5, 2.5, 150, -0.6, 0.6);
-      hResYVsPhi =
-          booker.book2D(pre + "_hResYVsPhi",
-                        "4D RecHit residual on position (y) in chamber vs "
-                        "phi;#phi (rad);y_{rec}-y_{sim} (cm)",
-                        100, -3.2, 3.2, 150, -0.6, 0.6);
+                                 100,
+                                 -2.5,
+                                 2.5,
+                                 150,
+                                 -0.6,
+                                 0.6);
+      hResYVsPhi = booker.book2D(pre + "_hResYVsPhi",
+                                 "4D RecHit residual on position (y) in chamber vs "
+                                 "phi;#phi (rad);y_{rec}-y_{sim} (cm)",
+                                 100,
+                                 -3.2,
+                                 3.2,
+                                 150,
+                                 -0.6,
+                                 0.6);
 
-      hResAlphaVsResBeta =
-          booker.book2D(pre + "_hResAlphaVsResBeta",
-                        "4D RecHit residual on alpha vs residual on beta", 200,
-                        -0.3, 0.3, 500, -0.15, 0.15);
-      hResXVsResY = booker.book2D(pre + "_hResXVsResY",
-                                  "4D RecHit residual on X vs residual on Y",
-                                  150, -0.6, 0.6, 50, -0.3, 0.3);
-      hResAlphaVsResX =
-          booker.book2D(pre + "_hResAlphaVsResX",
-                        "4D RecHit residual on alpha vs residual on x", 150,
-                        -0.3, 0.3, 500, -0.15, 0.15);
+      hResAlphaVsResBeta = booker.book2D(pre + "_hResAlphaVsResBeta",
+                                         "4D RecHit residual on alpha vs residual on beta",
+                                         200,
+                                         -0.3,
+                                         0.3,
+                                         500,
+                                         -0.15,
+                                         0.15);
+      hResXVsResY = booker.book2D(
+          pre + "_hResXVsResY", "4D RecHit residual on X vs residual on Y", 150, -0.6, 0.6, 50, -0.3, 0.3);
+      hResAlphaVsResX = booker.book2D(
+          pre + "_hResAlphaVsResX", "4D RecHit residual on alpha vs residual on x", 150, -0.3, 0.3, 500, -0.15, 0.15);
 
-      hResAlphaVsResY =
-          booker.book2D(pre + "_hResAlphaVsResY",
-                        "4D RecHit residual on alpha vs residual on y", 150,
-                        -0.6, 0.6, 500, -0.15, 0.15);
+      hResAlphaVsResY = booker.book2D(
+          pre + "_hResAlphaVsResY", "4D RecHit residual on alpha vs residual on y", 150, -0.6, 0.6, 500, -0.15, 0.15);
 
-      hRecBetaRZ = booker.book1D(pre + "_hRecBetaRZ",
-                                 "4D RecHit beta distribution:#alpha^{y} (rad)",
-                                 100, -1.5, 1.5);
+      hRecBetaRZ = booker.book1D(pre + "_hRecBetaRZ", "4D RecHit beta distribution:#alpha^{y} (rad)", 100, -1.5, 1.5);
 
       hSimBetaRZ = booker.book1D(
-          pre + "_hSimBetaRZ",
-          "4D segment from SimHit beta distribution in RZ SL;#alpha^{y} (rad)",
-          100, -1.5, 1.5);
-      hRecVsSimBetaRZ = booker.book2D(
-          pre + "_hRecVsSimBetaRZ",
-          "4D segment rec beta vs sim beta (RZ) in RZ SL;#alpha^{y} (rad)", 100,
-          -1.5, 1.5, 100, -1.5, 1.5);
+          pre + "_hSimBetaRZ", "4D segment from SimHit beta distribution in RZ SL;#alpha^{y} (rad)", 100, -1.5, 1.5);
+      hRecVsSimBetaRZ = booker.book2D(pre + "_hRecVsSimBetaRZ",
+                                      "4D segment rec beta vs sim beta (RZ) in RZ SL;#alpha^{y} (rad)",
+                                      100,
+                                      -1.5,
+                                      1.5,
+                                      100,
+                                      -1.5,
+                                      1.5);
 
-      hResBetaVsEtaRZ =
-          booker.book2D(pre + "_hResBetaVsEtaRZ",
-                        "4D RecHit residual on beta direction vs eta;#eta in "
-                        "RZ SL;#alpha^{y}_{rec}-#alpha^{y}_{sim} (rad)",
-                        100, -2.5, 2.5, 200, -0.2, 0.2);
-      hResBetaVsPhiRZ =
-          booker.book2D(pre + "_hResBetaVsPhiRZ",
-                        "4D RecHit residual on beta direction vs phi in RZ "
-                        "SL;#phi (rad);#alpha^{y}_{rec}-#alpha^{y}_{sim} (rad)",
-                        100, -3.2, 3.2, 200, -0.2, 0.2);
-      hResYVsEtaRZ =
-          booker.book2D(pre + "_hResYVsEtaRZ",
-                        "4D RecHit residual on position (y) in chamber vs eta "
-                        "in RZ SL;#eta;y_{rec}-y_{sim} (cm)",
-                        100, -2.5, 2.5, 150, -0.6, 0.6);
-      hResYVsPhiRZ =
-          booker.book2D(pre + "_hResYVsPhiRZ",
-                        "4D RecHit residual on position (y) in chamber vs phi "
-                        "in RZ SL;#phi (rad);y_{rec}-y_{sim} (cm)",
-                        100, -3.2, 3.2, 150, -0.6, 0.6);
+      hResBetaVsEtaRZ = booker.book2D(pre + "_hResBetaVsEtaRZ",
+                                      "4D RecHit residual on beta direction vs eta;#eta in "
+                                      "RZ SL;#alpha^{y}_{rec}-#alpha^{y}_{sim} (rad)",
+                                      100,
+                                      -2.5,
+                                      2.5,
+                                      200,
+                                      -0.2,
+                                      0.2);
+      hResBetaVsPhiRZ = booker.book2D(pre + "_hResBetaVsPhiRZ",
+                                      "4D RecHit residual on beta direction vs phi in RZ "
+                                      "SL;#phi (rad);#alpha^{y}_{rec}-#alpha^{y}_{sim} (rad)",
+                                      100,
+                                      -3.2,
+                                      3.2,
+                                      200,
+                                      -0.2,
+                                      0.2);
+      hResYVsEtaRZ = booker.book2D(pre + "_hResYVsEtaRZ",
+                                   "4D RecHit residual on position (y) in chamber vs eta "
+                                   "in RZ SL;#eta;y_{rec}-y_{sim} (cm)",
+                                   100,
+                                   -2.5,
+                                   2.5,
+                                   150,
+                                   -0.6,
+                                   0.6);
+      hResYVsPhiRZ = booker.book2D(pre + "_hResYVsPhiRZ",
+                                   "4D RecHit residual on position (y) in chamber vs phi "
+                                   "in RZ SL;#phi (rad);y_{rec}-y_{sim} (cm)",
+                                   100,
+                                   -3.2,
+                                   3.2,
+                                   150,
+                                   -0.6,
+                                   0.6);
 
       booker.setCurrentFolder("DT/4DSegments/Pull/");
-      hPullAlphaVsEta =
-          booker.book2D(pre + "_hPullAlphaVsEta",
-                        "4D RecHit pull on #alpha_x direction vs "
-                        "eta;#eta;(#alpha^{x}_{rec}-#alpha^{x}_{sim})/#sigma",
-                        100, -2.5, 2.5, 100, -5, 5);
-      hPullAlphaVsPhi = booker.book2D(
-          pre + "_hPullAlphaVsPhi",
-          "4D RecHit pull on #alpha_x direction vs phi (rad);#phi "
-          "(rad);(#alpha^{x}_{rec}-#alpha^{x}_{sim})/#sigma",
-          100, -3.2, 3.2, 100, -5, 5);
-      hPullBetaVsEta =
-          booker.book2D(pre + "_hPullBetaVsEta",
-                        "4D RecHit pull on beta direction vs "
-                        "eta;#eta;(#alpha^{y}_{rec}-#alpha^{y}_{sim})/#sigma",
-                        100, -2.5, 2.5, 200, -5, 5);
-      hPullBetaVsPhi =
-          booker.book2D(pre + "_hPullBetaVsPhi",
-                        "4D RecHit pull on beta direction vs phi;#phi "
-                        "(rad);(#alpha^{y}_{rec}-#alpha^{y}_{sim})/#sigma",
-                        100, -3.2, 3.2, 200, -5, 5);
+      hPullAlphaVsEta = booker.book2D(pre + "_hPullAlphaVsEta",
+                                      "4D RecHit pull on #alpha_x direction vs "
+                                      "eta;#eta;(#alpha^{x}_{rec}-#alpha^{x}_{sim})/#sigma",
+                                      100,
+                                      -2.5,
+                                      2.5,
+                                      100,
+                                      -5,
+                                      5);
+      hPullAlphaVsPhi = booker.book2D(pre + "_hPullAlphaVsPhi",
+                                      "4D RecHit pull on #alpha_x direction vs phi (rad);#phi "
+                                      "(rad);(#alpha^{x}_{rec}-#alpha^{x}_{sim})/#sigma",
+                                      100,
+                                      -3.2,
+                                      3.2,
+                                      100,
+                                      -5,
+                                      5);
+      hPullBetaVsEta = booker.book2D(pre + "_hPullBetaVsEta",
+                                     "4D RecHit pull on beta direction vs "
+                                     "eta;#eta;(#alpha^{y}_{rec}-#alpha^{y}_{sim})/#sigma",
+                                     100,
+                                     -2.5,
+                                     2.5,
+                                     200,
+                                     -5,
+                                     5);
+      hPullBetaVsPhi = booker.book2D(pre + "_hPullBetaVsPhi",
+                                     "4D RecHit pull on beta direction vs phi;#phi "
+                                     "(rad);(#alpha^{y}_{rec}-#alpha^{y}_{sim})/#sigma",
+                                     100,
+                                     -3.2,
+                                     3.2,
+                                     200,
+                                     -5,
+                                     5);
       hPullXVsEta = booker.book2D(pre + "_hPullXVsEta",
                                   "4D RecHit pull on position (x) in chamber "
                                   "vs eta;#eta;(x_{rec}-x_{sim})#sigma",
-                                  100, -2.5, 2.5, 150, -5, 5);
+                                  100,
+                                  -2.5,
+                                  2.5,
+                                  150,
+                                  -5,
+                                  5);
       hPullXVsPhi = booker.book2D(pre + "_hPullXVsPhi",
                                   "4D RecHit pull on position (x) in chamber "
                                   "vs phi;#phi (rad);(x_{rec}-x_{sim})/#sigma",
-                                  100, -3.2, 3.2, 150, -5, 5);
+                                  100,
+                                  -3.2,
+                                  3.2,
+                                  150,
+                                  -5,
+                                  5);
       hPullYVsEta = booker.book2D(pre + "_hPullYVsEta",
                                   "4D RecHit pull on position (y) in chamber "
                                   "vs eta;#eta;(y_{rec}-y_{sim})/#sigma",
-                                  100, -2.5, 2.5, 150, -5, 5);
+                                  100,
+                                  -2.5,
+                                  2.5,
+                                  150,
+                                  -5,
+                                  5);
       hPullYVsPhi = booker.book2D(pre + "_hPullYVsPhi",
                                   "4D RecHit pull on position (y) in chamber "
                                   "vs phi;#phi (rad);(y_{rec}-y_{sim})/#sigma",
-                                  100, -3.2, 3.2, 150, -5, 5);
-      hPullBetaVsEtaRZ =
-          booker.book2D(pre + "_hPullBetaVsEtaRZ",
-                        "4D RecHit pull on beta direction vs eta;#eta in RZ "
-                        "SL;(#alpha^{y}_{rec}-#alpha^{y}_{sim})/#sigma",
-                        100, -2.5, 2.5, 200, -5, 5);
-      hPullBetaVsPhiRZ =
-          booker.book2D(pre + "_hPullBetaVsPhiRZ",
-                        "4D RecHit pull on beta direction vs phi in RZ SL;#phi "
-                        "(rad);(#alpha^{y}_{rec}-#alpha^{y}_{sim})/#sigma",
-                        100, -3.2, 3.2, 200, -5, 5);
-      hPullYVsEtaRZ =
-          booker.book2D(pre + "_hPullYVsEtaRZ",
-                        "4D RecHit pull on position (y) in chamber vs eta in "
-                        "RZ SL;#eta;(y_{rec}-y_{sim})/#sigma",
-                        100, -2.5, 2.5, 150, -5, 5);
-      hPullYVsPhiRZ =
-          booker.book2D(pre + "_hPullYVsPhiRZ",
-                        "4D RecHit pull on position (y) in chamber vs phi in "
-                        "RZ SL;#phi (rad);(y_{rec}-y_{sim})/#sigma",
-                        100, -3.2, 3.2, 150, -5, 5);
+                                  100,
+                                  -3.2,
+                                  3.2,
+                                  150,
+                                  -5,
+                                  5);
+      hPullBetaVsEtaRZ = booker.book2D(pre + "_hPullBetaVsEtaRZ",
+                                       "4D RecHit pull on beta direction vs eta;#eta in RZ "
+                                       "SL;(#alpha^{y}_{rec}-#alpha^{y}_{sim})/#sigma",
+                                       100,
+                                       -2.5,
+                                       2.5,
+                                       200,
+                                       -5,
+                                       5);
+      hPullBetaVsPhiRZ = booker.book2D(pre + "_hPullBetaVsPhiRZ",
+                                       "4D RecHit pull on beta direction vs phi in RZ SL;#phi "
+                                       "(rad);(#alpha^{y}_{rec}-#alpha^{y}_{sim})/#sigma",
+                                       100,
+                                       -3.2,
+                                       3.2,
+                                       200,
+                                       -5,
+                                       5);
+      hPullYVsEtaRZ = booker.book2D(pre + "_hPullYVsEtaRZ",
+                                    "4D RecHit pull on position (y) in chamber vs eta in "
+                                    "RZ SL;#eta;(y_{rec}-y_{sim})/#sigma",
+                                    100,
+                                    -2.5,
+                                    2.5,
+                                    150,
+                                    -5,
+                                    5);
+      hPullYVsPhiRZ = booker.book2D(pre + "_hPullYVsPhiRZ",
+                                    "4D RecHit pull on position (y) in chamber vs phi in "
+                                    "RZ SL;#phi (rad);(y_{rec}-y_{sim})/#sigma",
+                                    100,
+                                    -3.2,
+                                    3.2,
+                                    150,
+                                    -5,
+                                    5);
     }
     booker.setCurrentFolder("DT/4DSegments/Res/");
-    hResAlpha =
-        booker.book1D(pre + "_hResAlpha",
-                      "4D RecHit residual on #alpha_x "
-                      "direction;#alpha^{x}_{rec}-#alpha^{x}_{sim} (rad)",
-                      200, -0.015, 0.015);
+    hResAlpha = booker.book1D(pre + "_hResAlpha",
+                              "4D RecHit residual on #alpha_x "
+                              "direction;#alpha^{x}_{rec}-#alpha^{x}_{sim} (rad)",
+                              200,
+                              -0.015,
+                              0.015);
 
-    hResBeta =
-        booker.book1D(pre + "_hResBeta",
-                      "4D RecHit residual on beta "
-                      "direction;#alpha^{y}_{rec}-#alpha^{y}_{sim} (rad)",
-                      200, -0.1, 0.1);
+    hResBeta = booker.book1D(pre + "_hResBeta",
+                             "4D RecHit residual on beta "
+                             "direction;#alpha^{y}_{rec}-#alpha^{y}_{sim} (rad)",
+                             200,
+                             -0.1,
+                             0.1);
     hResX = booker.book1D(
-        pre + "_hResX",
-        "4D RecHit residual on position (x) in chamber;x_{rec}-x_{sim} (cm)",
-        150, -0.15, 0.15);
+        pre + "_hResX", "4D RecHit residual on position (x) in chamber;x_{rec}-x_{sim} (cm)", 150, -0.15, 0.15);
     hResY = booker.book1D(
-        pre + "_hResY",
-        "4D RecHit residual on position (y) in chamber;y_{rec}-y_{sim} (cm)",
-        150, -0.6, 0.6);
+        pre + "_hResY", "4D RecHit residual on position (y) in chamber;y_{rec}-y_{sim} (cm)", 150, -0.6, 0.6);
 
     // histo in rz SL reference frame.
     hResBetaRZ = booker.book1D(pre + "_hResBetaRZ",
                                "4D RecHit residual on beta direction in RZ "
                                "SL;#alpha^{y}_{rec}-#alpha^{y}_{sim} (rad)",
-                               200, -0.1, 0.1);
+                               200,
+                               -0.1,
+                               0.1);
 
     hResYRZ = booker.book1D(pre + "_hResYRZ",
                             "4D RecHit residual on position (y) in chamber in "
                             "RZ SL;y_{rec}-y_{sim} (cm)",
-                            150, -0.15, 0.15);
+                            150,
+                            -0.15,
+                            0.15);
 
     // Pulls
     booker.setCurrentFolder("DT/4DSegments/Pull/");
 
-    hPullAlpha =
-        booker.book1D(pre + "_hPullAlpha",
-                      "4D RecHit pull on #alpha_x "
-                      "direction;(#alpha^{x}_{rec}-#alpha^{x}_{sim})/#sigma",
-                      200, -5, 5);
-    hPullBeta =
-        booker.book1D(pre + "_hPullBeta",
-                      "4D RecHit pull on beta "
-                      "direction;(#alpha^{y}_{rec}-#alpha^{y}_{sim})/#sigma",
-                      200, -5, 5);
+    hPullAlpha = booker.book1D(pre + "_hPullAlpha",
+                               "4D RecHit pull on #alpha_x "
+                               "direction;(#alpha^{x}_{rec}-#alpha^{x}_{sim})/#sigma",
+                               200,
+                               -5,
+                               5);
+    hPullBeta = booker.book1D(pre + "_hPullBeta",
+                              "4D RecHit pull on beta "
+                              "direction;(#alpha^{y}_{rec}-#alpha^{y}_{sim})/#sigma",
+                              200,
+                              -5,
+                              5);
 
-    hPullX = booker.book1D(
-        pre + "_hPullX",
-        "4D RecHit pull on position (x) in chamber;(x_{rec}-x_{sim})#sigma",
-        150, -5, 5);
+    hPullX =
+        booker.book1D(pre + "_hPullX", "4D RecHit pull on position (x) in chamber;(x_{rec}-x_{sim})#sigma", 150, -5, 5);
 
     hPullY = booker.book1D(
-        pre + "_hPullY",
-        "4D RecHit pull on position (y) in chamber;(y_{rec}-y_{sim})/#sigma",
-        150, -5, 5);
+        pre + "_hPullY", "4D RecHit pull on position (y) in chamber;(y_{rec}-y_{sim})/#sigma", 150, -5, 5);
 
     hPullBetaRZ = booker.book1D(pre + "_hPullBetaRZ",
                                 "4D RecHit pull on beta direction in RZ "
                                 "SL;(#alpha^{y}_{rec}-#alpha^{y}_{sim})/#sigma",
-                                200, -5, 5);
+                                200,
+                                -5,
+                                5);
 
     hPullYRZ = booker.book1D(pre + "_hPullYRZ",
                              "4D RecHit pull on position (y) in chamber in RZ "
                              "SL;(y_{rec}-y_{sim})/#sigma",
-                             150, -5, 5);
+                             150,
+                             -5,
+                             5);
 
     // NHits, t0
     if (local_) {
@@ -714,13 +764,30 @@ public:
     }
   }
 
-  void fill(float simDirectionAlpha, float recDirectionAlpha,
-            float simDirectionBeta, float recDirectionBeta, float simX,
-            float recX, float simY, float recY, float simEta, float simPhi,
-            float recYRZ, float simYRZ, float recBetaRZ, float simBetaRZ,
-            float sigmaAlpha, float sigmaBeta, float sigmaX, float sigmaY,
-            float sigmaBetaRZ, float sigmaYRZ, int nHitsPhi, int nHitsTheta,
-            float t0Phi, float t0Theta) {
+  void fill(float simDirectionAlpha,
+            float recDirectionAlpha,
+            float simDirectionBeta,
+            float recDirectionBeta,
+            float simX,
+            float recX,
+            float simY,
+            float recY,
+            float simEta,
+            float simPhi,
+            float recYRZ,
+            float simYRZ,
+            float recBetaRZ,
+            float simBetaRZ,
+            float sigmaAlpha,
+            float sigmaBeta,
+            float sigmaX,
+            float sigmaY,
+            float sigmaBetaRZ,
+            float sigmaYRZ,
+            int nHitsPhi,
+            int nHitsTheta,
+            float t0Phi,
+            float t0Theta) {
     float resAlpha = recDirectionAlpha - simDirectionAlpha;
     hResAlpha.fill(resAlpha);
     hPullAlpha.fill(resAlpha / sigmaAlpha);
@@ -857,53 +924,39 @@ public:
     pre += name;
     name_ = pre;
     booker.setCurrentFolder("DT/4DSegments/");
-    hEtaSimSegm = booker.book1D(pre + "_hEtaSimSegm", "Eta of SimHit segment",
-                                100, -1.5, 1.5);
-    hEtaRecHit = booker.book1D(
-        pre + "_hEtaRecHit",
-        "Eta distribution of SimHit segment with 4D RecHit", 100, -1.5, 1.5);
+    hEtaSimSegm = booker.book1D(pre + "_hEtaSimSegm", "Eta of SimHit segment", 100, -1.5, 1.5);
+    hEtaRecHit =
+        booker.book1D(pre + "_hEtaRecHit", "Eta distribution of SimHit segment with 4D RecHit", 100, -1.5, 1.5);
 
-    hPhiSimSegm = booker.book1D(pre + "_hPhiSimSegm", "Phi of SimHit segment",
-                                100, -M_PI, M_PI);
-    hPhiRecHit = booker.book1D(
-        pre + "_hPhiRecHit",
-        "Phi distribution of SimHit segment with 4D RecHit", 100, -M_PI, M_PI);
+    hPhiSimSegm = booker.book1D(pre + "_hPhiSimSegm", "Phi of SimHit segment", 100, -M_PI, M_PI);
+    hPhiRecHit =
+        booker.book1D(pre + "_hPhiRecHit", "Phi distribution of SimHit segment with 4D RecHit", 100, -M_PI, M_PI);
 
-    hXSimSegm = booker.book1D(pre + "_hXSimSegm",
-                              "X position in Chamber of SimHit segment (cm)",
-                              100, -200, 200);
-    hXRecHit = booker.book1D(
-        pre + "_hXRecHit",
-        "X position in Chamber of SimHit segment with 4D RecHit (cm)", 100,
-        -200, 200);
+    hXSimSegm = booker.book1D(pre + "_hXSimSegm", "X position in Chamber of SimHit segment (cm)", 100, -200, 200);
+    hXRecHit =
+        booker.book1D(pre + "_hXRecHit", "X position in Chamber of SimHit segment with 4D RecHit (cm)", 100, -200, 200);
 
-    hYSimSegm = booker.book1D(pre + "_hYSimSegm",
-                              "Y position in Chamber of SimHit segment (cm)",
-                              100, -200, 200);
-    hYRecHit = booker.book1D(
-        pre + "_hYRecHit",
-        "Y position in Chamber of SimHit segment with 4D RecHit (cm)", 100,
-        -200, 200);
+    hYSimSegm = booker.book1D(pre + "_hYSimSegm", "Y position in Chamber of SimHit segment (cm)", 100, -200, 200);
+    hYRecHit =
+        booker.book1D(pre + "_hYRecHit", "Y position in Chamber of SimHit segment with 4D RecHit (cm)", 100, -200, 200);
 
-    hAlphaSimSegm =
-        booker.book1D(pre + "_hAlphaSimSegm", "Alpha of SimHit segment (rad)",
-                      100, -1.5, 1.5);
-    hAlphaRecHit = booker.book1D(pre + "_hAlphaRecHit",
-                                 "Alpha of SimHit segment with 4D RecHit (rad)",
-                                 100, -1.5, 1.5);
+    hAlphaSimSegm = booker.book1D(pre + "_hAlphaSimSegm", "Alpha of SimHit segment (rad)", 100, -1.5, 1.5);
+    hAlphaRecHit = booker.book1D(pre + "_hAlphaRecHit", "Alpha of SimHit segment with 4D RecHit (rad)", 100, -1.5, 1.5);
 
-    hBetaSimSegm = booker.book1D(pre + "_hBetaSimSegm",
-                                 "Beta of SimHit segment (rad)", 100, -2, 2);
-    hBetaRecHit = booker.book1D(pre + "_hBetaRecHit",
-                                "Beta of SimHit segment with 4D RecHit (rad)",
-                                100, -2, 2);
+    hBetaSimSegm = booker.book1D(pre + "_hBetaSimSegm", "Beta of SimHit segment (rad)", 100, -2, 2);
+    hBetaRecHit = booker.book1D(pre + "_hBetaRecHit", "Beta of SimHit segment with 4D RecHit (rad)", 100, -2, 2);
 
-    hNSeg = booker.book1D(pre + "_hNSeg", "Number of rec segment per sim seg",
-                          20, 0, 20);
+    hNSeg = booker.book1D(pre + "_hNSeg", "Number of rec segment per sim seg", 20, 0, 20);
   }
 
-  void fill(float etaSimSegm, float phiSimSegm, float xSimSegm, float ySimSegm,
-            float alphaSimSegm, float betaSimSegm, bool fillRecHit, int nSeg) {
+  void fill(float etaSimSegm,
+            float phiSimSegm,
+            float xSimSegm,
+            float ySimSegm,
+            float alphaSimSegm,
+            float betaSimSegm,
+            bool fillRecHit,
+            int nSeg) {
     hEtaSimSegm.fill(etaSimSegm);
     hPhiSimSegm.fill(phiSimSegm);
     hXSimSegm.fill(xSimSegm);
@@ -945,50 +998,31 @@ private:
 /// A set of histograms for efficiency 4D RecHits (harvesting)
 class HEff4DHitHarvest {
 public:
-  HEff4DHitHarvest(const std::string &name, DQMStore::IBooker &booker,
-                   DQMStore::IGetter &getter) {
+  HEff4DHitHarvest(const std::string &name, DQMStore::IBooker &booker, DQMStore::IGetter &getter) {
     std::string pre = "4D_";
     pre += name;
     name_ = pre;
     booker.setCurrentFolder("DT/4DSegments/");
-    hEffVsEta = booker.book1D(pre + "_hEffVsEta",
-                              "4D RecHit Efficiency as a function of Eta", 100,
-                              -1.5, 1.5);
-    hEffVsPhi = booker.book1D(pre + "_hEffVsPhi",
-                              "4D RecHit Efficiency as a function of Phi", 100,
-                              -M_PI, M_PI);
-    hEffVsX = booker.book1D(
-        pre + "_hEffVsX",
-        "4D RecHit Efficiency as a function of x position in Chamber", 100,
-        -200, 200);
-    hEffVsY = booker.book1D(
-        pre + "_hEffVsY",
-        "4D RecHit Efficiency as a function of y position in Chamber", 100,
-        -200, 200);
-    hEffVsAlpha = booker.book1D(pre + "_hEffVsAlpha",
-                                "4D RecHit Efficiency as a function of alpha",
-                                100, -1.5, 1.5);
-    hEffVsBeta =
-        booker.book1D(pre + "_hEffVsBeta",
-                      "4D RecHit Efficiency as a function of beta", 100, -2, 2);
+    hEffVsEta = booker.book1D(pre + "_hEffVsEta", "4D RecHit Efficiency as a function of Eta", 100, -1.5, 1.5);
+    hEffVsPhi = booker.book1D(pre + "_hEffVsPhi", "4D RecHit Efficiency as a function of Phi", 100, -M_PI, M_PI);
+    hEffVsX =
+        booker.book1D(pre + "_hEffVsX", "4D RecHit Efficiency as a function of x position in Chamber", 100, -200, 200);
+    hEffVsY =
+        booker.book1D(pre + "_hEffVsY", "4D RecHit Efficiency as a function of y position in Chamber", 100, -200, 200);
+    hEffVsAlpha = booker.book1D(pre + "_hEffVsAlpha", "4D RecHit Efficiency as a function of alpha", 100, -1.5, 1.5);
+    hEffVsBeta = booker.book1D(pre + "_hEffVsBeta", "4D RecHit Efficiency as a function of beta", 100, -2, 2);
 
     computeEfficiency(getter);
   }
 
   void computeEfficiency(DQMStore::IGetter &getter) {
     std::string pre = "DT/4DSegments/" + name_;
-    divide(hEffVsEta, getter.get(pre + "_hEtaRecHit"),
-           getter.get(pre + "_hEtaSimSegm"));
-    divide(hEffVsPhi, getter.get(pre + "_hPhiRecHit"),
-           getter.get(pre + "_hPhiSimSegm"));
-    divide(hEffVsX, getter.get(pre + "_hXRecHit"),
-           getter.get(pre + "_hXSimSegm"));
-    divide(hEffVsY, getter.get(pre + "_hYRecHit"),
-           getter.get(pre + "_hYSimSegm"));
-    divide(hEffVsAlpha, getter.get(pre + "_hAlphaRecHit"),
-           getter.get(pre + "_hAlphaSimSegm"));
-    divide(hEffVsBeta, getter.get(pre + "_hBetaRecHit"),
-           getter.get(pre + "_hBetaSimSegm"));
+    divide(hEffVsEta, getter.get(pre + "_hEtaRecHit"), getter.get(pre + "_hEtaSimSegm"));
+    divide(hEffVsPhi, getter.get(pre + "_hPhiRecHit"), getter.get(pre + "_hPhiSimSegm"));
+    divide(hEffVsX, getter.get(pre + "_hXRecHit"), getter.get(pre + "_hXSimSegm"));
+    divide(hEffVsY, getter.get(pre + "_hYRecHit"), getter.get(pre + "_hYSimSegm"));
+    divide(hEffVsAlpha, getter.get(pre + "_hAlphaRecHit"), getter.get(pre + "_hAlphaSimSegm"));
+    divide(hEffVsBeta, getter.get(pre + "_hBetaRecHit"), getter.get(pre + "_hBetaSimSegm"));
   }
 
 private:
@@ -1004,4 +1038,4 @@ private:
   std::string name_;
 };
 
-#endif // Validation_DTRecHits_Histograms_h
+#endif  // Validation_DTRecHits_Histograms_h

--- a/Validation/DTRecHits/src/DTHitQualityUtils.cc
+++ b/Validation/DTRecHits/src/DTHitQualityUtils.cc
@@ -20,12 +20,10 @@ std::atomic<bool> DTHitQualityUtils::debug{false};
 
 // Return a map between simhits of a layer,superlayer or chamber and the wireId
 // of their cell
-map<DTWireId, PSimHitContainer>
-DTHitQualityUtils::mapSimHitsPerWire(const PSimHitContainer &simhits) {
+map<DTWireId, PSimHitContainer> DTHitQualityUtils::mapSimHitsPerWire(const PSimHitContainer &simhits) {
   map<DTWireId, PSimHitContainer> hitWireMapResult;
 
-  for (PSimHitContainer::const_iterator simhit = simhits.begin();
-       simhit != simhits.end(); simhit++) {
+  for (PSimHitContainer::const_iterator simhit = simhits.begin(); simhit != simhits.end(); simhit++) {
     hitWireMapResult[DTWireId((*simhit).detUnitId())].push_back(*simhit);
   }
 
@@ -35,13 +33,11 @@ DTHitQualityUtils::mapSimHitsPerWire(const PSimHitContainer &simhits) {
 // Extract mu simhits from a map of simhits by wire and map them by wire
 map<DTWireId, const PSimHit *> DTHitQualityUtils::mapMuSimHitsPerWire(
     const map<DTWireId, PSimHitContainer> &simHitWireMap) {
-
   map<DTWireId, const PSimHit *> ret;
 
-  for (map<DTWireId, PSimHitContainer>::const_iterator wireAndSimHit =
-           simHitWireMap.begin();
-       wireAndSimHit != simHitWireMap.end(); wireAndSimHit++) {
-
+  for (map<DTWireId, PSimHitContainer>::const_iterator wireAndSimHit = simHitWireMap.begin();
+       wireAndSimHit != simHitWireMap.end();
+       wireAndSimHit++) {
     const PSimHit *muHit = findMuSimHit((*wireAndSimHit).second);
     if (muHit != nullptr) {
       ret[(*wireAndSimHit).first] = (muHit);
@@ -57,18 +53,16 @@ const PSimHit *DTHitQualityUtils::findMuSimHit(const PSimHitContainer &hits) {
   vector<const PSimHit *> muHits;
 
   // Loop over simhits
-  for (PSimHitContainer::const_iterator hit = hits.begin(); hit != hits.end();
-       hit++) {
+  for (PSimHitContainer::const_iterator hit = hits.begin(); hit != hits.end(); hit++) {
     if (abs((*hit).particleType()) == 13)
       muHits.push_back(&(*hit));
   }
 
   if (muHits.empty())
-    return nullptr; // FIXME: Throw of exception???
+    return nullptr;  // FIXME: Throw of exception???
   else if (muHits.size() > 1)
     if (debug)
-      cout << "[DTHitQualityUtils]***WARNING: # muSimHits in a wire = "
-           << muHits.size() << endl;
+      cout << "[DTHitQualityUtils]***WARNING: # muSimHits in a wire = " << muHits.size() << endl;
 
   return (muHits.front());
 }
@@ -77,7 +71,6 @@ const PSimHit *DTHitQualityUtils::findMuSimHit(const PSimHitContainer &hits) {
 // simulated segment)
 pair<const PSimHit *, const PSimHit *> DTHitQualityUtils::findMuSimSegment(
     const map<DTWireId, const PSimHit *> &mapWireAndMuSimHit) {
-
   int outSL = 0;
   int inSL = 4;
   int outLayer = 0;
@@ -85,10 +78,9 @@ pair<const PSimHit *, const PSimHit *> DTHitQualityUtils::findMuSimSegment(
   const PSimHit *inSimHit = nullptr;
   const PSimHit *outSimHit = nullptr;
 
-  for (map<DTWireId, const PSimHit *>::const_iterator wireAndMuSimHit =
-           mapWireAndMuSimHit.begin();
-       wireAndMuSimHit != mapWireAndMuSimHit.end(); wireAndMuSimHit++) {
-
+  for (map<DTWireId, const PSimHit *>::const_iterator wireAndMuSimHit = mapWireAndMuSimHit.begin();
+       wireAndMuSimHit != mapWireAndMuSimHit.end();
+       wireAndMuSimHit++) {
     const DTWireId wireId = (*wireAndMuSimHit).first;
     const PSimHit *theMuHit = (*wireAndMuSimHit).second;
 
@@ -121,8 +113,7 @@ pair<const PSimHit *, const PSimHit *> DTHitQualityUtils::findMuSimSegment(
 
   if (inSimHit != nullptr) {
     if (debug)
-      cout << "Innermost SimHit on SL: " << inSL << " layer: " << inLayer
-           << endl;
+      cout << "Innermost SimHit on SL: " << inSL << " layer: " << inLayer << endl;
   } else {
     cout << "[DTHitQualityUtils]***Error: No Innermost SimHit found!!!" << endl;
     abort();
@@ -130,8 +121,7 @@ pair<const PSimHit *, const PSimHit *> DTHitQualityUtils::findMuSimSegment(
 
   if (outSimHit != nullptr) {
     if (debug)
-      cout << "Outermost SimHit on SL: " << outSL << " layer: " << outLayer
-           << endl;
+      cout << "Outermost SimHit on SL: " << outSL << " layer: " << outLayer << endl;
   } else {
     cout << "[DTHitQualityUtils]***Error: No Outermost SimHit found!!!" << endl;
     abort();
@@ -149,33 +139,24 @@ pair<const PSimHit *, const PSimHit *> DTHitQualityUtils::findMuSimSegment(
 // mu SimHit in the RF of object Det (Concrete implementation of Det are MuBarSL
 // and MuBarChamber)
 pair<LocalVector, LocalPoint> DTHitQualityUtils::findMuSimSegmentDirAndPos(
-    const pair<const PSimHit *, const PSimHit *> &inAndOutSimHit,
-    const DetId detId, const DTGeometry *muonGeom) {
-
+    const pair<const PSimHit *, const PSimHit *> &inAndOutSimHit, const DetId detId, const DTGeometry *muonGeom) {
   // FIXME: What should happen if outSimHit = inSimHit???? Now, this case is not
   // considered
   const PSimHit *innermostMuSimHit = inAndOutSimHit.first;
   const PSimHit *outermostMuSimHit = inAndOutSimHit.second;
 
   // Find simulated segment direction from SimHits position
-  const DTLayer *layerIn =
-      muonGeom->layer((DTWireId(innermostMuSimHit->detUnitId())).layerId());
-  const DTLayer *layerOut =
-      muonGeom->layer((DTWireId(outermostMuSimHit->detUnitId())).layerId());
-  GlobalPoint inGlobalPos =
-      layerIn->toGlobal(innermostMuSimHit->localPosition());
-  GlobalPoint outGlobalPos =
-      layerOut->toGlobal(outermostMuSimHit->localPosition());
-  LocalVector simHitDirection =
-      (muonGeom->idToDet(detId))->toLocal(inGlobalPos - outGlobalPos);
+  const DTLayer *layerIn = muonGeom->layer((DTWireId(innermostMuSimHit->detUnitId())).layerId());
+  const DTLayer *layerOut = muonGeom->layer((DTWireId(outermostMuSimHit->detUnitId())).layerId());
+  GlobalPoint inGlobalPos = layerIn->toGlobal(innermostMuSimHit->localPosition());
+  GlobalPoint outGlobalPos = layerOut->toGlobal(outermostMuSimHit->localPosition());
+  LocalVector simHitDirection = (muonGeom->idToDet(detId))->toLocal(inGlobalPos - outGlobalPos);
   simHitDirection = -simHitDirection.unit();
 
   // SimHit position extrapolated at z=0 in the Det RF
   LocalPoint outLocalPos = (muonGeom->idToDet(detId))->toLocal(outGlobalPos);
   LocalPoint simSegLocalPosition =
-      outLocalPos +
-      simHitDirection * (-outLocalPos.z() / (simHitDirection.mag() *
-                                             cos(simHitDirection.theta())));
+      outLocalPos + simHitDirection * (-outLocalPos.z() / (simHitDirection.mag() * cos(simHitDirection.theta())));
 
   return make_pair(simHitDirection, simSegLocalPosition);
 }
@@ -184,16 +165,13 @@ pair<LocalVector, LocalPoint> DTHitQualityUtils::findMuSimSegmentDirAndPos(
 // atan(dx/dz) = "phi"   angle in the chamber RF
 // atan(dy/dz) = "theta" angle in the chamber RF (note: this has opposite sign
 // in the SLZ RF!)
-pair<double, double>
-DTHitQualityUtils::findSegmentAlphaAndBeta(const LocalVector &direction) {
-  return make_pair(atan(direction.x() / direction.z()),
-                   atan(direction.y() / direction.z()));
+pair<double, double> DTHitQualityUtils::findSegmentAlphaAndBeta(const LocalVector &direction) {
+  return make_pair(atan(direction.x() / direction.z()), atan(direction.y() / direction.z()));
 }
 
 // Find error on angle (squared) from localDirectionError, which is the error on
 // tan(Angle)
 double DTHitQualityUtils::sigmaAngle(double Angle, double sigma2TanAngle) {
-
   double XdivZ = tan(Angle);
   double sigma2Angle = 1 / (1 + XdivZ * XdivZ);
   sigma2Angle *= sigma2Angle * sigma2TanAngle;

--- a/Validation/DTRecHits/src/utils.cc
+++ b/Validation/DTRecHits/src/utils.cc
@@ -2,8 +2,7 @@
 #include "TProfile.h"
 #include "Validation/DTRecHits/interface/utils.h"
 //#include "TLine.h"
-void Tutils::drawGFit(TH1 *h1, float min, float max, float minfit,
-                      float maxfit) {
+void Tutils::drawGFit(TH1 *h1, float min, float max, float minfit, float maxfit) {
   setStyle(h1);
   static int i = 0;
   i++;
@@ -72,9 +71,9 @@ TStyle *Tutils::getStyle(const TString &name) {
     // For the canvas:
     theStyle->SetCanvasBorderMode(0);
     theStyle->SetCanvasColor(kWhite);
-    theStyle->SetCanvasDefH(600); // Height of canvas
-    theStyle->SetCanvasDefW(600); // Width of canvas
-    theStyle->SetCanvasDefX(0);   // POsition on screen
+    theStyle->SetCanvasDefH(600);  // Height of canvas
+    theStyle->SetCanvasDefW(600);  // Width of canvas
+    theStyle->SetCanvasDefX(0);    // POsition on screen
     theStyle->SetCanvasDefY(0);
 
     // For the Pad:
@@ -185,8 +184,7 @@ TStyle *Tutils::getStyle(const TString &name) {
     theStyle->SetStripDecimals(kTRUE);
     theStyle->SetTickLength(0.03, "XYZ");
     theStyle->SetNdivisions(510, "XYZ");
-    theStyle->SetPadTickX(
-        1); // To get tick marks on the opposite side of the frame
+    theStyle->SetPadTickX(1);  // To get tick marks on the opposite side of the frame
     theStyle->SetPadTickY(1);
 
     // Change for log plots:

--- a/Validation/HcalRecHits/interface/HcalRecHitsClient.h
+++ b/Validation/HcalRecHits/interface/HcalRecHitsClient.h
@@ -32,7 +32,6 @@
 class MonitorElement;
 
 class HcalRecHitsClient : public DQMEDHarvester {
-
 private:
   std::string outputFile_;
 

--- a/Validation/HcalRecHits/interface/HcalRecHitsValidation.h
+++ b/Validation/HcalRecHits/interface/HcalRecHitsValidation.h
@@ -58,8 +58,7 @@ public:
   ~HcalRecHitsValidation() override;
   void analyze(edm::Event const &ev, edm::EventSetup const &c) override;
 
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:
   virtual void fillRecHitsTmp(int subdet_, edm::Event const &ev);

--- a/Validation/HcalRecHits/interface/NoiseRates.h
+++ b/Validation/HcalRecHits/interface/NoiseRates.h
@@ -44,8 +44,7 @@ public:
   explicit NoiseRates(const edm::ParameterSet &);
   ~NoiseRates() override;
 
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
@@ -53,10 +52,10 @@ private:
   std::string outputFile_;
 
   // parameters
-  edm::InputTag rbxCollName_; // label for the rbx collection
+  edm::InputTag rbxCollName_;  // label for the rbx collection
   edm::EDGetTokenT<reco::HcalNoiseRBXCollection> tok_rbx_;
-  double minRBXEnergy_; // RBX energy threshold
-  double minHitEnergy_; // RecHit energy threshold
+  double minRBXEnergy_;  // RBX energy threshold
+  double minHitEnergy_;  // RecHit energy threshold
 
   bool useAllHistos_;
 

--- a/Validation/HcalRecHits/interface/NoiseRatesClient.h
+++ b/Validation/HcalRecHits/interface/NoiseRatesClient.h
@@ -32,7 +32,6 @@
 class MonitorElement;
 
 class NoiseRatesClient : public DQMEDHarvester {
-
 private:
   std::string outputFile_;
 

--- a/Validation/HcalRecHits/src/HcalRecHitsClient.cc
+++ b/Validation/HcalRecHits/src/HcalRecHitsClient.cc
@@ -9,11 +9,8 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 
-HcalRecHitsClient::HcalRecHitsClient(const edm::ParameterSet &iConfig)
-    : conf_(iConfig) {
-
-  outputFile_ =
-      iConfig.getUntrackedParameter<std::string>("outputFile", "myfile.root");
+HcalRecHitsClient::HcalRecHitsClient(const edm::ParameterSet &iConfig) : conf_(iConfig) {
+  outputFile_ = iConfig.getUntrackedParameter<std::string>("outputFile", "myfile.root");
 
   debug_ = false;
   verbose_ = false;
@@ -23,17 +20,12 @@ HcalRecHitsClient::HcalRecHitsClient(const edm::ParameterSet &iConfig)
 
 HcalRecHitsClient::~HcalRecHitsClient() {}
 
-void HcalRecHitsClient::dqmEndJob(DQMStore::IBooker &ib,
-                                  DQMStore::IGetter &ig) {
-  ig.setCurrentFolder(dirName_);
-}
+void HcalRecHitsClient::dqmEndJob(DQMStore::IBooker &ib, DQMStore::IGetter &ig) { ig.setCurrentFolder(dirName_); }
 
 // called after entering the HcalRecHitsV/HcalRecHitTask directory
 // hcalMEs are within that directory
-int HcalRecHitsClient::HcalRecHitsEndjob(
-    const std::vector<MonitorElement *> &hcalMEs) {
-
-  return 1; // Removed all actions
+int HcalRecHitsClient::HcalRecHitsEndjob(const std::vector<MonitorElement *> &hcalMEs) {
+  return 1;  // Removed all actions
 }
 
 DEFINE_FWK_MODULE(HcalRecHitsClient);

--- a/Validation/HcalRecHits/src/HcalRecHitsValidation.cc
+++ b/Validation/HcalRecHits/src/HcalRecHitsValidation.cc
@@ -8,47 +8,35 @@
 HcalRecHitsValidation::HcalRecHitsValidation(edm::ParameterSet const &conf)
     : topFolderName_(conf.getParameter<std::string>("TopFolderName")) {
   // DQM ROOT output
-  outputFile_ =
-      conf.getUntrackedParameter<std::string>("outputFile", "myfile.root");
+  outputFile_ = conf.getUntrackedParameter<std::string>("outputFile", "myfile.root");
 
   if (!outputFile_.empty()) {
-    edm::LogInfo("OutputInfo")
-        << " Hcal RecHit Task histograms will be saved to '"
-        << outputFile_.c_str() << "'";
+    edm::LogInfo("OutputInfo") << " Hcal RecHit Task histograms will be saved to '" << outputFile_.c_str() << "'";
   } else {
-    edm::LogInfo("OutputInfo")
-        << " Hcal RecHit Task histograms will NOT be saved";
+    edm::LogInfo("OutputInfo") << " Hcal RecHit Task histograms will NOT be saved";
   }
 
   nevtot = 0;
 
-  hcalselector_ =
-      conf.getUntrackedParameter<std::string>("hcalselector", "all");
-  ecalselector_ =
-      conf.getUntrackedParameter<std::string>("ecalselector", "yes");
+  hcalselector_ = conf.getUntrackedParameter<std::string>("hcalselector", "all");
+  ecalselector_ = conf.getUntrackedParameter<std::string>("ecalselector", "yes");
   sign_ = conf.getUntrackedParameter<std::string>("sign", "*");
   mc_ = conf.getUntrackedParameter<std::string>("mc", "yes");
   testNumber_ = conf.getParameter<bool>("TestNumber");
 
   // Collections
-  tok_hbhe_ = consumes<HBHERecHitCollection>(
-      conf.getUntrackedParameter<edm::InputTag>("HBHERecHitCollectionLabel"));
-  tok_hf_ = consumes<HFRecHitCollection>(
-      conf.getUntrackedParameter<edm::InputTag>("HFRecHitCollectionLabel"));
-  tok_ho_ = consumes<HORecHitCollection>(
-      conf.getUntrackedParameter<edm::InputTag>("HORecHitCollectionLabel"));
+  tok_hbhe_ = consumes<HBHERecHitCollection>(conf.getUntrackedParameter<edm::InputTag>("HBHERecHitCollectionLabel"));
+  tok_hf_ = consumes<HFRecHitCollection>(conf.getUntrackedParameter<edm::InputTag>("HFRecHitCollectionLabel"));
+  tok_ho_ = consumes<HORecHitCollection>(conf.getUntrackedParameter<edm::InputTag>("HORecHitCollectionLabel"));
 
   // register for data access
   tok_evt_ = consumes<edm::HepMCProduct>(edm::InputTag("generatorSmeared"));
-  edm::InputTag EBRecHitCollectionLabel =
-      conf.getParameter<edm::InputTag>("EBRecHitCollectionLabel");
+  edm::InputTag EBRecHitCollectionLabel = conf.getParameter<edm::InputTag>("EBRecHitCollectionLabel");
   tok_EB_ = consumes<EBRecHitCollection>(EBRecHitCollectionLabel);
-  edm::InputTag EERecHitCollectionLabel =
-      conf.getParameter<edm::InputTag>("EERecHitCollectionLabel");
+  edm::InputTag EERecHitCollectionLabel = conf.getParameter<edm::InputTag>("EERecHitCollectionLabel");
   tok_EE_ = consumes<EERecHitCollection>(EERecHitCollectionLabel);
 
-  tok_hh_ = consumes<edm::PCaloHitContainer>(
-      conf.getUntrackedParameter<edm::InputTag>("SimHitCollectionLabel"));
+  tok_hh_ = consumes<edm::PCaloHitContainer>(conf.getUntrackedParameter<edm::InputTag>("SimHitCollectionLabel"));
 
   subdet_ = 5;
   if (hcalselector_ == "noise")
@@ -79,10 +67,7 @@ HcalRecHitsValidation::HcalRecHitsValidation(edm::ParameterSet const &conf)
 
 HcalRecHitsValidation::~HcalRecHitsValidation() {}
 
-void HcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ib,
-                                           edm::Run const &run,
-                                           edm::EventSetup const &es) {
-
+void HcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ib, edm::Run const &run, edm::EventSetup const &es) {
   Char_t histo[200];
 
   ib.setCurrentFolder(topFolderName_);
@@ -90,89 +75,72 @@ void HcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ib,
   //======================= Now various cases one by one ===================
 
   // Histograms drawn for single pion scan
-  if (subdet_ != 0 && imc != 0) { // just not for noise
+  if (subdet_ != 0 && imc != 0) {  // just not for noise
     sprintf(histo, "HcalRecHitTask_En_rechits_cone_profile_vs_ieta_all_depths");
-    meEnConeEtaProfile =
-        ib.bookProfile(histo, histo, 83, -41.5, 41.5, -100., 2000., " ");
+    meEnConeEtaProfile = ib.bookProfile(histo, histo, 83, -41.5, 41.5, -100., 2000., " ");
 
-    sprintf(histo,
-            "HcalRecHitTask_En_rechits_cone_profile_vs_ieta_all_depths_E");
-    meEnConeEtaProfile_E =
-        ib.bookProfile(histo, histo, 83, -41.5, 41.5, -100., 2000., " ");
+    sprintf(histo, "HcalRecHitTask_En_rechits_cone_profile_vs_ieta_all_depths_E");
+    meEnConeEtaProfile_E = ib.bookProfile(histo, histo, 83, -41.5, 41.5, -100., 2000., " ");
 
-    sprintf(histo,
-            "HcalRecHitTask_En_rechits_cone_profile_vs_ieta_all_depths_EH");
-    meEnConeEtaProfile_EH =
-        ib.bookProfile(histo, histo, 83, -41.5, 41.5, -100., 2000., " ");
+    sprintf(histo, "HcalRecHitTask_En_rechits_cone_profile_vs_ieta_all_depths_EH");
+    meEnConeEtaProfile_EH = ib.bookProfile(histo, histo, 83, -41.5, 41.5, -100., 2000., " ");
   }
 
   // ************** HB **********************************
   if (subdet_ == 1 || subdet_ == 5) {
-
-    sprintf(histo, "HcalRecHitTask_M2Log10Chi2_of_rechits_HB"); //   Chi2
+    sprintf(histo, "HcalRecHitTask_M2Log10Chi2_of_rechits_HB");  //   Chi2
     meRecHitsM2Chi2HB = ib.book1D(histo, histo, 120, -2., 10.);
 
     sprintf(histo, "HcalRecHitTask_Log10Chi2_vs_energy_profile_HB");
-    meLog10Chi2profileHB =
-        ib.bookProfile(histo, histo, 300, -5., 295., -2., 9.9, " ");
+    meLog10Chi2profileHB = ib.bookProfile(histo, histo, 300, -5., 295., -2., 9.9, " ");
 
     sprintf(histo, "HcalRecHitTask_energy_of_rechits_HB");
     meRecHitsEnergyHB = ib.book1D(histo, histo, 2010, -10., 2000.);
 
     sprintf(histo, "HcalRecHitTask_timing_vs_energy_profile_HB");
-    meTEprofileHB =
-        ib.bookProfile(histo, histo, 150, -5., 295., -48., 92., " ");
+    meTEprofileHB = ib.bookProfile(histo, histo, 150, -5., 295., -48., 92., " ");
 
     sprintf(histo, "HcalRecHitTask_timing_vs_energy_profile_Low_HB");
-    meTEprofileHB_Low =
-        ib.bookProfile(histo, histo, 150, -5., 295., -48., 92., " ");
+    meTEprofileHB_Low = ib.bookProfile(histo, histo, 150, -5., 295., -48., 92., " ");
 
     sprintf(histo, "HcalRecHitTask_timing_vs_energy_profile_High_HB");
-    meTEprofileHB_High =
-        ib.bookProfile(histo, histo, 150, -5., 295., 48., 92., " ");
+    meTEprofileHB_High = ib.bookProfile(histo, histo, 150, -5., 295., 48., 92., " ");
 
     if (imc != 0) {
       sprintf(histo, "HcalRecHitTask_energy_rechits_vs_simhits_HB");
       meRecHitSimHitHB = ib.book2D(histo, histo, 120, 0., 1.2, 300, 0., 150.);
       sprintf(histo, "HcalRecHitTask_energy_rechits_vs_simhits_profile_HB");
-      meRecHitSimHitProfileHB =
-          ib.bookProfile(histo, histo, 120, 0., 1.2, 0., 500., " ");
+      meRecHitSimHitProfileHB = ib.bookProfile(histo, histo, 120, 0., 1.2, 0., 500., " ");
     }
   }
 
   // ********************** HE ************************************
   if (subdet_ == 2 || subdet_ == 5) {
-
-    sprintf(histo, "HcalRecHitTask_M2Log10Chi2_of_rechits_HE"); //   Chi2
+    sprintf(histo, "HcalRecHitTask_M2Log10Chi2_of_rechits_HE");  //   Chi2
     meRecHitsM2Chi2HE = ib.book1D(histo, histo, 120, -2., 10.);
 
     sprintf(histo, "HcalRecHitTask_Log10Chi2_vs_energy_profile_HE");
-    meLog10Chi2profileHE =
-        ib.bookProfile(histo, histo, 1000, -5., 995., -2., 9.9, " ");
+    meLog10Chi2profileHE = ib.bookProfile(histo, histo, 1000, -5., 995., -2., 9.9, " ");
 
     sprintf(histo, "HcalRecHitTask_energy_of_rechits_HE");
     meRecHitsEnergyHE = ib.book1D(histo, histo, 2010, -10., 2000.);
 
     sprintf(histo, "HcalRecHitTask_timing_vs_energy_profile_Low_HE");
-    meTEprofileHE_Low =
-        ib.bookProfile(histo, histo, 80, -5., 75., -48., 92., " ");
+    meTEprofileHE_Low = ib.bookProfile(histo, histo, 80, -5., 75., -48., 92., " ");
 
     sprintf(histo, "HcalRecHitTask_timing_vs_energy_profile_HE");
-    meTEprofileHE =
-        ib.bookProfile(histo, histo, 200, -5., 2995., -48., 92., " ");
+    meTEprofileHE = ib.bookProfile(histo, histo, 200, -5., 2995., -48., 92., " ");
 
     if (imc != 0) {
       sprintf(histo, "HcalRecHitTask_energy_rechits_vs_simhits_HE");
       meRecHitSimHitHE = ib.book2D(histo, histo, 120, 0., 0.6, 300, 0., 150.);
       sprintf(histo, "HcalRecHitTask_energy_rechits_vs_simhits_profile_HE");
-      meRecHitSimHitProfileHE =
-          ib.bookProfile(histo, histo, 120, 0., 0.6, 0., 500., " ");
+      meRecHitSimHitProfileHE = ib.bookProfile(histo, histo, 120, 0., 0.6, 0., 500., " ");
     }
   }
 
   // ************** HO ****************************************
   if (subdet_ == 3 || subdet_ == 5) {
-
     sprintf(histo, "HcalRecHitTask_energy_of_rechits_HO");
     meRecHitsEnergyHO = ib.book1D(histo, histo, 2010, -10., 2000.);
 
@@ -180,31 +148,26 @@ void HcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ib,
     meTEprofileHO = ib.bookProfile(histo, histo, 60, -5., 55., -48., 92., " ");
 
     sprintf(histo, "HcalRecHitTask_timing_vs_energy_profile_High_HO");
-    meTEprofileHO_High =
-        ib.bookProfile(histo, histo, 100, -5., 995., -48., 92., " ");
+    meTEprofileHO_High = ib.bookProfile(histo, histo, 100, -5., 995., -48., 92., " ");
 
     if (imc != 0) {
       sprintf(histo, "HcalRecHitTask_energy_rechits_vs_simhits_HO");
       meRecHitSimHitHO = ib.book2D(histo, histo, 150, 0., 1.5, 350, 0., 350.);
       sprintf(histo, "HcalRecHitTask_energy_rechits_vs_simhits_profile_HO");
-      meRecHitSimHitProfileHO =
-          ib.bookProfile(histo, histo, 150, 0., 1.5, 0., 500., " ");
+      meRecHitSimHitProfileHO = ib.bookProfile(histo, histo, 150, 0., 1.5, 0., 500., " ");
     }
   }
 
   // ********************** HF ************************************
   if (subdet_ == 4 || subdet_ == 5) {
-
     sprintf(histo, "HcalRecHitTask_energy_of_rechits_HF");
     meRecHitsEnergyHF = ib.book1D(histo, histo, 2010, -10., 2000.);
 
     sprintf(histo, "HcalRecHitTask_timing_vs_energy_profile_Low_HF");
-    meTEprofileHF_Low =
-        ib.bookProfile(histo, histo, 100, -5., 195., -48., 92., " ");
+    meTEprofileHF_Low = ib.bookProfile(histo, histo, 100, -5., 195., -48., 92., " ");
 
     sprintf(histo, "HcalRecHitTask_timing_vs_energy_profile_HF");
-    meTEprofileHF =
-        ib.bookProfile(histo, histo, 200, -5., 995., -48., 92., " ");
+    meTEprofileHF = ib.bookProfile(histo, histo, 200, -5., 995., -48., 92., " ");
 
     if (imc != 0) {
       sprintf(histo, "HcalRecHitTask_energy_rechits_vs_simhits_HF");
@@ -214,21 +177,16 @@ void HcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ib,
       sprintf(histo, "HcalRecHitTask_energy_rechits_vs_simhits_HFS");
       meRecHitSimHitHFS = ib.book2D(histo, histo, 50, 0., 50., 150, 0., 150.);
       sprintf(histo, "HcalRecHitTask_energy_rechits_vs_simhits_profile_HF");
-      meRecHitSimHitProfileHF =
-          ib.bookProfile(histo, histo, 50, 0., 50., 0., 500., " ");
+      meRecHitSimHitProfileHF = ib.bookProfile(histo, histo, 50, 0., 50., 0., 500., " ");
       sprintf(histo, "HcalRecHitTask_energy_rechits_vs_simhits_profile_HFL");
-      meRecHitSimHitProfileHFL =
-          ib.bookProfile(histo, histo, 50, 0., 50., 0., 500., " ");
+      meRecHitSimHitProfileHFL = ib.bookProfile(histo, histo, 50, 0., 50., 0., 500., " ");
       sprintf(histo, "HcalRecHitTask_energy_rechits_vs_simhits_profile_HFS");
-      meRecHitSimHitProfileHFS =
-          ib.bookProfile(histo, histo, 50, 0., 50., 0., 500., " ");
+      meRecHitSimHitProfileHFS = ib.bookProfile(histo, histo, 50, 0., 50., 0., 500., " ");
     }
   }
 }
 
-void HcalRecHitsValidation::analyze(edm::Event const &ev,
-                                    edm::EventSetup const &c) {
-
+void HcalRecHitsValidation::analyze(edm::Event const &ev, edm::EventSetup const &c) {
   using namespace edm;
 
   edm::ESHandle<HcalDDDRecConstants> pHRNDC;
@@ -261,16 +219,15 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev,
   int numrechitsEcal = 0;
 
   // MC info
-  double phi_MC = -999999.; // phi of initial particle from HepMC
-  double eta_MC = -999999.; // eta of initial particle from HepMC
+  double phi_MC = -999999.;  // phi of initial particle from HepMC
+  double eta_MC = -999999.;  // eta of initial particle from HepMC
 
   // HCAL energy around MC eta-phi at all depths;
   double partR = 0.3;
 
   if (imc != 0) {
-
     edm::Handle<edm::HepMCProduct> evtMC;
-    ev.getByToken(tok_evt_, evtMC); // generator in late 310_preX
+    ev.getByToken(tok_evt_, evtMC);  // generator in late 310_preX
     if (!evtMC.isValid()) {
       edm::LogInfo("HcalRecHitsValidation") << "no HepMCProduct found";
     } else {
@@ -281,9 +238,8 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev,
     double maxPt = -99999.;
     int npart = 0;
     const HepMC::GenEvent *myGenEvent = evtMC->GetEvent();
-    for (HepMC::GenEvent::particle_const_iterator p =
-             myGenEvent->particles_begin();
-         p != myGenEvent->particles_end(); ++p) {
+    for (HepMC::GenEvent::particle_const_iterator p = myGenEvent->particles_begin(); p != myGenEvent->particles_end();
+         ++p) {
       double phip = (*p)->momentum().phi();
       double etap = (*p)->momentum().eta();
       //    phi_MC = phip;
@@ -313,23 +269,20 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev,
   //===========================================================================
 
   // ECAL
-  if (ecalselector_ == "yes" &&
-      (subdet_ == 1 || subdet_ == 2 || subdet_ == 5)) {
+  if (ecalselector_ == "yes" && (subdet_ == 1 || subdet_ == 2 || subdet_ == 5)) {
     Handle<EBRecHitCollection> rhitEB;
 
     EcalRecHitCollection::const_iterator RecHit;
     EcalRecHitCollection::const_iterator RecHitEnd;
 
     if (ev.getByToken(tok_EB_, rhitEB)) {
-
       RecHit = rhitEB.product()->begin();
       RecHitEnd = rhitEB.product()->end();
 
       for (; RecHit != RecHitEnd; ++RecHit) {
         EBDetId EBid = EBDetId(RecHit->id());
 
-        auto cellGeometry =
-            geometry->getSubdetectorGeometry(EBid)->getGeometry(EBid);
+        auto cellGeometry = geometry->getSubdetectorGeometry(EBid)->getGeometry(EBid);
         double eta = cellGeometry->getPosition().eta();
         double phi = cellGeometry->getPosition().phi();
         double en = RecHit->energy();
@@ -347,15 +300,13 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev,
     Handle<EERecHitCollection> rhitEE;
 
     if (ev.getByToken(tok_EE_, rhitEE)) {
-
       RecHit = rhitEE.product()->begin();
       RecHitEnd = rhitEE.product()->end();
 
       for (; RecHit != RecHitEnd; ++RecHit) {
         EEDetId EEid = EEDetId(RecHit->id());
 
-        auto cellGeometry =
-            geometry->getSubdetectorGeometry(EEid)->getGeometry(EEid);
+        auto cellGeometry = geometry->getSubdetectorGeometry(EEid)->getGeometry(EEid);
         double eta = cellGeometry->getPosition().eta();
         double phi = cellGeometry->getPosition().phi();
         double en = RecHit->energy();
@@ -369,7 +320,7 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev,
         }
       }
     }
-  } // end of ECAL selection
+  }  // end of ECAL selection
 
   //     std::cout << "*** 4" << std::endl;
 
@@ -378,7 +329,6 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev,
   //===========================================================================
 
   if ((subdet_ != 6) && (subdet_ != 0)) {
-
     //       std::cout << "*** 6" << std::endl;
 
     double HcalCone = 0.;
@@ -398,8 +348,7 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev,
       int ieta = cieta[i];
       double chi2 = cchi2[i];
 
-      double chi2_log10 =
-          9.99; // initial value above histos limits , keep it if chi2 <= 0.
+      double chi2_log10 = 9.99;  // initial value above histos limits , keep it if chi2 <= 0.
       if (chi2 > 0.)
         chi2_log10 = log10(chi2);
 
@@ -439,7 +388,6 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev,
       // The energy and overall timing histos are drawn while
       // the ones split by depth are not
       if (sub == 1 && (subdet_ == 1 || subdet_ == 5)) {
-
         meRecHitsM2Chi2HB->Fill(chi2_log10);
         meLog10Chi2profileHB->Fill(en, chi2_log10);
 
@@ -450,7 +398,6 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev,
         meTEprofileHB_High->Fill(en, t);
       }
       if (sub == 2 && (subdet_ == 2 || subdet_ == 5)) {
-
         meRecHitsM2Chi2HE->Fill(chi2_log10);
         meLog10Chi2profileHE->Fill(en, chi2_log10);
 
@@ -474,7 +421,7 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev,
     }
 
     if (imc != 0) {
-      meEnConeEtaProfile->Fill(double(ietaMax), HcalCone); //
+      meEnConeEtaProfile->Fill(double(ietaMax), HcalCone);  //
       meEnConeEtaProfile_E->Fill(double(ietaMax), eEcalCone);
       meEnConeEtaProfile_EH->Fill(double(ietaMax), HcalCone + eEcalCone);
     }
@@ -484,7 +431,7 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev,
 
   // SimHits vs. RecHits
   const CaloGeometry *geo = geometry.product();
-  if (subdet_ > 0 && subdet_ < 6 && imc != 0) { // not noise
+  if (subdet_ > 0 && subdet_ < 6 && imc != 0) {  // not noise
 
     edm::Handle<PCaloHitContainer> hcalHits;
     if (ev.getByToken(tok_hh_, hcalHits)) {
@@ -499,10 +446,8 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev,
       double enSimHitsHFS = 0.;
       // sum of SimHits in the cone
 
-      for (std::vector<PCaloHit>::const_iterator SimHits =
-               SimHitResult->begin();
-           SimHits != SimHitResult->end(); ++SimHits) {
-
+      for (std::vector<PCaloHit>::const_iterator SimHits = SimHitResult->begin(); SimHits != SimHitResult->end();
+           ++SimHits) {
         int sub, depth;
         HcalDetId cell;
 
@@ -515,19 +460,19 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev,
         depth = cell.depth();
 
         if (sub != subdet_ && subdet_ != 5)
-          continue; // If we are not looking at all of the subdetectors and the
-                    // simhit doesn't come from the specific subdetector of
-                    // interest, then we won't do any thing with it
+          continue;  // If we are not looking at all of the subdetectors and the
+                     // simhit doesn't come from the specific subdetector of
+                     // interest, then we won't do any thing with it
 
-        const HcalGeometry *cellGeometry = dynamic_cast<const HcalGeometry *>(
-            geo->getSubdetectorGeometry(DetId::Hcal, cell.subdet()));
+        const HcalGeometry *cellGeometry =
+            dynamic_cast<const HcalGeometry *>(geo->getSubdetectorGeometry(DetId::Hcal, cell.subdet()));
         double etaS = cellGeometry->getPosition(cell).eta();
         double phiS = cellGeometry->getPosition(cell).phi();
         double en = SimHits->energy();
 
         double r = dR(eta_MC, phi_MC, etaS, phiS);
 
-        if (r < partR) { // just energy in the small cone
+        if (r < partR) {  // just energy in the small cone
 
           enSimHits += en;
           if (sub == static_cast<int>(HcalBarrel))
@@ -577,7 +522,6 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev,
 
 ///////////////////////////////////////////////////////////////////////////////
 void HcalRecHitsValidation::fillRecHitsTmp(int subdet_, edm::Event const &ev) {
-
   using namespace edm;
 
   // initialize data vectors
@@ -592,20 +536,16 @@ void HcalRecHitsValidation::fillRecHitsTmp(int subdet_, edm::Event const &ev) {
   cz.clear();
   cchi2.clear();
 
-  if (subdet_ == 1 || subdet_ == 2 || subdet_ == 5 || subdet_ == 6 ||
-      subdet_ == 0) {
-
+  if (subdet_ == 1 || subdet_ == 2 || subdet_ == 5 || subdet_ == 6 || subdet_ == 0) {
     // HBHE
     edm::Handle<HBHERecHitCollection> hbhecoll;
     if (ev.getByToken(tok_hbhe_, hbhecoll)) {
       const CaloGeometry *geo = geometry.product();
 
-      for (HBHERecHitCollection::const_iterator j = hbhecoll->begin();
-           j != hbhecoll->end(); j++) {
-
+      for (HBHERecHitCollection::const_iterator j = hbhecoll->begin(); j != hbhecoll->end(); j++) {
         HcalDetId cell(j->id());
-        const HcalGeometry *cellGeometry = dynamic_cast<const HcalGeometry *>(
-            geo->getSubdetectorGeometry(DetId::Hcal, cell.subdet()));
+        const HcalGeometry *cellGeometry =
+            dynamic_cast<const HcalGeometry *>(geo->getSubdetectorGeometry(DetId::Hcal, cell.subdet()));
         double eta = cellGeometry->getPosition(cell).eta();
         double phi = cellGeometry->getPosition(cell).phi();
         double zc = cellGeometry->getPosition(cell).z();
@@ -618,7 +558,6 @@ void HcalRecHitsValidation::fillRecHitsTmp(int subdet_, edm::Event const &ev) {
         double chi2 = j->chi2();
 
         if ((iz > 0 && eta > 0.) || (iz < 0 && eta < 0.) || iz == 0) {
-
           csub.push_back(sub);
           cen.push_back(en);
           ceta.push_back(eta);
@@ -635,17 +574,12 @@ void HcalRecHitsValidation::fillRecHitsTmp(int subdet_, edm::Event const &ev) {
   }
 
   if (subdet_ == 4 || subdet_ == 5 || subdet_ == 6 || subdet_ == 0) {
-
     // HF
     edm::Handle<HFRecHitCollection> hfcoll;
     if (ev.getByToken(tok_hf_, hfcoll)) {
-
-      for (HFRecHitCollection::const_iterator j = hfcoll->begin();
-           j != hfcoll->end(); j++) {
-
+      for (HFRecHitCollection::const_iterator j = hfcoll->begin(); j != hfcoll->end(); j++) {
         HcalDetId cell(j->id());
-        auto cellGeometry =
-            geometry->getSubdetectorGeometry(cell)->getGeometry(cell);
+        auto cellGeometry = geometry->getSubdetectorGeometry(cell)->getGeometry(cell);
 
         double eta = cellGeometry->getPosition().eta();
         double phi = cellGeometry->getPosition().phi();
@@ -658,7 +592,6 @@ void HcalRecHitsValidation::fillRecHitsTmp(int subdet_, edm::Event const &ev) {
         double t = j->time();
 
         if ((iz > 0 && eta > 0.) || (iz < 0 && eta < 0.) || iz == 0) {
-
           csub.push_back(sub);
           cen.push_back(en);
           ceta.push_back(eta);
@@ -676,16 +609,11 @@ void HcalRecHitsValidation::fillRecHitsTmp(int subdet_, edm::Event const &ev) {
 
   // HO
   if (subdet_ == 3 || subdet_ == 5 || subdet_ == 6 || subdet_ == 0) {
-
     edm::Handle<HORecHitCollection> hocoll;
     if (ev.getByToken(tok_ho_, hocoll)) {
-
-      for (HORecHitCollection::const_iterator j = hocoll->begin();
-           j != hocoll->end(); j++) {
-
+      for (HORecHitCollection::const_iterator j = hocoll->begin(); j != hocoll->end(); j++) {
         HcalDetId cell(j->id());
-        auto cellGeometry =
-            geometry->getSubdetectorGeometry(cell)->getGeometry(cell);
+        auto cellGeometry = geometry->getSubdetectorGeometry(cell)->getGeometry(cell);
 
         double eta = cellGeometry->getPosition().eta();
         double phi = cellGeometry->getPosition().phi();
@@ -714,8 +642,7 @@ void HcalRecHitsValidation::fillRecHitsTmp(int subdet_, edm::Event const &ev) {
   }
 }
 
-double HcalRecHitsValidation::dR(double eta1, double phi1, double eta2,
-                                 double phi2) {
+double HcalRecHitsValidation::dR(double eta1, double phi1, double eta2, double phi2) {
   double PI = 3.1415926535898;
   double deltaphi = phi1 - phi2;
   if (phi2 > phi1) {
@@ -729,8 +656,7 @@ double HcalRecHitsValidation::dR(double eta1, double phi1, double eta2,
   return tmp;
 }
 
-double HcalRecHitsValidation::phi12(double phi1, double en1, double phi2,
-                                    double en2) {
+double HcalRecHitsValidation::phi12(double phi1, double en1, double phi2, double en2) {
   // weighted mean value of phi1 and phi2
 
   double tmp;

--- a/Validation/HcalRecHits/src/NoiseRates.cc
+++ b/Validation/HcalRecHits/src/NoiseRates.cc
@@ -15,10 +15,8 @@
 //
 
 NoiseRates::NoiseRates(const edm::ParameterSet &iConfig) {
-
   // DQM ROOT output
-  outputFile_ =
-      iConfig.getUntrackedParameter<std::string>("outputFile", "myfile.root");
+  outputFile_ = iConfig.getUntrackedParameter<std::string>("outputFile", "myfile.root");
 
   // set parameters
   rbxCollName_ = iConfig.getUntrackedParameter<edm::InputTag>("rbxCollName");
@@ -30,8 +28,7 @@ NoiseRates::NoiseRates(const edm::ParameterSet &iConfig) {
   useAllHistos_ = iConfig.getUntrackedParameter<bool>("useAllHistos", false);
 
   // Hcal Noise Summary
-  noisetoken_ = consumes<HcalNoiseSummary>(
-      iConfig.getParameter<edm::InputTag>("noiselabel"));
+  noisetoken_ = consumes<HcalNoiseSummary>(iConfig.getParameter<edm::InputTag>("noiselabel"));
 }
 
 NoiseRates::~NoiseRates() {}
@@ -40,9 +37,7 @@ NoiseRates::~NoiseRates() {}
 // member functions
 //
 
-void NoiseRates::bookHistograms(DQMStore::IBooker &ib, edm::Run const &run,
-                                edm::EventSetup const &es) {
-
+void NoiseRates::bookHistograms(DQMStore::IBooker &ib, edm::Run const &run, edm::EventSetup const &es) {
   ib.setCurrentFolder("NoiseRatesV/NoiseRatesTask");
 
   // book histograms
@@ -101,9 +96,7 @@ void NoiseRates::bookHistograms(DQMStore::IBooker &ib, edm::Run const &run,
 }
 
 // ------------ method called to for each event  ------------
-void NoiseRates::analyze(const edm::Event &iEvent,
-                         const edm::EventSetup &evSetup) {
-
+void NoiseRates::analyze(const edm::Event &iEvent, const edm::EventSetup &evSetup) {
   // get the lumi section
   int lumiSection = iEvent.luminosityBlock();
   lumiCountMap_[lumiSection]++;
@@ -113,8 +106,7 @@ void NoiseRates::analyze(const edm::Event &iEvent,
   iEvent.getByToken(tok_rbx_, handle);
   if (!handle.isValid()) {
     throw edm::Exception(edm::errors::ProductNotFound)
-        << " could not find HcalNoiseRBXCollection named " << rbxCollName_
-        << ".\n";
+        << " could not find HcalNoiseRBXCollection named " << rbxCollName_ << ".\n";
     return;
   }
 
@@ -122,8 +114,7 @@ void NoiseRates::analyze(const edm::Event &iEvent,
   edm::Handle<HcalNoiseSummary> summary_h;
   iEvent.getByToken(noisetoken_, summary_h);
   if (!summary_h.isValid()) {
-    throw edm::Exception(edm::errors::ProductNotFound)
-        << " could not find HcalNoiseSummary.\n";
+    throw edm::Exception(edm::errors::ProductNotFound) << " could not find HcalNoiseSummary.\n";
     return;
   }
   const HcalNoiseSummary summary = *summary_h;
@@ -146,8 +137,7 @@ void NoiseRates::analyze(const edm::Event &iEvent,
   hNoise_maxHPDNoOtherHits_->Fill(summary.maxHPDNoOtherHits());
 
   // loop over the RBXs and fill the histograms
-  for (reco::HcalNoiseRBXCollection::const_iterator it = handle->begin();
-       it != handle->end(); ++it) {
+  for (reco::HcalNoiseRBXCollection::const_iterator it = handle->begin(); it != handle->end(); ++it) {
     const reco::HcalNoiseRBX &rbx = (*it);
 
     double energy = rbx.recHitEnergy(minHitEnergy_);
@@ -168,7 +158,7 @@ void NoiseRates::analyze(const edm::Event &iEvent,
 
     hRBXNHits_->Fill(nhits);
 
-  } // done looping over RBXs
+  }  // done looping over RBXs
 }
 
 // define this as a plug-in

--- a/Validation/HcalRecHits/src/NoiseRatesClient.cc
+++ b/Validation/HcalRecHits/src/NoiseRatesClient.cc
@@ -8,11 +8,8 @@
 
 #include "DQMServices/Core/interface/MonitorElement.h"
 
-NoiseRatesClient::NoiseRatesClient(const edm::ParameterSet &iConfig)
-    : conf_(iConfig) {
-
-  outputFile_ =
-      iConfig.getUntrackedParameter<std::string>("outputFile", "myfile.root");
+NoiseRatesClient::NoiseRatesClient(const edm::ParameterSet &iConfig) : conf_(iConfig) {
+  outputFile_ = iConfig.getUntrackedParameter<std::string>("outputFile", "myfile.root");
 
   debug_ = false;
   verbose_ = false;
@@ -22,12 +19,9 @@ NoiseRatesClient::NoiseRatesClient(const edm::ParameterSet &iConfig)
 
 NoiseRatesClient::~NoiseRatesClient() {}
 
-void NoiseRatesClient::dqmEndJob(DQMStore::IBooker &ib, DQMStore::IGetter &ig) {
-  runClient_(ib, ig);
-}
+void NoiseRatesClient::dqmEndJob(DQMStore::IBooker &ib, DQMStore::IGetter &ig) { runClient_(ib, ig); }
 
-void NoiseRatesClient::runClient_(DQMStore::IBooker &ib,
-                                  DQMStore::IGetter &ig) {
+void NoiseRatesClient::runClient_(DQMStore::IBooker &ib, DQMStore::IGetter &ig) {
   ig.setCurrentFolder(dirName_);
 
   if (verbose_)
@@ -40,19 +34,16 @@ void NoiseRatesClient::runClient_(DQMStore::IBooker &ib,
   // NoiseRatesV/NoiseRatesTask.
   std::vector<std::string> fullPathHLTFolders = ig.getSubdirs();
   for (unsigned int i = 0; i < fullPathHLTFolders.size(); i++) {
-
     if (verbose_)
       std::cout << "\nfullPath: " << fullPathHLTFolders[i] << std::endl;
     ig.setCurrentFolder(fullPathHLTFolders[i]);
 
     std::vector<std::string> fullSubPathHLTFolders = ig.getSubdirs();
     for (unsigned int j = 0; j < fullSubPathHLTFolders.size(); j++) {
-
       if (verbose_)
         std::cout << "fullSub: " << fullSubPathHLTFolders[j] << std::endl;
 
-      if (strcmp(fullSubPathHLTFolders[j].c_str(),
-                 "NoiseRatesV/NoiseRatesTask") == 0) {
+      if (strcmp(fullSubPathHLTFolders[j].c_str(), "NoiseRatesV/NoiseRatesTask") == 0) {
         hcalMEs = ig.getContents(fullSubPathHLTFolders[j]);
         if (verbose_)
           std::cout << "hltMES size : " << hcalMEs.size() << std::endl;
@@ -65,9 +56,7 @@ void NoiseRatesClient::runClient_(DQMStore::IBooker &ib,
 
 // called after entering the NoiseRatesV/NoiseRatesTask directory
 // hcalMEs are within that directory
-int NoiseRatesClient::NoiseRatesEndjob(
-    const std::vector<MonitorElement *> &hcalMEs) {
-
+int NoiseRatesClient::NoiseRatesEndjob(const std::vector<MonitorElement *> &hcalMEs) {
   int useAllHistos = 0;
   MonitorElement *hLumiBlockCount = nullptr;
   for (unsigned int ih = 0; ih < hcalMEs.size(); ih++) {
@@ -81,7 +70,7 @@ int NoiseRatesClient::NoiseRatesEndjob(
 
   // FIXME: dummy lumiCountMap.size since hLumiBlockCount is disabled
   // in a general case.
-  int lumiCountMapsize = -1; // dummy
+  int lumiCountMapsize = -1;  // dummy
   if (useAllHistos)
     hLumiBlockCount->Fill(0.0, lumiCountMapsize);
 

--- a/Validation/MuonRPCDigis/interface/RPCDigiValid.h
+++ b/Validation/MuonRPCDigis/interface/RPCDigiValid.h
@@ -15,15 +15,13 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
 class RPCDigiValid : public DQMEDAnalyzer {
-
 public:
   RPCDigiValid(const edm::ParameterSet &ps);
   ~RPCDigiValid() override;
 
 protected:
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:
   MonitorElement *xyview;

--- a/Validation/MuonRPCDigis/src/RPCDigiValid.cc
+++ b/Validation/MuonRPCDigis/src/RPCDigiValid.cc
@@ -16,27 +16,22 @@ using namespace std;
 using namespace edm;
 
 RPCDigiValid::RPCDigiValid(const ParameterSet &ps) {
-
   //  Init the tokens for run data retrieval - stanislav
   //  ps.getUntackedParameter<InputTag> retrieves a InputTag from the
   //  configuration. The second param is default value module, instance and
   //  process labels may be passed in a single string if separated by colon ':'
   //  (@see the edm::InputTag constructor documentation)
-  simHitToken =
-      consumes<PSimHitContainer>(ps.getUntrackedParameter<edm::InputTag>(
-          "simHitTag", edm::InputTag("g4SimHits:MuonRPCHits")));
-  rpcDigiToken =
-      consumes<RPCDigiCollection>(ps.getUntrackedParameter<edm::InputTag>(
-          "rpcDigiTag", edm::InputTag("simMuonRPCDigis")));
+  simHitToken = consumes<PSimHitContainer>(
+      ps.getUntrackedParameter<edm::InputTag>("simHitTag", edm::InputTag("g4SimHits:MuonRPCHits")));
+  rpcDigiToken = consumes<RPCDigiCollection>(
+      ps.getUntrackedParameter<edm::InputTag>("rpcDigiTag", edm::InputTag("simMuonRPCDigis")));
 
-  outputFile_ =
-      ps.getUntrackedParameter<string>("outputFile", "rpcDigiValidPlots.root");
+  outputFile_ = ps.getUntrackedParameter<string>("outputFile", "rpcDigiValidPlots.root");
 }
 
 RPCDigiValid::~RPCDigiValid() {}
 
 void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
-
   // Get the RPC Geometry
   edm::ESHandle<RPCGeometry> rpcGeom;
   eventSetup.get<MuonGeometryRecord>().get(rpcGeom);
@@ -58,7 +53,6 @@ void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
     int ptype = simIt->particleType();
 
     if (ptype == 13 || ptype == -13) {
-
       std::vector<double> buff;
       if (allsims.find(Rsid) != allsims.end()) {
         buff = allsims[Rsid];
@@ -88,8 +82,7 @@ void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
   }
   // loop over Digis
   RPCDigiCollection::DigiRangeIterator detUnitIt;
-  for (detUnitIt = rpcDigis->begin(); detUnitIt != rpcDigis->end();
-       ++detUnitIt) {
+  for (detUnitIt = rpcDigis->begin(); detUnitIt != rpcDigis->end(); ++detUnitIt) {
     const RPCDetId Rsid = (*detUnitIt).first;
     const RPCRoll *roll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(Rsid));
 
@@ -100,8 +93,7 @@ void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
     }
 
     int ndigi = 0;
-    for (RPCDigiCollection::const_iterator digiIt = range.first;
-         digiIt != range.second; ++digiIt) {
+    for (RPCDigiCollection::const_iterator digiIt = range.first; digiIt != range.second; ++digiIt) {
       StripProf->Fill(digiIt->strip());
       BxDist->Fill(digiIt->bx());
       // bx for 4 endcaps
@@ -114,8 +106,7 @@ void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
       }
 
       // Fill timing information
-      const double digiTime =
-          digiIt->hasTime() ? digiIt->time() : digiIt->bx() * 25;
+      const double digiTime = digiIt->hasTime() ? digiIt->time() : digiIt->bx() * 25;
       hDigiTimeAll->Fill(digiTime);
       if (digiIt->hasTime()) {
         hDigiTime->Fill(digiTime);
@@ -186,7 +177,6 @@ void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
       }
 
       if (Rsid.region() == (+1)) {
-
         if (Rsid.station() == 1)
           ResDplu1->Fill(dis);
         else if (Rsid.station() == 2)
@@ -197,7 +187,6 @@ void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
           ResDplu4->Fill(dis);
       }
       if (Rsid.region() == (-1)) {
-
         if (Rsid.station() == 1)
           ResDmin1->Fill(dis);
         else if (Rsid.station() == 2)
@@ -211,41 +200,28 @@ void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
   }
 }
 
-void RPCDigiValid::bookHistograms(DQMStore::IBooker &booker,
-                                  edm::Run const &run,
-                                  edm::EventSetup const &eSetup) {
+void RPCDigiValid::bookHistograms(DQMStore::IBooker &booker, edm::Run const &run, edm::EventSetup const &eSetup) {
   booker.setCurrentFolder("RPCDigisV/RPCDigis");
 
-  xyview = booker.book2D("X_Vs_Y_View", "X_Vs_Y_View", 155, -775., 775., 155,
-                         -775., 775.);
+  xyview = booker.book2D("X_Vs_Y_View", "X_Vs_Y_View", 155, -775., 775., 155, -775., 775.);
 
-  xyvDplu4 = booker.book2D("Dplu4_XvsY", "Dplu4_XvsY", 155, -775., 775., 155,
-                           -775., 775.);
-  xyvDmin4 = booker.book2D("Dmin4_XvsY", "Dmin4_XvsY", 155, -775., 775., 155,
-                           -775., 775.);
+  xyvDplu4 = booker.book2D("Dplu4_XvsY", "Dplu4_XvsY", 155, -775., 775., 155, -775., 775.);
+  xyvDmin4 = booker.book2D("Dmin4_XvsY", "Dmin4_XvsY", 155, -775., 775., 155, -775., 775.);
 
-  rzview = booker.book2D("R_Vs_Z_View", "R_Vs_Z_View", 216, -1080., 1080., 52,
-                         260., 780.);
-  Res = booker.book1D("Digi_SimHit_difference", "Digi_SimHit_difference", 300,
-                      -8, 8);
+  rzview = booker.book2D("R_Vs_Z_View", "R_Vs_Z_View", 216, -1080., 1080., 52, 260., 780.);
+  Res = booker.book1D("Digi_SimHit_difference", "Digi_SimHit_difference", 300, -8, 8);
   ResWmin2 = booker.book1D("W_Min2_Residuals", "W_Min2_Residuals", 400, -8, 8);
   ResWmin1 = booker.book1D("W_Min1_Residuals", "W_Min1_Residuals", 400, -8, 8);
   ResWzer0 = booker.book1D("W_Zer0_Residuals", "W_Zer0_Residuals", 400, -8, 8);
   ResWplu1 = booker.book1D("W_Plu1_Residuals", "W_Plu1_Residuals", 400, -8, 8);
   ResWplu2 = booker.book1D("W_Plu2_Residuals", "W_Plu2_Residuals", 400, -8, 8);
 
-  ResLayer1_barrel =
-      booker.book1D("ResLayer1_barrel", "ResLayer1_barrel", 400, -8, 8);
-  ResLayer2_barrel =
-      booker.book1D("ResLayer2_barrel", "ResLayer2_barrel", 400, -8, 8);
-  ResLayer3_barrel =
-      booker.book1D("ResLayer3_barrel", "ResLayer3_barrel", 400, -8, 8);
-  ResLayer4_barrel =
-      booker.book1D("ResLayer4_barrel", "ResLayer4_barrel", 400, -8, 8);
-  ResLayer5_barrel =
-      booker.book1D("ResLayer5_barrel", "ResLayer5_barrel", 400, -8, 8);
-  ResLayer6_barrel =
-      booker.book1D("ResLayer6_barrel", "ResLayer6_barrel", 400, -8, 8);
+  ResLayer1_barrel = booker.book1D("ResLayer1_barrel", "ResLayer1_barrel", 400, -8, 8);
+  ResLayer2_barrel = booker.book1D("ResLayer2_barrel", "ResLayer2_barrel", 400, -8, 8);
+  ResLayer3_barrel = booker.book1D("ResLayer3_barrel", "ResLayer3_barrel", 400, -8, 8);
+  ResLayer4_barrel = booker.book1D("ResLayer4_barrel", "ResLayer4_barrel", 400, -8, 8);
+  ResLayer5_barrel = booker.book1D("ResLayer5_barrel", "ResLayer5_barrel", 400, -8, 8);
+  ResLayer6_barrel = booker.book1D("ResLayer6_barrel", "ResLayer6_barrel", 400, -8, 8);
 
   BxDist = booker.book1D("Bunch_Crossing", "Bunch_Crossing", 20, -10., 10.);
   StripProf = booker.book1D("Strip_Profile", "Strip_Profile", 100, 0, 100);
@@ -254,54 +230,32 @@ void RPCDigiValid::bookHistograms(DQMStore::IBooker &booker,
   BxDisc_4Min = booker.book1D("BxDisc_4Min", "BxDisc_4Min", 20, -10., 10.);
 
   // endcap residuals
-  ResDmin1 =
-      booker.book1D("Disk_Min1_Residuals", "Disk_Min1_Residuals", 400, -8, 8);
-  ResDmin2 =
-      booker.book1D("Disk_Min2_Residuals", "Disk_Min2_Residuals", 400, -8, 8);
-  ResDmin3 =
-      booker.book1D("Disk_Min3_Residuals", "Disk_Min3_Residuals", 400, -8, 8);
-  ResDplu1 =
-      booker.book1D("Disk_Plu1_Residuals", "Disk_Plu1_Residuals", 400, -8, 8);
-  ResDplu2 =
-      booker.book1D("Disk_Plu2_Residuals", "Disk_Plu2_Residuals", 400, -8, 8);
-  ResDplu3 =
-      booker.book1D("Disk_Plu3_Residuals", "Disk_Plu3_Residuals", 400, -8, 8);
+  ResDmin1 = booker.book1D("Disk_Min1_Residuals", "Disk_Min1_Residuals", 400, -8, 8);
+  ResDmin2 = booker.book1D("Disk_Min2_Residuals", "Disk_Min2_Residuals", 400, -8, 8);
+  ResDmin3 = booker.book1D("Disk_Min3_Residuals", "Disk_Min3_Residuals", 400, -8, 8);
+  ResDplu1 = booker.book1D("Disk_Plu1_Residuals", "Disk_Plu1_Residuals", 400, -8, 8);
+  ResDplu2 = booker.book1D("Disk_Plu2_Residuals", "Disk_Plu2_Residuals", 400, -8, 8);
+  ResDplu3 = booker.book1D("Disk_Plu3_Residuals", "Disk_Plu3_Residuals", 400, -8, 8);
 
-  ResDmin4 =
-      booker.book1D("Disk_Min4_Residuals", "Disk_Min4_Residuals", 400, -8, 8);
-  ResDplu4 =
-      booker.book1D("Disk_Plu4_Residuals", "Disk_Plu4_Residuals", 400, -8, 8);
+  ResDmin4 = booker.book1D("Disk_Min4_Residuals", "Disk_Min4_Residuals", 400, -8, 8);
+  ResDplu4 = booker.book1D("Disk_Plu4_Residuals", "Disk_Plu4_Residuals", 400, -8, 8);
 
-  Res_Endcap1_Ring2_A =
-      booker.book1D("Res_Endcap1_Ring2_A", "Res_Endcap1_Ring2_A", 400, -8, 8);
-  Res_Endcap1_Ring2_B =
-      booker.book1D("Res_Endcap1_Ring2_B", "Res_Endcap1_Ring2_B", 400, -8, 8);
-  Res_Endcap1_Ring2_C =
-      booker.book1D("Res_Endcap1_Ring2_C", "Res_Endcap1_Ring2_C", 400, -8, 8);
+  Res_Endcap1_Ring2_A = booker.book1D("Res_Endcap1_Ring2_A", "Res_Endcap1_Ring2_A", 400, -8, 8);
+  Res_Endcap1_Ring2_B = booker.book1D("Res_Endcap1_Ring2_B", "Res_Endcap1_Ring2_B", 400, -8, 8);
+  Res_Endcap1_Ring2_C = booker.book1D("Res_Endcap1_Ring2_C", "Res_Endcap1_Ring2_C", 400, -8, 8);
 
-  Res_Endcap23_Ring2_A =
-      booker.book1D("Res_Endcap23_Ring2_A", "Res_Endcap23_Ring2_A", 400, -8, 8);
-  Res_Endcap23_Ring2_B =
-      booker.book1D("Res_Endcap23_Ring2_B", "Res_Endcap23_Ring2_B", 400, -8, 8);
-  Res_Endcap23_Ring2_C =
-      booker.book1D("Res_Endcap23_Ring2_C", "Res_Endcap23_Ring2_C", 400, -8, 8);
+  Res_Endcap23_Ring2_A = booker.book1D("Res_Endcap23_Ring2_A", "Res_Endcap23_Ring2_A", 400, -8, 8);
+  Res_Endcap23_Ring2_B = booker.book1D("Res_Endcap23_Ring2_B", "Res_Endcap23_Ring2_B", 400, -8, 8);
+  Res_Endcap23_Ring2_C = booker.book1D("Res_Endcap23_Ring2_C", "Res_Endcap23_Ring2_C", 400, -8, 8);
 
-  Res_Endcap123_Ring3_A = booker.book1D("Res_Endcap123_Ring3_A",
-                                        "Res_Endcap123_Ring3_A", 400, -8, 8);
-  Res_Endcap123_Ring3_B = booker.book1D("Res_Endcap123_Ring3_B",
-                                        "Res_Endcap123_Ring3_B", 400, -8, 8);
-  Res_Endcap123_Ring3_C = booker.book1D("Res_Endcap123_Ring3_C",
-                                        "Res_Endcap123_Ring3_C", 400, -8, 8);
+  Res_Endcap123_Ring3_A = booker.book1D("Res_Endcap123_Ring3_A", "Res_Endcap123_Ring3_A", 400, -8, 8);
+  Res_Endcap123_Ring3_B = booker.book1D("Res_Endcap123_Ring3_B", "Res_Endcap123_Ring3_B", 400, -8, 8);
+  Res_Endcap123_Ring3_C = booker.book1D("Res_Endcap123_Ring3_C", "Res_Endcap123_Ring3_C", 400, -8, 8);
 
   // Timing informations
-  hDigiTimeAll = booker.book1D(
-      "DigiTimeAll", "Digi time including present electronics;Digi time (ns)",
-      100, -12.5, 12.5);
-  hDigiTime = booker.book1D(
-      "DigiTime", "Digi time only with timing information;Digi time (ns)", 100,
-      -12.5, 12.5);
-  hDigiTimeIRPC = booker.book1D("DigiTimeIRPC", "IRPC Digi time;Digi time (ns)",
-                                100, -12.5, 12.5);
-  hDigiTimeNoIRPC = booker.book1D(
-      "DigiTimeNoIRPC", "non-IRPC Digi time;Digi time (ns)", 100, -12.5, 12.5);
+  hDigiTimeAll =
+      booker.book1D("DigiTimeAll", "Digi time including present electronics;Digi time (ns)", 100, -12.5, 12.5);
+  hDigiTime = booker.book1D("DigiTime", "Digi time only with timing information;Digi time (ns)", 100, -12.5, 12.5);
+  hDigiTimeIRPC = booker.book1D("DigiTimeIRPC", "IRPC Digi time;Digi time (ns)", 100, -12.5, 12.5);
+  hDigiTimeNoIRPC = booker.book1D("DigiTimeNoIRPC", "non-IRPC Digi time;Digi time (ns)", 100, -12.5, 12.5);
 }

--- a/Validation/RecoParticleFlow/bin/HistoData.cpp
+++ b/Validation/RecoParticleFlow/bin/HistoData.cpp
@@ -10,9 +10,8 @@
 
 using namespace std;
 
-HistoData::HistoData(std::string Name, int Type, int Bin, string NewPath,
-                     TFile *NewFile, string RefPath, TFile *RefFile) {
-
+HistoData::HistoData(
+    std::string Name, int Type, int Bin, string NewPath, TFile *NewFile, string RefPath, TFile *RefFile) {
   name = Name;
   type = Type;
   bin = Bin;
@@ -23,9 +22,7 @@ HistoData::HistoData(std::string Name, int Type, int Bin, string NewPath,
   initialize();
 }
 
-HistoData::HistoData(std::string Name, int Type, int Bin, TH1 *NewHisto,
-                     TH1 *RefHisto) {
-
+HistoData::HistoData(std::string Name, int Type, int Bin, TH1 *NewHisto, TH1 *RefHisto) {
   name = Name;
   type = Type;
   bin = Bin;
@@ -36,7 +33,6 @@ HistoData::HistoData(std::string Name, int Type, int Bin, TH1 *NewHisto,
 }
 
 void HistoData::initialize() {
-
   // scores/tests initialization
   lowScore = 10.0;
   highScore = 0.0;
@@ -64,7 +60,7 @@ void HistoData::initialize() {
   // test result color conventions
   passColor = kGreen;
   failColor = kRed;
-  errorColor = 16; // kGray
+  errorColor = 16;  // kGray
 
   // default color and style scheme
   lineUseFillColor = true;
@@ -77,7 +73,6 @@ void HistoData::initialize() {
 }
 
 void HistoData::setResult(bool Result) {
-
   // set the test result
   result = Result;
 
@@ -87,7 +82,6 @@ void HistoData::setResult(bool Result) {
 }
 
 void HistoData::dump() {
-
   cout << "name      = " << name << endl
        << "type      = " << type << endl
        << "bin       = " << bin << endl
@@ -97,7 +91,6 @@ void HistoData::dump() {
 }
 
 void HistoData::drawResult(TH1 *Summary, bool Vertical, bool SetBinLabel) {
-
   // add label to the summary if desired
   if (SetBinLabel) {
     Summary->GetXaxis()->SetBinLabel(bin, getRefHisto()->GetTitle());
@@ -112,8 +105,7 @@ void HistoData::drawResult(TH1 *Summary, bool Vertical, bool SetBinLabel) {
   //   3: hatched bar ends
   double score1 = minimum;
   double score2 = (lowScore == 10. || lowScore < minimum) ? minimum : lowScore;
-  double score3 =
-      (lowScore == 10.) ? 1 : ((highScore < minimum) ? minimum : highScore);
+  double score3 = (lowScore == 10.) ? 1 : ((highScore < minimum) ? minimum : highScore);
 
   // determine where to draw the result (binning axis)
   double binCenter = Summary->GetBinCenter(bin);
@@ -165,11 +157,9 @@ void HistoData::drawResult(TH1 *Summary, bool Vertical, bool SetBinLabel) {
 
   // a hatched bar is drawn from the lowest score to the highest score
   if ((lowScore != highScore && highScore > minimum) || lowScore == 10.) {
-    TPave *hatchedBar =
-        new TPave(hatchedX1, hatchedY1, hatchedX2, hatchedY2, 1, "");
+    TPave *hatchedBar = new TPave(hatchedX1, hatchedY1, hatchedX2, hatchedY2, 1, "");
     hatchedBar->SetBit(kCanDelete);
-    hatchedBar->SetLineColor(lineUseFillColor ? shadedFillColor
-                                              : shadedLineColor);
+    hatchedBar->SetLineColor(lineUseFillColor ? shadedFillColor : shadedLineColor);
     hatchedBar->SetFillColor(shadedFillColor);
     hatchedBar->SetFillStyle(3004);
     hatchedBar->Draw();

--- a/Validation/RecoParticleFlow/bin/PlotCompareUtility.cpp
+++ b/Validation/RecoParticleFlow/bin/PlotCompareUtility.cpp
@@ -18,12 +18,12 @@
 #include <TText.h>
 using namespace std;
 
-PlotCompareUtility::PlotCompareUtility(std::string Reference, std::string New,
+PlotCompareUtility::PlotCompareUtility(std::string Reference,
+                                       std::string New,
                                        std::string NewBasePath,
                                        std::string NewPrefix,
                                        std::string RefBasePath,
                                        std::string RefPrefix) {
-
   // open TFiles
   cout << refFile << " " << newFile << endl;
   refFile = new TFile(Reference.c_str(), "READ");
@@ -43,7 +43,7 @@ PlotCompareUtility::PlotCompareUtility(std::string Reference, std::string New,
   summaryWidth = 700;
   summaryBarsThickness = 20;
   summaryTopMargin = 60;
-  summaryLeftMargin = 250; // former 180
+  summaryLeftMargin = 250;  // former 180
   summaryRightMargin = 60;
   summaryBottomMargin = 60;
 
@@ -72,7 +72,6 @@ PlotCompareUtility::PlotCompareUtility(std::string Reference, std::string New,
 }
 
 PlotCompareUtility::~PlotCompareUtility() {
-
   // close TFiles
   if (refFile != nullptr)
     refFile->Close();
@@ -81,7 +80,6 @@ PlotCompareUtility::~PlotCompareUtility() {
 }
 
 void PlotCompareUtility::dump() {
-
   cout << "RefFile     = " << refFile->GetName() << endl
        << "RefBasePath = " << refBasePath << endl
        << "RefPrefix   = " << refPrefix << endl
@@ -92,15 +90,14 @@ void PlotCompareUtility::dump() {
 }
 
 bool PlotCompareUtility::compare(HistoData *HD) {
-
   bool retval = false;
   switch (HD->getType()) {
-  case Plot1D:
-    retval = compare<Plot1D>(HD);
-    break;
-  case Plot2D:
-    retval = compare<Plot2D>(HD);
-    break;
+    case Plot1D:
+      retval = compare<Plot1D>(HD);
+      break;
+    case Plot2D:
+      retval = compare<Plot2D>(HD);
+      break;
   }
 
   finalResult &= retval;
@@ -108,32 +105,28 @@ bool PlotCompareUtility::compare(HistoData *HD) {
 }
 
 void PlotCompareUtility::makePlots(HistoData *HD) {
-
   switch (HD->getType()) {
-  case Plot1D:
-    makePlots<Plot1D>(HD);
-    break;
-  case Plot2D:
-    makePlots<Plot2D>(HD);
-    break;
+    case Plot1D:
+      makePlots<Plot1D>(HD);
+      break;
+    case Plot2D:
+      makePlots<Plot2D>(HD);
+      break;
   }
 }
 
 void PlotCompareUtility::makeHTML(HistoData *HD) {
-
   switch (HD->getType()) {
-  case Plot1D:
-    makeHTML<Plot1D>(HD);
-    break;
-  case Plot2D:
-    makeHTML<Plot2D>(HD);
-    break;
+    case Plot1D:
+      makeHTML<Plot1D>(HD);
+      break;
+    case Plot2D:
+      makeHTML<Plot2D>(HD);
+      break;
   }
 }
 
-HistoData *PlotCompareUtility::addHistoData(string NewName, string RefName,
-                                            int Type) {
-
+HistoData *PlotCompareUtility::addHistoData(string NewName, string RefName, int Type) {
   // location of this HistoData within the PCU
   static int bin = 0;
   bin++;
@@ -150,22 +143,16 @@ HistoData *PlotCompareUtility::addHistoData(string NewName, string RefName,
   return &(*histos.rbegin());
 }
 
-HistoData *PlotCompareUtility::addProjectionXData(HistoData *Parent,
-                                                  std::string Name, int Type,
-                                                  int Bin, TH1 *NewHisto,
-                                                  TH1 *RefHisto) {
-
+HistoData *PlotCompareUtility::addProjectionXData(
+    HistoData *Parent, std::string Name, int Type, int Bin, TH1 *NewHisto, TH1 *RefHisto) {
   // store the HistoData/projection information
   HistoData hd(Name, Type, Bin, NewHisto, RefHisto);
   projectionsX[Parent].push_back(hd);
   return &(*projectionsX[Parent].rbegin());
 }
 
-HistoData *PlotCompareUtility::addProjectionYData(HistoData *Parent,
-                                                  std::string Name, int Type,
-                                                  int Bin, TH1 *NewHisto,
-                                                  TH1 *RefHisto) {
-
+HistoData *PlotCompareUtility::addProjectionYData(
+    HistoData *Parent, std::string Name, int Type, int Bin, TH1 *NewHisto, TH1 *RefHisto) {
   // store the HistoData/projection information
   HistoData hd(Name, Type, Bin, NewHisto, RefHisto);
   projectionsY[Parent].push_back(hd);
@@ -173,20 +160,16 @@ HistoData *PlotCompareUtility::addProjectionYData(HistoData *Parent,
 }
 
 bool PlotCompareUtility::isValid() const {
-
   string newPath = newBasePath + "/" + newPrefix;
   string refPath = refBasePath + "/" + refPrefix;
   // check the files and that the paths are valid
-  bool refValid =
-      (refFile != nullptr) && (refFile->Get(refPath.c_str()) != nullptr);
-  bool newValid =
-      (newFile != nullptr) && (newFile->Get(newPath.c_str()) != nullptr);
+  bool refValid = (refFile != nullptr) && (refFile->Get(refPath.c_str()) != nullptr);
+  bool newValid = (newFile != nullptr) && (newFile->Get(newPath.c_str()) != nullptr);
 
   return refValid && newValid;
 }
 
 void PlotCompareUtility::centerRebin(TH1 *H1, TH1 *H2) {
-
   // determine x axis range and binning requirements
   float h1RMS = H1->GetRMS();
   float h2RMS = H2->GetRMS();
@@ -232,13 +215,11 @@ void PlotCompareUtility::centerRebin(TH1 *H1, TH1 *H2) {
 }
 
 void PlotCompareUtility::renormalize(TH1 *H1, TH1 *H2) {
-
   // normalize H2 to H1 (typically this would be hnew to href)
   H2->SetNormFactor(H1->GetEntries());
 }
 
 double PlotCompareUtility::getThreshold() const {
-
   double threshold;
 
   // the largest non-zero threshold
@@ -251,14 +232,12 @@ double PlotCompareUtility::getThreshold() const {
 }
 
 void PlotCompareUtility::makeSummary(string Name) {
-
   // produce plot and html
   makeSummaryPlot(Name);
   makeSummaryHTML(Name);
 }
 
 void PlotCompareUtility::makeDefaultPlots() {
-
   // make a default plot for when there i nothing to display
   TCanvas noDataCanvas("noDataCanvas", "noDataCanvas", plotsWidth, plotsHeight);
   noDataCanvas.SetFrameFillColor(10);
@@ -269,11 +248,9 @@ void PlotCompareUtility::makeDefaultPlots() {
 }
 
 void PlotCompareUtility::makeSummaryPlot(string Name) {
-
   // generate a reasonable height for the summary plot
   int numHistos = histos.size();
-  summaryHeight = summaryBottomMargin + summaryTopMargin +
-                  int(float(numHistos * summaryBarsThickness) * 1.5);
+  summaryHeight = summaryBottomMargin + summaryTopMargin + int(float(numHistos * summaryBarsThickness) * 1.5);
 
   // the canvas is rescaled during gif conversion, so add padding to Canvas
   // dimensions
@@ -281,8 +258,7 @@ void PlotCompareUtility::makeSummaryPlot(string Name) {
   int summaryCanvasHeight = summaryHeight + 28;
 
   // create and setup summary canvas
-  TCanvas summaryCanvas("summaryCanvas", "summaryCanvas", summaryCanvasWidth,
-                        summaryCanvasHeight);
+  TCanvas summaryCanvas("summaryCanvas", "summaryCanvas", summaryCanvasWidth, summaryCanvasHeight);
   summaryCanvas.SetFrameFillColor(10);
   summaryCanvas.SetLogx(1);
   summaryCanvas.SetGrid();
@@ -293,10 +269,8 @@ void PlotCompareUtility::makeSummaryPlot(string Name) {
   summaryCanvas.Draw();
 
   // create and setup the summary histogram
-  TH1F summary("summary", "Compatibility with Reference Histograms", numHistos,
-               1, numHistos + 1);
-  summary.GetXaxis()->SetLabelSize(float(summaryLeftMargin) /
-                                   (11 * summaryWidth)); // used to be 3*
+  TH1F summary("summary", "Compatibility with Reference Histograms", numHistos, 1, numHistos + 1);
+  summary.GetXaxis()->SetLabelSize(float(summaryLeftMargin) / (11 * summaryWidth));  // used to be 3*
   summary.GetYaxis()->SetLabelSize(summary.GetXaxis()->GetLabelSize());
   summary.GetYaxis()->SetTitle("Compatibility");
   summary.SetStats(false);
@@ -321,15 +295,13 @@ void PlotCompareUtility::makeSummaryPlot(string Name) {
 }
 
 void PlotCompareUtility::makeSummaryHTML(string Name) {
-
   // create HTML support code
   string gifName = Name + ".gif";
   string html = "index.html";
   ofstream fout(html.c_str());
 
   // print top portion of document
-  fout << "<!DOCTYPE gif PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">"
-       << endl
+  fout << "<!DOCTYPE gif PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">" << endl
        << "<html>" << endl
        << endl
        << "  <head>" << endl
@@ -363,50 +335,43 @@ void PlotCompareUtility::makeSummaryHTML(string Name) {
        << "    </script> -->" << endl
        << endl
        << "    <div id=\"main_d\">" << endl
-       << "      <img src=\"" << gifName << "\" usemap=\"#" << Name
-       << "\" alt=\"\" style=\"border-style: none;\""
-       << " height=" << summaryHeight << " width=" << summaryWidth
-       << " border=0>" << endl
+       << "      <img src=\"" << gifName << "\" usemap=\"#" << Name << "\" alt=\"\" style=\"border-style: none;\""
+       << " height=" << summaryHeight << " width=" << summaryWidth << " border=0>" << endl
        << "      <map id=\"" << Name << "\" name=\"" << Name << "\">" << endl;
 
   // loop over HistoData entries
   vector<HistoData>::iterator hd;
   for (hd = histos.begin(); hd != histos.end(); hd++) {
-
     // determine map coordinates for this bin (2 pixel offset due to borders?)
     int bin = hd->getBin();
     int x1 = summaryLeftMargin;
-    int y1 = summaryHeight - summaryBottomMargin -
-             int(float(bin * 1.5 - .25) * summaryBarsThickness) + 2;
+    int y1 = summaryHeight - summaryBottomMargin - int(float(bin * 1.5 - .25) * summaryBarsThickness) + 2;
     int x2 = summaryWidth - summaryRightMargin;
     int y2 = y1 + summaryBarsThickness;
     string image = hd->getResultImage();
     string target = hd->getResultTarget();
 
     // add coordinates area to image map
-    fout << "        <area shape=\"rect\" alt=\"\" coords=\"" << x1 << "," << y1
-         << "," << x2 << "," << y2 << "\" href=\"" << target
-         << "\" onMouseOver=\"tn('" << target << "','" << image << "')\">"
-         << endl;
+    fout << "        <area shape=\"rect\" alt=\"\" coords=\"" << x1 << "," << y1 << "," << x2 << "," << y2
+         << "\" href=\"" << target << "\" onMouseOver=\"tn('" << target << "','" << image << "')\">" << endl;
   }
 
   // print bottom portion of document
-  fout
-      << "        <area shape=\"default\" nohref=\"nohref\" alt=\"\">" << endl
-      << "      </map>" << endl
-      << "    </div>" << endl
-      << endl
-      << "    <div id=\"thumb_d\">" << endl
-      << "      <a href=\"#\" id=\"thumblink\"><img src=\"NoData_Results.gif\" "
-         "id=\"thumb\" width=200 height=150 border=0></a>"
-      << endl
-      << "      <br><a href=\"log.txt\">Root Output</a>" << endl
-      << "      <br><a href=\"err.txt\">Root Warnings</a>" << endl
-      << "    </div>" << endl
-      << endl
-      << "  </body>" << endl
-      << endl
-      << "</html>" << endl;
+  fout << "        <area shape=\"default\" nohref=\"nohref\" alt=\"\">" << endl
+       << "      </map>" << endl
+       << "    </div>" << endl
+       << endl
+       << "    <div id=\"thumb_d\">" << endl
+       << "      <a href=\"#\" id=\"thumblink\"><img src=\"NoData_Results.gif\" "
+          "id=\"thumb\" width=200 height=150 border=0></a>"
+       << endl
+       << "      <br><a href=\"log.txt\">Root Output</a>" << endl
+       << "      <br><a href=\"err.txt\">Root Warnings</a>" << endl
+       << "    </div>" << endl
+       << endl
+       << "  </body>" << endl
+       << endl
+       << "</html>" << endl;
 
   // close the file
   fout.close();

--- a/Validation/RecoParticleFlow/bin/include/HistoData.h
+++ b/Validation/RecoParticleFlow/bin/include/HistoData.h
@@ -8,10 +8,9 @@
 
 class HistoData {
 public:
-  HistoData(std::string Name, int PlotType, int Bin, std::string NewPath,
-            TFile *NewFile, std::string RefPath, TFile *RefFile);
-  HistoData(std::string Name, int PlotType, int Bin, TH1 *NewHisto,
-            TH1 *RefHisto);
+  HistoData(
+      std::string Name, int PlotType, int Bin, std::string NewPath, TFile *NewFile, std::string RefPath, TFile *RefFile);
+  HistoData(std::string Name, int PlotType, int Bin, TH1 *NewHisto, TH1 *RefHisto);
   virtual ~HistoData() {}
 
   // Get General Information
@@ -45,14 +44,10 @@ public:
 
   // Get Visual Attributes
   bool getLineUseFillColor() const { return lineUseFillColor; }
-  int getSolidLineColor() const {
-    return lineUseFillColor ? solidFillColor : solidLineColor;
-  }
+  int getSolidLineColor() const { return lineUseFillColor ? solidFillColor : solidLineColor; }
   int getSolidFillColor() const { return solidFillColor; }
   int getSolidFillStyle() const { return solidFillStyle; }
-  int getShadedLineColor() const {
-    return lineUseFillColor ? shadedFillColor : shadedLineColor;
-  }
+  int getShadedLineColor() const { return lineUseFillColor ? shadedFillColor : shadedLineColor; }
   int getShadedFillColor() const { return shadedFillColor; }
   int getShadedFillStyle() const { return shadedFillStyle; }
 
@@ -83,7 +78,7 @@ public:
   void setChi2Score(float Score) { chi2Score = Score; }
   void setLowScore(float Score) { lowScore = Score; }
   void setHighScore(float Score) { highScore = Score; }
-  void setResult(bool Result); // also sets display colors
+  void setResult(bool Result);  // also sets display colors
   void setIsEmpty(bool Toggle) { isEmpty = Toggle; }
 
   // Set Visual Attributes
@@ -142,4 +137,4 @@ private:
   void initialize();
 };
 
-#endif // HISTO_DATA__H
+#endif  // HISTO_DATA__H

--- a/Validation/RecoParticleFlow/bin/include/Plot1D.h
+++ b/Validation/RecoParticleFlow/bin/include/Plot1D.h
@@ -14,15 +14,14 @@
 #include <iostream>
 #include <string>
 
-template <> bool PlotCompareUtility::compare<Plot1D>(HistoData *HD) {
-
+template <>
+bool PlotCompareUtility::compare<Plot1D>(HistoData *HD) {
   // get the reference and comparison histograms
   TH1F *href = (TH1F *)HD->getRefHisto();
   TH1F *hnew = (TH1F *)HD->getNewHisto();
 
   // do not run comparisons if either histogram is empty/broken
-  if (hnew == nullptr || href == nullptr || hnew->GetEntries() <= 1 ||
-      href->GetEntries() <= 1) {
+  if (hnew == nullptr || href == nullptr || hnew->GetEntries() <= 1 || href->GetEntries() <= 1) {
     // std::cerr << HD->getName() << " error: unable to retrieve histogram (or
     // no entries)\n";
     HD->setIsEmpty(true);
@@ -53,8 +52,7 @@ template <> bool PlotCompareUtility::compare<Plot1D>(HistoData *HD) {
     HD->setLowScore(chi2Score);
     HD->setHighScore(chi2Score);
   } else
-    std::cerr
-        << "error: no test performed? chi2Threshold and ksThreshold <= 0\n";
+    std::cerr << "error: no test performed? chi2Threshold and ksThreshold <= 0\n";
 
   // check overall result
   bool passed = (ksScore >= ksThreshold && chi2Score >= chi2Threshold);
@@ -65,8 +63,8 @@ template <> bool PlotCompareUtility::compare<Plot1D>(HistoData *HD) {
   return passed;
 }
 
-template <> void PlotCompareUtility::makePlots<Plot1D>(HistoData *HD) {
-
+template <>
+void PlotCompareUtility::makePlots<Plot1D>(HistoData *HD) {
   std::cerr << HD->getName() << "makePlots<Plot1D>\n";
 
   // do not make any new plot if empty
@@ -147,8 +145,8 @@ template <> void PlotCompareUtility::makePlots<Plot1D>(HistoData *HD) {
   hCanvas.Print(gifName.c_str());
 }
 
-template <> void PlotCompareUtility::makeHTML<Plot1D>(HistoData *HD) {
-
+template <>
+void PlotCompareUtility::makeHTML<Plot1D>(HistoData *HD) {
   /* HTML is not presently required for 1D histograms -- do nothing
 
   // create HTML support code for this HistoData
@@ -166,4 +164,4 @@ template <> void PlotCompareUtility::makeHTML<Plot1D>(HistoData *HD) {
   */
 }
 
-#endif // PLOT_1D__H
+#endif  // PLOT_1D__H

--- a/Validation/RecoParticleFlow/bin/include/Plot2D.h
+++ b/Validation/RecoParticleFlow/bin/include/Plot2D.h
@@ -17,15 +17,14 @@
 #include <iostream>
 #include <string>
 
-template <> bool PlotCompareUtility::compare<Plot2D>(HistoData *HD) {
-
+template <>
+bool PlotCompareUtility::compare<Plot2D>(HistoData *HD) {
   // get the reference and comparison histograms
   TH2F *href2d = (TH2F *)HD->getRefHisto();
   TH2F *hnew2d = (TH2F *)HD->getNewHisto();
 
   // do not run comparisons if either histogram is empty/broken
-  if (hnew2d == nullptr || href2d == nullptr || hnew2d->GetEntries() <= 1 ||
-      href2d->GetEntries() <= 1) {
+  if (hnew2d == nullptr || href2d == nullptr || hnew2d->GetEntries() <= 1 || href2d->GetEntries() <= 1) {
     // std::cerr << HD->getName() << " error: unable to retrieve histogram (or
     // no entries)\n";
     HD->setIsEmpty(true);
@@ -37,14 +36,12 @@ template <> bool PlotCompareUtility::compare<Plot2D>(HistoData *HD) {
 
   // loop over axes (projections on one or both may be requested)
   for (int axis = axisX; axis <= axisY; ++axis) {
-
     // for X: verify projections requested and proper Y binning of href2d and
     // hnew2d
     if (axis == axisX && !HD->getDoProjectionsX())
       continue;
     if (axis == axisX && href2d->GetNbinsY() != hnew2d->GetNbinsY()) {
-      std::cerr << HD->getName()
-                << " error: incorrect number of bins for X projection tests\n";
+      std::cerr << HD->getName() << " error: incorrect number of bins for X projection tests\n";
       projectionsPassed = false;
       continue;
     }
@@ -54,16 +51,14 @@ template <> bool PlotCompareUtility::compare<Plot2D>(HistoData *HD) {
     if (axis == axisY && !HD->getDoProjectionsY())
       continue;
     if (axis == axisY && href2d->GetNbinsX() != hnew2d->GetNbinsX()) {
-      std::cerr << HD->getName()
-                << " error: incorrect number of bins for Y projection tests\n";
+      std::cerr << HD->getName() << " error: incorrect number of bins for Y projection tests\n";
       projectionsPassed = false;
       continue;
     }
 
     // setup the rebinning variables
     int nBins = (axis == axisX) ? href2d->GetNbinsY() : href2d->GetNbinsX();
-    int nProjections =
-        (axis == axisX) ? HD->getMaxProjectionsX() : HD->getMaxProjectionsY();
+    int nProjections = (axis == axisX) ? HD->getMaxProjectionsX() : HD->getMaxProjectionsY();
     int nGroups = (int)ceil(float(nBins) / nProjections);
     bool rebinned = false;
 
@@ -86,7 +81,6 @@ template <> bool PlotCompareUtility::compare<Plot2D>(HistoData *HD) {
     // loop over bins in histograms (go backwords to keep in order)
     // for (int bin = nBins; bin >= 1; --bin) {
     for (int bin = 1; bin <= nBins; ++bin) {
-
       std::cout << "bin " << bin << " of " << nBins << std::endl;
       // create some unique identifiers for the histogram names
       TString projName = HD->getName() + (axis == axisX ? "_px" : "_py");
@@ -97,36 +91,26 @@ template <> bool PlotCompareUtility::compare<Plot2D>(HistoData *HD) {
       refProjName += projName;
 
       // get the 1d projections for this bin out of the histogram
-      TH1D *hnew = (axis == axisX)
-                       ? hnew2d->ProjectionX(newProjName.Data(), bin, bin)
-                       : hnew2d->ProjectionY(newProjName.Data(), bin, bin);
-      TH1D *href = (axis == axisX)
-                       ? href2d->ProjectionX(refProjName.Data(), bin, bin)
-                       : href2d->ProjectionY(refProjName.Data(), bin, bin);
+      TH1D *hnew = (axis == axisX) ? hnew2d->ProjectionX(newProjName.Data(), bin, bin)
+                                   : hnew2d->ProjectionY(newProjName.Data(), bin, bin);
+      TH1D *href = (axis == axisX) ? href2d->ProjectionX(refProjName.Data(), bin, bin)
+                                   : href2d->ProjectionY(refProjName.Data(), bin, bin);
 
       // set histogram axis labels
-      hnew->GetXaxis()->SetTitle((axis == axisX
-                                      ? hnew2d->GetXaxis()->GetTitle()
-                                      : hnew2d->GetYaxis()->GetTitle()));
-      href->GetXaxis()->SetTitle((axis == axisX
-                                      ? href2d->GetXaxis()->GetTitle()
-                                      : href2d->GetYaxis()->GetTitle()));
+      hnew->GetXaxis()->SetTitle((axis == axisX ? hnew2d->GetXaxis()->GetTitle() : hnew2d->GetYaxis()->GetTitle()));
+      href->GetXaxis()->SetTitle((axis == axisX ? href2d->GetXaxis()->GetTitle() : href2d->GetYaxis()->GetTitle()));
 
       // allow Root to delete these histograms after display
       hnew->SetBit(kCanDelete);
       href->SetBit(kCanDelete);
 
       // create a new HistoData based on this projection
-      HistoData *proj =
-          (axis == axisX)
-              ? addProjectionXData(HD, projName.Data(), Plot1D, bin, hnew, href)
-              : addProjectionYData(HD, projName.Data(), Plot1D, bin, hnew,
-                                   href);
+      HistoData *proj = (axis == axisX) ? addProjectionXData(HD, projName.Data(), Plot1D, bin, hnew, href)
+                                        : addProjectionYData(HD, projName.Data(), Plot1D, bin, hnew, href);
 
       // ignore empty bins
       // if (hnew->Integral() == 0 || href->Integral() == 0) continue;
-      if (hnew->GetEntries() <= 1 || href->GetEntries() <= 1 ||
-          hnew->Integral() == 0 || href->Integral() == 0)
+      if (hnew->GetEntries() <= 1 || href->GetEntries() <= 1 || hnew->Integral() == 0 || href->Integral() == 0)
         continue;
 
       // run this new HistoData through compare<Plot1D>
@@ -158,8 +142,8 @@ template <> bool PlotCompareUtility::compare<Plot2D>(HistoData *HD) {
   return projectionsPassed;
 }
 
-template <> void PlotCompareUtility::makePlots<Plot2D>(HistoData *HD) {
-
+template <>
+void PlotCompareUtility::makePlots<Plot2D>(HistoData *HD) {
   // do not make any new plot if empty
   if (HD->getIsEmpty()) {
     HD->setResultImage("NoData_Results.gif");
@@ -176,10 +160,8 @@ template <> void PlotCompareUtility::makePlots<Plot2D>(HistoData *HD) {
 
   // make projection summaries
   for (int axis = axisX; axis <= axisY; ++axis) {
-
     // get the list of projections associated with this HistoData
-    std::vector<HistoData> *proj =
-        (axis == axisX) ? &projectionsX[HD] : &projectionsY[HD];
+    std::vector<HistoData> *proj = (axis == axisX) ? &projectionsX[HD] : &projectionsY[HD];
     if (proj == nullptr || proj->empty())
       continue;
 
@@ -190,8 +172,7 @@ template <> void PlotCompareUtility::makePlots<Plot2D>(HistoData *HD) {
     // generate a reasonable width for the projections summary
     int numHistos = proj->size();
     int bodyWidth = int(float(numHistos * projectionsBarsThickness) * 1.5);
-    projectionsWidth =
-        projectionsLeftMargin + projectionsRightMargin + bodyWidth;
+    projectionsWidth = projectionsLeftMargin + projectionsRightMargin + bodyWidth;
 
     // the canvas is rescaled during gif conversion, so add padding to Canvas
     // dimensions
@@ -199,24 +180,19 @@ template <> void PlotCompareUtility::makePlots<Plot2D>(HistoData *HD) {
     int projectionsCanvasHeight = projectionsHeight + 28;
 
     // create and setup projections canvas
-    TCanvas projectionsCanvas("projectionsCanvas", "projectionsCanvas",
-                              projectionsCanvasWidth, projectionsCanvasHeight);
+    TCanvas projectionsCanvas(
+        "projectionsCanvas", "projectionsCanvas", projectionsCanvasWidth, projectionsCanvasHeight);
     projectionsCanvas.SetFrameFillColor(10);
     projectionsCanvas.SetLogy(1);
-    projectionsCanvas.SetTopMargin(float(projectionsTopMargin) /
-                                   projectionsHeight);
-    projectionsCanvas.SetLeftMargin(float(projectionsLeftMargin) /
-                                    projectionsWidth);
-    projectionsCanvas.SetRightMargin(float(projectionsRightMargin) /
-                                     projectionsWidth);
-    projectionsCanvas.SetBottomMargin(float(projectionsBottomMargin) /
-                                      projectionsHeight);
+    projectionsCanvas.SetTopMargin(float(projectionsTopMargin) / projectionsHeight);
+    projectionsCanvas.SetLeftMargin(float(projectionsLeftMargin) / projectionsWidth);
+    projectionsCanvas.SetRightMargin(float(projectionsRightMargin) / projectionsWidth);
+    projectionsCanvas.SetBottomMargin(float(projectionsBottomMargin) / projectionsHeight);
     projectionsCanvas.Draw();
 
     // create and setup the summary histogram
-    TH1F projectionsSummary("projectionsSummary",
-                            "Compatibility with Reference Histograms",
-                            numHistos, 1, numHistos + 1);
+    TH1F projectionsSummary(
+        "projectionsSummary", "Compatibility with Reference Histograms", numHistos, 1, numHistos + 1);
     projectionsSummary.GetYaxis()->SetRangeUser(getThreshold() / 10, 2);
     projectionsSummary.SetStats(false);
 
@@ -226,9 +202,8 @@ template <> void PlotCompareUtility::makePlots<Plot2D>(HistoData *HD) {
     // draw X axis
     float xMin = hnew2d->GetXaxis()->GetXmin();
     float xMax = hnew2d->GetXaxis()->GetXmax();
-    int ticksNDiv = numHistos * 20 + bodyWidth / 50; // formerly *20
-    TGaxis *xAxis =
-        new TGaxis(1, 0, numHistos + 1, 0, xMin, xMax, ticksNDiv, "");
+    int ticksNDiv = numHistos * 20 + bodyWidth / 50;  // formerly *20
+    TGaxis *xAxis = new TGaxis(1, 0, numHistos + 1, 0, xMin, xMax, ticksNDiv, "");
     if (axis == axisX)
       xAxis->SetTitle(hnew2d->GetYaxis()->GetTitle());
     if (axis == axisY)
@@ -255,18 +230,15 @@ template <> void PlotCompareUtility::makePlots<Plot2D>(HistoData *HD) {
     passLine.Draw("SAME");
 
     // create the summary image
-    std::string gifName =
-        HD->getName() + (axis == axisX ? "_Results_px.gif" : "_Results_py.gif");
+    std::string gifName = HD->getName() + (axis == axisX ? "_Results_px.gif" : "_Results_py.gif");
     projectionsCanvas.Print(gifName.c_str());
 
     // make overall projection plot of the original 2d histogram
     std::string projName = HD->getName() + (axis == axisX ? "_py" : "_px");
     std::string newBinsProj = projName + "_new";
     std::string refBinsProj = projName + "_ref";
-    TH1D *href = (axis == axisX) ? href2d->ProjectionY(refBinsProj.c_str())
-                                 : href2d->ProjectionX(refBinsProj.c_str());
-    TH1D *hnew = (axis == axisX) ? hnew2d->ProjectionY(newBinsProj.c_str())
-                                 : hnew2d->ProjectionX(newBinsProj.c_str());
+    TH1D *href = (axis == axisX) ? href2d->ProjectionY(refBinsProj.c_str()) : href2d->ProjectionX(refBinsProj.c_str());
+    TH1D *hnew = (axis == axisX) ? hnew2d->ProjectionY(newBinsProj.c_str()) : hnew2d->ProjectionX(newBinsProj.c_str());
 
     // allow Root to delete these histograms after display
     href->SetBit(kCanDelete);
@@ -364,8 +336,8 @@ template <> void PlotCompareUtility::makePlots<Plot2D>(HistoData *HD) {
   */
 }
 
-template <> void PlotCompareUtility::makeHTML<Plot2D>(HistoData *HD) {
-
+template <>
+void PlotCompareUtility::makeHTML<Plot2D>(HistoData *HD) {
   /* at present, makeHTML<Plot1D> does nothing, so don't waste the CPU cycles
   // loop over projections and produce HTML
   std::vector<HistoData>::iterator hd;
@@ -380,47 +352,37 @@ template <> void PlotCompareUtility::makeHTML<Plot2D>(HistoData *HD) {
   // loop over the axes to see if projections were produced
   bool pfDone[2] = {false, false};
   for (int axis = axisX; axis <= axisY; axis++) {
-
     // get the list of projections associated with this HistoData
-    std::vector<HistoData> *proj =
-        (axis == axisX) ? &projectionsX[HD] : &projectionsY[HD];
+    std::vector<HistoData> *proj = (axis == axisX) ? &projectionsX[HD] : &projectionsY[HD];
     if (proj == nullptr || proj->empty())
       continue;
     else
       pfDone[axis] = true;
 
     // setup some names, etc. for insertion into the HTML
-    std::string gifNameProjections =
-        Name + (axis == axisX ? "_Results_px.gif" : "_Results_py.gif");
-    std::string gifNameAllProj =
-        Name + (axis == axisX ? "_py_Results.gif" : "_px_Results.gif");
-    std::string gifNameProfile =
-        Name + (axis == axisX ? "_pfx.gif" : "_pfy.gif");
+    std::string gifNameProjections = Name + (axis == axisX ? "_Results_px.gif" : "_Results_py.gif");
+    std::string gifNameAllProj = Name + (axis == axisX ? "_py_Results.gif" : "_px_Results.gif");
+    std::string gifNameProfile = Name + (axis == axisX ? "_pfx.gif" : "_pfy.gif");
     std::string gifBinPrefix = Name + (axis == axisX ? "_px" : "_py");
 
     // setup some locations to put thumbnails, etc.
     int offset = 10;
     int thumbWidth = plotsWidth / 4;
     int thumbHeight = plotsHeight / 4;
-    int bodyWidth =
-        projectionsWidth - projectionsLeftMargin - projectionsRightMargin;
-    int leftThumbPos =
-        offset + projectionsLeftMargin + bodyWidth / 4 - thumbWidth / 2;
+    int bodyWidth = projectionsWidth - projectionsLeftMargin - projectionsRightMargin;
+    int leftThumbPos = offset + projectionsLeftMargin + bodyWidth / 4 - thumbWidth / 2;
     int rightThumbPos = leftThumbPos + bodyWidth / 2;
     int thumbsLoc = projectionsTopMargin + thumbHeight / 2;
 
     // create the profile's HTML document
-    std::string htmlNameProfile =
-        Name + (axis == axisX ? "_Results_px.html" : "_Results_py.html");
+    std::string htmlNameProfile = Name + (axis == axisX ? "_Results_px.html" : "_Results_py.html");
     std::ofstream fout(htmlNameProfile.c_str());
 
     // print top portion of document
-    fout << "<!DOCTYPE gif PUBLIC '-//W3C//DTD HTML 4.01 Transitional//EN'>"
-         << std::endl
+    fout << "<!DOCTYPE gif PUBLIC '-//W3C//DTD HTML 4.01 Transitional//EN'>" << std::endl
          << "<html>" << std::endl
          << "  <head>" << std::endl
-         << "    <title>Compatibility of Projections for "
-         << HD->getRefHisto()->GetTitle() << "</title>" << std::endl
+         << "    <title>Compatibility of Projections for " << HD->getRefHisto()->GetTitle() << "</title>" << std::endl
          << "    <script type='text/javascript'>" << std::endl
          << std::endl
          << "      function tn(target,image,class) {" << std::endl
@@ -432,28 +394,19 @@ template <> void PlotCompareUtility::makeHTML<Plot2D>(HistoData *HD) {
             "document.getElementById('thumb_div').setAttribute('className',"
             "class)"
          << std::endl
-         << "        document.getElementById('thumb_link').href = target"
-         << std::endl
-         << "        document.getElementById('thumb_img').src = image"
-         << std::endl
-         << "        document.getElementById('thumb_img').width = '"
-         << thumbWidth << "'" << std::endl
-         << "        document.getElementById('thumb_img').height = '"
-         << thumbHeight << "'" << std::endl
-         << "        document.getElementById('thumb_img').border = '1'"
-         << std::endl
+         << "        document.getElementById('thumb_link').href = target" << std::endl
+         << "        document.getElementById('thumb_img').src = image" << std::endl
+         << "        document.getElementById('thumb_img').width = '" << thumbWidth << "'" << std::endl
+         << "        document.getElementById('thumb_img').height = '" << thumbHeight << "'" << std::endl
+         << "        document.getElementById('thumb_img').border = '1'" << std::endl
          << "      }" << std::endl
          << std::endl
          << "      function clear() {" << std::endl
-         << "        document.getElementById('thumb_link').href = '#'"
-         << std::endl
+         << "        document.getElementById('thumb_link').href = '#'" << std::endl
          << "        document.getElementById('thumb_img').src = ''" << std::endl
-         << "        document.getElementById('thumb_img').width = '0'"
-         << std::endl
-         << "        document.getElementById('thumb_img').height = '0'"
-         << std::endl
-         << "        document.getElementById('thumb_img').border = '0'"
-         << std::endl
+         << "        document.getElementById('thumb_img').width = '0'" << std::endl
+         << "        document.getElementById('thumb_img').height = '0'" << std::endl
+         << "        document.getElementById('thumb_img').border = '0'" << std::endl
          << "      }" << std::endl
          << std::endl
          << "    </script>" << std::endl
@@ -463,12 +416,11 @@ template <> void PlotCompareUtility::makeHTML<Plot2D>(HistoData *HD) {
          //         << "<a href='index.html'>"
          << "    <style type='text/css'>" << std::endl
          << "      #thumb_div {}" << std::endl
-         << "      div.thumb_left {position: absolute; left: " << leftThumbPos
-         << "px; top: " << thumbsLoc << "px;}" << std::endl
-         << "      div.thumb_right {position: absolute; left: " << rightThumbPos
-         << "px; top: " << thumbsLoc << "px;}" << std::endl
-         << "      #main_d {position: absolute; left: " << offset << "px;}"
+         << "      div.thumb_left {position: absolute; left: " << leftThumbPos << "px; top: " << thumbsLoc << "px;}"
          << std::endl
+         << "      div.thumb_right {position: absolute; left: " << rightThumbPos << "px; top: " << thumbsLoc << "px;}"
+         << std::endl
+         << "      #main_d {position: absolute; left: " << offset << "px;}" << std::endl
          << "      a:link {color: #000000}" << std::endl
          << "      a:visited {color: #000000}" << std::endl
          << "      a:hover {color: #000000}" << std::endl
@@ -478,21 +430,16 @@ template <> void PlotCompareUtility::makeHTML<Plot2D>(HistoData *HD) {
          << std::endl
          // << " <p>" <<   HD->getRefHisto()->GetTitle() << "</p>"  //include
          // the Title of the Plot as a title of the page
-         << "      <img src='" << gifNameProjections
-         << "' usemap='#results' alt=''"
-         << " height=" << projectionsHeight << " width=" << projectionsWidth
-         << " border=0>" << std::endl
-         << "      <map id='#results' name='results' onMouseOut=\"clear()\">"
-         << std::endl;
+         << "      <img src='" << gifNameProjections << "' usemap='#results' alt=''"
+         << " height=" << projectionsHeight << " width=" << projectionsWidth << " border=0>" << std::endl
+         << "      <map id='#results' name='results' onMouseOut=\"clear()\">" << std::endl;
 
     // loop over projections
     std::vector<HistoData>::iterator pd;
     for (pd = proj->begin(); pd != proj->end(); pd++) {
-
       // determine map coordinates for this bin (1 pixel offset due to borders?)
       int bin = pd->getBin();
-      int x1 = projectionsLeftMargin +
-               int(float(bin * 1.5 - 1.25) * projectionsBarsThickness);
+      int x1 = projectionsLeftMargin + int(float(bin * 1.5 - 1.25) * projectionsBarsThickness);
       int x2 = x1 + projectionsBarsThickness;
       int y1 = projectionsTopMargin + 1;
       int y2 = projectionsHeight - projectionsBottomMargin;
@@ -500,14 +447,10 @@ template <> void PlotCompareUtility::makeHTML<Plot2D>(HistoData *HD) {
       std::string target = pd->getResultTarget();
 
       // add coordinates area to image map
-      std::string tnClass =
-          (bin - 1 >= float(proj->size()) / 2 ? "thumb_left" : "thumb_right");
-      fout << "        <area shape='rect' alt='' coords='" << x1 << "," << y1
-           << "," << x2 << "," << y2 << "'"
-           << " href='" << target << "' onMouseOver=\"tn('" << target << "','"
-           << image << "','" << tnClass << "')\" "
-           << "onMouseDown=\"window.location.href='" << target << "'\">"
-           << std::endl;
+      std::string tnClass = (bin - 1 >= float(proj->size()) / 2 ? "thumb_left" : "thumb_right");
+      fout << "        <area shape='rect' alt='' coords='" << x1 << "," << y1 << "," << x2 << "," << y2 << "'"
+           << " href='" << target << "' onMouseOver=\"tn('" << target << "','" << image << "','" << tnClass << "')\" "
+           << "onMouseDown=\"window.location.href='" << target << "'\">" << std::endl;
     }
 
     fout << "        <area shape='default' nohref='nohref' "
@@ -530,7 +473,6 @@ template <> void PlotCompareUtility::makeHTML<Plot2D>(HistoData *HD) {
 
   // if both profile dimensions were filled, we need an additional HTML document
   if (pfDone[axisX] && pfDone[axisY]) {
-
     // create HTML support code for this HistoData
     std::string html = Name + "_Results_Profiles.html";
     std::ofstream fout(html.c_str());
@@ -541,12 +483,9 @@ template <> void PlotCompareUtility::makeHTML<Plot2D>(HistoData *HD) {
          << "    <frame src=\"" << Name << "_Results_py.html\">" << std::endl
          << "    <frame src=\"" << Name << "_Results_px.html\">" << std::endl
          << "    <noframes><body>" << std::endl
-         << "      unable to display frames -- click to select desired page"
-         << std::endl
-         << "      <br><a href =\"" << Name
-         << "_Results_py.html\">Y Projections</a>" << std::endl
-         << "      <br><a href =\"" << Name
-         << "_Results_px.html\">X Projections</a>" << std::endl
+         << "      unable to display frames -- click to select desired page" << std::endl
+         << "      <br><a href =\"" << Name << "_Results_py.html\">Y Projections</a>" << std::endl
+         << "      <br><a href =\"" << Name << "_Results_px.html\">X Projections</a>" << std::endl
          << "    </body></noframes>" << std::endl
          << "  </frameset>" << std::endl
          << "</html>" << std::endl;
@@ -557,4 +496,4 @@ template <> void PlotCompareUtility::makeHTML<Plot2D>(HistoData *HD) {
   }
 }
 
-#endif // PLOT_2D__H
+#endif  // PLOT_2D__H

--- a/Validation/RecoParticleFlow/bin/include/PlotCompareUtility.h
+++ b/Validation/RecoParticleFlow/bin/include/PlotCompareUtility.h
@@ -19,9 +19,12 @@ public:
   // BasePath = the path to data in the DQM root file (eg.,
   // "DQMData/METTask/ECAL/data") Prefix = the prefix common to all histograms
   // in area (eg., "METTask_" or "")
-  PlotCompareUtility(std::string Reference, std::string New,
-                     std::string NewBasePath, std::string NewPrefix = "",
-                     std::string RefBasePath = "", std::string RefPrefix = "");
+  PlotCompareUtility(std::string Reference,
+                     std::string New,
+                     std::string NewBasePath,
+                     std::string NewPrefix = "",
+                     std::string RefBasePath = "",
+                     std::string RefPrefix = "");
   virtual ~PlotCompareUtility();
 
   // Axis Conventions (For Specifying Profiles, Projections, etc.)
@@ -29,12 +32,8 @@ public:
 
   // Getters for HistoData Information
   std::vector<HistoData> *getHistos() { return &histos; }
-  std::vector<HistoData> *getProjectionsX(HistoData *HD) {
-    return &projectionsX[HD];
-  }
-  std::vector<HistoData> *getProjectionsY(HistoData *HD) {
-    return &projectionsY[HD];
-  }
+  std::vector<HistoData> *getProjectionsX(HistoData *HD) { return &projectionsX[HD]; }
+  std::vector<HistoData> *getProjectionsY(HistoData *HD) { return &projectionsY[HD]; }
   int getNumHistos() const { return histos.size(); }
   // int getNumProjectionsX(HistoData *HD) const { return
   // projectionsX[HD].size(); } int getNumProjectionsY(HistoData *HD) const {
@@ -43,7 +42,7 @@ public:
   // Getters for Statistical Comparisons
   double getKSThreshold() const { return ksThreshold; }
   double getChi2Threshold() const { return chi2Threshold; }
-  double getThreshold() const; // the lowest non-zero test threshold
+  double getThreshold() const;  // the lowest non-zero test threshold
   bool getFinalResult() const { return finalResult; }
 
   // Getters for Drawing Options
@@ -82,17 +81,11 @@ public:
   void setSummaryBottomMargin(int Pixels) { summaryBottomMargin = Pixels; }
   void setProjectionsiWidth(int Pixels) { projectionsWidth = Pixels; }
   void setProjectionsHeight(int Pixels) { projectionsHeight = Pixels; }
-  void setProjectionsBarsThickness(int Pixels) {
-    projectionsBarsThickness = Pixels;
-  }
+  void setProjectionsBarsThickness(int Pixels) { projectionsBarsThickness = Pixels; }
   void setProjectionsTopMargin(int Pixels) { projectionsTopMargin = Pixels; }
   void setProjectionsLeftMargin(int Pixels) { projectionsLeftMargin = Pixels; }
-  void setProjectionsRightMargin(int Pixels) {
-    projectionsRightMargin = Pixels;
-  }
-  void setProjectionsBottomMargin(int Pixels) {
-    projectionsBottomMargin = Pixels;
-  }
+  void setProjectionsRightMargin(int Pixels) { projectionsRightMargin = Pixels; }
+  void setProjectionsBottomMargin(int Pixels) { projectionsBottomMargin = Pixels; }
   void setPlotsHeight(int Pixels) { plotsHeight = Pixels; }
   void setPlotsWidth(int Pixels) { plotsWidth = Pixels; }
   void setPlotsTopMargin(int Pixels) { plotsTopMargin = Pixels; }
@@ -101,17 +94,12 @@ public:
   void setPlotsBottomMargin(int Pixels) { plotsBottomMargin = Pixels; }
 
   // Add HistoData Objects for Comparison
-  HistoData *addHistoData(std::string NewName, std::string RefName,
-                          int PlotType);
-  HistoData *addHistoData(std::string Name, int PlotType) {
-    return addHistoData(Name, Name, PlotType);
-  }
-  HistoData *addProjectionXData(HistoData *Parent, std::string Name,
-                                int PlotType, int Bin, TH1 *NewHisto,
-                                TH1 *RefHisto);
-  HistoData *addProjectionYData(HistoData *Parent, std::string Name,
-                                int PlotType, int Bin, TH1 *NewHisto,
-                                TH1 *RefHisto);
+  HistoData *addHistoData(std::string NewName, std::string RefName, int PlotType);
+  HistoData *addHistoData(std::string Name, int PlotType) { return addHistoData(Name, Name, PlotType); }
+  HistoData *addProjectionXData(
+      HistoData *Parent, std::string Name, int PlotType, int Bin, TH1 *NewHisto, TH1 *RefHisto);
+  HistoData *addProjectionYData(
+      HistoData *Parent, std::string Name, int PlotType, int Bin, TH1 *NewHisto, TH1 *RefHisto);
   void clearHistos() { histos.clear(); }
   void clearProjectionsX(HistoData *Parent) { projectionsX[Parent].clear(); }
   void clearProjectionsY(HistoData *Parent) { projectionsY[Parent].clear(); }
@@ -149,15 +137,18 @@ private:
   double chi2Threshold;
 
   // private (implementation/helper) functions
-  template <int PlotType> bool compare(HistoData *);
-  template <int PlotType> void makePlots(HistoData *);
-  template <int PlotType> void makeHTML(HistoData *);
+  template <int PlotType>
+  bool compare(HistoData *);
+  template <int PlotType>
+  void makePlots(HistoData *);
+  template <int PlotType>
+  void makeHTML(HistoData *);
   void centerRebin(TH1 *, TH1 *);
   void renormalize(TH1 *, TH1 *);
 
   // summary settings
-  int summaryWidth;  // user defined
-  int summaryHeight; // set by plotter
+  int summaryWidth;   // user defined
+  int summaryHeight;  // set by plotter
   int summaryBarsThickness;
   int summaryTopMargin;
   int summaryLeftMargin;
@@ -165,8 +156,8 @@ private:
   int summaryBottomMargin;
 
   // 2d projections summary settings
-  int projectionsWidth;  // set by plotter
-  int projectionsHeight; // user defined
+  int projectionsWidth;   // set by plotter
+  int projectionsHeight;  // user defined
   int projectionsBarsThickness;
   int projectionsTopMargin;
   int projectionsLeftMargin;
@@ -174,8 +165,8 @@ private:
   int projectionsBottomMargin;
 
   // 1d distribution plots settings
-  int plotsWidth;  // user defined
-  int plotsHeight; // user defined
+  int plotsWidth;   // user defined
+  int plotsHeight;  // user defined
   int plotsTopMargin;
   int plotsLeftMargin;
   int plotsRightMargin;
@@ -185,4 +176,4 @@ private:
   bool finalResult;
 };
 
-#endif // PLOT_COMPARE_UTILITY__H
+#endif  // PLOT_COMPARE_UTILITY__H

--- a/Validation/RecoParticleFlow/bin/include/PlotTypes.h
+++ b/Validation/RecoParticleFlow/bin/include/PlotTypes.h
@@ -3,4 +3,4 @@
 
 enum PlotType { Plot1D, Plot2D };
 
-#endif // PLOT_TYPES__H
+#endif  // PLOT_TYPES__H

--- a/Validation/RecoParticleFlow/bin/include/Style.h
+++ b/Validation/RecoParticleFlow/bin/include/Style.h
@@ -5,15 +5,14 @@
 
 // tdrGrid: Turns the grid lines on (true) or off (false)
 TStyle genStyle() {
-
   TStyle myStyle("myStyle", "Style similar to P-TDR");
 
   // For the canvas:
   myStyle.SetCanvasBorderMode(0);
   myStyle.SetCanvasColor(kWhite);
-  myStyle.SetCanvasDefH(600); // Height of canvas
-  myStyle.SetCanvasDefW(600); // Width of canvas
-  myStyle.SetCanvasDefX(0);   // POsition on screen
+  myStyle.SetCanvasDefH(600);  // Height of canvas
+  myStyle.SetCanvasDefW(600);  // Width of canvas
+  myStyle.SetCanvasDefX(0);    // POsition on screen
   myStyle.SetCanvasDefY(0);
 
   // For the Pad:
@@ -64,7 +63,7 @@ TStyle genStyle() {
 
   // For the statistics box:
   myStyle.SetOptFile(1);
-  myStyle.SetOptStat("mre"); // To display the mean and RMS:   SetOptStat("mr");
+  myStyle.SetOptStat("mre");  // To display the mean and RMS:   SetOptStat("mr");
   myStyle.SetStatColor(kWhite);
   myStyle.SetStatFont(42);
   myStyle.SetStatFontSize(0.025);
@@ -122,7 +121,7 @@ TStyle genStyle() {
   myStyle.SetStripDecimals(kTRUE);
   myStyle.SetTickLength(0.03, "XYZ");
   myStyle.SetNdivisions(510, "XYZ");
-  myStyle.SetPadTickX(1); // To get tick marks on the opposite side of the frame
+  myStyle.SetPadTickX(1);  // To get tick marks on the opposite side of the frame
   myStyle.SetPadTickY(1);
 
   // Change for log plots:
@@ -147,4 +146,4 @@ TStyle genStyle() {
   return myStyle;
 }
 
-#endif // STYLE__H
+#endif  // STYLE__H

--- a/Validation/RecoParticleFlow/bin/plotCompare.cpp
+++ b/Validation/RecoParticleFlow/bin/plotCompare.cpp
@@ -7,7 +7,6 @@
 using namespace std;
 
 int main(int argc, char *argv[]) {
-
   std::string branchRef("DQMData/PFTask/Benchmarks");
   std::string branchNew("DQMData/PFTask/Benchmarks");
 
@@ -34,8 +33,8 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  PlotCompareUtility *pc = new PlotCompareUtility(
-      argv[1], argv[2], branchNew, branchNewPrefix, branchRef, branchRefPrefix);
+  PlotCompareUtility *pc =
+      new PlotCompareUtility(argv[1], argv[2], branchNew, branchNewPrefix, branchRef, branchRefPrefix);
 
   // set thresholds for tests (set to zero or negative to ignore results)
   // pc->setKSThreshold(1e-6);
@@ -91,8 +90,7 @@ int main(int argc, char *argv[]) {
 
   // check if everything was set up properly
   if (!pc->isValid()) {
-    cout << "PlotCompareUtility failed to initialize!!!" << endl
-         << "Final Result: no_data" << endl;
+    cout << "PlotCompareUtility failed to initialize!!!" << endl << "Final Result: no_data" << endl;
     cerr << "Invalid TFile(s), directory, task, or no histograms specified.\n";
     pc->dump();
     return 1;

--- a/Validation/RecoParticleFlow/interface/Comparator.h
+++ b/Validation/RecoParticleFlow/interface/Comparator.h
@@ -13,26 +13,19 @@
 class Style;
 
 class Comparator {
-
 public:
   enum Mode { NORMAL, SCALE, RATIO, GRAPH, EFF };
 
-  Comparator()
-      : rebin_(-1), xMin_(0), xMax_(0), resetAxis_(false), s0_(nullptr),
-        s1_(nullptr), legend_(0, 0, 1, 1) {}
+  Comparator() : rebin_(-1), xMin_(0), xMax_(0), resetAxis_(false), s0_(nullptr), s1_(nullptr), legend_(0, 0, 1, 1) {}
 
-  Comparator(const char *file0, const char *dir0, const char *file1,
-             const char *dir1)
-      : rebin_(-1), xMin_(0), xMax_(0), resetAxis_(false), s0_(nullptr),
-        s1_(nullptr), legend_(0, 0, 1, 1) {
-
+  Comparator(const char *file0, const char *dir0, const char *file1, const char *dir1)
+      : rebin_(-1), xMin_(0), xMax_(0), resetAxis_(false), s0_(nullptr), s1_(nullptr), legend_(0, 0, 1, 1) {
     SetDirs(file0, dir0, file1, dir1);
   }
 
   /// set the 2 files, and the directory within each file, in which the
   /// histograms will be compared
-  void SetDirs(const char *file0, const char *dir0, const char *file1,
-               const char *dir1);
+  void SetDirs(const char *file0, const char *dir0, const char *file1, const char *dir1);
 
   // set the rebinning factor and the range
   void SetAxis(int rebin, float xmin, float xmax) {
@@ -54,14 +47,11 @@ public:
   void DrawMeanSlice(const char *key, const int rebinFactor, Mode mode);
   void DrawSigmaSlice(const char *key, const int rebinFactor, Mode mode);
   void DrawGaussSigmaSlice(const char *key, const int rebinFactor, Mode mode);
-  void DrawGaussSigmaSlice(const char *key, const int rebinFactor,
-                           const int binxmin, const int binxmax,
-                           const bool cst_binning, Mode mode);
-  void DrawGaussSigmaOverMeanXSlice(const char *key, const int rebinFactor,
-                                    const int binxmin, const int binxmax,
-                                    const bool cst_binning, Mode mode);
-  void DrawGaussSigmaOverMeanSlice(const char *key, const char *key2,
-                                   const int rebinFactor, Mode mode);
+  void DrawGaussSigmaSlice(
+      const char *key, const int rebinFactor, const int binxmin, const int binxmax, const bool cst_binning, Mode mode);
+  void DrawGaussSigmaOverMeanXSlice(
+      const char *key, const int rebinFactor, const int binxmin, const int binxmax, const bool cst_binning, Mode mode);
+  void DrawGaussSigmaOverMeanSlice(const char *key, const char *key2, const int rebinFactor, Mode mode);
 
   void Draw(const char *key, Mode mode);
 

--- a/Validation/RecoParticleFlow/interface/NicePlot.h
+++ b/Validation/RecoParticleFlow/interface/NicePlot.h
@@ -21,8 +21,7 @@ public:
 
   static void FormatHisto(TH1 *h, const Style *s);
 
-  static void FormatPad(TPad *pad, bool grid = true, bool logx = false,
-                        bool logy = false);
+  static void FormatPad(TPad *pad, bool grid = true, bool logx = false, bool logy = false);
 
   static void SavePlot(const char *name, const char *dir);
 };

--- a/Validation/RecoParticleFlow/interface/TH2Analyzer.h
+++ b/Validation/RecoParticleFlow/interface/TH2Analyzer.h
@@ -18,18 +18,24 @@ class TH2D;
 // (key) which starts with name_RMS
 
 class TH2Analyzer : public TObject {
-
 public:
   TH2Analyzer(const TH2 *h, int rebin = 1)
-      : hist2D_(h), rebinnedHist2D_(nullptr), average_(nullptr), RMS_(nullptr),
-        sigmaGauss_(nullptr), meanXslice_(nullptr) {
+      : hist2D_(h),
+        rebinnedHist2D_(nullptr),
+        average_(nullptr),
+        RMS_(nullptr),
+        sigmaGauss_(nullptr),
+        meanXslice_(nullptr) {
     Eval(rebin);
   }
 
-  TH2Analyzer(const TH2 *h, const int binxmin, const int binxmax,
-              const int rebin, const bool cst_binning = true)
-      : hist2D_(h), rebinnedHist2D_(nullptr), average_(nullptr), RMS_(nullptr),
-        sigmaGauss_(nullptr), meanXslice_(nullptr) {
+  TH2Analyzer(const TH2 *h, const int binxmin, const int binxmax, const int rebin, const bool cst_binning = true)
+      : hist2D_(h),
+        rebinnedHist2D_(nullptr),
+        average_(nullptr),
+        RMS_(nullptr),
+        sigmaGauss_(nullptr),
+        meanXslice_(nullptr) {
     Eval(rebin, binxmin, binxmax, cst_binning);
   }
 
@@ -40,8 +46,7 @@ public:
   void SetHisto(const TH2 *h) { hist2D_ = h; }
 
   void Eval(const int rebinFactor);
-  void Eval(const int rebinFactor, const int binxmin, const int binxmax,
-            const bool cst_binning);
+  void Eval(const int rebinFactor, const int binxmin, const int binxmax, const bool cst_binning);
 
   TH1D *Average() { return average_; }
   TH1D *RMS() { return RMS_; }

--- a/Validation/RecoParticleFlow/plugins/GenJetClosestMatchSelector.cc
+++ b/Validation/RecoParticleFlow/plugins/GenJetClosestMatchSelector.cc
@@ -4,7 +4,6 @@
 #include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
 #include "Validation/RecoParticleFlow/plugins/GenJetClosestMatchSelectorDefinition.h"
 
-typedef ObjectSelector<GenJetClosestMatchSelectorDefinition>
-    GenJetClosestMatchSelector;
+typedef ObjectSelector<GenJetClosestMatchSelectorDefinition> GenJetClosestMatchSelector;
 
 DEFINE_FWK_MODULE(GenJetClosestMatchSelector);

--- a/Validation/RecoParticleFlow/plugins/GenJetClosestMatchSelectorDefinition.h
+++ b/Validation/RecoParticleFlow/plugins/GenJetClosestMatchSelectorDefinition.h
@@ -13,26 +13,20 @@
 #include <iostream>
 
 struct GenJetClosestMatchSelectorDefinition {
-
   typedef reco::GenJetCollection collection;
   typedef edm::Handle<collection> HandleToCollection;
   typedef std::vector<reco::GenJet *> container;
   typedef container::const_iterator const_iterator;
 
-  GenJetClosestMatchSelectorDefinition(const edm::ParameterSet &cfg,
-                                       edm::ConsumesCollector &&iC) {
-
-    matchTo_ = iC.consumes<edm::View<reco::Candidate>>(
-        cfg.getParameter<edm::InputTag>("MatchTo"));
+  GenJetClosestMatchSelectorDefinition(const edm::ParameterSet &cfg, edm::ConsumesCollector &&iC) {
+    matchTo_ = iC.consumes<edm::View<reco::Candidate>>(cfg.getParameter<edm::InputTag>("MatchTo"));
   }
 
   const_iterator begin() const { return selected_.begin(); }
 
   const_iterator end() const { return selected_.end(); }
 
-  void select(const HandleToCollection &hc, const edm::Event &e,
-              const edm::EventSetup &s) {
-
+  void select(const HandleToCollection &hc, const edm::Event &e, const edm::EventSetup &s) {
     selected_.clear();
 
     edm::Handle<edm::View<reco::Candidate>> matchCandidates;
@@ -45,7 +39,6 @@ struct GenJetClosestMatchSelectorDefinition {
 
     typedef edm::View<reco::Candidate>::const_iterator IC;
     for (IC ic = matchCandidates->begin(); ic != matchCandidates->end(); ++ic) {
-
       double eta2 = ic->eta();
       double phi2 = ic->phi();
 
@@ -54,9 +47,7 @@ struct GenJetClosestMatchSelectorDefinition {
       // look for the closest gen jet
       double deltaR2Min = 9999;
       collection::const_iterator closest = hc->end();
-      for (collection::const_iterator genjet = hc->begin(); genjet != hc->end();
-           ++genjet, ++key) {
-
+      for (collection::const_iterator genjet = hc->begin(); genjet != hc->end(); ++genjet, ++key) {
         reco::GenJetRef genJetRef(hc, key);
 
         // is it matched?
@@ -79,10 +70,10 @@ struct GenJetClosestMatchSelectorDefinition {
         // std::cout<<deltaR2Min<<std::endl;
         selected_.push_back(new reco::GenJet(*closest));
       }
-    } // end collection iteration
+    }  // end collection iteration
 
     // std::cout<<selected_.size()<<std::endl;
-  } // end select()
+  }  // end select()
 
   size_t size() const { return selected_.size(); }
 

--- a/Validation/RecoParticleFlow/plugins/GenericBenchmarkAnalyzer.cc
+++ b/Validation/RecoParticleFlow/plugins/GenericBenchmarkAnalyzer.cc
@@ -34,16 +34,13 @@ using namespace reco;
 using namespace edm;
 using namespace std;
 
-GenericBenchmarkAnalyzer::GenericBenchmarkAnalyzer(
-    const edm::ParameterSet &iConfig) {
-
+GenericBenchmarkAnalyzer::GenericBenchmarkAnalyzer(const edm::ParameterSet &iConfig) {
   inputTruthLabel_ = iConfig.getParameter<edm::InputTag>("InputTruthLabel");
   inputRecoLabel_ = iConfig.getParameter<edm::InputTag>("InputRecoLabel");
   outputFile_ = iConfig.getUntrackedParameter<std::string>("OutputFile");
   benchmarkLabel_ = iConfig.getParameter<std::string>("BenchmarkLabel");
   startFromGen_ = iConfig.getParameter<bool>("StartFromGen");
-  plotAgainstRecoQuantities_ =
-      iConfig.getParameter<bool>("PlotAgainstRecoQuantities");
+  plotAgainstRecoQuantities_ = iConfig.getParameter<bool>("PlotAgainstRecoQuantities");
   onlyTwoJets_ = iConfig.getParameter<bool>("OnlyTwoJets");
   recPt_cut = iConfig.getParameter<double>("recPt");
   minEta_cut = iConfig.getParameter<double>("minEta");
@@ -57,12 +54,9 @@ GenericBenchmarkAnalyzer::GenericBenchmarkAnalyzer(
   doMetPlots_ = iConfig.getParameter<bool>("doMetPlots");
 
   if (!outputFile_.empty())
-    edm::LogInfo("OutputInfo")
-        << " ParticleFLow Task histograms will be saved to '"
-        << outputFile_.c_str() << "'";
+    edm::LogInfo("OutputInfo") << " ParticleFLow Task histograms will be saved to '" << outputFile_.c_str() << "'";
   else
-    edm::LogInfo("OutputInfo")
-        << " ParticleFlow Task histograms will NOT be saved";
+    edm::LogInfo("OutputInfo") << " ParticleFlow Task histograms will NOT be saved";
 
   myTruth_ = consumes<edm::View<reco::Candidate>>(inputTruthLabel_);
   myReco_ = consumes<edm::View<reco::Candidate>>(inputRecoLabel_);
@@ -71,7 +65,6 @@ GenericBenchmarkAnalyzer::GenericBenchmarkAnalyzer(
 GenericBenchmarkAnalyzer::~GenericBenchmarkAnalyzer() {}
 
 void GenericBenchmarkAnalyzer::beginJob() {
-
   // get ahold of back-end interface
   dbe_ = edm::Service<DQMStore>().operator->();
 
@@ -84,14 +77,11 @@ void GenericBenchmarkAnalyzer::beginJob() {
     else
       path += "Gen";
     dbe_->setCurrentFolder(path);
-    setup(dbe_, plotAgainstRecoQuantities_, minDeltaEt_, maxDeltaEt_,
-          minDeltaPhi_, maxDeltaPhi_, doMetPlots_);
+    setup(dbe_, plotAgainstRecoQuantities_, minDeltaEt_, maxDeltaEt_, minDeltaPhi_, maxDeltaPhi_, doMetPlots_);
   }
 }
 
-void GenericBenchmarkAnalyzer::analyze(const edm::Event &iEvent,
-                                       const edm::EventSetup &iSetup) {
-
+void GenericBenchmarkAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // Typedefs to use views
   typedef edm::View<reco::Candidate> candidateCollection;
   typedef edm::View<reco::Candidate> candidateCollection;
@@ -131,9 +121,7 @@ void GenericBenchmarkAnalyzer::analyze(const edm::Event &iEvent,
     // &reco_storage;
   }
   if (!truth_candidates || !reco_candidates) {
-
-    edm::LogInfo("OutputInfo")
-        << " failed to retrieve data required by ParticleFlow Task";
+    edm::LogInfo("OutputInfo") << " failed to retrieve data required by ParticleFlow Task";
     edm::LogInfo("OutputInfo") << " ParticleFlow Task cannot continue...!";
     return;
   }
@@ -142,13 +130,18 @@ void GenericBenchmarkAnalyzer::analyze(const edm::Event &iEvent,
   // Analyze!
   // ==========================================================
 
-  fill(reco_candidates, truth_candidates, startFromGen_,
-       plotAgainstRecoQuantities_, onlyTwoJets_, recPt_cut, minEta_cut,
-       maxEta_cut, deltaR_cut);
+  fill(reco_candidates,
+       truth_candidates,
+       startFromGen_,
+       plotAgainstRecoQuantities_,
+       onlyTwoJets_,
+       recPt_cut,
+       minEta_cut,
+       maxEta_cut,
+       deltaR_cut);
 }
 
 void GenericBenchmarkAnalyzer::endJob() {
-
   // Store the DAQ Histograms
   if (!outputFile_.empty())
     dbe_->save(outputFile_);

--- a/Validation/RecoParticleFlow/plugins/GenericBenchmarkAnalyzer.h
+++ b/Validation/RecoParticleFlow/plugins/GenericBenchmarkAnalyzer.h
@@ -14,8 +14,7 @@
 
 #include <map>
 
-class GenericBenchmarkAnalyzer : public edm::EDAnalyzer,
-                                 public GenericBenchmark {
+class GenericBenchmarkAnalyzer : public edm::EDAnalyzer, public GenericBenchmark {
 public:
   explicit GenericBenchmarkAnalyzer(const edm::ParameterSet &);
   ~GenericBenchmarkAnalyzer() override;
@@ -46,4 +45,4 @@ private:
   bool doMetPlots_;
 };
 
-#endif // GENERICBENCHMARKANALYZER_H
+#endif  // GENERICBENCHMARKANALYZER_H

--- a/Validation/RecoParticleFlow/plugins/PFFilter.cc
+++ b/Validation/RecoParticleFlow/plugins/PFFilter.cc
@@ -21,36 +21,31 @@ PFFilter::~PFFilter() {}
 
 bool PFFilter::checkInput() {
   if (collections_.size() != min_.size()) {
-    std::cout << "Error: in PFFilter: collections_.size()!=min_.size()"
-              << std::endl;
+    std::cout << "Error: in PFFilter: collections_.size()!=min_.size()" << std::endl;
     std::cout << "collections_.size() = " << collections_.size() << std::endl;
     std::cout << "min_.size() = " << min_.size() << std::endl;
     return false;
   }
   if (collections_.size() != max_.size()) {
-    std::cout << "Error: in PFFilter: collections_.size()!=max_.size()"
-              << std::endl;
+    std::cout << "Error: in PFFilter: collections_.size()!=max_.size()" << std::endl;
     std::cout << "collections_.size() = " << collections_.size() << std::endl;
     std::cout << "max_.size() = " << max_.size() << std::endl;
     return false;
   }
   if (collections_.size() != doMin_.size()) {
-    std::cout << "Error: in PFFilter: collections_.size()!=min_.size()"
-              << std::endl;
+    std::cout << "Error: in PFFilter: collections_.size()!=min_.size()" << std::endl;
     std::cout << "collections_.size() = " << collections_.size() << std::endl;
     std::cout << "doMin_.size() = " << doMin_.size() << std::endl;
     return false;
   }
   if (collections_.size() != doMax_.size()) {
-    std::cout << "Error: in PFFilter: collections_.size()!=min_.size()"
-              << std::endl;
+    std::cout << "Error: in PFFilter: collections_.size()!=min_.size()" << std::endl;
     std::cout << "collections_.size() = " << collections_.size() << std::endl;
     std::cout << "doMax_.size() = " << doMax_.size() << std::endl;
     return false;
   }
   if (collections_.size() != variables_.size()) {
-    std::cout << "Error: in PFFilter: collections_.size()!=variables_.size()"
-              << std::endl;
+    std::cout << "Error: in PFFilter: collections_.size()!=variables_.size()" << std::endl;
     std::cout << "collections_.size() = " << collections_.size() << std::endl;
     std::cout << "variables_.size() = " << variables_.size() << std::endl;
     return false;
@@ -67,7 +62,7 @@ bool PFFilter::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // std::cout << "FL: Mins = " << min_ << std::endl;
 
   if (!checkInput())
-    return true; // no filtering !
+    return true;  // no filtering !
 
   bool skip = false;
 
@@ -82,16 +77,14 @@ bool PFFilter::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
       collection1.assign(collections_[varc], 0, minuspos);
       // std::cout << "collection1 = " << collection1 << std::endl;
       std::string collection2;
-      collection2.assign(collections_[varc], minuspos + 1,
-                         collections_[varc].size());
+      collection2.assign(collections_[varc], minuspos + 1, collections_[varc].size());
       // std::cout << "collection2 = " << collection2 << std::endl;
 
       const edm::View<reco::Candidate> *var1;
       edm::Handle<edm::View<reco::Candidate>> var1_hnd;
       bool isVar1 = iEvent.getByLabel(collection1, var1_hnd);
       if (!isVar1) {
-        std::cout << "Warning : no " << collection1 << " in input !"
-                  << std::endl;
+        std::cout << "Warning : no " << collection1 << " in input !" << std::endl;
         return false;
       }
       var1 = var1_hnd.product();
@@ -105,8 +98,7 @@ bool PFFilter::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
       else if (variables_[varc] == "eta")
         coll_var1 = var10->eta();
       else {
-        std::cout << "Error: PFFilter: variable unknown: " << variables_[varc]
-                  << std::endl;
+        std::cout << "Error: PFFilter: variable unknown: " << variables_[varc] << std::endl;
         return true;
       }
       // std::cout << "FL: coll_var1[" << variables_[varc] << "] = " <<
@@ -116,8 +108,7 @@ bool PFFilter::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
       edm::Handle<edm::View<reco::Candidate>> var2_hnd;
       bool isVar2 = iEvent.getByLabel(collection2, var2_hnd);
       if (!isVar2) {
-        std::cout << "Warning : no " << collection2 << " in input !"
-                  << std::endl;
+        std::cout << "Warning : no " << collection2 << " in input !" << std::endl;
         return false;
       }
       var2 = var2_hnd.product();
@@ -131,8 +122,7 @@ bool PFFilter::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
       else if (variables_[varc] == "eta")
         coll_var2 = var20->eta();
       else {
-        std::cout << "Error: PFFilter: variable unknown: " << variables_[varc]
-                  << std::endl;
+        std::cout << "Error: PFFilter: variable unknown: " << variables_[varc] << std::endl;
         return true;
       }
       // std::cout << "FL: coll_var2[" << variables_[varc] << "] = " <<
@@ -182,8 +172,7 @@ bool PFFilter::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
       edm::Handle<edm::View<reco::Candidate>> var0_hnd;
       bool isVar0 = iEvent.getByLabel(collections_[varc], var0_hnd);
       if (!isVar0) {
-        std::cout << "Warning : no " << collections_[varc] << " in input !"
-                  << std::endl;
+        std::cout << "Warning : no " << collections_[varc] << " in input !" << std::endl;
         return false;
       }
       var0 = var0_hnd.product();
@@ -197,8 +186,7 @@ bool PFFilter::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
       else if (variables_[varc] == "eta")
         coll_var = var00->eta();
       else {
-        std::cout << "Error: PFFilter: variable unknown: " << variables_[varc]
-                  << std::endl;
+        std::cout << "Error: PFFilter: variable unknown: " << variables_[varc] << std::endl;
         return true;
       }
       // std::cout << "FL: coll_var[" << variables_[varc] << "] = " << coll_var

--- a/Validation/RecoParticleFlow/plugins/PFFilter.h
+++ b/Validation/RecoParticleFlow/plugins/PFFilter.h
@@ -27,4 +27,4 @@ private:
   std::vector<int> doMax_;
 };
 
-#endif // PFFILTER_H
+#endif  // PFFILTER_H

--- a/Validation/RecoParticleFlow/plugins/PFJetBenchmarkAnalyzer.cc
+++ b/Validation/RecoParticleFlow/plugins/PFJetBenchmarkAnalyzer.cc
@@ -88,10 +88,8 @@ PFJetBenchmarkAnalyzer::PFJetBenchmarkAnalyzer(const edm::ParameterSet &iConfig)
 
 {
   // now do what ever initialization is needed
-  sGenJetAlgo_tok_ = consumes<reco::GenJetCollection>(
-      iConfig.getParameter<edm::InputTag>("InputTruthLabel"));
-  sJetAlgo_tok_ = consumes<reco::PFJetCollection>(
-      iConfig.getParameter<edm::InputTag>("InputRecoLabel"));
+  sGenJetAlgo_tok_ = consumes<reco::GenJetCollection>(iConfig.getParameter<edm::InputTag>("InputTruthLabel"));
+  sJetAlgo_tok_ = consumes<reco::PFJetCollection>(iConfig.getParameter<edm::InputTag>("InputRecoLabel"));
   outjetfilename = iConfig.getUntrackedParameter<string>("OutputFile");
   pfjBenchmarkDebug = iConfig.getParameter<bool>("pfjBenchmarkDebug");
   plotAgainstReco = iConfig.getParameter<bool>("PlotAgainstRecoQuantities");
@@ -103,9 +101,8 @@ PFJetBenchmarkAnalyzer::PFJetBenchmarkAnalyzer(const edm::ParameterSet &iConfig)
 
   dbe_ = edm::Service<DQMStore>().operator->();
 
-  PFJetBenchmark_.setup(outjetfilename, pfjBenchmarkDebug, plotAgainstReco,
-                        onlyTwoJets, deltaRMax, benchmarkLabel_, recPt, maxEta,
-                        dbe_);
+  PFJetBenchmark_.setup(
+      outjetfilename, pfjBenchmarkDebug, plotAgainstReco, onlyTwoJets, deltaRMax, benchmarkLabel_, recPt, maxEta, dbe_);
 }
 
 PFJetBenchmarkAnalyzer::~PFJetBenchmarkAnalyzer() {
@@ -118,8 +115,7 @@ PFJetBenchmarkAnalyzer::~PFJetBenchmarkAnalyzer() {
 //
 
 // ------------ method called to for each event  ------------
-void PFJetBenchmarkAnalyzer::analyze(const edm::Event &iEvent,
-                                     const edm::EventSetup &iSetup) {
+void PFJetBenchmarkAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // get gen jet collection
   Handle<GenJetCollection> genjets;
   bool isGen = iEvent.getByToken(sGenJetAlgo_tok_, genjets);

--- a/Validation/RecoParticleFlow/plugins/PFJetFilter.cc
+++ b/Validation/RecoParticleFlow/plugins/PFJetFilter.cc
@@ -14,10 +14,8 @@ using namespace edm;
 using namespace std;
 
 PFJetFilter::PFJetFilter(const edm::ParameterSet &iConfig) {
-  inputTruthLabel_ = consumes<edm::View<reco::Candidate>>(
-      iConfig.getParameter<edm::InputTag>("InputTruthLabel"));
-  inputRecoLabel_ = consumes<edm::View<reco::Candidate>>(
-      iConfig.getParameter<edm::InputTag>("InputRecoLabel"));
+  inputTruthLabel_ = consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("InputTruthLabel"));
+  inputRecoLabel_ = consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("InputRecoLabel"));
 
   recPt_cut = iConfig.getParameter<double>("recPt");
   genPt_cut = iConfig.getParameter<double>("genPt");
@@ -43,7 +41,6 @@ void PFJetFilter::beginJob() {}
 void PFJetFilter::endJob() {}
 
 bool PFJetFilter::filter(edm::Event &iEvent, const edm::EventSetup &iESetup) {
-
   // Typedefs to use views
   typedef edm::View<reco::Candidate> candidateCollection;
   typedef edm::View<reco::Candidate> candidateCollection;
@@ -79,7 +76,6 @@ bool PFJetFilter::filter(edm::Event &iEvent, const edm::EventSetup &iESetup) {
   bool pass = false;
 
   for (unsigned int i = 0; i < reco_candidates->size(); i++) {
-
     const reco::Candidate *particle = &(*reco_candidates)[i];
 
     // This protection is meant at not being used !
@@ -115,13 +111,11 @@ bool PFJetFilter::filter(edm::Event &iEvent, const edm::EventSetup &iESetup) {
     double deltaRmin = 999.;
     double ptmin = 0.;
     for (unsigned int j = 0; j < reco_candidates->size(); j++) {
-
       if (i == j)
         continue;
       const reco::Candidate *other = &(*reco_candidates)[j];
       double deltaR = algo_->deltaR(particle, other);
-      if (deltaR < deltaRmin && other->pt() > 0.25 * particle->pt() &&
-          other->pt() > recPt_cut) {
+      if (deltaR < deltaRmin && other->pt() > 0.25 * particle->pt() && other->pt() > recPt_cut) {
         deltaRmin = deltaR;
         ptmin = other->pt();
       }
@@ -132,8 +126,7 @@ bool PFJetFilter::filter(edm::Event &iEvent, const edm::EventSetup &iESetup) {
       continue;
 
     // Find the closest genJet.
-    const reco::Candidate *gen_particle =
-        algo_->matchByDeltaR(particle, truth_candidates);
+    const reco::Candidate *gen_particle = algo_->matchByDeltaR(particle, truth_candidates);
 
     // Check there is a genJet associated to the recoJet
     if (gen_particle == nullptr)
@@ -162,12 +155,9 @@ bool PFJetFilter::filter(edm::Event &iEvent, const edm::EventSetup &iESetup) {
     if (nSig > deltaEt_max || nSig < deltaEt_min) {
       /* */
       if (verbose)
-        std::cout << "Entry " << entry << " resPt = " << resPt
-                  << " sigma/avera/nSig = " << sigma << "/" << avera << "/"
-                  << nSig << " pT (T/R) " << true_pt << "/" << rec_pt
-                  << " Eta (T/R) " << true_eta << "/" << rec_eta
-                  << " Phi (T/R) " << true_phi << "/" << rec_phi
-                  << " deltaRMin/ptmin " << deltaRmin << "/" << ptmin
+        std::cout << "Entry " << entry << " resPt = " << resPt << " sigma/avera/nSig = " << sigma << "/" << avera << "/"
+                  << nSig << " pT (T/R) " << true_pt << "/" << rec_pt << " Eta (T/R) " << true_eta << "/" << rec_eta
+                  << " Phi (T/R) " << true_phi << "/" << rec_phi << " deltaRMin/ptmin " << deltaRmin << "/" << ptmin
                   << std::endl;
       /* */
       pass = true;
@@ -182,7 +172,6 @@ bool PFJetFilter::filter(edm::Event &iEvent, const edm::EventSetup &iESetup) {
 }
 
 double PFJetFilter::resolution(double pt, bool barrel) {
-
   double p0 = barrel ? 1.19200e-02 : 8.45341e-03;
   double p1 = barrel ? 1.06138e+00 : 7.96855e-01;
   double p2 = barrel ? -2.05929e+00 : -3.12076e-01;
@@ -192,7 +181,6 @@ double PFJetFilter::resolution(double pt, bool barrel) {
 }
 
 double PFJetFilter::response(double pt, bool barrel) {
-
   double p0 = barrel ? 1.09906E-1 : 6.91939E+1;
   double p1 = barrel ? -1.61443E-1 : -6.92733E+1;
   double p2 = barrel ? 3.45489E+3 : 1.58207E+6;

--- a/Validation/RecoParticleFlow/plugins/PFJetFilter.h
+++ b/Validation/RecoParticleFlow/plugins/PFJetFilter.h
@@ -40,4 +40,4 @@ private:
   PFBenchmarkAlgo *algo_;
 };
 
-#endif // PFJETBENCHMARKFILTER_H
+#endif  // PFJETBENCHMARKFILTER_H

--- a/Validation/RecoParticleFlow/plugins/PFMETBenchmarkAnalyzer.cc
+++ b/Validation/RecoParticleFlow/plugins/PFMETBenchmarkAnalyzer.cc
@@ -88,22 +88,17 @@ PFMETBenchmarkAnalyzer::PFMETBenchmarkAnalyzer(const edm::ParameterSet &iConfig)
 
 {
   // now do what ever initialization is needed
-  sInputTruthLabel_tok_ = consumes<reco::GenParticleCollection>(
-      iConfig.getParameter<InputTag>("InputTruthLabel"));
-  sInputRecoLabel_tok_ = consumes<reco::PFMETCollection>(
-      iConfig.getParameter<InputTag>("InputRecoLabel"));
-  sInputCaloLabel_tok_ = consumes<reco::CaloMETCollection>(
-      iConfig.getParameter<InputTag>("InputCaloLabel"));
-  sInputTCLabel_tok_ = consumes<reco::METCollection>(
-      iConfig.getParameter<InputTag>("InputTCLabel"));
+  sInputTruthLabel_tok_ = consumes<reco::GenParticleCollection>(iConfig.getParameter<InputTag>("InputTruthLabel"));
+  sInputRecoLabel_tok_ = consumes<reco::PFMETCollection>(iConfig.getParameter<InputTag>("InputRecoLabel"));
+  sInputCaloLabel_tok_ = consumes<reco::CaloMETCollection>(iConfig.getParameter<InputTag>("InputCaloLabel"));
+  sInputTCLabel_tok_ = consumes<reco::METCollection>(iConfig.getParameter<InputTag>("InputTCLabel"));
   OutputFileName = iConfig.getUntrackedParameter<string>("OutputFile");
   pfmBenchmarkDebug = iConfig.getParameter<bool>("pfjBenchmarkDebug");
   xplotAgainstReco = iConfig.getParameter<bool>("PlotAgainstRecoQuantities");
   xbenchmarkLabel_ = iConfig.getParameter<string>("BenchmarkLabel");
   xdbe_ = edm::Service<DQMStore>().operator->();
 
-  PFMETBenchmark_.setup(OutputFileName, pfmBenchmarkDebug, xplotAgainstReco,
-                        xbenchmarkLabel_, xdbe_);
+  PFMETBenchmark_.setup(OutputFileName, pfmBenchmarkDebug, xplotAgainstReco, xbenchmarkLabel_, xdbe_);
 }
 
 PFMETBenchmarkAnalyzer::~PFMETBenchmarkAnalyzer() {
@@ -116,8 +111,7 @@ PFMETBenchmarkAnalyzer::~PFMETBenchmarkAnalyzer() {
 //
 
 // ------------ method called to for each event  ------------
-void PFMETBenchmarkAnalyzer::analyze(const edm::Event &iEvent,
-                                     const edm::EventSetup &iSetup) {
+void PFMETBenchmarkAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // get gen jet collection
   Handle<GenParticleCollection> genparticles;
   bool isGen = iEvent.getByToken(sInputTruthLabel_tok_, genparticles);

--- a/Validation/RecoParticleFlow/plugins/PFMETFilter.cc
+++ b/Validation/RecoParticleFlow/plugins/PFMETFilter.cc
@@ -28,36 +28,31 @@ PFMETFilter::~PFMETFilter() {}
 
 bool PFMETFilter::checkInput() {
   if (collections_.size() != min_.size()) {
-    std::cout << "Error: in PFMETFilter: collections_.size()!=min_.size()"
-              << std::endl;
+    std::cout << "Error: in PFMETFilter: collections_.size()!=min_.size()" << std::endl;
     std::cout << "collections_.size() = " << collections_.size() << std::endl;
     std::cout << "min_.size() = " << min_.size() << std::endl;
     return false;
   }
   if (collections_.size() != max_.size()) {
-    std::cout << "Error: in PFMETFilter: collections_.size()!=max_.size()"
-              << std::endl;
+    std::cout << "Error: in PFMETFilter: collections_.size()!=max_.size()" << std::endl;
     std::cout << "collections_.size() = " << collections_.size() << std::endl;
     std::cout << "max_.size() = " << max_.size() << std::endl;
     return false;
   }
   if (collections_.size() != doMin_.size()) {
-    std::cout << "Error: in PFMETFilter: collections_.size()!=min_.size()"
-              << std::endl;
+    std::cout << "Error: in PFMETFilter: collections_.size()!=min_.size()" << std::endl;
     std::cout << "collections_.size() = " << collections_.size() << std::endl;
     std::cout << "doMin_.size() = " << doMin_.size() << std::endl;
     return false;
   }
   if (collections_.size() != doMax_.size()) {
-    std::cout << "Error: in PFMETFilter: collections_.size()!=min_.size()"
-              << std::endl;
+    std::cout << "Error: in PFMETFilter: collections_.size()!=min_.size()" << std::endl;
     std::cout << "collections_.size() = " << collections_.size() << std::endl;
     std::cout << "doMax_.size() = " << doMax_.size() << std::endl;
     return false;
   }
   if (collections_.size() != variables_.size()) {
-    std::cout << "Error: in PFMETFilter: collections_.size()!=variables_.size()"
-              << std::endl;
+    std::cout << "Error: in PFMETFilter: collections_.size()!=variables_.size()" << std::endl;
     std::cout << "collections_.size() = " << collections_.size() << std::endl;
     std::cout << "variables_.size() = " << variables_.size() << std::endl;
     return false;
@@ -74,7 +69,7 @@ bool PFMETFilter::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // std::cout << "FL: Mins = " << min_ << std::endl;
 
   if (!checkInput())
-    return true; // no filtering !
+    return true;  // no filtering !
 
   bool skip = false;
 
@@ -89,16 +84,14 @@ bool PFMETFilter::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
       collection1.assign(collections_[varc], 0, minuspos);
       // std::cout << "collection1 = " << collection1 << std::endl;
       std::string collection2;
-      collection2.assign(collections_[varc], minuspos + 1,
-                         collections_[varc].size());
+      collection2.assign(collections_[varc], minuspos + 1, collections_[varc].size());
       // std::cout << "collection2 = " << collection2 << std::endl;
 
       const edm::View<reco::Candidate> *var1;
       edm::Handle<edm::View<reco::Candidate>> var1_hnd;
       bool isVar1 = iEvent.getByLabel(collection1, var1_hnd);
       if (!isVar1) {
-        std::cout << "Warning : no " << collection1 << " in input !"
-                  << std::endl;
+        std::cout << "Warning : no " << collection1 << " in input !" << std::endl;
         return false;
       }
       var1 = var1_hnd.product();
@@ -112,8 +105,7 @@ bool PFMETFilter::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
       else if (variables_[varc] == "eta")
         coll_var1 = var10->eta();
       else {
-        std::cout << "Error: PFMETFilter: variable unknown: "
-                  << variables_[varc] << std::endl;
+        std::cout << "Error: PFMETFilter: variable unknown: " << variables_[varc] << std::endl;
         return true;
       }
       // std::cout << "FL: coll_var1[" << variables_[varc] << "] = " <<
@@ -123,8 +115,7 @@ bool PFMETFilter::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
       edm::Handle<edm::View<reco::Candidate>> var2_hnd;
       bool isVar2 = iEvent.getByLabel(collection2, var2_hnd);
       if (!isVar2) {
-        std::cout << "Warning : no " << collection2 << " in input !"
-                  << std::endl;
+        std::cout << "Warning : no " << collection2 << " in input !" << std::endl;
         return false;
       }
       var2 = var2_hnd.product();
@@ -138,8 +129,7 @@ bool PFMETFilter::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
       else if (variables_[varc] == "eta")
         coll_var2 = var20->eta();
       else {
-        std::cout << "Error: PFMETFilter: variable unknown: "
-                  << variables_[varc] << std::endl;
+        std::cout << "Error: PFMETFilter: variable unknown: " << variables_[varc] << std::endl;
         return true;
       }
       // std::cout << "FL: coll_var2[" << variables_[varc] << "] = " <<
@@ -189,8 +179,7 @@ bool PFMETFilter::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
       edm::Handle<edm::View<reco::Candidate>> var0_hnd;
       bool isVar0 = iEvent.getByLabel(collections_[varc], var0_hnd);
       if (!isVar0) {
-        std::cout << "Warning : no " << collections_[varc] << " in input !"
-                  << std::endl;
+        std::cout << "Warning : no " << collections_[varc] << " in input !" << std::endl;
         return false;
       }
       var0 = var0_hnd.product();
@@ -204,13 +193,11 @@ bool PFMETFilter::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
       else if (variables_[varc] == "eta")
         coll_var = var00->eta();
       else if (variables_[varc] == "DeltaMEXcut") {
-
         const edm::View<reco::Candidate> *truevar0;
         edm::Handle<edm::View<reco::Candidate>> truevar0_hnd;
         bool istrueVar0 = iEvent.getByLabel(TrueMET_, truevar0_hnd);
         if (!istrueVar0) {
-          std::cout << "Warning : no " << TrueMET_ << " in input !"
-                    << std::endl;
+          std::cout << "Warning : no " << TrueMET_ << " in input !" << std::endl;
           return false;
         }
         truevar0 = truevar0_hnd.product();
@@ -222,12 +209,10 @@ bool PFMETFilter::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
         const reco::MET *met = static_cast<const reco::MET *>(truevar00);
         const double SETc = met->sumEt();
         // std::cout << "FL: SETc = " << SETc << std::endl;
-        const double sigmac =
-            sigma_a_ + sigma_b_ * sqrt(SETc) + sigma_c_ * SETc;
+        const double sigmac = sigma_a_ + sigma_b_ * sqrt(SETc) + sigma_c_ * SETc;
         if (cutvalc > DeltaMEXsigma_ * sigmac) {
           if (verbose_) {
-            std::cout << "DeltaMET = " << var00->et() - truevar00->et()
-                      << std::endl;
+            std::cout << "DeltaMET = " << var00->et() - truevar00->et() << std::endl;
             std::cout << "trueSET = " << SETc << std::endl;
             std::cout << "pfMET = " << var00->et() << std::endl;
             std::cout << "trueMET = " << truevar00->et() << std::endl;
@@ -241,8 +226,7 @@ bool PFMETFilter::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
         } else {
           if (verbose_ && (var00->et() - truevar00->et()) > 300.0) {
             std::cout << "EVENT NOT KEPT:" << std::endl;
-            std::cout << "DeltaMET = " << var00->et() - truevar00->et()
-                      << std::endl;
+            std::cout << "DeltaMET = " << var00->et() - truevar00->et() << std::endl;
             std::cout << "SETc = " << SETc << std::endl;
             std::cout << "pfMET = " << var00->et() << std::endl;
             std::cout << "trueMET = " << truevar00->et() << std::endl;
@@ -255,8 +239,7 @@ bool PFMETFilter::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
           return false;
         }
       } else {
-        std::cout << "Error: PFMETFilter: variable unknown: "
-                  << variables_[varc] << std::endl;
+        std::cout << "Error: PFMETFilter: variable unknown: " << variables_[varc] << std::endl;
         return true;
       }
       // std::cout << "FL: coll_var[" << variables_[varc] << "] = " << coll_var

--- a/Validation/RecoParticleFlow/plugins/PFMETFilter.h
+++ b/Validation/RecoParticleFlow/plugins/PFMETFilter.h
@@ -36,4 +36,4 @@ private:
   bool verbose_;
 };
 
-#endif // PFMETFILTER_H
+#endif  // PFMETFILTER_H

--- a/Validation/RecoParticleFlow/plugins/PFTauElecRejectionBenchMarkAnalyzer.cc
+++ b/Validation/RecoParticleFlow/plugins/PFTauElecRejectionBenchMarkAnalyzer.cc
@@ -45,10 +45,8 @@ private:
 
   edm::EDGetTokenT<edm::HepMCProduct> sGenParticleSource_tok_;
   edm::EDGetTokenT<reco::PFTauCollection> pfTauProducer_tok_;
-  edm::EDGetTokenT<reco::PFTauDiscriminator>
-      pfTauDiscriminatorByIsolationProducer_tok_;
-  edm::EDGetTokenT<reco::PFTauDiscriminator>
-      pfTauDiscriminatorAgainstElectronProducer_tok_;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> pfTauDiscriminatorByIsolationProducer_tok_;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> pfTauDiscriminatorAgainstElectronProducer_tok_;
 
   PFTauElecRejectionBenchmark PFTauElecRejectionBenchmark_;
 };
@@ -65,36 +63,38 @@ private:
 //
 // constructors and destructor
 //
-PFTauElecRejectionBenchmarkAnalyzer::PFTauElecRejectionBenchmarkAnalyzer(
-    const edm::ParameterSet &iConfig)
+PFTauElecRejectionBenchmarkAnalyzer::PFTauElecRejectionBenchmarkAnalyzer(const edm::ParameterSet &iConfig)
 
 {
   // now do what ever initialization is needed
   outputfile = iConfig.getUntrackedParameter<string>("OutputFile");
   benchmarkLabel = iConfig.getParameter<string>("BenchmarkLabel");
-  sGenParticleSource_tok_ = consumes<edm::HepMCProduct>(
-      iConfig.getParameter<InputTag>("InputTruthLabel"));
+  sGenParticleSource_tok_ = consumes<edm::HepMCProduct>(iConfig.getParameter<InputTag>("InputTruthLabel"));
   maxDeltaR = iConfig.getParameter<double>("maxDeltaR");
   minMCPt = iConfig.getParameter<double>("minMCPt");
   maxMCAbsEta = iConfig.getParameter<double>("maxMCAbsEta");
   minRecoPt = iConfig.getParameter<double>("minRecoPt");
   maxRecoAbsEta = iConfig.getParameter<double>("maxRecoAbsEta");
-  pfTauProducer_tok_ = consumes<reco::PFTauCollection>(
-      iConfig.getParameter<InputTag>("PFTauProducer"));
+  pfTauProducer_tok_ = consumes<reco::PFTauCollection>(iConfig.getParameter<InputTag>("PFTauProducer"));
   pfTauDiscriminatorByIsolationProducer_tok_ =
-      consumes<reco::PFTauDiscriminator>(iConfig.getParameter<InputTag>(
-          "PFTauDiscriminatorByIsolationProducer"));
+      consumes<reco::PFTauDiscriminator>(iConfig.getParameter<InputTag>("PFTauDiscriminatorByIsolationProducer"));
   pfTauDiscriminatorAgainstElectronProducer_tok_ =
-      consumes<reco::PFTauDiscriminator>(iConfig.getParameter<InputTag>(
-          "PFTauDiscriminatorAgainstElectronProducer"));
+      consumes<reco::PFTauDiscriminator>(iConfig.getParameter<InputTag>("PFTauDiscriminatorAgainstElectronProducer"));
   sGenMatchObjectLabel = iConfig.getParameter<string>("GenMatchObjectLabel");
   applyEcalCrackCut = iConfig.getParameter<bool>("ApplyEcalCrackCut");
 
   db = edm::Service<DQMStore>().operator->();
 
-  PFTauElecRejectionBenchmark_.setup(
-      outputfile, benchmarkLabel, maxDeltaR, minRecoPt, maxRecoAbsEta, minMCPt,
-      maxMCAbsEta, sGenMatchObjectLabel, applyEcalCrackCut, db);
+  PFTauElecRejectionBenchmark_.setup(outputfile,
+                                     benchmarkLabel,
+                                     maxDeltaR,
+                                     minRecoPt,
+                                     maxRecoAbsEta,
+                                     minMCPt,
+                                     maxMCAbsEta,
+                                     sGenMatchObjectLabel,
+                                     applyEcalCrackCut,
+                                     db);
 }
 
 PFTauElecRejectionBenchmarkAnalyzer::~PFTauElecRejectionBenchmarkAnalyzer() {
@@ -107,9 +107,7 @@ PFTauElecRejectionBenchmarkAnalyzer::~PFTauElecRejectionBenchmarkAnalyzer() {
 //
 
 // ------------ method called to for each event  ------------
-void PFTauElecRejectionBenchmarkAnalyzer::analyze(
-    const edm::Event &iEvent, const edm::EventSetup &iSetup) {
-
+void PFTauElecRejectionBenchmarkAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // get gen products
   Handle<HepMCProduct> mcevt;
   iEvent.getByToken(sGenParticleSource_tok_, mcevt);
@@ -120,17 +118,14 @@ void PFTauElecRejectionBenchmarkAnalyzer::analyze(
 
   // get iso discriminator association vector
   Handle<PFTauDiscriminator> thePFTauDiscriminatorByIsolation;
-  iEvent.getByToken(pfTauDiscriminatorByIsolationProducer_tok_,
-                    thePFTauDiscriminatorByIsolation);
+  iEvent.getByToken(pfTauDiscriminatorByIsolationProducer_tok_, thePFTauDiscriminatorByIsolation);
 
   // get anti-elec discriminator association vector
   Handle<PFTauDiscriminator> thePFTauDiscriminatorAgainstElectron;
-  iEvent.getByToken(pfTauDiscriminatorAgainstElectronProducer_tok_,
-                    thePFTauDiscriminatorAgainstElectron);
+  iEvent.getByToken(pfTauDiscriminatorAgainstElectronProducer_tok_, thePFTauDiscriminatorAgainstElectron);
 
-  PFTauElecRejectionBenchmark_.process(mcevt, thePFTau,
-                                       thePFTauDiscriminatorByIsolation,
-                                       thePFTauDiscriminatorAgainstElectron);
+  PFTauElecRejectionBenchmark_.process(
+      mcevt, thePFTau, thePFTauDiscriminatorByIsolation, thePFTauDiscriminatorAgainstElectron);
 }
 
 // ------------ method called once each job just before starting event loop
@@ -139,9 +134,7 @@ void PFTauElecRejectionBenchmarkAnalyzer::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop
 // ------------
-void PFTauElecRejectionBenchmarkAnalyzer::endJob() {
-  PFTauElecRejectionBenchmark_.write();
-}
+void PFTauElecRejectionBenchmarkAnalyzer::endJob() { PFTauElecRejectionBenchmark_.write(); }
 
 // define this as a plug-in
 DEFINE_FWK_MODULE(PFTauElecRejectionBenchmarkAnalyzer);

--- a/Validation/RecoParticleFlow/plugins/PFTester.cc
+++ b/Validation/RecoParticleFlow/plugins/PFTester.cc
@@ -37,75 +37,52 @@ using namespace std;
 using namespace reco;
 
 PFTester::PFTester(const edm::ParameterSet &iConfig) {
-
-  inputPFlowLabel_tok_ = consumes<reco::PFCandidateCollection>(
-      iConfig.getParameter<std::string>("InputPFlowLabel"));
+  inputPFlowLabel_tok_ = consumes<reco::PFCandidateCollection>(iConfig.getParameter<std::string>("InputPFlowLabel"));
   outputFile_ = iConfig.getUntrackedParameter<std::string>("OutputFile");
 
   if (!outputFile_.empty())
-    edm::LogInfo("OutputInfo")
-        << " ParticleFLow Task histograms will be saved to '"
-        << outputFile_.c_str() << "'";
+    edm::LogInfo("OutputInfo") << " ParticleFLow Task histograms will be saved to '" << outputFile_.c_str() << "'";
   else
-    edm::LogInfo("OutputInfo")
-        << " ParticleFlow Task histograms will NOT be saved";
+    edm::LogInfo("OutputInfo") << " ParticleFlow Task histograms will NOT be saved";
 }
 
 PFTester::~PFTester() {}
 
 void PFTester::beginJob() {
-
   // get ahold of back-end interface
   dbe_ = edm::Service<DQMStore>().operator->();
 
   if (dbe_) {
-
     dbe_->setCurrentFolder("PFTask/PFCandidates");
 
-    me["CandidateEt"] =
-        dbe_->book1D("CandidateEt", "CandidateEt", 1000, 0, 1000);
-    me["CandidateEta"] =
-        dbe_->book1D("CandidateEta", "CandidateEta", 200, -5, 5);
-    me["CandidatePhi"] =
-        dbe_->book1D("CandidatePhi", "CandidatePhi", 200, -M_PI, M_PI);
-    me["CandidateCharge"] =
-        dbe_->book1D("CandidateCharge", "CandidateCharge", 5, -2, 2);
-    me["PFCandidateType"] =
-        dbe_->book1D("PFCandidateType", "PFCandidateType", 10, 0, 10);
+    me["CandidateEt"] = dbe_->book1D("CandidateEt", "CandidateEt", 1000, 0, 1000);
+    me["CandidateEta"] = dbe_->book1D("CandidateEta", "CandidateEta", 200, -5, 5);
+    me["CandidatePhi"] = dbe_->book1D("CandidatePhi", "CandidatePhi", 200, -M_PI, M_PI);
+    me["CandidateCharge"] = dbe_->book1D("CandidateCharge", "CandidateCharge", 5, -2, 2);
+    me["PFCandidateType"] = dbe_->book1D("PFCandidateType", "PFCandidateType", 10, 0, 10);
 
     dbe_->setCurrentFolder("PFTask/PFBlocks");
 
     me["NumElements"] = dbe_->book1D("NumElements", "NumElements", 25, 0, 25);
-    me["NumTrackElements"] =
-        dbe_->book1D("NumTrackElements", "NumTrackElements", 5, 0, 5);
-    me["NumPS1Elements"] =
-        dbe_->book1D("NumPS1Elements", "NumPS1Elements", 5, 0, 5);
-    me["NumPS2Elements"] =
-        dbe_->book1D("NumPS2Elements", "NumPS2Elements", 5, 0, 5);
-    me["NumECALElements"] =
-        dbe_->book1D("NumECALElements", "NumECALElements", 5, 0, 5);
-    me["NumHCALElements"] =
-        dbe_->book1D("NumHCALElements", "NumHCALElements", 5, 0, 5);
-    me["NumMuonElements"] =
-        dbe_->book1D("NumMuonElements", "NumMuonElements", 5, 0, 5);
+    me["NumTrackElements"] = dbe_->book1D("NumTrackElements", "NumTrackElements", 5, 0, 5);
+    me["NumPS1Elements"] = dbe_->book1D("NumPS1Elements", "NumPS1Elements", 5, 0, 5);
+    me["NumPS2Elements"] = dbe_->book1D("NumPS2Elements", "NumPS2Elements", 5, 0, 5);
+    me["NumECALElements"] = dbe_->book1D("NumECALElements", "NumECALElements", 5, 0, 5);
+    me["NumHCALElements"] = dbe_->book1D("NumHCALElements", "NumHCALElements", 5, 0, 5);
+    me["NumMuonElements"] = dbe_->book1D("NumMuonElements", "NumMuonElements", 5, 0, 5);
 
     dbe_->setCurrentFolder("PFTask/PFTracks");
 
     me["TrackCharge"] = dbe_->book1D("TrackCharge", "TrackCharge", 5, -2, 2);
-    me["TrackNumPoints"] =
-        dbe_->book1D("TrackNumPoints", "TrackNumPoints", 100, 0, 100);
-    me["TrackNumMeasurements"] = dbe_->book1D(
-        "TrackNumMeasurements", "TrackNumMeasurements", 100, 0, 100);
-    me["TrackImpactParameter"] = dbe_->book1D(
-        "TrackImpactParameter", "TrackImpactParameter", 1000, 0, 1);
+    me["TrackNumPoints"] = dbe_->book1D("TrackNumPoints", "TrackNumPoints", 100, 0, 100);
+    me["TrackNumMeasurements"] = dbe_->book1D("TrackNumMeasurements", "TrackNumMeasurements", 100, 0, 100);
+    me["TrackImpactParameter"] = dbe_->book1D("TrackImpactParameter", "TrackImpactParameter", 1000, 0, 1);
 
     dbe_->setCurrentFolder("PFTask/PFClusters");
   }
 }
 
-void PFTester::analyze(const edm::Event &iEvent,
-                       const edm::EventSetup &iSetup) {
-
+void PFTester::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // Data to Retrieve from the Event
   const PFCandidateCollection *pflow_candidates;
 
@@ -114,7 +91,6 @@ void PFTester::analyze(const edm::Event &iEvent,
   // ==========================================================
 
   {
-
     // Get Particle Flow Candidates
     Handle<PFCandidateCollection> pflow_hnd;
     iEvent.getByToken(inputPFlowLabel_tok_, pflow_hnd);
@@ -122,9 +98,7 @@ void PFTester::analyze(const edm::Event &iEvent,
   }
 
   if (!pflow_candidates) {
-
-    edm::LogInfo("OutputInfo")
-        << " failed to retrieve data required by ParticleFlow Task";
+    edm::LogInfo("OutputInfo") << " failed to retrieve data required by ParticleFlow Task";
     edm::LogInfo("OutputInfo") << " ParticleFlow Task cannot continue...!";
     return;
   }
@@ -136,7 +110,6 @@ void PFTester::analyze(const edm::Event &iEvent,
   // Loop Over Particle Flow Candidates
   PFCandidateCollection::const_iterator pf;
   for (pf = pflow_candidates->begin(); pf != pflow_candidates->end(); pf++) {
-
     const PFCandidate *particle = &(*pf);
 
     // Fill Histograms for Candidate Methods
@@ -219,7 +192,6 @@ void PFTester::analyze(const edm::Event &iEvent,
 }
 
 void PFTester::endJob() {
-
   // Store the DAQ Histograms
   if (!outputFile_.empty() && dbe_)
     dbe_->save(outputFile_);

--- a/Validation/RecoParticleFlow/plugins/PFTester.h
+++ b/Validation/RecoParticleFlow/plugins/PFTester.h
@@ -35,4 +35,4 @@ private:
   edm::EDGetTokenT<reco::PFCandidateCollection> inputPFlowLabel_tok_;
 };
 
-#endif // PFTESTER_H
+#endif  // PFTESTER_H

--- a/Validation/RecoParticleFlow/src/Comparator.cc
+++ b/Validation/RecoParticleFlow/src/Comparator.cc
@@ -14,9 +14,7 @@
 
 using namespace std;
 
-void Comparator::SetDirs(const char *file0, const char *dir0, const char *file1,
-                         const char *dir1) {
-
+void Comparator::SetDirs(const char *file0, const char *dir0, const char *file1, const char *dir1) {
   file0_ = new TFile(file0);
   if (file0_->IsZombie())
     exit(1);
@@ -32,8 +30,7 @@ void Comparator::SetDirs(const char *file0, const char *dir0, const char *file1,
     exit(1);
 }
 
-void Comparator::SetStyles(Style *s0, Style *s1, const char *leg0,
-                           const char *leg1) {
+void Comparator::SetStyles(Style *s0, Style *s1, const char *leg0, const char *leg1) {
   s0_ = s0;
   s1_ = s1;
 
@@ -42,9 +39,7 @@ void Comparator::SetStyles(Style *s0, Style *s1, const char *leg0,
   legend_.AddEntry(s1_, leg1, "mlf");
 }
 
-void Comparator::DrawSlice(const char *key, int binxmin, int binxmax,
-                           Mode mode) {
-
+void Comparator::DrawSlice(const char *key, int binxmin, int binxmax, Mode mode) {
   static int num = 0;
 
   ostringstream out0;
@@ -75,8 +70,7 @@ void Comparator::DrawSlice(const char *key, int binxmin, int binxmax,
   Draw(h0_slice, h1_slice, mode);
 }
 
-void Comparator::DrawMeanSlice(const char *key, const int rebinFactor,
-                               Mode mode) {
+void Comparator::DrawMeanSlice(const char *key, const int rebinFactor, Mode mode) {
   TDirectory *dir = dir1_;
   dir->cd();
   TH2D *h2 = (TH2D *)dir->Get(key);
@@ -92,8 +86,7 @@ void Comparator::DrawMeanSlice(const char *key, const int rebinFactor,
   Draw(hb, ha, mode);
 }
 
-void Comparator::DrawSigmaSlice(const char *key, const int rebinFactor,
-                                Mode mode) {
+void Comparator::DrawSigmaSlice(const char *key, const int rebinFactor, Mode mode) {
   TDirectory *dir = dir1_;
   dir->cd();
   TH2D *h2 = (TH2D *)dir->Get(key);
@@ -109,8 +102,7 @@ void Comparator::DrawSigmaSlice(const char *key, const int rebinFactor,
   Draw(hb, ha, mode);
 }
 
-void Comparator::DrawGaussSigmaSlice(const char *key, const int rebinFactor,
-                                     Mode mode) {
+void Comparator::DrawGaussSigmaSlice(const char *key, const int rebinFactor, Mode mode) {
   TDirectory *dir = dir1_;
   dir->cd();
   TH2D *h2 = (TH2D *)dir->Get(key);
@@ -128,23 +120,23 @@ void Comparator::DrawGaussSigmaSlice(const char *key, const int rebinFactor,
 
 Double_t fitFunction_f(Double_t *x, Double_t *par) {
   const Double_t value =
-      sqrt(par[0] * par[0] + par[1] * par[1] * (x[0] - par[3]) +
-           par[2] * par[2] * (x[0] - par[3]) * (x[0] - par[3])) /
+      sqrt(par[0] * par[0] + par[1] * par[1] * (x[0] - par[3]) + par[2] * par[2] * (x[0] - par[3]) * (x[0] - par[3])) /
       x[0];
   return value;
 }
 
-void Comparator::DrawGaussSigmaSlice(const char *key, const int rebinFactor,
-                                     const int binxmin, const int binxmax,
-                                     const bool cst_binning, Mode mode) {
+void Comparator::DrawGaussSigmaSlice(
+    const char *key, const int rebinFactor, const int binxmin, const int binxmax, const bool cst_binning, Mode mode) {
   TDirectory *dir = dir1_;
   dir->cd();
   TH2D *h2 = (TH2D *)dir->Get(key);
   TH2Analyzer TH2Ana(h2, binxmin, binxmax, rebinFactor, cst_binning);
   TH1D *hrms = TH2Ana.RMS();
-  TF1 *fitfcndgssrms3 = new TF1(
-      "fitfcndgssrms3", fitFunction_f, hrms->GetXaxis()->GetBinLowEdge(1),
-      hrms->GetXaxis()->GetBinUpEdge(hrms->GetNbinsX()), 4);
+  TF1 *fitfcndgssrms3 = new TF1("fitfcndgssrms3",
+                                fitFunction_f,
+                                hrms->GetXaxis()->GetBinLowEdge(1),
+                                hrms->GetXaxis()->GetBinUpEdge(hrms->GetNbinsX()),
+                                4);
   fitfcndgssrms3->SetNpx(500);
   fitfcndgssrms3->SetLineWidth(3);
   fitfcndgssrms3->SetLineStyle(2);
@@ -152,9 +144,11 @@ void Comparator::DrawGaussSigmaSlice(const char *key, const int rebinFactor,
   hrms->Fit(fitfcndgssrms3, "0R");
 
   TH1D *ha = TH2Ana.SigmaGauss();
-  TF1 *fitfcndgsse3 =
-      new TF1("fitfcndgsse3", fitFunction_f, hrms->GetXaxis()->GetBinLowEdge(1),
-              hrms->GetXaxis()->GetBinUpEdge(hrms->GetNbinsX()), 4);
+  TF1 *fitfcndgsse3 = new TF1("fitfcndgsse3",
+                              fitFunction_f,
+                              hrms->GetXaxis()->GetBinLowEdge(1),
+                              hrms->GetXaxis()->GetBinUpEdge(hrms->GetNbinsX()),
+                              4);
   fitfcndgsse3->SetNpx(500);
   fitfcndgsse3->SetLineWidth(3);
   fitfcndgsse3->SetLineStyle(1);
@@ -166,9 +160,11 @@ void Comparator::DrawGaussSigmaSlice(const char *key, const int rebinFactor,
   TH2D *h2b = (TH2D *)dir->Get(key);
   TH2Analyzer TH2Anab(h2b, binxmin, binxmax, rebinFactor, cst_binning);
   TH1D *hrmsb = TH2Anab.RMS();
-  TF1 *fitfcndgssrmsb3 = new TF1(
-      "fitfcndgssrmsb3", fitFunction_f, hrms->GetXaxis()->GetBinLowEdge(1),
-      hrms->GetXaxis()->GetBinUpEdge(hrms->GetNbinsX()), 4);
+  TF1 *fitfcndgssrmsb3 = new TF1("fitfcndgssrmsb3",
+                                 fitFunction_f,
+                                 hrms->GetXaxis()->GetBinLowEdge(1),
+                                 hrms->GetXaxis()->GetBinUpEdge(hrms->GetNbinsX()),
+                                 4);
   fitfcndgssrmsb3->SetNpx(500);
   fitfcndgssrmsb3->SetLineWidth(3);
   fitfcndgssrmsb3->SetLineStyle(2);
@@ -176,9 +172,11 @@ void Comparator::DrawGaussSigmaSlice(const char *key, const int rebinFactor,
   hrmsb->Fit(fitfcndgssrmsb3, "0R");
 
   TH1D *hb = TH2Anab.SigmaGauss();
-  TF1 *fitfcndgsseb3 = new TF1(
-      "fitfcndgsseb3", fitFunction_f, hrms->GetXaxis()->GetBinLowEdge(1),
-      hrms->GetXaxis()->GetBinUpEdge(hrms->GetNbinsX()), 4);
+  TF1 *fitfcndgsseb3 = new TF1("fitfcndgsseb3",
+                               fitFunction_f,
+                               hrms->GetXaxis()->GetBinLowEdge(1),
+                               hrms->GetXaxis()->GetBinUpEdge(hrms->GetNbinsX()),
+                               4);
   fitfcndgsseb3->SetNpx(500);
   fitfcndgsseb3->SetLineWidth(3);
   fitfcndgsseb3->SetLineStyle(1);
@@ -195,9 +193,7 @@ void Comparator::DrawGaussSigmaSlice(const char *key, const int rebinFactor,
 }
 
 void Comparator::DrawGaussSigmaOverMeanXSlice(
-    const char *key, const int rebinFactor, const int binxmin,
-    const int binxmax, const bool cst_binning, Mode mode) {
-
+    const char *key, const int rebinFactor, const int binxmin, const int binxmax, const bool cst_binning, Mode mode) {
   TDirectory *dir = dir1_;
   dir->cd();
   TH2D *h2 = (TH2D *)dir->Get(key);
@@ -214,9 +210,11 @@ void Comparator::DrawGaussSigmaOverMeanXSlice(
   // Draw(meanXslice,meanXslice,mode);
   hrms->Divide(meanXslice);
 
-  TF1 *fitXfcndgssrms3 = new TF1(
-      "fitXfcndgssrms3", fitFunction_f, hrms->GetXaxis()->GetBinLowEdge(1),
-      hrms->GetXaxis()->GetBinUpEdge(hrms->GetNbinsX()), 4);
+  TF1 *fitXfcndgssrms3 = new TF1("fitXfcndgssrms3",
+                                 fitFunction_f,
+                                 hrms->GetXaxis()->GetBinLowEdge(1),
+                                 hrms->GetXaxis()->GetBinUpEdge(hrms->GetNbinsX()),
+                                 4);
   fitXfcndgssrms3->SetNpx(500);
   fitXfcndgssrms3->SetLineWidth(3);
   fitXfcndgssrms3->SetLineStyle(2);
@@ -225,9 +223,11 @@ void Comparator::DrawGaussSigmaOverMeanXSlice(
 
   TH1D *ha = TH2Ana.SigmaGauss();
   ha->Divide(meanXslice);
-  TF1 *fitXfcndgsse3 =
-      new TF1("fitXfcndgsse3", fitFunction_f, ha->GetXaxis()->GetBinLowEdge(1),
-              ha->GetXaxis()->GetBinUpEdge(ha->GetNbinsX()), 4);
+  TF1 *fitXfcndgsse3 = new TF1("fitXfcndgsse3",
+                               fitFunction_f,
+                               ha->GetXaxis()->GetBinLowEdge(1),
+                               ha->GetXaxis()->GetBinUpEdge(ha->GetNbinsX()),
+                               4);
   fitXfcndgsse3->SetNpx(500);
   fitXfcndgsse3->SetLineWidth(3);
   fitXfcndgsse3->SetLineStyle(1);
@@ -240,9 +240,11 @@ void Comparator::DrawGaussSigmaOverMeanXSlice(
   TH2Analyzer TH2Anab(h2b, binxmin, binxmax, rebinFactor, cst_binning);
   TH1D *hrmsb = TH2Anab.RMS();
   hrmsb->Divide(meanXslice);
-  TF1 *fitXfcndgssrmsb3 = new TF1(
-      "fitXfcndgssrmsb3", fitFunction_f, hrmsb->GetXaxis()->GetBinLowEdge(1),
-      hrmsb->GetXaxis()->GetBinUpEdge(hrmsb->GetNbinsX()), 4);
+  TF1 *fitXfcndgssrmsb3 = new TF1("fitXfcndgssrmsb3",
+                                  fitFunction_f,
+                                  hrmsb->GetXaxis()->GetBinLowEdge(1),
+                                  hrmsb->GetXaxis()->GetBinUpEdge(hrmsb->GetNbinsX()),
+                                  4);
   fitXfcndgssrmsb3->SetNpx(500);
   fitXfcndgssrmsb3->SetLineWidth(3);
   fitXfcndgssrmsb3->SetLineStyle(2);
@@ -251,9 +253,11 @@ void Comparator::DrawGaussSigmaOverMeanXSlice(
 
   TH1D *hb = TH2Anab.SigmaGauss();
   hb->Divide(meanXslice);
-  TF1 *fitXfcndgsseb3 =
-      new TF1("fitXfcndgsseb3", fitFunction_f, hb->GetXaxis()->GetBinLowEdge(1),
-              hb->GetXaxis()->GetBinUpEdge(hb->GetNbinsX()), 4);
+  TF1 *fitXfcndgsseb3 = new TF1("fitXfcndgsseb3",
+                                fitFunction_f,
+                                hb->GetXaxis()->GetBinLowEdge(1),
+                                hb->GetXaxis()->GetBinUpEdge(hb->GetNbinsX()),
+                                4);
   fitXfcndgsseb3->SetNpx(500);
   fitXfcndgsseb3->SetLineWidth(3);
   fitXfcndgsseb3->SetLineStyle(1);
@@ -269,8 +273,7 @@ void Comparator::DrawGaussSigmaOverMeanXSlice(
   fitXfcndgsseb3->Draw("same");
 }
 
-void Comparator::DrawGaussSigmaOverMeanSlice(const char *key, const char *key2,
-                                             const int rebinFactor, Mode mode) {
+void Comparator::DrawGaussSigmaOverMeanSlice(const char *key, const char *key2, const int rebinFactor, Mode mode) {
   TDirectory *dir = dir1_;
   dir->cd();
 
@@ -301,7 +304,6 @@ void Comparator::DrawGaussSigmaOverMeanSlice(const char *key, const char *key2,
 }
 
 void Comparator::Draw(const char *key, Mode mode) {
-
   TH1::AddDirectory(false);
   TH1 *h0 = Histo(key, 0);
   TH1 *h1 = (TH1 *)Histo(key, 1)->Clone("h1");
@@ -345,7 +347,7 @@ void Comparator::Draw(const char *key0, const char *key1, Mode mode) {
 }
 
 TH1 *Comparator::Histo(const char *key, unsigned dirIndex) {
-  if (dirIndex > 1U) { // dirIndex >= 0, since dirIndex is unsigned
+  if (dirIndex > 1U) {  // dirIndex >= 0, since dirIndex is unsigned
     cerr << "bad dir index: " << dirIndex << endl;
     return nullptr;
   }
@@ -396,9 +398,7 @@ void Comparator::Draw(TH1 *h0, TH1 *h1, Mode mode) {
   }
 
   if (mode != GRAPH) {
-
-    TPaveStats *ptstats =
-        new TPaveStats(0.7385057, 0.720339, 0.9396552, 0.8792373, "brNDC");
+    TPaveStats *ptstats = new TPaveStats(0.7385057, 0.720339, 0.9396552, 0.8792373, "brNDC");
     ptstats->SetName("stats");
     ptstats->SetBorderSize(1);
     ptstats->SetLineColor(2);
@@ -416,8 +416,7 @@ void Comparator::Draw(TH1 *h0, TH1 *h1, Mode mode) {
     // std::cout << "FL: h1_->GetMean() = " << h1_->GetMean() << std::endl;
     // std::cout << "FL: h1_->GetRMS() = " << h1_->GetRMS() << std::endl;
     // std::cout << "FL: test2" << std::endl;
-    TPaveStats *ptstats2 =
-        new TPaveStats(0.7399425, 0.529661, 0.941092, 0.6885593, "brNDC");
+    TPaveStats *ptstats2 = new TPaveStats(0.7399425, 0.529661, 0.941092, 0.6885593, "brNDC");
     ptstats2->SetName("stats");
     ptstats2->SetBorderSize(1);
     ptstats2->SetLineColor(4);
@@ -454,78 +453,78 @@ void Comparator::Draw(TH1 *h0, TH1 *h1, Mode mode) {
   float min = -999.;
   float max = +999.;
   switch (mode) {
-  case SCALE:
-    h1_->Scale(h0_->GetEntries() / h1_->GetEntries());
-  case NORMAL:
-    if (s0_)
-      Styles::FormatHisto(h0_, s0_);
-    if (s1_)
-      Styles::FormatHisto(h1_, s1_);
+    case SCALE:
+      h1_->Scale(h0_->GetEntries() / h1_->GetEntries());
+    case NORMAL:
+      if (s0_)
+        Styles::FormatHisto(h0_, s0_);
+      if (s1_)
+        Styles::FormatHisto(h1_, s1_);
 
-    if (h1_->GetMaximum() > h0_->GetMaximum()) {
-      h0_->SetMaximum(h1_->GetMaximum() * 1.15);
-    }
+      if (h1_->GetMaximum() > h0_->GetMaximum()) {
+        h0_->SetMaximum(h1_->GetMaximum() * 1.15);
+      }
 
-    h0_->Draw();
-    h1_->Draw("same");
+      h0_->Draw();
+      h1_->Draw("same");
 
-    break;
-  case EFF:
-    if (s0_)
-      Styles::FormatHisto(h0_, s0_);
-    if (s1_)
-      Styles::FormatHisto(h1_, s1_);
+      break;
+    case EFF:
+      if (s0_)
+        Styles::FormatHisto(h0_, s0_);
+      if (s1_)
+        Styles::FormatHisto(h1_, s1_);
 
-    // rather arbitrary but useful
-    max = h0_->GetMaximum();
-    if (h1_->GetMaximum() > max)
-      max = h1_->GetMaximum();
-    if (max > 0.8)
-      max = 1;
+      // rather arbitrary but useful
+      max = h0_->GetMaximum();
+      if (h1_->GetMaximum() > max)
+        max = h1_->GetMaximum();
+      if (max > 0.8)
+        max = 1;
 
-    max *= 1.1;
+      max *= 1.1;
 
-    min = h0_->GetMinimum();
-    if (h1_->GetMinimum() < min)
-      min = h1_->GetMinimum();
-    if (min > 0.2)
-      min = 0.;
+      min = h0_->GetMinimum();
+      if (h1_->GetMinimum() < min)
+        min = h1_->GetMinimum();
+      if (min > 0.2)
+        min = 0.;
 
-    min *= 0.8;
-    h0_->SetMaximum(max);
-    h0_->SetMinimum(min);
+      min *= 0.8;
+      h0_->SetMaximum(max);
+      h0_->SetMinimum(min);
 
-    h0_->Draw("E");
-    h1_->Draw("Esame");
-    break;
-  case GRAPH:
-    if (s0_)
-      Styles::FormatHisto(h0_, s0_);
-    if (s1_)
-      Styles::FormatHisto(h1_, s1_);
+      h0_->Draw("E");
+      h1_->Draw("Esame");
+      break;
+    case GRAPH:
+      if (s0_)
+        Styles::FormatHisto(h0_, s0_);
+      if (s1_)
+        Styles::FormatHisto(h1_, s1_);
 
-    if (h1_->GetMaximum() > h0_->GetMaximum()) {
-      h0_->SetMaximum(h1_->GetMaximum() * 1.15);
-    }
-    if (h1_->GetMinimum() < h0_->GetMinimum()) {
-      h0_->SetMinimum(h1_->GetMinimum() * 1.15);
-    }
-    h0_->SetMarkerStyle(21);
-    h0_->SetMarkerColor(2);
-    h1_->SetMarkerStyle(21);
-    h1_->SetMarkerColor(4);
+      if (h1_->GetMaximum() > h0_->GetMaximum()) {
+        h0_->SetMaximum(h1_->GetMaximum() * 1.15);
+      }
+      if (h1_->GetMinimum() < h0_->GetMinimum()) {
+        h0_->SetMinimum(h1_->GetMinimum() * 1.15);
+      }
+      h0_->SetMarkerStyle(21);
+      h0_->SetMarkerColor(2);
+      h1_->SetMarkerStyle(21);
+      h1_->SetMarkerColor(4);
 
-    h0_->Draw("E1");
-    h1_->Draw("E1same");
-    break;
-  case RATIO:
-    h0_->Sumw2();
-    h1_->Sumw2();
-    h0_->Divide(h1_);
-    if (s0_)
-      Styles::FormatHisto(h0_, s0_);
-    h0_->Draw();
-  default:
-    break;
+      h0_->Draw("E1");
+      h1_->Draw("E1same");
+      break;
+    case RATIO:
+      h0_->Sumw2();
+      h1_->Sumw2();
+      h0_->Divide(h1_);
+      if (s0_)
+        Styles::FormatHisto(h0_, s0_);
+      h0_->Draw();
+    default:
+      break;
   }
 }

--- a/Validation/RecoParticleFlow/src/NicePlot.cc
+++ b/Validation/RecoParticleFlow/src/NicePlot.cc
@@ -7,7 +7,6 @@
 using namespace std;
 
 Styles::Styles() {
-
   gROOT->SetStyle("Plain");
   gStyle->SetPalette(1);
   gStyle->SetHistMinimumZero(kTRUE);
@@ -69,7 +68,6 @@ void Styles::FormatHisto(TH1 *h, const Style *s) {
 }
 
 void Styles::FormatPad(TPad *pad, bool grid, bool logx, bool logy) {
-
   pad->SetGridx(grid);
   pad->SetGridy(grid);
 

--- a/Validation/RecoParticleFlow/src/TH2Analyzer.cc
+++ b/Validation/RecoParticleFlow/src/TH2Analyzer.cc
@@ -24,27 +24,32 @@ void TH2Analyzer::Eval(int rebinFactor) {
   rebinnedHist2D_->RebinX(rebinFactor);
 
   const string averageName = bname + "_average";
-  average_ = new TH1D(averageName.c_str(), "arithmetic average",
+  average_ = new TH1D(averageName.c_str(),
+                      "arithmetic average",
                       rebinnedHist2D_->GetNbinsX(),
                       rebinnedHist2D_->GetXaxis()->GetXmin(),
                       rebinnedHist2D_->GetXaxis()->GetXmax());
 
   const string rmsName = bname + "_RMS";
-  RMS_ = new TH1D(rmsName.c_str(), "RMS", rebinnedHist2D_->GetNbinsX(),
+  RMS_ = new TH1D(rmsName.c_str(),
+                  "RMS",
+                  rebinnedHist2D_->GetNbinsX(),
                   rebinnedHist2D_->GetXaxis()->GetXmin(),
                   rebinnedHist2D_->GetXaxis()->GetXmax());
 
   const string sigmaGaussName = bname + "_sigmaGauss";
-  sigmaGauss_ = new TH1D(sigmaGaussName.c_str(), "sigmaGauss",
+  sigmaGauss_ = new TH1D(sigmaGaussName.c_str(),
+                         "sigmaGauss",
                          rebinnedHist2D_->GetNbinsX(),
                          rebinnedHist2D_->GetXaxis()->GetXmin(),
                          rebinnedHist2D_->GetXaxis()->GetXmax());
 
   const string meanXName = bname + "_meanX";
-  meanXslice_ =
-      new TH1D(meanXName.c_str(), "meanX", rebinnedHist2D_->GetNbinsX(),
-               rebinnedHist2D_->GetXaxis()->GetXmin(),
-               rebinnedHist2D_->GetXaxis()->GetXmax());
+  meanXslice_ = new TH1D(meanXName.c_str(),
+                         "meanX",
+                         rebinnedHist2D_->GetNbinsX(),
+                         rebinnedHist2D_->GetXaxis()->GetXmin(),
+                         rebinnedHist2D_->GetXaxis()->GetXmax());
 
   ProcessSlices(rebinnedHist2D_);
 }
@@ -68,15 +73,13 @@ void TH2Analyzer::Reset() {
   // parameters_.clear();
 }
 
-void TH2Analyzer::Eval(const int rebinFactor, const int binxmin,
-                       const int binxmax, const bool cst_binning) {
+void TH2Analyzer::Eval(const int rebinFactor, const int binxmin, const int binxmax, const bool cst_binning) {
   Reset();
   const string bname = hist2D_->GetName();
   const string rebinName = bname + "_rebin";
 
   if (binxmax > hist2D_->GetNbinsX()) {
-    std::cout << "Error: TH2Analyzer.cc: binxmax>hist2D_->GetNbinsX()"
-              << std::endl;
+    std::cout << "Error: TH2Analyzer.cc: binxmax>hist2D_->GetNbinsX()" << std::endl;
     return;
   }
 
@@ -89,11 +92,14 @@ void TH2Analyzer::Eval(const int rebinFactor, const int binxmin,
     // << "hist2D_->GetYaxis()->GetXmin() = " << hist2D_->GetYaxis()->GetXmin()
     // << std::endl; std::cout << "hist2D_->GetYaxis()->GetXmax() = " <<
     // hist2D_->GetYaxis()->GetXmax() << std::endl;
-    rebinnedHist2D_ = new TH2D(
-        rebinName.c_str(), "rebinned histo", binxmax - binxmin + 1,
-        hist2D_->GetXaxis()->GetBinLowEdge(binxmin),
-        hist2D_->GetXaxis()->GetBinUpEdge(binxmax), hist2D_->GetNbinsY(),
-        hist2D_->GetYaxis()->GetXmin(), hist2D_->GetYaxis()->GetXmax());
+    rebinnedHist2D_ = new TH2D(rebinName.c_str(),
+                               "rebinned histo",
+                               binxmax - binxmin + 1,
+                               hist2D_->GetXaxis()->GetBinLowEdge(binxmin),
+                               hist2D_->GetXaxis()->GetBinUpEdge(binxmax),
+                               hist2D_->GetNbinsY(),
+                               hist2D_->GetYaxis()->GetXmin(),
+                               hist2D_->GetYaxis()->GetXmax());
     for (int binyc = 1; binyc < hist2D_->GetNbinsY() + 1; ++binyc) {
       for (int binxc = binxmin; binxc < binxmax + 1; ++binxc) {
         // std::cout << "hist2D_->GetBinContent(" << binxc << "," << binyc << ")
@@ -101,36 +107,39 @@ void TH2Analyzer::Eval(const int rebinFactor, const int binxmin,
         // "hist2D_->GetBinError(" << binxc << "," << binyc << ") = " <<
         // hist2D_->GetBinError(binxc,binyc) << std::endl; std::cout <<
         // "binxc-binxmin+1 = " << binxc-binxmin+1 << std::endl;
-        rebinnedHist2D_->SetBinContent(binxc - binxmin + 1, binyc,
-                                       hist2D_->GetBinContent(binxc, binyc));
-        rebinnedHist2D_->SetBinError(binxc - binxmin + 1, binyc,
-                                     hist2D_->GetBinError(binxc, binyc));
+        rebinnedHist2D_->SetBinContent(binxc - binxmin + 1, binyc, hist2D_->GetBinContent(binxc, binyc));
+        rebinnedHist2D_->SetBinError(binxc - binxmin + 1, binyc, hist2D_->GetBinError(binxc, binyc));
       }
     }
     rebinnedHist2D_->RebinX(rebinFactor);
 
     const string averageName = bname + "_average";
-    average_ = new TH1D(averageName.c_str(), "arithmetic average",
+    average_ = new TH1D(averageName.c_str(),
+                        "arithmetic average",
                         rebinnedHist2D_->GetNbinsX(),
                         rebinnedHist2D_->GetXaxis()->GetXmin(),
                         rebinnedHist2D_->GetXaxis()->GetXmax());
 
     const string rmsName = bname + "_RMS";
-    RMS_ = new TH1D(rmsName.c_str(), "RMS", rebinnedHist2D_->GetNbinsX(),
+    RMS_ = new TH1D(rmsName.c_str(),
+                    "RMS",
+                    rebinnedHist2D_->GetNbinsX(),
                     rebinnedHist2D_->GetXaxis()->GetXmin(),
                     rebinnedHist2D_->GetXaxis()->GetXmax());
 
     const string sigmaGaussName = bname + "_sigmaGauss";
-    sigmaGauss_ = new TH1D(sigmaGaussName.c_str(), "sigmaGauss",
+    sigmaGauss_ = new TH1D(sigmaGaussName.c_str(),
+                           "sigmaGauss",
                            rebinnedHist2D_->GetNbinsX(),
                            rebinnedHist2D_->GetXaxis()->GetXmin(),
                            rebinnedHist2D_->GetXaxis()->GetXmax());
 
     const string meanXName = bname + "_meanX";
-    meanXslice_ =
-        new TH1D(meanXName.c_str(), "meanX", rebinnedHist2D_->GetNbinsX(),
-                 rebinnedHist2D_->GetXaxis()->GetXmin(),
-                 rebinnedHist2D_->GetXaxis()->GetXmax());
+    meanXslice_ = new TH1D(meanXName.c_str(),
+                           "meanX",
+                           rebinnedHist2D_->GetNbinsX(),
+                           rebinnedHist2D_->GetXaxis()->GetXmin(),
+                           rebinnedHist2D_->GetXaxis()->GetXmax());
   } else {
     // binning is not constant, but made to obtain almost the same number of
     // events in each bin
@@ -154,8 +163,7 @@ void TH2Analyzer::Eval(const int rebinFactor, const int binxmin,
     int *binlow = new int[nbin + 1];
 
     TH1D *h0_slice1 = hist2D_->ProjectionY("h0_slice1", binxmin, binxmax, "");
-    const unsigned int totalNumberOfEvents =
-        static_cast<unsigned int>(h0_slice1->GetEntries());
+    const unsigned int totalNumberOfEvents = static_cast<unsigned int>(h0_slice1->GetEntries());
     // std::cout << "totalNumberOfEvents = " << totalNumberOfEvents <<
     // std::endl;
     delete h0_slice1;
@@ -166,8 +174,7 @@ void TH2Analyzer::Eval(const int rebinFactor, const int binxmin,
     binlow[0] = binxmin;
     for (unsigned int binc = 1; binc < nbin; ++binc) {
       while (neventsc < binc * totalNumberOfEvents / nbin) {
-        TH1D *h0_slice1c =
-            hist2D_->ProjectionY("h0_slice1", binxmin, binXmaxc, "");
+        TH1D *h0_slice1c = hist2D_->ProjectionY("h0_slice1", binxmin, binXmaxc, "");
         neventsc = static_cast<unsigned int>(h0_slice1c->GetEntries());
         //        //std::cout << "FL : neventsc = " << neventsc << std::endl;
         //        //std::cout << "FL : binXmaxc = " << binXmaxc << std::endl;
@@ -186,14 +193,17 @@ void TH2Analyzer::Eval(const int rebinFactor, const int binxmin,
     //  std::cout << "xlow[" << binc << "] = " << xlow[binc] << std::endl;
     //}
 
-    rebinnedHist2D_ = new TH2D(
-        rebinName.c_str(), "rebinned histo", nbin, xlow, hist2D_->GetNbinsY(),
-        hist2D_->GetYaxis()->GetXmin(), hist2D_->GetYaxis()->GetXmax());
+    rebinnedHist2D_ = new TH2D(rebinName.c_str(),
+                               "rebinned histo",
+                               nbin,
+                               xlow,
+                               hist2D_->GetNbinsY(),
+                               hist2D_->GetYaxis()->GetXmin(),
+                               hist2D_->GetYaxis()->GetXmax());
     for (int binyc = 1; binyc < hist2D_->GetNbinsY() + 1; ++binyc) {
       for (unsigned int binxc = 1; binxc < nbin + 1; ++binxc) {
         double sum = 0.0;
-        for (int binxh2c = binlow[binxc - 1]; binxh2c < binlow[binxc];
-             ++binxh2c) {
+        for (int binxh2c = binlow[binxc - 1]; binxh2c < binlow[binxc]; ++binxh2c) {
           sum += hist2D_->GetBinContent(binxh2c, binyc);
         }
         rebinnedHist2D_->SetBinContent(binxc, binyc, sum);
@@ -218,7 +228,6 @@ void TH2Analyzer::Eval(const int rebinFactor, const int binxmin,
 }
 
 void TH2Analyzer::ProcessSlices(const TH2D *histo) {
-
   // std::cout << "ProcessSlices!" << std::endl;
 
   TH1::AddDirectory(false);
@@ -234,9 +243,7 @@ void TH2Analyzer::ProcessSlices(const TH2D *histo) {
     RMS_->SetBinContent(i, rms);
     RMS_->SetBinError(i, proj->GetRMSError());
 
-    const double error = (histo->GetXaxis()->GetBinUpEdge(i) -
-                          histo->GetXaxis()->GetBinLowEdge(i)) /
-                         2.0;
+    const double error = (histo->GetXaxis()->GetBinUpEdge(i) - histo->GetXaxis()->GetBinLowEdge(i)) / 2.0;
     // std::cout << "error = " << error << std::endl;
     meanXslice_->SetBinContent(i, histo->GetXaxis()->GetBinLowEdge(i) + error);
     meanXslice_->SetBinError(i, error);
@@ -252,7 +259,6 @@ void TH2Analyzer::ProcessSlices(const TH2D *histo) {
 }
 
 void TH2Analyzer::ProcessSlice(const int i, TH1D *proj) const {
-
   // const double mean = proj->GetMean();
   const double rms = proj->GetRMS();
   // std::cout << "FL: mean = " << mean << std::endl;
@@ -268,10 +274,8 @@ void TH2Analyzer::ProcessSlice(const int i, TH1D *proj) const {
 
     // proj->Draw();
     TF1 *f1 = new TF1("f1", "gaus", fitmin, fitmax);
-    f1->SetParameters(proj->GetRMS(), proj->GetMean(),
-                      proj->GetBinContent(proj->GetMaximumBin()));
-    proj->Fit(f1, "R", "", proj->GetXaxis()->GetXmin(),
-              proj->GetXaxis()->GetXmax());
+    f1->SetParameters(proj->GetRMS(), proj->GetMean(), proj->GetBinContent(proj->GetMaximumBin()));
+    proj->Fit(f1, "R", "", proj->GetXaxis()->GetXmin(), proj->GetXaxis()->GetXmax());
 
     // std::ostringstream oss;
     // oss << i;

--- a/Validation/SiOuterTrackerV/interface/OuterTrackerMCHarvester.h
+++ b/Validation/SiOuterTrackerV/interface/OuterTrackerMCHarvester.h
@@ -14,8 +14,7 @@ class OuterTrackerMCHarvester : public DQMEDHarvester {
 public:
   explicit OuterTrackerMCHarvester(const edm::ParameterSet &);
   ~OuterTrackerMCHarvester() override;
-  void dqmEndJob(DQMStore::IBooker &ibooker,
-                 DQMStore::IGetter &igetter) override;
+  void dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) override;
 
 private:
   // ----------member data ---------------------------

--- a/Validation/SiOuterTrackerV/interface/OuterTrackerMonitorTrackingParticles.h
+++ b/Validation/SiOuterTrackerV/interface/OuterTrackerMonitorTrackingParticles.h
@@ -24,13 +24,11 @@
 class DQMStore;
 
 class OuterTrackerMonitorTrackingParticles : public DQMEDAnalyzer {
-
 public:
   explicit OuterTrackerMonitorTrackingParticles(const edm::ParameterSet &);
   ~OuterTrackerMonitorTrackingParticles() override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
-                      edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   int Layer(const float R_, const float Z_) const;
 
   // Tracking particle distributions
@@ -39,29 +37,27 @@ public:
   MonitorElement *trackParts_Pt = nullptr;
 
   // Plots for correctly matched tracks
-  MonitorElement *Track_MatchedChi2 =
-      nullptr; // Chi2 for only tracks correctly matched to truth level
-  MonitorElement *Track_MatchedChi2Red =
-      nullptr; // Chi2/dof for only tracks correctly matched to truth level
+  MonitorElement *Track_MatchedChi2 = nullptr;     // Chi2 for only tracks correctly matched to truth level
+  MonitorElement *Track_MatchedChi2Red = nullptr;  // Chi2/dof for only tracks correctly matched to truth level
 
   // pT and eta for efficiency plots
-  MonitorElement *tp_pt = nullptr;            // denominator
-  MonitorElement *tp_pt_zoom = nullptr;       // denominator
-  MonitorElement *tp_eta = nullptr;           // denominator
-  MonitorElement *tp_d0 = nullptr;            // denominator
-  MonitorElement *tp_VtxR = nullptr;          // denominator (also known as vxy)
-  MonitorElement *tp_VtxZ = nullptr;          // denominator
-  MonitorElement *match_tp_pt = nullptr;      // numerator
-  MonitorElement *match_tp_pt_zoom = nullptr; // numerator
-  MonitorElement *match_tp_eta = nullptr;     // numerator
-  MonitorElement *match_tp_d0 = nullptr;      // numerator
-  MonitorElement *match_tp_VtxR = nullptr;    // numerator (also known as vxy)
-  MonitorElement *match_tp_VtxZ = nullptr;    // numerator
+  MonitorElement *tp_pt = nullptr;             // denominator
+  MonitorElement *tp_pt_zoom = nullptr;        // denominator
+  MonitorElement *tp_eta = nullptr;            // denominator
+  MonitorElement *tp_d0 = nullptr;             // denominator
+  MonitorElement *tp_VtxR = nullptr;           // denominator (also known as vxy)
+  MonitorElement *tp_VtxZ = nullptr;           // denominator
+  MonitorElement *match_tp_pt = nullptr;       // numerator
+  MonitorElement *match_tp_pt_zoom = nullptr;  // numerator
+  MonitorElement *match_tp_eta = nullptr;      // numerator
+  MonitorElement *match_tp_d0 = nullptr;       // numerator
+  MonitorElement *match_tp_VtxR = nullptr;     // numerator (also known as vxy)
+  MonitorElement *match_tp_VtxZ = nullptr;     // numerator
 
   // 1D intermediate resolution plots (pT and eta)
-  MonitorElement *res_eta = nullptr;   // for all eta and pT
-  MonitorElement *res_pt = nullptr;    // for all eta and pT
-  MonitorElement *res_ptRel = nullptr; // for all eta and pT (delta(pT)/pT)
+  MonitorElement *res_eta = nullptr;    // for all eta and pT
+  MonitorElement *res_pt = nullptr;     // for all eta and pT
+  MonitorElement *res_ptRel = nullptr;  // for all eta and pT (delta(pT)/pT)
   MonitorElement *respt_eta0to0p7_pt2to3 = nullptr;
   MonitorElement *respt_eta0p7to1_pt2to3 = nullptr;
   MonitorElement *respt_eta1to1p2_pt2to3 = nullptr;
@@ -110,15 +106,14 @@ public:
 private:
   edm::ParameterSet conf_;
   edm::EDGetTokenT<std::vector<TrackingParticle>> trackingParticleToken_;
-  edm::EDGetTokenT<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>
-      ttStubToken_;
+  edm::EDGetTokenT<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>> ttStubToken_;
   edm::EDGetTokenT<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>> ttTrackToken_;
   edm::EDGetTokenT<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>>
-      ttClusterMCTruthToken_; // MC truth association map for clusters
+      ttClusterMCTruthToken_;  // MC truth association map for clusters
   edm::EDGetTokenT<TTStubAssociationMap<Ref_Phase2TrackerDigi_>>
-      ttStubMCTruthToken_; // MC truth association map for stubs
+      ttStubMCTruthToken_;  // MC truth association map for stubs
   edm::EDGetTokenT<TTTrackAssociationMap<Ref_Phase2TrackerDigi_>>
-      ttTrackMCTruthToken_; // MC truth association map for tracks
+      ttTrackMCTruthToken_;  // MC truth association map for tracks
   int L1Tk_nPar;
   int L1Tk_minNStub;
   double L1Tk_maxChi2;
@@ -136,8 +131,7 @@ private:
   struct TpStruct {
     int TpId;
     std::vector<bool> layer;
-    int
-    Nlayers() { // Counts how many layers are set to "true" for their hit status
+    int Nlayers() {  // Counts how many layers are set to "true" for their hit status
       int layers = 0;
       for (unsigned l = 0; l < layer.size(); ++l)
         if (layer[l])

--- a/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.cc
+++ b/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.cc
@@ -36,45 +36,33 @@
 //
 // constructors and destructor
 //
-OuterTrackerMonitorTrackingParticles::OuterTrackerMonitorTrackingParticles(
-    const edm::ParameterSet &iConfig)
+OuterTrackerMonitorTrackingParticles::OuterTrackerMonitorTrackingParticles(const edm::ParameterSet &iConfig)
     : conf_(iConfig) {
   topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
-  trackingParticleToken_ = consumes<std::vector<TrackingParticle>>(
-      conf_.getParameter<edm::InputTag>("trackingParticleToken"));
-  ttStubMCTruthToken_ = consumes<TTStubAssociationMap<Ref_Phase2TrackerDigi_>>(
-      conf_.getParameter<edm::InputTag>("MCTruthStubInputTag"));
-  ttClusterMCTruthToken_ =
-      consumes<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>>(
-          conf_.getParameter<edm::InputTag>("MCTruthClusterInputTag"));
-  ttTrackMCTruthToken_ =
-      consumes<TTTrackAssociationMap<Ref_Phase2TrackerDigi_>>(
-          conf_.getParameter<edm::InputTag>("MCTruthTrackInputTag"));
-  ttStubToken_ = consumes<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>(
-      conf_.getParameter<edm::InputTag>("StubInputTag"));
-  ttTrackToken_ = consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>(
-      conf_.getParameter<edm::InputTag>("TTTracksTag"));
-  L1Tk_nPar =
-      conf_.getParameter<int>("L1Tk_nPar"); // 4 or 5(d0) track parameters
-  L1Tk_minNStub = conf_.getParameter<int>(
-      "L1Tk_minNStub"); // min number of stubs in the track
-  L1Tk_maxChi2 =
-      conf_.getParameter<double>("L1Tk_maxChi2"); // maximum chi2 of the track
-  L1Tk_maxChi2dof = conf_.getParameter<double>(
-      "L1Tk_maxChi2dof"); // maximum chi2/dof of the track
-  TP_minNStub = conf_.getParameter<int>(
-      "TP_minNStub"); // min number of stubs in the tracking particle to
-                      // consider matching
-  TP_minPt =
-      conf_.getParameter<double>("TP_minPt"); // min pT to consider matching
-  TP_maxPt =
-      conf_.getParameter<double>("TP_maxPt"); // max pT to consider matching
-  TP_maxEta =
-      conf_.getParameter<double>("TP_maxEta"); // max eta to consider matching
-  TP_maxVtxZ = conf_.getParameter<double>(
-      "TP_maxVtxZ"); // max vertZ (or z0) to consider matching
+  trackingParticleToken_ =
+      consumes<std::vector<TrackingParticle>>(conf_.getParameter<edm::InputTag>("trackingParticleToken"));
+  ttStubMCTruthToken_ =
+      consumes<TTStubAssociationMap<Ref_Phase2TrackerDigi_>>(conf_.getParameter<edm::InputTag>("MCTruthStubInputTag"));
+  ttClusterMCTruthToken_ = consumes<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>>(
+      conf_.getParameter<edm::InputTag>("MCTruthClusterInputTag"));
+  ttTrackMCTruthToken_ = consumes<TTTrackAssociationMap<Ref_Phase2TrackerDigi_>>(
+      conf_.getParameter<edm::InputTag>("MCTruthTrackInputTag"));
+  ttStubToken_ =
+      consumes<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>(conf_.getParameter<edm::InputTag>("StubInputTag"));
+  ttTrackToken_ =
+      consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>(conf_.getParameter<edm::InputTag>("TTTracksTag"));
+  L1Tk_nPar = conf_.getParameter<int>("L1Tk_nPar");                 // 4 or 5(d0) track parameters
+  L1Tk_minNStub = conf_.getParameter<int>("L1Tk_minNStub");         // min number of stubs in the track
+  L1Tk_maxChi2 = conf_.getParameter<double>("L1Tk_maxChi2");        // maximum chi2 of the track
+  L1Tk_maxChi2dof = conf_.getParameter<double>("L1Tk_maxChi2dof");  // maximum chi2/dof of the track
+  TP_minNStub = conf_.getParameter<int>("TP_minNStub");             // min number of stubs in the tracking particle to
+                                                                    // consider matching
+  TP_minPt = conf_.getParameter<double>("TP_minPt");                // min pT to consider matching
+  TP_maxPt = conf_.getParameter<double>("TP_maxPt");                // max pT to consider matching
+  TP_maxEta = conf_.getParameter<double>("TP_maxEta");              // max eta to consider matching
+  TP_maxVtxZ = conf_.getParameter<double>("TP_maxVtxZ");            // max vertZ (or z0) to consider matching
   TP_select_eventid = conf_.getParameter<int>("TP_select_eventid");
-} // PI or not
+}  // PI or not
 
 OuterTrackerMonitorTrackingParticles::~OuterTrackerMonitorTrackingParticles() {
   // do anything here that needs to be done at desctruction time
@@ -84,12 +72,9 @@ OuterTrackerMonitorTrackingParticles::~OuterTrackerMonitorTrackingParticles() {
 // member functions
 
 // ------------ method called for each event  ------------
-void OuterTrackerMonitorTrackingParticles::analyze(
-    const edm::Event &iEvent, const edm::EventSetup &iSetup) {
-  typename edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>::const_iterator
-      inputIter;
-  typename edmNew::DetSet<TTStub<Ref_Phase2TrackerDigi_>>::const_iterator
-      contentIter;
+void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  typename edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>::const_iterator inputIter;
+  typename edmNew::DetSet<TTStub<Ref_Phase2TrackerDigi_>>::const_iterator contentIter;
   typedef std::vector<TrackingParticle> TrackingParticleCollection;
 
   // Tracking Particles
@@ -97,18 +82,15 @@ void OuterTrackerMonitorTrackingParticles::analyze(
   iEvent.getByToken(trackingParticleToken_, trackingParticleHandle);
 
   // L1 Primaries
-  edm::Handle<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>
-      TTStubHandle;
+  edm::Handle<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>> TTStubHandle;
   iEvent.getByToken(ttStubToken_, TTStubHandle);
   edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>> TTTrackHandle;
   iEvent.getByToken(ttTrackToken_, TTTrackHandle);
 
   // Truth Association Maps
-  edm::Handle<TTTrackAssociationMap<Ref_Phase2TrackerDigi_>>
-      MCTruthTTTrackHandle;
+  edm::Handle<TTTrackAssociationMap<Ref_Phase2TrackerDigi_>> MCTruthTTTrackHandle;
   iEvent.getByToken(ttTrackMCTruthToken_, MCTruthTTTrackHandle);
-  edm::Handle<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>>
-      MCTruthTTClusterHandle;
+  edm::Handle<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>> MCTruthTTClusterHandle;
   iEvent.getByToken(ttClusterMCTruthToken_, MCTruthTTClusterHandle);
   edm::Handle<TTStubAssociationMap<Ref_Phase2TrackerDigi_>> MCTruthTTStubHandle;
   iEvent.getByToken(ttStubMCTruthToken_, MCTruthTTStubHandle);
@@ -126,7 +108,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(
   std::vector<float> TTStubs_r;
   std::vector<float> TTStubs_eta;
   std::vector<float> TTStubs_phi;
-  std::vector<int> TTStubs_tpId; // Relates the stub to its tracking particle
+  std::vector<int> TTStubs_tpId;  // Relates the stub to its tracking particle
 
   // Tracking particle distribution, to be used for 1D distribution plots with
   // pT>2, abs(eta)<2.4, and num layers hit >=4 These are slightly different
@@ -135,35 +117,25 @@ void OuterTrackerMonitorTrackingParticles::analyze(
   std::vector<float> v_tp_pt;
   std::vector<float> v_tp_eta;
   std::vector<float> v_tp_phi;
-  std::vector<float> v_tp_nLayers; // Calculated as the number of layers hit
+  std::vector<float> v_tp_nLayers;  // Calculated as the number of layers hit
 
   // Add protection
   if (!TTStubHandle.isValid())
     return;
 
   // Loop through stubs to determine a link to each stub's tracking particle
-  for (inputIter = TTStubHandle->begin(); inputIter != TTStubHandle->end();
-       ++inputIter) {
-    for (contentIter = inputIter->begin(); contentIter != inputIter->end();
-         ++contentIter) {
-      edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>,
-               TTStub<Ref_Phase2TrackerDigi_>>
-          tempStubRef = edmNew::makeRefTo(
-              TTStubHandle, contentIter); /// Positions, directions
+  for (inputIter = TTStubHandle->begin(); inputIter != TTStubHandle->end(); ++inputIter) {
+    for (contentIter = inputIter->begin(); contentIter != inputIter->end(); ++contentIter) {
+      edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>> tempStubRef =
+          edmNew::makeRefTo(TTStubHandle, contentIter);  /// Positions, directions
 
-      DetId detIdStub =
-          theTrackerGeometry
-              ->idToDet((tempStubRef->getClusterRef(0))->getDetId())
-              ->geographicalId();
-      const MeasurementPoint &mp =
-          (tempStubRef->getClusterRef(0))->findAverageLocalCoordinates();
+      DetId detIdStub = theTrackerGeometry->idToDet((tempStubRef->getClusterRef(0))->getDetId())->geographicalId();
+      const MeasurementPoint &mp = (tempStubRef->getClusterRef(0))->findAverageLocalCoordinates();
       const GeomDet *theGeomDet = theTrackerGeometry->idToDet(detIdStub);
-      Global3DPoint posStub = theGeomDet->surface().toGlobal(
-          theGeomDet->topology().localPosition(mp));
+      Global3DPoint posStub = theGeomDet->surface().toGlobal(theGeomDet->topology().localPosition(mp));
 
-      edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>,
-               TTStub<Ref_Phase2TrackerDigi_>>
-          tempStubPtr = edmNew::makeRefTo(TTStubHandle, contentIter);
+      edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>> tempStubPtr =
+          edmNew::makeRefTo(TTStubHandle, contentIter);
 
       float stubs_x = posStub.x();
       float stubs_y = posStub.y();
@@ -187,8 +159,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(
         genuineStub = MCTruthTTStubHandle->isGenuine(tempStubPtr);
       }
       if (genuineStub) {
-        edm::Ptr<TrackingParticle> tpPtr =
-            MCTruthTTStubHandle->findTrackingParticlePtr(tempStubPtr);
+        edm::Ptr<TrackingParticle> tpPtr = MCTruthTTStubHandle->findTrackingParticlePtr(tempStubPtr);
         if (tpPtr.isNonnull()) {
           float x = tpPtr->vertex().x();
           float y = tpPtr->vertex().y();
@@ -199,7 +170,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(
           int idx = -1;
           int counter = 0;
           // Determine to which tracking particle the stub is associated
-          for (auto it : *trackingParticleHandle) { // Loop over TPs
+          for (auto it : *trackingParticleHandle) {  // Loop over TPs
             counter++;
             float allowedRes = 0.001;
             if (std::fabs(it.vx() - x) > allowedRes)
@@ -217,25 +188,25 @@ void OuterTrackerMonitorTrackingParticles::analyze(
 
             idx = counter;
           }
-          TTStubs_tpId.back() = idx; // Set the tpId: a link between the stub
-                                     // and its tracking particle
+          TTStubs_tpId.back() = idx;  // Set the tpId: a link between the stub
+                                      // and its tracking particle
         }
       }
-    } // End content iterator
-  }   // End input iterator
+    }  // End content iterator
+  }    // End input iterator
 
   // Effectively, a loop through all tracking particles through their stubs
   // For each tracking particle, will determine whether the layer has a stub
   // (true) or not (false)
   std::vector<TpStruct> TPStructs;
-  for (unsigned j = 0; j < TTStubs_tpId.size(); j++) { // Loop over all stubs
+  for (unsigned j = 0; j < TTStubs_tpId.size(); j++) {  // Loop over all stubs
     const int ID = TTStubs_tpId[j];
     if (ID < 0)
       continue;
     int pos = -1;
-    int p = 0;                          // Counter
-    for (auto thisStruct : TPStructs) { // make sure you only assign one
-                                        // tracking particle to one TpStruct
+    int p = 0;                           // Counter
+    for (auto thisStruct : TPStructs) {  // make sure you only assign one
+                                         // tracking particle to one TpStruct
       if (ID == thisStruct.TpId) {
         pos = p;
         break;
@@ -243,23 +214,21 @@ void OuterTrackerMonitorTrackingParticles::analyze(
       p++;
     }
 
-    if (pos <
-        0) { // if you have not yet looped through this tracking particle...
+    if (pos < 0) {  // if you have not yet looped through this tracking particle...
       TpStruct thisTPStruct;
       thisTPStruct.TpId = ID;
       int totalLayers = 11;
-      std::vector<bool> layerElement(
-          totalLayers, false); // set each layer's "hit" status to false
+      std::vector<bool> layerElement(totalLayers, false);  // set each layer's "hit" status to false
       thisTPStruct.layer = layerElement;
       TPStructs.push_back(thisTPStruct);
       pos = TPStructs.size() - 1;
     }
     int l = Layer(TTStubs_r[j],
-                  TTStubs_z[j]); // Send through function Layer, which
-                                 // determines which layer the stub is in
+                  TTStubs_z[j]);  // Send through function Layer, which
+                                  // determines which layer the stub is in
     if (l >= 0)
-      TPStructs[pos].layer[l] = true; // Set the layer that is "hit" to true
-  }                                   // End loop over stubs
+      TPStructs[pos].layer[l] = true;  // Set the layer that is "hit" to true
+  }                                    // End loop over stubs
 
   // Fill the tracking particle quantities
   // std::vector< TrackingParticle >::const_iterator iterTP1;
@@ -267,7 +236,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(
     v_tp_pt.push_back(iterTP1.pt());
     v_tp_eta.push_back(iterTP1.eta());
     v_tp_phi.push_back(iterTP1.phi());
-    v_tp_nLayers.push_back(-1); // Set to dummy values first
+    v_tp_nLayers.push_back(-1);  // Set to dummy values first
   }
 
   // Fill nLayers variable for tracking particles
@@ -279,17 +248,15 @@ void OuterTrackerMonitorTrackingParticles::analyze(
   }
   // Includes all tracking particles, different cuts than those used in the
   // efficiency
-  for (unsigned j = 0; j < v_tp_eta.size(); j++) { // Over all TPs
+  for (unsigned j = 0; j < v_tp_eta.size(); j++) {  // Over all TPs
     double trkParts_eta = v_tp_eta[j];
     double trkParts_pt = v_tp_pt[j];
     double trkParts_phi = v_tp_phi[j];
-    double trkParts_nLayers =
-        v_tp_nLayers[j]; // the number of layers hit for each tracking particle
+    double trkParts_nLayers = v_tp_nLayers[j];  // the number of layers hit for each tracking particle
 
     // Fill the 1D distribution plots for tracking particles, to monitor change
     // in stub definition
-    if (std::fabs(trkParts_eta) < 2.4 && trkParts_pt > 2 &&
-        trkParts_nLayers >= 4) {
+    if (std::fabs(trkParts_eta) < 2.4 && trkParts_pt > 2 && trkParts_nLayers >= 4) {
       // Fill 1D distributions
       trackParts_Pt->Fill(trkParts_pt);
       trackParts_Eta->Fill(trkParts_eta);
@@ -343,7 +310,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(
     float tmp_tp_t = tan(2.0 * atan(1.0) - 2.0 * atan(exp(-tmp_tp_eta)));
     float delx = -tmp_tp_vx;
     float dely = -tmp_tp_vy;
-    float K = 0.01 * 0.5696 / tmp_tp_pt * tmp_tp_charge; // curvature correction
+    float K = 0.01 * 0.5696 / tmp_tp_pt * tmp_tp_charge;  // curvature correction
     float A = 1. / (2. * K);
     float tmp_tp_x0p = delx - A * sin(tmp_tp_phi);
     float tmp_tp_y0p = dely + A * cos(tmp_tp_phi);
@@ -363,15 +330,14 @@ void OuterTrackerMonitorTrackingParticles::analyze(
     // simpler formula for d0, in cases where the charge is zero:
     // https://github.com/cms-sw/cmssw/blob/master/DataFormats/TrackReco/interface/TrackBase.h
     float other_d0 = -tmp_tp_vx * sin(tmp_tp_phi) + tmp_tp_vy * cos(tmp_tp_phi);
-    tmp_tp_d0 = tmp_tp_d0 * (-1); // fix d0 sign
+    tmp_tp_d0 = tmp_tp_d0 * (-1);  // fix d0 sign
     if (K == 0) {
       tmp_tp_d0 = other_d0;
       tmp_tp_VtxZ = tmp_tp_vz;
     }
     int nStubTP = -1;
     if (MCTruthTTStubHandle.isValid()) {
-      std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>,
-                           TTStub<Ref_Phase2TrackerDigi_>>>
+      std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
           theStubRefs = MCTruthTTStubHandle->findTTStubRefs(tp_ptr);
       nStubTP = (int)theStubRefs.size();
     }
@@ -379,8 +345,8 @@ void OuterTrackerMonitorTrackingParticles::analyze(
     // ----------------------------------------------------------------------------------------------
     // look for L1 tracks matched to the tracking particle
     if (tmp_eventid > 0)
-      continue; // only care about tracking particles from the primary
-                // interaction
+      continue;  // only care about tracking particles from the primary
+                 // interaction
     if (std::fabs(tmp_tp_eta) > TP_maxEta)
       continue;
     if (std::fabs(tmp_tp_VtxZ) > TP_maxVtxZ)
@@ -395,15 +361,13 @@ void OuterTrackerMonitorTrackingParticles::analyze(
 
     // To make efficiency plots where the denominator has NO stub cuts
     if (VtxR < 1.0) {
-      tp_pt->Fill(
-          tmp_tp_pt); // pT efficiency has no cut on pT, but includes VtxR cut
+      tp_pt->Fill(tmp_tp_pt);  // pT efficiency has no cut on pT, but includes VtxR cut
       if (tmp_tp_pt > 0 && tmp_tp_pt <= 10)
-        tp_pt_zoom->Fill(
-            tmp_tp_pt); // pT efficiency has no cut on pT, but includes VtxR cut
+        tp_pt_zoom->Fill(tmp_tp_pt);  // pT efficiency has no cut on pT, but includes VtxR cut
     }
     if (tmp_tp_pt < TP_minPt)
       continue;
-    tp_VtxR->Fill(tmp_tp_VtxR); // VtxR efficiency has no cut on VtxR
+    tp_VtxR->Fill(tmp_tp_VtxR);  // VtxR efficiency has no cut on VtxR
     if (VtxR > 1.0)
       continue;
     tp_eta->Fill(tmp_tp_eta);
@@ -445,18 +409,15 @@ void OuterTrackerMonitorTrackingParticles::analyze(
       float dmatch_phi = 999;
       int match_id = 999;
 
-      edm::Ptr<TrackingParticle> my_tp =
-          MCTruthTTTrackHandle->findTrackingParticlePtr(thisTrack);
+      edm::Ptr<TrackingParticle> my_tp = MCTruthTTTrackHandle->findTrackingParticlePtr(thisTrack);
       dmatch_pt = std::fabs(my_tp->p4().pt() - tmp_tp_pt);
       dmatch_eta = std::fabs(my_tp->p4().eta() - tmp_tp_eta);
       dmatch_phi = std::fabs(my_tp->p4().phi() - tmp_tp_phi);
       match_id = my_tp->pdgId();
-      float tmp_trk_chi2dof =
-          (thisTrack->getChi2(L1Tk_nPar)) / (2 * tmp_trk_nstub - L1Tk_nPar);
+      float tmp_trk_chi2dof = (thisTrack->getChi2(L1Tk_nPar)) / (2 * tmp_trk_nstub - L1Tk_nPar);
 
       // ensure that track is uniquely matched to the TP we are looking at!
-      if (dmatch_pt < 0.1 && dmatch_eta < 0.1 && dmatch_phi < 0.1 &&
-          tmp_tp_pdgid == match_id) {
+      if (dmatch_pt < 0.1 && dmatch_eta < 0.1 && dmatch_phi < 0.1 && tmp_tp_pdgid == match_id) {
         nMatch++;
         if (i_track < 0 || tmp_trk_chi2dof < i_chi2dof) {
           i_track = trkCounter;
@@ -464,7 +425,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(
         }
       }
       trkCounter++;
-    } // end loop over matched L1 tracks
+    }  // end loop over matched L1 tracks
     // ----------------------------------------------------------------------------------------------
 
     // Get information on the matched tracks
@@ -492,8 +453,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(
       // for d0
       float tmp_matchtrk_x0 = matchedTracks[i_track]->getPOCA(L1Tk_nPar).x();
       float tmp_matchtrk_y0 = matchedTracks[i_track]->getPOCA(L1Tk_nPar).y();
-      tmp_matchtrk_d0 = -tmp_matchtrk_x0 * sin(tmp_matchtrk_phi) +
-                        tmp_matchtrk_y0 * cos(tmp_matchtrk_phi);
+      tmp_matchtrk_d0 = -tmp_matchtrk_x0 * sin(tmp_matchtrk_phi) + tmp_matchtrk_y0 * cos(tmp_matchtrk_phi);
     }
 
     trkParts_pt.push_back(tmp_tp_pt);
@@ -516,9 +476,9 @@ void OuterTrackerMonitorTrackingParticles::analyze(
 
     matchTrk_chi2.push_back(tmp_matchtrk_chi2);
     matchTrk_nStub.push_back(tmp_matchTrk_nStub);
-  } // End loop over tracking particles
+  }  // End loop over tracking particles
 
-  for (unsigned j = 0; j < trkParts_eta.size(); j++) { // Over all TPs
+  for (unsigned j = 0; j < trkParts_eta.size(); j++) {  // Over all TPs
     float eta = trkParts_eta[j];
     float pt = trkParts_pt[j];
     float VtxR = trkParts_VtxR[j];
@@ -539,9 +499,9 @@ void OuterTrackerMonitorTrackingParticles::analyze(
     if (std::fabs(eta) > TP_maxEta)
       continue;
     if (trkParts_nMatch[j] < 1)
-      continue; // was the tracking particle matched to a L1 track?
+      continue;  // was the tracking particle matched to a L1 track?
     if (matchTrk_nStub[j] < L1Tk_minNStub)
-      continue; // use only tracks with min X stubs
+      continue;  // use only tracks with min X stubs
 
     // for matched track, retain info on chi2 and chi2/dof
     float chi2 = matchTrk_chi2[j];
@@ -549,7 +509,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(
     float chi2dof = (float)chi2 / ndof;
 
     if (chi2 > L1Tk_maxChi2)
-      continue; // cut on chi2
+      continue;  // cut on chi2
     if (chi2dof > L1Tk_maxChi2dof)
       continue;
 
@@ -563,7 +523,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(
     match_tp_VtxZ->Fill(VtxZ);
 
     if (pt < TP_minPt)
-      continue; // only consider TPs with pt > TP_minPt
+      continue;  // only consider TPs with pt > TP_minPt
     // fill total resolution histograms
     res_pt->Fill(matchTrk_pt[j] - trkParts_pt[j]);
     res_ptRel->Fill((matchTrk_pt[j] - trkParts_pt[j]) / trkParts_pt[j]);
@@ -679,81 +639,81 @@ void OuterTrackerMonitorTrackingParticles::analyze(
   matchTrk_VtxZ.clear();
   matchTrk_chi2.clear();
   matchTrk_nStub.clear();
-} // end of method
+}  // end of method
 
 // ------------ method called once each job just before starting event loop
 // ------------
-void OuterTrackerMonitorTrackingParticles::bookHistograms(
-    DQMStore::IBooker &iBooker, edm::Run const &run,
-    edm::EventSetup const &es) {
+void OuterTrackerMonitorTrackingParticles::bookHistograms(DQMStore::IBooker &iBooker,
+                                                          edm::Run const &run,
+                                                          edm::EventSetup const &es) {
   // Histogram setup and definitions
   std::string HistoName;
   iBooker.setCurrentFolder(topFolderName_ + "/trackParticles");
 
   // 1D: pT
-  edm::ParameterSet psTrackParts_Pt =
-      conf_.getParameter<edm::ParameterSet>("TH1TrackParts_Pt");
+  edm::ParameterSet psTrackParts_Pt = conf_.getParameter<edm::ParameterSet>("TH1TrackParts_Pt");
   HistoName = "trackParts_Pt";
-  trackParts_Pt = iBooker.book1D(
-      HistoName, HistoName, psTrackParts_Pt.getParameter<int32_t>("Nbinsx"),
-      psTrackParts_Pt.getParameter<double>("xmin"),
-      psTrackParts_Pt.getParameter<double>("xmax"));
+  trackParts_Pt = iBooker.book1D(HistoName,
+                                 HistoName,
+                                 psTrackParts_Pt.getParameter<int32_t>("Nbinsx"),
+                                 psTrackParts_Pt.getParameter<double>("xmin"),
+                                 psTrackParts_Pt.getParameter<double>("xmax"));
   trackParts_Pt->setAxisTitle("p_{T} [GeV]", 1);
   trackParts_Pt->setAxisTitle("# tracking particles", 2);
 
   // 1D: eta
-  edm::ParameterSet psTrackParts_Eta =
-      conf_.getParameter<edm::ParameterSet>("TH1TrackParts_Eta");
+  edm::ParameterSet psTrackParts_Eta = conf_.getParameter<edm::ParameterSet>("TH1TrackParts_Eta");
   HistoName = "trackParts_Eta";
-  trackParts_Eta = iBooker.book1D(
-      HistoName, HistoName, psTrackParts_Eta.getParameter<int32_t>("Nbinsx"),
-      psTrackParts_Eta.getParameter<double>("xmin"),
-      psTrackParts_Eta.getParameter<double>("xmax"));
+  trackParts_Eta = iBooker.book1D(HistoName,
+                                  HistoName,
+                                  psTrackParts_Eta.getParameter<int32_t>("Nbinsx"),
+                                  psTrackParts_Eta.getParameter<double>("xmin"),
+                                  psTrackParts_Eta.getParameter<double>("xmax"));
   trackParts_Eta->setAxisTitle("#eta", 1);
   trackParts_Eta->setAxisTitle("# tracking particles", 2);
 
   // 1D: phi
-  edm::ParameterSet psTrackParts_Phi =
-      conf_.getParameter<edm::ParameterSet>("TH1TrackParts_Phi");
+  edm::ParameterSet psTrackParts_Phi = conf_.getParameter<edm::ParameterSet>("TH1TrackParts_Phi");
   HistoName = "trackParts_Phi";
-  trackParts_Phi = iBooker.book1D(
-      HistoName, HistoName, psTrackParts_Phi.getParameter<int32_t>("Nbinsx"),
-      psTrackParts_Phi.getParameter<double>("xmin"),
-      psTrackParts_Phi.getParameter<double>("xmax"));
+  trackParts_Phi = iBooker.book1D(HistoName,
+                                  HistoName,
+                                  psTrackParts_Phi.getParameter<int32_t>("Nbinsx"),
+                                  psTrackParts_Phi.getParameter<double>("xmin"),
+                                  psTrackParts_Phi.getParameter<double>("xmax"));
   trackParts_Phi->setAxisTitle("#phi", 1);
   trackParts_Phi->setAxisTitle("# tracking particles", 2);
 
   // For tracks correctly matched to truth-level track
   iBooker.setCurrentFolder(topFolderName_ + "/Tracks");
   // chi2
-  edm::ParameterSet psTrack_Chi2 =
-      conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2");
+  edm::ParameterSet psTrack_Chi2 = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2");
   HistoName = "Track_MatchedChi2";
-  Track_MatchedChi2 = iBooker.book1D(
-      HistoName, HistoName, psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
-      psTrack_Chi2.getParameter<double>("xmin"),
-      psTrack_Chi2.getParameter<double>("xmax"));
+  Track_MatchedChi2 = iBooker.book1D(HistoName,
+                                     HistoName,
+                                     psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
+                                     psTrack_Chi2.getParameter<double>("xmin"),
+                                     psTrack_Chi2.getParameter<double>("xmax"));
   Track_MatchedChi2->setAxisTitle("L1 Track #chi^{2}", 1);
   Track_MatchedChi2->setAxisTitle("# Correctly Matched L1 Tracks", 2);
 
   // chi2Red
-  edm::ParameterSet psTrack_Chi2Red =
-      conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2R");
+  edm::ParameterSet psTrack_Chi2Red = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2R");
   HistoName = "Track_MatchedChi2Red";
-  Track_MatchedChi2Red = iBooker.book1D(
-      HistoName, HistoName, psTrack_Chi2Red.getParameter<int32_t>("Nbinsx"),
-      psTrack_Chi2Red.getParameter<double>("xmin"),
-      psTrack_Chi2Red.getParameter<double>("xmax"));
+  Track_MatchedChi2Red = iBooker.book1D(HistoName,
+                                        HistoName,
+                                        psTrack_Chi2Red.getParameter<int32_t>("Nbinsx"),
+                                        psTrack_Chi2Red.getParameter<double>("xmin"),
+                                        psTrack_Chi2Red.getParameter<double>("xmax"));
   Track_MatchedChi2Red->setAxisTitle("L1 Track #chi^{2}/ndf", 1);
   Track_MatchedChi2Red->setAxisTitle("# Correctly Matched L1 Tracks", 2);
 
   // 1D plots for efficiency
   iBooker.setCurrentFolder(topFolderName_ + "/Tracks/Efficiency");
   // pT
-  edm::ParameterSet psEffic_pt =
-      conf_.getParameter<edm::ParameterSet>("TH1Effic_pt");
+  edm::ParameterSet psEffic_pt = conf_.getParameter<edm::ParameterSet>("TH1Effic_pt");
   HistoName = "tp_pt";
-  tp_pt = iBooker.book1D(HistoName, HistoName,
+  tp_pt = iBooker.book1D(HistoName,
+                         HistoName,
                          psEffic_pt.getParameter<int32_t>("Nbinsx"),
                          psEffic_pt.getParameter<double>("xmin"),
                          psEffic_pt.getParameter<double>("xmax"));
@@ -762,7 +722,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Matched TP's pT
   HistoName = "match_tp_pt";
-  match_tp_pt = iBooker.book1D(HistoName, HistoName,
+  match_tp_pt = iBooker.book1D(HistoName,
+                               HistoName,
                                psEffic_pt.getParameter<int32_t>("Nbinsx"),
                                psEffic_pt.getParameter<double>("xmin"),
                                psEffic_pt.getParameter<double>("xmax"));
@@ -770,10 +731,10 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
   match_tp_pt->setAxisTitle("# matched tracking particles", 2);
 
   // pT zoom (0-10 GeV)
-  edm::ParameterSet psEffic_pt_zoom =
-      conf_.getParameter<edm::ParameterSet>("TH1Effic_pt_zoom");
+  edm::ParameterSet psEffic_pt_zoom = conf_.getParameter<edm::ParameterSet>("TH1Effic_pt_zoom");
   HistoName = "tp_pt_zoom";
-  tp_pt_zoom = iBooker.book1D(HistoName, HistoName,
+  tp_pt_zoom = iBooker.book1D(HistoName,
+                              HistoName,
                               psEffic_pt_zoom.getParameter<int32_t>("Nbinsx"),
                               psEffic_pt_zoom.getParameter<double>("xmin"),
                               psEffic_pt_zoom.getParameter<double>("xmax"));
@@ -782,18 +743,19 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Matched pT zoom (0-10 GeV)
   HistoName = "match_tp_pt_zoom";
-  match_tp_pt_zoom = iBooker.book1D(
-      HistoName, HistoName, psEffic_pt_zoom.getParameter<int32_t>("Nbinsx"),
-      psEffic_pt_zoom.getParameter<double>("xmin"),
-      psEffic_pt_zoom.getParameter<double>("xmax"));
+  match_tp_pt_zoom = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psEffic_pt_zoom.getParameter<int32_t>("Nbinsx"),
+                                    psEffic_pt_zoom.getParameter<double>("xmin"),
+                                    psEffic_pt_zoom.getParameter<double>("xmax"));
   match_tp_pt_zoom->setAxisTitle("p_{T} [GeV]", 1);
   match_tp_pt_zoom->setAxisTitle("# matched tracking particles", 2);
 
   // eta
-  edm::ParameterSet psEffic_eta =
-      conf_.getParameter<edm::ParameterSet>("TH1Effic_eta");
+  edm::ParameterSet psEffic_eta = conf_.getParameter<edm::ParameterSet>("TH1Effic_eta");
   HistoName = "tp_eta";
-  tp_eta = iBooker.book1D(HistoName, HistoName,
+  tp_eta = iBooker.book1D(HistoName,
+                          HistoName,
                           psEffic_eta.getParameter<int32_t>("Nbinsx"),
                           psEffic_eta.getParameter<double>("xmin"),
                           psEffic_eta.getParameter<double>("xmax"));
@@ -802,7 +764,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Matched eta
   HistoName = "match_tp_eta";
-  match_tp_eta = iBooker.book1D(HistoName, HistoName,
+  match_tp_eta = iBooker.book1D(HistoName,
+                                HistoName,
                                 psEffic_eta.getParameter<int32_t>("Nbinsx"),
                                 psEffic_eta.getParameter<double>("xmin"),
                                 psEffic_eta.getParameter<double>("xmax"));
@@ -810,10 +773,10 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
   match_tp_eta->setAxisTitle("# matched tracking particles", 2);
 
   // d0
-  edm::ParameterSet psEffic_d0 =
-      conf_.getParameter<edm::ParameterSet>("TH1Effic_d0");
+  edm::ParameterSet psEffic_d0 = conf_.getParameter<edm::ParameterSet>("TH1Effic_d0");
   HistoName = "tp_d0";
-  tp_d0 = iBooker.book1D(HistoName, HistoName,
+  tp_d0 = iBooker.book1D(HistoName,
+                         HistoName,
                          psEffic_d0.getParameter<int32_t>("Nbinsx"),
                          psEffic_d0.getParameter<double>("xmin"),
                          psEffic_d0.getParameter<double>("xmax"));
@@ -822,7 +785,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Matched d0
   HistoName = "match_tp_d0";
-  match_tp_d0 = iBooker.book1D(HistoName, HistoName,
+  match_tp_d0 = iBooker.book1D(HistoName,
+                               HistoName,
                                psEffic_d0.getParameter<int32_t>("Nbinsx"),
                                psEffic_d0.getParameter<double>("xmin"),
                                psEffic_d0.getParameter<double>("xmax"));
@@ -830,10 +794,10 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
   match_tp_d0->setAxisTitle("# matched tracking particles", 2);
 
   // VtxR (also known as vxy)
-  edm::ParameterSet psEffic_VtxR =
-      conf_.getParameter<edm::ParameterSet>("TH1Effic_VtxR");
+  edm::ParameterSet psEffic_VtxR = conf_.getParameter<edm::ParameterSet>("TH1Effic_VtxR");
   HistoName = "tp_VtxR";
-  tp_VtxR = iBooker.book1D(HistoName, HistoName,
+  tp_VtxR = iBooker.book1D(HistoName,
+                           HistoName,
                            psEffic_VtxR.getParameter<int32_t>("Nbinsx"),
                            psEffic_VtxR.getParameter<double>("xmin"),
                            psEffic_VtxR.getParameter<double>("xmax"));
@@ -842,7 +806,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Matched VtxR
   HistoName = "match_tp_VtxR";
-  match_tp_VtxR = iBooker.book1D(HistoName, HistoName,
+  match_tp_VtxR = iBooker.book1D(HistoName,
+                                 HistoName,
                                  psEffic_VtxR.getParameter<int32_t>("Nbinsx"),
                                  psEffic_VtxR.getParameter<double>("xmin"),
                                  psEffic_VtxR.getParameter<double>("xmax"));
@@ -850,10 +815,10 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
   match_tp_VtxR->setAxisTitle("# matched tracking particles", 2);
 
   // VtxZ
-  edm::ParameterSet psEffic_VtxZ =
-      conf_.getParameter<edm::ParameterSet>("TH1Effic_VtxZ");
+  edm::ParameterSet psEffic_VtxZ = conf_.getParameter<edm::ParameterSet>("TH1Effic_VtxZ");
   HistoName = "tp_VtxZ";
-  tp_VtxZ = iBooker.book1D(HistoName, HistoName,
+  tp_VtxZ = iBooker.book1D(HistoName,
+                           HistoName,
                            psEffic_VtxZ.getParameter<int32_t>("Nbinsx"),
                            psEffic_VtxZ.getParameter<double>("xmin"),
                            psEffic_VtxZ.getParameter<double>("xmax"));
@@ -862,7 +827,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Matched d0
   HistoName = "match_tp_VtxZ";
-  match_tp_VtxZ = iBooker.book1D(HistoName, HistoName,
+  match_tp_VtxZ = iBooker.book1D(HistoName,
+                                 HistoName,
                                  psEffic_VtxZ.getParameter<int32_t>("Nbinsx"),
                                  psEffic_VtxZ.getParameter<double>("xmin"),
                                  psEffic_VtxZ.getParameter<double>("xmax"));
@@ -872,10 +838,10 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
   // 1D plots for resolution
   iBooker.setCurrentFolder(topFolderName_ + "/Tracks/Resolution");
   // full pT
-  edm::ParameterSet psRes_pt =
-      conf_.getParameter<edm::ParameterSet>("TH1Res_pt");
+  edm::ParameterSet psRes_pt = conf_.getParameter<edm::ParameterSet>("TH1Res_pt");
   HistoName = "res_pt";
-  res_pt = iBooker.book1D(HistoName, HistoName,
+  res_pt = iBooker.book1D(HistoName,
+                          HistoName,
                           psRes_pt.getParameter<int32_t>("Nbinsx"),
                           psRes_pt.getParameter<double>("xmin"),
                           psRes_pt.getParameter<double>("xmax"));
@@ -883,10 +849,10 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
   res_pt->setAxisTitle("# tracking particles", 2);
 
   // Full eta
-  edm::ParameterSet psRes_eta =
-      conf_.getParameter<edm::ParameterSet>("TH1Res_eta");
+  edm::ParameterSet psRes_eta = conf_.getParameter<edm::ParameterSet>("TH1Res_eta");
   HistoName = "res_eta";
-  res_eta = iBooker.book1D(HistoName, HistoName,
+  res_eta = iBooker.book1D(HistoName,
+                           HistoName,
                            psRes_eta.getParameter<int32_t>("Nbinsx"),
                            psRes_eta.getParameter<double>("xmin"),
                            psRes_eta.getParameter<double>("xmax"));
@@ -894,10 +860,10 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
   res_eta->setAxisTitle("# tracking particles", 2);
 
   // Relative pT
-  edm::ParameterSet psRes_ptRel =
-      conf_.getParameter<edm::ParameterSet>("TH1Res_ptRel");
+  edm::ParameterSet psRes_ptRel = conf_.getParameter<edm::ParameterSet>("TH1Res_ptRel");
   HistoName = "res_ptRel";
-  res_ptRel = iBooker.book1D(HistoName, HistoName,
+  res_ptRel = iBooker.book1D(HistoName,
+                             HistoName,
                              psRes_ptRel.getParameter<int32_t>("Nbinsx"),
                              psRes_ptRel.getParameter<double>("xmin"),
                              psRes_ptRel.getParameter<double>("xmax"));
@@ -907,7 +873,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
   // Eta parts (for resolution)
   // Eta 1 (0 to 0.7)
   HistoName = "reseta_eta0to0p7";
-  reseta_eta0to0p7 = iBooker.book1D(HistoName, HistoName,
+  reseta_eta0to0p7 = iBooker.book1D(HistoName,
+                                    HistoName,
                                     psRes_eta.getParameter<int32_t>("Nbinsx"),
                                     psRes_eta.getParameter<double>("xmin"),
                                     psRes_eta.getParameter<double>("xmax"));
@@ -916,7 +883,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Eta 2 (0.7 to 1.0)
   HistoName = "reseta_eta0p7to1";
-  reseta_eta0p7to1 = iBooker.book1D(HistoName, HistoName,
+  reseta_eta0p7to1 = iBooker.book1D(HistoName,
+                                    HistoName,
                                     psRes_eta.getParameter<int32_t>("Nbinsx"),
                                     psRes_eta.getParameter<double>("xmin"),
                                     psRes_eta.getParameter<double>("xmax"));
@@ -925,7 +893,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Eta 3 (1.0 to 1.2)
   HistoName = "reseta_eta1to1p2";
-  reseta_eta1to1p2 = iBooker.book1D(HistoName, HistoName,
+  reseta_eta1to1p2 = iBooker.book1D(HistoName,
+                                    HistoName,
                                     psRes_eta.getParameter<int32_t>("Nbinsx"),
                                     psRes_eta.getParameter<double>("xmin"),
                                     psRes_eta.getParameter<double>("xmax"));
@@ -934,7 +903,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Eta 4 (1.2 to 1.6)
   HistoName = "reseta_eta1p2to1p6";
-  reseta_eta1p2to1p6 = iBooker.book1D(HistoName, HistoName,
+  reseta_eta1p2to1p6 = iBooker.book1D(HistoName,
+                                      HistoName,
                                       psRes_eta.getParameter<int32_t>("Nbinsx"),
                                       psRes_eta.getParameter<double>("xmin"),
                                       psRes_eta.getParameter<double>("xmax"));
@@ -943,7 +913,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Eta 5 (1.6 to 2.0)
   HistoName = "reseta_eta1p6to2";
-  reseta_eta1p6to2 = iBooker.book1D(HistoName, HistoName,
+  reseta_eta1p6to2 = iBooker.book1D(HistoName,
+                                    HistoName,
                                     psRes_eta.getParameter<int32_t>("Nbinsx"),
                                     psRes_eta.getParameter<double>("xmin"),
                                     psRes_eta.getParameter<double>("xmax"));
@@ -952,7 +923,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Eta 6 (2.0 to 2.4)
   HistoName = "reseta_eta2to2p4";
-  reseta_eta2to2p4 = iBooker.book1D(HistoName, HistoName,
+  reseta_eta2to2p4 = iBooker.book1D(HistoName,
+                                    HistoName,
                                     psRes_eta.getParameter<int32_t>("Nbinsx"),
                                     psRes_eta.getParameter<double>("xmin"),
                                     psRes_eta.getParameter<double>("xmax"));
@@ -963,182 +935,192 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
   // pT a (2 to 3 GeV)
   // Eta 1 (0 to 0.7)
   HistoName = "respt_eta0to0p7_pt2to3";
-  respt_eta0to0p7_pt2to3 = iBooker.book1D(
-      HistoName, HistoName, psRes_pt.getParameter<int32_t>("Nbinsx"),
-      psRes_pt.getParameter<double>("xmin"),
-      psRes_pt.getParameter<double>("xmax"));
+  respt_eta0to0p7_pt2to3 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
   respt_eta0to0p7_pt2to3->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
   respt_eta0to0p7_pt2to3->setAxisTitle("# tracking particles", 2);
 
   // Eta 2 (0.7 to 1.0)
   HistoName = "respt_eta0p7to1_pt2to3";
-  respt_eta0p7to1_pt2to3 = iBooker.book1D(
-      HistoName, HistoName, psRes_pt.getParameter<int32_t>("Nbinsx"),
-      psRes_pt.getParameter<double>("xmin"),
-      psRes_pt.getParameter<double>("xmax"));
+  respt_eta0p7to1_pt2to3 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
   respt_eta0p7to1_pt2to3->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
   respt_eta0p7to1_pt2to3->setAxisTitle("# tracking particles", 2);
 
   // Eta 3 (1.0 to 1.2)
   HistoName = "respt_eta1to1p2_pt2to3";
-  respt_eta1to1p2_pt2to3 = iBooker.book1D(
-      HistoName, HistoName, psRes_pt.getParameter<int32_t>("Nbinsx"),
-      psRes_pt.getParameter<double>("xmin"),
-      psRes_pt.getParameter<double>("xmax"));
+  respt_eta1to1p2_pt2to3 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
   respt_eta1to1p2_pt2to3->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
   respt_eta1to1p2_pt2to3->setAxisTitle("# tracking particles", 2);
 
   // Eta 4 (1.2 to 1.6)
   HistoName = "respt_eta1p2to1p6_pt2to3";
-  respt_eta1p2to1p6_pt2to3 = iBooker.book1D(
-      HistoName, HistoName, psRes_pt.getParameter<int32_t>("Nbinsx"),
-      psRes_pt.getParameter<double>("xmin"),
-      psRes_pt.getParameter<double>("xmax"));
-  respt_eta1p2to1p6_pt2to3->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)",
-                                         1);
+  respt_eta1p2to1p6_pt2to3 = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                            psRes_pt.getParameter<double>("xmin"),
+                                            psRes_pt.getParameter<double>("xmax"));
+  respt_eta1p2to1p6_pt2to3->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
   respt_eta1p2to1p6_pt2to3->setAxisTitle("# tracking particles", 2);
 
   // Eta 5 (1.6 to 2.0)
   HistoName = "respt_eta1p6to2_pt2to3";
-  respt_eta1p6to2_pt2to3 = iBooker.book1D(
-      HistoName, HistoName, psRes_pt.getParameter<int32_t>("Nbinsx"),
-      psRes_pt.getParameter<double>("xmin"),
-      psRes_pt.getParameter<double>("xmax"));
+  respt_eta1p6to2_pt2to3 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
   respt_eta1p6to2_pt2to3->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
   respt_eta1p6to2_pt2to3->setAxisTitle("# tracking particles", 2);
 
   // Eta 6 (2.0 to 2.4)
   HistoName = "respt_eta2to2p4_pt2to3";
-  respt_eta2to2p4_pt2to3 = iBooker.book1D(
-      HistoName, HistoName, psRes_pt.getParameter<int32_t>("Nbinsx"),
-      psRes_pt.getParameter<double>("xmin"),
-      psRes_pt.getParameter<double>("xmax"));
+  respt_eta2to2p4_pt2to3 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
   respt_eta2to2p4_pt2to3->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
   respt_eta2to2p4_pt2to3->setAxisTitle("# tracking particles", 2);
 
   // pT b (3 to 8 GeV)
   // Eta 1 (0 to 0.7)
   HistoName = "respt_eta0to0p7_pt3to8";
-  respt_eta0to0p7_pt3to8 = iBooker.book1D(
-      HistoName, HistoName, psRes_pt.getParameter<int32_t>("Nbinsx"),
-      psRes_pt.getParameter<double>("xmin"),
-      psRes_pt.getParameter<double>("xmax"));
+  respt_eta0to0p7_pt3to8 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
   respt_eta0to0p7_pt3to8->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
   respt_eta0to0p7_pt3to8->setAxisTitle("# tracking particles", 2);
 
   // Eta 2 (0.7 to 1.0)
   HistoName = "respt_eta0p7to1_pt3to8";
-  respt_eta0p7to1_pt3to8 = iBooker.book1D(
-      HistoName, HistoName, psRes_pt.getParameter<int32_t>("Nbinsx"),
-      psRes_pt.getParameter<double>("xmin"),
-      psRes_pt.getParameter<double>("xmax"));
+  respt_eta0p7to1_pt3to8 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
   respt_eta0p7to1_pt3to8->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
   respt_eta0p7to1_pt3to8->setAxisTitle("# tracking particles", 2);
 
   // Eta 3 (1.0 to 1.2)
   HistoName = "respt_eta1to1p2_pt3to8";
-  respt_eta1to1p2_pt3to8 = iBooker.book1D(
-      HistoName, HistoName, psRes_pt.getParameter<int32_t>("Nbinsx"),
-      psRes_pt.getParameter<double>("xmin"),
-      psRes_pt.getParameter<double>("xmax"));
+  respt_eta1to1p2_pt3to8 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
   respt_eta1to1p2_pt3to8->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
   respt_eta1to1p2_pt3to8->setAxisTitle("# tracking particles", 2);
 
   // Eta 4 (1.2 to 1.6)
   HistoName = "respt_eta1p2to1p6_pt3to8";
-  respt_eta1p2to1p6_pt3to8 = iBooker.book1D(
-      HistoName, HistoName, psRes_pt.getParameter<int32_t>("Nbinsx"),
-      psRes_pt.getParameter<double>("xmin"),
-      psRes_pt.getParameter<double>("xmax"));
-  respt_eta1p2to1p6_pt3to8->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)",
-                                         1);
+  respt_eta1p2to1p6_pt3to8 = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                            psRes_pt.getParameter<double>("xmin"),
+                                            psRes_pt.getParameter<double>("xmax"));
+  respt_eta1p2to1p6_pt3to8->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
   respt_eta1p2to1p6_pt3to8->setAxisTitle("# tracking particles", 2);
 
   // Eta 5 (1.6 to 2.0)
   HistoName = "respt_eta1p6to2_pt3to8";
-  respt_eta1p6to2_pt3to8 = iBooker.book1D(
-      HistoName, HistoName, psRes_pt.getParameter<int32_t>("Nbinsx"),
-      psRes_pt.getParameter<double>("xmin"),
-      psRes_pt.getParameter<double>("xmax"));
+  respt_eta1p6to2_pt3to8 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
   respt_eta1p6to2_pt3to8->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
   respt_eta1p6to2_pt3to8->setAxisTitle("# tracking particles", 2);
 
   // Eta 6 (2.0 to 2.4)
   HistoName = "respt_eta2to2p4_pt3to8";
-  respt_eta2to2p4_pt3to8 = iBooker.book1D(
-      HistoName, HistoName, psRes_pt.getParameter<int32_t>("Nbinsx"),
-      psRes_pt.getParameter<double>("xmin"),
-      psRes_pt.getParameter<double>("xmax"));
+  respt_eta2to2p4_pt3to8 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
   respt_eta2to2p4_pt3to8->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
   respt_eta2to2p4_pt3to8->setAxisTitle("# tracking particles", 2);
 
   // pT c (>8 GeV)
   // Eta 1 (0 to 0.7)
   HistoName = "respt_eta0to0p7_pt8toInf";
-  respt_eta0to0p7_pt8toInf = iBooker.book1D(
-      HistoName, HistoName, psRes_pt.getParameter<int32_t>("Nbinsx"),
-      psRes_pt.getParameter<double>("xmin"),
-      psRes_pt.getParameter<double>("xmax"));
-  respt_eta0to0p7_pt8toInf->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)",
-                                         1);
+  respt_eta0to0p7_pt8toInf = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                            psRes_pt.getParameter<double>("xmin"),
+                                            psRes_pt.getParameter<double>("xmax"));
+  respt_eta0to0p7_pt8toInf->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
   respt_eta0to0p7_pt8toInf->setAxisTitle("# tracking particles", 2);
 
   // Eta 2 (0.7 to 1.0)
   HistoName = "respt_eta0p7to1_pt8toInf";
-  respt_eta0p7to1_pt8toInf = iBooker.book1D(
-      HistoName, HistoName, psRes_pt.getParameter<int32_t>("Nbinsx"),
-      psRes_pt.getParameter<double>("xmin"),
-      psRes_pt.getParameter<double>("xmax"));
-  respt_eta0p7to1_pt8toInf->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)",
-                                         1);
+  respt_eta0p7to1_pt8toInf = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                            psRes_pt.getParameter<double>("xmin"),
+                                            psRes_pt.getParameter<double>("xmax"));
+  respt_eta0p7to1_pt8toInf->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
   respt_eta0p7to1_pt8toInf->setAxisTitle("# tracking particles", 2);
 
   // Eta 3 (1.0 to 1.2)
   HistoName = "respt_eta1to1p2_pt8toInf";
-  respt_eta1to1p2_pt8toInf = iBooker.book1D(
-      HistoName, HistoName, psRes_pt.getParameter<int32_t>("Nbinsx"),
-      psRes_pt.getParameter<double>("xmin"),
-      psRes_pt.getParameter<double>("xmax"));
-  respt_eta1to1p2_pt8toInf->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)",
-                                         1);
+  respt_eta1to1p2_pt8toInf = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                            psRes_pt.getParameter<double>("xmin"),
+                                            psRes_pt.getParameter<double>("xmax"));
+  respt_eta1to1p2_pt8toInf->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
   respt_eta1to1p2_pt8toInf->setAxisTitle("# tracking particles", 2);
 
   // Eta 4 (1.2 to 1.6)
   HistoName = "respt_eta1p2to1p6_pt8toInf";
-  respt_eta1p2to1p6_pt8toInf = iBooker.book1D(
-      HistoName, HistoName, psRes_pt.getParameter<int32_t>("Nbinsx"),
-      psRes_pt.getParameter<double>("xmin"),
-      psRes_pt.getParameter<double>("xmax"));
-  respt_eta1p2to1p6_pt8toInf->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)",
-                                           1);
+  respt_eta1p2to1p6_pt8toInf = iBooker.book1D(HistoName,
+                                              HistoName,
+                                              psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                              psRes_pt.getParameter<double>("xmin"),
+                                              psRes_pt.getParameter<double>("xmax"));
+  respt_eta1p2to1p6_pt8toInf->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
   respt_eta1p2to1p6_pt8toInf->setAxisTitle("# tracking particles", 2);
 
   // Eta 5 (1.6 to 2.0)
   HistoName = "respt_eta1p6to2_pt8toInf";
-  respt_eta1p6to2_pt8toInf = iBooker.book1D(
-      HistoName, HistoName, psRes_pt.getParameter<int32_t>("Nbinsx"),
-      psRes_pt.getParameter<double>("xmin"),
-      psRes_pt.getParameter<double>("xmax"));
-  respt_eta1p6to2_pt8toInf->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)",
-                                         1);
+  respt_eta1p6to2_pt8toInf = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                            psRes_pt.getParameter<double>("xmin"),
+                                            psRes_pt.getParameter<double>("xmax"));
+  respt_eta1p6to2_pt8toInf->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
   respt_eta1p6to2_pt8toInf->setAxisTitle("# tracking particles", 2);
 
   // Eta 6 (2.0 to 2.4)
   HistoName = "respt_eta2to2p4_pt8toInf";
-  respt_eta2to2p4_pt8toInf = iBooker.book1D(
-      HistoName, HistoName, psRes_pt.getParameter<int32_t>("Nbinsx"),
-      psRes_pt.getParameter<double>("xmin"),
-      psRes_pt.getParameter<double>("xmax"));
-  respt_eta2to2p4_pt8toInf->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)",
-                                         1);
+  respt_eta2to2p4_pt8toInf = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                            psRes_pt.getParameter<double>("xmin"),
+                                            psRes_pt.getParameter<double>("xmax"));
+  respt_eta2to2p4_pt8toInf->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
   respt_eta2to2p4_pt8toInf->setAxisTitle("# tracking particles", 2);
 
   // Phi parts (for resolution)
   // Eta 1 (0 to 0.7)
-  edm::ParameterSet psRes_phi =
-      conf_.getParameter<edm::ParameterSet>("TH1Res_phi");
+  edm::ParameterSet psRes_phi = conf_.getParameter<edm::ParameterSet>("TH1Res_phi");
   HistoName = "resphi_eta0to0p7";
-  resphi_eta0to0p7 = iBooker.book1D(HistoName, HistoName,
+  resphi_eta0to0p7 = iBooker.book1D(HistoName,
+                                    HistoName,
                                     psRes_phi.getParameter<int32_t>("Nbinsx"),
                                     psRes_phi.getParameter<double>("xmin"),
                                     psRes_phi.getParameter<double>("xmax"));
@@ -1147,7 +1129,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Eta 2 (0.7 to 1.0)
   HistoName = "resphi_eta0p7to1";
-  resphi_eta0p7to1 = iBooker.book1D(HistoName, HistoName,
+  resphi_eta0p7to1 = iBooker.book1D(HistoName,
+                                    HistoName,
                                     psRes_phi.getParameter<int32_t>("Nbinsx"),
                                     psRes_phi.getParameter<double>("xmin"),
                                     psRes_phi.getParameter<double>("xmax"));
@@ -1156,7 +1139,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Eta 3 (1.0 to 1.2)
   HistoName = "resphi_eta1to1p2";
-  resphi_eta1to1p2 = iBooker.book1D(HistoName, HistoName,
+  resphi_eta1to1p2 = iBooker.book1D(HistoName,
+                                    HistoName,
                                     psRes_phi.getParameter<int32_t>("Nbinsx"),
                                     psRes_phi.getParameter<double>("xmin"),
                                     psRes_phi.getParameter<double>("xmax"));
@@ -1165,7 +1149,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Eta 4 (1.2 to 1.6)
   HistoName = "resphi_eta1p2to1p6";
-  resphi_eta1p2to1p6 = iBooker.book1D(HistoName, HistoName,
+  resphi_eta1p2to1p6 = iBooker.book1D(HistoName,
+                                      HistoName,
                                       psRes_phi.getParameter<int32_t>("Nbinsx"),
                                       psRes_phi.getParameter<double>("xmin"),
                                       psRes_phi.getParameter<double>("xmax"));
@@ -1174,7 +1159,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Eta 5 (1.6 to 2.0)
   HistoName = "resphi_eta1p6to2";
-  resphi_eta1p6to2 = iBooker.book1D(HistoName, HistoName,
+  resphi_eta1p6to2 = iBooker.book1D(HistoName,
+                                    HistoName,
                                     psRes_phi.getParameter<int32_t>("Nbinsx"),
                                     psRes_phi.getParameter<double>("xmin"),
                                     psRes_phi.getParameter<double>("xmax"));
@@ -1183,7 +1169,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Eta 6 (2.0 to 2.4)
   HistoName = "resphi_eta2to2p4";
-  resphi_eta2to2p4 = iBooker.book1D(HistoName, HistoName,
+  resphi_eta2to2p4 = iBooker.book1D(HistoName,
+                                    HistoName,
                                     psRes_phi.getParameter<int32_t>("Nbinsx"),
                                     psRes_phi.getParameter<double>("xmin"),
                                     psRes_phi.getParameter<double>("xmax"));
@@ -1192,10 +1179,10 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // VtxZ parts (for resolution)
   // Eta 1 (0 to 0.7)
-  edm::ParameterSet psRes_VtxZ =
-      conf_.getParameter<edm::ParameterSet>("TH1Res_VtxZ");
+  edm::ParameterSet psRes_VtxZ = conf_.getParameter<edm::ParameterSet>("TH1Res_VtxZ");
   HistoName = "resVtxZ_eta0to0p7";
-  resVtxZ_eta0to0p7 = iBooker.book1D(HistoName, HistoName,
+  resVtxZ_eta0to0p7 = iBooker.book1D(HistoName,
+                                     HistoName,
                                      psRes_VtxZ.getParameter<int32_t>("Nbinsx"),
                                      psRes_VtxZ.getParameter<double>("xmin"),
                                      psRes_VtxZ.getParameter<double>("xmax"));
@@ -1204,7 +1191,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Eta 2 (0.7 to 1.0)
   HistoName = "resVtxZ_eta0p7to1";
-  resVtxZ_eta0p7to1 = iBooker.book1D(HistoName, HistoName,
+  resVtxZ_eta0p7to1 = iBooker.book1D(HistoName,
+                                     HistoName,
                                      psRes_VtxZ.getParameter<int32_t>("Nbinsx"),
                                      psRes_VtxZ.getParameter<double>("xmin"),
                                      psRes_VtxZ.getParameter<double>("xmax"));
@@ -1213,7 +1201,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Eta 3 (1.0 to 1.2)
   HistoName = "resVtxZ_eta1to1p2";
-  resVtxZ_eta1to1p2 = iBooker.book1D(HistoName, HistoName,
+  resVtxZ_eta1to1p2 = iBooker.book1D(HistoName,
+                                     HistoName,
                                      psRes_VtxZ.getParameter<int32_t>("Nbinsx"),
                                      psRes_VtxZ.getParameter<double>("xmin"),
                                      psRes_VtxZ.getParameter<double>("xmax"));
@@ -1222,16 +1211,18 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Eta 4 (1.2 to 1.6)
   HistoName = "resVtxZ_eta1p2to1p6";
-  resVtxZ_eta1p2to1p6 = iBooker.book1D(
-      HistoName, HistoName, psRes_VtxZ.getParameter<int32_t>("Nbinsx"),
-      psRes_VtxZ.getParameter<double>("xmin"),
-      psRes_VtxZ.getParameter<double>("xmax"));
+  resVtxZ_eta1p2to1p6 = iBooker.book1D(HistoName,
+                                       HistoName,
+                                       psRes_VtxZ.getParameter<int32_t>("Nbinsx"),
+                                       psRes_VtxZ.getParameter<double>("xmin"),
+                                       psRes_VtxZ.getParameter<double>("xmax"));
   resVtxZ_eta1p2to1p6->setAxisTitle("VtxZ_{trk} - VtxZ_{tp} [cm]", 1);
   resVtxZ_eta1p2to1p6->setAxisTitle("# tracking particles", 2);
 
   // Eta 5 (1.6 to 2.0)
   HistoName = "resVtxZ_eta1p6to2";
-  resVtxZ_eta1p6to2 = iBooker.book1D(HistoName, HistoName,
+  resVtxZ_eta1p6to2 = iBooker.book1D(HistoName,
+                                     HistoName,
                                      psRes_VtxZ.getParameter<int32_t>("Nbinsx"),
                                      psRes_VtxZ.getParameter<double>("xmin"),
                                      psRes_VtxZ.getParameter<double>("xmax"));
@@ -1240,7 +1231,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Eta 6 (2.0 to 2.4)
   HistoName = "resVtxZ_eta2to2p4";
-  resVtxZ_eta2to2p4 = iBooker.book1D(HistoName, HistoName,
+  resVtxZ_eta2to2p4 = iBooker.book1D(HistoName,
+                                     HistoName,
                                      psRes_VtxZ.getParameter<int32_t>("Nbinsx"),
                                      psRes_VtxZ.getParameter<double>("xmin"),
                                      psRes_VtxZ.getParameter<double>("xmax"));
@@ -1249,10 +1241,10 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // d0 parts (for resolution)
   // Eta 1 (0 to 0.7)
-  edm::ParameterSet psRes_d0 =
-      conf_.getParameter<edm::ParameterSet>("TH1Res_d0");
+  edm::ParameterSet psRes_d0 = conf_.getParameter<edm::ParameterSet>("TH1Res_d0");
   HistoName = "resd0_eta0to0p7";
-  resd0_eta0to0p7 = iBooker.book1D(HistoName, HistoName,
+  resd0_eta0to0p7 = iBooker.book1D(HistoName,
+                                   HistoName,
                                    psRes_d0.getParameter<int32_t>("Nbinsx"),
                                    psRes_d0.getParameter<double>("xmin"),
                                    psRes_d0.getParameter<double>("xmax"));
@@ -1261,7 +1253,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Eta 2 (0.7 to 1.0)
   HistoName = "resd0_eta0p7to1";
-  resd0_eta0p7to1 = iBooker.book1D(HistoName, HistoName,
+  resd0_eta0p7to1 = iBooker.book1D(HistoName,
+                                   HistoName,
                                    psRes_d0.getParameter<int32_t>("Nbinsx"),
                                    psRes_d0.getParameter<double>("xmin"),
                                    psRes_d0.getParameter<double>("xmax"));
@@ -1270,7 +1263,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Eta 3 (1.0 to 1.2)
   HistoName = "resd0_eta1to1p2";
-  resd0_eta1to1p2 = iBooker.book1D(HistoName, HistoName,
+  resd0_eta1to1p2 = iBooker.book1D(HistoName,
+                                   HistoName,
                                    psRes_d0.getParameter<int32_t>("Nbinsx"),
                                    psRes_d0.getParameter<double>("xmin"),
                                    psRes_d0.getParameter<double>("xmax"));
@@ -1279,7 +1273,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Eta 4 (1.2 to 1.6)
   HistoName = "resd0_eta1p2to1p6";
-  resd0_eta1p2to1p6 = iBooker.book1D(HistoName, HistoName,
+  resd0_eta1p2to1p6 = iBooker.book1D(HistoName,
+                                     HistoName,
                                      psRes_d0.getParameter<int32_t>("Nbinsx"),
                                      psRes_d0.getParameter<double>("xmin"),
                                      psRes_d0.getParameter<double>("xmax"));
@@ -1288,7 +1283,8 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Eta 5 (1.6 to 2.0)
   HistoName = "resd0_eta1p6to2";
-  resd0_eta1p6to2 = iBooker.book1D(HistoName, HistoName,
+  resd0_eta1p6to2 = iBooker.book1D(HistoName,
+                                   HistoName,
                                    psRes_d0.getParameter<int32_t>("Nbinsx"),
                                    psRes_d0.getParameter<double>("xmin"),
                                    psRes_d0.getParameter<double>("xmax"));
@@ -1297,19 +1293,19 @@ void OuterTrackerMonitorTrackingParticles::bookHistograms(
 
   // Eta 6 (2.0 to 2.4)
   HistoName = "resd0_eta2to2p4";
-  resd0_eta2to2p4 = iBooker.book1D(HistoName, HistoName,
+  resd0_eta2to2p4 = iBooker.book1D(HistoName,
+                                   HistoName,
                                    psRes_d0.getParameter<int32_t>("Nbinsx"),
                                    psRes_d0.getParameter<double>("xmin"),
                                    psRes_d0.getParameter<double>("xmax"));
   resd0_eta2to2p4->setAxisTitle("d0_{trk} - d0_{tp} [cm]", 1);
   resd0_eta2to2p4->setAxisTitle("# tracking particles", 2);
 
-} // end of method
+}  // end of method
 
 // Function to determine which layer of the detector the stub is in
-int OuterTrackerMonitorTrackingParticles::Layer(const float R_,
-                                                const float Z_) const {
-  const int sectionNum = 6; // 6 layers, 5 discs (per EC) + 1 "disc" for barrel
+int OuterTrackerMonitorTrackingParticles::Layer(const float R_, const float Z_) const {
+  const int sectionNum = 6;  // 6 layers, 5 discs (per EC) + 1 "disc" for barrel
   const float Rmin[sectionNum] = {20., 33., 48., 65., 82., 105.};
   const float Rmax[sectionNum] = {30., 40., 58., 75., 91., 120.};
   const float zMin[sectionNum] = {0., 125., 145., 165., 200., 240.};

--- a/Validation/SiOuterTrackerV/src/OuterTrackerMCHarvester.cc
+++ b/Validation/SiOuterTrackerV/src/OuterTrackerMCHarvester.cc
@@ -1,14 +1,12 @@
 #include "Validation/SiOuterTrackerV/interface/OuterTrackerMCHarvester.h"
 
-OuterTrackerMCHarvester::OuterTrackerMCHarvester(
-    const edm::ParameterSet &iConfig) {}
+OuterTrackerMCHarvester::OuterTrackerMCHarvester(const edm::ParameterSet &iConfig) {}
 
 OuterTrackerMCHarvester::~OuterTrackerMCHarvester() {}
 
 // ------------ method called once each job just after ending the event loop
 // ------------
-void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
-                                        DQMStore::IGetter &igetter) {
+void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
   using namespace edm;
 
   // Global variables
@@ -39,119 +37,66 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
 
   if (dbe) {
     // Find all monitor elements for histograms
-    MonitorElement *meN_eta =
-        dbe->get("SiOuterTrackerV/Tracks/Efficiency/match_tp_eta");
-    MonitorElement *meD_eta =
-        dbe->get("SiOuterTrackerV/Tracks/Efficiency/tp_eta");
-    MonitorElement *meN_pt =
-        dbe->get("SiOuterTrackerV/Tracks/Efficiency/match_tp_pt");
-    MonitorElement *meD_pt =
-        dbe->get("SiOuterTrackerV/Tracks/Efficiency/tp_pt");
-    MonitorElement *meN_pt_zoom =
-        dbe->get("SiOuterTrackerV/Tracks/Efficiency/match_tp_pt_zoom");
-    MonitorElement *meD_pt_zoom =
-        dbe->get("SiOuterTrackerV/Tracks/Efficiency/tp_pt_zoom");
-    MonitorElement *meN_d0 =
-        dbe->get("SiOuterTrackerV/Tracks/Efficiency/match_tp_d0");
-    MonitorElement *meD_d0 =
-        dbe->get("SiOuterTrackerV/Tracks/Efficiency/tp_d0");
-    MonitorElement *meN_VtxR =
-        dbe->get("SiOuterTrackerV/Tracks/Efficiency/match_tp_VtxR");
-    MonitorElement *meD_VtxR =
-        dbe->get("SiOuterTrackerV/Tracks/Efficiency/tp_VtxR");
-    MonitorElement *meN_VtxZ =
-        dbe->get("SiOuterTrackerV/Tracks/Efficiency/match_tp_VtxZ");
-    MonitorElement *meD_VtxZ =
-        dbe->get("SiOuterTrackerV/Tracks/Efficiency/tp_VtxZ");
+    MonitorElement *meN_eta = dbe->get("SiOuterTrackerV/Tracks/Efficiency/match_tp_eta");
+    MonitorElement *meD_eta = dbe->get("SiOuterTrackerV/Tracks/Efficiency/tp_eta");
+    MonitorElement *meN_pt = dbe->get("SiOuterTrackerV/Tracks/Efficiency/match_tp_pt");
+    MonitorElement *meD_pt = dbe->get("SiOuterTrackerV/Tracks/Efficiency/tp_pt");
+    MonitorElement *meN_pt_zoom = dbe->get("SiOuterTrackerV/Tracks/Efficiency/match_tp_pt_zoom");
+    MonitorElement *meD_pt_zoom = dbe->get("SiOuterTrackerV/Tracks/Efficiency/tp_pt_zoom");
+    MonitorElement *meN_d0 = dbe->get("SiOuterTrackerV/Tracks/Efficiency/match_tp_d0");
+    MonitorElement *meD_d0 = dbe->get("SiOuterTrackerV/Tracks/Efficiency/tp_d0");
+    MonitorElement *meN_VtxR = dbe->get("SiOuterTrackerV/Tracks/Efficiency/match_tp_VtxR");
+    MonitorElement *meD_VtxR = dbe->get("SiOuterTrackerV/Tracks/Efficiency/tp_VtxR");
+    MonitorElement *meN_VtxZ = dbe->get("SiOuterTrackerV/Tracks/Efficiency/match_tp_VtxZ");
+    MonitorElement *meD_VtxZ = dbe->get("SiOuterTrackerV/Tracks/Efficiency/tp_VtxZ");
 
-    MonitorElement *merespt_eta0to0p7_pt2to3 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta0to0p7_pt2to3");
-    MonitorElement *merespt_eta0p7to1_pt2to3 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta0p7to1_pt2to3");
-    MonitorElement *merespt_eta1to1p2_pt2to3 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta1to1p2_pt2to3");
-    MonitorElement *merespt_eta1p2to1p6_pt2to3 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta1p2to1p6_pt2to3");
-    MonitorElement *merespt_eta1p6to2_pt2to3 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta1p6to2_pt2to3");
-    MonitorElement *merespt_eta2to2p4_pt2to3 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta2to2p4_pt2to3");
-    MonitorElement *merespt_eta0to0p7_pt3to8 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta0to0p7_pt3to8");
-    MonitorElement *merespt_eta0p7to1_pt3to8 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta0p7to1_pt3to8");
-    MonitorElement *merespt_eta1to1p2_pt3to8 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta1to1p2_pt3to8");
-    MonitorElement *merespt_eta1p2to1p6_pt3to8 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta1p2to1p6_pt3to8");
-    MonitorElement *merespt_eta1p6to2_pt3to8 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta1p6to2_pt3to8");
-    MonitorElement *merespt_eta2to2p4_pt3to8 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta2to2p4_pt3to8");
-    MonitorElement *merespt_eta0to0p7_pt8toInf =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta0to0p7_pt8toInf");
-    MonitorElement *merespt_eta0p7to1_pt8toInf =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta0p7to1_pt8toInf");
-    MonitorElement *merespt_eta1to1p2_pt8toInf =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta1to1p2_pt8toInf");
-    MonitorElement *merespt_eta1p2to1p6_pt8toInf = dbe->get(
-        "SiOuterTrackerV/Tracks/Resolution/respt_eta1p2to1p6_pt8toInf");
-    MonitorElement *merespt_eta1p6to2_pt8toInf =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta1p6to2_pt8toInf");
-    MonitorElement *merespt_eta2to2p4_pt8toInf =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta2to2p4_pt8toInf");
+    MonitorElement *merespt_eta0to0p7_pt2to3 = dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta0to0p7_pt2to3");
+    MonitorElement *merespt_eta0p7to1_pt2to3 = dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta0p7to1_pt2to3");
+    MonitorElement *merespt_eta1to1p2_pt2to3 = dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta1to1p2_pt2to3");
+    MonitorElement *merespt_eta1p2to1p6_pt2to3 = dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta1p2to1p6_pt2to3");
+    MonitorElement *merespt_eta1p6to2_pt2to3 = dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta1p6to2_pt2to3");
+    MonitorElement *merespt_eta2to2p4_pt2to3 = dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta2to2p4_pt2to3");
+    MonitorElement *merespt_eta0to0p7_pt3to8 = dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta0to0p7_pt3to8");
+    MonitorElement *merespt_eta0p7to1_pt3to8 = dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta0p7to1_pt3to8");
+    MonitorElement *merespt_eta1to1p2_pt3to8 = dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta1to1p2_pt3to8");
+    MonitorElement *merespt_eta1p2to1p6_pt3to8 = dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta1p2to1p6_pt3to8");
+    MonitorElement *merespt_eta1p6to2_pt3to8 = dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta1p6to2_pt3to8");
+    MonitorElement *merespt_eta2to2p4_pt3to8 = dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta2to2p4_pt3to8");
+    MonitorElement *merespt_eta0to0p7_pt8toInf = dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta0to0p7_pt8toInf");
+    MonitorElement *merespt_eta0p7to1_pt8toInf = dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta0p7to1_pt8toInf");
+    MonitorElement *merespt_eta1to1p2_pt8toInf = dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta1to1p2_pt8toInf");
+    MonitorElement *merespt_eta1p2to1p6_pt8toInf =
+        dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta1p2to1p6_pt8toInf");
+    MonitorElement *merespt_eta1p6to2_pt8toInf = dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta1p6to2_pt8toInf");
+    MonitorElement *merespt_eta2to2p4_pt8toInf = dbe->get("SiOuterTrackerV/Tracks/Resolution/respt_eta2to2p4_pt8toInf");
 
-    MonitorElement *mereseta_eta0to0p7 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/reseta_eta0to0p7");
-    MonitorElement *mereseta_eta0p7to1 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/reseta_eta0p7to1");
-    MonitorElement *mereseta_eta1to1p2 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/reseta_eta1to1p2");
-    MonitorElement *mereseta_eta1p2to1p6 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/reseta_eta1p2to1p6");
-    MonitorElement *mereseta_eta1p6to2 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/reseta_eta1p6to2");
-    MonitorElement *mereseta_eta2to2p4 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/reseta_eta2to2p4");
+    MonitorElement *mereseta_eta0to0p7 = dbe->get("SiOuterTrackerV/Tracks/Resolution/reseta_eta0to0p7");
+    MonitorElement *mereseta_eta0p7to1 = dbe->get("SiOuterTrackerV/Tracks/Resolution/reseta_eta0p7to1");
+    MonitorElement *mereseta_eta1to1p2 = dbe->get("SiOuterTrackerV/Tracks/Resolution/reseta_eta1to1p2");
+    MonitorElement *mereseta_eta1p2to1p6 = dbe->get("SiOuterTrackerV/Tracks/Resolution/reseta_eta1p2to1p6");
+    MonitorElement *mereseta_eta1p6to2 = dbe->get("SiOuterTrackerV/Tracks/Resolution/reseta_eta1p6to2");
+    MonitorElement *mereseta_eta2to2p4 = dbe->get("SiOuterTrackerV/Tracks/Resolution/reseta_eta2to2p4");
 
-    MonitorElement *meresphi_eta0to0p7 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/resphi_eta0to0p7");
-    MonitorElement *meresphi_eta0p7to1 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/resphi_eta0p7to1");
-    MonitorElement *meresphi_eta1to1p2 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/resphi_eta1to1p2");
-    MonitorElement *meresphi_eta1p2to1p6 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/resphi_eta1p2to1p6");
-    MonitorElement *meresphi_eta1p6to2 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/resphi_eta1p6to2");
-    MonitorElement *meresphi_eta2to2p4 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/resphi_eta2to2p4");
+    MonitorElement *meresphi_eta0to0p7 = dbe->get("SiOuterTrackerV/Tracks/Resolution/resphi_eta0to0p7");
+    MonitorElement *meresphi_eta0p7to1 = dbe->get("SiOuterTrackerV/Tracks/Resolution/resphi_eta0p7to1");
+    MonitorElement *meresphi_eta1to1p2 = dbe->get("SiOuterTrackerV/Tracks/Resolution/resphi_eta1to1p2");
+    MonitorElement *meresphi_eta1p2to1p6 = dbe->get("SiOuterTrackerV/Tracks/Resolution/resphi_eta1p2to1p6");
+    MonitorElement *meresphi_eta1p6to2 = dbe->get("SiOuterTrackerV/Tracks/Resolution/resphi_eta1p6to2");
+    MonitorElement *meresphi_eta2to2p4 = dbe->get("SiOuterTrackerV/Tracks/Resolution/resphi_eta2to2p4");
 
-    MonitorElement *meresVtxZ_eta0to0p7 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/resVtxZ_eta0to0p7");
-    MonitorElement *meresVtxZ_eta0p7to1 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/resVtxZ_eta0p7to1");
-    MonitorElement *meresVtxZ_eta1to1p2 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/resVtxZ_eta1to1p2");
-    MonitorElement *meresVtxZ_eta1p2to1p6 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/resVtxZ_eta1p2to1p6");
-    MonitorElement *meresVtxZ_eta1p6to2 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/resVtxZ_eta1p6to2");
-    MonitorElement *meresVtxZ_eta2to2p4 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/resVtxZ_eta2to2p4");
+    MonitorElement *meresVtxZ_eta0to0p7 = dbe->get("SiOuterTrackerV/Tracks/Resolution/resVtxZ_eta0to0p7");
+    MonitorElement *meresVtxZ_eta0p7to1 = dbe->get("SiOuterTrackerV/Tracks/Resolution/resVtxZ_eta0p7to1");
+    MonitorElement *meresVtxZ_eta1to1p2 = dbe->get("SiOuterTrackerV/Tracks/Resolution/resVtxZ_eta1to1p2");
+    MonitorElement *meresVtxZ_eta1p2to1p6 = dbe->get("SiOuterTrackerV/Tracks/Resolution/resVtxZ_eta1p2to1p6");
+    MonitorElement *meresVtxZ_eta1p6to2 = dbe->get("SiOuterTrackerV/Tracks/Resolution/resVtxZ_eta1p6to2");
+    MonitorElement *meresVtxZ_eta2to2p4 = dbe->get("SiOuterTrackerV/Tracks/Resolution/resVtxZ_eta2to2p4");
 
-    MonitorElement *meresd0_eta0to0p7 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/resd0_eta0to0p7");
-    MonitorElement *meresd0_eta0p7to1 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/resd0_eta0p7to1");
-    MonitorElement *meresd0_eta1to1p2 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/resd0_eta1to1p2");
-    MonitorElement *meresd0_eta1p2to1p6 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/resd0_eta1p2to1p6");
-    MonitorElement *meresd0_eta1p6to2 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/resd0_eta1p6to2");
-    MonitorElement *meresd0_eta2to2p4 =
-        dbe->get("SiOuterTrackerV/Tracks/Resolution/resd0_eta2to2p4");
+    MonitorElement *meresd0_eta0to0p7 = dbe->get("SiOuterTrackerV/Tracks/Resolution/resd0_eta0to0p7");
+    MonitorElement *meresd0_eta0p7to1 = dbe->get("SiOuterTrackerV/Tracks/Resolution/resd0_eta0p7to1");
+    MonitorElement *meresd0_eta1to1p2 = dbe->get("SiOuterTrackerV/Tracks/Resolution/resd0_eta1to1p2");
+    MonitorElement *meresd0_eta1p2to1p6 = dbe->get("SiOuterTrackerV/Tracks/Resolution/resd0_eta1p2to1p6");
+    MonitorElement *meresd0_eta1p6to2 = dbe->get("SiOuterTrackerV/Tracks/Resolution/resd0_eta1p6to2");
+    MonitorElement *meresd0_eta2to2p4 = dbe->get("SiOuterTrackerV/Tracks/Resolution/resd0_eta2to2p4");
 
     if (meN_eta && meD_eta) {
       // Get the numerator and denominator histograms
@@ -164,9 +109,11 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
       dbe->setCurrentFolder("SiOuterTrackerV/Tracks/FinalEfficiency");
 
       // Book the new histogram to contain the results
-      MonitorElement *me_effic_eta = ibooker.book1D(
-          "EtaEfficiency", "#eta efficiency", numerator->GetNbinsX(),
-          numerator->GetXaxis()->GetXmin(), numerator->GetXaxis()->GetXmax());
+      MonitorElement *me_effic_eta = ibooker.book1D("EtaEfficiency",
+                                                    "#eta efficiency",
+                                                    numerator->GetNbinsX(),
+                                                    numerator->GetXaxis()->GetXmin(),
+                                                    numerator->GetXaxis()->GetXmax());
 
       // Calculate the efficiency
       me_effic_eta->getTH1F()->Divide(numerator, denominator, 1., 1., "B");
@@ -175,10 +122,9 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
       me_effic_eta->getTH1F()->SetMaximum(1.0);
       me_effic_eta->getTH1F()->SetMinimum(0.0);
       me_effic_eta->getTH1F()->SetStats(false);
-    } // if ME found
+    }  // if ME found
     else {
-      edm::LogWarning("DataNotFound")
-          << "Monitor elements for eta efficiency cannot be found!\n";
+      edm::LogWarning("DataNotFound") << "Monitor elements for eta efficiency cannot be found!\n";
     }
 
     if (meN_pt && meD_pt) {
@@ -192,22 +138,22 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
       dbe->setCurrentFolder("SiOuterTrackerV/Tracks/FinalEfficiency");
 
       // Book the new histogram to contain the results
-      MonitorElement *me_effic_pt = ibooker.book1D(
-          "PtEfficiency", "p_{T} efficiency", numerator2->GetNbinsX(),
-          numerator2->GetXaxis()->GetXmin(), numerator2->GetXaxis()->GetXmax());
+      MonitorElement *me_effic_pt = ibooker.book1D("PtEfficiency",
+                                                   "p_{T} efficiency",
+                                                   numerator2->GetNbinsX(),
+                                                   numerator2->GetXaxis()->GetXmin(),
+                                                   numerator2->GetXaxis()->GetXmax());
 
       // Calculate the efficiency
       me_effic_pt->getTH1F()->Divide(numerator2, denominator2, 1., 1., "B");
-      me_effic_pt->getTH1F()->GetXaxis()->SetTitle(
-          "Tracking particle p_{T} [GeV]");
+      me_effic_pt->getTH1F()->GetXaxis()->SetTitle("Tracking particle p_{T} [GeV]");
       me_effic_pt->getTH1F()->GetYaxis()->SetTitle("Efficiency");
       me_effic_pt->getTH1F()->SetMaximum(1.0);
       me_effic_pt->getTH1F()->SetMinimum(0.0);
       me_effic_pt->getTH1F()->SetStats(false);
-    } // if ME found
+    }  // if ME found
     else {
-      edm::LogWarning("DataNotFound")
-          << "Monitor elements for pT efficiency cannot be found!\n";
+      edm::LogWarning("DataNotFound") << "Monitor elements for pT efficiency cannot be found!\n";
     }
 
     if (meN_pt_zoom && meD_pt_zoom) {
@@ -221,24 +167,22 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
       dbe->setCurrentFolder("SiOuterTrackerV/Tracks/FinalEfficiency");
 
       // Book the new histogram to contain the results
-      MonitorElement *me_effic_pt_zoom = ibooker.book1D(
-          "PtEfficiency_zoom", "p_{T} efficiency", numerator2_zoom->GetNbinsX(),
-          numerator2_zoom->GetXaxis()->GetXmin(),
-          numerator2_zoom->GetXaxis()->GetXmax());
+      MonitorElement *me_effic_pt_zoom = ibooker.book1D("PtEfficiency_zoom",
+                                                        "p_{T} efficiency",
+                                                        numerator2_zoom->GetNbinsX(),
+                                                        numerator2_zoom->GetXaxis()->GetXmin(),
+                                                        numerator2_zoom->GetXaxis()->GetXmax());
 
       // Calculate the efficiency
-      me_effic_pt_zoom->getTH1F()->Divide(numerator2_zoom, denominator2_zoom,
-                                          1., 1., "B");
-      me_effic_pt_zoom->getTH1F()->GetXaxis()->SetTitle(
-          "Tracking particle p_{T} [GeV]");
+      me_effic_pt_zoom->getTH1F()->Divide(numerator2_zoom, denominator2_zoom, 1., 1., "B");
+      me_effic_pt_zoom->getTH1F()->GetXaxis()->SetTitle("Tracking particle p_{T} [GeV]");
       me_effic_pt_zoom->getTH1F()->GetYaxis()->SetTitle("Efficiency");
       me_effic_pt_zoom->getTH1F()->SetMaximum(1.0);
       me_effic_pt_zoom->getTH1F()->SetMinimum(0.0);
       me_effic_pt_zoom->getTH1F()->SetStats(false);
-    } // if ME found
+    }  // if ME found
     else {
-      edm::LogWarning("DataNotFound")
-          << "Monitor elements for zoom pT efficiency cannot be found!\n";
+      edm::LogWarning("DataNotFound") << "Monitor elements for zoom pT efficiency cannot be found!\n";
     }
 
     if (meN_d0 && meD_d0) {
@@ -252,22 +196,22 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
       dbe->setCurrentFolder("SiOuterTrackerV/Tracks/FinalEfficiency");
 
       // Book the new histogram to contain the results
-      MonitorElement *me_effic_d0 = ibooker.book1D(
-          "d0Efficiency", "d_{0} efficiency", numerator5->GetNbinsX(),
-          numerator5->GetXaxis()->GetXmin(), numerator5->GetXaxis()->GetXmax());
+      MonitorElement *me_effic_d0 = ibooker.book1D("d0Efficiency",
+                                                   "d_{0} efficiency",
+                                                   numerator5->GetNbinsX(),
+                                                   numerator5->GetXaxis()->GetXmin(),
+                                                   numerator5->GetXaxis()->GetXmax());
 
       // Calculate the efficiency
       me_effic_d0->getTH1F()->Divide(numerator5, denominator5, 1., 1., "B");
-      me_effic_d0->getTH1F()->GetXaxis()->SetTitle(
-          "Tracking particle d_{0} [cm]");
+      me_effic_d0->getTH1F()->GetXaxis()->SetTitle("Tracking particle d_{0} [cm]");
       me_effic_d0->getTH1F()->GetYaxis()->SetTitle("Efficiency");
       me_effic_d0->getTH1F()->SetMaximum(1.0);
       me_effic_d0->getTH1F()->SetMinimum(0.0);
       me_effic_d0->getTH1F()->SetStats(false);
-    } // if ME found
+    }  // if ME found
     else {
-      edm::LogWarning("DataNotFound")
-          << "Monitor elements for d0 efficiency cannot be found!\n";
+      edm::LogWarning("DataNotFound") << "Monitor elements for d0 efficiency cannot be found!\n";
     }
 
     if (meN_VtxR && meD_VtxR) {
@@ -281,22 +225,22 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
       dbe->setCurrentFolder("SiOuterTrackerV/Tracks/FinalEfficiency");
 
       // Book the new histogram to contain the results
-      MonitorElement *me_effic_VtxR = ibooker.book1D(
-          "VtxREfficiency", "Vtx R efficiency", numerator6->GetNbinsX(),
-          numerator6->GetXaxis()->GetXmin(), numerator6->GetXaxis()->GetXmax());
+      MonitorElement *me_effic_VtxR = ibooker.book1D("VtxREfficiency",
+                                                     "Vtx R efficiency",
+                                                     numerator6->GetNbinsX(),
+                                                     numerator6->GetXaxis()->GetXmin(),
+                                                     numerator6->GetXaxis()->GetXmax());
 
       // Calculate the efficiency
       me_effic_VtxR->getTH1F()->Divide(numerator6, denominator6, 1., 1., "B");
-      me_effic_VtxR->getTH1F()->GetXaxis()->SetTitle(
-          "Tracking particle VtxR [cm]");
+      me_effic_VtxR->getTH1F()->GetXaxis()->SetTitle("Tracking particle VtxR [cm]");
       me_effic_VtxR->getTH1F()->GetYaxis()->SetTitle("Efficiency");
       me_effic_VtxR->getTH1F()->SetMaximum(1.0);
       me_effic_VtxR->getTH1F()->SetMinimum(0.0);
       me_effic_VtxR->getTH1F()->SetStats(false);
-    } // if ME found
+    }  // if ME found
     else {
-      edm::LogWarning("DataNotFound")
-          << "Monitor elements for VtxR efficiency cannot be found!\n";
+      edm::LogWarning("DataNotFound") << "Monitor elements for VtxR efficiency cannot be found!\n";
     }
 
     if (meN_VtxZ && meD_VtxZ) {
@@ -310,27 +254,26 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
       dbe->setCurrentFolder("SiOuterTrackerV/Tracks/FinalEfficiency");
 
       // Book the new histogram to contain the results
-      MonitorElement *me_effic_VtxZ = ibooker.book1D(
-          "VtxZEfficiency", "Vtx Z efficiency", numerator7->GetNbinsX(),
-          numerator7->GetXaxis()->GetXmin(), numerator7->GetXaxis()->GetXmax());
+      MonitorElement *me_effic_VtxZ = ibooker.book1D("VtxZEfficiency",
+                                                     "Vtx Z efficiency",
+                                                     numerator7->GetNbinsX(),
+                                                     numerator7->GetXaxis()->GetXmin(),
+                                                     numerator7->GetXaxis()->GetXmax());
 
       // Calculate the efficiency
       me_effic_VtxZ->getTH1F()->Divide(numerator7, denominator7, 1., 1., "B");
-      me_effic_VtxZ->getTH1F()->GetXaxis()->SetTitle(
-          "Tracking particle VtxZ [cm]");
+      me_effic_VtxZ->getTH1F()->GetXaxis()->SetTitle("Tracking particle VtxZ [cm]");
       me_effic_VtxZ->getTH1F()->GetYaxis()->SetTitle("Efficiency");
       me_effic_VtxZ->getTH1F()->SetMaximum(1.0);
       me_effic_VtxZ->getTH1F()->SetMinimum(0.0);
       me_effic_VtxZ->getTH1F()->SetStats(false);
-    } // if ME found
+    }  // if ME found
     else {
-      edm::LogWarning("DataNotFound")
-          << "Monitor elements for VtxZ efficiency cannot be found!\n";
+      edm::LogWarning("DataNotFound") << "Monitor elements for VtxZ efficiency cannot be found!\n";
     }
 
-    if (merespt_eta0to0p7_pt2to3 && merespt_eta0p7to1_pt2to3 &&
-        merespt_eta1to1p2_pt2to3 && merespt_eta1p2to1p6_pt2to3 &&
-        merespt_eta1p6to2_pt2to3 && merespt_eta2to2p4_pt2to3) {
+    if (merespt_eta0to0p7_pt2to3 && merespt_eta0p7to1_pt2to3 && merespt_eta1to1p2_pt2to3 &&
+        merespt_eta1p2to1p6_pt2to3 && merespt_eta1p6to2_pt2to3 && merespt_eta2to2p4_pt2to3) {
       // Set the current directoy
       dbe->setCurrentFolder("SiOuterTrackerV/Tracks/FinalResolution");
 
@@ -343,9 +286,8 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
       TH1F *resPt6a = merespt_eta2to2p4_pt2to3->getTH1F();
 
       // Book the new histogram to contain the results
-      MonitorElement *me_res_pt1 = ibooker.book1D(
-          "pTResVsEta_2-3", "p_{T} resolution vs |#eta|, for p_{T}: 2-3 GeV",
-          eta_binnum, eta_bins);
+      MonitorElement *me_res_pt1 =
+          ibooker.book1D("pTResVsEta_2-3", "p_{T} resolution vs |#eta|, for p_{T}: 2-3 GeV", eta_binnum, eta_bins);
       TH1F *resPt1 = me_res_pt1->getTH1F();
       resPt1->GetXaxis()->SetTitle("tracking particle |#eta|");
       resPt1->GetYaxis()->SetTitle("#sigma(#Deltap_{T}/p_{T})");
@@ -381,22 +323,19 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
           resPt1->SetBinError(i + 1, error_pt1[i]);
         }
       } else {
-        edm::LogWarning("DataNotFound")
-            << "L1 tracks not found for pT resolution (2-3)!\n";
+        edm::LogWarning("DataNotFound") << "L1 tracks not found for pT resolution (2-3)!\n";
         for (int i = 0; i < 6; i++) {
           resPt1->SetBinContent(i + 1, -1);
           resPt1->SetBinError(i + 1, -1);
         }
       }
-    } // if ME found
+    }  // if ME found
     else {
-      edm::LogWarning("DataNotFound")
-          << "Monitor elements for pT resolution (2-3) cannot be found!\n";
+      edm::LogWarning("DataNotFound") << "Monitor elements for pT resolution (2-3) cannot be found!\n";
     }
 
-    if (merespt_eta0to0p7_pt3to8 && merespt_eta0p7to1_pt3to8 &&
-        merespt_eta1to1p2_pt3to8 && merespt_eta1p2to1p6_pt3to8 &&
-        merespt_eta1p6to2_pt3to8 && merespt_eta2to2p4_pt3to8) {
+    if (merespt_eta0to0p7_pt3to8 && merespt_eta0p7to1_pt3to8 && merespt_eta1to1p2_pt3to8 &&
+        merespt_eta1p2to1p6_pt3to8 && merespt_eta1p6to2_pt3to8 && merespt_eta2to2p4_pt3to8) {
       // Set the current directoy
       dbe->setCurrentFolder("SiOuterTrackerV/Tracks/FinalResolution");
 
@@ -409,9 +348,8 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
       TH1F *resPt6b = merespt_eta2to2p4_pt3to8->getTH1F();
 
       // Book the new histogram to contain the results
-      MonitorElement *me_res_pt2 = ibooker.book1D(
-          "pTResVsEta_3-8", "p_{T} resolution vs |#eta|, for p_{T}: 3-8 GeV",
-          eta_binnum, eta_bins);
+      MonitorElement *me_res_pt2 =
+          ibooker.book1D("pTResVsEta_3-8", "p_{T} resolution vs |#eta|, for p_{T}: 3-8 GeV", eta_binnum, eta_bins);
       TH1F *resPt2 = me_res_pt2->getTH1F();
       resPt2->GetXaxis()->SetTitle("tracking particle |#eta|");
       resPt2->GetYaxis()->SetTitle("#sigma(#Deltap_{T}/p_{T})");
@@ -447,22 +385,19 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
           resPt2->SetBinError(i + 1, error_pt2[i]);
         }
       } else {
-        edm::LogWarning("DataNotFound")
-            << "L1 tracks not found for pT resolution (3-8)!\n";
+        edm::LogWarning("DataNotFound") << "L1 tracks not found for pT resolution (3-8)!\n";
         for (int i = 0; i < 6; i++) {
           resPt2->SetBinContent(i + 1, -1);
           resPt2->SetBinError(i + 1, -1);
         }
       }
-    } // if ME found
+    }  // if ME found
     else {
-      edm::LogWarning("DataNotFound")
-          << "Monitor elements for pT resolution (3-8) cannot be found!\n";
+      edm::LogWarning("DataNotFound") << "Monitor elements for pT resolution (3-8) cannot be found!\n";
     }
 
-    if (merespt_eta0to0p7_pt8toInf && merespt_eta0p7to1_pt8toInf &&
-        merespt_eta1to1p2_pt8toInf && merespt_eta1p2to1p6_pt8toInf &&
-        merespt_eta1p6to2_pt8toInf && merespt_eta2to2p4_pt8toInf) {
+    if (merespt_eta0to0p7_pt8toInf && merespt_eta0p7to1_pt8toInf && merespt_eta1to1p2_pt8toInf &&
+        merespt_eta1p2to1p6_pt8toInf && merespt_eta1p6to2_pt8toInf && merespt_eta2to2p4_pt8toInf) {
       // Set the current directoy
       dbe->setCurrentFolder("SiOuterTrackerV/Tracks/FinalResolution");
 
@@ -475,9 +410,8 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
       TH1F *resPt6c = merespt_eta2to2p4_pt8toInf->getTH1F();
 
       // Book the new histogram to contain the results
-      MonitorElement *me_res_pt3 = ibooker.book1D(
-          "pTResVsEta_8-inf", "p_{T} resolution vs |#eta|, for p_{T}: >8 GeV",
-          eta_binnum, eta_bins);
+      MonitorElement *me_res_pt3 =
+          ibooker.book1D("pTResVsEta_8-inf", "p_{T} resolution vs |#eta|, for p_{T}: >8 GeV", eta_binnum, eta_bins);
       TH1F *resPt3 = me_res_pt3->getTH1F();
       resPt3->GetXaxis()->SetTitle("tracking particle |#eta|");
       resPt3->GetYaxis()->SetTitle("#sigma(#Deltap_{T}/p_{T})");
@@ -513,21 +447,19 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
           resPt3->SetBinError(i + 1, error_pt3[i]);
         }
       } else {
-        edm::LogWarning("DataNotFound")
-            << "L1 tracks not found for pT resolution (8-inf)!\n";
+        edm::LogWarning("DataNotFound") << "L1 tracks not found for pT resolution (8-inf)!\n";
         for (int i = 0; i < 6; i++) {
           resPt3->SetBinContent(i + 1, -1);
           resPt3->SetBinError(i + 1, -1);
         }
       }
-    } // if ME found
+    }  // if ME found
     else {
-      edm::LogWarning("DataNotFound")
-          << "Monitor elements for pT resolution (8-inf) cannot be found!\n";
+      edm::LogWarning("DataNotFound") << "Monitor elements for pT resolution (8-inf) cannot be found!\n";
     }
 
-    if (mereseta_eta0to0p7 && mereseta_eta0p7to1 && mereseta_eta1to1p2 &&
-        mereseta_eta1p2to1p6 && mereseta_eta1p6to2 && mereseta_eta2to2p4) {
+    if (mereseta_eta0to0p7 && mereseta_eta0p7to1 && mereseta_eta1to1p2 && mereseta_eta1p2to1p6 && mereseta_eta1p6to2 &&
+        mereseta_eta2to2p4) {
       // Set the current directoy
       dbe->setCurrentFolder("SiOuterTrackerV/Tracks/FinalResolution");
 
@@ -540,8 +472,7 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
       TH1F *resEta6 = mereseta_eta2to2p4->getTH1F();
 
       // Book the new histogram to contain the results
-      MonitorElement *me_res_eta = ibooker.book1D(
-          "EtaResolution", "#eta resolution vs |#eta|", eta_binnum, eta_bins);
+      MonitorElement *me_res_eta = ibooker.book1D("EtaResolution", "#eta resolution vs |#eta|", eta_binnum, eta_bins);
       TH1F *resEta = me_res_eta->getTH1F();
       resEta->GetXaxis()->SetTitle("tracking particle |#eta|");
       resEta->GetYaxis()->SetTitle("#sigma(#Delta#eta)");
@@ -550,7 +481,6 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
 
       int testNumEntries4 = resEta1->GetEntries();
       if (testNumEntries4 > 0) {
-
         // Fit the histograms with a gaussian curve - take sigma and the error
         // from the fit
         resEta1->Fit(fit, "R");
@@ -578,21 +508,19 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
           resEta->SetBinError(i + 1, error_eta[i]);
         }
       } else {
-        edm::LogWarning("DataNotFound")
-            << "L1 tracks not found for eta resolution!\n";
+        edm::LogWarning("DataNotFound") << "L1 tracks not found for eta resolution!\n";
         for (int i = 0; i < 6; i++) {
           resEta->SetBinContent(i + 1, -1);
           resEta->SetBinError(i + 1, -1);
         }
       }
-    } // if ME found
+    }  // if ME found
     else {
-      edm::LogWarning("DataNotFound")
-          << "Monitor elements for eta resolution cannot be found!\n";
+      edm::LogWarning("DataNotFound") << "Monitor elements for eta resolution cannot be found!\n";
     }
 
-    if (meresphi_eta0to0p7 && meresphi_eta0p7to1 && meresphi_eta1to1p2 &&
-        meresphi_eta1p2to1p6 && meresphi_eta1p6to2 && meresphi_eta2to2p4) {
+    if (meresphi_eta0to0p7 && meresphi_eta0p7to1 && meresphi_eta1to1p2 && meresphi_eta1p2to1p6 && meresphi_eta1p6to2 &&
+        meresphi_eta2to2p4) {
       // Set the current directoy
       dbe->setCurrentFolder("SiOuterTrackerV/Tracks/FinalResolution");
 
@@ -605,8 +533,7 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
       TH1F *resPhi6 = meresphi_eta2to2p4->getTH1F();
 
       // Book the new histogram to contain the results
-      MonitorElement *me_res_phi = ibooker.book1D(
-          "PhiResolution", "#phi resolution vs |#eta|", eta_binnum, eta_bins);
+      MonitorElement *me_res_phi = ibooker.book1D("PhiResolution", "#phi resolution vs |#eta|", eta_binnum, eta_bins);
       TH1F *resPhi = me_res_phi->getTH1F();
       resPhi->GetXaxis()->SetTitle("tracking particle |#eta|");
       resPhi->GetYaxis()->SetTitle("#sigma(#Delta#phi)");
@@ -642,21 +569,19 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
           resPhi->SetBinError(i + 1, error_phi[i]);
         }
       } else {
-        edm::LogWarning("DataNotFound")
-            << "L1 tracks not found for phi resolution!\n";
+        edm::LogWarning("DataNotFound") << "L1 tracks not found for phi resolution!\n";
         for (int i = 0; i < 6; i++) {
           resPhi->SetBinContent(i + 1, -1);
           resPhi->SetBinError(i + 1, -1);
         }
       }
-    } // if ME found
+    }  // if ME found
     else {
-      edm::LogWarning("DataNotFound")
-          << "Monitor elements for phi resolution cannot be found!\n";
+      edm::LogWarning("DataNotFound") << "Monitor elements for phi resolution cannot be found!\n";
     }
 
-    if (meresVtxZ_eta0to0p7 && meresVtxZ_eta0p7to1 && meresVtxZ_eta1to1p2 &&
-        meresVtxZ_eta1p2to1p6 && meresVtxZ_eta1p6to2 && meresVtxZ_eta2to2p4) {
+    if (meresVtxZ_eta0to0p7 && meresVtxZ_eta0p7to1 && meresVtxZ_eta1to1p2 && meresVtxZ_eta1p2to1p6 &&
+        meresVtxZ_eta1p6to2 && meresVtxZ_eta2to2p4) {
       // Set the current directoy
       dbe->setCurrentFolder("SiOuterTrackerV/Tracks/FinalResolution");
 
@@ -669,8 +594,7 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
       TH1F *resVtxZ_6 = meresVtxZ_eta2to2p4->getTH1F();
 
       // Book the new histogram to contain the results
-      MonitorElement *me_res_VtxZ = ibooker.book1D(
-          "VtxZResolution", "VtxZ resolution vs |#eta|", eta_binnum, eta_bins);
+      MonitorElement *me_res_VtxZ = ibooker.book1D("VtxZResolution", "VtxZ resolution vs |#eta|", eta_binnum, eta_bins);
       TH1F *resVtxZ = me_res_VtxZ->getTH1F();
       resVtxZ->GetXaxis()->SetTitle("tracking particle |#eta|");
       resVtxZ->GetYaxis()->SetTitle("#sigma(#DeltaVtxZ) [cm]");
@@ -706,21 +630,19 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
           resVtxZ->SetBinError(i + 1, error_VtxZ[i]);
         }
       } else {
-        edm::LogWarning("DataNotFound")
-            << "L1 tracks not found for VtxZ resolution!\n";
+        edm::LogWarning("DataNotFound") << "L1 tracks not found for VtxZ resolution!\n";
         for (int i = 0; i < 6; i++) {
           resVtxZ->SetBinContent(i + 1, -1);
           resVtxZ->SetBinError(i + 1, -1);
         }
       }
-    } // if ME found
+    }  // if ME found
     else {
-      edm::LogWarning("DataNotFound")
-          << "Monitor elements for VtxZ resolution cannot be found!\n";
+      edm::LogWarning("DataNotFound") << "Monitor elements for VtxZ resolution cannot be found!\n";
     }
 
-    if (meresd0_eta0to0p7 && meresd0_eta0p7to1 && meresd0_eta1to1p2 &&
-        meresd0_eta1p2to1p6 && meresd0_eta1p6to2 && meresd0_eta2to2p4) {
+    if (meresd0_eta0to0p7 && meresd0_eta0p7to1 && meresd0_eta1to1p2 && meresd0_eta1p2to1p6 && meresd0_eta1p6to2 &&
+        meresd0_eta2to2p4) {
       // Set the current directoy
       dbe->setCurrentFolder("SiOuterTrackerV/Tracks/FinalResolution");
 
@@ -733,8 +655,7 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
       TH1F *resd0_6 = meresd0_eta2to2p4->getTH1F();
 
       // Book the new histogram to contain the results
-      MonitorElement *me_res_d0 = ibooker.book1D(
-          "d0Resolution", "d_{0} resolution vs |#eta|", eta_binnum, eta_bins);
+      MonitorElement *me_res_d0 = ibooker.book1D("d0Resolution", "d_{0} resolution vs |#eta|", eta_binnum, eta_bins);
       TH1F *resd0 = me_res_d0->getTH1F();
       resd0->GetXaxis()->SetTitle("tracking particle |#eta|");
       resd0->GetYaxis()->SetTitle("#sigma(#Deltad_{0}) [cm]");
@@ -770,26 +691,24 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker,
           resd0->SetBinError(i + 1, error_d0[i]);
         }
       } else {
-        edm::LogWarning("DataNotFound")
-            << "L1 tracks not found for d0 resolution!\n";
+        edm::LogWarning("DataNotFound") << "L1 tracks not found for d0 resolution!\n";
         for (int i = 0; i < 6; i++) {
           resd0->SetBinContent(i + 1, -1);
           resd0->SetBinError(i + 1, -1);
         }
       }
-    } // if ME found
+    }  // if ME found
     else {
-      edm::LogWarning("DataNotFound")
-          << "Monitor elements for d0 resolution cannot be found!\n";
+      edm::LogWarning("DataNotFound") << "Monitor elements for d0 resolution cannot be found!\n";
     }
 
-  } // if dbe found
+  }  // if dbe found
   else {
     edm::LogWarning("DataNotFound") << "Cannot find valid DQM back end \n";
   }
   delete fit;
   delete fit2;
   delete fit3;
-} // end dqmEndJob
+}  // end dqmEndJob
 
 DEFINE_FWK_MODULE(OuterTrackerMCHarvester);


### PR DESCRIPTION

Applying code-format for CMSSW category dqm.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/192//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Fixes the code-formats suggested by #26627 (see #26686)
