### PR TITLE
Added EventSetup consumes calls to MuonNumberingESProducer

### DIFF
--- a/Geometry/MuonNumbering/plugins/MuonNumberingESProducer.cc
+++ b/Geometry/MuonNumbering/plugins/MuonNumberingESProducer.cc
@@ -39,15 +39,14 @@ public:
 private:
   const std::string m_label;
   const std::string m_key;
+  const edm::ESGetToken<cms::DDSpecParRegistry,DDSpecParRegistryRcd> m_token;
 };
 
 MuonNumberingESProducer::MuonNumberingESProducer(const edm::ParameterSet& iConfig)
   : m_label(iConfig.getParameter<std::string>("label")),
-    m_key(iConfig.getParameter<std::string>("key"))
-
-{
-  setWhatProduced(this);
-}
+    m_key(iConfig.getParameter<std::string>("key")),
+    m_token( setWhatProduced(this).consumesFrom<cms::DDSpecParRegistry,DDSpecParRegistryRcd>(edm::ESInputTag("",m_label)) )
+{}
 
 MuonNumberingESProducer::~MuonNumberingESProducer()
 {}
@@ -58,10 +57,9 @@ MuonNumberingESProducer::produce(const MuonNumberingRecord& iRecord)
   LogDebug("Geometry") << "MuonNumberingESProducer::produce from " << m_label << " with " << m_key;
   auto product = std::make_unique<cms::MuonNumbering>();
 
-  edm::ESHandle<cms::DDSpecParRegistry> registry;
-  iRecord.getRecord<DDSpecParRegistryRcd>().get(m_label, registry);
-  auto it = registry->specpars.find(m_key);
-  if(it != end(registry->specpars)) {
+  cms::DDSpecParRegistry const& registry = iRecord.get( m_token );
+  auto it = registry.specpars.find(m_key);
+  if(it != end(registry.specpars)) {
     for(const auto& l : it->second.spars) {
       if(l.first == "OnlyForMuonNumbering") {
 	for(const auto& k : it->second.numpars) {


### PR DESCRIPTION
#### PR description:

Added EventSetup consumes calls to MuonNumberingESProducer.

#### PR validation:

Code compiles.