### PR TITLE
Phase2 Cluster1D Visualization

### DIFF
--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -29,6 +29,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetType.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/CommonTopologies/interface/RectangularStripTopology.h"
 #include "Geometry/CommonTopologies/interface/TrapezoidalStripTopology.h"
@@ -56,33 +57,50 @@ void FWRecoGeometryESProducer::ADD_PIXEL_TOPOLOGY( unsigned int rawid,
    }
 }
 
+using Phase2TrackerGeomDetUnit = PixelGeomDetUnit;
+using Phase2TrackerTopology = PixelTopology;
+
 # define ADD_SISTRIP_TOPOLOGY( rawid, detUnit )			\
   const StripGeomDetUnit* det = dynamic_cast<const StripGeomDetUnit*>( detUnit ); \
-  if( det )                                                     \
+  if( det )							\
   {                                                             \
-    const StripTopology* topo = dynamic_cast<const StripTopology*>( &det->specificTopology() ); \
-    fwRecoGeometry.idToName[rawid].topology[0] = 0;            		    \
-    fwRecoGeometry.idToName[rawid].topology[1] = topo->nstrips();            \
-    fwRecoGeometry.idToName[rawid].topology[2] = topo->stripLength();        \
-    if( const RadialStripTopology* rtop = dynamic_cast<const RadialStripTopology*>( &(det->specificType().specificTopology()) ) ) \
-      {									\
+    if( const StripTopology* topo = dynamic_cast<const StripTopology*>( &det->specificTopology())) \
+    {                                                                   \
+      fwRecoGeometry.idToName[rawid].topology[0] = 0;			\
+      fwRecoGeometry.idToName[rawid].topology[1] = topo->nstrips();	\
+      fwRecoGeometry.idToName[rawid].topology[2] = topo->stripLength();	\
+    } else                                                              \
+    if( const RadialStripTopology* rtop = dynamic_cast<const RadialStripTopology*>( &(det->specificType().specificTopology()))) \
+    {									\
       fwRecoGeometry.idToName[rawid].topology[0] = 1;			\
       fwRecoGeometry.idToName[rawid].topology[3] = rtop->yAxisOrientation(); \
       fwRecoGeometry.idToName[rawid].topology[4] = rtop->originToIntersection(); \
       fwRecoGeometry.idToName[rawid].topology[5] = rtop->phiOfOneEdge(); \
       fwRecoGeometry.idToName[rawid].topology[6] = rtop->angularWidth(); \
     }                                                                   \
-    else if( dynamic_cast<const RectangularStripTopology*>( &(det->specificType().specificTopology()) ) )     \
+    else if( dynamic_cast<const RectangularStripTopology*>( &(det->specificType().specificTopology()))) \
     {                                                                   \
       fwRecoGeometry.idToName[rawid].topology[0] = 2;			\
       fwRecoGeometry.idToName[rawid].topology[3] = topo->pitch();	\
     }									\
-    else if( dynamic_cast<const TrapezoidalStripTopology*>( &(det->specificType().specificTopology()) ) )     \
+    else if( dynamic_cast<const TrapezoidalStripTopology*>( &(det->specificType().specificTopology()))) \
     {                                                                   \
       fwRecoGeometry.idToName[rawid].topology[0] = 3;			\
       fwRecoGeometry.idToName[rawid].topology[3] = topo->pitch();	\
-    }									\
+    }                                                                   \
   }                                                                     \
