### PR TITLE
Migrate Geometry/HcalEventSetup to EventSetup consumes

### DIFF
--- a/Geometry/HcalEventSetup/interface/CaloTowerTopologyEP.h
+++ b/Geometry/HcalEventSetup/interface/CaloTowerTopologyEP.h
@@ -9,7 +9,6 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "Geometry/CaloTopology/interface/CaloTowerTopology.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
@@ -37,6 +36,6 @@ public:
 
 private:
   // ----------member data ---------------------------
-
+  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topoToken_;
 };
 #endif

--- a/Geometry/HcalEventSetup/interface/HcalAlignmentEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalAlignmentEP.h
@@ -15,7 +15,6 @@
 #include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 #include "CondFormats/AlignmentRecord/interface/HcalAlignmentRcd.h"
 #include "CondFormats/AlignmentRecord/interface/HcalAlignmentErrorExtendedRcd.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 class HcalAlignmentEP : public edm::ESProducer {
 
@@ -32,6 +31,12 @@ public:
 //-------------------------------------------------------------------
  
   ReturnAli    produceHcalAli( const HcalAlignmentRcd& iRecord );
+
+private:
+  edm::ESGetToken<Alignments, HBAlignmentRcd> hbToken_;
+  edm::ESGetToken<Alignments, HEAlignmentRcd> heToken_;
+  edm::ESGetToken<Alignments, HFAlignmentRcd> hfToken_;
+  edm::ESGetToken<Alignments, HOAlignmentRcd> hoToken_;
 };
 
 #endif

--- a/Geometry/HcalEventSetup/interface/HcalDDDGeometryEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalDDDGeometryEP.h
@@ -6,8 +6,6 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
-
 #include "Geometry/Records/interface/HcalGeometryRecord.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
@@ -24,5 +22,7 @@ public:
   ReturnType produceAligned(const HcalGeometryRecord&);
 
 private:
+  edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> consToken_;
+  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topologyToken_;
 };
 #endif

--- a/Geometry/HcalEventSetup/interface/HcalDDDGeometryEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalDDDGeometryEP.h
@@ -21,11 +21,8 @@ public:
 
   using ReturnType = std::unique_ptr<CaloSubdetectorGeometry>;
 
-  ReturnType produceIdeal(const HcalRecNumberingRecord&);
   ReturnType produceAligned(const HcalGeometryRecord&);
 
 private:
-
-  bool m_applyAlignment ;
 };
 #endif

--- a/Geometry/HcalEventSetup/interface/HcalHardcodeGeometryEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalHardcodeGeometryEP.h
@@ -5,10 +5,13 @@
 
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 class CaloSubdetectorGeometry;
 class HcalRecNumberingRecord;
 class HcalGeometryRecord;
+class HcalDDDRecConstants;
+class HcalTopology;
 
 class HcalHardcodeGeometryEP : public edm::ESProducer {
 
@@ -20,7 +23,8 @@ public:
   ReturnType produceAligned(const HcalGeometryRecord& );
 
 private:
-
+  edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> consToken_;
+  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topologyToken_;
   bool              useOld_;
 };
 #endif

--- a/Geometry/HcalEventSetup/interface/HcalHardcodeGeometryEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalHardcodeGeometryEP.h
@@ -17,7 +17,6 @@ public:
 
   using ReturnType = std::unique_ptr<CaloSubdetectorGeometry>;
 
-  ReturnType produceIdeal(const HcalRecNumberingRecord&);
   ReturnType produceAligned(const HcalGeometryRecord& );
 
 private:

--- a/Geometry/HcalEventSetup/interface/HcalTopologyIdealEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalTopologyIdealEP.h
@@ -6,7 +6,6 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
@@ -28,6 +27,7 @@ public:
 
 private:
   // ----------member data ---------------------------
+  edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> m_hdcToken;
   std::string m_restrictions;
   bool        m_mergePosition;
 };

