### PR TITLE
[muon] add sim hit match quality and pileup identification information in MiniAOD

### DIFF
--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -296,11 +296,13 @@ namespace pat {
       int simPdgId() const { return simPdgId_;}
       int simMotherPdgId() const { return simMotherPdgId_;}
       int simBX() const { return simBX_;}
+      int simTpEvent() const {   return simTpEvent_;}
       float simProdRho() const { return simProdRho_;}
       float simProdZ() const {   return simProdZ_;}
       float simPt() const {      return simPt_;}
       float simEta() const {     return simEta_;}
       float simPhi() const {     return simPhi_;}
+      float simMatchQuality() const {     return simMatchQuality_;}
 
       void initSimInfo(void); 
       void setSimType(reco::MuonSimType type){ simType_ = type; }
@@ -310,11 +312,13 @@ namespace pat {
       void setSimPdgId(int id){ simPdgId_ = id;}
       void setSimMotherPdgId(int id){ simMotherPdgId_ = id;}
       void setSimBX(int bx){ simBX_ = bx;}
+      void setSimTpEvent(int tpEvent){ simTpEvent_ = tpEvent;}
       void setSimProdRho(float rho){ simProdRho_ = rho;}
       void setSimProdZ(float z){ simProdZ_ = z;}
       void setSimPt(float pt){ simPt_ = pt;}
       void setSimEta(float eta){ simEta_ = eta;}
       void setSimPhi(float phi){ simPhi_ = phi;}
+      void setSimMatchQuality(float quality){ simMatchQuality_ = quality;}
       
       /// Trigger information
       const pat::TriggerObjectStandAlone* l1Object(const size_t idx=0)  const { 
@@ -412,11 +416,13 @@ namespace pat {
       int simPdgId_;
       int simMotherPdgId_;
       int simBX_;
+      int simTpEvent_;
       float simProdRho_;
       float simProdZ_;
       float simPt_;
       float simEta_;
       float simPhi_;
+      float simMatchQuality_;
   };
 
 

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -67,7 +67,8 @@
   </ioread>
 
 
-  <class name="pat::Muon"  ClassVersion="26">
+  <class name="pat::Muon"  ClassVersion="27">
+   <version ClassVersion="27" checksum="3473399161"/>
    <version ClassVersion="26" checksum="1156855644"/>
    <version ClassVersion="25" checksum="574733987"/>
    <version ClassVersion="24" checksum="2298704767"/>

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -609,11 +609,13 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
 	aMuon.setSimPdgId(msi.pdgId);
 	aMuon.setSimMotherPdgId(msi.motherPdgId);
 	aMuon.setSimBX(msi.tpBX);
+	aMuon.setSimTpEvent(msi.tpEvent);
 	aMuon.setSimProdRho(msi.vertex.Rho());
 	aMuon.setSimProdZ(msi.vertex.Z());
 	aMuon.setSimPt(msi.p4.pt());
 	aMuon.setSimEta(msi.p4.eta());
 	aMuon.setSimPhi(msi.p4.phi());
+	aMuon.setSimMatchQuality(msi.tpAssoQuality);
       }
       patMuons->push_back(aMuon);
     }


### PR DESCRIPTION
This requests adds two numbers for each muon to improve physics analyzers to interpret muon matching information. The information is copied from the corresponding value map, which is only available in AODSIM and such samples are not available in most cases for physics analysis.