### PR TITLE
DataFormats/SiPixelDetId: fix for undefined unordered_map when compiling with clang 4.0.1 and macos10.9.X SDK under Conda

### DIFF
--- a/DataFormats/SiPixelDetId/src/ES_PixelFEDChannelCollectionMap.cc
+++ b/DataFormats/SiPixelDetId/src/ES_PixelFEDChannelCollectionMap.cc
@@ -1,6 +1,6 @@
 #include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
 #include "FWCore/Utilities/interface/typelookup.h"
-
+#include <unordered_map>
 typedef std::unordered_map<std::string,PixelFEDChannelCollection> PixelFEDChannelCollectionMap;
 
 TYPELOOKUP_DATA_REG(PixelFEDChannelCollectionMap);


### PR DESCRIPTION
Adding this #include allows this to compile under Conda which uses clang4.0.1 and macOS10.9.x SDK.