--- a/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.cc
+++ b/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.cc
@@ -26,20 +26,20 @@ CaloTowerHardcodeGeometryEP::CaloTowerHardcodeGeometryEP(const edm::ParameterSet
 {
    //the following line is needed to tell the framework what
    // data is being produced
-   setWhatProduced(this,
-                   &CaloTowerHardcodeGeometryEP::produce,
-		   edm::es::Label("TOWER"));
+  auto cc = setWhatProduced(this,
+                            &CaloTowerHardcodeGeometryEP::produce,
+                            edm::es::Label("TOWER"));
+  cttopoToken_ = cc.consumesFrom<CaloTowerTopology, HcalRecNumberingRecord>(edm::ESInputTag{});
+  hcaltopoToken_ = cc.consumesFrom<HcalTopology, HcalRecNumberingRecord>(edm::ESInputTag{});
+  consToken_ = cc.consumesFrom<HcalDDDRecConstants, HcalRecNumberingRecord>(edm::ESInputTag{});
 }
 
 // ------------ method called to produce the data  ------------
 CaloTowerHardcodeGeometryEP::ReturnType
 CaloTowerHardcodeGeometryEP::produce(const CaloTowerGeometryRecord& iRecord) {
-  edm::ESHandle<CaloTowerTopology> cttopo;
-  iRecord.getRecord<HcalRecNumberingRecord>().get( cttopo );
-  edm::ESHandle<HcalTopology> hcaltopo;
-  iRecord.getRecord<HcalRecNumberingRecord>().get( hcaltopo );
-  edm::ESHandle<HcalDDDRecConstants> pHRNDC;
-  iRecord.getRecord<HcalRecNumberingRecord>().get( pHRNDC );
+  const auto& cttopo = iRecord.get(cttopoToken_);
+  const auto& hcaltopo = iRecord.get(hcaltopoToken_);
+  const auto& cons = iRecord.get(consToken_);
 
-  return std::unique_ptr<CaloSubdetectorGeometry>( loader_.load( &*cttopo, &*hcaltopo, &*pHRNDC ));
+  return std::unique_ptr<CaloSubdetectorGeometry>( loader_.load( &cttopo, &hcaltopo, &cons ));
 }

--- a/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.cc
+++ b/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.cc
@@ -29,12 +29,6 @@ CaloTowerHardcodeGeometryEP::CaloTowerHardcodeGeometryEP(const edm::ParameterSet
    setWhatProduced(this,
                    &CaloTowerHardcodeGeometryEP::produce,
 		   edm::es::Label("TOWER"));
-
-  loader_=new CaloTowerHardcodeGeometryLoader(); /// TODO : allow override of Topology.
-}
-
-CaloTowerHardcodeGeometryEP::~CaloTowerHardcodeGeometryEP() {
-  delete loader_;
 }
 
 // ------------ method called to produce the data  ------------
@@ -47,5 +41,5 @@ CaloTowerHardcodeGeometryEP::produce(const CaloTowerGeometryRecord& iRecord) {
   edm::ESHandle<HcalDDDRecConstants> pHRNDC;
   iRecord.getRecord<HcalRecNumberingRecord>().get( pHRNDC );
 
-  return std::unique_ptr<CaloSubdetectorGeometry>( loader_->load( &*cttopo, &*hcaltopo, &*pHRNDC ));
+  return std::unique_ptr<CaloSubdetectorGeometry>( loader_.load( &*cttopo, &*hcaltopo, &*pHRNDC ));
 }

--- a/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.h
+++ b/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.h
@@ -18,7 +18,6 @@ class IdealGeometryRecord;
 class CaloTowerHardcodeGeometryEP : public edm::ESProducer {
 public:
   CaloTowerHardcodeGeometryEP(const edm::ParameterSet&);
-  ~CaloTowerHardcodeGeometryEP() override;
 
   using ReturnType = std::unique_ptr<CaloSubdetectorGeometry>;
 
@@ -26,7 +25,7 @@ public:
 
 private:
   // ----------member data ---------------------------
-  CaloTowerHardcodeGeometryLoader* loader_;
+  CaloTowerHardcodeGeometryLoader loader_;
 };
 
 #endif

--- a/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.h
+++ b/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.h
@@ -6,7 +6,6 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/Records/interface/CaloTowerGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/HcalTowerAlgo/interface/CaloTowerHardcodeGeometryLoader.h"
@@ -26,6 +25,9 @@ public:
 private:
   // ----------member data ---------------------------
   CaloTowerHardcodeGeometryLoader loader_;
+  edm::ESGetToken<CaloTowerTopology, HcalRecNumberingRecord> cttopoToken_;
+  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> hcaltopoToken_;
+  edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> consToken_;
 };
 
 #endif

