### PR TITLE
MTV : adjust impact parameter selection 

### DIFF
--- a/Validation/RecoTrack/python/GenParticleSelectionsForEfficiency_cff.py
+++ b/Validation/RecoTrack/python/GenParticleSelectionsForEfficiency_cff.py
@@ -10,6 +10,12 @@ GenParticleSelectionForEfficiency = cms.PSet(
     tipGP = cms.double(60),
     statusGP = cms.int32(1)
 )
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase1Pixel.toModify(GenParticleSelectionForEfficiency,minRapidityGP = -3.0, maxRapidityGP = 3.0)
+run3_common.toModify(GenParticleSelectionForEfficiency,minRapidityGP = -3.0, maxRapidityGP = 3.0)
+phase2_tracker.toModify(GenParticleSelectionForEfficiency,minRapidityGP = -4.5, maxRapidityGP = 4.5)
 
 generalGpSelectorBlock = cms.PSet(
     status = cms.int32(1),
@@ -77,3 +83,35 @@ GpSelectorForEfficiencyVsVTXZBlock = cms.PSet(
     lip = cms.double(35.0),
     tip = cms.double(3.5)
 )
+
+def _modifyForPhase1(pset):
+    pset.minRapidity = -3
+    pset.maxRapidity = 3
+    pset.tip = 2.5 # beampipe is around 2.0, BPIX1 is at 2.9
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(generalGpSelectorBlock,             _modifyForPhase1)
+phase1Pixel.toModify(GpSelectorForEfficiencyVsEtaBlock,  _modifyForPhase1)
+phase1Pixel.toModify(GpSelectorForEfficiencyVsPhiBlock,  _modifyForPhase1)
+phase1Pixel.toModify(GpSelectorForEfficiencyVsPtBlock,   _modifyForPhase1)
+phase1Pixel.toModify(GpSelectorForEfficiencyVsVTXRBlock, _modifyForPhase1)
+phase1Pixel.toModify(GpSelectorForEfficiencyVsVTXZBlock, _modifyForPhase1)
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(generalGpSelectorBlock,             _modifyForPhase1)
+run3_common.toModify(GpSelectorForEfficiencyVsEtaBlock,  _modifyForPhase1)
+run3_common.toModify(GpSelectorForEfficiencyVsPhiBlock,  _modifyForPhase1)
+run3_common.toModify(GpSelectorForEfficiencyVsPtBlock,   _modifyForPhase1)
+run3_common.toModify(GpSelectorForEfficiencyVsVTXRBlock, _modifyForPhase1)
+run3_common.toModify(GpSelectorForEfficiencyVsVTXZBlock, _modifyForPhase1)
+
+def _modifyForPhase2(pset):
+    pset.minRapidity = -4.5
+    pset.maxRapidity = 4.5
+    pset.tip = 2.5 # IT1 will be around 3.0 (as in Phase1)
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(generalGpSelectorBlock,             _modifyForPhase2)
+phase2_tracker.toModify(GpSelectorForEfficiencyVsEtaBlock,  _modifyForPhase2)
+phase2_tracker.toModify(GpSelectorForEfficiencyVsPhiBlock,  _modifyForPhase2)
+phase2_tracker.toModify(GpSelectorForEfficiencyVsPtBlock,   _modifyForPhase2)
+phase2_tracker.toModify(GpSelectorForEfficiencyVsVTXRBlock, _modifyForPhase2)
+phase2_tracker.toModify(GpSelectorForEfficiencyVsVTXZBlock, _modifyForPhase2)

--- a/Validation/RecoTrack/python/GenParticleSelectionsForEfficiency_cff.py
+++ b/Validation/RecoTrack/python/GenParticleSelectionsForEfficiency_cff.py
@@ -11,10 +11,8 @@ GenParticleSelectionForEfficiency = cms.PSet(
     statusGP = cms.int32(1)
 )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase1Pixel.toModify(GenParticleSelectionForEfficiency,minRapidityGP = -3.0, maxRapidityGP = 3.0)
-run3_common.toModify(GenParticleSelectionForEfficiency,minRapidityGP = -3.0, maxRapidityGP = 3.0)
 phase2_tracker.toModify(GenParticleSelectionForEfficiency,minRapidityGP = -4.5, maxRapidityGP = 4.5)
 
 generalGpSelectorBlock = cms.PSet(
@@ -95,14 +93,6 @@ phase1Pixel.toModify(GpSelectorForEfficiencyVsPhiBlock,  _modifyForPhase1)
 phase1Pixel.toModify(GpSelectorForEfficiencyVsPtBlock,   _modifyForPhase1)
 phase1Pixel.toModify(GpSelectorForEfficiencyVsVTXRBlock, _modifyForPhase1)
 phase1Pixel.toModify(GpSelectorForEfficiencyVsVTXZBlock, _modifyForPhase1)
-
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(generalGpSelectorBlock,             _modifyForPhase1)
-run3_common.toModify(GpSelectorForEfficiencyVsEtaBlock,  _modifyForPhase1)
-run3_common.toModify(GpSelectorForEfficiencyVsPhiBlock,  _modifyForPhase1)
-run3_common.toModify(GpSelectorForEfficiencyVsPtBlock,   _modifyForPhase1)
-run3_common.toModify(GpSelectorForEfficiencyVsVTXRBlock, _modifyForPhase1)
-run3_common.toModify(GpSelectorForEfficiencyVsVTXZBlock, _modifyForPhase1)
 
 def _modifyForPhase2(pset):
     pset.minRapidity = -4.5

--- a/Validation/RecoTrack/python/MultiTrackValidatorGenPs_cfi.py
+++ b/Validation/RecoTrack/python/MultiTrackValidatorGenPs_cfi.py
@@ -69,3 +69,8 @@ multiTrackValidatorGenPs = DQMEDAnalyzer(
     doRecoTrackPlots = cms.untracked.bool(True),
     dodEdxPlots = cms.untracked.bool(False),
 )
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(multiTrackValidator,
+    label_tv = "mixData:MergedTrackTruth",
+)

--- a/Validation/RecoTrack/python/TrackingParticleSelectionsForEfficiency_cff.py
+++ b/Validation/RecoTrack/python/TrackingParticleSelectionsForEfficiency_cff.py
@@ -33,9 +33,6 @@ def _modifyForPhase1(pset):
 phase1Pixel.toModify(generalTpSelectorBlock, _modifyForPhase1)
 phase1Pixel.toModify(TpSelectorForEfficiencyVsEtaBlock, _modifyForPhase1)
 
-run3_common.toModify(generalTpSelectorBlock, _modifyForPhase1)
-run3_common.toModify(TpSelectorForEfficiencyVsEtaBlock, _modifyForPhase1)
-
 def _modifyForPhase2(pset):
     pset.minRapidity = -4.5
     pset.maxRapidity = 4.5

--- a/Validation/RecoTrack/python/TrackingParticleSelectionsForEfficiency_cff.py
+++ b/Validation/RecoTrack/python/TrackingParticleSelectionsForEfficiency_cff.py
@@ -29,9 +29,16 @@ TpSelectorForEfficiencyVsVTXZBlock = generalTpSelectorBlock.clone()
 def _modifyForPhase1(pset):
     pset.minRapidity = -3
     pset.maxRapidity = 3
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+    pset.tip = 2.5 # beampipe is around 2.0, BPIX1 is at 2.9
 phase1Pixel.toModify(generalTpSelectorBlock, _modifyForPhase1)
 phase1Pixel.toModify(TpSelectorForEfficiencyVsEtaBlock, _modifyForPhase1)
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(generalTpSelectorBlock, minRapidity=-4.5, maxRapidity=4.5)
-phase2_tracker.toModify(TpSelectorForEfficiencyVsEtaBlock, minRapidity=-4.5, maxRapidity=4.5)
+
+run3_common.toModify(generalTpSelectorBlock, _modifyForPhase1)
+run3_common.toModify(TpSelectorForEfficiencyVsEtaBlock, _modifyForPhase1)
+
+def _modifyForPhase2(pset):
+    pset.minRapidity = -4.5
+    pset.maxRapidity = 4.5
+    pset.tip = 2.5 # IT1 will be around 3.0 (as in Phase1)
+phase2_tracker.toModify(generalTpSelectorBlock, _modifyForPhase2)
+phase2_tracker.toModify(TpSelectorForEfficiencyVsEtaBlock, _modifyForPhase2)

--- a/Validation/RecoTrack/python/TrackingParticleSelectionsForEfficiency_cff.py
+++ b/Validation/RecoTrack/python/TrackingParticleSelectionsForEfficiency_cff.py
@@ -30,6 +30,8 @@ def _modifyForPhase1(pset):
     pset.minRapidity = -3
     pset.maxRapidity = 3
     pset.tip = 2.5 # beampipe is around 2.0, BPIX1 is at 2.9
+
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(generalTpSelectorBlock, _modifyForPhase1)
 phase1Pixel.toModify(TpSelectorForEfficiencyVsEtaBlock, _modifyForPhase1)
 
@@ -37,5 +39,7 @@ def _modifyForPhase2(pset):
     pset.minRapidity = -4.5
     pset.maxRapidity = 4.5
     pset.tip = 2.5 # IT1 will be around 3.0 (as in Phase1)
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(generalTpSelectorBlock, _modifyForPhase2)
 phase2_tracker.toModify(TpSelectorForEfficiencyVsEtaBlock, _modifyForPhase2)


### PR DESCRIPTION
#### PR description:

adjust the impact parameter selection
for avoiding the 1st layer of the pixel detector (for phase1 : bug fix, for phase2 : new feature)

the efficiency plots produced by the MTV will be affected
in the phase1, run3 and phase2_tracker era


I have a question on the different eras in phase2
the MTV still makes use of either
Modifier_phase2_tracker_cff.py
or
Modifier_phase2_timing_layer_cff.py

shall we move to 
Modifier_phase2_common_cff.py ?

#### PR validation:
`scram b runtests`
`runTheMatrix.py -l limited -i all --ibeos` done