+  else								        \
+  {                                                                     \
+    const Phase2TrackerGeomDetUnit* det = dynamic_cast<const Phase2TrackerGeomDetUnit*>( detUnit ); \
+    if( det ) 								\
+    {                                                                   \
+      if( const Phase2TrackerTopology *topo = dynamic_cast<const Phase2TrackerTopology *>( &(det->specificTopology())))   \
+      {                                                                   \
+        fwRecoGeometry.idToName[rawid].topology[0] = topo->pitch().first; \
+        fwRecoGeometry.idToName[rawid].topology[1] = topo->pitch().second;\
+      }                                                                   \
+    }                                                                     \
+  }                                                                       \
 
 namespace {
   const std::array<std::string,3> hgcal_geom_names =  { { "HGCalEESensitive",

--- a/Fireworks/Tracks/interface/TrackUtils.h
+++ b/Fireworks/Tracks/interface/TrackUtils.h
@@ -67,6 +67,9 @@ TEveTrack* prepareTrack( const reco::Track& track,
 float pixelLocalX( const double mpx, const float* );
 float pixelLocalY( const double mpy, const float* );
 
+float phase2PixelLocalX( const double mpx, const float*, const float* );
+float phase2PixelLocalY( const double mpy, const float*, const float* );
+
 void localSiStrip( short strip, float* localTop, float* localBottom, const float* pars, unsigned int id );
 
 void pushPixelHits( std::vector<TVector3> &pixelPoints, const FWEventItem &iItem, const reco::Track &t );   

--- a/Fireworks/Tracks/plugins/FWItemTrackAccessors.cc
+++ b/Fireworks/Tracks/plugins/FWItemTrackAccessors.cc
@@ -19,6 +19,7 @@
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
 
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 
@@ -36,5 +37,6 @@ REGISTER_TEMPLATE_FWITEMACCESSOR( FWItemDetSetAccessor<edm::DetSetVector<SiStrip
 REGISTER_TEMPLATE_FWITEMACCESSOR( FWItemDetSetAccessor<edm::DetSetVector<PixelDigi> >, edm::DetSetVector<PixelDigi>, "SiPixelDigiCollectionAccessor" );
 REGISTER_TEMPLATE_FWITEMACCESSOR( FWItemNewDetSetAccessor<edmNew::DetSetVector<SiStripCluster> >, edmNew::DetSetVector<SiStripCluster>, "SiStripClusterCollectionNewAccessor" );
 REGISTER_TEMPLATE_FWITEMACCESSOR( FWItemNewDetSetAccessor<edmNew::DetSetVector<SiPixelCluster> >, edmNew::DetSetVector<SiPixelCluster>, "SiPixelClusterCollectionNewAccessor" );
+REGISTER_TEMPLATE_FWITEMACCESSOR( FWItemNewDetSetAccessor<edmNew::DetSetVector<Phase2TrackerCluster1D> >, edmNew::DetSetVector<Phase2TrackerCluster1D>, "Phase2TrackerCluster1DCollectionNewAccessor" );
 
 REGISTER_FWITEMACCESSOR(BeamSpotSingleAccessor, reco::BeamSpot, "BeamSpotAccessor");

--- a/Fireworks/Tracks/plugins/FWPhase2TrackerCluster1DDetProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWPhase2TrackerCluster1DDetProxyBuilder.cc
@@ -1,0 +1,64 @@
+// -*- C++ -*-
+//
+// Package:     Tracks
+// Class  :     FWPhase2TrackerCluster1DDetProxyBuilder
+//
+//
+
+#include "TEveGeoNode.h"
+
+#include "Fireworks/Core/interface/FWProxyBuilderBase.h"
+#include "Fireworks/Core/interface/FWEventItem.h"
+#include "Fireworks/Core/interface/FWGeometry.h"
+
+#include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
+#include "DataFormats/DetId/interface/DetId.h"
+
+class FWPhase2TrackerCluster1DDetProxyBuilder : public FWProxyBuilderBase
+{
+public:
+  FWPhase2TrackerCluster1DDetProxyBuilder() {}
+  ~FWPhase2TrackerCluster1DDetProxyBuilder() override {}
+  
+  REGISTER_PROXYBUILDER_METHODS();
+
+private:
+  using FWProxyBuilderBase::build;
+  void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
+  FWPhase2TrackerCluster1DDetProxyBuilder(const FWPhase2TrackerCluster1DDetProxyBuilder&) = delete;
+  const FWPhase2TrackerCluster1DDetProxyBuilder& operator=(const FWPhase2TrackerCluster1DDetProxyBuilder&) = delete;
+};
+
+void FWPhase2TrackerCluster1DDetProxyBuilder::build( const FWEventItem* iItem, TEveElementList* product , const FWViewContext*)
+{
+  const Phase2TrackerCluster1DCollectionNew* pixels = nullptr;
+  
+  iItem->get(pixels);
+  
+  if( ! pixels ) 
+    return;
+  
+  const FWGeometry* geom = iItem->getGeom();
+  
+  for( Phase2TrackerCluster1DCollectionNew::const_iterator set = pixels->begin(), setEnd = pixels->end();
+       set != setEnd; ++set) {
+    unsigned int id = set->detId();
+    DetId detid(id);
+    
+    if( geom->contains( detid )) {
+      const edmNew::DetSet<Phase2TrackerCluster1D> & clusters = *set;
+	
+      for( edmNew::DetSet<Phase2TrackerCluster1D>::const_iterator itc = clusters.begin(), edc = clusters.end(); 
+           itc != edc; ++itc ) {
+        TEveGeoShape* shape = geom->getEveShape(detid);
+	
+        if ( shape ) {
+          shape->SetMainTransparency(50);
+          setupAddElement(shape, product);
+        }
+      }
+    }
+  }
+}
+
+REGISTER_FWPROXYBUILDER( FWPhase2TrackerCluster1DDetProxyBuilder, Phase2TrackerCluster1DCollectionNew, "Phase2TrackerCluster1DDets", FWViewType::kAll3DBits | FWViewType::kAllRPZBits );

--- a/Fireworks/Tracks/plugins/FWPhase2TrackerCluster1DProxyBuilder.cc
+++ b/Fireworks/Tracks/plugins/FWPhase2TrackerCluster1DProxyBuilder.cc
@@ -1,0 +1,89 @@
+
+// -*- C++ -*-
+//
+// Package:     Tracks
+// Class  :     FWPhase2TrackerCluster1DProxyBuilder
+//
+//
+
+#include "TEvePointSet.h"
+#include "TEveStraightLineSet.h"
+#include "TEveCompound.h"
+#include "TEveBox.h"
+#include "Fireworks/Core/interface/FWProxyBuilderBase.h"
+#include "Fireworks/Core/interface/FWEventItem.h"
+#include "Fireworks/Core/interface/FWGeometry.h"
+#include "Fireworks/Core/interface/fwLog.h"
+#include "Fireworks/Tracks/interface/TrackUtils.h"
+
+#include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
+
+class FWPhase2TrackerCluster1DProxyBuilder : public FWProxyBuilderBase
+{
+public:
+  FWPhase2TrackerCluster1DProxyBuilder( void ) {}
+  ~FWPhase2TrackerCluster1DProxyBuilder( void ) override {}
+
+  REGISTER_PROXYBUILDER_METHODS();
+
+  FWPhase2TrackerCluster1DProxyBuilder( const FWPhase2TrackerCluster1DProxyBuilder& ) = delete;
+  const FWPhase2TrackerCluster1DProxyBuilder& operator=( const FWPhase2TrackerCluster1DProxyBuilder& ) = delete;
+
+private:
+  using FWProxyBuilderBase::build;
+  void build( const FWEventItem* iItem, TEveElementList* product, const FWViewContext* ) override;
+};
+
+void
+FWPhase2TrackerCluster1DProxyBuilder::build( const FWEventItem* iItem, TEveElementList* product , const FWViewContext* )
+{
+  const Phase2TrackerCluster1DCollectionNew* pixels = nullptr;
+  
+  iItem->get( pixels );
+  
+  if( ! pixels ) {    
+    fwLog( fwlog::kWarning ) << "failed get SiPixelDigis" << std::endl;
+    return;
+  }
+
+  for( Phase2TrackerCluster1DCollectionNew::const_iterator set = pixels->begin(), setEnd = pixels->end();
+       set != setEnd; ++set ) {    
+    unsigned int id = set->detId();
+    
+    const FWGeometry *geom = iItem->getGeom();
+    const float* pars = geom->getParameters( id );
+    const float* shape = geom->getShapePars( id );
+
+    const edmNew::DetSet<Phase2TrackerCluster1D> & clusters = *set;
+      
+    for( edmNew::DetSet<Phase2TrackerCluster1D>::const_iterator itc = clusters.begin(), edc = clusters.end(); 
+	 itc != edc; ++itc ) {
+      TEveElement* itemHolder = createCompound();
+      product->AddElement(itemHolder);
+      
+      TEvePointSet* pointSet = new TEvePointSet;
+      
+      if( ! geom->contains( id )) {
+	fwLog( fwlog::kWarning ) 
+	  << "failed get geometry of Phase2TrackerCluster1D with detid: "
+	  << id << std::endl;
+	continue;
+      }
+      
+      float localPoint[3] = {     
+	fireworks::phase2PixelLocalX(( *itc ).center(), pars, shape ),
+	fireworks::phase2PixelLocalY(( *itc ).column(), pars, shape ),
+	0.0
+      };
+
+      float globalPoint[3];
+      geom->localToGlobal( id, localPoint, globalPoint );
+      
+      pointSet->SetNextPoint( globalPoint[0], globalPoint[1], globalPoint[2] );
+      
+      setupAddElement( pointSet, itemHolder );
+    }
+  }    
+}
+
+REGISTER_FWPROXYBUILDER( FWPhase2TrackerCluster1DProxyBuilder, Phase2TrackerCluster1DCollectionNew, "Phase2TrackerCluster1D", FWViewType::kAll3DBits | FWViewType::kAllRPZBits );

--- a/Fireworks/Tracks/src/TrackUtils.cc
+++ b/Fireworks/Tracks/src/TrackUtils.cc
@@ -256,6 +256,22 @@ pixelLocalY( const double mpy, const float* par )
   return lpY;
 }
 
+// Transform measurement to local coordinates in X dimension
+float
+phase2PixelLocalX( const double mpx, const float* par, const float* shape )
+{
+  // The final position in local coordinates
+  return (-shape[1] + mpx * par[0]);
+}
+
+// Transform measurement to local coordinates in Y dimension
+float
+phase2PixelLocalY( const double mpy, const float* par, const float* shape )
+{
+  // The final position in local coordinates
+  return (-shape[2] + mpy * par[1]);
+}
+
 //
 // Returns strip geometry in local coordinates of a detunit.
 // The strip is a line from a localTop to a localBottom point.


### PR DESCRIPTION
#### PR description:

* Add a proxy builder for Phase2 Cluster1D
* Add a proxy builder for Phase2 Cluster1D Dets
* Store Phase2 tracker topology of a Phase2 tracker geometric DetUnit: _par[0] == pitch_ and _par[1] == length_ 

#### PR validation:

Produce an updated reco geometry file to include the topology:
```
cmsRun Fireworks/Geometry/python/dumpRecoGeometry_cfg.py tag=2023 version=D41
```
Then display (note, add a Phase2 Cluster1D collection from a GUI):
```
cmsShow -c cluster1d.fwc -g cmsRecoGeom-2023.root step3_200.root
```
#### if this PR is a backport please specify the original PR:

if a back-port is needed, the changes do not affect anything but the event display.
![Screen Shot 2019-05-08 at 16 02 15](https://user-images.githubusercontent.com/1390682/57382251-dd24c980-71ac-11e9-938a-f303e590638e.png)