--- a/Geometry/HcalEventSetup/src/CaloTowerTopologyEP.cc
+++ b/Geometry/HcalEventSetup/src/CaloTowerTopologyEP.cc
@@ -29,9 +29,9 @@
 // constructors and destructor
 //
 CaloTowerTopologyEP::CaloTowerTopologyEP(const edm::ParameterSet& conf)
+  : topoToken_{setWhatProduced(this).consumes<HcalTopology>(edm::ESInputTag{})}
 {
   edm::LogInfo("HCAL") << "CaloTowerTopologyEP::CaloTowerTopologyEP";
-  setWhatProduced(this);
 }
 
 
@@ -50,12 +50,11 @@ void CaloTowerTopologyEP::fillDescriptions( edm::ConfigurationDescriptions & des
 // ------------ method called to produce the data  ------------
 CaloTowerTopologyEP::ReturnType
 CaloTowerTopologyEP::produce(const HcalRecNumberingRecord& iRecord) {
-  edm::ESHandle<HcalTopology> hcaltopo;
-  iRecord.get(hcaltopo);
+  const auto& hcaltopo = iRecord.get(topoToken_);
 
   edm::LogInfo("HCAL") << "CaloTowerTopologyEP::produce(const HcalRecNumberingRecord& iRecord)";
 
-  return std::make_unique<CaloTowerTopology>(&*hcaltopo);
+  return std::make_unique<CaloTowerTopology>(&hcaltopo);
 }
 
 

--- a/Geometry/HcalEventSetup/src/HcalAlignmentEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalAlignmentEP.cc
@@ -11,7 +11,11 @@
 #include "Geometry/HcalEventSetup/interface/HcalAlignmentEP.h"
 
 HcalAlignmentEP::HcalAlignmentEP(const edm::ParameterSet&) {
-  setWhatProduced( this, &HcalAlignmentEP::produceHcalAli    ) ;
+  auto cc = setWhatProduced( this, &HcalAlignmentEP::produceHcalAli    ) ;
+  hbToken_ = cc.consumesFrom<Alignments, HBAlignmentRcd>(edm::ESInputTag{});
+  heToken_ = cc.consumesFrom<Alignments, HEAlignmentRcd>(edm::ESInputTag{});
+  hfToken_ = cc.consumesFrom<Alignments, HFAlignmentRcd>(edm::ESInputTag{});
+  hoToken_ = cc.consumesFrom<Alignments, HOAlignmentRcd>(edm::ESInputTag{});
 }
 
 HcalAlignmentEP::~HcalAlignmentEP() {}
@@ -24,27 +28,20 @@ HcalAlignmentEP::ReturnAli HcalAlignmentEP::produceHcalAli( const HcalAlignmentR
   const unsigned int nA ( HcalGeometry::numberOfAlignments() ) ; 
   vtr.resize( nA ) ;
 
-  edm::ESHandle<Alignments> hb ;
-  edm::ESHandle<Alignments> he ;
-  edm::ESHandle<Alignments> hf ;
-  edm::ESHandle<Alignments> ho ;
-  iRecord.getRecord<HBAlignmentRcd>().get( hb ) ;
-  iRecord.getRecord<HEAlignmentRcd>().get( he ) ;
-  iRecord.getRecord<HFAlignmentRcd>().get( hf ) ;
-  iRecord.getRecord<HOAlignmentRcd>().get( ho ) ;
+  const auto& hb = iRecord.get(hbToken_);
+  const auto& he = iRecord.get(heToken_);
+  const auto& hf = iRecord.get(hfToken_);
+  const auto& ho = iRecord.get(hoToken_);
 
-  assert( hb.isValid() && // require valid alignments and expected size
-	  ( hb->m_align.size() == HcalGeometry::numberOfBarrelAlignments() ) ) ;
-  assert( he.isValid() && // require valid alignments and expected size
-	  ( he->m_align.size() == HcalGeometry::numberOfEndcapAlignments() ) ) ;
-  assert( hf.isValid() && // require valid alignments and expected size
-	  ( hf->m_align.size() == HcalGeometry::numberOfForwardAlignments() ) ) ;
-  assert( ho.isValid() && // require valid alignments and expected size
-	  ( ho->m_align.size() == HcalGeometry::numberOfOuterAlignments() ) ) ;
-  const std::vector<AlignTransform>& hbt = hb->m_align ;
-  const std::vector<AlignTransform>& het = he->m_align ;
-  const std::vector<AlignTransform>& hft = hf->m_align ;
-  const std::vector<AlignTransform>& hot = ho->m_align ;
+  // require valid alignments and expected size
+  assert( hb.m_align.size() == HcalGeometry::numberOfBarrelAlignments() ) ;
+  assert( he.m_align.size() == HcalGeometry::numberOfEndcapAlignments() ) ;
+  assert( hf.m_align.size() == HcalGeometry::numberOfForwardAlignments() ) ;
+  assert( ho.m_align.size() == HcalGeometry::numberOfOuterAlignments() ) ;
+  const std::vector<AlignTransform>& hbt = hb.m_align ;
+  const std::vector<AlignTransform>& het = he.m_align ;
+  const std::vector<AlignTransform>& hft = hf.m_align ;
+  const std::vector<AlignTransform>& hot = ho.m_align ;
 
   copy( hbt.begin(), hbt.end(), vtr.begin() ) ;
   copy( het.begin(), het.end(), vtr.begin()+hbt.size() ) ;

--- a/Geometry/HcalEventSetup/src/HcalDDDGeometryEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalDDDGeometryEP.cc
@@ -24,25 +24,21 @@ HcalDDDGeometryEP::HcalDDDGeometryEP(const edm::ParameterSet& ps ){
 
   //the following line is needed to tell the framework what
   // data is being produced
-  setWhatProduced( this,
-		   &HcalDDDGeometryEP::produceAligned,
-		   edm::es::Label("HCAL"));
+  auto cc = setWhatProduced( this,
+                             &HcalDDDGeometryEP::produceAligned,
+                             edm::es::Label("HCAL"));
+  consToken_ = cc.consumesFrom<HcalDDDRecConstants, HcalRecNumberingRecord>(edm::ESInputTag{});
+  topologyToken_ = cc.consumesFrom<HcalTopology, HcalRecNumberingRecord>(edm::ESInputTag{});
 }
 
 // ------------ method called to produce the data  ------------
 HcalDDDGeometryEP::ReturnType
 HcalDDDGeometryEP::produceAligned(const HcalGeometryRecord& iRecord) {
-
-  const HcalRecNumberingRecord& idealRecord = iRecord.getRecord<HcalRecNumberingRecord>();
-
   edm::LogInfo("HCAL") << "Using default HCAL topology" ;
-  edm::ESHandle<HcalDDDRecConstants> hcons;
-  idealRecord.get( hcons ) ;
+  const auto& cons = iRecord.get(consToken_);
+  const auto& topology = iRecord.get(topologyToken_);
 
-  edm::ESHandle<HcalTopology> topology ;
-  idealRecord.get( topology ) ;
+  HcalDDDGeometryLoader loader(&cons);
 
-  HcalDDDGeometryLoader loader(&(*hcons));
-
-  return ReturnType(loader.load(*topology));
+  return ReturnType(loader.load(topology));
 }

--- a/Geometry/HcalEventSetup/src/HcalDDDGeometryEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalDDDGeometryEP.cc
@@ -20,8 +20,7 @@
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-HcalDDDGeometryEP::HcalDDDGeometryEP(const edm::ParameterSet& ps ) :
-  m_applyAlignment(ps.getUntrackedParameter<bool>("applyAlignment", false) ) {
+HcalDDDGeometryEP::HcalDDDGeometryEP(const edm::ParameterSet& ps ){
 
   //the following line is needed to tell the framework what
   // data is being produced
@@ -32,23 +31,18 @@ HcalDDDGeometryEP::HcalDDDGeometryEP(const edm::ParameterSet& ps ) :
 
 // ------------ method called to produce the data  ------------
 HcalDDDGeometryEP::ReturnType
-HcalDDDGeometryEP::produceIdeal(const HcalRecNumberingRecord& iRecord) {
+HcalDDDGeometryEP::produceAligned(const HcalGeometryRecord& iRecord) {
+
+  const HcalRecNumberingRecord& idealRecord = iRecord.getRecord<HcalRecNumberingRecord>();
 
   edm::LogInfo("HCAL") << "Using default HCAL topology" ;
   edm::ESHandle<HcalDDDRecConstants> hcons;
-  iRecord.get( hcons ) ;
+  idealRecord.get( hcons ) ;
 
   edm::ESHandle<HcalTopology> topology ;
-  iRecord.get( topology ) ;
+  idealRecord.get( topology ) ;
 
   HcalDDDGeometryLoader loader(&(*hcons));
 
   return ReturnType(loader.load(*topology));
-}
-
-HcalDDDGeometryEP::ReturnType
-HcalDDDGeometryEP::produceAligned(const HcalGeometryRecord& iRecord) {
-
-  const HcalRecNumberingRecord& idealRecord = iRecord.getRecord<HcalRecNumberingRecord>();
-  return produceIdeal (idealRecord);
 }

--- a/Geometry/HcalEventSetup/src/HcalHardcodeGeometryEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalHardcodeGeometryEP.cc
@@ -18,7 +18,6 @@
 
 #include "Geometry/HcalEventSetup/interface/HcalHardcodeGeometryEP.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "Geometry/Records/interface/HcalGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
@@ -34,25 +33,25 @@ HcalHardcodeGeometryEP::HcalHardcodeGeometryEP( const edm::ParameterSet& ps ) {
   useOld_ = ps.getParameter<bool>("UseOldLoader");
   //the following line is needed to tell the framework what
   // data is being produced
-  setWhatProduced( this,
-		   &HcalHardcodeGeometryEP::produceAligned,
-		   edm::es::Label(HcalGeometry::producerTag()));
+  auto cc = setWhatProduced( this,
+                             &HcalHardcodeGeometryEP::produceAligned,
+                             edm::es::Label(HcalGeometry::producerTag()));
+  if(not useOld_) {
+    consToken_ = cc.consumesFrom<HcalDDDRecConstants, HcalRecNumberingRecord>(edm::ESInputTag{});
+  }
+  topologyToken_ = cc.consumesFrom<HcalTopology, HcalRecNumberingRecord>(edm::ESInputTag{});
 }
 
 HcalHardcodeGeometryEP::ReturnType
 HcalHardcodeGeometryEP::produceAligned( const HcalGeometryRecord& iRecord ) {
-  const HcalRecNumberingRecord& idealRecord = iRecord.getRecord<HcalRecNumberingRecord>();
-
   edm::LogInfo("HCAL") << "Using default HCAL topology" ;
-  edm::ESHandle<HcalTopology> topology ;
-  iRecord.get( topology ) ;
+  const auto& topology = iRecord.get(topologyToken_);
   if (useOld_) {
     HcalHardcodeGeometryLoader loader;
-    return ReturnType (loader.load (*topology));
+    return ReturnType (loader.load (topology));
   } else {
-    edm::ESHandle<HcalDDDRecConstants> hcons;
-    iRecord.get( hcons ) ;
+    const auto& cons = iRecord.get(consToken_);
     HcalFlexiHardcodeGeometryLoader loader;
-    return ReturnType (loader.load (*topology, *hcons));
+    return ReturnType (loader.load (topology, cons));
   }
 }

--- a/Geometry/HcalEventSetup/src/HcalHardcodeGeometryEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalHardcodeGeometryEP.cc
@@ -40,24 +40,19 @@ HcalHardcodeGeometryEP::HcalHardcodeGeometryEP( const edm::ParameterSet& ps ) {
 }
 
 HcalHardcodeGeometryEP::ReturnType
-HcalHardcodeGeometryEP::produceIdeal( const HcalRecNumberingRecord& iRecord ) {
-
-   edm::LogInfo("HCAL") << "Using default HCAL topology" ;
-   edm::ESHandle<HcalDDDRecConstants> hcons;
-   iRecord.get( hcons ) ;
-   edm::ESHandle<HcalTopology> topology ;
-   iRecord.get( topology ) ;
-   if (useOld_) {
-     HcalHardcodeGeometryLoader loader;
-     return ReturnType (loader.load (*topology));
-   } else {
-      HcalFlexiHardcodeGeometryLoader loader;
-     return ReturnType (loader.load (*topology, *hcons));
-   }
-}
-
-HcalHardcodeGeometryEP::ReturnType
 HcalHardcodeGeometryEP::produceAligned( const HcalGeometryRecord& iRecord ) {
   const HcalRecNumberingRecord& idealRecord = iRecord.getRecord<HcalRecNumberingRecord>();
-  return produceIdeal (idealRecord);
+
+  edm::LogInfo("HCAL") << "Using default HCAL topology" ;
+  edm::ESHandle<HcalTopology> topology ;
+  iRecord.get( topology ) ;
+  if (useOld_) {
+    HcalHardcodeGeometryLoader loader;
+    return ReturnType (loader.load (*topology));
+  } else {
+    edm::ESHandle<HcalDDDRecConstants> hcons;
+    iRecord.get( hcons ) ;
+    HcalFlexiHardcodeGeometryLoader loader;
+    return ReturnType (loader.load (*topology, *hcons));
+  }
 }

--- a/Geometry/HcalEventSetup/src/HcalTopologyIdealEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalTopologyIdealEP.cc
@@ -27,7 +27,8 @@
 //#define DebugLog
 
 HcalTopologyIdealEP::HcalTopologyIdealEP(const edm::ParameterSet& conf)
-  : m_restrictions(conf.getUntrackedParameter<std::string>("Exclude")),
+  : m_hdcToken{setWhatProduced(this, &HcalTopologyIdealEP::produce).consumes<HcalDDDRecConstants>(edm::ESInputTag{})},
+    m_restrictions(conf.getUntrackedParameter<std::string>("Exclude")),
     m_mergePosition(conf.getUntrackedParameter<bool>("MergePosition")) {
 #ifdef DebugLog
   std::cout << "HcalTopologyIdealEP::HcalTopologyIdealEP with Exclude: "
@@ -35,8 +36,6 @@ HcalTopologyIdealEP::HcalTopologyIdealEP(const edm::ParameterSet& conf)
 	    << std::endl;
   edm::LogInfo("HCAL") << "HcalTopologyIdealEP::HcalTopologyIdealEP";
 #endif
-  setWhatProduced(this,
-                  &HcalTopologyIdealEP::produce);
 }
 
 void HcalTopologyIdealEP::fillDescriptions( edm::ConfigurationDescriptions & descriptions ) {
@@ -54,20 +53,18 @@ HcalTopologyIdealEP::produce(const HcalRecNumberingRecord& iRecord) {
   std::cout << "HcalTopologyIdealEP::produce(const IdealGeometryRecord& iRecord)" << std::endl;
   edm::LogInfo("HCAL") << "HcalTopologyIdealEP::produce(const HcalGeometryRecord& iRecord)";
 #endif
-  edm::ESHandle<HcalDDDRecConstants> pHRNDC;
-  iRecord.get( pHRNDC );
-  const HcalDDDRecConstants* hdc = &(*pHRNDC);
+  const HcalDDDRecConstants& hdc = iRecord.get(m_hdcToken);
 
 #ifdef DebugLog
-  std::cout << "mode = " << hdc->getTopoMode() << ", maxDepthHB = "
-	    << hdc->getMaxDepth(0) << ", maxDepthHE = " << hdc->getMaxDepth(1)
-	    << ", maxDepthHF = " << hdc->getMaxDepth(2) << std::endl;
-  edm::LogInfo("HCAL") << "mode = " << hdc->getTopoMode() << ", maxDepthHB = "
-		       << hdc->getMaxDepth(0) << ", maxDepthHE = "
-		       << hdc->getMaxDepth(1) << ", maxDepthHF = "
-		       << hdc->getMaxDepth(2);
+  std::cout << "mode = " << hdc.getTopoMode() << ", maxDepthHB = "
+	    << hdc.getMaxDepth(0) << ", maxDepthHE = " << hdc.getMaxDepth(1)
+	    << ", maxDepthHF = " << hdc.getMaxDepth(2) << std::endl;
+  edm::LogInfo("HCAL") << "mode = " << hdc.getTopoMode() << ", maxDepthHB = "
+		       << hdc.getMaxDepth(0) << ", maxDepthHE = "
+		       << hdc.getMaxDepth(1) << ", maxDepthHF = "
+		       << hdc.getMaxDepth(2);
 #endif
-  ReturnType myTopo(new HcalTopology(hdc,m_mergePosition));
+  ReturnType myTopo(new HcalTopology(&hdc,m_mergePosition));
 
   HcalTopologyRestrictionParser parser(*myTopo);
   if (!m_restrictions.empty()) {

--- a/Geometry/HcalEventSetup/test/HcalDDDGeometryAnalyzer.cc
+++ b/Geometry/HcalEventSetup/test/HcalDDDGeometryAnalyzer.cc
@@ -24,7 +24,6 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -54,10 +53,12 @@ public:
   void endJob() override {}
 
 private:
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
   int pass_;
 };
 
 HcalDDDGeometryAnalyzer::HcalDDDGeometryAnalyzer(const edm::ParameterSet& )
+  : geometryToken_{esConsumes<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{})}
 {
   pass_=0;
 }
@@ -70,8 +71,8 @@ void HcalDDDGeometryAnalyzer::analyze(const edm::Event& ,
 
   LogDebug("HCalGeom") << "HcalDDDGeometryAnalyzer::analyze at pass " << pass_;
 
-  edm::ESHandle<CaloGeometry> geometry;
-  iSetup.get<CaloGeometryRecord>().get(geometry);     
+  const auto& geometryR = iSetup.getData(geometryToken_);
+  const auto* geometry = &geometryR;
   //
   // get the ecal & hcal geometry
   //


### PR DESCRIPTION
#### PR description:

This PR migrates all ES and ED modules in Geometry/HcalGeometry to EventSetup consumes (#26584).

In addition this PR contains some simplifications on the code.

#### PR validation:

Limited matrix runs
