### PR TITLE
Running code-format for simulation

### DIFF
--- a/SimCalorimetry/CastorSim/plugins/CastorDigiAnalyzer.cc
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiAnalyzer.cc
@@ -4,42 +4,36 @@
 #include <iostream>
 
 CastorDigiAnalyzer::CastorDigiAnalyzer(edm::ParameterSet const &conf)
-    : hitReadoutName_("CastorHits"), simParameterMap_(),
+    : hitReadoutName_("CastorHits"),
+      simParameterMap_(),
       castorHitAnalyzer_("CASTORDigi", 1., &simParameterMap_, &castorFilter_),
-      castorDigiStatistics_("CASTORDigi", 3, 10., 6., 0.1, 0.5,
-                            castorHitAnalyzer_),
-      castorDigiCollectionTag_(
-          conf.getParameter<edm::InputTag>("castorDigiCollectionTag")) {}
+      castorDigiStatistics_("CASTORDigi", 3, 10., 6., 0.1, 0.5, castorHitAnalyzer_),
+      castorDigiCollectionTag_(conf.getParameter<edm::InputTag>("castorDigiCollectionTag")) {}
 
 namespace CastorDigiAnalyzerImpl {
-template <class Collection>
-void analyze(edm::Event const &e, CastorDigiStatistics &statistics,
-             edm::InputTag &tag) {
-  edm::Handle<Collection> digis;
-  e.getByLabel(tag, digis);
-  if (!digis.isValid()) {
-    edm::LogError("CastorDigiAnalyzer")
-        << "Could not find Castor Digi Container ";
-  } else {
-    for (unsigned i = 0; i < digis->size(); ++i) {
-      statistics.analyze((*digis)[i]);
+  template <class Collection>
+  void analyze(edm::Event const &e, CastorDigiStatistics &statistics, edm::InputTag &tag) {
+    edm::Handle<Collection> digis;
+    e.getByLabel(tag, digis);
+    if (!digis.isValid()) {
+      edm::LogError("CastorDigiAnalyzer") << "Could not find Castor Digi Container ";
+    } else {
+      for (unsigned i = 0; i < digis->size(); ++i) {
+        statistics.analyze((*digis)[i]);
+      }
     }
   }
-}
-} // namespace CastorDigiAnalyzerImpl
+}  // namespace CastorDigiAnalyzerImpl
 
-void CastorDigiAnalyzer::analyze(edm::Event const &e,
-                                 edm::EventSetup const &c) {
+void CastorDigiAnalyzer::analyze(edm::Event const &e, edm::EventSetup const &c) {
   //  edm::Handle<edm::PCaloHitContainer> hits;
   edm::Handle<CrossingFrame<PCaloHit>> castorcf;
 
   e.getByLabel("mix", "g4SimHitsCastorFI", castorcf);
 
   // access to SimHits
-  std::unique_ptr<MixCollection<PCaloHit>> hits(
-      new MixCollection<PCaloHit>(castorcf.product()));
+  std::unique_ptr<MixCollection<PCaloHit>> hits(new MixCollection<PCaloHit>(castorcf.product()));
   //  if (hits.isValid()) {
   castorHitAnalyzer_.fillHits(*hits);
-  CastorDigiAnalyzerImpl::analyze<CastorDigiCollection>(
-      e, castorDigiStatistics_, castorDigiCollectionTag_);
+  CastorDigiAnalyzerImpl::analyze<CastorDigiCollection>(e, castorDigiStatistics_, castorDigiCollectionTag_);
 }

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
@@ -21,12 +21,12 @@
 #include <vector>
 
 namespace edm {
-class StreamID;
-class ConsumesCollector;
-} // namespace edm
+  class StreamID;
+  class ConsumesCollector;
+}  // namespace edm
 
 namespace CLHEP {
-class HepRandomEngine;
+  class HepRandomEngine;
 }
 
 class PCaloHit;
@@ -34,15 +34,12 @@ class PileUpEventPrincipal;
 
 class CastorDigiProducer : public DigiAccumulatorMixMod {
 public:
-  explicit CastorDigiProducer(const edm::ParameterSet &ps,
-                              edm::ProducerBase &mixMod,
-                              edm::ConsumesCollector &iC);
+  explicit CastorDigiProducer(const edm::ParameterSet &ps, edm::ProducerBase &mixMod, edm::ConsumesCollector &iC);
   ~CastorDigiProducer() override;
 
   void initializeEvent(edm::Event const &e, edm::EventSetup const &c) override;
   void accumulate(edm::Event const &e, edm::EventSetup const &c) override;
-  void accumulate(PileUpEventPrincipal const &e, edm::EventSetup const &c,
-                  edm::StreamID const &) override;
+  void accumulate(PileUpEventPrincipal const &e, edm::EventSetup const &c, edm::StreamID const &) override;
   void finalizeEvent(edm::Event &e, edm::EventSetup const &c) override;
 
 private:

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiStatistics.h
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiStatistics.h
@@ -8,17 +8,22 @@
 
 class CastorDigiStatistics {
 public:
-  CastorDigiStatistics(std::string name, int maxBin, float amplitudeThreshold,
-                       float expectedPedestal, float binPrevToBinMax,
+  CastorDigiStatistics(std::string name,
+                       int maxBin,
+                       float amplitudeThreshold,
+                       float expectedPedestal,
+                       float binPrevToBinMax,
                        float binNextToBinMax,
                        CaloHitAnalyzer &amplitudeAnalyzer)
-      : maxBin_(maxBin), amplitudeThreshold_(amplitudeThreshold),
+      : maxBin_(maxBin),
+        amplitudeThreshold_(amplitudeThreshold),
         pedestal_(name + " pedestal", expectedPedestal, 0.),
         binPrevToBinMax_(name + " binPrevToBinMax", binPrevToBinMax, 0.),
         binNextToBinMax_(name + " binNextToBinMax", binNextToBinMax, 0.),
         amplitudeAnalyzer_(amplitudeAnalyzer) {}
 
-  template <class Digi> void analyze(const Digi &digi);
+  template <class Digi>
+  void analyze(const Digi &digi);
 
 private:
   int maxBin_;
@@ -29,7 +34,8 @@ private:
   CaloHitAnalyzer &amplitudeAnalyzer_;
 };
 
-template <class Digi> void CastorDigiStatistics::analyze(const Digi &digi) {
+template <class Digi>
+void CastorDigiStatistics::analyze(const Digi &digi) {
   pedestal_.addEntry(digi[0].adc());
   pedestal_.addEntry(digi[1].adc());
 
@@ -38,17 +44,13 @@ template <class Digi> void CastorDigiStatistics::analyze(const Digi &digi) {
   double maxAmplitude = digi[maxBin_].nominal_fC() - pedestal_fC;
 
   if (maxAmplitude > amplitudeThreshold_) {
-
-    double binPrevToBinMax =
-        (digi[maxBin_ - 1].nominal_fC() - pedestal_fC) / maxAmplitude;
+    double binPrevToBinMax = (digi[maxBin_ - 1].nominal_fC() - pedestal_fC) / maxAmplitude;
     binPrevToBinMax_.addEntry(binPrevToBinMax);
 
-    double binNextToBinMax =
-        (digi[maxBin_ + 1].nominal_fC() - pedestal_fC) / maxAmplitude;
+    double binNextToBinMax = (digi[maxBin_ + 1].nominal_fC() - pedestal_fC) / maxAmplitude;
     binNextToBinMax_.addEntry(binNextToBinMax);
 
-    double amplitude = digi[maxBin_].nominal_fC() +
-                       digi[maxBin_ + 1].nominal_fC() - 2 * pedestal_fC;
+    double amplitude = digi[maxBin_].nominal_fC() + digi[maxBin_ + 1].nominal_fC() - 2 * pedestal_fC;
 
     amplitudeAnalyzer_.analyze(digi.id().rawId(), amplitude);
   }

--- a/SimCalorimetry/CastorSim/plugins/CastorHitAnalyzer.cc
+++ b/SimCalorimetry/CastorSim/plugins/CastorHitAnalyzer.cc
@@ -4,36 +4,33 @@
 #include <iostream>
 
 CastorHitAnalyzer::CastorHitAnalyzer(edm::ParameterSet const &conf)
-    : hitReadoutName_("CastorHits"), simParameterMap_(), castorFilter_(),
+    : hitReadoutName_("CastorHits"),
+      simParameterMap_(),
+      castorFilter_(),
       castorAnalyzer_("CASTOR", 1., &simParameterMap_, &castorFilter_),
-      castorRecHitCollectionTag_(
-          conf.getParameter<edm::InputTag>("castorRecHitCollectionTag")) {}
+      castorRecHitCollectionTag_(conf.getParameter<edm::InputTag>("castorRecHitCollectionTag")) {}
 
 namespace CastorHitAnalyzerImpl {
-template <class Collection>
-void analyze(edm::Event const &e, CaloHitAnalyzer &analyzer,
-             edm::InputTag &tag) {
-  edm::Handle<Collection> recHits;
-  e.getByLabel(tag, recHits);
-  if (!recHits.isValid()) {
-    edm::LogError("CastorHitAnalyzer")
-        << "Could not find Castor RecHitContainer ";
-  } else {
-    for (unsigned i = 0; i < recHits->size(); ++i) {
-      analyzer.analyze((*recHits)[i].id().rawId(), (*recHits)[i].energy());
+  template <class Collection>
+  void analyze(edm::Event const &e, CaloHitAnalyzer &analyzer, edm::InputTag &tag) {
+    edm::Handle<Collection> recHits;
+    e.getByLabel(tag, recHits);
+    if (!recHits.isValid()) {
+      edm::LogError("CastorHitAnalyzer") << "Could not find Castor RecHitContainer ";
+    } else {
+      for (unsigned i = 0; i < recHits->size(); ++i) {
+        analyzer.analyze((*recHits)[i].id().rawId(), (*recHits)[i].energy());
+      }
     }
   }
-}
-} // namespace CastorHitAnalyzerImpl
+}  // namespace CastorHitAnalyzerImpl
 
 void CastorHitAnalyzer::analyze(edm::Event const &e, edm::EventSetup const &c) {
   edm::Handle<CrossingFrame<PCaloHit>> castorcf;
   e.getByLabel("mix", "g4SimHitsCastorFI", castorcf);
 
   // access to SimHits
-  std::unique_ptr<MixCollection<PCaloHit>> hits(
-      new MixCollection<PCaloHit>(castorcf.product()));
+  std::unique_ptr<MixCollection<PCaloHit>> hits(new MixCollection<PCaloHit>(castorcf.product()));
   castorAnalyzer_.fillHits(*hits);
-  CastorHitAnalyzerImpl::analyze<CastorRecHitCollection>(
-      e, castorAnalyzer_, castorRecHitCollectionTag_);
+  CastorHitAnalyzerImpl::analyze<CastorRecHitCollection>(e, castorAnalyzer_, castorRecHitCollectionTag_);
 }

--- a/SimCalorimetry/CastorSim/src/CastorAmplifier.cc
+++ b/SimCalorimetry/CastorSim/src/CastorAmplifier.cc
@@ -13,26 +13,20 @@
 
 #include <iostream>
 
-CastorAmplifier::CastorAmplifier(const CastorSimParameterMap *parameters,
-                                 bool addNoise)
-    : theDbService(nullptr), theParameterMap(parameters), theStartingCapId(0),
-      addNoise_(addNoise) {}
+CastorAmplifier::CastorAmplifier(const CastorSimParameterMap *parameters, bool addNoise)
+    : theDbService(nullptr), theParameterMap(parameters), theStartingCapId(0), addNoise_(addNoise) {}
 
-void CastorAmplifier::amplify(CaloSamples &frame,
-                              CLHEP::HepRandomEngine *engine) const {
+void CastorAmplifier::amplify(CaloSamples &frame, CLHEP::HepRandomEngine *engine) const {
   const CastorSimParameters &parameters = theParameterMap->castorParameters();
   assert(theDbService != nullptr);
   HcalGenericDetId hcalGenDetId(frame.id());
   const CastorPedestal *peds = theDbService->getPedestal(hcalGenDetId);
-  const CastorPedestalWidth *pwidths =
-      theDbService->getPedestalWidth(hcalGenDetId);
+  const CastorPedestalWidth *pwidths = theDbService->getPedestalWidth(hcalGenDetId);
   if (!peds || !pwidths) {
-    edm::LogError("CastorAmplifier")
-        << "Could not fetch HCAL/CASTOR conditions for channel "
-        << hcalGenDetId;
+    edm::LogError("CastorAmplifier") << "Could not fetch HCAL/CASTOR conditions for channel " << hcalGenDetId;
   } else {
-    double gauss[32]; // big enough
-    double noise[32]; // big enough
+    double gauss[32];  // big enough
+    double noise[32];  // big enough
     double fCperPE = parameters.photoelectronsToAnalog(frame.id());
     double nominalfCperPE = parameters.getNominalfCperPE();
 

--- a/SimCalorimetry/CastorSim/src/CastorAmplifier.h
+++ b/SimCalorimetry/CastorSim/src/CastorAmplifier.h
@@ -7,7 +7,7 @@
 class CastorDbService;
 
 namespace CLHEP {
-class HepRandomEngine;
+  class HepRandomEngine;
 }
 
 class CastorAmplifier {
@@ -18,8 +18,7 @@ public:
   /// the Producer will probably update this every event
   void setDbService(const CastorDbService *service) { theDbService = service; }
 
-  virtual void amplify(CaloSamples &linearFrame,
-                       CLHEP::HepRandomEngine *) const;
+  virtual void amplify(CaloSamples &linearFrame, CLHEP::HepRandomEngine *) const;
 
   void setStartingCapId(int capId) { theStartingCapId = capId; }
 

--- a/SimCalorimetry/CastorSim/src/CastorCoderFactory.cc
+++ b/SimCalorimetry/CastorSim/src/CastorCoderFactory.cc
@@ -2,8 +2,7 @@
 #include "CalibFormats/CastorObjects/interface/CastorNominalCoder.h"
 #include "SimCalorimetry/CastorSim/src/CastorCoderFactory.h"
 
-CastorCoderFactory::CastorCoderFactory(CoderType coderType)
-    : theCoderType(coderType), theDbService(nullptr) {}
+CastorCoderFactory::CastorCoderFactory(CoderType coderType) : theCoderType(coderType), theDbService(nullptr) {}
 
 std::unique_ptr<CastorCoder> CastorCoderFactory::coder(const DetId &id) const {
   CastorCoder *result = nullptr;

--- a/SimCalorimetry/CastorSim/src/CastorElectronicsSim.cc
+++ b/SimCalorimetry/CastorSim/src/CastorElectronicsSim.cc
@@ -5,24 +5,19 @@
 
 #include "CLHEP/Random/RandFlat.h"
 
-CastorElectronicsSim::CastorElectronicsSim(
-    CastorAmplifier *amplifier, const CastorCoderFactory *coderFactory)
-    : theAmplifier(amplifier), theCoderFactory(coderFactory),
-      theStartingCapId(0) {}
+CastorElectronicsSim::CastorElectronicsSim(CastorAmplifier *amplifier, const CastorCoderFactory *coderFactory)
+    : theAmplifier(amplifier), theCoderFactory(coderFactory), theStartingCapId(0) {}
 
 CastorElectronicsSim::~CastorElectronicsSim() {}
 
 template <class Digi>
-void CastorElectronicsSim::convert(CaloSamples &frame, Digi &result,
-                                   CLHEP::HepRandomEngine *engine) {
+void CastorElectronicsSim::convert(CaloSamples &frame, Digi &result, CLHEP::HepRandomEngine *engine) {
   result.setSize(frame.size());
   theAmplifier->amplify(frame, engine);
   theCoderFactory->coder(frame.id())->fC2adc(frame, result, theStartingCapId);
 }
 
-void CastorElectronicsSim::analogToDigital(CLHEP::HepRandomEngine *engine,
-                                           CaloSamples &lf,
-                                           CastorDataFrame &result) {
+void CastorElectronicsSim::analogToDigital(CLHEP::HepRandomEngine *engine, CaloSamples &lf, CastorDataFrame &result) {
   convert<CastorDataFrame>(lf, result, engine);
 }
 

--- a/SimCalorimetry/CastorSim/src/CastorElectronicsSim.h
+++ b/SimCalorimetry/CastorSim/src/CastorElectronicsSim.h
@@ -13,17 +13,15 @@ class CastorAmplifier;
 class CastorCoderFactory;
 
 namespace CLHEP {
-class HepRandomEngine;
+  class HepRandomEngine;
 }
 
 class CastorElectronicsSim {
 public:
-  CastorElectronicsSim(CastorAmplifier *amplifier,
-                       const CastorCoderFactory *coderFactory);
+  CastorElectronicsSim(CastorAmplifier *amplifier, const CastorCoderFactory *coderFactory);
   ~CastorElectronicsSim();
 
-  void analogToDigital(CLHEP::HepRandomEngine *, CaloSamples &linearFrame,
-                       CastorDataFrame &result);
+  void analogToDigital(CLHEP::HepRandomEngine *, CaloSamples &linearFrame, CastorDataFrame &result);
 
   /// Things that need to be initialized every event
   void newEvent(CLHEP::HepRandomEngine *);

--- a/SimCalorimetry/CastorSim/src/CastorHitCorrection.h
+++ b/SimCalorimetry/CastorSim/src/CastorHitCorrection.h
@@ -15,7 +15,7 @@
 #include <vector>
 
 namespace CLHEP {
-class HepRandomEngine;
+  class HepRandomEngine;
 }
 
 class CastorHitCorrection : public CaloVHitCorrection {

--- a/SimCalorimetry/CastorSim/src/CastorHitFilter.h
+++ b/SimCalorimetry/CastorSim/src/CastorHitFilter.h
@@ -8,8 +8,7 @@
 class CastorHitFilter : public CaloVHitFilter {
   bool accepts(const PCaloHit &hit) const override {
     DetId detId(hit.id());
-    return (detId.det() == DetId::Calo &&
-            detId.subdetId() == HcalCastorDetId::SubdetectorId);
+    return (detId.det() == DetId::Calo && detId.subdetId() == HcalCastorDetId::SubdetectorId);
   }
 };
 

--- a/SimCalorimetry/CastorSim/src/CastorShape.cc
+++ b/SimCalorimetry/CastorSim/src/CastorShape.cc
@@ -1,18 +1,14 @@
 #include "SimCalorimetry/CastorSim/src/CastorShape.h"
 #include <cmath>
 
-CastorShape::CastorShape() : nbin_(256), nt_(nbin_, 0.) {
-  computeShapeCastor();
-}
+CastorShape::CastorShape() : nbin_(256), nt_(nbin_, 0.) { computeShapeCastor(); }
 
-CastorShape::CastorShape(const CastorShape &d)
-    : CaloVShape(d), nbin_(d.nbin_), nt_(d.nt_) {}
+CastorShape::CastorShape(const CastorShape &d) : CaloVShape(d), nbin_(d.nbin_), nt_(d.nt_) {}
 
 void CastorShape::computeShapeCastor() {
-
   //  cout << endl << " ===== computeShapeCastor  !!! " << endl << endl;
 
-  const float ts = 3.0; // time constant in   t * exp(-(t/ts)**2)
+  const float ts = 3.0;  // time constant in   t * exp(-(t/ts)**2)
 
   int j;
   float norm;
@@ -31,7 +27,6 @@ void CastorShape::computeShapeCastor() {
 }
 
 double CastorShape::operator()(double time) const {
-
   // return pulse amplitude for request time in ns
   int jtime;
   jtime = static_cast<int>(time + 0.5);

--- a/SimCalorimetry/CastorSim/src/CastorSimParameterMap.cc
+++ b/SimCalorimetry/CastorSim/src/CastorSimParameterMap.cc
@@ -6,8 +6,7 @@
 #include <iostream>
 
 // some arbitrary numbers for now
-CastorSimParameterMap::CastorSimParameterMap()
-    : theCastorParameters(1., 4.3333, 2.09, -4., false) {}
+CastorSimParameterMap::CastorSimParameterMap() : theCastorParameters(1., 4.3333, 2.09, -4., false) {}
 /*
   CaloSimParameters(double photomultiplierGain, double amplifierGain,
                  double samplingFactor, double timePhase,
@@ -18,8 +17,7 @@ CastorSimParameterMap::CastorSimParameterMap()
 CastorSimParameterMap::CastorSimParameterMap(const edm::ParameterSet &p)
     : theCastorParameters(p.getParameter<edm::ParameterSet>("castor")) {}
 
-const CaloSimParameters &
-CastorSimParameterMap::simParameters(const DetId &detId) const {
+const CaloSimParameters &CastorSimParameterMap::simParameters(const DetId &detId) const {
   HcalGenericDetId genericId(detId);
 
   //  if(detId.det()==DetId::Calo &&

--- a/SimCalorimetry/CastorSim/src/CastorSimParameters.cc
+++ b/SimCalorimetry/CastorSim/src/CastorSimParameters.cc
@@ -10,14 +10,17 @@
 CastorSimParameters::CastorSimParameters(double simHitToPhotoelectrons,
                                          double photoelectronsToAnalog,
                                          double samplingFactor,
-                                         double timePhase, bool syncPhase)
-    : CaloSimParameters(simHitToPhotoelectrons, photoelectronsToAnalog,
-                        samplingFactor, timePhase, 6, 4, false, syncPhase),
-      theDbService(nullptr), theSamplingFactor(samplingFactor),
+                                         double timePhase,
+                                         bool syncPhase)
+    : CaloSimParameters(
+          simHitToPhotoelectrons, photoelectronsToAnalog, samplingFactor, timePhase, 6, 4, false, syncPhase),
+      theDbService(nullptr),
+      theSamplingFactor(samplingFactor),
       nominalfCperPE(1) {}
 
 CastorSimParameters::CastorSimParameters(const edm::ParameterSet &p)
-    : CaloSimParameters(p), theDbService(nullptr),
+    : CaloSimParameters(p),
+      theDbService(nullptr),
       theSamplingFactor(p.getParameter<double>("samplingFactor")),
       nominalfCperPE(p.getParameter<double>("photoelectronsToAnalog")) {}
 
@@ -39,8 +42,7 @@ double CastorSimParameters::fCtoGeV(const DetId &detId) const {
   const CastorGainWidth *gwidths = theDbService->getGainWidth(hcalGenDetId);
   double result = 0.0;
   if (!gains || !gwidths) {
-    edm::LogError("CastorAmplifier")
-        << "Could not fetch HCAL conditions for channel " << hcalGenDetId;
+    edm::LogError("CastorAmplifier") << "Could not fetch HCAL conditions for channel " << hcalGenDetId;
   } else {
     // only one gain will be recorded per channel, so just use capID 0 for now
     result = gains->getValue(0);

--- a/SimCalorimetry/CastorSim/src/CastorSimParameters.h
+++ b/SimCalorimetry/CastorSim/src/CastorSimParameters.h
@@ -8,8 +8,10 @@
 class CastorSimParameters : public CaloSimParameters {
 public:
   CastorSimParameters(double simHitToPhotoelectrons,
-                      double photoelectronsToAnalog, double samplingFactor,
-                      double timePhase, bool syncPhase);
+                      double photoelectronsToAnalog,
+                      double samplingFactor,
+                      double timePhase,
+                      bool syncPhase);
   CastorSimParameters(const edm::ParameterSet &p);
 
   ~CastorSimParameters() override {}

--- a/SimCalorimetry/CastorSim/test/CastorDigitizerTest.cpp
+++ b/SimCalorimetry/CastorSim/test/CastorDigitizerTest.cpp
@@ -29,13 +29,11 @@
 using namespace std;
 using namespace cms;
 
-void testHitCorrection(CastorHitCorrection *correction,
-                       std::vector<PCaloHit> &hits) {
+void testHitCorrection(CastorHitCorrection *correction, std::vector<PCaloHit> &hits) {
   correction->fillChargeSums(hits);
   for (PCaloHit &hit : hits) {
     DetId detId(hit.id());
-    if (detId.det() == DetId::Calo &&
-        detId.subdetId() == HcalCastorDetId::SubdetectorId) {
+    if (detId.det() == DetId::Calo && detId.subdetId() == HcalCastorDetId::SubdetectorId) {
       std::cout << "Castor -- ";
     }
     std::cout << "HIT charge " << correction->charge(hit)
@@ -123,8 +121,7 @@ int main() {
   CastorGainWidths gainWidths;
 
   // make a calibration service by hand
-  for (vector<DetId>::const_iterator detItr = allDetIds.begin();
-       detItr != allDetIds.end(); ++detItr) {
+  for (vector<DetId>::const_iterator detItr = allDetIds.begin(); detItr != allDetIds.end(); ++detItr) {
     /* check CastorCondObjectContainer!
           pedestals.addValues(*detItr,
        CastorDbHardcode::makePedestal(*detItr).getValues ());
@@ -175,8 +172,7 @@ int main() {
   amplifier.setDbService(&calibratorHandle);
   parameterMap.setDbService(&calibratorHandle);
 
-  CaloTDigitizer<CastorDigitizerTraits> castorDigitizer(
-      &castorResponse, &electronicsSim, addNoise);
+  CaloTDigitizer<CastorDigitizerTraits> castorDigitizer(&castorResponse, &electronicsSim, addNoise);
 
   castorDigitizer.setDetIds(hcastorDetIds);
   cout << "setDetIds" << std::endl;
@@ -194,8 +190,7 @@ int main() {
   castorDigitizer.run(*castorResult, &randomEngine);
 
   cout << "Castor Frames" << std::endl;
-  copy(castorResult->begin(), castorResult->end(),
-       std::ostream_iterator<CastorDataFrame>(std::cout, "\n"));
+  copy(castorResult->begin(), castorResult->end(), std::ostream_iterator<CastorDataFrame>(std::cout, "\n"));
 
   return 0;
 }

--- a/SimCalorimetry/EcalElectronicsEmulation/bin/GenABIO.cc
+++ b/SimCalorimetry/EcalElectronicsEmulation/bin/GenABIO.cc
@@ -28,70 +28,69 @@
 #define SSIZE_MAX ((ssize_t)(SIZE_MAX / 2))
 #endif
 namespace {
-ssize_t getline(char **lineptr, size_t *n, FILE *fp) {
-  ssize_t result;
-  size_t cur_len = 0;
+  ssize_t getline(char **lineptr, size_t *n, FILE *fp) {
+    ssize_t result;
+    size_t cur_len = 0;
 
-  if (lineptr == NULL || n == NULL || fp == NULL) {
-    errno = EINVAL;
-    return -1;
-  }
-
-  if (*lineptr == NULL || *n == 0) {
-    *n = 120;
-    *lineptr = (char *)malloc(*n);
-    if (*lineptr == NULL) {
-      result = -1;
-      goto end;
-    }
-  }
-
-  for (;;) {
-    int i;
-
-    i = getc(fp);
-    if (i == EOF) {
-      result = -1;
-      break;
+    if (lineptr == NULL || n == NULL || fp == NULL) {
+      errno = EINVAL;
+      return -1;
     }
 
-    /* Make enough space for len+1 (for final NUL) bytes.  */
-    if (cur_len + 1 >= *n) {
-      size_t needed_max =
-          SSIZE_MAX < SIZE_MAX ? (size_t)SSIZE_MAX + 1 : SIZE_MAX;
-      size_t needed = 2 * *n + 1; /* Be generous. */
-      char *new_lineptr;
-
-      if (needed_max < needed)
-        needed = needed_max;
-      if (cur_len + 1 >= needed) {
+    if (*lineptr == NULL || *n == 0) {
+      *n = 120;
+      *lineptr = (char *)malloc(*n);
+      if (*lineptr == NULL) {
         result = -1;
         goto end;
       }
-
-      new_lineptr = (char *)realloc(*lineptr, needed);
-      if (new_lineptr == NULL) {
-        result = -1;
-        goto end;
-      }
-
-      *lineptr = new_lineptr;
-      *n = needed;
     }
 
-    (*lineptr)[cur_len] = i;
-    cur_len++;
+    for (;;) {
+      int i;
 
-    if (i == '\n')
-      break;
+      i = getc(fp);
+      if (i == EOF) {
+        result = -1;
+        break;
+      }
+
+      /* Make enough space for len+1 (for final NUL) bytes.  */
+      if (cur_len + 1 >= *n) {
+        size_t needed_max = SSIZE_MAX < SIZE_MAX ? (size_t)SSIZE_MAX + 1 : SIZE_MAX;
+        size_t needed = 2 * *n + 1; /* Be generous. */
+        char *new_lineptr;
+
+        if (needed_max < needed)
+          needed = needed_max;
+        if (cur_len + 1 >= needed) {
+          result = -1;
+          goto end;
+        }
+
+        new_lineptr = (char *)realloc(*lineptr, needed);
+        if (new_lineptr == NULL) {
+          result = -1;
+          goto end;
+        }
+
+        *lineptr = new_lineptr;
+        *n = needed;
+      }
+
+      (*lineptr)[cur_len] = i;
+      cur_len++;
+
+      if (i == '\n')
+        break;
+    }
+    (*lineptr)[cur_len] = '\0';
+    result = cur_len ? (ssize_t)cur_len : result;
+
+  end:
+    return result;
   }
-  (*lineptr)[cur_len] = '\0';
-  result = cur_len ? (ssize_t)cur_len : result;
-
-end:
-  return result;
-}
-} // namespace
+}  // namespace
 #endif
 
 using namespace std;
@@ -135,10 +134,10 @@ const int nABInPhi = 3;
 /** Number of DCCs in an endcap
  */
 const int nDCCEE = 9;
-const int nABABCh = 8;   // nbr of AB input/output ch. on an AB
-const int nABTCCCh = 12; // nbr of TCC inputs on an AB
-const int nDCCCh = 12;   // nbr of DCC outputs on an AB
-const int nTCCInEta = 6; // nbr of TCC bins along eta
+const int nABABCh = 8;    // nbr of AB input/output ch. on an AB
+const int nABTCCCh = 12;  // nbr of TCC inputs on an AB
+const int nDCCCh = 12;    // nbr of DCC outputs on an AB
+const int nTCCInEta = 6;  // nbr of TCC bins along eta
 const int nAB = nABInPhi * nABInEta;
 const int nTTInABAlongPhi = nTTInPhi / nABInPhi;
 const int iTTEtaMin[nABInEta] = {0, 11, 28, 45};
@@ -166,62 +165,60 @@ const char tccFlagMarker[] = {'.', 'S', '?', 'C', '4', '5', '6', '7'};
 
 char srp2roFlags[128];
 
-typedef enum {
-  suppress = 0,
-  sr2,
-  sr1,
-  full,
-  fsuppress,
-  fsr2,
-  fsr1,
-  ffull
-} roAction_t;
+typedef enum { suppress = 0, sr2, sr1, full, fsuppress, fsr2, fsr1, ffull } roAction_t;
 char roFlagMarker[] = {
-    /*suppress*/ '.',  /*sr1*/ 'z',  /*sr1*/ 'Z',  /*full*/ 'F',
-    /*fsuppress*/ '4', /*fsr2*/ '5', /*fsr1*/ '6', /*ffull*/ '7'};
+    /*suppress*/ '.',
+    /*sr1*/ 'z',
+    /*sr1*/ 'Z',
+    /*full*/ 'F',
+    /*fsuppress*/ '4',
+    /*fsr2*/ '5',
+    /*fsr1*/ '6',
+    /*ffull*/ '7'};
 
 const int nactions = 8;
 // can be overwritten according by cmd line arguments
 roAction_t actions[nactions] = {
-    /*LI->*/ sr2,  /*S->*/ full, /*N->*/ full, /*C->*/ full,
-    /*fLI->*/ sr2, /*fS->*/ sr2, /*fN->*/ sr2, /*fC->*/ sr2};
+    /*LI->*/ sr2,
+    /*S->*/ full,
+    /*N->*/ full,
+    /*C->*/ full,
+    /*fLI->*/ sr2,
+    /*fS->*/ sr2,
+    /*fN->*/ sr2,
+    /*fC->*/ sr2};
 
 // list of SC deserves by an endcap DCC [0(EE-)|1(EE+)][iDCCPhi]
 vector<pair<int, int>> ecalDccSC[nEndcaps][nDCCEE];
 
 void fillABTTFFiles(const char ttFlags[nTTInEta][nTTInPhi], ofstream files[]);
-void fillABSRPFiles(
-    const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
-    const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
-    ofstream files[]);
-void fillABIOFiles(
-    const char ttFlags[nTTInEta][nTTInPhi],
-    const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
-    const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
-    ofstream files[]);
+void fillABSRPFiles(const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
+                    const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
+                    ofstream files[]);
+void fillABIOFiles(const char ttFlags[nTTInEta][nTTInPhi],
+                   const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
+                   const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
+                   ofstream files[]);
 inline int abNum(int iABEta, int iABPhi) { return 3 * iABEta + iABPhi; }
 
 bool readTTF(FILE *file, char ttFlags[nTTInEta][nTTInPhi]);
-bool readSRF(
-    FILE *file, char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
-    char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins]);
+bool readSRF(FILE *file,
+             char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
+             char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins]);
 
 void writeABTTFFileHeader(ofstream &f, int abNum);
 void writeABSRFFileHeader(ofstream &f, int abNum);
 void writeABIOFileHeader(ofstream &f, int abNum);
-string getFlagStream(char flags[nTTInEta][nTTInPhi], int iEtaMin, int iEtaMax,
-                     int iPhiMin, int iPhiMax);
-string getABTCCInputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta,
-                           int iABPhi, int iTCCCh);
+string getFlagStream(char flags[nTTInEta][nTTInPhi], int iEtaMin, int iEtaMax, int iPhiMin, int iPhiMax);
+string getABTCCInputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta, int iABPhi, int iTCCCh);
 void getABTTPhiBounds(int iABPhi, int &iTTPhiMin, int &iTTPhiMax);
-string getABABOutputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta,
-                           int iABPhi, int iABCh);
-string getABABInputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta,
-                          int iABPhi, int iABCh);
-string getABDCCOutputStream(
-    const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
-    const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
-    int iABEta, int iABPhi, int DCCCh);
+string getABABOutputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta, int iABPhi, int iABCh);
+string getABABInputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta, int iABPhi, int iABCh);
+string getABDCCOutputStream(const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
+                            const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
+                            int iABEta,
+                            int iABPhi,
+                            int DCCCh);
 void abConnect(int iAB, int iABCh, int &iOtherAB, int &iOtherABCh);
 
 int iEvent = 0;
@@ -239,35 +236,34 @@ int main(int argc, char *argv[]) {
   int iarg = 0;
   while (++iarg < argc) {
     if (strcmp(argv[iarg], "-h") == 0 || strcmp(argv[iarg], "--help") == 0) {
-      cout
-          << "Usage: GenABIO [OPTIONS]\n\n"
-             "Produces TT and SR flag files for each SRP board from TTF.txt "
-             "and "
-             "SRF.txt global flag files. Requires the SRP cross-connect "
-             "description"
-             " description file (xconnect_universal.txt). TTF.txt, SRF.txt and "
-             "xconnect_universal.txt must be in the directory the command is "
-             "launched.\n\n"
-             "OPTIONS:\n"
-             "  -A, --actions IJKLMNOP. IJKLMNOP I..P integers from 0 to 7.\n"
-             "                I: action flag for low interest RUs\n"
-             "                J: action flag for single RUs\n"
-             "                K: action flag for neighbour RUs\n"
-             "                L: action flag for centers RUs\n"
-             "                M: action flag for forced low interest RUs\n"
-             "                N: action flag for forced single RUs\n"
-             "                O: action flag for forced neighbour RUs\n"
-             "                P: action flag for forced centers RUs\n\n"
-             " -h, --help display this help\n"
-             " -a n, --ab n specifies indices of the AB whose file must be "
-             "produced. The ab number runs from 1 to 12. Use -1 to produce "
-             "files "
-             "for every AB\n\n";
+      cout << "Usage: GenABIO [OPTIONS]\n\n"
+              "Produces TT and SR flag files for each SRP board from TTF.txt "
+              "and "
+              "SRF.txt global flag files. Requires the SRP cross-connect "
+              "description"
+              " description file (xconnect_universal.txt). TTF.txt, SRF.txt and "
+              "xconnect_universal.txt must be in the directory the command is "
+              "launched.\n\n"
+              "OPTIONS:\n"
+              "  -A, --actions IJKLMNOP. IJKLMNOP I..P integers from 0 to 7.\n"
+              "                I: action flag for low interest RUs\n"
+              "                J: action flag for single RUs\n"
+              "                K: action flag for neighbour RUs\n"
+              "                L: action flag for centers RUs\n"
+              "                M: action flag for forced low interest RUs\n"
+              "                N: action flag for forced single RUs\n"
+              "                O: action flag for forced neighbour RUs\n"
+              "                P: action flag for forced centers RUs\n\n"
+              " -h, --help display this help\n"
+              " -a n, --ab n specifies indices of the AB whose file must be "
+              "produced. The ab number runs from 1 to 12. Use -1 to produce "
+              "files "
+              "for every AB\n\n";
 
       return 0;
     }
 
-    if (!strcmp(argv[iarg], "-A") || !strcmp(argv[iarg], "-A")) { // actions
+    if (!strcmp(argv[iarg], "-A") || !strcmp(argv[iarg], "-A")) {  // actions
       if (++iarg >= argc) {
         cout << "Option error. Try -h\n";
         return 1;
@@ -298,8 +294,7 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  for (size_t i = 0; i < sizeof(srp2roFlags) / sizeof(srp2roFlags[0]);
-       srp2roFlags[i++] = '?')
+  for (size_t i = 0; i < sizeof(srp2roFlags) / sizeof(srp2roFlags[0]); srp2roFlags[i++] = '?')
     ;
   for (size_t i = 0; i < sizeof(actions) / sizeof(actions[0]); ++i) {
     srp2roFlags[(int)srpFlagMarker[i]] = roFlagMarker[actions[i]];
@@ -309,7 +304,7 @@ int main(int argc, char *argv[]) {
     for (int iY = 0; iY < nSupercrystalXBins; ++iY) {
       for (int iX = 0; iX < nSupercrystalYBins; ++iX) {
         int iDCCPhi = dccPhiIndexOfRU(iEE == 0 ? 0 : 2, iX, iY);
-        if (iDCCPhi >= 0) { // SC exists
+        if (iDCCPhi >= 0) {  // SC exists
           ecalDccSC[iEE][iDCCPhi].push_back(pair<int, int>(iX, iY));
         }
       }
@@ -347,8 +342,7 @@ int main(int argc, char *argv[]) {
   }
 
   iEvent = 0;
-  while (readSRF(srfFile, barrelSrFlags, endcapSrFlags) &&
-         readTTF(ttfFile, ttFlags)) {
+  while (readSRF(srfFile, barrelSrFlags, endcapSrFlags) && readTTF(ttfFile, ttFlags)) {
     if (iEvent % 100 == 0) {
       cout << "Event " << iEvent << endl;
     }
@@ -381,8 +375,7 @@ void fillABTTFFiles(const char ttFlags[nTTInEta][nTTInPhi], ofstream files[]) {
         } else {
           iTTEta = iTTEtaMax[iABEta] - i;
         }
-        for (int iTTPhi = iTTPhiMin;
-             mod(iTTPhiMax - iTTPhi, nTTInPhi) < nTTInABAlongPhi;
+        for (int iTTPhi = iTTPhiMin; mod(iTTPhiMax - iTTPhi, nTTInPhi) < nTTInABAlongPhi;
              iTTPhi = mod(++iTTPhi, nTTInPhi)) {
           files[iAB] << ttFlags[iTTEta][iTTPhi];
         }
@@ -394,10 +387,9 @@ void fillABTTFFiles(const char ttFlags[nTTInEta][nTTInPhi], ofstream files[]) {
   }
 }
 
-void fillABSRPFiles(
-    const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
-    const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
-    ofstream files[nAB]) {
+void fillABSRPFiles(const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
+                    const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
+                    ofstream files[nAB]) {
   // event headers:
   for (int iAB = 0; iAB < nAB; ++iAB) {
     files[iAB] << "# Event " << iEvent << "\n";
@@ -422,14 +414,14 @@ void fillABSRPFiles(
           files[iAB] << srp2roFlags[(int)endcapSrFlags[iEE][iX][iY]];
           lineAppended[iAB] = true;
         }
-      } // next iY
+      }  // next iY
       for (int iFile = 0; iFile < nAB; ++iFile) {
         if (lineAppended[iFile]) {
           files[iFile] << "\n";
           lineAppended[iFile] = false;
         }
       }
-    } // next iX
+    }  // next iX
   }
 
   // EB:
@@ -447,11 +439,9 @@ void fillABSRPFiles(
         } else {
           iTTEta = iTTEtaMax[iABEta] - i;
         }
-        for (int iTTPhi = iTTPhiMin;
-             mod(iTTPhiMax - iTTPhi, nTTInPhi) < nTTInABAlongPhi;
+        for (int iTTPhi = iTTPhiMin; mod(iTTPhiMax - iTTPhi, nTTInPhi) < nTTInABAlongPhi;
              iTTPhi = mod(++iTTPhi, nTTInPhi)) {
-          files[iAB] << srp2roFlags[(
-              int)barrelSrFlags[iTTEta - nEndcapTTInEta][iTTPhi]];
+          files[iAB] << srp2roFlags[(int)barrelSrFlags[iTTEta - nEndcapTTInEta][iTTPhi]];
         }
         files[iAB] << "\n";
       }
@@ -466,11 +456,10 @@ void fillABSRPFiles(
   }
 }
 
-void fillABIOFiles(
-    const char ttFlags[nTTInEta][nTTInPhi],
-    const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
-    const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
-    ofstream files[]) {
+void fillABIOFiles(const char ttFlags[nTTInEta][nTTInPhi],
+                   const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
+                   const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
+                   ofstream files[]) {
   for (int iABEta = 0; iABEta < nABInEta; ++iABEta) {
     for (int iABPhi = 0; iABPhi < nABInPhi; ++iABPhi) {
       int iAB = abNum(iABEta, iABPhi);
@@ -478,29 +467,21 @@ void fillABIOFiles(
       files[iAB] << "# Event " << iEvent << "\n";
       // TCC inputs:
       for (int iTCC = 0; iTCC < nABTCCCh; ++iTCC) {
-        files[iAB] << "ITCC" << iTCC + 1 << ":"
-                   << getABTCCInputStream(ttFlags, iABEta, iABPhi, iTCC)
-                   << "\n";
+        files[iAB] << "ITCC" << iTCC + 1 << ":" << getABTCCInputStream(ttFlags, iABEta, iABPhi, iTCC) << "\n";
       }
       // AB inputs:
       for (int iABCh = 0; iABCh < nABABCh; ++iABCh) {
-        files[iAB] << "IAB" << iABCh + 1 << ":"
-                   << getABABInputStream(ttFlags, iABEta, iABPhi, iABCh)
-                   << "\n";
+        files[iAB] << "IAB" << iABCh + 1 << ":" << getABABInputStream(ttFlags, iABEta, iABPhi, iABCh) << "\n";
       }
       // AB outputs:
       for (int iABCh = 0; iABCh < nABABCh; ++iABCh) {
-        files[iAB] << "OAB" << iABCh + 1 << ":"
-                   << getABABOutputStream(ttFlags, iABEta, iABPhi, iABCh)
-                   << "\n";
+        files[iAB] << "OAB" << iABCh + 1 << ":" << getABABOutputStream(ttFlags, iABEta, iABPhi, iABCh) << "\n";
       }
       // DCC output:
       for (int iDCCCh = 0; iDCCCh < nDCCCh; ++iDCCCh) {
         files[iAB] << "ODCC";
         files[iAB] << (iDCCCh <= 8 ? "0" : "") << iDCCCh + 1 << ":"
-                   << getABDCCOutputStream(barrelSrFlags, endcapSrFlags, iABEta,
-                                           iABPhi, iDCCCh)
-                   << "\n";
+                   << getABDCCOutputStream(barrelSrFlags, endcapSrFlags, iABEta, iABPhi, iDCCCh) << "\n";
       }
       files[iAB] << "#\n";
     }
@@ -527,8 +508,8 @@ bool readTTF(FILE *f, char ttFlags[nTTInEta][nTTInPhi]) {
     ++line;
     char *pos = buffer;
     while (*pos == ' ' || *pos == '\t')
-      ++pos;                           // skip spaces
-    if (*pos != '#' && *pos != '\n') { // not a comment line nor an empty line
+      ++pos;                            // skip spaces
+    if (*pos != '#' && *pos != '\n') {  // not a comment line nor an empty line
       if (read - 1 != nTTInPhi) {
         cerr << "Error: line " << line << " of file " << ttfFilename
              << " has incorrect length"
@@ -552,9 +533,9 @@ bool readTTF(FILE *f, char ttFlags[nTTInEta][nTTInPhi]) {
   return (iEta == nTTInEta) ? true : false;
 }
 
-bool readSRF(
-    FILE *f, char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
-    char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins]) {
+bool readSRF(FILE *f,
+             char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
+             char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins]) {
   char *buffer = nullptr;
   size_t bufferSize = 0;
   int read;
@@ -564,35 +545,31 @@ bool readSRF(
   int iEta = 0;
   int iXm = 0;
   int iXp = 0;
-  int iReadLine = 0; // number of read line, comment lines excluded
+  int iReadLine = 0;  // number of read line, comment lines excluded
   // number of non-comment lines to read:
   const int nReadLine = nBarrelTTInEta + nEndcaps * nSupercrystalXBins;
-  while (iReadLine < nReadLine &&
-         (read = getline(&buffer, &bufferSize, f)) != -1) {
+  while (iReadLine < nReadLine && (read = getline(&buffer, &bufferSize, f)) != -1) {
     ++line;
     char *pos = buffer;
     while (*pos == ' ' || *pos == '\t')
-      ++pos;                           // skip spaces
-    if (*pos != '#' && *pos != '\n') { // not a comment line nor an empty line
+      ++pos;                            // skip spaces
+    if (*pos != '#' && *pos != '\n') {  // not a comment line nor an empty line
       // go back to beginning of line:
       pos = buffer;
-      if (iReadLine < nSupercrystalXBins) { // EE- reading
+      if (iReadLine < nSupercrystalXBins) {  // EE- reading
         if (read - 1 != nSupercrystalYBins) {
-          cerr << "Error: line " << line << " of file " << srfFilename
-               << " has incorrect length"
-               << " (" << read - 1 << " instead of " << nSupercrystalYBins
-               << ")" << endl;
+          cerr << "Error: line " << line << " of file " << srfFilename << " has incorrect length"
+               << " (" << read - 1 << " instead of " << nSupercrystalYBins << ")" << endl;
           exit(EXIT_FAILURE);
         }
         for (int iY = 0; iY < nSupercrystalYBins; ++iY) {
           endcapSrFlags[0][iXm][iY] = buffer[iY];
         }
         ++iXm;
-      } else if (iReadLine < nSupercrystalYBins + nBarrelTTInEta) { // EB
-                                                                    // reading
+      } else if (iReadLine < nSupercrystalYBins + nBarrelTTInEta) {  // EB
+                                                                     // reading
         if (read - 1 != nTTInPhi) {
-          cerr << "Error: line " << line << " of file " << srfFilename
-               << " has incorrect length"
+          cerr << "Error: line " << line << " of file " << srfFilename << " has incorrect length"
                << " (" << read - 1 << " instead of " << nTTInPhi << ")" << endl;
           exit(EXIT_FAILURE);
         }
@@ -600,13 +577,10 @@ bool readSRF(
           barrelSrFlags[iEta][iPhi] = buffer[iPhi];
         }
         ++iEta;
-      } else if (iReadLine <
-                 2 * nSupercrystalXBins + nBarrelTTInEta) { // EE+ reading
+      } else if (iReadLine < 2 * nSupercrystalXBins + nBarrelTTInEta) {  // EE+ reading
         if (read - 1 != nSupercrystalYBins) {
-          cerr << "Error: line " << line << " of file " << srfFilename
-               << " has incorrect length"
-               << " (" << read - 1 << " instead of " << nSupercrystalYBins
-               << ")" << endl;
+          cerr << "Error: line " << line << " of file " << srfFilename << " has incorrect length"
+               << " (" << read - 1 << " instead of " << nSupercrystalYBins << ")" << endl;
           exit(EXIT_FAILURE);
         }
         for (int iY = 0; iY < nSupercrystalYBins; ++iY) {
@@ -615,7 +589,7 @@ bool readSRF(
         ++iXp;
       }
       ++iReadLine;
-    } // not a comment or empty line
+    }  // not a comment or empty line
   }
   // returns 0 if all TT were read:
   return (iReadLine == nReadLine) ? true : false;
@@ -674,10 +648,10 @@ void writeABSRFFileHeader(ofstream &f, int abNum) {
   const char *date = ctime(&t);
   const char *xLabel;
   const char *yLabel;
-  if (abNum < 3 || abNum > 8) { // endcap
+  if (abNum < 3 || abNum > 8) {  // endcap
     xLabel = "Y  ";
     yLabel = "X    ";
-  } else { // barrel
+  } else {  // barrel
     xLabel = "Phi";
     yLabel = "|Eta|";
   }
@@ -724,20 +698,16 @@ void writeABIOFileHeader(ofstream &f, int abNum) {
     << date
     << "#\n"
        "# "
-    << srpFlagMarker[0] << ": 000 (low interest)   " << tccFlagMarker[0]
-    << ": 000 (low interest)   " << roFlagMarker[0]
+    << srpFlagMarker[0] << ": 000 (low interest)   " << tccFlagMarker[0] << ": 000 (low interest)   " << roFlagMarker[0]
     << ": 000 (suppress)\n"
        "# "
-    << srpFlagMarker[1] << ": 001 (single)         " << tccFlagMarker[1]
-    << ": 001 (mid interest)   " << roFlagMarker[1]
+    << srpFlagMarker[1] << ": 001 (single)         " << tccFlagMarker[1] << ": 001 (mid interest)   " << roFlagMarker[1]
     << ": 010 (SR Threshold 2)\n"
        "# "
-    << srpFlagMarker[2] << ": 010 (neighbour)      " << tccFlagMarker[2]
-    << ": 010 (not valid)      " << roFlagMarker[2]
+    << srpFlagMarker[2] << ": 010 (neighbour)      " << tccFlagMarker[2] << ": 010 (not valid)      " << roFlagMarker[2]
     << ": 001 (SR Threshold 1)\n"
        "# "
-    << srpFlagMarker[3] << ": 011 (center)         " << tccFlagMarker[3]
-    << ": 011 (high interest)  " << roFlagMarker[3]
+    << srpFlagMarker[3] << ": 011 (center)         " << tccFlagMarker[3] << ": 011 (high interest)  " << roFlagMarker[3]
     << ": 011 (Full readout)\n"
        "#\n"
        "# action table (when forced):\n"
@@ -756,8 +726,7 @@ void writeABIOFileHeader(ofstream &f, int abNum) {
        "#\n";
 }
 
-string getFlagStream(const char flags[nTTInEta][nTTInPhi], int iEtaMin,
-                     int iEtaMax, int iPhiMin, int iPhiMax) {
+string getFlagStream(const char flags[nTTInEta][nTTInPhi], int iEtaMin, int iEtaMax, int iPhiMin, int iPhiMax) {
   assert(0 <= iEtaMin && iEtaMin <= iEtaMax && iEtaMax < nTTInEta);
   if (iEtaMin <= nTTInEta / 2 && iEtaMax > nTTInEta) {
     cerr << "Implementation Errror:" << __FILE__ << ":" << __LINE__
@@ -778,8 +747,7 @@ string getFlagStream(const char flags[nTTInEta][nTTInPhi], int iEtaMin,
       iEta = iEtaMax - jEta;
     }
 
-    for (int iPhi = mod(iPhiMin, nTTInPhi);
-         mod(iPhiMax + 1 - iPhi, nTTInPhi) != 0; iPhi = mod(++iPhi, nTTInPhi)) {
+    for (int iPhi = mod(iPhiMin, nTTInPhi); mod(iPhiMax + 1 - iPhi, nTTInPhi) != 0; iPhi = mod(++iPhi, nTTInPhi)) {
       buffer << flags[iEta][iPhi];
     }
   }
@@ -787,18 +755,17 @@ string getFlagStream(const char flags[nTTInEta][nTTInPhi], int iEtaMin,
   return buffer.str();
 }
 
-string getABTCCInputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta,
-                           int iABPhi, int iTCCCh) {
+string getABTCCInputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta, int iABPhi, int iTCCCh) {
   // gets eta bounds for this tcc channel:
   int iTCCEta;
-  if (iABEta == 1 || iABEta == 2) { // barrel
+  if (iABEta == 1 || iABEta == 2) {  // barrel
     if (iTCCCh > 5)
-      return ""; // only 6 TCCs per AB for barrel
+      return "";  // only 6 TCCs per AB for barrel
     iTCCEta = 1 + iABEta;
-  } else {             // endcap
-    if (iABEta == 0) { // EE-
+  } else {              // endcap
+    if (iABEta == 0) {  // EE-
       iTCCEta = (iTCCCh < 6) ? 1 : 0;
-    } else { // EE+
+    } else {  // EE+
       iTCCEta = (iTCCCh < 6) ? 4 : 5;
     }
   }
@@ -818,81 +785,77 @@ string getABTCCInputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta,
   return getFlagStream(tccFlags, iEtaMin, iEtaMax, iPhiMin, iPhiMax);
 }
 
-string getABABOutputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta,
-                           int iABPhi, int iABCh) {
+string getABABOutputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta, int iABPhi, int iABCh) {
   stringstream buffer;
   buffer.str("");
-  bool barrel =
-      (iABEta == 1 || iABEta == 2); // true for barrel, false for endcap
+  bool barrel = (iABEta == 1 || iABEta == 2);  // true for barrel, false for endcap
   switch (iABCh) {
-  case 0:
-    // to AB ch #0 are sent the 16 1st TCC flags received on TCC input Ch. 0
-    buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 0).substr(0, 16);
-    break;
-  case 1:
-    // to AB ch #1 are sent the 16 1st TCC flags received on TCC input Ch. 0 to
-    // 5:
-    for (int iTCCCh = 0; iTCCCh < 6; ++iTCCCh) {
-      buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, iTCCCh)
-                    .substr(0, 16);
-    }
-    break;
-  case 2:
-    // to AB ch #2 are sent the 16 1st TCC flags received on TCC input Ch. 5:
-    buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 5).substr(0, 16);
-    break;
-  case 3:
-    // to AB ch #3 are sent TCC flags received on TCC input Ch. 0 and 6:
-    buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 0);
-    buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 6);
-    break;
-  case 4:
-    // to AB ch #4 are sent TCC flags received on TCC input Ch 5 and 11:
-    buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 5);
-    buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 11);
-    break;
-  case 5:
-    // for endcaps AB output ch 5 is not used.
-    // for barrel, to AB ch #5 are sent the 16 last TCC flags received on TCC
-    // input Ch. 0:
-    if (barrel) { // in barrel
-      string s = getABTCCInputStream(tccFlags, iABEta, iABPhi, 0);
-      assert(s.size() >= 16);
-      buffer << s.substr(s.size() - 16, 16);
-    }
-    break;
-  case 6:
-    // for endcaps AB output ch 6 is not used.
-    // for barrel, to AB ch #6 are sent the 16 last TCC flags received on TCC
-    // input Ch. 0 to 5:
-    if (barrel) { // in barrel
+    case 0:
+      // to AB ch #0 are sent the 16 1st TCC flags received on TCC input Ch. 0
+      buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 0).substr(0, 16);
+      break;
+    case 1:
+      // to AB ch #1 are sent the 16 1st TCC flags received on TCC input Ch. 0 to
+      // 5:
       for (int iTCCCh = 0; iTCCCh < 6; ++iTCCCh) {
-        string s = getABTCCInputStream(tccFlags, iABEta, iABPhi, iTCCCh);
+        buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, iTCCCh).substr(0, 16);
+      }
+      break;
+    case 2:
+      // to AB ch #2 are sent the 16 1st TCC flags received on TCC input Ch. 5:
+      buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 5).substr(0, 16);
+      break;
+    case 3:
+      // to AB ch #3 are sent TCC flags received on TCC input Ch. 0 and 6:
+      buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 0);
+      buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 6);
+      break;
+    case 4:
+      // to AB ch #4 are sent TCC flags received on TCC input Ch 5 and 11:
+      buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 5);
+      buffer << getABTCCInputStream(tccFlags, iABEta, iABPhi, 11);
+      break;
+    case 5:
+      // for endcaps AB output ch 5 is not used.
+      // for barrel, to AB ch #5 are sent the 16 last TCC flags received on TCC
+      // input Ch. 0:
+      if (barrel) {  // in barrel
+        string s = getABTCCInputStream(tccFlags, iABEta, iABPhi, 0);
+        assert(s.size() >= 16);
         buffer << s.substr(s.size() - 16, 16);
       }
-    }
-    break;
-  case 7:
-    // for endcaps AB output ch 7 is not used.
-    // for barrel, to AB ch #7 are sent the 16 last TCC flags received on TCC
-    // input Ch. 5:
-    if (barrel) { // in barrel
-      string s = getABTCCInputStream(tccFlags, iABEta, iABPhi, 5);
-      assert(s.size() >= 16);
-      buffer << s.substr(s.size() - 16, 16);
-    }
-    break;
-  default:
-    assert(false);
+      break;
+    case 6:
+      // for endcaps AB output ch 6 is not used.
+      // for barrel, to AB ch #6 are sent the 16 last TCC flags received on TCC
+      // input Ch. 0 to 5:
+      if (barrel) {  // in barrel
+        for (int iTCCCh = 0; iTCCCh < 6; ++iTCCCh) {
+          string s = getABTCCInputStream(tccFlags, iABEta, iABPhi, iTCCCh);
+          buffer << s.substr(s.size() - 16, 16);
+        }
+      }
+      break;
+    case 7:
+      // for endcaps AB output ch 7 is not used.
+      // for barrel, to AB ch #7 are sent the 16 last TCC flags received on TCC
+      // input Ch. 5:
+      if (barrel) {  // in barrel
+        string s = getABTCCInputStream(tccFlags, iABEta, iABPhi, 5);
+        assert(s.size() >= 16);
+        buffer << s.substr(s.size() - 16, 16);
+      }
+      break;
+    default:
+      assert(false);
   }
   return buffer.str();
 }
 
-string getABABInputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta,
-                          int iABPhi, int iABCh) {
+string getABABInputStream(const char tccFlags[nTTInEta][nTTInPhi], int iABEta, int iABPhi, int iABCh) {
   int iAB = abNum(iABEta, iABPhi);
-  int iOtherAB;   // AB which this channel is connected to
-  int iOtherABCh; // ch # on the other side of the AB-AB link
+  int iOtherAB;    // AB which this channel is connected to
+  int iOtherABCh;  // ch # on the other side of the AB-AB link
   abConnect(iAB, iABCh, iOtherAB, iOtherABCh);
   int iOtherABEta = iOtherAB / 3;
   int iOtherABPhi = iOtherAB % 3;
@@ -910,8 +873,7 @@ void abConnect(int iAB, int iABCh, int &iOtherAB, int &iOtherABCh) {
   if (firstCall) {
     FILE *f = fopen(xconnectFilename, "r");
     if (f == nullptr) {
-      cerr << "Error. Failed to open xconnect definition file,"
-           << xconnectFilename << endl;
+      cerr << "Error. Failed to open xconnect definition file," << xconnectFilename << endl;
       exit(EXIT_FAILURE);
     }
     // skips two first lines:
@@ -944,22 +906,22 @@ void abConnect(int iAB, int iABCh, int &iOtherAB, int &iOtherABCh) {
   iOtherABCh = xconnectMap[iAB][iABCh][1];
 }
 
-string getABDCCOutputStream(
-    const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
-    const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
-    int iABEta, int iABPhi, int iDCCCh) {
+string getABDCCOutputStream(const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
+                            const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
+                            int iABEta,
+                            int iABPhi,
+                            int iDCCCh) {
   bool barrel = (iABEta == 1 || iABEta == 2);
   if (barrel) {
     // same as TCC with same ch number but with TCC flags replaced by SRP flags:
-    string stream = getABTCCInputStream(barrelSrFlags - nEndcapTTInEta, iABEta,
-                                        iABPhi, iDCCCh);
+    string stream = getABTCCInputStream(barrelSrFlags - nEndcapTTInEta, iABEta, iABPhi, iDCCCh);
     // converts srp flags to readout flags:
     for (size_t i = 0; i < stream.size(); ++i) {
       stream[i] = srp2roFlags[(int)stream[i]];
     }
     return stream;
-  } else {            // endcap
-    if (iDCCCh < 3) { // used DCC output channel
+  } else {             // endcap
+    if (iDCCCh < 3) {  // used DCC output channel
       // endcap index:
       int iEE = (iABEta == 0) ? 0 : 1;
       stringstream buffer("");
@@ -971,7 +933,7 @@ string getABDCCOutputStream(
         buffer << srp2roFlags[(int)endcapSrFlags[iEE][sc.first][sc.second]];
       }
       return buffer.str();
-    } else { // unused output channel
+    } else {  // unused output channel
       return "";
     }
   }

--- a/SimCalorimetry/EcalElectronicsEmulation/bin/ecalDccMap.h
+++ b/SimCalorimetry/EcalElectronicsEmulation/bin/ecalDccMap.h
@@ -1,30 +1,32 @@
 #include <iostream>
 
-template <class T> T mod(const T &a, const T &b) {
+template <class T>
+T mod(const T &a, const T &b) {
   T c = a % b;
   return c < 0 ? c + b : c;
 }
 
-static const char endcapDccMap[401] = {"       777777       "
-                                       "    666777777888    "
-                                       "   66667777778888   "
-                                       "  6666667777888888  "
-                                       " 666666677778888888 "
-                                       " 566666677778888880 " //    Z
-                                       " 555666667788888000 " //     x-----> X
-                                       "55555566677888000000" //     |
-                                       "555555566  880000000" //     |
-                                       "55555555    00000000" //_          // |
-                                       "55555554    10000000" //     V Y
-                                       "554444444  111111100"
-                                       "44444444332211111111"
-                                       " 444444333222111111 "
-                                       " 444443333222211111 "
-                                       " 444433333222221111 "
-                                       "  4443333322222111  "
-                                       "   43333332222221   "
-                                       "    333333222222    "
-                                       "       333222       "};
+static const char endcapDccMap[401] = {
+    "       777777       "
+    "    666777777888    "
+    "   66667777778888   "
+    "  6666667777888888  "
+    " 666666677778888888 "
+    " 566666677778888880 "  //    Z
+    " 555666667788888000 "  //     x-----> X
+    "55555566677888000000"  //     |
+    "555555566  880000000"  //     |
+    "55555555    00000000"  //_          // |
+    "55555554    10000000"  //     V Y
+    "554444444  111111100"
+    "44444444332211111111"
+    " 444444333222111111 "
+    " 444443333222211111 "
+    " 444433333222221111 "
+    "  4443333322222111  "
+    "   43333332222221   "
+    "    333333222222    "
+    "       333222       "};
 
 /** Gets the phi index of the DCC reading a RU (SC or TT)
  * @param iDet 0 for EE-, 1 for EB, 2 for EE+
@@ -34,7 +36,7 @@ static const char endcapDccMap[401] = {"       777777       "
  * and between 0 and 17 for EB
  */
 inline int dccPhiIndexOfRU(int iDet, int i, int j) {
-  if (iDet == 1) { // barrel
+  if (iDet == 1) {  // barrel
     // iEta=i, iPhi=j
     // phi edge of a SM is 4 TT
     return j / 4;
@@ -50,9 +52,7 @@ inline int dccPhiIndexOfRU(int iDet, int i, int j) {
  * @return DCC phi index between 0 and 8 for EE
  * and between 0 and 17 for EB
  */
-inline int dccPhiIndex(int iDet, int i, int j) {
-  return dccPhiIndexOfRU(iDet, i / 5, j / 5);
-}
+inline int dccPhiIndex(int iDet, int i, int j) { return dccPhiIndexOfRU(iDet, i / 5, j / 5); }
 
 /** Gets the index of the DCC reading a crystal
  * @param iDet 0 for EE-, 1 for EB, 2 for EE+
@@ -61,7 +61,7 @@ inline int dccPhiIndex(int iDet, int i, int j) {
  * @return DCC index between 0 and 53
  */
 inline int dccIndex(int iDet, int i, int j) {
-  if (iDet == 1) { // barrel
+  if (iDet == 1) {  // barrel
     // a SM is 85 crystal long:
     int iEtaSM = i / 85;
     // a SM is 20 crystal wide:
@@ -84,7 +84,7 @@ inline int dccIndex(int iDet, int i, int j) {
  * @return DCC index between 0 and 53
  */
 inline int dccIndexOfRU(int iDet, int i, int j) {
-  if (iDet == 1) { // barrel
+  if (iDet == 1) {  // barrel
     // a SM is 17 RU long:
     int iEtaSM = i / 17;
     // a SM is 4 RU wide:
@@ -103,21 +103,21 @@ inline int dccIndexOfRU(int iDet, int i, int j) {
 inline int abOfDcc(int iDCC) {
   if (iDCC < 0 || iDCC > 54)
     return -1;
-  if (iDCC < 9) { // EE-
+  if (iDCC < 9) {  // EE-
     return iDCC / 3;
-  } else if (iDCC < 27) { // EB-
+  } else if (iDCC < 27) {  // EB-
     // an EB AB is made of 6 DCCs,
     // first EB- AB is numbered 3
     // and "1st" DCC of AB 3 is DCC 26
     //(AB 3 made of DCCs 26,9,10,11,12,13):
     return 3 + mod(iDCC - 26, 18) / 6;
-  } else if (iDCC < 45) { // EB+
+  } else if (iDCC < 45) {  // EB+
     // an EB AB is made of 6 DCCs,
     // first EB+ AB is numbered 6
     // and "1st" DCC of AB6 is DCC 44
     //(AB 6 made of DCCs 44,27,28,29,30,31):
     return 6 + mod(iDCC - 44, 18) / 6;
-  } else { // EE+
+  } else {  // EE+
     // AB numbering starts at DCC=45 and runs along phi in increasing phi
     // first EE+ AB is numbered 9:
     return 9 + (iDCC - 45) / 3;

--- a/SimCalorimetry/EcalElectronicsEmulation/interface/EcalFEtoDigi.h
+++ b/SimCalorimetry/EcalElectronicsEmulation/interface/EcalFEtoDigi.h
@@ -31,10 +31,9 @@
 
 struct TCCinput;
 typedef std::vector<TCCinput> TCCInputData;
-static const int N_SM = 36; // number of ecal barrel supermodules
+static const int N_SM = 36;  // number of ecal barrel supermodules
 
 class EcalFEtoDigi : public edm::one::EDProducer<> {
-
 public:
   explicit EcalFEtoDigi(const edm::ParameterSet &);
   ~EcalFEtoDigi() override {}
@@ -47,11 +46,9 @@ private:
   void readInput();
   EcalTrigTowerDetId create_TTDetId(TCCinput);
   EcalTriggerPrimitiveSample create_TPSample(TCCinput, const edm::EventSetup &);
-  EcalTriggerPrimitiveSample create_TPSampleTcp(TCCinput,
-                                                const edm::EventSetup &);
+  EcalTriggerPrimitiveSample create_TPSampleTcp(TCCinput, const edm::EventSetup &);
   int SMidToTCCid(const int) const;
-  void getLUT(unsigned int *lut, const int towerId,
-              const edm::EventSetup &) const;
+  void getLUT(unsigned int *lut, const int towerId, const edm::EventSetup &) const;
 
   TCCInputData inputdata_[N_SM];
 

--- a/SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimRawData.h
+++ b/SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimRawData.h
@@ -104,11 +104,11 @@ private:
 
   /** Number of TTs along Ecal Phi
    */
-  static const int nTtPhi = nEbPhi / ttEdge; // 72
+  static const int nTtPhi = nEbPhi / ttEdge;  // 72
 
   /** Number of TTs along Ecal barrel eta
    */
-  static const int nEbTtEta = nEbEta / ttEdge; // 34
+  static const int nEbTtEta = nEbEta / ttEdge;  // 34
 
   /** Number of TTs along eta for one endcap.
    */
@@ -116,7 +116,7 @@ private:
 
   /** Number of TTs along ECAL eta
    */
-  static const int nTtEta = nEbTtEta + 2 * nEeTtEta; // 56
+  static const int nTtEta = nEbTtEta + 2 * nEeTtEta;  // 56
 
   /** Number of barrel DCCs along Phi
    */
@@ -226,17 +226,13 @@ private:
    * @param iEta std CMSSW trigger tower eta index
    * @return the c-array index
    */
-  int iTtEta2cIndex(int iTtEta) const {
-    return (iTtEta < 0) ? (iTtEta + 28) : (iTtEta + 27);
-  }
+  int iTtEta2cIndex(int iTtEta) const { return (iTtEta < 0) ? (iTtEta + 28) : (iTtEta + 27); }
 
   /** Converse of iTtEta2cIndex
    * @param iTtEta0 c eta index of TT
    * @param std CMSSW TT eta index
    */
-  int cIndex2iTtEta(int iTtEta0) const {
-    return (iTtEta0 < 28) ? (iTtEta0 - 28) : (iTtEta0 - 27);
-  }
+  int cIndex2iTtEta(int iTtEta0) const { return (iTtEta0 < 28) ? (iTtEta0 - 28) : (iTtEta0 - 27); }
 
   /** Converse of iTtPhi2cIndex
    * @param iTtPhi0 phi index of TT
@@ -266,8 +262,7 @@ private:
    * @param [out] iEta0 eta c index of the channel
    * @param [out] iPhi0 eta c index of the channel
    */
-  void elec2GeomNum(int ittEta0, int ittPhi0, int strip1, int ch1, int &iEta0,
-                    int &iPhi0) const;
+  void elec2GeomNum(int ittEta0, int ittPhi0, int strip1, int ch1, int &iEta0, int &iPhi0) const;
 
   /* Set horizontal parity of a 16-bit word of FE data
    * @param a the word whose parity must be set.
@@ -280,8 +275,7 @@ private:
    * @param iEvent event index
    * @param adcCount the payload, the ADC count of the channels.
    */
-  void genFeData(std::string basename, int iEvent,
-                 const std::vector<uint16_t> adcCount[nEbEta][nEbPhi]) const;
+  void genFeData(std::string basename, int iEvent, const std::vector<uint16_t> adcCount[nEbEta][nEbPhi]) const;
 
   /** Generates FE trigger primitives data
    * @param basename base for the output file name. DCC number is appended to
@@ -289,8 +283,7 @@ private:
    * @param iEvent event index
    * @param tps the payload, the trigger primitives
    */
-  void genTccIn(std::string basename, int iEvent,
-                const int tps[nTtEta][nTtPhi]) const;
+  void genTccIn(std::string basename, int iEvent, const int tps[nTtEta][nTtPhi]) const;
 
   /** Generates TCC->DCC data
    * @param basename base for the output file name. DCC number is appended to
@@ -298,15 +291,13 @@ private:
    * @param iEvent event index
    * @param tps the payload, the trigger primitives
    */
-  void genTccOut(std::string basename, int iEvent,
-                 const int tps[nTtEta][nTtPhi]) const;
+  void genTccOut(std::string basename, int iEvent, const int tps[nTtEta][nTtPhi]) const;
 
   /** Retrieves barrel digis (APD ADC count).
    * @param event CMS event
    * @param adc [out] the adc counts: adc[iEta0][iPhi0][iTimeSample0]
    */
-  void getEbDigi(const edm::Event &event,
-                 std::vector<uint16_t> adc[nEbEta][nEbPhi]) const;
+  void getEbDigi(const edm::Event &event, std::vector<uint16_t> adc[nEbEta][nEbPhi]) const;
 
   /** Extracts the trigger primitive (TP). The collection name
    * parameter permits to select either the TCP Fenix output
@@ -316,8 +307,7 @@ private:
    * @param collName label of the EDM collection containing the TP.
    * @param tp [out] the trigger primitives
    */
-  void getTp(const edm::Event &event, const std::string &collName,
-             int tp[nTtEta][nTtPhi]) const;
+  void getTp(const edm::Event &event, const std::string &collName, int tp[nTtEta][nTtPhi]) const;
 
   /** Help function to get the file extension which depends on the output
    * formats.
@@ -333,16 +323,14 @@ private:
    * @param hpar if true the horizontal odd word parity is set before writing
    * the word into the file.
    */
-  void fwrite(std::ofstream &f, uint16_t data, int &iword,
-              bool hpar = true) const;
+  void fwrite(std::ofstream &f, uint16_t data, int &iword, bool hpar = true) const;
 
   /** Computes the selective readout flags.
    * @param [in] event CMS event
    * @param [out] ebSrf the computed SR flags for barrel
    * @param [out] eeSrf the computed SR flags for endcaps
    */
-  void getSrfs(const edm::Event &event, int ebSrf[nTtEta][nTtPhi],
-               int eeSrf[nEndcaps][nScX][nScY]) const;
+  void getSrfs(const edm::Event &event, int ebSrf[nTtEta][nTtPhi], int eeSrf[nEndcaps][nScX][nScY]) const;
 
   /** Generates SR flags
    * @param basename base for the output file name. DCC number is appended to
@@ -350,8 +338,7 @@ private:
    * @param iEvent event index
    * @param the trigger tower flags
    */
-  void genSrData(std::string basename, int iEvent,
-                 int ttf[nEbTtEta][nTtPhi]) const;
+  void genSrData(std::string basename, int iEvent, int ttf[nEbTtEta][nTtPhi]) const;
 
 private:
   /** Name of module/plugin/producer making digis

--- a/SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimpleProducer.h
+++ b/SimCalorimetry/EcalElectronicsEmulation/interface/EcalSimpleProducer.h
@@ -36,7 +36,6 @@
  *
  */
 class EcalSimpleProducer : public edm::one::EDProducer<> {
-
   // constructor(s) and destructor(s)
 public:
   /** Constructs an EcalSimpleProducer
@@ -68,17 +67,14 @@ private:
    * @param pattern to replace.
    * @param string to substitute to the pattern
    */
-  void replaceAll(std::string &s, const std::string &from,
-                  const std::string &to) const;
+  void replaceAll(std::string &s, const std::string &from, const std::string &to) const;
 
   /** Converts c-array index (contiguous integer starting from 0) to
    * std CMSSW ECAL crystal eta index.
    * @param iEta0 c-array index. '0' postfix reminds the index starts from 0
    * @return std CMSSW ECAL crystal index.
    */
-  int cIndex2iEta(int iEta0) const {
-    return (iEta0 < 85) ? iEta0 - 85 : iEta0 - 84;
-  }
+  int cIndex2iEta(int iEta0) const { return (iEta0 < 85) ? iEta0 - 85 : iEta0 - 84; }
 
   /** Converts c-array index (contiguous integer starting from 0) to
    * std CMSSW ECAL crystal phi index.
@@ -92,9 +88,7 @@ private:
    * @param iEta0 c-array index. '0' postfix reminds the index starts from 0
    * @return std CMSSW ECAL trigger tower index.
    */
-  int cIndex2iTtEta(int iEta0) const {
-    return (iEta0 < 28) ? iEta0 - 28 : iEta0 - 27;
-  }
+  int cIndex2iTtEta(int iEta0) const { return (iEta0 < 28) ? iEta0 - 28 : iEta0 - 27; }
 
   /** Converts c-array index (contiguous integer starting from 0) to
    * std CMSSW ECAL trigger tower phi index.

--- a/SimCalorimetry/EcalElectronicsEmulation/interface/TCCinput.h
+++ b/SimCalorimetry/EcalElectronicsEmulation/interface/TCCinput.h
@@ -10,26 +10,23 @@
 #include <iostream>
 
 struct TCCinput {
-
-  int tower; // tower number in SM
+  int tower;  // tower number in SM
   int bunchCrossing;
-  unsigned input; // 11 bit value input (10 energy, 1 fg)
+  unsigned input;  // 11 bit value input (10 energy, 1 fg)
 
-  TCCinput(int tt = 0, int bx = 0, unsigned val = 0x0)
-      : tower(tt), bunchCrossing(bx), input(val) {
+  TCCinput(int tt = 0, int bx = 0, unsigned val = 0x0) : tower(tt), bunchCrossing(bx), input(val) {
     if (input > 0x7ff) {
-      std::cout << "[TCCinput] saturated value 0x" << std::hex << input
-                << std::dec << std::endl;
+      std::cout << "[TCCinput] saturated value 0x" << std::hex << input << std::dec << std::endl;
       input &= 0x7ff;
     }
   };
 
   int get_energy() const {
-    return input & 0x3ff; // get bits 9:0
+    return input & 0x3ff;  // get bits 9:0
   }
 
   int get_fg() const {
-    return input & 0x400; // get bit number 10
+    return input & 0x400;  // get bit number 10
   }
 
   bool is_current(int n) const { return (n == bunchCrossing); }
@@ -41,14 +38,11 @@ struct TCCinput {
 
 inline std::ostream &TCCinput::operator<<(std::ostream &os) {
   os << " tcc input "
-     << " bx:" << bunchCrossing << " tt:" << tower << " raw:0x" << std::hex
-     << input << std::dec << " fg:" << this->get_fg()
-     << " energy:" << this->get_energy() << std::endl;
+     << " bx:" << bunchCrossing << " tt:" << tower << " raw:0x" << std::hex << input << std::dec
+     << " fg:" << this->get_fg() << " energy:" << this->get_energy() << std::endl;
   return os;
 }
 
-inline bool TCCinput::operator<(const TCCinput &k) const {
-  return (bunchCrossing < k.bunchCrossing);
-}
+inline bool TCCinput::operator<(const TCCinput &k) const { return (bunchCrossing < k.bunchCrossing); }
 
 #endif

--- a/SimCalorimetry/EcalElectronicsEmulation/src/EcalFEtoDigi.cc
+++ b/SimCalorimetry/EcalElectronicsEmulation/src/EcalFEtoDigi.cc
@@ -5,12 +5,10 @@
 #include "SimCalorimetry/EcalElectronicsEmulation/interface/EcalFEtoDigi.h"
 
 EcalFEtoDigi::EcalFEtoDigi(const edm::ParameterSet &iConfig) {
-  basename_ =
-      iConfig.getUntrackedParameter<std::string>("FlatBaseName", "ecal_tcc_");
+  basename_ = iConfig.getUntrackedParameter<std::string>("FlatBaseName", "ecal_tcc_");
   sm_ = iConfig.getUntrackedParameter<int>("SuperModuleId", -1);
   fileEventOffset_ = iConfig.getUntrackedParameter<int>("FileEventOffset", 0);
-  useIdentityLUT_ =
-      iConfig.getUntrackedParameter<bool>("UseIdentityLUT", false);
+  useIdentityLUT_ = iConfig.getUntrackedParameter<bool>("UseIdentityLUT", false);
   debug_ = iConfig.getUntrackedParameter<bool>("debugPrintFlag", false);
 
   singlefile = (sm_ == -1) ? false : true;
@@ -21,7 +19,6 @@ EcalFEtoDigi::EcalFEtoDigi(const edm::ParameterSet &iConfig) {
 
 /// method called to produce the data
 void EcalFEtoDigi::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
-
   /// event counter
   static int current_bx = -1;
   current_bx++;
@@ -30,31 +27,25 @@ void EcalFEtoDigi::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // readInput();
 
   if (debug_)
-    std::cout << "[EcalFEtoDigi::produce] producing event " << current_bx
-              << std::endl;
+    std::cout << "[EcalFEtoDigi::produce] producing event " << current_bx << std::endl;
 
-  std::unique_ptr<EcalTrigPrimDigiCollection> e_tpdigis(
-      new EcalTrigPrimDigiCollection);
-  std::unique_ptr<EcalTrigPrimDigiCollection> e_tpdigisTcp(
-      new EcalTrigPrimDigiCollection);
+  std::unique_ptr<EcalTrigPrimDigiCollection> e_tpdigis(new EcalTrigPrimDigiCollection);
+  std::unique_ptr<EcalTrigPrimDigiCollection> e_tpdigisTcp(new EcalTrigPrimDigiCollection);
 
   std::vector<TCCinput>::const_iterator it;
 
   for (int i = 0; i < N_SM; i++) {
-
     if (!singlefile)
       sm_ = i + 1;
 
     for (it = inputdata_[i].begin(); it != inputdata_[i].end(); it++) {
-
       if (!(*it).is_current(current_bx + fileEventOffset_))
         continue;
       else if (debug_ && (*it).input != 0)
         std::cout << "[EcalFEtoDigi] "
-                  << "\tsupermodule:" << sm_ << "\tevent: " << current_bx
-                  << "\tbx: " << (*it).bunchCrossing << "\tvalue:0x"
-                  << std::setfill('0') << std::setw(4) << std::hex
-                  << (*it).input << std::setfill(' ') << std::dec << std::endl;
+                  << "\tsupermodule:" << sm_ << "\tevent: " << current_bx << "\tbx: " << (*it).bunchCrossing
+                  << "\tvalue:0x" << std::setfill('0') << std::setw(4) << std::hex << (*it).input << std::setfill(' ')
+                  << std::dec << std::endl;
 
       /// create EcalTrigTowerDetId
       const EcalTrigTowerDetId e_id = create_TTDetId(*it);
@@ -73,36 +64,30 @@ void EcalFEtoDigi::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
       EcalTriggerPrimitiveSample e_sampleTcp = create_TPSampleTcp(*it, iSetup);
 
       /// set sample
-      e_digi->setSize(1); // set sampleOfInterest to 0
+      e_digi->setSize(1);  // set sampleOfInterest to 0
       e_digi->setSample(0, e_sample);
 
       /// add to EcalTrigPrimDigiCollection
       e_tpdigis->push_back(*e_digi);
 
       /// set sample (uncompressed format)
-      e_digiTcp->setSize(1); // set sampleOfInterest to 0
+      e_digiTcp->setSize(1);  // set sampleOfInterest to 0
       e_digiTcp->setSample(0, e_sampleTcp);
 
       /// add to EcalTrigPrimDigiCollection (uncompressed format)
       e_tpdigisTcp->push_back(*e_digiTcp);
 
       if (debug_)
-        outfile << (*it).tower << '\t' << (*it).bunchCrossing << '\t'
-                << std::setfill('0') << std::hex << "0x" << std::setw(4)
-                << (*it).input << '\t' << "0" << std::dec << std::setfill(' ')
-                << std::endl;
+        outfile << (*it).tower << '\t' << (*it).bunchCrossing << '\t' << std::setfill('0') << std::hex << "0x"
+                << std::setw(4) << (*it).input << '\t' << "0" << std::dec << std::setfill(' ') << std::endl;
 
       /// print & debug
       if (debug_ && (*it).input != 0)
-        std::cout << "[EcalFEtoDigi] debug id: " << e_digi->id() << "\n\t"
-                  << std::dec << "\tieta: " << e_digi->id().ieta()
-                  << "\tiphi: " << e_digi->id().iphi()
-                  << "\tsize: " << e_digi->size()
-                  << "\tfg: " << (e_digi->fineGrain() ? 1 : 0) << std::hex
-                  << "\tEt: 0x" << e_digi->compressedEt() << " (0x"
-                  << (*it).get_energy() << ")"
-                  << "\tttflag: 0x" << e_digi->ttFlag() << std::dec
-                  << std::endl;
+        std::cout << "[EcalFEtoDigi] debug id: " << e_digi->id() << "\n\t" << std::dec
+                  << "\tieta: " << e_digi->id().ieta() << "\tiphi: " << e_digi->id().iphi()
+                  << "\tsize: " << e_digi->size() << "\tfg: " << (e_digi->fineGrain() ? 1 : 0) << std::hex << "\tEt: 0x"
+                  << e_digi->compressedEt() << " (0x" << (*it).get_energy() << ")"
+                  << "\tttflag: 0x" << e_digi->ttFlag() << std::dec << std::endl;
 
       delete e_digi;
       delete e_digiTcp;
@@ -125,7 +110,6 @@ void EcalFEtoDigi::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
 
 /// open and read in input (flat) data file
 void EcalFEtoDigi::readInput() {
-
   if (debug_)
     std::cout << "\n[EcalFEtoDigi::readInput] Reading input data\n";
 
@@ -138,7 +122,6 @@ void EcalFEtoDigi::readInput() {
   int tcc;
 
   for (int i = 0; i < N_SM; i++) {
-
     tcc = (sm_ == -1) ? SMidToTCCid(i + 1) : SMidToTCCid(sm_);
 
     s.str("");
@@ -178,8 +161,7 @@ void EcalFEtoDigi::readInput() {
       inputdata_[i].push_back(ttdata);
 
       if (debug_ && val != 0)
-        printf("\treading tower:%d  bx:%d input:0x%x dummy:%2d\n", tt, bx, val,
-               dummy);
+        printf("\treading tower:%d  bx:%d input:0x%x dummy:%2d\n", tt, bx, val, dummy);
     }
 
     f.close();
@@ -196,7 +178,6 @@ void EcalFEtoDigi::readInput() {
 
 /// create EcalTrigTowerDetId from input data (line)
 EcalTrigTowerDetId EcalFEtoDigi::create_TTDetId(TCCinput data) {
-
   // (EcalBarrel only)
   static const int kTowersInPhi = 4;
 
@@ -210,8 +191,7 @@ EcalTrigTowerDetId EcalFEtoDigi::create_TTDetId(TCCinput data) {
   if (zside < 0)
     phiTT = (SMid - 19) * kTowersInPhi + jtower % kTowersInPhi;
   else
-    phiTT =
-        (SMid - 1) * kTowersInPhi + kTowersInPhi - (jtower % kTowersInPhi) - 1;
+    phiTT = (SMid - 1) * kTowersInPhi + kTowersInPhi - (jtower % kTowersInPhi) - 1;
 
   phiTT++;
   // needed as phi=0 (iphi=1) is at middle of lower SMs (1 and 19), need shift
@@ -222,9 +202,13 @@ EcalTrigTowerDetId EcalFEtoDigi::create_TTDetId(TCCinput data) {
 
   /// construct the EcalTrigTowerDetId object
   if (debug_ && data.get_energy() != 0)
-    printf("[EcalFEtoDigi] Creating EcalTrigTowerDetId "
-           "(SMid,itt)=(%d,%d)->(eta,phi)=(%d,%d) \n",
-           SMid, iTT, etaTT, phiTT);
+    printf(
+        "[EcalFEtoDigi] Creating EcalTrigTowerDetId "
+        "(SMid,itt)=(%d,%d)->(eta,phi)=(%d,%d) \n",
+        SMid,
+        iTT,
+        etaTT,
+        phiTT);
 
   EcalTrigTowerDetId e_id(zside, EcalBarrel, etaTT, phiTT, 0);
 
@@ -232,9 +216,7 @@ EcalTrigTowerDetId EcalFEtoDigi::create_TTDetId(TCCinput data) {
 }
 
 /// create EcalTriggerPrimitiveSample from input data (line)
-EcalTriggerPrimitiveSample
-EcalFEtoDigi::create_TPSample(TCCinput data, const edm::EventSetup &evtSetup) {
-
+EcalTriggerPrimitiveSample EcalFEtoDigi::create_TPSample(TCCinput data, const edm::EventSetup &evtSetup) {
   int tower = create_TTDetId(data).rawId();
   int Et = data.get_energy();
   bool tt_fg = data.get_fg();
@@ -248,7 +230,7 @@ EcalFEtoDigi::create_TPSample(TCCinput data, const edm::EventSetup &evtSetup) {
     getLUT(lut_, tower, evtSetup);
   else
     for (int i = 0; i < 1024; i++)
-      lut_[i] = i; // identity lut!
+      lut_[i] = i;  // identity lut!
 
   /// compress energy 10 -> 8  bit
   int lut_out = lut_[Et];
@@ -257,9 +239,14 @@ EcalFEtoDigi::create_TPSample(TCCinput data, const edm::EventSetup &evtSetup) {
 
   /// crate sample
   if (debug_ && data.get_energy() != 0)
-    printf("[EcalFEtoDigi] Creating sample; input:0x%X (Et:0x%x) cEt:0x%x "
-           "fg:%d ttflag:0x%x \n",
-           data.input, Et, cEt, tt_fg, ttFlag);
+    printf(
+        "[EcalFEtoDigi] Creating sample; input:0x%X (Et:0x%x) cEt:0x%x "
+        "fg:%d ttflag:0x%x \n",
+        data.input,
+        Et,
+        cEt,
+        tt_fg,
+        ttFlag);
 
   EcalTriggerPrimitiveSample e_sample(cEt, tt_fg, ttFlag);
 
@@ -267,10 +254,7 @@ EcalFEtoDigi::create_TPSample(TCCinput data, const edm::EventSetup &evtSetup) {
 }
 
 /// create EcalTriggerPrimitiveSample in tcp format (uncomrpessed energy)
-EcalTriggerPrimitiveSample
-EcalFEtoDigi::create_TPSampleTcp(TCCinput data,
-                                 const edm::EventSetup &evtSetup) {
-
+EcalTriggerPrimitiveSample EcalFEtoDigi::create_TPSampleTcp(TCCinput data, const edm::EventSetup &evtSetup) {
   int tower = create_TTDetId(data).rawId();
   int Et = data.get_energy();
   bool tt_fg = data.get_fg();
@@ -281,7 +265,7 @@ EcalFEtoDigi::create_TPSampleTcp(TCCinput data,
     getLUT(lut_, tower, evtSetup);
   else
     for (int i = 0; i < 1024; i++)
-      lut_[i] = i; // identity lut!
+      lut_[i] = i;  // identity lut!
 
   int lut_out = lut_[Et];
   int ttFlag = (lut_out & 0x700) >> 8;
@@ -294,12 +278,10 @@ EcalFEtoDigi::create_TPSampleTcp(TCCinput data,
 
 /// method called once each job just before starting event loop
 void EcalFEtoDigi::beginJob() {
-
   /// check SM numbering convetion: 1-38
   /// [or -1 flag to indicate all sm's are to be read in]
   if (sm_ != -1 && (sm_ < 1 || sm_ > 36))
-    throw cms::Exception("EcalFEtoDigiInvalidDetId")
-        << "EcalFEtoDigi: Adapt SM numbering convention.\n";
+    throw cms::Exception("EcalFEtoDigiInvalidDetId") << "EcalFEtoDigi: Adapt SM numbering convention.\n";
 
   /// debug: open file for recreating input copy
   if (debug_)
@@ -315,18 +297,13 @@ void EcalFEtoDigi::endJob() {
 }
 
 /// translate input supermodule id into TCC id (barrel)
-int EcalFEtoDigi::SMidToTCCid(const int smid) const {
-
-  return (smid <= 18) ? smid + 55 - 1 : smid + 37 - 19;
-}
+int EcalFEtoDigi::SMidToTCCid(const int smid) const { return (smid <= 18) ? smid + 55 - 1 : smid + 37 - 19; }
 
 /// return the LUT from eventSetup
-void EcalFEtoDigi::getLUT(unsigned int *lut, const int towerId,
-                          const edm::EventSetup &evtSetup) const {
+void EcalFEtoDigi::getLUT(unsigned int *lut, const int towerId, const edm::EventSetup &evtSetup) const {
   edm::ESHandle<EcalTPGLutGroup> lutGrpHandle;
   evtSetup.get<EcalTPGLutGroupRcd>().get(lutGrpHandle);
-  const EcalTPGGroups::EcalTPGGroupsMap &lutGrpMap =
-      lutGrpHandle.product()->getMap();
+  const EcalTPGGroups::EcalTPGGroupsMap &lutGrpMap = lutGrpHandle.product()->getMap();
   EcalTPGGroups::EcalTPGGroupsMapItr itgrp = lutGrpMap.find(towerId);
   uint32_t lutGrp = 999;
   if (itgrp != lutGrpMap.end())
@@ -334,8 +311,7 @@ void EcalFEtoDigi::getLUT(unsigned int *lut, const int towerId,
 
   edm::ESHandle<EcalTPGLutIdMap> lutMapHandle;
   evtSetup.get<EcalTPGLutIdMapRcd>().get(lutMapHandle);
-  const EcalTPGLutIdMap::EcalTPGLutMap &lutMap =
-      lutMapHandle.product()->getMap();
+  const EcalTPGLutIdMap::EcalTPGLutMap &lutMap = lutMapHandle.product()->getMap();
   EcalTPGLutIdMap::EcalTPGLutMapItr itLut = lutMap.find(lutGrp);
   if (itLut != lutMap.end()) {
     const unsigned int *theLut = (itLut->second).getLut();

--- a/SimCalorimetry/EcalElectronicsEmulation/src/EcalSimRawData.cc
+++ b/SimCalorimetry/EcalElectronicsEmulation/src/EcalSimRawData.cc
@@ -11,7 +11,7 @@
 #include "DataFormats/EcalDigi/interface/EcalMGPASample.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include <cmath>
-#include <fstream> //used for debugging
+#include <fstream>  //used for debugging
 #include <iomanip>
 #include <iostream>
 
@@ -19,8 +19,8 @@ using namespace std;
 using namespace edm;
 
 const int EcalSimRawData::ttType[nEbTtEta] = {
-    0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, // EE-
-    0, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1  // EE+
+    0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1,  // EE-
+    0, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1   // EE+
 };
 
 const int EcalSimRawData::stripCh2Phi[nTtTypes][ttEdge][ttEdge] = {
@@ -32,15 +32,11 @@ const int EcalSimRawData::stripCh2Phi[nTtTypes][ttEdge][ttEdge] = {
      {0, 1, 2, 3, 4},  /*|*/
      {4, 3, 2, 1, 0}}, /*V*/
     // TT type 1:
-    {{0, 1, 2, 3, 4},
-     {4, 3, 2, 1, 0},
-     {0, 1, 2, 3, 4},
-     {4, 3, 2, 1, 0},
-     {0, 1, 2, 3, 4}}};
+    {{0, 1, 2, 3, 4}, {4, 3, 2, 1, 0}, {0, 1, 2, 3, 4}, {4, 3, 2, 1, 0}, {0, 1, 2, 3, 4}}};
 
 const int EcalSimRawData::strip2Eta[nTtTypes][ttEdge] = {
-    {4, 3, 2, 1, 0}, // TT type 0
-    {0, 1, 2, 3, 4}  // TT type 1
+    {4, 3, 2, 1, 0},  // TT type 0
+    {0, 1, 2, 3, 4}   // TT type 1
 };
 
 EcalSimRawData::EcalSimRawData(const edm::ParameterSet &params) {
@@ -51,8 +47,7 @@ EcalSimRawData::EcalSimRawData(const edm::ParameterSet &params) {
   srDigiProducer_ = params.getParameter<string>("srProducer");
   ebSrFlagCollection_ = params.getParameter<std::string>("EBSrFlagCollection");
   eeSrFlagCollection_ = params.getParameter<std::string>("EESrFlagCollection");
-  tpDigiCollection_ =
-      params.getParameter<std::string>("trigPrimDigiCollection");
+  tpDigiCollection_ = params.getParameter<std::string>("trigPrimDigiCollection");
   tcpDigiCollection_ = params.getParameter<std::string>("tcpDigiCollection");
   tpProducer_ = params.getParameter<string>("trigPrimProducer");
   xtalVerbose_ = params.getUntrackedParameter<bool>("xtalVerbose", false);
@@ -63,8 +58,7 @@ EcalSimRawData::EcalSimRawData(const edm::ParameterSet &params) {
   fe2tcc_ = params.getUntrackedParameter<bool>("fe2tccData", true);
   dccNum_ = params.getUntrackedParameter<int>("dccNum", -1);
   tccNum_ = params.getUntrackedParameter<int>("tccNum", -1);
-  tccInDefaultVal_ =
-      params.getUntrackedParameter<int>("tccInDefaultVal", 0xffff);
+  tccInDefaultVal_ = params.getUntrackedParameter<int>("tccInDefaultVal", 0xffff);
   basename_ = params.getUntrackedParameter<std::string>("outputBaseName");
 
   iEvent = 0;
@@ -80,8 +74,7 @@ EcalSimRawData::EcalSimRawData(const edm::ParameterSet &params) {
   }
 }
 
-void EcalSimRawData::analyze(const edm::Event &event,
-                             const edm::EventSetup &es) {
+void EcalSimRawData::analyze(const edm::Event &event, const edm::EventSetup &es) {
   // Event counter:
   ++iEvent;
 
@@ -121,8 +114,7 @@ void EcalSimRawData::analyze(const edm::Event &event,
   }
 }
 
-void EcalSimRawData::elec2GeomNum(int ittEta0, int ittPhi0, int strip1, int ch1,
-                                  int &iEta0, int &iPhi0) const {
+void EcalSimRawData::elec2GeomNum(int ittEta0, int ittPhi0, int strip1, int ch1, int &iEta0, int &iPhi0) const {
   assert(0 <= ittEta0 && ittEta0 < nEbTtEta);
   assert(0 <= ittPhi0 && ittPhi0 < nTtPhi);
   assert(1 <= strip1 && strip1 <= ttEdge);
@@ -134,51 +126,47 @@ void EcalSimRawData::elec2GeomNum(int ittEta0, int ittPhi0, int strip1, int ch1,
   assert(0 <= iPhi0 && iPhi0 < nEbPhi);
 }
 
-void EcalSimRawData::fwrite(ofstream &f, uint16_t data, int &iWord,
-                            bool hpar) const {
-
+void EcalSimRawData::fwrite(ofstream &f, uint16_t data, int &iWord, bool hpar) const {
   if (hpar) {
     // set horizontal odd parity bit:
     setHParity(data);
   }
 
   switch (writeMode_) {
-  case littleEndian: {
-    char c = data & 0x00FF;
-    f.write(&c, sizeof(c));
-    c = (data >> 8) & 0x00FF;
-    f.write(&c, sizeof(c));
-  } break;
-  case bigEndian: {
-    char c = (data >> 8) & 0x00FF;
-    f.write(&c, sizeof(c));
-    c = data & 0x00FF;
-    f.write(&c, sizeof(c));
-  } break;
-  case ascii:
-    f << ((iWord % 8 == 0 && iWord != 0) ? "\n" : "") << "0x" << setfill('0')
-      << setw(4) << hex << data << "\t" << dec << setfill(' ');
-    break;
+    case littleEndian: {
+      char c = data & 0x00FF;
+      f.write(&c, sizeof(c));
+      c = (data >> 8) & 0x00FF;
+      f.write(&c, sizeof(c));
+    } break;
+    case bigEndian: {
+      char c = (data >> 8) & 0x00FF;
+      f.write(&c, sizeof(c));
+      c = data & 0x00FF;
+      f.write(&c, sizeof(c));
+    } break;
+    case ascii:
+      f << ((iWord % 8 == 0 && iWord != 0) ? "\n" : "") << "0x" << setfill('0') << setw(4) << hex << data << "\t" << dec
+        << setfill(' ');
+      break;
   }
   ++iWord;
 }
 
 string EcalSimRawData::getExt() const {
   switch (writeMode_) {
-  case littleEndian:
-    return ".le";
-  case bigEndian:
-    return ".be";
-  case ascii:
-    return ".txt";
-  default:
-    return ".?";
+    case littleEndian:
+      return ".le";
+    case bigEndian:
+      return ".be";
+    case ascii:
+      return ".txt";
+    default:
+      return ".?";
   }
 }
 
-void EcalSimRawData::genFeData(
-    string basename, int iEvent,
-    const vector<uint16_t> adcCount[nEbEta][nEbPhi]) const {
+void EcalSimRawData::genFeData(string basename, int iEvent, const vector<uint16_t> adcCount[nEbEta][nEbPhi]) const {
   int smf = 0;
   int gmf = 0;
   int nPendingEvt = 0;
@@ -197,8 +185,7 @@ void EcalSimRawData::genFeData(
       stringstream s;
       s.str("");
       const string &ext = getExt();
-      s << basename << "_fe2dcc" << setfill('0') << setw(2) << iDcc1
-        << setfill(' ') << ext;
+      s << basename << "_fe2dcc" << setfill('0') << setw(2) << iDcc1 << setfill(' ') << ext;
       ofstream f(s.str().c_str(), (iEvent == 1 ? ios::ate : ios::app));
 
       if (f.fail())
@@ -212,22 +199,17 @@ void EcalSimRawData::genFeData(
         int iTtEta0 = iZ0 * nTtSmEta + iTtEtaInSm0;
         for (int iTtPhiInSm0 = 0; iTtPhiInSm0 < nTtSmPhi; ++iTtPhiInSm0) {
           // phi=0deg at middle of 1st barrel DCC:
-          int iTtPhi0 =
-              -nTtPhisPerEbDcc / 2 + iDccPhi0 * nTtPhisPerEbDcc + iTtPhiInSm0;
+          int iTtPhi0 = -nTtPhisPerEbDcc / 2 + iDccPhi0 * nTtPhisPerEbDcc + iTtPhiInSm0;
           if (iTtPhi0 < 0)
             iTtPhi0 += nTtPhi;
           for (int stripId1 = 1; stripId1 <= ttEdge; ++stripId1) {
-            uint16_t stripHeader = 0xF << 11 | (nPendingEvt & 0x3F) << 5 |
-                                   (gmf & 0x1) << 4 | (smf & 0x1) << 3 |
-                                   (stripId1 & 0x7);
+            uint16_t stripHeader =
+                0xF << 11 | (nPendingEvt & 0x3F) << 5 | (gmf & 0x1) << 4 | (smf & 0x1) << 3 | (stripId1 & 0x7);
             ///	    stripHeader |= parity(stripHeader) << 15;
             fwrite(f, stripHeader, iWord);
 
             for (int xtalId1 = 1; xtalId1 <= ttEdge; ++xtalId1) {
-
-              uint16_t crystalHeader = 1 << 14 | (chFrameLen & 0xFF) << 4 |
-                                       (monitorFlag & 0x1) << 3 |
-                                       (xtalId1 & 0x7);
+              uint16_t crystalHeader = 1 << 14 | (chFrameLen & 0xFF) << 4 | (monitorFlag & 0x1) << 3 | (xtalId1 & 0x7);
               //	      crystalHeader |=parity(crystalHeader) << 15;
               fwrite(f, crystalHeader, iWord);
 
@@ -242,8 +224,7 @@ void EcalSimRawData::genFeData(
                      << "xtalId1 = " << xtalId1 << "\t"
                      << "iEta0 = " << iEta0 << "\t"
                      << "iPhi0 = " << iPhi0 << "\t"
-                     << "adc[5] = 0x" << hex << adcCount[iEta0][iPhi0][5] << dec
-                     << "\n";
+                     << "adc[5] = 0x" << hex << adcCount[iEta0][iPhi0][5] << dec << "\n";
               }
 
               const vector<uint16_t> &adc = adcCount[iEta0][iPhi0];
@@ -251,17 +232,16 @@ void EcalSimRawData::genFeData(
                 uint16_t data = adc[iSample] & 0x3FFF;
                 //		data |= parity(data);
                 fwrite(f, data, iWord);
-              } // next time sample
-            }   // next crystal in strip
-          }     // next strip in TT
-        }       // next TT along phi
-      }         // next TT along eta
-    }           // next DCC
-  }             // next half-barrel
+              }  // next time sample
+            }    // next crystal in strip
+          }      // next strip in TT
+        }        // next TT along phi
+      }          // next TT along eta
+    }            // next DCC
+  }              // next half-barrel
 }
 
-void EcalSimRawData::genSrData(string basename, int iEvent,
-                               int srf[nEbTtEta][nTtPhi]) const {
+void EcalSimRawData::genSrData(string basename, int iEvent, int srf[nEbTtEta][nTtPhi]) const {
   for (int iZ0 = 0; iZ0 < 2; ++iZ0) {
     for (int iDccPhi0 = 0; iDccPhi0 < nDccInPhi; ++iDccPhi0) {
       int iDcc1 = iDccPhi0 + iZ0 * nDccInPhi + nDccEndcap + 1;
@@ -269,13 +249,11 @@ void EcalSimRawData::genSrData(string basename, int iEvent,
         continue;
       stringstream s;
       s.str("");
-      s << basename << "_ab2dcc" << setfill('0') << setw(2) << iDcc1
-        << setfill(' ') << getExt();
+      s << basename << "_ab2dcc" << setfill('0') << setw(2) << iDcc1 << setfill(' ') << getExt();
       ofstream f(s.str().c_str(), (iEvent == 1 ? ios::ate : ios::app));
 
       if (f.fail())
-        throw cms::Exception(string("Cannot create/open file ") + s.str() +
-                             ".");
+        throw cms::Exception(string("Cannot create/open file ") + s.str() + ".");
 
       int iWord = 0;
 
@@ -287,8 +265,7 @@ void EcalSimRawData::genSrData(string basename, int iEvent,
       const uint16_t le0 = 0;
       const uint16_t h1 = 1;
       const uint16_t nFlags = 68;
-      uint16_t data = (h1 & 0x1) << 14 | (le1 & 0x1) << 12 | (le0 & 0x1) << 11 |
-                      (nFlags & 0x7F);
+      uint16_t data = (h1 & 0x1) << 14 | (le1 & 0x1) << 12 | (le0 & 0x1) << 11 | (nFlags & 0x7F);
 
       fwrite(f, data, iWord, true);
 
@@ -300,8 +277,7 @@ void EcalSimRawData::genSrData(string basename, int iEvent,
         int iTtEta0 = nEeTtEta + iZ0 * nTtSmEta + iTtEtaInSm0;
         for (int iTtPhiInSm0 = 0; iTtPhiInSm0 < nTtSmPhi; ++iTtPhiInSm0) {
           // phi=0deg at middle of 1st barrel DCC:
-          int iTtPhi0 =
-              -nTtPhisPerEbDcc / 2 + iDccPhi0 * nTtPhisPerEbDcc + iTtPhiInSm0;
+          int iTtPhi0 = -nTtPhisPerEbDcc / 2 + iDccPhi0 * nTtPhisPerEbDcc + iTtPhiInSm0;
           if (iTtPhi0 < 0)
             iTtPhi0 += nTtPhi;
           // flags are packed by four:
@@ -322,14 +298,13 @@ void EcalSimRawData::genSrData(string basename, int iEvent,
             data = 0;
           }
           ++iFlag;
-        } // next TT along phi
-      }   // next TT along eta
-    }     // next DCC
-  }       // next half-barrel
+        }  // next TT along phi
+      }    // next TT along eta
+    }      // next DCC
+  }        // next half-barrel
 }
 
-void EcalSimRawData::genTccIn(string basename, int iEvent,
-                              const int tcp[nTtEta][nTtPhi]) const {
+void EcalSimRawData::genTccIn(string basename, int iEvent, const int tcp[nTtEta][nTtPhi]) const {
   for (int iZ0 = 0; iZ0 < 2; ++iZ0) {
     for (int iTccPhi0 = 0; iTccPhi0 < nTccInPhi; ++iTccPhi0) {
       int iTcc1 = iTccPhi0 + iZ0 * nTccInPhi + nTccEndcap + 1;
@@ -339,10 +314,9 @@ void EcalSimRawData::genTccIn(string basename, int iEvent,
 
       stringstream s;
       s.str("");
-      const char *ext = ".txt"; // only ascii mode supported for TCP
+      const char *ext = ".txt";  // only ascii mode supported for TCP
 
-      s << basename << "_tcc" << setfill('0') << setw(2) << iTcc1
-        << setfill(' ') << ext;
+      s << basename << "_tcc" << setfill('0') << setw(2) << iTcc1 << setfill(' ') << ext;
       ofstream fe2tcc(s.str().c_str(), (iEvent == 1 ? ios::ate : ios::app));
 
       if (fe2tcc.fail())
@@ -354,13 +328,11 @@ void EcalSimRawData::genTccIn(string basename, int iEvent,
         int iTtEta0 = (iZ0 == 0) ? 27 - iTtEtaInSm0 : 28 + iTtEtaInSm0;
         for (int iTtPhiInSm0 = 0; iTtPhiInSm0 < nTtSmPhi; ++iTtPhiInSm0) {
           // phi=0deg at middle of 1st barrel DCC:
-          int iTtPhi0 =
-              -nTtPhisPerEbTcc / 2 + iTccPhi0 * nTtPhisPerEbTcc + iTtPhiInSm0;
+          int iTtPhi0 = -nTtPhisPerEbTcc / 2 + iTccPhi0 * nTtPhisPerEbTcc + iTtPhiInSm0;
           iTtPhi0 += nTtPhisPerEbTcc * iTccPhi0;
           if (iTtPhi0 < 0)
             iTtPhi0 += nTtPhi;
-          uint16_t tp_fe2tcc = (tcp[iTtEta0][iTtPhi0] &
-                                0x7ff); // keep only Et (9:0) and FineGrain (10)
+          uint16_t tp_fe2tcc = (tcp[iTtEta0][iTtPhi0] & 0x7ff);  // keep only Et (9:0) and FineGrain (10)
 
           if (tpVerbose_ && tp_fe2tcc != 0) {
             cout << dec << "iTcc1 = " << iTcc1 << "\t"
@@ -368,23 +340,20 @@ void EcalSimRawData::genTccIn(string basename, int iEvent,
                  << "iTtPhi0 = " << iTtPhi0 << "\t"
                  << "iCh1 = " << iCh1 << "\t"
                  << "memPos = " << memPos << "\t"
-                 << "tp = 0x" << setfill('0') << hex << setw(3) << tp_fe2tcc
-                 << dec << setfill(' ') << "\n";
+                 << "tp = 0x" << setfill('0') << hex << setw(3) << tp_fe2tcc << dec << setfill(' ') << "\n";
           }
-          fe2tcc << iCh1 << "\t" << memPos << "\t" << setfill('0') << hex
-                 << "0x" << setw(4) << tp_fe2tcc << "\t"
+          fe2tcc << iCh1 << "\t" << memPos << "\t" << setfill('0') << hex << "0x" << setw(4) << tp_fe2tcc << "\t"
                  << "0" << dec << setfill(' ') << "\n";
           ++iCh1;
-        } // next TT along phi
-      }   // next TT along eta
+        }  // next TT along phi
+      }    // next TT along eta
       fe2tcc << std::flush;
       fe2tcc.close();
-    } // next TCC
-  }   // next half-barrel
+    }  // next TCC
+  }    // next half-barrel
 }
 
-void EcalSimRawData::genTccOut(string basename, int iEvent,
-                               const int tps[nTtEta][nTtPhi]) const {
+void EcalSimRawData::genTccOut(string basename, int iEvent, const int tps[nTtEta][nTtPhi]) const {
   int iDccWord = 0;
 
   for (int iZ0 = 0; iZ0 < 2; ++iZ0) {
@@ -396,14 +365,12 @@ void EcalSimRawData::genTccOut(string basename, int iEvent,
 
       stringstream s;
       s.str("");
-      const char *ext = ".txt"; // only ascii mode supported for TCP
+      const char *ext = ".txt";  // only ascii mode supported for TCP
 
-      s << basename << "_tcc" << setfill('0') << setw(2) << iTcc1
-        << setfill(' ') << ext;
+      s << basename << "_tcc" << setfill('0') << setw(2) << iTcc1 << setfill(' ') << ext;
 
       s.str("");
-      s << basename << "_tcc2dcc" << setfill('0') << setw(2) << iTcc1
-        << setfill(' ') << getExt();
+      s << basename << "_tcc2dcc" << setfill('0') << setw(2) << iTcc1 << setfill(' ') << getExt();
       ofstream dccF(s.str().c_str(), (iEvent == 1 ? ios::ate : ios::app));
 
       if (dccF.fail()) {
@@ -416,9 +383,8 @@ void EcalSimRawData::genTccOut(string basename, int iEvent,
       const uint16_t le0 = 0;
       const uint16_t nSamples = 1;
       const uint16_t nTts = 68;
-      const uint16_t data = (h1 & 0x1) << 14 | (le1 & 0x1) << 12 |
-                            (le0 & 0x1) << 11 | (nSamples & 0xF) << 7 |
-                            (nTts & 0x7F);
+      const uint16_t data =
+          (h1 & 0x1) << 14 | (le1 & 0x1) << 12 | (le0 & 0x1) << 11 | (nSamples & 0xF) << 7 | (nTts & 0x7F);
       dccF << (iEvent == 1 ? "" : "\n") << "[Event:" << iEvent << "]\n";
       fwrite(dccF, data, iDccWord, false);
 
@@ -428,8 +394,7 @@ void EcalSimRawData::genTccOut(string basename, int iEvent,
         int iTtEta0 = nEeTtEta + iZ0 * nTtSmEta + iTtEtaInSm0;
         for (int iTtPhiInSm0 = 0; iTtPhiInSm0 < nTtSmPhi; ++iTtPhiInSm0) {
           // phi=0deg at middle of 1st barrel DCC:
-          int iTtPhi0 =
-              -nTtPhisPerEbTcc / 2 + iTccPhi0 * nTtPhisPerEbTcc + iTtPhiInSm0;
+          int iTtPhi0 = -nTtPhisPerEbTcc / 2 + iTccPhi0 * nTtPhisPerEbTcc + iTtPhiInSm0;
           if (iTtPhi0 < 0)
             iTtPhi0 += nTtPhi;
 
@@ -443,10 +408,10 @@ void EcalSimRawData::genTccOut(string basename, int iEvent,
           }
           fwrite(dccF, tps[iTtEta0][iTtPhi0], iDccWord, false);
           ++iCh1;
-        } // next TT along phi
-      }   // next TT along eta
-    }     // next TCC
-  }       // next half-barrel
+        }  // next TT along phi
+      }    // next TT along eta
+    }      // next TCC
+  }        // next half-barrel
 }
 
 void EcalSimRawData::setHParity(uint16_t &a) const {
@@ -455,24 +420,21 @@ void EcalSimRawData::setHParity(uint16_t &a) const {
   // parity bit of numbers from 0x0 to 0xF:
   //                    0   1   2    3   4    5    6   7   8    9    A   B    C
   //                    D   E    F
-  const int p[16] = {even, odd,  odd,  even, odd,  even, even, odd,
-                     odd,  even, even, odd,  even, odd,  odd,  even};
+  const int p[16] = {even, odd, odd, even, odd, even, even, odd, odd, even, even, odd, even, odd, odd, even};
   // inverts parity bit (LSB) of 'a' in case of even parity:
-  a ^= p[a & 0xF] ^ p[(a >> 4) & 0xF] ^ p[(a >> 8) & 0xF] ^ p[a >> 12 & 0xF] ^
-       odd;
+  a ^= p[a & 0xF] ^ p[(a >> 4) & 0xF] ^ p[(a >> 8) & 0xF] ^ p[a >> 12 & 0xF] ^ odd;
 }
 
-void EcalSimRawData::getSrfs(const edm::Event &event, int ebSrf[nTtEta][nTtPhi],
+void EcalSimRawData::getSrfs(const edm::Event &event,
+                             int ebSrf[nTtEta][nTtPhi],
                              int eeSrf[nEndcaps][nScX][nScY]) const {
-
   // EE
   edm::Handle<EESrFlagCollection> hEeSrFlags;
   event.getByLabel(srDigiProducer_, eeSrFlagCollection_, hEeSrFlags);
   for (size_t i = 0; i < (nEndcaps * nScX * nScY); ((int *)eeSrf)[i++] = -1) {
   };
   if (hEeSrFlags.isValid()) {
-    for (EESrFlagCollection::const_iterator it = hEeSrFlags->begin();
-         it != hEeSrFlags->end(); ++it) {
+    for (EESrFlagCollection::const_iterator it = hEeSrFlags->begin(); it != hEeSrFlags->end(); ++it) {
       const EESrFlag &flag = *it;
       int iZ0 = flag.id().zside() > 0 ? 1 : 0;
       int iX0 = flag.id().ix() - 1;
@@ -483,10 +445,9 @@ void EcalSimRawData::getSrfs(const edm::Event &event, int ebSrf[nTtEta][nTtPhi],
       eeSrf[iZ0][iX0][iY0] = flag.value();
     }
   } else {
-    LogWarning("EcalSimRawData")
-        << "EE SR flag not found ("
-        << "Product label: " << srDigiProducer_
-        << "Producet instance: " << eeSrFlagCollection_ << ")";
+    LogWarning("EcalSimRawData") << "EE SR flag not found ("
+                                 << "Product label: " << srDigiProducer_ << "Producet instance: " << eeSrFlagCollection_
+                                 << ")";
   }
 
   // EB
@@ -495,14 +456,11 @@ void EcalSimRawData::getSrfs(const edm::Event &event, int ebSrf[nTtEta][nTtPhi],
   for (size_t i = 0; i < (nTtEta * nTtPhi); ((int *)ebSrf)[i++] = -1) {
   };
   if (hEbSrFlags.isValid()) {
-    for (EBSrFlagCollection::const_iterator it = hEbSrFlags->begin();
-         it != hEbSrFlags->end(); ++it) {
-
+    for (EBSrFlagCollection::const_iterator it = hEbSrFlags->begin(); it != hEbSrFlags->end(); ++it) {
       const EBSrFlag &flag = *it;
       int iEta = flag.id().ieta();
-      int iEta0 =
-          iEta + nTtEta / 2 - (iEta >= 0 ? 1 : 0); // 0->55 from eta=-3 to eta=3
-      int iEbEta0 = iEta0 - nEeTtEta; // 0->33 from eta=-1.48 to eta=1.48
+      int iEta0 = iEta + nTtEta / 2 - (iEta >= 0 ? 1 : 0);  // 0->55 from eta=-3 to eta=3
+      int iEbEta0 = iEta0 - nEeTtEta;                       // 0->33 from eta=-1.48 to eta=1.48
       int iPhi0 = flag.id().iphi() - 1;
 
       assert(iEbEta0 >= 0 && iEbEta0 < nEbTtEta);
@@ -511,22 +469,19 @@ void EcalSimRawData::getSrfs(const edm::Event &event, int ebSrf[nTtEta][nTtPhi],
       ebSrf[iEbEta0][iPhi0] = flag.value();
     }
   } else {
-    LogWarning("EcalSimRawData")
-        << "EB SR flag not found ("
-        << "Product label: " << srDigiProducer_
-        << "Producet instance: " << ebSrFlagCollection_ << ")";
+    LogWarning("EcalSimRawData") << "EB SR flag not found ("
+                                 << "Product label: " << srDigiProducer_ << "Producet instance: " << ebSrFlagCollection_
+                                 << ")";
   }
 }
 
-void EcalSimRawData::getEbDigi(const edm::Event &event,
-                               vector<uint16_t> adc[nEbEta][nEbPhi]) const {
-
+void EcalSimRawData::getEbDigi(const edm::Event &event, vector<uint16_t> adc[nEbEta][nEbPhi]) const {
   edm::Handle<EBDigiCollection> hEbDigis;
   event.getByLabel(digiProducer_, ebDigiCollection_, hEbDigis);
 
   int nSamples = 0;
-  if (hEbDigis.isValid() && !hEbDigis->empty()) { // there is at least one digi
-    nSamples = hEbDigis->begin()->size(); // gets the sample count from 1st digi
+  if (hEbDigis.isValid() && !hEbDigis->empty()) {  // there is at least one digi
+    nSamples = hEbDigis->begin()->size();          // gets the sample count from 1st digi
   }
 
   const uint16_t suppressed = 0xFFFF;
@@ -541,8 +496,7 @@ void EcalSimRawData::getEbDigi(const edm::Event &event,
   if (hEbDigis.isValid()) {
     if (xtalVerbose_)
       cout << setfill('0');
-    for (EBDigiCollection::const_iterator it = hEbDigis->begin();
-         it != hEbDigis->end(); ++it) {
+    for (EBDigiCollection::const_iterator it = hEbDigis->begin(); it != hEbDigis->end(); ++it) {
       const EBDataFrame &frame = *it;
 
       int iEta0 = iEta2cIndex((frame.id()).ieta());
@@ -588,8 +542,7 @@ void EcalSimRawData::getEbDigi(const edm::Event &event,
   }
 }
 
-void EcalSimRawData::getTp(const edm::Event &event, const std::string &collName,
-                           int tcp[nTtEta][nTtPhi]) const {
+void EcalSimRawData::getTp(const edm::Event &event, const std::string &collName, int tcp[nTtEta][nTtPhi]) const {
   edm::Handle<EcalTrigPrimDigiCollection> hTpDigis;
   event.getByLabel(tpProducer_, collName, hTpDigis);
   if (hTpDigis.isValid() && !hTpDigis->empty()) {
@@ -604,8 +557,7 @@ void EcalSimRawData::getTp(const edm::Event &event, const std::string &collName,
     if (tpVerbose_) {
       cout << setfill('0');
     }
-    for (EcalTrigPrimDigiCollection::const_iterator it = tpDigis.begin();
-         it != tpDigis.end(); ++it) {
+    for (EcalTrigPrimDigiCollection::const_iterator it = tpDigis.begin(); it != tpDigis.end(); ++it) {
       const EcalTriggerPrimitiveDigi &tp = *it;
       int iTtEta0 = iTtEta2cIndex(tp.id().ieta());
       int iTtPhi0 = iTtPhi2cIndex(tp.id().iphi());
@@ -621,14 +573,12 @@ void EcalSimRawData::getTp(const edm::Event &event, const std::string &collName,
       tcp[iTtEta0][iTtPhi0] = tp[tp.sampleOfInterest()].raw();
 
       if (tpVerbose_) {
-        if (tcp[iTtEta0][iTtPhi0] != 0) // print non-zero values only
-          cout << collName << (collName.empty() ? "" : " ") << "TP(" << setw(2)
-               << iTtEta0 << "," << iTtPhi0 << ") = "
-               << "0x" << setw(4) << tcp[iTtEta0][iTtPhi0]
-               << "\tcmssw indices: " << tp.id().ieta() << " " << tp.id().iphi()
-               << "\n";
+        if (tcp[iTtEta0][iTtPhi0] != 0)  // print non-zero values only
+          cout << collName << (collName.empty() ? "" : " ") << "TP(" << setw(2) << iTtEta0 << "," << iTtPhi0 << ") = "
+               << "0x" << setw(4) << tcp[iTtEta0][iTtPhi0] << "\tcmssw indices: " << tp.id().ieta() << " "
+               << tp.id().iphi() << "\n";
       }
-    } // next TP
+    }  // next TP
     if (tpVerbose_)
       cout << setfill(' ');
   }

--- a/SimCalorimetry/EcalElectronicsEmulation/src/EcalSimpleProducer.cc
+++ b/SimCalorimetry/EcalElectronicsEmulation/src/EcalSimpleProducer.cc
@@ -31,8 +31,7 @@ void EcalSimpleProducer::produce(edm::Event &evt, const edm::EventSetup &) {
         DataFrame dframe(digis->back());
 
         for (int t = 0; t < nSamples; ++t) {
-          uint16_t encodedAdc =
-              (uint16_t)formula_->Eval(iEta0, iPhi0, ievt - 1, t);
+          uint16_t encodedAdc = (uint16_t)formula_->Eval(iEta0, iPhi0, ievt - 1, t);
           if (verbose_)
             cout << encodedAdc << ((t < (nSamples - 1)) ? "\t" : "\n");
           dframe[t] = encodedAdc;
@@ -44,8 +43,7 @@ void EcalSimpleProducer::produce(edm::Event &evt, const edm::EventSetup &) {
     evt.put(unique_ptr<EEDigiCollection>(new EEDigiCollection()));
   }
   if (tpFormula_.get() != nullptr) {
-    unique_ptr<EcalTrigPrimDigiCollection> tps =
-        unique_ptr<EcalTrigPrimDigiCollection>(new EcalTrigPrimDigiCollection);
+    unique_ptr<EcalTrigPrimDigiCollection> tps = unique_ptr<EcalTrigPrimDigiCollection>(new EcalTrigPrimDigiCollection);
     tps->reserve(56 * 72);
     const int nSamples = 5;
     for (int iTtEta0 = 0; iTtEta0 < 56; ++iTtEta0) {
@@ -56,20 +54,17 @@ void EcalSimpleProducer::produce(edm::Event &evt, const edm::EventSetup &) {
         if (verbose_)
           cout << "(" << iTtEta0 << "," << iTtPhi0 << "): ";
         int zside = iTtEta1 < 0 ? -1 : 1;
-        EcalTriggerPrimitiveDigi tpframe(
-            EcalTrigTowerDetId(zside, EcalTriggerTower, abs(iTtEta1), iTtPhi));
+        EcalTriggerPrimitiveDigi tpframe(EcalTrigTowerDetId(zside, EcalTriggerTower, abs(iTtEta1), iTtPhi));
 
         tpframe.setSize(nSamples);
 
         if (verbose_)
           cout << "TP: ";
         for (int t = 0; t < nSamples; ++t) {
-          uint16_t encodedTp =
-              (uint16_t)tpFormula_->Eval(iTtEta0, iTtPhi0, ievt - 1, t);
+          uint16_t encodedTp = (uint16_t)tpFormula_->Eval(iTtEta0, iTtPhi0, ievt - 1, t);
 
           if (verbose_)
-            cout << "TP(" << iTtEta0 << "," << iTtPhi0 << ") = " << encodedTp
-                 << ((t < (nSamples - 1)) ? "\t" : "\n");
+            cout << "TP(" << iTtEta0 << "," << iTtPhi0 << ") = " << encodedTp << ((t < (nSamples - 1)) ? "\t" : "\n");
           tpframe.setSample(t, EcalTriggerPrimitiveSample(encodedTp));
         }
         tps->push_back(tpframe);
@@ -77,9 +72,8 @@ void EcalSimpleProducer::produce(edm::Event &evt, const edm::EventSetup &) {
     }
     evt.put(std::move(tps));
   }
-  if (simHitFormula_.get() != nullptr) { // generation of barrel sim hits
-    unique_ptr<PCaloHitContainer> hits =
-        unique_ptr<PCaloHitContainer>(new PCaloHitContainer);
+  if (simHitFormula_.get() != nullptr) {  // generation of barrel sim hits
+    unique_ptr<PCaloHitContainer> hits = unique_ptr<PCaloHitContainer>(new PCaloHitContainer);
     for (int iEta0 = 0; iEta0 < 170; ++iEta0) {
       for (int iPhi0 = 0; iPhi0 < 360; ++iPhi0) {
         int iEta1 = cIndex2iEta(iEta0);
@@ -96,13 +90,11 @@ void EcalSimpleProducer::produce(edm::Event &evt, const edm::EventSetup &) {
     }
     evt.put(std::move(hits), "EcalHitsEB");
     // puts an empty digi collecion for endcap:
-    evt.put(unique_ptr<PCaloHitContainer>(new PCaloHitContainer()),
-            "EcalHitsEE");
+    evt.put(unique_ptr<PCaloHitContainer>(new PCaloHitContainer()), "EcalHitsEE");
   }
 }
 
-EcalSimpleProducer::EcalSimpleProducer(const edm::ParameterSet &pset)
-    : EDProducer() {
+EcalSimpleProducer::EcalSimpleProducer(const edm::ParameterSet &pset) : EDProducer() {
   string formula = pset.getParameter<string>("formula");
   string tpFormula = pset.getParameter<string>("tpFormula");
   string simHitFormula = pset.getParameter<string>("simHitFormula");
@@ -118,8 +110,7 @@ EcalSimpleProducer::EcalSimpleProducer(const edm::ParameterSet &pset)
   replaceAll(formula, "isample0", "t");
   //  cout << "----------> " << formula << endl;
 
-  replaceAll(tpFormula, "itt0",
-             "((ieta0<28)*(27-ieta0)+(ieta0>=28)*(ieta0-28))*4+(iphi0+2)%4");
+  replaceAll(tpFormula, "itt0", "((ieta0<28)*(27-ieta0)+(ieta0>=28)*(ieta0-28))*4+(iphi0+2)%4");
   replaceAll(tpFormula, "eb", "(ieta0>10 && ieta0<45)");
   replaceAll(tpFormula, "ebm", "(ieta0>10 && ieta0<28)");
   replaceAll(tpFormula, "ebp", "(ieta0>27 && ieta0<45)");
@@ -158,20 +149,19 @@ EcalSimpleProducer::EcalSimpleProducer(const edm::ParameterSet &pset)
     produces<EcalTrigPrimDigiCollection>();
   }
   if (!simHitFormula.empty()) {
-    simHitFormula_ =
-        unique_ptr<TFormula>(new TFormula("f", simHitFormula.c_str()));
+    simHitFormula_ = unique_ptr<TFormula>(new TFormula("f", simHitFormula.c_str()));
     Int_t err = simHitFormula_->Compile();
     if (err != 0) {
-      throw cms::Exception("Error in EcalSimpleProducer "
-                           "'simHitFormula' config.");
+      throw cms::Exception(
+          "Error in EcalSimpleProducer "
+          "'simHitFormula' config.");
     }
     produces<edm::PCaloHitContainer>("EcalHitsEB");
     produces<edm::PCaloHitContainer>("EcalHitsEE");
   }
 }
 
-void EcalSimpleProducer::replaceAll(std::string &s, const std::string &from,
-                                    const std::string &to) const {
+void EcalSimpleProducer::replaceAll(std::string &s, const std::string &from, const std::string &to) const {
   string::size_type pos = 0;
   //  cout << "replaceAll(" << s << "," << from << "," << to << ")\n";
   while ((pos = s.find(from, pos)) != string::npos) {

--- a/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
+++ b/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
@@ -41,33 +41,31 @@ class ESDigiCollection;
 class PileUpEventPrincipal;
 
 namespace edm {
-class ConsumesCollector;
-class ProducerBase;
-class Event;
-class EventSetup;
-template <typename T> class Handle;
-class ParameterSet;
-class StreamID;
-} // namespace edm
+  class ConsumesCollector;
+  class ProducerBase;
+  class Event;
+  class EventSetup;
+  template <typename T>
+  class Handle;
+  class ParameterSet;
+  class StreamID;
+}  // namespace edm
 
 namespace CLHEP {
-class HepRandomEngine;
+  class HepRandomEngine;
 }
 
 class EcalDigiProducer : public DigiAccumulatorMixMod {
 public:
-  EcalDigiProducer(const edm::ParameterSet &params, edm::ProducerBase &mixMod,
-                   edm::ConsumesCollector &iC);
+  EcalDigiProducer(const edm::ParameterSet &params, edm::ProducerBase &mixMod, edm::ConsumesCollector &iC);
   EcalDigiProducer(const edm::ParameterSet &params, edm::ConsumesCollector &iC);
   ~EcalDigiProducer() override;
 
   void initializeEvent(edm::Event const &e, edm::EventSetup const &c) override;
   void accumulate(edm::Event const &e, edm::EventSetup const &c) override;
-  void accumulate(PileUpEventPrincipal const &e, edm::EventSetup const &c,
-                  edm::StreamID const &) override;
+  void accumulate(PileUpEventPrincipal const &e, edm::EventSetup const &c, edm::StreamID const &) override;
   void finalizeEvent(edm::Event &e, edm::EventSetup const &c) override;
-  void beginLuminosityBlock(edm::LuminosityBlock const &lumi,
-                            edm::EventSetup const &setup) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const &lumi, edm::EventSetup const &setup) override;
   void beginRun(edm::Run const &run, edm::EventSetup const &setup) override;
 
   void setEBNoiseSignalGenerator(EcalBaseSignalGenerator *noiseGenerator);
@@ -81,19 +79,19 @@ private:
   typedef edm::Handle<std::vector<PCaloHit>> HitsHandle;
   void accumulateCaloHits(HitsHandle const &ebHandle,
                           HitsHandle const &eeHandle,
-                          HitsHandle const &esHandle, int bunchCrossing);
+                          HitsHandle const &esHandle,
+                          int bunchCrossing);
 
   void checkGeometry(const edm::EventSetup &eventSetup);
 
   void updateGeometry();
 
-  void checkCalibrations(const edm::Event &event,
-                         const edm::EventSetup &eventSetup);
+  void checkCalibrations(const edm::Event &event, const edm::EventSetup &eventSetup);
 
   APDShape m_APDShape;
   EBShape m_EBShape;
   EEShape m_EEShape;
-  ESShape m_ESShape; // no const because gain must be set
+  ESShape m_ESShape;  // no const because gain must be set
 
   const std::string m_EBdigiCollection;
   const std::string m_EEdigiCollection;
@@ -151,10 +149,8 @@ private:
 
   const CaloGeometry *m_Geometry;
 
-  std::array<std::unique_ptr<CorrelatedNoisifier<EcalCorrMatrix>>, 3>
-      m_EBCorrNoise;
-  std::array<std::unique_ptr<CorrelatedNoisifier<EcalCorrMatrix>>, 3>
-      m_EECorrNoise;
+  std::array<std::unique_ptr<CorrelatedNoisifier<EcalCorrMatrix>>, 3> m_EBCorrNoise;
+  std::array<std::unique_ptr<CorrelatedNoisifier<EcalCorrMatrix>>, 3> m_EECorrNoise;
 
   CLHEP::HepRandomEngine *randomEngine_ = nullptr;
 };

--- a/SimCalorimetry/EcalSimProducers/interface/EcalTimeDigiProducer.h
+++ b/SimCalorimetry/EcalSimProducers/interface/EcalTimeDigiProducer.h
@@ -22,28 +22,26 @@ class PileUpEventPrincipal;
 class EcalTimeMapDigitizer;
 
 namespace edm {
-class Event;
-class EventSetup;
-template <typename T> class Handle;
-class ParameterSet;
-} // namespace edm
+  class Event;
+  class EventSetup;
+  template <typename T>
+  class Handle;
+  class ParameterSet;
+}  // namespace edm
 
 class EcalTimeDigiProducer : public DigiAccumulatorMixMod {
 public:
-  EcalTimeDigiProducer(const edm::ParameterSet &params,
-                       edm::ProducerBase &mixMod, edm::ConsumesCollector &);
+  EcalTimeDigiProducer(const edm::ParameterSet &params, edm::ProducerBase &mixMod, edm::ConsumesCollector &);
   ~EcalTimeDigiProducer() override;
 
   void initializeEvent(edm::Event const &e, edm::EventSetup const &c) override;
   void accumulate(edm::Event const &e, edm::EventSetup const &c) override;
-  void accumulate(PileUpEventPrincipal const &e, edm::EventSetup const &c,
-                  edm::StreamID const &) override;
+  void accumulate(PileUpEventPrincipal const &e, edm::EventSetup const &c, edm::StreamID const &) override;
   void finalizeEvent(edm::Event &e, edm::EventSetup const &c) override;
 
 private:
   typedef edm::Handle<std::vector<PCaloHit>> HitsHandle;
-  void accumulateCaloHits(HitsHandle const &ebHandle,
-                          HitsHandle const &eeHandle, int bunchCrossing);
+  void accumulateCaloHits(HitsHandle const &ebHandle, HitsHandle const &eeHandle, int bunchCrossing);
 
   void checkGeometry(const edm::EventSetup &eventSetup);
 

--- a/SimCalorimetry/EcalSimProducers/plugins/PreMixingEcalWorker.cc
+++ b/SimCalorimetry/EcalSimProducers/plugins/PreMixingEcalWorker.cc
@@ -19,34 +19,27 @@
 
 class PreMixingEcalWorker : public PreMixingWorker {
 public:
-  PreMixingEcalWorker(const edm::ParameterSet &ps, edm::ProducerBase &producer,
-                      edm::ConsumesCollector &&iC);
+  PreMixingEcalWorker(const edm::ParameterSet &ps, edm::ProducerBase &producer, edm::ConsumesCollector &&iC);
   ~PreMixingEcalWorker() override = default;
 
   PreMixingEcalWorker(const PreMixingEcalWorker &) = delete;
   PreMixingEcalWorker &operator=(const PreMixingEcalWorker &) = delete;
 
-  void beginLuminosityBlock(edm::LuminosityBlock const &lumi,
-                            edm::EventSetup const &setup) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const &lumi, edm::EventSetup const &setup) override;
 
   void initializeEvent(edm::Event const &e, edm::EventSetup const &ES) override;
   void addSignals(edm::Event const &e, edm::EventSetup const &ES) override;
-  void addPileups(PileUpEventPrincipal const &pep,
-                  edm::EventSetup const &es) override;
-  void put(edm::Event &e, edm::EventSetup const &iSetup,
-           std::vector<PileupSummaryInfo> const &ps, int bs) override;
+  void addPileups(PileUpEventPrincipal const &pep, edm::EventSetup const &es) override;
+  void put(edm::Event &e, edm::EventSetup const &iSetup, std::vector<PileupSummaryInfo> const &ps, int bs) override;
 
 private:
-  edm::InputTag EBPileInputTag_; // InputTag for Pileup Digis collection
-  edm::InputTag EEPileInputTag_; // InputTag for Pileup Digis collection
-  edm::InputTag ESPileInputTag_; // InputTag for Pileup Digis collection
+  edm::InputTag EBPileInputTag_;  // InputTag for Pileup Digis collection
+  edm::InputTag EEPileInputTag_;  // InputTag for Pileup Digis collection
+  edm::InputTag ESPileInputTag_;  // InputTag for Pileup Digis collection
 
-  std::string
-      EBDigiCollectionDM_; // secondary name to be given to collection of digis
-  std::string
-      EEDigiCollectionDM_; // secondary name to be given to collection of digis
-  std::string
-      ESDigiCollectionDM_; // secondary name to be given to collection of digis
+  std::string EBDigiCollectionDM_;  // secondary name to be given to collection of digis
+  std::string EEDigiCollectionDM_;  // secondary name to be given to collection of digis
+  std::string ESDigiCollectionDM_;  // secondary name to be given to collection of digis
 
   edm::EDGetTokenT<EBDigitizerTraits::DigiCollection> tok_eb_;
   edm::EDGetTokenT<EEDigitizerTraits::DigiCollection> tok_ee_;
@@ -77,12 +70,9 @@ PreMixingEcalWorker::PreMixingEcalWorker(const edm::ParameterSet &ps,
       m_EEs25notCont(ps.getParameter<double>("EEs25notContainment")),
       m_peToABarrel(ps.getParameter<double>("photoelectronsToAnalogBarrel")),
       m_peToAEndcap(ps.getParameter<double>("photoelectronsToAnalogEndcap")),
-      theEBSignalGenerator(EBPileInputTag_, tok_eb_, m_EBs25notCont,
-                           m_EEs25notCont, m_peToABarrel, m_peToAEndcap),
-      theEESignalGenerator(EEPileInputTag_, tok_ee_, m_EBs25notCont,
-                           m_EEs25notCont, m_peToABarrel, m_peToAEndcap),
-      theESSignalGenerator(ESPileInputTag_, tok_es_, m_EBs25notCont,
-                           m_EEs25notCont, m_peToABarrel, m_peToAEndcap),
+      theEBSignalGenerator(EBPileInputTag_, tok_eb_, m_EBs25notCont, m_EEs25notCont, m_peToABarrel, m_peToAEndcap),
+      theEESignalGenerator(EEPileInputTag_, tok_ee_, m_EBs25notCont, m_EEs25notCont, m_peToABarrel, m_peToAEndcap),
+      theESSignalGenerator(ESPileInputTag_, tok_es_, m_EBs25notCont, m_EEs25notCont, m_peToABarrel, m_peToAEndcap),
       myEcalDigitizer_(ps, iC) {
   EBDigiCollectionDM_ = ps.getParameter<std::string>("EBDigiCollectionDM");
   EEDigiCollectionDM_ = ps.getParameter<std::string>("EEDigiCollectionDM");
@@ -97,22 +87,17 @@ PreMixingEcalWorker::PreMixingEcalWorker(const edm::ParameterSet &ps,
   myEcalDigitizer_.setESNoiseSignalGenerator(&theESSignalGenerator);
 }
 
-void PreMixingEcalWorker::initializeEvent(const edm::Event &e,
-                                          const edm::EventSetup &ES) {
+void PreMixingEcalWorker::initializeEvent(const edm::Event &e, const edm::EventSetup &ES) {
   myEcalDigitizer_.initializeEvent(e, ES);
 }
 
-void PreMixingEcalWorker::addSignals(const edm::Event &e,
-                                     const edm::EventSetup &ES) {
+void PreMixingEcalWorker::addSignals(const edm::Event &e, const edm::EventSetup &ES) {
   myEcalDigitizer_.accumulate(e, ES);
 }
 
-void PreMixingEcalWorker::addPileups(const PileUpEventPrincipal &pep,
-                                     const edm::EventSetup &ES) {
-
-  LogDebug("PreMixingEcalWorker")
-      << "\n===============> adding pileups from event  "
-      << pep.principal().id() << " for bunchcrossing " << pep.bunchCrossing();
+void PreMixingEcalWorker::addPileups(const PileUpEventPrincipal &pep, const edm::EventSetup &ES) {
+  LogDebug("PreMixingEcalWorker") << "\n===============> adding pileups from event  " << pep.principal().id()
+                                  << " for bunchcrossing " << pep.bunchCrossing();
 
   theEBSignalGenerator.initializeEvent(&pep.principal(), &ES);
   theEESignalGenerator.initializeEvent(&pep.principal(), &ES);
@@ -124,14 +109,14 @@ void PreMixingEcalWorker::addPileups(const PileUpEventPrincipal &pep,
   theESSignalGenerator.fill(pep.moduleCallingContext());
 }
 
-void PreMixingEcalWorker::put(edm::Event &e, const edm::EventSetup &ES,
+void PreMixingEcalWorker::put(edm::Event &e,
+                              const edm::EventSetup &ES,
                               std::vector<PileupSummaryInfo> const &ps,
                               int bs) {
   myEcalDigitizer_.finalizeEvent(e, ES);
 }
 
-void PreMixingEcalWorker::beginLuminosityBlock(edm::LuminosityBlock const &lumi,
-                                               edm::EventSetup const &setup) {
+void PreMixingEcalWorker::beginLuminosityBlock(edm::LuminosityBlock const &lumi, edm::EventSetup const &setup) {
   myEcalDigitizer_.beginLuminosityBlock(lumi, setup);
 }
 

--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -66,10 +66,12 @@ EcalDigiProducer::EcalDigiProducer(const edm::ParameterSet &params,
 }
 
 // version for Pre-Mixing, for use outside of MixingModule
-EcalDigiProducer::EcalDigiProducer(const edm::ParameterSet &params,
-                                   edm::ConsumesCollector &iC)
-    : DigiAccumulatorMixMod(), m_APDShape(true), m_EBShape(true),
-      m_EEShape(true), m_ESShape(),
+EcalDigiProducer::EcalDigiProducer(const edm::ParameterSet &params, edm::ConsumesCollector &iC)
+    : DigiAccumulatorMixMod(),
+      m_APDShape(true),
+      m_EBShape(true),
+      m_EEShape(true),
+      m_ESShape(),
       m_EBdigiCollection(params.getParameter<std::string>("EBdigiCollection")),
       m_EEdigiCollection(params.getParameter<std::string>("EEdigiCollection")),
       m_ESdigiCollection(params.getParameter<std::string>("ESdigiCollection")),
@@ -81,36 +83,38 @@ EcalDigiProducer::EcalDigiProducer(const edm::ParameterSet &params,
       m_EEs25notCont(params.getParameter<double>("EEs25notContainment")),
 
       m_readoutFrameSize(params.getParameter<int>("readoutFrameSize")),
-      m_ParameterMap(new EcalSimParameterMap(
-          params.getParameter<double>("simHitToPhotoelectronsBarrel"),
-          params.getParameter<double>("simHitToPhotoelectronsEndcap"),
-          params.getParameter<double>("photoelectronsToAnalogBarrel"),
-          params.getParameter<double>("photoelectronsToAnalogEndcap"),
-          params.getParameter<double>("samplingFactor"),
-          params.getParameter<double>("timePhase"), m_readoutFrameSize,
-          params.getParameter<int>("binOfMaximum"),
-          params.getParameter<bool>("doPhotostatistics"),
-          params.getParameter<bool>("syncPhase"))),
+      m_ParameterMap(new EcalSimParameterMap(params.getParameter<double>("simHitToPhotoelectronsBarrel"),
+                                             params.getParameter<double>("simHitToPhotoelectronsEndcap"),
+                                             params.getParameter<double>("photoelectronsToAnalogBarrel"),
+                                             params.getParameter<double>("photoelectronsToAnalogEndcap"),
+                                             params.getParameter<double>("samplingFactor"),
+                                             params.getParameter<double>("timePhase"),
+                                             m_readoutFrameSize,
+                                             params.getParameter<int>("binOfMaximum"),
+                                             params.getParameter<bool>("doPhotostatistics"),
+                                             params.getParameter<bool>("syncPhase"))),
 
       m_apdDigiTag(params.getParameter<std::string>("apdDigiTag")),
-      m_apdParameters(new APDSimParameters(
-          params.getParameter<bool>("apdAddToBarrel"), m_apdSeparateDigi,
-          params.getParameter<double>("apdSimToPELow"),
-          params.getParameter<double>("apdSimToPEHigh"),
-          params.getParameter<double>("apdTimeOffset"),
-          params.getParameter<double>("apdTimeOffWidth"),
-          params.getParameter<bool>("apdDoPEStats"), m_apdDigiTag,
-          params.getParameter<std::vector<double>>("apdNonlParms"))),
+      m_apdParameters(new APDSimParameters(params.getParameter<bool>("apdAddToBarrel"),
+                                           m_apdSeparateDigi,
+                                           params.getParameter<double>("apdSimToPELow"),
+                                           params.getParameter<double>("apdSimToPEHigh"),
+                                           params.getParameter<double>("apdTimeOffset"),
+                                           params.getParameter<double>("apdTimeOffWidth"),
+                                           params.getParameter<bool>("apdDoPEStats"),
+                                           m_apdDigiTag,
+                                           params.getParameter<std::vector<double>>("apdNonlParms"))),
 
-      m_APDResponse(!m_apdSeparateDigi
-                        ? nullptr
-                        : new EBHitResponse(m_ParameterMap.get(), &m_EBShape,
-                                            true, m_apdParameters.get(),
-                                            &m_APDShape)),
+      m_APDResponse(
+          !m_apdSeparateDigi
+              ? nullptr
+              : new EBHitResponse(m_ParameterMap.get(), &m_EBShape, true, m_apdParameters.get(), &m_APDShape)),
 
-      m_EBResponse(new EBHitResponse(m_ParameterMap.get(), &m_EBShape,
-                                     false, // barrel
-                                     m_apdParameters.get(), &m_APDShape)),
+      m_EBResponse(new EBHitResponse(m_ParameterMap.get(),
+                                     &m_EBShape,
+                                     false,  // barrel
+                                     m_apdParameters.get(),
+                                     &m_APDShape)),
 
       m_EEResponse(new EEHitResponse(m_ParameterMap.get(), &m_EEShape)),
       m_ESResponse(new ESHitResponse(m_ParameterMap.get(), &m_ESShape)),
@@ -126,26 +130,24 @@ EcalDigiProducer::EcalDigiProducer(const edm::ParameterSet &params,
       m_doEE(params.getParameter<bool>("doEE")),
       m_doES(params.getParameter<bool>("doES")),
 
-      m_ESElectronicsSim(m_doFastES ? nullptr
-                                    : new ESElectronicsSim(m_addESNoise)),
+      m_ESElectronicsSim(m_doFastES ? nullptr : new ESElectronicsSim(m_addESNoise)),
 
       m_ESOldDigitizer(m_doFastES ? nullptr
-                                  : new ESOldDigitizer(m_ESOldResponse.get(),
-                                                       m_ESElectronicsSim.get(),
-                                                       m_addESNoise)),
+                                  : new ESOldDigitizer(m_ESOldResponse.get(), m_ESElectronicsSim.get(), m_addESNoise)),
 
-      m_ESElectronicsSimFast(
-          !m_doFastES ? nullptr
-                      : new ESElectronicsSimFast(m_addESNoise, m_PreMix1)),
+      m_ESElectronicsSimFast(!m_doFastES ? nullptr : new ESElectronicsSimFast(m_addESNoise, m_PreMix1)),
 
       m_ESDigitizer(!m_doFastES ? nullptr
-                                : new ESDigitizer(m_ESResponse.get(),
-                                                  m_ESElectronicsSimFast.get(),
-                                                  m_addESNoise)),
+                                : new ESDigitizer(m_ESResponse.get(), m_ESElectronicsSimFast.get(), m_addESNoise)),
 
-      m_APDDigitizer(nullptr), m_BarrelDigitizer(nullptr),
-      m_EndcapDigitizer(nullptr), m_ElectronicsSim(nullptr), m_Coder(nullptr),
-      m_APDElectronicsSim(nullptr), m_APDCoder(nullptr), m_Geometry(nullptr),
+      m_APDDigitizer(nullptr),
+      m_BarrelDigitizer(nullptr),
+      m_EndcapDigitizer(nullptr),
+      m_ElectronicsSim(nullptr),
+      m_Coder(nullptr),
+      m_APDElectronicsSim(nullptr),
+      m_APDCoder(nullptr),
+      m_Geometry(nullptr),
       m_EBCorrNoise({{nullptr, nullptr, nullptr}}),
       m_EECorrNoise({{nullptr, nullptr, nullptr}}) {
   // "produces" statements taken care of elsewhere.
@@ -154,27 +156,18 @@ EcalDigiProducer::EcalDigiProducer(const edm::ParameterSet &params,
   // mixMod.produces<EEDigiCollection>(m_EEdigiCollection);
   // mixMod.produces<ESDigiCollection>(m_ESdigiCollection);
   if (m_doEB)
-    iC.consumes<std::vector<PCaloHit>>(
-        edm::InputTag(m_hitsProducerTag, "EcalHitsEB"));
+    iC.consumes<std::vector<PCaloHit>>(edm::InputTag(m_hitsProducerTag, "EcalHitsEB"));
   if (m_doEE)
-    iC.consumes<std::vector<PCaloHit>>(
-        edm::InputTag(m_hitsProducerTag, "EcalHitsEE"));
+    iC.consumes<std::vector<PCaloHit>>(edm::InputTag(m_hitsProducerTag, "EcalHitsEE"));
   if (m_doES)
-    iC.consumes<std::vector<PCaloHit>>(
-        edm::InputTag(m_hitsProducerTag, "EcalHitsES"));
+    iC.consumes<std::vector<PCaloHit>>(edm::InputTag(m_hitsProducerTag, "EcalHitsES"));
 
-  const std::vector<double> ebCorMatG12 =
-      params.getParameter<std::vector<double>>("EBCorrNoiseMatrixG12");
-  const std::vector<double> eeCorMatG12 =
-      params.getParameter<std::vector<double>>("EECorrNoiseMatrixG12");
-  const std::vector<double> ebCorMatG06 =
-      params.getParameter<std::vector<double>>("EBCorrNoiseMatrixG06");
-  const std::vector<double> eeCorMatG06 =
-      params.getParameter<std::vector<double>>("EECorrNoiseMatrixG06");
-  const std::vector<double> ebCorMatG01 =
-      params.getParameter<std::vector<double>>("EBCorrNoiseMatrixG01");
-  const std::vector<double> eeCorMatG01 =
-      params.getParameter<std::vector<double>>("EECorrNoiseMatrixG01");
+  const std::vector<double> ebCorMatG12 = params.getParameter<std::vector<double>>("EBCorrNoiseMatrixG12");
+  const std::vector<double> eeCorMatG12 = params.getParameter<std::vector<double>>("EECorrNoiseMatrixG12");
+  const std::vector<double> ebCorMatG06 = params.getParameter<std::vector<double>>("EBCorrNoiseMatrixG06");
+  const std::vector<double> eeCorMatG06 = params.getParameter<std::vector<double>>("EECorrNoiseMatrixG06");
+  const std::vector<double> ebCorMatG01 = params.getParameter<std::vector<double>>("EBCorrNoiseMatrixG01");
+  const std::vector<double> eeCorMatG01 = params.getParameter<std::vector<double>>("EECorrNoiseMatrixG01");
 
   const bool applyConstantTerm = params.getParameter<bool>("applyConstantTerm");
   const double rmsConstantTerm = params.getParameter<double>("ConstantTerm");
@@ -235,43 +228,46 @@ EcalDigiProducer::EcalDigiProducer(const edm::ParameterSet &params,
   m_EBCorrNoise[2].reset(new CorrelatedNoisifier<EcalCorrMatrix>(ebMatrix[2]));
   m_EECorrNoise[2].reset(new CorrelatedNoisifier<EcalCorrMatrix>(eeMatrix[2]));
 
-  m_Coder.reset(new EcalCoder(addNoise, m_PreMix1, m_EBCorrNoise[0].get(),
-                              m_EECorrNoise[0].get(), m_EBCorrNoise[1].get(),
-                              m_EECorrNoise[1].get(), m_EBCorrNoise[2].get(),
+  m_Coder.reset(new EcalCoder(addNoise,
+                              m_PreMix1,
+                              m_EBCorrNoise[0].get(),
+                              m_EECorrNoise[0].get(),
+                              m_EBCorrNoise[1].get(),
+                              m_EECorrNoise[1].get(),
+                              m_EBCorrNoise[2].get(),
                               m_EECorrNoise[2].get()));
 
-  m_ElectronicsSim.reset(new EcalElectronicsSim(
-      m_ParameterMap.get(), m_Coder.get(), applyConstantTerm, rmsConstantTerm));
+  m_ElectronicsSim.reset(
+      new EcalElectronicsSim(m_ParameterMap.get(), m_Coder.get(), applyConstantTerm, rmsConstantTerm));
 
   if (m_apdSeparateDigi) {
-    m_APDCoder.reset(new EcalCoder(
-        false, m_PreMix1, m_EBCorrNoise[0].get(), m_EECorrNoise[0].get(),
-        m_EBCorrNoise[1].get(), m_EECorrNoise[1].get(), m_EBCorrNoise[2].get(),
-        m_EECorrNoise[2].get()));
+    m_APDCoder.reset(new EcalCoder(false,
+                                   m_PreMix1,
+                                   m_EBCorrNoise[0].get(),
+                                   m_EECorrNoise[0].get(),
+                                   m_EBCorrNoise[1].get(),
+                                   m_EECorrNoise[1].get(),
+                                   m_EBCorrNoise[2].get(),
+                                   m_EECorrNoise[2].get()));
 
     m_APDElectronicsSim.reset(
-        new EcalElectronicsSim(m_ParameterMap.get(), m_APDCoder.get(),
-                               applyConstantTerm, rmsConstantTerm));
+        new EcalElectronicsSim(m_ParameterMap.get(), m_APDCoder.get(), applyConstantTerm, rmsConstantTerm));
 
-    m_APDDigitizer.reset(
-        new EBDigitizer(m_APDResponse.get(), m_APDElectronicsSim.get(), false));
+    m_APDDigitizer.reset(new EBDigitizer(m_APDResponse.get(), m_APDElectronicsSim.get(), false));
   }
 
   if (m_doEB) {
-    m_BarrelDigitizer.reset(
-        new EBDigitizer(m_EBResponse.get(), m_ElectronicsSim.get(), addNoise));
+    m_BarrelDigitizer.reset(new EBDigitizer(m_EBResponse.get(), m_ElectronicsSim.get(), addNoise));
   }
 
   if (m_doEE) {
-    m_EndcapDigitizer.reset(
-        new EEDigitizer(m_EEResponse.get(), m_ElectronicsSim.get(), addNoise));
+    m_EndcapDigitizer.reset(new EEDigitizer(m_EEResponse.get(), m_ElectronicsSim.get(), addNoise));
   }
 }
 
 EcalDigiProducer::~EcalDigiProducer() {}
 
-void EcalDigiProducer::initializeEvent(edm::Event const &event,
-                                       edm::EventSetup const &eventSetup) {
+void EcalDigiProducer::initializeEvent(edm::Event const &event, edm::EventSetup const &eventSetup) {
   edm::Service<edm::RandomNumberGenerator> rng;
   randomEngine_ = &rng->getEngine(event.streamID());
 
@@ -320,24 +316,21 @@ void EcalDigiProducer::accumulateCaloHits(HitsHandle const &ebHandle,
   }
 }
 
-void EcalDigiProducer::accumulate(edm::Event const &e,
-                                  edm::EventSetup const &eventSetup) {
+void EcalDigiProducer::accumulate(edm::Event const &e, edm::EventSetup const &eventSetup) {
   // Step A: Get Inputs
   edm::Handle<std::vector<PCaloHit>> ebHandle;
   if (m_doEB) {
-    m_EBShape.setEventSetup(
-        eventSetup); // need to set the eventSetup here, otherwise pre-mixing
-                     // module will not wrk
-    m_APDShape.setEventSetup(eventSetup); //
+    m_EBShape.setEventSetup(eventSetup);   // need to set the eventSetup here, otherwise pre-mixing
+                                           // module will not wrk
+    m_APDShape.setEventSetup(eventSetup);  //
     edm::InputTag ebTag(m_hitsProducerTag, "EcalHitsEB");
     e.getByLabel(ebTag, ebHandle);
   }
 
   edm::Handle<std::vector<PCaloHit>> eeHandle;
   if (m_doEE) {
-    m_EEShape.setEventSetup(
-        eventSetup); // need to set the eventSetup here, otherwise pre-mixing
-                     // module will not work
+    m_EEShape.setEventSetup(eventSetup);  // need to set the eventSetup here, otherwise pre-mixing
+                                          // module will not work
     edm::InputTag eeTag(m_hitsProducerTag, "EcalHitsEE");
     e.getByLabel(eeTag, eeHandle);
   }
@@ -376,11 +369,9 @@ void EcalDigiProducer::accumulate(PileUpEventPrincipal const &e,
   accumulateCaloHits(ebHandle, eeHandle, esHandle, e.bunchCrossing());
 }
 
-void EcalDigiProducer::finalizeEvent(edm::Event &event,
-                                     edm::EventSetup const &eventSetup) {
+void EcalDigiProducer::finalizeEvent(edm::Event &event, edm::EventSetup const &eventSetup) {
   // Step B: Create empty output
-  std::unique_ptr<EBDigiCollection> apdResult(
-      !m_apdSeparateDigi || !m_doEB ? nullptr : new EBDigiCollection());
+  std::unique_ptr<EBDigiCollection> apdResult(!m_apdSeparateDigi || !m_doEB ? nullptr : new EBDigiCollection());
   std::unique_ptr<EBDigiCollection> barrelResult(new EBDigiCollection());
   std::unique_ptr<EEDigiCollection> endcapResult(new EEDigiCollection());
   std::unique_ptr<ESDigiCollection> preshowerResult(new ESDigiCollection());
@@ -422,17 +413,15 @@ void EcalDigiProducer::finalizeEvent(edm::Event &event,
   event.put(std::move(endcapResult), m_EEdigiCollection);
   event.put(std::move(preshowerResult), m_ESdigiCollection);
 
-  randomEngine_ = nullptr; // to prevent access outside event
+  randomEngine_ = nullptr;  // to prevent access outside event
 }
 
-void EcalDigiProducer::beginLuminosityBlock(edm::LuminosityBlock const &lumi,
-                                            edm::EventSetup const &setup) {
+void EcalDigiProducer::beginLuminosityBlock(edm::LuminosityBlock const &lumi, edm::EventSetup const &setup) {
   edm::Service<edm::RandomNumberGenerator> rng;
   if (!rng.isAvailable()) {
-    throw cms::Exception("Configuration")
-        << "RandomNumberGenerator service is not available.\n"
-           "You must add the service in the configuration file\n"
-           "or remove the module that requires it.";
+    throw cms::Exception("Configuration") << "RandomNumberGenerator service is not available.\n"
+                                             "You must add the service in the configuration file\n"
+                                             "or remove the module that requires it.";
   }
   CLHEP::HepRandomEngine *engine = &rng->getEngine(lumi.index());
 
@@ -443,8 +432,7 @@ void EcalDigiProducer::beginLuminosityBlock(edm::LuminosityBlock const &lumi,
   }
 }
 
-void EcalDigiProducer::checkCalibrations(const edm::Event &event,
-                                         const edm::EventSetup &eventSetup) {
+void EcalDigiProducer::checkCalibrations(const edm::Event &event, const edm::EventSetup &eventSetup) {
   // Pedestals from event setup
 
   edm::ESHandle<EcalPedestals> dbPed;
@@ -509,21 +497,17 @@ void EcalDigiProducer::checkCalibrations(const edm::Event &event,
 
   delete defaultRatios;
 
-  const double EBscale((agc->getEBValue()) * theGains[1] * (m_Coder->MAXADC) *
-                       m_EBs25notCont);
+  const double EBscale((agc->getEBValue()) * theGains[1] * (m_Coder->MAXADC) * m_EBs25notCont);
 
   LogDebug("EcalDigi") << " GeV/ADC = " << agc->getEBValue() << "\n"
                        << " notCont = " << m_EBs25notCont << "\n"
-                       << " saturation for EB = " << EBscale << ", "
-                       << m_EBs25notCont;
+                       << " saturation for EB = " << EBscale << ", " << m_EBs25notCont;
 
-  const double EEscale((agc->getEEValue()) * theGains[1] * (m_Coder->MAXADC) *
-                       m_EEs25notCont);
+  const double EEscale((agc->getEEValue()) * theGains[1] * (m_Coder->MAXADC) * m_EEs25notCont);
 
   LogDebug("EcalDigi") << " GeV/ADC = " << agc->getEEValue() << "\n"
                        << " notCont = " << m_EEs25notCont << "\n"
-                       << " saturation for EB = " << EEscale << ", "
-                       << m_EEs25notCont;
+                       << " saturation for EB = " << EEscale << ", " << m_EEs25notCont;
 
   m_Coder->setFullScaleEnergy(EBscale, EEscale);
   if (nullptr != m_APDCoder)
@@ -546,8 +530,7 @@ void EcalDigiProducer::checkCalibrations(const edm::Event &event,
     const ESIntercalibConstants *esmips(hesMIPs.product());
     const ESMIPToGeVConstant *esMipToGeV(hesMIPToGeV.product());
     const int ESGain(1.1 > esgain->getESGain() ? 1 : 2);
-    const double ESMIPToGeV((1 == ESGain) ? esMipToGeV->getESValueLow()
-                                          : esMipToGeV->getESValueHigh());
+    const double ESMIPToGeV((1 == ESGain) ? esMipToGeV->getESValueLow() : esMipToGeV->getESValueHigh());
 
     if (m_doES) {
       m_ESShape.setGain(ESGain);
@@ -582,25 +565,19 @@ void EcalDigiProducer::checkGeometry(const edm::EventSetup &eventSetup) {
 void EcalDigiProducer::updateGeometry() {
   if (m_doEB) {
     if (nullptr != m_APDResponse)
-      m_APDResponse->setGeometry(
-          m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalBarrel));
-    m_EBResponse->setGeometry(
-        m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalBarrel));
+      m_APDResponse->setGeometry(m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalBarrel));
+    m_EBResponse->setGeometry(m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalBarrel));
   }
   if (m_doEE) {
-    m_EEResponse->setGeometry(
-        m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalEndcap));
+    m_EEResponse->setGeometry(m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalEndcap));
   }
   if (m_doES) {
-    m_ESResponse->setGeometry(
-        m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalPreshower));
+    m_ESResponse->setGeometry(m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalPreshower));
     m_ESOldResponse->setGeometry(m_Geometry);
 
     const std::vector<DetId> *theESDets(
-        nullptr !=
-                m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalPreshower)
-            ? &m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalPreshower)
-                   ->getValidDetIds()
+        nullptr != m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalPreshower)
+            ? &m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalPreshower)->getValidDetIds()
             : nullptr);
 
     if (!m_doFastES) {
@@ -613,29 +590,25 @@ void EcalDigiProducer::updateGeometry() {
   }
 }
 
-void EcalDigiProducer::setEBNoiseSignalGenerator(
-    EcalBaseSignalGenerator *noiseGenerator) {
+void EcalDigiProducer::setEBNoiseSignalGenerator(EcalBaseSignalGenerator *noiseGenerator) {
   // noiseGenerator->setParameterMap(theParameterMap);
   if (nullptr != m_BarrelDigitizer)
     m_BarrelDigitizer->setNoiseSignalGenerator(noiseGenerator);
 }
 
-void EcalDigiProducer::setEENoiseSignalGenerator(
-    EcalBaseSignalGenerator *noiseGenerator) {
+void EcalDigiProducer::setEENoiseSignalGenerator(EcalBaseSignalGenerator *noiseGenerator) {
   // noiseGenerator->setParameterMap(theParameterMap);
   if (nullptr != m_EndcapDigitizer)
     m_EndcapDigitizer->setNoiseSignalGenerator(noiseGenerator);
 }
 
-void EcalDigiProducer::setESNoiseSignalGenerator(
-    EcalBaseSignalGenerator *noiseGenerator) {
+void EcalDigiProducer::setESNoiseSignalGenerator(EcalBaseSignalGenerator *noiseGenerator) {
   // noiseGenerator->setParameterMap(theParameterMap);
   if (nullptr != m_ESDigitizer)
     m_ESDigitizer->setNoiseSignalGenerator(noiseGenerator);
 }
 
-void EcalDigiProducer::beginRun(edm::Run const &run,
-                                edm::EventSetup const &setup) {
+void EcalDigiProducer::beginRun(edm::Run const &run, edm::EventSetup const &setup) {
   m_EBShape.setEventSetup(setup);
   m_EEShape.setEventSetup(setup);
   m_APDShape.setEventSetup(setup);

--- a/SimCalorimetry/EcalSimProducers/src/EcalTimeDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalTimeDigiProducer.cc
@@ -24,16 +24,12 @@ EcalTimeDigiProducer::EcalTimeDigiProducer(const edm::ParameterSet &params,
                                            edm::ProducerBase &mixMod,
                                            edm::ConsumesCollector &sumes)
     : DigiAccumulatorMixMod(),
-      m_EBdigiCollection(
-          params.getParameter<std::string>("EBtimeDigiCollection")),
-      m_EEdigiCollection(
-          params.getParameter<std::string>("EEtimeDigiCollection")),
+      m_EBdigiCollection(params.getParameter<std::string>("EBtimeDigiCollection")),
+      m_EEdigiCollection(params.getParameter<std::string>("EEtimeDigiCollection")),
       m_hitsProducerTagEB(params.getParameter<edm::InputTag>("hitsProducerEB")),
       m_hitsProducerTagEE(params.getParameter<edm::InputTag>("hitsProducerEE")),
-      m_hitsProducerTokenEB(
-          sumes.consumes<std::vector<PCaloHit>>(m_hitsProducerTagEB)),
-      m_hitsProducerTokenEE(
-          sumes.consumes<std::vector<PCaloHit>>(m_hitsProducerTagEE)),
+      m_hitsProducerTokenEB(sumes.consumes<std::vector<PCaloHit>>(m_hitsProducerTagEB)),
+      m_hitsProducerTokenEE(sumes.consumes<std::vector<PCaloHit>>(m_hitsProducerTagEE)),
       m_timeLayerEB(params.getParameter<int>("timeLayerBarrel")),
       m_timeLayerEE(params.getParameter<int>("timeLayerEndcap")),
       m_Geometry(nullptr) {
@@ -44,9 +40,8 @@ EcalTimeDigiProducer::EcalTimeDigiProducer(const edm::ParameterSet &params,
   m_EndcapDigitizer = new EcalTimeMapDigitizer(EcalEndcap);
 
 #ifdef ecal_time_debug
-  std::cout << "[EcalTimeDigiProducer]::Create EB " << m_EBdigiCollection
-            << " and EE " << m_EEdigiCollection << " collections and digitizers"
-            << std::endl;
+  std::cout << "[EcalTimeDigiProducer]::Create EB " << m_EBdigiCollection << " and EE " << m_EEdigiCollection
+            << " collections and digitizers" << std::endl;
 #endif
 
   m_BarrelDigitizer->setTimeLayerId(m_timeLayerEB);
@@ -55,8 +50,7 @@ EcalTimeDigiProducer::EcalTimeDigiProducer(const edm::ParameterSet &params,
 
 EcalTimeDigiProducer::~EcalTimeDigiProducer() {}
 
-void EcalTimeDigiProducer::initializeEvent(edm::Event const &event,
-                                           edm::EventSetup const &eventSetup) {
+void EcalTimeDigiProducer::initializeEvent(edm::Event const &event, edm::EventSetup const &eventSetup) {
   checkGeometry(eventSetup);
   //    checkCalibrations( event, eventSetup );
   // here the methods to clean the maps
@@ -78,8 +72,7 @@ void EcalTimeDigiProducer::accumulateCaloHits(HitsHandle const &ebHandle,
   }
 }
 
-void EcalTimeDigiProducer::accumulate(edm::Event const &e,
-                                      edm::EventSetup const &eventSetup) {
+void EcalTimeDigiProducer::accumulate(edm::Event const &e, edm::EventSetup const &eventSetup) {
   // Step A: Get Inputs
   edm::Handle<std::vector<PCaloHit>> ebHandle;
   e.getByToken(m_hitsProducerTokenEB, ebHandle);
@@ -104,18 +97,14 @@ void EcalTimeDigiProducer::accumulate(PileUpEventPrincipal const &e,
   e.getByLabel(m_hitsProducerTagEE, eeHandle);
 
 #ifdef ecal_time_debug
-  std::cout << "[EcalTimeDigiProducer]::Accumulate Hits for BC "
-            << e.bunchCrossing() << std::endl;
+  std::cout << "[EcalTimeDigiProducer]::Accumulate Hits for BC " << e.bunchCrossing() << std::endl;
 #endif
   accumulateCaloHits(ebHandle, eeHandle, e.bunchCrossing());
 }
 
-void EcalTimeDigiProducer::finalizeEvent(edm::Event &event,
-                                         edm::EventSetup const &eventSetup) {
-  std::unique_ptr<EcalTimeDigiCollection> barrelResult(
-      new EcalTimeDigiCollection());
-  std::unique_ptr<EcalTimeDigiCollection> endcapResult(
-      new EcalTimeDigiCollection());
+void EcalTimeDigiProducer::finalizeEvent(edm::Event &event, edm::EventSetup const &eventSetup) {
+  std::unique_ptr<EcalTimeDigiCollection> barrelResult(new EcalTimeDigiCollection());
+  std::unique_ptr<EcalTimeDigiCollection> endcapResult(new EcalTimeDigiCollection());
 
 #ifdef ecal_time_debug
   std::cout << "[EcalTimeDigiProducer]::finalizeEvent" << std::endl;
@@ -125,8 +114,7 @@ void EcalTimeDigiProducer::finalizeEvent(edm::Event &event,
   m_BarrelDigitizer->run(*barrelResult);
 
 #ifdef ecal_time_debug
-  std::cout << "[EcalTimeDigiProducer]::EB Digi size " << barrelResult->size()
-            << std::endl;
+  std::cout << "[EcalTimeDigiProducer]::EB Digi size " << barrelResult->size() << std::endl;
 #endif
 
   edm::LogInfo("TimeDigiInfo") << "EB time Digis: " << barrelResult->size();
@@ -134,15 +122,13 @@ void EcalTimeDigiProducer::finalizeEvent(edm::Event &event,
   m_EndcapDigitizer->run(*endcapResult);
 
 #ifdef ecal_time_debug
-  std::cout << "[EcalTimeDigiProducer]::EE Digi size " << endcapResult->size()
-            << std::endl;
+  std::cout << "[EcalTimeDigiProducer]::EE Digi size " << endcapResult->size() << std::endl;
 #endif
 
   edm::LogInfo("TimeDigiInfo") << "EE Digis: " << endcapResult->size();
 
 #ifdef ecal_time_debug
-  std::cout << "[EcalTimeDigiProducer]::putting collections into the event "
-            << std::endl;
+  std::cout << "[EcalTimeDigiProducer]::putting collections into the event " << std::endl;
 #endif
 
   event.put(std::move(barrelResult), m_EBdigiCollection);
@@ -163,8 +149,6 @@ void EcalTimeDigiProducer::checkGeometry(const edm::EventSetup &eventSetup) {
 }
 
 void EcalTimeDigiProducer::updateGeometry() {
-  m_BarrelDigitizer->setGeometry(
-      m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalBarrel));
-  m_EndcapDigitizer->setGeometry(
-      m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalEndcap));
+  m_BarrelDigitizer->setGeometry(m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalBarrel));
+  m_EndcapDigitizer->setGeometry(m_Geometry->getSubdetectorGeometry(DetId::Ecal, EcalEndcap));
 }

--- a/SimCalorimetry/EcalSimProducers/test/ESDigisReferenceDistrib.cc
+++ b/SimCalorimetry/EcalSimProducers/test/ESDigisReferenceDistrib.cc
@@ -19,15 +19,12 @@ ESDigisReferenceDistrib::ESDigisReferenceDistrib(const edm::ParameterSet &ps)
     meESDigiADC_[ii] = new TH1F(histo, histo, 80, 960.5, 1040.5);
   }
 
-  meESDigi3D_ = new TH3F("meESDigi3D_", "meESDigi3D_", 80, 960.5, 1040.5, 80,
-                         960.5, 1040.5, 80, 960.5, 1040.5);
+  meESDigi3D_ = new TH3F("meESDigi3D_", "meESDigi3D_", 80, 960.5, 1040.5, 80, 960.5, 1040.5, 80, 960.5, 1040.5);
 }
 
 ESDigisReferenceDistrib::~ESDigisReferenceDistrib() {
-
   // preparing the txt file with the histo infos
-  std::ofstream *outFile_ =
-      new std::ofstream(outputTxtFile_.c_str(), std::ios::out);
+  std::ofstream *outFile_ = new std::ofstream(outputTxtFile_.c_str(), std::ios::out);
   *outFile_ << "# number of bin" << std::endl;
   *outFile_ << "# axis inf (common to the three axes" << std::endl;
   *outFile_ << "# axis sup (common to the three axes" << std::endl;
@@ -35,26 +32,20 @@ ESDigisReferenceDistrib::~ESDigisReferenceDistrib() {
   *outFile_ << "# " << std::endl;
 
   if (!meESDigi3D_)
-    throw cms::Exception(
-        "ESDigisReferenceDistrib: problems with the reference histo");
+    throw cms::Exception("ESDigisReferenceDistrib: problems with the reference histo");
   else {
     float histoBin_ = meESDigi3D_->GetNbinsX();
     float histoInf_ = meESDigi3D_->GetBinLowEdge(1);
-    float histoSup_ = meESDigi3D_->GetBinLowEdge((int)histoBin_) +
-                      meESDigi3D_->GetBinWidth((int)histoBin_);
+    float histoSup_ = meESDigi3D_->GetBinLowEdge((int)histoBin_) + meESDigi3D_->GetBinWidth((int)histoBin_);
 
     *outFile_ << histoBin_ << std::endl;
     *outFile_ << histoInf_ << std::endl;
     *outFile_ << histoSup_ << std::endl;
 
-    for (int thisBinZ = 1; thisBinZ <= meESDigi3D_->GetNbinsZ();
-         thisBinZ++) { // sample2
-      for (int thisBinY = 1; thisBinY <= meESDigi3D_->GetNbinsY();
-           thisBinY++) { // sample1
-        for (int thisBinX = 1; thisBinX <= meESDigi3D_->GetNbinsX();
-             thisBinX++) { // sample0
-          *outFile_ << meESDigi3D_->GetBinContent(thisBinX, thisBinY, thisBinZ)
-                    << std::endl;
+    for (int thisBinZ = 1; thisBinZ <= meESDigi3D_->GetNbinsZ(); thisBinZ++) {      // sample2
+      for (int thisBinY = 1; thisBinY <= meESDigi3D_->GetNbinsY(); thisBinY++) {    // sample1
+        for (int thisBinX = 1; thisBinX <= meESDigi3D_->GetNbinsX(); thisBinX++) {  // sample0
+          *outFile_ << meESDigi3D_->GetBinContent(thisBinX, thisBinY, thisBinZ) << std::endl;
         }
       }
     }
@@ -81,9 +72,7 @@ void ESDigisReferenceDistrib::beginJob() {}
 
 void ESDigisReferenceDistrib::endJob() {}
 
-void ESDigisReferenceDistrib::analyze(const edm::Event &e,
-                                      const edm::EventSetup &c) {
-
+void ESDigisReferenceDistrib::analyze(const edm::Event &e, const edm::EventSetup &c) {
   edm::Handle<ESDigiCollection> EcalDigiES;
   e.getByLabel(ESdigiCollection_, EcalDigiES);
 
@@ -94,7 +83,6 @@ void ESDigisReferenceDistrib::analyze(const edm::Event &e,
   esADCCounts.reserve(ESDataFrame::MAXSAMPLES);
 
   for (unsigned int digis = 0; digis < EcalDigiES->size(); ++digis) {
-
     ESDataFrame esdf = (*preshowerDigi)[digis];
     int nrSamples = esdf.size();
 

--- a/SimCalorimetry/EcalSimProducers/test/ESDigisReferenceDistrib.h
+++ b/SimCalorimetry/EcalSimProducers/test/ESDigisReferenceDistrib.h
@@ -24,7 +24,6 @@
 #include "TH3F.h"
 
 class ESDigisReferenceDistrib : public edm::EDAnalyzer {
-
 public:
   /// Constructor
   ESDigisReferenceDistrib(const edm::ParameterSet &ps);

--- a/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
+++ b/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
@@ -8,19 +8,18 @@
 #include "TBDataFormats/EcalTBObjects/interface/EcalTBTDCRawInfo.h"
 
 namespace edm {
-class ConsumesCollector;
-class ProducerBase;
-class Event;
-class EventSetup;
-class ParameterSet;
-} // namespace edm
+  class ConsumesCollector;
+  class ProducerBase;
+  class Event;
+  class EventSetup;
+  class ParameterSet;
+}  // namespace edm
 class PEcalTBInfo;
 class PileUpEventPrincipal;
 
 class EcalTBDigiProducer : public EcalDigiProducer {
 public:
-  EcalTBDigiProducer(const edm::ParameterSet &params, edm::ProducerBase &mixMod,
-                     edm::ConsumesCollector &iC);
+  EcalTBDigiProducer(const edm::ParameterSet &params, edm::ProducerBase &mixMod, edm::ConsumesCollector &iC);
   ~EcalTBDigiProducer() override;
 
   void initializeEvent(edm::Event const &, edm::EventSetup const &) override;

--- a/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
+++ b/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
@@ -20,8 +20,7 @@ EcalTBDigiProducer::EcalTBDigiProducer(const edm::ParameterSet &params,
   m_EBdigiFinalTag = params.getParameter<std::string>("EBdigiFinalCollection");
   m_EBdigiTempTag = params.getParameter<std::string>("EBdigiCollection");
 
-  mixMod.produces<EBDigiCollection>(
-      instance + m_EBdigiFinalTag); // after selective readout
+  mixMod.produces<EBDigiCollection>(instance + m_EBdigiFinalTag);  // after selective readout
   mixMod.produces<EcalTBTDCRawInfo>(instance);
 
   const bool syncPhase(params.getParameter<bool>("syncPhase"));
@@ -33,8 +32,7 @@ EcalTBDigiProducer::EcalTBDigiProducer(const edm::ParameterSet &params,
 
   typedef std::vector<edm::ParameterSet> Parameters;
   Parameters ranges = params.getParameter<Parameters>("tdcRanges");
-  for (Parameters::iterator itRanges = ranges.begin(); itRanges != ranges.end();
-       ++itRanges) {
+  for (Parameters::iterator itRanges = ranges.begin(); itRanges != ranges.end(); ++itRanges) {
     EcalTBTDCRecInfoAlgo::EcalTBTDCRanges aRange;
     aRange.runRanges.first = itRanges->getParameter<int>("startRun");
     aRange.runRanges.second = itRanges->getParameter<int>("endRun");
@@ -43,11 +41,9 @@ EcalTBDigiProducer::EcalTBDigiProducer(const edm::ParameterSet &params,
     m_tdcRanges.push_back(std::move(aRange));
   }
 
-  m_use2004OffsetConvention =
-      params.getUntrackedParameter<bool>("use2004OffsetConvention", false);
+  m_use2004OffsetConvention = params.getUntrackedParameter<bool>("use2004OffsetConvention", false);
 
-  m_ecalTBInfoLabel = params.getUntrackedParameter<std::string>(
-      "EcalTBInfoLabel", "SimEcalTBG4Object");
+  m_ecalTBInfoLabel = params.getUntrackedParameter<std::string>("EcalTBInfoLabel", "SimEcalTBG4Object");
 
   m_doReadout = params.getParameter<bool>("doReadout");
 
@@ -57,20 +53,17 @@ EcalTBDigiProducer::EcalTBDigiProducer(const edm::ParameterSet &params,
 
   if (m_doPhaseShift) {
     iC.consumes<PEcalTBInfo>(
-        edm::InputTag(params.getUntrackedParameter<std::string>(
-            "EcalTBInfoLabel", "SimEcalTBG4Object")));
+        edm::InputTag(params.getUntrackedParameter<std::string>("EcalTBInfoLabel", "SimEcalTBG4Object")));
   }
 }
 
 EcalTBDigiProducer::~EcalTBDigiProducer() {}
 
-void EcalTBDigiProducer::initializeEvent(edm::Event const &event,
-                                         edm::EventSetup const &eventSetup) {
+void EcalTBDigiProducer::initializeEvent(edm::Event const &event, edm::EventSetup const &eventSetup) {
   std::cout << "====****Entering EcalTBDigiProducer produce()" << std::endl;
   edm::ESHandle<CaloGeometry> hGeometry;
   eventSetup.get<CaloGeometryRecord>().get(hGeometry);
-  const std::vector<DetId> &theBarrelDets(
-      hGeometry->getValidDetIds(DetId::Ecal, EcalBarrel));
+  const std::vector<DetId> &theBarrelDets(hGeometry->getValidDetIds(DetId::Ecal, EcalBarrel));
 
   m_theTBReadout->setDetIds(theBarrelDets);
 
@@ -83,13 +76,12 @@ void EcalTBDigiProducer::initializeEvent(edm::Event const &event,
     DetId detId(DetId::Ecal, 1);
     setPhaseShift(detId);
 
-    fillTBTDCRawInfo(*m_TDCproduct); // fill the TDC info in the event
+    fillTBTDCRawInfo(*m_TDCproduct);  // fill the TDC info in the event
   }
   EcalDigiProducer::initializeEvent(event, eventSetup);
 }
 
-void EcalTBDigiProducer::finalizeEvent(edm::Event &event,
-                                       const edm::EventSetup &eventSetup) {
+void EcalTBDigiProducer::finalizeEvent(edm::Event &event, const edm::EventSetup &eventSetup) {
   m_ebDigis.reset(new EBDigiCollection);
 
   EcalDigiProducer::finalizeEvent(event, eventSetup);
@@ -98,32 +90,28 @@ void EcalTBDigiProducer::finalizeEvent(edm::Event &event,
 
   std::unique_ptr<EBDigiCollection> barrelReadout(new EBDigiCollection());
   if (m_doReadout) {
-    m_theTBReadout->performReadout(event, m_theTTmap, *barrelResult,
-                                   *barrelReadout);
+    m_theTBReadout->performReadout(event, m_theTTmap, *barrelResult, *barrelReadout);
   } else {
     *barrelReadout = *barrelResult;
   }
 
-  std::cout << "===**** EcalTBDigiProducer: number of barrel digis = "
-            << barrelReadout->size() << std::endl;
+  std::cout << "===**** EcalTBDigiProducer: number of barrel digis = " << barrelReadout->size() << std::endl;
 
   std::string const instance("simEcalUnsuppressedDigis");
   event.put(std::move(barrelReadout), instance + m_EBdigiFinalTag);
   event.put(std::move(m_TDCproduct), instance);
 
-  m_ebDigis.reset(); // release memory
-  m_eeDigis.reset(); // release memory
+  m_ebDigis.reset();  // release memory
+  m_eeDigis.reset();  // release memory
 }
 
 void EcalTBDigiProducer::setPhaseShift(const DetId &detId) {
-  const CaloSimParameters &parameters(
-      EcalDigiProducer::m_ParameterMap->simParameters(detId));
+  const CaloSimParameters &parameters(EcalDigiProducer::m_ParameterMap->simParameters(detId));
 
   if (!parameters.syncPhase()) {
     const int myDet(detId.subdetId());
 
-    LogDebug("EcalDigi") << "Setting the phase shift " << m_thisPhaseShift
-                         << " and the offset " << m_tunePhaseShift
+    LogDebug("EcalDigi") << "Setting the phase shift " << m_thisPhaseShift << " and the offset " << m_tunePhaseShift
                          << " for the subdetector " << myDet;
 
     if (myDet == 1) {
@@ -139,10 +127,8 @@ void EcalTBDigiProducer::setPhaseShift(const DetId &detId) {
 void EcalTBDigiProducer::fillTBTDCRawInfo(EcalTBTDCRawInfo &theTBTDCRawInfo) {
   const unsigned int thisChannel(1);
 
-  const unsigned int thisCount(
-      (unsigned int)(m_thisPhaseShift *
-                         (m_tdcRanges[0].tdcMax[0] - m_tdcRanges[0].tdcMin[0]) +
-                     m_tdcRanges[0].tdcMin[0]));
+  const unsigned int thisCount((unsigned int)(m_thisPhaseShift * (m_tdcRanges[0].tdcMax[0] - m_tdcRanges[0].tdcMin[0]) +
+                                              m_tdcRanges[0].tdcMin[0]));
 
   EcalTBTDCSample theTBTDCSample(thisChannel, thisCount);
 
@@ -158,6 +144,5 @@ void EcalTBDigiProducer::cacheEBDigis(const EBDigiCollection *ebDigiPtr) const {
 }
 
 void EcalTBDigiProducer::cacheEEDigis(const EEDigiCollection *eeDigiPtr) const {
-  std::cout << "===**** EcalTBDigiProducer: number of endcap digis = "
-            << eeDigiPtr->size() << std::endl;
+  std::cout << "===**** EcalTBDigiProducer: number of endcap digis = " << eeDigiPtr->size() << std::endl;
 }

--- a/SimG4Core/GFlash/interface/GflashEMShowerModel.h
+++ b/SimG4Core/GFlash/interface/GflashEMShowerModel.h
@@ -26,10 +26,8 @@ class GflashEMShowerProfile;
 class G4Region;
 
 class GflashEMShowerModel : public G4VFastSimulationModel {
-
 public:
-  GflashEMShowerModel(const G4String &name, G4Envelope *env,
-                      const edm::ParameterSet &parSet);
+  GflashEMShowerModel(const G4String &name, G4Envelope *env, const edm::ParameterSet &parSet);
   ~GflashEMShowerModel() override;
 
   G4bool ModelTrigger(const G4FastTrack &) override;

--- a/SimG4Core/GFlash/interface/GflashG4Watcher.h
+++ b/SimG4Core/GFlash/interface/GflashG4Watcher.h
@@ -23,7 +23,6 @@ class GflashG4Watcher : public SimWatcher,
                         public Observer<const BeginOfEvent *>,
                         public Observer<const EndOfEvent *>,
                         public Observer<const G4Step *> {
-
 public:
   GflashG4Watcher(const edm::ParameterSet &p);
   ~GflashG4Watcher() override;

--- a/SimG4Core/GFlash/interface/GflashHadronShowerModel.h
+++ b/SimG4Core/GFlash/interface/GflashHadronShowerModel.h
@@ -21,8 +21,7 @@ public:
   //-------------------------
   // Constructor, destructor
   //-------------------------
-  GflashHadronShowerModel(G4String modelName, G4Region *envelope,
-                          const edm::ParameterSet &parSet);
+  GflashHadronShowerModel(G4String modelName, G4Region *envelope, const edm::ParameterSet &parSet);
   ~GflashHadronShowerModel() override;
 
   //------------------------------------------------------------------------

--- a/SimG4Core/GFlash/interface/GflashHadronWrapperProcess.h
+++ b/SimG4Core/GFlash/interface/GflashHadronWrapperProcess.h
@@ -12,7 +12,6 @@ class G4ProcessVector;
 class G4VProcess;
 
 class GflashHadronWrapperProcess : public G4WrapperProcess {
-
 public:
   GflashHadronWrapperProcess(G4String processName);
   //  GflashHadronWrapperProcess();
@@ -20,8 +19,7 @@ public:
   ~GflashHadronWrapperProcess() override;
 
   // Override PostStepDoIt  method
-  G4VParticleChange *PostStepDoIt(const G4Track &track,
-                                  const G4Step &step) override;
+  G4VParticleChange *PostStepDoIt(const G4Track &track, const G4Step &step) override;
 
   G4String GetName() { return theProcessName; };
 

--- a/SimG4Core/GFlash/plugins/GFlash.cc
+++ b/SimG4Core/GFlash/plugins/GFlash.cc
@@ -16,9 +16,7 @@
 
 #include <string>
 
-GFlash::GFlash(const edm::ParameterSet &p)
-    : PhysicsList(p), thePar(p.getParameter<edm::ParameterSet>("GFlash")) {
-
+GFlash::GFlash(const edm::ParameterSet &p) : PhysicsList(p), thePar(p.getParameter<edm::ParameterSet>("GFlash")) {
   G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
@@ -27,18 +25,15 @@ GFlash::GFlash(const edm::ParameterSet &p)
   bool tracking = p.getParameter<bool>("TrackingCut");
   std::string region = p.getParameter<std::string>("Region");
 
-  edm::LogInfo("PhysicsList")
-      << "You are using the obsolete simulation engine: "
-      << " GFlash with Flags for EM Physics " << emPhys
-      << ", for Hadronic Physics " << hadPhys << " and tracking cut "
-      << tracking << " with special region " << region;
+  edm::LogInfo("PhysicsList") << "You are using the obsolete simulation engine: "
+                              << " GFlash with Flags for EM Physics " << emPhys << ", for Hadronic Physics " << hadPhys
+                              << " and tracking cut " << tracking << " with special region " << region;
 
   RegisterPhysics(new ParametrisedPhysics("parametrised", thePar));
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics(
-        new CMSEmStandardPhysics95msc93("EM standard msc93", ver, region));
+    RegisterPhysics(new CMSEmStandardPhysics95msc93("EM standard msc93", ver, region));
 
     // Synchroton Radiation & GN Physics
     RegisterPhysics(new G4EmExtraPhysics(ver));
@@ -68,13 +63,11 @@ GFlash::GFlash(const edm::ParameterSet &p)
   if (thePar.getParameter<bool>("GflashHistogram")) {
     theHisto = GflashHistogram::instance();
     theHisto->setStoreFlag(true);
-    theHisto->bookHistogram(
-        thePar.getParameter<std::string>("GflashHistogramName"));
+    theHisto->bookHistogram(thePar.getParameter<std::string>("GflashHistogramName"));
   }
 }
 
 GFlash::~GFlash() {
-
   if (thePar.getParameter<bool>("GflashHistogram")) {
     if (theHisto)
       delete theHisto;

--- a/SimG4Core/GFlash/plugins/GflashG4Watcher.cc
+++ b/SimG4Core/GFlash/plugins/GflashG4Watcher.cc
@@ -19,7 +19,6 @@ using namespace CLHEP;
 // constructors and destructor
 //
 GflashG4Watcher::GflashG4Watcher(const edm::ParameterSet &p) {
-
   edm::ParameterSet myP = p.getParameter<edm::ParameterSet>("GflashG4Watcher");
   histFileName_ = myP.getParameter<std::string>("histFileName");
   recoEnergyScaleEB_ = myP.getParameter<double>("recoEnergyScaleEB");
@@ -29,72 +28,73 @@ GflashG4Watcher::GflashG4Watcher(const edm::ParameterSet &p) {
 
   TH1::AddDirectory(kTRUE);
 
-  em_incE =
-      new TH1F("em_incE", "Incoming energy at Ecal;E (GeV);Number of Events",
-               500, 0.0, 500.0);
-  em_vtx_rho =
-      new TH1F("em_vtx_rho", "vertex position;#rho (cm);Number of Events", 100,
-               0.0, 10.0);
-  em_vtx_z = new TH1F("em_vtx_z", "vertex position;z (cm);Number of Events",
-                      100, -10.0, 10.0);
+  em_incE = new TH1F("em_incE", "Incoming energy at Ecal;E (GeV);Number of Events", 500, 0.0, 500.0);
+  em_vtx_rho = new TH1F("em_vtx_rho", "vertex position;#rho (cm);Number of Events", 100, 0.0, 10.0);
+  em_vtx_z = new TH1F("em_vtx_z", "vertex position;z (cm);Number of Events", 100, -10.0, 10.0);
 
-  eb_ssp_rho = new TH1F("eb_ssp_rho",
-                        "Shower starting position;#rho (cm);Number of Events",
-                        200, 0.0, 200.0);
+  eb_ssp_rho = new TH1F("eb_ssp_rho", "Shower starting position;#rho (cm);Number of Events", 200, 0.0, 200.0);
   eb_hit_long = new TH1F("eb_hit_long",
                          "longitudinal hit position;shower depth (cm);Number "
                          "of energy weighted hits",
-                         400, 0.0, 200.0);
-  eb_hit_lat =
-      new TH1F("eb_hit_lat",
-               "lateral hit position;arm (cm);Number of energy weighted hits",
-               100, 0.0, 5.0);
+                         400,
+                         0.0,
+                         200.0);
+  eb_hit_lat = new TH1F("eb_hit_lat", "lateral hit position;arm (cm);Number of energy weighted hits", 100, 0.0, 5.0);
   eb_hit_rz = new TH2F(
-      "eb_hit_rz",
-      "hit position along the shower direction;shower depth (cm);arm (cm)", 400,
-      0.0, 200.0, 100, 0.0, 5.0);
-  eb_hit_long_sd =
-      new TH1F("eb_hit_long_sd",
-               "longitudinal hit position in Sensitive Detector;shower depth "
-               "(cm);Number of energy weighted hits",
-               400, 0.0, 200.0);
+      "eb_hit_rz", "hit position along the shower direction;shower depth (cm);arm (cm)", 400, 0.0, 200.0, 100, 0.0, 5.0);
+  eb_hit_long_sd = new TH1F("eb_hit_long_sd",
+                            "longitudinal hit position in Sensitive Detector;shower depth "
+                            "(cm);Number of energy weighted hits",
+                            400,
+                            0.0,
+                            200.0);
   eb_hit_lat_sd = new TH1F("eb_hit_lat_sd",
                            "lateral hit position in Sensitive Detector;arm "
                            "(cm);Number of energy weighted hits",
-                           100, 0.0, 5.0);
+                           100,
+                           0.0,
+                           5.0);
   eb_hit_rz_sd = new TH2F("eb_hit_rz_sd",
                           "hit position along the shower direction in "
                           "Sensitive Detector;shower depth (cm);arm (cm)",
-                          400, 0.0, 200.0, 100, 0.0, 5.0);
+                          400,
+                          0.0,
+                          200.0,
+                          100,
+                          0.0,
+                          5.0);
 
-  ee_ssp_z =
-      new TH1F("ee_ssp_z", "Shower starting position;z (cm);Number of Events",
-               800, -400.0, 400.0);
+  ee_ssp_z = new TH1F("ee_ssp_z", "Shower starting position;z (cm);Number of Events", 800, -400.0, 400.0);
   ee_hit_long = new TH1F("ee_hit_long",
                          "longitudinal hit position;shower depth (cm);Number "
                          "of energy weighted hits",
-                         800, 0.0, 400.0);
-  ee_hit_lat =
-      new TH1F("ee_hit_lat",
-               "lateral hit position;arm (cm);Number of energy weighted hits",
-               100, 0.0, 5.0);
+                         800,
+                         0.0,
+                         400.0);
+  ee_hit_lat = new TH1F("ee_hit_lat", "lateral hit position;arm (cm);Number of energy weighted hits", 100, 0.0, 5.0);
   ee_hit_rz = new TH2F(
-      "ee_hit_rz",
-      "hit position along the shower direction;shower depth (cm);arm (cm)", 800,
-      0.0, 400.0, 100, 0.0, 5.0);
-  ee_hit_long_sd =
-      new TH1F("ee_hit_long_sd",
-               "longitudinal hit position in Sensitive Detector;shower depth "
-               "(cm);Number of energy weighted hits",
-               800, 0.0, 400.0);
+      "ee_hit_rz", "hit position along the shower direction;shower depth (cm);arm (cm)", 800, 0.0, 400.0, 100, 0.0, 5.0);
+  ee_hit_long_sd = new TH1F("ee_hit_long_sd",
+                            "longitudinal hit position in Sensitive Detector;shower depth "
+                            "(cm);Number of energy weighted hits",
+                            800,
+                            0.0,
+                            400.0);
   ee_hit_lat_sd = new TH1F("ee_hit_lat_sd",
                            "lateral hit position in Sensitive Detector;arm "
                            "(cm);Number of energy weighted hits",
-                           100, 0.0, 5.0);
+                           100,
+                           0.0,
+                           5.0);
   ee_hit_rz_sd = new TH2F("ee_hit_rz_sd",
                           "hit position along the shower direction in "
                           "Sensitive Detector;shower depth (cm);arm (cm)",
-                          800, 0.0, 400.0, 100, 0.0, 5.0);
+                          800,
+                          0.0,
+                          400.0,
+                          100,
+                          0.0,
+                          5.0);
 }
 
 GflashG4Watcher::~GflashG4Watcher() {
@@ -104,7 +104,6 @@ GflashG4Watcher::~GflashG4Watcher() {
 }
 
 void GflashG4Watcher::update(const BeginOfEvent *g4Event) {
-
   inc_flag = false;
 
   const G4Event *evt = (*g4Event)();
@@ -127,7 +126,6 @@ void GflashG4Watcher::update(const BeginOfEvent *g4Event) {
 void GflashG4Watcher::update(const EndOfEvent *g4Event) {}
 
 void GflashG4Watcher::update(const G4Step *aStep) {
-
   if (aStep == nullptr)
     return;
 
@@ -138,7 +136,7 @@ void GflashG4Watcher::update(const G4Step *aStep) {
 
   bool inEB = std::abs(inc_direction.eta()) < 1.5;
 
-  out_energy += hitEnergy; // to check outgoing energy
+  out_energy += hitEnergy;  // to check outgoing energy
 
   // This is to calculate shower depth and arm of hits from the shower direction
   G4ThreeVector hitPosition = aStep->GetPreStepPoint()->GetPosition();
@@ -147,10 +145,9 @@ void GflashG4Watcher::update(const G4Step *aStep) {
   double diff_z = std::abs(diff.mag() * std::cos(angle));
   double diff_r = std::abs(diff.mag() * std::sin(angle));
 
-  G4VSensitiveDetector *aSensitive =
-      aStep->GetPreStepPoint()->GetSensitiveDetector();
+  G4VSensitiveDetector *aSensitive = aStep->GetPreStepPoint()->GetSensitiveDetector();
 
-  if (inEB) { // showers in barrel crystals
+  if (inEB) {  // showers in barrel crystals
     hitEnergy *= recoEnergyScaleEB_;
     eb_hit_long->Fill(diff_z / cm, hitEnergy / GeV);
     eb_hit_lat->Fill(diff_r / cm, hitEnergy / GeV);
@@ -160,7 +157,7 @@ void GflashG4Watcher::update(const G4Step *aStep) {
       eb_hit_lat_sd->Fill(diff_r / cm, hitEnergy / GeV);
       eb_hit_rz_sd->Fill(diff_z / cm, diff_r / cm, hitEnergy / GeV);
     }
-  } else { // showers in endcap crystals
+  } else {  // showers in endcap crystals
     hitEnergy *= recoEnergyScaleEE_;
     ee_hit_long->Fill(diff_z / cm, hitEnergy / GeV);
     ee_hit_lat->Fill(diff_r / cm, hitEnergy / GeV);

--- a/SimG4Core/GFlash/src/GflashHadronWrapperProcess.cc
+++ b/SimG4Core/GFlash/src/GflashHadronWrapperProcess.cc
@@ -13,16 +13,13 @@
 using namespace CLHEP;
 
 GflashHadronWrapperProcess::GflashHadronWrapperProcess(G4String processName)
-    : particleChange(nullptr), pmanager(nullptr), fProcessVector(nullptr),
-      fProcess(nullptr) {
+    : particleChange(nullptr), pmanager(nullptr), fProcessVector(nullptr), fProcess(nullptr) {
   theProcessName = processName;
 }
 
 GflashHadronWrapperProcess::~GflashHadronWrapperProcess() {}
 
-G4VParticleChange *
-GflashHadronWrapperProcess::PostStepDoIt(const G4Track &track,
-                                         const G4Step &step) {
+G4VParticleChange *GflashHadronWrapperProcess::PostStepDoIt(const G4Track &track, const G4Step &step) {
   // process PostStepDoIt for the original process
 
   particleChange = pRegProcess->PostStepDoIt(track, step);
@@ -66,7 +63,7 @@ GflashHadronWrapperProcess::PostStepDoIt(const G4Track &track,
     // add secondaries from this wrapper process to the existing list
     fSecondary->push_back(tempSecondaryTrack);
 
-  } // end of loop on secondary
+  }  // end of loop on secondary
 
   // Now we can still impose conditions on the secondaries from ModelTrigger,
   // such as the number of secondaries produced by the original process as well
@@ -112,7 +109,6 @@ GflashHadronWrapperProcess::PostStepDoIt(const G4Track &track,
       // physics process takes over the current process
 
       if (fForceCondition == ExclusivelyForced) {
-
         // clean up memory for changing the process - counter clean up for
         // the secondaries created by new G4Track in
         // G4HadronicProcess::FillTotalResult
@@ -150,8 +146,7 @@ GflashHadronWrapperProcess::PostStepDoIt(const G4Track &track,
         step.GetPostStepPoint()->SetSafety(0.0);
 
         // additional nullification
-        (const_cast<G4Track *>(&track))
-            ->SetTrackStatus(particleChange->GetTrackStatus());
+        (const_cast<G4Track *>(&track))->SetTrackStatus(particleChange->GetTrackStatus());
       } else {
         // restore TrackStatus if fForceCondition !=  ExclusivelyForced
         (const_cast<G4Track *>(&track))->SetTrackStatus(keepStatus);
@@ -178,14 +173,10 @@ GflashHadronWrapperProcess::PostStepDoIt(const G4Track &track,
 }
 
 void GflashHadronWrapperProcess::Print(const G4Step &step) {
-
-  std::cout
-      << " GflashHadronWrapperProcess ProcessName, PreStepPosition, "
-         "preStepPoint KE, PostStepPoint KE, DeltaEnergy Nsec \n "
-      << step.GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName()
-      << " " << step.GetPostStepPoint()->GetPosition() << " "
-      << step.GetPreStepPoint()->GetKineticEnergy() / GeV << " "
-      << step.GetPostStepPoint()->GetKineticEnergy() / GeV << " "
-      << step.GetDeltaEnergy() / GeV << " "
-      << particleChange->GetNumberOfSecondaries() << std::endl;
+  std::cout << " GflashHadronWrapperProcess ProcessName, PreStepPosition, "
+               "preStepPoint KE, PostStepPoint KE, DeltaEnergy Nsec \n "
+            << step.GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName() << " "
+            << step.GetPostStepPoint()->GetPosition() << " " << step.GetPreStepPoint()->GetKineticEnergy() / GeV << " "
+            << step.GetPostStepPoint()->GetKineticEnergy() / GeV << " " << step.GetDeltaEnergy() / GeV << " "
+            << particleChange->GetNumberOfSecondaries() << std::endl;
 }

--- a/SimG4Core/GFlash/src/ParametrisedPhysics.cc
+++ b/SimG4Core/GFlash/src/ParametrisedPhysics.cc
@@ -13,11 +13,9 @@
 
 using namespace CLHEP;
 
-G4ThreadLocal ParametrisedPhysics::ThreadPrivate *ParametrisedPhysics::tpdata =
-    nullptr;
+G4ThreadLocal ParametrisedPhysics::ThreadPrivate *ParametrisedPhysics::tpdata = nullptr;
 
-ParametrisedPhysics::ParametrisedPhysics(std::string name,
-                                         const edm::ParameterSet &p)
+ParametrisedPhysics::ParametrisedPhysics(std::string name, const edm::ParameterSet &p)
     : G4VPhysicsConstructor(name), theParSet(p) {}
 
 ParametrisedPhysics::~ParametrisedPhysics() {
@@ -48,7 +46,6 @@ void ParametrisedPhysics::ConstructParticle() {
 }
 
 void ParametrisedPhysics::ConstructProcess() {
-
   tpdata = new ThreadPrivate;
   tpdata->theEMShowerModel = nullptr;
   tpdata->theHadShowerModel = nullptr;
@@ -60,8 +57,7 @@ void ParametrisedPhysics::ConstructProcess() {
   G4cout << "GFlash Construct: " << gem << "  " << ghad << G4endl;
 
   if (gem || ghad) {
-    tpdata->theFastSimulationManagerProcess =
-        new G4FastSimulationManagerProcess();
+    tpdata->theFastSimulationManagerProcess = new G4FastSimulationManagerProcess();
 
     G4ParticleTable *table = G4ParticleTable::GetParticleTable();
     EmParticleList emList;
@@ -82,10 +78,8 @@ void ParametrisedPhysics::ConstructProcess() {
         G4cout << "This means that GFlash will not be turned on." << G4endl;
 
       } else {
-
         // Electromagnetic Shower Model for ECAL
-        tpdata->theEMShowerModel =
-            new GflashEMShowerModel("GflashEMShowerModel", aRegion, theParSet);
+        tpdata->theEMShowerModel = new GflashEMShowerModel("GflashEMShowerModel", aRegion, theParSet);
         G4cout << "GFlash is defined for EcalRegion" << G4endl;
       }
     }
@@ -96,10 +90,8 @@ void ParametrisedPhysics::ConstructProcess() {
         G4cout << "This means that GFlash will not be turned on." << G4endl;
 
       } else {
-
         // Electromagnetic Shower Model for HCAL
-        tpdata->theHadShowerModel =
-            new GflashEMShowerModel("GflashHadShowerModel", aRegion, theParSet);
+        tpdata->theHadShowerModel = new GflashEMShowerModel("GflashHadShowerModel", aRegion, theParSet);
         G4cout << "GFlash is defined for HcalRegion" << G4endl;
       }
     }

--- a/SimGeneral/TrackingAnalysis/interface/EncodedTruthId.h
+++ b/SimGeneral/TrackingAnalysis/interface/EncodedTruthId.h
@@ -5,7 +5,6 @@
 #include <iosfwd>
 
 class EncodedTruthId : public EncodedEventId {
-
   friend std::ostream &operator<<(std::ostream &os, const EncodedTruthId &id);
 
 public:

--- a/SimGeneral/TrackingAnalysis/interface/MuonPSimHitSelector.h
+++ b/SimGeneral/TrackingAnalysis/interface/MuonPSimHitSelector.h
@@ -5,19 +5,16 @@
 
 //! MuonPSimHitSelector class
 class MuonPSimHitSelector : public PSimHitSelector {
-
 public:
   //! Constructor by pset.
   /* Creates a MuonPSimHitSelector with association given by pset.
 
      /param[in] pset with the configuration values
   */
-  MuonPSimHitSelector(edm::ParameterSet const &config)
-      : PSimHitSelector(config) {}
+  MuonPSimHitSelector(edm::ParameterSet const &config) : PSimHitSelector(config) {}
 
   //! Pre-process event information
-  void select(PSimHitCollection &, edm::Event const &,
-              edm::EventSetup const &) const override;
+  void select(PSimHitCollection &, edm::Event const &, edm::EventSetup const &) const override;
 };
 
 #endif

--- a/SimGeneral/TrackingAnalysis/interface/PSimHitSelector.h
+++ b/SimGeneral/TrackingAnalysis/interface/PSimHitSelector.h
@@ -13,7 +13,6 @@
 
 //! PSimHitSelector class
 class PSimHitSelector {
-
 public:
   typedef std::vector<PSimHit> PSimHitCollection;
 
@@ -29,8 +28,7 @@ public:
   virtual ~PSimHitSelector() {}
 
   //! Select the psimhit add them to a PSimHitCollection
-  virtual void select(PSimHitCollection &, edm::Event const &,
-                      edm::EventSetup const &) const;
+  virtual void select(PSimHitCollection &, edm::Event const &, edm::EventSetup const &) const;
 
 protected:
   typedef std::map<std::string, std::vector<std::string>> PSimHitCollectionMap;

--- a/SimGeneral/TrackingAnalysis/interface/PixelPSimHitSelector.h
+++ b/SimGeneral/TrackingAnalysis/interface/PixelPSimHitSelector.h
@@ -5,19 +5,16 @@
 
 //! PixelPSimHitSelector class
 class PixelPSimHitSelector : public PSimHitSelector {
-
 public:
   //! Constructor by pset.
   /* Creates a PixelPSimHitSelector with association given by pset.
 
      /param[in] pset with the configuration values
   */
-  PixelPSimHitSelector(edm::ParameterSet const &config)
-      : PSimHitSelector(config) {}
+  PixelPSimHitSelector(edm::ParameterSet const &config) : PSimHitSelector(config) {}
 
   //! Pre-process event information
-  void select(PSimHitCollection &, edm::Event const &,
-              edm::EventSetup const &) const override;
+  void select(PSimHitCollection &, edm::Event const &, edm::EventSetup const &) const override;
 };
 
 #endif

--- a/SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h
+++ b/SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h
@@ -20,13 +20,10 @@ public:
   explicit SimHitTPAssociationProducer(const edm::ParameterSet &);
   ~SimHitTPAssociationProducer() override;
 
-  static bool simHitTPAssociationListGreater(SimHitTPPair i, SimHitTPPair j) {
-    return (i.first.key() > j.first.key());
-  }
+  static bool simHitTPAssociationListGreater(SimHitTPPair i, SimHitTPPair j) { return (i.first.key() > j.first.key()); }
 
 private:
-  void produce(edm::StreamID, edm::Event &,
-               const edm::EventSetup &) const override;
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
 
   std::vector<edm::EDGetTokenT<edm::PSimHitContainer>> _simHitSrc;
   edm::EDGetTokenT<TrackingParticleCollection> _trackingParticleSrc;

--- a/SimGeneral/TrackingAnalysis/interface/TrackerPSimHitSelector.h
+++ b/SimGeneral/TrackingAnalysis/interface/TrackerPSimHitSelector.h
@@ -5,19 +5,16 @@
 
 //! TrackerPSimHitSelector class
 class TrackerPSimHitSelector : public PSimHitSelector {
-
 public:
   //! Constructor by pset.
   /* Creates a TrackerPSimHitSelector with association given by pset.
 
      /param[in] pset with the configuration values
   */
-  TrackerPSimHitSelector(edm::ParameterSet const &config)
-      : PSimHitSelector(config) {}
+  TrackerPSimHitSelector(edm::ParameterSet const &config) : PSimHitSelector(config) {}
 
   //! Pre-process event information
-  void select(PSimHitCollection &, edm::Event const &,
-              edm::EventSetup const &) const override;
+  void select(PSimHitCollection &, edm::Event const &, edm::EventSetup const &) const override;
 };
 
 #endif

--- a/SimGeneral/TrackingAnalysis/interface/TrackingParticleNumberOfLayers.h
+++ b/SimGeneral/TrackingAnalysis/interface/TrackingParticleNumberOfLayers.h
@@ -43,16 +43,14 @@
  */
 class TrackingParticleNumberOfLayers {
 public:
-  TrackingParticleNumberOfLayers(
-      const edm::Event &iEvent,
-      const std::vector<edm::EDGetTokenT<std::vector<PSimHit>>> &simHitTokens);
+  TrackingParticleNumberOfLayers(const edm::Event &iEvent,
+                                 const std::vector<edm::EDGetTokenT<std::vector<PSimHit>>> &simHitTokens);
 
   enum { nTrackerLayers = 0, nPixelLayers = 1, nStripMonoAndStereoLayers = 2 };
   std::tuple<std::unique_ptr<edm::ValueMap<unsigned int>>,
              std::unique_ptr<edm::ValueMap<unsigned int>>,
              std::unique_ptr<edm::ValueMap<unsigned int>>>
-  calculate(const edm::Handle<TrackingParticleCollection> &tps,
-            const edm::EventSetup &iSetup) const;
+  calculate(const edm::Handle<TrackingParticleCollection> &tps, const edm::EventSetup &iSetup) const;
 
 private:
   // used as multimap, but faster

--- a/SimGeneral/TrackingAnalysis/plugins/PreMixingTrackerDigiSimLinkWorkers.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/PreMixingTrackerDigiSimLinkWorkers.cc
@@ -4,10 +4,8 @@
 #include "SimGeneral/PreMixingModule/interface/PreMixingDigiSimLinkWorker.h"
 #include "SimGeneral/PreMixingModule/interface/PreMixingWorkerFactory.h"
 
-using PreMixingPixelDigiSimLinkWorker =
-    PreMixingDigiSimLinkWorker<edm::DetSetVector<PixelDigiSimLink>>;
-using PreMixingStripDigiSimLinkWorker =
-    PreMixingDigiSimLinkWorker<edm::DetSetVector<StripDigiSimLink>>;
+using PreMixingPixelDigiSimLinkWorker = PreMixingDigiSimLinkWorker<edm::DetSetVector<PixelDigiSimLink>>;
+using PreMixingStripDigiSimLinkWorker = PreMixingDigiSimLinkWorker<edm::DetSetVector<StripDigiSimLink>>;
 
 DEFINE_PREMIXING_WORKER(PreMixingPixelDigiSimLinkWorker);
 DEFINE_PREMIXING_WORKER(PreMixingStripDigiSimLinkWorker);

--- a/SimGeneral/TrackingAnalysis/plugins/PreMixingTrackingParticleWorker.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/PreMixingTrackingParticleWorker.cc
@@ -19,28 +19,24 @@ public:
                                   edm::ConsumesCollector &&iC);
   ~PreMixingTrackingParticleWorker() override = default;
 
-  void initializeEvent(edm::Event const &iEvent,
-                       edm::EventSetup const &iSetup) override;
-  void addSignals(edm::Event const &iEvent,
-                  edm::EventSetup const &iSetup) override;
-  void addPileups(PileUpEventPrincipal const &pep,
-                  edm::EventSetup const &iSetup) override;
-  void put(edm::Event &iEvent, edm::EventSetup const &iSetup,
-           std::vector<PileupSummaryInfo> const &ps, int bunchSpacing) override;
+  void initializeEvent(edm::Event const &iEvent, edm::EventSetup const &iSetup) override;
+  void addSignals(edm::Event const &iEvent, edm::EventSetup const &iSetup) override;
+  void addPileups(PileUpEventPrincipal const &pep, edm::EventSetup const &iSetup) override;
+  void put(edm::Event &iEvent,
+           edm::EventSetup const &iSetup,
+           std::vector<PileupSummaryInfo> const &ps,
+           int bunchSpacing) override;
 
 private:
-  void add(const std::vector<TrackingParticle> &particles,
-           const std::vector<TrackingVertex> &vertices);
+  void add(const std::vector<TrackingParticle> &particles, const std::vector<TrackingVertex> &vertices);
 
-  edm::EDGetTokenT<std::vector<TrackingParticle>>
-      TrackSigToken_; // Token to retrieve information
-  edm::EDGetTokenT<std::vector<TrackingVertex>>
-      VtxSigToken_; // Token to retrieve information
+  edm::EDGetTokenT<std::vector<TrackingParticle>> TrackSigToken_;  // Token to retrieve information
+  edm::EDGetTokenT<std::vector<TrackingVertex>> VtxSigToken_;      // Token to retrieve information
 
-  edm::InputTag TrackingParticlePileInputTag_; // InputTag for pileup tracks
+  edm::InputTag TrackingParticlePileInputTag_;  // InputTag for pileup tracks
 
-  std::string TrackingParticleCollectionDM_; // secondary name to be given to
-                                             // new TrackingParticle
+  std::string TrackingParticleCollectionDM_;  // secondary name to be given to
+                                              // new TrackingParticle
 
   std::unique_ptr<std::vector<TrackingParticle>> NewTrackList_;
   std::unique_ptr<std::vector<TrackingVertex>> NewVertexList_;
@@ -48,40 +44,31 @@ private:
   TrackingVertexRefProd VertexListRef_;
 };
 
-PreMixingTrackingParticleWorker::PreMixingTrackingParticleWorker(
-    const edm::ParameterSet &ps, edm::ProducerBase &producer,
-    edm::ConsumesCollector &&iC)
-    : TrackSigToken_(iC.consumes<std::vector<TrackingParticle>>(
-          ps.getParameter<edm::InputTag>("labelSig"))),
-      VtxSigToken_(iC.consumes<std::vector<TrackingVertex>>(
-          ps.getParameter<edm::InputTag>("labelSig"))),
-      TrackingParticlePileInputTag_(
-          ps.getParameter<edm::InputTag>("pileInputTag")),
-      TrackingParticleCollectionDM_(
-          ps.getParameter<std::string>("collectionDM")) {
-  producer.produces<std::vector<TrackingParticle>>(
-      TrackingParticleCollectionDM_);
+PreMixingTrackingParticleWorker::PreMixingTrackingParticleWorker(const edm::ParameterSet &ps,
+                                                                 edm::ProducerBase &producer,
+                                                                 edm::ConsumesCollector &&iC)
+    : TrackSigToken_(iC.consumes<std::vector<TrackingParticle>>(ps.getParameter<edm::InputTag>("labelSig"))),
+      VtxSigToken_(iC.consumes<std::vector<TrackingVertex>>(ps.getParameter<edm::InputTag>("labelSig"))),
+      TrackingParticlePileInputTag_(ps.getParameter<edm::InputTag>("pileInputTag")),
+      TrackingParticleCollectionDM_(ps.getParameter<std::string>("collectionDM")) {
+  producer.produces<std::vector<TrackingParticle>>(TrackingParticleCollectionDM_);
   producer.produces<std::vector<TrackingVertex>>(TrackingParticleCollectionDM_);
 }
 
-void PreMixingTrackingParticleWorker::initializeEvent(
-    edm::Event const &iEvent, edm::EventSetup const &iSetup) {
+void PreMixingTrackingParticleWorker::initializeEvent(edm::Event const &iEvent, edm::EventSetup const &iSetup) {
   NewTrackList_ = std::make_unique<std::vector<TrackingParticle>>();
   NewVertexList_ = std::make_unique<std::vector<TrackingVertex>>();
 
   // need RefProds in order to re-key the particle<->vertex refs
   // TODO: try to remove const_cast, requires making Event non-const in
   // BMixingModule::initializeEvent
-  TrackListRef_ = const_cast<edm::Event &>(iEvent)
-                      .getRefBeforePut<std::vector<TrackingParticle>>(
-                          TrackingParticleCollectionDM_);
-  VertexListRef_ = const_cast<edm::Event &>(iEvent)
-                       .getRefBeforePut<std::vector<TrackingVertex>>(
-                           TrackingParticleCollectionDM_);
+  TrackListRef_ =
+      const_cast<edm::Event &>(iEvent).getRefBeforePut<std::vector<TrackingParticle>>(TrackingParticleCollectionDM_);
+  VertexListRef_ =
+      const_cast<edm::Event &>(iEvent).getRefBeforePut<std::vector<TrackingVertex>>(TrackingParticleCollectionDM_);
 }
 
-void PreMixingTrackingParticleWorker::addSignals(
-    edm::Event const &iEvent, edm::EventSetup const &iSetup) {
+void PreMixingTrackingParticleWorker::addSignals(edm::Event const &iEvent, edm::EventSetup const &iSetup) {
   edm::Handle<std::vector<TrackingParticle>> tracks;
   iEvent.getByToken(TrackSigToken_, tracks);
 
@@ -93,11 +80,9 @@ void PreMixingTrackingParticleWorker::addSignals(
   }
 }
 
-void PreMixingTrackingParticleWorker::addPileups(
-    PileUpEventPrincipal const &pep, edm::EventSetup const &iSetup) {
-  LogDebug("PreMixingTrackingParticleWorker")
-      << "\n===============> adding pileups from event  "
-      << pep.principal().id() << " for bunchcrossing " << pep.bunchCrossing();
+void PreMixingTrackingParticleWorker::addPileups(PileUpEventPrincipal const &pep, edm::EventSetup const &iSetup) {
+  LogDebug("PreMixingTrackingParticleWorker") << "\n===============> adding pileups from event  "
+                                              << pep.principal().id() << " for bunchcrossing " << pep.bunchCrossing();
 
   edm::Handle<std::vector<TrackingParticle>> inputHandle;
   pep.getByLabel(TrackingParticlePileInputTag_, inputHandle);
@@ -110,9 +95,8 @@ void PreMixingTrackingParticleWorker::addPileups(
   }
 }
 
-void PreMixingTrackingParticleWorker::add(
-    const std::vector<TrackingParticle> &particles,
-    const std::vector<TrackingVertex> &vertices) {
+void PreMixingTrackingParticleWorker::add(const std::vector<TrackingParticle> &particles,
+                                          const std::vector<TrackingVertex> &vertices) {
   const size_t StartingIndexV = NewVertexList_->size();
   const size_t StartingIndexT = NewTrackList_->size();
 
@@ -125,19 +109,17 @@ void PreMixingTrackingParticleWorker::add(
   // grab tracks, store copy
   for (const auto &track : particles) {
     const auto &oldRef = track.parentVertex();
-    auto newRef =
-        TrackingVertexRef(VertexListRef_, oldRef.index() + StartingIndexV);
+    auto newRef = TrackingVertexRef(VertexListRef_, oldRef.index() + StartingIndexV);
     NewTrackList_->push_back(track);
 
-    auto &Ntrack = NewTrackList_->back(); // modify copy
+    auto &Ntrack = NewTrackList_->back();  // modify copy
 
     Ntrack.setParentVertex(newRef);
     Ntrack.clearDecayVertices();
 
     // next, loop over daughter vertices, same strategy
     for (auto const &vertexRef : track.decayVertices()) {
-      auto newRef =
-          TrackingVertexRef(VertexListRef_, vertexRef.index() + StartingIndexV);
+      auto newRef = TrackingVertexRef(VertexListRef_, vertexRef.index() + StartingIndexV);
       Ntrack.addDecayVertex(newRef);
     }
   }
@@ -147,8 +129,7 @@ void PreMixingTrackingParticleWorker::add(
   // vertices untouched
   std::vector<decltype(TrackingParticleRef().index())> sourceTrackIndices;
   std::vector<decltype(TrackingParticleRef().index())> daughterTrackIndices;
-  for (size_t iVertex = StartingIndexV; iVertex != NewVertexList_->size();
-       ++iVertex) {
+  for (size_t iVertex = StartingIndexV; iVertex != NewVertexList_->size(); ++iVertex) {
     auto &vertex = (*NewVertexList_)[iVertex];
 
     // Need to copy the indices before clearing the vectors
@@ -178,11 +159,11 @@ void PreMixingTrackingParticleWorker::add(
   }
 }
 
-void PreMixingTrackingParticleWorker::put(
-    edm::Event &iEvent, edm::EventSetup const &iSetup,
-    std::vector<PileupSummaryInfo> const &ps, int bunchSpacing) {
-  edm::LogInfo("PreMixingTrackingParticleWorker")
-      << "total # Merged Tracks: " << NewTrackList_->size();
+void PreMixingTrackingParticleWorker::put(edm::Event &iEvent,
+                                          edm::EventSetup const &iSetup,
+                                          std::vector<PileupSummaryInfo> const &ps,
+                                          int bunchSpacing) {
+  edm::LogInfo("PreMixingTrackingParticleWorker") << "total # Merged Tracks: " << NewTrackList_->size();
   iEvent.put(std::move(NewTrackList_), TrackingParticleCollectionDM_);
   iEvent.put(std::move(NewVertexList_), TrackingParticleCollectionDM_);
 }

--- a/SimGeneral/TrackingAnalysis/plugins/SimHitTPAssociationProducer.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/SimHitTPAssociationProducer.cc
@@ -14,14 +14,12 @@
 
 #include "SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h"
 
-SimHitTPAssociationProducer::SimHitTPAssociationProducer(
-    const edm::ParameterSet &cfg)
+SimHitTPAssociationProducer::SimHitTPAssociationProducer(const edm::ParameterSet &cfg)
     : _simHitSrc(),
-      _trackingParticleSrc(consumes<TrackingParticleCollection>(
-          cfg.getParameter<edm::InputTag>("trackingParticleSrc"))) {
+      _trackingParticleSrc(
+          consumes<TrackingParticleCollection>(cfg.getParameter<edm::InputTag>("trackingParticleSrc"))) {
   produces<SimHitTPAssociationList>();
-  std::vector<edm::InputTag> tags =
-      cfg.getParameter<std::vector<edm::InputTag>>("simHitSrc");
+  std::vector<edm::InputTag> tags = cfg.getParameter<std::vector<edm::InputTag>>("simHitSrc");
   _simHitSrc.reserve(tags.size());
   for (auto const &tag : tags) {
     _simHitSrc.emplace_back(consumes<edm::PSimHitContainer>(tag));
@@ -30,10 +28,8 @@ SimHitTPAssociationProducer::SimHitTPAssociationProducer(
 
 SimHitTPAssociationProducer::~SimHitTPAssociationProducer() {}
 
-void SimHitTPAssociationProducer::produce(edm::StreamID, edm::Event &iEvent,
-                                          const edm::EventSetup &es) const {
-  std::unique_ptr<SimHitTPAssociationList> simHitTPList(
-      new SimHitTPAssociationList);
+void SimHitTPAssociationProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &es) const {
+  std::unique_ptr<SimHitTPAssociationList> simHitTPList(new SimHitTPAssociationList);
 
   // TrackingParticle
   edm::Handle<TrackingParticleCollection> TPCollectionH;
@@ -41,13 +37,11 @@ void SimHitTPAssociationProducer::produce(edm::StreamID, edm::Event &iEvent,
 
   // prepare temporary map between SimTrackId and TrackingParticle index
   std::map<std::pair<size_t, EncodedEventId>, TrackingParticleRef> mapping;
-  for (TrackingParticleCollection::size_type itp = 0;
-       itp < TPCollectionH.product()->size(); ++itp) {
+  for (TrackingParticleCollection::size_type itp = 0; itp < TPCollectionH.product()->size(); ++itp) {
     TrackingParticleRef trackingParticle(TPCollectionH, itp);
     // SimTracks inside TrackingParticle
     EncodedEventId eid(trackingParticle->eventId());
-    for (auto itrk = trackingParticle->g4Track_begin();
-         itrk != trackingParticle->g4Track_end(); ++itrk) {
+    for (auto itrk = trackingParticle->g4Track_begin(); itrk != trackingParticle->g4Track_end(); ++itrk) {
       std::pair<uint32_t, EncodedEventId> trkid(itrk->trackId(), eid);
       mapping.insert(std::make_pair(trkid, trackingParticle));
     }
@@ -57,11 +51,9 @@ void SimHitTPAssociationProducer::produce(edm::StreamID, edm::Event &iEvent,
   for (auto const &psit : _simHitSrc) {
     edm::Handle<edm::PSimHitContainer> PSimHitCollectionH;
     iEvent.getByToken(psit, PSimHitCollectionH);
-    for (unsigned int psimHit = 0; psimHit != PSimHitCollectionH->size();
-         ++psimHit) {
+    for (unsigned int psimHit = 0; psimHit != PSimHitCollectionH->size(); ++psimHit) {
       TrackPSimHitRef pSimHitRef(PSimHitCollectionH, psimHit);
-      std::pair<uint32_t, EncodedEventId> simTkIds(pSimHitRef->trackId(),
-                                                   pSimHitRef->eventId());
+      std::pair<uint32_t, EncodedEventId> simTkIds(pSimHitRef->trackId(), pSimHitRef->eventId());
       auto ipos = mapping.find(simTkIds);
       if (ipos != mapping.end()) {
         simHitTPList->push_back(std::make_pair(ipos->second, pSimHitRef));
@@ -69,8 +61,7 @@ void SimHitTPAssociationProducer::produce(edm::StreamID, edm::Event &iEvent,
     }
   }
 
-  std::sort(simHitTPList->begin(), simHitTPList->end(),
-            simHitTPAssociationListGreater);
+  std::sort(simHitTPList->begin(), simHitTPList->end(), simHitTPAssociationListGreater);
   iEvent.put(std::move(simHitTPList));
 }
 

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingParticleNumberOfLayersProducer.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingParticleNumberOfLayersProducer.cc
@@ -12,27 +12,22 @@
  * unsigned int>> for the number of pixel and strip stereo tracker layers the
  * TrackingParticle has hits on.
  */
-class TrackingParticleNumberOfLayersProducer
-    : public edm::global::EDProducer<> {
+class TrackingParticleNumberOfLayersProducer : public edm::global::EDProducer<> {
 public:
   TrackingParticleNumberOfLayersProducer(const edm::ParameterSet &iConfig);
 
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
-  void produce(edm::StreamID, edm::Event &iEvent,
-               const edm::EventSetup &iSetup) const override;
+  void produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const override;
 
 private:
   edm::EDGetTokenT<TrackingParticleCollection> tpToken_;
   std::vector<edm::EDGetTokenT<std::vector<PSimHit>>> simHitTokens_;
 };
 
-TrackingParticleNumberOfLayersProducer::TrackingParticleNumberOfLayersProducer(
-    const edm::ParameterSet &iConfig)
-    : tpToken_(consumes<TrackingParticleCollection>(
-          iConfig.getParameter<edm::InputTag>("trackingParticles"))) {
-  for (const auto &tag :
-       iConfig.getParameter<std::vector<edm::InputTag>>("simHits")) {
+TrackingParticleNumberOfLayersProducer::TrackingParticleNumberOfLayersProducer(const edm::ParameterSet &iConfig)
+    : tpToken_(consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("trackingParticles"))) {
+  for (const auto &tag : iConfig.getParameter<std::vector<edm::InputTag>>("simHits")) {
     simHitTokens_.push_back(consumes<std::vector<PSimHit>>(tag));
   }
 
@@ -41,47 +36,38 @@ TrackingParticleNumberOfLayersProducer::TrackingParticleNumberOfLayersProducer(
   produces<edm::ValueMap<unsigned int>>("stripStereoLayers");
 }
 
-void TrackingParticleNumberOfLayersProducer::fillDescriptions(
-    edm::ConfigurationDescriptions &descriptions) {
+void TrackingParticleNumberOfLayersProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("trackingParticles",
-                          edm::InputTag("mix", "MergedTrackTruth"));
+  desc.add<edm::InputTag>("trackingParticles", edm::InputTag("mix", "MergedTrackTruth"));
 
-  desc.add<std::vector<edm::InputTag>>(
-      "simHits", {edm::InputTag("g4SimHits", "TrackerHitsPixelBarrelLowTof"),
-                  edm::InputTag("g4SimHits", "TrackerHitsPixelBarrelHighTof"),
-                  edm::InputTag("g4SimHits", "TrackerHitsPixelEndcapLowTof"),
-                  edm::InputTag("g4SimHits", "TrackerHitsPixelEndcapHighTof"),
-                  edm::InputTag("g4SimHits", "TrackerHitsTIBLowTof"),
-                  edm::InputTag("g4SimHits", "TrackerHitsTIBHighTof"),
-                  edm::InputTag("g4SimHits", "TrackerHitsTIDLowTof"),
-                  edm::InputTag("g4SimHits", "TrackerHitsTIDHighTof"),
-                  edm::InputTag("g4SimHits", "TrackerHitsTOBLowTof"),
-                  edm::InputTag("g4SimHits", "TrackerHitsTOBHighTof"),
-                  edm::InputTag("g4SimHits", "TrackerHitsTECLowTof"),
-                  edm::InputTag("g4SimHits", "TrackerHitsTECHighTof")});
+  desc.add<std::vector<edm::InputTag>>("simHits",
+                                       {edm::InputTag("g4SimHits", "TrackerHitsPixelBarrelLowTof"),
+                                        edm::InputTag("g4SimHits", "TrackerHitsPixelBarrelHighTof"),
+                                        edm::InputTag("g4SimHits", "TrackerHitsPixelEndcapLowTof"),
+                                        edm::InputTag("g4SimHits", "TrackerHitsPixelEndcapHighTof"),
+                                        edm::InputTag("g4SimHits", "TrackerHitsTIBLowTof"),
+                                        edm::InputTag("g4SimHits", "TrackerHitsTIBHighTof"),
+                                        edm::InputTag("g4SimHits", "TrackerHitsTIDLowTof"),
+                                        edm::InputTag("g4SimHits", "TrackerHitsTIDHighTof"),
+                                        edm::InputTag("g4SimHits", "TrackerHitsTOBLowTof"),
+                                        edm::InputTag("g4SimHits", "TrackerHitsTOBHighTof"),
+                                        edm::InputTag("g4SimHits", "TrackerHitsTECLowTof"),
+                                        edm::InputTag("g4SimHits", "TrackerHitsTECHighTof")});
 
   descriptions.add("trackingParticleNumberOfLayersProducer", desc);
 }
 
-void TrackingParticleNumberOfLayersProducer::produce(
-    edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+void TrackingParticleNumberOfLayersProducer::produce(edm::StreamID,
+                                                     edm::Event &iEvent,
+                                                     const edm::EventSetup &iSetup) const {
   edm::Handle<TrackingParticleCollection> htps;
   iEvent.getByToken(tpToken_, htps);
 
   TrackingParticleNumberOfLayers algo(iEvent, simHitTokens_);
   auto ret = algo.calculate(htps, iSetup);
-  iEvent.put(
-      std::move(std::get<TrackingParticleNumberOfLayers::nTrackerLayers>(ret)),
-      "trackerLayers");
-  iEvent.put(
-      std::move(std::get<TrackingParticleNumberOfLayers::nPixelLayers>(ret)),
-      "pixelLayers");
-  iEvent.put(
-      std::move(
-          std::get<TrackingParticleNumberOfLayers::nStripMonoAndStereoLayers>(
-              ret)),
-      "stripStereoLayers");
+  iEvent.put(std::move(std::get<TrackingParticleNumberOfLayers::nTrackerLayers>(ret)), "trackerLayers");
+  iEvent.put(std::move(std::get<TrackingParticleNumberOfLayers::nPixelLayers>(ret)), "pixelLayers");
+  iEvent.put(std::move(std::get<TrackingParticleNumberOfLayers::nStripMonoAndStereoLayers>(ret)), "stripStereoLayers");
 }
 
 DEFINE_FWK_MODULE(TrackingParticleNumberOfLayersProducer);

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
@@ -69,42 +69,37 @@
 //---------------------------------------------------------------------------------
 
 namespace {
-/** @brief Class to represent tracks in the decay chain.
+  /** @brief Class to represent tracks in the decay chain.
  * @author Mark Grimes (mark.grimes@bristol.ac.uk)
  * @date 30/Oct/2012
  */
-struct DecayChainTrack {
-  int simTrackIndex;
-  struct DecayChainVertex *pParentVertex;
-  // Some things have multiple decay vertices. Not sure how that works but it
-  // seems to be mostly electrons and some photons.
-  std::vector<struct DecayChainVertex *> daughterVertices;
-  DecayChainTrack *pMergedBremSource;
-  DecayChainTrack()
-      : simTrackIndex(-1), pParentVertex(nullptr), pMergedBremSource(nullptr) {}
-  DecayChainTrack(int newSimTrackIndex)
-      : simTrackIndex(newSimTrackIndex), pParentVertex(nullptr),
-        pMergedBremSource() {}
-};
+  struct DecayChainTrack {
+    int simTrackIndex;
+    struct DecayChainVertex *pParentVertex;
+    // Some things have multiple decay vertices. Not sure how that works but it
+    // seems to be mostly electrons and some photons.
+    std::vector<struct DecayChainVertex *> daughterVertices;
+    DecayChainTrack *pMergedBremSource;
+    DecayChainTrack() : simTrackIndex(-1), pParentVertex(nullptr), pMergedBremSource(nullptr) {}
+    DecayChainTrack(int newSimTrackIndex)
+        : simTrackIndex(newSimTrackIndex), pParentVertex(nullptr), pMergedBremSource() {}
+  };
 
-/** @brief Class to represent a vertex in the decay chain, and it's relationship
+  /** @brief Class to represent a vertex in the decay chain, and it's relationship
  * with parents and daughters.
  * @author Mark Grimes (mark.grimes@bristol.ac.uk)
  * @date 30/Oct/2012
  */
-struct DecayChainVertex {
-  int simVertexIndex;
-  DecayChainTrack *pParentTrack;
-  std::vector<DecayChainTrack *> daughterTracks;
-  DecayChainVertex *pMergedBremSource;
-  DecayChainVertex()
-      : simVertexIndex(-1), pParentTrack(nullptr), pMergedBremSource(nullptr) {}
-  DecayChainVertex(int newIndex)
-      : simVertexIndex(newIndex), pParentTrack(nullptr),
-        pMergedBremSource(nullptr) {}
-};
+  struct DecayChainVertex {
+    int simVertexIndex;
+    DecayChainTrack *pParentTrack;
+    std::vector<DecayChainTrack *> daughterTracks;
+    DecayChainVertex *pMergedBremSource;
+    DecayChainVertex() : simVertexIndex(-1), pParentTrack(nullptr), pMergedBremSource(nullptr) {}
+    DecayChainVertex(int newIndex) : simVertexIndex(newIndex), pParentTrack(nullptr), pMergedBremSource(nullptr) {}
+  };
 
-/** @brief Intermediary class. Mainly here to handle memory safely.
+  /** @brief Intermediary class. Mainly here to handle memory safely.
  *
  * Reconstructs the parent and child information from SimVertex and SimTracks to
  * create the decay chain. SimVertex and SimTrack only have information about
@@ -116,151 +111,139 @@ struct DecayChainVertex {
  * @author Mark Grimes (mark.grimes@bristol.ac.uk)
  * @date 31/Oct/2012
  */
-struct DecayChain {
-public:
-  DecayChain(const std::vector<SimTrack> &trackCollection,
-             const std::vector<SimVertex> &vertexCollection);
-  const size_t decayTracksSize;
-  const size_t decayVerticesSize;
+  struct DecayChain {
+  public:
+    DecayChain(const std::vector<SimTrack> &trackCollection, const std::vector<SimVertex> &vertexCollection);
+    const size_t decayTracksSize;
+    const size_t decayVerticesSize;
 
 #if defined(DO_DEBUG_TESTING)
-  /** @brief Testing check. Won't actually be called when the code becomes
+    /** @brief Testing check. Won't actually be called when the code becomes
    * production.
    *
    * Checks that there are no dangling objects not associated in the decay
    * chain.
    */
-  void integrityCheck();
+    void integrityCheck();
 #endif
-  const SimTrack &getSimTrack(const ::DecayChainTrack *pDecayTrack) const {
-    return simTrackCollection_.at(pDecayTrack->simTrackIndex);
-  }
-  const SimVertex &getSimVertex(const ::DecayChainVertex *pDecayVertex) const {
-    return simVertexCollection_.at(pDecayVertex->simVertexIndex);
-  }
+    const SimTrack &getSimTrack(const ::DecayChainTrack *pDecayTrack) const {
+      return simTrackCollection_.at(pDecayTrack->simTrackIndex);
+    }
+    const SimVertex &getSimVertex(const ::DecayChainVertex *pDecayVertex) const {
+      return simVertexCollection_.at(pDecayVertex->simVertexIndex);
+    }
 
-private:
-  void findBrem(const std::vector<SimTrack> &trackCollection,
-                const std::vector<SimVertex> &vertexCollection);
-  std::unique_ptr<::DecayChainTrack[]> decayTracks_;
-  std::unique_ptr<::DecayChainVertex[]> decayVertices_;
+  private:
+    void findBrem(const std::vector<SimTrack> &trackCollection, const std::vector<SimVertex> &vertexCollection);
+    std::unique_ptr<::DecayChainTrack[]> decayTracks_;
+    std::unique_ptr<::DecayChainVertex[]> decayVertices_;
 
-  /// The vertices at the top of the decay chain. These are a subset of the ones
-  /// in the decayVertices member. Don't delete them.
-  std::vector<::DecayChainVertex *> rootVertices_;
+    /// The vertices at the top of the decay chain. These are a subset of the ones
+    /// in the decayVertices member. Don't delete them.
+    std::vector<::DecayChainVertex *> rootVertices_;
 
-  // Keep a record of the constructor parameters
-  const std::vector<SimTrack> &simTrackCollection_;
-  const std::vector<SimVertex> &simVertexCollection_;
+    // Keep a record of the constructor parameters
+    const std::vector<SimTrack> &simTrackCollection_;
+    const std::vector<SimVertex> &simVertexCollection_;
 
-public:
-  const std::unique_ptr<::DecayChainTrack[]>
-      &decayTracks; ///< Reference maps to decayTracks_ for easy external const
-                    ///< access.
-  const std::unique_ptr<::DecayChainVertex[]>
-      &decayVertices; ///< Reference maps to decayVertices_ for easy external
-                      ///< const access.
-  const std::vector<::DecayChainVertex *>
-      &rootVertices; ///< Reference maps to rootVertices_ for easy external
-                     ///< const access.
-};
+  public:
+    const std::unique_ptr<::DecayChainTrack[]> &decayTracks;  ///< Reference maps to decayTracks_ for easy external const
+                                                              ///< access.
+    const std::unique_ptr<::DecayChainVertex[]> &decayVertices;  ///< Reference maps to decayVertices_ for easy external
+                                                                 ///< const access.
+    const std::vector<::DecayChainVertex *> &rootVertices;       ///< Reference maps to rootVertices_ for easy external
+                                                                 ///< const access.
+  };
 
-/** @brief Class to create TrackingParticle and TrackingVertex objects.
+  /** @brief Class to create TrackingParticle and TrackingVertex objects.
  * @author Mark Grimes (mark.grimes@bristol.ac.uk)
  * @date 12/Nov/2012
  */
-class TrackingParticleFactory {
-public:
-  TrackingParticleFactory(
-      const ::DecayChain &decayChain,
-      const edm::Handle<std::vector<reco::GenParticle>> &hGenParticles,
-      const edm::Handle<edm::HepMCProduct> &hepMCproduct,
-      const edm::Handle<std::vector<int>> &hHepMCGenParticleIndices,
-      const std::vector<const PSimHit *> &simHits, double volumeRadius,
-      double volumeZ, double vertexDistanceCut,
-      bool allowDifferentProcessTypes);
-  TrackingParticle createTrackingParticle(const DecayChainTrack *pTrack,
-                                          const TrackerTopology *tTopo) const;
-  TrackingVertex createTrackingVertex(const DecayChainVertex *pVertex) const;
-  bool vectorIsInsideVolume(const math::XYZTLorentzVectorD &vector) const;
+  class TrackingParticleFactory {
+  public:
+    TrackingParticleFactory(const ::DecayChain &decayChain,
+                            const edm::Handle<std::vector<reco::GenParticle>> &hGenParticles,
+                            const edm::Handle<edm::HepMCProduct> &hepMCproduct,
+                            const edm::Handle<std::vector<int>> &hHepMCGenParticleIndices,
+                            const std::vector<const PSimHit *> &simHits,
+                            double volumeRadius,
+                            double volumeZ,
+                            double vertexDistanceCut,
+                            bool allowDifferentProcessTypes);
+    TrackingParticle createTrackingParticle(const DecayChainTrack *pTrack, const TrackerTopology *tTopo) const;
+    TrackingVertex createTrackingVertex(const DecayChainVertex *pVertex) const;
+    bool vectorIsInsideVolume(const math::XYZTLorentzVectorD &vector) const;
 
-private:
-  const ::DecayChain &decayChain_;
-  const edm::Handle<std::vector<reco::GenParticle>> &hGenParticles_;
-  const edm::Handle<edm::HepMCProduct> &hepMCproduct_;
-  std::vector<int> genParticleIndices_;
-  const std::vector<const PSimHit *> &simHits_;
-  const double volumeRadius_;
-  const double volumeZ_;
-  const double vertexDistanceCut2_; // distance based on which HepMC::GenVertexs
-                                    // are added to SimVertexs
-  std::multimap<unsigned int, size_t>
-      trackIdToHitIndex_; ///< A multimap linking SimTrack::trackId() to the hit
-                          ///< index in pSimHits_
-  bool
-      allowDifferentProcessTypeForDifferentDetectors_; ///< See the comment for
-                                                       ///< the same member in
-                                                       ///< TrackingTruthAccumulator
-};
+  private:
+    const ::DecayChain &decayChain_;
+    const edm::Handle<std::vector<reco::GenParticle>> &hGenParticles_;
+    const edm::Handle<edm::HepMCProduct> &hepMCproduct_;
+    std::vector<int> genParticleIndices_;
+    const std::vector<const PSimHit *> &simHits_;
+    const double volumeRadius_;
+    const double volumeZ_;
+    const double vertexDistanceCut2_;                        // distance based on which HepMC::GenVertexs
+                                                             // are added to SimVertexs
+    std::multimap<unsigned int, size_t> trackIdToHitIndex_;  ///< A multimap linking SimTrack::trackId() to the hit
+                                                             ///< index in pSimHits_
+    bool allowDifferentProcessTypeForDifferentDetectors_;    ///< See the comment for
+                                                             ///< the same member in
+                                                             ///< TrackingTruthAccumulator
+  };
 
-/** @brief Handles adding objects to the output collections correctly, and
+  /** @brief Handles adding objects to the output collections correctly, and
  * checks to see if a particular object already exists.
  * @author Mark Grimes (mark.grimes@bristol.ac.uk)
  * @date 09/Nov/2012
  */
-class OutputCollectionWrapper {
-public:
-  OutputCollectionWrapper(
-      const DecayChain &decayChain,
-      TrackingTruthAccumulator::OutputCollections &outputCollections);
-  TrackingParticle *
-  addTrackingParticle(const ::DecayChainTrack *pDecayTrack,
-                      const TrackingParticle &trackingParticle);
-  TrackingVertex *addTrackingVertex(const ::DecayChainVertex *pDecayVertex,
-                                    const TrackingVertex &trackingVertex);
-  TrackingParticle *getTrackingParticle(const ::DecayChainTrack *pDecayTrack);
-  /// @brief After this call, any call to getTrackingParticle or getRef with
-  /// pOriginalTrack will return the TrackingParticle for pProxyTrack instead.
-  void setProxy(const ::DecayChainTrack *pOriginalTrack,
-                const ::DecayChainTrack *pProxyTrack);
-  void setProxy(const ::DecayChainVertex *pOriginalVertex,
-                const ::DecayChainVertex *pProxyVertex);
-  TrackingVertex *getTrackingVertex(const ::DecayChainVertex *pDecayVertex);
-  TrackingParticleRef getRef(const ::DecayChainTrack *pDecayTrack);
-  TrackingVertexRef getRef(const ::DecayChainVertex *pDecayVertex);
+  class OutputCollectionWrapper {
+  public:
+    OutputCollectionWrapper(const DecayChain &decayChain,
+                            TrackingTruthAccumulator::OutputCollections &outputCollections);
+    TrackingParticle *addTrackingParticle(const ::DecayChainTrack *pDecayTrack,
+                                          const TrackingParticle &trackingParticle);
+    TrackingVertex *addTrackingVertex(const ::DecayChainVertex *pDecayVertex, const TrackingVertex &trackingVertex);
+    TrackingParticle *getTrackingParticle(const ::DecayChainTrack *pDecayTrack);
+    /// @brief After this call, any call to getTrackingParticle or getRef with
+    /// pOriginalTrack will return the TrackingParticle for pProxyTrack instead.
+    void setProxy(const ::DecayChainTrack *pOriginalTrack, const ::DecayChainTrack *pProxyTrack);
+    void setProxy(const ::DecayChainVertex *pOriginalVertex, const ::DecayChainVertex *pProxyVertex);
+    TrackingVertex *getTrackingVertex(const ::DecayChainVertex *pDecayVertex);
+    TrackingParticleRef getRef(const ::DecayChainTrack *pDecayTrack);
+    TrackingVertexRef getRef(const ::DecayChainVertex *pDecayVertex);
 
-private:
-  void associateToExistingObjects(const ::DecayChainVertex *pChainVertex);
-  void associateToExistingObjects(const ::DecayChainTrack *pChainTrack);
-  TrackingTruthAccumulator::OutputCollections &output_;
-  std::vector<int> trackingParticleIndices_;
-  std::vector<int> trackingVertexIndices_;
-};
+  private:
+    void associateToExistingObjects(const ::DecayChainVertex *pChainVertex);
+    void associateToExistingObjects(const ::DecayChainTrack *pChainTrack);
+    TrackingTruthAccumulator::OutputCollections &output_;
+    std::vector<int> trackingParticleIndices_;
+    std::vector<int> trackingVertexIndices_;
+  };
 
-/** @brief Adds the supplied TrackingParticle and its parent TrackingVertex to
+  /** @brief Adds the supplied TrackingParticle and its parent TrackingVertex to
  * the output collection. Checks to make sure they don't already exist first.
  * @author Mark Grimes (mark.grimes@bristol.ac.uk)
  * @date 12/Nov/2012
  */
-TrackingParticle *
-addTrackAndParentVertex(::DecayChainTrack *pDecayTrack,
-                        const TrackingParticle &trackingParticle,
-                        ::OutputCollectionWrapper *pOutput);
+  TrackingParticle *addTrackAndParentVertex(::DecayChainTrack *pDecayTrack,
+                                            const TrackingParticle &trackingParticle,
+                                            ::OutputCollectionWrapper *pOutput);
 
-/** @brief Creates a TrackingParticle for the supplied DecayChainTrack and adds
+  /** @brief Creates a TrackingParticle for the supplied DecayChainTrack and adds
  * it to the output if it passes selection. Gets called recursively if adding
  * parents.
  * @author Mark Grimes (mark.grimes@bristol.ac.uk)
  * @date 05/Nov/2012
  */
-void addTrack(::DecayChainTrack *pDecayChainTrack,
-              const TrackingParticleSelector *pSelector,
-              ::OutputCollectionWrapper *pUnmergedOutput,
-              ::OutputCollectionWrapper *pMergedOutput,
-              const ::TrackingParticleFactory &objectFactory, bool addAncestors,
-              const TrackerTopology *tTopo);
+  void addTrack(::DecayChainTrack *pDecayChainTrack,
+                const TrackingParticleSelector *pSelector,
+                ::OutputCollectionWrapper *pUnmergedOutput,
+                ::OutputCollectionWrapper *pMergedOutput,
+                const ::TrackingParticleFactory &objectFactory,
+                bool addAncestors,
+                const TrackerTopology *tTopo);
 
-} // namespace
+}  // namespace
 
 //---------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------
@@ -273,63 +256,52 @@ void addTrack(::DecayChainTrack *pDecayChainTrack,
 //---------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------
 
-TrackingTruthAccumulator::TrackingTruthAccumulator(
-    const edm::ParameterSet &config, edm::ProducerBase &mixMod,
-    edm::ConsumesCollector &iC)
+TrackingTruthAccumulator::TrackingTruthAccumulator(const edm::ParameterSet &config,
+                                                   edm::ProducerBase &mixMod,
+                                                   edm::ConsumesCollector &iC)
     : messageCategory_("TrackingTruthAccumulator"),
       volumeRadius_(config.getParameter<double>("volumeRadius")),
       volumeZ_(config.getParameter<double>("volumeZ")),
       vertexDistanceCut_(config.getParameter<double>("vertexDistanceCut")),
-      ignoreTracksOutsideVolume_(
-          config.getParameter<bool>("ignoreTracksOutsideVolume")),
-      maximumPreviousBunchCrossing_(
-          config.getParameter<unsigned int>("maximumPreviousBunchCrossing")),
-      maximumSubsequentBunchCrossing_(
-          config.getParameter<unsigned int>("maximumSubsequentBunchCrossing")),
-      createUnmergedCollection_(
-          config.getParameter<bool>("createUnmergedCollection")),
-      createMergedCollection_(
-          config.getParameter<bool>("createMergedBremsstrahlung")),
-      createInitialVertexCollection_(
-          config.getParameter<bool>("createInitialVertexCollection")),
+      ignoreTracksOutsideVolume_(config.getParameter<bool>("ignoreTracksOutsideVolume")),
+      maximumPreviousBunchCrossing_(config.getParameter<unsigned int>("maximumPreviousBunchCrossing")),
+      maximumSubsequentBunchCrossing_(config.getParameter<unsigned int>("maximumSubsequentBunchCrossing")),
+      createUnmergedCollection_(config.getParameter<bool>("createUnmergedCollection")),
+      createMergedCollection_(config.getParameter<bool>("createMergedBremsstrahlung")),
+      createInitialVertexCollection_(config.getParameter<bool>("createInitialVertexCollection")),
       addAncestors_(config.getParameter<bool>("alwaysAddAncestors")),
       removeDeadModules_(config.getParameter<bool>("removeDeadModules")),
       simTrackLabel_(config.getParameter<edm::InputTag>("simTrackCollection")),
-      simVertexLabel_(
-          config.getParameter<edm::InputTag>("simVertexCollection")),
-      collectionTags_(), genParticleLabel_(config.getParameter<edm::InputTag>(
-                             "genParticleCollection")),
-      hepMCproductLabel_(
-          config.getParameter<edm::InputTag>("HepMCProductLabel")),
-      allowDifferentProcessTypeForDifferentDetectors_(
-          config.getParameter<bool>("allowDifferentSimHitProcesses")) {
+      simVertexLabel_(config.getParameter<edm::InputTag>("simVertexCollection")),
+      collectionTags_(),
+      genParticleLabel_(config.getParameter<edm::InputTag>("genParticleCollection")),
+      hepMCproductLabel_(config.getParameter<edm::InputTag>("HepMCProductLabel")),
+      allowDifferentProcessTypeForDifferentDetectors_(config.getParameter<bool>("allowDifferentSimHitProcesses")) {
   //
   // Make sure at least one of the merged and unmerged collections have been set
   // to be created.
   //
   if (!createUnmergedCollection_ && !createMergedCollection_)
-    edm::LogError(messageCategory_)
-        << "Both \"createUnmergedCollection\" and "
-           "\"createMergedBremsstrahlung\" have been"
-        << "set to false, which means no collections will be created";
+    edm::LogError(messageCategory_) << "Both \"createUnmergedCollection\" and "
+                                       "\"createMergedBremsstrahlung\" have been"
+                                    << "set to false, which means no collections will be created";
 
   // Initialize selection for building TrackingParticles
   //
   if (config.exists("select")) {
     edm::ParameterSet param = config.getParameter<edm::ParameterSet>("select");
-    selector_ = TrackingParticleSelector(
-        param.getParameter<double>("ptMinTP"),
-        param.getParameter<double>("ptMaxTP"),
-        param.getParameter<double>("minRapidityTP"),
-        param.getParameter<double>("maxRapidityTP"),
-        param.getParameter<double>("tipTP"),
-        param.getParameter<double>("lipTP"),
-        param.getParameter<int>("minHitTP"),
-        param.getParameter<bool>("signalOnlyTP"),
-        param.getParameter<bool>("intimeOnlyTP"),
-        param.getParameter<bool>("chargedOnlyTP"),
-        param.getParameter<bool>("stableOnlyTP"),
-        param.getParameter<std::vector<int>>("pdgIdTP"));
+    selector_ = TrackingParticleSelector(param.getParameter<double>("ptMinTP"),
+                                         param.getParameter<double>("ptMaxTP"),
+                                         param.getParameter<double>("minRapidityTP"),
+                                         param.getParameter<double>("maxRapidityTP"),
+                                         param.getParameter<double>("tipTP"),
+                                         param.getParameter<double>("lipTP"),
+                                         param.getParameter<int>("minHitTP"),
+                                         param.getParameter<bool>("signalOnlyTP"),
+                                         param.getParameter<bool>("intimeOnlyTP"),
+                                         param.getParameter<bool>("chargedOnlyTP"),
+                                         param.getParameter<bool>("stableOnlyTP"),
+                                         param.getParameter<std::vector<int>>("pdgIdTP"));
     selectorFlag_ = true;
 
     // Also set these two variables, which are used to drop out early if the
@@ -369,15 +341,11 @@ TrackingTruthAccumulator::TrackingTruthAccumulator(
   iC.consumes<std::vector<int>>(hepMCproductLabel_);
 
   // Fill the collection tags
-  const edm::ParameterSet &simHitCollectionConfig =
-      config.getParameterSet("simHitCollections");
-  std::vector<std::string> parameterNames =
-      simHitCollectionConfig.getParameterNames();
+  const edm::ParameterSet &simHitCollectionConfig = config.getParameterSet("simHitCollections");
+  std::vector<std::string> parameterNames = simHitCollectionConfig.getParameterNames();
 
   for (const auto &parameterName : parameterNames) {
-    std::vector<edm::InputTag> tags =
-        simHitCollectionConfig.getParameter<std::vector<edm::InputTag>>(
-            parameterName);
+    std::vector<edm::InputTag> tags = simHitCollectionConfig.getParameter<std::vector<edm::InputTag>>(parameterName);
     collectionTags_.insert(collectionTags_.end(), tags.begin(), tags.end());
   }
 
@@ -386,28 +354,22 @@ TrackingTruthAccumulator::TrackingTruthAccumulator(
   }
 }
 
-void TrackingTruthAccumulator::initializeEvent(edm::Event const &event,
-                                               edm::EventSetup const &setup) {
+void TrackingTruthAccumulator::initializeEvent(edm::Event const &event, edm::EventSetup const &setup) {
   if (createUnmergedCollection_) {
     unmergedOutput_.pTrackingParticles.reset(new TrackingParticleCollection);
     unmergedOutput_.pTrackingVertices.reset(new TrackingVertexCollection);
     unmergedOutput_.refTrackingParticles =
-        const_cast<edm::Event &>(event)
-            .getRefBeforePut<TrackingParticleCollection>();
-    unmergedOutput_.refTrackingVertexes =
-        const_cast<edm::Event &>(event)
-            .getRefBeforePut<TrackingVertexCollection>();
+        const_cast<edm::Event &>(event).getRefBeforePut<TrackingParticleCollection>();
+    unmergedOutput_.refTrackingVertexes = const_cast<edm::Event &>(event).getRefBeforePut<TrackingVertexCollection>();
   }
 
   if (createMergedCollection_) {
     mergedOutput_.pTrackingParticles.reset(new TrackingParticleCollection);
     mergedOutput_.pTrackingVertices.reset(new TrackingVertexCollection);
     mergedOutput_.refTrackingParticles =
-        const_cast<edm::Event &>(event)
-            .getRefBeforePut<TrackingParticleCollection>("MergedTrackTruth");
+        const_cast<edm::Event &>(event).getRefBeforePut<TrackingParticleCollection>("MergedTrackTruth");
     mergedOutput_.refTrackingVertexes =
-        const_cast<edm::Event &>(event)
-            .getRefBeforePut<TrackingVertexCollection>("MergedTrackTruth");
+        const_cast<edm::Event &>(event).getRefBeforePut<TrackingVertexCollection>("MergedTrackTruth");
   }
 
   if (createInitialVertexCollection_) {
@@ -422,8 +384,7 @@ void TrackingTruthAccumulator::initializeEvent(edm::Event const &event,
 /// to get a handle to) which is only implemented for container-like objects
 /// like std::vector but not for edm::HepMCProduct!
 
-void TrackingTruthAccumulator::accumulate(edm::Event const &event,
-                                          edm::EventSetup const &setup) {
+void TrackingTruthAccumulator::accumulate(edm::Event const &event, edm::EventSetup const &setup) {
   // Call the templated version that does the same for both signal and pileup
   // events
 
@@ -438,10 +399,8 @@ void TrackingTruthAccumulator::accumulate(PileUpEventPrincipal const &event,
                                           edm::StreamID const &) {
   // If this bunch crossing is outside the user configured limit, don't do
   // anything.
-  if (event.bunchCrossing() >=
-          -static_cast<int>(maximumPreviousBunchCrossing_) &&
-      event.bunchCrossing() <=
-          static_cast<int>(maximumSubsequentBunchCrossing_)) {
+  if (event.bunchCrossing() >= -static_cast<int>(maximumPreviousBunchCrossing_) &&
+      event.bunchCrossing() <= static_cast<int>(maximumSubsequentBunchCrossing_)) {
     // edm::LogInfo(messageCategory_) << "Analysing pileup event for bunch
     // crossing " << event.bunchCrossing();
 
@@ -449,19 +408,14 @@ void TrackingTruthAccumulator::accumulate(PileUpEventPrincipal const &event,
     edm::Handle<edm::HepMCProduct> hepmc;
     accumulateEvent(event, setup, hepmc);
   } else
-    edm::LogInfo(messageCategory_)
-        << "Skipping pileup event for bunch crossing " << event.bunchCrossing();
+    edm::LogInfo(messageCategory_) << "Skipping pileup event for bunch crossing " << event.bunchCrossing();
 }
 
-void TrackingTruthAccumulator::finalizeEvent(edm::Event &event,
-                                             edm::EventSetup const &setup) {
-
+void TrackingTruthAccumulator::finalizeEvent(edm::Event &event, edm::EventSetup const &setup) {
   if (createUnmergedCollection_) {
     edm::LogInfo("TrackingTruthAccumulator")
-        << "Adding " << unmergedOutput_.pTrackingParticles->size()
-        << " TrackingParticles and "
-        << unmergedOutput_.pTrackingVertices->size()
-        << " TrackingVertexs to the event.";
+        << "Adding " << unmergedOutput_.pTrackingParticles->size() << " TrackingParticles and "
+        << unmergedOutput_.pTrackingVertices->size() << " TrackingVertexs to the event.";
 
     event.put(std::move(unmergedOutput_.pTrackingParticles));
     event.put(std::move(unmergedOutput_.pTrackingVertices));
@@ -469,10 +423,8 @@ void TrackingTruthAccumulator::finalizeEvent(edm::Event &event,
 
   if (createMergedCollection_) {
     edm::LogInfo("TrackingTruthAccumulator")
-        << "Adding " << mergedOutput_.pTrackingParticles->size()
-        << " merged TrackingParticles and "
-        << mergedOutput_.pTrackingVertices->size()
-        << " merged TrackingVertexs to the event.";
+        << "Adding " << mergedOutput_.pTrackingParticles->size() << " merged TrackingParticles and "
+        << mergedOutput_.pTrackingVertices->size() << " merged TrackingVertexs to the event.";
 
     event.put(std::move(mergedOutput_.pTrackingParticles), "MergedTrackTruth");
     event.put(std::move(mergedOutput_.pTrackingVertices), "MergedTrackTruth");
@@ -480,17 +432,16 @@ void TrackingTruthAccumulator::finalizeEvent(edm::Event &event,
 
   if (createInitialVertexCollection_) {
     edm::LogInfo("TrackingTruthAccumulator")
-        << "Adding " << pInitialVertices_->size()
-        << " initial TrackingVertexs to the event.";
+        << "Adding " << pInitialVertices_->size() << " initial TrackingVertexs to the event.";
 
     event.put(std::move(pInitialVertices_), "InitialVertices");
   }
 }
 
 template <class T>
-void TrackingTruthAccumulator::accumulateEvent(
-    const T &event, const edm::EventSetup &setup,
-    const edm::Handle<edm::HepMCProduct> &hepMCproduct) {
+void TrackingTruthAccumulator::accumulateEvent(const T &event,
+                                               const edm::EventSetup &setup,
+                                               const edm::Handle<edm::HepMCProduct> &hepMCproduct) {
   //
   // Get the collections
   //
@@ -531,18 +482,21 @@ void TrackingTruthAccumulator::accumulateEvent(
   std::unique_ptr<::OutputCollectionWrapper> pUnmergedCollectionWrapper;
   std::unique_ptr<::OutputCollectionWrapper> pMergedCollectionWrapper;
   if (createUnmergedCollection_)
-    pUnmergedCollectionWrapper.reset(
-        new ::OutputCollectionWrapper(decayChain, unmergedOutput_));
+    pUnmergedCollectionWrapper.reset(new ::OutputCollectionWrapper(decayChain, unmergedOutput_));
   if (createMergedCollection_)
-    pMergedCollectionWrapper.reset(
-        new ::OutputCollectionWrapper(decayChain, mergedOutput_));
+    pMergedCollectionWrapper.reset(new ::OutputCollectionWrapper(decayChain, mergedOutput_));
 
   std::vector<const PSimHit *> simHitPointers;
   fillSimHits(simHitPointers, event, setup);
-  TrackingParticleFactory objectFactory(
-      decayChain, hGenParticles, hepMCproduct, hGenParticleIndices,
-      simHitPointers, volumeRadius_, volumeZ_, vertexDistanceCut_,
-      allowDifferentProcessTypeForDifferentDetectors_);
+  TrackingParticleFactory objectFactory(decayChain,
+                                        hGenParticles,
+                                        hepMCproduct,
+                                        hGenParticleIndices,
+                                        simHitPointers,
+                                        volumeRadius_,
+                                        volumeZ_,
+                                        vertexDistanceCut_,
+                                        allowDifferentProcessTypeForDifferentDetectors_);
 
 #if defined(DO_DEBUG_TESTING)
   // While I'm testing, perform some checks.
@@ -570,15 +524,13 @@ void TrackingTruthAccumulator::accumulateEvent(
     // expensive.
     if (chargedOnly_ && simTrack.charge() == 0)
       continue;
-    if (signalOnly_ && (simTrack.eventId().bunchCrossing() != 0 ||
-                        simTrack.eventId().event() != 0))
+    if (signalOnly_ && (simTrack.eventId().bunchCrossing() != 0 || simTrack.eventId().event() != 0))
       continue;
 
     // Also perform a check to see if the production vertex is inside the
     // tracker volume (if required).
     if (ignoreTracksOutsideVolume_) {
-      const SimVertex &simVertex =
-          hSimVertices->at(pDecayTrack->pParentVertex->simVertexIndex);
+      const SimVertex &simVertex = hSimVertices->at(pDecayTrack->pParentVertex->simVertexIndex);
       if (!objectFactory.vectorIsInsideVolume(simVertex.position()))
         continue;
     }
@@ -587,8 +539,12 @@ void TrackingTruthAccumulator::accumulateEvent(
     // if it passes the selection criteria specified in the configuration. If
     // the config specifies adding ancestors, the function is called recursively
     // to do that.
-    ::addTrack(pDecayTrack, pSelector, pUnmergedCollectionWrapper.get(),
-               pMergedCollectionWrapper.get(), objectFactory, addAncestors_,
+    ::addTrack(pDecayTrack,
+               pSelector,
+               pUnmergedCollectionWrapper.get(),
+               pMergedCollectionWrapper.get(),
+               objectFactory,
+               addAncestors_,
                tTopo);
   }
 
@@ -602,22 +558,20 @@ void TrackingTruthAccumulator::accumulateEvent(
     // Pretty sure the one with vertexId==0 is always the first one, but doesn't
     // hurt to check
     for (const auto &pRootVertex : decayChain.rootVertices) {
-      const SimVertex &vertex =
-          hSimVertices->at(decayChain.rootVertices[0]->simVertexIndex);
+      const SimVertex &vertex = hSimVertices->at(decayChain.rootVertices[0]->simVertexIndex);
       if (vertex.vertexId() != 0)
         continue;
 
-      pInitialVertices_->push_back(
-          objectFactory.createTrackingVertex(pRootVertex));
+      pInitialVertices_->push_back(objectFactory.createTrackingVertex(pRootVertex));
       break;
     }
   }
 }
 
 template <class T>
-void TrackingTruthAccumulator::fillSimHits(
-    std::vector<const PSimHit *> &returnValue, const T &event,
-    const edm::EventSetup &setup) {
+void TrackingTruthAccumulator::fillSimHits(std::vector<const PSimHit *> &returnValue,
+                                           const T &event,
+                                           const edm::EventSetup &setup) {
   // loop over the collections
   for (const auto &collectionTag : collectionTags_) {
     edm::Handle<std::vector<PSimHit>> hSimHits;
@@ -628,23 +582,18 @@ void TrackingTruthAccumulator::fillSimHits(
       returnValue.push_back(&simHit);
     }
 
-  } // end of loop over InputTags
+  }  // end of loop over InputTags
 
   // sort the SimHits according to their time of flight,
   // necessary for looping over them "in order" in
   // TrackingParticleFactory::createTrackingParticle()
-  std::sort(returnValue.begin(), returnValue.end(),
-            [](const PSimHit *a, const PSimHit *b) {
-              const auto atof =
-                  edm::isFinite(a->timeOfFlight())
-                      ? a->timeOfFlight()
-                      : std::numeric_limits<decltype(a->timeOfFlight())>::max();
-              const auto btof =
-                  edm::isFinite(b->timeOfFlight())
-                      ? b->timeOfFlight()
-                      : std::numeric_limits<decltype(b->timeOfFlight())>::max();
-              return atof < btof;
-            });
+  std::sort(returnValue.begin(), returnValue.end(), [](const PSimHit *a, const PSimHit *b) {
+    const auto atof =
+        edm::isFinite(a->timeOfFlight()) ? a->timeOfFlight() : std::numeric_limits<decltype(a->timeOfFlight())>::max();
+    const auto btof =
+        edm::isFinite(b->timeOfFlight()) ? b->timeOfFlight() : std::numeric_limits<decltype(b->timeOfFlight())>::max();
+    return atof < btof;
+  });
 }
 
 //---------------------------------------------------------------------------------
@@ -662,852 +611,806 @@ void TrackingTruthAccumulator::fillSimHits(
 //---------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------
 
-namespace // Unnamed namespace for things only used in this file
+namespace  // Unnamed namespace for things only used in this file
 {
-//---------------------------------------------------------------------------------
-//---------------------------------------------------------------------------------
-//----   TrackingParticleFactory methods
-//----------------------------------------
-//---------------------------------------------------------------------------------
-//---------------------------------------------------------------------------------
+  //---------------------------------------------------------------------------------
+  //---------------------------------------------------------------------------------
+  //----   TrackingParticleFactory methods
+  //----------------------------------------
+  //---------------------------------------------------------------------------------
+  //---------------------------------------------------------------------------------
 
-::TrackingParticleFactory::TrackingParticleFactory(
-    const ::DecayChain &decayChain,
-    const edm::Handle<std::vector<reco::GenParticle>> &hGenParticles,
-    const edm::Handle<edm::HepMCProduct> &hepMCproduct,
-    const edm::Handle<std::vector<int>> &hHepMCGenParticleIndices,
-    const std::vector<const PSimHit *> &simHits, double volumeRadius,
-    double volumeZ, double vertexDistanceCut, bool allowDifferentProcessTypes)
-    : decayChain_(decayChain), hGenParticles_(hGenParticles),
-      hepMCproduct_(hepMCproduct), simHits_(simHits),
-      volumeRadius_(volumeRadius), volumeZ_(volumeZ),
-      vertexDistanceCut2_(vertexDistanceCut * vertexDistanceCut),
-      allowDifferentProcessTypeForDifferentDetectors_(
-          allowDifferentProcessTypes) {
-  // Need to create a multimap to get from a SimTrackId to all of the hits in
-  // it. The SimTrackId is an unsigned int.
-  for (size_t index = 0; index < simHits_.size(); ++index) {
-    trackIdToHitIndex_.insert(
-        std::make_pair(simHits_[index]->trackId(), index));
-  }
-
-  if (hHepMCGenParticleIndices.isValid()) // Monte Carlo might not be available
-                                          // for the pileup events
-  {
-    genParticleIndices_.resize(hHepMCGenParticleIndices->size() + 1);
-
-    // What I need is the reverse mapping of this vector. The sizes are already
-    // equivalent because I set the size in the initialiser list.
-    for (size_t recoGenParticleIndex = 0;
-         recoGenParticleIndex < hHepMCGenParticleIndices->size();
-         ++recoGenParticleIndex) {
-      size_t hepMCGenParticleIndex =
-          (*hHepMCGenParticleIndices)[recoGenParticleIndex];
-
-      // They should be the same size, give or take a fencepost error, so this
-      // should never happen - but just in case
-      if (genParticleIndices_.size() <= hepMCGenParticleIndex)
-        genParticleIndices_.resize(hepMCGenParticleIndex + 1);
-
-      genParticleIndices_[hepMCGenParticleIndex] = recoGenParticleIndex;
+  ::TrackingParticleFactory::TrackingParticleFactory(const ::DecayChain &decayChain,
+                                                     const edm::Handle<std::vector<reco::GenParticle>> &hGenParticles,
+                                                     const edm::Handle<edm::HepMCProduct> &hepMCproduct,
+                                                     const edm::Handle<std::vector<int>> &hHepMCGenParticleIndices,
+                                                     const std::vector<const PSimHit *> &simHits,
+                                                     double volumeRadius,
+                                                     double volumeZ,
+                                                     double vertexDistanceCut,
+                                                     bool allowDifferentProcessTypes)
+      : decayChain_(decayChain),
+        hGenParticles_(hGenParticles),
+        hepMCproduct_(hepMCproduct),
+        simHits_(simHits),
+        volumeRadius_(volumeRadius),
+        volumeZ_(volumeZ),
+        vertexDistanceCut2_(vertexDistanceCut * vertexDistanceCut),
+        allowDifferentProcessTypeForDifferentDetectors_(allowDifferentProcessTypes) {
+    // Need to create a multimap to get from a SimTrackId to all of the hits in
+    // it. The SimTrackId is an unsigned int.
+    for (size_t index = 0; index < simHits_.size(); ++index) {
+      trackIdToHitIndex_.insert(std::make_pair(simHits_[index]->trackId(), index));
     }
-  }
-}
 
-TrackingParticle TrackingParticleFactory::createTrackingParticle(
-    const ::DecayChainTrack *pChainTrack, const TrackerTopology *tTopo) const {
-  typedef math::XYZTLorentzVectorD LorentzVector;
-  typedef math::XYZPoint Vector;
+    if (hHepMCGenParticleIndices.isValid())  // Monte Carlo might not be available
+                                             // for the pileup events
+    {
+      genParticleIndices_.resize(hHepMCGenParticleIndices->size() + 1);
 
-  const SimTrack &simTrack = decayChain_.getSimTrack(pChainTrack);
-  const SimVertex &parentSimVertex =
-      decayChain_.getSimVertex(pChainTrack->pParentVertex);
+      // What I need is the reverse mapping of this vector. The sizes are already
+      // equivalent because I set the size in the initialiser list.
+      for (size_t recoGenParticleIndex = 0; recoGenParticleIndex < hHepMCGenParticleIndices->size();
+           ++recoGenParticleIndex) {
+        size_t hepMCGenParticleIndex = (*hHepMCGenParticleIndices)[recoGenParticleIndex];
 
-  LorentzVector position(0, 0, 0, 0);
-  if (!simTrack.noVertex())
-    position = parentSimVertex.position();
+        // They should be the same size, give or take a fencepost error, so this
+        // should never happen - but just in case
+        if (genParticleIndices_.size() <= hepMCGenParticleIndex)
+          genParticleIndices_.resize(hepMCGenParticleIndex + 1);
 
-  int pdgId = simTrack.type();
-
-  TrackingParticle returnValue;
-  // N.B. The sim track is added a few lines below, the parent and decay
-  // vertices are added in another function later on.
-
-  //
-  // If there is some valid Monte Carlo for this track, take some information
-  // from that. Only do so if it is from the signal event however. Not sure why
-  // but that's what the old code did.
-  //
-  if (simTrack.eventId().event() == 0 &&
-      simTrack.eventId().bunchCrossing() ==
-          0) // if this is a track in the signal event
-  {
-    int hepMCGenParticleIndex = simTrack.genpartIndex();
-    if (hepMCGenParticleIndex >= 0 &&
-        hepMCGenParticleIndex < static_cast<int>(genParticleIndices_.size()) &&
-        hGenParticles_.isValid()) {
-      int recoGenParticleIndex = genParticleIndices_[hepMCGenParticleIndex];
-      reco::GenParticleRef generatorParticleRef(hGenParticles_,
-                                                recoGenParticleIndex);
-      pdgId = generatorParticleRef->pdgId();
-      returnValue.addGenParticle(generatorParticleRef);
+        genParticleIndices_[hepMCGenParticleIndex] = recoGenParticleIndex;
+      }
     }
   }
 
-  returnValue.addG4Track(simTrack);
+  TrackingParticle TrackingParticleFactory::createTrackingParticle(const ::DecayChainTrack *pChainTrack,
+                                                                   const TrackerTopology *tTopo) const {
+    typedef math::XYZTLorentzVectorD LorentzVector;
+    typedef math::XYZPoint Vector;
 
-  // I need to run over the sim hits and count up the different types of hits.
-  // To be honest I don't fully understand this next section of code, I copied
-  // it from the old TrackingTruthProducer to provide the same results. The
-  // different types of hits that I need to count are:
-  size_t matchedHits =
-      0; // As far as I can tell, this is the number of tracker layers with hits
-         // on them, i.e. taking account of overlaps.
-  size_t numberOfHits =
-      0; // The total number of hits not taking account of overlaps.
-  size_t numberOfTrackerHits =
-      0; // The number of tracker hits not taking account of overlaps.
+    const SimTrack &simTrack = decayChain_.getSimTrack(pChainTrack);
+    const SimVertex &parentSimVertex = decayChain_.getSimVertex(pChainTrack->pParentVertex);
 
-  bool init = true;
-  int processType = 0;
-  int particleType = 0;
-  int oldLayer = 0;
-  int newLayer = 0;
-  DetId oldDetector;
-  DetId newDetector;
+    LorentzVector position(0, 0, 0, 0);
+    if (!simTrack.noVertex())
+      position = parentSimVertex.position();
 
-  // Loop over the SimHits associated to this SimTrack
-  // in the order defined by time of flight, which is
-  // probably the best quantity available for going
-  // through the hits "in order" (ok, most important is
-  // to get the first hit right because processType and
-  // particleType are taken from it)
-  for (auto iHitIndex = trackIdToHitIndex_.lower_bound(simTrack.trackId()),
-            end = trackIdToHitIndex_.upper_bound(simTrack.trackId());
-       iHitIndex != end; ++iHitIndex) {
-    const auto &pSimHit = simHits_[iHitIndex->second];
+    int pdgId = simTrack.type();
 
-    // Skip hits with particle type different from SimTrack pdgId
-    if (pSimHit->particleType() != pdgId)
-      continue;
+    TrackingParticle returnValue;
+    // N.B. The sim track is added a few lines below, the parent and decay
+    // vertices are added in another function later on.
 
-    // Initial condition for consistent simhit selection
-    if (init) {
-      processType = pSimHit->processType();
-      particleType = pSimHit->particleType();
+    //
+    // If there is some valid Monte Carlo for this track, take some information
+    // from that. Only do so if it is from the signal event however. Not sure why
+    // but that's what the old code did.
+    //
+    if (simTrack.eventId().event() == 0 &&
+        simTrack.eventId().bunchCrossing() == 0)  // if this is a track in the signal event
+    {
+      int hepMCGenParticleIndex = simTrack.genpartIndex();
+      if (hepMCGenParticleIndex >= 0 && hepMCGenParticleIndex < static_cast<int>(genParticleIndices_.size()) &&
+          hGenParticles_.isValid()) {
+        int recoGenParticleIndex = genParticleIndices_[hepMCGenParticleIndex];
+        reco::GenParticleRef generatorParticleRef(hGenParticles_, recoGenParticleIndex);
+        pdgId = generatorParticleRef->pdgId();
+        returnValue.addGenParticle(generatorParticleRef);
+      }
+    }
+
+    returnValue.addG4Track(simTrack);
+
+    // I need to run over the sim hits and count up the different types of hits.
+    // To be honest I don't fully understand this next section of code, I copied
+    // it from the old TrackingTruthProducer to provide the same results. The
+    // different types of hits that I need to count are:
+    size_t matchedHits = 0;          // As far as I can tell, this is the number of tracker layers with hits
+                                     // on them, i.e. taking account of overlaps.
+    size_t numberOfHits = 0;         // The total number of hits not taking account of overlaps.
+    size_t numberOfTrackerHits = 0;  // The number of tracker hits not taking account of overlaps.
+
+    bool init = true;
+    int processType = 0;
+    int particleType = 0;
+    int oldLayer = 0;
+    int newLayer = 0;
+    DetId oldDetector;
+    DetId newDetector;
+
+    // Loop over the SimHits associated to this SimTrack
+    // in the order defined by time of flight, which is
+    // probably the best quantity available for going
+    // through the hits "in order" (ok, most important is
+    // to get the first hit right because processType and
+    // particleType are taken from it)
+    for (auto iHitIndex = trackIdToHitIndex_.lower_bound(simTrack.trackId()),
+              end = trackIdToHitIndex_.upper_bound(simTrack.trackId());
+         iHitIndex != end;
+         ++iHitIndex) {
+      const auto &pSimHit = simHits_[iHitIndex->second];
+
+      // Skip hits with particle type different from SimTrack pdgId
+      if (pSimHit->particleType() != pdgId)
+        continue;
+
+      // Initial condition for consistent simhit selection
+      if (init) {
+        processType = pSimHit->processType();
+        particleType = pSimHit->particleType();
+        newDetector = DetId(pSimHit->detUnitId());
+        init = false;
+      }
+
+      oldDetector = newDetector;
       newDetector = DetId(pSimHit->detUnitId());
-      init = false;
-    }
 
-    oldDetector = newDetector;
-    newDetector = DetId(pSimHit->detUnitId());
+      // Fast sim seems to have different processType between tracker and muons,
+      // so if this flag has been set allow the processType to change if the
+      // detector changes.
+      if (allowDifferentProcessTypeForDifferentDetectors_ && newDetector.det() != oldDetector.det())
+        processType = pSimHit->processType();
 
-    // Fast sim seems to have different processType between tracker and muons,
-    // so if this flag has been set allow the processType to change if the
-    // detector changes.
-    if (allowDifferentProcessTypeForDifferentDetectors_ &&
-        newDetector.det() != oldDetector.det())
-      processType = pSimHit->processType();
+      // Check for delta and interaction products discards
+      if (processType == pSimHit->processType() && particleType == pSimHit->particleType()) {
+        ++numberOfHits;
+        oldLayer = newLayer;
+        newLayer = 0;
+        if (newDetector.det() == DetId::Tracker) {
+          ++numberOfTrackerHits;
 
-    // Check for delta and interaction products discards
-    if (processType == pSimHit->processType() &&
-        particleType == pSimHit->particleType()) {
-      ++numberOfHits;
-      oldLayer = newLayer;
-      newLayer = 0;
-      if (newDetector.det() == DetId::Tracker) {
-        ++numberOfTrackerHits;
+          newLayer = tTopo->layer(newDetector);
 
-        newLayer = tTopo->layer(newDetector);
-
-        // Count hits using layers for glued detectors
-        if ((oldLayer != newLayer ||
-             (oldLayer == newLayer &&
-              oldDetector.subdetId() != newDetector.subdetId())))
-          ++matchedHits;
+          // Count hits using layers for glued detectors
+          if ((oldLayer != newLayer || (oldLayer == newLayer && oldDetector.subdetId() != newDetector.subdetId())))
+            ++matchedHits;
+        }
       }
-    }
-  } // end of loop over the sim hits for this sim track
+    }  // end of loop over the sim hits for this sim track
 
-  returnValue.setNumberOfTrackerLayers(matchedHits);
-  returnValue.setNumberOfHits(numberOfHits);
-  returnValue.setNumberOfTrackerHits(numberOfTrackerHits);
+    returnValue.setNumberOfTrackerLayers(matchedHits);
+    returnValue.setNumberOfHits(numberOfHits);
+    returnValue.setNumberOfTrackerHits(numberOfTrackerHits);
 
-  return returnValue;
-}
-
-TrackingVertex TrackingParticleFactory::createTrackingVertex(
-    const ::DecayChainVertex *pChainVertex) const {
-
-  typedef math::XYZTLorentzVectorD LorentzVector;
-  typedef math::XYZPoint Vector;
-  typedef edm::Ref<edm::HepMCProduct, HepMC::GenVertex> GenVertexRef;
-
-  const SimVertex &simVertex = decayChain_.getSimVertex(pChainVertex);
-
-  bool isInVolume = this->vectorIsInsideVolume(simVertex.position());
-
-  TrackingVertex returnValue(simVertex.position(), isInVolume,
-                             simVertex.eventId());
-
-  // add the SimVertex to the TrackingVertex
-  returnValue.addG4Vertex(simVertex);
-
-  // also add refs to nearby HepMC::GenVertexs; the way this is done (i.e. based
-  // on the position) is transcribed over from the old TrackingTruthProducer
-  if (simVertex.eventId().event() == 0 &&
-      simVertex.eventId().bunchCrossing() == 0 &&
-      hepMCproduct_.isValid()) // if this is a track in the signal event
-  {
-    const HepMC::GenEvent *genEvent = hepMCproduct_->GetEvent();
-
-    if (genEvent != nullptr) {
-      Vector tvPosition(returnValue.position().x(), returnValue.position().y(),
-                        returnValue.position().z());
-
-      for (HepMC::GenEvent::vertex_const_iterator iGenVertex =
-               genEvent->vertices_begin();
-           iGenVertex != genEvent->vertices_end(); ++iGenVertex) {
-        HepMC::ThreeVector rawPosition = (*iGenVertex)->position();
-
-        Vector genPosition(rawPosition.x() * 0.1, rawPosition.y() * 0.1,
-                           rawPosition.z() * 0.1);
-
-        auto distance2 = (tvPosition - genPosition).mag2();
-
-        if (distance2 < vertexDistanceCut2_)
-          returnValue.addGenVertex(
-              GenVertexRef(hepMCproduct_, (*iGenVertex)->barcode()));
-      }
-    }
+    return returnValue;
   }
 
-  return returnValue;
-}
+  TrackingVertex TrackingParticleFactory::createTrackingVertex(const ::DecayChainVertex *pChainVertex) const {
+    typedef math::XYZTLorentzVectorD LorentzVector;
+    typedef math::XYZPoint Vector;
+    typedef edm::Ref<edm::HepMCProduct, HepMC::GenVertex> GenVertexRef;
 
-bool ::TrackingParticleFactory::vectorIsInsideVolume(
-    const math::XYZTLorentzVectorD &vector) const {
-  return (vector.Pt() < volumeRadius_ && std::abs(vector.z()) < volumeZ_);
-}
+    const SimVertex &simVertex = decayChain_.getSimVertex(pChainVertex);
 
-//---------------------------------------------------------------------------------
-//---------------------------------------------------------------------------------
-//----   DecayChain methods
-//-----------------------------------------------------
-//---------------------------------------------------------------------------------
-//---------------------------------------------------------------------------------
+    bool isInVolume = this->vectorIsInsideVolume(simVertex.position());
 
-::DecayChain::DecayChain(const std::vector<SimTrack> &trackCollection,
-                         const std::vector<SimVertex> &vertexCollection)
-    : decayTracksSize(trackCollection.size()),
-      decayVerticesSize(vertexCollection.size()),
-      decayTracks_(new DecayChainTrack[decayTracksSize]),
-      decayVertices_(new DecayChainVertex[decayVerticesSize]),
-      simTrackCollection_(trackCollection),
-      simVertexCollection_(vertexCollection),
-      decayTracks(decayTracks_), // These const references map onto the actual
-                                 // members for public const access
-      decayVertices(decayVertices_), rootVertices(rootVertices_) {
-  // I need some maps to be able to get object pointers from the track/vertex ID
-  std::map<int, ::DecayChainTrack *> trackIdToDecayTrack;
-  std::map<int, ::DecayChainVertex *> vertexIdToDecayVertex;
+    TrackingVertex returnValue(simVertex.position(), isInVolume, simVertex.eventId());
 
-  // First create a DecayChainTrack for every SimTrack and make a note of the
-  // trackIds in the map. Also add a pointer to the daughter list of the parent
-  // DecayChainVertex, which might include creating the vertex object if it
-  // doesn't already exist.
-  size_t decayVertexIndex =
-      0; // The index of the next free slot in the DecayChainVertex array.
-  for (size_t index = 0; index < trackCollection.size(); ++index) {
-    ::DecayChainTrack *pDecayTrack =
-        &decayTracks_[index]; // Get a pointer for ease of use
+    // add the SimVertex to the TrackingVertex
+    returnValue.addG4Vertex(simVertex);
 
-    // This is the array index of the SimTrack that this DecayChainTrack
-    // corresponds to. At the moment this is a 1 to 1 relationship with the
-    // DecayChainTrack index, but they won't necessarily be accessed through the
-    // array later so it's still required to store it.
-    pDecayTrack->simTrackIndex = index;
+    // also add refs to nearby HepMC::GenVertexs; the way this is done (i.e. based
+    // on the position) is transcribed over from the old TrackingTruthProducer
+    if (simVertex.eventId().event() == 0 && simVertex.eventId().bunchCrossing() == 0 &&
+        hepMCproduct_.isValid())  // if this is a track in the signal event
+    {
+      const HepMC::GenEvent *genEvent = hepMCproduct_->GetEvent();
 
-    trackIdToDecayTrack[trackCollection[index].trackId()] = pDecayTrack;
+      if (genEvent != nullptr) {
+        Vector tvPosition(returnValue.position().x(), returnValue.position().y(), returnValue.position().z());
 
-    int parentVertexIndex = trackCollection[index].vertIndex();
-    if (parentVertexIndex >= 0) {
-      // Get the DecayChainVertex corresponding to this SimVertex, or initialise
-      // it if it hasn't been done already.
-      ::DecayChainVertex *&pParentVertex =
-          vertexIdToDecayVertex[parentVertexIndex];
-      if (pParentVertex == nullptr) {
-        // Note that I'm using a reference, so changing pParentVertex will
-        // change the entry in the map too.
-        pParentVertex = &decayVertices_[decayVertexIndex];
-        ++decayVertexIndex;
-        pParentVertex->simVertexIndex = parentVertexIndex;
+        for (HepMC::GenEvent::vertex_const_iterator iGenVertex = genEvent->vertices_begin();
+             iGenVertex != genEvent->vertices_end();
+             ++iGenVertex) {
+          HepMC::ThreeVector rawPosition = (*iGenVertex)->position();
+
+          Vector genPosition(rawPosition.x() * 0.1, rawPosition.y() * 0.1, rawPosition.z() * 0.1);
+
+          auto distance2 = (tvPosition - genPosition).mag2();
+
+          if (distance2 < vertexDistanceCut2_)
+            returnValue.addGenVertex(GenVertexRef(hepMCproduct_, (*iGenVertex)->barcode()));
+        }
       }
-      pParentVertex->daughterTracks.push_back(pDecayTrack);
-      pDecayTrack->pParentVertex = pParentVertex;
-    } else
-      throw std::runtime_error("TrackingTruthAccumulator: Found a track with "
-                               "an invalid parent vertex index.");
+    }
+
+    return returnValue;
   }
 
-  // This assert was originally in to check the internal consistency of the
-  // decay chain. Fast sim pileup seems to have a load of vertices with no
-  // tracks pointing to them though, so fast sim fails this assert if pileup is
-  // added. I don't think the problem is vital however, so if the assert is
-  // taken out these extra vertices are ignored.
-  // assert( vertexIdToDecayVertex.size()==vertexCollection.size() &&
-  // vertexCollection.size()==decayVertexIndex );
+  bool ::TrackingParticleFactory::vectorIsInsideVolume(const math::XYZTLorentzVectorD &vector) const {
+    return (vector.Pt() < volumeRadius_ && std::abs(vector.z()) < volumeZ_);
+  }
 
-  // I still need to set DecayChainTrack::daughterVertices and
-  // DecayChainVertex::pParentTrack. The information to do this comes from
-  // SimVertex::parentIndex. I couldn't do this before because I need all of the
-  // DecayChainTracks initialised.
-  for (auto &decayVertexMapPair : vertexIdToDecayVertex) {
-    ::DecayChainVertex *pDecayVertex = decayVertexMapPair.second;
-    int parentTrackIndex =
-        vertexCollection[pDecayVertex->simVertexIndex].parentIndex();
-    if (parentTrackIndex != -1) {
-      std::map<int, ::DecayChainTrack *>::iterator iParentTrackMapPair =
-          trackIdToDecayTrack.find(parentTrackIndex);
-      if (iParentTrackMapPair == trackIdToDecayTrack.end()) {
-        std::stringstream errorStream;
-        errorStream << "TrackingTruthAccumulator: Something has gone wrong "
-                       "with the indexing. Parent track index is "
-                    << parentTrackIndex << ".";
-        throw std::runtime_error(errorStream.str());
-      }
+  //---------------------------------------------------------------------------------
+  //---------------------------------------------------------------------------------
+  //----   DecayChain methods
+  //-----------------------------------------------------
+  //---------------------------------------------------------------------------------
+  //---------------------------------------------------------------------------------
 
-      ::DecayChainTrack *pParentTrackHierarchy = iParentTrackMapPair->second;
+  ::DecayChain::DecayChain(const std::vector<SimTrack> &trackCollection, const std::vector<SimVertex> &vertexCollection)
+      : decayTracksSize(trackCollection.size()),
+        decayVerticesSize(vertexCollection.size()),
+        decayTracks_(new DecayChainTrack[decayTracksSize]),
+        decayVertices_(new DecayChainVertex[decayVerticesSize]),
+        simTrackCollection_(trackCollection),
+        simVertexCollection_(vertexCollection),
+        decayTracks(decayTracks_),  // These const references map onto the actual
+                                    // members for public const access
+        decayVertices(decayVertices_),
+        rootVertices(rootVertices_) {
+    // I need some maps to be able to get object pointers from the track/vertex ID
+    std::map<int, ::DecayChainTrack *> trackIdToDecayTrack;
+    std::map<int, ::DecayChainVertex *> vertexIdToDecayVertex;
 
-      pParentTrackHierarchy->daughterVertices.push_back(pDecayVertex);
-      pDecayVertex->pParentTrack = pParentTrackHierarchy;
-    } else
-      rootVertices_.push_back(
-          pDecayVertex); // Has no parent so is at the top of the decay chain.
-  }                      // end of loop over the vertexIdToDecayVertex map
+    // First create a DecayChainTrack for every SimTrack and make a note of the
+    // trackIds in the map. Also add a pointer to the daughter list of the parent
+    // DecayChainVertex, which might include creating the vertex object if it
+    // doesn't already exist.
+    size_t decayVertexIndex = 0;  // The index of the next free slot in the DecayChainVertex array.
+    for (size_t index = 0; index < trackCollection.size(); ++index) {
+      ::DecayChainTrack *pDecayTrack = &decayTracks_[index];  // Get a pointer for ease of use
 
-  findBrem(trackCollection, vertexCollection);
+      // This is the array index of the SimTrack that this DecayChainTrack
+      // corresponds to. At the moment this is a 1 to 1 relationship with the
+      // DecayChainTrack index, but they won't necessarily be accessed through the
+      // array later so it's still required to store it.
+      pDecayTrack->simTrackIndex = index;
 
-} // end of ::DecayChain constructor
+      trackIdToDecayTrack[trackCollection[index].trackId()] = pDecayTrack;
+
+      int parentVertexIndex = trackCollection[index].vertIndex();
+      if (parentVertexIndex >= 0) {
+        // Get the DecayChainVertex corresponding to this SimVertex, or initialise
+        // it if it hasn't been done already.
+        ::DecayChainVertex *&pParentVertex = vertexIdToDecayVertex[parentVertexIndex];
+        if (pParentVertex == nullptr) {
+          // Note that I'm using a reference, so changing pParentVertex will
+          // change the entry in the map too.
+          pParentVertex = &decayVertices_[decayVertexIndex];
+          ++decayVertexIndex;
+          pParentVertex->simVertexIndex = parentVertexIndex;
+        }
+        pParentVertex->daughterTracks.push_back(pDecayTrack);
+        pDecayTrack->pParentVertex = pParentVertex;
+      } else
+        throw std::runtime_error(
+            "TrackingTruthAccumulator: Found a track with "
+            "an invalid parent vertex index.");
+    }
+
+    // This assert was originally in to check the internal consistency of the
+    // decay chain. Fast sim pileup seems to have a load of vertices with no
+    // tracks pointing to them though, so fast sim fails this assert if pileup is
+    // added. I don't think the problem is vital however, so if the assert is
+    // taken out these extra vertices are ignored.
+    // assert( vertexIdToDecayVertex.size()==vertexCollection.size() &&
+    // vertexCollection.size()==decayVertexIndex );
+
+    // I still need to set DecayChainTrack::daughterVertices and
+    // DecayChainVertex::pParentTrack. The information to do this comes from
+    // SimVertex::parentIndex. I couldn't do this before because I need all of the
+    // DecayChainTracks initialised.
+    for (auto &decayVertexMapPair : vertexIdToDecayVertex) {
+      ::DecayChainVertex *pDecayVertex = decayVertexMapPair.second;
+      int parentTrackIndex = vertexCollection[pDecayVertex->simVertexIndex].parentIndex();
+      if (parentTrackIndex != -1) {
+        std::map<int, ::DecayChainTrack *>::iterator iParentTrackMapPair = trackIdToDecayTrack.find(parentTrackIndex);
+        if (iParentTrackMapPair == trackIdToDecayTrack.end()) {
+          std::stringstream errorStream;
+          errorStream << "TrackingTruthAccumulator: Something has gone wrong "
+                         "with the indexing. Parent track index is "
+                      << parentTrackIndex << ".";
+          throw std::runtime_error(errorStream.str());
+        }
+
+        ::DecayChainTrack *pParentTrackHierarchy = iParentTrackMapPair->second;
+
+        pParentTrackHierarchy->daughterVertices.push_back(pDecayVertex);
+        pDecayVertex->pParentTrack = pParentTrackHierarchy;
+      } else
+        rootVertices_.push_back(pDecayVertex);  // Has no parent so is at the top of the decay chain.
+    }                                           // end of loop over the vertexIdToDecayVertex map
+
+    findBrem(trackCollection, vertexCollection);
+
+  }  // end of ::DecayChain constructor
 
 #if defined(DO_DEBUG_TESTING)
-// Function documentation is with the declaration above. This function is only
-// used for testing.
-void ::DecayChain::integrityCheck() {
-  //
-  // Start off checking the tracks
-  //
-  for (size_t index = 0; index < decayTracksSize; ++index) {
-    const auto &decayTrack = decayTracks[index];
+  // Function documentation is with the declaration above. This function is only
+  // used for testing.
+  void ::DecayChain::integrityCheck() {
     //
-    // Tracks should always have a production vertex
+    // Start off checking the tracks
     //
-    if (decayTrack.pParentVertex == NULL)
-      throw std::runtime_error("TrackingTruthAccumulator.cc integrityCheck(): "
-                               "Found DecayChainTrack with no parent vertex.");
-
-    //
-    // Make sure the parent has this as a child. Also make sure it's only listed
-    // once.
-    //
-    size_t numberOfTimesListed = 0;
-    for (const auto pSiblingTrack : decayTrack.pParentVertex->daughterTracks) {
-      if (pSiblingTrack == &decayTrack)
-        ++numberOfTimesListed;
-    }
-    if (numberOfTimesListed != 1)
-      throw std::runtime_error("TrackingTruthAccumulator.cc integrityCheck(): "
-                               "Found DecayChainTrack whose parent does not "
-                               "have it listed once and only once as a child.");
-
-    //
-    // Make sure all of the children have this listed as a parent.
-    //
-    for (const auto pDaughterVertex : decayTrack.daughterVertices) {
-      if (pDaughterVertex->pParentTrack != &decayTrack)
+    for (size_t index = 0; index < decayTracksSize; ++index) {
+      const auto &decayTrack = decayTracks[index];
+      //
+      // Tracks should always have a production vertex
+      //
+      if (decayTrack.pParentVertex == NULL)
         throw std::runtime_error(
-            "TrackingTruthAccumulator.cc integrityCheck(): Found "
-            "DecayChainTrack whose child does not have it listed as the "
-            "parent.");
-    }
+            "TrackingTruthAccumulator.cc integrityCheck(): "
+            "Found DecayChainTrack with no parent vertex.");
 
-    //
-    // Follow the chain up to the root vertex, and make sure that is listed in
-    // rootVertices
-    //
-    const DecayChainVertex *pAncestorVertex = decayTrack.pParentVertex;
-    while (pAncestorVertex->pParentTrack != NULL) {
-      if (pAncestorVertex->pParentTrack->pParentVertex == NULL)
-        throw std::runtime_error(
-            "TrackingTruthAccumulator.cc integrityCheck(): Found "
-            "DecayChainTrack with no parent vertex higher in the decay chain.");
-      pAncestorVertex = pAncestorVertex->pParentTrack->pParentVertex;
-    }
-    if (std::find(rootVertices.begin(), rootVertices.end(), pAncestorVertex) ==
-        rootVertices.end()) {
-      throw std::runtime_error(
-          "TrackingTruthAccumulator.cc integrityCheck(): Found DecayChainTrack "
-          "whose root vertex is not recorded anywhere.");
-    }
-  } // end of loop over decayTracks
-
-  //
-  // Now check the vertices
-  //
-  for (size_t index = 0; index < decayVerticesSize; ++index) {
-    const auto &decayVertex = decayVertices[index];
-
-    //
-    // Make sure this, or a vertex higher in the chain, is in the list of root
-    // vertices.
-    //
-    const DecayChainVertex *pAncestorVertex = &decayVertex;
-    while (pAncestorVertex->pParentTrack != NULL) {
-      if (pAncestorVertex->pParentTrack->pParentVertex == NULL)
-        throw std::runtime_error(
-            "TrackingTruthAccumulator.cc integrityCheck(): Found "
-            "DecayChainTrack with no parent vertex higher in the vertex decay "
-            "chain.");
-      pAncestorVertex = pAncestorVertex->pParentTrack->pParentVertex;
-    }
-    if (std::find(rootVertices.begin(), rootVertices.end(), pAncestorVertex) ==
-        rootVertices.end()) {
-      throw std::runtime_error(
-          "TrackingTruthAccumulator.cc integrityCheck(): Found DecayChainTrack "
-          "whose root vertex is not recorded anywhere.");
-    }
-
-    //
-    // Make sure the parent has this listed in its daughters once and only once.
-    //
-    if (decayVertex.pParentTrack != NULL) {
+      //
+      // Make sure the parent has this as a child. Also make sure it's only listed
+      // once.
+      //
       size_t numberOfTimesListed = 0;
-      for (const auto pSibling : decayVertex.pParentTrack->daughterVertices) {
-        if (pSibling == &decayVertex)
+      for (const auto pSiblingTrack : decayTrack.pParentVertex->daughterTracks) {
+        if (pSiblingTrack == &decayTrack)
           ++numberOfTimesListed;
       }
       if (numberOfTimesListed != 1)
         throw std::runtime_error(
-            "TrackingTruthAccumulator.cc integrityCheck(): Found "
-            "DecayChainVertex whose parent does not have it listed once and "
-            "only once as a child.");
-    }
+            "TrackingTruthAccumulator.cc integrityCheck(): "
+            "Found DecayChainTrack whose parent does not "
+            "have it listed once and only once as a child.");
 
-    //
-    // Make sure all of the children have this listed as the parent
-    //
-    for (const auto pDaughter : decayVertex.daughterTracks) {
-      if (pDaughter->pParentVertex != &decayVertex)
+      //
+      // Make sure all of the children have this listed as a parent.
+      //
+      for (const auto pDaughterVertex : decayTrack.daughterVertices) {
+        if (pDaughterVertex->pParentTrack != &decayTrack)
+          throw std::runtime_error(
+              "TrackingTruthAccumulator.cc integrityCheck(): Found "
+              "DecayChainTrack whose child does not have it listed as the "
+              "parent.");
+      }
+
+      //
+      // Follow the chain up to the root vertex, and make sure that is listed in
+      // rootVertices
+      //
+      const DecayChainVertex *pAncestorVertex = decayTrack.pParentVertex;
+      while (pAncestorVertex->pParentTrack != NULL) {
+        if (pAncestorVertex->pParentTrack->pParentVertex == NULL)
+          throw std::runtime_error(
+              "TrackingTruthAccumulator.cc integrityCheck(): Found "
+              "DecayChainTrack with no parent vertex higher in the decay chain.");
+        pAncestorVertex = pAncestorVertex->pParentTrack->pParentVertex;
+      }
+      if (std::find(rootVertices.begin(), rootVertices.end(), pAncestorVertex) == rootVertices.end()) {
         throw std::runtime_error(
-            "TrackingTruthAccumulator.cc integrityCheck(): Found "
-            "DecayChainVertex whose child does not have it listed as the "
-            "parent.");
-    }
-  } // end of loop over decay vertices
+            "TrackingTruthAccumulator.cc integrityCheck(): Found DecayChainTrack "
+            "whose root vertex is not recorded anywhere.");
+      }
+    }  // end of loop over decayTracks
 
-  std::cout
-      << "TrackingTruthAccumulator.cc integrityCheck() completed successfully"
-      << std::endl;
-} // end of ::DecayChain::integrityCheck()
+    //
+    // Now check the vertices
+    //
+    for (size_t index = 0; index < decayVerticesSize; ++index) {
+      const auto &decayVertex = decayVertices[index];
+
+      //
+      // Make sure this, or a vertex higher in the chain, is in the list of root
+      // vertices.
+      //
+      const DecayChainVertex *pAncestorVertex = &decayVertex;
+      while (pAncestorVertex->pParentTrack != NULL) {
+        if (pAncestorVertex->pParentTrack->pParentVertex == NULL)
+          throw std::runtime_error(
+              "TrackingTruthAccumulator.cc integrityCheck(): Found "
+              "DecayChainTrack with no parent vertex higher in the vertex decay "
+              "chain.");
+        pAncestorVertex = pAncestorVertex->pParentTrack->pParentVertex;
+      }
+      if (std::find(rootVertices.begin(), rootVertices.end(), pAncestorVertex) == rootVertices.end()) {
+        throw std::runtime_error(
+            "TrackingTruthAccumulator.cc integrityCheck(): Found DecayChainTrack "
+            "whose root vertex is not recorded anywhere.");
+      }
+
+      //
+      // Make sure the parent has this listed in its daughters once and only once.
+      //
+      if (decayVertex.pParentTrack != NULL) {
+        size_t numberOfTimesListed = 0;
+        for (const auto pSibling : decayVertex.pParentTrack->daughterVertices) {
+          if (pSibling == &decayVertex)
+            ++numberOfTimesListed;
+        }
+        if (numberOfTimesListed != 1)
+          throw std::runtime_error(
+              "TrackingTruthAccumulator.cc integrityCheck(): Found "
+              "DecayChainVertex whose parent does not have it listed once and "
+              "only once as a child.");
+      }
+
+      //
+      // Make sure all of the children have this listed as the parent
+      //
+      for (const auto pDaughter : decayVertex.daughterTracks) {
+        if (pDaughter->pParentVertex != &decayVertex)
+          throw std::runtime_error(
+              "TrackingTruthAccumulator.cc integrityCheck(): Found "
+              "DecayChainVertex whose child does not have it listed as the "
+              "parent.");
+      }
+    }  // end of loop over decay vertices
+
+    std::cout << "TrackingTruthAccumulator.cc integrityCheck() completed successfully" << std::endl;
+  }  // end of ::DecayChain::integrityCheck()
 #endif
 
-void ::DecayChain::findBrem(const std::vector<SimTrack> &trackCollection,
-                            const std::vector<SimVertex> &vertexCollection) {
-  for (size_t index = 0; index < decayVerticesSize; ++index) {
-    auto &vertex = decayVertices_[index];
+  void ::DecayChain::findBrem(const std::vector<SimTrack> &trackCollection,
+                              const std::vector<SimVertex> &vertexCollection) {
+    for (size_t index = 0; index < decayVerticesSize; ++index) {
+      auto &vertex = decayVertices_[index];
 
-    // Make sure parent is an electron
-    if (vertex.pParentTrack == nullptr)
-      continue;
-    int parentTrackPDG =
-        trackCollection[vertex.pParentTrack->simTrackIndex].type();
-    if (std::abs(parentTrackPDG) != 11)
-      continue;
+      // Make sure parent is an electron
+      if (vertex.pParentTrack == nullptr)
+        continue;
+      int parentTrackPDG = trackCollection[vertex.pParentTrack->simTrackIndex].type();
+      if (std::abs(parentTrackPDG) != 11)
+        continue;
 
-    size_t numberOfElectrons = 0;
-    size_t numberOfNonElectronsOrPhotons = 0;
-    for (auto &pDaughterTrack : vertex.daughterTracks) {
-      const auto &simTrack = trackCollection[pDaughterTrack->simTrackIndex];
-      if (simTrack.type() == 11 || simTrack.type() == -11)
-        ++numberOfElectrons;
-      else if (simTrack.type() != 22)
-        ++numberOfNonElectronsOrPhotons;
-    }
-    if (numberOfElectrons == 1 && numberOfNonElectronsOrPhotons == 0) {
-      // This is a valid brem, run through and tell all daughters to use the
-      // parent as the brem
-      for (auto &pDaughterTrack : vertex.daughterTracks)
-        pDaughterTrack->pMergedBremSource = vertex.pParentTrack;
-      vertex.pMergedBremSource = vertex.pParentTrack->pParentVertex;
-    }
-  }
-} // end of ::DecayChain::findBrem()
-
-//---------------------------------------------------------------------------------
-//---------------------------------------------------------------------------------
-//----   OutputCollectionWrapper methods
-//----------------------------------------
-//---------------------------------------------------------------------------------
-//---------------------------------------------------------------------------------
-
-::OutputCollectionWrapper::OutputCollectionWrapper(
-    const ::DecayChain &decayChain,
-    TrackingTruthAccumulator::OutputCollections &outputCollections)
-    : output_(outputCollections),
-      trackingParticleIndices_(decayChain.decayTracksSize, -1),
-      trackingVertexIndices_(decayChain.decayVerticesSize, -1) {
-  // No operation besides the initialiser list
-}
-
-TrackingParticle * ::OutputCollectionWrapper::addTrackingParticle(
-    const ::DecayChainTrack *pDecayTrack,
-    const TrackingParticle &trackingParticle) {
-  if (trackingParticleIndices_[pDecayTrack->simTrackIndex] != -1)
-    throw std::runtime_error("OutputCollectionWrapper::addTrackingParticle - "
-                             "trying to add a particle twice");
-
-  trackingParticleIndices_[pDecayTrack->simTrackIndex] =
-      output_.pTrackingParticles->size();
-  output_.pTrackingParticles->push_back(trackingParticle);
-
-  // Clear any associations in case there were any beforehand
-  output_.pTrackingParticles->back().clearDecayVertices();
-  output_.pTrackingParticles->back().clearParentVertex();
-
-  // Associate to the objects that are already in the output collections
-  associateToExistingObjects(pDecayTrack);
-
-  return &output_.pTrackingParticles->back();
-}
-
-TrackingVertex * ::OutputCollectionWrapper::addTrackingVertex(
-    const ::DecayChainVertex *pDecayVertex,
-    const TrackingVertex &trackingVertex) {
-  if (trackingVertexIndices_[pDecayVertex->simVertexIndex] != -1)
-    throw std::runtime_error("OutputCollectionWrapper::addTrackingVertex - "
-                             "trying to add a vertex twice");
-
-  trackingVertexIndices_[pDecayVertex->simVertexIndex] =
-      output_.pTrackingVertices->size();
-  output_.pTrackingVertices->push_back(trackingVertex);
-
-  // Associate the new vertex to any parents or children that are already in the
-  // output collections
-  associateToExistingObjects(pDecayVertex);
-
-  return &output_.pTrackingVertices->back();
-}
-
-TrackingParticle * ::OutputCollectionWrapper::getTrackingParticle(
-    const ::DecayChainTrack *pDecayTrack) {
-  const int index = trackingParticleIndices_[pDecayTrack->simTrackIndex];
-  if (index == -1)
-    return nullptr;
-  else
-    return &(*output_.pTrackingParticles)[index];
-}
-
-TrackingVertex * ::OutputCollectionWrapper::getTrackingVertex(
-    const ::DecayChainVertex *pDecayVertex) {
-  const int index = trackingVertexIndices_[pDecayVertex->simVertexIndex];
-  if (index == -1)
-    return nullptr;
-  else
-    return &(*output_.pTrackingVertices)[index];
-}
-
-TrackingParticleRef
-OutputCollectionWrapper::getRef(const ::DecayChainTrack *pDecayTrack) {
-  const int index = trackingParticleIndices_[pDecayTrack->simTrackIndex];
-  if (index == -1)
-    throw std::runtime_error(
-        "OutputCollectionWrapper::getRefTrackingParticle - ref requested for a "
-        "non existent TrackingParticle");
-  else
-    return TrackingParticleRef(output_.refTrackingParticles, index);
-}
-
-TrackingVertexRef
-OutputCollectionWrapper::getRef(const ::DecayChainVertex *pDecayVertex) {
-  const int index = trackingVertexIndices_[pDecayVertex->simVertexIndex];
-  if (index == -1)
-    throw std::runtime_error(
-        "OutputCollectionWrapper::getRefTrackingParticle - ref requested for a "
-        "non existent TrackingVertex");
-  else
-    return TrackingVertexRef(output_.refTrackingVertexes, index);
-}
-
-void ::OutputCollectionWrapper::setProxy(
-    const ::DecayChainTrack *pOriginalTrack,
-    const ::DecayChainTrack *pProxyTrack) {
-  int &index = trackingParticleIndices_[pOriginalTrack->simTrackIndex];
-  if (index != -1)
-    throw std::runtime_error(
-        "OutputCollectionWrapper::setProxy() was called for a TrackingParticle "
-        "that has already been created");
-  // Note that index is a reference so this call changes the value in the vector
-  // too
-  index = trackingParticleIndices_[pProxyTrack->simTrackIndex];
-}
-
-void ::OutputCollectionWrapper::setProxy(
-    const ::DecayChainVertex *pOriginalVertex,
-    const ::DecayChainVertex *pProxyVertex) {
-  int &index = trackingVertexIndices_[pOriginalVertex->simVertexIndex];
-  const int newIndex = trackingVertexIndices_[pProxyVertex->simVertexIndex];
-
-  if (index != -1 && index != newIndex)
-    throw std::runtime_error(
-        "OutputCollectionWrapper::setProxy() was called for a TrackingVertex "
-        "that has already been created");
-
-  // Note that index is a reference so this call changes the value in the vector
-  // too
-  index = newIndex;
-}
-
-void ::OutputCollectionWrapper::associateToExistingObjects(
-    const ::DecayChainVertex *pChainVertex) {
-  // First make sure the DecayChainVertex supplied has been turned into a
-  // TrackingVertex
-  TrackingVertex *pTrackingVertex = getTrackingVertex(pChainVertex);
-  if (pTrackingVertex == nullptr)
-    throw std::runtime_error(
-        "associateToExistingObjects was passed a non existent TrackingVertex");
-
-  //
-  // Associate to the parent track (if there is one)
-  //
-  ::DecayChainTrack *pParentChainTrack = pChainVertex->pParentTrack;
-  if (pParentChainTrack != nullptr) // Make sure there is a parent track first
-  {
-    // There is a parent track, but it might not have been turned into a
-    // TrackingParticle yet
-    TrackingParticle *pParentTrackingParticle =
-        getTrackingParticle(pParentChainTrack);
-    if (pParentTrackingParticle != nullptr) {
-      pParentTrackingParticle->addDecayVertex(getRef(pChainVertex));
-      pTrackingVertex->addParentTrack(getRef(pParentChainTrack));
-    }
-    // Don't worry about the "else" case - the parent track might not
-    // necessarily get added to the output collection at all. A check is done on
-    // daughter vertices when tracks are added, so the association will be
-    // picked up then.
-  }
-
-  //
-  // A parent TrackingVertex is always associated to a daughter TrackingParticle
-  // when the TrackingParticle is created. Hence there is no need to check the
-  // list of daughter tracks.
-  //
-}
-
-void ::OutputCollectionWrapper::associateToExistingObjects(
-    const ::DecayChainTrack *pChainTrack) {
-  //
-  // First make sure this DecayChainTrack has been turned into a
-  // TrackingParticle
-  //
-  TrackingParticle *pTrackingParticle = getTrackingParticle(pChainTrack);
-  if (pTrackingParticle == nullptr)
-    throw std::runtime_error("associateToExistingObjects was passed a non "
-                             "existent TrackingParticle");
-
-  // Get the parent vertex. This should always already have been turned into a
-  // TrackingVertex, and there should always be a parent DecayChainVertex.
-  ::DecayChainVertex *pParentChainVertex = pChainTrack->pParentVertex;
-  TrackingVertex *pParentTrackingVertex = getTrackingVertex(pParentChainVertex);
-
-  //
-  // First associate to the parent vertex.
-  //
-  pTrackingParticle->setParentVertex(getRef(pParentChainVertex));
-  pParentTrackingVertex->addDaughterTrack(getRef(pChainTrack));
-
-  // If there are any daughter vertices that have already been made into a
-  // TrackingVertex make sure they know about each other. If the daughter
-  // vertices haven't been made into TrackingVertexs yet, I won't do anything
-  // and create the association when the vertex is made.
-  for (auto pDaughterChainVertex : pChainTrack->daughterVertices) {
-    TrackingVertex *pDaughterTrackingVertex =
-        getTrackingVertex(pDaughterChainVertex);
-    if (pDaughterTrackingVertex != nullptr) {
-      pTrackingParticle->addDecayVertex(getRef(pDaughterChainVertex));
-      pDaughterTrackingVertex->addParentTrack(getRef(pChainTrack));
-    }
-  }
-}
-
-TrackingParticle *
-addTrackAndParentVertex(::DecayChainTrack *pDecayTrack,
-                        const TrackingParticle &trackingParticle,
-                        ::OutputCollectionWrapper *pOutput) {
-  // See if this TrackingParticle has already been created (could be if the
-  // DecayChainTracks are looped over in a funny order). If it has then there's
-  // no need to do anything.
-  TrackingParticle *pTrackingParticle =
-      pOutput->getTrackingParticle(pDecayTrack);
-  if (pTrackingParticle == nullptr) {
-    // Need to make sure the production vertex has been created first
-    if (pOutput->getTrackingVertex(pDecayTrack->pParentVertex) == nullptr) {
-      // TrackingVertex doesn't exist in the output collection yet. However,
-      // it's already been created in the addTrack() function and a temporary
-      // reference to it set in the TrackingParticle. I'll use that reference to
-      // create a copy in the output collection. When the TrackingParticle is
-      // added to the output collection a few lines below the temporary
-      // reference to the parent vertex will be cleared, and the correct one
-      // referring to the output collection will be set.
-      pOutput->addTrackingVertex(pDecayTrack->pParentVertex,
-                                 *trackingParticle.parentVertex());
-    }
-
-    pTrackingParticle =
-        pOutput->addTrackingParticle(pDecayTrack, trackingParticle);
-  }
-
-  return pTrackingParticle;
-}
-
-void addTrack(::DecayChainTrack *pDecayChainTrack,
-              const TrackingParticleSelector *pSelector,
-              ::OutputCollectionWrapper *pUnmergedOutput,
-              ::OutputCollectionWrapper *pMergedOutput,
-              const ::TrackingParticleFactory &objectFactory, bool addAncestors,
-              const TrackerTopology *tTopo) {
-  if (pDecayChainTrack == nullptr)
-    return; // This is required for when the addAncestors_ recursive call
-            // reaches the top of the chain
-
-  // Check to see if this particle has already been processed while traversing
-  // up the parents of another split in the decay chain. The check in the line
-  // above only stops when the top of the chain is reached, whereas this will
-  // stop when a previously traversed split is reached.
-  { // block to limit the scope of temporary variables
-    bool alreadyProcessed = true;
-    if (pUnmergedOutput != nullptr) {
-      if (pUnmergedOutput->getTrackingParticle(pDecayChainTrack) == nullptr)
-        alreadyProcessed = false;
-    }
-    if (pMergedOutput != nullptr) {
-      if (pMergedOutput->getTrackingParticle(pDecayChainTrack) == nullptr)
-        alreadyProcessed = false;
-    }
-    if (alreadyProcessed)
-      return;
-  }
-
-  // Create a TrackingParticle.
-  TrackingParticle newTrackingParticle =
-      objectFactory.createTrackingParticle(pDecayChainTrack, tTopo);
-
-  // The selector checks the impact parameters from the vertex, so I need to
-  // have a valid reference to the parent vertex in the TrackingParticle before
-  // that can be called. TrackingParticle needs an edm::Ref for the parent
-  // TrackingVertex though. I still don't know if this is going to be added to
-  // the collection so I can't take it from there, so I need to create a
-  // temporary one. When the addTrackAndParentVertex() is called (assuming it
-  // passes selection) it will use the temporary reference to create a copy of
-  // the parent vertex, put that in the output collection, and then set the
-  // reference in the TrackingParticle properly.
-  TrackingVertexCollection dummyCollection; // Only needed to create an edm::Ref
-  dummyCollection.push_back(
-      objectFactory.createTrackingVertex(pDecayChainTrack->pParentVertex));
-  TrackingVertexRef temporaryRef(&dummyCollection, 0);
-  newTrackingParticle.setParentVertex(temporaryRef);
-
-  // If a selector has been supplied apply it on the new TrackingParticle and
-  // return if it fails.
-  if (pSelector) {
-    if (!(*pSelector)(newTrackingParticle))
-      return; // Return if the TrackingParticle fails selection
-  }
-
-  // Add the ancestors first (if required) so that the collection has some kind
-  // of chronological order. I don't know how important that is but other code
-  // might assume chronological order. If adding ancestors, no selection is
-  // applied. Note that I've already checked that all DecayChainTracks have a
-  // pParentVertex.
-  if (addAncestors)
-    addTrack(pDecayChainTrack->pParentVertex->pParentTrack, nullptr,
-             pUnmergedOutput, pMergedOutput, objectFactory, addAncestors,
-             tTopo);
-
-  // If creation of the unmerged collection has been turned off in the config
-  // this pointer will be null.
-  if (pUnmergedOutput != nullptr)
-    addTrackAndParentVertex(pDecayChainTrack, newTrackingParticle,
-                            pUnmergedOutput);
-
-  // If creation of the merged collection has been turned off in the config this
-  // pointer will be null.
-  if (pMergedOutput != nullptr) {
-    ::DecayChainTrack *pBremParentChainTrack = pDecayChainTrack;
-    while (pBremParentChainTrack->pMergedBremSource != nullptr)
-      pBremParentChainTrack = pBremParentChainTrack->pMergedBremSource;
-
-    if (pBremParentChainTrack != pDecayChainTrack) {
-      TrackingParticle *pBremParentTrackingParticle = addTrackAndParentVertex(
-          pBremParentChainTrack, newTrackingParticle, pMergedOutput);
-      // The original particle in the bremsstrahlung decay chain has been
-      // created (or retrieved if it already existed), now copy in the
-      // extra information.
-      // TODO - copy extra information.
-
-      if (std::abs(newTrackingParticle.pdgId()) == 22) {
-        // Photons are added as separate TrackingParticles, but with the
-        // production vertex changed to be the production vertex of the original
-        // electron.
-
-        // Set up a proxy, so that all requests for the parent TrackingVertex
-        // get redirected to the brem parent's TrackingVertex.
-        pMergedOutput->setProxy(pDecayChainTrack->pParentVertex,
-                                pBremParentChainTrack->pParentVertex);
-
-        // Now that pMergedOutput thinks the parent vertex is the brem parent's
-        // vertex I can call this and it will set the TrackingParticle parent
-        // vertex correctly to the brem parent vertex.
-        addTrackAndParentVertex(pDecayChainTrack, newTrackingParticle,
-                                pMergedOutput);
-      } else if (std::abs(newTrackingParticle.pdgId()) == 11) {
-        // Electrons have their G4 tracks and SimHits copied to the parent
-        // TrackingParticle.
-        for (const auto &trackSegment : newTrackingParticle.g4Tracks()) {
-          pBremParentTrackingParticle->addG4Track(trackSegment);
-        }
-
-        // Also copy the generator particle references
-        for (const auto &genParticleRef : newTrackingParticle.genParticles()) {
-          pBremParentTrackingParticle->addGenParticle(genParticleRef);
-        }
-
-        pBremParentTrackingParticle->setNumberOfHits(
-            pBremParentTrackingParticle->numberOfHits() +
-            newTrackingParticle.numberOfHits());
-        pBremParentTrackingParticle->setNumberOfTrackerHits(
-            pBremParentTrackingParticle->numberOfTrackerHits() +
-            newTrackingParticle.numberOfTrackerHits());
-        pBremParentTrackingParticle->setNumberOfTrackerLayers(
-            pBremParentTrackingParticle->numberOfTrackerLayers() +
-            newTrackingParticle.numberOfTrackerLayers());
-
-        // Set a proxy in the output collection wrapper so that any attempt to
-        // get objects for this DecayChainTrack again get redirected to the brem
-        // parent.
-        pMergedOutput->setProxy(pDecayChainTrack, pBremParentChainTrack);
+      size_t numberOfElectrons = 0;
+      size_t numberOfNonElectronsOrPhotons = 0;
+      for (auto &pDaughterTrack : vertex.daughterTracks) {
+        const auto &simTrack = trackCollection[pDaughterTrack->simTrackIndex];
+        if (simTrack.type() == 11 || simTrack.type() == -11)
+          ++numberOfElectrons;
+        else if (simTrack.type() != 22)
+          ++numberOfNonElectronsOrPhotons;
       }
-    } else {
-      // This is not the result of bremsstrahlung so add to the collection as
-      // normal.
-      addTrackAndParentVertex(pDecayChainTrack, newTrackingParticle,
-                              pMergedOutput);
+      if (numberOfElectrons == 1 && numberOfNonElectronsOrPhotons == 0) {
+        // This is a valid brem, run through and tell all daughters to use the
+        // parent as the brem
+        for (auto &pDaughterTrack : vertex.daughterTracks)
+          pDaughterTrack->pMergedBremSource = vertex.pParentTrack;
+        vertex.pMergedBremSource = vertex.pParentTrack->pParentVertex;
+      }
     }
-  } // end of "if( pMergedOutput!=NULL )", i.e. end of "if bremsstrahlung
-    // merging is turned on"
+  }  // end of ::DecayChain::findBrem()
 
-} // end of addTrack function
+  //---------------------------------------------------------------------------------
+  //---------------------------------------------------------------------------------
+  //----   OutputCollectionWrapper methods
+  //----------------------------------------
+  //---------------------------------------------------------------------------------
+  //---------------------------------------------------------------------------------
 
-} // namespace
+  ::OutputCollectionWrapper::OutputCollectionWrapper(const ::DecayChain &decayChain,
+                                                     TrackingTruthAccumulator::OutputCollections &outputCollections)
+      : output_(outputCollections),
+        trackingParticleIndices_(decayChain.decayTracksSize, -1),
+        trackingVertexIndices_(decayChain.decayVerticesSize, -1) {
+    // No operation besides the initialiser list
+  }
+
+  TrackingParticle * ::OutputCollectionWrapper::addTrackingParticle(const ::DecayChainTrack *pDecayTrack,
+                                                                    const TrackingParticle &trackingParticle) {
+    if (trackingParticleIndices_[pDecayTrack->simTrackIndex] != -1)
+      throw std::runtime_error(
+          "OutputCollectionWrapper::addTrackingParticle - "
+          "trying to add a particle twice");
+
+    trackingParticleIndices_[pDecayTrack->simTrackIndex] = output_.pTrackingParticles->size();
+    output_.pTrackingParticles->push_back(trackingParticle);
+
+    // Clear any associations in case there were any beforehand
+    output_.pTrackingParticles->back().clearDecayVertices();
+    output_.pTrackingParticles->back().clearParentVertex();
+
+    // Associate to the objects that are already in the output collections
+    associateToExistingObjects(pDecayTrack);
+
+    return &output_.pTrackingParticles->back();
+  }
+
+  TrackingVertex * ::OutputCollectionWrapper::addTrackingVertex(const ::DecayChainVertex *pDecayVertex,
+                                                                const TrackingVertex &trackingVertex) {
+    if (trackingVertexIndices_[pDecayVertex->simVertexIndex] != -1)
+      throw std::runtime_error(
+          "OutputCollectionWrapper::addTrackingVertex - "
+          "trying to add a vertex twice");
+
+    trackingVertexIndices_[pDecayVertex->simVertexIndex] = output_.pTrackingVertices->size();
+    output_.pTrackingVertices->push_back(trackingVertex);
+
+    // Associate the new vertex to any parents or children that are already in the
+    // output collections
+    associateToExistingObjects(pDecayVertex);
+
+    return &output_.pTrackingVertices->back();
+  }
+
+  TrackingParticle * ::OutputCollectionWrapper::getTrackingParticle(const ::DecayChainTrack *pDecayTrack) {
+    const int index = trackingParticleIndices_[pDecayTrack->simTrackIndex];
+    if (index == -1)
+      return nullptr;
+    else
+      return &(*output_.pTrackingParticles)[index];
+  }
+
+  TrackingVertex * ::OutputCollectionWrapper::getTrackingVertex(const ::DecayChainVertex *pDecayVertex) {
+    const int index = trackingVertexIndices_[pDecayVertex->simVertexIndex];
+    if (index == -1)
+      return nullptr;
+    else
+      return &(*output_.pTrackingVertices)[index];
+  }
+
+  TrackingParticleRef OutputCollectionWrapper::getRef(const ::DecayChainTrack *pDecayTrack) {
+    const int index = trackingParticleIndices_[pDecayTrack->simTrackIndex];
+    if (index == -1)
+      throw std::runtime_error(
+          "OutputCollectionWrapper::getRefTrackingParticle - ref requested for a "
+          "non existent TrackingParticle");
+    else
+      return TrackingParticleRef(output_.refTrackingParticles, index);
+  }
+
+  TrackingVertexRef OutputCollectionWrapper::getRef(const ::DecayChainVertex *pDecayVertex) {
+    const int index = trackingVertexIndices_[pDecayVertex->simVertexIndex];
+    if (index == -1)
+      throw std::runtime_error(
+          "OutputCollectionWrapper::getRefTrackingParticle - ref requested for a "
+          "non existent TrackingVertex");
+    else
+      return TrackingVertexRef(output_.refTrackingVertexes, index);
+  }
+
+  void ::OutputCollectionWrapper::setProxy(const ::DecayChainTrack *pOriginalTrack,
+                                           const ::DecayChainTrack *pProxyTrack) {
+    int &index = trackingParticleIndices_[pOriginalTrack->simTrackIndex];
+    if (index != -1)
+      throw std::runtime_error(
+          "OutputCollectionWrapper::setProxy() was called for a TrackingParticle "
+          "that has already been created");
+    // Note that index is a reference so this call changes the value in the vector
+    // too
+    index = trackingParticleIndices_[pProxyTrack->simTrackIndex];
+  }
+
+  void ::OutputCollectionWrapper::setProxy(const ::DecayChainVertex *pOriginalVertex,
+                                           const ::DecayChainVertex *pProxyVertex) {
+    int &index = trackingVertexIndices_[pOriginalVertex->simVertexIndex];
+    const int newIndex = trackingVertexIndices_[pProxyVertex->simVertexIndex];
+
+    if (index != -1 && index != newIndex)
+      throw std::runtime_error(
+          "OutputCollectionWrapper::setProxy() was called for a TrackingVertex "
+          "that has already been created");
+
+    // Note that index is a reference so this call changes the value in the vector
+    // too
+    index = newIndex;
+  }
+
+  void ::OutputCollectionWrapper::associateToExistingObjects(const ::DecayChainVertex *pChainVertex) {
+    // First make sure the DecayChainVertex supplied has been turned into a
+    // TrackingVertex
+    TrackingVertex *pTrackingVertex = getTrackingVertex(pChainVertex);
+    if (pTrackingVertex == nullptr)
+      throw std::runtime_error("associateToExistingObjects was passed a non existent TrackingVertex");
+
+    //
+    // Associate to the parent track (if there is one)
+    //
+    ::DecayChainTrack *pParentChainTrack = pChainVertex->pParentTrack;
+    if (pParentChainTrack != nullptr)  // Make sure there is a parent track first
+    {
+      // There is a parent track, but it might not have been turned into a
+      // TrackingParticle yet
+      TrackingParticle *pParentTrackingParticle = getTrackingParticle(pParentChainTrack);
+      if (pParentTrackingParticle != nullptr) {
+        pParentTrackingParticle->addDecayVertex(getRef(pChainVertex));
+        pTrackingVertex->addParentTrack(getRef(pParentChainTrack));
+      }
+      // Don't worry about the "else" case - the parent track might not
+      // necessarily get added to the output collection at all. A check is done on
+      // daughter vertices when tracks are added, so the association will be
+      // picked up then.
+    }
+
+    //
+    // A parent TrackingVertex is always associated to a daughter TrackingParticle
+    // when the TrackingParticle is created. Hence there is no need to check the
+    // list of daughter tracks.
+    //
+  }
+
+  void ::OutputCollectionWrapper::associateToExistingObjects(const ::DecayChainTrack *pChainTrack) {
+    //
+    // First make sure this DecayChainTrack has been turned into a
+    // TrackingParticle
+    //
+    TrackingParticle *pTrackingParticle = getTrackingParticle(pChainTrack);
+    if (pTrackingParticle == nullptr)
+      throw std::runtime_error(
+          "associateToExistingObjects was passed a non "
+          "existent TrackingParticle");
+
+    // Get the parent vertex. This should always already have been turned into a
+    // TrackingVertex, and there should always be a parent DecayChainVertex.
+    ::DecayChainVertex *pParentChainVertex = pChainTrack->pParentVertex;
+    TrackingVertex *pParentTrackingVertex = getTrackingVertex(pParentChainVertex);
+
+    //
+    // First associate to the parent vertex.
+    //
+    pTrackingParticle->setParentVertex(getRef(pParentChainVertex));
+    pParentTrackingVertex->addDaughterTrack(getRef(pChainTrack));
+
+    // If there are any daughter vertices that have already been made into a
+    // TrackingVertex make sure they know about each other. If the daughter
+    // vertices haven't been made into TrackingVertexs yet, I won't do anything
+    // and create the association when the vertex is made.
+    for (auto pDaughterChainVertex : pChainTrack->daughterVertices) {
+      TrackingVertex *pDaughterTrackingVertex = getTrackingVertex(pDaughterChainVertex);
+      if (pDaughterTrackingVertex != nullptr) {
+        pTrackingParticle->addDecayVertex(getRef(pDaughterChainVertex));
+        pDaughterTrackingVertex->addParentTrack(getRef(pChainTrack));
+      }
+    }
+  }
+
+  TrackingParticle *addTrackAndParentVertex(::DecayChainTrack *pDecayTrack,
+                                            const TrackingParticle &trackingParticle,
+                                            ::OutputCollectionWrapper *pOutput) {
+    // See if this TrackingParticle has already been created (could be if the
+    // DecayChainTracks are looped over in a funny order). If it has then there's
+    // no need to do anything.
+    TrackingParticle *pTrackingParticle = pOutput->getTrackingParticle(pDecayTrack);
+    if (pTrackingParticle == nullptr) {
+      // Need to make sure the production vertex has been created first
+      if (pOutput->getTrackingVertex(pDecayTrack->pParentVertex) == nullptr) {
+        // TrackingVertex doesn't exist in the output collection yet. However,
+        // it's already been created in the addTrack() function and a temporary
+        // reference to it set in the TrackingParticle. I'll use that reference to
+        // create a copy in the output collection. When the TrackingParticle is
+        // added to the output collection a few lines below the temporary
+        // reference to the parent vertex will be cleared, and the correct one
+        // referring to the output collection will be set.
+        pOutput->addTrackingVertex(pDecayTrack->pParentVertex, *trackingParticle.parentVertex());
+      }
+
+      pTrackingParticle = pOutput->addTrackingParticle(pDecayTrack, trackingParticle);
+    }
+
+    return pTrackingParticle;
+  }
+
+  void addTrack(::DecayChainTrack *pDecayChainTrack,
+                const TrackingParticleSelector *pSelector,
+                ::OutputCollectionWrapper *pUnmergedOutput,
+                ::OutputCollectionWrapper *pMergedOutput,
+                const ::TrackingParticleFactory &objectFactory,
+                bool addAncestors,
+                const TrackerTopology *tTopo) {
+    if (pDecayChainTrack == nullptr)
+      return;  // This is required for when the addAncestors_ recursive call
+               // reaches the top of the chain
+
+    // Check to see if this particle has already been processed while traversing
+    // up the parents of another split in the decay chain. The check in the line
+    // above only stops when the top of the chain is reached, whereas this will
+    // stop when a previously traversed split is reached.
+    {  // block to limit the scope of temporary variables
+      bool alreadyProcessed = true;
+      if (pUnmergedOutput != nullptr) {
+        if (pUnmergedOutput->getTrackingParticle(pDecayChainTrack) == nullptr)
+          alreadyProcessed = false;
+      }
+      if (pMergedOutput != nullptr) {
+        if (pMergedOutput->getTrackingParticle(pDecayChainTrack) == nullptr)
+          alreadyProcessed = false;
+      }
+      if (alreadyProcessed)
+        return;
+    }
+
+    // Create a TrackingParticle.
+    TrackingParticle newTrackingParticle = objectFactory.createTrackingParticle(pDecayChainTrack, tTopo);
+
+    // The selector checks the impact parameters from the vertex, so I need to
+    // have a valid reference to the parent vertex in the TrackingParticle before
+    // that can be called. TrackingParticle needs an edm::Ref for the parent
+    // TrackingVertex though. I still don't know if this is going to be added to
+    // the collection so I can't take it from there, so I need to create a
+    // temporary one. When the addTrackAndParentVertex() is called (assuming it
+    // passes selection) it will use the temporary reference to create a copy of
+    // the parent vertex, put that in the output collection, and then set the
+    // reference in the TrackingParticle properly.
+    TrackingVertexCollection dummyCollection;  // Only needed to create an edm::Ref
+    dummyCollection.push_back(objectFactory.createTrackingVertex(pDecayChainTrack->pParentVertex));
+    TrackingVertexRef temporaryRef(&dummyCollection, 0);
+    newTrackingParticle.setParentVertex(temporaryRef);
+
+    // If a selector has been supplied apply it on the new TrackingParticle and
+    // return if it fails.
+    if (pSelector) {
+      if (!(*pSelector)(newTrackingParticle))
+        return;  // Return if the TrackingParticle fails selection
+    }
+
+    // Add the ancestors first (if required) so that the collection has some kind
+    // of chronological order. I don't know how important that is but other code
+    // might assume chronological order. If adding ancestors, no selection is
+    // applied. Note that I've already checked that all DecayChainTracks have a
+    // pParentVertex.
+    if (addAncestors)
+      addTrack(pDecayChainTrack->pParentVertex->pParentTrack,
+               nullptr,
+               pUnmergedOutput,
+               pMergedOutput,
+               objectFactory,
+               addAncestors,
+               tTopo);
+
+    // If creation of the unmerged collection has been turned off in the config
+    // this pointer will be null.
+    if (pUnmergedOutput != nullptr)
+      addTrackAndParentVertex(pDecayChainTrack, newTrackingParticle, pUnmergedOutput);
+
+    // If creation of the merged collection has been turned off in the config this
+    // pointer will be null.
+    if (pMergedOutput != nullptr) {
+      ::DecayChainTrack *pBremParentChainTrack = pDecayChainTrack;
+      while (pBremParentChainTrack->pMergedBremSource != nullptr)
+        pBremParentChainTrack = pBremParentChainTrack->pMergedBremSource;
+
+      if (pBremParentChainTrack != pDecayChainTrack) {
+        TrackingParticle *pBremParentTrackingParticle =
+            addTrackAndParentVertex(pBremParentChainTrack, newTrackingParticle, pMergedOutput);
+        // The original particle in the bremsstrahlung decay chain has been
+        // created (or retrieved if it already existed), now copy in the
+        // extra information.
+        // TODO - copy extra information.
+
+        if (std::abs(newTrackingParticle.pdgId()) == 22) {
+          // Photons are added as separate TrackingParticles, but with the
+          // production vertex changed to be the production vertex of the original
+          // electron.
+
+          // Set up a proxy, so that all requests for the parent TrackingVertex
+          // get redirected to the brem parent's TrackingVertex.
+          pMergedOutput->setProxy(pDecayChainTrack->pParentVertex, pBremParentChainTrack->pParentVertex);
+
+          // Now that pMergedOutput thinks the parent vertex is the brem parent's
+          // vertex I can call this and it will set the TrackingParticle parent
+          // vertex correctly to the brem parent vertex.
+          addTrackAndParentVertex(pDecayChainTrack, newTrackingParticle, pMergedOutput);
+        } else if (std::abs(newTrackingParticle.pdgId()) == 11) {
+          // Electrons have their G4 tracks and SimHits copied to the parent
+          // TrackingParticle.
+          for (const auto &trackSegment : newTrackingParticle.g4Tracks()) {
+            pBremParentTrackingParticle->addG4Track(trackSegment);
+          }
+
+          // Also copy the generator particle references
+          for (const auto &genParticleRef : newTrackingParticle.genParticles()) {
+            pBremParentTrackingParticle->addGenParticle(genParticleRef);
+          }
+
+          pBremParentTrackingParticle->setNumberOfHits(pBremParentTrackingParticle->numberOfHits() +
+                                                       newTrackingParticle.numberOfHits());
+          pBremParentTrackingParticle->setNumberOfTrackerHits(pBremParentTrackingParticle->numberOfTrackerHits() +
+                                                              newTrackingParticle.numberOfTrackerHits());
+          pBremParentTrackingParticle->setNumberOfTrackerLayers(pBremParentTrackingParticle->numberOfTrackerLayers() +
+                                                                newTrackingParticle.numberOfTrackerLayers());
+
+          // Set a proxy in the output collection wrapper so that any attempt to
+          // get objects for this DecayChainTrack again get redirected to the brem
+          // parent.
+          pMergedOutput->setProxy(pDecayChainTrack, pBremParentChainTrack);
+        }
+      } else {
+        // This is not the result of bremsstrahlung so add to the collection as
+        // normal.
+        addTrackAndParentVertex(pDecayChainTrack, newTrackingParticle, pMergedOutput);
+      }
+    }  // end of "if( pMergedOutput!=NULL )", i.e. end of "if bremsstrahlung
+       // merging is turned on"
+
+  }  // end of addTrack function
+
+}  // namespace
 
 // Register with the framework
 DEFINE_DIGI_ACCUMULATOR(TrackingTruthAccumulator);

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.h
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.h
@@ -5,17 +5,17 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 #include "SimTracker/Common/interface/TrackingParticleSelector.h"
-#include <memory> // required for std::unique_ptr
+#include <memory>  // required for std::unique_ptr
 
 // Forward declarations
 namespace edm {
-class ParameterSet;
-class ConsumesCollector;
-class ProducerBase;
-class Event;
-class EventSetup;
-class StreamID;
-} // namespace edm
+  class ParameterSet;
+  class ConsumesCollector;
+  class ProducerBase;
+  class Event;
+  class EventSetup;
+  class StreamID;
+}  // namespace edm
 class PileUpEventPrincipal;
 class PSimHit;
 
@@ -93,27 +93,24 @@ public:
                                     edm::ConsumesCollector &iC);
 
 private:
-  void initializeEvent(const edm::Event &event,
-                       const edm::EventSetup &setup) override;
-  void accumulate(const edm::Event &event,
-                  const edm::EventSetup &setup) override;
-  void accumulate(const PileUpEventPrincipal &event,
-                  const edm::EventSetup &setup, edm::StreamID const &) override;
+  void initializeEvent(const edm::Event &event, const edm::EventSetup &setup) override;
+  void accumulate(const edm::Event &event, const edm::EventSetup &setup) override;
+  void accumulate(const PileUpEventPrincipal &event, const edm::EventSetup &setup, edm::StreamID const &) override;
   void finalizeEvent(edm::Event &event, const edm::EventSetup &setup) override;
 
   /** @brief Both forms of accumulate() delegate to this templated method. */
   template <class T>
-  void accumulateEvent(const T &event, const edm::EventSetup &setup,
+  void accumulateEvent(const T &event,
+                       const edm::EventSetup &setup,
                        const edm::Handle<edm::HepMCProduct> &hepMCproduct);
 
   /** @brief Fills the supplied vector with pointers to the SimHits, checking
    * for bad modules if required */
   template <class T>
-  void fillSimHits(std::vector<const PSimHit *> &returnValue, const T &event,
-                   const edm::EventSetup &setup);
+  void fillSimHits(std::vector<const PSimHit *> &returnValue, const T &event, const edm::EventSetup &setup);
 
-  const std::string messageCategory_; ///< The message category used to send
-                                      ///< messages to MessageLogger
+  const std::string messageCategory_;  ///< The message category used to send
+                                       ///< messages to MessageLogger
 
   const double volumeRadius_;
   const double volumeZ_;
@@ -188,4 +185,4 @@ private:
   std::unique_ptr<TrackingVertexCollection> pInitialVertices_;
 };
 
-#endif // end of "#ifndef TrackingAnalysis_TrackingTruthAccumulator_h"
+#endif  // end of "#ifndef TrackingAnalysis_TrackingTruthAccumulator_h"

--- a/SimGeneral/TrackingAnalysis/src/EncodedTruthId.cc
+++ b/SimGeneral/TrackingAnalysis/src/EncodedTruthId.cc
@@ -2,10 +2,8 @@
 
 EncodedTruthId::EncodedTruthId() {}
 
-EncodedTruthId::EncodedTruthId(EncodedEventId eid, int index)
-    : EncodedEventId(eid), index_(index) {}
+EncodedTruthId::EncodedTruthId(EncodedEventId eid, int index) : EncodedEventId(eid), index_(index) {}
 
 std::ostream &operator<<(std::ostream &os, EncodedTruthId &id) {
-  return os << "(" << id.bunchCrossing() << "," << id.event() << ","
-            << id.index() << ")";
+  return os << "(" << id.bunchCrossing() << "," << id.event() << "," << id.index() << ")";
 }

--- a/SimGeneral/TrackingAnalysis/src/MuonPSimHitSelector.cc
+++ b/SimGeneral/TrackingAnalysis/src/MuonPSimHitSelector.cc
@@ -15,8 +15,7 @@ void MuonPSimHitSelector::select(PSimHitCollection &selection,
                                  edm::Event const &event,
                                  edm::EventSetup const &setup) const {
   // Look for psimhit collection associated to the muon system
-  PSimHitCollectionMap::const_iterator pSimHitCollections =
-      pSimHitCollectionMap_.find("muon");
+  PSimHitCollectionMap::const_iterator pSimHitCollections = pSimHitCollectionMap_.find("muon");
 
   // Check that there are psimhit collections defined for the tracker
   if (pSimHitCollections == pSimHitCollectionMap_.end())
@@ -33,16 +32,14 @@ void MuonPSimHitSelector::select(PSimHitCollection &selection,
   }
 
   // Create a mix collection from the different psimhit collections
-  std::unique_ptr<MixCollection<PSimHit>> pSimHits(
-      new MixCollection<PSimHit>(cfPSimHitProductPointers));
+  std::unique_ptr<MixCollection<PSimHit>> pSimHits(new MixCollection<PSimHit>(cfPSimHitProductPointers));
 
   // Get CSC Bad Chambers (ME4/2)
   edm::ESHandle<CSCBadChambers> cscBadChambers;
   setup.get<CSCBadChambersRcd>().get(cscBadChambers);
 
   // Select only psimhits from alive modules
-  for (MixCollection<PSimHit>::MixItr pSimHit = pSimHits->begin();
-       pSimHit != pSimHits->end(); ++pSimHit) {
+  for (MixCollection<PSimHit>::MixItr pSimHit = pSimHits->begin(); pSimHit != pSimHits->end(); ++pSimHit) {
     DetId dId = DetId(pSimHit->detUnitId());
 
     if (dId.det() == DetId::Muon && dId.subdetId() == MuonSubdetId::CSC) {

--- a/SimGeneral/TrackingAnalysis/src/PSimHitSelector.cc
+++ b/SimGeneral/TrackingAnalysis/src/PSimHitSelector.cc
@@ -6,19 +6,15 @@
 
 PSimHitSelector::PSimHitSelector(edm::ParameterSet const &config) {
   // Initilize psimhit collection discriminated by sub systems
-  edm::ParameterSet pSimHitCollections =
-      config.getParameter<edm::ParameterSet>("simHitCollections");
+  edm::ParameterSet pSimHitCollections = config.getParameter<edm::ParameterSet>("simHitCollections");
 
   std::vector<std::string> subdetectors(pSimHitCollections.getParameterNames());
 
   mixLabel_ = config.getParameter<std::string>("mixLabel");
 
   for (size_t i = 0; i < subdetectors.size(); ++i) {
-    pSimHitCollectionMap_.insert(
-        std::pair<std::string, std::vector<std::string>>(
-            subdetectors[i],
-            pSimHitCollections.getParameter<std::vector<std::string>>(
-                subdetectors[i])));
+    pSimHitCollectionMap_.insert(std::pair<std::string, std::vector<std::string>>(
+        subdetectors[i], pSimHitCollections.getParameter<std::vector<std::string>>(subdetectors[i])));
   }
 }
 
@@ -26,13 +22,11 @@ void PSimHitSelector::select(PSimHitCollection &selection,
                              edm::Event const &event,
                              edm::EventSetup const &setup) const {
   // Look for all psimhit collections
-  PSimHitCollectionMap::const_iterator pSimHitCollections =
-      pSimHitCollectionMap_.begin();
+  PSimHitCollectionMap::const_iterator pSimHitCollections = pSimHitCollectionMap_.begin();
 
   std::vector<const CrossingFrame<PSimHit> *> cfPSimHitProductPointers;
 
-  for (; pSimHitCollections != pSimHitCollectionMap_.end();
-       ++pSimHitCollections) {
+  for (; pSimHitCollections != pSimHitCollectionMap_.end(); ++pSimHitCollections) {
     // Grab all the PSimHit from the different sencitive volumes
     edm::Handle<CrossingFrame<PSimHit>> cfPSimHits;
 
@@ -47,11 +41,9 @@ void PSimHitSelector::select(PSimHitCollection &selection,
     return;
 
   // Create a mix collection from the different psimhit collections
-  std::unique_ptr<MixCollection<PSimHit>> pSimHits(
-      new MixCollection<PSimHit>(cfPSimHitProductPointers));
+  std::unique_ptr<MixCollection<PSimHit>> pSimHits(new MixCollection<PSimHit>(cfPSimHitProductPointers));
 
   // Select all psimhits
-  for (MixCollection<PSimHit>::MixItr pSimHit = pSimHits->begin();
-       pSimHit != pSimHits->end(); ++pSimHit)
+  for (MixCollection<PSimHit>::MixItr pSimHit = pSimHits->begin(); pSimHit != pSimHits->end(); ++pSimHit)
     selection.push_back(*pSimHit);
 }

--- a/SimGeneral/TrackingAnalysis/src/PixelPSimHitSelector.cc
+++ b/SimGeneral/TrackingAnalysis/src/PixelPSimHitSelector.cc
@@ -13,8 +13,7 @@ void PixelPSimHitSelector::select(PSimHitCollection &selection,
                                   edm::Event const &event,
                                   edm::EventSetup const &setup) const {
   // Look for psimhit collection associated o the tracker
-  PSimHitCollectionMap::const_iterator pSimHitCollections =
-      pSimHitCollectionMap_.find("pixel");
+  PSimHitCollectionMap::const_iterator pSimHitCollections = pSimHitCollectionMap_.find("pixel");
 
   // Check that there are psimhit collections defined for the tracker
   if (pSimHitCollections == pSimHitCollectionMap_.end())
@@ -31,21 +30,18 @@ void PixelPSimHitSelector::select(PSimHitCollection &selection,
   }
 
   // Create a mix collection from the different psimhit collections
-  std::unique_ptr<MixCollection<PSimHit>> pSimHits(
-      new MixCollection<PSimHit>(cfPSimHitProductPointers));
+  std::unique_ptr<MixCollection<PSimHit>> pSimHits(new MixCollection<PSimHit>(cfPSimHitProductPointers));
 
   // Accessing dead pixel modules from DB:
   edm::ESHandle<SiPixelQuality> siPixelBadModule;
   setup.get<SiPixelQualityRcd>().get(siPixelBadModule);
 
   // Reading the DB information
-  std::vector<SiPixelQuality::disabledModuleType> badModules(
-      siPixelBadModule->getBadComponentList());
+  std::vector<SiPixelQuality::disabledModuleType> badModules(siPixelBadModule->getBadComponentList());
   SiPixelQuality pixelQuality(badModules);
 
   // Select only psimhits from alive modules
-  for (MixCollection<PSimHit>::MixItr pSimHit = pSimHits->begin();
-       pSimHit != pSimHits->end(); ++pSimHit) {
+  for (MixCollection<PSimHit>::MixItr pSimHit = pSimHits->begin(); pSimHit != pSimHits->end(); ++pSimHit) {
     if (!pixelQuality.IsModuleBad(pSimHit->detUnitId()))
       selection.push_back(*pSimHit);
   }

--- a/SimGeneral/TrackingAnalysis/src/TrackerPSimHitSelector.cc
+++ b/SimGeneral/TrackingAnalysis/src/TrackerPSimHitSelector.cc
@@ -16,8 +16,7 @@ void TrackerPSimHitSelector::select(PSimHitCollection &selection,
                                     edm::Event const &event,
                                     edm::EventSetup const &setup) const {
   // Look for psimhit collection associated o the tracker
-  PSimHitCollectionMap::const_iterator pSimHitCollections =
-      pSimHitCollectionMap_.find("tracker");
+  PSimHitCollectionMap::const_iterator pSimHitCollections = pSimHitCollectionMap_.find("tracker");
 
   // Check that there are psimhit collections defined for the tracker
   if (pSimHitCollections == pSimHitCollectionMap_.end())
@@ -34,8 +33,7 @@ void TrackerPSimHitSelector::select(PSimHitCollection &selection,
   }
 
   // Create a mix collection from the different psimhit collections
-  std::unique_ptr<MixCollection<PSimHit>> pSimHits(
-      new MixCollection<PSimHit>(cfPSimHitProductPointers));
+  std::unique_ptr<MixCollection<PSimHit>> pSimHits(new MixCollection<PSimHit>(cfPSimHitProductPointers));
 
   // Setup the cabling mapping
   std::map<uint32_t, std::vector<int>> theDetIdList;
@@ -44,8 +42,7 @@ void TrackerPSimHitSelector::select(PSimHitCollection &selection,
   detCabling->addConnected(theDetIdList);
 
   // Select only psimhits from alive modules
-  std::vector<std::pair<const PSimHit *, int>> psimhits(
-      SimHitSelectorFromDB().getSimHit(pSimHits, theDetIdList));
+  std::vector<std::pair<const PSimHit *, int>> psimhits(SimHitSelectorFromDB().getSimHit(pSimHits, theDetIdList));
 
   // Add the selected psimhit to the main list
   for (std::size_t i = 0; i < psimhits.size(); ++i)

--- a/SimGeneral/TrackingAnalysis/src/classes.h
+++ b/SimGeneral/TrackingAnalysis/src/classes.h
@@ -5,27 +5,18 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
 namespace SimGeneral_TrackingAnalysis {
-struct dictionary {
-  edm::Ptr<TrackingParticle> TP;
-  std::vector<edm::Ptr<TrackingParticle>> V_TP;
-  std::pair<TrackingParticleRef, TrackPSimHitRef> dummy13;
-  edm::Wrapper<std::pair<TrackingParticleRef, TrackPSimHitRef>> dummy14;
-  std::vector<std::pair<TrackingParticleRef, TrackPSimHitRef>> dummy07;
-  edm::Wrapper<std::vector<std::pair<TrackingParticleRef, TrackPSimHitRef>>>
-      dummy08;
+  struct dictionary {
+    edm::Ptr<TrackingParticle> TP;
+    std::vector<edm::Ptr<TrackingParticle>> V_TP;
+    std::pair<TrackingParticleRef, TrackPSimHitRef> dummy13;
+    edm::Wrapper<std::pair<TrackingParticleRef, TrackPSimHitRef>> dummy14;
+    std::vector<std::pair<TrackingParticleRef, TrackPSimHitRef>> dummy07;
+    edm::Wrapper<std::vector<std::pair<TrackingParticleRef, TrackPSimHitRef>>> dummy08;
 
-  std::pair<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>,
-            edm::Ptr<TrackingParticle>>
-      P_TAM_S_TP_PD;
-  std::pair<edm::Ptr<TrackingParticle>,
-            std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>>>
-      P_TAM_TP_S_PD;
+    std::pair<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>, edm::Ptr<TrackingParticle>> P_TAM_S_TP_PD;
+    std::pair<edm::Ptr<TrackingParticle>, std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>>> P_TAM_TP_S_PD;
 
-  std::map<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>,
-           edm::Ptr<TrackingParticle>>
-      M_TAM_S_TP_PD;
-  std::map<edm::Ptr<TrackingParticle>,
-           std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>>>
-      M_TAM_TP_S_PD;
-};
-} // namespace SimGeneral_TrackingAnalysis
+    std::map<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>, edm::Ptr<TrackingParticle>> M_TAM_S_TP_PD;
+    std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>>> M_TAM_TP_S_PD;
+  };
+}  // namespace SimGeneral_TrackingAnalysis

--- a/SimGeneral/TrackingAnalysis/test/TrackingTruthOutputTest.cc
+++ b/SimGeneral/TrackingAnalysis/test/TrackingTruthOutputTest.cc
@@ -22,32 +22,25 @@ typedef TrackingParticleRefVector::iterator tp_iterator;
 typedef TrackingVertex::genv_iterator genv_iterator;
 typedef TrackingVertex::g4v_iterator g4v_iterator;
 
-TrackingTruthOutputTest::TrackingTruthOutputTest(
-    const edm::ParameterSet &conf) {
-  conf_ = conf;
-}
+TrackingTruthOutputTest::TrackingTruthOutputTest(const edm::ParameterSet &conf) { conf_ = conf; }
 
-void TrackingTruthOutputTest::analyze(const edm::Event &event,
-                                      const edm::EventSetup &c) {
+void TrackingTruthOutputTest::analyze(const edm::Event &event, const edm::EventSetup &c) {
   using namespace std;
 
   edm::Handle<TrackingParticleCollection> mergedPH;
   edm::Handle<TrackingVertexCollection> mergedVH;
 
-  edm::InputTag trackingTruth =
-      conf_.getUntrackedParameter<edm::InputTag>("trackingTruth");
+  edm::InputTag trackingTruth = conf_.getUntrackedParameter<edm::InputTag>("trackingTruth");
 
   event.getByLabel(trackingTruth, mergedPH);
   event.getByLabel(trackingTruth, mergedVH);
 
   if (conf_.getUntrackedParameter<bool>("dumpVertexes")) {
     std::cout << std::endl << "Dumping merged vertices: " << std::endl;
-    for (TrackingVertexCollection::const_iterator iVertex = mergedVH->begin();
-         iVertex != mergedVH->end(); ++iVertex) {
+    for (TrackingVertexCollection::const_iterator iVertex = mergedVH->begin(); iVertex != mergedVH->end(); ++iVertex) {
       std::cout << std::endl << *iVertex;
       std::cout << "Daughters of this vertex:" << std::endl;
-      for (tp_iterator iTrack = iVertex->daughterTracks_begin();
-           iTrack != iVertex->daughterTracks_end(); ++iTrack)
+      for (tp_iterator iTrack = iVertex->daughterTracks_begin(); iTrack != iVertex->daughterTracks_end(); ++iTrack)
         std::cout << **iTrack;
     }
     std::cout << std::endl;
@@ -55,14 +48,12 @@ void TrackingTruthOutputTest::analyze(const edm::Event &event,
 
   if (conf_.getUntrackedParameter<bool>("dumpOnlyBremsstrahlung")) {
     std::cout << std::endl << "Dumping only merged tracks: " << std::endl;
-    for (TrackingParticleCollection::const_iterator iTrack = mergedPH->begin();
-         iTrack != mergedPH->end(); ++iTrack)
+    for (TrackingParticleCollection::const_iterator iTrack = mergedPH->begin(); iTrack != mergedPH->end(); ++iTrack)
       if (iTrack->g4Tracks().size() > 1)
         std::cout << *iTrack << std::endl;
   } else {
     std::cout << std::endl << "Dump of merged tracks: " << std::endl;
-    for (TrackingParticleCollection::const_iterator iTrack = mergedPH->begin();
-         iTrack != mergedPH->end(); ++iTrack)
+    for (TrackingParticleCollection::const_iterator iTrack = mergedPH->begin(); iTrack != mergedPH->end(); ++iTrack)
       std::cout << *iTrack << std::endl;
   }
 }

--- a/SimMuon/MCTruth/interface/CSCHitAssociator.h
+++ b/SimMuon/MCTruth/interface/CSCHitAssociator.h
@@ -28,8 +28,7 @@ public:
   typedef edm::DetSet<StripDigiSimLink> LayerLinks;
   typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
 
-  CSCHitAssociator(const edm::Event &, const edm::EventSetup &,
-                   const edm::ParameterSet &);
+  CSCHitAssociator(const edm::Event &, const edm::EventSetup &, const edm::ParameterSet &);
   CSCHitAssociator(const edm::ParameterSet &, edm::ConsumesCollector &&iC);
 
   void initEvent(const edm::Event &, const edm::EventSetup &);

--- a/SimMuon/MCTruth/interface/CSCTruthTest.h
+++ b/SimMuon/MCTruth/interface/CSCTruthTest.h
@@ -6,7 +6,6 @@
 #include "SimMuon/MCTruth/interface/MuonTruth.h"
 
 class CSCTruthTest : public edm::stream::EDAnalyzer<> {
-
 public:
   explicit CSCTruthTest(const edm::ParameterSet &);
   ~CSCTruthTest() override;

--- a/SimMuon/MCTruth/interface/DTHitAssociator.h
+++ b/SimMuon/MCTruth/interface/DTHitAssociator.h
@@ -20,7 +20,6 @@
 #include <vector>
 
 class DTHitAssociator {
-
 public:
   typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
   typedef std::pair<PSimHit, bool> PSimHit_withFlag;
@@ -29,8 +28,7 @@ public:
   typedef std::map<DTWireId, std::vector<DTDigi>> DigiMap;
   typedef std::map<DTWireId, std::vector<DTDigiSimLink>> LinksMap;
 
-  DTHitAssociator(const edm::Event &, const edm::EventSetup &,
-                  const edm::ParameterSet &, bool printRtS);
+  DTHitAssociator(const edm::Event &, const edm::EventSetup &, const edm::ParameterSet &, bool printRtS);
   DTHitAssociator(const edm::ParameterSet &, edm::ConsumesCollector &&iC);
 
   void initEvent(const edm::Event &, const edm::EventSetup &);

--- a/SimMuon/MCTruth/interface/GEMHitAssociator.h
+++ b/SimMuon/MCTruth/interface/GEMHitAssociator.h
@@ -31,7 +31,6 @@
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 
 class GEMHitAssociator {
-
 public:
   typedef edm::DetSetVector<StripDigiSimLink> DigiSimLinks;
   typedef edm::DetSet<StripDigiSimLink> LayerLinks;
@@ -39,8 +38,7 @@ public:
 
   // Constructor with configurable parameters
   GEMHitAssociator(const edm::ParameterSet &, edm::ConsumesCollector &&ic);
-  GEMHitAssociator(const edm::Event &e, const edm::EventSetup &eventSetup,
-                   const edm::ParameterSet &conf);
+  GEMHitAssociator(const edm::Event &e, const edm::EventSetup &eventSetup, const edm::ParameterSet &conf);
 
   void initEvent(const edm::Event &, const edm::EventSetup &);
 

--- a/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
+++ b/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
@@ -19,23 +19,20 @@
 #include <memory>
 
 namespace muonAssociatorByHitsDiagnostics {
-class InputDumper;
+  class InputDumper;
 }
 
 class MuonAssociatorByHits {
-
 public:
-  MuonAssociatorByHits(const edm::ParameterSet &conf,
-                       edm::ConsumesCollector &&iC);
+  MuonAssociatorByHits(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC);
   virtual ~MuonAssociatorByHits();
 
   // Originally from TrackAssociatorBase from where this class used to inherit
   // from
-  reco::RecoToSimCollection
-  associateRecoToSim(edm::Handle<edm::View<reco::Track>> &tCH,
-                     edm::Handle<TrackingParticleCollection> &tPCH,
-                     const edm::Event *event,
-                     const edm::EventSetup *setup) const {
+  reco::RecoToSimCollection associateRecoToSim(edm::Handle<edm::View<reco::Track>> &tCH,
+                                               edm::Handle<TrackingParticleCollection> &tPCH,
+                                               const edm::Event *event,
+                                               const edm::EventSetup *setup) const {
     edm::RefToBaseVector<reco::Track> tc;
     for (unsigned int j = 0; j < tCH->size(); j++)
       tc.push_back(tCH->refAt(j));
@@ -47,11 +44,10 @@ public:
     return associateRecoToSim(tc, tpc, event, setup);
   }
 
-  virtual reco::SimToRecoCollection
-  associateSimToReco(edm::Handle<edm::View<reco::Track>> &tCH,
-                     edm::Handle<TrackingParticleCollection> &tPCH,
-                     const edm::Event *event,
-                     const edm::EventSetup *setup) const {
+  virtual reco::SimToRecoCollection associateSimToReco(edm::Handle<edm::View<reco::Track>> &tCH,
+                                                       edm::Handle<TrackingParticleCollection> &tPCH,
+                                                       const edm::Event *event,
+                                                       const edm::EventSetup *setup) const {
     edm::RefToBaseVector<reco::Track> tc;
     for (unsigned int j = 0; j < tCH->size(); j++)
       tc.push_back(tCH->refAt(j));
@@ -65,18 +61,16 @@ public:
 
   /* Associate SimTracks to RecoTracks By Hits */
   /// Association Reco To Sim with Collections
-  reco::RecoToSimCollection
-  associateRecoToSim(const edm::RefToBaseVector<reco::Track> &,
-                     const edm::RefVector<TrackingParticleCollection> &,
-                     const edm::Event *event = nullptr,
-                     const edm::EventSetup *setup = nullptr) const;
+  reco::RecoToSimCollection associateRecoToSim(const edm::RefToBaseVector<reco::Track> &,
+                                               const edm::RefVector<TrackingParticleCollection> &,
+                                               const edm::Event *event = nullptr,
+                                               const edm::EventSetup *setup = nullptr) const;
 
   /// Association Sim To Reco with Collections
-  reco::SimToRecoCollection
-  associateSimToReco(const edm::RefToBaseVector<reco::Track> &,
-                     const edm::RefVector<TrackingParticleCollection> &,
-                     const edm::Event *event = nullptr,
-                     const edm::EventSetup *setup = nullptr) const;
+  reco::SimToRecoCollection associateSimToReco(const edm::RefToBaseVector<reco::Track> &,
+                                               const edm::RefVector<TrackingParticleCollection> &,
+                                               const edm::Event *event = nullptr,
+                                               const edm::EventSetup *setup = nullptr) const;
 
 private:
   MuonAssociatorByHitsHelper helper_;

--- a/SimMuon/MCTruth/interface/MuonAssociatorByHitsHelper.h
+++ b/SimMuon/MCTruth/interface/MuonAssociatorByHitsHelper.h
@@ -25,15 +25,12 @@
 class TrackerTopology;
 
 class MuonAssociatorByHitsHelper {
-
 public:
   typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
   // typedef std::map<unsigned int, std::vector<SimHitIdpr> > MapOfMatchedIds;
   typedef std::pair<unsigned int, std::vector<SimHitIdpr>> uint_SimHitIdpr_pair;
   typedef boost::ptr_vector<uint_SimHitIdpr_pair> MapOfMatchedIds;
-  typedef std::vector<
-      std::pair<trackingRecHit_iterator, trackingRecHit_iterator>>
-      TrackHitsCollection;
+  typedef std::vector<std::pair<trackingRecHit_iterator, trackingRecHit_iterator>> TrackHitsCollection;
 
   MuonAssociatorByHitsHelper(const edm::ParameterSet &conf);
 
@@ -44,53 +41,61 @@ public:
     DTHitAssociator const *dtHitAssoc_;
     RPCHitAssociator const *rpcHitAssoc_;
     GEMHitAssociator const *gemHitAssoc_;
-    std::function<void(const TrackHitsCollection &,
-                       const TrackingParticleCollection &)>
-        diagnostics_;
+    std::function<void(const TrackHitsCollection &, const TrackingParticleCollection &)> diagnostics_;
   };
 
   struct IndexMatch {
-    IndexMatch(size_t index, double global_quality)
-        : idx(index), quality(global_quality) {}
+    IndexMatch(size_t index, double global_quality) : idx(index), quality(global_quality) {}
     size_t idx;
     double quality;
-    bool operator<(const IndexMatch &other) const {
-      return other.quality < quality;
-    }
+    bool operator<(const IndexMatch &other) const { return other.quality < quality; }
   };
   typedef std::map<size_t, std::vector<IndexMatch>> IndexAssociation;
 
-  IndexAssociation
-  associateSimToRecoIndices(const TrackHitsCollection &,
-                            const edm::RefVector<TrackingParticleCollection> &,
-                            Resources const &) const;
+  IndexAssociation associateSimToRecoIndices(const TrackHitsCollection &,
+                                             const edm::RefVector<TrackingParticleCollection> &,
+                                             Resources const &) const;
 
-  IndexAssociation
-  associateRecoToSimIndices(const TrackHitsCollection &,
-                            const edm::RefVector<TrackingParticleCollection> &,
-                            Resources const &) const;
+  IndexAssociation associateRecoToSimIndices(const TrackHitsCollection &,
+                                             const edm::RefVector<TrackingParticleCollection> &,
+                                             Resources const &) const;
 
 private:
-  void getMatchedIds(
-      MapOfMatchedIds &tracker_matchedIds_valid,
-      MapOfMatchedIds &muon_matchedIds_valid,
-      MapOfMatchedIds &tracker_matchedIds_INVALID,
-      MapOfMatchedIds &muon_matchedIds_INVALID, int &n_tracker_valid,
-      int &n_dt_valid, int &n_csc_valid, int &n_rpc_valid, int &n_gem_valid,
-      int &n_tracker_matched_valid, int &n_dt_matched_valid,
-      int &n_csc_matched_valid, int &n_rpc_matched_valid,
-      int &n_gem_matched_valid, int &n_tracker_INVALID, int &n_dt_INVALID,
-      int &n_csc_INVALID, int &n_rpc_INVALID, int &n_gem_INVALID,
-      int &n_tracker_matched_INVALID, int &n_dt_matched_INVALID,
-      int &n_csc_matched_INVALID, int &n_rpc_matched_INVALID,
-      int &n_gem_matched_INVALID, trackingRecHit_iterator begin,
-      trackingRecHit_iterator end, const TrackerHitAssociator *trackertruth,
-      const DTHitAssociator &dttruth, const CSCHitAssociator &csctruth,
-      const RPCHitAssociator &rpctruth, const GEMHitAssociator &gemtruth,
-      bool printRts, const TrackerTopology *) const;
+  void getMatchedIds(MapOfMatchedIds &tracker_matchedIds_valid,
+                     MapOfMatchedIds &muon_matchedIds_valid,
+                     MapOfMatchedIds &tracker_matchedIds_INVALID,
+                     MapOfMatchedIds &muon_matchedIds_INVALID,
+                     int &n_tracker_valid,
+                     int &n_dt_valid,
+                     int &n_csc_valid,
+                     int &n_rpc_valid,
+                     int &n_gem_valid,
+                     int &n_tracker_matched_valid,
+                     int &n_dt_matched_valid,
+                     int &n_csc_matched_valid,
+                     int &n_rpc_matched_valid,
+                     int &n_gem_matched_valid,
+                     int &n_tracker_INVALID,
+                     int &n_dt_INVALID,
+                     int &n_csc_INVALID,
+                     int &n_rpc_INVALID,
+                     int &n_gem_INVALID,
+                     int &n_tracker_matched_INVALID,
+                     int &n_dt_matched_INVALID,
+                     int &n_csc_matched_INVALID,
+                     int &n_rpc_matched_INVALID,
+                     int &n_gem_matched_INVALID,
+                     trackingRecHit_iterator begin,
+                     trackingRecHit_iterator end,
+                     const TrackerHitAssociator *trackertruth,
+                     const DTHitAssociator &dttruth,
+                     const CSCHitAssociator &csctruth,
+                     const RPCHitAssociator &rpctruth,
+                     const GEMHitAssociator &gemtruth,
+                     bool printRts,
+                     const TrackerTopology *) const;
 
-  int getShared(MapOfMatchedIds &matchedIds,
-                TrackingParticleCollection::const_iterator trpart) const;
+  int getShared(MapOfMatchedIds &matchedIds, TrackingParticleCollection::const_iterator trpart) const;
 
   const bool includeZeroHitMuons;
   const bool acceptOneStubMatchings;
@@ -111,13 +116,8 @@ private:
   const bool dumpDT;
 
   int LayerFromDetid(const DetId &) const;
-  const TrackingRecHit *
-  getHitPtr(edm::OwnVector<TrackingRecHit>::const_iterator iter) const {
-    return &*iter;
-  }
-  const TrackingRecHit *getHitPtr(const trackingRecHit_iterator &iter) const {
-    return &**iter;
-  }
+  const TrackingRecHit *getHitPtr(edm::OwnVector<TrackingRecHit>::const_iterator iter) const { return &*iter; }
+  const TrackingRecHit *getHitPtr(const trackingRecHit_iterator &iter) const { return &**iter; }
 
   std::string write_matched_simtracks(const std::vector<SimHitIdpr> &) const;
 };

--- a/SimMuon/MCTruth/interface/MuonToSimAssociatorBase.h
+++ b/SimMuon/MCTruth/interface/MuonToSimAssociatorBase.h
@@ -13,7 +13,6 @@
 class TrackerTopology;
 
 class MuonToSimAssociatorBase {
-
 public:
   MuonToSimAssociatorBase();
   virtual ~MuonToSimAssociatorBase();
@@ -22,25 +21,21 @@ public:
 
   struct RefToBaseSort {
     template <typename T>
-    bool operator()(const edm::RefToBase<T> &r1,
-                    const edm::RefToBase<T> &r2) const {
+    bool operator()(const edm::RefToBase<T> &r1, const edm::RefToBase<T> &r2) const {
       return (r1.id() == r2.id() ? r1.key() < r2.key() : r1.id() < r2.id());
     }
   };
-  typedef std::map<edm::RefToBase<reco::Muon>,
-                   std::vector<std::pair<TrackingParticleRef, double>>,
-                   RefToBaseSort>
+  typedef std::map<edm::RefToBase<reco::Muon>, std::vector<std::pair<TrackingParticleRef, double>>, RefToBaseSort>
       MuonToSimCollection;
-  typedef std::map<TrackingParticleRef,
-                   std::vector<std::pair<edm::RefToBase<reco::Muon>, double>>>
-      SimToMuonCollection;
+  typedef std::map<TrackingParticleRef, std::vector<std::pair<edm::RefToBase<reco::Muon>, double>>> SimToMuonCollection;
 
-  virtual void
-  associateMuons(MuonToSimCollection &recoToSim, SimToMuonCollection &simToReco,
-                 const edm::RefToBaseVector<reco::Muon> &, MuonTrackType,
-                 const edm::RefVector<TrackingParticleCollection> &,
-                 const edm::Event *event = nullptr,
-                 const edm::EventSetup *setup = nullptr) const = 0;
+  virtual void associateMuons(MuonToSimCollection &recoToSim,
+                              SimToMuonCollection &simToReco,
+                              const edm::RefToBaseVector<reco::Muon> &,
+                              MuonTrackType,
+                              const edm::RefVector<TrackingParticleCollection> &,
+                              const edm::Event *event = nullptr,
+                              const edm::EventSetup *setup = nullptr) const = 0;
 
   virtual void associateMuons(MuonToSimCollection &recoToSim,
                               SimToMuonCollection &simToReco,

--- a/SimMuon/MCTruth/interface/MuonToSimAssociatorByHits.h
+++ b/SimMuon/MCTruth/interface/MuonToSimAssociatorByHits.h
@@ -9,22 +9,22 @@
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 
 class MuonToSimAssociatorByHits : public MuonToSimAssociatorBase {
-
 public:
-  MuonToSimAssociatorByHits(const edm::ParameterSet &conf,
-                            edm::ConsumesCollector &&iC);
+  MuonToSimAssociatorByHits(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC);
   ~MuonToSimAssociatorByHits() override;
 
   void associateMuons(MuonToSimCollection &recoToSim,
                       SimToMuonCollection &simToReco,
-                      const edm::RefToBaseVector<reco::Muon> &, MuonTrackType,
+                      const edm::RefToBaseVector<reco::Muon> &,
+                      MuonTrackType,
                       const edm::RefVector<TrackingParticleCollection> &,
                       const edm::Event *event = nullptr,
                       const edm::EventSetup *setup = nullptr) const override;
 
   void associateMuons(MuonToSimCollection &recoToSim,
                       SimToMuonCollection &simToReco,
-                      const edm::Handle<edm::View<reco::Muon>> &, MuonTrackType,
+                      const edm::Handle<edm::View<reco::Muon>> &,
+                      MuonTrackType,
                       const edm::Handle<TrackingParticleCollection> &,
                       const edm::Event *event = nullptr,
                       const edm::EventSetup *setup = nullptr) const override;

--- a/SimMuon/MCTruth/interface/MuonTruth.h
+++ b/SimMuon/MCTruth/interface/MuonTruth.h
@@ -28,17 +28,14 @@ public:
   typedef edm::DetSet<StripDigiSimLink> LayerLinks;
   typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
 
-  MuonTruth(const edm::Event &, const edm::EventSetup &,
-            const edm::ParameterSet &);
+  MuonTruth(const edm::Event &, const edm::EventSetup &, const edm::ParameterSet &);
   MuonTruth(const edm::ParameterSet &, edm::ConsumesCollector &&iC);
 
   void initEvent(const edm::Event &, const edm::EventSetup &);
 
   void analyze(const CSCRecHit2D &recHit);
-  void analyze(const CSCStripDigi &stripDigi,
-               int rawDetIdCorrespondingToCSCLayer);
-  void analyze(const CSCWireDigi &wireDigi,
-               int rawDetIdCorrespondingToCSCLayer);
+  void analyze(const CSCStripDigi &stripDigi, int rawDetIdCorrespondingToCSCLayer);
+  void analyze(const CSCWireDigi &wireDigi, int rawDetIdCorrespondingToCSCLayer);
 
   /// analyze() must be called before any of the following
   float muonFraction();

--- a/SimMuon/MCTruth/interface/PSimHitMap.h
+++ b/SimMuon/MCTruth/interface/PSimHitMap.h
@@ -10,8 +10,7 @@
 
 class PSimHitMap {
 public:
-  PSimHitMap(const edm::InputTag &iT, edm::ConsumesCollector &&iC)
-      : theMap(), theEmptyContainer() {
+  PSimHitMap(const edm::InputTag &iT, edm::ConsumesCollector &&iC) : theMap(), theEmptyContainer() {
     sh_token = iC.consumes<CrossingFrame<PSimHit>>(iT);
   }
 

--- a/SimMuon/MCTruth/interface/RPCHitAssociator.h
+++ b/SimMuon/MCTruth/interface/RPCHitAssociator.h
@@ -30,15 +30,13 @@
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 
 class RPCHitAssociator {
-
 public:
   typedef edm::DetSetVector<RPCDigiSimLink> RPCDigiSimLinks;
   typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
 
   // Constructor with configurable parameters
   RPCHitAssociator(const edm::ParameterSet &, edm::ConsumesCollector &&ic);
-  RPCHitAssociator(const edm::Event &e, const edm::EventSetup &eventSetup,
-                   const edm::ParameterSet &conf);
+  RPCHitAssociator(const edm::Event &e, const edm::EventSetup &eventSetup, const edm::ParameterSet &conf);
 
   void initEvent(const edm::Event &, const edm::EventSetup &);
 
@@ -46,8 +44,7 @@ public:
   ~RPCHitAssociator() {}
 
   std::vector<SimHitIdpr> associateRecHit(const TrackingRecHit &hit) const;
-  std::set<RPCDigiSimLink> findRPCDigiSimLink(uint32_t rpcDetId, int strip,
-                                              int bx) const;
+  std::set<RPCDigiSimLink> findRPCDigiSimLink(uint32_t rpcDetId, int strip, int bx) const;
   //   const PSimHit* linkToSimHit(RPCDigiSimLink link);
 
 private:

--- a/SimMuon/MCTruth/interface/TrackerMuonHitExtractor.h
+++ b/SimMuon/MCTruth/interface/TrackerMuonHitExtractor.h
@@ -17,8 +17,7 @@
 
 class TrackerMuonHitExtractor {
 public:
-  explicit TrackerMuonHitExtractor(const edm::ParameterSet &,
-                                   edm::ConsumesCollector &&ic);
+  explicit TrackerMuonHitExtractor(const edm::ParameterSet &, edm::ConsumesCollector &&ic);
   explicit TrackerMuonHitExtractor(const edm::ParameterSet &);
   ~TrackerMuonHitExtractor();
 

--- a/SimMuon/MCTruth/plugins/MuonAssociatorEDProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonAssociatorEDProducer.cc
@@ -4,66 +4,54 @@
 #include "SimMuon/MCTruth/plugins/MuonAssociatorEDProducer.h"
 #include <memory>
 
-MuonAssociatorEDProducer::MuonAssociatorEDProducer(
-    const edm::ParameterSet &parset)
+MuonAssociatorEDProducer::MuonAssociatorEDProducer(const edm::ParameterSet &parset)
     : tracksTag(parset.getParameter<edm::InputTag>("tracksTag")),
       tpTag(parset.getParameter<edm::InputTag>("tpTag")),
-      ignoreMissingTrackCollection(parset.getUntrackedParameter<bool>(
-          "ignoreMissingTrackCollection", false)),
+      ignoreMissingTrackCollection(parset.getUntrackedParameter<bool>("ignoreMissingTrackCollection", false)),
       parset_(parset) {
-
-  edm::LogVerbatim("MuonAssociatorEDProducer")
-      << "constructing  MuonAssociatorEDProducer";
+  edm::LogVerbatim("MuonAssociatorEDProducer") << "constructing  MuonAssociatorEDProducer";
   produces<reco::RecoToSimCollection>();
   produces<reco::SimToRecoCollection>();
   tpToken_ = consumes<TrackingParticleCollection>(tpTag);
   tracksToken_ = consumes<edm::View<reco::Track>>(tracksTag);
 
   /// Perform some sanity checks of the configuration
-  LogTrace("MuonAssociatorEDProducer")
-      << "constructing  MuonAssociatorByHits" << parset_.dump();
-  edm::LogVerbatim("MuonAssociatorEDProducer")
-      << "\n MuonAssociatorByHits will associate reco::Tracks with "
-      << tracksTag << "\n\t\t and TrackingParticles with " << tpTag;
+  LogTrace("MuonAssociatorEDProducer") << "constructing  MuonAssociatorByHits" << parset_.dump();
+  edm::LogVerbatim("MuonAssociatorEDProducer") << "\n MuonAssociatorByHits will associate reco::Tracks with "
+                                               << tracksTag << "\n\t\t and TrackingParticles with " << tpTag;
   const std::string recoTracksLabel = tracksTag.label();
   const std::string recoTracksInstance = tracksTag.instance();
 
   // check and fix inconsistent input settings
   // tracks with hits only on muon detectors
-  if (recoTracksLabel == "standAloneMuons" ||
-      recoTracksLabel == "standAloneSETMuons" ||
+  if (recoTracksLabel == "standAloneMuons" || recoTracksLabel == "standAloneSETMuons" ||
       recoTracksLabel == "cosmicMuons" || recoTracksLabel == "hltL2Muons") {
     if (parset_.getParameter<bool>("UseTracker")) {
       edm::LogWarning("MuonAssociatorEDProducer")
-          << "\n*** WARNING : inconsistent input tracksTag = " << tracksTag
-          << "\n with UseTracker = true"
+          << "\n*** WARNING : inconsistent input tracksTag = " << tracksTag << "\n with UseTracker = true"
           << "\n ---> setting UseTracker = false ";
       parset_.addParameter<bool>("UseTracker", false);
     }
     if (!parset_.getParameter<bool>("UseMuon")) {
       edm::LogWarning("MuonAssociatorEDProducer")
-          << "\n*** WARNING : inconsistent input tracksTag = " << tracksTag
-          << "\n with UseMuon = false"
+          << "\n*** WARNING : inconsistent input tracksTag = " << tracksTag << "\n with UseMuon = false"
           << "\n ---> setting UseMuon = true ";
       parset_.addParameter<bool>("UseMuon", true);
     }
   }
   // tracks with hits only on tracker
-  if (recoTracksLabel == "generalTracks" ||
-      recoTracksLabel == "ctfWithMaterialTracksP5LHCNavigation" ||
+  if (recoTracksLabel == "generalTracks" || recoTracksLabel == "ctfWithMaterialTracksP5LHCNavigation" ||
       recoTracksLabel == "hltL3TkTracksFromL2" ||
       (recoTracksLabel == "hltL3Muons" && recoTracksInstance == "L2Seeded")) {
     if (parset_.getParameter<bool>("UseMuon")) {
       edm::LogWarning("MuonAssociatorEDProducer")
-          << "\n*** WARNING : inconsistent input tracksTag = " << tracksTag
-          << "\n with UseMuon = true"
+          << "\n*** WARNING : inconsistent input tracksTag = " << tracksTag << "\n with UseMuon = true"
           << "\n ---> setting UseMuon = false ";
       parset_.addParameter<bool>("UseMuon", false);
     }
     if (!parset_.getParameter<bool>("UseTracker")) {
       edm::LogWarning("MuonAssociatorEDProducer")
-          << "\n*** WARNING : inconsistent input tracksTag = " << tracksTag
-          << "\n with UseTracker = false"
+          << "\n*** WARNING : inconsistent input tracksTag = " << tracksTag << "\n with UseTracker = false"
           << "\n ---> setting UseTracker = true ";
       parset_.addParameter<bool>("UseTracker", true);
     }
@@ -80,24 +68,19 @@ void MuonAssociatorEDProducer::beginJob() {}
 
 void MuonAssociatorEDProducer::endJob() {}
 
-void MuonAssociatorEDProducer::produce(edm::Event &event,
-                                       const edm::EventSetup &setup) {
+void MuonAssociatorEDProducer::produce(edm::Event &event, const edm::EventSetup &setup) {
   using namespace edm;
 
   Handle<TrackingParticleCollection> TPCollection;
-  LogTrace("MuonAssociatorEDProducer")
-      << "getting TrackingParticle collection - " << tpTag;
+  LogTrace("MuonAssociatorEDProducer") << "getting TrackingParticle collection - " << tpTag;
   event.getByToken(tpToken_, TPCollection);
-  LogTrace("MuonAssociatorEDProducer")
-      << "\t... size = " << TPCollection->size();
+  LogTrace("MuonAssociatorEDProducer") << "\t... size = " << TPCollection->size();
 
   Handle<edm::View<reco::Track>> trackCollection;
-  LogTrace("MuonAssociatorEDProducer")
-      << "getting reco::Track collection - " << tracksTag;
+  LogTrace("MuonAssociatorEDProducer") << "getting reco::Track collection - " << tracksTag;
   bool trackAvailable = event.getByToken(tracksToken_, trackCollection);
   if (trackAvailable)
-    LogTrace("MuonAssociatorEDProducer")
-        << "\t... size = " << trackCollection->size();
+    LogTrace("MuonAssociatorEDProducer") << "\t... size = " << trackCollection->size();
   else
     LogTrace("MuonAssociatorEDProducer") << "\t... NOT FOUND.";
 
@@ -108,31 +91,28 @@ void MuonAssociatorEDProducer::produce(edm::Event &event,
     // the track collection is not in the event and we're being told to ignore
     // this. do not output anything to the event, other wise this would be
     // considered as inefficiency.
-    LogTrace("MuonAssociatorEDProducer")
-        << "\n ignoring missing track collection."
-        << "\n";
+    LogTrace("MuonAssociatorEDProducer") << "\n ignoring missing track collection."
+                                         << "\n";
   } else {
     edm::LogVerbatim("MuonAssociatorEDProducer")
         << "\n >>> RecoToSim association <<< \n"
-        << "     Track collection : " << tracksTag.label() << ":"
-        << tracksTag.instance() << " (size = " << trackCollection->size()
-        << ") \n"
-        << "     TrackingParticle collection : " << tpTag.label() << ":"
-        << tpTag.instance() << " (size = " << TPCollection->size() << ")";
+        << "     Track collection : " << tracksTag.label() << ":" << tracksTag.instance()
+        << " (size = " << trackCollection->size() << ") \n"
+        << "     TrackingParticle collection : " << tpTag.label() << ":" << tpTag.instance()
+        << " (size = " << TPCollection->size() << ")";
 
-    reco::RecoToSimCollection recSimColl = associatorByHits->associateRecoToSim(
-        trackCollection, TPCollection, &event, &setup);
+    reco::RecoToSimCollection recSimColl =
+        associatorByHits->associateRecoToSim(trackCollection, TPCollection, &event, &setup);
 
     edm::LogVerbatim("MuonAssociatorEDProducer")
         << "\n >>> SimToReco association <<< \n"
-        << "     TrackingParticle collection : " << tpTag.label() << ":"
-        << tpTag.instance() << " (size = " << TPCollection->size() << ") \n"
-        << "     Track collection : " << tracksTag.label() << ":"
-        << tracksTag.instance() << " (size = " << trackCollection->size()
-        << ")";
+        << "     TrackingParticle collection : " << tpTag.label() << ":" << tpTag.instance()
+        << " (size = " << TPCollection->size() << ") \n"
+        << "     Track collection : " << tracksTag.label() << ":" << tracksTag.instance()
+        << " (size = " << trackCollection->size() << ")";
 
-    reco::SimToRecoCollection simRecColl = associatorByHits->associateSimToReco(
-        trackCollection, TPCollection, &event, &setup);
+    reco::SimToRecoCollection simRecColl =
+        associatorByHits->associateSimToReco(trackCollection, TPCollection, &event, &setup);
 
     rts.reset(new reco::RecoToSimCollection(recSimColl));
     str.reset(new reco::SimToRecoCollection(simRecColl));

--- a/SimMuon/MCTruth/plugins/MuonSimClassifier.cc
+++ b/SimMuon/MCTruth/plugins/MuonSimClassifier.cc
@@ -106,8 +106,7 @@ private:
                      const std::string &label) const;
 
   TrackingParticleRef getTpMother(TrackingParticleRef tp) {
-    if (tp.isNonnull() && tp->parentVertex().isNonnull() &&
-        !tp->parentVertex()->sourceTracks().empty()) {
+    if (tp.isNonnull() && tp->parentVertex().isNonnull() && !tp->parentVertex()->sourceTracks().empty()) {
       return tp->parentVertex()->sourceTracks()[0];
     } else {
       return TrackingParticleRef();
@@ -117,25 +116,22 @@ private:
   /// Convert TrackingParticle into GenParticle, save into output collection,
   /// if mother is primary set reference to it,
   /// return index in output collection
-  int convertAndPush(
-      const TrackingParticle &tp, reco::GenParticleCollection &out,
-      const TrackingParticleRef &momRef,
-      const edm::Handle<reco::GenParticleCollection> &genParticles) const;
+  int convertAndPush(const TrackingParticle &tp,
+                     reco::GenParticleCollection &out,
+                     const TrackingParticleRef &momRef,
+                     const edm::Handle<reco::GenParticleCollection> &genParticles) const;
 };
 
 MuonSimClassifier::MuonSimClassifier(const edm::ParameterSet &iConfig)
-    : muonsToken_(consumes<edm::View<reco::Muon>>(
-          iConfig.getParameter<edm::InputTag>("muons"))),
-      trackingParticlesToken_(consumes<TrackingParticleCollection>(
-          iConfig.getParameter<edm::InputTag>("trackingParticles"))),
-      muAssocToken_(consumes<reco::MuonToTrackingParticleAssociator>(
-          iConfig.getParameter<edm::InputTag>("associatorLabel"))),
+    : muonsToken_(consumes<edm::View<reco::Muon>>(iConfig.getParameter<edm::InputTag>("muons"))),
+      trackingParticlesToken_(
+          consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("trackingParticles"))),
+      muAssocToken_(
+          consumes<reco::MuonToTrackingParticleAssociator>(iConfig.getParameter<edm::InputTag>("associatorLabel"))),
       decayRho_(iConfig.getParameter<double>("decayRho")),
       decayAbsZ_(iConfig.getParameter<double>("decayAbsZ")),
       linkToGenParticles_(iConfig.getParameter<bool>("linkToGenParticles")),
-      genParticles_(linkToGenParticles_
-                        ? iConfig.getParameter<edm::InputTag>("genParticles")
-                        : edm::InputTag())
+      genParticles_(linkToGenParticles_ ? iConfig.getParameter<edm::InputTag>("genParticles") : edm::InputTag())
 
 {
   std::string trackType = iConfig.getParameter<std::string>("trackType");
@@ -150,8 +146,7 @@ MuonSimClassifier::MuonSimClassifier(const edm::ParameterSet &iConfig)
   else if (trackType == "glb_or_trk")
     trackType_ = reco::GlbOrTrk;
   else
-    throw cms::Exception("Configuration")
-        << "Track type '" << trackType << "' not supported.\n";
+    throw cms::Exception("Configuration") << "Track type '" << trackType << "' not supported.\n";
   if (linkToGenParticles_) {
     genParticlesToken_ = consumes<reco::GenParticleCollection>(genParticles_);
   }
@@ -168,19 +163,16 @@ MuonSimClassifier::~MuonSimClassifier() {}
 
 void dumpFormatedInfo(const reco::MuonSimInfo &simInfo) {
   return;
-  LogTrace("MuonSimClassifier")
-      << "\t Particle pdgId = " << simInfo.pdgId << ", (Event,Bx) = "
-      << "(" << simInfo.tpEvent << "," << simInfo.tpBX << ")"
-      << "\n\t   q*p = " << simInfo.charge * simInfo.p4.P()
-      << ", pT = " << simInfo.p4.pt() << ", eta = " << simInfo.p4.eta()
-      << ", phi = " << simInfo.p4.phi()
-      << "\n\t   produced at vertex rho = " << simInfo.vertex.Rho()
-      << ", z = " << simInfo.vertex.Z()
-      << ", (GEANT4 process = " << simInfo.g4processType << ")\n";
+  LogTrace("MuonSimClassifier") << "\t Particle pdgId = " << simInfo.pdgId << ", (Event,Bx) = "
+                                << "(" << simInfo.tpEvent << "," << simInfo.tpBX << ")"
+                                << "\n\t   q*p = " << simInfo.charge * simInfo.p4.P() << ", pT = " << simInfo.p4.pt()
+                                << ", eta = " << simInfo.p4.eta() << ", phi = " << simInfo.p4.phi()
+                                << "\n\t   produced at vertex rho = " << simInfo.vertex.Rho()
+                                << ", z = " << simInfo.vertex.Z() << ", (GEANT4 process = " << simInfo.g4processType
+                                << ")\n";
 }
 
-void MuonSimClassifier::produce(edm::Event &iEvent,
-                                const edm::EventSetup &iSetup) {
+void MuonSimClassifier::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   edm::Handle<edm::View<reco::Muon>> muons;
   iEvent.getByToken(muonsToken_, muons);
 
@@ -194,16 +186,13 @@ void MuonSimClassifier::produce(edm::Event &iEvent,
 
   edm::Handle<reco::MuonToTrackingParticleAssociator> associatorBase;
   iEvent.getByToken(muAssocToken_, associatorBase);
-  const reco::MuonToTrackingParticleAssociator *assoByHits =
-      associatorBase.product();
+  const reco::MuonToTrackingParticleAssociator *assoByHits = associatorBase.product();
 
   reco::MuonToSimCollection recSimColl;
   reco::SimToMuonCollection simRecColl;
-  LogTrace("MuonSimClassifier")
-      << "\n "
-         "***************************************************************** ";
-  LogTrace("MuonSimClassifier")
-      << " RECO MUON association, type:  " << trackType_;
+  LogTrace("MuonSimClassifier") << "\n "
+                                   "***************************************************************** ";
+  LogTrace("MuonSimClassifier") << " RECO MUON association, type:  " << trackType_;
   LogTrace("MuonSimClassifier") << " ******************************************"
                                    "*********************** \n";
 
@@ -217,22 +206,19 @@ void MuonSimClassifier::produce(edm::Event &iEvent,
     allTPs.push_back(TrackingParticleRef(trackingParticles, i));
   }
 
-  assoByHits->associateMuons(recSimColl, simRecColl, allMuons, trackType_,
-                             allTPs);
+  assoByHits->associateMuons(recSimColl, simRecColl, allMuons, trackType_, allTPs);
 
   // for global muons without hits on muon detectors, look at the linked
   // standalone muon
   reco::MuonToSimCollection updSTA_recSimColl;
   reco::SimToMuonCollection updSTA_simRecColl;
   if (trackType_ == reco::GlobalTk) {
-    LogTrace("MuonSimClassifier")
-        << "\n "
-           "***************************************************************** ";
+    LogTrace("MuonSimClassifier") << "\n "
+                                     "***************************************************************** ";
     LogTrace("MuonSimClassifier") << " STANDALONE (UpdAtVtx) MUON association ";
     LogTrace("MuonSimClassifier") << " ****************************************"
                                      "************************* \n";
-    assoByHits->associateMuons(updSTA_recSimColl, updSTA_simRecColl, allMuons,
-                               reco::OuterTk, allTPs);
+    assoByHits->associateMuons(updSTA_recSimColl, updSTA_simRecColl, allMuons, reco::OuterTk, allTPs);
   }
 
   typedef reco::MuonToSimCollection::const_iterator r2s_it;
@@ -243,13 +229,10 @@ void MuonSimClassifier::produce(edm::Event &iEvent,
 
   std::vector<reco::MuonSimInfo> simInfo;
 
-  std::unique_ptr<reco::GenParticleCollection>
-      secondaries; // output collection of secondary muons
-  std::map<TrackingParticleRef, int>
-      tpToSecondaries; // map from tp to (index+1) in output collection
-  std::vector<int> muToPrimary(nmu, -1),
-      muToSecondary(nmu,
-                    -1); // map from input into (index) in output, -1 for null
+  std::unique_ptr<reco::GenParticleCollection> secondaries;  // output collection of secondary muons
+  std::map<TrackingParticleRef, int> tpToSecondaries;        // map from tp to (index+1) in output collection
+  std::vector<int> muToPrimary(nmu, -1), muToSecondary(nmu,
+                                                       -1);  // map from input into (index) in output, -1 for null
   if (linkToGenParticles_)
     secondaries.reset(new reco::GenParticleCollection());
 
@@ -266,18 +249,14 @@ void MuonSimClassifier::produce(edm::Event &iEvent,
       // match->second is vector, front is first element, first is the ref
       // (second would be the quality)
       tp = match->second.front().first;
-      simInfo[i].tpId =
-          tp.isNonnull()
-              ? tp.key()
-              : -1; // we check, even if null refs should not appear here at all
+      simInfo[i].tpId = tp.isNonnull() ? tp.key() : -1;  // we check, even if null refs should not appear here at all
       simInfo[i].tpAssoQuality = match->second.front().second;
       s2r_it matchback = simRecColl.find(tp);
       if (matchback != simRecColl.end()) {
         muMatchBack = matchback->second.front().first;
       } else {
-        LogTrace("MuonSimClassifier")
-            << "\n***WARNING:  This I do NOT understand: why no match back? "
-               "*** \n";
+        LogTrace("MuonSimClassifier") << "\n***WARNING:  This I do NOT understand: why no match back? "
+                                         "*** \n";
       }
     } else {
       if ((trackType_ == reco::GlobalTk) && allMuons.at(i)->isGlobalMuon()) {
@@ -285,22 +264,19 @@ void MuonSimClassifier::produce(edm::Event &iEvent,
         r2s_it matchSta = updSTA_recSimColl.find(allMuons.at(i));
         if (matchSta != updSTA_recSimColl.end()) {
           tp = matchSta->second.front().first;
-          simInfo[i].tpId =
-              tp.isNonnull() ? tp.key() : -1; // we check, even if null refs
-                                              // should not appear here at all
+          simInfo[i].tpId = tp.isNonnull() ? tp.key() : -1;  // we check, even if null refs
+                                                             // should not appear here at all
           simInfo[i].tpAssoQuality = matchSta->second.front().second;
           s2r_it matchback = updSTA_simRecColl.find(tp);
           if (matchback != updSTA_simRecColl.end()) {
             muMatchBack = matchback->second.front().first;
           } else {
-            LogTrace("MuonSimClassifier")
-                << "\n***WARNING:  This I do NOT understand: why no match back "
-                   "in updSTA? *** \n";
+            LogTrace("MuonSimClassifier") << "\n***WARNING:  This I do NOT understand: why no match back "
+                                             "in updSTA? *** \n";
           }
         }
       } else {
-        LogTrace("MuonSimClassifier")
-            << "\t No matching TrackingParticle is found ";
+        LogTrace("MuonSimClassifier") << "\t No matching TrackingParticle is found ";
       }
     }
 
@@ -326,11 +302,9 @@ void MuonSimClassifier::produce(edm::Event &iEvent,
 
       // Try to extract mother and grand mother of this muon.
       // Unfortunately, SIM and GEN histories require diffent code :-(
-      if (!tp->genParticles().empty()) { // Muon is in GEN
+      if (!tp->genParticles().empty()) {  // Muon is in GEN
         reco::GenParticleRef genp = tp->genParticles()[0];
-        reco::GenParticleRef genMom = genp->numberOfMothers() > 0
-                                          ? genp->motherRef()
-                                          : reco::GenParticleRef();
+        reco::GenParticleRef genMom = genp->numberOfMothers() > 0 ? genp->motherRef() : reco::GenParticleRef();
         reco::GenParticleRef mMom = genMom;
 
         if (genMom.isNonnull()) {
@@ -347,82 +321,68 @@ void MuonSimClassifier::produce(edm::Event &iEvent,
               if (mMom->numberOfMothers() > 0) {
                 mMom = mMom->motherRef();
               }
-              LogTrace("MuonSimClassifier") << "\t\t backtracking mother " << jm
-                                            << ", pdgId = " << mMom->pdgId()
+              LogTrace("MuonSimClassifier") << "\t\t backtracking mother " << jm << ", pdgId = " << mMom->pdgId()
                                             << ", status= " << mMom->status();
             }
-            genMom = mMom; // redefine genMom
+            genMom = mMom;  // redefine genMom
             simInfo[i].motherPdgId = genMom->pdgId();
             simInfo[i].motherStatus = genMom->status();
             simInfo[i].motherVertex = genMom->vertex();
           }
           dumpFormatedInfo(simInfo[i]);
-          LogTrace("MuonSimClassifier")
-              << "\t   has GEN mother pdgId = " << simInfo[i].motherPdgId
-              << " (status = " << simInfo[i].motherStatus << ")";
+          LogTrace("MuonSimClassifier") << "\t   has GEN mother pdgId = " << simInfo[i].motherPdgId
+                                        << " (status = " << simInfo[i].motherStatus << ")";
 
-          reco::GenParticleRef genGMom = genMom->numberOfMothers() > 0
-                                             ? genMom->motherRef()
-                                             : reco::GenParticleRef();
+          reco::GenParticleRef genGMom = genMom->numberOfMothers() > 0 ? genMom->motherRef() : reco::GenParticleRef();
 
           if (genGMom.isNonnull()) {
             simInfo[i].grandMotherPdgId = genGMom->pdgId();
             LogTrace("MuonSimClassifier")
-                << "\t\t mother prod. vertex rho = "
-                << simInfo[i].motherVertex.Rho()
-                << ", z = " << simInfo[i].motherVertex.Z()
-                << ", grand-mom pdgId = " << simInfo[i].grandMotherPdgId;
+                << "\t\t mother prod. vertex rho = " << simInfo[i].motherVertex.Rho()
+                << ", z = " << simInfo[i].motherVertex.Z() << ", grand-mom pdgId = " << simInfo[i].grandMotherPdgId;
           }
           // in this case, we might want to know the heaviest mom flavour
           for (reco::GenParticleRef nMom = genMom;
-               nMom.isNonnull() &&
-               std::abs(nMom->pdgId()) >= 100; // stop when we're no longer
-                                               // looking at hadrons or mesons
-               nMom = nMom->numberOfMothers() > 0 ? nMom->motherRef()
-                                                  : reco::GenParticleRef()) {
+               nMom.isNonnull() && std::abs(nMom->pdgId()) >= 100;  // stop when we're no longer
+                                                                    // looking at hadrons or mesons
+               nMom = nMom->numberOfMothers() > 0 ? nMom->motherRef() : reco::GenParticleRef()) {
             int flav = flavour(nMom->pdgId());
             if (simInfo[i].heaviestMotherFlavour < flav)
               simInfo[i].heaviestMotherFlavour = flav;
             LogTrace("MuonSimClassifier")
-                << "\t\t backtracking flavour: mom pdgId = " << nMom->pdgId()
-                << ", flavour = " << flav
+                << "\t\t backtracking flavour: mom pdgId = " << nMom->pdgId() << ", flavour = " << flav
                 << ", heaviest so far = " << simInfo[i].heaviestMotherFlavour;
           }
-        } else { // mother is null ??
+        } else {  // mother is null ??
           dumpFormatedInfo(simInfo[i]);
           LogTrace("MuonSimClassifier") << "\t   has NO mother!";
         }
-      } else { // Muon is in SIM Only
+      } else {  // Muon is in SIM Only
         TrackingParticleRef simMom = getTpMother(tp);
         if (simMom.isNonnull()) {
           simInfo[i].motherPdgId = simMom->pdgId();
           simInfo[i].motherVertex = simMom->vertex();
           dumpFormatedInfo(simInfo[i]);
-          LogTrace("MuonSimClassifier")
-              << "\t   has SIM mother pdgId = " << simInfo[i].motherPdgId
-              << " produced at rho = " << simMom->vertex().Rho()
-              << ", z = " << simMom->vertex().Z();
+          LogTrace("MuonSimClassifier") << "\t   has SIM mother pdgId = " << simInfo[i].motherPdgId
+                                        << " produced at rho = " << simMom->vertex().Rho()
+                                        << ", z = " << simMom->vertex().Z();
 
           if (!simMom->genParticles().empty()) {
             simInfo[i].motherStatus = simMom->genParticles()[0]->status();
             reco::GenParticleRef genGMom =
-                (simMom->genParticles()[0]->numberOfMothers() > 0
-                     ? simMom->genParticles()[0]->motherRef()
-                     : reco::GenParticleRef());
+                (simMom->genParticles()[0]->numberOfMothers() > 0 ? simMom->genParticles()[0]->motherRef()
+                                                                  : reco::GenParticleRef());
             if (genGMom.isNonnull())
               simInfo[i].grandMotherPdgId = genGMom->pdgId();
-            LogTrace("MuonSimClassifier")
-                << "\t\t SIM mother is in GEN (status "
-                << simInfo[i].motherStatus
-                << "), grand-mom id = " << simInfo[i].grandMotherPdgId;
+            LogTrace("MuonSimClassifier") << "\t\t SIM mother is in GEN (status " << simInfo[i].motherStatus
+                                          << "), grand-mom id = " << simInfo[i].grandMotherPdgId;
           } else {
             simInfo[i].motherStatus = -1;
             TrackingParticleRef simGMom = getTpMother(simMom);
             if (simGMom.isNonnull())
               simInfo[i].grandMotherPdgId = simGMom->pdgId();
             LogTrace("MuonSimClassifier")
-                << "\t\t SIM mother is in SIM only, grand-mom id = "
-                << simInfo[i].grandMotherPdgId;
+                << "\t\t SIM mother is in SIM only, grand-mom id = " << simInfo[i].grandMotherPdgId;
           }
         } else {
           dumpFormatedInfo(simInfo[i]);
@@ -435,190 +395,139 @@ void MuonSimClassifier::produce(edm::Event &iEvent,
       // Check first IF this is a muon at all
       if (std::abs(tp->pdgId()) != 13) {
         if (std::abs(tp->pdgId()) == 11) {
-          simInfo[i].primaryClass = isGhost
-                                        ? reco::MuonSimType::GhostElectron
-                                        : reco::MuonSimType::MatchedElectron;
+          simInfo[i].primaryClass = isGhost ? reco::MuonSimType::GhostElectron : reco::MuonSimType::MatchedElectron;
           simInfo[i].extendedClass =
-              isGhost ? reco::ExtendedMuonSimType::ExtGhostElectron
-                      : reco::ExtendedMuonSimType::ExtMatchedElectron;
-          LogTrace("MuonSimClassifier")
-              << "\t This is electron/positron. classif[i] = "
-              << simInfo[i].primaryClass;
+              isGhost ? reco::ExtendedMuonSimType::ExtGhostElectron : reco::ExtendedMuonSimType::ExtMatchedElectron;
+          LogTrace("MuonSimClassifier") << "\t This is electron/positron. classif[i] = " << simInfo[i].primaryClass;
         } else {
           simInfo[i].primaryClass =
-              isGhost ? reco::MuonSimType::GhostPunchthrough
-                      : reco::MuonSimType::MatchedPunchthrough;
-          simInfo[i].extendedClass =
-              isGhost ? reco::ExtendedMuonSimType::ExtGhostPunchthrough
-                      : reco::ExtendedMuonSimType::ExtMatchedPunchthrough;
-          LogTrace("MuonSimClassifier")
-              << "\t This is not a muon. Sorry. classif[i] = "
-              << simInfo[i].primaryClass;
+              isGhost ? reco::MuonSimType::GhostPunchthrough : reco::MuonSimType::MatchedPunchthrough;
+          simInfo[i].extendedClass = isGhost ? reco::ExtendedMuonSimType::ExtGhostPunchthrough
+                                             : reco::ExtendedMuonSimType::ExtMatchedPunchthrough;
+          LogTrace("MuonSimClassifier") << "\t This is not a muon. Sorry. classif[i] = " << simInfo[i].primaryClass;
         }
         continue;
       }
 
       // Is this SIM muon also a GEN muon, with a mother?
       if (!tp->genParticles().empty() && (simInfo[i].motherPdgId != 0)) {
-        if (std::abs(simInfo[i].motherPdgId) < 100 &&
-            (std::abs(simInfo[i].motherPdgId) != 15)) {
-          simInfo[i].primaryClass = isGhost
-                                        ? reco::MuonSimType::GhostPrimaryMuon
-                                        : reco::MuonSimType::MatchedPrimaryMuon;
-          simInfo[i].flavour = 13;
-          simInfo[i].extendedClass =
-              isGhost
-                  ? reco::ExtendedMuonSimType::GhostMuonFromGaugeOrHiggsBoson
-                  : reco::ExtendedMuonSimType::MatchedMuonFromGaugeOrHiggsBoson;
-          LogTrace("MuonSimClassifier")
-              << "\t This seems PRIMARY MUON ! classif[i] = "
-              << simInfo[i].primaryClass;
-        } else if (simInfo[i].motherFlavour == 4 ||
-                   simInfo[i].motherFlavour == 5 ||
-                   simInfo[i].motherFlavour == 15) {
+        if (std::abs(simInfo[i].motherPdgId) < 100 && (std::abs(simInfo[i].motherPdgId) != 15)) {
           simInfo[i].primaryClass =
-              isGhost ? reco::MuonSimType::GhostMuonFromHeavyFlavour
-                      : reco::MuonSimType::MatchedMuonFromHeavyFlavour;
+              isGhost ? reco::MuonSimType::GhostPrimaryMuon : reco::MuonSimType::MatchedPrimaryMuon;
+          simInfo[i].flavour = 13;
+          simInfo[i].extendedClass = isGhost ? reco::ExtendedMuonSimType::GhostMuonFromGaugeOrHiggsBoson
+                                             : reco::ExtendedMuonSimType::MatchedMuonFromGaugeOrHiggsBoson;
+          LogTrace("MuonSimClassifier") << "\t This seems PRIMARY MUON ! classif[i] = " << simInfo[i].primaryClass;
+        } else if (simInfo[i].motherFlavour == 4 || simInfo[i].motherFlavour == 5 || simInfo[i].motherFlavour == 15) {
+          simInfo[i].primaryClass =
+              isGhost ? reco::MuonSimType::GhostMuonFromHeavyFlavour : reco::MuonSimType::MatchedMuonFromHeavyFlavour;
           simInfo[i].flavour = simInfo[i].motherFlavour;
           if (simInfo[i].motherFlavour == 15)
             simInfo[i].extendedClass =
-                isGhost ? reco::ExtendedMuonSimType::GhostMuonFromTau
-                        : reco::ExtendedMuonSimType::MatchedMuonFromTau;
+                isGhost ? reco::ExtendedMuonSimType::GhostMuonFromTau : reco::ExtendedMuonSimType::MatchedMuonFromTau;
           else if (simInfo[i].motherFlavour == 5)
             simInfo[i].extendedClass =
-                isGhost ? reco::ExtendedMuonSimType::GhostMuonFromB
-                        : reco::ExtendedMuonSimType::MatchedMuonFromB;
+                isGhost ? reco::ExtendedMuonSimType::GhostMuonFromB : reco::ExtendedMuonSimType::MatchedMuonFromB;
           else if (simInfo[i].heaviestMotherFlavour == 5)
             simInfo[i].extendedClass =
-                isGhost ? reco::ExtendedMuonSimType::GhostMuonFromBtoC
-                        : reco::ExtendedMuonSimType::MatchedMuonFromBtoC;
+                isGhost ? reco::ExtendedMuonSimType::GhostMuonFromBtoC : reco::ExtendedMuonSimType::MatchedMuonFromBtoC;
           else
             simInfo[i].extendedClass =
-                isGhost ? reco::ExtendedMuonSimType::GhostMuonFromC
-                        : reco::ExtendedMuonSimType::MatchedMuonFromC;
-          LogTrace("MuonSimClassifier")
-              << "\t This seems HEAVY FLAVOUR ! classif[i] = "
-              << simInfo[i].primaryClass;
+                isGhost ? reco::ExtendedMuonSimType::GhostMuonFromC : reco::ExtendedMuonSimType::MatchedMuonFromC;
+          LogTrace("MuonSimClassifier") << "\t This seems HEAVY FLAVOUR ! classif[i] = " << simInfo[i].primaryClass;
         } else {
           simInfo[i].primaryClass =
-              isGhost ? reco::MuonSimType::GhostMuonFromLightFlavour
-                      : reco::MuonSimType::MatchedMuonFromLightFlavour;
+              isGhost ? reco::MuonSimType::GhostMuonFromLightFlavour : reco::MuonSimType::MatchedMuonFromLightFlavour;
           simInfo[i].flavour = simInfo[i].motherFlavour;
-          LogTrace("MuonSimClassifier")
-              << "\t This seems LIGHT FLAVOUR ! classif[i] = "
-              << simInfo[i].primaryClass;
+          LogTrace("MuonSimClassifier") << "\t This seems LIGHT FLAVOUR ! classif[i] = " << simInfo[i].primaryClass;
         }
       } else {
         simInfo[i].primaryClass =
-            isGhost ? reco::MuonSimType::GhostMuonFromLightFlavour
-                    : reco::MuonSimType::MatchedMuonFromLightFlavour;
+            isGhost ? reco::MuonSimType::GhostMuonFromLightFlavour : reco::MuonSimType::MatchedMuonFromLightFlavour;
         simInfo[i].flavour = simInfo[i].motherFlavour;
-        LogTrace("MuonSimClassifier")
-            << "\t This seems LIGHT FLAVOUR ! classif[i] = "
-            << simInfo[i].primaryClass;
+        LogTrace("MuonSimClassifier") << "\t This seems LIGHT FLAVOUR ! classif[i] = " << simInfo[i].primaryClass;
       }
 
       // extended classification
       // don't we override previous decisions?
       if (simInfo[i].motherPdgId == 0)
         // if it has no mom, it's not a primary particle so it won't be in ppMuX
-        simInfo[i].extendedClass =
-            isGhost
-                ? reco::ExtendedMuonSimType::GhostMuonFromNonPrimaryParticle
-                : reco::ExtendedMuonSimType::MatchedMuonFromNonPrimaryParticle;
+        simInfo[i].extendedClass = isGhost ? reco::ExtendedMuonSimType::GhostMuonFromNonPrimaryParticle
+                                           : reco::ExtendedMuonSimType::MatchedMuonFromNonPrimaryParticle;
       else if (std::abs(simInfo[i].motherPdgId) < 100) {
         if (simInfo[i].motherFlavour == 15)
           simInfo[i].extendedClass =
-              isGhost ? reco::ExtendedMuonSimType::GhostMuonFromTau
-                      : reco::ExtendedMuonSimType::MatchedMuonFromTau;
+              isGhost ? reco::ExtendedMuonSimType::GhostMuonFromTau : reco::ExtendedMuonSimType::MatchedMuonFromTau;
         else
-          simInfo[i].extendedClass =
-              isGhost
-                  ? reco::ExtendedMuonSimType::GhostMuonFromGaugeOrHiggsBoson
-                  : reco::ExtendedMuonSimType::MatchedMuonFromGaugeOrHiggsBoson;
+          simInfo[i].extendedClass = isGhost ? reco::ExtendedMuonSimType::GhostMuonFromGaugeOrHiggsBoson
+                                             : reco::ExtendedMuonSimType::MatchedMuonFromGaugeOrHiggsBoson;
       } else if (simInfo[i].motherFlavour == 5)
         simInfo[i].extendedClass =
-            isGhost ? reco::ExtendedMuonSimType::GhostMuonFromB
-                    : reco::ExtendedMuonSimType::MatchedMuonFromB;
+            isGhost ? reco::ExtendedMuonSimType::GhostMuonFromB : reco::ExtendedMuonSimType::MatchedMuonFromB;
       else if (simInfo[i].motherFlavour == 4) {
         if (simInfo[i].heaviestMotherFlavour == 5)
           simInfo[i].extendedClass =
-              isGhost ? reco::ExtendedMuonSimType::GhostMuonFromBtoC
-                      : reco::ExtendedMuonSimType::MatchedMuonFromBtoC;
+              isGhost ? reco::ExtendedMuonSimType::GhostMuonFromBtoC : reco::ExtendedMuonSimType::MatchedMuonFromBtoC;
         else
           simInfo[i].extendedClass =
-              isGhost ? reco::ExtendedMuonSimType::GhostMuonFromC
-                      : reco::ExtendedMuonSimType::MatchedMuonFromC;
-      } else if (simInfo[i].motherStatus != -1) { // primary light particle
+              isGhost ? reco::ExtendedMuonSimType::GhostMuonFromC : reco::ExtendedMuonSimType::MatchedMuonFromC;
+      } else if (simInfo[i].motherStatus != -1) {  // primary light particle
         int id = std::abs(simInfo[i].motherPdgId);
         if (id != /*pi+*/ 211 && id != /*K+*/ 321 && id != 130 /*K0L*/)
           // other light particle, possibly short-lived
-          simInfo[i].extendedClass =
-              isGhost ? reco::ExtendedMuonSimType::GhostMuonFromOtherLight
-                      : reco::ExtendedMuonSimType::MatchedMuonFromOtherLight;
-        else if (simInfo[i].vertex.Rho() < decayRho_ &&
-                 std::abs(simInfo[i].vertex.Z()) < decayAbsZ_)
+          simInfo[i].extendedClass = isGhost ? reco::ExtendedMuonSimType::GhostMuonFromOtherLight
+                                             : reco::ExtendedMuonSimType::MatchedMuonFromOtherLight;
+        else if (simInfo[i].vertex.Rho() < decayRho_ && std::abs(simInfo[i].vertex.Z()) < decayAbsZ_)
           // decay a la ppMuX (primary pi/K within a cylinder)
-          simInfo[i].extendedClass =
-              isGhost ? reco::ExtendedMuonSimType::GhostMuonFromPiKppMuX
-                      : reco::ExtendedMuonSimType::MatchedMuonFromPiKppMuX;
+          simInfo[i].extendedClass = isGhost ? reco::ExtendedMuonSimType::GhostMuonFromPiKppMuX
+                                             : reco::ExtendedMuonSimType::MatchedMuonFromPiKppMuX;
         else
           // late decay that wouldn't be in ppMuX
-          simInfo[i].extendedClass =
-              isGhost ? reco::ExtendedMuonSimType::GhostMuonFromPiKNotppMuX
-                      : reco::ExtendedMuonSimType::MatchedMuonFromPiKNotppMuX;
+          simInfo[i].extendedClass = isGhost ? reco::ExtendedMuonSimType::GhostMuonFromPiKNotppMuX
+                                             : reco::ExtendedMuonSimType::MatchedMuonFromPiKNotppMuX;
       } else
         // decay of non-primary particle, would not be in ppMuX
-        simInfo[i].extendedClass =
-            isGhost
-                ? reco::ExtendedMuonSimType::GhostMuonFromNonPrimaryParticle
-                : reco::ExtendedMuonSimType::MatchedMuonFromNonPrimaryParticle;
+        simInfo[i].extendedClass = isGhost ? reco::ExtendedMuonSimType::GhostMuonFromNonPrimaryParticle
+                                           : reco::ExtendedMuonSimType::MatchedMuonFromNonPrimaryParticle;
 
       if (linkToGenParticles_ && std::abs(simInfo[i].extendedClass) >= 2) {
         // Link to the genParticle if possible, but not decays in flight (in
         // ppMuX they're in GEN block, but they have wrong parameters)
-        if (!tp->genParticles().empty() &&
-            std::abs(simInfo[i].extendedClass) >= 5) {
+        if (!tp->genParticles().empty() && std::abs(simInfo[i].extendedClass) >= 5) {
           if (genParticles.id() != tp->genParticles().id()) {
             throw cms::Exception("Configuration")
-                << "Product ID mismatch between the genParticle collection ("
-                << genParticles_ << ", id " << genParticles.id()
-                << ") and the references in the TrackingParticles (id "
-                << tp->genParticles().id() << ")\n";
+                << "Product ID mismatch between the genParticle collection (" << genParticles_ << ", id "
+                << genParticles.id() << ") and the references in the TrackingParticles (id " << tp->genParticles().id()
+                << ")\n";
           }
           muToPrimary[i] = tp->genParticles()[0].key();
         } else {
           // Don't put the same trackingParticle twice!
-          int &indexPlus1 = tpToSecondaries[tp]; // will create a 0 if the tp is
-                                                 // not in the list already
+          int &indexPlus1 = tpToSecondaries[tp];  // will create a 0 if the tp is
+                                                  // not in the list already
           if (indexPlus1 == 0)
-            indexPlus1 = convertAndPush(*tp, *secondaries, getTpMother(tp),
-                                        genParticles) +
-                         1;
+            indexPlus1 = convertAndPush(*tp, *secondaries, getTpMother(tp), genParticles) + 1;
           muToSecondary[i] = indexPlus1 - 1;
         }
       }
-      LogTrace("MuonSimClassifier")
-          << "\t Extended classification code = " << simInfo[i].extendedClass;
-    } else { // if (tp.isNonnull())
+      LogTrace("MuonSimClassifier") << "\t Extended classification code = " << simInfo[i].extendedClass;
+    } else {  // if (tp.isNonnull())
       simInfo[i].primaryClass = reco::MuonSimType::NotMatched;
       simInfo[i].extendedClass = reco::ExtendedMuonSimType::ExtNotMatched;
     }
-  } // end loop on reco muons
+  }  // end loop on reco muons
 
   writeValueMap(iEvent, muons, simInfo, "");
 
   if (linkToGenParticles_) {
-    edm::OrphanHandle<reco::GenParticleCollection> secHandle =
-        iEvent.put(std::move(secondaries), "secondaries");
+    edm::OrphanHandle<reco::GenParticleCollection> secHandle = iEvent.put(std::move(secondaries), "secondaries");
     edm::RefProd<reco::GenParticleCollection> priRP(genParticles);
     edm::RefProd<reco::GenParticleCollection> secRP(secHandle);
     std::unique_ptr<edm::Association<reco::GenParticleCollection>> outPri(
         new edm::Association<reco::GenParticleCollection>(priRP));
     std::unique_ptr<edm::Association<reco::GenParticleCollection>> outSec(
         new edm::Association<reco::GenParticleCollection>(secRP));
-    edm::Association<reco::GenParticleCollection>::Filler fillPri(*outPri),
-        fillSec(*outSec);
+    edm::Association<reco::GenParticleCollection>::Filler fillPri(*outPri), fillSec(*outSec);
     fillPri.insert(muons, muToPrimary.begin(), muToPrimary.end());
     fillSec.insert(muons, muToSecondary.begin(), muToSecondary.end());
     fillPri.fill();
@@ -629,9 +538,10 @@ void MuonSimClassifier::produce(edm::Event &iEvent,
 }
 
 template <typename T>
-void MuonSimClassifier::writeValueMap(
-    edm::Event &iEvent, const edm::Handle<edm::View<reco::Muon>> &handle,
-    const std::vector<T> &values, const std::string &label) const {
+void MuonSimClassifier::writeValueMap(edm::Event &iEvent,
+                                      const edm::Handle<edm::View<reco::Muon>> &handle,
+                                      const std::vector<T> &values,
+                                      const std::string &label) const {
   using namespace edm;
   using namespace std;
   unique_ptr<ValueMap<T>> valMap(new ValueMap<T>());
@@ -660,19 +570,16 @@ int MuonSimClassifier::flavour(int pdgId) const {
 
 // push secondary in collection.
 // if it has a primary mother link to it.
-int MuonSimClassifier::convertAndPush(
-    const TrackingParticle &tp, reco::GenParticleCollection &out,
-    const TrackingParticleRef &simMom,
-    const edm::Handle<reco::GenParticleCollection> &genParticles) const {
-  out.push_back(reco::GenParticle(tp.charge(), tp.p4(), tp.vertex(), tp.pdgId(),
-                                  tp.status(), true));
+int MuonSimClassifier::convertAndPush(const TrackingParticle &tp,
+                                      reco::GenParticleCollection &out,
+                                      const TrackingParticleRef &simMom,
+                                      const edm::Handle<reco::GenParticleCollection> &genParticles) const {
+  out.push_back(reco::GenParticle(tp.charge(), tp.p4(), tp.vertex(), tp.pdgId(), tp.status(), true));
   if (simMom.isNonnull() && !simMom->genParticles().empty()) {
     if (genParticles.id() != simMom->genParticles().id()) {
       throw cms::Exception("Configuration")
-          << "Product ID mismatch between the genParticle collection ("
-          << genParticles_ << ", id " << genParticles.id()
-          << ") and the references in the TrackingParticles (id "
-          << simMom->genParticles().id() << ")\n";
+          << "Product ID mismatch between the genParticle collection (" << genParticles_ << ", id " << genParticles.id()
+          << ") and the references in the TrackingParticles (id " << simMom->genParticles().id() << ")\n";
     }
     out.back().addMother(simMom->genParticles()[0]);
   }

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.cc
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.cc
@@ -27,13 +27,11 @@
 //
 // constructors and destructor
 //
-MuonToTrackingParticleAssociatorByHitsImpl::
-    MuonToTrackingParticleAssociatorByHitsImpl(
-        TrackerMuonHitExtractor const &iHitExtractor,
-        MuonAssociatorByHitsHelper::Resources const &iResources,
-        MuonAssociatorByHitsHelper const *iHelper)
-    : m_hitExtractor(&iHitExtractor), m_resources(iResources),
-      m_helper(iHelper) {}
+MuonToTrackingParticleAssociatorByHitsImpl::MuonToTrackingParticleAssociatorByHitsImpl(
+    TrackerMuonHitExtractor const &iHitExtractor,
+    MuonAssociatorByHitsHelper::Resources const &iResources,
+    MuonAssociatorByHitsHelper const *iHelper)
+    : m_hitExtractor(&iHitExtractor), m_resources(iResources), m_helper(iHelper) {}
 
 //
 // member functions
@@ -43,176 +41,137 @@ MuonToTrackingParticleAssociatorByHitsImpl::
 // const member functions
 //
 void MuonToTrackingParticleAssociatorByHitsImpl::associateMuons(
-    reco::MuonToSimCollection &recToSim, reco::SimToMuonCollection &simToRec,
-    const edm::RefToBaseVector<reco::Muon> &muons, reco::MuonTrackType type,
+    reco::MuonToSimCollection &recToSim,
+    reco::SimToMuonCollection &simToRec,
+    const edm::RefToBaseVector<reco::Muon> &muons,
+    reco::MuonTrackType type,
     const edm::RefVector<TrackingParticleCollection> &tPC) const {
   /// PART 1: Fill MuonToSimAssociatorByHits::TrackHitsCollection
   MuonAssociatorByHitsHelper::TrackHitsCollection muonHitRefs;
-  edm::OwnVector<TrackingRecHit>
-      allTMRecHits; // this I will fill in only for tracker muon hits from
-                    // segments
+  edm::OwnVector<TrackingRecHit> allTMRecHits;  // this I will fill in only for tracker muon hits from
+                                                // segments
 
-  std::vector<edm::OwnVector<TrackingRecHit>>
-      TMRecHits; // used for case GlbOrTrk
+  std::vector<edm::OwnVector<TrackingRecHit>> TMRecHits;  // used for case GlbOrTrk
   edm::OwnVector<TrackingRecHit> noTM;
 
   switch (type) {
-
-  case reco::InnerTk:
-    for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(),
-                                                          ed = muons.end();
-         it != ed; ++it) {
-      edm::RefToBase<reco::Muon> mur = *it;
-      if (mur->track().isNonnull()) {
-        muonHitRefs.push_back(std::make_pair(mur->track()->recHitsBegin(),
-                                             mur->track()->recHitsEnd()));
-      } else {
-        muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(),
-                                             allTMRecHits.data().end()));
-      }
-    }
-    break;
-  case reco::OuterTk:
-    for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(),
-                                                          ed = muons.end();
-         it != ed; ++it) {
-      edm::RefToBase<reco::Muon> mur = *it;
-      if (mur->outerTrack().isNonnull()) {
-        muonHitRefs.push_back(std::make_pair(mur->outerTrack()->recHitsBegin(),
-                                             mur->outerTrack()->recHitsEnd()));
-      } else {
-        muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(),
-                                             allTMRecHits.data().end()));
-      }
-    }
-    break;
-  case reco::GlobalTk:
-    for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(),
-                                                          ed = muons.end();
-         it != ed; ++it) {
-      edm::RefToBase<reco::Muon> mur = *it;
-      if (mur->globalTrack().isNonnull()) {
-        muonHitRefs.push_back(std::make_pair(mur->globalTrack()->recHitsBegin(),
-                                             mur->globalTrack()->recHitsEnd()));
-      } else {
-        muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(),
-                                             allTMRecHits.data().end()));
-      }
-    }
-    break;
-  case reco::Segments: {
-    // puts hits in the vector, and record indices
-    std::vector<std::pair<size_t, size_t>> muonHitIndices;
-    for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(),
-                                                          ed = muons.end();
-         it != ed; ++it) {
-      edm::RefToBase<reco::Muon> mur = *it;
-      std::pair<size_t, size_t> indices(allTMRecHits.size(),
-                                        allTMRecHits.size());
-      if (mur->isTrackerMuon()) {
-        std::vector<const TrackingRecHit *> hits =
-            m_hitExtractor->getMuonHits(*mur);
-        for (std::vector<const TrackingRecHit *>::const_iterator
-                 ith = hits.begin(),
-                 edh = hits.end();
-             ith != edh; ++ith) {
-          allTMRecHits.push_back(**ith);
+    case reco::InnerTk:
+      for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
+        edm::RefToBase<reco::Muon> mur = *it;
+        if (mur->track().isNonnull()) {
+          muonHitRefs.push_back(std::make_pair(mur->track()->recHitsBegin(), mur->track()->recHitsEnd()));
+        } else {
+          muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
         }
-        indices.second += hits.size();
       }
-      muonHitIndices.push_back(indices);
-    }
-    // convert indices into pairs of iterators to references
-    typedef std::pair<size_t, size_t> index_pair;
-    trackingRecHit_iterator hitRefBegin = allTMRecHits.data().begin();
-    for (std::vector<std::pair<size_t, size_t>>::const_iterator
-             idxs = muonHitIndices.begin(),
-             idxend = muonHitIndices.end();
-         idxs != idxend; ++idxs) {
-      muonHitRefs.push_back(std::make_pair(hitRefBegin + idxs->first,
-                                           hitRefBegin + idxs->second));
-    }
+      break;
+    case reco::OuterTk:
+      for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
+        edm::RefToBase<reco::Muon> mur = *it;
+        if (mur->outerTrack().isNonnull()) {
+          muonHitRefs.push_back(std::make_pair(mur->outerTrack()->recHitsBegin(), mur->outerTrack()->recHitsEnd()));
+        } else {
+          muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
+        }
+      }
+      break;
+    case reco::GlobalTk:
+      for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
+        edm::RefToBase<reco::Muon> mur = *it;
+        if (mur->globalTrack().isNonnull()) {
+          muonHitRefs.push_back(std::make_pair(mur->globalTrack()->recHitsBegin(), mur->globalTrack()->recHitsEnd()));
+        } else {
+          muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
+        }
+      }
+      break;
+    case reco::Segments: {
+      // puts hits in the vector, and record indices
+      std::vector<std::pair<size_t, size_t>> muonHitIndices;
+      for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
+        edm::RefToBase<reco::Muon> mur = *it;
+        std::pair<size_t, size_t> indices(allTMRecHits.size(), allTMRecHits.size());
+        if (mur->isTrackerMuon()) {
+          std::vector<const TrackingRecHit *> hits = m_hitExtractor->getMuonHits(*mur);
+          for (std::vector<const TrackingRecHit *>::const_iterator ith = hits.begin(), edh = hits.end(); ith != edh;
+               ++ith) {
+            allTMRecHits.push_back(**ith);
+          }
+          indices.second += hits.size();
+        }
+        muonHitIndices.push_back(indices);
+      }
+      // convert indices into pairs of iterators to references
+      typedef std::pair<size_t, size_t> index_pair;
+      trackingRecHit_iterator hitRefBegin = allTMRecHits.data().begin();
+      for (std::vector<std::pair<size_t, size_t>>::const_iterator idxs = muonHitIndices.begin(),
+                                                                  idxend = muonHitIndices.end();
+           idxs != idxend;
+           ++idxs) {
+        muonHitRefs.push_back(std::make_pair(hitRefBegin + idxs->first, hitRefBegin + idxs->second));
+      }
 
-  } break;
-  case reco::GlbOrTrk: {
-    edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl")
-        << "\n"
-        << "There are " << muons.size() << " selected reco::Muons.";
-
-    int isel = 0;
-    for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(),
-                                                          ed = muons.end();
-         it != ed; ++it) {
-      edm::RefToBase<reco::Muon> mur = *it;
-
+    } break;
+    case reco::GlbOrTrk: {
       edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl")
-          << " #" << isel << ", reco::Muon key = " << mur.key()
-          << ", q*p = " << mur->charge() * mur->p() << ", pT = " << mur->pt()
-          << ", eta = " << mur->eta() << ", phi = " << mur->phi();
+          << "\n"
+          << "There are " << muons.size() << " selected reco::Muons.";
 
-      // Global muon with valid muon hits
-      if (mur->isGlobalMuon() &&
-          mur->globalTrack()->hitPattern().numberOfValidMuonHits() > 0) {
+      int isel = 0;
+      for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
+        edm::RefToBase<reco::Muon> mur = *it;
+
         edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl")
-            << "\t this is a Global Muon with valid muon hits";
-        muonHitRefs.push_back(std::make_pair(mur->globalTrack()->recHitsBegin(),
-                                             mur->globalTrack()->recHitsEnd()));
-      }
+            << " #" << isel << ", reco::Muon key = " << mur.key() << ", q*p = " << mur->charge() * mur->p()
+            << ", pT = " << mur->pt() << ", eta = " << mur->eta() << ", phi = " << mur->phi();
 
-      // Tracker Muon
-      else if (mur->isTrackerMuon()) {
-        edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl")
-            << "\t this is a Tracker Muon";
-        edm::OwnVector<TrackingRecHit> TMvec;
-
-        std::vector<const TrackingRecHit *> hits =
-            m_hitExtractor->getMuonHits(*mur);
-        for (std::vector<const TrackingRecHit *>::const_iterator
-                 ith = hits.begin(),
-                 edh = hits.end();
-             ith != edh; ++ith) {
-          TMvec.push_back(**ith);
+        // Global muon with valid muon hits
+        if (mur->isGlobalMuon() && mur->globalTrack()->hitPattern().numberOfValidMuonHits() > 0) {
+          edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl")
+              << "\t this is a Global Muon with valid muon hits";
+          muonHitRefs.push_back(std::make_pair(mur->globalTrack()->recHitsBegin(), mur->globalTrack()->recHitsEnd()));
         }
 
-        TMRecHits.push_back(TMvec);
+        // Tracker Muon
+        else if (mur->isTrackerMuon()) {
+          edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl") << "\t this is a Tracker Muon";
+          edm::OwnVector<TrackingRecHit> TMvec;
 
-        muonHitRefs.push_back(std::make_pair(TMRecHits.rbegin()->data().begin(),
-                                             TMRecHits.rbegin()->data().end()));
-      }
+          std::vector<const TrackingRecHit *> hits = m_hitExtractor->getMuonHits(*mur);
+          for (std::vector<const TrackingRecHit *>::const_iterator ith = hits.begin(), edh = hits.end(); ith != edh;
+               ++ith) {
+            TMvec.push_back(**ith);
+          }
 
-      // Standalone muon or Global without valid muon hits
-      else if (mur->outerTrack().isNonnull()) {
-        edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl")
-            << "\t this is a Standalone muon";
-        muonHitRefs.push_back(std::make_pair(mur->outerTrack()->recHitsBegin(),
-                                             mur->outerTrack()->recHitsEnd()));
-      }
+          TMRecHits.push_back(TMvec);
 
-      else {
-        edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl")
-            << "\t what muon is this ?";
-        edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl")
-            << "isMuon : " << mur->isMuon()
-            << ", isPFMuon : " << mur->isPFMuon()
-            << ", isTrackerMuon : " << mur->isTrackerMuon()
-            << ", isStandAloneMuon : " << mur->isStandAloneMuon()
-            << ", isGlobalMuon : " << mur->isGlobalMuon()
-            << ", isRPCMuon : " << mur->isRPCMuon()
-            << ", isGEMMuon : " << mur->isGEMMuon()
-            << ", isME0Muon : " << mur->isME0Muon();
-        muonHitRefs.push_back(
-            std::make_pair(noTM.data().end(), noTM.data().end()));
-      }
+          muonHitRefs.push_back(std::make_pair(TMRecHits.rbegin()->data().begin(), TMRecHits.rbegin()->data().end()));
+        }
 
-      isel++;
-    } // loop on muons
+        // Standalone muon or Global without valid muon hits
+        else if (mur->outerTrack().isNonnull()) {
+          edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl") << "\t this is a Standalone muon";
+          muonHitRefs.push_back(std::make_pair(mur->outerTrack()->recHitsBegin(), mur->outerTrack()->recHitsEnd()));
+        }
 
-  } break;
+        else {
+          edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl") << "\t what muon is this ?";
+          edm::LogVerbatim("MuonToTrackingParticleAssociatorByHitsImpl")
+              << "isMuon : " << mur->isMuon() << ", isPFMuon : " << mur->isPFMuon()
+              << ", isTrackerMuon : " << mur->isTrackerMuon() << ", isStandAloneMuon : " << mur->isStandAloneMuon()
+              << ", isGlobalMuon : " << mur->isGlobalMuon() << ", isRPCMuon : " << mur->isRPCMuon()
+              << ", isGEMMuon : " << mur->isGEMMuon() << ", isME0Muon : " << mur->isME0Muon();
+          muonHitRefs.push_back(std::make_pair(noTM.data().end(), noTM.data().end()));
+        }
+
+        isel++;
+      }  // loop on muons
+
+    } break;
   }
 
   /// PART 2: call the association routines
-  auto recSimColl =
-      m_helper->associateRecoToSimIndices(muonHitRefs, tPC, m_resources);
+  auto recSimColl = m_helper->associateRecoToSimIndices(muonHitRefs, tPC, m_resources);
   for (auto it = recSimColl.begin(), ed = recSimColl.end(); it != ed; ++it) {
     edm::RefToBase<reco::Muon> rec = muons[it->first];
     std::vector<std::pair<TrackingParticleRef, double>> &tpAss = recToSim[rec];
@@ -220,12 +179,10 @@ void MuonToTrackingParticleAssociatorByHitsImpl::associateMuons(
       tpAss.push_back(std::make_pair(tPC[a.idx], a.quality));
     }
   }
-  auto simRecColl =
-      m_helper->associateSimToRecoIndices(muonHitRefs, tPC, m_resources);
+  auto simRecColl = m_helper->associateSimToRecoIndices(muonHitRefs, tPC, m_resources);
   for (auto it = simRecColl.begin(), ed = simRecColl.end(); it != ed; ++it) {
     TrackingParticleRef sim = tPC[it->first];
-    std::vector<std::pair<edm::RefToBase<reco::Muon>, double>> &recAss =
-        simToRec[sim];
+    std::vector<std::pair<edm::RefToBase<reco::Muon>, double>> &recAss = simToRec[sim];
     for (auto const &a : it->second) {
       recAss.push_back(std::make_pair(muons[a.idx], a.quality));
     }
@@ -233,10 +190,11 @@ void MuonToTrackingParticleAssociatorByHitsImpl::associateMuons(
 }
 
 void MuonToTrackingParticleAssociatorByHitsImpl::associateMuons(
-    reco::MuonToSimCollection &recToSim, reco::SimToMuonCollection &simToRec,
-    const edm::Handle<edm::View<reco::Muon>> &tCH, reco::MuonTrackType type,
+    reco::MuonToSimCollection &recToSim,
+    reco::SimToMuonCollection &simToRec,
+    const edm::Handle<edm::View<reco::Muon>> &tCH,
+    reco::MuonTrackType type,
     const edm::Handle<TrackingParticleCollection> &tPCH) const {
-
   edm::RefVector<TrackingParticleCollection> tpc(tPCH.id());
   for (unsigned int j = 0; j < tPCH->size(); j++)
     tpc.push_back(edm::Ref<TrackingParticleCollection>(tPCH, j));

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.h
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorByHitsImpl.h
@@ -29,40 +29,35 @@
 // forward declarations
 class TrackerMuonHitExtractor;
 
-class MuonToTrackingParticleAssociatorByHitsImpl
-    : public reco::MuonToTrackingParticleAssociatorBaseImpl {
-
+class MuonToTrackingParticleAssociatorByHitsImpl : public reco::MuonToTrackingParticleAssociatorBaseImpl {
 public:
-  MuonToTrackingParticleAssociatorByHitsImpl(
-      TrackerMuonHitExtractor const &iHitExtractor,
-      MuonAssociatorByHitsHelper::Resources const &iResources,
-      MuonAssociatorByHitsHelper const *iHelper);
+  MuonToTrackingParticleAssociatorByHitsImpl(TrackerMuonHitExtractor const &iHitExtractor,
+                                             MuonAssociatorByHitsHelper::Resources const &iResources,
+                                             MuonAssociatorByHitsHelper const *iHelper);
 
   // ---------- const member functions ---------------------
-  void associateMuons(
-      reco::MuonToSimCollection &recoToSim,
-      reco::SimToMuonCollection &simToReco,
-      const edm::RefToBaseVector<reco::Muon> &muons, reco::MuonTrackType type,
-      const edm::RefVector<TrackingParticleCollection> &tpColl) const override;
+  void associateMuons(reco::MuonToSimCollection &recoToSim,
+                      reco::SimToMuonCollection &simToReco,
+                      const edm::RefToBaseVector<reco::Muon> &muons,
+                      reco::MuonTrackType type,
+                      const edm::RefVector<TrackingParticleCollection> &tpColl) const override;
 
-  void associateMuons(
-      reco::MuonToSimCollection &recoToSim,
-      reco::SimToMuonCollection &simToReco,
-      const edm::Handle<edm::View<reco::Muon>> &muons, reco::MuonTrackType type,
-      const edm::Handle<TrackingParticleCollection> &tpColl) const override;
+  void associateMuons(reco::MuonToSimCollection &recoToSim,
+                      reco::SimToMuonCollection &simToReco,
+                      const edm::Handle<edm::View<reco::Muon>> &muons,
+                      reco::MuonTrackType type,
+                      const edm::Handle<TrackingParticleCollection> &tpColl) const override;
 
   // ---------- static member functions --------------------
 
   // ---------- member functions ---------------------------
 
 private:
-  MuonToTrackingParticleAssociatorByHitsImpl(
-      const MuonToTrackingParticleAssociatorByHitsImpl &) =
-      delete; // stop default
+  MuonToTrackingParticleAssociatorByHitsImpl(const MuonToTrackingParticleAssociatorByHitsImpl &) =
+      delete;  // stop default
 
-  const MuonToTrackingParticleAssociatorByHitsImpl &
-  operator=(const MuonToTrackingParticleAssociatorByHitsImpl &) =
-      delete; // stop default
+  const MuonToTrackingParticleAssociatorByHitsImpl &operator=(const MuonToTrackingParticleAssociatorByHitsImpl &) =
+      delete;  // stop default
 
   // ---------- member data --------------------------------
   TrackerMuonHitExtractor const *m_hitExtractor;

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
@@ -40,175 +40,141 @@
 // class declaration
 //
 namespace {
-using TrackHitsCollection = MuonAssociatorByHitsHelper::TrackHitsCollection;
+  using TrackHitsCollection = MuonAssociatorByHitsHelper::TrackHitsCollection;
 
-class InputDumper {
-public:
-  InputDumper(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
-      : simtracksTag(conf.getParameter<edm::InputTag>("simtracksTag")),
-        simtracksXFTag(conf.getParameter<edm::InputTag>("simtracksXFTag")),
-        crossingframe(conf.getParameter<bool>("crossingframe")) {
+  class InputDumper {
+  public:
+    InputDumper(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
+        : simtracksTag(conf.getParameter<edm::InputTag>("simtracksTag")),
+          simtracksXFTag(conf.getParameter<edm::InputTag>("simtracksXFTag")),
+          crossingframe(conf.getParameter<bool>("crossingframe")) {
+      if (crossingframe) {
+        simtracksXFToken_ = iC.consumes<CrossingFrame<SimTrack>>(simtracksXFTag);
+        simvertsXFToken_ = iC.consumes<CrossingFrame<SimVertex>>(simtracksXFTag);
+      } else {
+        simtracksToken_ = iC.consumes<edm::SimTrackContainer>(simtracksTag);
+        simvertsToken_ = iC.consumes<edm::SimVertexContainer>(simtracksTag);
+      }
+    }
+
+    void read(const edm::Event &);
+    void dump(const TrackHitsCollection &, const TrackingParticleCollection &) const;
+
+  private:
+    edm::InputTag simtracksTag;
+    edm::InputTag simtracksXFTag;
+    edm::EDGetTokenT<CrossingFrame<SimTrack>> simtracksXFToken_;
+    edm::EDGetTokenT<CrossingFrame<SimVertex>> simvertsXFToken_;
+    edm::EDGetTokenT<edm::SimTrackContainer> simtracksToken_;
+    edm::EDGetTokenT<edm::SimVertexContainer> simvertsToken_;
+
+    edm::Handle<CrossingFrame<SimTrack>> simtracksXF_;
+    edm::Handle<CrossingFrame<SimVertex>> simvertsXF_;
+    edm::Handle<edm::SimTrackContainer> simtracks_;
+    edm::Handle<edm::SimVertexContainer> simverts_;
+    bool const crossingframe;
+  };
+
+  void InputDumper::read(const edm::Event &iEvent) {
     if (crossingframe) {
-      simtracksXFToken_ = iC.consumes<CrossingFrame<SimTrack>>(simtracksXFTag);
-      simvertsXFToken_ = iC.consumes<CrossingFrame<SimVertex>>(simtracksXFTag);
+      iEvent.getByToken(simtracksXFToken_, simtracksXF_);
+      iEvent.getByToken(simvertsXFToken_, simvertsXF_);
     } else {
-      simtracksToken_ = iC.consumes<edm::SimTrackContainer>(simtracksTag);
-      simvertsToken_ = iC.consumes<edm::SimVertexContainer>(simtracksTag);
+      iEvent.getByToken(simtracksToken_, simtracks_);
+      iEvent.getByToken(simvertsToken_, simverts_);
     }
   }
 
-  void read(const edm::Event &);
-  void dump(const TrackHitsCollection &,
-            const TrackingParticleCollection &) const;
+  void InputDumper::dump(const TrackHitsCollection &tC, const TrackingParticleCollection &tPC) const {
+    using namespace std;
+    // reco::Track collection
+    edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer") << "\n"
+                                                                   << "reco::Track collection --- size = " << tC.size();
 
-private:
-  edm::InputTag simtracksTag;
-  edm::InputTag simtracksXFTag;
-  edm::EDGetTokenT<CrossingFrame<SimTrack>> simtracksXFToken_;
-  edm::EDGetTokenT<CrossingFrame<SimVertex>> simvertsXFToken_;
-  edm::EDGetTokenT<edm::SimTrackContainer> simtracksToken_;
-  edm::EDGetTokenT<edm::SimVertexContainer> simvertsToken_;
-
-  edm::Handle<CrossingFrame<SimTrack>> simtracksXF_;
-  edm::Handle<CrossingFrame<SimVertex>> simvertsXF_;
-  edm::Handle<edm::SimTrackContainer> simtracks_;
-  edm::Handle<edm::SimVertexContainer> simverts_;
-  bool const crossingframe;
-};
-
-void InputDumper::read(const edm::Event &iEvent) {
-  if (crossingframe) {
-    iEvent.getByToken(simtracksXFToken_, simtracksXF_);
-    iEvent.getByToken(simvertsXFToken_, simvertsXF_);
-  } else {
-    iEvent.getByToken(simtracksToken_, simtracks_);
-    iEvent.getByToken(simvertsToken_, simverts_);
-  }
-}
-
-void InputDumper::dump(const TrackHitsCollection &tC,
-                       const TrackingParticleCollection &tPC) const {
-  using namespace std;
-  // reco::Track collection
-  edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-      << "\n"
-      << "reco::Track collection --- size = " << tC.size();
-
-  // TrackingParticle collection
-  edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-      << "\n"
-      << "TrackingParticle collection --- size = " << tPC.size();
-  int j = 0;
-  for (TrackingParticleCollection::const_iterator ITER = tPC.begin();
-       ITER != tPC.end(); ITER++, j++) {
-    edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-        << "TrackingParticle " << j << ", q = " << ITER->charge()
-        << ", p = " << ITER->p() << ", pT = " << ITER->pt()
-        << ", eta = " << ITER->eta() << ", phi = " << ITER->phi();
-
-    edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-        << "\t pdg code = " << ITER->pdgId() << ", made of "
-        << ITER->numberOfHits() << " PSimHit"
-        << " (in " << ITER->numberOfTrackerLayers() << " layers)"
-        << " from " << ITER->g4Tracks().size() << " SimTrack:";
-    for (TrackingParticle::g4t_iterator g4T = ITER->g4Track_begin();
-         g4T != ITER->g4Track_end(); g4T++) {
-      edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-          << "\t\t Id:" << g4T->trackId() << "/Evt:(" << g4T->eventId().event()
-          << "," << g4T->eventId().bunchCrossing() << ")";
-    }
-  }
-
-  if (crossingframe) {
-    std::unique_ptr<MixCollection<SimTrack>> SimTk(
-        new MixCollection<SimTrack>(simtracksXF_.product()));
+    // TrackingParticle collection
     edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
         << "\n"
-        << "CrossingFrame<SimTrack> collection with InputTag = "
-        << simtracksXFTag << " has size = " << SimTk->size();
-    int k = 0;
-    for (MixCollection<SimTrack>::MixItr ITER = SimTk->begin();
-         ITER != SimTk->end(); ITER++, k++) {
+        << "TrackingParticle collection --- size = " << tPC.size();
+    int j = 0;
+    for (TrackingParticleCollection::const_iterator ITER = tPC.begin(); ITER != tPC.end(); ITER++, j++) {
       edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-          << "SimTrack " << k << " - Id:" << ITER->trackId() << "/Evt:("
-          << ITER->eventId().event() << "," << ITER->eventId().bunchCrossing()
-          << ")"
-          << ", q = " << ITER->charge() << ", p = " << ITER->momentum().P()
-          << ", pT = " << ITER->momentum().Pt()
-          << ", eta = " << ITER->momentum().Eta()
-          << ", phi = " << ITER->momentum().Phi()
-          << "\n\t pdgId = " << ITER->type()
-          << ", Vertex index = " << ITER->vertIndex()
-          << ", Gen Particle index = "
-          << (ITER->genpartIndex() > 0 ? ITER->genpartIndex() - 1
-                                       : ITER->genpartIndex())
-          << endl;
+          << "TrackingParticle " << j << ", q = " << ITER->charge() << ", p = " << ITER->p() << ", pT = " << ITER->pt()
+          << ", eta = " << ITER->eta() << ", phi = " << ITER->phi();
+
+      edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+          << "\t pdg code = " << ITER->pdgId() << ", made of " << ITER->numberOfHits() << " PSimHit"
+          << " (in " << ITER->numberOfTrackerLayers() << " layers)"
+          << " from " << ITER->g4Tracks().size() << " SimTrack:";
+      for (TrackingParticle::g4t_iterator g4T = ITER->g4Track_begin(); g4T != ITER->g4Track_end(); g4T++) {
+        edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+            << "\t\t Id:" << g4T->trackId() << "/Evt:(" << g4T->eventId().event() << ","
+            << g4T->eventId().bunchCrossing() << ")";
+      }
     }
 
-    std::unique_ptr<MixCollection<SimVertex>> SimVtx(
-        new MixCollection<SimVertex>(simvertsXF_.product()));
-    edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-        << "\n"
-        << "CrossingFrame<SimVertex> collection with InputTag = "
-        << simtracksXFTag << " has size = " << SimVtx->size();
-    int kv = 0;
-    for (MixCollection<SimVertex>::MixItr VITER = SimVtx->begin();
-         VITER != SimVtx->end(); VITER++, kv++) {
+    if (crossingframe) {
+      std::unique_ptr<MixCollection<SimTrack>> SimTk(new MixCollection<SimTrack>(simtracksXF_.product()));
       edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-          << "SimVertex " << kv << " - Id:" << VITER->vertexId()
-          << ", position = " << VITER->position()
-          << ", parent SimTrack Id = " << VITER->parentIndex()
-          << ", processType = " << VITER->processType();
-    }
-  } else {
-    const edm::SimTrackContainer simTC = *(simtracks_.product());
-    edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-        << "\n"
-        << "SimTrack collection with InputTag = " << simtracksTag
-        << " has size = " << simTC.size() << endl;
-    int k = 0;
-    for (edm::SimTrackContainer::const_iterator ITER = simTC.begin();
-         ITER != simTC.end(); ITER++, k++) {
+          << "\n"
+          << "CrossingFrame<SimTrack> collection with InputTag = " << simtracksXFTag << " has size = " << SimTk->size();
+      int k = 0;
+      for (MixCollection<SimTrack>::MixItr ITER = SimTk->begin(); ITER != SimTk->end(); ITER++, k++) {
+        edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+            << "SimTrack " << k << " - Id:" << ITER->trackId() << "/Evt:(" << ITER->eventId().event() << ","
+            << ITER->eventId().bunchCrossing() << ")"
+            << ", q = " << ITER->charge() << ", p = " << ITER->momentum().P() << ", pT = " << ITER->momentum().Pt()
+            << ", eta = " << ITER->momentum().Eta() << ", phi = " << ITER->momentum().Phi()
+            << "\n\t pdgId = " << ITER->type() << ", Vertex index = " << ITER->vertIndex()
+            << ", Gen Particle index = " << (ITER->genpartIndex() > 0 ? ITER->genpartIndex() - 1 : ITER->genpartIndex())
+            << endl;
+      }
+
+      std::unique_ptr<MixCollection<SimVertex>> SimVtx(new MixCollection<SimVertex>(simvertsXF_.product()));
       edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-          << "SimTrack " << k << " - Id:" << ITER->trackId() << "/Evt:("
-          << ITER->eventId().event() << "," << ITER->eventId().bunchCrossing()
-          << ")"
-          << ", q = " << ITER->charge() << ", p = " << ITER->momentum().P()
-          << ", pT = " << ITER->momentum().Pt()
-          << ", eta = " << ITER->momentum().Eta()
-          << ", phi = " << ITER->momentum().Phi()
-          << "\n\t pdgId = " << ITER->type()
-          << ", Vertex index = " << ITER->vertIndex()
-          << ", Gen Particle index = "
-          << (ITER->genpartIndex() > 0 ? ITER->genpartIndex() - 1
-                                       : ITER->genpartIndex())
-          << endl;
-    }
-    const edm::SimVertexContainer simVC = *(simverts_.product());
-    edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-        << "\n"
-        << "SimVertex collection with InputTag = "
-        << "g4SimHits"
-        << " has size = " << simVC.size() << endl;
-    int kv = 0;
-    for (edm::SimVertexContainer::const_iterator VITER = simVC.begin();
-         VITER != simVC.end(); VITER++, kv++) {
+          << "\n"
+          << "CrossingFrame<SimVertex> collection with InputTag = " << simtracksXFTag
+          << " has size = " << SimVtx->size();
+      int kv = 0;
+      for (MixCollection<SimVertex>::MixItr VITER = SimVtx->begin(); VITER != SimVtx->end(); VITER++, kv++) {
+        edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+            << "SimVertex " << kv << " - Id:" << VITER->vertexId() << ", position = " << VITER->position()
+            << ", parent SimTrack Id = " << VITER->parentIndex() << ", processType = " << VITER->processType();
+      }
+    } else {
+      const edm::SimTrackContainer simTC = *(simtracks_.product());
       edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
-          << "SimVertex " << kv << " - Id:" << VITER->vertexId()
-          << ", position = " << VITER->position()
-          << ", parent SimTrack Id = " << VITER->parentIndex()
-          << ", processType = " << VITER->processType();
+          << "\n"
+          << "SimTrack collection with InputTag = " << simtracksTag << " has size = " << simTC.size() << endl;
+      int k = 0;
+      for (edm::SimTrackContainer::const_iterator ITER = simTC.begin(); ITER != simTC.end(); ITER++, k++) {
+        edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+            << "SimTrack " << k << " - Id:" << ITER->trackId() << "/Evt:(" << ITER->eventId().event() << ","
+            << ITER->eventId().bunchCrossing() << ")"
+            << ", q = " << ITER->charge() << ", p = " << ITER->momentum().P() << ", pT = " << ITER->momentum().Pt()
+            << ", eta = " << ITER->momentum().Eta() << ", phi = " << ITER->momentum().Phi()
+            << "\n\t pdgId = " << ITER->type() << ", Vertex index = " << ITER->vertIndex()
+            << ", Gen Particle index = " << (ITER->genpartIndex() > 0 ? ITER->genpartIndex() - 1 : ITER->genpartIndex())
+            << endl;
+      }
+      const edm::SimVertexContainer simVC = *(simverts_.product());
+      edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer") << "\n"
+                                                                     << "SimVertex collection with InputTag = "
+                                                                     << "g4SimHits"
+                                                                     << " has size = " << simVC.size() << endl;
+      int kv = 0;
+      for (edm::SimVertexContainer::const_iterator VITER = simVC.begin(); VITER != simVC.end(); VITER++, kv++) {
+        edm::LogVerbatim("MuonToTrackingParticleAssociatorEDProducer")
+            << "SimVertex " << kv << " - Id:" << VITER->vertexId() << ", position = " << VITER->position()
+            << ", parent SimTrack Id = " << VITER->parentIndex() << ", processType = " << VITER->processType();
+      }
     }
   }
-}
 
-} // namespace
+}  // namespace
 
-class MuonToTrackingParticleAssociatorEDProducer
-    : public edm::stream::EDProducer<> {
+class MuonToTrackingParticleAssociatorEDProducer : public edm::stream::EDProducer<> {
 public:
-  explicit MuonToTrackingParticleAssociatorEDProducer(
-      const edm::ParameterSet &);
+  explicit MuonToTrackingParticleAssociatorEDProducer(const edm::ParameterSet &);
   ~MuonToTrackingParticleAssociatorEDProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
@@ -241,9 +207,9 @@ private:
 //
 // constructors and destructor
 //
-MuonToTrackingParticleAssociatorEDProducer::
-    MuonToTrackingParticleAssociatorEDProducer(const edm::ParameterSet &iConfig)
-    : config_(iConfig), helper_(iConfig),
+MuonToTrackingParticleAssociatorEDProducer::MuonToTrackingParticleAssociatorEDProducer(const edm::ParameterSet &iConfig)
+    : config_(iConfig),
+      helper_(iConfig),
       trackerHitAssociatorConfig_(iConfig, consumesCollector()),
       hitExtractor_(iConfig, consumesCollector()) {
   // register your products
@@ -260,9 +226,7 @@ MuonToTrackingParticleAssociatorEDProducer::
   }
 }
 
-MuonToTrackingParticleAssociatorEDProducer::
-    ~MuonToTrackingParticleAssociatorEDProducer() {
-
+MuonToTrackingParticleAssociatorEDProducer::~MuonToTrackingParticleAssociatorEDProducer() {
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -272,8 +236,7 @@ MuonToTrackingParticleAssociatorEDProducer::
 //
 
 // ------------ method called to produce the data  ------------
-void MuonToTrackingParticleAssociatorEDProducer::produce(
-    edm::Event &iEvent, const edm::EventSetup &iSetup) {
+void MuonToTrackingParticleAssociatorEDProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
 
   hitExtractor_.init(iEvent, iSetup);
@@ -291,8 +254,7 @@ void MuonToTrackingParticleAssociatorEDProducer::produce(
   // the resources own the memory.
 
   // Tracker hit association
-  trackertruth_.reset(
-      new TrackerHitAssociator(iEvent, trackerHitAssociatorConfig_));
+  trackertruth_.reset(new TrackerHitAssociator(iEvent, trackerHitAssociatorConfig_));
   // CSC hit association
   csctruth_.reset(new CSCHitAssociator(iEvent, iSetup, config_));
   // DT hit association
@@ -304,20 +266,17 @@ void MuonToTrackingParticleAssociatorEDProducer::produce(
   gemtruth_.reset(new GEMHitAssociator(iEvent, iSetup, config_));
 
   MuonAssociatorByHitsHelper::Resources resources = {
-      tTopo,          trackertruth_.get(), csctruth_.get(),
-      dttruth_.get(), rpctruth_.get(),     gemtruth_.get()};
+      tTopo, trackertruth_.get(), csctruth_.get(), dttruth_.get(), rpctruth_.get(), gemtruth_.get()};
 
   if (diagnostics_) {
     diagnostics_->read(iEvent);
-    resources.diagnostics_ = [this](const TrackHitsCollection &hC,
-                                    const TrackingParticleCollection &pC) {
+    resources.diagnostics_ = [this](const TrackHitsCollection &hC, const TrackingParticleCollection &pC) {
       diagnostics_->dump(hC, pC);
     };
   }
 
   std::unique_ptr<reco::MuonToTrackingParticleAssociatorBaseImpl> impl{
-      new MuonToTrackingParticleAssociatorByHitsImpl(hitExtractor_, resources,
-                                                     &helper_)};
+      new MuonToTrackingParticleAssociatorByHitsImpl(hitExtractor_, resources, &helper_)};
   std::unique_ptr<reco::MuonToTrackingParticleAssociator> toPut(
       new reco::MuonToTrackingParticleAssociator(std::move(impl)));
   iEvent.put(std::move(toPut));
@@ -325,8 +284,7 @@ void MuonToTrackingParticleAssociatorEDProducer::produce(
 
 // ------------ method fills 'descriptions' with the allowed parameters for the
 // module  ------------
-void MuonToTrackingParticleAssociatorEDProducer::fillDescriptions(
-    edm::ConfigurationDescriptions &descriptions) {
+void MuonToTrackingParticleAssociatorEDProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   // The following says we do not know what parameters are allowed so do no
   // validation
   // Please change this to state exactly what you do use, even if it is no

--- a/SimMuon/MCTruth/plugins/MuonTrackProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonTrackProducer.cc
@@ -18,18 +18,15 @@
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 MuonTrackProducer::MuonTrackProducer(const edm::ParameterSet &parset)
-    : muonsToken(consumes<reco::MuonCollection>(
-          parset.getParameter<edm::InputTag>("muonsTag"))),
-      inputDTRecSegment4DToken_(consumes<DTRecSegment4DCollection>(
-          parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection"))),
-      inputCSCSegmentToken_(consumes<CSCSegmentCollection>(
-          parset.getParameter<edm::InputTag>("inputCSCSegmentCollection"))),
-      selectionTags(
-          parset.getParameter<std::vector<std::string>>("selectionTags")),
+    : muonsToken(consumes<reco::MuonCollection>(parset.getParameter<edm::InputTag>("muonsTag"))),
+      inputDTRecSegment4DToken_(
+          consumes<DTRecSegment4DCollection>(parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection"))),
+      inputCSCSegmentToken_(
+          consumes<CSCSegmentCollection>(parset.getParameter<edm::InputTag>("inputCSCSegmentCollection"))),
+      selectionTags(parset.getParameter<std::vector<std::string>>("selectionTags")),
       trackType(parset.getParameter<std::string>("trackType")),
       parset_(parset) {
-  edm::LogVerbatim("MuonTrackProducer")
-      << "constructing  MuonTrackProducer" << parset_.dump();
+  edm::LogVerbatim("MuonTrackProducer") << "constructing  MuonTrackProducer" << parset_.dump();
   produces<reco::TrackCollection>();
   produces<reco::TrackExtraCollection>();
   produces<TrackingRecHitCollection>();
@@ -37,8 +34,7 @@ MuonTrackProducer::MuonTrackProducer(const edm::ParameterSet &parset)
 
 MuonTrackProducer::~MuonTrackProducer() {}
 
-void MuonTrackProducer::produce(edm::Event &iEvent,
-                                const edm::EventSetup &iSetup) {
+void MuonTrackProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   iEvent.getByToken(muonsToken, muonCollectionH);
   iEvent.getByToken(inputDTRecSegment4DToken_, dtSegmentCollectionH_);
   iEvent.getByToken(inputCSCSegmentToken_, cscSegmentCollectionH_);
@@ -47,28 +43,22 @@ void MuonTrackProducer::produce(edm::Event &iEvent,
   iSetup.get<TrackerTopologyRcd>().get(httopo);
   const TrackerTopology &ttopo = *httopo;
 
-  std::unique_ptr<reco::TrackCollection> selectedTracks(
-      new reco::TrackCollection);
-  std::unique_ptr<reco::TrackExtraCollection> selectedTrackExtras(
-      new reco::TrackExtraCollection());
-  std::unique_ptr<TrackingRecHitCollection> selectedTrackHits(
-      new TrackingRecHitCollection());
+  std::unique_ptr<reco::TrackCollection> selectedTracks(new reco::TrackCollection);
+  std::unique_ptr<reco::TrackExtraCollection> selectedTrackExtras(new reco::TrackExtraCollection());
+  std::unique_ptr<TrackingRecHitCollection> selectedTrackHits(new TrackingRecHitCollection());
 
   reco::TrackRefProd rTracks = iEvent.getRefBeforePut<reco::TrackCollection>();
-  reco::TrackExtraRefProd rTrackExtras =
-      iEvent.getRefBeforePut<reco::TrackExtraCollection>();
-  TrackingRecHitRefProd rHits =
-      iEvent.getRefBeforePut<TrackingRecHitCollection>();
+  reco::TrackExtraRefProd rTrackExtras = iEvent.getRefBeforePut<reco::TrackExtraCollection>();
+  TrackingRecHitRefProd rHits = iEvent.getRefBeforePut<TrackingRecHitCollection>();
 
   edm::Ref<reco::TrackExtraCollection>::key_type idx = 0;
   edm::Ref<reco::TrackExtraCollection>::key_type hidx = 0;
 
-  edm::LogVerbatim("MuonTrackProducer")
-      << "\nThere are " << dtSegmentCollectionH_->size() << " DT segments.";
+  edm::LogVerbatim("MuonTrackProducer") << "\nThere are " << dtSegmentCollectionH_->size() << " DT segments.";
   unsigned int index_dt_segment = 0;
-  for (DTRecSegment4DCollection::const_iterator segment =
-           dtSegmentCollectionH_->begin();
-       segment != dtSegmentCollectionH_->end(); ++segment, index_dt_segment++) {
+  for (DTRecSegment4DCollection::const_iterator segment = dtSegmentCollectionH_->begin();
+       segment != dtSegmentCollectionH_->end();
+       ++segment, index_dt_segment++) {
     LocalPoint segmentLocalPosition = segment->localPosition();
     LocalVector segmentLocalDirection = segment->localDirection();
     LocalError segmentLocalPositionError = segment->localPositionError();
@@ -89,19 +79,16 @@ void MuonTrackProducer::produce(edm::Event &iEvent,
     float segmentdYdZerr = sqrt(segmentLocalDirectionError.yy());
 
     edm::LogVerbatim("MuonTrackProducer")
-        << "\nDT segment index :" << index_dt_segment
-        << "\nchamber Wh:" << wheel << ",St:" << station << ",Se:" << sector
-        << "\nLocal Position (X,Y)=(" << segmentX << "," << segmentY
-        << ") +/- (" << segmentXerr << "," << segmentYerr << "), "
-        << "Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << "," << segmentdYdZ
-        << ") +/- (" << segmentdXdZerr << "," << segmentdYdZerr << ")";
+        << "\nDT segment index :" << index_dt_segment << "\nchamber Wh:" << wheel << ",St:" << station
+        << ",Se:" << sector << "\nLocal Position (X,Y)=(" << segmentX << "," << segmentY << ") +/- (" << segmentXerr
+        << "," << segmentYerr << "), "
+        << "Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << "," << segmentdYdZ << ") +/- (" << segmentdXdZerr << ","
+        << segmentdYdZerr << ")";
   }
 
-  edm::LogVerbatim("MuonTrackProducer")
-      << "\nThere are " << cscSegmentCollectionH_->size() << " CSC segments.";
+  edm::LogVerbatim("MuonTrackProducer") << "\nThere are " << cscSegmentCollectionH_->size() << " CSC segments.";
   unsigned int index_csc_segment = 0;
-  for (CSCSegmentCollection::const_iterator segment =
-           cscSegmentCollectionH_->begin();
+  for (CSCSegmentCollection::const_iterator segment = cscSegmentCollectionH_->begin();
        segment != cscSegmentCollectionH_->end();
        ++segment, index_csc_segment++) {
     LocalPoint segmentLocalPosition = segment->localPosition();
@@ -126,36 +113,31 @@ void MuonTrackProducer::produce(edm::Event &iEvent,
     float segmentdYdZerr = sqrt(segmentLocalDirectionError.yy());
 
     edm::LogVerbatim("MuonTrackProducer")
-        << "\nCSC segment index :" << index_csc_segment
-        << "\nchamber Endcap:" << endcap << ",St:" << station << ",Ri:" << ring
-        << ",Ch:" << chamber << "\nLocal Position (X,Y)=(" << segmentX << ","
-        << segmentY << ") +/- (" << segmentXerr << "," << segmentYerr << "), "
-        << "Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << "," << segmentdYdZ
-        << ") +/- (" << segmentdXdZerr << "," << segmentdYdZerr << ")";
+        << "\nCSC segment index :" << index_csc_segment << "\nchamber Endcap:" << endcap << ",St:" << station
+        << ",Ri:" << ring << ",Ch:" << chamber << "\nLocal Position (X,Y)=(" << segmentX << "," << segmentY << ") +/- ("
+        << segmentXerr << "," << segmentYerr << "), "
+        << "Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << "," << segmentdYdZ << ") +/- (" << segmentdXdZerr << ","
+        << segmentdYdZerr << ")";
   }
 
-  edm::LogVerbatim("MuonTrackProducer")
-      << "\nThere are " << muonCollectionH->size() << " reco::Muons.";
+  edm::LogVerbatim("MuonTrackProducer") << "\nThere are " << muonCollectionH->size() << " reco::Muons.";
   unsigned int muon_index = 0;
-  for (reco::MuonCollection::const_iterator muon = muonCollectionH->begin();
-       muon != muonCollectionH->end(); ++muon, muon_index++) {
-    edm::LogVerbatim("MuonTrackProducer")
-        << "\n******* muon index : " << muon_index;
+  for (reco::MuonCollection::const_iterator muon = muonCollectionH->begin(); muon != muonCollectionH->end();
+       ++muon, muon_index++) {
+    edm::LogVerbatim("MuonTrackProducer") << "\n******* muon index : " << muon_index;
 
     std::vector<bool> isGood;
     for (unsigned int index = 0; index < selectionTags.size(); ++index) {
       isGood.push_back(false);
 
-      muon::SelectionType muonType =
-          muon::selectionTypeFromString(selectionTags[index]);
+      muon::SelectionType muonType = muon::selectionTypeFromString(selectionTags[index]);
       isGood[index] = muon::isGoodMuon(*muon, muonType);
     }
 
     bool isGoodResult = true;
     for (unsigned int index = 0; index < isGood.size(); ++index) {
       edm::LogVerbatim("MuonTrackProducer")
-          << "selectionTag = " << selectionTags[index] << ": " << isGood[index]
-          << "\n";
+          << "selectionTag = " << selectionTags[index] << ": " << isGood[index] << "\n";
       isGoodResult *= isGood[index];
     }
 
@@ -201,11 +183,17 @@ void MuonTrackProducer::produce(edm::Event &iEvent,
       newTrk->setExtra(reco::TrackExtraRef(rTrackExtras, idx++));
       PropagationDirection seedDir = trk->seedDirection();
       // new copy of track Extras
-      std::unique_ptr<reco::TrackExtra> newExtra(new reco::TrackExtra(
-          trk->outerPosition(), trk->outerMomentum(), trk->outerOk(),
-          trk->innerPosition(), trk->innerMomentum(), trk->innerOk(),
-          trk->outerStateCovariance(), trk->outerDetId(),
-          trk->innerStateCovariance(), trk->innerDetId(), seedDir));
+      std::unique_ptr<reco::TrackExtra> newExtra(new reco::TrackExtra(trk->outerPosition(),
+                                                                      trk->outerMomentum(),
+                                                                      trk->outerOk(),
+                                                                      trk->innerPosition(),
+                                                                      trk->innerMomentum(),
+                                                                      trk->innerOk(),
+                                                                      trk->outerStateCovariance(),
+                                                                      trk->outerDetId(),
+                                                                      trk->innerStateCovariance(),
+                                                                      trk->innerDetId(),
+                                                                      seedDir));
 
       // new copy of the silicon hits; add hit refs to Extra and hits to hit
       // collection
@@ -213,8 +201,7 @@ void MuonTrackProducer::produce(edm::Event &iEvent,
       //      edm::LogVerbatim("MuonTrackProducer")<<"\n printing initial
       //      hit_pattern"; trk->hitPattern().print();
       unsigned int nHitsToAdd = 0;
-      for (trackingRecHit_iterator iHit = trk->recHitsBegin();
-           iHit != trk->recHitsEnd(); iHit++) {
+      for (trackingRecHit_iterator iHit = trk->recHitsBegin(); iHit != trk->recHitsEnd(); iHit++) {
         TrackingRecHit *hit = (*iHit)->clone();
         selectedTrackHits->push_back(hit);
         ++nHitsToAdd;
@@ -222,18 +209,15 @@ void MuonTrackProducer::produce(edm::Event &iEvent,
       newExtra->setHits(rHits, hidx, nHitsToAdd);
       hidx += nHitsToAdd;
       if (trackType == "innerTrackPlusSegments") {
-
         int wheel, station, sector;
         int endcap, /*station, */ ring, chamber;
 
         edm::LogVerbatim("MuonTrackProducer")
             << "Number of chambers: " << muon->matches().size()
-            << ", arbitrated: "
-            << muon->numberOfMatches(reco::Muon::SegmentAndTrackArbitration);
+            << ", arbitrated: " << muon->numberOfMatches(reco::Muon::SegmentAndTrackArbitration);
         unsigned int index_chamber = 0;
 
-        for (std::vector<reco::MuonChamberMatch>::const_iterator chamberMatch =
-                 muon->matches().begin();
+        for (std::vector<reco::MuonChamberMatch>::const_iterator chamberMatch = muon->matches().begin();
              chamberMatch != muon->matches().end();
              ++chamberMatch, index_chamber++) {
           std::stringstream chamberStr;
@@ -247,29 +231,24 @@ void MuonTrackProducer::produce(edm::Event &iEvent,
             wheel = dtdetid.wheel();
             station = dtdetid.station();
             sector = dtdetid.sector();
-            chamberStr << ", DT chamber Wh:" << wheel << ",St:" << station
-                       << ",Se:" << sector;
+            chamberStr << ", DT chamber Wh:" << wheel << ",St:" << station << ",Se:" << sector;
           } else if (subdet == MuonSubdetId::CSC) {
             CSCDetId cscdetid = CSCDetId(did);
             endcap = cscdetid.endcap();
             station = cscdetid.station();
             ring = cscdetid.ring();
             chamber = cscdetid.chamber();
-            chamberStr << ", CSC chamber End:" << endcap << ",St:" << station
-                       << ",Ri:" << ring << ",Ch:" << chamber;
+            chamberStr << ", CSC chamber End:" << endcap << ",St:" << station << ",Ri:" << ring << ",Ch:" << chamber;
           }
 
-          chamberStr << ", Number of segments: "
-                     << chamberMatch->segmentMatches.size();
+          chamberStr << ", Number of segments: " << chamberMatch->segmentMatches.size();
           edm::LogVerbatim("MuonTrackProducer") << chamberStr.str();
 
           unsigned int index_segment = 0;
 
-          for (std::vector<reco::MuonSegmentMatch>::const_iterator
-                   segmentMatch = chamberMatch->segmentMatches.begin();
+          for (std::vector<reco::MuonSegmentMatch>::const_iterator segmentMatch = chamberMatch->segmentMatches.begin();
                segmentMatch != chamberMatch->segmentMatches.end();
                ++segmentMatch, index_segment++) {
-
             float segmentX = segmentMatch->x;
             float segmentY = segmentMatch->y;
             float segmentdXdZ = segmentMatch->dXdZ;
@@ -282,11 +261,8 @@ void MuonTrackProducer::produce(edm::Event &iEvent,
             CSCSegmentRef segmentCSC = segmentMatch->cscSegmentRef;
             DTRecSegment4DRef segmentDT = segmentMatch->dtSegmentRef;
 
-            bool segment_arbitrated_Ok =
-                (segmentMatch->isMask(
-                     reco::MuonSegmentMatch::BestInChamberByDR) &&
-                 segmentMatch->isMask(
-                     reco::MuonSegmentMatch::BelongsToTrackByDR));
+            bool segment_arbitrated_Ok = (segmentMatch->isMask(reco::MuonSegmentMatch::BestInChamberByDR) &&
+                                          segmentMatch->isMask(reco::MuonSegmentMatch::BelongsToTrackByDR));
 
             std::string ARBITRATED(" ***Arbitrated Off*** ");
             if (segment_arbitrated_Ok)
@@ -294,13 +270,10 @@ void MuonTrackProducer::produce(edm::Event &iEvent,
 
             if (subdet == MuonSubdetId::DT) {
               edm::LogVerbatim("MuonTrackProducer")
-                  << "\n\t segment index: " << index_segment << ARBITRATED
-                  << "\n\t  Local Position (X,Y)=(" << segmentX << ","
-                  << segmentY << ") +/- (" << segmentXerr << "," << segmentYerr
-                  << "), "
-                  << "\n\t  Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << ","
-                  << segmentdYdZ << ") +/- (" << segmentdXdZerr << ","
-                  << segmentdYdZerr << ")";
+                  << "\n\t segment index: " << index_segment << ARBITRATED << "\n\t  Local Position (X,Y)=(" << segmentX
+                  << "," << segmentY << ") +/- (" << segmentXerr << "," << segmentYerr << "), "
+                  << "\n\t  Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << "," << segmentdYdZ << ") +/- ("
+                  << segmentdXdZerr << "," << segmentdYdZerr << ")";
 
               if (!segment_arbitrated_Ok)
                 continue;
@@ -309,17 +282,15 @@ void MuonTrackProducer::produce(edm::Event &iEvent,
                 const DTRecSegment4D *segment = segmentDT.get();
 
                 edm::LogVerbatim("MuonTrackProducer")
-                    << "\t ===> MATCHING with DT segment with index = "
-                    << segmentDT.key();
+                    << "\t ===> MATCHING with DT segment with index = " << segmentDT.key();
 
                 if (segment->hasPhi()) {
                   const DTChamberRecSegment2D *phiSeg = segment->phiSegment();
-                  std::vector<const TrackingRecHit *> phiHits =
-                      phiSeg->recHits();
+                  std::vector<const TrackingRecHit *> phiHits = phiSeg->recHits();
                   unsigned int nHitsAdded = 0;
-                  for (std::vector<const TrackingRecHit *>::const_iterator
-                           ihit = phiHits.begin();
-                       ihit != phiHits.end(); ++ihit) {
+                  for (std::vector<const TrackingRecHit *>::const_iterator ihit = phiHits.begin();
+                       ihit != phiHits.end();
+                       ++ihit) {
                     TrackingRecHit *seghit = (*ihit)->clone();
                     newTrk->appendHitPattern(*seghit, ttopo);
                     //		    edm::LogVerbatim("MuonTrackProducer")<<"hit
@@ -337,9 +308,9 @@ void MuonTrackProducer::produce(edm::Event &iEvent,
                   const DTSLRecSegment2D *zSeg = (*segment).zSegment();
                   std::vector<const TrackingRecHit *> zedHits = zSeg->recHits();
                   unsigned int nHitsAdded = 0;
-                  for (std::vector<const TrackingRecHit *>::const_iterator
-                           ihit = zedHits.begin();
-                       ihit != zedHits.end(); ++ihit) {
+                  for (std::vector<const TrackingRecHit *>::const_iterator ihit = zedHits.begin();
+                       ihit != zedHits.end();
+                       ++ihit) {
                     TrackingRecHit *seghit = (*ihit)->clone();
                     newTrk->appendHitPattern(*seghit, ttopo);
                     //		    edm::LogVerbatim("MuonTrackProducer")<<"hit
@@ -353,19 +324,15 @@ void MuonTrackProducer::produce(edm::Event &iEvent,
                   hidx += nHitsAdded;
                 }
               } else
-                edm::LogWarning("MuonTrackProducer")
-                    << "\n***WARNING: UNMATCHED DT segment ! \n";
-            } // if (subdet == MuonSubdetId::DT)
+                edm::LogWarning("MuonTrackProducer") << "\n***WARNING: UNMATCHED DT segment ! \n";
+            }  // if (subdet == MuonSubdetId::DT)
 
             else if (subdet == MuonSubdetId::CSC) {
               edm::LogVerbatim("MuonTrackProducer")
-                  << "\n\t segment index: " << index_segment << ARBITRATED
-                  << "\n\t  Local Position (X,Y)=(" << segmentX << ","
-                  << segmentY << ") +/- (" << segmentXerr << "," << segmentYerr
-                  << "), "
-                  << "\n\t  Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << ","
-                  << segmentdYdZ << ") +/- (" << segmentdXdZerr << ","
-                  << segmentdYdZerr << ")";
+                  << "\n\t segment index: " << index_segment << ARBITRATED << "\n\t  Local Position (X,Y)=(" << segmentX
+                  << "," << segmentY << ") +/- (" << segmentXerr << "," << segmentYerr << "), "
+                  << "\n\t  Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << "," << segmentdYdZ << ") +/- ("
+                  << segmentdXdZerr << "," << segmentdYdZerr << ")";
 
               if (!segment_arbitrated_Ok)
                 continue;
@@ -374,14 +341,12 @@ void MuonTrackProducer::produce(edm::Event &iEvent,
                 const CSCSegment *segment = segmentCSC.get();
 
                 edm::LogVerbatim("MuonTrackProducer")
-                    << "\t ===> MATCHING with CSC segment with index = "
-                    << segmentCSC.key();
+                    << "\t ===> MATCHING with CSC segment with index = " << segmentCSC.key();
 
                 std::vector<const TrackingRecHit *> hits = segment->recHits();
                 unsigned int nHitsAdded = 0;
-                for (std::vector<const TrackingRecHit *>::const_iterator ihit =
-                         hits.begin();
-                     ihit != hits.end(); ++ihit) {
+                for (std::vector<const TrackingRecHit *>::const_iterator ihit = hits.begin(); ihit != hits.end();
+                     ++ihit) {
                   TrackingRecHit *seghit = (*ihit)->clone();
                   newTrk->appendHitPattern(*seghit, ttopo);
                   //		    edm::LogVerbatim("MuonTrackProducer")<<"hit
@@ -394,13 +359,12 @@ void MuonTrackProducer::produce(edm::Event &iEvent,
                 newExtra->setHits(rHits, hidx, nHitsAdded);
                 hidx += nHitsAdded;
               } else
-                edm::LogWarning("MuonTrackProducer")
-                    << "\n***WARNING: UNMATCHED CSC segment ! \n";
-            } //  else if (subdet == MuonSubdetId::CSC)
+                edm::LogWarning("MuonTrackProducer") << "\n***WARNING: UNMATCHED CSC segment ! \n";
+            }  //  else if (subdet == MuonSubdetId::CSC)
 
-          } // loop on vector<MuonSegmentMatch>
-        }   // loop on vector<MuonChamberMatch>
-      }     // if (trackType == "innerTrackPlusSegments")
+          }  // loop on vector<MuonSegmentMatch>
+        }    // loop on vector<MuonChamberMatch>
+      }      // if (trackType == "innerTrackPlusSegments")
 
       //      edm::LogVerbatim("MuonTrackProducer")<<"\n printing final
       //      hit_pattern"; newTrk->hitPattern().print();
@@ -408,8 +372,8 @@ void MuonTrackProducer::produce(edm::Event &iEvent,
       selectedTracks->push_back(*newTrk);
       selectedTrackExtras->push_back(*newExtra);
 
-    } // if (isGoodResult)
-  }   // loop on reco::MuonCollection
+    }  // if (isGoodResult)
+  }    // loop on reco::MuonCollection
 
   iEvent.put(std::move(selectedTracks));
   iEvent.put(std::move(selectedTrackExtras));

--- a/SimMuon/MCTruth/plugins/SimMuFilter.cc
+++ b/SimMuon/MCTruth/plugins/SimMuFilter.cc
@@ -28,14 +28,10 @@ private:
 };
 
 SimMuFilter::SimMuFilter(const edm::ParameterSet &iConfig) {
-  simTracksToken_ = consumes<std::vector<SimTrack>>(
-      iConfig.getParameter<edm::InputTag>("simTracksInput"));
-  simHitsMuonRPCToken_ = consumes<edm::PSimHitContainer>(
-      iConfig.getParameter<edm::InputTag>("simHitsMuonRPCInput"));
-  simHitsMuonCSCToken_ = consumes<edm::PSimHitContainer>(
-      iConfig.getParameter<edm::InputTag>("simHitsMuonCSCInput"));
-  simHitsMuonDTToken_ = consumes<edm::PSimHitContainer>(
-      iConfig.getParameter<edm::InputTag>("simHitsMuonDTInput"));
+  simTracksToken_ = consumes<std::vector<SimTrack>>(iConfig.getParameter<edm::InputTag>("simTracksInput"));
+  simHitsMuonRPCToken_ = consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("simHitsMuonRPCInput"));
+  simHitsMuonCSCToken_ = consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("simHitsMuonCSCInput"));
+  simHitsMuonDTToken_ = consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("simHitsMuonDTInput"));
   nMuSel_ = iConfig.getParameter<int>("nMuSel");
 }
 
@@ -70,27 +66,27 @@ bool SimMuFilter::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
     int nSimHitCSC = 0;
     int nSimHitDT = 0;
 
-    for (PSimHitContainer::const_iterator simHitIt =
-             simHitsMuonRPCHandle->begin();
-         simHitIt != simHitsMuonRPCHandle->end(); simHitIt++) {
+    for (PSimHitContainer::const_iterator simHitIt = simHitsMuonRPCHandle->begin();
+         simHitIt != simHitsMuonRPCHandle->end();
+         simHitIt++) {
       if (simHitIt->trackId() != simTrk.trackId())
         continue;
 
       nSimHitRPC++;
     }
 
-    for (PSimHitContainer::const_iterator simHitIt =
-             simHitsMuonCSCHandle->begin();
-         simHitIt != simHitsMuonCSCHandle->end(); simHitIt++) {
+    for (PSimHitContainer::const_iterator simHitIt = simHitsMuonCSCHandle->begin();
+         simHitIt != simHitsMuonCSCHandle->end();
+         simHitIt++) {
       if (simHitIt->trackId() != simTrk.trackId())
         continue;
 
       nSimHitCSC++;
     }
 
-    for (PSimHitContainer::const_iterator simHitIt =
-             simHitsMuonDTHandle->begin();
-         simHitIt != simHitsMuonDTHandle->end(); simHitIt++) {
+    for (PSimHitContainer::const_iterator simHitIt = simHitsMuonDTHandle->begin();
+         simHitIt != simHitsMuonDTHandle->end();
+         simHitIt++) {
       if (simHitIt->trackId() != simTrk.trackId())
         continue;
 

--- a/SimMuon/MCTruth/src/CSCHitAssociator.cc
+++ b/SimMuon/MCTruth/src/CSCHitAssociator.cc
@@ -5,27 +5,19 @@
 #include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
 #include "SimMuon/MCTruth/interface/CSCHitAssociator.h"
 
-CSCHitAssociator::CSCHitAssociator(const edm::Event &event,
-                                   const edm::EventSetup &setup,
-                                   const edm::ParameterSet &conf)
-    : theDigiSimLinks(nullptr),
-      linksTag(conf.getParameter<edm::InputTag>("CSClinksTag")) {
+CSCHitAssociator::CSCHitAssociator(const edm::Event &event, const edm::EventSetup &setup, const edm::ParameterSet &conf)
+    : theDigiSimLinks(nullptr), linksTag(conf.getParameter<edm::InputTag>("CSClinksTag")) {
   initEvent(event, setup);
 }
 
-CSCHitAssociator::CSCHitAssociator(const edm::ParameterSet &conf,
-                                   edm::ConsumesCollector &&iC)
-    : theDigiSimLinks(nullptr),
-      linksTag(conf.getParameter<edm::InputTag>("CSClinksTag")) {
+CSCHitAssociator::CSCHitAssociator(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
+    : theDigiSimLinks(nullptr), linksTag(conf.getParameter<edm::InputTag>("CSClinksTag")) {
   iC.consumes<DigiSimLinks>(linksTag);
 }
 
-void CSCHitAssociator::initEvent(const edm::Event &event,
-                                 const edm::EventSetup &setup) {
-
+void CSCHitAssociator::initEvent(const edm::Event &event, const edm::EventSetup &setup) {
   edm::Handle<DigiSimLinks> digiSimLinks;
-  LogTrace("CSCHitAssociator")
-      << "getting CSC Strip DigiSimLink collection - " << linksTag;
+  LogTrace("CSCHitAssociator") << "getting CSC Strip DigiSimLink collection - " << linksTag;
   event.getByLabel(linksTag, digiSimLinks);
   theDigiSimLinks = digiSimLinks.product();
 
@@ -35,88 +27,74 @@ void CSCHitAssociator::initEvent(const edm::Event &event,
   cscgeom = &*mugeom;
 }
 
-std::vector<CSCHitAssociator::SimHitIdpr>
-CSCHitAssociator::associateCSCHitId(const CSCRecHit2D *cscrechit) const {
+std::vector<CSCHitAssociator::SimHitIdpr> CSCHitAssociator::associateCSCHitId(const CSCRecHit2D *cscrechit) const {
   std::vector<SimHitIdpr> simtrackids;
 
   unsigned int detId = cscrechit->geographicalId().rawId();
   int nchannels = cscrechit->nStrips();
-  const CSCLayerGeometry *laygeom =
-      cscgeom->layer(cscrechit->cscDetId())->geometry();
+  const CSCLayerGeometry *laygeom = cscgeom->layer(cscrechit->cscDetId())->geometry();
 
   DigiSimLinks::const_iterator layerLinks = theDigiSimLinks->find(detId);
 
   if (layerLinks != theDigiSimLinks->end()) {
-
     for (int idigi = 0; idigi < nchannels; ++idigi) {
       // strip and readout channel numbers may differ in ME1/1A
       int istrip = cscrechit->channels(idigi);
       int channel = laygeom->channel(istrip);
 
-      for (LayerLinks::const_iterator link = layerLinks->begin();
-           link != layerLinks->end(); ++link) {
+      for (LayerLinks::const_iterator link = layerLinks->begin(); link != layerLinks->end(); ++link) {
         int ch = static_cast<int>(link->channel());
         if (ch == channel) {
           SimHitIdpr currentId(link->SimTrackId(), link->eventId());
-          if (find(simtrackids.begin(), simtrackids.end(), currentId) ==
-              simtrackids.end())
+          if (find(simtrackids.begin(), simtrackids.end(), currentId) == simtrackids.end())
             simtrackids.push_back(currentId);
         }
       }
     }
 
   } else
-    LogTrace("CSCHitAssociator")
-        << "*** WARNING in CSCHitAssociator::associateCSCHitId - CSC layer "
-        << detId << " has no DigiSimLinks !" << std::endl;
+    LogTrace("CSCHitAssociator") << "*** WARNING in CSCHitAssociator::associateCSCHitId - CSC layer " << detId
+                                 << " has no DigiSimLinks !" << std::endl;
 
   return simtrackids;
 }
 
-std::vector<CSCHitAssociator::SimHitIdpr>
-CSCHitAssociator::associateHitId(const TrackingRecHit &hit) const {
+std::vector<CSCHitAssociator::SimHitIdpr> CSCHitAssociator::associateHitId(const TrackingRecHit &hit) const {
   std::vector<SimHitIdpr> simtrackids;
 
   const TrackingRecHit *hitp = &hit;
   const CSCRecHit2D *cscrechit = dynamic_cast<const CSCRecHit2D *>(hitp);
 
   if (cscrechit) {
-
     unsigned int detId = cscrechit->geographicalId().rawId();
     int nchannels = cscrechit->nStrips();
-    const CSCLayerGeometry *laygeom =
-        cscgeom->layer(cscrechit->cscDetId())->geometry();
+    const CSCLayerGeometry *laygeom = cscgeom->layer(cscrechit->cscDetId())->geometry();
 
     DigiSimLinks::const_iterator layerLinks = theDigiSimLinks->find(detId);
 
     if (layerLinks != theDigiSimLinks->end()) {
-
       for (int idigi = 0; idigi < nchannels; ++idigi) {
         // strip and readout channel numbers may differ in ME1/1A
         int istrip = cscrechit->channels(idigi);
         int channel = laygeom->channel(istrip);
 
-        for (LayerLinks::const_iterator link = layerLinks->begin();
-             link != layerLinks->end(); ++link) {
+        for (LayerLinks::const_iterator link = layerLinks->begin(); link != layerLinks->end(); ++link) {
           int ch = static_cast<int>(link->channel());
           if (ch == channel) {
             SimHitIdpr currentId(link->SimTrackId(), link->eventId());
-            if (find(simtrackids.begin(), simtrackids.end(), currentId) ==
-                simtrackids.end())
+            if (find(simtrackids.begin(), simtrackids.end(), currentId) == simtrackids.end())
               simtrackids.push_back(currentId);
           }
         }
       }
 
     } else
-      LogTrace("CSCHitAssociator")
-          << "*** WARNING in CSCHitAssociator::associateHitId - CSC layer "
-          << detId << " has no DigiSimLinks !" << std::endl;
+      LogTrace("CSCHitAssociator") << "*** WARNING in CSCHitAssociator::associateHitId - CSC layer " << detId
+                                   << " has no DigiSimLinks !" << std::endl;
 
   } else
-    LogTrace("CSCHitAssociator")
-        << "*** WARNING in CSCHitAssociator::associateHitId, null dynamic_cast "
-           "!";
+    LogTrace("CSCHitAssociator") << "*** WARNING in CSCHitAssociator::associateHitId, null dynamic_cast "
+                                    "!";
 
   return simtrackids;
 }

--- a/SimMuon/MCTruth/src/CSCTruthTest.cc
+++ b/SimMuon/MCTruth/src/CSCTruthTest.cc
@@ -8,8 +8,7 @@ CSCTruthTest::CSCTruthTest(const edm::ParameterSet &iConfig) : conf_(iConfig) {}
 
 CSCTruthTest::~CSCTruthTest() {}
 
-void CSCTruthTest::analyze(const edm::Event &iEvent,
-                           const edm::EventSetup &iSetup) {
+void CSCTruthTest::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
 
   Handle<CSCRecHit2DCollection> cscRecHits;
@@ -17,10 +16,9 @@ void CSCTruthTest::analyze(const edm::Event &iEvent,
 
   MuonTruth theTruth(iEvent, iSetup, conf_);
 
-  for (CSCRecHit2DCollection::const_iterator recHitItr = cscRecHits->begin();
-       recHitItr != cscRecHits->end(); recHitItr++) {
+  for (CSCRecHit2DCollection::const_iterator recHitItr = cscRecHits->begin(); recHitItr != cscRecHits->end();
+       recHitItr++) {
     theTruth.analyze(*recHitItr);
-    edm::LogVerbatim("SimMuonCSCTruthTest")
-        << theTruth.muonFraction() << " " << recHitItr->cscDetId();
+    edm::LogVerbatim("SimMuonCSCTruthTest") << theTruth.muonFraction() << " " << recHitItr->cscDetId();
   }
 }

--- a/SimMuon/MCTruth/src/DTHitAssociator.cc
+++ b/SimMuon/MCTruth/src/DTHitAssociator.cc
@@ -14,8 +14,7 @@
 using namespace std;
 
 // Constructor
-DTHitAssociator::DTHitAssociator(const edm::ParameterSet &conf,
-                                 edm::ConsumesCollector &&iC)
+DTHitAssociator::DTHitAssociator(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
     : DTsimhitsTag(conf.getParameter<edm::InputTag>("DTsimhitsTag")),
       DTsimhitsXFTag(conf.getParameter<edm::InputTag>("DTsimhitsXFTag")),
       DTdigiTag(conf.getParameter<edm::InputTag>("DTdigiTag")),
@@ -33,7 +32,6 @@ DTHitAssociator::DTHitAssociator(const edm::ParameterSet &conf,
       associatorByWire(conf.getParameter<bool>("associatorByWire")),
 
       printRtS(true) {
-
   if (crossingframe) {
     iC.consumes<CrossingFrame<PSimHit>>(DTsimhitsXFTag);
   } else if (!DTsimhitsTag.label().empty()) {
@@ -49,8 +47,9 @@ DTHitAssociator::DTHitAssociator(const edm::ParameterSet &conf,
 
 DTHitAssociator::DTHitAssociator(const edm::Event &iEvent,
                                  const edm::EventSetup &iSetup,
-                                 const edm::ParameterSet &conf, bool printRtS)
-    : // input collection labels
+                                 const edm::ParameterSet &conf,
+                                 bool printRtS)
+    :  // input collection labels
       DTsimhitsTag(conf.getParameter<edm::InputTag>("DTsimhitsTag")),
       DTsimhitsXFTag(conf.getParameter<edm::InputTag>("DTsimhitsXFTag")),
       DTdigiTag(conf.getParameter<edm::InputTag>("DTdigiTag")),
@@ -73,20 +72,15 @@ DTHitAssociator::DTHitAssociator(const edm::Event &iEvent,
   initEvent(iEvent, iSetup);
 }
 
-void DTHitAssociator::initEvent(const edm::Event &iEvent,
-                                const edm::EventSetup &iSetup) {
-
-  LogTrace("DTHitAssociator")
-      << "DTHitAssociator constructor: dumpDT = " << dumpDT
-      << ", crossingframe = " << crossingframe
-      << ", links_exist = " << links_exist
-      << ", associatorByWire = " << associatorByWire;
+void DTHitAssociator::initEvent(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  LogTrace("DTHitAssociator") << "DTHitAssociator constructor: dumpDT = " << dumpDT
+                              << ", crossingframe = " << crossingframe << ", links_exist = " << links_exist
+                              << ", associatorByWire = " << associatorByWire;
 
   if (!links_exist && !associatorByWire) {
-    LogTrace("DTHitAssociator")
-        << "*** WARNING in DTHitAssociator::DTHitAssociator: associatorByWire "
-           "reset to TRUE !"
-        << "    \t (missing DTDigiSimLinkCollection ?)";
+    LogTrace("DTHitAssociator") << "*** WARNING in DTHitAssociator::DTHitAssociator: associatorByWire "
+                                   "reset to TRUE !"
+                                << "    \t (missing DTDigiSimLinkCollection ?)";
     associatorByWire = true;
   }
 
@@ -101,11 +95,9 @@ void DTHitAssociator::initEvent(const edm::Event &iEvent,
 
   if (crossingframe) {
     edm::Handle<CrossingFrame<PSimHit>> xFrame;
-    LogTrace("DTHitAssociator")
-        << "getting CrossingFrame<PSimHit> collection - " << DTsimhitsXFTag;
+    LogTrace("DTHitAssociator") << "getting CrossingFrame<PSimHit> collection - " << DTsimhitsXFTag;
     iEvent.getByLabel(DTsimhitsXFTag, xFrame);
-    unique_ptr<MixCollection<PSimHit>> DTsimhits(
-        new MixCollection<PSimHit>(xFrame.product()));
+    unique_ptr<MixCollection<PSimHit>> DTsimhits(new MixCollection<PSimHit>(xFrame.product()));
     LogTrace("DTHitAssociator") << "... size = " << DTsimhits->size();
     MixCollection<PSimHit>::MixItr isimhit;
     for (isimhit = DTsimhits->begin(); isimhit != DTsimhits->end(); isimhit++) {
@@ -115,8 +107,7 @@ void DTHitAssociator::initEvent(const edm::Event &iEvent,
     }
   } else if (!DTsimhitsTag.label().empty()) {
     edm::Handle<edm::PSimHitContainer> DTsimhits;
-    LogTrace("DTHitAssociator")
-        << "getting PSimHit collection - " << DTsimhitsTag;
+    LogTrace("DTHitAssociator") << "getting PSimHit collection - " << DTsimhitsTag;
     iEvent.getByLabel(DTsimhitsTag, DTsimhits);
     LogTrace("DTHitAssociator") << "... size = " << DTsimhits->size();
     edm::PSimHitContainer::const_iterator isimhit;
@@ -135,8 +126,7 @@ void DTHitAssociator::initEvent(const edm::Event &iEvent,
 
   if (digis.isValid()) {
     // Map DTDigi by DTWireId
-    for (DTDigiCollection::DigiRangeIterator detUnit = digis->begin();
-         detUnit != digis->end(); ++detUnit) {
+    for (DTDigiCollection::DigiRangeIterator detUnit = digis->begin(); detUnit != digis->end(); ++detUnit) {
       const DTLayerId &layerid = (*detUnit).first;
       const DTDigiCollection::Range &range = (*detUnit).second;
 
@@ -155,13 +145,11 @@ void DTHitAssociator::initEvent(const edm::Event &iEvent,
     // Get the DT DigiSimLink collection from the event and map DTDigiSimLink by
     // DTWireId
     edm::Handle<DTDigiSimLinkCollection> digisimlinks;
-    LogTrace("DTHitAssociator")
-        << "getting DTDigiSimLink collection - " << DTdigisimlinkTag;
+    LogTrace("DTHitAssociator") << "getting DTDigiSimLink collection - " << DTdigisimlinkTag;
     iEvent.getByLabel(DTdigisimlinkTag, digisimlinks);
 
-    for (DTDigiSimLinkCollection::DigiRangeIterator detUnit =
-             digisimlinks->begin();
-         detUnit != digisimlinks->end(); ++detUnit) {
+    for (DTDigiSimLinkCollection::DigiRangeIterator detUnit = digisimlinks->begin(); detUnit != digisimlinks->end();
+         ++detUnit) {
       const DTLayerId &layerid = (*detUnit).first;
       const DTDigiSimLinkCollection::Range &range = (*detUnit).second;
 
@@ -174,11 +162,9 @@ void DTHitAssociator::initEvent(const edm::Event &iEvent,
   }
 
   if (dumpDT && printRtS) {
-
     // Get the DT rechits from the event
     edm::Handle<DTRecHitCollection> DTrechits;
-    LogTrace("DTHitAssociator")
-        << "getting DTRecHit1DPair collection - " << DTrechitTag;
+    LogTrace("DTHitAssociator") << "getting DTRecHit1DPair collection - " << DTrechitTag;
     iEvent.getByLabel(DTrechitTag, DTrechits);
     LogTrace("DTHitAssociator") << "... size = " << DTrechits->size();
 
@@ -196,22 +182,16 @@ void DTHitAssociator::initEvent(const edm::Event &iEvent,
       int jwire = 0;
       int ihit = 0;
 
-      for (SimHitMap::const_iterator mapIT = mapOfSimHit.begin();
-           mapIT != mapOfSimHit.end(); ++mapIT, jwire++) {
-
+      for (SimHitMap::const_iterator mapIT = mapOfSimHit.begin(); mapIT != mapOfSimHit.end(); ++mapIT, jwire++) {
         DTWireId wireid = (*mapIT).first;
-        for (vector<PSimHit_withFlag>::const_iterator hitIT =
-                 mapOfSimHit[wireid].begin();
-             hitIT != mapOfSimHit[wireid].end(); hitIT++, ihit++) {
+        for (vector<PSimHit_withFlag>::const_iterator hitIT = mapOfSimHit[wireid].begin();
+             hitIT != mapOfSimHit[wireid].end();
+             hitIT++, ihit++) {
           PSimHit hit = hitIT->first;
-          LogTrace("DTHitAssociator")
-              << "PSimHit " << ihit << ", wire "
-              << wireid //<<", detID = "<<hit.detUnitId()
-              << ", SimTrack Id:" << hit.trackId() << "/Evt:("
-              << hit.eventId().event() << "," << hit.eventId().bunchCrossing()
-              << ") "
-              << ", pdg = " << hit.particleType()
-              << ", procs = " << hit.processType();
+          LogTrace("DTHitAssociator") << "PSimHit " << ihit << ", wire " << wireid  //<<", detID = "<<hit.detUnitId()
+                                      << ", SimTrack Id:" << hit.trackId() << "/Evt:(" << hit.eventId().event() << ","
+                                      << hit.eventId().bunchCrossing() << ") "
+                                      << ", pdg = " << hit.particleType() << ", procs = " << hit.processType();
         }
       }
     } else {
@@ -219,21 +199,17 @@ void DTHitAssociator::initEvent(const edm::Event &iEvent,
     }
 
     if (mapOfDigi.end() != mapOfDigi.begin()) {
-
       int jwire = 0;
       int ihit = 0;
 
-      for (DigiMap::const_iterator mapIT = mapOfDigi.begin();
-           mapIT != mapOfDigi.end(); ++mapIT, jwire++) {
+      for (DigiMap::const_iterator mapIT = mapOfDigi.begin(); mapIT != mapOfDigi.end(); ++mapIT, jwire++) {
         LogTrace("DTHitAssociator") << "\n *** Dump DT digis ***";
 
         DTWireId wireid = (*mapIT).first;
-        for (vector<DTDigi>::const_iterator hitIT = mapOfDigi[wireid].begin();
-             hitIT != mapOfDigi[wireid].end(); hitIT++, ihit++) {
-          LogTrace("DTHitAssociator")
-              << "DTDigi " << ihit << ", wire " << wireid
-              << ", number = " << hitIT->number()
-              << ", TDC counts = " << hitIT->countsTDC();
+        for (vector<DTDigi>::const_iterator hitIT = mapOfDigi[wireid].begin(); hitIT != mapOfDigi[wireid].end();
+             hitIT++, ihit++) {
+          LogTrace("DTHitAssociator") << "DTDigi " << ihit << ", wire " << wireid << ", number = " << hitIT->number()
+                                      << ", TDC counts = " << hitIT->countsTDC();
         }
       }
     } else {
@@ -241,28 +217,22 @@ void DTHitAssociator::initEvent(const edm::Event &iEvent,
     }
 
     if (mapOfRecHit.end() != mapOfRecHit.begin())
-      LogTrace("DTHitAssociator")
-          << "\n *** Analyze DTRecHitCollection by DTWireId ***";
+      LogTrace("DTHitAssociator") << "\n *** Analyze DTRecHitCollection by DTWireId ***";
 
     int iwire = 0;
-    for (RecHitMap::const_iterator mapIT = mapOfRecHit.begin();
-         mapIT != mapOfRecHit.end(); ++mapIT, iwire++) {
-
+    for (RecHitMap::const_iterator mapIT = mapOfRecHit.begin(); mapIT != mapOfRecHit.end(); ++mapIT, iwire++) {
       DTWireId wireid = (*mapIT).first;
       LogTrace("DTHitAssociator") << "\n======================================="
                                      "============================";
-      LogTrace("DTHitAssociator")
-          << "wire index = " << iwire << "  *** DTWireId = "
-          << " (" << wireid << ")";
+      LogTrace("DTHitAssociator") << "wire index = " << iwire << "  *** DTWireId = "
+                                  << " (" << wireid << ")";
 
       if (mapOfSimHit.find(wireid) != mapOfSimHit.end()) {
-        LogTrace("DTHitAssociator")
-            << "\n"
-            << mapOfSimHit[wireid].size() << " SimHits (PSimHit):";
+        LogTrace("DTHitAssociator") << "\n" << mapOfSimHit[wireid].size() << " SimHits (PSimHit):";
 
-        for (vector<PSimHit_withFlag>::const_iterator hitIT =
-                 mapOfSimHit[wireid].begin();
-             hitIT != mapOfSimHit[wireid].end(); ++hitIT) {
+        for (vector<PSimHit_withFlag>::const_iterator hitIT = mapOfSimHit[wireid].begin();
+             hitIT != mapOfSimHit[wireid].end();
+             ++hitIT) {
           stringstream tId;
           tId << (hitIT->first).trackId();
           string simhitlog = "\t SimTrack Id = " + tId.str();
@@ -275,36 +245,26 @@ void DTHitAssociator::initEvent(const edm::Event &iEvent,
       }
 
       if (mapOfLinks.find(wireid) != mapOfLinks.end()) {
-        LogTrace("DTHitAssociator")
-            << "\n"
-            << mapOfLinks[wireid].size() << " Links (DTDigiSimLink):";
+        LogTrace("DTHitAssociator") << "\n" << mapOfLinks[wireid].size() << " Links (DTDigiSimLink):";
 
-        for (vector<DTDigiSimLink>::const_iterator hitIT =
-                 mapOfLinks[wireid].begin();
-             hitIT != mapOfLinks[wireid].end(); ++hitIT) {
-          LogTrace("DTHitAssociator")
-              << "\t digi number = " << hitIT->number()
-              << ", time = " << hitIT->time()
-              << ", SimTrackId = " << hitIT->SimTrackId();
+        for (vector<DTDigiSimLink>::const_iterator hitIT = mapOfLinks[wireid].begin();
+             hitIT != mapOfLinks[wireid].end();
+             ++hitIT) {
+          LogTrace("DTHitAssociator") << "\t digi number = " << hitIT->number() << ", time = " << hitIT->time()
+                                      << ", SimTrackId = " << hitIT->SimTrackId();
         }
       }
 
       if (mapOfDigi.find(wireid) != mapOfDigi.end()) {
-        LogTrace("DTHitAssociator")
-            << "\n"
-            << mapOfDigi[wireid].size() << " Digis (DTDigi):";
-        for (vector<DTDigi>::const_iterator hitIT = mapOfDigi[wireid].begin();
-             hitIT != mapOfDigi[wireid].end(); ++hitIT) {
-          LogTrace("DTHitAssociator") << "\t digi number = " << hitIT->number()
-                                      << ", time = " << hitIT->time();
+        LogTrace("DTHitAssociator") << "\n" << mapOfDigi[wireid].size() << " Digis (DTDigi):";
+        for (vector<DTDigi>::const_iterator hitIT = mapOfDigi[wireid].begin(); hitIT != mapOfDigi[wireid].end();
+             ++hitIT) {
+          LogTrace("DTHitAssociator") << "\t digi number = " << hitIT->number() << ", time = " << hitIT->time();
         }
       }
 
-      LogTrace("DTHitAssociator")
-          << "\n"
-          << (*mapIT).second.size() << " RecHits (DTRecHit1DPair):";
-      for (vector<DTRecHit1DPair>::const_iterator vIT = (*mapIT).second.begin();
-           vIT != (*mapIT).second.end(); ++vIT) {
+      LogTrace("DTHitAssociator") << "\n" << (*mapIT).second.size() << " RecHits (DTRecHit1DPair):";
+      for (vector<DTRecHit1DPair>::const_iterator vIT = (*mapIT).second.begin(); vIT != (*mapIT).second.end(); ++vIT) {
         LogTrace("DTHitAssociator") << "\t digi time = " << vIT->digiTime();
       }
     }
@@ -312,9 +272,7 @@ void DTHitAssociator::initEvent(const edm::Event &iEvent,
 }
 // end of constructor
 
-std::vector<DTHitAssociator::SimHitIdpr>
-DTHitAssociator::associateHitId(const TrackingRecHit &hit) const {
-
+std::vector<DTHitAssociator::SimHitIdpr> DTHitAssociator::associateHitId(const TrackingRecHit &hit) const {
   std::vector<SimHitIdpr> simtrackids;
   const TrackingRecHit *hitp = &hit;
   const DTRecHit1D *dtrechit = dynamic_cast<const DTRecHit1D *>(hitp);
@@ -322,16 +280,13 @@ DTHitAssociator::associateHitId(const TrackingRecHit &hit) const {
   if (dtrechit) {
     simtrackids = associateDTHitId(dtrechit);
   } else {
-    LogTrace("DTHitAssociator")
-        << "*** WARNING in DTHitAssociator::associateHitId, null dynamic_cast "
-           "!";
+    LogTrace("DTHitAssociator") << "*** WARNING in DTHitAssociator::associateHitId, null dynamic_cast "
+                                   "!";
   }
   return simtrackids;
 }
 
-std::vector<DTHitAssociator::SimHitIdpr>
-DTHitAssociator::associateDTHitId(const DTRecHit1D *dtrechit) const {
-
+std::vector<DTHitAssociator::SimHitIdpr> DTHitAssociator::associateDTHitId(const DTRecHit1D *dtrechit) const {
   std::vector<SimHitIdpr> matched;
 
   DTWireId wireid = dtrechit->wireId();
@@ -341,10 +296,8 @@ DTHitAssociator::associateDTHitId(const DTRecHit1D *dtrechit) const {
 
     auto found = mapOfSimHit.find(wireid);
     if (found != mapOfSimHit.end()) {
-      for (vector<PSimHit_withFlag>::const_iterator hitIT =
-               found->second.begin();
-           hitIT != found->second.end(); ++hitIT) {
-
+      for (vector<PSimHit_withFlag>::const_iterator hitIT = found->second.begin(); hitIT != found->second.end();
+           ++hitIT) {
         bool valid_hit = hitIT->second;
         PSimHit this_hit = hitIT->first;
 
@@ -371,8 +324,8 @@ DTHitAssociator::associateDTHitId(const DTRecHit1D *dtrechit) const {
       // the same DTDigiSimLink::number()
 
       // first find the associated digi Number
-      for (vector<DTDigiSimLink>::const_iterator linkIT = found->second.begin();
-           linkIT != found->second.end(); ++linkIT) {
+      for (vector<DTDigiSimLink>::const_iterator linkIT = found->second.begin(); linkIT != found->second.end();
+           ++linkIT) {
         float digitime = linkIT->time();
         if (fabs(digitime - theTime) < 0.1) {
           theNumber = linkIT->number();
@@ -383,9 +336,8 @@ DTHitAssociator::associateDTHitId(const DTRecHit1D *dtrechit) const {
       // valid SimHits
       //  within a time window of the order of the time resolution, specified in
       //  the DTDigitizer)
-      for (vector<DTDigiSimLink>::const_iterator linkIT = found->second.begin();
-           linkIT != found->second.end(); ++linkIT) {
-
+      for (vector<DTDigiSimLink>::const_iterator linkIT = found->second.begin(); linkIT != found->second.end();
+           ++linkIT) {
         int digiNr = linkIT->number();
         if (digiNr == theNumber) {
           SimHitIdpr currentId(linkIT->SimTrackId(), linkIT->eventId());
@@ -394,9 +346,8 @@ DTHitAssociator::associateDTHitId(const DTRecHit1D *dtrechit) const {
       }
 
     } else {
-      LogTrace("DTHitAssociator")
-          << "*** ERROR in DTHitAssociator::associateDTHitId - DTRecHit1D: "
-          << *dtrechit << " has no associated DTDigiSimLink !" << endl;
+      LogTrace("DTHitAssociator") << "*** ERROR in DTHitAssociator::associateDTHitId - DTRecHit1D: " << *dtrechit
+                                  << " has no associated DTDigiSimLink !" << endl;
       return matched;
     }
   }
@@ -404,9 +355,7 @@ DTHitAssociator::associateDTHitId(const DTRecHit1D *dtrechit) const {
   return matched;
 }
 
-std::vector<PSimHit>
-DTHitAssociator::associateHit(const TrackingRecHit &hit) const {
-
+std::vector<PSimHit> DTHitAssociator::associateHit(const TrackingRecHit &hit) const {
   std::vector<PSimHit> simhits;
   std::vector<SimHitIdpr> simtrackids;
 
@@ -421,10 +370,8 @@ DTHitAssociator::associateHit(const TrackingRecHit &hit) const {
 
       auto found = mapOfSimHit.find(wireid);
       if (found != mapOfSimHit.end()) {
-        for (vector<PSimHit_withFlag>::const_iterator hitIT =
-                 found->second.begin();
-             hitIT != found->second.end(); ++hitIT) {
-
+        for (vector<PSimHit_withFlag>::const_iterator hitIT = found->second.begin(); hitIT != found->second.end();
+             ++hitIT) {
           bool valid_hit = hitIT->second;
           if (valid_hit)
             simhits.push_back(hitIT->first);
@@ -435,19 +382,15 @@ DTHitAssociator::associateHit(const TrackingRecHit &hit) const {
 
       simtrackids = associateDTHitId(dtrechit);
 
-      for (vector<SimHitIdpr>::const_iterator idIT = simtrackids.begin();
-           idIT != simtrackids.end(); ++idIT) {
+      for (vector<SimHitIdpr>::const_iterator idIT = simtrackids.begin(); idIT != simtrackids.end(); ++idIT) {
         uint32_t trId = idIT->first;
         EncodedEventId evId = idIT->second;
 
         auto found = mapOfSimHit.find(wireid);
         if (found != mapOfSimHit.end()) {
-          for (vector<PSimHit_withFlag>::const_iterator hitIT =
-                   found->second.begin();
-               hitIT != found->second.end(); ++hitIT) {
-
-            if (hitIT->first.trackId() == trId &&
-                hitIT->first.eventId() == evId)
+          for (vector<PSimHit_withFlag>::const_iterator hitIT = found->second.begin(); hitIT != found->second.end();
+               ++hitIT) {
+            if (hitIT->first.trackId() == trId && hitIT->first.eventId() == evId)
               simhits.push_back(hitIT->first);
           }
         }
@@ -455,14 +398,12 @@ DTHitAssociator::associateHit(const TrackingRecHit &hit) const {
     }
 
   } else {
-    LogTrace("DTHitAssociator")
-        << "*** WARNING in DTHitAssociator::associateHit, null dynamic_cast !";
+    LogTrace("DTHitAssociator") << "*** WARNING in DTHitAssociator::associateHit, null dynamic_cast !";
   }
   return simhits;
 }
 
-bool DTHitAssociator::SimHitOK(const edm::ESHandle<DTGeometry> &muongeom,
-                               const PSimHit &simhit) {
+bool DTHitAssociator::SimHitOK(const edm::ESHandle<DTGeometry> &muongeom, const PSimHit &simhit) {
   bool result = true;
 
   DTWireId wireid(simhit.detUnitId());
@@ -473,13 +414,11 @@ bool DTHitAssociator::SimHitOK(const edm::ESHandle<DTGeometry> &muongeom,
   float xwire = topo.wirePosition(wireid.wire());
   float xEntry = entryP.x() - xwire;
   float xExit = exitP.x() - xwire;
-  DTTopology::Side entrySide =
-      topo.onWhichBorder(xEntry, entryP.y(), entryP.z());
+  DTTopology::Side entrySide = topo.onWhichBorder(xEntry, entryP.y(), entryP.z());
   DTTopology::Side exitSide = topo.onWhichBorder(xExit, exitP.y(), exitP.z());
 
   bool noParametrisation =
-      ((entrySide == DTTopology::none || exitSide == DTTopology::none) ||
-       (entrySide == exitSide) ||
+      ((entrySide == DTTopology::none || exitSide == DTTopology::none) || (entrySide == exitSide) ||
        ((entrySide == DTTopology::xMin && exitSide == DTTopology::xMax) ||
         (entrySide == DTTopology::xMax && exitSide == DTTopology::xMin)));
 
@@ -500,7 +439,7 @@ bool DTHitAssociator::SimHitOK(const edm::ESHandle<DTGeometry> &muongeom,
   }
 
   // discard hits where x is out of range of the parametrization (|x|>2.1 cm)
-  x *= 10.; // cm -> mm
+  x *= 10.;  // cm -> mm
   if (fabs(x) > 21.)
     result = false;
 

--- a/SimMuon/MCTruth/src/GEMHitAssociator.cc
+++ b/SimMuon/MCTruth/src/GEMHitAssociator.cc
@@ -3,8 +3,7 @@
 using namespace std;
 
 // Constructor
-GEMHitAssociator::GEMHitAssociator(const edm::ParameterSet &conf,
-                                   edm::ConsumesCollector &&iC)
+GEMHitAssociator::GEMHitAssociator(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
     : GEMdigisimlinkTag(conf.getParameter<edm::InputTag>("GEMdigisimlinkTag")),
       // CrossingFrame used or not ?
       crossingframe(conf.getParameter<bool>("crossingframe")),
@@ -17,8 +16,7 @@ GEMHitAssociator::GEMHitAssociator(const edm::ParameterSet &conf,
     GEMsimhitsToken_ = iC.consumes<edm::PSimHitContainer>(GEMsimhitsTag);
   }
 
-  GEMdigisimlinkToken_ =
-      iC.consumes<edm::DetSetVector<StripDigiSimLink>>(GEMdigisimlinkTag);
+  GEMdigisimlinkToken_ = iC.consumes<edm::DetSetVector<StripDigiSimLink>>(GEMdigisimlinkTag);
 }
 
 GEMHitAssociator::GEMHitAssociator(const edm::Event &e,
@@ -33,60 +31,47 @@ GEMHitAssociator::GEMHitAssociator(const edm::Event &e,
   initEvent(e, eventSetup);
 }
 
-void GEMHitAssociator::initEvent(const edm::Event &e,
-                                 const edm::EventSetup &eventSetup) {
-
+void GEMHitAssociator::initEvent(const edm::Event &e, const edm::EventSetup &eventSetup) {
   if (useGEMs_) {
-
     if (crossingframe) {
-
       edm::Handle<CrossingFrame<PSimHit>> cf;
-      LogTrace("GEMHitAssociator")
-          << "getting CrossingFrame<PSimHit> collection - " << GEMsimhitsXFTag;
+      LogTrace("GEMHitAssociator") << "getting CrossingFrame<PSimHit> collection - " << GEMsimhitsXFTag;
       e.getByLabel(GEMsimhitsXFTag, cf);
 
-      std::unique_ptr<MixCollection<PSimHit>> GEMsimhits(
-          new MixCollection<PSimHit>(cf.product()));
+      std::unique_ptr<MixCollection<PSimHit>> GEMsimhits(new MixCollection<PSimHit>(cf.product()));
       LogTrace("GEMHitAssociator") << "... size = " << GEMsimhits->size();
 
       //   MixCollection<PSimHit> & simHits = *hits;
 
-      for (MixCollection<PSimHit>::MixItr hitItr = GEMsimhits->begin();
-           hitItr != GEMsimhits->end(); ++hitItr) {
+      for (MixCollection<PSimHit>::MixItr hitItr = GEMsimhits->begin(); hitItr != GEMsimhits->end(); ++hitItr) {
         _SimHitMap[hitItr->detUnitId()].push_back(*hitItr);
       }
 
     } else if (!GEMsimhitsTag.label().empty()) {
       edm::Handle<edm::PSimHitContainer> GEMsimhits;
-      LogTrace("GEMHitAssociator")
-          << "getting PSimHit collection - " << GEMsimhitsTag;
+      LogTrace("GEMHitAssociator") << "getting PSimHit collection - " << GEMsimhitsTag;
       e.getByLabel(GEMsimhitsTag, GEMsimhits);
       LogTrace("GEMHitAssociator") << "... size = " << GEMsimhits->size();
 
       // arrange the hits by detUnit
-      for (edm::PSimHitContainer::const_iterator hitItr = GEMsimhits->begin();
-           hitItr != GEMsimhits->end(); ++hitItr) {
+      for (edm::PSimHitContainer::const_iterator hitItr = GEMsimhits->begin(); hitItr != GEMsimhits->end(); ++hitItr) {
         _SimHitMap[hitItr->detUnitId()].push_back(*hitItr);
       }
     }
 
     edm::Handle<DigiSimLinks> digiSimLinks;
-    LogTrace("GEMHitAssociator")
-        << "getting GEM Strip DigiSimLink collection - " << GEMdigisimlinkTag;
+    LogTrace("GEMHitAssociator") << "getting GEM Strip DigiSimLink collection - " << GEMdigisimlinkTag;
     e.getByLabel(GEMdigisimlinkTag, digiSimLinks);
     theDigiSimLinks = digiSimLinks.product();
   }
 }
 // end of constructor
 
-std::vector<GEMHitAssociator::SimHitIdpr>
-GEMHitAssociator::associateRecHit(const GEMRecHit *gemrechit) const {
-
+std::vector<GEMHitAssociator::SimHitIdpr> GEMHitAssociator::associateRecHit(const GEMRecHit *gemrechit) const {
   std::vector<SimHitIdpr> matched;
 
   if (useGEMs_) {
     if (gemrechit) {
-
       GEMDetId gemDetId = gemrechit->gemId();
       int fstrip = gemrechit->firstClusterStrip();
       int cls = gemrechit->clusterSize();
@@ -95,32 +80,25 @@ GEMHitAssociator::associateRecHit(const GEMRecHit *gemrechit) const {
       DigiSimLinks::const_iterator layerLinks = theDigiSimLinks->find(gemDetId);
 
       if (layerLinks != theDigiSimLinks->end()) {
-
         for (int i = fstrip; i < (fstrip + cls); ++i) {
-
-          for (LayerLinks::const_iterator itlink = layerLinks->begin();
-               itlink != layerLinks->end(); ++itlink) {
-
+          for (LayerLinks::const_iterator itlink = layerLinks->begin(); itlink != layerLinks->end(); ++itlink) {
             int ch = static_cast<int>(itlink->channel());
             if (ch != i)
               continue;
 
             SimHitIdpr currentId(itlink->SimTrackId(), itlink->eventId());
-            if (find(matched.begin(), matched.end(), currentId) ==
-                matched.end())
+            if (find(matched.begin(), matched.end(), currentId) == matched.end())
               matched.push_back(currentId);
           }
         }
 
       } else
         edm::LogWarning("GEMHitAssociator")
-            << "*** WARNING in GEMHitAssociator: GEM layer " << gemDetId
-            << " has no DigiSimLinks !" << std::endl;
+            << "*** WARNING in GEMHitAssociator: GEM layer " << gemDetId << " has no DigiSimLinks !" << std::endl;
 
     } else
-      edm::LogWarning("GEMHitAssociator")
-          << "*** WARNING in GEMHitAssociator::associateRecHit, null "
-             "dynamic_cast !";
+      edm::LogWarning("GEMHitAssociator") << "*** WARNING in GEMHitAssociator::associateRecHit, null "
+                                             "dynamic_cast !";
   }
 
   return matched;

--- a/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
@@ -18,152 +18,124 @@ using namespace std;
 using namespace muonAssociatorByHitsDiagnostics;
 
 namespace muonAssociatorByHitsDiagnostics {
-using TrackHitsCollection = MuonAssociatorByHitsHelper::TrackHitsCollection;
+  using TrackHitsCollection = MuonAssociatorByHitsHelper::TrackHitsCollection;
 
-class InputDumper {
-public:
-  InputDumper(const edm::ParameterSet &conf)
-      : simtracksTag(conf.getParameter<edm::InputTag>("simtracksTag")),
-        simtracksXFTag(conf.getParameter<edm::InputTag>("simtracksXFTag")),
-        crossingframe(conf.getParameter<bool>("crossingframe")) {}
+  class InputDumper {
+  public:
+    InputDumper(const edm::ParameterSet &conf)
+        : simtracksTag(conf.getParameter<edm::InputTag>("simtracksTag")),
+          simtracksXFTag(conf.getParameter<edm::InputTag>("simtracksXFTag")),
+          crossingframe(conf.getParameter<bool>("crossingframe")) {}
 
-  InputDumper(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
-      : InputDumper(conf) {
+    InputDumper(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC) : InputDumper(conf) {
+      if (crossingframe) {
+        iC.consumes<CrossingFrame<SimTrack>>(simtracksXFTag);
+        iC.consumes<CrossingFrame<SimVertex>>(simtracksXFTag);
+      } else {
+        iC.consumes<edm::SimTrackContainer>(simtracksTag);
+        iC.consumes<edm::SimVertexContainer>(simtracksTag);
+      }
+    }
+
+    void dump(const TrackHitsCollection &, const TrackingParticleCollection &, const edm::Event &) const;
+
+  private:
+    edm::InputTag const simtracksTag;
+    edm::InputTag const simtracksXFTag;
+    bool const crossingframe;
+  };
+
+  void InputDumper::dump(const TrackHitsCollection &tC,
+                         const TrackingParticleCollection &tPC,
+                         const edm::Event &event) const {
+    // reco::Track collection
+    edm::LogVerbatim("MuonAssociatorByHits") << "\n"
+                                             << "reco::Track collection --- size = " << tC.size();
+
+    // TrackingParticle collection
+    edm::LogVerbatim("MuonAssociatorByHits") << "\n"
+                                             << "TrackingParticle collection --- size = " << tPC.size();
+    int j = 0;
+    for (TrackingParticleCollection::const_iterator ITER = tPC.begin(); ITER != tPC.end(); ITER++, j++) {
+      edm::LogVerbatim("MuonAssociatorByHits")
+          << "TrackingParticle " << j << ", q = " << ITER->charge() << ", p = " << ITER->p() << ", pT = " << ITER->pt()
+          << ", eta = " << ITER->eta() << ", phi = " << ITER->phi();
+
+      edm::LogVerbatim("MuonAssociatorByHits")
+          << "\t pdg code = " << ITER->pdgId() << ", made of " << ITER->numberOfHits() << " PSimHit"
+          << " (in " << ITER->numberOfTrackerLayers() << " layers)"
+          << " from " << ITER->g4Tracks().size() << " SimTrack:";
+      for (TrackingParticle::g4t_iterator g4T = ITER->g4Track_begin(); g4T != ITER->g4Track_end(); g4T++) {
+        edm::LogVerbatim("MuonAssociatorByHits") << "\t\t Id:" << g4T->trackId() << "/Evt:(" << g4T->eventId().event()
+                                                 << "," << g4T->eventId().bunchCrossing() << ")";
+      }
+    }
+
+    // SimTrack collection
+    edm::Handle<CrossingFrame<SimTrack>> cf_simtracks;
+    edm::Handle<edm::SimTrackContainer> simTrackCollection;
+
+    // SimVertex collection
+    edm::Handle<CrossingFrame<SimVertex>> cf_simvertices;
+    edm::Handle<edm::SimVertexContainer> simVertexCollection;
+
     if (crossingframe) {
-      iC.consumes<CrossingFrame<SimTrack>>(simtracksXFTag);
-      iC.consumes<CrossingFrame<SimVertex>>(simtracksXFTag);
+      event.getByLabel(simtracksXFTag, cf_simtracks);
+      unique_ptr<MixCollection<SimTrack>> SimTk(new MixCollection<SimTrack>(cf_simtracks.product()));
+      edm::LogVerbatim("MuonAssociatorByHits")
+          << "\n"
+          << "CrossingFrame<SimTrack> collection with InputTag = " << simtracksXFTag << " has size = " << SimTk->size();
+      int k = 0;
+      for (MixCollection<SimTrack>::MixItr ITER = SimTk->begin(); ITER != SimTk->end(); ITER++, k++) {
+        edm::LogVerbatim("MuonAssociatorByHits")
+            << "SimTrack " << k << " - Id:" << ITER->trackId() << "/Evt:(" << ITER->eventId().event() << ","
+            << ITER->eventId().bunchCrossing() << ")"
+            << " pdgId = " << ITER->type() << ", q = " << ITER->charge() << ", p = " << ITER->momentum().P()
+            << ", pT = " << ITER->momentum().Pt() << ", eta = " << ITER->momentum().Eta()
+            << ", phi = " << ITER->momentum().Phi() << "\n * " << *ITER << endl;
+      }
+      event.getByLabel(simtracksXFTag, cf_simvertices);
+      unique_ptr<MixCollection<SimVertex>> SimVtx(new MixCollection<SimVertex>(cf_simvertices.product()));
+      edm::LogVerbatim("MuonAssociatorByHits")
+          << "\n"
+          << "CrossingFrame<SimVertex> collection with InputTag = " << simtracksXFTag
+          << " has size = " << SimVtx->size();
+      int kv = 0;
+      for (MixCollection<SimVertex>::MixItr VITER = SimVtx->begin(); VITER != SimVtx->end(); VITER++, kv++) {
+        edm::LogVerbatim("MuonAssociatorByHits") << "SimVertex " << kv << " : " << *VITER << endl;
+      }
     } else {
-      iC.consumes<edm::SimTrackContainer>(simtracksTag);
-      iC.consumes<edm::SimVertexContainer>(simtracksTag);
+      event.getByLabel(simtracksTag, simTrackCollection);
+      const edm::SimTrackContainer simTC = *(simTrackCollection.product());
+      edm::LogVerbatim("MuonAssociatorByHits")
+          << "\n"
+          << "SimTrack collection with InputTag = " << simtracksTag << " has size = " << simTC.size() << endl;
+      int k = 0;
+      for (edm::SimTrackContainer::const_iterator ITER = simTC.begin(); ITER != simTC.end(); ITER++, k++) {
+        edm::LogVerbatim("MuonAssociatorByHits")
+            << "SimTrack " << k << " - Id:" << ITER->trackId() << "/Evt:(" << ITER->eventId().event() << ","
+            << ITER->eventId().bunchCrossing() << ")"
+            << " pdgId = " << ITER->type() << ", q = " << ITER->charge() << ", p = " << ITER->momentum().P()
+            << ", pT = " << ITER->momentum().Pt() << ", eta = " << ITER->momentum().Eta()
+            << ", phi = " << ITER->momentum().Phi() << "\n * " << *ITER << endl;
+      }
+      event.getByLabel(simtracksTag, simVertexCollection);
+      const edm::SimVertexContainer simVC = *(simVertexCollection.product());
+      edm::LogVerbatim("MuonAssociatorByHits") << "\n"
+                                               << "SimVertex collection with InputTag = "
+                                               << "g4SimHits"
+                                               << " has size = " << simVC.size() << endl;
+      int kv = 0;
+      for (edm::SimVertexContainer::const_iterator VITER = simVC.begin(); VITER != simVC.end(); VITER++, kv++) {
+        edm::LogVerbatim("MuonAssociatorByHits") << "SimVertex " << kv << " : " << *VITER << endl;
+      }
     }
   }
 
-  void dump(const TrackHitsCollection &, const TrackingParticleCollection &,
-            const edm::Event &) const;
+}  // namespace muonAssociatorByHitsDiagnostics
 
-private:
-  edm::InputTag const simtracksTag;
-  edm::InputTag const simtracksXFTag;
-  bool const crossingframe;
-};
-
-void InputDumper::dump(const TrackHitsCollection &tC,
-                       const TrackingParticleCollection &tPC,
-                       const edm::Event &event) const {
-  // reco::Track collection
-  edm::LogVerbatim("MuonAssociatorByHits")
-      << "\n"
-      << "reco::Track collection --- size = " << tC.size();
-
-  // TrackingParticle collection
-  edm::LogVerbatim("MuonAssociatorByHits")
-      << "\n"
-      << "TrackingParticle collection --- size = " << tPC.size();
-  int j = 0;
-  for (TrackingParticleCollection::const_iterator ITER = tPC.begin();
-       ITER != tPC.end(); ITER++, j++) {
-    edm::LogVerbatim("MuonAssociatorByHits")
-        << "TrackingParticle " << j << ", q = " << ITER->charge()
-        << ", p = " << ITER->p() << ", pT = " << ITER->pt()
-        << ", eta = " << ITER->eta() << ", phi = " << ITER->phi();
-
-    edm::LogVerbatim("MuonAssociatorByHits")
-        << "\t pdg code = " << ITER->pdgId() << ", made of "
-        << ITER->numberOfHits() << " PSimHit"
-        << " (in " << ITER->numberOfTrackerLayers() << " layers)"
-        << " from " << ITER->g4Tracks().size() << " SimTrack:";
-    for (TrackingParticle::g4t_iterator g4T = ITER->g4Track_begin();
-         g4T != ITER->g4Track_end(); g4T++) {
-      edm::LogVerbatim("MuonAssociatorByHits")
-          << "\t\t Id:" << g4T->trackId() << "/Evt:(" << g4T->eventId().event()
-          << "," << g4T->eventId().bunchCrossing() << ")";
-    }
-  }
-
-  // SimTrack collection
-  edm::Handle<CrossingFrame<SimTrack>> cf_simtracks;
-  edm::Handle<edm::SimTrackContainer> simTrackCollection;
-
-  // SimVertex collection
-  edm::Handle<CrossingFrame<SimVertex>> cf_simvertices;
-  edm::Handle<edm::SimVertexContainer> simVertexCollection;
-
-  if (crossingframe) {
-    event.getByLabel(simtracksXFTag, cf_simtracks);
-    unique_ptr<MixCollection<SimTrack>> SimTk(
-        new MixCollection<SimTrack>(cf_simtracks.product()));
-    edm::LogVerbatim("MuonAssociatorByHits")
-        << "\n"
-        << "CrossingFrame<SimTrack> collection with InputTag = "
-        << simtracksXFTag << " has size = " << SimTk->size();
-    int k = 0;
-    for (MixCollection<SimTrack>::MixItr ITER = SimTk->begin();
-         ITER != SimTk->end(); ITER++, k++) {
-      edm::LogVerbatim("MuonAssociatorByHits")
-          << "SimTrack " << k << " - Id:" << ITER->trackId() << "/Evt:("
-          << ITER->eventId().event() << "," << ITER->eventId().bunchCrossing()
-          << ")"
-          << " pdgId = " << ITER->type() << ", q = " << ITER->charge()
-          << ", p = " << ITER->momentum().P()
-          << ", pT = " << ITER->momentum().Pt()
-          << ", eta = " << ITER->momentum().Eta()
-          << ", phi = " << ITER->momentum().Phi() << "\n * " << *ITER << endl;
-    }
-    event.getByLabel(simtracksXFTag, cf_simvertices);
-    unique_ptr<MixCollection<SimVertex>> SimVtx(
-        new MixCollection<SimVertex>(cf_simvertices.product()));
-    edm::LogVerbatim("MuonAssociatorByHits")
-        << "\n"
-        << "CrossingFrame<SimVertex> collection with InputTag = "
-        << simtracksXFTag << " has size = " << SimVtx->size();
-    int kv = 0;
-    for (MixCollection<SimVertex>::MixItr VITER = SimVtx->begin();
-         VITER != SimVtx->end(); VITER++, kv++) {
-      edm::LogVerbatim("MuonAssociatorByHits")
-          << "SimVertex " << kv << " : " << *VITER << endl;
-    }
-  } else {
-    event.getByLabel(simtracksTag, simTrackCollection);
-    const edm::SimTrackContainer simTC = *(simTrackCollection.product());
-    edm::LogVerbatim("MuonAssociatorByHits")
-        << "\n"
-        << "SimTrack collection with InputTag = " << simtracksTag
-        << " has size = " << simTC.size() << endl;
-    int k = 0;
-    for (edm::SimTrackContainer::const_iterator ITER = simTC.begin();
-         ITER != simTC.end(); ITER++, k++) {
-      edm::LogVerbatim("MuonAssociatorByHits")
-          << "SimTrack " << k << " - Id:" << ITER->trackId() << "/Evt:("
-          << ITER->eventId().event() << "," << ITER->eventId().bunchCrossing()
-          << ")"
-          << " pdgId = " << ITER->type() << ", q = " << ITER->charge()
-          << ", p = " << ITER->momentum().P()
-          << ", pT = " << ITER->momentum().Pt()
-          << ", eta = " << ITER->momentum().Eta()
-          << ", phi = " << ITER->momentum().Phi() << "\n * " << *ITER << endl;
-    }
-    event.getByLabel(simtracksTag, simVertexCollection);
-    const edm::SimVertexContainer simVC = *(simVertexCollection.product());
-    edm::LogVerbatim("MuonAssociatorByHits")
-        << "\n"
-        << "SimVertex collection with InputTag = "
-        << "g4SimHits"
-        << " has size = " << simVC.size() << endl;
-    int kv = 0;
-    for (edm::SimVertexContainer::const_iterator VITER = simVC.begin();
-         VITER != simVC.end(); VITER++, kv++) {
-      edm::LogVerbatim("MuonAssociatorByHits")
-          << "SimVertex " << kv << " : " << *VITER << endl;
-    }
-  }
-}
-
-} // namespace muonAssociatorByHitsDiagnostics
-
-MuonAssociatorByHits::MuonAssociatorByHits(const edm::ParameterSet &conf,
-                                           edm::ConsumesCollector &&iC)
-    : helper_(conf), conf_(conf),
-      trackerHitAssociatorConfig_(conf, std::move(iC)) {
+MuonAssociatorByHits::MuonAssociatorByHits(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
+    : helper_(conf), conf_(conf), trackerHitAssociatorConfig_(conf, std::move(iC)) {
   // hack for consumes
   RPCHitAssociator rpctruth(conf, std::move(iC));
   GEMHitAssociator gemtruth(conf, std::move(iC));
@@ -179,7 +151,8 @@ MuonAssociatorByHits::~MuonAssociatorByHits() {}
 RecoToSimCollection MuonAssociatorByHits::associateRecoToSim(
     const edm::RefToBaseVector<reco::Track> &tC,
     const edm::RefVector<TrackingParticleCollection> &TPCollectionH,
-    const edm::Event *e, const edm::EventSetup *setup) const {
+    const edm::Event *e,
+    const edm::EventSetup *setup) const {
   RecoToSimCollection outputCollection(&e->productGetter());
 
   MuonAssociatorByHitsHelper::TrackHitsCollection tH;
@@ -204,36 +177,30 @@ RecoToSimCollection MuonAssociatorByHits::associateRecoToSim(
   // GEM hit association
   GEMHitAssociator gemtruth(*e, *setup, conf_);
 
-  MuonAssociatorByHitsHelper::Resources resources = {
-      tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth};
+  MuonAssociatorByHitsHelper::Resources resources = {tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth};
 
   if (diagnostics_) {
-    resources.diagnostics_ = [this, e](const TrackHitsCollection &hC,
-                                       const TrackingParticleCollection &pC) {
+    resources.diagnostics_ = [this, e](const TrackHitsCollection &hC, const TrackingParticleCollection &pC) {
       diagnostics_->dump(hC, pC, *e);
     };
   }
 
-  auto bareAssoc =
-      helper_.associateRecoToSimIndices(tH, TPCollectionH, resources);
+  auto bareAssoc = helper_.associateRecoToSimIndices(tH, TPCollectionH, resources);
   for (auto it = bareAssoc.begin(), ed = bareAssoc.end(); it != ed; ++it) {
-    for (auto itma = it->second.begin(), edma = it->second.end(); itma != edma;
-         ++itma) {
-      outputCollection.insert(
-          tC[it->first],
-          std::make_pair(TPCollectionH[itma->idx], itma->quality));
+    for (auto itma = it->second.begin(), edma = it->second.end(); itma != edma; ++itma) {
+      outputCollection.insert(tC[it->first], std::make_pair(TPCollectionH[itma->idx], itma->quality));
     }
   }
 
-  outputCollection.post_insert(); // perhaps not even necessary
+  outputCollection.post_insert();  // perhaps not even necessary
   return outputCollection;
 }
 
 SimToRecoCollection MuonAssociatorByHits::associateSimToReco(
     const edm::RefToBaseVector<reco::Track> &tC,
     const edm::RefVector<TrackingParticleCollection> &TPCollectionH,
-    const edm::Event *e, const edm::EventSetup *setup) const {
-
+    const edm::Event *e,
+    const edm::EventSetup *setup) const {
   SimToRecoCollection outputCollection(&e->productGetter());
   MuonAssociatorByHitsHelper::TrackHitsCollection tH;
   for (auto it = tC.begin(), ed = tC.end(); it != ed; ++it) {
@@ -257,19 +224,15 @@ SimToRecoCollection MuonAssociatorByHits::associateSimToReco(
   // GEM hit association
   GEMHitAssociator gemtruth(*e, *setup, conf_);
 
-  MuonAssociatorByHitsHelper::Resources resources = {
-      tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth};
+  MuonAssociatorByHitsHelper::Resources resources = {tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth};
 
-  auto bareAssoc =
-      helper_.associateSimToRecoIndices(tH, TPCollectionH, resources);
+  auto bareAssoc = helper_.associateSimToRecoIndices(tH, TPCollectionH, resources);
   for (auto it = bareAssoc.begin(), ed = bareAssoc.end(); it != ed; ++it) {
-    for (auto itma = it->second.begin(), edma = it->second.end(); itma != edma;
-         ++itma) {
-      outputCollection.insert(TPCollectionH[it->first],
-                              std::make_pair(tC[itma->idx], itma->quality));
+    for (auto itma = it->second.begin(), edma = it->second.end(); itma != edma; ++itma) {
+      outputCollection.insert(TPCollectionH[it->first], std::make_pair(tC[itma->idx], itma->quality));
     }
   }
 
-  outputCollection.post_insert(); // perhaps not even necessary
+  outputCollection.post_insert();  // perhaps not even necessary
   return outputCollection;
 }

--- a/SimMuon/MCTruth/src/MuonAssociatorByHitsHelper.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHitsHelper.cc
@@ -14,70 +14,58 @@
 using namespace reco;
 using namespace std;
 
-MuonAssociatorByHitsHelper::MuonAssociatorByHitsHelper(
-    const edm::ParameterSet &conf)
+MuonAssociatorByHitsHelper::MuonAssociatorByHitsHelper(const edm::ParameterSet &conf)
     : includeZeroHitMuons(conf.getParameter<bool>("includeZeroHitMuons")),
       acceptOneStubMatchings(conf.getParameter<bool>("acceptOneStubMatchings")),
       UseTracker(conf.getParameter<bool>("UseTracker")),
       UseMuon(conf.getParameter<bool>("UseMuon")),
-      AbsoluteNumberOfHits_track(
-          conf.getParameter<bool>("AbsoluteNumberOfHits_track")),
+      AbsoluteNumberOfHits_track(conf.getParameter<bool>("AbsoluteNumberOfHits_track")),
       NHitCut_track(conf.getParameter<unsigned int>("NHitCut_track")),
       EfficiencyCut_track(conf.getParameter<double>("EfficiencyCut_track")),
       PurityCut_track(conf.getParameter<double>("PurityCut_track")),
-      AbsoluteNumberOfHits_muon(
-          conf.getParameter<bool>("AbsoluteNumberOfHits_muon")),
+      AbsoluteNumberOfHits_muon(conf.getParameter<bool>("AbsoluteNumberOfHits_muon")),
       NHitCut_muon(conf.getParameter<unsigned int>("NHitCut_muon")),
       EfficiencyCut_muon(conf.getParameter<double>("EfficiencyCut_muon")),
       PurityCut_muon(conf.getParameter<double>("PurityCut_muon")),
       UsePixels(conf.getParameter<bool>("UsePixels")),
       UseGrouped(conf.getParameter<bool>("UseGrouped")),
       UseSplitting(conf.getParameter<bool>("UseSplitting")),
-      ThreeHitTracksAreSpecial(
-          conf.getParameter<bool>("ThreeHitTracksAreSpecial")),
+      ThreeHitTracksAreSpecial(conf.getParameter<bool>("ThreeHitTracksAreSpecial")),
       dumpDT(conf.getParameter<bool>("dumpDT")) {
-  edm::LogVerbatim("MuonAssociatorByHitsHelper")
-      << "constructing  MuonAssociatorByHitsHelper" << conf.dump();
+  edm::LogVerbatim("MuonAssociatorByHitsHelper") << "constructing  MuonAssociatorByHitsHelper" << conf.dump();
 
   // up to the user in the other cases - print a message
   if (UseTracker)
-    edm::LogVerbatim("MuonAssociatorByHitsHelper")
-        << "\n UseTracker = TRUE  : Tracker SimHits and RecHits WILL be "
-           "counted";
+    edm::LogVerbatim("MuonAssociatorByHitsHelper") << "\n UseTracker = TRUE  : Tracker SimHits and RecHits WILL be "
+                                                      "counted";
   else
-    edm::LogVerbatim("MuonAssociatorByHitsHelper")
-        << "\n UseTracker = FALSE : Tracker SimHits and RecHits WILL NOT be "
-           "counted";
+    edm::LogVerbatim("MuonAssociatorByHitsHelper") << "\n UseTracker = FALSE : Tracker SimHits and RecHits WILL NOT be "
+                                                      "counted";
 
   // up to the user in the other cases - print a message
   if (UseMuon)
-    edm::LogVerbatim("MuonAssociatorByHitsHelper")
-        << " UseMuon = TRUE  : Muon SimHits and RecHits WILL be counted";
+    edm::LogVerbatim("MuonAssociatorByHitsHelper") << " UseMuon = TRUE  : Muon SimHits and RecHits WILL be counted";
   else
     edm::LogVerbatim("MuonAssociatorByHitsHelper")
-        << " UseMuon = FALSE : Muon SimHits and RecHits WILL NOT be counted"
-        << endl;
+        << " UseMuon = FALSE : Muon SimHits and RecHits WILL NOT be counted" << endl;
 
   // check consistency of the configuration when allowing zero-hit muon matching
   // (counting invalid hits)
   if (includeZeroHitMuons) {
-    edm::LogVerbatim("MuonAssociatorByHitsHelper")
-        << "\n includeZeroHitMuons = TRUE"
-        << "\n ==> (re)set NHitCut_muon = 0, PurityCut_muon = 0, "
-           "EfficiencyCut_muon = 0"
-        << endl;
+    edm::LogVerbatim("MuonAssociatorByHitsHelper") << "\n includeZeroHitMuons = TRUE"
+                                                   << "\n ==> (re)set NHitCut_muon = 0, PurityCut_muon = 0, "
+                                                      "EfficiencyCut_muon = 0"
+                                                   << endl;
     NHitCut_muon = 0;
     PurityCut_muon = 0.;
     EfficiencyCut_muon = 0.;
   }
 }
 
-MuonAssociatorByHitsHelper::IndexAssociation
-MuonAssociatorByHitsHelper::associateRecoToSimIndices(
+MuonAssociatorByHitsHelper::IndexAssociation MuonAssociatorByHitsHelper::associateRecoToSimIndices(
     const TrackHitsCollection &tC,
     const edm::RefVector<TrackingParticleCollection> &TPCollectionH,
     const Resources &resources) const {
-
   auto tTopo = resources.tTopo_;
   auto trackertruth = resources.trackerHitAssoc_;
   auto const &csctruth = *resources.cscHitAssoc_;
@@ -122,12 +110,10 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(
   }
 
   int tindex = 0;
-  for (TrackHitsCollection::const_iterator track = tC.begin();
-       track != tC.end(); track++, tindex++) {
+  for (TrackHitsCollection::const_iterator track = tC.begin(); track != tC.end(); track++, tindex++) {
     edm::LogVerbatim("MuonAssociatorByHitsHelper")
         << "\n"
-        << "reco::Track " << tindex
-        << ", number of RecHits = " << (track->second - track->first) << "\n";
+        << "reco::Track " << tindex << ", number of RecHits = " << (track->second - track->first) << "\n";
     tracker_matchedIds_valid.clear();
     muon_matchedIds_valid.clear();
 
@@ -176,26 +162,46 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(
     int n_gem_matched_INVALID = 0;
 
     printRtS = true;
-    getMatchedIds(tracker_matchedIds_valid, muon_matchedIds_valid,
-                  tracker_matchedIds_INVALID, muon_matchedIds_INVALID,
-                  n_tracker_valid, n_dt_valid, n_csc_valid, n_rpc_valid,
-                  n_gem_valid, n_tracker_matched_valid, n_dt_matched_valid,
-                  n_csc_matched_valid, n_rpc_matched_valid, n_gem_matched_valid,
-                  n_tracker_INVALID, n_dt_INVALID, n_csc_INVALID, n_rpc_INVALID,
-                  n_gem_INVALID, n_tracker_matched_INVALID,
-                  n_dt_matched_INVALID, n_csc_matched_INVALID,
-                  n_rpc_matched_INVALID, n_gem_matched_INVALID, track->first,
-                  track->second, trackertruth, dttruth, csctruth, rpctruth,
-                  gemtruth, printRtS, tTopo);
+    getMatchedIds(tracker_matchedIds_valid,
+                  muon_matchedIds_valid,
+                  tracker_matchedIds_INVALID,
+                  muon_matchedIds_INVALID,
+                  n_tracker_valid,
+                  n_dt_valid,
+                  n_csc_valid,
+                  n_rpc_valid,
+                  n_gem_valid,
+                  n_tracker_matched_valid,
+                  n_dt_matched_valid,
+                  n_csc_matched_valid,
+                  n_rpc_matched_valid,
+                  n_gem_matched_valid,
+                  n_tracker_INVALID,
+                  n_dt_INVALID,
+                  n_csc_INVALID,
+                  n_rpc_INVALID,
+                  n_gem_INVALID,
+                  n_tracker_matched_INVALID,
+                  n_dt_matched_INVALID,
+                  n_csc_matched_INVALID,
+                  n_rpc_matched_INVALID,
+                  n_gem_matched_INVALID,
+                  track->first,
+                  track->second,
+                  trackertruth,
+                  dttruth,
+                  csctruth,
+                  rpctruth,
+                  gemtruth,
+                  printRtS,
+                  tTopo);
 
-    n_matching_simhits =
-        tracker_matchedIds_valid.size() + muon_matchedIds_valid.size() +
-        tracker_matchedIds_INVALID.size() + muon_matchedIds_INVALID.size();
+    n_matching_simhits = tracker_matchedIds_valid.size() + muon_matchedIds_valid.size() +
+                         tracker_matchedIds_INVALID.size() + muon_matchedIds_INVALID.size();
 
     n_muon_valid = n_dt_valid + n_csc_valid + n_rpc_valid + n_gem_valid;
     n_valid = n_tracker_valid + n_muon_valid;
-    n_muon_INVALID =
-        n_dt_INVALID + n_csc_INVALID + n_rpc_INVALID + n_gem_INVALID;
+    n_muon_INVALID = n_dt_INVALID + n_csc_INVALID + n_rpc_INVALID + n_gem_INVALID;
     n_INVALID = n_tracker_INVALID + n_muon_INVALID;
 
     // all used hits (valid+INVALID), defined by UseTracker, UseMuon
@@ -206,10 +212,9 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(
     n_gem_all = n_gem_valid + n_gem_INVALID;
     n_all = n_valid + n_INVALID;
 
-    n_muon_matched_valid = n_dt_matched_valid + n_csc_matched_valid +
-                           n_rpc_matched_valid + n_gem_matched_valid;
-    n_muon_matched_INVALID = n_dt_matched_INVALID + n_csc_matched_INVALID +
-                             n_rpc_matched_INVALID + n_gem_matched_INVALID;
+    n_muon_matched_valid = n_dt_matched_valid + n_csc_matched_valid + n_rpc_matched_valid + n_gem_matched_valid;
+    n_muon_matched_INVALID =
+        n_dt_matched_INVALID + n_csc_matched_INVALID + n_rpc_matched_INVALID + n_gem_matched_INVALID;
 
     // selected hits are set initially to valid hits
     int n_tracker_selected_hits = n_tracker_valid;
@@ -255,19 +260,15 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(
     edm::LogVerbatim("MuonAssociatorByHitsHelper")
         << "\n"
         << "# TrackingRecHits: " << (track->second - track->first) << "\n"
-        << "# used RecHits     = " << n_all << " (" << n_tracker_all << "/"
-        << n_dt_all << "/" << n_csc_all << "/" << n_rpc_all << "/" << n_gem_all
-        << " in Tracker/DT/CSC/RPC/GEM)"
+        << "# used RecHits     = " << n_all << " (" << n_tracker_all << "/" << n_dt_all << "/" << n_csc_all << "/"
+        << n_rpc_all << "/" << n_gem_all << " in Tracker/DT/CSC/RPC/GEM)"
         << ", obtained from " << n_matching_simhits << " SimHits"
         << "\n"
-        << "# selected RecHits = " << n_selected_hits << " ("
-        << n_tracker_selected_hits << "/" << n_dt_selected_hits << "/"
-        << n_csc_selected_hits << "/" << n_rpc_selected_hits << "/"
-        << n_gem_selected_hits << " in Tracker/DT/CSC/RPC/GEM)" << InvMuonHits
-        << "\n"
-        << "# matched RecHits  = " << n_matched << " (" << n_tracker_matched
-        << "/" << n_dt_matched << "/" << n_csc_matched << "/" << n_rpc_matched
-        << "/" << n_gem_matched << " in Tracker/DT/CSC/RPC/GEM)";
+        << "# selected RecHits = " << n_selected_hits << " (" << n_tracker_selected_hits << "/" << n_dt_selected_hits
+        << "/" << n_csc_selected_hits << "/" << n_rpc_selected_hits << "/" << n_gem_selected_hits
+        << " in Tracker/DT/CSC/RPC/GEM)" << InvMuonHits << "\n"
+        << "# matched RecHits  = " << n_matched << " (" << n_tracker_matched << "/" << n_dt_matched << "/"
+        << n_csc_matched << "/" << n_rpc_matched << "/" << n_gem_matched << " in Tracker/DT/CSC/RPC/GEM)";
 
     if (n_all > 0 && n_matching_simhits == 0)
       edm::LogVerbatim("MuonAssociatorByHitsHelper")
@@ -281,13 +282,11 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(
              "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
           << "\n"
           << "reco::Track " << tindex << ZeroHitMuon << "\n\t"
-          << "made of " << n_selected_hits
-          << " selected RecHits (tracker:" << n_tracker_selected_hits
+          << "made of " << n_selected_hits << " selected RecHits (tracker:" << n_tracker_selected_hits
           << "/muons:" << n_muon_selected_hits << ")";
 
       int tpindex = 0;
-      for (TrackingParticleCollection::const_iterator trpart = tPC.begin();
-           trpart != tPC.end(); ++trpart, ++tpindex) {
+      for (TrackingParticleCollection::const_iterator trpart = tPC.begin(); trpart != tPC.end(); ++trpart, ++tpindex) {
         tracker_nshared = getShared(tracker_matchedIds_valid, trpart);
         muon_nshared = getShared(muon_matchedIds_valid, trpart);
 
@@ -299,16 +298,14 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(
         if (AbsoluteNumberOfHits_track)
           tracker_quality = static_cast<double>(tracker_nshared);
         else if (n_tracker_selected_hits != 0)
-          tracker_quality = (static_cast<double>(tracker_nshared) /
-                             static_cast<double>(n_tracker_selected_hits));
+          tracker_quality = (static_cast<double>(tracker_nshared) / static_cast<double>(n_tracker_selected_hits));
         else
           tracker_quality = 0;
 
         if (AbsoluteNumberOfHits_muon)
           muon_quality = static_cast<double>(muon_nshared);
         else if (n_muon_selected_hits != 0)
-          muon_quality = (static_cast<double>(muon_nshared) /
-                          static_cast<double>(n_muon_selected_hits));
+          muon_quality = (static_cast<double>(muon_nshared) / static_cast<double>(n_muon_selected_hits));
         else
           muon_quality = 0;
 
@@ -317,8 +314,7 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(
           if (AbsoluteNumberOfHits_muon && AbsoluteNumberOfHits_track)
             global_quality = global_nshared;
           else
-            global_quality = (static_cast<double>(global_nshared) /
-                              static_cast<double>(n_selected_hits));
+            global_quality = (static_cast<double>(global_nshared) / static_cast<double>(n_selected_hits));
         } else
           global_quality = 0;
 
@@ -328,8 +324,7 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(
             trackerOk = true;
           // if a track has just 3 hits in the Tracker we require that all 3
           // hits are shared
-          if (ThreeHitTracksAreSpecial && n_tracker_selected_hits == 3 &&
-              tracker_nshared < 3)
+          if (ThreeHitTracksAreSpecial && n_tracker_selected_hits == 3 && tracker_nshared < 3)
             trackerOk = false;
         }
 
@@ -345,39 +340,29 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(
 
         // only for global muons: match both tracker and muon stub unless
         // (acceptOneStubMatchings==true)
-        if (!acceptOneStubMatchings && n_tracker_selected_hits != 0 &&
-            n_muon_selected_hits != 0)
+        if (!acceptOneStubMatchings && n_tracker_selected_hits != 0 && n_muon_selected_hits != 0)
           matchOk = trackerOk && muonOk;
 
         if (matchOk) {
-
-          outputCollection[tindex].push_back(
-              IndexMatch(tpindex, global_quality));
+          outputCollection[tindex].push_back(IndexMatch(tpindex, global_quality));
           this_track_matched = true;
 
           edm::LogVerbatim("MuonAssociatorByHitsHelper")
               << "\n\t"
-              << " **MATCHED** with quality = " << global_quality
-              << " (tracker: " << tracker_quality << " / muon: " << muon_quality
-              << ")"
+              << " **MATCHED** with quality = " << global_quality << " (tracker: " << tracker_quality
+              << " / muon: " << muon_quality << ")"
               << "\n\t"
-              << "   N shared hits = " << global_nshared
-              << " (tracker: " << tracker_nshared << " / muon: " << muon_nshared
-              << ")"
+              << "   N shared hits = " << global_nshared << " (tracker: " << tracker_nshared
+              << " / muon: " << muon_nshared << ")"
               << "\n"
-              << "   to: TrackingParticle " << tpindex
-              << ", q = " << (*trpart).charge() << ", p = " << (*trpart).p()
-              << ", pT = " << (*trpart).pt() << ", eta = " << (*trpart).eta()
-              << ", phi = " << (*trpart).phi() << "\n\t"
-              << " pdg code = " << (*trpart).pdgId() << ", made of "
-              << (*trpart).numberOfHits() << " PSimHits"
+              << "   to: TrackingParticle " << tpindex << ", q = " << (*trpart).charge() << ", p = " << (*trpart).p()
+              << ", pT = " << (*trpart).pt() << ", eta = " << (*trpart).eta() << ", phi = " << (*trpart).phi() << "\n\t"
+              << " pdg code = " << (*trpart).pdgId() << ", made of " << (*trpart).numberOfHits() << " PSimHits"
               << " from " << (*trpart).g4Tracks().size() << " SimTrack:";
-          for (TrackingParticle::g4t_iterator g4T = (*trpart).g4Track_begin();
-               g4T != (*trpart).g4Track_end(); ++g4T) {
+          for (TrackingParticle::g4t_iterator g4T = (*trpart).g4Track_begin(); g4T != (*trpart).g4Track_end(); ++g4T) {
             edm::LogVerbatim("MuonAssociatorByHitsHelper")
                 << "\t"
-                << " Id:" << (*g4T).trackId() << "/Evt:("
-                << (*g4T).eventId().event() << ","
+                << " Id:" << (*g4T).trackId() << "/Evt:(" << (*g4T).eventId().event() << ","
                 << (*g4T).eventId().bunchCrossing() << ")";
           }
         } else {
@@ -386,22 +371,18 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(
           if (global_nshared != 0)
             edm::LogVerbatim("MuonAssociatorByHitsHelper")
                 << "\n\t"
-                << " NOT matched to TrackingParticle " << tpindex
-                << " with quality = " << global_quality
-                << " (tracker: " << tracker_quality
-                << " / muon: " << muon_quality << ")"
+                << " NOT matched to TrackingParticle " << tpindex << " with quality = " << global_quality
+                << " (tracker: " << tracker_quality << " / muon: " << muon_quality << ")"
                 << "\n"
-                << "   N shared hits = " << global_nshared
-                << " (tracker: " << tracker_nshared
+                << "   N shared hits = " << global_nshared << " (tracker: " << tracker_nshared
                 << " / muon: " << muon_nshared << ")";
         }
 
-      } //  loop over TrackingParticle
+      }  //  loop over TrackingParticle
 
       if (!this_track_matched) {
-        edm::LogVerbatim("MuonAssociatorByHitsHelper")
-            << "\n"
-            << " NOT matched to any TrackingParticle";
+        edm::LogVerbatim("MuonAssociatorByHitsHelper") << "\n"
+                                                       << " NOT matched to any TrackingParticle";
       }
 
       edm::LogVerbatim("MuonAssociatorByHitsHelper")
@@ -409,24 +390,20 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(
              "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
           << "\n";
 
-    } //  if(n_matching_simhits != 0)
+    }  //  if(n_matching_simhits != 0)
 
-  } // loop over reco::Track
+  }  // loop over reco::Track
 
   if (tC.empty())
-    edm::LogVerbatim("MuonAssociatorByHitsHelper")
-        << "0 reconstructed tracks (-->> 0 associated !)";
+    edm::LogVerbatim("MuonAssociatorByHitsHelper") << "0 reconstructed tracks (-->> 0 associated !)";
 
-  for (IndexAssociation::iterator it = outputCollection.begin(),
-                                  ed = outputCollection.end();
-       it != ed; ++it) {
+  for (IndexAssociation::iterator it = outputCollection.begin(), ed = outputCollection.end(); it != ed; ++it) {
     std::sort(it->second.begin(), it->second.end());
   }
   return outputCollection;
 }
 
-MuonAssociatorByHitsHelper::IndexAssociation
-MuonAssociatorByHitsHelper::associateSimToRecoIndices(
+MuonAssociatorByHitsHelper::IndexAssociation MuonAssociatorByHitsHelper::associateSimToRecoIndices(
     const TrackHitsCollection &tC,
     const edm::RefVector<TrackingParticleCollection> &TPCollectionH,
     const Resources &resources) const {
@@ -477,13 +454,11 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices(
   bool any_trackingParticle_matched = false;
 
   int tindex = 0;
-  for (TrackHitsCollection::const_iterator track = tC.begin();
-       track != tC.end(); track++, tindex++) {
+  for (TrackHitsCollection::const_iterator track = tC.begin(); track != tC.end(); track++, tindex++) {
     if (printRtS)
       edm::LogVerbatim("MuonAssociatorByHitsHelper")
           << "\n"
-          << "reco::Track " << tindex
-          << ", number of RecHits = " << (track->second - track->first) << "\n";
+          << "reco::Track " << tindex << ", number of RecHits = " << (track->second - track->first) << "\n";
 
     tracker_matchedIds_valid.clear();
     muon_matchedIds_valid.clear();
@@ -532,26 +507,46 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices(
     int n_gem_matched_INVALID = 0;
 
     printRtS = false;
-    getMatchedIds(tracker_matchedIds_valid, muon_matchedIds_valid,
-                  tracker_matchedIds_INVALID, muon_matchedIds_INVALID,
-                  n_tracker_valid, n_dt_valid, n_csc_valid, n_rpc_valid,
-                  n_gem_valid, n_tracker_matched_valid, n_dt_matched_valid,
-                  n_csc_matched_valid, n_rpc_matched_valid, n_gem_matched_valid,
-                  n_tracker_INVALID, n_dt_INVALID, n_csc_INVALID, n_rpc_INVALID,
-                  n_gem_INVALID, n_tracker_matched_INVALID,
-                  n_dt_matched_INVALID, n_csc_matched_INVALID,
-                  n_rpc_matched_INVALID, n_gem_matched_INVALID, track->first,
-                  track->second, trackertruth, dttruth, csctruth, rpctruth,
-                  gemtruth, printRtS, tTopo);
+    getMatchedIds(tracker_matchedIds_valid,
+                  muon_matchedIds_valid,
+                  tracker_matchedIds_INVALID,
+                  muon_matchedIds_INVALID,
+                  n_tracker_valid,
+                  n_dt_valid,
+                  n_csc_valid,
+                  n_rpc_valid,
+                  n_gem_valid,
+                  n_tracker_matched_valid,
+                  n_dt_matched_valid,
+                  n_csc_matched_valid,
+                  n_rpc_matched_valid,
+                  n_gem_matched_valid,
+                  n_tracker_INVALID,
+                  n_dt_INVALID,
+                  n_csc_INVALID,
+                  n_rpc_INVALID,
+                  n_gem_INVALID,
+                  n_tracker_matched_INVALID,
+                  n_dt_matched_INVALID,
+                  n_csc_matched_INVALID,
+                  n_rpc_matched_INVALID,
+                  n_gem_matched_INVALID,
+                  track->first,
+                  track->second,
+                  trackertruth,
+                  dttruth,
+                  csctruth,
+                  rpctruth,
+                  gemtruth,
+                  printRtS,
+                  tTopo);
 
-    n_matching_simhits =
-        tracker_matchedIds_valid.size() + muon_matchedIds_valid.size() +
-        tracker_matchedIds_INVALID.size() + muon_matchedIds_INVALID.size();
+    n_matching_simhits = tracker_matchedIds_valid.size() + muon_matchedIds_valid.size() +
+                         tracker_matchedIds_INVALID.size() + muon_matchedIds_INVALID.size();
 
     n_muon_valid = n_dt_valid + n_csc_valid + n_rpc_valid + n_gem_valid;
     n_valid = n_tracker_valid + n_muon_valid;
-    n_muon_INVALID =
-        n_dt_INVALID + n_csc_INVALID + n_rpc_INVALID + n_gem_INVALID;
+    n_muon_INVALID = n_dt_INVALID + n_csc_INVALID + n_rpc_INVALID + n_gem_INVALID;
     n_INVALID = n_tracker_INVALID + n_muon_INVALID;
 
     // all used hits (valid+INVALID), defined by UseTracker, UseMuon
@@ -562,10 +557,9 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices(
     n_gem_all = n_gem_valid + n_gem_INVALID;
     n_all = n_valid + n_INVALID;
 
-    n_muon_matched_valid = n_dt_matched_valid + n_csc_matched_valid +
-                           n_rpc_matched_valid + n_gem_matched_valid;
-    n_muon_matched_INVALID = n_dt_matched_INVALID + n_csc_matched_INVALID +
-                             n_rpc_matched_INVALID + n_gem_matched_INVALID;
+    n_muon_matched_valid = n_dt_matched_valid + n_csc_matched_valid + n_rpc_matched_valid + n_gem_matched_valid;
+    n_muon_matched_INVALID =
+        n_dt_matched_INVALID + n_csc_matched_INVALID + n_rpc_matched_INVALID + n_gem_matched_INVALID;
 
     // selected hits are set initially to valid hits
     int n_tracker_selected_hits = n_tracker_valid;
@@ -612,19 +606,15 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices(
       edm::LogVerbatim("MuonAssociatorByHitsHelper")
           << "\n"
           << "# TrackingRecHits: " << (track->second - track->first) << "\n"
-          << "# used RecHits     = " << n_all << " (" << n_tracker_all << "/"
-          << n_dt_all << "/" << n_csc_all << "/" << n_rpc_all << "/"
-          << n_gem_all << " in Tracker/DT/CSC/RPC/GEM)"
+          << "# used RecHits     = " << n_all << " (" << n_tracker_all << "/" << n_dt_all << "/" << n_csc_all << "/"
+          << n_rpc_all << "/" << n_gem_all << " in Tracker/DT/CSC/RPC/GEM)"
           << ", obtained from " << n_matching_simhits << " SimHits"
           << "\n"
-          << "# selected RecHits = " << n_selected_hits << " ("
-          << n_tracker_selected_hits << "/" << n_dt_selected_hits << "/"
-          << n_csc_selected_hits << "/" << n_rpc_selected_hits << "/"
-          << n_gem_selected_hits << " in Tracker/DT/CSC/RPC/GEM)" << InvMuonHits
-          << "\n"
-          << "# matched RecHits = " << n_matched << " (" << n_tracker_matched
-          << "/" << n_dt_matched << "/" << n_csc_matched << "/" << n_rpc_matched
-          << "/" << n_gem_matched << " in Tracker/DT/CSC/RPC/GEM)";
+          << "# selected RecHits = " << n_selected_hits << " (" << n_tracker_selected_hits << "/" << n_dt_selected_hits
+          << "/" << n_csc_selected_hits << "/" << n_rpc_selected_hits << "/" << n_gem_selected_hits
+          << " in Tracker/DT/CSC/RPC/GEM)" << InvMuonHits << "\n"
+          << "# matched RecHits = " << n_matched << " (" << n_tracker_matched << "/" << n_dt_matched << "/"
+          << n_csc_matched << "/" << n_rpc_matched << "/" << n_gem_matched << " in Tracker/DT/CSC/RPC/GEM)";
 
     if (printRtS && n_all > 0 && n_matching_simhits == 0)
       edm::LogVerbatim("MuonAssociatorByHitsHelper")
@@ -633,9 +623,7 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices(
 
     if (n_matching_simhits != 0) {
       int tpindex = 0;
-      for (TrackingParticleCollection::const_iterator trpart = tPC.begin();
-           trpart != tPC.end(); ++trpart, ++tpindex) {
-
+      for (TrackingParticleCollection::const_iterator trpart = tPC.begin(); trpart != tPC.end(); ++trpart, ++tpindex) {
         //	int n_tracker_simhits = 0;
         int n_tracker_recounted_simhits = 0;
         int n_muon_simhits = 0;
@@ -655,8 +643,8 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices(
 
         global_nshared = tracker_nshared + muon_nshared;
         if (global_nshared == 0)
-          continue; // if this TP shares no hits with the current reco::Track
-                    // loop over
+          continue;  // if this TP shares no hits with the current reco::Track
+                     // loop over
 
         // This does not work with the new TP interface
         /*
@@ -758,16 +746,14 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices(
         if (AbsoluteNumberOfHits_track)
           tracker_quality = static_cast<double>(tracker_nshared);
         else if (n_tracker_selected_simhits != 0)
-          tracker_quality = static_cast<double>(tracker_nshared) /
-                            static_cast<double>(n_tracker_selected_simhits);
+          tracker_quality = static_cast<double>(tracker_nshared) / static_cast<double>(n_tracker_selected_simhits);
         else
           tracker_quality = 0;
 
         if (AbsoluteNumberOfHits_muon)
           muon_quality = static_cast<double>(muon_nshared);
         else if (n_muon_selected_simhits != 0)
-          muon_quality = static_cast<double>(muon_nshared) /
-                         static_cast<double>(n_muon_selected_simhits);
+          muon_quality = static_cast<double>(muon_nshared) / static_cast<double>(n_muon_selected_simhits);
         else
           muon_quality = 0;
 
@@ -776,8 +762,7 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices(
           if (AbsoluteNumberOfHits_muon && AbsoluteNumberOfHits_track)
             global_quality = global_nshared;
           else
-            global_quality = static_cast<double>(global_nshared) /
-                             static_cast<double>(n_global_selected_simhits);
+            global_quality = static_cast<double>(global_nshared) / static_cast<double>(n_global_selected_simhits);
         } else
           global_quality = 0;
 
@@ -786,8 +771,7 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices(
           if (AbsoluteNumberOfHits_muon && AbsoluteNumberOfHits_track)
             global_purity = global_nshared;
           else
-            global_purity = static_cast<double>(global_nshared) /
-                            static_cast<double>(n_selected_hits);
+            global_purity = static_cast<double>(global_nshared) / static_cast<double>(n_selected_hits);
         } else
           global_purity = 0;
 
@@ -796,19 +780,16 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices(
           if (tracker_quality > tracker_quality_cut)
             trackerOk = true;
 
-          tracker_purity = static_cast<double>(tracker_nshared) /
-                           static_cast<double>(n_tracker_selected_hits);
+          tracker_purity = static_cast<double>(tracker_nshared) / static_cast<double>(n_tracker_selected_hits);
           if (AbsoluteNumberOfHits_track)
             tracker_purity = static_cast<double>(tracker_nshared);
 
-          if ((!AbsoluteNumberOfHits_track) &&
-              tracker_purity <= PurityCut_track)
+          if ((!AbsoluteNumberOfHits_track) && tracker_purity <= PurityCut_track)
             trackerOk = false;
 
           // if a track has just 3 hits in the Tracker we require that all 3
           // hits are shared
-          if (ThreeHitTracksAreSpecial && n_tracker_selected_hits == 3 &&
-              tracker_nshared < 3)
+          if (ThreeHitTracksAreSpecial && n_tracker_selected_hits == 3 && tracker_nshared < 3)
             trackerOk = false;
         }
 
@@ -817,8 +798,7 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices(
           if (muon_quality > muon_quality_cut)
             muonOk = true;
 
-          muon_purity = static_cast<double>(muon_nshared) /
-                        static_cast<double>(n_muon_selected_hits);
+          muon_purity = static_cast<double>(muon_nshared) / static_cast<double>(n_muon_selected_hits);
           if (AbsoluteNumberOfHits_muon)
             muon_purity = static_cast<double>(muon_nshared);
 
@@ -832,54 +812,40 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices(
 
         // only for global muons: match both tracker and muon stub unless
         // (acceptOneStubMatchings==true)
-        if (!acceptOneStubMatchings && n_tracker_selected_hits != 0 &&
-            n_muon_selected_hits != 0)
+        if (!acceptOneStubMatchings && n_tracker_selected_hits != 0 && n_muon_selected_hits != 0)
           matchOk = trackerOk && muonOk;
 
         if (matchOk) {
-
-          outputCollection[tpindex].push_back(
-              IndexMatch(tindex, global_quality));
+          outputCollection[tpindex].push_back(IndexMatch(tindex, global_quality));
           any_trackingParticle_matched = true;
 
           edm::LogVerbatim("MuonAssociatorByHitsHelper")
               << "*************************************************************"
                  "***********************************************************"
               << "\n"
-              << "TrackingParticle " << tpindex
-              << ", q = " << (*trpart).charge() << ", p = " << (*trpart).p()
-              << ", pT = " << (*trpart).pt() << ", eta = " << (*trpart).eta()
-              << ", phi = " << (*trpart).phi() << "\n"
-              << " pdg code = " << (*trpart).pdgId() << ", made of "
-              << (*trpart).numberOfHits() << " PSimHits, recounted "
-              << n_global_simhits << " PSimHits"
-              << " (tracker:" << n_tracker_recounted_simhits
-              << "/muons:" << n_muon_simhits << ")"
+              << "TrackingParticle " << tpindex << ", q = " << (*trpart).charge() << ", p = " << (*trpart).p()
+              << ", pT = " << (*trpart).pt() << ", eta = " << (*trpart).eta() << ", phi = " << (*trpart).phi() << "\n"
+              << " pdg code = " << (*trpart).pdgId() << ", made of " << (*trpart).numberOfHits()
+              << " PSimHits, recounted " << n_global_simhits << " PSimHits"
+              << " (tracker:" << n_tracker_recounted_simhits << "/muons:" << n_muon_simhits << ")"
               << ", from " << (*trpart).g4Tracks().size() << " SimTrack:";
-          for (TrackingParticle::g4t_iterator g4T = (*trpart).g4Track_begin();
-               g4T != (*trpart).g4Track_end(); ++g4T) {
+          for (TrackingParticle::g4t_iterator g4T = (*trpart).g4Track_begin(); g4T != (*trpart).g4Track_end(); ++g4T) {
             edm::LogVerbatim("MuonAssociatorByHitsHelper")
-                << " Id:" << (*g4T).trackId() << "/Evt:("
-                << (*g4T).eventId().event() << ","
+                << " Id:" << (*g4T).trackId() << "/Evt:(" << (*g4T).eventId().event() << ","
                 << (*g4T).eventId().bunchCrossing() << ")";
           }
           edm::LogVerbatim("MuonAssociatorByHitsHelper")
               << "\t selected " << n_global_selected_simhits << " PSimHits"
-              << " (tracker:" << n_tracker_selected_simhits
-              << "/muons:" << n_muon_selected_simhits << ")"
-              << "\n\t **MATCHED** with quality = " << global_quality
-              << " (tracker: " << tracker_quality << " / muon: " << muon_quality
-              << ")"
-              << "\n\t               and purity = " << global_purity
-              << " (tracker: " << tracker_purity << " / muon: " << muon_purity
-              << ")"
-              << "\n\t   N shared hits = " << global_nshared
-              << " (tracker: " << tracker_nshared << " / muon: " << muon_nshared
-              << ")"
+              << " (tracker:" << n_tracker_selected_simhits << "/muons:" << n_muon_selected_simhits << ")"
+              << "\n\t **MATCHED** with quality = " << global_quality << " (tracker: " << tracker_quality
+              << " / muon: " << muon_quality << ")"
+              << "\n\t               and purity = " << global_purity << " (tracker: " << tracker_purity
+              << " / muon: " << muon_purity << ")"
+              << "\n\t   N shared hits = " << global_nshared << " (tracker: " << tracker_nshared
+              << " / muon: " << muon_nshared << ")"
               << "\n"
               << "   to: reco::Track " << tindex << ZeroHitMuon << "\n\t"
-              << " made of " << n_selected_hits
-              << " RecHits (tracker:" << n_tracker_valid
+              << " made of " << n_selected_hits << " RecHits (tracker:" << n_tracker_valid
               << "/muons:" << n_muon_selected_hits << ")";
         } else {
           // print something only if this TrackingParticle shares some hits with
@@ -891,45 +857,36 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices(
                      "*********************************************************"
                      "******"
                   << "\n"
-                  << "TrackingParticle " << tpindex
-                  << ", q = " << (*trpart).charge() << ", p = " << (*trpart).p()
-                  << ", pT = " << (*trpart).pt()
-                  << ", eta = " << (*trpart).eta()
-                  << ", phi = " << (*trpart).phi() << "\n"
-                  << " pdg code = " << (*trpart).pdgId() << ", made of "
-                  << (*trpart).numberOfHits() << " PSimHits, recounted "
-                  << n_global_simhits << " PSimHits"
-                  << " (tracker:" << n_tracker_recounted_simhits
-                  << "/muons:" << n_muon_simhits << ")"
+                  << "TrackingParticle " << tpindex << ", q = " << (*trpart).charge() << ", p = " << (*trpart).p()
+                  << ", pT = " << (*trpart).pt() << ", eta = " << (*trpart).eta() << ", phi = " << (*trpart).phi()
+                  << "\n"
+                  << " pdg code = " << (*trpart).pdgId() << ", made of " << (*trpart).numberOfHits()
+                  << " PSimHits, recounted " << n_global_simhits << " PSimHits"
+                  << " (tracker:" << n_tracker_recounted_simhits << "/muons:" << n_muon_simhits << ")"
                   << ", from " << (*trpart).g4Tracks().size() << " SimTrack:";
-            for (TrackingParticle::g4t_iterator g4T = (*trpart).g4Track_begin();
-                 g4T != (*trpart).g4Track_end(); ++g4T) {
+            for (TrackingParticle::g4t_iterator g4T = (*trpart).g4Track_begin(); g4T != (*trpart).g4Track_end();
+                 ++g4T) {
               if (printRtS)
                 edm::LogVerbatim("MuonAssociatorByHitsHelper")
-                    << " Id:" << (*g4T).trackId() << "/Evt:("
-                    << (*g4T).eventId().event() << ","
+                    << " Id:" << (*g4T).trackId() << "/Evt:(" << (*g4T).eventId().event() << ","
                     << (*g4T).eventId().bunchCrossing() << ")";
             }
             if (printRtS)
               edm::LogVerbatim("MuonAssociatorByHitsHelper")
                   << "\t selected " << n_global_selected_simhits << " PSimHits"
-                  << " (tracker:" << n_tracker_selected_simhits
-                  << "/muons:" << n_muon_selected_simhits << ")"
-                  << "\n\t NOT matched  to reco::Track " << tindex
-                  << ZeroHitMuon << " with quality = " << global_quality
-                  << " (tracker: " << tracker_quality
+                  << " (tracker:" << n_tracker_selected_simhits << "/muons:" << n_muon_selected_simhits << ")"
+                  << "\n\t NOT matched  to reco::Track " << tindex << ZeroHitMuon
+                  << " with quality = " << global_quality << " (tracker: " << tracker_quality
                   << " / muon: " << muon_quality << ")"
-                  << "\n\t and purity = " << global_purity
-                  << " (tracker: " << tracker_purity
+                  << "\n\t and purity = " << global_purity << " (tracker: " << tracker_purity
                   << " / muon: " << muon_purity << ")"
-                  << "\n\t     N shared hits = " << global_nshared
-                  << " (tracker: " << tracker_nshared
+                  << "\n\t     N shared hits = " << global_nshared << " (tracker: " << tracker_nshared
                   << " / muon: " << muon_nshared << ")";
           }
         }
-      } // loop over TrackingParticle's
-    }   // if(n_matching_simhits != 0)
-  }     // loop over reco Tracks
+      }  // loop over TrackingParticle's
+    }    // if(n_matching_simhits != 0)
+  }      // loop over reco Tracks
 
   if (!any_trackingParticle_matched) {
     edm::LogVerbatim("MuonAssociatorByHitsHelper")
@@ -947,31 +904,45 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices(
         << "\n";
   }
 
-  for (IndexAssociation::iterator it = outputCollection.begin(),
-                                  ed = outputCollection.end();
-       it != ed; ++it) {
+  for (IndexAssociation::iterator it = outputCollection.begin(), ed = outputCollection.end(); it != ed; ++it) {
     std::sort(it->second.begin(), it->second.end());
   }
   return outputCollection;
 }
 
-void MuonAssociatorByHitsHelper::getMatchedIds(
-    MapOfMatchedIds &tracker_matchedIds_valid,
-    MapOfMatchedIds &muon_matchedIds_valid,
-    MapOfMatchedIds &tracker_matchedIds_INVALID,
-    MapOfMatchedIds &muon_matchedIds_INVALID, int &n_tracker_valid,
-    int &n_dt_valid, int &n_csc_valid, int &n_rpc_valid, int &n_gem_valid,
-    int &n_tracker_matched_valid, int &n_dt_matched_valid,
-    int &n_csc_matched_valid, int &n_rpc_matched_valid,
-    int &n_gem_matched_valid, int &n_tracker_INVALID, int &n_dt_INVALID,
-    int &n_csc_INVALID, int &n_rpc_INVALID, int &n_gem_INVALID,
-    int &n_tracker_matched_INVALID, int &n_dt_matched_INVALID,
-    int &n_csc_matched_INVALID, int &n_rpc_matched_INVALID,
-    int &n_gem_matched_INVALID, trackingRecHit_iterator begin,
-    trackingRecHit_iterator end, const TrackerHitAssociator *trackertruth,
-    const DTHitAssociator &dttruth, const CSCHitAssociator &csctruth,
-    const RPCHitAssociator &rpctruth, const GEMHitAssociator &gemtruth,
-    bool printRtS, const TrackerTopology *tTopo) const
+void MuonAssociatorByHitsHelper::getMatchedIds(MapOfMatchedIds &tracker_matchedIds_valid,
+                                               MapOfMatchedIds &muon_matchedIds_valid,
+                                               MapOfMatchedIds &tracker_matchedIds_INVALID,
+                                               MapOfMatchedIds &muon_matchedIds_INVALID,
+                                               int &n_tracker_valid,
+                                               int &n_dt_valid,
+                                               int &n_csc_valid,
+                                               int &n_rpc_valid,
+                                               int &n_gem_valid,
+                                               int &n_tracker_matched_valid,
+                                               int &n_dt_matched_valid,
+                                               int &n_csc_matched_valid,
+                                               int &n_rpc_matched_valid,
+                                               int &n_gem_matched_valid,
+                                               int &n_tracker_INVALID,
+                                               int &n_dt_INVALID,
+                                               int &n_csc_INVALID,
+                                               int &n_rpc_INVALID,
+                                               int &n_gem_INVALID,
+                                               int &n_tracker_matched_INVALID,
+                                               int &n_dt_matched_INVALID,
+                                               int &n_csc_matched_INVALID,
+                                               int &n_rpc_matched_INVALID,
+                                               int &n_gem_matched_INVALID,
+                                               trackingRecHit_iterator begin,
+                                               trackingRecHit_iterator end,
+                                               const TrackerHitAssociator *trackertruth,
+                                               const DTHitAssociator &dttruth,
+                                               const CSCHitAssociator &csctruth,
+                                               const RPCHitAssociator &rpctruth,
+                                               const GEMHitAssociator &gemtruth,
+                                               bool printRtS,
+                                               const TrackerTopology *tTopo) const
 
 {
   tracker_matchedIds_valid.clear();
@@ -1037,8 +1008,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
       if (valid_Hit)
         hitlog = hitlog + " -Tracker - detID = " + detector_id.str();
       else
-        hitlog = hitlog + " *** INVALID ***" +
-                 " -Tracker - detID = " + detector_id.str();
+        hitlog = hitlog + " *** INVALID ***" + " -Tracker - detID = " + detector_id.str();
 
       iH++;
       SimTrackIds = trackertruth->associateHitId(*hitp);
@@ -1049,8 +1019,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
         if (!SimTrackIds.empty()) {
           n_tracker_matched_valid++;
           // tracker_matchedIds_valid[iH] = SimTrackIds;
-          tracker_matchedIds_valid.push_back(
-              new uint_SimHitIdpr_pair(iH, SimTrackIds));
+          tracker_matchedIds_valid.push_back(new uint_SimHitIdpr_pair(iH, SimTrackIds));
         }
       } else {
         n_tracker_INVALID++;
@@ -1058,14 +1027,12 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
         if (!SimTrackIds.empty()) {
           n_tracker_matched_INVALID++;
           // tracker_matchedIds_INVALID[iH] = SimTrackIds;
-          tracker_matchedIds_INVALID.push_back(
-              new uint_SimHitIdpr_pair(iH, SimTrackIds));
+          tracker_matchedIds_INVALID.push_back(new uint_SimHitIdpr_pair(iH, SimTrackIds));
         }
       }
     }
     // Muon detector Hits
     else if (det == DetId::Muon && UseMuon) {
-
       // DT Hits
       if (subdet == MuonSubdetId::DT) {
         DTWireId dtdetid = DTWireId(detid);
@@ -1074,8 +1041,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
         if (valid_Hit)
           hitlog = hitlog + " -Muon DT - detID = " + dt_detector_id.str();
         else
-          hitlog = hitlog + " *** INVALID ***" +
-                   " -Muon DT - detID = " + dt_detector_id.str();
+          hitlog = hitlog + " *** INVALID ***" + " -Muon DT - detID = " + dt_detector_id.str();
 
         const DTRecHit1D *dtrechit = dynamic_cast<const DTRecHit1D *>(hitp);
 
@@ -1090,8 +1056,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
             if (!SimTrackIds.empty()) {
               n_dt_matched_valid++;
               // muon_matchedIds_valid[iH] = SimTrackIds;
-              muon_matchedIds_valid.push_back(
-                  new uint_SimHitIdpr_pair(iH, SimTrackIds));
+              muon_matchedIds_valid.push_back(new uint_SimHitIdpr_pair(iH, SimTrackIds));
             }
           } else {
             n_dt_INVALID++;
@@ -1099,8 +1064,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
             if (!SimTrackIds.empty()) {
               n_dt_matched_INVALID++;
               // muon_matchedIds_INVALID[iH] = SimTrackIds;
-              muon_matchedIds_INVALID.push_back(
-                  new uint_SimHitIdpr_pair(iH, SimTrackIds));
+              muon_matchedIds_INVALID.push_back(new uint_SimHitIdpr_pair(iH, SimTrackIds));
             }
           }
 
@@ -1112,55 +1076,47 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
 
             stringstream ndthits;
             ndthits << dtSimHits.size();
-            wireidlog = "\t DTWireId :" + wid.str() + ", " + ndthits.str() +
-                        " associated PSimHit :";
+            wireidlog = "\t DTWireId :" + wid.str() + ", " + ndthits.str() + " associated PSimHit :";
 
             for (unsigned int j = 0; j < dtSimHits.size(); j++) {
               stringstream index;
               index << j;
               stringstream simhit;
               simhit << dtSimHits[j];
-              string simhitlog =
-                  "\t\t PSimHit " + index.str() + ": " + simhit.str();
+              string simhitlog = "\t\t PSimHit " + index.str() + ": " + simhit.str();
               DTSimHits.push_back(simhitlog);
             }
-          } // if (dumpDT)
+          }  // if (dumpDT)
         }
 
         // DT segments
         else {
-          const DTRecSegment4D *dtsegment =
-              dynamic_cast<const DTRecSegment4D *>(hitp);
+          const DTRecSegment4D *dtsegment = dynamic_cast<const DTRecSegment4D *>(hitp);
 
           if (dtsegment) {
-
             std::vector<const TrackingRecHit *> componentHits, phiHits, zHits;
             if (dtsegment->hasPhi()) {
               phiHits = dtsegment->phiSegment()->recHits();
-              componentHits.insert(componentHits.end(), phiHits.begin(),
-                                   phiHits.end());
+              componentHits.insert(componentHits.end(), phiHits.begin(), phiHits.end());
             }
             if (dtsegment->hasZed()) {
               zHits = dtsegment->zSegment()->recHits();
-              componentHits.insert(componentHits.end(), zHits.begin(),
-                                   zHits.end());
+              componentHits.insert(componentHits.end(), zHits.begin(), zHits.end());
             }
             if (printRtS)
               edm::LogVerbatim("MuonAssociatorByHitsHelper")
-                  << "\n\t this TrackingRecHit is a DTRecSegment4D with "
-                  << componentHits.size() << " hits (phi:" << phiHits.size()
-                  << ", z:" << zHits.size() << ")";
+                  << "\n\t this TrackingRecHit is a DTRecSegment4D with " << componentHits.size()
+                  << " hits (phi:" << phiHits.size() << ", z:" << zHits.size() << ")";
 
             SimTrackIds.clear();
             std::vector<SimHitIdpr> i_SimTrackIds;
             int i_compHit = 0;
-            for (std::vector<const TrackingRecHit *>::const_iterator ithit =
-                     componentHits.begin();
-                 ithit != componentHits.end(); ++ithit) {
+            for (std::vector<const TrackingRecHit *>::const_iterator ithit = componentHits.begin();
+                 ithit != componentHits.end();
+                 ++ithit) {
               i_compHit++;
 
-              const DTRecHit1D *dtrechit1D =
-                  dynamic_cast<const DTRecHit1D *>(*ithit);
+              const DTRecHit1D *dtrechit1D = dynamic_cast<const DTRecHit1D *>(*ithit);
 
               i_SimTrackIds.clear();
               if (dtrechit1D) {
@@ -1175,8 +1131,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
                   if (!i_SimTrackIds.empty()) {
                     n_dt_matched_valid++;
                     // muon_matchedIds_valid[iH] = i_SimTrackIds;
-                    muon_matchedIds_valid.push_back(
-                        new uint_SimHitIdpr_pair(iH, i_SimTrackIds));
+                    muon_matchedIds_valid.push_back(new uint_SimHitIdpr_pair(iH, i_SimTrackIds));
                   }
                 } else {
                   n_dt_INVALID++;
@@ -1184,15 +1139,13 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
                   if (!i_SimTrackIds.empty()) {
                     n_dt_matched_INVALID++;
                     // muon_matchedIds_INVALID[iH] = i_SimTrackIds;
-                    muon_matchedIds_INVALID.push_back(
-                        new uint_SimHitIdpr_pair(iH, i_SimTrackIds));
+                    muon_matchedIds_INVALID.push_back(new uint_SimHitIdpr_pair(iH, i_SimTrackIds));
                   }
                 }
               } else if (printRtS)
-                edm::LogVerbatim("MuonAssociatorByHitsHelper")
-                    << "*** WARNING in "
-                       "MuonAssociatorByHitsHelper::getMatchedIds, null "
-                       "dynamic_cast of a DT TrackingRecHit !";
+                edm::LogVerbatim("MuonAssociatorByHitsHelper") << "*** WARNING in "
+                                                                  "MuonAssociatorByHitsHelper::getMatchedIds, null "
+                                                                  "dynamic_cast of a DT TrackingRecHit !";
 
               unsigned int i_detid = (*ithit)->geographicalId().rawId();
               DTWireId i_dtdetid = DTWireId(i_detid);
@@ -1201,18 +1154,16 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
               i_dt_detector_id << i_dtdetid;
 
               stringstream i_ss;
-              i_ss << "\t\t hit " << i_compHit
-                   << " -Muon DT - detID = " << i_dt_detector_id.str();
+              i_ss << "\t\t hit " << i_compHit << " -Muon DT - detID = " << i_dt_detector_id.str();
 
               string i_hitlog = i_ss.str();
               i_hitlog = i_hitlog + write_matched_simtracks(i_SimTrackIds);
               if (printRtS)
                 edm::LogVerbatim("MuonAssociatorByHitsHelper") << i_hitlog;
 
-              SimTrackIds.insert(SimTrackIds.end(), i_SimTrackIds.begin(),
-                                 i_SimTrackIds.end());
+              SimTrackIds.insert(SimTrackIds.end(), i_SimTrackIds.begin(), i_SimTrackIds.end());
             }
-          } // if (dtsegment)
+          }  // if (dtsegment)
 
           else if (printRtS)
             edm::LogVerbatim("MuonAssociatorByHitsHelper")
@@ -1230,8 +1181,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
         if (valid_Hit)
           hitlog = hitlog + " -Muon CSC- detID = " + csc_detector_id.str();
         else
-          hitlog = hitlog + " *** INVALID ***" +
-                   " -Muon CSC- detID = " + csc_detector_id.str();
+          hitlog = hitlog + " *** INVALID ***" + " -Muon CSC- detID = " + csc_detector_id.str();
 
         const CSCRecHit2D *cscrechit = dynamic_cast<const CSCRecHit2D *>(hitp);
 
@@ -1246,8 +1196,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
             if (!SimTrackIds.empty()) {
               n_csc_matched_valid++;
               // muon_matchedIds_valid[iH] = SimTrackIds;
-              muon_matchedIds_valid.push_back(
-                  new uint_SimHitIdpr_pair(iH, SimTrackIds));
+              muon_matchedIds_valid.push_back(new uint_SimHitIdpr_pair(iH, SimTrackIds));
             }
           } else {
             n_csc_INVALID++;
@@ -1255,8 +1204,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
             if (!SimTrackIds.empty()) {
               n_csc_matched_INVALID++;
               // muon_matchedIds_INVALID[iH] = SimTrackIds;
-              muon_matchedIds_INVALID.push_back(
-                  new uint_SimHitIdpr_pair(iH, SimTrackIds));
+              muon_matchedIds_INVALID.push_back(new uint_SimHitIdpr_pair(iH, SimTrackIds));
             }
           }
         }
@@ -1266,24 +1214,20 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
           const CSCSegment *cscsegment = dynamic_cast<const CSCSegment *>(hitp);
 
           if (cscsegment) {
-
-            std::vector<const TrackingRecHit *> componentHits =
-                cscsegment->recHits();
+            std::vector<const TrackingRecHit *> componentHits = cscsegment->recHits();
             if (printRtS)
               edm::LogVerbatim("MuonAssociatorByHitsHelper")
-                  << "\n\t this TrackingRecHit is a CSCSegment with "
-                  << componentHits.size() << " hits";
+                  << "\n\t this TrackingRecHit is a CSCSegment with " << componentHits.size() << " hits";
 
             SimTrackIds.clear();
             std::vector<SimHitIdpr> i_SimTrackIds;
             int i_compHit = 0;
-            for (std::vector<const TrackingRecHit *>::const_iterator ithit =
-                     componentHits.begin();
-                 ithit != componentHits.end(); ++ithit) {
+            for (std::vector<const TrackingRecHit *>::const_iterator ithit = componentHits.begin();
+                 ithit != componentHits.end();
+                 ++ithit) {
               i_compHit++;
 
-              const CSCRecHit2D *cscrechit2D =
-                  dynamic_cast<const CSCRecHit2D *>(*ithit);
+              const CSCRecHit2D *cscrechit2D = dynamic_cast<const CSCRecHit2D *>(*ithit);
 
               i_SimTrackIds.clear();
               if (cscrechit2D) {
@@ -1298,8 +1242,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
                   if (!i_SimTrackIds.empty()) {
                     n_csc_matched_valid++;
                     // muon_matchedIds_valid[iH] =  i_SimTrackIds;
-                    muon_matchedIds_valid.push_back(
-                        new uint_SimHitIdpr_pair(iH, i_SimTrackIds));
+                    muon_matchedIds_valid.push_back(new uint_SimHitIdpr_pair(iH, i_SimTrackIds));
                   }
                 } else {
                   n_csc_INVALID++;
@@ -1307,15 +1250,13 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
                   if (!i_SimTrackIds.empty()) {
                     n_csc_matched_INVALID++;
                     // muon_matchedIds_INVALID[iH] =  i_SimTrackIds;
-                    muon_matchedIds_INVALID.push_back(
-                        new uint_SimHitIdpr_pair(iH, i_SimTrackIds));
+                    muon_matchedIds_INVALID.push_back(new uint_SimHitIdpr_pair(iH, i_SimTrackIds));
                   }
                 }
               } else if (printRtS)
-                edm::LogVerbatim("MuonAssociatorByHitsHelper")
-                    << "*** WARNING in "
-                       "MuonAssociatorByHitsHelper::getMatchedIds, null "
-                       "dynamic_cast of a CSC TrackingRecHit !";
+                edm::LogVerbatim("MuonAssociatorByHitsHelper") << "*** WARNING in "
+                                                                  "MuonAssociatorByHitsHelper::getMatchedIds, null "
+                                                                  "dynamic_cast of a CSC TrackingRecHit !";
 
               unsigned int i_detid = (*ithit)->geographicalId().rawId();
               CSCDetId i_cscdetid = CSCDetId(i_detid);
@@ -1324,18 +1265,16 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
               i_csc_detector_id << i_cscdetid;
 
               stringstream i_ss;
-              i_ss << "\t\t hit " << i_compHit
-                   << " -Muon CSC- detID = " << i_csc_detector_id.str();
+              i_ss << "\t\t hit " << i_compHit << " -Muon CSC- detID = " << i_csc_detector_id.str();
 
               string i_hitlog = i_ss.str();
               i_hitlog = i_hitlog + write_matched_simtracks(i_SimTrackIds);
               if (printRtS)
                 edm::LogVerbatim("MuonAssociatorByHitsHelper") << i_hitlog;
 
-              SimTrackIds.insert(SimTrackIds.end(), i_SimTrackIds.begin(),
-                                 i_SimTrackIds.end());
+              SimTrackIds.insert(SimTrackIds.end(), i_SimTrackIds.begin(), i_SimTrackIds.end());
             }
-          } // if (cscsegment)
+          }  // if (cscsegment)
 
           else if (printRtS)
             edm::LogVerbatim("MuonAssociatorByHitsHelper")
@@ -1353,8 +1292,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
         if (valid_Hit)
           hitlog = hitlog + " -Muon RPC- detID = " + rpc_detector_id.str();
         else
-          hitlog = hitlog + " *** INVALID ***" +
-                   " -Muon RPC- detID = " + rpc_detector_id.str();
+          hitlog = hitlog + " *** INVALID ***" + " -Muon RPC- detID = " + rpc_detector_id.str();
 
         iH++;
         SimTrackIds = rpctruth.associateRecHit(*hitp);
@@ -1365,8 +1303,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
           if (!SimTrackIds.empty()) {
             n_rpc_matched_valid++;
             // muon_matchedIds_valid[iH] = SimTrackIds;
-            muon_matchedIds_valid.push_back(
-                new uint_SimHitIdpr_pair(iH, SimTrackIds));
+            muon_matchedIds_valid.push_back(new uint_SimHitIdpr_pair(iH, SimTrackIds));
           }
         } else {
           n_rpc_INVALID++;
@@ -1374,8 +1311,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
           if (!SimTrackIds.empty()) {
             n_rpc_matched_INVALID++;
             // muon_matchedIds_INVALID[iH] = SimTrackIds;
-            muon_matchedIds_INVALID.push_back(
-                new uint_SimHitIdpr_pair(iH, SimTrackIds));
+            muon_matchedIds_INVALID.push_back(new uint_SimHitIdpr_pair(iH, SimTrackIds));
           }
         }
       }
@@ -1388,8 +1324,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
         if (valid_Hit)
           hitlog = hitlog + " -Muon GEM- detID = " + gem_detector_id.str();
         else
-          hitlog = hitlog + " *** INVALID ***" +
-                   " -Muon GEM- detID = " + gem_detector_id.str();
+          hitlog = hitlog + " *** INVALID ***" + " -Muon GEM- detID = " + gem_detector_id.str();
 
         const GEMRecHit *gemrechit = dynamic_cast<const GEMRecHit *>(hitp);
         if (gemrechit) {
@@ -1402,8 +1337,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
             if (!SimTrackIds.empty()) {
               n_gem_matched_valid++;
               // muon_matchedIds_valid[iH] = SimTrackIds;
-              muon_matchedIds_valid.push_back(
-                  new uint_SimHitIdpr_pair(iH, SimTrackIds));
+              muon_matchedIds_valid.push_back(new uint_SimHitIdpr_pair(iH, SimTrackIds));
             }
           } else {
             n_gem_INVALID++;
@@ -1411,31 +1345,25 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
             if (!SimTrackIds.empty()) {
               n_gem_matched_INVALID++;
               // muon_matchedIds_INVALID[iH] = SimTrackIds;
-              muon_matchedIds_INVALID.push_back(
-                  new uint_SimHitIdpr_pair(iH, SimTrackIds));
+              muon_matchedIds_INVALID.push_back(new uint_SimHitIdpr_pair(iH, SimTrackIds));
             }
           }
         } else {
           const GEMSegment *gemsegment = dynamic_cast<const GEMSegment *>(hitp);
           if (gemsegment) {
-
-            std::vector<const TrackingRecHit *> componentHits =
-                gemsegment->recHits();
+            std::vector<const TrackingRecHit *> componentHits = gemsegment->recHits();
             if (printRtS)
               edm::LogVerbatim("MuonAssociatorByHitsHelper")
-                  << "\n\t this TrackingRecHit is a GEMSegment with "
-                  << componentHits.size() << " hits";
+                  << "\n\t this TrackingRecHit is a GEMSegment with " << componentHits.size() << " hits";
 
             SimTrackIds.clear();
             std::vector<SimHitIdpr> i_SimTrackIds;
             int i_compHit = 0;
 
             for (auto const &ithit : componentHits) {
-
               i_compHit++;
 
-              const GEMRecHit *gemrechitseg =
-                  dynamic_cast<const GEMRecHit *>(ithit);
+              const GEMRecHit *gemrechitseg = dynamic_cast<const GEMRecHit *>(ithit);
 
               i_SimTrackIds.clear();
               if (gemrechitseg) {
@@ -1450,8 +1378,7 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
                   if (!i_SimTrackIds.empty()) {
                     n_gem_matched_valid++;
                     // muon_matchedIds_valid[iH] =  i_SimTrackIds;
-                    muon_matchedIds_valid.push_back(
-                        new uint_SimHitIdpr_pair(iH, i_SimTrackIds));
+                    muon_matchedIds_valid.push_back(new uint_SimHitIdpr_pair(iH, i_SimTrackIds));
                   }
                 } else {
                   n_gem_INVALID++;
@@ -1459,15 +1386,13 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
                   if (!i_SimTrackIds.empty()) {
                     n_gem_matched_INVALID++;
                     // muon_matchedIds_INVALID[iH] =  i_SimTrackIds;
-                    muon_matchedIds_INVALID.push_back(
-                        new uint_SimHitIdpr_pair(iH, i_SimTrackIds));
+                    muon_matchedIds_INVALID.push_back(new uint_SimHitIdpr_pair(iH, i_SimTrackIds));
                   }
                 }
               } else if (printRtS)
-                edm::LogVerbatim("MuonAssociatorByHitsHelper")
-                    << "*** WARNING in "
-                       "MuonAssociatorByHitsHelper::getMatchedIds, null "
-                       "dynamic_cast of a GEM TrackingRecHit !";
+                edm::LogVerbatim("MuonAssociatorByHitsHelper") << "*** WARNING in "
+                                                                  "MuonAssociatorByHitsHelper::getMatchedIds, null "
+                                                                  "dynamic_cast of a GEM TrackingRecHit !";
 
               if (printRtS) {
                 unsigned int i_detid = ithit->geographicalId().rawId();
@@ -1478,17 +1403,15 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
                 edm::LogVerbatim("MuonAssociatorByHitsHelper") << i_hitlog;
               }
 
-              SimTrackIds.insert(SimTrackIds.end(), i_SimTrackIds.begin(),
-                                 i_SimTrackIds.end());
+              SimTrackIds.insert(SimTrackIds.end(), i_SimTrackIds.begin(), i_SimTrackIds.end());
             }
-          } // if (gemsegment)
+          }  // if (gemsegment)
 
-        } // if (gemrechit
+        }  // if (gemrechit
       } else if (printRtS)
         edm::LogVerbatim("MuonAssociatorByHitsHelper")
-            << "TrackingRecHit " << iloop
-            << "  *** WARNING *** Unexpected Hit from Detector = " << det;
-    } // end if (det == DetId::Muon && UseMuon)
+            << "TrackingRecHit " << iloop << "  *** WARNING *** Unexpected Hit from Detector = " << det;
+    }  // end if (det == DetId::Muon && UseMuon)
     else
       continue;
 
@@ -1496,43 +1419,36 @@ void MuonAssociatorByHitsHelper::getMatchedIds(
 
     if (printRtS)
       edm::LogVerbatim("MuonAssociatorByHitsHelper") << hitlog;
-    if (printRtS && dumpDT && det == DetId::Muon &&
-        subdet == MuonSubdetId::DT) {
+    if (printRtS && dumpDT && det == DetId::Muon && subdet == MuonSubdetId::DT) {
       edm::LogVerbatim("MuonAssociatorByHitsHelper") << wireidlog;
       for (unsigned int j = 0; j < DTSimHits.size(); j++) {
         edm::LogVerbatim("MuonAssociatorByHitsHelper") << DTSimHits[j];
       }
     }
 
-  } // trackingRecHit loop
+  }  // trackingRecHit loop
 }
 
-int MuonAssociatorByHitsHelper::getShared(
-    MapOfMatchedIds &matchedIds,
-    TrackingParticleCollection::const_iterator trpart) const {
-
+int MuonAssociatorByHitsHelper::getShared(MapOfMatchedIds &matchedIds,
+                                          TrackingParticleCollection::const_iterator trpart) const {
   int nshared = 0;
   const std::vector<SimTrack> &g4Tracks = trpart->g4Tracks();
 
   // map is indexed over the rechits of the reco::Track (no double-countings
   // allowed)
-  for (MapOfMatchedIds::const_iterator iRecH = matchedIds.begin();
-       iRecH != matchedIds.end(); ++iRecH) {
-
+  for (MapOfMatchedIds::const_iterator iRecH = matchedIds.begin(); iRecH != matchedIds.end(); ++iRecH) {
     // vector of associated simhits associated to the current rechit
     std::vector<SimHitIdpr> const &SimTrackIds = (*iRecH).second;
 
     bool found = false;
 
     for (const auto &iSimH : SimTrackIds) {
-
       uint32_t simtrackId = iSimH.first;
       EncodedEventId evtId = iSimH.second;
 
       // look for shared hits with the given TrackingParticle (looping over
       // component SimTracks)
       for (const auto &simtrack : g4Tracks) {
-
         if (simtrack.trackId() == simtrackId && simtrack.eventId() == evtId) {
           found = true;
           break;
@@ -1549,8 +1465,7 @@ int MuonAssociatorByHitsHelper::getShared(
   return nshared;
 }
 
-std::string MuonAssociatorByHitsHelper::write_matched_simtracks(
-    const std::vector<SimHitIdpr> &SimTrackIds) const {
+std::string MuonAssociatorByHitsHelper::write_matched_simtracks(const std::vector<SimHitIdpr> &SimTrackIds) const {
   if (SimTrackIds.empty())
     return "  *** UNMATCHED ***";
 
@@ -1558,7 +1473,10 @@ std::string MuonAssociatorByHitsHelper::write_matched_simtracks(
 
   for (size_t j = 0; j < SimTrackIds.size(); j++) {
     char buf[64];
-    snprintf(buf, 64, " Id:%i/Evt:(%i,%i) ", SimTrackIds[j].first,
+    snprintf(buf,
+             64,
+             " Id:%i/Evt:(%i,%i) ",
+             SimTrackIds[j].first,
              SimTrackIds[j].second.event(),
              SimTrackIds[j].second.bunchCrossing());
     hitlog += buf;

--- a/SimMuon/MCTruth/src/MuonToSimAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonToSimAssociatorByHits.cc
@@ -16,10 +16,8 @@
 using namespace reco;
 using namespace std;
 
-MuonToSimAssociatorByHits::MuonToSimAssociatorByHits(
-    const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
-    : helper_(conf), conf_(conf),
-      trackerHitAssociatorConfig_(conf, std::move(iC)) {
+MuonToSimAssociatorByHits::MuonToSimAssociatorByHits(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
+    : helper_(conf), conf_(conf), trackerHitAssociatorConfig_(conf, std::move(iC)) {
   TrackerMuonHitExtractor hitExtractor(conf_, std::move(iC));
 
   // hack for consumes
@@ -31,12 +29,13 @@ MuonToSimAssociatorByHits::MuonToSimAssociatorByHits(
 
 MuonToSimAssociatorByHits::~MuonToSimAssociatorByHits() {}
 
-void MuonToSimAssociatorByHits::associateMuons(
-    MuonToSimCollection &recToSim, SimToMuonCollection &simToRec,
-    const edm::Handle<edm::View<reco::Muon>> &tCH, MuonTrackType type,
-    const edm::Handle<TrackingParticleCollection> &tPCH,
-    const edm::Event *event, const edm::EventSetup *setup) const {
-
+void MuonToSimAssociatorByHits::associateMuons(MuonToSimCollection &recToSim,
+                                               SimToMuonCollection &simToRec,
+                                               const edm::Handle<edm::View<reco::Muon>> &tCH,
+                                               MuonTrackType type,
+                                               const edm::Handle<TrackingParticleCollection> &tPCH,
+                                               const edm::Event *event,
+                                               const edm::EventSetup *setup) const {
   edm::RefVector<TrackingParticleCollection> tpc(tPCH.id());
   for (unsigned int j = 0; j < tPCH->size(); j++)
     tpc.push_back(edm::Ref<TrackingParticleCollection>(tPCH, j));
@@ -45,100 +44,80 @@ void MuonToSimAssociatorByHits::associateMuons(
   for (size_t i = 0; i < tCH->size(); ++i)
     muonBaseRefVector.push_back(tCH->refAt(i));
 
-  associateMuons(recToSim, simToRec, muonBaseRefVector, type, tpc, event,
-                 setup);
+  associateMuons(recToSim, simToRec, muonBaseRefVector, type, tpc, event, setup);
 }
 
-void MuonToSimAssociatorByHits::associateMuons(
-    MuonToSimCollection &recToSim, SimToMuonCollection &simToRec,
-    const edm::RefToBaseVector<reco::Muon> &muons, MuonTrackType trackType,
-    const edm::RefVector<TrackingParticleCollection> &tPC,
-    const edm::Event *event, const edm::EventSetup *setup) const {
-
+void MuonToSimAssociatorByHits::associateMuons(MuonToSimCollection &recToSim,
+                                               SimToMuonCollection &simToRec,
+                                               const edm::RefToBaseVector<reco::Muon> &muons,
+                                               MuonTrackType trackType,
+                                               const edm::RefVector<TrackingParticleCollection> &tPC,
+                                               const edm::Event *event,
+                                               const edm::EventSetup *setup) const {
   /// PART 1: Fill MuonToSimAssociatorByHits::TrackHitsCollection
   MuonAssociatorByHitsHelper::TrackHitsCollection muonHitRefs;
-  edm::OwnVector<TrackingRecHit>
-      allTMRecHits; // this I will fill in only for tracker muon hits from
-                    // segments
+  edm::OwnVector<TrackingRecHit> allTMRecHits;  // this I will fill in only for tracker muon hits from
+                                                // segments
   switch (trackType) {
-  case InnerTk:
-    for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(),
-                                                          ed = muons.end();
-         it != ed; ++it) {
-      edm::RefToBase<reco::Muon> mur = *it;
-      if (mur->track().isNonnull()) {
-        muonHitRefs.push_back(std::make_pair(mur->track()->recHitsBegin(),
-                                             mur->track()->recHitsEnd()));
-      } else {
-        muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(),
-                                             allTMRecHits.data().end()));
-      }
-    }
-    break;
-  case OuterTk:
-    for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(),
-                                                          ed = muons.end();
-         it != ed; ++it) {
-      edm::RefToBase<reco::Muon> mur = *it;
-      if (mur->outerTrack().isNonnull()) {
-        muonHitRefs.push_back(std::make_pair(mur->outerTrack()->recHitsBegin(),
-                                             mur->outerTrack()->recHitsEnd()));
-      } else {
-        muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(),
-                                             allTMRecHits.data().end()));
-      }
-    }
-    break;
-  case GlobalTk:
-    for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(),
-                                                          ed = muons.end();
-         it != ed; ++it) {
-      edm::RefToBase<reco::Muon> mur = *it;
-      if (mur->globalTrack().isNonnull()) {
-        muonHitRefs.push_back(std::make_pair(mur->globalTrack()->recHitsBegin(),
-                                             mur->globalTrack()->recHitsEnd()));
-      } else {
-        muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(),
-                                             allTMRecHits.data().end()));
-      }
-    }
-    break;
-  case Segments: {
-    TrackerMuonHitExtractor hitExtractor(conf_);
-    hitExtractor.init(*event, *setup);
-    // puts hits in the vector, and record indices
-    std::vector<std::pair<size_t, size_t>> muonHitIndices;
-    for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(),
-                                                          ed = muons.end();
-         it != ed; ++it) {
-      edm::RefToBase<reco::Muon> mur = *it;
-      std::pair<size_t, size_t> indices(allTMRecHits.size(),
-                                        allTMRecHits.size());
-      if (mur->isTrackerMuon()) {
-        std::vector<const TrackingRecHit *> hits =
-            hitExtractor.getMuonHits(*mur);
-        for (std::vector<const TrackingRecHit *>::const_iterator
-                 ith = hits.begin(),
-                 edh = hits.end();
-             ith != edh; ++ith) {
-          allTMRecHits.push_back(**ith);
+    case InnerTk:
+      for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
+        edm::RefToBase<reco::Muon> mur = *it;
+        if (mur->track().isNonnull()) {
+          muonHitRefs.push_back(std::make_pair(mur->track()->recHitsBegin(), mur->track()->recHitsEnd()));
+        } else {
+          muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
         }
-        indices.second += hits.size();
       }
-      muonHitIndices.push_back(indices);
-    }
-    // convert indices into pairs of iterators to references
-    typedef std::pair<size_t, size_t> index_pair;
-    trackingRecHit_iterator hitRefBegin = allTMRecHits.data().begin();
-    for (std::vector<std::pair<size_t, size_t>>::const_iterator
-             idxs = muonHitIndices.begin(),
-             idxend = muonHitIndices.end();
-         idxs != idxend; ++idxs) {
-      muonHitRefs.push_back(std::make_pair(hitRefBegin + idxs->first,
-                                           hitRefBegin + idxs->second));
-    }
+      break;
+    case OuterTk:
+      for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
+        edm::RefToBase<reco::Muon> mur = *it;
+        if (mur->outerTrack().isNonnull()) {
+          muonHitRefs.push_back(std::make_pair(mur->outerTrack()->recHitsBegin(), mur->outerTrack()->recHitsEnd()));
+        } else {
+          muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
+        }
+      }
+      break;
+    case GlobalTk:
+      for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
+        edm::RefToBase<reco::Muon> mur = *it;
+        if (mur->globalTrack().isNonnull()) {
+          muonHitRefs.push_back(std::make_pair(mur->globalTrack()->recHitsBegin(), mur->globalTrack()->recHitsEnd()));
+        } else {
+          muonHitRefs.push_back(std::make_pair(allTMRecHits.data().end(), allTMRecHits.data().end()));
+        }
+      }
+      break;
+    case Segments: {
+      TrackerMuonHitExtractor hitExtractor(conf_);
+      hitExtractor.init(*event, *setup);
+      // puts hits in the vector, and record indices
+      std::vector<std::pair<size_t, size_t>> muonHitIndices;
+      for (edm::RefToBaseVector<reco::Muon>::const_iterator it = muons.begin(), ed = muons.end(); it != ed; ++it) {
+        edm::RefToBase<reco::Muon> mur = *it;
+        std::pair<size_t, size_t> indices(allTMRecHits.size(), allTMRecHits.size());
+        if (mur->isTrackerMuon()) {
+          std::vector<const TrackingRecHit *> hits = hitExtractor.getMuonHits(*mur);
+          for (std::vector<const TrackingRecHit *>::const_iterator ith = hits.begin(), edh = hits.end(); ith != edh;
+               ++ith) {
+            allTMRecHits.push_back(**ith);
+          }
+          indices.second += hits.size();
+        }
+        muonHitIndices.push_back(indices);
+      }
+      // convert indices into pairs of iterators to references
+      typedef std::pair<size_t, size_t> index_pair;
+      trackingRecHit_iterator hitRefBegin = allTMRecHits.data().begin();
+      for (std::vector<std::pair<size_t, size_t>>::const_iterator idxs = muonHitIndices.begin(),
+                                                                  idxend = muonHitIndices.end();
+           idxs != idxend;
+           ++idxs) {
+        muonHitRefs.push_back(std::make_pair(hitRefBegin + idxs->first, hitRefBegin + idxs->second));
+      }
 
-  } break;
+    } break;
   }
 
   /// PART 2: call the association routines
@@ -159,11 +138,9 @@ void MuonToSimAssociatorByHits::associateMuons(
   // GEM hit association
   GEMHitAssociator gemtruth(*event, *setup, conf_);
 
-  MuonAssociatorByHitsHelper::Resources resources = {
-      tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth};
+  MuonAssociatorByHitsHelper::Resources resources = {tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth};
 
-  auto recSimColl =
-      helper_.associateRecoToSimIndices(muonHitRefs, tPC, resources);
+  auto recSimColl = helper_.associateRecoToSimIndices(muonHitRefs, tPC, resources);
   for (auto it = recSimColl.begin(), ed = recSimColl.end(); it != ed; ++it) {
     edm::RefToBase<reco::Muon> rec = muons[it->first];
     std::vector<std::pair<TrackingParticleRef, double>> &tpAss = recToSim[rec];
@@ -171,12 +148,10 @@ void MuonToSimAssociatorByHits::associateMuons(
       tpAss.push_back(std::make_pair(tPC[a.idx], a.quality));
     }
   }
-  auto simRecColl =
-      helper_.associateSimToRecoIndices(muonHitRefs, tPC, resources);
+  auto simRecColl = helper_.associateSimToRecoIndices(muonHitRefs, tPC, resources);
   for (auto it = simRecColl.begin(), ed = simRecColl.end(); it != ed; ++it) {
     TrackingParticleRef sim = tPC[it->first];
-    std::vector<std::pair<edm::RefToBase<reco::Muon>, double>> &recAss =
-        simToRec[sim];
+    std::vector<std::pair<edm::RefToBase<reco::Muon>, double>> &recAss = simToRec[sim];
     for (auto const &a : it->second) {
       recAss.push_back(std::make_pair(muons[a.idx], a.quality));
     }

--- a/SimMuon/MCTruth/src/MuonTruth.cc
+++ b/SimMuon/MCTruth/src/MuonTruth.cc
@@ -5,9 +5,9 @@
 #include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
 #include "SimMuon/MCTruth/interface/MuonTruth.h"
 
-MuonTruth::MuonTruth(const edm::Event &event, const edm::EventSetup &setup,
-                     const edm::ParameterSet &conf)
-    : theDigiSimLinks(nullptr), theWireDigiSimLinks(nullptr),
+MuonTruth::MuonTruth(const edm::Event &event, const edm::EventSetup &setup, const edm::ParameterSet &conf)
+    : theDigiSimLinks(nullptr),
+      theWireDigiSimLinks(nullptr),
       linksTag(conf.getParameter<edm::InputTag>("CSClinksTag")),
       wireLinksTag(conf.getParameter<edm::InputTag>("CSCwireLinksTag")),
       // CrossingFrame used or not ?
@@ -20,7 +20,8 @@ MuonTruth::MuonTruth(const edm::Event &event, const edm::EventSetup &setup,
 }
 
 MuonTruth::MuonTruth(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
-    : theDigiSimLinks(nullptr), theWireDigiSimLinks(nullptr),
+    : theDigiSimLinks(nullptr),
+      theWireDigiSimLinks(nullptr),
       linksTag(conf.getParameter<edm::InputTag>("CSClinksTag")),
       wireLinksTag(conf.getParameter<edm::InputTag>("CSCwireLinksTag")),
       // CrossingFrame used or not ?
@@ -38,18 +39,14 @@ MuonTruth::MuonTruth(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
   }
 }
 
-void MuonTruth::initEvent(const edm::Event &event,
-                          const edm::EventSetup &setup) {
-
+void MuonTruth::initEvent(const edm::Event &event, const edm::EventSetup &setup) {
   edm::Handle<DigiSimLinks> digiSimLinks;
-  LogTrace("MuonTruth") << "getting CSC Strip DigiSimLink collection - "
-                        << linksTag;
+  LogTrace("MuonTruth") << "getting CSC Strip DigiSimLink collection - " << linksTag;
   event.getByLabel(linksTag, digiSimLinks);
   theDigiSimLinks = digiSimLinks.product();
 
   edm::Handle<DigiSimLinks> wireDigiSimLinks;
-  LogTrace("MuonTruth") << "getting CSC Wire DigiSimLink collection - "
-                        << wireLinksTag;
+  LogTrace("MuonTruth") << "getting CSC Wire DigiSimLink collection - " << wireLinksTag;
   event.getByLabel(wireLinksTag, wireDigiSimLinks);
   theWireDigiSimLinks = wireDigiSimLinks.product();
 
@@ -66,30 +63,24 @@ void MuonTruth::initEvent(const edm::Event &event,
   theSimHitMap.clear();
 
   if (crossingframe) {
-
     edm::Handle<CrossingFrame<PSimHit>> cf;
-    LogTrace("MuonTruth") << "getting CrossingFrame<PSimHit> collection - "
-                          << CSCsimHitsXFTag;
+    LogTrace("MuonTruth") << "getting CrossingFrame<PSimHit> collection - " << CSCsimHitsXFTag;
     event.getByLabel(CSCsimHitsXFTag, cf);
 
-    std::unique_ptr<MixCollection<PSimHit>> CSCsimhits(
-        new MixCollection<PSimHit>(cf.product()));
+    std::unique_ptr<MixCollection<PSimHit>> CSCsimhits(new MixCollection<PSimHit>(cf.product()));
     LogTrace("MuonTruth") << "... size = " << CSCsimhits->size();
 
-    for (MixCollection<PSimHit>::MixItr hitItr = CSCsimhits->begin();
-         hitItr != CSCsimhits->end(); ++hitItr) {
+    for (MixCollection<PSimHit>::MixItr hitItr = CSCsimhits->begin(); hitItr != CSCsimhits->end(); ++hitItr) {
       theSimHitMap[hitItr->detUnitId()].push_back(*hitItr);
     }
 
   } else if (!CSCsimHitsTag.label().empty()) {
-
     edm::Handle<edm::PSimHitContainer> CSCsimhits;
     LogTrace("MuonTruth") << "getting PSimHit collection - " << CSCsimHitsTag;
     event.getByLabel(CSCsimHitsTag, CSCsimhits);
     LogTrace("MuonTruth") << "... size = " << CSCsimhits->size();
 
-    for (edm::PSimHitContainer::const_iterator hitItr = CSCsimhits->begin();
-         hitItr != CSCsimhits->end(); ++hitItr) {
+    for (edm::PSimHitContainer::const_iterator hitItr = CSCsimhits->begin(); hitItr != CSCsimhits->end(); ++hitItr) {
       theSimHitMap[hitItr->detUnitId()].push_back(*hitItr);
     }
   }
@@ -100,9 +91,9 @@ float MuonTruth::muonFraction() {
     return 0.;
 
   float muonCharge = 0.;
-  for (std::map<SimHitIdpr, float>::const_iterator chargeMapItr =
-           theChargeMap.begin();
-       chargeMapItr != theChargeMap.end(); ++chargeMapItr) {
+  for (std::map<SimHitIdpr, float>::const_iterator chargeMapItr = theChargeMap.begin();
+       chargeMapItr != theChargeMap.end();
+       ++chargeMapItr) {
     if (abs(particleType(chargeMapItr->first)) == 13) {
       muonCharge += chargeMapItr->second;
     }
@@ -113,9 +104,9 @@ float MuonTruth::muonFraction() {
 
 std::vector<PSimHit> MuonTruth::simHits() {
   std::vector<PSimHit> result;
-  for (std::map<SimHitIdpr, float>::const_iterator chargeMapItr =
-           theChargeMap.begin();
-       chargeMapItr != theChargeMap.end(); ++chargeMapItr) {
+  for (std::map<SimHitIdpr, float>::const_iterator chargeMapItr = theChargeMap.begin();
+       chargeMapItr != theChargeMap.end();
+       ++chargeMapItr) {
     std::vector<PSimHit> trackHits = hitsFromSimTrack(chargeMapItr->first);
     result.insert(result.end(), trackHits.begin(), trackHits.end());
   }
@@ -126,8 +117,7 @@ std::vector<PSimHit> MuonTruth::simHits() {
 std::vector<PSimHit> MuonTruth::muonHits() {
   std::vector<PSimHit> result;
   std::vector<PSimHit> allHits = simHits();
-  std::vector<PSimHit>::const_iterator hitItr = allHits.begin(),
-                                       lastHit = allHits.end();
+  std::vector<PSimHit>::const_iterator hitItr = allHits.begin(), lastHit = allHits.end();
 
   for (; hitItr != lastHit; ++hitItr) {
     if (abs((*hitItr).particleType()) == 13) {
@@ -137,13 +127,11 @@ std::vector<PSimHit> MuonTruth::muonHits() {
   return result;
 }
 
-std::vector<PSimHit>
-MuonTruth::hitsFromSimTrack(MuonTruth::SimHitIdpr truthId) {
+std::vector<PSimHit> MuonTruth::hitsFromSimTrack(MuonTruth::SimHitIdpr truthId) {
   std::vector<PSimHit> result;
 
   auto found = theSimHitMap.find(theDetId);
   if (found != theSimHitMap.end()) {
-
     for (auto const &hit : found->second) {
       unsigned int hitTrack = hit.trackId();
       EncodedEventId hitEvId = hit.eventId();
@@ -171,16 +159,14 @@ void MuonTruth::analyze(const CSCRecHit2D &recHit) {
   theDetId = recHit.geographicalId().rawId();
 
   int nchannels = recHit.nStrips();
-  const CSCLayerGeometry *laygeom =
-      cscgeom->layer(recHit.cscDetId())->geometry();
+  const CSCLayerGeometry *laygeom = cscgeom->layer(recHit.cscDetId())->geometry();
 
   for (int idigi = 0; idigi < nchannels; ++idigi) {
     // strip and readout channel numbers may differ in ME1/1A
     int istrip = recHit.channels(idigi);
     int channel = laygeom->channel(istrip);
-    float weight = recHit.adcs(
-        idigi, 0); // DL: I think this is wrong before and after...seems to
-                   // assume one time binadcContainer[idigi];
+    float weight = recHit.adcs(idigi, 0);  // DL: I think this is wrong before and after...seems to
+                                           // assume one time binadcContainer[idigi];
 
     DigiSimLinks::const_iterator layerLinks = theDigiSimLinks->find(theDetId);
 
@@ -190,8 +176,7 @@ void MuonTruth::analyze(const CSCRecHit2D &recHit) {
   }
 }
 
-void MuonTruth::analyze(const CSCStripDigi &stripDigi,
-                        int rawDetIdCorrespondingToCSCLayer) {
+void MuonTruth::analyze(const CSCStripDigi &stripDigi, int rawDetIdCorrespondingToCSCLayer) {
   theDetId = rawDetIdCorrespondingToCSCLayer;
   theChargeMap.clear();
   theTotalCharge = 0.;
@@ -202,14 +187,12 @@ void MuonTruth::analyze(const CSCStripDigi &stripDigi,
   }
 }
 
-void MuonTruth::analyze(const CSCWireDigi &wireDigi,
-                        int rawDetIdCorrespondingToCSCLayer) {
+void MuonTruth::analyze(const CSCWireDigi &wireDigi, int rawDetIdCorrespondingToCSCLayer) {
   theDetId = rawDetIdCorrespondingToCSCLayer;
   theChargeMap.clear();
   theTotalCharge = 0.;
 
-  WireDigiSimLinks::const_iterator layerLinks =
-      theWireDigiSimLinks->find(theDetId);
+  WireDigiSimLinks::const_iterator layerLinks = theWireDigiSimLinks->find(theDetId);
 
   if (layerLinks != theDigiSimLinks->end()) {
     // In the simulation digis, the channel labels for wires and strips must be
@@ -220,10 +203,8 @@ void MuonTruth::analyze(const CSCWireDigi &wireDigi,
   }
 }
 
-void MuonTruth::addChannel(const LayerLinks &layerLinks, int channel,
-                           float weight) {
-  LayerLinks::const_iterator linkItr = layerLinks.begin(),
-                             lastLayerLink = layerLinks.end();
+void MuonTruth::addChannel(const LayerLinks &layerLinks, int channel, float weight) {
+  LayerLinks::const_iterator linkItr = layerLinks.begin(), lastLayerLink = layerLinks.end();
 
   for (; linkItr != lastLayerLink; ++linkItr) {
     int linkChannel = linkItr->channel();
@@ -232,8 +213,7 @@ void MuonTruth::addChannel(const LayerLinks &layerLinks, int channel,
       theTotalCharge += charge;
       // see if it's in the map
       SimHitIdpr truthId(linkItr->SimTrackId(), linkItr->eventId());
-      std::map<SimHitIdpr, float>::const_iterator chargeMapItr =
-          theChargeMap.find(truthId);
+      std::map<SimHitIdpr, float>::const_iterator chargeMapItr = theChargeMap.find(truthId);
       if (chargeMapItr == theChargeMap.end()) {
         theChargeMap[truthId] = charge;
       } else {

--- a/SimMuon/MCTruth/src/PSimHitMap.cc
+++ b/SimMuon/MCTruth/src/PSimHitMap.cc
@@ -11,15 +11,13 @@ void PSimHitMap::fill(const edm::Event &e) {
   LogTrace("PSimHitMap") << "... size = " << simHits.size();
 
   // arrange the hits by detUnit
-  for (MixCollection<PSimHit>::MixItr hitItr = simHits.begin();
-       hitItr != simHits.end(); ++hitItr) {
+  for (MixCollection<PSimHit>::MixItr hitItr = simHits.begin(); hitItr != simHits.end(); ++hitItr) {
     theMap[hitItr->detUnitId()].push_back(*hitItr);
   }
 }
 
 const edm::PSimHitContainer &PSimHitMap::hits(int detId) const {
-  std::map<int, edm::PSimHitContainer>::const_iterator mapItr =
-      theMap.find(detId);
+  std::map<int, edm::PSimHitContainer>::const_iterator mapItr = theMap.find(detId);
   if (mapItr != theMap.end()) {
     return mapItr->second;
   } else {
@@ -30,10 +28,9 @@ const edm::PSimHitContainer &PSimHitMap::hits(int detId) const {
 std::vector<int> PSimHitMap::detsWithHits() const {
   std::vector<int> result;
   result.reserve(theMap.size());
-  for (std::map<int, edm::PSimHitContainer>::const_iterator
-           mapItr = theMap.begin(),
-           mapEnd = theMap.end();
-       mapItr != mapEnd; ++mapItr) {
+  for (std::map<int, edm::PSimHitContainer>::const_iterator mapItr = theMap.begin(), mapEnd = theMap.end();
+       mapItr != mapEnd;
+       ++mapItr) {
     result.push_back(mapItr->first);
   }
   return result;

--- a/SimMuon/MCTruth/src/TrackerMuonHitExtractor.cc
+++ b/SimMuon/MCTruth/src/TrackerMuonHitExtractor.cc
@@ -13,37 +13,29 @@
 #include "SimMuon/MCTruth/interface/TrackerMuonHitExtractor.h"
 #include <sstream>
 
-TrackerMuonHitExtractor::TrackerMuonHitExtractor(
-    const edm::ParameterSet &parset, edm::ConsumesCollector &&ic)
-    : inputDTRecSegment4DToken_(ic.consumes<DTRecSegment4DCollection>(
-          parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection"))),
-      inputCSCSegmentToken_(ic.consumes<CSCSegmentCollection>(
-          parset.getParameter<edm::InputTag>("inputCSCSegmentCollection"))),
-      inputDTRecSegment4DCollection_(
-          parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection")),
-      inputCSCSegmentCollection_(
-          parset.getParameter<edm::InputTag>("inputCSCSegmentCollection")) {}
+TrackerMuonHitExtractor::TrackerMuonHitExtractor(const edm::ParameterSet &parset, edm::ConsumesCollector &&ic)
+    : inputDTRecSegment4DToken_(
+          ic.consumes<DTRecSegment4DCollection>(parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection"))),
+      inputCSCSegmentToken_(
+          ic.consumes<CSCSegmentCollection>(parset.getParameter<edm::InputTag>("inputCSCSegmentCollection"))),
+      inputDTRecSegment4DCollection_(parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection")),
+      inputCSCSegmentCollection_(parset.getParameter<edm::InputTag>("inputCSCSegmentCollection")) {}
 
-TrackerMuonHitExtractor::TrackerMuonHitExtractor(
-    const edm::ParameterSet &parset)
-    : inputDTRecSegment4DCollection_(
-          parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection")),
-      inputCSCSegmentCollection_(
-          parset.getParameter<edm::InputTag>("inputCSCSegmentCollection")) {}
+TrackerMuonHitExtractor::TrackerMuonHitExtractor(const edm::ParameterSet &parset)
+    : inputDTRecSegment4DCollection_(parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection")),
+      inputCSCSegmentCollection_(parset.getParameter<edm::InputTag>("inputCSCSegmentCollection")) {}
 
 TrackerMuonHitExtractor::~TrackerMuonHitExtractor() {}
 
-void TrackerMuonHitExtractor::init(const edm::Event &iEvent,
-                                   const edm::EventSetup &iSetup) {
+void TrackerMuonHitExtractor::init(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   iEvent.getByLabel(inputDTRecSegment4DCollection_, dtSegmentCollectionH_);
   iEvent.getByLabel(inputCSCSegmentCollection_, cscSegmentCollectionH_);
 
-  edm::LogVerbatim("TrackerMuonHitExtractor")
-      << "\nThere are " << dtSegmentCollectionH_->size() << " DT segments.";
+  edm::LogVerbatim("TrackerMuonHitExtractor") << "\nThere are " << dtSegmentCollectionH_->size() << " DT segments.";
   unsigned int index_dt_segment = 0;
-  for (DTRecSegment4DCollection::const_iterator segment =
-           dtSegmentCollectionH_->begin();
-       segment != dtSegmentCollectionH_->end(); ++segment, index_dt_segment++) {
+  for (DTRecSegment4DCollection::const_iterator segment = dtSegmentCollectionH_->begin();
+       segment != dtSegmentCollectionH_->end();
+       ++segment, index_dt_segment++) {
     LocalPoint segmentLocalPosition = segment->localPosition();
     LocalVector segmentLocalDirection = segment->localDirection();
     LocalError segmentLocalPositionError = segment->localPositionError();
@@ -64,19 +56,16 @@ void TrackerMuonHitExtractor::init(const edm::Event &iEvent,
     float segmentdYdZerr = sqrt(segmentLocalDirectionError.yy());
 
     edm::LogVerbatim("TrackerMuonHitExtractor")
-        << "\nDT segment index :" << index_dt_segment
-        << "\nchamber Wh:" << wheel << ",St:" << station << ",Se:" << sector
-        << "\nLocal Position (X,Y)=(" << segmentX << "," << segmentY
-        << ") +/- (" << segmentXerr << "," << segmentYerr << "), "
-        << "Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << "," << segmentdYdZ
-        << ") +/- (" << segmentdXdZerr << "," << segmentdYdZerr << ")";
+        << "\nDT segment index :" << index_dt_segment << "\nchamber Wh:" << wheel << ",St:" << station
+        << ",Se:" << sector << "\nLocal Position (X,Y)=(" << segmentX << "," << segmentY << ") +/- (" << segmentXerr
+        << "," << segmentYerr << "), "
+        << "Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << "," << segmentdYdZ << ") +/- (" << segmentdXdZerr << ","
+        << segmentdYdZerr << ")";
   }
 
-  edm::LogVerbatim("TrackerMuonHitExtractor")
-      << "\nThere are " << cscSegmentCollectionH_->size() << " CSC segments.";
+  edm::LogVerbatim("TrackerMuonHitExtractor") << "\nThere are " << cscSegmentCollectionH_->size() << " CSC segments.";
   unsigned int index_csc_segment = 0;
-  for (CSCSegmentCollection::const_iterator segment =
-           cscSegmentCollectionH_->begin();
+  for (CSCSegmentCollection::const_iterator segment = cscSegmentCollectionH_->begin();
        segment != cscSegmentCollectionH_->end();
        ++segment, index_csc_segment++) {
     LocalPoint segmentLocalPosition = segment->localPosition();
@@ -101,32 +90,29 @@ void TrackerMuonHitExtractor::init(const edm::Event &iEvent,
     float segmentdYdZerr = sqrt(segmentLocalDirectionError.yy());
 
     edm::LogVerbatim("TrackerMuonHitExtractor")
-        << "\nCSC segment index :" << index_csc_segment
-        << "\nchamber Endcap:" << endcap << ",St:" << station << ",Ri:" << ring
-        << ",Ch:" << chamber << "\nLocal Position (X,Y)=(" << segmentX << ","
-        << segmentY << ") +/- (" << segmentXerr << "," << segmentYerr << "), "
-        << "Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << "," << segmentdYdZ
-        << ") +/- (" << segmentdXdZerr << "," << segmentdYdZerr << ")";
+        << "\nCSC segment index :" << index_csc_segment << "\nchamber Endcap:" << endcap << ",St:" << station
+        << ",Ri:" << ring << ",Ch:" << chamber << "\nLocal Position (X,Y)=(" << segmentX << "," << segmentY << ") +/- ("
+        << segmentXerr << "," << segmentYerr << "), "
+        << "Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << "," << segmentdYdZ << ") +/- (" << segmentdXdZerr << ","
+        << segmentdYdZerr << ")";
   }
 }
-std::vector<const TrackingRecHit *>
-TrackerMuonHitExtractor::getMuonHits(const reco::Muon &mu) const {
+std::vector<const TrackingRecHit *> TrackerMuonHitExtractor::getMuonHits(const reco::Muon &mu) const {
   std::vector<const TrackingRecHit *> ret;
 
   int wheel, station, sector;
   int endcap, /*station, */ ring, chamber;
 
   edm::LogVerbatim("TrackerMuonHitExtractor")
-      << "Number of chambers: " << mu.matches().size() << ", arbitrated: "
-      << mu.numberOfMatches(reco::Muon::SegmentAndTrackArbitration)
-      << ", tot (no arbitration): "
-      << mu.numberOfMatches(reco::Muon::NoArbitration);
+      << "Number of chambers: " << mu.matches().size()
+      << ", arbitrated: " << mu.numberOfMatches(reco::Muon::SegmentAndTrackArbitration)
+      << ", tot (no arbitration): " << mu.numberOfMatches(reco::Muon::NoArbitration);
   unsigned int index_chamber = 0;
   int n_segments_noArb = 0;
 
-  for (std::vector<reco::MuonChamberMatch>::const_iterator chamberMatch =
-           mu.matches().begin();
-       chamberMatch != mu.matches().end(); ++chamberMatch, index_chamber++) {
+  for (std::vector<reco::MuonChamberMatch>::const_iterator chamberMatch = mu.matches().begin();
+       chamberMatch != mu.matches().end();
+       ++chamberMatch, index_chamber++) {
     std::stringstream chamberStr;
     chamberStr << "\nchamber index: " << index_chamber;
 
@@ -138,30 +124,25 @@ TrackerMuonHitExtractor::getMuonHits(const reco::Muon &mu) const {
       wheel = dtdetid.wheel();
       station = dtdetid.station();
       sector = dtdetid.sector();
-      chamberStr << ", DT chamber Wh:" << wheel << ",St:" << station
-                 << ",Se:" << sector;
+      chamberStr << ", DT chamber Wh:" << wheel << ",St:" << station << ",Se:" << sector;
     } else if (subdet == MuonSubdetId::CSC) {
       CSCDetId cscdetid = CSCDetId(did);
       endcap = cscdetid.endcap();
       station = cscdetid.station();
       ring = cscdetid.ring();
       chamber = cscdetid.chamber();
-      chamberStr << ", CSC chamber End:" << endcap << ",St:" << station
-                 << ",Ri:" << ring << ",Ch:" << chamber;
+      chamberStr << ", CSC chamber End:" << endcap << ",St:" << station << ",Ri:" << ring << ",Ch:" << chamber;
     }
 
-    chamberStr << ", Number of segments: "
-               << chamberMatch->segmentMatches.size();
+    chamberStr << ", Number of segments: " << chamberMatch->segmentMatches.size();
     edm::LogVerbatim("TrackerMuonHitExtractor") << chamberStr.str();
     n_segments_noArb = n_segments_noArb + chamberMatch->segmentMatches.size();
 
     unsigned int index_segment = 0;
 
-    for (std::vector<reco::MuonSegmentMatch>::const_iterator segmentMatch =
-             chamberMatch->segmentMatches.begin();
+    for (std::vector<reco::MuonSegmentMatch>::const_iterator segmentMatch = chamberMatch->segmentMatches.begin();
          segmentMatch != chamberMatch->segmentMatches.end();
          ++segmentMatch, index_segment++) {
-
       float segmentX = segmentMatch->x;
       float segmentY = segmentMatch->y;
       float segmentdXdZ = segmentMatch->dXdZ;
@@ -174,9 +155,8 @@ TrackerMuonHitExtractor::getMuonHits(const reco::Muon &mu) const {
       CSCSegmentRef segmentCSC = segmentMatch->cscSegmentRef;
       DTRecSegment4DRef segmentDT = segmentMatch->dtSegmentRef;
 
-      bool segment_arbitrated_Ok =
-          (segmentMatch->isMask(reco::MuonSegmentMatch::BestInChamberByDR) &&
-           segmentMatch->isMask(reco::MuonSegmentMatch::BelongsToTrackByDR));
+      bool segment_arbitrated_Ok = (segmentMatch->isMask(reco::MuonSegmentMatch::BestInChamberByDR) &&
+                                    segmentMatch->isMask(reco::MuonSegmentMatch::BelongsToTrackByDR));
 
       std::string ARBITRATED(" ***Arbitrated Off*** ");
       if (segment_arbitrated_Ok)
@@ -184,12 +164,10 @@ TrackerMuonHitExtractor::getMuonHits(const reco::Muon &mu) const {
 
       if (subdet == MuonSubdetId::DT) {
         edm::LogVerbatim("TrackerMuonHitExtractor")
-            << "\n\t segment index: " << index_segment << ARBITRATED
-            << "\n\t  Local Position (X,Y)=(" << segmentX << "," << segmentY
-            << ") +/- (" << segmentXerr << "," << segmentYerr << "), "
-            << "\n\t  Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << ","
-            << segmentdYdZ << ") +/- (" << segmentdXdZerr << ","
-            << segmentdYdZerr << ")";
+            << "\n\t segment index: " << index_segment << ARBITRATED << "\n\t  Local Position (X,Y)=(" << segmentX
+            << "," << segmentY << ") +/- (" << segmentXerr << "," << segmentYerr << "), "
+            << "\n\t  Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << "," << segmentdYdZ << ") +/- (" << segmentdXdZerr
+            << "," << segmentdYdZerr << ")";
 
         // with the following line the DT segments failing standard arbitration
         // are skipped
@@ -200,15 +178,13 @@ TrackerMuonHitExtractor::getMuonHits(const reco::Muon &mu) const {
           const DTRecSegment4D *segment = segmentDT.get();
 
           edm::LogVerbatim("TrackerMuonHitExtractor")
-              << "\t ===> MATCHING with DT segment with index = "
-              << segmentDT.key();
+              << "\t ===> MATCHING with DT segment with index = " << segmentDT.key();
 
           if (segment->hasPhi()) {
             const DTChamberRecSegment2D *phiSeg = segment->phiSegment();
             std::vector<const TrackingRecHit *> phiHits = phiSeg->recHits();
-            for (std::vector<const TrackingRecHit *>::const_iterator ihit =
-                     phiHits.begin();
-                 ihit != phiHits.end(); ++ihit) {
+            for (std::vector<const TrackingRecHit *>::const_iterator ihit = phiHits.begin(); ihit != phiHits.end();
+                 ++ihit) {
               ret.push_back(*ihit);
             }
           }
@@ -216,25 +192,21 @@ TrackerMuonHitExtractor::getMuonHits(const reco::Muon &mu) const {
           if (segment->hasZed()) {
             const DTSLRecSegment2D *zSeg = (*segment).zSegment();
             std::vector<const TrackingRecHit *> zedHits = zSeg->recHits();
-            for (std::vector<const TrackingRecHit *>::const_iterator ihit =
-                     zedHits.begin();
-                 ihit != zedHits.end(); ++ihit) {
+            for (std::vector<const TrackingRecHit *>::const_iterator ihit = zedHits.begin(); ihit != zedHits.end();
+                 ++ihit) {
               ret.push_back(*ihit);
             }
           }
         } else
-          edm::LogWarning("TrackerMuonHitExtractor")
-              << "\n***WARNING: UNMATCHED DT segment ! \n";
-      } // if (subdet == MuonSubdetId::DT)
+          edm::LogWarning("TrackerMuonHitExtractor") << "\n***WARNING: UNMATCHED DT segment ! \n";
+      }  // if (subdet == MuonSubdetId::DT)
 
       else if (subdet == MuonSubdetId::CSC) {
         edm::LogVerbatim("TrackerMuonHitExtractor")
-            << "\n\t segment index: " << index_segment << ARBITRATED
-            << "\n\t  Local Position (X,Y)=(" << segmentX << "," << segmentY
-            << ") +/- (" << segmentXerr << "," << segmentYerr << "), "
-            << "\n\t  Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << ","
-            << segmentdYdZ << ") +/- (" << segmentdXdZerr << ","
-            << segmentdYdZerr << ")";
+            << "\n\t segment index: " << index_segment << ARBITRATED << "\n\t  Local Position (X,Y)=(" << segmentX
+            << "," << segmentY << ") +/- (" << segmentXerr << "," << segmentYerr << "), "
+            << "\n\t  Local Direction (dXdZ,dYdZ)=(" << segmentdXdZ << "," << segmentdYdZ << ") +/- (" << segmentdXdZerr
+            << "," << segmentdYdZerr << ")";
 
         // with the following line the CSC segments failing standard arbitration
         // are skipped
@@ -245,25 +217,20 @@ TrackerMuonHitExtractor::getMuonHits(const reco::Muon &mu) const {
           const CSCSegment *segment = segmentCSC.get();
 
           edm::LogVerbatim("TrackerMuonHitExtractor")
-              << "\t ===> MATCHING with CSC segment with index = "
-              << segmentCSC.key();
+              << "\t ===> MATCHING with CSC segment with index = " << segmentCSC.key();
 
           std::vector<const TrackingRecHit *> hits = segment->recHits();
-          for (std::vector<const TrackingRecHit *>::const_iterator ihit =
-                   hits.begin();
-               ihit != hits.end(); ++ihit) {
+          for (std::vector<const TrackingRecHit *>::const_iterator ihit = hits.begin(); ihit != hits.end(); ++ihit) {
             ret.push_back(*ihit);
           }
         } else
-          edm::LogWarning("TrackerMuonHitExtractor")
-              << "\n***WARNING: UNMATCHED CSC segment ! \n";
-      } // else if (subdet == MuonSubdetId::CSC)
+          edm::LogWarning("TrackerMuonHitExtractor") << "\n***WARNING: UNMATCHED CSC segment ! \n";
+      }  // else if (subdet == MuonSubdetId::CSC)
 
-    } // loop on vector<MuonSegmentMatch>
-  }   // loop on vector<MuonChamberMatch>
+    }  // loop on vector<MuonSegmentMatch>
+  }    // loop on vector<MuonChamberMatch>
 
-  edm::LogVerbatim("TrackerMuonHitExtractor")
-      << "\n N. matched Segments before arbitration = " << n_segments_noArb;
+  edm::LogVerbatim("TrackerMuonHitExtractor") << "\n N. matched Segments before arbitration = " << n_segments_noArb;
 
   return ret;
 }

--- a/SimMuon/MCTruth/test/testReader.cc
+++ b/SimMuon/MCTruth/test/testReader.cc
@@ -11,12 +11,10 @@ testReader::testReader(const edm::ParameterSet &parset)
 
 testReader::~testReader() {}
 
-void testReader::analyze(const edm::Event &event,
-                         const edm::EventSetup &setup) {
+void testReader::analyze(const edm::Event &event, const edm::EventSetup &setup) {
   edm::Handle<edm::View<reco::Track>> trackCollectionH;
   edm::View<reco::Track> trackCollection;
-  LogTrace("testReader")
-      << "testReader::analyze : getting reco::Track collection, " << tracksTag;
+  LogTrace("testReader") << "testReader::analyze : getting reco::Track collection, " << tracksTag;
   event.getByLabel(tracksTag, trackCollectionH);
   if (trackCollectionH.isValid()) {
     trackCollection = *(trackCollectionH.product());
@@ -26,8 +24,7 @@ void testReader::analyze(const edm::Event &event,
 
   edm::Handle<TrackingParticleCollection> TPCollectionH;
   TrackingParticleCollection tPC;
-  LogTrace("testReader")
-      << "testReader::analyze : getting TrackingParticle collection, " << tpTag;
+  LogTrace("testReader") << "testReader::analyze : getting TrackingParticle collection, " << tpTag;
   event.getByLabel(tpTag, TPCollectionH);
   if (TPCollectionH.isValid()) {
     tPC = *(TPCollectionH.product());
@@ -37,8 +34,7 @@ void testReader::analyze(const edm::Event &event,
 
   edm::Handle<reco::RecoToSimCollection> recSimH;
   reco::RecoToSimCollection recSimColl;
-  LogTrace("testReader")
-      << "testReader::analyze : getting  RecoToSimCollection - " << assoMapsTag;
+  LogTrace("testReader") << "testReader::analyze : getting  RecoToSimCollection - " << assoMapsTag;
   event.getByLabel(assoMapsTag, recSimH);
   if (recSimH.isValid()) {
     recSimColl = *(recSimH.product());
@@ -49,8 +45,7 @@ void testReader::analyze(const edm::Event &event,
 
   edm::Handle<reco::SimToRecoCollection> simRecH;
   reco::SimToRecoCollection simRecColl;
-  LogTrace("testReader")
-      << "testReader::analyze : getting  SimToRecoCollection - " << assoMapsTag;
+  LogTrace("testReader") << "testReader::analyze : getting  SimToRecoCollection - " << assoMapsTag;
   event.getByLabel(assoMapsTag, simRecH);
   if (simRecH.isValid()) {
     simRecColl = *(simRecH.product());
@@ -59,42 +54,34 @@ void testReader::analyze(const edm::Event &event,
     LogTrace("testReader") << "... NOT FOUND.";
   }
 
-  edm::LogVerbatim("testReader")
-      << "\n === Event ID = " << event.id() << " ===";
+  edm::LogVerbatim("testReader") << "\n === Event ID = " << event.id() << " ===";
 
   // RECOTOSIM
-  edm::LogVerbatim("testReader")
-      << "\n                      ****************** Reco To Sim "
-         "****************** ";
+  edm::LogVerbatim("testReader") << "\n                      ****************** Reco To Sim "
+                                    "****************** ";
   if (recSimH.isValid()) {
+    edm::LogVerbatim("testReader") << "\n There are " << trackCollection.size() << " reco::Tracks "
+                                   << "(" << recSimColl.size() << " matched) \n";
 
-    edm::LogVerbatim("testReader")
-        << "\n There are " << trackCollection.size() << " reco::Tracks "
-        << "(" << recSimColl.size() << " matched) \n";
-
-    for (edm::View<reco::Track>::size_type i = 0; i < trackCollection.size();
-         ++i) {
+    for (edm::View<reco::Track>::size_type i = 0; i < trackCollection.size(); ++i) {
       edm::RefToBase<reco::Track> track(trackCollectionH, i);
 
       if (recSimColl.find(track) != recSimColl.end()) {
-        std::vector<std::pair<TrackingParticleRef, double>> recSimAsso =
-            recSimColl[track];
+        std::vector<std::pair<TrackingParticleRef, double>> recSimAsso = recSimColl[track];
 
-        for (std::vector<std::pair<TrackingParticleRef, double>>::const_iterator
-                 IT = recSimAsso.begin();
-             IT != recSimAsso.end(); ++IT) {
+        for (std::vector<std::pair<TrackingParticleRef, double>>::const_iterator IT = recSimAsso.begin();
+             IT != recSimAsso.end();
+             ++IT) {
           TrackingParticleRef trpart = IT->first;
           double purity = IT->second;
-          edm::LogVerbatim("testReader")
-              << "reco::Track #" << int(i) << " with pt = " << track->pt()
-              << " associated to TrackingParticle #" << trpart.key()
-              << " (pt = " << trpart->pt() << ") with Quality = " << purity;
+          edm::LogVerbatim("testReader") << "reco::Track #" << int(i) << " with pt = " << track->pt()
+                                         << " associated to TrackingParticle #" << trpart.key()
+                                         << " (pt = " << trpart->pt() << ") with Quality = " << purity;
         }
       } else {
-        edm::LogVerbatim("testReader")
-            << "reco::Track #" << int(i) << " with pt = " << track->pt()
-            << " NOT associated to any TrackingParticle"
-            << "\n";
+        edm::LogVerbatim("testReader") << "reco::Track #" << int(i) << " with pt = " << track->pt()
+                                       << " NOT associated to any TrackingParticle"
+                                       << "\n";
       }
     }
 
@@ -102,14 +89,11 @@ void testReader::analyze(const edm::Event &event,
     edm::LogVerbatim("testReader") << "\n RtS map not found in the Event.";
 
   // SIMTORECO
-  edm::LogVerbatim("testReader")
-      << "\n                      ****************** Sim To Reco "
-         "****************** ";
+  edm::LogVerbatim("testReader") << "\n                      ****************** Sim To Reco "
+                                    "****************** ";
   if (simRecH.isValid()) {
-
-    edm::LogVerbatim("testReader")
-        << "\n There are " << tPC.size() << " TrackingParticles "
-        << "(" << simRecColl.size() << " matched) \n";
+    edm::LogVerbatim("testReader") << "\n There are " << tPC.size() << " TrackingParticles "
+                                   << "(" << simRecColl.size() << " matched) \n";
     bool any_trackingParticle_matched = false;
 
     for (TrackingParticleCollection::size_type i = 0; i < tPC.size(); i++) {
@@ -118,13 +102,11 @@ void testReader::analyze(const edm::Event &event,
       std::vector<std::pair<edm::RefToBase<reco::Track>, double>> simRecAsso;
 
       if (simRecColl.find(trpart) != simRecColl.end()) {
-        simRecAsso =
-            (std::vector<std::pair<edm::RefToBase<reco::Track>, double>>)
-                simRecColl[trpart];
+        simRecAsso = (std::vector<std::pair<edm::RefToBase<reco::Track>, double>>)simRecColl[trpart];
 
-        for (std::vector<std::pair<edm::RefToBase<reco::Track>, double>>::
-                 const_iterator IT = simRecAsso.begin();
-             IT != simRecAsso.end(); ++IT) {
+        for (std::vector<std::pair<edm::RefToBase<reco::Track>, double>>::const_iterator IT = simRecAsso.begin();
+             IT != simRecAsso.end();
+             ++IT) {
           edm::RefToBase<reco::Track> track = IT->first;
           double quality = IT->second;
           any_trackingParticle_matched = true;
@@ -133,22 +115,19 @@ void testReader::analyze(const edm::Event &event,
           // unmatched recoToSim)
           double purity = -1.;
           if (recSimColl.find(track) != recSimColl.end()) {
-            std::vector<std::pair<TrackingParticleRef, double>> recSimAsso =
-                recSimColl[track];
-            for (std::vector<std::pair<TrackingParticleRef, double>>::
-                     const_iterator ITS = recSimAsso.begin();
-                 ITS != recSimAsso.end(); ++ITS) {
+            std::vector<std::pair<TrackingParticleRef, double>> recSimAsso = recSimColl[track];
+            for (std::vector<std::pair<TrackingParticleRef, double>>::const_iterator ITS = recSimAsso.begin();
+                 ITS != recSimAsso.end();
+                 ++ITS) {
               TrackingParticleRef tp = ITS->first;
               if (tp == trpart)
                 purity = ITS->second;
             }
           }
 
-          edm::LogVerbatim("testReader")
-              << "TrackingParticle #" << int(i) << " with pt = " << trpart->pt()
-              << " associated to reco::Track #" << track.key()
-              << " (pt = " << track->pt() << ") with Quality = " << quality
-              << " and Purity = " << purity;
+          edm::LogVerbatim("testReader") << "TrackingParticle #" << int(i) << " with pt = " << trpart->pt()
+                                         << " associated to reco::Track #" << track.key() << " (pt = " << track->pt()
+                                         << ") with Quality = " << quality << " and Purity = " << purity;
         }
       }
 
@@ -161,9 +140,8 @@ void testReader::analyze(const edm::Event &event,
     }
 
     if (!any_trackingParticle_matched) {
-      edm::LogVerbatim("testReader")
-          << "NO TrackingParticle associated to ANY input reco::Track !"
-          << "\n";
+      edm::LogVerbatim("testReader") << "NO TrackingParticle associated to ANY input reco::Track !"
+                                     << "\n";
     }
 
   } else

--- a/SimMuon/MCTruth/test/testReader.h
+++ b/SimMuon/MCTruth/test/testReader.h
@@ -9,7 +9,6 @@
 #include <memory>
 
 class testReader : public edm::EDAnalyzer {
-
 public:
   testReader(const edm::ParameterSet &);
   ~testReader() override;

--- a/SimTracker/TrackHistory/interface/CategoryCriteria.h
+++ b/SimTracker/TrackHistory/interface/CategoryCriteria.h
@@ -11,8 +11,8 @@
 
 //! Implement a selector given a track or vertex collection and track or vertex
 //! classifier.
-template <typename Collection, typename Classifier> class CategoryCriteria {
-
+template <typename Collection, typename Classifier>
+class CategoryCriteria {
 public:
   // Input collection type
   typedef Collection collection;
@@ -28,21 +28,17 @@ public:
 
   // Constructor from parameter set configurability
   CategoryCriteria(const edm::ParameterSet &config, edm::ConsumesCollector &&iC)
-      : classifier_(config, std::move(iC)),
-        evaluate_(config.getParameter<std::string>("cut")) {}
+      : classifier_(config, std::move(iC)), evaluate_(config.getParameter<std::string>("cut")) {}
 
   // Select object from a collection and possibly event content
-  void select(const edm::Handle<collection> &collectionHandler,
-              const edm::Event &event, const edm::EventSetup &setup) {
-
+  void select(const edm::Handle<collection> &collectionHandler, const edm::Event &event, const edm::EventSetup &setup) {
     selected_.clear();
 
     // const collection & collectionPointer = *(collectionHandler.product());
 
     classifier_.newEvent(event, setup);
 
-    for (typename collection::size_type i = 0; i < collectionHandler->size();
-         ++i) {
+    for (typename collection::size_type i = 0; i < collectionHandler->size(); ++i) {
       edm::Ref<Collection> member(collectionHandler, i);
 
       classifier_.evaluate(member);

--- a/SimTracker/TrackHistory/interface/HistoryBase.h
+++ b/SimTracker/TrackHistory/interface/HistoryBase.h
@@ -10,7 +10,6 @@
 
 //! Base class to all the history types.
 class HistoryBase {
-
 public:
   //! HepMC::GenParticle trail type.
   typedef std::vector<const HepMC::GenParticle *> GenParticleTrail;
@@ -62,14 +61,10 @@ public:
   GenParticleTrail const &genParticleTrail() const { return genParticleTrail_; }
 
   //! Return all reco::GenParticle in the history.
-  RecoGenParticleTrail const &recoGenParticleTrail() const {
-    return recoGenParticleTrail_;
-  }
+  RecoGenParticleTrail const &recoGenParticleTrail() const { return recoGenParticleTrail_; }
 
   //! Return the initial tracking particle from the history.
-  const TrackingParticleRef &simParticle() const {
-    return simParticleTrail_[0];
-  }
+  const TrackingParticleRef &simParticle() const { return simParticleTrail_[0]; }
 
   //! Return the initial tracking vertex from the history.
   const TrackingVertexRef &simVertex() const { return simVertexTrail_[0]; }

--- a/SimTracker/TrackHistory/interface/JetVetoedTracksAssociatorDRVertex.h
+++ b/SimTracker/TrackHistory/interface/JetVetoedTracksAssociatorDRVertex.h
@@ -11,7 +11,6 @@
 #include "SimTracker/TrackHistory/interface/TrackClassifier.h"
 
 class JetVetoedTracksAssociationDRVertex {
-
 public:
   JetVetoedTracksAssociationDRVertex(double fDr);
   ~JetVetoedTracksAssociationDRVertex() {}

--- a/SimTracker/TrackHistory/interface/TrackCategories.h
+++ b/SimTracker/TrackHistory/interface/TrackCategories.h
@@ -6,7 +6,6 @@
 #include <vector>
 
 class TrackCategories {
-
 public:
   //! Categories available to vertex
   enum Category {

--- a/SimTracker/TrackHistory/interface/TrackClassifier.h
+++ b/SimTracker/TrackHistory/interface/TrackClassifier.h
@@ -27,7 +27,6 @@ class TrackTopology;
 
 //! Get track history and classify it in function of their .
 class TrackClassifier : public TrackCategories {
-
 public:
   //! Type to the associate category
   typedef TrackCategories Categories;
@@ -45,9 +44,7 @@ public:
   TrackClassifier const &evaluate(TrackingParticleRef const &);
 
   //! Classify the RecoTrack in categories.
-  TrackClassifier const &evaluate(reco::TrackRef const &track) {
-    return evaluate(reco::TrackBaseRef(track));
-  }
+  TrackClassifier const &evaluate(reco::TrackRef const &track) { return evaluate(reco::TrackBaseRef(track)); }
 
   //! Returns a reference to the track history used in the classification.
   TrackHistory const &history() const { return tracer_; }
@@ -107,13 +104,9 @@ private:
 
   //! Auxiliary class holding simulated primary vertices
   struct GeneratedPrimaryVertex {
+    GeneratedPrimaryVertex(double x1, double y1, double z1) : x(x1), y(y1), z(z1), ptsq(0), nGenTrk(0) {}
 
-    GeneratedPrimaryVertex(double x1, double y1, double z1)
-        : x(x1), y(y1), z(z1), ptsq(0), nGenTrk(0) {}
-
-    bool operator<(GeneratedPrimaryVertex const &reference) const {
-      return ptsq < reference.ptsq;
-    }
+    bool operator<(GeneratedPrimaryVertex const &reference) const { return ptsq < reference.ptsq; }
 
     double x, y, z;
     double ptsq;

--- a/SimTracker/TrackHistory/interface/TrackHistory.h
+++ b/SimTracker/TrackHistory/interface/TrackHistory.h
@@ -15,7 +15,6 @@
 
 //! This class traces the simulated and generated history of a given track.
 class TrackHistory : public HistoryBase {
-
 public:
   //! Constructor by pset.
   /* Creates a TrackHistory with association given by pset.
@@ -37,8 +36,7 @@ public:
   */
   bool evaluate(TrackingParticleRef tpr) {
     if (enableSimToReco_) {
-      std::pair<reco::TrackBaseRef, double> result =
-          match(tpr, simToReco_, bestMatchByMaxValue_);
+      std::pair<reco::TrackBaseRef, double> result = match(tpr, simToReco_, bestMatchByMaxValue_);
       recotrack_ = result.first;
       quality_ = result.second;
     }
@@ -57,8 +55,7 @@ public:
   const reco::TrackBaseRef &recoTrack() const { return recotrack_; }
 
   // return the TrackingParticle to which the Track was matched
-  const std::pair<TrackingParticleRef, double>
-  getMatchedTrackingParticle() const {
+  const std::pair<TrackingParticleRef, double> getMatchedTrackingParticle() const {
     std::pair<TrackingParticleRef, double> result;
     result.first = trackingParticle_;
     result.second = quality_;

--- a/SimTracker/TrackHistory/interface/TrackQuality.h
+++ b/SimTracker/TrackHistory/interface/TrackQuality.h
@@ -44,16 +44,7 @@ public:
       MuonRPCEndcap
     };
 
-    enum State {
-      Unknown = 0,
-      Good,
-      Missed,
-      Noise,
-      Bad,
-      Dead,
-      Shared,
-      Misassoc
-    };
+    enum State { Unknown = 0, Good, Missed, Noise, Bad, Dead, Shared, Misassoc };
 
     struct Hit {
       short int recHitId;
@@ -77,8 +68,7 @@ public:
   void newEvent(const edm::Event &, const edm::EventSetup &);
 
   //! Compute information about the track reconstruction quality
-  void evaluate(SimParticleTrail const &, reco::TrackBaseRef const &,
-                const TrackerTopology *tTopo);
+  void evaluate(SimParticleTrail const &, reco::TrackBaseRef const &, const TrackerTopology *tTopo);
 
   //! Return the number of layers with simulated and/or reconstructed hits
   unsigned int numberOfLayers() const { return layers_.size(); }

--- a/SimTracker/TrackHistory/interface/Utils.h
+++ b/SimTracker/TrackHistory/interface/Utils.h
@@ -7,29 +7,27 @@
 
 //! Generic matching function
 template <typename Reference, typename Association>
-std::pair<typename Association::data_type::first_type, double>
-match(Reference key, Association association, bool bestMatchByMaxValue) {
+std::pair<typename Association::data_type::first_type, double> match(Reference key,
+                                                                     Association association,
+                                                                     bool bestMatchByMaxValue) {
   typename Association::data_type::first_type value;
 
   typename Association::const_iterator pos = association.find(key);
 
   if (pos == association.end())
-    return std::pair<typename Association::data_type::first_type, double>(value,
-                                                                          0);
+    return std::pair<typename Association::data_type::first_type, double>(value, 0);
 
   const std::vector<typename Association::data_type> &matches = pos->val;
 
   double q = bestMatchByMaxValue ? -1e30 : 1e30;
 
   for (std::size_t i = 0; i < matches.size(); ++i)
-    if (bestMatchByMaxValue ? (matches[i].second > q)
-                            : (matches[i].second < q)) {
+    if (bestMatchByMaxValue ? (matches[i].second > q) : (matches[i].second < q)) {
       value = matches[i].first;
       q = matches[i].second;
     }
 
-  return std::pair<typename Association::data_type::first_type, double>(value,
-                                                                        q);
+  return std::pair<typename Association::data_type::first_type, double>(value, q);
 }
 
 //! Class that maps the native Geant4 process types to the legacy CMS process

--- a/SimTracker/TrackHistory/interface/VertexCategories.h
+++ b/SimTracker/TrackHistory/interface/VertexCategories.h
@@ -6,7 +6,6 @@
 #include <vector>
 
 class VertexCategories {
-
 public:
   //! Categories available to vertexes
   enum Category {

--- a/SimTracker/TrackHistory/interface/VertexClassifier.h
+++ b/SimTracker/TrackHistory/interface/VertexClassifier.h
@@ -16,7 +16,6 @@
 
 //! Get track history and classify it in function of their .
 class VertexClassifier : public VertexCategories {
-
 public:
   //! Type to the associate category
   typedef VertexCategories Categories;
@@ -36,9 +35,7 @@ public:
   VertexClassifier const &evaluate(TrackingVertexRef const &);
 
   //! Classify the RecoVertex in categories.
-  VertexClassifier const &evaluate(reco::VertexRef const &vertex) {
-    return evaluate(reco::VertexBaseRef(vertex));
-  }
+  VertexClassifier const &evaluate(reco::VertexRef const &vertex) { return evaluate(reco::VertexBaseRef(vertex)); }
 
   //! Returns a reference to the vertex history used in the classification.
   VertexHistory const &history() const { return tracer_; }
@@ -74,12 +71,9 @@ private:
 
   //! Auxiliary class holding simulated primary vertices
   struct GeneratedPrimaryVertex {
-    GeneratedPrimaryVertex(double x1, double y1, double z1)
-        : x(x1), y(y1), z(z1), ptsq(0), nGenTrk(0) {}
+    GeneratedPrimaryVertex(double x1, double y1, double z1) : x(x1), y(y1), z(z1), ptsq(0), nGenTrk(0) {}
 
-    bool operator<(GeneratedPrimaryVertex const &reference) const {
-      return ptsq < reference.ptsq;
-    }
+    bool operator<(GeneratedPrimaryVertex const &reference) const { return ptsq < reference.ptsq; }
 
     double x, y, z;
     double ptsq;

--- a/SimTracker/TrackHistory/interface/VertexClassifierByProxy.h
+++ b/SimTracker/TrackHistory/interface/VertexClassifierByProxy.h
@@ -9,24 +9,19 @@
 //! Get track history and classification by proxy
 template <typename Collection>
 class VertexClassifierByProxy : public VertexClassifier {
-
 public:
   //! Association type.
-  typedef edm::AssociationMap<
-      edm::OneToMany<Collection, reco::VertexCollection>>
-      Association;
+  typedef edm::AssociationMap<edm::OneToMany<Collection, reco::VertexCollection>> Association;
 
   //! Constructor by ParameterSet.
-  VertexClassifierByProxy(edm::ParameterSet const &config,
-                          edm::ConsumesCollector &&collector)
+  VertexClassifierByProxy(edm::ParameterSet const &config, edm::ConsumesCollector &&collector)
       : VertexClassifier(config, std::move(collector)),
         proxy_(config.getUntrackedParameter<edm::InputTag>("vertexProducer")) {
     collector.consumes<Association>(proxy_);
   }
 
   //! Pre-process event information (for accessing reconstraction information).
-  void newEvent(edm::Event const &event,
-                edm::EventSetup const &config) override {
+  void newEvent(edm::Event const &event, edm::EventSetup const &config) override {
     // Get the association part of the proxy to the collection
     event.getByLabel(proxy_, proxyHandler_);
     // Call the previous new event
@@ -34,15 +29,13 @@ public:
   }
 
   //! Classify the TrackingVertex in categories.
-  VertexClassifierByProxy<Collection> const &
-  evaluate(TrackingVertexRef const &vertex) {
+  VertexClassifierByProxy<Collection> const &evaluate(TrackingVertexRef const &vertex) {
     VertexClassifier::evaluate(vertex);
     return *this;
   }
 
   //! Classify any vertexes in categories.
-  VertexClassifierByProxy<Collection> const &
-  evaluate(edm::Ref<Collection> const &vertex, std::size_t index) {
+  VertexClassifierByProxy<Collection> const &evaluate(edm::Ref<Collection> const &vertex, std::size_t index) {
     const reco::VertexRefVector *vertexes = nullptr;
 
     try {
@@ -62,8 +55,7 @@ public:
   }
 
   //! Classify any vertexes in categories.
-  VertexClassifierByProxy<Collection> const &
-  evaluate(edm::Ref<Collection> const &vertex) {
+  VertexClassifierByProxy<Collection> const &evaluate(edm::Ref<Collection> const &vertex) {
     const reco::VertexRefVector *vertexes = nullptr;
 
     try {

--- a/SimTracker/TrackHistory/interface/VertexHistory.h
+++ b/SimTracker/TrackHistory/interface/VertexHistory.h
@@ -16,7 +16,6 @@
 
 //! This class traces the simulated and generated history of a given track.
 class VertexHistory : public HistoryBase {
-
 public:
   //! Constructor by pset.
   /* Creates a VertexHistory with association given by pset.
@@ -38,9 +37,7 @@ public:
   */
   bool evaluate(TrackingVertexRef tvr) {
     if (enableSimToReco_) {
-
-      std::pair<reco::VertexBaseRef, double> result =
-          match(tvr, simToReco_, bestMatchByMaxValue_);
+      std::pair<reco::VertexBaseRef, double> result = match(tvr, simToReco_, bestMatchByMaxValue_);
       recovertex_ = result.first;
       quality_ = result.second;
     }

--- a/SimTracker/TrackHistory/plugins/CategorySelectors.cc
+++ b/SimTracker/TrackHistory/plugins/CategorySelectors.cc
@@ -16,35 +16,29 @@
 #include "SimTracker/TrackHistory/interface/VertexClassifierByProxy.h"
 
 namespace reco {
-namespace modules {
+  namespace modules {
 
-// Generic TrackCategory selector
+    // Generic TrackCategory selector
 
-typedef ObjectSelector<CategoryCriteria<TrackCollection, TrackClassifier>>
-    TrackCategorySelector;
-DEFINE_FWK_MODULE(TrackCategorySelector);
+    typedef ObjectSelector<CategoryCriteria<TrackCollection, TrackClassifier>> TrackCategorySelector;
+    DEFINE_FWK_MODULE(TrackCategorySelector);
 
-typedef ObjectSelector<
-    CategoryCriteria<TrackingParticleCollection, TrackClassifier>>
-    TrackingParticleCategorySelector;
-DEFINE_FWK_MODULE(TrackingParticleCategorySelector);
+    typedef ObjectSelector<CategoryCriteria<TrackingParticleCollection, TrackClassifier>>
+        TrackingParticleCategorySelector;
+    DEFINE_FWK_MODULE(TrackingParticleCategorySelector);
 
-// Generic VertexCategory selector
+    // Generic VertexCategory selector
 
-typedef ObjectSelector<CategoryCriteria<VertexCollection, VertexClassifier>>
-    VertexCategorySelector;
-DEFINE_FWK_MODULE(VertexCategorySelector);
+    typedef ObjectSelector<CategoryCriteria<VertexCollection, VertexClassifier>> VertexCategorySelector;
+    DEFINE_FWK_MODULE(VertexCategorySelector);
 
-typedef ObjectSelector<
-    CategoryCriteria<TrackingVertexCollection, VertexClassifier>>
-    TrackingVertexCategorySelector;
-DEFINE_FWK_MODULE(TrackingVertexCategorySelector);
+    typedef ObjectSelector<CategoryCriteria<TrackingVertexCollection, VertexClassifier>> TrackingVertexCategorySelector;
+    DEFINE_FWK_MODULE(TrackingVertexCategorySelector);
 
-typedef ObjectSelector<
-    CategoryCriteria<SecondaryVertexTagInfoCollection,
-                     VertexClassifierByProxy<SecondaryVertexTagInfoCollection>>>
-    SecondaryVertexTagInfoCategorySelector;
-DEFINE_FWK_MODULE(SecondaryVertexTagInfoCategorySelector);
+    typedef ObjectSelector<
+        CategoryCriteria<SecondaryVertexTagInfoCollection, VertexClassifierByProxy<SecondaryVertexTagInfoCollection>>>
+        SecondaryVertexTagInfoCategorySelector;
+    DEFINE_FWK_MODULE(SecondaryVertexTagInfoCategorySelector);
 
-} // namespace modules
-} // namespace reco
+  }  // namespace modules
+}  // namespace reco

--- a/SimTracker/TrackHistory/plugins/GenTrackMatcher.cc
+++ b/SimTracker/TrackHistory/plugins/GenTrackMatcher.cc
@@ -12,7 +12,7 @@
 #include "SimTracker/TrackHistory/interface/TrackHistory.h"
 
 namespace edm {
-class ParameterSet;
+  class ParameterSet;
 }
 
 using namespace edm;
@@ -41,12 +41,9 @@ private:
 
 GenTrackMatcher::GenTrackMatcher(const ParameterSet &p)
     : tracer_(p, consumesCollector()),
-      tracks_(consumes<View<Track>>(
-          p.getUntrackedParameter<edm::InputTag>("trackProducer"))),
-      genParticles_(consumes<GenParticleCollection>(
-          p.getUntrackedParameter<edm::InputTag>("genParticles"))),
-      genParticleInts_(consumes<vector<int>>(
-          p.getUntrackedParameter<edm::InputTag>("genParticles"))) {
+      tracks_(consumes<View<Track>>(p.getUntrackedParameter<edm::InputTag>("trackProducer"))),
+      genParticles_(consumes<GenParticleCollection>(p.getUntrackedParameter<edm::InputTag>("genParticles"))),
+      genParticleInts_(consumes<vector<int>>(p.getUntrackedParameter<edm::InputTag>("genParticles"))) {
   produces<GenParticleMatch>();
 }
 
@@ -57,8 +54,7 @@ void GenTrackMatcher::produce(Event &evt, const EventSetup &es) {
   evt.getByToken(genParticles_, barCodes);
   Handle<GenParticleCollection> genParticles;
   evt.getByToken(genParticles_, genParticles);
-  unique_ptr<GenParticleMatch> match(
-      new GenParticleMatch(GenParticleRefProd(genParticles)));
+  unique_ptr<GenParticleMatch> match(new GenParticleMatch(GenParticleRefProd(genParticles)));
   GenParticleMatch::Filler filler(*match);
   size_t n = tracks->size();
   vector<int> indices(n, -1);
@@ -69,14 +65,12 @@ void GenTrackMatcher::produce(Event &evt, const EventSetup &es) {
       const HepMC::GenParticle *particle = tracer_.genParticle();
       if (particle) {
         int barCode = particle->barcode();
-        vector<int>::const_iterator b = barCodes->begin(), e = barCodes->end(),
-                                    f = find(b, e, barCode);
+        vector<int>::const_iterator b = barCodes->begin(), e = barCodes->end(), f = find(b, e, barCode);
         if (f == e) {
           edm::EDConsumerBase::Labels labels;
           labelsForToken(genParticles_, labels);
           throw edm::Exception(errors::InvalidReference)
-              << "found matching particle with barcode" << *f
-              << " which has not been found in " << labels.module;
+              << "found matching particle with barcode" << *f << " which has not been found in " << labels.module;
         }
         indices[i] = *f;
       }

--- a/SimTracker/TrackHistory/plugins/JetVetoedTracksAssociatorAtVertex.cc
+++ b/SimTracker/TrackHistory/plugins/JetVetoedTracksAssociatorAtVertex.cc
@@ -34,12 +34,9 @@ private:
   TrackClassifier classifier;
 };
 
-JetVetoedTracksAssociatorAtVertex::JetVetoedTracksAssociatorAtVertex(
-    const edm::ParameterSet &fConfig)
-    : mJets(consumes<edm::View<reco::Jet>>(
-          fConfig.getParameter<edm::InputTag>("jets"))),
-      mTracks(consumes<reco::TrackCollection>(
-          fConfig.getParameter<edm::InputTag>("tracks"))),
+JetVetoedTracksAssociatorAtVertex::JetVetoedTracksAssociatorAtVertex(const edm::ParameterSet &fConfig)
+    : mJets(consumes<edm::View<reco::Jet>>(fConfig.getParameter<edm::InputTag>("jets"))),
+      mTracks(consumes<reco::TrackCollection>(fConfig.getParameter<edm::InputTag>("tracks"))),
       mAssociator(fConfig.getParameter<double>("coneSize")),
       classifier(fConfig, consumesCollector()) {
   produces<reco::JetTracksAssociation::Container>();
@@ -47,8 +44,7 @@ JetVetoedTracksAssociatorAtVertex::JetVetoedTracksAssociatorAtVertex(
 
 JetVetoedTracksAssociatorAtVertex::~JetVetoedTracksAssociatorAtVertex() {}
 
-void JetVetoedTracksAssociatorAtVertex::produce(edm::Event &fEvent,
-                                                const edm::EventSetup &fSetup) {
+void JetVetoedTracksAssociatorAtVertex::produce(edm::Event &fEvent, const edm::EventSetup &fSetup) {
   // Gather contextual information for TrackCategories
   classifier.newEvent(fEvent, fSetup);
 

--- a/SimTracker/TrackHistory/plugins/QualityCutsAnalyzer.cc
+++ b/SimTracker/TrackHistory/plugins/QualityCutsAnalyzer.cc
@@ -34,7 +34,6 @@
 //
 
 class QualityCutsAnalyzer : public edm::one::EDAnalyzer<> {
-
 public:
   explicit QualityCutsAnalyzer(const edm::ParameterSet &);
   ~QualityCutsAnalyzer() override;
@@ -61,26 +60,25 @@ private:
   bool useAllQualities_;
   reco::TrackBase::TrackQuality trackQuality_;
 
-  void LoopOverJetTracksAssociation(
-      const edm::ESHandle<TransientTrackBuilder> &,
-      const edm::Handle<reco::VertexCollection> &,
-      const edm::Handle<reco::JetTracksAssociationCollection> &);
+  void LoopOverJetTracksAssociation(const edm::ESHandle<TransientTrackBuilder> &,
+                                    const edm::Handle<reco::VertexCollection> &,
+                                    const edm::Handle<reco::JetTracksAssociationCollection> &);
 
   // Histograms for optimization
 
   struct histogram_element_t {
-    double sdl;            // Signed decay length
-    double dta;            // Distance to jet axis
-    double tip;            // Transverse impact parameter
-    double lip;            // Longitudinal impact parameter
-    double ips;            // Impact parameter significance.
-    double pt;             // Transverse momentum
-    double chi2;           // Chi^2
-    std::size_t hits;      // Number of hits
-    std::size_t pixelhits; // Number of hits
+    double sdl;             // Signed decay length
+    double dta;             // Distance to jet axis
+    double tip;             // Transverse impact parameter
+    double lip;             // Longitudinal impact parameter
+    double ips;             // Impact parameter significance.
+    double pt;              // Transverse momentum
+    double chi2;            // Chi^2
+    std::size_t hits;       // Number of hits
+    std::size_t pixelhits;  // Number of hits
 
-    histogram_element_t(double d, double a, double t, double l, double i,
-                        double p, double c, std::size_t h, std::size_t x) {
+    histogram_element_t(
+        double d, double a, double t, double l, double i, double p, double c, std::size_t h, std::size_t x) {
       sdl = d;
       dta = a;
       tip = t;
@@ -109,7 +107,6 @@ private:
   histogram_data_t histogram_data_;
 
   class histogram_t {
-
     TH1F *sdl;
     TH1F *dta;
     TH1F *tip;
@@ -140,13 +137,11 @@ private:
       pt_1gev = new TH1F(name.c_str(), title.c_str(), 100, 0., 2.);
 
       name = std::string("tip_") + particleType;
-      title = std::string("Transverse impact parameter distribution for ") +
-              particleType;
+      title = std::string("Transverse impact parameter distribution for ") + particleType;
       tip = new TH1F(name.c_str(), title.c_str(), 100, -0.3, 0.3);
 
       name = std::string("lip_") + particleType;
-      title = std::string("Longitudinal impact parameter distribution for ") +
-              particleType;
+      title = std::string("Longitudinal impact parameter distribution for ") + particleType;
       lip = new TH1F(name.c_str(), title.c_str(), 100, -1., 1.);
 
       name = std::string("ips_") + particleType;
@@ -206,35 +201,27 @@ private:
 //
 // constructors and destructor
 //
-QualityCutsAnalyzer::QualityCutsAnalyzer(const edm::ParameterSet &config)
-    : classifier_(config, consumesCollector()) {
+QualityCutsAnalyzer::QualityCutsAnalyzer(const edm::ParameterSet &config) : classifier_(config, consumesCollector()) {
   trackProducer_ = config.getUntrackedParameter<edm::InputTag>("trackProducer");
   consumes<edm::View<reco::Track>>(trackProducer_);
-  primaryVertexProducer_ =
-      config.getUntrackedParameter<edm::InputTag>("primaryVertexProducer");
+  primaryVertexProducer_ = config.getUntrackedParameter<edm::InputTag>("primaryVertexProducer");
   consumes<reco::VertexCollection>(primaryVertexProducer_);
-  jetTracksAssociation_ =
-      config.getUntrackedParameter<edm::InputTag>("jetTracksAssociation");
+  jetTracksAssociation_ = config.getUntrackedParameter<edm::InputTag>("jetTracksAssociation");
   consumes<reco::JetTracksAssociationCollection>(jetTracksAssociation_);
 
   rootFile_ = config.getUntrackedParameter<std::string>("rootFile");
 
-  minimumNumberOfHits_ =
-      config.getUntrackedParameter<int>("minimumNumberOfHits");
-  minimumNumberOfPixelHits_ =
-      config.getUntrackedParameter<int>("minimumNumberOfPixelHits");
-  minimumTransverseMomentum_ =
-      config.getUntrackedParameter<double>("minimumTransverseMomentum");
-  maximumChiSquared_ =
-      config.getUntrackedParameter<double>("maximumChiSquared");
+  minimumNumberOfHits_ = config.getUntrackedParameter<int>("minimumNumberOfHits");
+  minimumNumberOfPixelHits_ = config.getUntrackedParameter<int>("minimumNumberOfPixelHits");
+  minimumTransverseMomentum_ = config.getUntrackedParameter<double>("minimumTransverseMomentum");
+  maximumChiSquared_ = config.getUntrackedParameter<double>("maximumChiSquared");
 
-  std::string trackQualityType =
-      config.getUntrackedParameter<std::string>("trackQualityClass"); // used
+  std::string trackQualityType = config.getUntrackedParameter<std::string>("trackQualityClass");  // used
   trackQuality_ = reco::TrackBase::qualityByName(trackQualityType);
   useAllQualities_ = false;
 
-  std::transform(trackQualityType.begin(), trackQualityType.end(),
-                 trackQualityType.begin(), (int (*)(int))std::tolower);
+  std::transform(
+      trackQualityType.begin(), trackQualityType.end(), trackQualityType.begin(), (int (*)(int))std::tolower);
   if (trackQualityType == "any") {
     std::cout << "Using any" << std::endl;
     useAllQualities_ = true;
@@ -248,8 +235,7 @@ QualityCutsAnalyzer::~QualityCutsAnalyzer() {}
 //
 
 // ------------ method called to for each event  ------------
-void QualityCutsAnalyzer::analyze(const edm::Event &event,
-                                  const edm::EventSetup &setup) {
+void QualityCutsAnalyzer::analyze(const edm::Event &event, const edm::EventSetup &setup) {
   // Track collection
   edm::Handle<edm::View<reco::Track>> trackCollection;
   event.getByLabel(trackProducer_, trackCollection);
@@ -309,8 +295,7 @@ void QualityCutsAnalyzer::endJob() {
 void QualityCutsAnalyzer::LoopOverJetTracksAssociation(
     const edm::ESHandle<TransientTrackBuilder> &TTbuilder,
     const edm::Handle<reco::VertexCollection> &primaryVertexProducer_,
-    const edm::Handle<reco::JetTracksAssociationCollection>
-        &jetTracksAssociation) {
+    const edm::Handle<reco::JetTracksAssociationCollection> &jetTracksAssociation) {
   const TransientTrackBuilder *bproduct = TTbuilder.product();
 
   // getting the primary vertex
@@ -319,10 +304,9 @@ void QualityCutsAnalyzer::LoopOverJetTracksAssociation(
 
   if (!primaryVertexProducer_->empty()) {
     PrimaryVertexSorter pvs;
-    std::vector<reco::Vertex> sortedList =
-        pvs.sortedList(*(primaryVertexProducer_.product()));
+    std::vector<reco::Vertex> sortedList = pvs.sortedList(*(primaryVertexProducer_.product()));
     pv = (sortedList.front());
-  } else { // create a dummy PV
+  } else {  // create a dummy PV
     // cout << "NO PV FOUND" << endl;
     reco::Vertex::Error e;
     e(0, 0) = 0.0015 * 0.0015;
@@ -332,8 +316,7 @@ void QualityCutsAnalyzer::LoopOverJetTracksAssociation(
     pv = reco::Vertex(p, e, 1, 1, 1);
   }
 
-  reco::JetTracksAssociationCollection::const_iterator it =
-      jetTracksAssociation->begin();
+  reco::JetTracksAssociationCollection::const_iterator it = jetTracksAssociation->begin();
 
   int i = 0;
 
@@ -342,8 +325,7 @@ void QualityCutsAnalyzer::LoopOverJetTracksAssociation(
     reco::JetTracksAssociationRef jetTracks(jetTracksAssociation, i);
 
     double pvZ = pv.z();
-    GlobalVector direction(jetTracks->first->px(), jetTracks->first->py(),
-                           jetTracks->first->pz());
+    GlobalVector direction(jetTracks->first->px(), jetTracks->first->py(), jetTracks->first->pz());
 
     // get the tracks associated to the jet
     reco::TrackRefVector tracks = jetTracks->second;
@@ -355,24 +337,15 @@ void QualityCutsAnalyzer::LoopOverJetTracksAssociation(
       int hits = tracks[index]->hitPattern().numberOfValidHits();
       int pixelHits = tracks[index]->hitPattern().numberOfValidPixelHits();
 
-      if (hits < minimumNumberOfHits_ ||
-          pixelHits < minimumNumberOfPixelHits_ ||
-          pt < minimumTransverseMomentum_ || chi2 > maximumChiSquared_ ||
-          (!useAllQualities_ && !tracks[index]->quality(trackQuality_)))
+      if (hits < minimumNumberOfHits_ || pixelHits < minimumNumberOfPixelHits_ || pt < minimumTransverseMomentum_ ||
+          chi2 > maximumChiSquared_ || (!useAllQualities_ && !tracks[index]->quality(trackQuality_)))
         continue;
 
-      const reco::TransientTrack transientTrack =
-          bproduct->build(&(*tracks[index]));
-      double dta = -IPTools::jetTrackDistance(transientTrack, direction, pv)
-                        .second.value();
-      double sdl = IPTools::signedDecayLength3D(transientTrack, direction, pv)
-                       .second.value();
-      double ips =
-          IPTools::signedImpactParameter3D(transientTrack, direction, pv)
-              .second.value();
-      double d0 = IPTools::signedTransverseImpactParameter(transientTrack,
-                                                           direction, pv)
-                      .second.value();
+      const reco::TransientTrack transientTrack = bproduct->build(&(*tracks[index]));
+      double dta = -IPTools::jetTrackDistance(transientTrack, direction, pv).second.value();
+      double sdl = IPTools::signedDecayLength3D(transientTrack, direction, pv).second.value();
+      double ips = IPTools::signedImpactParameter3D(transientTrack, direction, pv).second.value();
+      double d0 = IPTools::signedTransverseImpactParameter(transientTrack, direction, pv).second.value();
       double dz = tracks[index]->dz() - pvZ;
 
       // Classify the reco track;
@@ -380,24 +353,17 @@ void QualityCutsAnalyzer::LoopOverJetTracksAssociation(
 
       // Check for the different categories
       if (classifier_.is(TrackClassifier::Fake))
-        histogram_data_[5].push_back(histogram_element_t(
-            sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
+        histogram_data_[5].push_back(histogram_element_t(sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
       else if (classifier_.is(TrackClassifier::BWeakDecay))
-        histogram_data_[0].push_back(histogram_element_t(
-            sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
+        histogram_data_[0].push_back(histogram_element_t(sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
       else if (classifier_.is(TrackClassifier::Bad))
-        histogram_data_[4].push_back(histogram_element_t(
-            sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
-      else if (!classifier_.is(TrackClassifier::CWeakDecay) &&
-               !classifier_.is(TrackClassifier::PrimaryVertex))
-        histogram_data_[3].push_back(histogram_element_t(
-            sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
+        histogram_data_[4].push_back(histogram_element_t(sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
+      else if (!classifier_.is(TrackClassifier::CWeakDecay) && !classifier_.is(TrackClassifier::PrimaryVertex))
+        histogram_data_[3].push_back(histogram_element_t(sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
       else if (classifier_.is(TrackClassifier::CWeakDecay))
-        histogram_data_[1].push_back(histogram_element_t(
-            sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
+        histogram_data_[1].push_back(histogram_element_t(sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
       else
-        histogram_data_[2].push_back(histogram_element_t(
-            sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
+        histogram_data_[2].push_back(histogram_element_t(sdl, dta, d0, dz, ips, pt, chi2, hits, pixelHits));
     }
   }
 }

--- a/SimTracker/TrackHistory/plugins/SVTagInfoValidationAnalyzer.cc
+++ b/SimTracker/TrackHistory/plugins/SVTagInfoValidationAnalyzer.cc
@@ -35,7 +35,6 @@ using namespace std;
 using namespace edm;
 
 class SVTagInfoValidationAnalyzer : public edm::one::EDAnalyzer<> {
-
 public:
   explicit SVTagInfoValidationAnalyzer(const edm::ParameterSet &);
 
@@ -75,17 +74,14 @@ private:
   void bookSimToReco(std::string const &);
 
   // Fill all histogram per category
-  void fillRecoToSim(std::string const &, reco::Vertex const &,
-                     TrackingVertexRef const &);
-  void fillSimToReco(std::string const &, reco::VertexBaseRef const &,
-                     TrackingVertexRef const &);
+  void fillRecoToSim(std::string const &, reco::Vertex const &, TrackingVertexRef const &);
+  void fillSimToReco(std::string const &, reco::VertexBaseRef const &, TrackingVertexRef const &);
 
   // Histogram handlers
   std::map<std::string, TH1D *> TH1Index_;
 };
 
-SVTagInfoValidationAnalyzer::SVTagInfoValidationAnalyzer(
-    const edm::ParameterSet &config)
+SVTagInfoValidationAnalyzer::SVTagInfoValidationAnalyzer(const edm::ParameterSet &config)
     : classifier_(config, consumesCollector()) {
   // Initialize counters
   n_event = 0;
@@ -106,8 +102,7 @@ SVTagInfoValidationAnalyzer::SVTagInfoValidationAnalyzer(
   total_nmiss = 0;
 
   // Get the track collection
-  svTagInfoProducer_ =
-      config.getUntrackedParameter<edm::InputTag>("svTagInfoProducer");
+  svTagInfoProducer_ = config.getUntrackedParameter<edm::InputTag>("svTagInfoProducer");
   consumes<reco::SecondaryVertexTagInfoCollection>(svTagInfoProducer_);
 
   // Name of the traking pariticle collection
@@ -118,65 +113,52 @@ SVTagInfoValidationAnalyzer::SVTagInfoValidationAnalyzer(
   numberVertexClassifier_ = VertexCategories::Unknown + 1;
 
   // Define histogram for counting categories
-  TH1Index_["VertexClassifier"] = fs_->make<TH1D>(
-      "VertexClassifier", "Frequency for the different track categories",
-      numberVertexClassifier_, -0.5, numberVertexClassifier_ - 0.5);
+  TH1Index_["VertexClassifier"] = fs_->make<TH1D>("VertexClassifier",
+                                                  "Frequency for the different track categories",
+                                                  numberVertexClassifier_,
+                                                  -0.5,
+                                                  numberVertexClassifier_ - 0.5);
 
   //--- RecoToSim
-  TH1Index_["rs_All_MatchQuality"] = fs_->make<TH1D>(
-      "rs_All_MatchQuality", "Quality of Match", 51, -0.01, 1.01);
-  TH1Index_["rs_All_FlightDistance2d"] = fs_->make<TH1D>(
-      "rs_All_FlightDistance2d", "Transverse flight distance [cm]", 100, 0, 5);
+  TH1Index_["rs_All_MatchQuality"] = fs_->make<TH1D>("rs_All_MatchQuality", "Quality of Match", 51, -0.01, 1.01);
+  TH1Index_["rs_All_FlightDistance2d"] =
+      fs_->make<TH1D>("rs_All_FlightDistance2d", "Transverse flight distance [cm]", 100, 0, 5);
   TH1Index_["rs_SecondaryVertex_FlightDistance2d"] =
-      fs_->make<TH1D>("rs_SecondaryVertex_FlightDistance2d",
-                      "Transverse flight distance [cm]", 100, 0, 5);
-  TH1Index_["rs_BSV_FlightDistance2d"] = fs_->make<TH1D>(
-      "rs_BSV_FlightDistance2d", "Transverse flight distance [cm]", 100, 0, 5);
+      fs_->make<TH1D>("rs_SecondaryVertex_FlightDistance2d", "Transverse flight distance [cm]", 100, 0, 5);
+  TH1Index_["rs_BSV_FlightDistance2d"] =
+      fs_->make<TH1D>("rs_BSV_FlightDistance2d", "Transverse flight distance [cm]", 100, 0, 5);
   TH1Index_["rs_BWeakDecay_FlightDistance2d"] =
-      fs_->make<TH1D>("rs_BWeakDecay_FlightDistance2d",
-                      "Transverse flight distance [cm]", 100, 0, 5);
+      fs_->make<TH1D>("rs_BWeakDecay_FlightDistance2d", "Transverse flight distance [cm]", 100, 0, 5);
   TH1Index_["rs_CWeakDecay_FlightDistance2d"] =
-      fs_->make<TH1D>("rs_CWeakDecay_FlightDistance2d",
-                      "Transverse flight distance [cm]", 100, 0, 5);
+      fs_->make<TH1D>("rs_CWeakDecay_FlightDistance2d", "Transverse flight distance [cm]", 100, 0, 5);
   TH1Index_["rs_Light_FlightDistance2d"] =
-      fs_->make<TH1D>("rs_Light_FlightDistance2d",
-                      "Transverse flight distance [cm]", 100, 0, 5);
+      fs_->make<TH1D>("rs_Light_FlightDistance2d", "Transverse flight distance [cm]", 100, 0, 5);
 
-  TH1Index_["rs_All_nRecVtx"] = fs_->make<TH1D>(
-      "rs_All_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["rs_All_nRecVtx"] = fs_->make<TH1D>("rs_All_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
   TH1Index_["rs_SecondaryVertex_nRecVtx"] =
-      fs_->make<TH1D>("rs_SecondaryVertex_nRecVtx",
-                      "Number of Vertices per event", 11, -0.5, 10.5);
-  TH1Index_["rs_BSV_nRecVtx"] = fs_->make<TH1D>(
-      "rs_BSV_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
-  TH1Index_["rs_BWeakDecay_nRecVtx"] = fs_->make<TH1D>(
-      "rs_BWeakDecay_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
-  TH1Index_["rs_CWeakDecay_nRecVtx"] = fs_->make<TH1D>(
-      "rs_CWeakDecay_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
-  TH1Index_["rs_Light_nRecVtx"] = fs_->make<TH1D>(
-      "rs_Light_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+      fs_->make<TH1D>("rs_SecondaryVertex_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["rs_BSV_nRecVtx"] = fs_->make<TH1D>("rs_BSV_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["rs_BWeakDecay_nRecVtx"] =
+      fs_->make<TH1D>("rs_BWeakDecay_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["rs_CWeakDecay_nRecVtx"] =
+      fs_->make<TH1D>("rs_CWeakDecay_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["rs_Light_nRecVtx"] = fs_->make<TH1D>("rs_Light_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
 
   //--- SimToReco
-  TH1Index_["sr_All_MatchQuality"] = fs_->make<TH1D>(
-      "sr_All_MatchQuality", "Quality of Match", 51, -0.01, 1.01);
-  TH1Index_["sr_All_nRecVtx"] = fs_->make<TH1D>(
-      "sr_All_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["sr_All_MatchQuality"] = fs_->make<TH1D>("sr_All_MatchQuality", "Quality of Match", 51, -0.01, 1.01);
+  TH1Index_["sr_All_nRecVtx"] = fs_->make<TH1D>("sr_All_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
   TH1Index_["sr_SecondaryVertex_nRecVtx"] =
-      fs_->make<TH1D>("sr_SecondaryVertex_nRecVtx",
-                      "Number of Vertices per event", 11, -0.5, 10.5);
-  TH1Index_["sr_BSV_nRecVtx"] = fs_->make<TH1D>(
-      "sr_BSV_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
-  TH1Index_["sr_BWeakDecay_nRecVtx"] = fs_->make<TH1D>(
-      "sr_BWeakDecay_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
-  TH1Index_["sr_CWeakDecay_nRecVtx"] = fs_->make<TH1D>(
-      "sr_CWeakDecay_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
-  TH1Index_["sr_Light_nRecVtx"] = fs_->make<TH1D>(
-      "sr_Light_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+      fs_->make<TH1D>("sr_SecondaryVertex_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["sr_BSV_nRecVtx"] = fs_->make<TH1D>("sr_BSV_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["sr_BWeakDecay_nRecVtx"] =
+      fs_->make<TH1D>("sr_BWeakDecay_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["sr_CWeakDecay_nRecVtx"] =
+      fs_->make<TH1D>("sr_CWeakDecay_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
+  TH1Index_["sr_Light_nRecVtx"] = fs_->make<TH1D>("sr_Light_nRecVtx", "Number of Vertices per event", 11, -0.5, 10.5);
 
   // Set the proper categories names
   for (Int_t i = 0; i < numberVertexClassifier_; ++i)
-    TH1Index_["VertexClassifier"]->GetXaxis()->SetBinLabel(
-        i + 1, VertexCategories::Names[i]);
+    TH1Index_["VertexClassifier"]->GetXaxis()->SetBinLabel(i + 1, VertexCategories::Names[i]);
 
   // book histograms
   bookRecoToSim("rs_All");
@@ -194,13 +176,10 @@ SVTagInfoValidationAnalyzer::SVTagInfoValidationAnalyzer(
   bookSimToReco("sr_Light");
 }
 
-void SVTagInfoValidationAnalyzer::analyze(const edm::Event &event,
-                                          const edm::EventSetup &setup) {
+void SVTagInfoValidationAnalyzer::analyze(const edm::Event &event, const edm::EventSetup &setup) {
   ++n_event;
 
-  std::cout << "*** Analyzing " << event.id() << " n_event = " << n_event
-            << std::endl
-            << std::endl;
+  std::cout << "*** Analyzing " << event.id() << " n_event = " << n_event << std::endl << std::endl;
 
   // Set the classifier for a new event
   classifier_.newEvent(event, setup);
@@ -212,9 +191,7 @@ void SVTagInfoValidationAnalyzer::analyze(const edm::Event &event,
   // Get a constant reference to the track history associated to the classifier
   VertexHistory const &tracer = classifier_.history();
 
-  cout << "* Event " << n_event
-       << " ; svTagInfoCollection->size() = " << svTagInfoCollection->size()
-       << endl;
+  cout << "* Event " << n_event << " ; svTagInfoCollection->size() = " << svTagInfoCollection->size() << endl;
 
   int rs_nall = 0;
   int rs_nsv = 0;
@@ -234,12 +211,10 @@ void SVTagInfoValidationAnalyzer::analyze(const edm::Event &event,
 
   // Loop over the svTagInfo collection.
   for (std::size_t index = 0; index < svTagInfoCollection->size(); ++index) {
-
     reco::SecondaryVertexTagInfoRef svTagInfo(svTagInfoCollection, index);
 
     // Loop over the vertexes in svTagInfo
     for (std::size_t vindex = 0; vindex < svTagInfo->nVertices(); ++vindex) {
-
       // Classify the vertices
       classifier_.evaluate(svTagInfo, vindex);
 
@@ -248,80 +223,62 @@ void SVTagInfoValidationAnalyzer::analyze(const edm::Event &event,
 
       // Fill the histogram with the categories
       for (Int_t i = 0; i != numberVertexClassifier_; ++i) {
-
         if (classifier_.is((VertexCategories::Category)i)) {
-
           TH1Index_["VertexClassifier"]->Fill(i);
         }
       }
       if (!classifier_.is(VertexCategories::Fake)) {
-
         cout << "R2S: MatchQuality = " << rs_quality << endl;
 
         TH1Index_["rs_All_MatchQuality"]->Fill(rs_quality);
-        fillRecoToSim("rs_All", svTagInfo->secondaryVertex(vindex),
-                      tracer.simVertex());
-        TH1Index_["rs_All_FlightDistance2d"]->Fill(
-            svTagInfo->flightDistance(vindex, true).value());
+        fillRecoToSim("rs_All", svTagInfo->secondaryVertex(vindex), tracer.simVertex());
+        TH1Index_["rs_All_FlightDistance2d"]->Fill(svTagInfo->flightDistance(vindex, true).value());
         rs_nall++;
 
         if (classifier_.is(VertexCategories::SecondaryVertex)) {
-
           // cout << "    R2S VertexCategories::SecondaryVertex" << endl;
-          fillRecoToSim("rs_SecondaryVertex",
-                        svTagInfo->secondaryVertex(vindex), tracer.simVertex());
-          TH1Index_["rs_SecondaryVertex_FlightDistance2d"]->Fill(
-              svTagInfo->flightDistance(vindex, true).value());
+          fillRecoToSim("rs_SecondaryVertex", svTagInfo->secondaryVertex(vindex), tracer.simVertex());
+          TH1Index_["rs_SecondaryVertex_FlightDistance2d"]->Fill(svTagInfo->flightDistance(vindex, true).value());
           rs_nsv++;
         }
 
         if (classifier_.is(VertexCategories::BWeakDecay)) {
-
           // cout << "    R2S VertexCategories::BWeakDecay" << endl;
-          fillRecoToSim("rs_BWeakDecay", svTagInfo->secondaryVertex(vindex),
-                        tracer.simVertex());
-          TH1Index_["rs_BWeakDecay_FlightDistance2d"]->Fill(
-              svTagInfo->flightDistance(vindex, true).value());
+          fillRecoToSim("rs_BWeakDecay", svTagInfo->secondaryVertex(vindex), tracer.simVertex());
+          TH1Index_["rs_BWeakDecay_FlightDistance2d"]->Fill(svTagInfo->flightDistance(vindex, true).value());
           rs_nbv++;
 
           if (classifier_.is(VertexCategories::SecondaryVertex)) {
             // cout << "    R2S VertexCategories::BWeakDecay SecondaryVertex" <<
             // endl;
-            fillRecoToSim("rs_BSV", svTagInfo->secondaryVertex(vindex),
-                          tracer.simVertex());
-            TH1Index_["rs_BSV_FlightDistance2d"]->Fill(
-                svTagInfo->flightDistance(vindex, true).value());
+            fillRecoToSim("rs_BSV", svTagInfo->secondaryVertex(vindex), tracer.simVertex());
+            TH1Index_["rs_BSV_FlightDistance2d"]->Fill(svTagInfo->flightDistance(vindex, true).value());
             rs_nbsv++;
           }
-        } // BWeakDecay
+        }  // BWeakDecay
 
         else if (classifier_.is(VertexCategories::CWeakDecay)) {
-
           // cout << "    R2S VertexCategories::CWeakDecay" << endl;
-          fillRecoToSim("rs_CWeakDecay", svTagInfo->secondaryVertex(vindex),
-                        tracer.simVertex());
-          TH1Index_["rs_CWeakDecay_FlightDistance2d"]->Fill(
-              svTagInfo->flightDistance(vindex, true).value());
+          fillRecoToSim("rs_CWeakDecay", svTagInfo->secondaryVertex(vindex), tracer.simVertex());
+          TH1Index_["rs_CWeakDecay_FlightDistance2d"]->Fill(svTagInfo->flightDistance(vindex, true).value());
           rs_ncv++;
 
         } else {
           // cout << "    R2S Light (rest of categories)" << endl;
-          fillRecoToSim("rs_Light", svTagInfo->secondaryVertex(vindex),
-                        tracer.simVertex());
-          TH1Index_["rs_Light_FlightDistance2d"]->Fill(
-              svTagInfo->flightDistance(vindex, true).value());
+          fillRecoToSim("rs_Light", svTagInfo->secondaryVertex(vindex), tracer.simVertex());
+          TH1Index_["rs_Light_FlightDistance2d"]->Fill(svTagInfo->flightDistance(vindex, true).value());
           rs_nlv++;
         }
-      } // end if classifier
+      }  // end if classifier
 
       else {
         cout << "    VertexCategories::Fake!!" << endl;
         nfake++;
       }
 
-    } // end loop over vertices in svTagInfo
+    }  // end loop over vertices in svTagInfo
 
-  } // loop over svTagInfo
+  }  // loop over svTagInfo
 
   TH1Index_["rs_All_nRecVtx"]->Fill(rs_nall);
   TH1Index_["rs_SecondaryVertex_nRecVtx"]->Fill(rs_nsv);
@@ -340,7 +297,6 @@ void SVTagInfoValidationAnalyzer::analyze(const edm::Event &event,
 
   // Loop over the TV collection.
   for (std::size_t index = 0; index < TVCollection->size(); ++index) {
-
     TrackingVertexRef trackingVertex(TVCollection, index);
 
     classifier_.evaluate(trackingVertex);
@@ -348,7 +304,6 @@ void SVTagInfoValidationAnalyzer::analyze(const edm::Event &event,
     double sr_quality = tracer.quality();
 
     if (classifier_.is(VertexCategories::Reconstructed)) {
-
       cout << "S2R: MatchQuality = " << sr_quality << endl;
 
       // cout << "    S2R VertexCategories::Reconstructed" << endl;
@@ -357,52 +312,46 @@ void SVTagInfoValidationAnalyzer::analyze(const edm::Event &event,
       sr_nall++;
 
       if (classifier_.is(VertexCategories::SecondaryVertex)) {
-
         // cout << "    S2R VertexCategories::Reconstructed::SecondaryVertex" <<
         // endl;
-        fillSimToReco("sr_SecondaryVertex", tracer.recoVertex(),
-                      trackingVertex);
+        fillSimToReco("sr_SecondaryVertex", tracer.recoVertex(), trackingVertex);
         sr_nsv++;
       }
 
       if (classifier_.is(VertexCategories::BWeakDecay)) {
-
         // cout << "    S2R VertexCategories::Reconstructed::BWeakDecay" <<
         // endl;
         fillSimToReco("sr_BWeakDecay", tracer.recoVertex(), trackingVertex);
         sr_nbv++;
 
         if (classifier_.is(VertexCategories::SecondaryVertex)) {
-
           // cout << "    S2R VertexCategories::Reconstructed::BWeakDecay
           // SecondaryVertex" << endl;
           fillSimToReco("sr_BSV", tracer.recoVertex(), trackingVertex);
           sr_nbsv++;
         }
 
-      } // BWeakDecay
+      }  // BWeakDecay
 
       else if (classifier_.is(VertexCategories::CWeakDecay)) {
-
         // cout << "    S2R VertexCategories::CWeakDecay" << endl;
         fillSimToReco("sr_CWeakDecay", tracer.recoVertex(), trackingVertex);
         sr_ncv++;
       }
 
       else {
-
         // cout << "    S2R Light (rest of categories)" << endl;
         fillSimToReco("sr_Light", tracer.recoVertex(), trackingVertex);
         sr_nlv++;
       }
 
-    } // Reconstructed
+    }  // Reconstructed
     else {
       // cout << "##### Not reconstructed!" << endl;
       nmiss++;
     }
 
-  } // TVCollection.size()
+  }  // TVCollection.size()
 
   TH1Index_["sr_All_nRecVtx"]->Fill(sr_nall);
   TH1Index_["sr_SecondaryVertex_nRecVtx"]->Fill(sr_nsv);
@@ -439,14 +388,11 @@ void SVTagInfoValidationAnalyzer::bookRecoToSim(std::string const &prefix) {
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -10., 10.);
 
   name = prefix + "_Resx";
-  TH1Index_[name] =
-      fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
   name = prefix + "_Resy";
-  TH1Index_[name] =
-      fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
   name = prefix + "_Resz";
-  TH1Index_[name] =
-      fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
 
   name = prefix + "_Chi2Norm";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, 0, 10.);
@@ -454,8 +400,7 @@ void SVTagInfoValidationAnalyzer::bookRecoToSim(std::string const &prefix) {
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, 0., 1.);
 
   name = prefix + "_nRecTrks";
-  TH1Index_[name] =
-      fs_->make<TH1D>(name.c_str(), name.c_str(), 501, -0.5, 500.5);
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 501, -0.5, 500.5);
 
   name = prefix + "_AverageTrackWeight";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.1, 1.1);
@@ -464,8 +409,7 @@ void SVTagInfoValidationAnalyzer::bookRecoToSim(std::string const &prefix) {
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 65, 0., 6.5);
 
   name = prefix + "_RecPt";
-  TH1Index_[name] =
-      fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
 
   name = prefix + "_RecEta";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 200, -3., 3.);
@@ -474,19 +418,16 @@ void SVTagInfoValidationAnalyzer::bookRecoToSim(std::string const &prefix) {
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 21, -0.5, 20.5);
 
   name = prefix + "_RecTrackPt";
-  TH1Index_[name] =
-      fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
 
   name = prefix + "_RecTrackEta";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 200, -3., 3.);
 
   name = prefix + "_nSimTrks";
-  TH1Index_[name] =
-      fs_->make<TH1D>(name.c_str(), name.c_str(), 501, -0.5, 500.5);
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 501, -0.5, 500.5);
 
   name = prefix + "_SimPt";
-  TH1Index_[name] =
-      fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
 
   name = prefix + "_SimEta";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 200, -3., 3.);
@@ -512,14 +453,11 @@ void SVTagInfoValidationAnalyzer::bookSimToReco(std::string const &prefix) {
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -10., 10.);
 
   name = prefix + "_Resx";
-  TH1Index_[name] =
-      fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
   name = prefix + "_Resy";
-  TH1Index_[name] =
-      fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
   name = prefix + "_Resz";
-  TH1Index_[name] =
-      fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.05, 0.05);
 
   name = prefix + "_Chi2Norm";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, 0, 10.);
@@ -527,8 +465,7 @@ void SVTagInfoValidationAnalyzer::bookSimToReco(std::string const &prefix) {
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, 0., 1.);
 
   name = prefix + "_nRecTrks";
-  TH1Index_[name] =
-      fs_->make<TH1D>(name.c_str(), name.c_str(), 501, -0.5, 500.5);
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 501, -0.5, 500.5);
 
   name = prefix + "_AverageTrackWeight";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 100, -0.1, 1.1);
@@ -537,8 +474,7 @@ void SVTagInfoValidationAnalyzer::bookSimToReco(std::string const &prefix) {
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 65, 0., 6.5);
 
   name = prefix + "_RecPt";
-  TH1Index_[name] =
-      fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
 
   name = prefix + "_RecEta";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 200, -3., 3.);
@@ -547,19 +483,16 @@ void SVTagInfoValidationAnalyzer::bookSimToReco(std::string const &prefix) {
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 21, -0.5, 20.5);
 
   name = prefix + "_RecTrackPt";
-  TH1Index_[name] =
-      fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
 
   name = prefix + "_RecTrackEta";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 200, -3., 3.);
 
   name = prefix + "_nSimTrks";
-  TH1Index_[name] =
-      fs_->make<TH1D>(name.c_str(), name.c_str(), 501, -0.5, 500.5);
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 501, -0.5, 500.5);
 
   name = prefix + "_SimPt";
-  TH1Index_[name] =
-      fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
+  TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 2000, 0., 1000.);
 
   name = prefix + "_SimEta";
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 200, -3., 3.);
@@ -574,10 +507,9 @@ void SVTagInfoValidationAnalyzer::bookSimToReco(std::string const &prefix) {
   TH1Index_[name] = fs_->make<TH1D>(name.c_str(), name.c_str(), 200, -3., 3.);
 }
 
-void SVTagInfoValidationAnalyzer::fillRecoToSim(
-    std::string const &prefix, reco::Vertex const &vertex,
-    TrackingVertexRef const &simVertex) {
-
+void SVTagInfoValidationAnalyzer::fillRecoToSim(std::string const &prefix,
+                                                reco::Vertex const &vertex,
+                                                TrackingVertexRef const &simVertex) {
   double pullx = (vertex.x() - simVertex->position().x()) / vertex.xError();
   double pully = (vertex.y() - simVertex->position().y()) / vertex.yError();
   double pullz = (vertex.z() - simVertex->position().z()) / vertex.zError();
@@ -596,9 +528,8 @@ void SVTagInfoValidationAnalyzer::fillRecoToSim(
   math::XYZTLorentzVector sum;
   int charge = 0;
   double thePiMass = 0.13957;
-  for (reco::Vertex::trackRef_iterator recDaughter = vertex.tracks_begin();
-       recDaughter != vertex.tracks_end(); ++recDaughter) {
-
+  for (reco::Vertex::trackRef_iterator recDaughter = vertex.tracks_begin(); recDaughter != vertex.tracks_end();
+       ++recDaughter) {
     ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double>> vec;
 
     vec.SetPx((**recDaughter).px());
@@ -619,7 +550,7 @@ void SVTagInfoValidationAnalyzer::fillRecoToSim(
 
     TH1Index_[prefix + "_RecTrackPt"]->Fill((*recDaughter)->pt());
     TH1Index_[prefix + "_RecTrackEta"]->Fill((*recDaughter)->eta());
-  } // end loop to recDaughters
+  }  // end loop to recDaughters
   // cout << "                   average sum of weights = " <<
   // sum_weight/tracksize << endl;
 
@@ -629,10 +560,9 @@ void SVTagInfoValidationAnalyzer::fillRecoToSim(
 
   math::XYZVector simmomentum;
   int simcharge = 0;
-  for (TrackingVertex::tp_iterator simDaughter =
-           simVertex->daughterTracks_begin();
-       simDaughter != simVertex->daughterTracks_end(); ++simDaughter) {
-
+  for (TrackingVertex::tp_iterator simDaughter = simVertex->daughterTracks_begin();
+       simDaughter != simVertex->daughterTracks_end();
+       ++simDaughter) {
     math::XYZVector p;
     p = (**simDaughter).momentum();
     simmomentum += p;
@@ -670,10 +600,9 @@ void SVTagInfoValidationAnalyzer::fillRecoToSim(
   TH1Index_[prefix + "_SimCharge"]->Fill(simcharge);
 }
 
-void SVTagInfoValidationAnalyzer::fillSimToReco(
-    std::string const &prefix, reco::VertexBaseRef const &vertex,
-    TrackingVertexRef const &simVertex) {
-
+void SVTagInfoValidationAnalyzer::fillSimToReco(std::string const &prefix,
+                                                reco::VertexBaseRef const &vertex,
+                                                TrackingVertexRef const &simVertex) {
   double pullx = (vertex->x() - simVertex->position().x()) / vertex->xError();
   double pully = (vertex->y() - simVertex->position().y()) / vertex->yError();
   double pullz = (vertex->z() - simVertex->position().z()) / vertex->zError();
@@ -692,9 +621,8 @@ void SVTagInfoValidationAnalyzer::fillSimToReco(
   math::XYZTLorentzVector sum;
   int charge = 0;
   double thePiMass = 0.13957;
-  for (reco::Vertex::trackRef_iterator recDaughter = vertex->tracks_begin();
-       recDaughter != vertex->tracks_end(); ++recDaughter) {
-
+  for (reco::Vertex::trackRef_iterator recDaughter = vertex->tracks_begin(); recDaughter != vertex->tracks_end();
+       ++recDaughter) {
     ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double>> vec;
 
     vec.SetPx((**recDaughter).px());
@@ -725,10 +653,9 @@ void SVTagInfoValidationAnalyzer::fillSimToReco(
 
   math::XYZVector simmomentum;
   int simcharge = 0;
-  for (TrackingVertex::tp_iterator simDaughter =
-           simVertex->daughterTracks_begin();
-       simDaughter != simVertex->daughterTracks_end(); ++simDaughter) {
-
+  for (TrackingVertex::tp_iterator simDaughter = simVertex->daughterTracks_begin();
+       simDaughter != simVertex->daughterTracks_end();
+       ++simDaughter) {
     math::XYZVector p;
     p = (**simDaughter).momentum();
     simmomentum += p;
@@ -767,38 +694,23 @@ void SVTagInfoValidationAnalyzer::fillSimToReco(
 }
 
 void SVTagInfoValidationAnalyzer::endJob() {
-
   std::cout << std::endl;
-  std::cout << " ====== Total Number of analyzed events: " << n_event
-            << " ====== " << std::endl;
-  std::cout << " ====== Total Number of R2S All:                         "
-            << rs_total_nall << " ====== " << std::endl;
-  std::cout << " ====== Total Number of R2S SecondaryVertex:             "
-            << rs_total_nsv << " ====== " << std::endl;
-  std::cout << " ====== Total Number of R2S BWeakDecay:                  "
-            << rs_total_nbv << " ====== " << std::endl;
-  std::cout << " ====== Total Number of R2S BWeakDecay::SecondaryVertex: "
-            << rs_total_nbsv << " ====== " << std::endl;
-  std::cout << " ====== Total Number of R2S CWeakDecay:                  "
-            << rs_total_ncv << " ====== " << std::endl;
-  std::cout << " ====== Total Number of R2S Light:                       "
-            << rs_total_nlv << " ====== " << std::endl;
+  std::cout << " ====== Total Number of analyzed events: " << n_event << " ====== " << std::endl;
+  std::cout << " ====== Total Number of R2S All:                         " << rs_total_nall << " ====== " << std::endl;
+  std::cout << " ====== Total Number of R2S SecondaryVertex:             " << rs_total_nsv << " ====== " << std::endl;
+  std::cout << " ====== Total Number of R2S BWeakDecay:                  " << rs_total_nbv << " ====== " << std::endl;
+  std::cout << " ====== Total Number of R2S BWeakDecay::SecondaryVertex: " << rs_total_nbsv << " ====== " << std::endl;
+  std::cout << " ====== Total Number of R2S CWeakDecay:                  " << rs_total_ncv << " ====== " << std::endl;
+  std::cout << " ====== Total Number of R2S Light:                       " << rs_total_nlv << " ====== " << std::endl;
   std::cout << std::endl;
-  std::cout << " ====== Total Number of S2R All:                         "
-            << sr_total_nall << " ====== " << std::endl;
-  std::cout << " ====== Total Number of S2R SecondaryVertex:             "
-            << sr_total_nsv << " ====== " << std::endl;
-  std::cout << " ====== Total Number of S2R BWeakDecay:                  "
-            << sr_total_nbv << " ====== " << std::endl;
-  std::cout << " ====== Total Number of S2R BWeakDecay::SecondaryVertex: "
-            << sr_total_nbsv << " ====== " << std::endl;
-  std::cout << " ====== Total Number of S2R CWeakDecay:                  "
-            << sr_total_ncv << " ====== " << std::endl;
-  std::cout << " ====== Total Number of S2R Light:                       "
-            << sr_total_nlv << " ====== " << std::endl;
+  std::cout << " ====== Total Number of S2R All:                         " << sr_total_nall << " ====== " << std::endl;
+  std::cout << " ====== Total Number of S2R SecondaryVertex:             " << sr_total_nsv << " ====== " << std::endl;
+  std::cout << " ====== Total Number of S2R BWeakDecay:                  " << sr_total_nbv << " ====== " << std::endl;
+  std::cout << " ====== Total Number of S2R BWeakDecay::SecondaryVertex: " << sr_total_nbsv << " ====== " << std::endl;
+  std::cout << " ====== Total Number of S2R CWeakDecay:                  " << sr_total_ncv << " ====== " << std::endl;
+  std::cout << " ====== Total Number of S2R Light:                       " << sr_total_nlv << " ====== " << std::endl;
   std::cout << std::endl;
-  std::cout << " ====== Total Number of Fake Vertices:              "
-            << total_nfake << " ====== " << std::endl;
+  std::cout << " ====== Total Number of Fake Vertices:              " << total_nfake << " ====== " << std::endl;
 }
 
 DEFINE_FWK_MODULE(SVTagInfoValidationAnalyzer);

--- a/SimTracker/TrackHistory/plugins/SecondaryVertexTagInfoProxy.cc
+++ b/SimTracker/TrackHistory/plugins/SecondaryVertexTagInfoProxy.cc
@@ -24,48 +24,39 @@ public:
   explicit SecondaryVertexTagInfoProxy(const edm::ParameterSet &);
 
 private:
-  void produce(edm::StreamID, edm::Event &,
-               const edm::EventSetup &) const override;
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
 
   edm::EDGetTokenT<reco::SecondaryVertexTagInfoCollection> svTagInfoCollection_;
 };
 
-SecondaryVertexTagInfoProxy::SecondaryVertexTagInfoProxy(
-    const edm::ParameterSet &config) {
+SecondaryVertexTagInfoProxy::SecondaryVertexTagInfoProxy(const edm::ParameterSet &config) {
   // Get the cfg parameter
   svTagInfoCollection_ = consumes<reco::SecondaryVertexTagInfoCollection>(
       config.getUntrackedParameter<edm::InputTag>("svTagInfoProducer"));
 
   // Declare the type of objects to be produced.
   produces<reco::VertexCollection>();
-  produces<edm::AssociationMap<edm::OneToMany<
-      reco::SecondaryVertexTagInfoCollection, reco::VertexCollection>>>();
+  produces<edm::AssociationMap<edm::OneToMany<reco::SecondaryVertexTagInfoCollection, reco::VertexCollection>>>();
 }
 
-void SecondaryVertexTagInfoProxy::produce(edm::StreamID, edm::Event &event,
-                                          const edm::EventSetup &setup) const {
+void SecondaryVertexTagInfoProxy::produce(edm::StreamID, edm::Event &event, const edm::EventSetup &setup) const {
   // Vertex collection
   edm::Handle<reco::SecondaryVertexTagInfoCollection> svTagInfoCollection;
   event.getByToken(svTagInfoCollection_, svTagInfoCollection);
 
   // Auto pointers to the collection to be added to the event
   std::unique_ptr<reco::VertexCollection> proxy(new reco::VertexCollection);
-  std::unique_ptr<edm::AssociationMap<edm::OneToMany<
-      reco::SecondaryVertexTagInfoCollection, reco::VertexCollection>>>
-      assoc(
-          new edm::AssociationMap<edm::OneToMany<
-              reco::SecondaryVertexTagInfoCollection, reco::VertexCollection>>);
+  std::unique_ptr<edm::AssociationMap<edm::OneToMany<reco::SecondaryVertexTagInfoCollection, reco::VertexCollection>>>
+      assoc(new edm::AssociationMap<edm::OneToMany<reco::SecondaryVertexTagInfoCollection, reco::VertexCollection>>);
 
   // Get a reference before to put in the event
-  reco::VertexRefProd vertexRefProd =
-      event.getRefBeforePut<reco::VertexCollection>();
+  reco::VertexRefProd vertexRefProd = event.getRefBeforePut<reco::VertexCollection>();
 
   // General index
   std::size_t index = 0;
 
   // Loop over SecondaryVertexTagInfo collection
-  for (std::size_t svIndex = 0; svIndex < svTagInfoCollection->size();
-       ++svIndex) {
+  for (std::size_t svIndex = 0; svIndex < svTagInfoCollection->size(); ++svIndex) {
     // Reference to svTagInfo
     reco::SecondaryVertexTagInfoRef svTagInfo(svTagInfoCollection, svIndex);
 

--- a/SimTracker/TrackHistory/plugins/TrackCategoriesAnalyzer.cc
+++ b/SimTracker/TrackHistory/plugins/TrackCategoriesAnalyzer.cc
@@ -21,8 +21,7 @@
 // class decleration
 //
 
-class TrackCategoriesAnalyzer
-    : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+class TrackCategoriesAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit TrackCategoriesAnalyzer(const edm::ParameterSet &);
   ~TrackCategoriesAnalyzer() override;
@@ -43,12 +42,10 @@ private:
   Int_t numberTrackCategories_;
 };
 
-TrackCategoriesAnalyzer::TrackCategoriesAnalyzer(
-    const edm::ParameterSet &config)
+TrackCategoriesAnalyzer::TrackCategoriesAnalyzer(const edm::ParameterSet &config)
     : classifier_(config, consumesCollector()) {
   // Get the track collection
-  trackProducer_ = consumes<edm::View<reco::Track>>(
-      config.getUntrackedParameter<edm::InputTag>("trackProducer"));
+  trackProducer_ = consumes<edm::View<reco::Track>>(config.getUntrackedParameter<edm::InputTag>("trackProducer"));
 
   // Get the file service
   usesResource("TFileService");
@@ -61,9 +58,11 @@ TrackCategoriesAnalyzer::TrackCategoriesAnalyzer(
   numberTrackCategories_ = TrackCategories::Unknown + 1;
 
   // Define a new histograms
-  trackCategories_ = fs->make<TH1F>(
-      "Frequency", "Frequency for the different track categories",
-      numberTrackCategories_, -0.5, numberTrackCategories_ - 0.5);
+  trackCategories_ = fs->make<TH1F>("Frequency",
+                                    "Frequency for the different track categories",
+                                    numberTrackCategories_,
+                                    -0.5,
+                                    numberTrackCategories_ - 0.5);
 
   // Set the proper categories names
   for (Int_t i = 0; i < numberTrackCategories_; ++i)
@@ -72,8 +71,7 @@ TrackCategoriesAnalyzer::TrackCategoriesAnalyzer(
 
 TrackCategoriesAnalyzer::~TrackCategoriesAnalyzer() {}
 
-void TrackCategoriesAnalyzer::analyze(const edm::Event &event,
-                                      const edm::EventSetup &setup) {
+void TrackCategoriesAnalyzer::analyze(const edm::Event &event, const edm::EventSetup &setup) {
   // Track collection
   edm::Handle<edm::View<reco::Track>> trackCollection;
   event.getByToken(trackProducer_, trackCollection);

--- a/SimTracker/TrackHistory/plugins/TrackHistoryAnalyzer.cc
+++ b/SimTracker/TrackHistory/plugins/TrackHistoryAnalyzer.cc
@@ -54,26 +54,22 @@ private:
 
   TrackClassifier classifier_;
 
-  std::string vertexString(const TrackingParticleRefVector &,
-                           const TrackingParticleRefVector &) const;
+  std::string vertexString(const TrackingParticleRefVector &, const TrackingParticleRefVector &) const;
 
-  std::string
-      vertexString(HepMC::GenVertex::particles_in_const_iterator,
-                   HepMC::GenVertex::particles_in_const_iterator,
-                   HepMC::GenVertex::particles_out_const_iterator,
-                   HepMC::GenVertex::particles_out_const_iterator) const;
+  std::string vertexString(HepMC::GenVertex::particles_in_const_iterator,
+                           HepMC::GenVertex::particles_in_const_iterator,
+                           HepMC::GenVertex::particles_out_const_iterator,
+                           HepMC::GenVertex::particles_out_const_iterator) const;
 };
 
-TrackHistoryAnalyzer::TrackHistoryAnalyzer(const edm::ParameterSet &config)
-    : classifier_(config, consumesCollector()) {
+TrackHistoryAnalyzer::TrackHistoryAnalyzer(const edm::ParameterSet &config) : classifier_(config, consumesCollector()) {
   trackProducer_ = config.getUntrackedParameter<edm::InputTag>("trackProducer");
   consumes<edm::View<reco::Track>>(trackProducer_);
 }
 
 TrackHistoryAnalyzer::~TrackHistoryAnalyzer() {}
 
-void TrackHistoryAnalyzer::analyze(const edm::Event &event,
-                                   const edm::EventSetup &setup) {
+void TrackHistoryAnalyzer::analyze(const edm::Event &event, const edm::EventSetup &setup) {
   // Track collection
   edm::Handle<edm::View<reco::Track>> trackCollection;
   event.getByLabel(trackProducer_, trackCollection);
@@ -86,19 +82,16 @@ void TrackHistoryAnalyzer::analyze(const edm::Event &event,
 
   // Loop over the track collection.
   for (std::size_t index = 0; index < trackCollection->size(); index++) {
-    std::cout << std::endl
-              << "History for track #" << index << " : " << std::endl;
+    std::cout << std::endl << "History for track #" << index << " : " << std::endl;
 
     // Classify the track and detect for fakes
-    if (!classifier_.evaluate(reco::TrackBaseRef(trackCollection, index))
-             .is(TrackClassifier::Fake)) {
+    if (!classifier_.evaluate(reco::TrackBaseRef(trackCollection, index)).is(TrackClassifier::Fake)) {
       // Get the list of TrackingParticles associated to
       TrackHistory::SimParticleTrail simParticles(tracer.simParticleTrail());
 
       // Loop over all simParticles
       for (std::size_t hindex = 0; hindex < simParticles.size(); hindex++) {
-        std::cout << "  simParticles [" << hindex
-                  << "] : " << particleString(simParticles[hindex]->pdgId())
+        std::cout << "  simParticles [" << hindex << "] : " << particleString(simParticles[hindex]->pdgId())
                   << std::endl;
       }
 
@@ -109,8 +102,7 @@ void TrackHistoryAnalyzer::analyze(const edm::Event &event,
       if (!simVertexes.empty()) {
         for (std::size_t hindex = 0; hindex < simVertexes.size(); hindex++) {
           std::cout << "  simVertex    [" << hindex << "] : "
-                    << vertexString(simVertexes[hindex]->sourceTracks(),
-                                    simVertexes[hindex]->daughterTracks())
+                    << vertexString(simVertexes[hindex]->sourceTracks(), simVertexes[hindex]->daughterTracks())
                     << std::endl;
         }
       } else
@@ -121,8 +113,7 @@ void TrackHistoryAnalyzer::analyze(const edm::Event &event,
 
       // Loop over all genParticles
       for (std::size_t hindex = 0; hindex < genParticles.size(); hindex++) {
-        std::cout << "  genParticles [" << hindex
-                  << "] : " << particleString(genParticles[hindex]->pdg_id())
+        std::cout << "  genParticles [" << hindex << "] : " << particleString(genParticles[hindex]->pdg_id())
                   << std::endl;
       }
 
@@ -133,11 +124,10 @@ void TrackHistoryAnalyzer::analyze(const edm::Event &event,
       if (!genVertexes.empty()) {
         for (std::size_t hindex = 0; hindex < genVertexes.size(); hindex++) {
           std::cout << "  genVertex    [" << hindex << "] : "
-                    << vertexString(
-                           genVertexes[hindex]->particles_in_const_begin(),
-                           genVertexes[hindex]->particles_in_const_end(),
-                           genVertexes[hindex]->particles_out_const_begin(),
-                           genVertexes[hindex]->particles_out_const_end())
+                    << vertexString(genVertexes[hindex]->particles_in_const_begin(),
+                                    genVertexes[hindex]->particles_in_const_end(),
+                                    genVertexes[hindex]->particles_out_const_begin(),
+                                    genVertexes[hindex]->particles_out_const_end())
                     << std::endl;
         }
       } else
@@ -150,8 +140,7 @@ void TrackHistoryAnalyzer::analyze(const edm::Event &event,
   }
 }
 
-void TrackHistoryAnalyzer::beginRun(const edm::Run &run,
-                                    const edm::EventSetup &setup) {
+void TrackHistoryAnalyzer::beginRun(const edm::Run &run, const edm::EventSetup &setup) {
   // Get the particles table.
   setup.getData(pdt_);
 }
@@ -177,9 +166,8 @@ std::string TrackHistoryAnalyzer::particleString(int pdgId) const {
   return vDescription.str();
 }
 
-std::string
-TrackHistoryAnalyzer::vertexString(const TrackingParticleRefVector &in,
-                                   const TrackingParticleRefVector &out) const {
+std::string TrackHistoryAnalyzer::vertexString(const TrackingParticleRefVector &in,
+                                               const TrackingParticleRefVector &out) const {
   ParticleData const *pid;
 
   std::ostringstream vDescription;
@@ -231,11 +219,10 @@ TrackHistoryAnalyzer::vertexString(const TrackingParticleRefVector &in,
   return vDescription.str();
 }
 
-std::string TrackHistoryAnalyzer::vertexString(
-    HepMC::GenVertex::particles_in_const_iterator in_begin,
-    HepMC::GenVertex::particles_in_const_iterator in_end,
-    HepMC::GenVertex::particles_out_const_iterator out_begin,
-    HepMC::GenVertex::particles_out_const_iterator out_end) const {
+std::string TrackHistoryAnalyzer::vertexString(HepMC::GenVertex::particles_in_const_iterator in_begin,
+                                               HepMC::GenVertex::particles_in_const_iterator in_end,
+                                               HepMC::GenVertex::particles_out_const_iterator out_begin,
+                                               HepMC::GenVertex::particles_out_const_iterator out_end) const {
   ParticleData const *pid;
 
   std::ostringstream vDescription;

--- a/SimTracker/TrackHistory/plugins/TrackingParticleBHadronRefSelector.cc
+++ b/SimTracker/TrackHistory/plugins/TrackingParticleBHadronRefSelector.cc
@@ -27,24 +27,20 @@ private:
   HistoryBase tracer_;
 };
 
-TrackingParticleBHadronRefSelector::TrackingParticleBHadronRefSelector(
-    const edm::ParameterSet &iConfig)
-    : tpToken_(consumes<TrackingParticleCollection>(
-          iConfig.getParameter<edm::InputTag>("src"))) {
-  tracer_.depth(-2); // as in SimTracker/TrackHistory/src/TrackClassifier.cc
+TrackingParticleBHadronRefSelector::TrackingParticleBHadronRefSelector(const edm::ParameterSet &iConfig)
+    : tpToken_(consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("src"))) {
+  tracer_.depth(-2);  // as in SimTracker/TrackHistory/src/TrackClassifier.cc
 
   produces<TrackingParticleRefVector>();
 }
 
-void TrackingParticleBHadronRefSelector::fillDescriptions(
-    edm::ConfigurationDescriptions &descriptions) {
+void TrackingParticleBHadronRefSelector::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag("mix", "MergedTrackTruth"));
   descriptions.add("trackingParticleBHadronRefSelectorDefault", desc);
 }
 
-void TrackingParticleBHadronRefSelector::produce(
-    edm::Event &iEvent, const edm::EventSetup &iSetup) {
+void TrackingParticleBHadronRefSelector::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   edm::Handle<TrackingParticleCollection> h_tps;
   iEvent.getByToken(tpToken_, h_tps);
 
@@ -53,10 +49,9 @@ void TrackingParticleBHadronRefSelector::produce(
   // Logic is similar to SimTracker/TrackHistory
   for (size_t i = 0, end = h_tps->size(); i < end; ++i) {
     auto tpRef = TrackingParticleRef(h_tps, i);
-    if (tracer_.evaluate(tpRef)) { // ignore TP if history can not be traced
+    if (tracer_.evaluate(tpRef)) {  // ignore TP if history can not be traced
       // following is from TrackClassifier::processesAtGenerator()
-      HistoryBase::RecoGenParticleTrail const &recoGenParticleTrail =
-          tracer_.recoGenParticleTrail();
+      HistoryBase::RecoGenParticleTrail const &recoGenParticleTrail = tracer_.recoGenParticleTrail();
       for (const auto &particle : recoGenParticleTrail) {
         HepPDT::ParticleID particleID(particle->pdgId());
         if (particleID.hasBottom()) {

--- a/SimTracker/TrackHistory/plugins/TrackingParticleCategoriesAnalyser.cc
+++ b/SimTracker/TrackHistory/plugins/TrackingParticleCategoriesAnalyser.cc
@@ -21,8 +21,7 @@
 // class decleration
 //
 
-class TrackingParticleCategoriesAnalyzer
-    : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+class TrackingParticleCategoriesAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit TrackingParticleCategoriesAnalyzer(const edm::ParameterSet &);
   ~TrackingParticleCategoriesAnalyzer() override;
@@ -43,12 +42,10 @@ private:
   Int_t numberTrackingParticleCategories_;
 };
 
-TrackingParticleCategoriesAnalyzer::TrackingParticleCategoriesAnalyzer(
-    const edm::ParameterSet &config)
+TrackingParticleCategoriesAnalyzer::TrackingParticleCategoriesAnalyzer(const edm::ParameterSet &config)
     : classifier_(config, consumesCollector()) {
   // Get the track collection
-  trackingTruth_ = consumes<TrackingParticleCollection>(
-      config.getUntrackedParameter<edm::InputTag>("trackingTruth"));
+  trackingTruth_ = consumes<TrackingParticleCollection>(config.getUntrackedParameter<edm::InputTag>("trackingTruth"));
 
   // Get the file service
   usesResource("TFileService");
@@ -61,21 +58,20 @@ TrackingParticleCategoriesAnalyzer::TrackingParticleCategoriesAnalyzer(
   numberTrackingParticleCategories_ = TrackCategories::Unknown + 1;
 
   // Define a new histograms
-  trackingParticleCategories_ = fs->make<TH1F>(
-      "Frequency", "Frequency for the different track categories",
-      numberTrackingParticleCategories_, -0.5,
-      numberTrackingParticleCategories_ - 0.5);
+  trackingParticleCategories_ = fs->make<TH1F>("Frequency",
+                                               "Frequency for the different track categories",
+                                               numberTrackingParticleCategories_,
+                                               -0.5,
+                                               numberTrackingParticleCategories_ - 0.5);
 
   // Set the proper categories names
   for (Int_t i = 0; i < numberTrackingParticleCategories_; ++i)
-    trackingParticleCategories_->GetXaxis()->SetBinLabel(
-        i + 1, TrackCategories::Names[i]);
+    trackingParticleCategories_->GetXaxis()->SetBinLabel(i + 1, TrackCategories::Names[i]);
 }
 
 TrackingParticleCategoriesAnalyzer::~TrackingParticleCategoriesAnalyzer() {}
 
-void TrackingParticleCategoriesAnalyzer::analyze(const edm::Event &event,
-                                                 const edm::EventSetup &setup) {
+void TrackingParticleCategoriesAnalyzer::analyze(const edm::Event &event, const edm::EventSetup &setup) {
   // Track collection
   edm::Handle<TrackingParticleCollection> TPCollection;
   event.getByToken(trackingTruth_, TPCollection);

--- a/SimTracker/TrackHistory/plugins/VertexHistoryAnalyzer.cc
+++ b/SimTracker/TrackHistory/plugins/VertexHistoryAnalyzer.cc
@@ -50,25 +50,21 @@ private:
 
   std::string particleString(int) const;
 
-  std::string vertexString(const TrackingParticleRefVector &,
-                           const TrackingParticleRefVector &) const;
+  std::string vertexString(const TrackingParticleRefVector &, const TrackingParticleRefVector &) const;
 
-  std::string
-      vertexString(HepMC::GenVertex::particles_in_const_iterator,
-                   HepMC::GenVertex::particles_in_const_iterator,
-                   HepMC::GenVertex::particles_out_const_iterator,
-                   HepMC::GenVertex::particles_out_const_iterator) const;
+  std::string vertexString(HepMC::GenVertex::particles_in_const_iterator,
+                           HepMC::GenVertex::particles_in_const_iterator,
+                           HepMC::GenVertex::particles_out_const_iterator,
+                           HepMC::GenVertex::particles_out_const_iterator) const;
 };
 
 VertexHistoryAnalyzer::VertexHistoryAnalyzer(const edm::ParameterSet &config)
     : classifier_(config, consumesCollector()) {
-  vertexProducer_ =
-      config.getUntrackedParameter<edm::InputTag>("vertexProducer");
+  vertexProducer_ = config.getUntrackedParameter<edm::InputTag>("vertexProducer");
   consumes<edm::View<reco::Vertex>>(vertexProducer_);
 }
 
-void VertexHistoryAnalyzer::analyze(const edm::Event &event,
-                                    const edm::EventSetup &setup) {
+void VertexHistoryAnalyzer::analyze(const edm::Event &event, const edm::EventSetup &setup) {
   // Set the classifier for a new event
   classifier_.newEvent(event, setup);
 
@@ -81,19 +77,16 @@ void VertexHistoryAnalyzer::analyze(const edm::Event &event,
 
   // Loop over the track collection.
   for (std::size_t index = 0; index < vertexCollection->size(); index++) {
-    std::cout << std::endl
-              << "History for vertex #" << index << " : " << std::endl;
+    std::cout << std::endl << "History for vertex #" << index << " : " << std::endl;
 
     // Classify the track and detect for fakes
-    if (!classifier_.evaluate(reco::VertexBaseRef(vertexCollection, index))
-             .is(VertexClassifier::Fake)) {
+    if (!classifier_.evaluate(reco::VertexBaseRef(vertexCollection, index)).is(VertexClassifier::Fake)) {
       // Get the list of TrackingParticles associated to
       VertexHistory::SimParticleTrail simParticles(tracer.simParticleTrail());
 
       // Loop over all simParticles
       for (std::size_t hindex = 0; hindex < simParticles.size(); hindex++) {
-        std::cout << "  simParticles [" << hindex
-                  << "] : " << particleString(simParticles[hindex]->pdgId())
+        std::cout << "  simParticles [" << hindex << "] : " << particleString(simParticles[hindex]->pdgId())
                   << std::endl;
       }
 
@@ -104,8 +97,7 @@ void VertexHistoryAnalyzer::analyze(const edm::Event &event,
       if (!simVertexes.empty()) {
         for (std::size_t hindex = 0; hindex < simVertexes.size(); hindex++) {
           std::cout << "  simVertex    [" << hindex << "] : "
-                    << vertexString(simVertexes[hindex]->sourceTracks(),
-                                    simVertexes[hindex]->daughterTracks())
+                    << vertexString(simVertexes[hindex]->sourceTracks(), simVertexes[hindex]->daughterTracks())
                     << std::endl;
         }
       } else
@@ -116,8 +108,7 @@ void VertexHistoryAnalyzer::analyze(const edm::Event &event,
 
       // Loop over all genParticles
       for (std::size_t hindex = 0; hindex < genParticles.size(); hindex++) {
-        std::cout << "  genParticles [" << hindex
-                  << "] : " << particleString(genParticles[hindex]->pdg_id())
+        std::cout << "  genParticles [" << hindex << "] : " << particleString(genParticles[hindex]->pdg_id())
                   << std::endl;
       }
 
@@ -128,11 +119,10 @@ void VertexHistoryAnalyzer::analyze(const edm::Event &event,
       if (!genVertexes.empty()) {
         for (std::size_t hindex = 0; hindex < genVertexes.size(); hindex++) {
           std::cout << "  genVertex    [" << hindex << "] : "
-                    << vertexString(
-                           genVertexes[hindex]->particles_in_const_begin(),
-                           genVertexes[hindex]->particles_in_const_end(),
-                           genVertexes[hindex]->particles_out_const_begin(),
-                           genVertexes[hindex]->particles_out_const_end())
+                    << vertexString(genVertexes[hindex]->particles_in_const_begin(),
+                                    genVertexes[hindex]->particles_in_const_end(),
+                                    genVertexes[hindex]->particles_out_const_begin(),
+                                    genVertexes[hindex]->particles_out_const_end())
                     << std::endl;
         }
       } else
@@ -145,8 +135,7 @@ void VertexHistoryAnalyzer::analyze(const edm::Event &event,
   }
 }
 
-void VertexHistoryAnalyzer::beginRun(const edm::Run &run,
-                                     const edm::EventSetup &setup) {
+void VertexHistoryAnalyzer::beginRun(const edm::Run &run, const edm::EventSetup &setup) {
   // Get the particles table.
   setup.getData(pdt_);
 }
@@ -172,9 +161,8 @@ std::string VertexHistoryAnalyzer::particleString(int pdgId) const {
   return vDescription.str();
 }
 
-std::string VertexHistoryAnalyzer::vertexString(
-    const TrackingParticleRefVector &in,
-    const TrackingParticleRefVector &out) const {
+std::string VertexHistoryAnalyzer::vertexString(const TrackingParticleRefVector &in,
+                                                const TrackingParticleRefVector &out) const {
   ParticleData const *pid;
 
   std::ostringstream vDescription;
@@ -226,11 +214,10 @@ std::string VertexHistoryAnalyzer::vertexString(
   return vDescription.str();
 }
 
-std::string VertexHistoryAnalyzer::vertexString(
-    HepMC::GenVertex::particles_in_const_iterator in_begin,
-    HepMC::GenVertex::particles_in_const_iterator in_end,
-    HepMC::GenVertex::particles_out_const_iterator out_begin,
-    HepMC::GenVertex::particles_out_const_iterator out_end) const {
+std::string VertexHistoryAnalyzer::vertexString(HepMC::GenVertex::particles_in_const_iterator in_begin,
+                                                HepMC::GenVertex::particles_in_const_iterator in_end,
+                                                HepMC::GenVertex::particles_out_const_iterator out_begin,
+                                                HepMC::GenVertex::particles_out_const_iterator out_end) const {
   ParticleData const *pid;
 
   std::ostringstream vDescription;

--- a/SimTracker/TrackHistory/src/HistoryBase.cc
+++ b/SimTracker/TrackHistory/src/HistoryBase.cc
@@ -13,12 +13,10 @@ void HistoryBase::traceRecoGenHistory(reco::GenParticle const *genParticle) {
   // depth is 2 and so you trace back untill you reach the hard partons see for
   // status():
   // https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookGenParticleCandidate#GenPCand
-  if (genParticle->status() <= abs(depth_) &&
-      (genParticle->pdgId() < 88 || genParticle->pdgId() > 99)) {
+  if (genParticle->status() <= abs(depth_) && (genParticle->pdgId() < 88 || genParticle->pdgId() > 99)) {
     // If the particle is already in the history, it is looping and you should
     // stop
-    if (recoGenParticleTrailHelper_.find(genParticle) !=
-        recoGenParticleTrailHelper_.end()) {
+    if (recoGenParticleTrailHelper_.find(genParticle) != recoGenParticleTrailHelper_.end()) {
       return;
     }
     recoGenParticleTrail_.push_back(genParticle);
@@ -34,8 +32,7 @@ void HistoryBase::traceGenHistory(HepMC::GenParticle const *genParticle) {
   // Third stop criteria: status abs(depth_) particles after the hadronization.
   // The after hadronization is done by detecting the pdg_id pythia code from 88
   // to 99
-  if (genParticle->status() <= abs(depth_) &&
-      (genParticle->pdg_id() < 88 || genParticle->pdg_id() > 99)) {
+  if (genParticle->status() <= abs(depth_) && (genParticle->pdg_id() < 88 || genParticle->pdg_id() > 99)) {
     genParticleTrail_.push_back(genParticle);
     // Get the producer vertex and trace it history
     traceGenHistory(genParticle->production_vertex());
@@ -57,47 +54,40 @@ void HistoryBase::traceGenHistory(HepMC::GenVertex const *genVertex) {
   }
 }
 
-bool HistoryBase::traceSimHistory(TrackingParticleRef const &trackingParticle,
-                                  int depth) {
+bool HistoryBase::traceSimHistory(TrackingParticleRef const &trackingParticle, int depth) {
   // first stop condition: if the required depth is reached
   if (depth == depth_ && depth_ >= 0)
     return true;
 
   // second stop condition: if a gen particle is associated to the TP
   if (!trackingParticle->genParticles().empty()) {
-    LogDebug("TrackHistory") << "Particle " << trackingParticle->pdgId()
-                             << " has a GenParicle image." << std::endl;
+    LogDebug("TrackHistory") << "Particle " << trackingParticle->pdgId() << " has a GenParicle image." << std::endl;
 
     traceRecoGenHistory(&(**(trackingParticle->genParticle_begin())));
   }
 
-  LogDebug("TrackHistory") << "No GenParticle image for "
-                           << trackingParticle->pdgId() << std::endl;
+  LogDebug("TrackHistory") << "No GenParticle image for " << trackingParticle->pdgId() << std::endl;
 
   // if no association between TP and genParticles is found: get a reference to
   // the TP's parent vertex and trace its history
   return traceSimHistory(trackingParticle->parentVertex(), depth);
 }
 
-bool HistoryBase::traceSimHistory(TrackingVertexRef const &trackingVertex,
-                                  int depth) {
+bool HistoryBase::traceSimHistory(TrackingVertexRef const &trackingVertex, int depth) {
   // verify if the parent vertex exists
   if (trackingVertex.isNonnull()) {
     // save the vertex in the trail
     simVertexTrail_.push_back(trackingVertex);
 
     if (!trackingVertex->sourceTracks().empty()) {
-      LogDebug("TrackHistory")
-          << "Moving on to the parent particle." << std::endl;
+      LogDebug("TrackHistory") << "Moving on to the parent particle." << std::endl;
 
       // select the original source in case of combined vertices
       bool flag = false;
       TrackingVertex::tp_iterator itd, its;
 
-      for (its = trackingVertex->sourceTracks_begin();
-           its != trackingVertex->sourceTracks_end(); its++) {
-        for (itd = trackingVertex->daughterTracks_begin();
-             itd != trackingVertex->daughterTracks_end(); itd++)
+      for (its = trackingVertex->sourceTracks_begin(); its != trackingVertex->sourceTracks_end(); its++) {
+        for (itd = trackingVertex->daughterTracks_begin(); itd != trackingVertex->daughterTracks_end(); itd++)
           if (itd != its) {
             flag = true;
             break;
@@ -110,10 +100,8 @@ bool HistoryBase::traceSimHistory(TrackingVertexRef const &trackingVertex,
         return false;
 
       // verify if the new particle is not in the trail (looping partiles)
-      if (std::find(simParticleTrail_.begin(), simParticleTrail_.end(), *its) !=
-          simParticleTrail_.end()) {
-        LogDebug("TrackHistory")
-            << "WARNING: Looping track found." << std::endl;
+      if (std::find(simParticleTrail_.begin(), simParticleTrail_.end(), *its) != simParticleTrail_.end()) {
+        LogDebug("TrackHistory") << "WARNING: Looping track found." << std::endl;
         return false;
       }
 
@@ -122,18 +110,15 @@ bool HistoryBase::traceSimHistory(TrackingVertexRef const &trackingVertex,
       return traceSimHistory(*its, --depth);
     } else if (!trackingVertex->genVertices().empty()) {
       // navigate over all the associated generated vertexes
-      LogDebug("TrackHistory")
-          << "Vertex has " << trackingVertex->genVertices().size()
-          << "GenVertex image." << std::endl;
-      for (TrackingVertex::genv_iterator ivertex =
-               trackingVertex->genVertices_begin();
-           ivertex != trackingVertex->genVertices_end(); ++ivertex)
+      LogDebug("TrackHistory") << "Vertex has " << trackingVertex->genVertices().size() << "GenVertex image."
+                               << std::endl;
+      for (TrackingVertex::genv_iterator ivertex = trackingVertex->genVertices_begin();
+           ivertex != trackingVertex->genVertices_end();
+           ++ivertex)
         traceGenHistory(&(**(ivertex)));
       return true;
     } else {
-      LogDebug("TrackHistory")
-          << "WARNING: Source track for tracking vertex cannot be found."
-          << std::endl;
+      LogDebug("TrackHistory") << "WARNING: Source track for tracking vertex cannot be found." << std::endl;
     }
   } else {
     LogDebug("TrackHistory") << " WARNING: Vertex cannot be found.";

--- a/SimTracker/TrackHistory/src/JetVetoedTracksAssociatorDRVertex.cc
+++ b/SimTracker/TrackHistory/src/JetVetoedTracksAssociatorDRVertex.cc
@@ -1,22 +1,18 @@
 
 #include "SimTracker/TrackHistory/interface/JetVetoedTracksAssociatorDRVertex.h"
 
-JetVetoedTracksAssociationDRVertex::JetVetoedTracksAssociationDRVertex(
-    double dr)
-    : mDeltaR2Threshold(dr * dr) {}
+JetVetoedTracksAssociationDRVertex::JetVetoedTracksAssociationDRVertex(double dr) : mDeltaR2Threshold(dr * dr) {}
 
-void JetVetoedTracksAssociationDRVertex::produce(
-    reco::JetTracksAssociation::Container *fAssociation,
-    const std::vector<edm::RefToBase<reco::Jet>> &fJets,
-    const std::vector<reco::TrackRef> &fTracks,
-    TrackClassifier &classifier) const {
+void JetVetoedTracksAssociationDRVertex::produce(reco::JetTracksAssociation::Container *fAssociation,
+                                                 const std::vector<edm::RefToBase<reco::Jet>> &fJets,
+                                                 const std::vector<reco::TrackRef> &fTracks,
+                                                 TrackClassifier &classifier) const {
   // cache tracks kinematics
   std::vector<math::RhoEtaPhiVector> trackP3s;
   trackP3s.reserve(fTracks.size());
   for (unsigned i = 0; i < fTracks.size(); ++i) {
     const reco::Track *track = &*(fTracks[i]);
-    trackP3s.push_back(
-        math::RhoEtaPhiVector(track->p(), track->eta(), track->phi()));
+    trackP3s.push_back(math::RhoEtaPhiVector(track->p(), track->eta(), track->phi()));
   }
   // loop on jets and associate
   for (unsigned j = 0; j < fJets.size(); ++j) {
@@ -25,12 +21,10 @@ void JetVetoedTracksAssociationDRVertex::produce(
     double jetEta = jet->eta();
     double jetPhi = jet->phi();
     for (unsigned t = 0; t < fTracks.size(); ++t) {
-      double dR2 =
-          deltaR2(jetEta, jetPhi, trackP3s[t].eta(), trackP3s[t].phi());
+      double dR2 = deltaR2(jetEta, jetPhi, trackP3s[t].eta(), trackP3s[t].phi());
       classifier.evaluate(reco::TrackBaseRef(fTracks[t]));
       if (dR2 < mDeltaR2Threshold &&
-          (classifier.is(TrackClassifier::BWeakDecay) ||
-           classifier.is(TrackClassifier::CWeakDecay) ||
+          (classifier.is(TrackClassifier::BWeakDecay) || classifier.is(TrackClassifier::CWeakDecay) ||
            classifier.is(TrackClassifier::PrimaryVertex)))
         assoTracks.push_back(fTracks[t]);
     }

--- a/SimTracker/TrackHistory/src/TrackClassifier.cc
+++ b/SimTracker/TrackHistory/src/TrackClassifier.cc
@@ -7,17 +7,17 @@
 
 #include "SimTracker/TrackHistory/interface/TrackClassifier.h"
 
-#define update(a, b)                                                           \
-  do {                                                                         \
-    (a) = (a) | (b);                                                           \
+#define update(a, b) \
+  do {               \
+    (a) = (a) | (b); \
   } while (0)
 
-TrackClassifier::TrackClassifier(edm::ParameterSet const &config,
-                                 edm::ConsumesCollector &&collector)
+TrackClassifier::TrackClassifier(edm::ParameterSet const &config, edm::ConsumesCollector &&collector)
     : TrackCategories(),
       hepMCLabel_(config.getUntrackedParameter<edm::InputTag>("hepMC")),
       beamSpotLabel_(config.getUntrackedParameter<edm::InputTag>("beamSpot")),
-      tracer_(config, std::move(collector)), quality_(config, collector) {
+      tracer_(config, std::move(collector)),
+      quality_(config, collector) {
   collector.consumes<edm::HepMCProduct>(hepMCLabel_);
   collector.consumes<reco::BeamSpot>(beamSpotLabel_);
 
@@ -28,26 +28,20 @@ TrackClassifier::TrackClassifier(edm::ParameterSet const &config,
   badPull_ = config.getUntrackedParameter<double>("badPull");
 
   // Set the minimum decay length for detecting long decays
-  longLivedDecayLength_ =
-      config.getUntrackedParameter<double>("longLivedDecayLength");
+  longLivedDecayLength_ = config.getUntrackedParameter<double>("longLivedDecayLength");
 
   // Set the distance for clustering vertices
-  float vertexClusteringDistance =
-      config.getUntrackedParameter<double>("vertexClusteringDistance");
-  vertexClusteringSqDistance_ =
-      vertexClusteringDistance * vertexClusteringDistance;
+  float vertexClusteringDistance = config.getUntrackedParameter<double>("vertexClusteringDistance");
+  vertexClusteringSqDistance_ = vertexClusteringDistance * vertexClusteringDistance;
 
   // Set the number of innermost layers to check for bad hits
-  numberOfInnerLayers_ =
-      config.getUntrackedParameter<unsigned int>("numberOfInnerLayers");
+  numberOfInnerLayers_ = config.getUntrackedParameter<unsigned int>("numberOfInnerLayers");
 
   // Set the minimum number of simhits in the tracker
-  minTrackerSimHits_ =
-      config.getUntrackedParameter<unsigned int>("minTrackerSimHits");
+  minTrackerSimHits_ = config.getUntrackedParameter<unsigned int>("minTrackerSimHits");
 }
 
-void TrackClassifier::newEvent(edm::Event const &event,
-                               edm::EventSetup const &setup) {
+void TrackClassifier::newEvent(edm::Event const &event, edm::EventSetup const &setup) {
   // Get the new event information for the tracer
   tracer_.newEvent(event, setup);
 
@@ -67,8 +61,7 @@ void TrackClassifier::newEvent(edm::Event const &event,
   event.getByLabel(beamSpotLabel_, beamSpot_);
 
   // Transient track builder
-  setup.get<TransientTrackRecord>().get("TransientTrackBuilder",
-                                        transientTrackBuilder_);
+  setup.get<TransientTrackRecord>().get("TransientTrackBuilder", transientTrackBuilder_);
 
   // Create the list of primary vertices associated to the event
   genPrimaryVertices();
@@ -79,8 +72,7 @@ void TrackClassifier::newEvent(edm::Event const &event,
   tTopo_ = tTopoHand.product();
 }
 
-TrackClassifier const &
-TrackClassifier::evaluate(reco::TrackBaseRef const &track) {
+TrackClassifier const &TrackClassifier::evaluate(reco::TrackBaseRef const &track) {
   // Initializing the category vector
   reset();
 
@@ -116,8 +108,7 @@ TrackClassifier::evaluate(reco::TrackBaseRef const &track) {
   return *this;
 }
 
-TrackClassifier const &
-TrackClassifier::evaluate(TrackingParticleRef const &track) {
+TrackClassifier const &TrackClassifier::evaluate(TrackingParticleRef const &track) {
   // Initializing the category vector
   reset();
 
@@ -159,8 +150,7 @@ TrackClassifier::evaluate(TrackingParticleRef const &track) {
   return *this;
 }
 
-void TrackClassifier::reconstructionInformation(
-    reco::TrackBaseRef const &track) {
+void TrackClassifier::reconstructionInformation(reco::TrackBaseRef const &track) {
   TrackingParticleRef tpr = tracer_.simParticle();
 
   // Compute tracking particle parameters at point of closest approach to the
@@ -170,19 +160,17 @@ void TrackClassifier::reconstructionInformation(
 
   FreeTrajectoryState ftsAtProduction(
       GlobalPoint(tpr->vertex().x(), tpr->vertex().y(), tpr->vertex().z()),
-      GlobalVector(assocTrack->momentum().x(), assocTrack->momentum().y(),
-                   assocTrack->momentum().z()),
-      TrackCharge(track->charge()), magneticField_.product());
+      GlobalVector(assocTrack->momentum().x(), assocTrack->momentum().y(), assocTrack->momentum().z()),
+      TrackCharge(track->charge()),
+      magneticField_.product());
 
   try {
     TSCPBuilderNoMaterial tscpBuilder;
-    TrajectoryStateClosestToPoint tsAtClosestApproach = tscpBuilder(
-        ftsAtProduction,
-        GlobalPoint(beamSpot_->x0(), beamSpot_->y0(), beamSpot_->z0()));
+    TrajectoryStateClosestToPoint tsAtClosestApproach =
+        tscpBuilder(ftsAtProduction, GlobalPoint(beamSpot_->x0(), beamSpot_->y0(), beamSpot_->z0()));
 
     GlobalVector v =
-        tsAtClosestApproach.theState().position() -
-        GlobalPoint(beamSpot_->x0(), beamSpot_->y0(), beamSpot_->z0());
+        tsAtClosestApproach.theState().position() - GlobalPoint(beamSpot_->x0(), beamSpot_->y0(), beamSpot_->z0());
     GlobalVector p = tsAtClosestApproach.theState().momentum();
 
     // Simulated dxy
@@ -193,16 +181,12 @@ void TrackClassifier::reconstructionInformation(
 
     // Calculate the dxy pull
     double dxyPull =
-        std::abs(track->dxy(reco::TrackBase::Point(
-                     beamSpot_->x0(), beamSpot_->y0(), beamSpot_->z0())) -
-                 dxySim) /
+        std::abs(track->dxy(reco::TrackBase::Point(beamSpot_->x0(), beamSpot_->y0(), beamSpot_->z0())) - dxySim) /
         track->dxyError();
 
     // Calculate the dx pull
     double dzPull =
-        std::abs(track->dz(reco::TrackBase::Point(
-                     beamSpot_->x0(), beamSpot_->y0(), beamSpot_->z0())) -
-                 dzSim) /
+        std::abs(track->dz(reco::TrackBase::Point(beamSpot_->x0(), beamSpot_->y0(), beamSpot_->z0())) - dzSim) /
         track->dzError();
 
     // Return true if d0Pull > badD0Pull sigmas
@@ -221,16 +205,14 @@ void TrackClassifier::simulationInformation() {
   // Check for muons
   flags_[Muon] = (abs(tracer_.simParticle()->pdgId()) == 13);
   // Check for the number of psimhit in tracker
-  flags_[TrackerSimHits] =
-      tracer_.simParticle()->numberOfTrackerLayers() >= (int)minTrackerSimHits_;
+  flags_[TrackerSimHits] = tracer_.simParticle()->numberOfTrackerLayers() >= (int)minTrackerSimHits_;
 }
 
 void TrackClassifier::qualityInformation(reco::TrackBaseRef const &track) {
   // run the hit-by-hit reconstruction quality analysis
   quality_.evaluate(tracer_.simParticleTrail(), track, tTopo_);
 
-  unsigned int maxLayers =
-      std::min(numberOfInnerLayers_, quality_.numberOfLayers());
+  unsigned int maxLayers = std::min(numberOfInnerLayers_, quality_.numberOfLayers());
 
   // check the innermost layers for bad hits
   for (unsigned int i = 0; i < maxLayers; i++) {
@@ -241,8 +223,7 @@ void TrackClassifier::qualityInformation(reco::TrackBaseRef const &track) {
       const TrackQuality::Layer::Hit &hit = layer.hits[j];
 
       // In those cases the bad hit was used by track reconstruction
-      if (hit.state == TrackQuality::Layer::Noise ||
-          hit.state == TrackQuality::Layer::Misassoc)
+      if (hit.state == TrackQuality::Layer::Noise || hit.state == TrackQuality::Layer::Misassoc)
         flags_[BadInnerHits] = true;
       else if (hit.state == TrackQuality::Layer::Shared)
         flags_[SharedInnerHits] = true;
@@ -269,14 +250,13 @@ void TrackClassifier::processesAtGenerator() {
 
   // Get the generated particles from track history (reco::GenParticle in the
   // recoGenParticleTrail)
-  TrackHistory::RecoGenParticleTrail const &recoGenParticleTrail =
-      tracer_.recoGenParticleTrail();
+  TrackHistory::RecoGenParticleTrail const &recoGenParticleTrail = tracer_.recoGenParticleTrail();
 
   // Loop over the generated particles (reco::GenParticle in the
   // recoGenParticleTrail)
-  for (TrackHistory::RecoGenParticleTrail::const_iterator iparticle =
-           recoGenParticleTrail.begin();
-       iparticle != recoGenParticleTrail.end(); ++iparticle) {
+  for (TrackHistory::RecoGenParticleTrail::const_iterator iparticle = recoGenParticleTrail.begin();
+       iparticle != recoGenParticleTrail.end();
+       ++iparticle) {
     pdgid = std::abs((*iparticle)->pdgId());
     // Get particle type
     HepPDT::ParticleID particleID(pdgid);
@@ -284,8 +264,7 @@ void TrackClassifier::processesAtGenerator() {
     // Check if the particle type is valid one
     if (particleID.isValid()) {
       // Get particle data
-      ParticleData const *particleData =
-          particleDataTable_->particle(particleID);
+      ParticleData const *particleData = particleDataTable_->particle(particleID);
       // Check if the particle exist in the table
       if (particleData) {
         // Check if their life time is bigger than longLivedDecayLength_
@@ -300,12 +279,8 @@ void TrackClassifier::processesAtGenerator() {
         for (size_t i = 0; i < ndau; ++i) {
           daughterIds.insert((*iparticle)->daughter(i)->pdgId());
         }
-        update(flags_[FromBWeakDecayMuon],
-               particleID.hasBottom() &&
-                   (daughterIds.find(13) != daughterIds.end()));
-        update(flags_[FromCWeakDecayMuon],
-               particleID.hasCharm() &&
-                   (daughterIds.find(13) != daughterIds.end()));
+        update(flags_[FromBWeakDecayMuon], particleID.hasBottom() && (daughterIds.find(13) != daughterIds.end()));
+        update(flags_[FromCWeakDecayMuon], particleID.hasCharm() && (daughterIds.find(13) != daughterIds.end()));
       }
       // Check Tau, Ks and Lambda decay
       update(flags_[ChargePionDecay], pdgid == 211);
@@ -322,18 +297,16 @@ void TrackClassifier::processesAtGenerator() {
   // Decays in flight
   update(flags_[FromChargePionMuon], flags_[Muon] && flags_[ChargePionDecay]);
   update(flags_[FromChargeKaonMuon], flags_[Muon] && flags_[ChargeKaonDecay]);
-  update(flags_[DecayOnFlightMuon],
-         (flags_[FromChargePionMuon] || flags_[FromChargeKaonMuon]));
+  update(flags_[DecayOnFlightMuon], (flags_[FromChargePionMuon] || flags_[FromChargeKaonMuon]));
 }
 
 void TrackClassifier::processesAtSimulation() {
-  TrackHistory::SimParticleTrail const &simParticleTrail =
-      tracer_.simParticleTrail();
+  TrackHistory::SimParticleTrail const &simParticleTrail = tracer_.simParticleTrail();
 
   // Loop over the simulated particles
-  for (TrackHistory::SimParticleTrail::const_iterator iparticle =
-           simParticleTrail.begin();
-       iparticle != simParticleTrail.end(); ++iparticle) {
+  for (TrackHistory::SimParticleTrail::const_iterator iparticle = simParticleTrail.begin();
+       iparticle != simParticleTrail.end();
+       ++iparticle) {
     // pdgid of the real source parent vertex
     int pdgid = 0;
 
@@ -346,10 +319,8 @@ void TrackClassifier::processesAtSimulation() {
       bool flag = false;
       TrackingVertex::tp_iterator itd, its;
 
-      for (its = parentVertex->sourceTracks_begin();
-           its != parentVertex->sourceTracks_end(); ++its) {
-        for (itd = parentVertex->daughterTracks_begin();
-             itd != parentVertex->daughterTracks_end(); ++itd)
+      for (its = parentVertex->sourceTracks_begin(); its != parentVertex->sourceTracks_end(); ++its) {
+        for (itd = parentVertex->daughterTracks_begin(); itd != parentVertex->daughterTracks_end(); ++itd)
           if (itd != its) {
             flag = true;
             break;
@@ -375,9 +346,7 @@ void TrackClassifier::processesAtSimulation() {
     unsigned int process = g4toCMSProcMap_.processId(processG4);
 
     // Flagging all the different processes
-    update(flags_[KnownProcess], process != CMS::Undefined &&
-                                     process != CMS::Unknown &&
-                                     process != CMS::Primary);
+    update(flags_[KnownProcess], process != CMS::Undefined && process != CMS::Unknown && process != CMS::Primary);
 
     update(flags_[UndefinedProcess], process == CMS::Undefined);
     update(flags_[UnknownProcess], process == CMS::Unknown);
@@ -393,8 +362,7 @@ void TrackClassifier::processesAtSimulation() {
     update(flags_[MuPairProdProcess], process == CMS::MuPairProd);
     update(flags_[ConversionsProcess], process == CMS::Conversions);
     update(flags_[EBremProcess], process == CMS::EBrem);
-    update(flags_[SynchrotronRadiationProcess],
-           process == CMS::SynchrotronRadiation);
+    update(flags_[SynchrotronRadiationProcess], process == CMS::SynchrotronRadiation);
     update(flags_[MuBremProcess], process == CMS::MuBrem);
     update(flags_[MuNuclProcess], process == CMS::MuNucl);
 
@@ -404,15 +372,13 @@ void TrackClassifier::processesAtSimulation() {
     // Check if the particle type is valid one
     if (particleID.isValid()) {
       // Get particle data
-      ParticleData const *particleData =
-          particleDataTable_->particle(particleID);
+      ParticleData const *particleData = particleDataTable_->particle(particleID);
       // Special treatment for decays
       if (process == CMS::Decay) {
         // Check if the particle exist in the table
         if (particleData) {
           // Check if their life time is bigger than 1e-14
-          if (particleDataTable_->particle(particleID)->lifetime() >
-              longLivedDecayLength_)
+          if (particleDataTable_->particle(particleID)->lifetime() > longLivedDecayLength_)
             update(flags_[LongLivedDecay], true);
 
           // Check for B and C weak decays
@@ -421,10 +387,8 @@ void TrackClassifier::processesAtSimulation() {
 
           // Check for B or C pure leptonic decays
           int daughtId = abs((*iparticle)->pdgId());
-          update(flags_[FromBWeakDecayMuon],
-                 particleID.hasBottom() && daughtId == 13);
-          update(flags_[FromCWeakDecayMuon],
-                 particleID.hasCharm() && daughtId == 13);
+          update(flags_[FromBWeakDecayMuon], particleID.hasBottom() && daughtId == 13);
+          update(flags_[FromCWeakDecayMuon], particleID.hasCharm() && daughtId == 13);
         }
         // Check decays
         update(flags_[ChargePionDecay], pdgid == 211);
@@ -443,8 +407,7 @@ void TrackClassifier::processesAtSimulation() {
   // Decays in flight
   update(flags_[FromChargePionMuon], flags_[Muon] && flags_[ChargePionDecay]);
   update(flags_[FromChargeKaonMuon], flags_[Muon] && flags_[ChargeKaonDecay]);
-  update(flags_[DecayOnFlightMuon],
-         flags_[FromChargePionMuon] || flags_[FromChargeKaonMuon]);
+  update(flags_[DecayOnFlightMuon], flags_[FromChargePionMuon] || flags_[FromChargeKaonMuon]);
 }
 
 void TrackClassifier::vertexInformation() {
@@ -452,8 +415,7 @@ void TrackClassifier::vertexInformation() {
   GeneratedPrimaryVertex const &genpv = genpvs_.back();
 
   // Get the generated history of the tracks
-  const TrackHistory::GenParticleTrail &genParticleTrail =
-      tracer_.genParticleTrail();
+  const TrackHistory::GenParticleTrail &genParticleTrail = tracer_.genParticleTrail();
 
   // Vertex counter
   int counter = 0;
@@ -466,20 +428,16 @@ void TrackClassifier::vertexInformation() {
   double oldZ = genpv.z;
 
   // Loop over the generated particles
-  for (TrackHistory::GenParticleTrail::const_reverse_iterator iparticle =
-           genParticleTrail.rbegin();
-       iparticle != genParticleTrail.rend(); ++iparticle) {
+  for (TrackHistory::GenParticleTrail::const_reverse_iterator iparticle = genParticleTrail.rbegin();
+       iparticle != genParticleTrail.rend();
+       ++iparticle) {
     // Look for those with production vertex
     HepMC::GenVertex *parent = (*iparticle)->production_vertex();
     if (parent) {
       HepMC::ThreeVector p = parent->point3d();
 
-      double distance2 = pow(p.x() * mm - genpv.x, 2) +
-                         pow(p.y() * mm - genpv.y, 2) +
-                         pow(p.z() * mm - genpv.z, 2);
-      double difference2 = pow(p.x() * mm - oldX, 2) +
-                           pow(p.y() * mm - oldY, 2) +
-                           pow(p.z() * mm - oldZ, 2);
+      double distance2 = pow(p.x() * mm - genpv.x, 2) + pow(p.y() * mm - genpv.y, 2) + pow(p.z() * mm - genpv.z, 2);
+      double difference2 = pow(p.x() * mm - oldX, 2) + pow(p.y() * mm - oldY, 2) + pow(p.z() * mm - oldZ, 2);
 
       // std::cout << "Distance2 : " << distance2 << " (" << p.x() * mm << ","
       // << p.y() * mm << "," << p.z() * mm << ")" << std::endl; std::cout <<
@@ -495,20 +453,17 @@ void TrackClassifier::vertexInformation() {
     }
   }
 
-  const TrackHistory::SimParticleTrail &simParticleTrail =
-      tracer_.simParticleTrail();
+  const TrackHistory::SimParticleTrail &simParticleTrail = tracer_.simParticleTrail();
 
   // Loop over the generated particles
-  for (TrackHistory::SimParticleTrail::const_reverse_iterator iparticle =
-           simParticleTrail.rbegin();
-       iparticle != simParticleTrail.rend(); ++iparticle) {
+  for (TrackHistory::SimParticleTrail::const_reverse_iterator iparticle = simParticleTrail.rbegin();
+       iparticle != simParticleTrail.rend();
+       ++iparticle) {
     // Look for those with production vertex
     TrackingParticle::Point p = (*iparticle)->vertex();
 
-    double distance2 = pow(p.x() - genpv.x, 2) + pow(p.y() - genpv.y, 2) +
-                       pow(p.z() - genpv.z, 2);
-    double difference2 =
-        pow(p.x() - oldX, 2) + pow(p.y() - oldY, 2) + pow(p.z() - oldZ, 2);
+    double distance2 = pow(p.x() - genpv.x, 2) + pow(p.y() - genpv.y, 2) + pow(p.z() - genpv.z, 2);
+    double difference2 = pow(p.x() - oldX, 2) + pow(p.y() - oldY, 2) + pow(p.z() - oldZ, 2);
 
     // std::cout << "Distance2 : " << distance2 << " (" << p.x() << "," << p.y()
     // << "," << p.z() << ")" << std::endl; std::cout << "Difference2 : " <<
@@ -531,9 +486,7 @@ void TrackClassifier::vertexInformation() {
     flags_[TertiaryVertex] = true;
 }
 
-bool TrackClassifier::isFinalstateParticle(const HepMC::GenParticle *p) {
-  return !p->end_vertex() && p->status() == 1;
-}
+bool TrackClassifier::isFinalstateParticle(const HepMC::GenParticle *p) { return !p->end_vertex() && p->status() == 1; }
 
 bool TrackClassifier::isCharged(const HepMC::GenParticle *p) {
   const ParticleData *part = particleDataTable_->particle(p->pdg_id());
@@ -554,16 +507,15 @@ void TrackClassifier::genPrimaryVertices() {
     int idx = 0;
 
     // Loop over the different GenVertex
-    for (HepMC::GenEvent::vertex_const_iterator ivertex =
-             event->vertices_begin();
-         ivertex != event->vertices_end(); ++ivertex) {
+    for (HepMC::GenEvent::vertex_const_iterator ivertex = event->vertices_begin(); ivertex != event->vertices_end();
+         ++ivertex) {
       bool hasParentVertex = false;
 
       // Loop over the parents looking to see if they are coming from a
       // production vertex
-      for (HepMC::GenVertex::particle_iterator iparent =
-               (*ivertex)->particles_begin(HepMC::parents);
-           iparent != (*ivertex)->particles_end(HepMC::parents); ++iparent)
+      for (HepMC::GenVertex::particle_iterator iparent = (*ivertex)->particles_begin(HepMC::parents);
+           iparent != (*ivertex)->particles_end(HepMC::parents);
+           ++iparent)
         if ((*iparent)->production_vertex()) {
           hasParentVertex = true;
           break;
@@ -584,8 +536,7 @@ void TrackClassifier::genPrimaryVertices() {
 
       // Search for a VERY close vertex in the list
       for (; ientry != genpvs_.end(); ++ientry) {
-        double distance2 = pow(pv.x - ientry->x, 2) + pow(pv.y - ientry->y, 2) +
-                           pow(pv.z - ientry->z, 2);
+        double distance2 = pow(pv.x - ientry->x, 2) + pow(pv.y - ientry->y, 2) + pow(pv.z - ientry->z, 2);
         if (distance2 < vertexClusteringSqDistance_)
           break;
       }
@@ -598,14 +549,11 @@ void TrackClassifier::genPrimaryVertices() {
       ientry->genVertex.push_back((*ivertex)->barcode());
 
       // Collect final state descendants
-      for (HepMC::GenVertex::particle_iterator idecendants =
-               (*ivertex)->particles_begin(HepMC::descendants);
+      for (HepMC::GenVertex::particle_iterator idecendants = (*ivertex)->particles_begin(HepMC::descendants);
            idecendants != (*ivertex)->particles_end(HepMC::descendants);
            ++idecendants) {
         if (isFinalstateParticle(*idecendants))
-          if (find(ientry->finalstateParticles.begin(),
-                   ientry->finalstateParticles.end(),
-                   (*idecendants)->barcode()) ==
+          if (find(ientry->finalstateParticles.begin(), ientry->finalstateParticles.end(), (*idecendants)->barcode()) ==
               ientry->finalstateParticles.end()) {
             ientry->finalstateParticles.push_back((*idecendants)->barcode());
             HepMC::FourVector m = (*idecendants)->momentum();
@@ -616,8 +564,7 @@ void TrackClassifier::genPrimaryVertices() {
             ientry->ptot.setE(ientry->ptot.e() + m.e());
             ientry->ptsq += m.perp() * m.perp();
 
-            if (m.perp() > 0.8 && std::abs(m.pseudoRapidity()) < 2.5 &&
-                isCharged(*idecendants))
+            if (m.perp() > 0.8 && std::abs(m.pseudoRapidity()) < 2.5 && isCharged(*idecendants))
               ientry->nGenTrk++;
           }
       }

--- a/SimTracker/TrackHistory/src/TrackHistory.cc
+++ b/SimTracker/TrackHistory/src/TrackHistory.cc
@@ -2,9 +2,7 @@
 #include "SimTracker/Records/interface/TrackAssociatorRecord.h"
 #include "SimTracker/TrackHistory/interface/TrackHistory.h"
 
-TrackHistory::TrackHistory(const edm::ParameterSet &config,
-                           edm::ConsumesCollector &&collector)
-    : HistoryBase() {
+TrackHistory::TrackHistory(const edm::ParameterSet &config, edm::ConsumesCollector &&collector) : HistoryBase() {
   // Name of the track collection
   trackProducer_ = config.getUntrackedParameter<edm::InputTag>("trackProducer");
   collector.consumes<edm::View<reco::Track>>(trackProducer_);
@@ -14,12 +12,10 @@ TrackHistory::TrackHistory(const edm::ParameterSet &config,
   collector.consumes<TrackingParticleCollection>(trackingTruth_);
 
   // Track association record
-  trackAssociator_ =
-      config.getUntrackedParameter<edm::InputTag>("trackAssociator");
+  trackAssociator_ = config.getUntrackedParameter<edm::InputTag>("trackAssociator");
 
   // Association by max. value
-  bestMatchByMaxValue_ =
-      config.getUntrackedParameter<bool>("bestMatchByMaxValue");
+  bestMatchByMaxValue_ = config.getUntrackedParameter<bool>("bestMatchByMaxValue");
 
   // Enable RecoToSim association
   enableRecoToSim_ = config.getUntrackedParameter<bool>("enableRecoToSim");
@@ -28,15 +24,13 @@ TrackHistory::TrackHistory(const edm::ParameterSet &config,
   enableSimToReco_ = config.getUntrackedParameter<bool>("enableSimToReco");
 
   if (enableRecoToSim_ or enableSimToReco_) {
-    collector.consumes<reco::TrackToTrackingParticleAssociator>(
-        trackAssociator_);
+    collector.consumes<reco::TrackToTrackingParticleAssociator>(trackAssociator_);
   }
 
   quality_ = 0.;
 }
 
-void TrackHistory::newEvent(const edm::Event &event,
-                            const edm::EventSetup &setup) {
+void TrackHistory::newEvent(const edm::Event &event, const edm::EventSetup &setup) {
   if (enableRecoToSim_ || enableSimToReco_) {
     // Track collection
     edm::Handle<edm::View<reco::Track>> trackCollection;
@@ -52,13 +46,11 @@ void TrackHistory::newEvent(const edm::Event &event,
 
     // Calculate the map between recotracks -> tp
     if (enableRecoToSim_)
-      recoToSim_ =
-          associator->associateRecoToSim(trackCollection, TPCollection);
+      recoToSim_ = associator->associateRecoToSim(trackCollection, TPCollection);
 
     // Calculate the map between recotracks <- tp
     if (enableSimToReco_)
-      simToReco_ =
-          associator->associateSimToReco(trackCollection, TPCollection);
+      simToReco_ = associator->associateSimToReco(trackCollection, TPCollection);
   }
 }
 
@@ -66,8 +58,7 @@ bool TrackHistory::evaluate(reco::TrackBaseRef tr) {
   if (!enableRecoToSim_)
     return false;
 
-  std::pair<TrackingParticleRef, double> result =
-      match(tr, recoToSim_, bestMatchByMaxValue_);
+  std::pair<TrackingParticleRef, double> result = match(tr, recoToSim_, bestMatchByMaxValue_);
 
   TrackingParticleRef tpr(result.first);
   quality_ = result.second;

--- a/SimTracker/TrackHistory/src/TrackQuality.cc
+++ b/SimTracker/TrackHistory/src/TrackQuality.cc
@@ -36,34 +36,33 @@
 // #define DEBUG_TRACK_QUALITY
 
 namespace {
-const uint32_t NonMatchedTrackId = (uint32_t)-1;
+  const uint32_t NonMatchedTrackId = (uint32_t)-1;
 
-struct MatchedHit {
-  DetId detId;
-  uint32_t simTrackId;
-  EncodedEventId collision;
-  int recHitId;
-  TrackQuality::Layer::State state;
+  struct MatchedHit {
+    DetId detId;
+    uint32_t simTrackId;
+    EncodedEventId collision;
+    int recHitId;
+    TrackQuality::Layer::State state;
 
-  bool operator<(const MatchedHit &other) const {
-    if (detId < other.detId)
-      return true;
-    else if (detId > other.detId)
-      return false;
-    else if (collision < other.collision)
-      return true;
-    else if (other.collision < collision)
-      return false;
-    else
-      return simTrackId < other.simTrackId;
-  }
+    bool operator<(const MatchedHit &other) const {
+      if (detId < other.detId)
+        return true;
+      else if (detId > other.detId)
+        return false;
+      else if (collision < other.collision)
+        return true;
+      else if (other.collision < collision)
+        return false;
+      else
+        return simTrackId < other.simTrackId;
+    }
 
-  bool operator==(const MatchedHit &other) const {
-    return detId == other.detId && collision == other.collision &&
-           simTrackId == other.simTrackId;
-  }
-};
-/*
+    bool operator==(const MatchedHit &other) const {
+      return detId == other.detId && collision == other.collision && simTrackId == other.simTrackId;
+    }
+  };
+  /*
 static bool operator < (const MatchedHit &hit, DetId detId)
 {
   return hit.detId < detId;
@@ -73,7 +72,7 @@ static bool operator < (DetId detId, const MatchedHit &hit)
   return detId < hit.detId;
 }
 */
-} // namespace
+}  // namespace
 
 typedef std::pair<TrackQuality::Layer::SubDet, short int> DetLayer;
 
@@ -93,62 +92,56 @@ DetLayer getDetLayer(DetId detId, const TrackerTopology *tTopo) {
   short int layer = 0;
 
   switch (detId.det()) {
-  case DetId::Tracker:
-    layer = tTopo->layer(detId);
-    break;
-
-  case DetId::Muon:
-    switch (detId.subdetId()) {
-    case MuonSubdetId::DT:
-      det = TrackQuality::Layer::MuonDT;
-      layer = DTLayerId(detId).layer();
+    case DetId::Tracker:
+      layer = tTopo->layer(detId);
       break;
 
-    case MuonSubdetId::CSC:
-      det = TrackQuality::Layer::MuonCSC;
-      layer = CSCDetId(detId).layer();
-      break;
+    case DetId::Muon:
+      switch (detId.subdetId()) {
+        case MuonSubdetId::DT:
+          det = TrackQuality::Layer::MuonDT;
+          layer = DTLayerId(detId).layer();
+          break;
 
-    case MuonSubdetId::RPC:
-      if (RPCDetId(detId).region())
-        det = TrackQuality::Layer::MuonRPCEndcap;
-      else
-        det = TrackQuality::Layer::MuonRPCBarrel;
-      layer = RPCDetId(detId).layer();
+        case MuonSubdetId::CSC:
+          det = TrackQuality::Layer::MuonCSC;
+          layer = CSCDetId(detId).layer();
+          break;
+
+        case MuonSubdetId::RPC:
+          if (RPCDetId(detId).region())
+            det = TrackQuality::Layer::MuonRPCEndcap;
+          else
+            det = TrackQuality::Layer::MuonRPCBarrel;
+          layer = RPCDetId(detId).layer();
+          break;
+
+        default:
+            /* should not get here */
+            ;
+      }
       break;
 
     default:
         /* should not get here */
         ;
-    }
-    break;
-
-  default:
-      /* should not get here */
-      ;
   }
 
   return DetLayer(det, layer);
 }
 
-TrackQuality::TrackQuality(const edm::ParameterSet &config,
-                           edm::ConsumesCollector &iC)
-    : trackerHitAssociatorConfig_(
-          config.getParameter<edm::ParameterSet>("hitAssociator"),
-          std::move(iC)) {}
+TrackQuality::TrackQuality(const edm::ParameterSet &config, edm::ConsumesCollector &iC)
+    : trackerHitAssociatorConfig_(config.getParameter<edm::ParameterSet>("hitAssociator"), std::move(iC)) {}
 
 void TrackQuality::newEvent(const edm::Event &ev, const edm::EventSetup &es) {
   associator_.reset(new TrackerHitAssociator(ev, trackerHitAssociatorConfig_));
 }
 
-void TrackQuality::evaluate(SimParticleTrail const &spt,
-                            reco::TrackBaseRef const &tr,
-                            const TrackerTopology *tTopo) {
+void TrackQuality::evaluate(SimParticleTrail const &spt, reco::TrackBaseRef const &tr, const TrackerTopology *tTopo) {
   std::vector<MatchedHit> matchedHits;
 
   // iterate over reconstructed hits
-  for (trackingRecHit_iterator hit = tr->recHitsBegin();
-       hit != tr->recHitsEnd(); ++hit) {
+  for (trackingRecHit_iterator hit = tr->recHitsBegin(); hit != tr->recHitsEnd(); ++hit) {
     // on which module the hit lies
     DetId detId = (*hit)->geographicalId();
 
@@ -161,16 +154,16 @@ void TrackQuality::evaluate(SimParticleTrail const &spt,
       matchedHit.simTrackId = NonMatchedTrackId;
       // check why hit wasn't valid and propagate information
       switch ((*hit)->getType()) {
-      case TrackingRecHit::inactive:
-        matchedHit.state = Layer::Dead;
-        break;
+        case TrackingRecHit::inactive:
+          matchedHit.state = Layer::Dead;
+          break;
 
-      case TrackingRecHit::bad:
-        matchedHit.state = Layer::Bad;
-        break;
+        case TrackingRecHit::bad:
+          matchedHit.state = Layer::Bad;
+          break;
 
-      default:
-        matchedHit.state = Layer::Missed;
+        default:
+          matchedHit.state = Layer::Missed;
       }
       matchedHit.recHitId = hit - tr->recHitsBegin();
       matchedHits.push_back(matchedHit);
@@ -192,8 +185,7 @@ void TrackQuality::evaluate(SimParticleTrail const &spt,
     }
 
     // register all simulated tracks contributing
-    for (std::vector<SimHitIdpr>::const_iterator i = simIds.begin();
-         i != simIds.end(); ++i) {
+    for (std::vector<SimHitIdpr>::const_iterator i = simIds.begin(); i != simIds.end(); ++i) {
       MatchedHit matchedHit;
       matchedHit.detId = detId;
       matchedHit.simTrackId = i->first;
@@ -220,8 +212,7 @@ void TrackQuality::evaluate(SimParticleTrail const &spt,
   LayerHitMap layerHitMap;
 
   // iterate over all simulated/reconstructed hits again
-  for (std::vector<MatchedHit>::const_iterator hit = matchedHits.begin();
-       hit != matchedHits.end();) {
+  for (std::vector<MatchedHit>::const_iterator hit = matchedHits.begin(); hit != matchedHits.end();) {
     // we can have multiple reco-to-sim matches per module, find best one
     const MatchedHit *best = nullptr;
 
@@ -247,21 +238,16 @@ void TrackQuality::evaluate(SimParticleTrail const &spt,
   std::cout << "---------------------" << std::endl;
 #endif
   // now prepare final collection
-  for (LayerHitMap::const_iterator hit = layerHitMap.begin();
-       hit != layerHitMap.end(); ++hit) {
+  for (LayerHitMap::const_iterator hit = layerHitMap.begin(); hit != layerHitMap.end(); ++hit) {
 #ifdef DEBUG_TRACK_QUALITY
-    std::cout << "detLayer (" << hit->first.first << ", " << hit->first.second
-              << ")"
-              << " [" << (uint32_t)hit->second->detId << "] sim("
-              << (int)hit->second->simTrackId << ")"
-              << " hit(" << hit->second->recHitId << ") -> "
-              << hit->second->state << std::endl;
+    std::cout << "detLayer (" << hit->first.first << ", " << hit->first.second << ")"
+              << " [" << (uint32_t)hit->second->detId << "] sim(" << (int)hit->second->simTrackId << ")"
+              << " hit(" << hit->second->recHitId << ") -> " << hit->second->state << std::endl;
 #endif
 
     // find out if we need to start a new layer
     Layer *layer = layers_.empty() ? nullptr : &layers_.back();
-    if (!layer || hit->first.first != layer->subDet ||
-        hit->first.second != layer->layer) {
+    if (!layer || hit->first.first != layer->subDet || hit->first.second != layer->layer) {
       Layer newLayer;
       newLayer.subDet = hit->first.first;
       newLayer.layer = hit->first.second;

--- a/SimTracker/TrackHistory/src/Utils.cc
+++ b/SimTracker/TrackHistory/src/Utils.cc
@@ -4,76 +4,64 @@
 
 G4toCMSLegacyProcTypeMap::G4toCMSLegacyProcTypeMap() {
   // Geant4Process -> CmsProcess
-  m_map[0] = CMS::Primary;  // "Primary"         -> "Primary"
-  m_map[91] = CMS::Unknown; // "Transportation"  -> "Unknown"
-  m_map[92] =
-      CMS::Unknown; // "CoupleTrans"     -> "Unknown" => DOUBLE-CHECK THIS
-  m_map[1] =
-      CMS::Unknown;      // "CoulombScat"     -> "Unknown" => DOUBLE-CHECK THIS
-  m_map[2] = CMS::EIoni; // "Ionisation"      -> "EIoni" => WHAT ABOUT MuIoni?
-  m_map[3] = CMS::EBrem; // "Brems"           -> "EBrem" => WHAT ABOUT MuBrem?
-  m_map[4] =
-      CMS::MuPairProd; // "PairProdCharged" -> "MuPairProd" => DOUBLE-CHECK THIS
-  m_map[5] = CMS::Annihilation; // "Annih"           -> "Annihilation"
-  m_map[6] = CMS::Annihilation; // "AnnihToMuMu"     -> "Annihilation"
-  m_map[7] = CMS::Annihilation; // "AnnihToHad"      -> "Annihilation"
-  m_map[8] =
-      CMS::Hadronic; // "NuclearStopp"    -> "Hadronic" => DOUBLE-CHECK THIS
-  m_map[10] =
-      CMS::Unknown; // "Msc"             -> "Unknown" => DOUBLE-CHECK THIS
-  m_map[11] =
-      CMS::Unknown; // "Rayleigh"        -> "Unknown" => DOUBLE-CHECK THIS
-  m_map[12] = CMS::Photon;      // "PhotoElectric"   -> "Photon"
-  m_map[13] = CMS::Compton;     // "Compton"         -> "Compton"
-  m_map[14] = CMS::Conversions; // "Conv"            -> "Conversions"
-  m_map[15] = CMS::Conversions; // "ConvToMuMu"      -> "Conversions"
-  m_map[21] =
-      CMS::Unknown; // "Cerenkov"        -> "Unknown" => DOUBLE-CHECK THIS
-  m_map[22] =
-      CMS::Unknown; // "Scintillation"   -> "Unknown" => DOUBLE-CHECK THIS
-  m_map[23] =
-      CMS::SynchrotronRadiation; // "SynchRad"        -> "SynchrotronRadiation"
-  m_map[24] =
-      CMS::SynchrotronRadiation; // "TransRad"        -> "SynchrotronRadiation"
-                                 // => DOUBLE-CHECK THIS
-  m_map[31] = CMS::Unknown; // "OpAbsorp"        -> "Unknown" => NOT USED IN CMS
-  m_map[32] = CMS::Unknown; // "OpBoundary"      -> "Unknown" => NOT USED IN CMS
-  m_map[33] = CMS::Unknown; // "OpRayleigh"      -> "Unknown" => NOT USED IN CMS
-  m_map[34] = CMS::Unknown; // "OpWLS"           -> "Unknown" => NOT USED IN CMS
-  m_map[35] = CMS::Unknown; // "OpMieHG"         -> "Unknown" => NOT USED IN CMS
-  m_map[51] = CMS::Unknown; // "DNAElastic"      -> "Unknown" => NOT USED IN CMS
-  m_map[52] = CMS::Unknown; // "DNAExcit"        -> "Unknown" => NOT USED IN CMS
-  m_map[53] = CMS::Unknown; // "DNAIonisation"   -> "Unknown" => NOT USED IN CMS
-  m_map[54] = CMS::Unknown; // "DNAVibExcit"     -> "Unknown" => NOT USED IN CMS
-  m_map[55] = CMS::Unknown; // "DNAAttachment"   -> "Unknown" => NOT USED IN CMS
-  m_map[56] = CMS::Unknown; // "DNAChargeDec"    -> "Unknown" => NOT USED IN CMS
-  m_map[57] = CMS::Unknown; // "DNAChargeInc"    -> "Unknown" => NOT USED IN CMS
-  m_map[111] = CMS::Hadronic; // "HadElastic"      -> "Hadronic"
-  m_map[121] = CMS::Hadronic; // "HadInelastic"    -> "Hadronic"
-  m_map[131] = CMS::Hadronic; // "HadCapture"      -> "Hadronic"
-  m_map[141] = CMS::Hadronic; // "HadFission"      -> "Hadronic"
-  m_map[151] = CMS::Hadronic; // "HadAtRest"       -> "Hadronic"
-  m_map[161] = CMS::Hadronic; // "HadCEX"          -> "Hadronic"
-  m_map[201] = CMS::Decay;    // "Decay"           -> "Decay"
-  m_map[202] = CMS::Decay;    // "DecayWSpin"      -> "Decay"
-  m_map[203] = CMS::Decay;    // "DecayPiWSpin"    -> "Decay"
-  m_map[210] = CMS::Decay;    // "DecayRadio"      -> "Decay"
-  m_map[211] = CMS::Decay;    // "DecayUnKnown"    -> "Decay"
-  m_map[231] = CMS::Decay;    // "DecayExt"        -> "Decay"
-  m_map[301] = CMS::Unknown;  // "GFlash"          -> "Unknown"
-  m_map[401] = CMS::Unknown;  // "StepLimiter"     -> "Unknown"
-  m_map[402] = CMS::Unknown;  // "UsrSpecCuts"     -> "Unknown"
-  m_map[403] = CMS::Unknown;  // "NeutronKiller"   -> "Unknown"
+  m_map[0] = CMS::Primary;                // "Primary"         -> "Primary"
+  m_map[91] = CMS::Unknown;               // "Transportation"  -> "Unknown"
+  m_map[92] = CMS::Unknown;               // "CoupleTrans"     -> "Unknown" => DOUBLE-CHECK THIS
+  m_map[1] = CMS::Unknown;                // "CoulombScat"     -> "Unknown" => DOUBLE-CHECK THIS
+  m_map[2] = CMS::EIoni;                  // "Ionisation"      -> "EIoni" => WHAT ABOUT MuIoni?
+  m_map[3] = CMS::EBrem;                  // "Brems"           -> "EBrem" => WHAT ABOUT MuBrem?
+  m_map[4] = CMS::MuPairProd;             // "PairProdCharged" -> "MuPairProd" => DOUBLE-CHECK THIS
+  m_map[5] = CMS::Annihilation;           // "Annih"           -> "Annihilation"
+  m_map[6] = CMS::Annihilation;           // "AnnihToMuMu"     -> "Annihilation"
+  m_map[7] = CMS::Annihilation;           // "AnnihToHad"      -> "Annihilation"
+  m_map[8] = CMS::Hadronic;               // "NuclearStopp"    -> "Hadronic" => DOUBLE-CHECK THIS
+  m_map[10] = CMS::Unknown;               // "Msc"             -> "Unknown" => DOUBLE-CHECK THIS
+  m_map[11] = CMS::Unknown;               // "Rayleigh"        -> "Unknown" => DOUBLE-CHECK THIS
+  m_map[12] = CMS::Photon;                // "PhotoElectric"   -> "Photon"
+  m_map[13] = CMS::Compton;               // "Compton"         -> "Compton"
+  m_map[14] = CMS::Conversions;           // "Conv"            -> "Conversions"
+  m_map[15] = CMS::Conversions;           // "ConvToMuMu"      -> "Conversions"
+  m_map[21] = CMS::Unknown;               // "Cerenkov"        -> "Unknown" => DOUBLE-CHECK THIS
+  m_map[22] = CMS::Unknown;               // "Scintillation"   -> "Unknown" => DOUBLE-CHECK THIS
+  m_map[23] = CMS::SynchrotronRadiation;  // "SynchRad"        -> "SynchrotronRadiation"
+  m_map[24] = CMS::SynchrotronRadiation;  // "TransRad"        -> "SynchrotronRadiation"
+                                          // => DOUBLE-CHECK THIS
+  m_map[31] = CMS::Unknown;               // "OpAbsorp"        -> "Unknown" => NOT USED IN CMS
+  m_map[32] = CMS::Unknown;               // "OpBoundary"      -> "Unknown" => NOT USED IN CMS
+  m_map[33] = CMS::Unknown;               // "OpRayleigh"      -> "Unknown" => NOT USED IN CMS
+  m_map[34] = CMS::Unknown;               // "OpWLS"           -> "Unknown" => NOT USED IN CMS
+  m_map[35] = CMS::Unknown;               // "OpMieHG"         -> "Unknown" => NOT USED IN CMS
+  m_map[51] = CMS::Unknown;               // "DNAElastic"      -> "Unknown" => NOT USED IN CMS
+  m_map[52] = CMS::Unknown;               // "DNAExcit"        -> "Unknown" => NOT USED IN CMS
+  m_map[53] = CMS::Unknown;               // "DNAIonisation"   -> "Unknown" => NOT USED IN CMS
+  m_map[54] = CMS::Unknown;               // "DNAVibExcit"     -> "Unknown" => NOT USED IN CMS
+  m_map[55] = CMS::Unknown;               // "DNAAttachment"   -> "Unknown" => NOT USED IN CMS
+  m_map[56] = CMS::Unknown;               // "DNAChargeDec"    -> "Unknown" => NOT USED IN CMS
+  m_map[57] = CMS::Unknown;               // "DNAChargeInc"    -> "Unknown" => NOT USED IN CMS
+  m_map[111] = CMS::Hadronic;             // "HadElastic"      -> "Hadronic"
+  m_map[121] = CMS::Hadronic;             // "HadInelastic"    -> "Hadronic"
+  m_map[131] = CMS::Hadronic;             // "HadCapture"      -> "Hadronic"
+  m_map[141] = CMS::Hadronic;             // "HadFission"      -> "Hadronic"
+  m_map[151] = CMS::Hadronic;             // "HadAtRest"       -> "Hadronic"
+  m_map[161] = CMS::Hadronic;             // "HadCEX"          -> "Hadronic"
+  m_map[201] = CMS::Decay;                // "Decay"           -> "Decay"
+  m_map[202] = CMS::Decay;                // "DecayWSpin"      -> "Decay"
+  m_map[203] = CMS::Decay;                // "DecayPiWSpin"    -> "Decay"
+  m_map[210] = CMS::Decay;                // "DecayRadio"      -> "Decay"
+  m_map[211] = CMS::Decay;                // "DecayUnKnown"    -> "Decay"
+  m_map[231] = CMS::Decay;                // "DecayExt"        -> "Decay"
+  m_map[301] = CMS::Unknown;              // "GFlash"          -> "Unknown"
+  m_map[401] = CMS::Unknown;              // "StepLimiter"     -> "Unknown"
+  m_map[402] = CMS::Unknown;              // "UsrSpecCuts"     -> "Unknown"
+  m_map[403] = CMS::Unknown;              // "NeutronKiller"   -> "Unknown"
 }
 
-const unsigned int
-G4toCMSLegacyProcTypeMap::processId(unsigned int g4ProcessId) const {
+const unsigned int G4toCMSLegacyProcTypeMap::processId(unsigned int g4ProcessId) const {
   MapType::const_iterator it = m_map.find(g4ProcessId);
 
   if (it == m_map.end()) {
-    edm::LogError("UnknownProcessType")
-        << "Encountered an unknown process type: " << g4ProcessId
-        << ". Mapping it to 'Undefined'.";
+    edm::LogError("UnknownProcessType") << "Encountered an unknown process type: " << g4ProcessId
+                                        << ". Mapping it to 'Undefined'.";
     return CMS::Undefined;
   } else
     return it->second;

--- a/SimTracker/TrackHistory/src/VertexClassifier.cc
+++ b/SimTracker/TrackHistory/src/VertexClassifier.cc
@@ -10,30 +10,27 @@
 
 #include "SimTracker/TrackHistory/interface/VertexClassifier.h"
 
-#define update(a, b)                                                           \
-  do {                                                                         \
-    (a) = (a) | (b);                                                           \
+#define update(a, b) \
+  do {               \
+    (a) = (a) | (b); \
   } while (0)
 
-VertexClassifier::VertexClassifier(edm::ParameterSet const &config,
-                                   edm::ConsumesCollector &&collector)
-    : VertexCategories(), tracer_(config, std::move(collector)),
+VertexClassifier::VertexClassifier(edm::ParameterSet const &config, edm::ConsumesCollector &&collector)
+    : VertexCategories(),
+      tracer_(config, std::move(collector)),
       hepMCLabel_(config.getUntrackedParameter<edm::InputTag>("hepMC")) {
   collector.consumes<edm::HepMCProduct>(hepMCLabel_);
   // Set the history depth after hadronization
   tracer_.depth(-2);
 
   // Set the minimum decay length for detecting long decays
-  longLivedDecayLength_ =
-      config.getUntrackedParameter<double>("longLivedDecayLength");
+  longLivedDecayLength_ = config.getUntrackedParameter<double>("longLivedDecayLength");
 
   // Set the distance for clustering vertices
-  vertexClusteringDistance_ =
-      config.getUntrackedParameter<double>("vertexClusteringDistance");
+  vertexClusteringDistance_ = config.getUntrackedParameter<double>("vertexClusteringDistance");
 }
 
-void VertexClassifier::newEvent(edm::Event const &event,
-                                edm::EventSetup const &setup) {
+void VertexClassifier::newEvent(edm::Event const &event, edm::EventSetup const &setup) {
   // Get the new event information for the tracer
   tracer_.newEvent(event, setup);
 
@@ -47,8 +44,7 @@ void VertexClassifier::newEvent(edm::Event const &event,
   genPrimaryVertices();
 }
 
-VertexClassifier const &
-VertexClassifier::evaluate(reco::VertexBaseRef const &vertex) {
+VertexClassifier const &VertexClassifier::evaluate(reco::VertexBaseRef const &vertex) {
   // Initializing the category vector
   reset();
 
@@ -74,8 +70,7 @@ VertexClassifier::evaluate(reco::VertexBaseRef const &vertex) {
   return *this;
 }
 
-VertexClassifier const &
-VertexClassifier::evaluate(TrackingVertexRef const &vertex) {
+VertexClassifier const &VertexClassifier::evaluate(TrackingVertexRef const &vertex) {
   // Initializing the category vector
   reset();
 
@@ -115,21 +110,19 @@ void VertexClassifier::simulationInformation() {
 
 void VertexClassifier::processesAtGenerator() {
   // Get the generated vetices from track history
-  VertexHistory::GenVertexTrail const &genVertexTrail =
-      tracer_.genVertexTrail();
+  VertexHistory::GenVertexTrail const &genVertexTrail = tracer_.genVertexTrail();
 
   // Loop over the generated vertices
-  for (VertexHistory::GenVertexTrail::const_iterator ivertex =
-           genVertexTrail.begin();
-       ivertex != genVertexTrail.end(); ++ivertex) {
+  for (VertexHistory::GenVertexTrail::const_iterator ivertex = genVertexTrail.begin(); ivertex != genVertexTrail.end();
+       ++ivertex) {
     // Get the pointer to the vertex by removing the const-ness (no const methos
     // in HepMC::GenVertex)
     HepMC::GenVertex *vertex = const_cast<HepMC::GenVertex *>(*ivertex);
 
     // Loop over the sources looking for specific decays
-    for (HepMC::GenVertex::particle_iterator iparent =
-             vertex->particles_begin(HepMC::parents);
-         iparent != vertex->particles_end(HepMC::parents); ++iparent) {
+    for (HepMC::GenVertex::particle_iterator iparent = vertex->particles_begin(HepMC::parents);
+         iparent != vertex->particles_end(HepMC::parents);
+         ++iparent) {
       // Collect the pdgid of the parent
       int pdgid = std::abs((*iparent)->pdg_id());
       // Get particle type
@@ -138,8 +131,7 @@ void VertexClassifier::processesAtGenerator() {
       // Check if the particle type is valid one
       if (particleID.isValid()) {
         // Get particle data
-        ParticleData const *particleData =
-            particleDataTable_->particle(particleID);
+        ParticleData const *particleData = particleDataTable_->particle(particleID);
         // Check if the particle exist in the table
         if (particleData) {
           // Check if their life time is bigger than longLivedDecayLength_
@@ -165,12 +157,10 @@ void VertexClassifier::processesAtGenerator() {
 }
 
 void VertexClassifier::processesAtSimulation() {
-  VertexHistory::SimVertexTrail const &simVertexTrail =
-      tracer_.simVertexTrail();
+  VertexHistory::SimVertexTrail const &simVertexTrail = tracer_.simVertexTrail();
 
-  for (VertexHistory::SimVertexTrail::const_iterator ivertex =
-           simVertexTrail.begin();
-       ivertex != simVertexTrail.end(); ++ivertex) {
+  for (VertexHistory::SimVertexTrail::const_iterator ivertex = simVertexTrail.begin(); ivertex != simVertexTrail.end();
+       ++ivertex) {
     // pdgid of the real source parent vertex
     int pdgid = 0;
 
@@ -178,10 +168,8 @@ void VertexClassifier::processesAtSimulation() {
     bool flag = false;
     TrackingVertex::tp_iterator itd, its;
 
-    for (its = (*ivertex)->sourceTracks_begin();
-         its != (*ivertex)->sourceTracks_end(); ++its) {
-      for (itd = (*ivertex)->daughterTracks_begin();
-           itd != (*ivertex)->daughterTracks_end(); ++itd)
+    for (its = (*ivertex)->sourceTracks_begin(); its != (*ivertex)->sourceTracks_end(); ++its) {
+      for (itd = (*ivertex)->daughterTracks_begin(); itd != (*ivertex)->daughterTracks_end(); ++itd)
         if (itd != its) {
           flag = true;
           break;
@@ -206,9 +194,7 @@ void VertexClassifier::processesAtSimulation() {
     unsigned int process = g4toCMSProcMap_.processId(processG4);
 
     // Flagging all the different processes
-    update(flags_[KnownProcess], process != CMS::Undefined &&
-                                     process != CMS::Unknown &&
-                                     process != CMS::Primary);
+    update(flags_[KnownProcess], process != CMS::Undefined && process != CMS::Unknown && process != CMS::Primary);
 
     update(flags_[UndefinedProcess], process == CMS::Undefined);
     update(flags_[UnknownProcess], process == CMS::Unknown);
@@ -224,18 +210,15 @@ void VertexClassifier::processesAtSimulation() {
     update(flags_[MuPairProdProcess], process == CMS::MuPairProd);
     update(flags_[ConversionsProcess], process == CMS::Conversions);
     update(flags_[EBremProcess], process == CMS::EBrem);
-    update(flags_[SynchrotronRadiationProcess],
-           process == CMS::SynchrotronRadiation);
+    update(flags_[SynchrotronRadiationProcess], process == CMS::SynchrotronRadiation);
     update(flags_[MuBremProcess], process == CMS::MuBrem);
     update(flags_[MuNuclProcess], process == CMS::MuNucl);
 
     // Loop over the simulated particles
-    for (TrackingVertex::tp_iterator iparticle =
-             (*ivertex)->daughterTracks_begin();
-         iparticle != (*ivertex)->daughterTracks_end(); ++iparticle) {
-
+    for (TrackingVertex::tp_iterator iparticle = (*ivertex)->daughterTracks_begin();
+         iparticle != (*ivertex)->daughterTracks_end();
+         ++iparticle) {
       if ((*iparticle)->numberOfTrackerLayers()) {
-
         // Special treatment for decays
         if (process == CMS::Decay) {
           // Get particle type
@@ -243,13 +226,11 @@ void VertexClassifier::processesAtSimulation() {
           // Check if the particle type is valid one
           if (particleID.isValid()) {
             // Get particle data
-            ParticleData const *particleData =
-                particleDataTable_->particle(particleID);
+            ParticleData const *particleData = particleDataTable_->particle(particleID);
             // Check if the particle exist in the table
             if (particleData) {
               // Check if their life time is bigger than 1e-14
-              if (particleDataTable_->particle(particleID)->lifetime() >
-                  longLivedDecayLength_) {
+              if (particleDataTable_->particle(particleID)->lifetime() > longLivedDecayLength_) {
                 // Check for B, C weak decays and long lived decays
                 update(flags_[BWeakDecay], particleID.hasBottom());
                 update(flags_[CWeakDecay], particleID.hasCharm());
@@ -283,40 +264,33 @@ void VertexClassifier::vertexInformation() {
   GeneratedPrimaryVertex const &genpv = genpvs_.back();
 
   // Get the generated history of the tracks
-  const VertexHistory::GenVertexTrail &genVertexTrail =
-      tracer_.genVertexTrail();
+  const VertexHistory::GenVertexTrail &genVertexTrail = tracer_.genVertexTrail();
 
   // Unit transformation from mm to cm
   double const mm = 0.1;
 
   // Loop over the generated vertexes
-  for (VertexHistory::GenVertexTrail::const_iterator ivertex =
-           genVertexTrail.begin();
-       ivertex != genVertexTrail.end(); ++ivertex) {
+  for (VertexHistory::GenVertexTrail::const_iterator ivertex = genVertexTrail.begin(); ivertex != genVertexTrail.end();
+       ++ivertex) {
     // Check vertex exist
     if (*ivertex) {
       // Measure the distance2 respecto the primary vertex
       HepMC::ThreeVector p = (*ivertex)->point3d();
       double distance =
-          sqrt(pow(p.x() * mm - genpv.x, 2) + pow(p.y() * mm - genpv.y, 2) +
-               pow(p.z() * mm - genpv.z, 2));
+          sqrt(pow(p.x() * mm - genpv.x, 2) + pow(p.y() * mm - genpv.y, 2) + pow(p.z() * mm - genpv.z, 2));
 
       // If there is not any clusters add the first vertex.
       if (clusters.empty()) {
-        clusters.insert(ClusterPair(
-            distance, HepMC::ThreeVector(p.x() * mm, p.y() * mm, p.z() * mm)));
+        clusters.insert(ClusterPair(distance, HepMC::ThreeVector(p.x() * mm, p.y() * mm, p.z() * mm)));
         continue;
       }
 
       // Check if there is already a cluster in the given distance from primary
       // vertex
-      Clusters::const_iterator icluster =
-          clusters.lower_bound(distance - vertexClusteringDistance_);
+      Clusters::const_iterator icluster = clusters.lower_bound(distance - vertexClusteringDistance_);
 
-      if (icluster ==
-          clusters.upper_bound(distance + vertexClusteringDistance_)) {
-        clusters.insert(ClusterPair(
-            distance, HepMC::ThreeVector(p.x() * mm, p.y() * mm, p.z() * mm)));
+      if (icluster == clusters.upper_bound(distance + vertexClusteringDistance_)) {
+        clusters.insert(ClusterPair(distance, HepMC::ThreeVector(p.x() * mm, p.y() * mm, p.z() * mm)));
         continue;
       }
 
@@ -324,11 +298,8 @@ void VertexClassifier::vertexInformation() {
 
       // Looping over the vertex clusters of a given distance from primary
       // vertex
-      for (; icluster !=
-             clusters.upper_bound(distance + vertexClusteringDistance_);
-           ++icluster) {
-        double difference = sqrt(pow(p.x() * mm - icluster->second.x(), 2) +
-                                 pow(p.y() * mm - icluster->second.y(), 2) +
+      for (; icluster != clusters.upper_bound(distance + vertexClusteringDistance_); ++icluster) {
+        double difference = sqrt(pow(p.x() * mm - icluster->second.x(), 2) + pow(p.y() * mm - icluster->second.y(), 2) +
                                  pow(p.z() * mm - icluster->second.z(), 2));
 
         if (difference < vertexClusteringDistance_) {
@@ -338,51 +309,41 @@ void VertexClassifier::vertexInformation() {
       }
 
       if (!cluster)
-        clusters.insert(ClusterPair(
-            distance, HepMC::ThreeVector(p.x() * mm, p.y() * mm, p.z() * mm)));
+        clusters.insert(ClusterPair(distance, HepMC::ThreeVector(p.x() * mm, p.y() * mm, p.z() * mm)));
     }
   }
 
-  const VertexHistory::SimVertexTrail &simVertexTrail =
-      tracer_.simVertexTrail();
+  const VertexHistory::SimVertexTrail &simVertexTrail = tracer_.simVertexTrail();
 
   // Loop over the generated particles
-  for (VertexHistory::SimVertexTrail::const_reverse_iterator ivertex =
-           simVertexTrail.rbegin();
-       ivertex != simVertexTrail.rend(); ++ivertex) {
+  for (VertexHistory::SimVertexTrail::const_reverse_iterator ivertex = simVertexTrail.rbegin();
+       ivertex != simVertexTrail.rend();
+       ++ivertex) {
     // Look for those with production vertex
     TrackingVertex::LorentzVector p = (*ivertex)->position();
 
-    double distance = sqrt(pow(p.x() - genpv.x, 2) + pow(p.y() - genpv.y, 2) +
-                           pow(p.z() - genpv.z, 2));
+    double distance = sqrt(pow(p.x() - genpv.x, 2) + pow(p.y() - genpv.y, 2) + pow(p.z() - genpv.z, 2));
 
     // If there is not any clusters add the first vertex.
     if (clusters.empty()) {
-      clusters.insert(
-          ClusterPair(distance, HepMC::ThreeVector(p.x(), p.y(), p.z())));
+      clusters.insert(ClusterPair(distance, HepMC::ThreeVector(p.x(), p.y(), p.z())));
       continue;
     }
 
     // Check if there is already a cluster in the given distance from primary
     // vertex
-    Clusters::const_iterator icluster =
-        clusters.lower_bound(distance - vertexClusteringDistance_);
+    Clusters::const_iterator icluster = clusters.lower_bound(distance - vertexClusteringDistance_);
 
-    if (icluster ==
-        clusters.upper_bound(distance + vertexClusteringDistance_)) {
-      clusters.insert(
-          ClusterPair(distance, HepMC::ThreeVector(p.x(), p.y(), p.z())));
+    if (icluster == clusters.upper_bound(distance + vertexClusteringDistance_)) {
+      clusters.insert(ClusterPair(distance, HepMC::ThreeVector(p.x(), p.y(), p.z())));
       continue;
     }
 
     bool cluster = false;
 
     // Looping over the vertex clusters of a given distance from primary vertex
-    for (;
-         icluster != clusters.upper_bound(distance + vertexClusteringDistance_);
-         ++icluster) {
-      double difference = sqrt(pow(p.x() - icluster->second.x(), 2) +
-                               pow(p.y() - icluster->second.y(), 2) +
+    for (; icluster != clusters.upper_bound(distance + vertexClusteringDistance_); ++icluster) {
+      double difference = sqrt(pow(p.x() - icluster->second.x(), 2) + pow(p.y() - icluster->second.y(), 2) +
                                pow(p.z() - icluster->second.z(), 2));
 
       if (difference < vertexClusteringDistance_) {
@@ -392,8 +353,7 @@ void VertexClassifier::vertexInformation() {
     }
 
     if (!cluster)
-      clusters.insert(
-          ClusterPair(distance, HepMC::ThreeVector(p.x(), p.y(), p.z())));
+      clusters.insert(ClusterPair(distance, HepMC::ThreeVector(p.x(), p.y(), p.z())));
   }
 
   if (clusters.size() == 1)
@@ -427,16 +387,15 @@ void VertexClassifier::genPrimaryVertices() {
     int idx = 0;
 
     // Loop over the different GenVertex
-    for (HepMC::GenEvent::vertex_const_iterator ivertex =
-             event->vertices_begin();
-         ivertex != event->vertices_end(); ++ivertex) {
+    for (HepMC::GenEvent::vertex_const_iterator ivertex = event->vertices_begin(); ivertex != event->vertices_end();
+         ++ivertex) {
       bool hasParentVertex = false;
 
       // Loop over the parents looking to see if they are coming from a
       // production vertex
-      for (HepMC::GenVertex::particle_iterator iparent =
-               (*ivertex)->particles_begin(HepMC::parents);
-           iparent != (*ivertex)->particles_end(HepMC::parents); ++iparent)
+      for (HepMC::GenVertex::particle_iterator iparent = (*ivertex)->particles_begin(HepMC::parents);
+           iparent != (*ivertex)->particles_end(HepMC::parents);
+           ++iparent)
         if ((*iparent)->production_vertex()) {
           hasParentVertex = true;
           break;
@@ -457,9 +416,7 @@ void VertexClassifier::genPrimaryVertices() {
 
       // Search for a VERY close vertex in the list
       for (; ientry != genpvs_.end(); ++ientry) {
-        double distance =
-            sqrt(pow(pv.x - ientry->x, 2) + pow(pv.y - ientry->y, 2) +
-                 pow(pv.z - ientry->z, 2));
+        double distance = sqrt(pow(pv.x - ientry->x, 2) + pow(pv.y - ientry->y, 2) + pow(pv.z - ientry->z, 2));
         if (distance < vertexClusteringDistance_)
           break;
       }
@@ -472,14 +429,11 @@ void VertexClassifier::genPrimaryVertices() {
       ientry->genVertex.push_back((*ivertex)->barcode());
 
       // Collect final state descendants
-      for (HepMC::GenVertex::particle_iterator idecendants =
-               (*ivertex)->particles_begin(HepMC::descendants);
+      for (HepMC::GenVertex::particle_iterator idecendants = (*ivertex)->particles_begin(HepMC::descendants);
            idecendants != (*ivertex)->particles_end(HepMC::descendants);
            ++idecendants) {
         if (isFinalstateParticle(*idecendants))
-          if (find(ientry->finalstateParticles.begin(),
-                   ientry->finalstateParticles.end(),
-                   (*idecendants)->barcode()) ==
+          if (find(ientry->finalstateParticles.begin(), ientry->finalstateParticles.end(), (*idecendants)->barcode()) ==
               ientry->finalstateParticles.end()) {
             ientry->finalstateParticles.push_back((*idecendants)->barcode());
             HepMC::FourVector m = (*idecendants)->momentum();
@@ -490,8 +444,7 @@ void VertexClassifier::genPrimaryVertices() {
             ientry->ptot.setE(ientry->ptot.e() + m.e());
             ientry->ptsq += m.perp() * m.perp();
 
-            if (m.perp() > 0.8 && std::abs(m.pseudoRapidity()) < 2.5 &&
-                isCharged(*idecendants))
+            if (m.perp() > 0.8 && std::abs(m.pseudoRapidity()) < 2.5 && isCharged(*idecendants))
               ientry->nGenTrk++;
           }
       }

--- a/SimTracker/TrackHistory/src/VertexHistory.cc
+++ b/SimTracker/TrackHistory/src/VertexHistory.cc
@@ -3,23 +3,18 @@
 #include "SimDataFormats/Associations/interface/VertexToTrackingVertexAssociator.h"
 #include "SimTracker/TrackHistory/interface/VertexHistory.h"
 
-VertexHistory::VertexHistory(const edm::ParameterSet &config,
-                             edm::ConsumesCollector &&collector)
-    : HistoryBase() {
+VertexHistory::VertexHistory(const edm::ParameterSet &config, edm::ConsumesCollector &&collector) : HistoryBase() {
   // Name of the track collection
-  vertexProducer_ =
-      config.getUntrackedParameter<edm::InputTag>("vertexProducer");
+  vertexProducer_ = config.getUntrackedParameter<edm::InputTag>("vertexProducer");
 
   // Name of the traking pariticle collection
   trackingTruth_ = config.getUntrackedParameter<edm::InputTag>("trackingTruth");
 
   // Vertex association record
-  vertexAssociator_ =
-      config.getUntrackedParameter<edm::InputTag>("vertexAssociator");
+  vertexAssociator_ = config.getUntrackedParameter<edm::InputTag>("vertexAssociator");
 
   // Association by max. value
-  bestMatchByMaxValue_ =
-      config.getUntrackedParameter<bool>("bestMatchByMaxValue");
+  bestMatchByMaxValue_ = config.getUntrackedParameter<bool>("bestMatchByMaxValue");
 
   // Enable RecoToSim association
   enableRecoToSim_ = config.getUntrackedParameter<bool>("enableRecoToSim");
@@ -30,15 +25,13 @@ VertexHistory::VertexHistory(const edm::ParameterSet &config,
   if (enableRecoToSim_ or enableSimToReco_) {
     collector.consumes<edm::View<reco::Vertex>>(vertexProducer_);
     collector.consumes<TrackingVertexCollection>(trackingTruth_);
-    collector.consumes<reco::VertexToTrackingVertexAssociator>(
-        vertexAssociator_);
+    collector.consumes<reco::VertexToTrackingVertexAssociator>(vertexAssociator_);
   }
 
   quality_ = 0.;
 }
 
-void VertexHistory::newEvent(const edm::Event &event,
-                             const edm::EventSetup &setup) {
+void VertexHistory::newEvent(const edm::Event &event, const edm::EventSetup &setup) {
   if (enableRecoToSim_ || enableSimToReco_) {
     // Vertex collection
     edm::Handle<edm::View<reco::Vertex>> vertexCollection;
@@ -54,25 +47,21 @@ void VertexHistory::newEvent(const edm::Event &event,
 
     if (enableRecoToSim_) {
       // Calculate the map between recovertex -> simvertex
-      recoToSim_ =
-          vertexAssociator->associateRecoToSim(vertexCollection, TVCollection);
+      recoToSim_ = vertexAssociator->associateRecoToSim(vertexCollection, TVCollection);
     }
 
     if (enableSimToReco_) {
       // Calculate the map between recovertex <- simvertex
-      simToReco_ =
-          vertexAssociator->associateSimToReco(vertexCollection, TVCollection);
+      simToReco_ = vertexAssociator->associateSimToReco(vertexCollection, TVCollection);
     }
   }
 }
 
 bool VertexHistory::evaluate(reco::VertexBaseRef tv) {
-
   if (!enableRecoToSim_)
     return false;
 
-  std::pair<TrackingVertexRef, double> result =
-      match(tv, recoToSim_, bestMatchByMaxValue_);
+  std::pair<TrackingVertexRef, double> result = match(tv, recoToSim_, bestMatchByMaxValue_);
 
   TrackingVertexRef tvr(result.first);
   quality_ = result.second;

--- a/SimTracker/TrackHistory/src/classes.h
+++ b/SimTracker/TrackHistory/src/classes.h
@@ -6,12 +6,12 @@
 #include "SimTracker/TrackHistory/interface/VertexCategories.h"
 
 namespace SimTracker_TrackHistory {
-struct dictionary {
-  // Dictionaires for Track and Vertex categories
+  struct dictionary {
+    // Dictionaires for Track and Vertex categories
 
-  std::vector<TrackCategories> dummy01;
-  std::vector<VertexCategories> dummy02;
-  edm::Wrapper<std::vector<TrackCategories>> dummy03;
-  edm::Wrapper<std::vector<VertexCategories>> dummy04;
-};
-} // namespace SimTracker_TrackHistory
+    std::vector<TrackCategories> dummy01;
+    std::vector<VertexCategories> dummy02;
+    edm::Wrapper<std::vector<TrackCategories>> dummy03;
+    edm::Wrapper<std::vector<VertexCategories>> dummy04;
+  };
+}  // namespace SimTracker_TrackHistory


### PR DESCRIPTION

Applying code-format for CMSSW category simulation.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/190//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Fixes the code-formats suggested by #26624 (see #26686)
