### PR TITLE
Running code-format for alca

### DIFF
--- a/Alignment/CommonAlignmentParametrization/interface/AlignmentParametersFactory.h
+++ b/Alignment/CommonAlignmentParametrization/interface/AlignmentParametersFactory.h
@@ -17,30 +17,29 @@ class Alignable;
 class AlignmentParameters;
 
 namespace AlignmentParametersFactory {
-/// enums for all available AlignmentParameters
-enum ParametersType {
-  kRigidBody = 0, // RigidBodyAlignmentParameters
-  kSurvey, // SurveyParameters GF: do not belong here, so remove in the long
-           // term...
-  kRigidBody4D,     // RigidBodyAlignmentParameters4D
-  kBeamSpot,        // BeamSpotAlignmentParameters
-  kBowedSurface,    // BowedSurfaceAlignmentParameters
-  kTwoBowedSurfaces // TwoBowedSurfacesAlignmentParameters
-};
+  /// enums for all available AlignmentParameters
+  enum ParametersType {
+    kRigidBody = 0,    // RigidBodyAlignmentParameters
+    kSurvey,           // SurveyParameters GF: do not belong here, so remove in the long
+                       // term...
+    kRigidBody4D,      // RigidBodyAlignmentParameters4D
+    kBeamSpot,         // BeamSpotAlignmentParameters
+    kBowedSurface,     // BowedSurfaceAlignmentParameters
+    kTwoBowedSurfaces  // TwoBowedSurfacesAlignmentParameters
+  };
 
-/// convert string to ParametersType - exception if not known
-ParametersType parametersType(const std::string &typeString);
-/// convert int to ParametersType (if same value) - exception if no
-/// corresponding type
-ParametersType parametersType(int typeInt);
-/// convert ParametersType to string understood by parametersType(string
-/// &typeString)
-std::string parametersTypeName(ParametersType parType);
+  /// convert string to ParametersType - exception if not known
+  ParametersType parametersType(const std::string &typeString);
+  /// convert int to ParametersType (if same value) - exception if no
+  /// corresponding type
+  ParametersType parametersType(int typeInt);
+  /// convert ParametersType to string understood by parametersType(string
+  /// &typeString)
+  std::string parametersTypeName(ParametersType parType);
 
-/// create AlignmentParameters of type 'parType' for Alignable 'ali' with
-/// selection 'sel' for active parameters
-AlignmentParameters *createParameters(Alignable *ali, ParametersType parType,
-                                      const std::vector<bool> &sel);
-} // namespace AlignmentParametersFactory
+  /// create AlignmentParameters of type 'parType' for Alignable 'ali' with
+  /// selection 'sel' for active parameters
+  AlignmentParameters *createParameters(Alignable *ali, ParametersType parType, const std::vector<bool> &sel);
+}  // namespace AlignmentParametersFactory
 
 #endif

--- a/Alignment/CommonAlignmentParametrization/interface/BeamSpotAlignmentParameters.h
+++ b/Alignment/CommonAlignmentParametrization/interface/BeamSpotAlignmentParameters.h
@@ -19,7 +19,6 @@ class AlignableDetOrUnitPtr;
 class TrajectoryStateOnSurface;
 
 class BeamSpotAlignmentParameters : public AlignmentParameters {
-
 public:
   /// Give parameters a name
   enum AlignmentParameterName { dx = 0, dy, dxslope, dyslope, N_PARAM };
@@ -46,23 +45,19 @@ public:
   int type() const override;
 
   /// Clone all parameters (for update of parameters)
-  BeamSpotAlignmentParameters *
-  clone(const AlgebraicVector &parameters,
-        const AlgebraicSymMatrix &covMatrix) const override;
+  BeamSpotAlignmentParameters *clone(const AlgebraicVector &parameters,
+                                     const AlgebraicSymMatrix &covMatrix) const override;
 
   /// Clone selected parameters (for update of parameters)
-  BeamSpotAlignmentParameters *
-  cloneFromSelected(const AlgebraicVector &parameters,
-                    const AlgebraicSymMatrix &covMatrix) const override;
+  BeamSpotAlignmentParameters *cloneFromSelected(const AlgebraicVector &parameters,
+                                                 const AlgebraicSymMatrix &covMatrix) const override;
 
   /// Get all derivatives
-  AlgebraicMatrix derivatives(const TrajectoryStateOnSurface &tsos,
-                              const AlignableDetOrUnitPtr &) const override;
+  AlgebraicMatrix derivatives(const TrajectoryStateOnSurface &tsos, const AlignableDetOrUnitPtr &) const override;
 
   /// Get selected derivatives
-  AlgebraicMatrix
-  selectedDerivatives(const TrajectoryStateOnSurface &tsos,
-                      const AlignableDetOrUnitPtr &) const override;
+  AlgebraicMatrix selectedDerivatives(const TrajectoryStateOnSurface &tsos,
+                                      const AlignableDetOrUnitPtr &) const override;
 
   /// Get translation parameters
   AlgebraicVector translation(void) const;

--- a/Alignment/CommonAlignmentParametrization/interface/BowedSurfaceAlignmentDerivatives.h
+++ b/Alignment/CommonAlignmentParametrization/interface/BowedSurfaceAlignmentDerivatives.h
@@ -28,9 +28,9 @@ public:
     dx = 0,
     dy,
     dz,
-    dslopeX, // NOTE: slope(u) -> k*tan(beta),
-    dslopeY, //       slope(v) -> k*tan(alpha)
-    drotZ,   // rotation around w axis, scaled by gammaScale
+    dslopeX,  // NOTE: slope(u) -> k*tan(beta),
+    dslopeY,  //       slope(v) -> k*tan(alpha)
+    drotZ,    // rotation around w axis, scaled by gammaScale
     dsagittaX,
     dsagittaXY,
     dsagittaY,
@@ -39,8 +39,10 @@ public:
 
   /// Returns 9x2 jacobian matrix
   AlgebraicMatrix operator()(const TrajectoryStateOnSurface &tsos,
-                             double uWidth, double vLength,
-                             bool doSplit = false, double ySplit = 0.) const;
+                             double uWidth,
+                             double vLength,
+                             bool doSplit = false,
+                             double ySplit = 0.) const;
 
   /// scale to apply to convert drotZ to karimaki-gamma,
   /// depending on module width and length (the latter after splitting!)

--- a/Alignment/CommonAlignmentParametrization/interface/BowedSurfaceAlignmentParameters.h
+++ b/Alignment/CommonAlignmentParametrization/interface/BowedSurfaceAlignmentParameters.h
@@ -32,9 +32,9 @@ public:
     dx = BowedDerivs::dx,
     dy = BowedDerivs::dy,
     dz = BowedDerivs::dz,
-    dslopeX = BowedDerivs::dslopeX, // NOTE: slope(u) -> k*tan(beta),
-    dslopeY = BowedDerivs::dslopeY, //       slope(v) -> l*tan(alpha)
-    drotZ = BowedDerivs::drotZ,     //       rot(w)   -> m*gamma
+    dslopeX = BowedDerivs::dslopeX,  // NOTE: slope(u) -> k*tan(beta),
+    dslopeY = BowedDerivs::dslopeY,  //       slope(v) -> l*tan(alpha)
+    drotZ = BowedDerivs::drotZ,      //       rot(w)   -> m*gamma
     dsagittaX = BowedDerivs::dsagittaX,
     dsagittaXY = BowedDerivs::dsagittaXY,
     dsagittaY = BowedDerivs::dsagittaY,
@@ -61,19 +61,15 @@ public:
   int type() const override;
 
   /// Clone all parameters (for update of parameters)
-  BowedSurfaceAlignmentParameters *
-  clone(const AlgebraicVector &parameters,
-        const AlgebraicSymMatrix &covMatrix) const override;
+  BowedSurfaceAlignmentParameters *clone(const AlgebraicVector &parameters,
+                                         const AlgebraicSymMatrix &covMatrix) const override;
 
   /// Clone selected parameters (for update of parameters)
-  BowedSurfaceAlignmentParameters *
-  cloneFromSelected(const AlgebraicVector &parameters,
-                    const AlgebraicSymMatrix &covMatrix) const override;
+  BowedSurfaceAlignmentParameters *cloneFromSelected(const AlgebraicVector &parameters,
+                                                     const AlgebraicSymMatrix &covMatrix) const override;
 
   /// Get all derivatives
-  AlgebraicMatrix
-  derivatives(const TrajectoryStateOnSurface &tsos,
-              const AlignableDetOrUnitPtr &aliDet) const override;
+  AlgebraicMatrix derivatives(const TrajectoryStateOnSurface &tsos, const AlignableDetOrUnitPtr &aliDet) const override;
 
   /// Get translation parameters in double precision
   align::LocalVector translation() const;

--- a/Alignment/CommonAlignmentParametrization/interface/CompositeAlignmentDerivativesExtractor.h
+++ b/Alignment/CommonAlignmentParametrization/interface/CompositeAlignmentDerivativesExtractor.h
@@ -18,42 +18,34 @@ class AlignableDetOrUnitPtr;
 class TrajectoryStateOnSurface;
 
 class CompositeAlignmentDerivativesExtractor {
-
 public:
   /// deprecated  constructor for backward compatibility (use mor general
   /// AlignableDetOrUnitPtr)
-  CompositeAlignmentDerivativesExtractor(
-      const align::Alignables &alignables,
-      const std::vector<AlignableDet *> &alignableDets,
-      const std::vector<TrajectoryStateOnSurface> &tsos);
+  CompositeAlignmentDerivativesExtractor(const align::Alignables &alignables,
+                                         const std::vector<AlignableDet *> &alignableDets,
+                                         const std::vector<TrajectoryStateOnSurface> &tsos);
   /// constructor
-  CompositeAlignmentDerivativesExtractor(
-      const align::Alignables &alignables,
-      const std::vector<AlignableDetOrUnitPtr> &alignableDets,
-      const std::vector<TrajectoryStateOnSurface> &tsos);
+  CompositeAlignmentDerivativesExtractor(const align::Alignables &alignables,
+                                         const std::vector<AlignableDetOrUnitPtr> &alignableDets,
+                                         const std::vector<TrajectoryStateOnSurface> &tsos);
 
   /// destructor
   ~CompositeAlignmentDerivativesExtractor(void){};
 
   const AlgebraicMatrix &derivatives(void) const { return theDerivatives; }
-  const AlgebraicVector &correctionTerm(void) const {
-    return theCorrectionTerm;
-  }
+  const AlgebraicVector &correctionTerm(void) const { return theCorrectionTerm; }
 
 private:
-  void extractCurrentAlignment(
-      const align::Alignables &alignables,
-      const std::vector<AlignableDetOrUnitPtr> &alignableDets,
-      const std::vector<TrajectoryStateOnSurface> &tsos);
+  void extractCurrentAlignment(const align::Alignables &alignables,
+                               const std::vector<AlignableDetOrUnitPtr> &alignableDets,
+                               const std::vector<TrajectoryStateOnSurface> &tsos);
 
-  void extractWithoutMultipleHits(
-      const std::vector<AlgebraicVector> &subCorrectionTerm,
-      const std::vector<AlgebraicMatrix> &subDerivatives);
+  void extractWithoutMultipleHits(const std::vector<AlgebraicVector> &subCorrectionTerm,
+                                  const std::vector<AlgebraicMatrix> &subDerivatives);
 
-  void
-  extractWithMultipleHits(const std::vector<AlgebraicVector> &subCorrectionTerm,
-                          const std::vector<AlgebraicMatrix> &subDerivatives,
-                          const align::Alignables &alignables);
+  void extractWithMultipleHits(const std::vector<AlgebraicVector> &subCorrectionTerm,
+                               const std::vector<AlgebraicMatrix> &subDerivatives,
+                               const align::Alignables &alignables);
 
   AlgebraicMatrix theDerivatives;
   AlgebraicVector theCorrectionTerm;

--- a/Alignment/CommonAlignmentParametrization/interface/CompositeAlignmentParameters.h
+++ b/Alignment/CommonAlignmentParametrization/interface/CompositeAlignmentParameters.h
@@ -25,13 +25,11 @@ class AlignableDet;
 class Alignable;
 
 class CompositeAlignmentParameters {
-
 public:
   /// vector of alignable components
   typedef align::Alignables Components;
 
-  typedef std::map<AlignableDetOrUnitPtr, Alignable *>
-      AlignableDetToAlignableMap;
+  typedef std::map<AlignableDetOrUnitPtr, Alignable *> AlignableDetToAlignableMap;
   typedef std::map<Alignable *, int> Aliposmap;
   typedef std::map<Alignable *, int> Alilenmap;
 
@@ -39,9 +37,7 @@ public:
 
   /// constructors
 
-  CompositeAlignmentParameters(const AlgebraicVector &par,
-                               const AlgebraicSymMatrix &cov,
-                               const Components &comp);
+  CompositeAlignmentParameters(const AlgebraicVector &par, const AlgebraicSymMatrix &cov, const Components &comp);
 
   CompositeAlignmentParameters(const AlgebraicVector &par,
                                const AlgebraicSymMatrix &cov,
@@ -66,8 +62,7 @@ public:
   const AlgebraicSymMatrix &covariance() const { return theData->covariance(); }
 
   /// Clone parameters
-  CompositeAlignmentParameters *clone(const AlgebraicVector &par,
-                                      const AlgebraicSymMatrix &cov) const;
+  CompositeAlignmentParameters *clone(const AlgebraicVector &par, const AlgebraicSymMatrix &cov) const;
 
   /// Clone parameters
   CompositeAlignmentParameters *clone(const AlgebraicVector &par,
@@ -80,53 +75,39 @@ public:
   Components components() const;
 
   /// Get derivatives
-  AlgebraicMatrix derivatives(const TrajectoryStateOnSurface &tsos,
-                              const AlignableDetOrUnitPtr &alidet) const;
+  AlgebraicMatrix derivatives(const TrajectoryStateOnSurface &tsos, const AlignableDetOrUnitPtr &alidet) const;
   /// Get derivatives for selected alignables
-  AlgebraicMatrix
-  selectedDerivatives(const TrajectoryStateOnSurface &tsos,
-                      const AlignableDetOrUnitPtr &alidet) const;
+  AlgebraicMatrix selectedDerivatives(const TrajectoryStateOnSurface &tsos, const AlignableDetOrUnitPtr &alidet) const;
   /// for backward compatibility, use std::vector<AlignableDetOrUnitPtr>
-  AlgebraicMatrix
-  derivatives(const std::vector<TrajectoryStateOnSurface> &tsosvec,
-              const std::vector<AlignableDet *> &alidetvec) const;
-  AlgebraicMatrix
-  derivatives(const std::vector<TrajectoryStateOnSurface> &tsosvec,
-              const std::vector<AlignableDetOrUnitPtr> &alidetvec) const;
+  AlgebraicMatrix derivatives(const std::vector<TrajectoryStateOnSurface> &tsosvec,
+                              const std::vector<AlignableDet *> &alidetvec) const;
+  AlgebraicMatrix derivatives(const std::vector<TrajectoryStateOnSurface> &tsosvec,
+                              const std::vector<AlignableDetOrUnitPtr> &alidetvec) const;
   /// for backward compatibility, use std::vector<AlignableDetOrUnitPtr>
-  AlgebraicMatrix
-  selectedDerivatives(const std::vector<TrajectoryStateOnSurface> &tsosvec,
-                      const std::vector<AlignableDet *> &alidetvec) const;
-  AlgebraicMatrix selectedDerivatives(
-      const std::vector<TrajectoryStateOnSurface> &tsosvec,
-      const std::vector<AlignableDetOrUnitPtr> &alidetvec) const;
+  AlgebraicMatrix selectedDerivatives(const std::vector<TrajectoryStateOnSurface> &tsosvec,
+                                      const std::vector<AlignableDet *> &alidetvec) const;
+  AlgebraicMatrix selectedDerivatives(const std::vector<TrajectoryStateOnSurface> &tsosvec,
+                                      const std::vector<AlignableDetOrUnitPtr> &alidetvec) const;
 
   /// for backward compatibility, use std::vector<AlignableDetOrUnitPtr>
-  AlgebraicVector
-  correctionTerm(const std::vector<TrajectoryStateOnSurface> &tsosvec,
-                 const std::vector<AlignableDet *> &alidetvec) const;
-  AlgebraicVector
-  correctionTerm(const std::vector<TrajectoryStateOnSurface> &tsosvec,
-                 const std::vector<AlignableDetOrUnitPtr> &alidetvec) const;
+  AlgebraicVector correctionTerm(const std::vector<TrajectoryStateOnSurface> &tsosvec,
+                                 const std::vector<AlignableDet *> &alidetvec) const;
+  AlgebraicVector correctionTerm(const std::vector<TrajectoryStateOnSurface> &tsosvec,
+                                 const std::vector<AlignableDetOrUnitPtr> &alidetvec) const;
   /// deprecated due to 'AlignableDet*' interface (legacy code should not be
   /// needed anymore)
-  AlgebraicMatrix derivativesLegacy(const TrajectoryStateOnSurface &tsos,
-                                    AlignableDet *alidet) const;
+  AlgebraicMatrix derivativesLegacy(const TrajectoryStateOnSurface &tsos, AlignableDet *alidet) const;
   /// deprecated due to 'AlignableDet*' interface (legacy code should not be
   /// needed anymore)
-  AlgebraicMatrix
-  selectedDerivativesLegacy(const TrajectoryStateOnSurface &tsos,
-                            AlignableDet *alidet) const;
+  AlgebraicMatrix selectedDerivativesLegacy(const TrajectoryStateOnSurface &tsos, AlignableDet *alidet) const;
   /// deprecated due to 'AlignableDet*' interface (legacy code should not be
   /// needed anymore)
-  AlgebraicMatrix
-  derivativesLegacy(const std::vector<TrajectoryStateOnSurface> &tsosvec,
-                    const std::vector<AlignableDet *> &alidetvec) const;
+  AlgebraicMatrix derivativesLegacy(const std::vector<TrajectoryStateOnSurface> &tsosvec,
+                                    const std::vector<AlignableDet *> &alidetvec) const;
   /// deprecated due to 'AlignableDet*' interface (legacy code should not be
   /// needed anymore)
-  AlgebraicMatrix selectedDerivativesLegacy(
-      const std::vector<TrajectoryStateOnSurface> &tsosvec,
-      const std::vector<AlignableDet *> &alidetvec) const;
+  AlgebraicMatrix selectedDerivativesLegacy(const std::vector<TrajectoryStateOnSurface> &tsosvec,
+                                            const std::vector<AlignableDet *> &alidetvec) const;
 
   /// Get relevant Alignable from AlignableDet
   Alignable *alignableFromAlignableDet(const AlignableDetOrUnitPtr &adet) const;
@@ -138,8 +119,7 @@ public:
   AlgebraicSymMatrix covarianceSubset(const align::Alignables &) const;
 
   /// Extract covariance matrix elements between two subsets of alignables
-  AlgebraicMatrix covarianceSubset(const align::Alignables &,
-                                   const align::Alignables &) const;
+  AlgebraicMatrix covarianceSubset(const align::Alignables &, const align::Alignables &) const;
 
 protected:
   DataContainer theData;
@@ -148,15 +128,15 @@ private:
   /// Extract position and length of parameters for a subset of Alignables.
   bool extractPositionAndLength(const align::Alignables &alignables,
                                 std::vector<int> &posvec,
-                                std::vector<int> &lenvec, int &length) const;
+                                std::vector<int> &lenvec,
+                                int &length) const;
 
   /// Return vector of alignables without multiple occurences.
   align::Alignables extractAlignables(const align::Alignables &) const;
 
   /// backward compatibility method to convert vectors from specific
   /// AlignableDet to more general AlignableDetOrUnitPtr
-  void convert(const std::vector<AlignableDet *> &input,
-               std::vector<AlignableDetOrUnitPtr> &output) const;
+  void convert(const std::vector<AlignableDet *> &input, std::vector<AlignableDetOrUnitPtr> &output) const;
 
   /// Vector of alignable components
   Components theComponents;

--- a/Alignment/CommonAlignmentParametrization/interface/FrameToFrameDerivative.h
+++ b/Alignment/CommonAlignmentParametrization/interface/FrameToFrameDerivative.h
@@ -32,8 +32,7 @@ public:
   /// where u, v, w, a, b, g are shifts and rotations of the object
   /// and u_c, v_c, w_c, a_c, b_c, g_c those of the composed object.
 
-  AlgebraicMatrix frameToFrameDerivative(const Alignable *object,
-                                         const Alignable *composedObject) const;
+  AlgebraicMatrix frameToFrameDerivative(const Alignable *object, const Alignable *composedObject) const;
 
   /// Calculates derivatives DeltaFrame(object)/DeltaFrame(composedobject)
   /// using their positions and orientations, see method
@@ -59,8 +58,7 @@ private:
   AlgebraicVector linearEulerAngles(const AlgebraicMatrix &rotDelta) const;
 
   /// Calculates the derivative DPos/DPos
-  AlgebraicMatrix derivativePosPos(const AlgebraicMatrix &RotDet,
-                                   const AlgebraicMatrix &RotRot) const;
+  AlgebraicMatrix derivativePosPos(const AlgebraicMatrix &RotDet, const AlgebraicMatrix &RotRot) const;
 
   /// Calculates the derivative DPos/DRot
   AlgebraicMatrix derivativePosRot(const AlgebraicMatrix &RotDet,
@@ -68,12 +66,10 @@ private:
                                    const AlgebraicVector &S) const;
 
   /// Calculates the derivative DRot/DRot
-  AlgebraicMatrix derivativeRotRot(const AlgebraicMatrix &RotDet,
-                                   const AlgebraicMatrix &RotRot) const;
+  AlgebraicMatrix derivativeRotRot(const AlgebraicMatrix &RotDet, const AlgebraicMatrix &RotRot) const;
 };
 
-AlgebraicMatrix
-FrameToFrameDerivative::transform(const align::RotationType &rot) {
+AlgebraicMatrix FrameToFrameDerivative::transform(const align::RotationType &rot) {
   AlgebraicMatrix R(3, 3);
 
   R(1, 1) = rot.xx();

--- a/Alignment/CommonAlignmentParametrization/interface/ParametersToParametersDerivatives.h
+++ b/Alignment/CommonAlignmentParametrization/interface/ParametersToParametersDerivatives.h
@@ -42,8 +42,7 @@ class Alignable;
 
 class ParametersToParametersDerivatives {
 public:
-  ParametersToParametersDerivatives(const Alignable &component,
-                                    const Alignable &mother);
+  ParametersToParametersDerivatives(const Alignable &component, const Alignable &mother);
 
   /// Indicate whether able to provide the derivatives.
   bool isOK() const { return isOK_; }
@@ -59,8 +58,7 @@ public:
 private:
   /// init by choosing the correct detailed init method depending on parameter
   /// types
-  bool init(const Alignable &component, int typeComponent,
-            const Alignable &mother, int typeMother);
+  bool init(const Alignable &component, int typeComponent, const Alignable &mother, int typeMother);
   /// init for component and mother both with RigidBody parameters
   bool initRigidRigid(const Alignable &component, const Alignable &mother);
   /// init for component with BowedSurface and mother with RigidBody parameters
@@ -69,17 +67,15 @@ private:
   /// parameters
   bool init2BowedRigid(const Alignable &component, const Alignable &mother);
 
-  typedef ROOT::Math::SMatrix<double, 6, 9, ROOT::Math::MatRepStd<double, 6, 9>>
-      AlgebraicMatrix69;
+  typedef ROOT::Math::SMatrix<double, 6, 9, ROOT::Math::MatRepStd<double, 6, 9>> AlgebraicMatrix69;
   /// from d(rigid_mother)/d(rigid_component) to
   /// d(rigid_mother)/d(bowed_component) for bad input (length or width zero),
   /// set object to invalid: isOK_ = false
-  AlgebraicMatrix69 dRigid_dBowed(const AlgebraicMatrix66 &dRigidM2dRigidC,
-                                  double halfWidth, double halfLength);
+  AlgebraicMatrix69 dRigid_dBowed(const AlgebraicMatrix66 &dRigidM2dRigidC, double halfWidth, double halfLength);
 
   /// data members
-  bool isOK_;            /// can we provide the desired?
-  TMatrixD derivatives_; /// matrix of derivatives
+  bool isOK_;             /// can we provide the desired?
+  TMatrixD derivatives_;  /// matrix of derivatives
 };
 
 #endif

--- a/Alignment/CommonAlignmentParametrization/interface/RigidBodyAlignmentParameters.h
+++ b/Alignment/CommonAlignmentParametrization/interface/RigidBodyAlignmentParameters.h
@@ -19,18 +19,9 @@ class AlignableDetOrUnitPtr;
 class TrajectoryStateOnSurface;
 
 class RigidBodyAlignmentParameters : public AlignmentParameters {
-
 public:
   /// Give parameters a name
-  enum AlignmentParameterName {
-    dx = 0,
-    dy,
-    dz,
-    dalpha,
-    dbeta,
-    dgamma,
-    N_PARAM
-  };
+  enum AlignmentParameterName { dx = 0, dy, dz, dalpha, dbeta, dgamma, N_PARAM };
 
   /// Constructor with empty parameters/covariance (if calcMis = false) or with
   /// parameters (no covariance) created from current (mis-)placement of
@@ -54,23 +45,19 @@ public:
   int type() const override;
 
   /// Clone all parameters (for update of parameters)
-  RigidBodyAlignmentParameters *
-  clone(const AlgebraicVector &parameters,
-        const AlgebraicSymMatrix &covMatrix) const override;
+  RigidBodyAlignmentParameters *clone(const AlgebraicVector &parameters,
+                                      const AlgebraicSymMatrix &covMatrix) const override;
 
   /// Clone selected parameters (for update of parameters)
-  RigidBodyAlignmentParameters *
-  cloneFromSelected(const AlgebraicVector &parameters,
-                    const AlgebraicSymMatrix &covMatrix) const override;
+  RigidBodyAlignmentParameters *cloneFromSelected(const AlgebraicVector &parameters,
+                                                  const AlgebraicSymMatrix &covMatrix) const override;
 
   /// Get all derivatives
-  AlgebraicMatrix derivatives(const TrajectoryStateOnSurface &tsos,
-                              const AlignableDetOrUnitPtr &) const override;
+  AlgebraicMatrix derivatives(const TrajectoryStateOnSurface &tsos, const AlignableDetOrUnitPtr &) const override;
 
   /// Get selected derivatives
-  AlgebraicMatrix
-  selectedDerivatives(const TrajectoryStateOnSurface &tsos,
-                      const AlignableDetOrUnitPtr &) const override;
+  AlgebraicMatrix selectedDerivatives(const TrajectoryStateOnSurface &tsos,
+                                      const AlignableDetOrUnitPtr &) const override;
 
   /// Get translation parameters
   AlgebraicVector translation(void) const;

--- a/Alignment/CommonAlignmentParametrization/interface/RigidBodyAlignmentParameters4D.h
+++ b/Alignment/CommonAlignmentParametrization/interface/RigidBodyAlignmentParameters4D.h
@@ -20,7 +20,6 @@ class AlignableDetOrUnitPtr;
 class TrajectoryStateOnSurface;
 
 class RigidBodyAlignmentParameters4D : public RigidBodyAlignmentParameters {
-
 public:
   /// Constructor with empty parameters/covariance (if calcMis = false) or with
   /// parameters (no covariance) created from current (mis-)placement of
@@ -39,8 +38,7 @@ public:
                                  const AlgebraicVector &parameters,
                                  const AlgebraicSymMatrix &covMatrix,
                                  const std::vector<bool> &selection)
-      : RigidBodyAlignmentParameters(alignable, parameters, covMatrix,
-                                     selection){};
+      : RigidBodyAlignmentParameters(alignable, parameters, covMatrix, selection){};
 
   /// Destructor
   ~RigidBodyAlignmentParameters4D() override{};
@@ -48,18 +46,15 @@ public:
   int type() const override;
 
   /// Get all derivatives
-  AlgebraicMatrix derivatives(const TrajectoryStateOnSurface &tsos,
-                              const AlignableDetOrUnitPtr &) const override;
+  AlgebraicMatrix derivatives(const TrajectoryStateOnSurface &tsos, const AlignableDetOrUnitPtr &) const override;
 
   /// Clone all parameters (for update of parameters)
-  RigidBodyAlignmentParameters4D *
-  clone(const AlgebraicVector &parameters,
-        const AlgebraicSymMatrix &covMatrix) const override;
+  RigidBodyAlignmentParameters4D *clone(const AlgebraicVector &parameters,
+                                        const AlgebraicSymMatrix &covMatrix) const override;
 
   /// Clone selected parameters (for update of parameters)
-  RigidBodyAlignmentParameters4D *
-  cloneFromSelected(const AlgebraicVector &parameters,
-                    const AlgebraicSymMatrix &covMatrix) const override;
+  RigidBodyAlignmentParameters4D *cloneFromSelected(const AlgebraicVector &parameters,
+                                                    const AlgebraicSymMatrix &covMatrix) const override;
 };
 
 #endif

--- a/Alignment/CommonAlignmentParametrization/interface/TwoBowedSurfacesAlignmentParameters.h
+++ b/Alignment/CommonAlignmentParametrization/interface/TwoBowedSurfacesAlignmentParameters.h
@@ -49,9 +49,9 @@ public:
     dx1 = BowedDerivs::dx,
     dy1 = BowedDerivs::dy,
     dz1 = BowedDerivs::dz,
-    dslopeX1 = BowedDerivs::dslopeX, // NOTE: slope(u) -> halfWidth*tan(beta),
-    dslopeY1 = BowedDerivs::dslopeY, //       slope(v) -> halfLength*tan(alpha)
-    drotZ1 = BowedDerivs::drotZ,     //       rot(w)   -> g-scale*gamma
+    dslopeX1 = BowedDerivs::dslopeX,  // NOTE: slope(u) -> halfWidth*tan(beta),
+    dslopeY1 = BowedDerivs::dslopeY,  //       slope(v) -> halfLength*tan(alpha)
+    drotZ1 = BowedDerivs::drotZ,      //       rot(w)   -> g-scale*gamma
     dsagittaX1 = BowedDerivs::dsagittaX,
     dsagittaXY1 = BowedDerivs::dsagittaXY,
     dsagittaY1 = BowedDerivs::dsagittaY,
@@ -59,12 +59,9 @@ public:
     dx2 = BowedDerivs::dx + BowedDerivs::N_PARAM,
     dy2 = BowedDerivs::dy + BowedDerivs::N_PARAM,
     dz2 = BowedDerivs::dz + BowedDerivs::N_PARAM,
-    dslopeX2 = BowedDerivs::dslopeX +
-               BowedDerivs::N_PARAM, // NOTE: slope(u) -> k*tan(beta),
-    dslopeY2 = BowedDerivs::dslopeY +
-               BowedDerivs::N_PARAM, //       slope(v) -> k*tan(alpha)
-    drotZ2 =
-        BowedDerivs::drotZ + BowedDerivs::N_PARAM, //       rot(w)   -> m*gamma
+    dslopeX2 = BowedDerivs::dslopeX + BowedDerivs::N_PARAM,  // NOTE: slope(u) -> k*tan(beta),
+    dslopeY2 = BowedDerivs::dslopeY + BowedDerivs::N_PARAM,  //       slope(v) -> k*tan(alpha)
+    drotZ2 = BowedDerivs::drotZ + BowedDerivs::N_PARAM,      //       rot(w)   -> m*gamma
     dsagittaX2 = BowedDerivs::dsagittaX + BowedDerivs::N_PARAM,
     dsagittaXY2 = BowedDerivs::dsagittaXY + BowedDerivs::N_PARAM,
     dsagittaY2 = BowedDerivs::dsagittaY + BowedDerivs::N_PARAM,
@@ -92,19 +89,15 @@ public:
   int type() const override;
 
   /// Clone all parameters (for update of parameters)
-  TwoBowedSurfacesAlignmentParameters *
-  clone(const AlgebraicVector &parameters,
-        const AlgebraicSymMatrix &covMatrix) const override;
+  TwoBowedSurfacesAlignmentParameters *clone(const AlgebraicVector &parameters,
+                                             const AlgebraicSymMatrix &covMatrix) const override;
 
   /// Clone selected parameters (for update of parameters)
-  TwoBowedSurfacesAlignmentParameters *
-  cloneFromSelected(const AlgebraicVector &parameters,
-                    const AlgebraicSymMatrix &covMatrix) const override;
+  TwoBowedSurfacesAlignmentParameters *cloneFromSelected(const AlgebraicVector &parameters,
+                                                         const AlgebraicSymMatrix &covMatrix) const override;
 
   /// Get all derivatives
-  AlgebraicMatrix
-  derivatives(const TrajectoryStateOnSurface &tsos,
-              const AlignableDetOrUnitPtr &aliDet) const override;
+  AlgebraicMatrix derivatives(const TrajectoryStateOnSurface &tsos, const AlignableDetOrUnitPtr &aliDet) const override;
 
   /// print parameters to screen
   virtual void print() const;

--- a/Alignment/CommonAlignmentParametrization/src/AlignmentParametersFactory.cc
+++ b/Alignment/CommonAlignmentParametrization/src/AlignmentParametersFactory.cc
@@ -18,112 +18,107 @@
 
 namespace AlignmentParametersFactory {
 
-//_______________________________________________________________________________________
-ParametersType parametersType(const std::string &typeString) {
-  if (typeString == "RigidBody")
-    return kRigidBody;
-  else if (typeString == "Survey")
-    return kSurvey; // GF: do not belong here, so remove in the long term...
-  else if (typeString == "RigidBody4D")
-    return kRigidBody4D;
-  else if (typeString == "BeamSpot")
-    return kBeamSpot;
-  else if (typeString == "BowedSurface")
-    return kBowedSurface;
-  else if (typeString == "TwoBowedSurfaces")
-    return kTwoBowedSurfaces;
-  throw cms::Exception("BadConfig")
-      << "AlignmentParametersFactory"
-      << " No AlignmentParameters with name '" << typeString << "'.";
+  //_______________________________________________________________________________________
+  ParametersType parametersType(const std::string &typeString) {
+    if (typeString == "RigidBody")
+      return kRigidBody;
+    else if (typeString == "Survey")
+      return kSurvey;  // GF: do not belong here, so remove in the long term...
+    else if (typeString == "RigidBody4D")
+      return kRigidBody4D;
+    else if (typeString == "BeamSpot")
+      return kBeamSpot;
+    else if (typeString == "BowedSurface")
+      return kBowedSurface;
+    else if (typeString == "TwoBowedSurfaces")
+      return kTwoBowedSurfaces;
+    throw cms::Exception("BadConfig") << "AlignmentParametersFactory"
+                                      << " No AlignmentParameters with name '" << typeString << "'.";
 
-  return kRigidBody; // to please compiler...
-}
-
-//_______________________________________________________________________________________
-ParametersType parametersType(int typeInt) {
-  if (typeInt == kRigidBody)
-    return kRigidBody;
-  if (typeInt == kSurvey)
-    return kSurvey; // GF: do not belong here, so remove in the long term...
-  if (typeInt == kRigidBody4D)
-    return kRigidBody4D;
-  if (typeInt == kBeamSpot)
-    return kBeamSpot;
-  if (typeInt == kBowedSurface)
-    return kBowedSurface;
-  if (typeInt == kTwoBowedSurfaces)
-    return kTwoBowedSurfaces;
-
-  throw cms::Exception("BadConfig")
-      << "AlignmentParametersFactory"
-      << " No AlignmentParameters with number " << typeInt << ".";
-
-  return kRigidBody; // to please compiler...
-}
-
-//_______________________________________________________________________________________
-std::string parametersTypeName(ParametersType parType) {
-  switch (parType) {
-  case kRigidBody:
-    return "RigiBody";
-  case kSurvey: // GF: do not belong here, so remove in the long term...
-    return "Survey";
-  case kRigidBody4D:
-    return "RigiBody4D";
-  case kBeamSpot:
-    return "BeamSpot";
-  case kBowedSurface:
-    return "BowedSurface";
-  case kTwoBowedSurfaces:
-    return "TwoBowedSurfaces";
+    return kRigidBody;  // to please compiler...
   }
 
-  return "unknown_should_never_reach"; // to please the compiler
-}
+  //_______________________________________________________________________________________
+  ParametersType parametersType(int typeInt) {
+    if (typeInt == kRigidBody)
+      return kRigidBody;
+    if (typeInt == kSurvey)
+      return kSurvey;  // GF: do not belong here, so remove in the long term...
+    if (typeInt == kRigidBody4D)
+      return kRigidBody4D;
+    if (typeInt == kBeamSpot)
+      return kBeamSpot;
+    if (typeInt == kBowedSurface)
+      return kBowedSurface;
+    if (typeInt == kTwoBowedSurfaces)
+      return kTwoBowedSurfaces;
 
-//_______________________________________________________________________________________
-AlignmentParameters *createParameters(Alignable *ali, ParametersType parType,
-                                      const std::vector<bool> &sel) {
-  switch (parType) {
-  case kRigidBody: {
-    const AlgebraicVector par(RigidBodyAlignmentParameters::N_PARAM, 0);
-    const AlgebraicSymMatrix cov(RigidBodyAlignmentParameters::N_PARAM, 0);
-    return new RigidBodyAlignmentParameters(ali, par, cov, sel);
-  } break;
-  case kSurvey:
-    // creates some unwanted dependencies - and does not fit into
-    // AlignmentParameters anyway!
-    throw cms::Exception("BadConfig")
-        << "AlignmentParametersFactory cannot create SurveyParameters.";
-    //       edm::LogWarning("Alignment") << "@SUB=createParameters"
-    // 				   << "Creating SurveyParameters of length 0!";
-    //       return new SurveyParameters(ali, AlgebraicVector(),
-    //       AlgebraicSymMatrix());
-    break;
-  case kRigidBody4D: {
-    const AlgebraicVector par(RigidBodyAlignmentParameters4D::N_PARAM, 0);
-    const AlgebraicSymMatrix cov(RigidBodyAlignmentParameters4D::N_PARAM, 0);
-    return new RigidBodyAlignmentParameters4D(ali, par, cov, sel);
-  } break;
-  case kBeamSpot: {
-    const AlgebraicVector par(BeamSpotAlignmentParameters::N_PARAM, 0);
-    const AlgebraicSymMatrix cov(BeamSpotAlignmentParameters::N_PARAM, 0);
-    return new BeamSpotAlignmentParameters(ali, par, cov, sel);
-  } break;
-  case kBowedSurface: {
-    const AlgebraicVector par(BowedSurfaceAlignmentParameters::N_PARAM, 0);
-    const AlgebraicSymMatrix cov(BowedSurfaceAlignmentParameters::N_PARAM, 0);
-    return new BowedSurfaceAlignmentParameters(ali, par, cov, sel);
-  } break;
-  case kTwoBowedSurfaces: {
-    const AlgebraicVector par(TwoBowedSurfacesAlignmentParameters::N_PARAM, 0);
-    const AlgebraicSymMatrix cov(TwoBowedSurfacesAlignmentParameters::N_PARAM,
-                                 0);
-    return new TwoBowedSurfacesAlignmentParameters(ali, par, cov, sel);
-  } break;
+    throw cms::Exception("BadConfig") << "AlignmentParametersFactory"
+                                      << " No AlignmentParameters with number " << typeInt << ".";
+
+    return kRigidBody;  // to please compiler...
   }
 
-  return nullptr; // unreached (all ParametersType appear in switch), to please
-                  // the compiler
-}
-} // namespace AlignmentParametersFactory
+  //_______________________________________________________________________________________
+  std::string parametersTypeName(ParametersType parType) {
+    switch (parType) {
+      case kRigidBody:
+        return "RigiBody";
+      case kSurvey:  // GF: do not belong here, so remove in the long term...
+        return "Survey";
+      case kRigidBody4D:
+        return "RigiBody4D";
+      case kBeamSpot:
+        return "BeamSpot";
+      case kBowedSurface:
+        return "BowedSurface";
+      case kTwoBowedSurfaces:
+        return "TwoBowedSurfaces";
+    }
+
+    return "unknown_should_never_reach";  // to please the compiler
+  }
+
+  //_______________________________________________________________________________________
+  AlignmentParameters *createParameters(Alignable *ali, ParametersType parType, const std::vector<bool> &sel) {
+    switch (parType) {
+      case kRigidBody: {
+        const AlgebraicVector par(RigidBodyAlignmentParameters::N_PARAM, 0);
+        const AlgebraicSymMatrix cov(RigidBodyAlignmentParameters::N_PARAM, 0);
+        return new RigidBodyAlignmentParameters(ali, par, cov, sel);
+      } break;
+      case kSurvey:
+        // creates some unwanted dependencies - and does not fit into
+        // AlignmentParameters anyway!
+        throw cms::Exception("BadConfig") << "AlignmentParametersFactory cannot create SurveyParameters.";
+        //       edm::LogWarning("Alignment") << "@SUB=createParameters"
+        // 				   << "Creating SurveyParameters of length 0!";
+        //       return new SurveyParameters(ali, AlgebraicVector(),
+        //       AlgebraicSymMatrix());
+        break;
+      case kRigidBody4D: {
+        const AlgebraicVector par(RigidBodyAlignmentParameters4D::N_PARAM, 0);
+        const AlgebraicSymMatrix cov(RigidBodyAlignmentParameters4D::N_PARAM, 0);
+        return new RigidBodyAlignmentParameters4D(ali, par, cov, sel);
+      } break;
+      case kBeamSpot: {
+        const AlgebraicVector par(BeamSpotAlignmentParameters::N_PARAM, 0);
+        const AlgebraicSymMatrix cov(BeamSpotAlignmentParameters::N_PARAM, 0);
+        return new BeamSpotAlignmentParameters(ali, par, cov, sel);
+      } break;
+      case kBowedSurface: {
+        const AlgebraicVector par(BowedSurfaceAlignmentParameters::N_PARAM, 0);
+        const AlgebraicSymMatrix cov(BowedSurfaceAlignmentParameters::N_PARAM, 0);
+        return new BowedSurfaceAlignmentParameters(ali, par, cov, sel);
+      } break;
+      case kTwoBowedSurfaces: {
+        const AlgebraicVector par(TwoBowedSurfacesAlignmentParameters::N_PARAM, 0);
+        const AlgebraicSymMatrix cov(TwoBowedSurfacesAlignmentParameters::N_PARAM, 0);
+        return new TwoBowedSurfacesAlignmentParameters(ali, par, cov, sel);
+      } break;
+    }
+
+    return nullptr;  // unreached (all ParametersType appear in switch), to please
+                     // the compiler
+  }
+}  // namespace AlignmentParametersFactory

--- a/Alignment/CommonAlignmentParametrization/src/BeamSpotAlignmentDerivatives.cc
+++ b/Alignment/CommonAlignmentParametrization/src/BeamSpotAlignmentDerivatives.cc
@@ -14,8 +14,7 @@
 
 #include "Alignment/CommonAlignmentParametrization/interface/BeamSpotAlignmentDerivatives.h"
 
-AlgebraicMatrix BeamSpotAlignmentDerivatives::
-operator()(const TrajectoryStateOnSurface &tsos) const {
+AlgebraicMatrix BeamSpotAlignmentDerivatives::operator()(const TrajectoryStateOnSurface &tsos) const {
   AlgebraicMatrix aliderivs(4, 2);
 
   if (!tsos.isValid())

--- a/Alignment/CommonAlignmentParametrization/src/BeamSpotAlignmentParameters.cc
+++ b/Alignment/CommonAlignmentParametrization/src/BeamSpotAlignmentParameters.cc
@@ -18,33 +18,29 @@
 #include "Alignment/CommonAlignmentParametrization/interface/BeamSpotAlignmentParameters.h"
 
 //__________________________________________________________________________________________________
-BeamSpotAlignmentParameters::BeamSpotAlignmentParameters(Alignable *ali,
-                                                         bool calcMis)
-    : AlignmentParameters(ali,
-                          displacementFromAlignable(calcMis ? ali : nullptr),
-                          AlgebraicSymMatrix(N_PARAM, 0)) {}
+BeamSpotAlignmentParameters::BeamSpotAlignmentParameters(Alignable *ali, bool calcMis)
+    : AlignmentParameters(ali, displacementFromAlignable(calcMis ? ali : nullptr), AlgebraicSymMatrix(N_PARAM, 0)) {}
 
 //__________________________________________________________________________________________________
-BeamSpotAlignmentParameters::BeamSpotAlignmentParameters(
-    Alignable *alignable, const AlgebraicVector &parameters,
-    const AlgebraicSymMatrix &covMatrix)
+BeamSpotAlignmentParameters::BeamSpotAlignmentParameters(Alignable *alignable,
+                                                         const AlgebraicVector &parameters,
+                                                         const AlgebraicSymMatrix &covMatrix)
     : AlignmentParameters(alignable, parameters, covMatrix) {
   if (parameters.num_row() != N_PARAM) {
     throw cms::Exception("BadParameters")
-        << "in BeamSpotAlignmentParameters(): " << parameters.num_row()
-        << " instead of " << N_PARAM << " parameters.";
+        << "in BeamSpotAlignmentParameters(): " << parameters.num_row() << " instead of " << N_PARAM << " parameters.";
   }
 }
 
 //__________________________________________________________________________________________________
-BeamSpotAlignmentParameters::BeamSpotAlignmentParameters(
-    Alignable *alignable, const AlgebraicVector &parameters,
-    const AlgebraicSymMatrix &covMatrix, const std::vector<bool> &selection)
+BeamSpotAlignmentParameters::BeamSpotAlignmentParameters(Alignable *alignable,
+                                                         const AlgebraicVector &parameters,
+                                                         const AlgebraicSymMatrix &covMatrix,
+                                                         const std::vector<bool> &selection)
     : AlignmentParameters(alignable, parameters, covMatrix, selection) {
   if (parameters.num_row() != N_PARAM) {
     throw cms::Exception("BadParameters")
-        << "in BeamSpotAlignmentParameters(): " << parameters.num_row()
-        << " instead of " << N_PARAM << " parameters.";
+        << "in BeamSpotAlignmentParameters(): " << parameters.num_row() << " instead of " << N_PARAM << " parameters.";
   }
 }
 
@@ -52,11 +48,9 @@ BeamSpotAlignmentParameters::BeamSpotAlignmentParameters(
 BeamSpotAlignmentParameters::~BeamSpotAlignmentParameters() {}
 
 //__________________________________________________________________________________________________
-BeamSpotAlignmentParameters *
-BeamSpotAlignmentParameters::clone(const AlgebraicVector &parameters,
-                                   const AlgebraicSymMatrix &covMatrix) const {
-  BeamSpotAlignmentParameters *rbap = new BeamSpotAlignmentParameters(
-      alignable(), parameters, covMatrix, selector());
+BeamSpotAlignmentParameters *BeamSpotAlignmentParameters::clone(const AlgebraicVector &parameters,
+                                                                const AlgebraicSymMatrix &covMatrix) const {
+  BeamSpotAlignmentParameters *rbap = new BeamSpotAlignmentParameters(alignable(), parameters, covMatrix, selector());
 
   if (userVariables())
     rbap->setUserVariables(userVariables()->clone());
@@ -66,12 +60,10 @@ BeamSpotAlignmentParameters::clone(const AlgebraicVector &parameters,
 }
 
 //__________________________________________________________________________________________________
-BeamSpotAlignmentParameters *BeamSpotAlignmentParameters::cloneFromSelected(
-    const AlgebraicVector &parameters,
-    const AlgebraicSymMatrix &covMatrix) const {
+BeamSpotAlignmentParameters *BeamSpotAlignmentParameters::cloneFromSelected(const AlgebraicVector &parameters,
+                                                                            const AlgebraicSymMatrix &covMatrix) const {
   BeamSpotAlignmentParameters *rbap = new BeamSpotAlignmentParameters(
-      alignable(), expandVector(parameters, selector()),
-      expandSymMatrix(covMatrix, selector()), selector());
+      alignable(), expandVector(parameters, selector()), expandSymMatrix(covMatrix, selector()), selector());
 
   if (userVariables())
     rbap->setUserVariables(userVariables()->clone());
@@ -81,27 +73,24 @@ BeamSpotAlignmentParameters *BeamSpotAlignmentParameters::cloneFromSelected(
 }
 
 //__________________________________________________________________________________________________
-AlgebraicMatrix BeamSpotAlignmentParameters::derivatives(
-    const TrajectoryStateOnSurface &tsos,
-    const AlignableDetOrUnitPtr &alidet) const {
-  const Alignable *ali = this->alignable(); // Alignable of these parameters
+AlgebraicMatrix BeamSpotAlignmentParameters::derivatives(const TrajectoryStateOnSurface &tsos,
+                                                         const AlignableDetOrUnitPtr &alidet) const {
+  const Alignable *ali = this->alignable();  // Alignable of these parameters
 
-  if (ali == alidet) { // same alignable => same frame
+  if (ali == alidet) {  // same alignable => same frame
     return BeamSpotAlignmentDerivatives()(tsos);
   } else {
-    throw cms::Exception("MisMatch")
-        << "BeamSpotAlignmentParameters::derivatives: The hit alignable must "
-           "match the "
-        << "aligned one, i.e. these parameters make only sense for "
-           "AlignableBeamSpot.\n";
-    return AlgebraicMatrix(N_PARAM, 2); // please compiler
+    throw cms::Exception("MisMatch") << "BeamSpotAlignmentParameters::derivatives: The hit alignable must "
+                                        "match the "
+                                     << "aligned one, i.e. these parameters make only sense for "
+                                        "AlignableBeamSpot.\n";
+    return AlgebraicMatrix(N_PARAM, 2);  // please compiler
   }
 }
 
 //__________________________________________________________________________________________________
-AlgebraicMatrix BeamSpotAlignmentParameters::selectedDerivatives(
-    const TrajectoryStateOnSurface &tsos,
-    const AlignableDetOrUnitPtr &alignableDet) const {
+AlgebraicMatrix BeamSpotAlignmentParameters::selectedDerivatives(const TrajectoryStateOnSurface &tsos,
+                                                                 const AlignableDetOrUnitPtr &alignableDet) const {
   const AlgebraicMatrix dev = this->derivatives(tsos, alignableDet);
 
   int ncols = dev.num_col();
@@ -141,11 +130,9 @@ AlgebraicVector BeamSpotAlignmentParameters::rotation(void) const {
   double angleY = std::atan(dxdz);
   double angleX = -std::atan(dydz);
 
-  align::RotationType rotY(std::cos(angleY), 0., -std::sin(angleY), 0., 1., 0.,
-                           std::sin(angleY), 0., std::cos(angleY));
+  align::RotationType rotY(std::cos(angleY), 0., -std::sin(angleY), 0., 1., 0., std::sin(angleY), 0., std::cos(angleY));
 
-  align::RotationType rotX(1., 0., 0., 0., std::cos(angleX), std::sin(angleX),
-                           0., -std::sin(angleX), std::cos(angleX));
+  align::RotationType rotX(1., 0., 0., 0., std::cos(angleX), std::sin(angleX), 0., -std::sin(angleX), std::cos(angleX));
 
   align::EulerAngles angles = align::toAngles(rotY * rotX);
 
@@ -160,12 +147,11 @@ AlgebraicVector BeamSpotAlignmentParameters::rotation(void) const {
 void BeamSpotAlignmentParameters::apply() {
   Alignable *alignable = this->alignable();
   if (!alignable) {
-    throw cms::Exception("BadParameters")
-        << "BeamSpotAlignmentParameters::apply: parameters without alignable";
+    throw cms::Exception("BadParameters") << "BeamSpotAlignmentParameters::apply: parameters without alignable";
   }
 
   // Translation in local frame
-  AlgebraicVector shift = this->translation(); // fixme: should be LocalVector
+  AlgebraicVector shift = this->translation();  // fixme: should be LocalVector
 
   // Translation local->global
   align::GlobalVector gv(shift[0], shift[1], shift[2]);
@@ -176,23 +162,19 @@ void BeamSpotAlignmentParameters::apply() {
   // original code:
   //  alignable->rotateInLocalFrame( align::toMatrix(angles) );
   // correct for rounding errors:
-  align::RotationType rot =
-      alignable->surface().toGlobal(align::toMatrix(angles));
+  align::RotationType rot = alignable->surface().toGlobal(align::toMatrix(angles));
   align::rectify(rot);
   alignable->rotateInGlobalFrame(rot);
 }
 
 //__________________________________________________________________________________________________
-int BeamSpotAlignmentParameters::type() const {
-  return AlignmentParametersFactory::kBeamSpot;
-}
+int BeamSpotAlignmentParameters::type() const { return AlignmentParametersFactory::kBeamSpot; }
 
 //__________________________________________________________________________________________________
 AlgebraicVector BeamSpotAlignmentParameters::globalParameters(void) const {
   AlgebraicVector m_GlobalParameters(N_PARAM, 0);
 
-  const AlgebraicVector shift =
-      translation(); // fixme: should return LocalVector
+  const AlgebraicVector shift = translation();  // fixme: should return LocalVector
 
   const align::GlobalVector dg(shift[0], shift[1], 0);
 
@@ -213,23 +195,18 @@ AlgebraicVector BeamSpotAlignmentParameters::globalParameters(void) const {
 
 //__________________________________________________________________________________________________
 void BeamSpotAlignmentParameters::print(void) const {
-
   std::cout << "Contents of BeamSpotAlignmentParameters:"
-            << "\nParameters: " << theData->parameters()
-            << "\nCovariance: " << theData->covariance() << std::endl;
+            << "\nParameters: " << theData->parameters() << "\nCovariance: " << theData->covariance() << std::endl;
 }
 
 //__________________________________________________________________________________________________
-AlgebraicVector
-BeamSpotAlignmentParameters::displacementFromAlignable(const Alignable *ali) {
+AlgebraicVector BeamSpotAlignmentParameters::displacementFromAlignable(const Alignable *ali) {
   AlgebraicVector displacement(N_PARAM);
 
   if (ali) {
     const align::RotationType &dR = ali->rotation();
 
-    const align::LocalVector shifts(
-        ali->globalRotation() *
-        (dR.transposed() * ali->displacement().basicVector()));
+    const align::LocalVector shifts(ali->globalRotation() * (dR.transposed() * ali->displacement().basicVector()));
 
     align::GlobalVector gv(0.0, 0.0, 1.0);
     align::LocalVector lv(dR.transposed() * gv.basicVector());

--- a/Alignment/CommonAlignmentParametrization/src/BowedSurfaceAlignmentDerivatives.cc
+++ b/Alignment/CommonAlignmentParametrization/src/BowedSurfaceAlignmentDerivatives.cc
@@ -10,10 +10,8 @@
 #include "Alignment/CommonAlignmentParametrization/interface/KarimakiAlignmentDerivatives.h"
 #include <cmath>
 
-AlgebraicMatrix BowedSurfaceAlignmentDerivatives::
-operator()(const TrajectoryStateOnSurface &tsos, double uWidth, double vLength,
-           bool doSplit, double ySplit) const {
-
+AlgebraicMatrix BowedSurfaceAlignmentDerivatives::operator()(
+    const TrajectoryStateOnSurface &tsos, double uWidth, double vLength, bool doSplit, double ySplit) const {
   AlgebraicMatrix result(N_PARAM, 2);
 
   // track parameters on surface:
@@ -24,19 +22,17 @@ operator()(const TrajectoryStateOnSurface &tsos, double uWidth, double vLength,
   // [4] y    : local y-coordinate
   double myY = tsosPar[4];
   double myLengthV = vLength;
-  if (doSplit) { // re-'calibrate' y length and transform myY to be w.r.t.
-                 // surface middle
+  if (doSplit) {  // re-'calibrate' y length and transform myY to be w.r.t.
+                  // surface middle
     // Some signs depend on whether we are in surface part below or above
     // ySplit:
     const double sign = (tsosPar[4] < ySplit ? +1. : -1.);
-    const double yMiddle =
-        ySplit * 0.5 - sign * vLength * .25; // middle of surface
+    const double yMiddle = ySplit * 0.5 - sign * vLength * .25;  // middle of surface
     myY = tsosPar[4] - yMiddle;
     myLengthV = vLength * 0.5 + sign * ySplit;
   }
 
-  const AlgebraicMatrix karimaki(
-      KarimakiAlignmentDerivatives()(tsos)); // it's just 6x2...
+  const AlgebraicMatrix karimaki(KarimakiAlignmentDerivatives()(tsos));  // it's just 6x2...
   // copy u, v, w from Karimaki - they are independent of splitting
   result[dx][0] = karimaki[0][0];
   result[dx][1] = karimaki[0][1];
@@ -45,11 +41,11 @@ operator()(const TrajectoryStateOnSurface &tsos, double uWidth, double vLength,
   result[dz][0] = karimaki[2][0];
   result[dz][1] = karimaki[2][1];
   const double aScale = gammaScale(uWidth, myLengthV);
-  result[drotZ][0] = myY / aScale; // Since karimaki[5][0] == vx;
+  result[drotZ][0] = myY / aScale;  // Since karimaki[5][0] == vx;
   result[drotZ][1] = karimaki[5][1] / aScale;
 
-  double uRel = 2. * tsosPar[3] / uWidth; // relative u (-1 .. +1)
-  double vRel = 2. * myY / myLengthV;     // relative v (-1 .. +1)
+  double uRel = 2. * tsosPar[3] / uWidth;  // relative u (-1 .. +1)
+  double vRel = 2. * myY / myLengthV;      // relative v (-1 .. +1)
   // 'range check':
   const double cutOff = 1.5;
   if (uRel < -cutOff) {
@@ -89,8 +85,7 @@ operator()(const TrajectoryStateOnSurface &tsos, double uWidth, double vLength,
 }
 
 //------------------------------------------------------------------------------
-double BowedSurfaceAlignmentDerivatives::gammaScale(double width,
-                                                    double splitLength) {
+double BowedSurfaceAlignmentDerivatives::gammaScale(double width, double splitLength) {
   //   return 0.5 * std::sqrt(width*width + splitLength*splitLength);
   //   return 0.5 * (std::fabs(width) + std::fabs(splitLength));
   return 0.5 * (width + splitLength);

--- a/Alignment/CommonAlignmentParametrization/src/BowedSurfaceAlignmentParameters.cc
+++ b/Alignment/CommonAlignmentParametrization/src/BowedSurfaceAlignmentParameters.cc
@@ -23,39 +23,36 @@
 #include <iostream>
 //_________________________________________________________________________________________________
 BowedSurfaceAlignmentParameters::BowedSurfaceAlignmentParameters(Alignable *ali)
-    : AlignmentParameters(ali, AlgebraicVector(N_PARAM),
-                          AlgebraicSymMatrix(N_PARAM, 0)) {}
+    : AlignmentParameters(ali, AlgebraicVector(N_PARAM), AlgebraicSymMatrix(N_PARAM, 0)) {}
 
 //_________________________________________________________________________________________________
-BowedSurfaceAlignmentParameters ::BowedSurfaceAlignmentParameters(
-    Alignable *alignable, const AlgebraicVector &parameters,
-    const AlgebraicSymMatrix &covMatrix)
+BowedSurfaceAlignmentParameters ::BowedSurfaceAlignmentParameters(Alignable *alignable,
+                                                                  const AlgebraicVector &parameters,
+                                                                  const AlgebraicSymMatrix &covMatrix)
     : AlignmentParameters(alignable, parameters, covMatrix) {
   if (parameters.num_row() != N_PARAM) {
-    throw cms::Exception("BadParameters")
-        << "in BowedSurfaceAlignmentParameters(): " << parameters.num_row()
-        << " instead of " << N_PARAM << " parameters.";
+    throw cms::Exception("BadParameters") << "in BowedSurfaceAlignmentParameters(): " << parameters.num_row()
+                                          << " instead of " << N_PARAM << " parameters.";
   }
 }
 
 //_________________________________________________________________________________________________
-BowedSurfaceAlignmentParameters ::BowedSurfaceAlignmentParameters(
-    Alignable *alignable, const AlgebraicVector &parameters,
-    const AlgebraicSymMatrix &covMatrix, const std::vector<bool> &selection)
+BowedSurfaceAlignmentParameters ::BowedSurfaceAlignmentParameters(Alignable *alignable,
+                                                                  const AlgebraicVector &parameters,
+                                                                  const AlgebraicSymMatrix &covMatrix,
+                                                                  const std::vector<bool> &selection)
     : AlignmentParameters(alignable, parameters, covMatrix, selection) {
   if (parameters.num_row() != N_PARAM) {
-    throw cms::Exception("BadParameters")
-        << "in BowedSurfaceAlignmentParameters(): " << parameters.num_row()
-        << " instead of " << N_PARAM << " parameters.";
+    throw cms::Exception("BadParameters") << "in BowedSurfaceAlignmentParameters(): " << parameters.num_row()
+                                          << " instead of " << N_PARAM << " parameters.";
   }
 }
 
 //_________________________________________________________________________________________________
-BowedSurfaceAlignmentParameters *BowedSurfaceAlignmentParameters::clone(
-    const AlgebraicVector &parameters,
-    const AlgebraicSymMatrix &covMatrix) const {
-  BowedSurfaceAlignmentParameters *rbap = new BowedSurfaceAlignmentParameters(
-      this->alignable(), parameters, covMatrix, selector());
+BowedSurfaceAlignmentParameters *BowedSurfaceAlignmentParameters::clone(const AlgebraicVector &parameters,
+                                                                        const AlgebraicSymMatrix &covMatrix) const {
+  BowedSurfaceAlignmentParameters *rbap =
+      new BowedSurfaceAlignmentParameters(this->alignable(), parameters, covMatrix, selector());
 
   if (this->userVariables())
     rbap->setUserVariables(this->userVariables()->clone());
@@ -65,19 +62,16 @@ BowedSurfaceAlignmentParameters *BowedSurfaceAlignmentParameters::clone(
 }
 
 //_________________________________________________________________________________________________
-BowedSurfaceAlignmentParameters *
-BowedSurfaceAlignmentParameters::cloneFromSelected(
-    const AlgebraicVector &parameters,
-    const AlgebraicSymMatrix &covMatrix) const {
+BowedSurfaceAlignmentParameters *BowedSurfaceAlignmentParameters::cloneFromSelected(
+    const AlgebraicVector &parameters, const AlgebraicSymMatrix &covMatrix) const {
   return this->clone(this->expandVector(parameters, this->selector()),
                      this->expandSymMatrix(covMatrix, this->selector()));
 }
 
 //_________________________________________________________________________________________________
-AlgebraicMatrix BowedSurfaceAlignmentParameters::derivatives(
-    const TrajectoryStateOnSurface &tsos,
-    const AlignableDetOrUnitPtr &alidet) const {
-  const Alignable *ali = this->alignable(); // Alignable of these parameters
+AlgebraicMatrix BowedSurfaceAlignmentParameters::derivatives(const TrajectoryStateOnSurface &tsos,
+                                                             const AlignableDetOrUnitPtr &alidet) const {
+  const Alignable *ali = this->alignable();  // Alignable of these parameters
 
   if (ali == alidet) {
     const AlignableSurface &surf = ali->surface();
@@ -89,12 +83,11 @@ AlgebraicMatrix BowedSurfaceAlignmentParameters::derivatives(
     // keep the remaining three untouched in local meaning.
     // In this way we could do higher level alignment and determine 'average'
     // surface structures for the components.
-    throw cms::Exception("MisMatch")
-        << "BowedSurfaceAlignmentParameters::derivatives: The hit alignable "
-           "must match the "
-        << "aligned one (i.e. bowed surface parameters cannot be used for "
-           "composed alignables)\n";
-    return AlgebraicMatrix(N_PARAM, 2); // please compiler
+    throw cms::Exception("MisMatch") << "BowedSurfaceAlignmentParameters::derivatives: The hit alignable "
+                                        "must match the "
+                                     << "aligned one (i.e. bowed surface parameters cannot be used for "
+                                        "composed alignables)\n";
+    return AlgebraicMatrix(N_PARAM, 2);  // please compiler
   }
 }
 
@@ -116,8 +109,7 @@ align::EulerAngles BowedSurfaceAlignmentParameters::rotation() const {
   // Should we use atan of these values? Anyway it is small...
   eulerAngles[0] = params[dslopeY] * 2. / surface.length();
   eulerAngles[1] = -params[dslopeX] * 2. / surface.width();
-  const double aScale =
-      BowedDerivs::gammaScale(surface.width(), surface.length());
+  const double aScale = BowedDerivs::gammaScale(surface.width(), surface.length());
   eulerAngles[2] = params[drotZ] / aScale;
 
   return eulerAngles;
@@ -127,9 +119,8 @@ align::EulerAngles BowedSurfaceAlignmentParameters::rotation() const {
 void BowedSurfaceAlignmentParameters::apply() {
   Alignable *alignable = this->alignable();
   if (!alignable) {
-    throw cms::Exception("BadParameters")
-        << "BowedSurfaceAlignmentParameters::apply: parameters without "
-           "alignable";
+    throw cms::Exception("BadParameters") << "BowedSurfaceAlignmentParameters::apply: parameters without "
+                                             "alignable";
   }
 
   // Get translation in local frame, transform to global and apply:
@@ -140,17 +131,14 @@ void BowedSurfaceAlignmentParameters::apply() {
   // original code:
   //  alignable->rotateInLocalFrame( align::toMatrix(angles) );
   // correct for rounding errors:
-  align::RotationType rot(
-      alignable->surface().toGlobal(align::toMatrix(angles)));
+  align::RotationType rot(alignable->surface().toGlobal(align::toMatrix(angles)));
   align::rectify(rot);
   alignable->rotateInGlobalFrame(rot);
 
   // only update the surface deformations if they were selected for alignment
-  if (selector()[dsagittaX] || selector()[dsagittaXY] ||
-      selector()[dsagittaY]) {
+  if (selector()[dsagittaX] || selector()[dsagittaXY] || selector()[dsagittaY]) {
     const auto &params = theData->parameters();
-    const BowedSurfaceDeformation deform{params[dsagittaX], params[dsagittaXY],
-                                         params[dsagittaY]};
+    const BowedSurfaceDeformation deform{params[dsagittaX], params[dsagittaXY], params[dsagittaY]};
 
     // FIXME: true to propagate down?
     //        Needed for hierarchy with common deformation parameter,
@@ -160,13 +148,10 @@ void BowedSurfaceAlignmentParameters::apply() {
 }
 
 //_________________________________________________________________________________________________
-int BowedSurfaceAlignmentParameters::type() const {
-  return AlignmentParametersFactory::kBowedSurface;
-}
+int BowedSurfaceAlignmentParameters::type() const { return AlignmentParametersFactory::kBowedSurface; }
 
 //_________________________________________________________________________________________________
 void BowedSurfaceAlignmentParameters::print() const {
   std::cout << "Contents of BowedSurfaceAlignmentParameters:"
-            << "\nParameters: " << theData->parameters()
-            << "\nCovariance: " << theData->covariance() << std::endl;
+            << "\nParameters: " << theData->parameters() << "\nCovariance: " << theData->covariance() << std::endl;
 }

--- a/Alignment/CommonAlignmentParametrization/src/CompositeAlignmentDerivativesExtractor.cc
+++ b/Alignment/CommonAlignmentParametrization/src/CompositeAlignmentDerivativesExtractor.cc
@@ -16,8 +16,7 @@ CompositeAlignmentDerivativesExtractor::CompositeAlignmentDerivativesExtractor(
   detOrUnits.reserve(alignableDets.size());
 
   std::vector<AlignableDet *>::const_iterator it, itEnd;
-  for (it = alignableDets.begin(), itEnd = alignableDets.end(); it != itEnd;
-       ++it)
+  for (it = alignableDets.begin(), itEnd = alignableDets.end(); it != itEnd; ++it)
     detOrUnits.push_back(AlignableDetOrUnitPtr(*it));
 
   extractCurrentAlignment(alignables, detOrUnits, tsos);
@@ -37,7 +36,6 @@ void CompositeAlignmentDerivativesExtractor::extractCurrentAlignment(
     const align::Alignables &alignables,
     const std::vector<AlignableDetOrUnitPtr> &alignableDets,
     const std::vector<TrajectoryStateOnSurface> &tsos) {
-
   // sanity check
   if (alignables.size() != alignableDets.size()) {
     edm::LogError("CompositeAlignmentDerivativesExtractor")
@@ -48,14 +46,12 @@ void CompositeAlignmentDerivativesExtractor::extractCurrentAlignment(
 
   if (alignables.size() != tsos.size()) {
     edm::LogError("CompositeAlignmentDerivativesExtractor")
-        << "Inconsistent length of arguments: alignables=" << alignables.size()
-        << ", tsos=" << tsos.size();
+        << "Inconsistent length of arguments: alignables=" << alignables.size() << ", tsos=" << tsos.size();
     return;
   }
 
   align::Alignables::const_iterator itAlignable = alignables.begin();
-  std::vector<AlignableDetOrUnitPtr>::const_iterator itAlignableDet =
-      alignableDets.begin();
+  std::vector<AlignableDetOrUnitPtr>::const_iterator itAlignableDet = alignableDets.begin();
   std::vector<TrajectoryStateOnSurface>::const_iterator itTsos = tsos.begin();
 
   int nRow = 0;
@@ -69,19 +65,15 @@ void CompositeAlignmentDerivativesExtractor::extractCurrentAlignment(
   // dimension
   while (itAlignable != alignables.end()) {
     // Get the current estimate on the alignment parameters
-    AlgebraicVector subAlignmentParameters =
-        (*itAlignable)->alignmentParameters()->selectedParameters();
+    AlgebraicVector subAlignmentParameters = (*itAlignable)->alignmentParameters()->selectedParameters();
 
     // Get the derivatives or the local coordinates w.r.t. the corresponding
     // alignment parameters
     AlgebraicMatrix subAlignmentDerivatives =
-        (*itAlignable)
-            ->alignmentParameters()
-            ->selectedDerivatives(*itTsos, *itAlignableDet);
+        (*itAlignable)->alignmentParameters()->selectedDerivatives(*itTsos, *itAlignableDet);
 
     subDerivatives.push_back(subAlignmentDerivatives.T());
-    subCorrectionTerm.push_back(subAlignmentDerivatives.T() *
-                                subAlignmentParameters);
+    subCorrectionTerm.push_back(subAlignmentDerivatives.T() * subAlignmentParameters);
 
     nRow += 2;
     // check if it is the first occurrence of this Alignable
@@ -113,12 +105,9 @@ void CompositeAlignmentDerivativesExtractor::extractCurrentAlignment(
 //--------------------------------------------------------------------------------------
 
 void CompositeAlignmentDerivativesExtractor::extractWithoutMultipleHits(
-    const std::vector<AlgebraicVector> &subCorrectionTerm,
-    const std::vector<AlgebraicMatrix> &subDerivatives) {
-  std::vector<AlgebraicVector>::const_iterator itSubCorrectionTerm =
-      subCorrectionTerm.begin();
-  std::vector<AlgebraicMatrix>::const_iterator itSubDerivatives =
-      subDerivatives.begin();
+    const std::vector<AlgebraicVector> &subCorrectionTerm, const std::vector<AlgebraicMatrix> &subDerivatives) {
+  std::vector<AlgebraicVector>::const_iterator itSubCorrectionTerm = subCorrectionTerm.begin();
+  std::vector<AlgebraicMatrix>::const_iterator itSubDerivatives = subDerivatives.begin();
 
   int iRow = 1;
   int iCollumn = 1;
@@ -144,11 +133,8 @@ void CompositeAlignmentDerivativesExtractor::extractWithMultipleHits(
     const std::vector<AlgebraicVector> &subCorrectionTerm,
     const std::vector<AlgebraicMatrix> &subDerivatives,
     const align::Alignables &alignables) {
-
-  std::vector<AlgebraicVector>::const_iterator itSubCorrectionTerm =
-      subCorrectionTerm.begin();
-  std::vector<AlgebraicMatrix>::const_iterator itSubDerivatives =
-      subDerivatives.begin();
+  std::vector<AlgebraicVector>::const_iterator itSubCorrectionTerm = subCorrectionTerm.begin();
+  std::vector<AlgebraicMatrix>::const_iterator itSubDerivatives = subDerivatives.begin();
   align::Alignables::const_iterator itAlignables = alignables.begin();
   align::Alignables::const_iterator itPosition;
   align::Alignables::const_iterator itLastPosition;
@@ -164,8 +150,7 @@ void CompositeAlignmentDerivativesExtractor::extractWithMultipleHits(
 
     itLastPosition = find(alignables.begin(), itAlignables, *itAlignables);
 
-    for (itPosition = alignables.begin(); itPosition != itLastPosition;
-         ++itPosition) {
+    for (itPosition = alignables.begin(); itPosition != itLastPosition; ++itPosition) {
       if (count(alignables.begin(), itPosition, *itPosition) == 0)
         iCollumn += subDerivatives[iAlignable].num_col();
       iAlignable++;

--- a/Alignment/CommonAlignmentParametrization/src/CompositeAlignmentParameters.cc
+++ b/Alignment/CommonAlignmentParametrization/src/CompositeAlignmentParameters.cc
@@ -14,77 +14,76 @@
 #include "Alignment/CommonAlignment/interface/AlignmentParameters.h"
 
 //__________________________________________________________________________________________________
-CompositeAlignmentParameters::CompositeAlignmentParameters(
-    const AlgebraicVector &par, const AlgebraicSymMatrix &cov,
-    const Components &comp)
-    : theData(DataContainer(new AlignmentParametersData(par, cov))),
-      theComponents(comp) {}
+CompositeAlignmentParameters::CompositeAlignmentParameters(const AlgebraicVector &par,
+                                                           const AlgebraicSymMatrix &cov,
+                                                           const Components &comp)
+    : theData(DataContainer(new AlignmentParametersData(par, cov))), theComponents(comp) {}
 
 //__________________________________________________________________________________________________
-CompositeAlignmentParameters::CompositeAlignmentParameters(
-    const AlgebraicVector &par, const AlgebraicSymMatrix &cov,
-    const Components &comp, const AlignableDetToAlignableMap &alimap,
-    const Aliposmap &aliposmap, const Alilenmap &alilenmap)
+CompositeAlignmentParameters::CompositeAlignmentParameters(const AlgebraicVector &par,
+                                                           const AlgebraicSymMatrix &cov,
+                                                           const Components &comp,
+                                                           const AlignableDetToAlignableMap &alimap,
+                                                           const Aliposmap &aliposmap,
+                                                           const Alilenmap &alilenmap)
     : theData(DataContainer(new AlignmentParametersData(par, cov))),
-      theComponents(comp), theAlignableDetToAlignableMap(alimap),
-      theAliposmap(aliposmap), theAlilenmap(alilenmap) {}
+      theComponents(comp),
+      theAlignableDetToAlignableMap(alimap),
+      theAliposmap(aliposmap),
+      theAlilenmap(alilenmap) {}
 
 //__________________________________________________________________________________________________
-CompositeAlignmentParameters::CompositeAlignmentParameters(
-    const DataContainer &data, const Components &comp,
-    const AlignableDetToAlignableMap &alimap, const Aliposmap &aliposmap,
-    const Alilenmap &alilenmap)
-    : theData(data), theComponents(comp), theAlignableDetToAlignableMap(alimap),
-      theAliposmap(aliposmap), theAlilenmap(alilenmap) {}
+CompositeAlignmentParameters::CompositeAlignmentParameters(const DataContainer &data,
+                                                           const Components &comp,
+                                                           const AlignableDetToAlignableMap &alimap,
+                                                           const Aliposmap &aliposmap,
+                                                           const Alilenmap &alilenmap)
+    : theData(data),
+      theComponents(comp),
+      theAlignableDetToAlignableMap(alimap),
+      theAliposmap(aliposmap),
+      theAlilenmap(alilenmap) {}
 
 //__________________________________________________________________________________________________
 CompositeAlignmentParameters::~CompositeAlignmentParameters() {}
 
 //__________________________________________________________________________________________________
-CompositeAlignmentParameters *
-CompositeAlignmentParameters::clone(const AlgebraicVector &par,
-                                    const AlgebraicSymMatrix &cov) const {
+CompositeAlignmentParameters *CompositeAlignmentParameters::clone(const AlgebraicVector &par,
+                                                                  const AlgebraicSymMatrix &cov) const {
+  CompositeAlignmentParameters *cap = new CompositeAlignmentParameters(par, cov, components());
+
+  return cap;
+}
+
+//__________________________________________________________________________________________________
+CompositeAlignmentParameters *CompositeAlignmentParameters::clone(const AlgebraicVector &par,
+                                                                  const AlgebraicSymMatrix &cov,
+                                                                  const AlignableDetToAlignableMap &alimap,
+                                                                  const Aliposmap &aliposmap,
+                                                                  const Alilenmap &alilenmap) const {
   CompositeAlignmentParameters *cap =
-      new CompositeAlignmentParameters(par, cov, components());
+      new CompositeAlignmentParameters(par, cov, components(), alimap, aliposmap, alilenmap);
 
   return cap;
 }
 
 //__________________________________________________________________________________________________
-CompositeAlignmentParameters *CompositeAlignmentParameters::clone(
-    const AlgebraicVector &par, const AlgebraicSymMatrix &cov,
-    const AlignableDetToAlignableMap &alimap, const Aliposmap &aliposmap,
-    const Alilenmap &alilenmap) const {
-  CompositeAlignmentParameters *cap = new CompositeAlignmentParameters(
-      par, cov, components(), alimap, aliposmap, alilenmap);
-
-  return cap;
-}
-
-//__________________________________________________________________________________________________
-CompositeAlignmentParameters::Components
-CompositeAlignmentParameters::components() const {
-  return theComponents;
-}
+CompositeAlignmentParameters::Components CompositeAlignmentParameters::components() const { return theComponents; }
 
 //__________________________________________________________________________________________________
 // full derivatives for a composed object
-AlgebraicMatrix CompositeAlignmentParameters::derivatives(
-    const std::vector<TrajectoryStateOnSurface> &tsosvec,
-    const std::vector<AlignableDet *> &alidetvec) const {
+AlgebraicMatrix CompositeAlignmentParameters::derivatives(const std::vector<TrajectoryStateOnSurface> &tsosvec,
+                                                          const std::vector<AlignableDet *> &alidetvec) const {
   std::vector<AlignableDetOrUnitPtr> detOrUnits;
   this->convert(alidetvec, detOrUnits);
 
   return this->derivatives(tsosvec, detOrUnits);
 }
 
-AlgebraicMatrix CompositeAlignmentParameters::derivatives(
-    const std::vector<TrajectoryStateOnSurface> &tsosvec,
-    const std::vector<AlignableDetOrUnitPtr> &alidetvec) const {
+AlgebraicMatrix CompositeAlignmentParameters::derivatives(const std::vector<TrajectoryStateOnSurface> &tsosvec,
+                                                          const std::vector<AlignableDetOrUnitPtr> &alidetvec) const {
   align::Alignables alivec;
-  for (std::vector<AlignableDetOrUnitPtr>::const_iterator it =
-           alidetvec.begin();
-       it != alidetvec.end(); ++it)
+  for (std::vector<AlignableDetOrUnitPtr>::const_iterator it = alidetvec.begin(); it != alidetvec.end(); ++it)
     alivec.push_back(alignableFromAlignableDet(*it));
 
   CompositeAlignmentDerivativesExtractor extractor(alivec, alidetvec, tsosvec);
@@ -92,9 +91,8 @@ AlgebraicMatrix CompositeAlignmentParameters::derivatives(
 }
 
 //__________________________________________________________________________________________________
-AlgebraicVector CompositeAlignmentParameters::correctionTerm(
-    const std::vector<TrajectoryStateOnSurface> &tsosvec,
-    const std::vector<AlignableDet *> &alidetvec) const {
+AlgebraicVector CompositeAlignmentParameters::correctionTerm(const std::vector<TrajectoryStateOnSurface> &tsosvec,
+                                                             const std::vector<AlignableDet *> &alidetvec) const {
   std::vector<AlignableDetOrUnitPtr> detOrUnits;
   this->convert(alidetvec, detOrUnits);
 
@@ -103,12 +101,9 @@ AlgebraicVector CompositeAlignmentParameters::correctionTerm(
 
 //__________________________________________________________________________________________________
 AlgebraicVector CompositeAlignmentParameters::correctionTerm(
-    const std::vector<TrajectoryStateOnSurface> &tsosvec,
-    const std::vector<AlignableDetOrUnitPtr> &alidetvec) const {
+    const std::vector<TrajectoryStateOnSurface> &tsosvec, const std::vector<AlignableDetOrUnitPtr> &alidetvec) const {
   align::Alignables alivec;
-  for (std::vector<AlignableDetOrUnitPtr>::const_iterator it =
-           alidetvec.begin();
-       it != alidetvec.end(); ++it)
+  for (std::vector<AlignableDetOrUnitPtr>::const_iterator it = alidetvec.begin(); it != alidetvec.end(); ++it)
     alivec.push_back(alignableFromAlignableDet(*it));
 
   CompositeAlignmentDerivativesExtractor extractor(alivec, alidetvec, tsosvec);
@@ -117,24 +112,21 @@ AlgebraicVector CompositeAlignmentParameters::correctionTerm(
 
 //__________________________________________________________________________________________________
 // assume all are selected
-AlgebraicMatrix CompositeAlignmentParameters::selectedDerivatives(
-    const std::vector<TrajectoryStateOnSurface> &tsosvec,
-    const std::vector<AlignableDet *> &alidetvec) const {
+AlgebraicMatrix CompositeAlignmentParameters::selectedDerivatives(const std::vector<TrajectoryStateOnSurface> &tsosvec,
+                                                                  const std::vector<AlignableDet *> &alidetvec) const {
   return derivatives(tsosvec, alidetvec);
 }
 //__________________________________________________________________________________________________
 // assume all are selected
 AlgebraicMatrix CompositeAlignmentParameters::selectedDerivatives(
-    const std::vector<TrajectoryStateOnSurface> &tsosvec,
-    const std::vector<AlignableDetOrUnitPtr> &alidetvec) const {
+    const std::vector<TrajectoryStateOnSurface> &tsosvec, const std::vector<AlignableDetOrUnitPtr> &alidetvec) const {
   return derivatives(tsosvec, alidetvec);
 }
 
 //__________________________________________________________________________________________________
 // only one (tsos,AlignableDet) as argument [for compatibility with base class]
-AlgebraicMatrix CompositeAlignmentParameters::derivatives(
-    const TrajectoryStateOnSurface &tsos,
-    const AlignableDetOrUnitPtr &alidet) const {
+AlgebraicMatrix CompositeAlignmentParameters::derivatives(const TrajectoryStateOnSurface &tsos,
+                                                          const AlignableDetOrUnitPtr &alidet) const {
   std::vector<TrajectoryStateOnSurface> tsosvec;
   std::vector<AlignableDetOrUnitPtr> alidetvec;
   tsosvec.push_back(tsos);
@@ -144,22 +136,19 @@ AlgebraicMatrix CompositeAlignmentParameters::derivatives(
 
 //__________________________________________________________________________________________________
 // assume all are selected
-AlgebraicMatrix CompositeAlignmentParameters::selectedDerivatives(
-    const TrajectoryStateOnSurface &tsos,
-    const AlignableDetOrUnitPtr &alidet) const {
+AlgebraicMatrix CompositeAlignmentParameters::selectedDerivatives(const TrajectoryStateOnSurface &tsos,
+                                                                  const AlignableDetOrUnitPtr &alidet) const {
   return derivatives(tsos, alidet);
 }
 
 // Derivatives ----------------------------------------------------------------
 // legacy methods
 // full derivatives for a composed object
-AlgebraicMatrix CompositeAlignmentParameters::derivativesLegacy(
-    const std::vector<TrajectoryStateOnSurface> &tsosvec,
-    const std::vector<AlignableDet *> &alidetvec) const {
+AlgebraicMatrix CompositeAlignmentParameters::derivativesLegacy(const std::vector<TrajectoryStateOnSurface> &tsosvec,
+                                                                const std::vector<AlignableDet *> &alidetvec) const {
   // sanity check: length of parameter argument vectors must be equal
   if (alidetvec.size() != tsosvec.size()) {
-    edm::LogError("BadArgument")
-        << " Inconsistent length of argument vectors! ";
+    edm::LogError("BadArgument") << " Inconsistent length of argument vectors! ";
     AlgebraicMatrix selderiv(1, 0);
     return selderiv;
   }
@@ -168,8 +157,7 @@ AlgebraicMatrix CompositeAlignmentParameters::derivativesLegacy(
   int nparam = 0;
 
   std::vector<TrajectoryStateOnSurface>::const_iterator itsos = tsosvec.begin();
-  for (std::vector<AlignableDet *>::const_iterator it = alidetvec.begin();
-       it != alidetvec.end(); ++it, ++itsos) {
+  for (std::vector<AlignableDet *>::const_iterator it = alidetvec.begin(); it != alidetvec.end(); ++it, ++itsos) {
     AlignableDet *ad = (*it);
     Alignable *ali = alignableFromAlignableDet(ad);
     AlignmentParameters *ap = ali->alignmentParameters();
@@ -180,8 +168,7 @@ AlgebraicMatrix CompositeAlignmentParameters::derivativesLegacy(
 
   int ipos = 1;
   AlgebraicMatrix selderiv(nparam, 2);
-  for (std::vector<AlgebraicMatrix>::const_iterator imat = vecderiv.begin();
-       imat != vecderiv.end(); ++imat) {
+  for (std::vector<AlgebraicMatrix>::const_iterator imat = vecderiv.begin(); imat != vecderiv.end(); ++imat) {
     AlgebraicMatrix thisselderiv = (*imat);
     int npar = thisselderiv.num_row();
     selderiv.sub(ipos, 1, thisselderiv);
@@ -194,15 +181,14 @@ AlgebraicMatrix CompositeAlignmentParameters::derivativesLegacy(
 //__________________________________________________________________________________________________
 // assume all are selected
 AlgebraicMatrix CompositeAlignmentParameters::selectedDerivativesLegacy(
-    const std::vector<TrajectoryStateOnSurface> &tsosvec,
-    const std::vector<AlignableDet *> &alidetvec) const {
+    const std::vector<TrajectoryStateOnSurface> &tsosvec, const std::vector<AlignableDet *> &alidetvec) const {
   return derivativesLegacy(tsosvec, alidetvec);
 }
 
 //__________________________________________________________________________________________________
 // only one (tsos,AlignableDet) as argument [for compatibility with base class]
-AlgebraicMatrix CompositeAlignmentParameters::derivativesLegacy(
-    const TrajectoryStateOnSurface &tsos, AlignableDet *alidet) const {
+AlgebraicMatrix CompositeAlignmentParameters::derivativesLegacy(const TrajectoryStateOnSurface &tsos,
+                                                                AlignableDet *alidet) const {
   std::vector<TrajectoryStateOnSurface> tsosvec;
   std::vector<AlignableDet *> alidetvec;
   tsosvec.push_back(tsos);
@@ -212,18 +198,15 @@ AlgebraicMatrix CompositeAlignmentParameters::derivativesLegacy(
 
 //__________________________________________________________________________________________________
 // assume all are selected
-AlgebraicMatrix CompositeAlignmentParameters::selectedDerivativesLegacy(
-    const TrajectoryStateOnSurface &tsos, AlignableDet *alidet) const {
+AlgebraicMatrix CompositeAlignmentParameters::selectedDerivativesLegacy(const TrajectoryStateOnSurface &tsos,
+                                                                        AlignableDet *alidet) const {
   return derivativesLegacy(tsos, alidet);
 }
 
 //__________________________________________________________________________________________________
 // finds Alignable corresponding to AlignableDet
-Alignable *CompositeAlignmentParameters::alignableFromAlignableDet(
-    const AlignableDetOrUnitPtr &adet) const {
-
-  AlignableDetToAlignableMap::const_iterator iali =
-      theAlignableDetToAlignableMap.find(adet);
+Alignable *CompositeAlignmentParameters::alignableFromAlignableDet(const AlignableDetOrUnitPtr &adet) const {
+  AlignableDetToAlignableMap::const_iterator iali = theAlignableDetToAlignableMap.find(adet);
   if (iali != theAlignableDetToAlignableMap.end())
     return (*iali).second;
   else
@@ -231,8 +214,7 @@ Alignable *CompositeAlignmentParameters::alignableFromAlignableDet(
 }
 
 //__________________________________________________________________________________________________
-AlgebraicVector CompositeAlignmentParameters::parameterSubset(
-    const align::Alignables &vec) const {
+AlgebraicVector CompositeAlignmentParameters::parameterSubset(const align::Alignables &vec) const {
   const auto &sel = extractAlignables(vec);
 
   const unsigned int nali = sel.size();
@@ -267,8 +249,7 @@ AlgebraicVector CompositeAlignmentParameters::parameterSubset(
 
 //__________________________________________________________________________________________________
 // extract covariance matrix for a subset of alignables
-AlgebraicSymMatrix CompositeAlignmentParameters::covarianceSubset(
-    const align::Alignables &vec) const {
+AlgebraicSymMatrix CompositeAlignmentParameters::covarianceSubset(const align::Alignables &vec) const {
   const auto &sel = extractAlignables(vec);
 
   const unsigned int nali = sel.size();
@@ -300,8 +281,7 @@ AlgebraicSymMatrix CompositeAlignmentParameters::covarianceSubset(
 
       for (int ir = 0; ir < leni; ++ir)
         for (int ic = 0; ic < lenj; ++ic)
-          result[resi + ir][resj + ic] =
-              theData->covariance()[posi - 1 + ir][posj - 1 + ic];
+          result[resi + ir][resj + ic] = theData->covariance()[posi - 1 + ir][posj - 1 + ic];
 
       resj += lenj;
     }
@@ -313,8 +293,8 @@ AlgebraicSymMatrix CompositeAlignmentParameters::covarianceSubset(
 
 //__________________________________________________________________________________________________
 // extract covariance matrix elements between two subsets of alignables
-AlgebraicMatrix CompositeAlignmentParameters::covarianceSubset(
-    const align::Alignables &veci, const align::Alignables &vecj) const {
+AlgebraicMatrix CompositeAlignmentParameters::covarianceSubset(const align::Alignables &veci,
+                                                               const align::Alignables &vecj) const {
   const auto &seli = extractAlignables(veci);
   const auto &selj = extractAlignables(vecj);
 
@@ -354,8 +334,7 @@ AlgebraicMatrix CompositeAlignmentParameters::covarianceSubset(
 
       for (int ir = 0; ir < leni; ++ir)
         for (int ic = 0; ic < lenj; ++ic)
-          result[resi + ir][resj + ic] =
-              theData->covariance()[posi - 1 + ir][posj - 1 + ic];
+          result[resi + ir][resj + ic] = theData->covariance()[posi - 1 + ir][posj - 1 + ic];
 
       resj += lenj;
     }
@@ -367,18 +346,17 @@ AlgebraicMatrix CompositeAlignmentParameters::covarianceSubset(
 
 //__________________________________________________________________________________________________
 // Extract position and length of parameters for a subset of Alignables.
-bool CompositeAlignmentParameters::extractPositionAndLength(
-    const align::Alignables &alignables, std::vector<int> &posvec,
-    std::vector<int> &lenvec, int &length) const {
+bool CompositeAlignmentParameters::extractPositionAndLength(const align::Alignables &alignables,
+                                                            std::vector<int> &posvec,
+                                                            std::vector<int> &lenvec,
+                                                            int &length) const {
   length = 0;
 
   for (const auto &it : alignables) {
     // check if in components
-    if (std::find(theComponents.begin(), theComponents.end(), it) ==
-        theComponents.end()) {
-      edm::LogError("NotFound")
-          << "@SUB=CompositeAlignmentParameters::extractPositionAndLength"
-          << "Alignable not found in components!";
+    if (std::find(theComponents.begin(), theComponents.end(), it) == theComponents.end()) {
+      edm::LogError("NotFound") << "@SUB=CompositeAlignmentParameters::extractPositionAndLength"
+                                << "Alignable not found in components!";
       return false;
     }
 
@@ -386,9 +364,8 @@ bool CompositeAlignmentParameters::extractPositionAndLength(
     Aliposmap::const_iterator iposmap = theAliposmap.find(it);
     Alilenmap::const_iterator ilenmap = theAlilenmap.find(it);
     if (iposmap == theAliposmap.end() || ilenmap == theAlilenmap.end()) {
-      edm::LogError("NotFound")
-          << "@SUB=CompositeAlignmentParameters::extractPositionAndLength"
-          << "position/length not found for Alignable in maps!";
+      edm::LogError("NotFound") << "@SUB=CompositeAlignmentParameters::extractPositionAndLength"
+                                << "position/length not found for Alignable in maps!";
       return false;
     }
     posvec.push_back(iposmap->second);
@@ -400,8 +377,7 @@ bool CompositeAlignmentParameters::extractPositionAndLength(
 }
 
 //__________________________________________________________________________________________________
-align::Alignables CompositeAlignmentParameters::extractAlignables(
-    const align::Alignables &alignables) const {
+align::Alignables CompositeAlignmentParameters::extractAlignables(const align::Alignables &alignables) const {
   align::Alignables result;
 
   for (const auto &itA : alignables) {
@@ -413,9 +389,8 @@ align::Alignables CompositeAlignmentParameters::extractAlignables(
 }
 
 //__________________________________________________________________________________________________
-void CompositeAlignmentParameters::convert(
-    const std::vector<AlignableDet *> &input,
-    std::vector<AlignableDetOrUnitPtr> &output) const {
+void CompositeAlignmentParameters::convert(const std::vector<AlignableDet *> &input,
+                                           std::vector<AlignableDetOrUnitPtr> &output) const {
   output.clear();
   output.reserve(input.size());
 

--- a/Alignment/CommonAlignmentParametrization/src/FrameToFrameDerivative.cc
+++ b/Alignment/CommonAlignmentParametrization/src/FrameToFrameDerivative.cc
@@ -13,29 +13,25 @@
 #include "DataFormats/CLHEP/interface/Migration.h"
 
 //__________________________________________________________________________________________________
-AlgebraicMatrix FrameToFrameDerivative::frameToFrameDerivative(
-    const Alignable *object, const Alignable *composedObject) const {
-
-  return getDerivative(
-      object->globalRotation(), composedObject->globalRotation(),
-      composedObject->globalPosition() - object->globalPosition());
+AlgebraicMatrix FrameToFrameDerivative::frameToFrameDerivative(const Alignable *object,
+                                                               const Alignable *composedObject) const {
+  return getDerivative(object->globalRotation(),
+                       composedObject->globalRotation(),
+                       composedObject->globalPosition() - object->globalPosition());
 }
 
 //__________________________________________________________________________________________________
-AlgebraicMatrix66 FrameToFrameDerivative::getDerivative(
-    const align::RotationType &objectRot, const align::RotationType &composeRot,
-    const align::GlobalPoint &objectPos,
-    const align::GlobalPoint &composePos) const {
-  return asSMatrix<6, 6>(
-      this->getDerivative(objectRot, composeRot, composePos - objectPos));
+AlgebraicMatrix66 FrameToFrameDerivative::getDerivative(const align::RotationType &objectRot,
+                                                        const align::RotationType &composeRot,
+                                                        const align::GlobalPoint &objectPos,
+                                                        const align::GlobalPoint &composePos) const {
+  return asSMatrix<6, 6>(this->getDerivative(objectRot, composeRot, composePos - objectPos));
 }
 
 //__________________________________________________________________________________________________
-AlgebraicMatrix
-FrameToFrameDerivative::getDerivative(const align::RotationType &objectRot,
-                                      const align::RotationType &composeRot,
-                                      const align::GlobalVector &posVec) const {
-
+AlgebraicMatrix FrameToFrameDerivative::getDerivative(const align::RotationType &objectRot,
+                                                      const align::RotationType &composeRot,
+                                                      const align::GlobalVector &posVec) const {
   AlgebraicMatrix rotDet = transform(objectRot);
   AlgebraicMatrix rotCompO = transform(composeRot);
 
@@ -96,19 +92,15 @@ FrameToFrameDerivative::getDerivative(const align::RotationType &objectRot,
 }
 
 //__________________________________________________________________________________________________
-AlgebraicMatrix
-FrameToFrameDerivative::derivativePosPos(const AlgebraicMatrix &RotDet,
-                                         const AlgebraicMatrix &RotRot) const {
-
+AlgebraicMatrix FrameToFrameDerivative::derivativePosPos(const AlgebraicMatrix &RotDet,
+                                                         const AlgebraicMatrix &RotRot) const {
   return RotDet * RotRot.T();
 }
 
 //__________________________________________________________________________________________________
-AlgebraicMatrix
-FrameToFrameDerivative::derivativePosRot(const AlgebraicMatrix &RotDet,
-                                         const AlgebraicMatrix &RotRot,
-                                         const AlgebraicVector &S) const {
-
+AlgebraicMatrix FrameToFrameDerivative::derivativePosRot(const AlgebraicMatrix &RotDet,
+                                                         const AlgebraicMatrix &RotRot,
+                                                         const AlgebraicVector &S) const {
   AlgebraicVector dEulerA(3);
   AlgebraicVector dEulerB(3);
   AlgebraicVector dEulerC(3);
@@ -119,7 +111,7 @@ FrameToFrameDerivative::derivativePosRot(const AlgebraicMatrix &RotDet,
   RotDa[1][2] = 1;
   RotDa[2][1] = -1;
   RotDb[0][2] = -1;
-  RotDb[2][0] = 1; // New beta sign
+  RotDb[2][0] = 1;  // New beta sign
   RotDc[0][1] = 1;
   RotDc[1][0] = -1;
 
@@ -142,10 +134,8 @@ FrameToFrameDerivative::derivativePosRot(const AlgebraicMatrix &RotDet,
 }
 
 //__________________________________________________________________________________________________
-AlgebraicMatrix
-FrameToFrameDerivative::derivativeRotRot(const AlgebraicMatrix &RotDet,
-                                         const AlgebraicMatrix &RotRot) const {
-
+AlgebraicMatrix FrameToFrameDerivative::derivativeRotRot(const AlgebraicMatrix &RotDet,
+                                                         const AlgebraicMatrix &RotRot) const {
   AlgebraicVector dEulerA(3);
   AlgebraicVector dEulerB(3);
   AlgebraicVector dEulerC(3);
@@ -156,16 +146,13 @@ FrameToFrameDerivative::derivativeRotRot(const AlgebraicMatrix &RotDet,
   RotDa[1][2] = 1;
   RotDa[2][1] = -1;
   RotDb[0][2] = -1;
-  RotDb[2][0] = 1; // New beta sign
+  RotDb[2][0] = 1;  // New beta sign
   RotDc[0][1] = 1;
   RotDc[1][0] = -1;
 
-  dEulerA =
-      linearEulerAngles(RotDet * RotRot.T() * RotDa * RotRot * RotDet.T());
-  dEulerB =
-      linearEulerAngles(RotDet * RotRot.T() * RotDb * RotRot * RotDet.T());
-  dEulerC =
-      linearEulerAngles(RotDet * RotRot.T() * RotDc * RotRot * RotDet.T());
+  dEulerA = linearEulerAngles(RotDet * RotRot.T() * RotDa * RotRot * RotDet.T());
+  dEulerB = linearEulerAngles(RotDet * RotRot.T() * RotDb * RotRot * RotDet.T());
+  dEulerC = linearEulerAngles(RotDet * RotRot.T() * RotDc * RotRot * RotDet.T());
 
   AlgebraicMatrix eulerDeriv(3, 3);
 
@@ -183,13 +170,11 @@ FrameToFrameDerivative::derivativeRotRot(const AlgebraicMatrix &RotDet,
 }
 
 //__________________________________________________________________________________________________
-AlgebraicVector FrameToFrameDerivative::linearEulerAngles(
-    const AlgebraicMatrix &rotDelta) const {
-
+AlgebraicVector FrameToFrameDerivative::linearEulerAngles(const AlgebraicMatrix &rotDelta) const {
   AlgebraicMatrix eulerAB(3, 3);
   AlgebraicVector aB(3);
   eulerAB[0][1] = 1;
-  eulerAB[1][0] = -1; // New beta sign
+  eulerAB[1][0] = -1;  // New beta sign
   aB[2] = 1;
 
   AlgebraicMatrix eulerC(3, 3);

--- a/Alignment/CommonAlignmentParametrization/src/KarimakiAlignmentDerivatives.cc
+++ b/Alignment/CommonAlignmentParametrization/src/KarimakiAlignmentDerivatives.cc
@@ -8,9 +8,7 @@
 
 #include "Alignment/CommonAlignmentParametrization/interface/KarimakiAlignmentDerivatives.h"
 
-AlgebraicMatrix KarimakiAlignmentDerivatives::
-operator()(const TrajectoryStateOnSurface &tsos) const {
-
+AlgebraicMatrix KarimakiAlignmentDerivatives::operator()(const TrajectoryStateOnSurface &tsos) const {
   // Get track parameters on surface
   AlgebraicVector5 alivec = tsos.localParameters().mixedFormatVector();
 
@@ -36,8 +34,8 @@ operator()(const TrajectoryStateOnSurface &tsos) const {
   aliderivs[2][1] = tantheta;
   aliderivs[3][0] = vx * tanpsi;
   aliderivs[3][1] = vx * tantheta;
-  aliderivs[4][0] = -ux * tanpsi;   // New beta sign convention
-  aliderivs[4][1] = -ux * tantheta; // New beta sign convention
+  aliderivs[4][0] = -ux * tanpsi;    // New beta sign convention
+  aliderivs[4][1] = -ux * tantheta;  // New beta sign convention
   aliderivs[5][0] = vx;
   aliderivs[5][1] = -ux;
 

--- a/Alignment/CommonAlignmentParametrization/src/ParametersToParametersDerivatives.cc
+++ b/Alignment/CommonAlignmentParametrization/src/ParametersToParametersDerivatives.cc
@@ -20,12 +20,12 @@
 // #include "DataFormats/Math/interface/AlgebraicROOTObjects.h"
 
 //_________________________________________________________________________________________________
-ParametersToParametersDerivatives ::ParametersToParametersDerivatives(
-    const Alignable &component, const Alignable &mother)
+ParametersToParametersDerivatives ::ParametersToParametersDerivatives(const Alignable &component,
+                                                                      const Alignable &mother)
     : isOK_(component.alignmentParameters() && mother.alignmentParameters()) {
   if (isOK_) {
-    isOK_ = this->init(component, component.alignmentParameters()->type(),
-                       mother, mother.alignmentParameters()->type());
+    isOK_ =
+        this->init(component, component.alignmentParameters()->type(), mother, mother.alignmentParameters()->type());
   }
 }
 
@@ -34,31 +34,26 @@ bool ParametersToParametersDerivatives::init(const Alignable &component,
                                              int typeComponent,
                                              const Alignable &mother,
                                              int typeMother) {
-  using namespace AlignmentParametersFactory; // for kRigidBody etc.
+  using namespace AlignmentParametersFactory;  // for kRigidBody etc.
   if ((typeMother == kRigidBody || typeMother == kRigidBody4D) &&
       (typeComponent == kRigidBody || typeComponent == kRigidBody4D)) {
     return this->initRigidRigid(component, mother);
-  } else if ((typeMother == kRigidBody || typeMother == kRigidBody4D) &&
-             typeComponent == kBowedSurface) {
+  } else if ((typeMother == kRigidBody || typeMother == kRigidBody4D) && typeComponent == kBowedSurface) {
     return this->initBowedRigid(component, mother);
-  } else if ((typeMother == kRigidBody || typeMother == kRigidBody4D) &&
-             typeComponent == kTwoBowedSurfaces) {
+  } else if ((typeMother == kRigidBody || typeMother == kRigidBody4D) && typeComponent == kTwoBowedSurfaces) {
     return this->init2BowedRigid(component, mother);
   } else {
     // missing: mother with bows and component without, i.e. having 'common' bow
     // parameters
-    edm::LogError("Alignment")
-        << "@SUB=ParametersToParametersDerivatives::init"
-        << "Mother " << parametersTypeName(parametersType(typeMother))
-        << ", component " << parametersTypeName(parametersType(typeComponent))
-        << ": not supported.";
+    edm::LogError("Alignment") << "@SUB=ParametersToParametersDerivatives::init"
+                               << "Mother " << parametersTypeName(parametersType(typeMother)) << ", component "
+                               << parametersTypeName(parametersType(typeComponent)) << ": not supported.";
     return false;
   }
 }
 
 //_________________________________________________________________________________________________
-bool ParametersToParametersDerivatives::initRigidRigid(
-    const Alignable &component, const Alignable &mother) {
+bool ParametersToParametersDerivatives::initRigidRigid(const Alignable &component, const Alignable &mother) {
   // See G. Flucke's presentation from  20 Feb 2007
   // https://indico.cern.ch/contributionDisplay.py?contribId=15&sessionId=1&confId=10930
   // and C. Kleinwort's one from 14 Feb 2013
@@ -67,10 +62,9 @@ bool ParametersToParametersDerivatives::initRigidRigid(
   FrameToFrameDerivative f2f;
   // frame2frame returns dcomponent/dmother for both being rigid body, so we
   // have to invert
-  AlgebraicMatrix66 m(
-      asSMatrix<6, 6>(f2f.frameToFrameDerivative(&component, &mother)));
+  AlgebraicMatrix66 m(asSMatrix<6, 6>(f2f.frameToFrameDerivative(&component, &mother)));
 
-  if (m.Invert()) { // now matrix is d(rigid_mother)/d(rigid_component)
+  if (m.Invert()) {  // now matrix is d(rigid_mother)/d(rigid_component)
     // copy to TMatrix
     derivatives_.ResizeTo(6, 6);
     derivatives_.SetMatrixArray(m.begin());
@@ -81,19 +75,16 @@ bool ParametersToParametersDerivatives::initRigidRigid(
 }
 
 //_________________________________________________________________________________________________
-bool ParametersToParametersDerivatives::initBowedRigid(
-    const Alignable &component, const Alignable &mother) {
+bool ParametersToParametersDerivatives::initBowedRigid(const Alignable &component, const Alignable &mother) {
   // component is bowed surface, mother rigid body
   FrameToFrameDerivative f2f;
   // frame2frame returns dcomponent/dmother for both being rigid body, so we
   // have to invert
-  AlgebraicMatrix66 rigM2rigC(
-      asSMatrix<6, 6>(f2f.frameToFrameDerivative(&component, &mother)));
-  if (rigM2rigC.Invert()) { // now matrix is d(rigid_mother)/d(rigid_component)
+  AlgebraicMatrix66 rigM2rigC(asSMatrix<6, 6>(f2f.frameToFrameDerivative(&component, &mother)));
+  if (rigM2rigC.Invert()) {  // now matrix is d(rigid_mother)/d(rigid_component)
     const double halfWidth = 0.5 * component.surface().width();
     const double halfLength = 0.5 * component.surface().length();
-    const AlgebraicMatrix69 m(
-        this->dRigid_dBowed(rigM2rigC, halfWidth, halfLength));
+    const AlgebraicMatrix69 m(this->dRigid_dBowed(rigM2rigC, halfWidth, halfLength));
 
     // copy to TMatrix
     derivatives_.ResizeTo(6, 9);
@@ -106,17 +97,14 @@ bool ParametersToParametersDerivatives::initBowedRigid(
 }
 
 //_________________________________________________________________________________________________
-bool ParametersToParametersDerivatives::init2BowedRigid(
-    const Alignable &component, const Alignable &mother) {
+bool ParametersToParametersDerivatives::init2BowedRigid(const Alignable &component, const Alignable &mother) {
   // component is two bowed surfaces, mother rigid body
   const TwoBowedSurfacesAlignmentParameters *aliPar =
-      dynamic_cast<TwoBowedSurfacesAlignmentParameters *>(
-          component.alignmentParameters());
+      dynamic_cast<TwoBowedSurfacesAlignmentParameters *>(component.alignmentParameters());
 
   if (!aliPar) {
-    edm::LogError("Alignment")
-        << "@SUB=ParametersToParametersDerivatives::init2BowedRigid"
-        << "dynamic_cast to TwoBowedSurfacesAlignmentParameters failed.";
+    edm::LogError("Alignment") << "@SUB=ParametersToParametersDerivatives::init2BowedRigid"
+                               << "dynamic_cast to TwoBowedSurfacesAlignmentParameters failed.";
     return false;
   }
 
@@ -127,41 +115,33 @@ bool ParametersToParametersDerivatives::init2BowedRigid(
   const double halfLength = 0.5 * component.surface().length();
   const double halfLength1 = 0.5 * (halfLength + ySplit);
   const double halfLength2 = 0.5 * (halfLength - ySplit);
-  const double yM1 = 0.5 * (ySplit - halfLength); // y_mean of surface 1
-  const double yM2 = yM1 + halfLength;            // y_mean of surface 2
+  const double yM1 = 0.5 * (ySplit - halfLength);  // y_mean of surface 1
+  const double yM2 = yM1 + halfLength;             // y_mean of surface 2
   // The sensor positions and orientations could be adjusted using
   // TwoBowedSurfacesDeformation attached to the component,
   // but that should be 2nd order effect.
-  const align::GlobalPoint posSurf1(
-      component.surface().toGlobal(align::LocalPoint(0., yM1, 0.)));
-  const align::GlobalPoint posSurf2(
-      component.surface().toGlobal(align::LocalPoint(0., yM2, 0.)));
+  const align::GlobalPoint posSurf1(component.surface().toGlobal(align::LocalPoint(0., yM1, 0.)));
+  const align::GlobalPoint posSurf2(component.surface().toGlobal(align::LocalPoint(0., yM2, 0.)));
 
   // 2) get derivatives for both,
   // getDerivative(..) returns dcomponent/dmother for both being rigid body
   FrameToFrameDerivative f2fMaker;
-  AlgebraicMatrix66 f2fSurf1(f2fMaker.getDerivative(
-      component.globalRotation(), mother.globalRotation(), posSurf1,
-      mother.globalPosition()));
-  AlgebraicMatrix66 f2fSurf2(f2fMaker.getDerivative(
-      component.globalRotation(), mother.globalRotation(), posSurf2,
-      mother.globalPosition()));
+  AlgebraicMatrix66 f2fSurf1(
+      f2fMaker.getDerivative(component.globalRotation(), mother.globalRotation(), posSurf1, mother.globalPosition()));
+  AlgebraicMatrix66 f2fSurf2(
+      f2fMaker.getDerivative(component.globalRotation(), mother.globalRotation(), posSurf2, mother.globalPosition()));
   // We have to invert matrices to get d(rigid_mother)/d(rigid_component):
   if (!f2fSurf1.Invert() || !f2fSurf2.Invert())
-    return false; // bail out if bad inversion
+    return false;  // bail out if bad inversion
   // Now get d(rigid_mother)/d(bowed_component):
-  const AlgebraicMatrix69 derivs1(
-      this->dRigid_dBowed(f2fSurf1, halfWidth, halfLength1));
-  const AlgebraicMatrix69 derivs2(
-      this->dRigid_dBowed(f2fSurf2, halfWidth, halfLength2));
+  const AlgebraicMatrix69 derivs1(this->dRigid_dBowed(f2fSurf1, halfWidth, halfLength1));
+  const AlgebraicMatrix69 derivs2(this->dRigid_dBowed(f2fSurf2, halfWidth, halfLength2));
 
   // 3) fill the common matrix by merging the two.
-  typedef ROOT::Math::SMatrix<double, 6, 18,
-                              ROOT::Math::MatRepStd<double, 6, 18>>
-      AlgebraicMatrix6_18;
+  typedef ROOT::Math::SMatrix<double, 6, 18, ROOT::Math::MatRepStd<double, 6, 18>> AlgebraicMatrix6_18;
   AlgebraicMatrix6_18 derivs;
-  derivs.Place_at(derivs1, 0, 0); // left half
-  derivs.Place_at(derivs2, 0, 9); // right half
+  derivs.Place_at(derivs1, 0, 0);  // left half
+  derivs.Place_at(derivs2, 0, 9);  // right half
 
   // copy to TMatrix
   derivatives_.ResizeTo(6, 18);
@@ -171,13 +151,10 @@ bool ParametersToParametersDerivatives::init2BowedRigid(
 }
 
 //_________________________________________________________________________________________________
-ParametersToParametersDerivatives::AlgebraicMatrix69
-ParametersToParametersDerivatives::dRigid_dBowed(
-    const AlgebraicMatrix66 &dRigidM2dRigidC, double halfWidth,
-    double halfLength) {
+ParametersToParametersDerivatives::AlgebraicMatrix69 ParametersToParametersDerivatives::dRigid_dBowed(
+    const AlgebraicMatrix66 &dRigidM2dRigidC, double halfWidth, double halfLength) {
   typedef BowedSurfaceAlignmentDerivatives BowedDerivs;
-  const double gammaScale =
-      BowedDerivs::gammaScale(2. * halfWidth, 2. * halfLength);
+  const double gammaScale = BowedDerivs::gammaScale(2. * halfWidth, 2. * halfLength);
 
   // 'dRigidM2dRigidC' is dmother/dcomponent for both being rigid body
   // final matrix will be dmother/dcomponent for mother as rigid body, component
@@ -185,11 +162,9 @@ ParametersToParametersDerivatives::dRigid_dBowed(
   // (column) that of component (0..8):
   AlgebraicMatrix69 derivs;
   if (0. == gammaScale || 0. == halfWidth || 0. == halfLength) {
-    isOK_ =
-        false; // bad input - we would have to devide by that in the following!
-    edm::LogError("Alignment")
-        << "@SUB=ParametersToParametersDerivatives::dRigid_dBowed"
-        << "Some zero length as input.";
+    isOK_ = false;  // bad input - we would have to devide by that in the following!
+    edm::LogError("Alignment") << "@SUB=ParametersToParametersDerivatives::dRigid_dBowed"
+                               << "Some zero length as input.";
     return derivs;
   }
 
@@ -197,7 +172,7 @@ ParametersToParametersDerivatives::dRigid_dBowed(
     // loop on 6 rigid body parameters of mother
     // First copy the common rigid body part, e.g.:
     // (0,0): du_moth/du_comp, (0,1): dv_moth/du_comp, (1,2): dw_moth/dv_comp
-    for (unsigned int iCol = 0; iCol < 3; ++iCol) { // 3 movements of component
+    for (unsigned int iCol = 0; iCol < 3; ++iCol) {  // 3 movements of component
       derivs(iRow, iCol) = dRigidM2dRigidC(iRow, iCol);
     }
 
@@ -218,7 +193,7 @@ ParametersToParametersDerivatives::dRigid_dBowed(
     // Finally, sensor internals like their curvatures have no influence on
     // mother:
     for (unsigned int iCol = 6; iCol < AlgebraicMatrix69::kCols; ++iCol) {
-      derivs(iRow, iCol) = 0.; // 3 sagittae of component
+      derivs(iRow, iCol) = 0.;  // 3 sagittae of component
     }
   }
 
@@ -226,8 +201,7 @@ ParametersToParametersDerivatives::dRigid_dBowed(
 }
 
 //_________________________________________________________________________________________________
-double ParametersToParametersDerivatives::
-operator()(unsigned int indParMother, unsigned int indParComp) const {
+double ParametersToParametersDerivatives::operator()(unsigned int indParMother, unsigned int indParComp) const {
   // Do range checks?
   return derivatives_(indParMother, indParComp);
 }

--- a/Alignment/CommonAlignmentParametrization/src/RigidBodyAlignmentParameters.cc
+++ b/Alignment/CommonAlignmentParametrization/src/RigidBodyAlignmentParameters.cc
@@ -18,43 +18,36 @@
 #include "Alignment/CommonAlignmentParametrization/interface/RigidBodyAlignmentParameters.h"
 
 //__________________________________________________________________________________________________
-RigidBodyAlignmentParameters::RigidBodyAlignmentParameters(Alignable *ali,
-                                                           bool calcMis)
-    : AlignmentParameters(ali,
-                          displacementFromAlignable(calcMis ? ali : nullptr),
-                          AlgebraicSymMatrix(N_PARAM, 0)) {}
+RigidBodyAlignmentParameters::RigidBodyAlignmentParameters(Alignable *ali, bool calcMis)
+    : AlignmentParameters(ali, displacementFromAlignable(calcMis ? ali : nullptr), AlgebraicSymMatrix(N_PARAM, 0)) {}
 
 //__________________________________________________________________________________________________
-RigidBodyAlignmentParameters::RigidBodyAlignmentParameters(
-    Alignable *alignable, const AlgebraicVector &parameters,
-    const AlgebraicSymMatrix &covMatrix)
+RigidBodyAlignmentParameters::RigidBodyAlignmentParameters(Alignable *alignable,
+                                                           const AlgebraicVector &parameters,
+                                                           const AlgebraicSymMatrix &covMatrix)
     : AlignmentParameters(alignable, parameters, covMatrix) {
-
   if (parameters.num_row() != N_PARAM) {
     throw cms::Exception("BadParameters")
-        << "in RigidBodyAlignmentParameters(): " << parameters.num_row()
-        << " instead of " << N_PARAM << " parameters.";
+        << "in RigidBodyAlignmentParameters(): " << parameters.num_row() << " instead of " << N_PARAM << " parameters.";
   }
 }
 
 //__________________________________________________________________________________________________
-RigidBodyAlignmentParameters::RigidBodyAlignmentParameters(
-    Alignable *alignable, const AlgebraicVector &parameters,
-    const AlgebraicSymMatrix &covMatrix, const std::vector<bool> &selection)
+RigidBodyAlignmentParameters::RigidBodyAlignmentParameters(Alignable *alignable,
+                                                           const AlgebraicVector &parameters,
+                                                           const AlgebraicSymMatrix &covMatrix,
+                                                           const std::vector<bool> &selection)
     : AlignmentParameters(alignable, parameters, covMatrix, selection) {
   if (parameters.num_row() != N_PARAM) {
     throw cms::Exception("BadParameters")
-        << "in RigidBodyAlignmentParameters(): " << parameters.num_row()
-        << " instead of " << N_PARAM << " parameters.";
+        << "in RigidBodyAlignmentParameters(): " << parameters.num_row() << " instead of " << N_PARAM << " parameters.";
   }
 }
 
 //__________________________________________________________________________________________________
-RigidBodyAlignmentParameters *
-RigidBodyAlignmentParameters::clone(const AlgebraicVector &parameters,
-                                    const AlgebraicSymMatrix &covMatrix) const {
-  RigidBodyAlignmentParameters *rbap = new RigidBodyAlignmentParameters(
-      alignable(), parameters, covMatrix, selector());
+RigidBodyAlignmentParameters *RigidBodyAlignmentParameters::clone(const AlgebraicVector &parameters,
+                                                                  const AlgebraicSymMatrix &covMatrix) const {
+  RigidBodyAlignmentParameters *rbap = new RigidBodyAlignmentParameters(alignable(), parameters, covMatrix, selector());
 
   if (userVariables())
     rbap->setUserVariables(userVariables()->clone());
@@ -65,11 +58,9 @@ RigidBodyAlignmentParameters::clone(const AlgebraicVector &parameters,
 
 //__________________________________________________________________________________________________
 RigidBodyAlignmentParameters *RigidBodyAlignmentParameters::cloneFromSelected(
-    const AlgebraicVector &parameters,
-    const AlgebraicSymMatrix &covMatrix) const {
+    const AlgebraicVector &parameters, const AlgebraicSymMatrix &covMatrix) const {
   RigidBodyAlignmentParameters *rbap = new RigidBodyAlignmentParameters(
-      alignable(), expandVector(parameters, selector()),
-      expandSymMatrix(covMatrix, selector()), selector());
+      alignable(), expandVector(parameters, selector()), expandSymMatrix(covMatrix, selector()), selector());
 
   if (userVariables())
     rbap->setUserVariables(userVariables()->clone());
@@ -79,14 +70,13 @@ RigidBodyAlignmentParameters *RigidBodyAlignmentParameters::cloneFromSelected(
 }
 
 //__________________________________________________________________________________________________
-AlgebraicMatrix RigidBodyAlignmentParameters::derivatives(
-    const TrajectoryStateOnSurface &tsos,
-    const AlignableDetOrUnitPtr &alidet) const {
-  const Alignable *ali = this->alignable(); // Alignable of these parameters
+AlgebraicMatrix RigidBodyAlignmentParameters::derivatives(const TrajectoryStateOnSurface &tsos,
+                                                          const AlignableDetOrUnitPtr &alidet) const {
+  const Alignable *ali = this->alignable();  // Alignable of these parameters
 
-  if (ali == alidet) { // same alignable => same frame
+  if (ali == alidet) {  // same alignable => same frame
     return KarimakiAlignmentDerivatives()(tsos);
-  } else { // different alignable => transform into correct frame
+  } else {  // different alignable => transform into correct frame
     const AlgebraicMatrix deriv = KarimakiAlignmentDerivatives()(tsos);
     FrameToFrameDerivative ftfd;
     return ftfd.frameToFrameDerivative(alidet, ali).T() * deriv;
@@ -94,9 +84,8 @@ AlgebraicMatrix RigidBodyAlignmentParameters::derivatives(
 }
 
 //__________________________________________________________________________________________________
-AlgebraicMatrix RigidBodyAlignmentParameters::selectedDerivatives(
-    const TrajectoryStateOnSurface &tsos,
-    const AlignableDetOrUnitPtr &alignableDet) const {
+AlgebraicMatrix RigidBodyAlignmentParameters::selectedDerivatives(const TrajectoryStateOnSurface &tsos,
+                                                                  const AlignableDetOrUnitPtr &alignableDet) const {
   const AlgebraicMatrix dev = this->derivatives(tsos, alignableDet);
 
   int ncols = dev.num_col();
@@ -139,12 +128,11 @@ AlgebraicVector RigidBodyAlignmentParameters::rotation(void) const {
 void RigidBodyAlignmentParameters::apply() {
   Alignable *alignable = this->alignable();
   if (!alignable) {
-    throw cms::Exception("BadParameters")
-        << "RigidBodyAlignmentParameters::apply: parameters without alignable";
+    throw cms::Exception("BadParameters") << "RigidBodyAlignmentParameters::apply: parameters without alignable";
   }
 
   // Translation in local frame
-  AlgebraicVector shift = this->translation(); // fixme: should be LocalVector
+  AlgebraicVector shift = this->translation();  // fixme: should be LocalVector
 
   // Translation local->global
   align::LocalVector lv(shift[0], shift[1], shift[2]);
@@ -155,23 +143,19 @@ void RigidBodyAlignmentParameters::apply() {
   // original code:
   //  alignable->rotateInLocalFrame( align::toMatrix(angles) );
   // correct for rounding errors:
-  align::RotationType rot =
-      alignable->surface().toGlobal(align::toMatrix(angles));
+  align::RotationType rot = alignable->surface().toGlobal(align::toMatrix(angles));
   align::rectify(rot);
   alignable->rotateInGlobalFrame(rot);
 }
 
 //__________________________________________________________________________________________________
-int RigidBodyAlignmentParameters::type() const {
-  return AlignmentParametersFactory::kRigidBody;
-}
+int RigidBodyAlignmentParameters::type() const { return AlignmentParametersFactory::kRigidBody; }
 
 //__________________________________________________________________________________________________
 AlgebraicVector RigidBodyAlignmentParameters::globalParameters(void) const {
   AlgebraicVector m_GlobalParameters(N_PARAM, 0);
 
-  const AlgebraicVector shift =
-      translation(); // fixme: should return LocalVector
+  const AlgebraicVector shift = translation();  // fixme: should return LocalVector
 
   const align::LocalVector lv(shift[0], shift[1], shift[2]);
   const align::GlobalVector dg = theAlignable->surface().toGlobal(lv);
@@ -180,8 +164,7 @@ AlgebraicVector RigidBodyAlignmentParameters::globalParameters(void) const {
   m_GlobalParameters[1] = dg.y();
   m_GlobalParameters[2] = dg.z();
 
-  const align::EulerAngles eulerglob =
-      theAlignable->surface().toGlobal(rotation());
+  const align::EulerAngles eulerglob = theAlignable->surface().toGlobal(rotation());
 
   m_GlobalParameters[3] = eulerglob(1);
   m_GlobalParameters[4] = eulerglob(2);
@@ -192,26 +175,20 @@ AlgebraicVector RigidBodyAlignmentParameters::globalParameters(void) const {
 
 //__________________________________________________________________________________________________
 void RigidBodyAlignmentParameters::print(void) const {
-
   std::cout << "Contents of RigidBodyAlignmentParameters:"
-            << "\nParameters: " << theData->parameters()
-            << "\nCovariance: " << theData->covariance() << std::endl;
+            << "\nParameters: " << theData->parameters() << "\nCovariance: " << theData->covariance() << std::endl;
 }
 
 //__________________________________________________________________________________________________
-AlgebraicVector
-RigidBodyAlignmentParameters::displacementFromAlignable(const Alignable *ali) {
+AlgebraicVector RigidBodyAlignmentParameters::displacementFromAlignable(const Alignable *ali) {
   AlgebraicVector displacement(N_PARAM);
 
   if (ali) {
     const align::RotationType &dR = ali->rotation();
 
-    const align::LocalVector shifts(
-        ali->globalRotation() *
-        (dR.transposed() * ali->displacement().basicVector()));
+    const align::LocalVector shifts(ali->globalRotation() * (dR.transposed() * ali->displacement().basicVector()));
 
-    const align::EulerAngles angles =
-        align::toAngles(ali->surface().toLocal(dR));
+    const align::EulerAngles angles = align::toAngles(ali->surface().toLocal(dR));
 
     displacement[0] = shifts.x();
     displacement[1] = shifts.y();

--- a/Alignment/CommonAlignmentParametrization/src/RigidBodyAlignmentParameters4D.cc
+++ b/Alignment/CommonAlignmentParametrization/src/RigidBodyAlignmentParameters4D.cc
@@ -18,14 +18,13 @@
 #include "Alignment/CommonAlignmentParametrization/interface/RigidBodyAlignmentParameters4D.h"
 
 //__________________________________________________________________________________________________
-AlgebraicMatrix RigidBodyAlignmentParameters4D::derivatives(
-    const TrajectoryStateOnSurface &tsos,
-    const AlignableDetOrUnitPtr &alidet) const {
-  const Alignable *ali = this->alignable(); // Alignable of these parameters
+AlgebraicMatrix RigidBodyAlignmentParameters4D::derivatives(const TrajectoryStateOnSurface &tsos,
+                                                            const AlignableDetOrUnitPtr &alidet) const {
+  const Alignable *ali = this->alignable();  // Alignable of these parameters
 
-  if (ali == alidet) { // same alignable => same frame
+  if (ali == alidet) {  // same alignable => same frame
     return SegmentAlignmentDerivatives4D()(tsos);
-  } else { // different alignable => transform into correct frame
+  } else {  // different alignable => transform into correct frame
     const AlgebraicMatrix deriv = SegmentAlignmentDerivatives4D()(tsos);
     FrameToFrameDerivative ftfd;
     return ftfd.frameToFrameDerivative(alidet, ali).T() * deriv;
@@ -33,11 +32,10 @@ AlgebraicMatrix RigidBodyAlignmentParameters4D::derivatives(
 }
 
 //__________________________________________________________________________________________________
-RigidBodyAlignmentParameters4D *RigidBodyAlignmentParameters4D::clone(
-    const AlgebraicVector &parameters,
-    const AlgebraicSymMatrix &covMatrix) const {
-  RigidBodyAlignmentParameters4D *rbap = new RigidBodyAlignmentParameters4D(
-      alignable(), parameters, covMatrix, selector());
+RigidBodyAlignmentParameters4D *RigidBodyAlignmentParameters4D::clone(const AlgebraicVector &parameters,
+                                                                      const AlgebraicSymMatrix &covMatrix) const {
+  RigidBodyAlignmentParameters4D *rbap =
+      new RigidBodyAlignmentParameters4D(alignable(), parameters, covMatrix, selector());
 
   if (userVariables())
     rbap->setUserVariables(userVariables()->clone());
@@ -47,13 +45,10 @@ RigidBodyAlignmentParameters4D *RigidBodyAlignmentParameters4D::clone(
 }
 
 //__________________________________________________________________________________________________
-RigidBodyAlignmentParameters4D *
-RigidBodyAlignmentParameters4D::cloneFromSelected(
-    const AlgebraicVector &parameters,
-    const AlgebraicSymMatrix &covMatrix) const {
+RigidBodyAlignmentParameters4D *RigidBodyAlignmentParameters4D::cloneFromSelected(
+    const AlgebraicVector &parameters, const AlgebraicSymMatrix &covMatrix) const {
   RigidBodyAlignmentParameters4D *rbap = new RigidBodyAlignmentParameters4D(
-      alignable(), expandVector(parameters, selector()),
-      expandSymMatrix(covMatrix, selector()), selector());
+      alignable(), expandVector(parameters, selector()), expandSymMatrix(covMatrix, selector()), selector());
 
   if (userVariables())
     rbap->setUserVariables(userVariables()->clone());
@@ -63,6 +58,4 @@ RigidBodyAlignmentParameters4D::cloneFromSelected(
 }
 
 //__________________________________________________________________________________________________
-int RigidBodyAlignmentParameters4D::type() const {
-  return AlignmentParametersFactory::kRigidBody4D;
-}
+int RigidBodyAlignmentParameters4D::type() const { return AlignmentParametersFactory::kRigidBody4D; }

--- a/Alignment/CommonAlignmentParametrization/src/SegmentAlignmentDerivatives4D.cc
+++ b/Alignment/CommonAlignmentParametrization/src/SegmentAlignmentDerivatives4D.cc
@@ -8,9 +8,7 @@
 
 #include "Alignment/CommonAlignmentParametrization/interface/SegmentAlignmentDerivatives4D.h"
 
-AlgebraicMatrix SegmentAlignmentDerivatives4D::
-operator()(const TrajectoryStateOnSurface &tsos) const {
-
+AlgebraicMatrix SegmentAlignmentDerivatives4D::operator()(const TrajectoryStateOnSurface &tsos) const {
   // Get track parameters on surface
   AlgebraicVector5 alivec = tsos.localParameters().mixedFormatVector();
 
@@ -49,8 +47,8 @@ operator()(const TrajectoryStateOnSurface &tsos) const {
   aliderivs[3][2] = 0;
   aliderivs[3][3] = 1.0;
   // beta
-  aliderivs[4][0] = -ux * tanpsi;   // New beta sign convention
-  aliderivs[4][1] = -ux * tantheta; // New beta sign convention
+  aliderivs[4][0] = -ux * tanpsi;    // New beta sign convention
+  aliderivs[4][1] = -ux * tantheta;  // New beta sign convention
   aliderivs[4][2] = -1.0;
   aliderivs[4][3] = 0.0;
   // gamma

--- a/Alignment/CommonAlignmentParametrization/src/TwoBowedSurfacesAlignmentParameters.cc
+++ b/Alignment/CommonAlignmentParametrization/src/TwoBowedSurfacesAlignmentParameters.cc
@@ -24,45 +24,38 @@
 #include <cmath>
 #include <iostream>
 //_________________________________________________________________________________________________
-TwoBowedSurfacesAlignmentParameters::TwoBowedSurfacesAlignmentParameters(
-    Alignable *ali)
-    : AlignmentParameters(ali, AlgebraicVector(N_PARAM),
-                          AlgebraicSymMatrix(N_PARAM, 0)),
+TwoBowedSurfacesAlignmentParameters::TwoBowedSurfacesAlignmentParameters(Alignable *ali)
+    : AlignmentParameters(ali, AlgebraicVector(N_PARAM), AlgebraicSymMatrix(N_PARAM, 0)),
       ySplit_(this->ySplitFromAlignable(ali)) {}
 
 //_________________________________________________________________________________________________
-TwoBowedSurfacesAlignmentParameters ::TwoBowedSurfacesAlignmentParameters(
-    Alignable *alignable, const AlgebraicVector &parameters,
-    const AlgebraicSymMatrix &covMatrix)
-    : AlignmentParameters(alignable, parameters, covMatrix),
-      ySplit_(this->ySplitFromAlignable(alignable)) {
+TwoBowedSurfacesAlignmentParameters ::TwoBowedSurfacesAlignmentParameters(Alignable *alignable,
+                                                                          const AlgebraicVector &parameters,
+                                                                          const AlgebraicSymMatrix &covMatrix)
+    : AlignmentParameters(alignable, parameters, covMatrix), ySplit_(this->ySplitFromAlignable(alignable)) {
   if (parameters.num_row() != N_PARAM) {
-    throw cms::Exception("BadParameters")
-        << "in TwoBowedSurfacesAlignmentParameters(): " << parameters.num_row()
-        << " instead of " << N_PARAM << " parameters.";
+    throw cms::Exception("BadParameters") << "in TwoBowedSurfacesAlignmentParameters(): " << parameters.num_row()
+                                          << " instead of " << N_PARAM << " parameters.";
   }
 }
 
 //_________________________________________________________________________________________________
-TwoBowedSurfacesAlignmentParameters ::TwoBowedSurfacesAlignmentParameters(
-    Alignable *alignable, const AlgebraicVector &parameters,
-    const AlgebraicSymMatrix &covMatrix, const std::vector<bool> &selection)
-    : AlignmentParameters(alignable, parameters, covMatrix, selection),
-      ySplit_(this->ySplitFromAlignable(alignable)) {
+TwoBowedSurfacesAlignmentParameters ::TwoBowedSurfacesAlignmentParameters(Alignable *alignable,
+                                                                          const AlgebraicVector &parameters,
+                                                                          const AlgebraicSymMatrix &covMatrix,
+                                                                          const std::vector<bool> &selection)
+    : AlignmentParameters(alignable, parameters, covMatrix, selection), ySplit_(this->ySplitFromAlignable(alignable)) {
   if (parameters.num_row() != N_PARAM) {
-    throw cms::Exception("BadParameters")
-        << "in TwoBowedSurfacesAlignmentParameters(): " << parameters.num_row()
-        << " instead of " << N_PARAM << " parameters.";
+    throw cms::Exception("BadParameters") << "in TwoBowedSurfacesAlignmentParameters(): " << parameters.num_row()
+                                          << " instead of " << N_PARAM << " parameters.";
   }
 }
 
 //_________________________________________________________________________________________________
 TwoBowedSurfacesAlignmentParameters *TwoBowedSurfacesAlignmentParameters::clone(
-    const AlgebraicVector &parameters,
-    const AlgebraicSymMatrix &covMatrix) const {
+    const AlgebraicVector &parameters, const AlgebraicSymMatrix &covMatrix) const {
   TwoBowedSurfacesAlignmentParameters *rbap =
-      new TwoBowedSurfacesAlignmentParameters(this->alignable(), parameters,
-                                              covMatrix, selector());
+      new TwoBowedSurfacesAlignmentParameters(this->alignable(), parameters, covMatrix, selector());
 
   if (this->userVariables())
     rbap->setUserVariables(this->userVariables()->clone());
@@ -72,27 +65,23 @@ TwoBowedSurfacesAlignmentParameters *TwoBowedSurfacesAlignmentParameters::clone(
 }
 
 //_________________________________________________________________________________________________
-TwoBowedSurfacesAlignmentParameters *
-TwoBowedSurfacesAlignmentParameters::cloneFromSelected(
-    const AlgebraicVector &parameters,
-    const AlgebraicSymMatrix &covMatrix) const {
+TwoBowedSurfacesAlignmentParameters *TwoBowedSurfacesAlignmentParameters::cloneFromSelected(
+    const AlgebraicVector &parameters, const AlgebraicSymMatrix &covMatrix) const {
   return this->clone(this->expandVector(parameters, this->selector()),
                      this->expandSymMatrix(covMatrix, this->selector()));
 }
 
 //_________________________________________________________________________________________________
-AlgebraicMatrix TwoBowedSurfacesAlignmentParameters::derivatives(
-    const TrajectoryStateOnSurface &tsos,
-    const AlignableDetOrUnitPtr &alidet) const {
-  const Alignable *ali = this->alignable(); // Alignable of these parameters
-  AlgebraicMatrix result(N_PARAM, 2);       // initialised with zeros
+AlgebraicMatrix TwoBowedSurfacesAlignmentParameters::derivatives(const TrajectoryStateOnSurface &tsos,
+                                                                 const AlignableDetOrUnitPtr &alidet) const {
+  const Alignable *ali = this->alignable();  // Alignable of these parameters
+  AlgebraicMatrix result(N_PARAM, 2);        // initialised with zeros
 
   if (ali == alidet) {
     const AlignableSurface &surf = ali->surface();
 
     // matrix of dimension BowedDerivs::N_PARAM x 2
-    const AlgebraicMatrix derivs(BowedDerivs()(
-        tsos, surf.width(), surf.length(), true, ySplit_)); // split at ySplit_!
+    const AlgebraicMatrix derivs(BowedDerivs()(tsos, surf.width(), surf.length(), true, ySplit_));  // split at ySplit_!
 
     // Parameters belong to surface part with y < ySplit_ or y >= ySplit_?
     const double localY = tsos.localParameters().mixedFormatVector()[4];
@@ -113,11 +102,10 @@ AlgebraicMatrix TwoBowedSurfacesAlignmentParameters::derivatives(
     // surface structure parameters untouched in local meaning. In this way we
     // could do higher level alignment and determine 'average' surface
     // structures for the components.
-    throw cms::Exception("MisMatch")
-        << "TwoBowedSurfacesAlignmentParameters::derivatives: The hit "
-           "alignable must match the "
-        << "aligned one (i.e. bowed surface parameters cannot be used for "
-           "composed alignables)\n";
+    throw cms::Exception("MisMatch") << "TwoBowedSurfacesAlignmentParameters::derivatives: The hit "
+                                        "alignable must match the "
+                                     << "aligned one (i.e. bowed surface parameters cannot be used for "
+                                        "composed alignables)\n";
   }
 
   return result;
@@ -127,66 +115,58 @@ AlgebraicMatrix TwoBowedSurfacesAlignmentParameters::derivatives(
 void TwoBowedSurfacesAlignmentParameters::apply() {
   Alignable *alignable = this->alignable();
   if (!alignable) {
-    throw cms::Exception("BadParameters")
-        << "TwoBowedSurfacesAlignmentParameters::apply: parameters without "
-           "alignable";
+    throw cms::Exception("BadParameters") << "TwoBowedSurfacesAlignmentParameters::apply: parameters without "
+                                             "alignable";
   }
 
   // Some repeatedly needed variables
   const AlignableSurface &surface = alignable->surface();
-  const double halfLength = surface.length() * 0.5;        // full module
-  const double halfLength1 = (halfLength + ySplit_) * 0.5; // low-y surface
-  const double halfLength2 = (halfLength - ySplit_) * 0.5; // high-y surface
+  const double halfLength = surface.length() * 0.5;         // full module
+  const double halfLength1 = (halfLength + ySplit_) * 0.5;  // low-y surface
+  const double halfLength2 = (halfLength - ySplit_) * 0.5;  // high-y surface
 
   // first copy the parameters into separate parts for the two surfaces
   const AlgebraicVector &params = theData->parameters();
-  std::vector<double> rigidBowPar1(
-      BowedDerivs::N_PARAM); // 1st surface (y <  ySplit_)
-  std::vector<double> rigidBowPar2(
-      BowedDerivs::N_PARAM); // 2nd surface (y >= ySplit_)
+  std::vector<double> rigidBowPar1(BowedDerivs::N_PARAM);  // 1st surface (y <  ySplit_)
+  std::vector<double> rigidBowPar2(BowedDerivs::N_PARAM);  // 2nd surface (y >= ySplit_)
   for (unsigned int i = 0; i < BowedDerivs::N_PARAM; ++i) {
     rigidBowPar1[i] = params[i];
     rigidBowPar2[i] = params[i + BowedDerivs::N_PARAM];
   }
   // Now adjust slopes to angles, note that dslopeX <-> -beta & dslopeY <->
   // alpha, see BowedSurfaceAlignmentParameters::rotation(): FIXME: use atan?
-  rigidBowPar1[3] = params[dslopeY1] / halfLength1;              // alpha1
-  rigidBowPar2[3] = params[dslopeY2] / halfLength2;              // alpha2
-  rigidBowPar1[4] = -params[dslopeX1] / (surface.width() * 0.5); // beta1
-  rigidBowPar2[4] = -params[dslopeX2] / (surface.width() * 0.5); // beta2
+  rigidBowPar1[3] = params[dslopeY1] / halfLength1;               // alpha1
+  rigidBowPar2[3] = params[dslopeY2] / halfLength2;               // alpha2
+  rigidBowPar1[4] = -params[dslopeX1] / (surface.width() * 0.5);  // beta1
+  rigidBowPar2[4] = -params[dslopeX2] / (surface.width() * 0.5);  // beta2
   // gamma is simply scaled
-  const double gammaScale1 =
-      BowedDerivs::gammaScale(surface.width(), 2.0 * halfLength1);
+  const double gammaScale1 = BowedDerivs::gammaScale(surface.width(), 2.0 * halfLength1);
   rigidBowPar1[5] = params[drotZ1] / gammaScale1;
   //   const double gammaScale2 = std::sqrt(halfLength2 * halfLength2
   // 				       + surface.width() * surface.width()/4.);
-  const double gammaScale2 =
-      BowedDerivs::gammaScale(surface.width(), 2.0 * halfLength2);
+  const double gammaScale2 = BowedDerivs::gammaScale(surface.width(), 2.0 * halfLength2);
   rigidBowPar2[5] = params[drotZ2] / gammaScale2;
 
   // Get rigid body rotations of full module as mean of the two surfaces:
-  align::EulerAngles angles(3); // to become 'common' rotation in local frame
+  align::EulerAngles angles(3);  // to become 'common' rotation in local frame
   for (unsigned int i = 0; i < 3; ++i) {
     angles[i] = (rigidBowPar1[i + 3] + rigidBowPar2[i + 3]) * 0.5;
   }
   // Module rotations are around other axes than the one we determined,
   // so we have to correct that the surfaces are shifted by the rotation around
   // the module axis - in linear approximation just an additional shift:
-  const double yMean1 =
-      -halfLength + halfLength1; // y of alpha1 rotation axis in module frame
-  const double yMean2 =
-      halfLength - halfLength2; // y of alpha2 rotation axis in module frame
-  rigidBowPar1[dz1] -= angles[0] * yMean1; // correct w1 for alpha
-  rigidBowPar2[dz1] -= angles[0] * yMean2; // correct w2 for alpha
+  const double yMean1 = -halfLength + halfLength1;  // y of alpha1 rotation axis in module frame
+  const double yMean2 = halfLength - halfLength2;   // y of alpha2 rotation axis in module frame
+  rigidBowPar1[dz1] -= angles[0] * yMean1;          // correct w1 for alpha
+  rigidBowPar2[dz1] -= angles[0] * yMean2;          // correct w2 for alpha
   // Nothing for beta1/2 since anyway both around the y-axis of the module.
-  rigidBowPar1[dx1] += angles[2] * yMean1; // correct x1 for gamma
-  rigidBowPar2[dx1] += angles[2] * yMean2; // correct x1 for gamma
+  rigidBowPar1[dx1] += angles[2] * yMean1;  // correct x1 for gamma
+  rigidBowPar2[dx1] += angles[2] * yMean2;  // correct x1 for gamma
 
   // Get rigid body shifts of full module as mean of the two surfaces:
-  const align::LocalVector shift(
-      (rigidBowPar1[dx1] + rigidBowPar2[dx1]) * 0.5,  // dx1!
-      (rigidBowPar1[dy1] + rigidBowPar2[dy1]) * 0.5,  // dy1!
-      (rigidBowPar1[dz1] + rigidBowPar2[dz1]) * 0.5); // dz1!
+  const align::LocalVector shift((rigidBowPar1[dx1] + rigidBowPar2[dx1]) * 0.5,   // dx1!
+                                 (rigidBowPar1[dy1] + rigidBowPar2[dy1]) * 0.5,   // dy1!
+                                 (rigidBowPar1[dz1] + rigidBowPar2[dz1]) * 0.5);  // dz1!
   // Apply module shift and rotation:
   alignable->move(surface.toGlobal(shift));
   // original code:
@@ -197,8 +177,7 @@ void TwoBowedSurfacesAlignmentParameters::apply() {
   alignable->rotateInGlobalFrame(rot);
 
   // only update the surface deformations if they were selected for alignment
-  if (selector()[dsagittaX1] || selector()[dsagittaXY1] ||
-      selector()[dsagittaY1] || selector()[dsagittaX2] ||
+  if (selector()[dsagittaX1] || selector()[dsagittaXY1] || selector()[dsagittaY1] || selector()[dsagittaX2] ||
       selector()[dsagittaXY2] || selector()[dsagittaY2]) {
     // Fill surface structures with mean bows and half differences for all
     // parameters:
@@ -218,7 +197,7 @@ void TwoBowedSurfacesAlignmentParameters::apply() {
       deformations.push_back((rigidBowPar1[i] - rigidBowPar2[i]) * 0.5);
     }
     // finally: keep track of where we have split the module
-    deformations.push_back(ySplit_); // index is 12
+    deformations.push_back(ySplit_);  // index is 12
 
     const TwoBowedSurfacesDeformation deform{deformations};
 
@@ -230,21 +209,16 @@ void TwoBowedSurfacesAlignmentParameters::apply() {
 }
 
 //_________________________________________________________________________________________________
-int TwoBowedSurfacesAlignmentParameters::type() const {
-  return AlignmentParametersFactory::kTwoBowedSurfaces;
-}
+int TwoBowedSurfacesAlignmentParameters::type() const { return AlignmentParametersFactory::kTwoBowedSurfaces; }
 
 //_________________________________________________________________________________________________
 void TwoBowedSurfacesAlignmentParameters::print() const {
-
   std::cout << "Contents of TwoBowedSurfacesAlignmentParameters:"
-            << "\nParameters: " << theData->parameters()
-            << "\nCovariance: " << theData->covariance() << std::endl;
+            << "\nParameters: " << theData->parameters() << "\nCovariance: " << theData->covariance() << std::endl;
 }
 
 //_________________________________________________________________________________________________
-double TwoBowedSurfacesAlignmentParameters::ySplitFromAlignable(
-    const Alignable *ali) const {
+double TwoBowedSurfacesAlignmentParameters::ySplitFromAlignable(const Alignable *ali) const {
   if (!ali)
     return 0.;
 
@@ -259,14 +233,13 @@ double TwoBowedSurfacesAlignmentParameters::ySplitFromAlignable(
   // have been cross checked with y-residuals in data, see
   // https://hypernews.cern.ch/HyperNews/CMS/get/recoTracking/1018/1/1/2/1/1/1/2/1.html.
 
-  if (r < 58.) { // Pixel, TIB, TID or TEC ring 1-4
-    edm::LogError("Alignment")
-        << "@SUB=TwoBowedSurfacesAlignmentParameters::ySplitFromAlignable"
-        << "There are no split modules for radii < 58, but r = " << r;
+  if (r < 58.) {  // Pixel, TIB, TID or TEC ring 1-4
+    edm::LogError("Alignment") << "@SUB=TwoBowedSurfacesAlignmentParameters::ySplitFromAlignable"
+                               << "There are no split modules for radii < 58, but r = " << r;
     return 0.;
-  } else if (fabs(pos.z()) < 118.) { // TOB
+  } else if (fabs(pos.z()) < 118.) {  // TOB
     return 0.;
-  } else if (r > 90.) { // TEC ring 7
+  } else if (r > 90.) {  // TEC ring 7
     // W7a Height active= 106.900mm (Tab. 2) (but 106.926 mm p. 40!?)
     // W7a R min active = 888.400mm (Paragraph 5.5.7)
     // W7a R max active = W7a R min active + W7a Height active =
@@ -280,7 +253,7 @@ double TwoBowedSurfacesAlignmentParameters::ySplitFromAlignable(
     // same directions!
     //        = 996.776mm - 990.776mm = 6mm
     return 0.6;
-  } else if (r > 75.) { // TEC ring 6
+  } else if (r > 75.) {  // TEC ring 6
     // W6a Height active= 96.100mm (Tab. 2) (but 96.136 mm p. 38!?)
     // W6a R min active = 727.000mm (Paragraph 5.5.5)
     // W6a R max active = W6a R min active + W6a Height active =
@@ -294,7 +267,7 @@ double TwoBowedSurfacesAlignmentParameters::ySplitFromAlignable(
     // ySplit = -1*(mean radius gap - mean radius module)
     //        = -1*(824.580mm - 818.980mm) = -5.6mm
     return -0.56;
-  } else { // TEC ring 5 - smaller radii alreay excluded before
+  } else {  // TEC ring 5 - smaller radii alreay excluded before
     // W5a Height active= 81.200mm (Tab. 2) (but 81.169 mm p. 36!?)
     // W5a R min active = 603.200mm (Paragraph 5.5.3)
     // W5a R max active = W5a R min active + W5a Height active =

--- a/Alignment/LaserAlignmentSimulation/interface/LaserBeamsBarrel.h
+++ b/Alignment/LaserAlignmentSimulation/interface/LaserBeamsBarrel.h
@@ -23,8 +23,7 @@ public:
   /// default constructor
   LaserBeamsBarrel();
   /// constructor
-  LaserBeamsBarrel(G4int nPhotonsInGun, G4int nPhotonsInBeam,
-                   G4double PhotonEnergy);
+  LaserBeamsBarrel(G4int nPhotonsInGun, G4int nPhotonsInBeam, G4double PhotonEnergy);
   /// destructor
   ~LaserBeamsBarrel() override;
 

--- a/Alignment/LaserAlignmentSimulation/interface/LaserBeamsTEC1.h
+++ b/Alignment/LaserAlignmentSimulation/interface/LaserBeamsTEC1.h
@@ -23,8 +23,7 @@ public:
   /// default constructor
   LaserBeamsTEC1();
   /// constructor
-  LaserBeamsTEC1(G4int nPhotonsInGun, G4int nPhotonsInBeam,
-                 G4double PhotonEnergy);
+  LaserBeamsTEC1(G4int nPhotonsInGun, G4int nPhotonsInBeam, G4double PhotonEnergy);
   /// destructor
   ~LaserBeamsTEC1() override;
 

--- a/Alignment/LaserAlignmentSimulation/interface/LaserBeamsTEC2.h
+++ b/Alignment/LaserAlignmentSimulation/interface/LaserBeamsTEC2.h
@@ -23,8 +23,7 @@ public:
   /// default constructor
   LaserBeamsTEC2();
   /// constructor
-  LaserBeamsTEC2(G4int nPhotonsInGun, G4int nPhotonsInBeam,
-                 G4double PhotonEnergy);
+  LaserBeamsTEC2(G4int nPhotonsInGun, G4int nPhotonsInBeam, G4double PhotonEnergy);
   /// destructor
   ~LaserBeamsTEC2() override;
 

--- a/Alignment/LaserAlignmentSimulation/plugins/LaserAlignmentProducer.cc
+++ b/Alignment/LaserAlignmentSimulation/plugins/LaserAlignmentProducer.cc
@@ -20,8 +20,7 @@
 //
 // constructors and destructor
 //
-LaserAlignmentProducer::LaserAlignmentProducer(const edm::ParameterSet &)
-    : EDProducer(), theEvent(nullptr) {
+LaserAlignmentProducer::LaserAlignmentProducer(const edm::ParameterSet &) : EDProducer(), theEvent(nullptr) {
   // register your products
   produces<edm::HepMCProduct>("unsmeared");
 
@@ -33,19 +32,16 @@ LaserAlignmentProducer::~LaserAlignmentProducer() {
 }
 
 // ------------ method called to produce the event  ------------
-void LaserAlignmentProducer::produce(edm::Event &iEvent,
-                                     const edm::EventSetup &) {
+void LaserAlignmentProducer::produce(edm::Event &iEvent, const edm::EventSetup &) {
   // create the event
   theEvent = new HepMC::GenEvent();
 
   // create a primary vertex
-  HepMC::GenVertex *theVtx =
-      new HepMC::GenVertex(HepMC::FourVector(0., 0., 0.));
+  HepMC::GenVertex *theVtx = new HepMC::GenVertex(HepMC::FourVector(0., 0., 0.));
 
   // add a particle to the vertex; this is needed to avoid crashes in
   // OscarProducer. Use a electron neutrino, with zero energy and mass
-  HepMC::GenParticle *theParticle =
-      new HepMC::GenParticle(HepMC::FourVector(0., 0., 0., 0.), 12, 1);
+  HepMC::GenParticle *theParticle = new HepMC::GenParticle(HepMC::FourVector(0., 0., 0., 0.), 12, 1);
 
   theVtx->add_particle_out(theParticle);
 

--- a/Alignment/LaserAlignmentSimulation/plugins/LaserAlignmentSimulation.cc
+++ b/Alignment/LaserAlignmentSimulation/plugins/LaserAlignmentSimulation.cc
@@ -22,25 +22,23 @@
 #include "G4StepPoint.hh"
 #include "SimG4CMS/Tracker/interface/TkAccumulatingSensitiveDetector.h"
 
-LaserAlignmentSimulation::LaserAlignmentSimulation(
-    edm::ParameterSet const &theConf)
+LaserAlignmentSimulation::LaserAlignmentSimulation(edm::ParameterSet const &theConf)
     : theDebugLevel(theConf.getUntrackedParameter<int>("DebugLevel", 0)),
-      theEnergyLossScalingFactor(theConf.getUntrackedParameter<double>(
-          "EnergyLossScalingFactor", 1.0)),
-      theMPDebug(theConf.getUntrackedParameter<int>(
-          "MaterialPropertiesDebugLevel", 0)),
-      theSiAbsLengthScale(theConf.getUntrackedParameter<double>(
-          "SiAbsorptionLengthScalingFactor", 1.0)),
-      theTimer(), theMaterialProperties(), thePrimaryGenerator(),
-      theSteppingAction(), theBarrelHits(0), theEndcapHits(0),
+      theEnergyLossScalingFactor(theConf.getUntrackedParameter<double>("EnergyLossScalingFactor", 1.0)),
+      theMPDebug(theConf.getUntrackedParameter<int>("MaterialPropertiesDebugLevel", 0)),
+      theSiAbsLengthScale(theConf.getUntrackedParameter<double>("SiAbsorptionLengthScalingFactor", 1.0)),
+      theTimer(),
+      theMaterialProperties(),
+      thePrimaryGenerator(),
+      theSteppingAction(),
+      theBarrelHits(0),
+      theEndcapHits(0),
       theParameterSet(theConf) {
-
   // make some noise
   edm::LogInfo("SimLaserAlignmentSimulation")
       << " *****     AC1CMS: Configuration from ParameterSet      ***** "
       << "\n  AC1CMS: theDebugLevel               = " << theDebugLevel
-      << "\n  AC1CMS: theEnergyLossScalingFactor  = "
-      << theEnergyLossScalingFactor
+      << "\n  AC1CMS: theEnergyLossScalingFactor  = " << theEnergyLossScalingFactor
       << "\n  AC1CMS: theMPDebugLevel             = " << theMPDebug
       << "\n  AC1CMS: theSiAbsLengthScalingFactor = " << theSiAbsLengthScale;
 
@@ -66,8 +64,7 @@ LaserAlignmentSimulation::~LaserAlignmentSimulation() {
 void LaserAlignmentSimulation::update(const BeginOfRun *myRun) {
   LogDebug("SimLaserAlignmentSimulation")
       << "<LaserAlignmentSimulation::update(const BeginOfRun * myRun)>"
-      << "\n *****     AC1CMS: Start of Run: " << (*myRun)()->GetRunID()
-      << "     ***** ";
+      << "\n *****     AC1CMS: Start of Run: " << (*myRun)()->GetRunID() << "     ***** ";
 
   // start timer
   theTimer->Start();
@@ -81,8 +78,7 @@ void LaserAlignmentSimulation::update(const BeginOfRun *myRun) {
 
   // construct your own material properties for setting refractionindex and so
   // on
-  theMaterialProperties =
-      new MaterialProperties(theMPDebug, theSiAbsLengthScale);
+  theMaterialProperties = new MaterialProperties(theMPDebug, theSiAbsLengthScale);
 
   // list the tree of sensitive detectors
   if (theDebugLevel >= 1) {
@@ -92,9 +88,8 @@ void LaserAlignmentSimulation::update(const BeginOfRun *myRun) {
 }
 
 void LaserAlignmentSimulation::update(const BeginOfEvent *myEvent) {
-  LogDebug("SimLaserAlignmentSimulation")
-      << "<LaserAlignmentSimulation::update(const BeginOfEvent * myEvent)>"
-      << "\n AC1CMS: Event number = " << (*myEvent)()->GetEventID();
+  LogDebug("SimLaserAlignmentSimulation") << "<LaserAlignmentSimulation::update(const BeginOfEvent * myEvent)>"
+                                          << "\n AC1CMS: Event number = " << (*myEvent)()->GetEventID();
 
   // some statistics for this event
   theBarrelHits = 0;
@@ -107,8 +102,7 @@ void LaserAlignmentSimulation::update(const BeginOfEvent *myEvent) {
 void LaserAlignmentSimulation::update(const BeginOfTrack *myTrack) {}
 
 void LaserAlignmentSimulation::update(const G4Step *myStep) {
-  LogDebug("SimLaserAlignmentSimulationStepping")
-      << "<LaserAlignmentSimulation::update(const G4Step * myStep)>";
+  LogDebug("SimLaserAlignmentSimulationStepping") << "<LaserAlignmentSimulation::update(const G4Step * myStep)>";
 
   G4Step *theStep = const_cast<G4Step *>(myStep);
 
@@ -116,68 +110,40 @@ void LaserAlignmentSimulation::update(const G4Step *myStep) {
   theSteppingAction->UserSteppingAction(theStep);
 
   // Trigger sensitive detector manually since photon is absorbed
-  if ((theStep->GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName() ==
-       "OpAbsorption")) {
-    LogDebug("SimLaserAlignmentSimulationStepping")
-        << "<LaserAlignmentSimulation::update(const G4Step*)>: Photon was "
-           "absorbed! ";
+  if ((theStep->GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName() == "OpAbsorption")) {
+    LogDebug("SimLaserAlignmentSimulationStepping") << "<LaserAlignmentSimulation::update(const G4Step*)>: Photon was "
+                                                       "absorbed! ";
 
-    if (theStep->GetPreStepPoint()
-            ->GetPhysicalVolume()
-            ->GetLogicalVolume()
-            ->GetSensitiveDetector()) {
+    if (theStep->GetPreStepPoint()->GetPhysicalVolume()->GetLogicalVolume()->GetSensitiveDetector()) {
       LogDebug("SimLaserAlignmentSimulationStepping")
-          << " AC1CMS: Setting the EnergyLoss to "
-          << theStep->GetTotalEnergyDeposit() << "\n AC1CMS: The z position is "
-          << theStep->GetPreStepPoint()->GetPosition().z()
+          << " AC1CMS: Setting the EnergyLoss to " << theStep->GetTotalEnergyDeposit()
+          << "\n AC1CMS: The z position is " << theStep->GetPreStepPoint()->GetPosition().z()
           << "\n AC1CMS: the Sensitive Detector: "
-          << theStep->GetPreStepPoint()
-                 ->GetPhysicalVolume()
-                 ->GetLogicalVolume()
-                 ->GetSensitiveDetector()
-                 ->GetName()
-          << "\n AC1CMS: the Material: "
-          << theStep->GetPreStepPoint()->GetMaterial()->GetName()
+          << theStep->GetPreStepPoint()->GetPhysicalVolume()->GetLogicalVolume()->GetSensitiveDetector()->GetName()
+          << "\n AC1CMS: the Material: " << theStep->GetPreStepPoint()->GetMaterial()->GetName()
           << "\n AC1CMS: the Logical Volume: "
-          << theStep->GetPostStepPoint()
-                 ->GetPhysicalVolume()
-                 ->GetLogicalVolume()
-                 ->GetName();
+          << theStep->GetPostStepPoint()->GetPhysicalVolume()->GetLogicalVolume()->GetName();
 
       if (theStep->GetTotalEnergyDeposit() > 0.0) {
         // process a hit
         TkAccumulatingSensitiveDetector *theSD =
-            (TkAccumulatingSensitiveDetector *)(theStep->GetPreStepPoint()
-                                                    ->GetPhysicalVolume()
-                                                    ->GetLogicalVolume()
-                                                    ->GetSensitiveDetector());
+            (TkAccumulatingSensitiveDetector
+                 *)(theStep->GetPreStepPoint()->GetPhysicalVolume()->GetLogicalVolume()->GetSensitiveDetector());
 
-        theSD->ProcessHits(theStep,
-                           ((G4TouchableHistory *)(theStep->GetPreStepPoint()
-                                                       ->GetTouchable())));
+        theSD->ProcessHits(theStep, ((G4TouchableHistory *)(theStep->GetPreStepPoint()->GetTouchable())));
 
         // some statistics for this event
-        if ((theStep->GetPostStepPoint()
-                 ->GetPhysicalVolume()
-                 ->GetLogicalVolume()
-                 ->GetName() == "TECModule3RphiActive") ||
-            (theStep->GetPostStepPoint()
-                 ->GetPhysicalVolume()
-                 ->GetLogicalVolume()
-                 ->GetName() == "TECModule5RphiActive")) {
+        if ((theStep->GetPostStepPoint()->GetPhysicalVolume()->GetLogicalVolume()->GetName() ==
+             "TECModule3RphiActive") ||
+            (theStep->GetPostStepPoint()->GetPhysicalVolume()->GetLogicalVolume()->GetName() ==
+             "TECModule5RphiActive")) {
           theEndcapHits++;
-        } else if ((theStep->GetPostStepPoint()
-                        ->GetPhysicalVolume()
-                        ->GetLogicalVolume()
-                        ->GetName() == "TOBActiveSter0") ||
-                   (theStep->GetPostStepPoint()
-                        ->GetPhysicalVolume()
-                        ->GetLogicalVolume()
-                        ->GetName() == "TOBActiveRphi0") ||
-                   (theStep->GetPostStepPoint()
-                        ->GetPhysicalVolume()
-                        ->GetLogicalVolume()
-                        ->GetName() == "TIBActiveRphi2")) {
+        } else if ((theStep->GetPostStepPoint()->GetPhysicalVolume()->GetLogicalVolume()->GetName() ==
+                    "TOBActiveSter0") ||
+                   (theStep->GetPostStepPoint()->GetPhysicalVolume()->GetLogicalVolume()->GetName() ==
+                    "TOBActiveRphi0") ||
+                   (theStep->GetPostStepPoint()->GetPhysicalVolume()->GetLogicalVolume()->GetName() ==
+                    "TIBActiveRphi2")) {
           theBarrelHits++;
         }
       }
@@ -185,8 +151,7 @@ void LaserAlignmentSimulation::update(const G4Step *myStep) {
       LogDebug("SimLaserAlignmentSimulationStepping")
           << " AC1CMS: No SensitiveDetector available for this Step ... No Hit "
              "created :-( "
-          << "\n AC1CMS: The Material was: "
-          << theStep->GetPreStepPoint()->GetMaterial()->GetName();
+          << "\n AC1CMS: The Material was: " << theStep->GetPreStepPoint()->GetMaterial()->GetName();
     }
   }
 }
@@ -194,27 +159,22 @@ void LaserAlignmentSimulation::update(const G4Step *myStep) {
 void LaserAlignmentSimulation::update(const EndOfTrack *myTrack) {}
 
 void LaserAlignmentSimulation::update(const EndOfEvent *myEvent) {
-  LogDebug("SimLaserAlignmentSimulation")
-      << "<LaserAlignmentSimulation::update(const EndOfEvent * myEvent)>"
-      << "\n AC1CMS: End of Event " << (*myEvent)()->GetEventID();
+  LogDebug("SimLaserAlignmentSimulation") << "<LaserAlignmentSimulation::update(const EndOfEvent * myEvent)>"
+                                          << "\n AC1CMS: End of Event " << (*myEvent)()->GetEventID();
 
   // some statistics for this event
   edm::LogInfo("SimLaserAlignmentSimulation")
-      << " *** Number of Hits: " << theBarrelHits << " / " << theEndcapHits
-      << " (Barrel / Endcaps) *** ";
+      << " *** Number of Hits: " << theBarrelHits << " / " << theEndcapHits << " (Barrel / Endcaps) *** ";
 }
 
 void LaserAlignmentSimulation::update(const EndOfRun *myRun) {
-  LogDebug("SimLaserAlignmentSimulation")
-      << "<LaserAlignmentSimulation::update(const EndOfRun * myRun)>";
+  LogDebug("SimLaserAlignmentSimulation") << "<LaserAlignmentSimulation::update(const EndOfRun * myRun)>";
 
   // stop timer
   theTimer->Stop();
   edm::LogInfo("SimLaserAlignmentSimulation")
-      << " AC1CMS: Number of Events = "
-      << (*myRun)()->GetNumberOfEventToBeProcessed() << " " << *theTimer
-      << " *****     AC1CMS: End of Run: " << (*myRun)()->GetRunID()
-      << "     ***** ";
+      << " AC1CMS: Number of Events = " << (*myRun)()->GetNumberOfEventToBeProcessed() << " " << *theTimer
+      << " *****     AC1CMS: End of Run: " << (*myRun)()->GetRunID() << "     ***** ";
 }
 
 // register a SimWatcher to get the Observer signals from OscarProducer

--- a/Alignment/LaserAlignmentSimulation/plugins/LaserOpticalPhysics.cc
+++ b/Alignment/LaserAlignmentSimulation/plugins/LaserOpticalPhysics.cc
@@ -23,8 +23,7 @@
 #include "G4IonPhysics.hh"
 #include "G4StoppingPhysics.hh"
 
-LaserOpticalPhysics::LaserOpticalPhysics(const edm::ParameterSet &p)
-    : PhysicsList(p) {
+LaserOpticalPhysics::LaserOpticalPhysics(const edm::ParameterSet &p) : PhysicsList(p) {
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   G4DataQuestionaire it(photon);
   std::cout << "You are using the simulation engine: QGSP together with "

--- a/Alignment/LaserAlignmentSimulation/src/LaserBeamsBarrel.cc
+++ b/Alignment/LaserAlignmentSimulation/src/LaserBeamsBarrel.cc
@@ -16,10 +16,9 @@
 #include "G4ParticleDefinition.hh"
 #include "G4ParticleGun.hh"
 #include "G4SystemOfUnits.hh"
-#include "globals.hh" // Global Constants and typedefs
+#include "globals.hh"  // Global Constants and typedefs
 
-LaserBeamsBarrel::LaserBeamsBarrel()
-    : theParticleGun(nullptr), theDRand48Engine(nullptr) {
+LaserBeamsBarrel::LaserBeamsBarrel() : theParticleGun(nullptr), theDRand48Engine(nullptr) {
   G4int nPhotonsGun = 1;
   G4int nPhotonsBeam = 1;
   G4double Energy = 1.15 * eV;
@@ -27,10 +26,8 @@ LaserBeamsBarrel::LaserBeamsBarrel()
   LaserBeamsBarrel(nPhotonsGun, nPhotonsBeam, Energy);
 }
 
-LaserBeamsBarrel::LaserBeamsBarrel(G4int nPhotonsInGun, G4int nPhotonsInBeam,
-                                   G4double PhotonEnergy)
-    : thenParticleInGun(0), thenParticle(0), thePhotonEnergy(0),
-      theParticleGun(), theDRand48Engine() {
+LaserBeamsBarrel::LaserBeamsBarrel(G4int nPhotonsInGun, G4int nPhotonsInBeam, G4double PhotonEnergy)
+    : thenParticleInGun(0), thenParticle(0), thePhotonEnergy(0), theParticleGun(), theDRand48Engine() {
   /* *********************************************************************** */
   /*  initialize and configure the particle gun                              */
   /* *********************************************************************** */
@@ -52,13 +49,11 @@ LaserBeamsBarrel::LaserBeamsBarrel(G4int nPhotonsInGun, G4int nPhotonsInBeam,
 
   // default kinematics
   G4ParticleTable *theParticleTable = G4ParticleTable::GetParticleTable();
-  G4ParticleDefinition *theOpticalPhoton =
-      theParticleTable->FindParticle("opticalphoton");
+  G4ParticleDefinition *theOpticalPhoton = theParticleTable->FindParticle("opticalphoton");
 
   theParticleGun->SetParticleDefinition(theOpticalPhoton);
   theParticleGun->SetParticleTime(0.0 * ns);
-  theParticleGun->SetParticlePosition(
-      G4ThreeVector(-500.0 * cm, 0.0 * cm, 0.0 * cm));
+  theParticleGun->SetParticlePosition(G4ThreeVector(-500.0 * cm, 0.0 * cm, 0.0 * cm));
   theParticleGun->SetParticleMomentumDirection(G4ThreeVector(5.0, 3.0, 0.0));
   theParticleGun->SetParticleEnergy(10.0 * keV);
   setOptPhotonPolar(90.0);
@@ -98,15 +93,14 @@ void LaserBeamsBarrel::GeneratePrimaries(G4Event *myEvent) {
 
   // phi positions of the Laserdiodes (from CMS Note 2001/053 or from
   // http://abbaneo.home.cern.ch/abbaneo/cms/layout)
-  G4double LaserPhi[nLaserBeams] = {
-      G4double(7.0 / 112.0) * G4double(2.0 * M_PI),
-      G4double(23.0 / 112.0) * G4double(2.0 * M_PI),
-      G4double(33.0 / 112.0) * G4double(2.0 * M_PI),
-      G4double(49.0 / 112.0) * G4double(2.0 * M_PI),
-      G4double(65.0 / 112.0) * G4double(2.0 * M_PI),
-      G4double(77.0 / 112.0) * G4double(2.0 * M_PI),
-      G4double(93.0 / 112.0) * G4double(2.0 * M_PI),
-      G4double(103.0 / 112.0) * G4double(2.0 * M_PI)};
+  G4double LaserPhi[nLaserBeams] = {G4double(7.0 / 112.0) * G4double(2.0 * M_PI),
+                                    G4double(23.0 / 112.0) * G4double(2.0 * M_PI),
+                                    G4double(33.0 / 112.0) * G4double(2.0 * M_PI),
+                                    G4double(49.0 / 112.0) * G4double(2.0 * M_PI),
+                                    G4double(65.0 / 112.0) * G4double(2.0 * M_PI),
+                                    G4double(77.0 / 112.0) * G4double(2.0 * M_PI),
+                                    G4double(93.0 / 112.0) * G4double(2.0 * M_PI),
+                                    G4double(103.0 / 112.0) * G4double(2.0 * M_PI)};
 
   // width of the LaserBeams
   G4double LaserBeamSigmaX = 0.5 * mm;
@@ -114,8 +108,7 @@ void LaserBeamsBarrel::GeneratePrimaries(G4Event *myEvent) {
 
   // get the definition of the optical photon
   G4ParticleTable *theParticleTable = G4ParticleTable::GetParticleTable();
-  G4ParticleDefinition *theOpticalPhoton =
-      theParticleTable->FindParticle("opticalphoton");
+  G4ParticleDefinition *theOpticalPhoton = theParticleTable->FindParticle("opticalphoton");
 
   // loop over the LaserBeams
   for (int theBeam = 0; theBeam < nLaserBeams; theBeam++) {
@@ -127,10 +120,8 @@ void LaserBeamsBarrel::GeneratePrimaries(G4Event *myEvent) {
     // loop over all the particles in one beam
     for (int theParticle = 0; theParticle < thenParticle; theParticle++) {
       // get randomnumbers  and calculate the position
-      CLHEP::RandGaussQ aGaussObjX(*theDRand48Engine, LaserPositionX,
-                                   LaserBeamSigmaX);
-      CLHEP::RandGaussQ aGaussObjY(*theDRand48Engine, LaserPositionY,
-                                   LaserBeamSigmaY);
+      CLHEP::RandGaussQ aGaussObjX(*theDRand48Engine, LaserPositionX, LaserBeamSigmaX);
+      CLHEP::RandGaussQ aGaussObjY(*theDRand48Engine, LaserPositionY, LaserBeamSigmaY);
 
       G4double theXPosition = aGaussObjX.fire();
       G4double theYPosition = aGaussObjY.fire();
@@ -139,33 +130,30 @@ void LaserBeamsBarrel::GeneratePrimaries(G4Event *myEvent) {
       // set the properties of the newly created particle
       theParticleGun->SetParticleDefinition(theOpticalPhoton);
       theParticleGun->SetParticleTime(0.0 * ns);
-      theParticleGun->SetParticlePosition(
-          G4ThreeVector(theXPosition, theYPosition, theZPosition));
+      theParticleGun->SetParticlePosition(G4ThreeVector(theXPosition, theYPosition, theZPosition));
       theParticleGun->SetParticleEnergy(thePhotonEnergy);
 
       // loop over both directions of the beam
       for (int theDirection = 0; theDirection < 2; theDirection++) {
         // shoot in both beam directions ...
-        if (theDirection == 0) // shoot in forward direction (+z)
+        if (theDirection == 0)  // shoot in forward direction (+z)
         {
-          theParticleGun->SetParticleMomentumDirection(
-              G4ThreeVector(0.0, 0.0, 1.0));
+          theParticleGun->SetParticleMomentumDirection(G4ThreeVector(0.0, 0.0, 1.0));
           // set the polarization
           setOptPhotonPolar(90.0);
           // generate the particle
           theParticleGun->GeneratePrimaryVertex(myEvent);
-        } else if (theDirection == 1) // shoot in backward direction (-z)
+        } else if (theDirection == 1)  // shoot in backward direction (-z)
         {
-          theParticleGun->SetParticleMomentumDirection(
-              G4ThreeVector(0.0, 0.0, -1.0));
+          theParticleGun->SetParticleMomentumDirection(G4ThreeVector(0.0, 0.0, -1.0));
           // set the polarization
           setOptPhotonPolar(90.0);
           // generate the particle
           theParticleGun->GeneratePrimaryVertex(myEvent);
         }
-      } // end looop over both beam directions
-    }   // end looop over particles in beam
-  }     // end loop over beams
+      }  // end looop over both beam directions
+    }    // end looop over particles in beam
+  }      // end loop over beams
 }
 
 void LaserBeamsBarrel::setOptPhotonPolar(G4double Angle) {
@@ -175,8 +163,7 @@ void LaserBeamsBarrel::setOptPhotonPolar(G4double Angle) {
   /* *********************************************************************** */
 
   // first check if we have an optical photon
-  if (theParticleGun->GetParticleDefinition()->GetParticleName() !=
-      "opticalphoton") {
+  if (theParticleGun->GetParticleDefinition()->GetParticleName() != "opticalphoton") {
     edm::LogWarning("SimLaserAlignment:LaserBeamsBarrel")
         << "<LaserBeamsBarrel::setOptPhotonPolar()>: WARNING! The ParticleGun "
            "is not an optical photon";

--- a/Alignment/LaserAlignmentSimulation/src/LaserBeamsTEC1.cc
+++ b/Alignment/LaserAlignmentSimulation/src/LaserBeamsTEC1.cc
@@ -16,10 +16,9 @@
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include "G4ParticleDefinition.hh"
 #include "G4ParticleGun.hh"
-#include "globals.hh" // Global Constants and typedefs
+#include "globals.hh"  // Global Constants and typedefs
 
-LaserBeamsTEC1::LaserBeamsTEC1()
-    : theParticleGun(nullptr), theDRand48Engine(nullptr) {
+LaserBeamsTEC1::LaserBeamsTEC1() : theParticleGun(nullptr), theDRand48Engine(nullptr) {
   G4int nPhotonsGun = 1;
   G4int nPhotonsBeam = 1;
   G4double Energy = 1.15 * eV;
@@ -27,8 +26,7 @@ LaserBeamsTEC1::LaserBeamsTEC1()
   LaserBeamsTEC1(nPhotonsGun, nPhotonsBeam, Energy);
 }
 
-LaserBeamsTEC1::LaserBeamsTEC1(G4int nPhotonsInGun, G4int nPhotonsInBeam,
-                               G4double PhotonEnergy)
+LaserBeamsTEC1::LaserBeamsTEC1(G4int nPhotonsInGun, G4int nPhotonsInBeam, G4double PhotonEnergy)
     : thenParticleInGun(0), thenParticle(0), thePhotonEnergy(0) {
   /* *********************************************************************** */
   /*  initialize and configure the particle gun                              */
@@ -51,13 +49,11 @@ LaserBeamsTEC1::LaserBeamsTEC1(G4int nPhotonsInGun, G4int nPhotonsInBeam,
 
   // default kinematics
   G4ParticleTable *theParticleTable = G4ParticleTable::GetParticleTable();
-  G4ParticleDefinition *theOpticalPhoton =
-      theParticleTable->FindParticle("opticalphoton");
+  G4ParticleDefinition *theOpticalPhoton = theParticleTable->FindParticle("opticalphoton");
 
   theParticleGun->SetParticleDefinition(theOpticalPhoton);
   theParticleGun->SetParticleTime(0.0 * ns);
-  theParticleGun->SetParticlePosition(
-      G4ThreeVector(-500.0 * cm, 0.0 * cm, 0.0 * cm));
+  theParticleGun->SetParticlePosition(G4ThreeVector(-500.0 * cm, 0.0 * cm, 0.0 * cm));
   theParticleGun->SetParticleMomentumDirection(G4ThreeVector(5.0, 3.0, 0.0));
   theParticleGun->SetParticleEnergy(10.0 * keV);
   setOptPhotonPolar(90.0);
@@ -106,8 +102,7 @@ void LaserBeamsTEC1::GeneratePrimaries(G4Event *myEvent) {
 
   // get the definition of the optical photon
   G4ParticleTable *theParticleTable = G4ParticleTable::GetParticleTable();
-  G4ParticleDefinition *theOpticalPhoton =
-      theParticleTable->FindParticle("opticalphoton");
+  G4ParticleDefinition *theOpticalPhoton = theParticleTable->FindParticle("opticalphoton");
 
   // loop over the LaserRings
   for (int theRing = 0; theRing < nLaserRings; theRing++) {
@@ -115,23 +110,17 @@ void LaserBeamsTEC1::GeneratePrimaries(G4Event *myEvent) {
     for (int theBeam = 0; theBeam < nLaserBeams; theBeam++) {
       // code for forward and backward beam
       // calculate the right phi for the current beam
-      G4double LaserPositionPhi =
-          LaserPhi0 +
-          G4double(theBeam * G4double(G4double(2 * M_PI) / nLaserBeams));
+      G4double LaserPositionPhi = LaserPhi0 + G4double(theBeam * G4double(G4double(2 * M_PI) / nLaserBeams));
 
       // calculate x and y position for the current beam
-      G4double LaserPositionX =
-          cos(LaserPositionPhi) * LaserRingRadius[theRing];
-      G4double LaserPositionY =
-          sin(LaserPositionPhi) * LaserRingRadius[theRing];
+      G4double LaserPositionX = cos(LaserPositionPhi) * LaserRingRadius[theRing];
+      G4double LaserPositionY = sin(LaserPositionPhi) * LaserRingRadius[theRing];
 
       // loop over all the particles in one beam
       for (int theParticle = 0; theParticle < thenParticle; theParticle++) {
         // get randomnumbers  and calculate the position
-        CLHEP::RandGaussQ aGaussObjX(*theDRand48Engine, LaserPositionX,
-                                     LaserRingSigmaX[theRing]);
-        CLHEP::RandGaussQ aGaussObjY(*theDRand48Engine, LaserPositionY,
-                                     LaserRingSigmaY[theRing]);
+        CLHEP::RandGaussQ aGaussObjX(*theDRand48Engine, LaserPositionX, LaserRingSigmaX[theRing]);
+        CLHEP::RandGaussQ aGaussObjY(*theDRand48Engine, LaserPositionY, LaserRingSigmaY[theRing]);
 
         G4double theXPosition = aGaussObjX.fire();
         G4double theYPosition = aGaussObjY.fire();
@@ -140,36 +129,33 @@ void LaserBeamsTEC1::GeneratePrimaries(G4Event *myEvent) {
         // set the properties of the newly created particle
         theParticleGun->SetParticleDefinition(theOpticalPhoton);
         theParticleGun->SetParticleTime(0.0 * ns);
-        theParticleGun->SetParticlePosition(
-            G4ThreeVector(theXPosition, theYPosition, theZPosition));
+        theParticleGun->SetParticlePosition(G4ThreeVector(theXPosition, theYPosition, theZPosition));
         theParticleGun->SetParticleEnergy(thePhotonEnergy);
 
         // loop over both directions of the beam
         for (int theDirection = 0; theDirection < 2; theDirection++) {
           // shoot in both beam directions ...
-          if (theDirection == 0) // shoot in forward direction (+z)
+          if (theDirection == 0)  // shoot in forward direction (+z)
           {
-            theParticleGun->SetParticleMomentumDirection(
-                G4ThreeVector(0.0, 0.0, 1.0));
+            theParticleGun->SetParticleMomentumDirection(G4ThreeVector(0.0, 0.0, 1.0));
             // set the polarization
             setOptPhotonPolar(90.0);
             // generate the particle
             theParticleGun->GeneratePrimaryVertex(myEvent);
           }
 
-          if (theDirection == 1) // shoot in backward direction (-z)
+          if (theDirection == 1)  // shoot in backward direction (-z)
           {
-            theParticleGun->SetParticleMomentumDirection(
-                G4ThreeVector(0.0, 0.0, -1.0));
+            theParticleGun->SetParticleMomentumDirection(G4ThreeVector(0.0, 0.0, -1.0));
             // set the polarization
             setOptPhotonPolar(90.0);
             // generate the particle
             theParticleGun->GeneratePrimaryVertex(myEvent);
           }
-        } // end loop over both beam directions
-      }   // end loop over particles in beam
-    }     // end loop over beams
-  }       // end loop over rings
+        }  // end loop over both beam directions
+      }    // end loop over particles in beam
+    }      // end loop over beams
+  }        // end loop over rings
 }
 
 void LaserBeamsTEC1::setOptPhotonPolar(G4double Angle) {
@@ -179,8 +165,7 @@ void LaserBeamsTEC1::setOptPhotonPolar(G4double Angle) {
   /* *********************************************************************** */
 
   // first check if we have an optical photon
-  if (theParticleGun->GetParticleDefinition()->GetParticleName() !=
-      "opticalphoton") {
+  if (theParticleGun->GetParticleDefinition()->GetParticleName() != "opticalphoton") {
     edm::LogWarning("SimLaserAlignment:LaserBeamsTEC1")
         << "<LaserBeamsTEC1::SetOptPhotonPolar()>: WARNING! The ParticleGun is "
            "not an optical photon";

--- a/Alignment/LaserAlignmentSimulation/src/LaserBeamsTEC2.cc
+++ b/Alignment/LaserAlignmentSimulation/src/LaserBeamsTEC2.cc
@@ -16,10 +16,9 @@
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include "G4ParticleDefinition.hh"
 #include "G4ParticleGun.hh"
-#include "globals.hh" // Global Constants and typedefs
+#include "globals.hh"  // Global Constants and typedefs
 
-LaserBeamsTEC2::LaserBeamsTEC2()
-    : theParticleGun(nullptr), theDRand48Engine(nullptr) {
+LaserBeamsTEC2::LaserBeamsTEC2() : theParticleGun(nullptr), theDRand48Engine(nullptr) {
   G4int nPhotonsGun = 1;
   G4int nPhotonsBeam = 1;
   G4double Energy = 1.15 * eV;
@@ -27,10 +26,8 @@ LaserBeamsTEC2::LaserBeamsTEC2()
   LaserBeamsTEC2(nPhotonsGun, nPhotonsBeam, Energy);
 }
 
-LaserBeamsTEC2::LaserBeamsTEC2(G4int nPhotonsInGun, G4int nPhotonsInBeam,
-                               G4double PhotonEnergy)
-    : thenParticleInGun(0), thenParticle(0), thePhotonEnergy(0),
-      theParticleGun(), theDRand48Engine() {
+LaserBeamsTEC2::LaserBeamsTEC2(G4int nPhotonsInGun, G4int nPhotonsInBeam, G4double PhotonEnergy)
+    : thenParticleInGun(0), thenParticle(0), thePhotonEnergy(0), theParticleGun(), theDRand48Engine() {
   /* *********************************************************************** */
   /*  initialize and configure the particle gun                              */
   /* *********************************************************************** */
@@ -52,13 +49,11 @@ LaserBeamsTEC2::LaserBeamsTEC2(G4int nPhotonsInGun, G4int nPhotonsInBeam,
 
   // default kinematics
   G4ParticleTable *theParticleTable = G4ParticleTable::GetParticleTable();
-  G4ParticleDefinition *theOpticalPhoton =
-      theParticleTable->FindParticle("opticalphoton");
+  G4ParticleDefinition *theOpticalPhoton = theParticleTable->FindParticle("opticalphoton");
 
   theParticleGun->SetParticleDefinition(theOpticalPhoton);
   theParticleGun->SetParticleTime(0.0 * ns);
-  theParticleGun->SetParticlePosition(
-      G4ThreeVector(-500.0 * cm, 0.0 * cm, 0.0 * cm));
+  theParticleGun->SetParticlePosition(G4ThreeVector(-500.0 * cm, 0.0 * cm, 0.0 * cm));
   theParticleGun->SetParticleMomentumDirection(G4ThreeVector(5.0, 3.0, 0.0));
   theParticleGun->SetParticleEnergy(10.0 * keV);
   setOptPhotonPolar(90.0);
@@ -107,8 +102,7 @@ void LaserBeamsTEC2::GeneratePrimaries(G4Event *myEvent) {
 
   // get the definition of the optical photon
   G4ParticleTable *theParticleTable = G4ParticleTable::GetParticleTable();
-  G4ParticleDefinition *theOpticalPhoton =
-      theParticleTable->FindParticle("opticalphoton");
+  G4ParticleDefinition *theOpticalPhoton = theParticleTable->FindParticle("opticalphoton");
 
   // loop over the LaserRings
   for (int theRing = 0; theRing < nLaserRings; theRing++) {
@@ -116,23 +110,17 @@ void LaserBeamsTEC2::GeneratePrimaries(G4Event *myEvent) {
     for (int theBeam = 0; theBeam < nLaserBeams; theBeam++) {
       // code for forward and backward beam
       // calculate the right phi for the current beam
-      G4double LaserPositionPhi =
-          LaserPhi0 +
-          G4double(theBeam * G4double(G4double(2 * M_PI) / nLaserBeams));
+      G4double LaserPositionPhi = LaserPhi0 + G4double(theBeam * G4double(G4double(2 * M_PI) / nLaserBeams));
 
       // calculate x and y position for the current beam
-      G4double LaserPositionX =
-          cos(LaserPositionPhi) * LaserRingRadius[theRing];
-      G4double LaserPositionY =
-          sin(LaserPositionPhi) * LaserRingRadius[theRing];
+      G4double LaserPositionX = cos(LaserPositionPhi) * LaserRingRadius[theRing];
+      G4double LaserPositionY = sin(LaserPositionPhi) * LaserRingRadius[theRing];
 
       // loop over all the particles in one beam
       for (int theParticle = 0; theParticle < thenParticle; theParticle++) {
         // get randomnumbers  and calculate the position
-        CLHEP::RandGaussQ aGaussObjX(*theDRand48Engine, LaserPositionX,
-                                     LaserRingSigmaX[theRing]);
-        CLHEP::RandGaussQ aGaussObjY(*theDRand48Engine, LaserPositionY,
-                                     LaserRingSigmaY[theRing]);
+        CLHEP::RandGaussQ aGaussObjX(*theDRand48Engine, LaserPositionX, LaserRingSigmaX[theRing]);
+        CLHEP::RandGaussQ aGaussObjY(*theDRand48Engine, LaserPositionY, LaserRingSigmaY[theRing]);
 
         G4double theXPosition = aGaussObjX.fire();
         G4double theYPosition = aGaussObjY.fire();
@@ -141,36 +129,33 @@ void LaserBeamsTEC2::GeneratePrimaries(G4Event *myEvent) {
         // set the properties of the newly created particle
         theParticleGun->SetParticleDefinition(theOpticalPhoton);
         theParticleGun->SetParticleTime(0.0 * ns);
-        theParticleGun->SetParticlePosition(
-            G4ThreeVector(theXPosition, theYPosition, theZPosition));
+        theParticleGun->SetParticlePosition(G4ThreeVector(theXPosition, theYPosition, theZPosition));
         theParticleGun->SetParticleEnergy(thePhotonEnergy);
 
         // loop over both directions of the beam
         for (int theDirection = 0; theDirection < 2; theDirection++) {
           // shoot in both beam directions ...
-          if (theDirection == 0) // shoot in forward direction (+z)
+          if (theDirection == 0)  // shoot in forward direction (+z)
           {
-            theParticleGun->SetParticleMomentumDirection(
-                G4ThreeVector(0.0, 0.0, 1.0));
+            theParticleGun->SetParticleMomentumDirection(G4ThreeVector(0.0, 0.0, 1.0));
             // set the polarization
             setOptPhotonPolar(90.0);
             // generate the particle
             theParticleGun->GeneratePrimaryVertex(myEvent);
           }
 
-          if (theDirection == 1) // shoot in backward direction (-z)
+          if (theDirection == 1)  // shoot in backward direction (-z)
           {
-            theParticleGun->SetParticleMomentumDirection(
-                G4ThreeVector(0.0, 0.0, -1.0));
+            theParticleGun->SetParticleMomentumDirection(G4ThreeVector(0.0, 0.0, -1.0));
             // set the polarization
             setOptPhotonPolar(90.0);
             // generate the particle
             theParticleGun->GeneratePrimaryVertex(myEvent);
           }
-        } // end loop over both beam directions
-      }   // end loop over particles in beam
-    }     // end loop over beams
-  }       // end loop over rings
+        }  // end loop over both beam directions
+      }    // end loop over particles in beam
+    }      // end loop over beams
+  }        // end loop over rings
 }
 
 void LaserBeamsTEC2::setOptPhotonPolar(G4double Angle) {
@@ -180,8 +165,7 @@ void LaserBeamsTEC2::setOptPhotonPolar(G4double Angle) {
   /* *********************************************************************** */
 
   // first check if we have an optical photon
-  if (theParticleGun->GetParticleDefinition()->GetParticleName() !=
-      "opticalphoton") {
+  if (theParticleGun->GetParticleDefinition()->GetParticleName() != "opticalphoton") {
     edm::LogWarning("SimLaserAlignment:LaserBeamsTEC2")
         << "<LaserBeamsTEC2::setOptPhotonPolar()>: WARNING! The ParticleGun is "
            "not an optical photon";

--- a/Alignment/LaserAlignmentSimulation/src/LaserOpticalPhysicsList.cc
+++ b/Alignment/LaserAlignmentSimulation/src/LaserOpticalPhysicsList.cc
@@ -19,9 +19,14 @@
 #include "G4Scintillation.hh"
 
 LaserOpticalPhysicsList::LaserOpticalPhysicsList(const G4String &name)
-    : G4VPhysicsConstructor(name), wasActivated(false), theScintProcess(),
-      theCerenkovProcess(), theAbsorptionProcess(), theRayleighScattering(),
-      theBoundaryProcess(), theWLSProcess() {
+    : G4VPhysicsConstructor(name),
+      wasActivated(false),
+      theScintProcess(),
+      theCerenkovProcess(),
+      theAbsorptionProcess(),
+      theRayleighScattering(),
+      theBoundaryProcess(),
+      theWLSProcess() {
   if (verboseLevel > 0)
     std::cout << "<LaserOpticalPhysicsList::LaserOpticalPhysicsList(...)> "
                  "entering constructor ..."

--- a/Alignment/LaserAlignmentSimulation/src/LaserPrimaryGeneratorAction.cc
+++ b/Alignment/LaserAlignmentSimulation/src/LaserPrimaryGeneratorAction.cc
@@ -13,42 +13,38 @@
 
 #include "G4SystemOfUnits.hh"
 
-LaserPrimaryGeneratorAction::LaserPrimaryGeneratorAction(
-    edm::ParameterSet const &theConf)
-    : thePhotonEnergy(0), thenParticleInGun(0), thenParticle(0),
-      theLaserBeamsInTEC1(), theLaserBeamsInTEC2(),
+LaserPrimaryGeneratorAction::LaserPrimaryGeneratorAction(edm::ParameterSet const &theConf)
+    : thePhotonEnergy(0),
+      thenParticleInGun(0),
+      thenParticle(0),
+      theLaserBeamsInTEC1(),
+      theLaserBeamsInTEC2(),
       theLaserBeamsInTECTIBTOBTEC() {
   // {{{ LaserPrimaryGeneratorAction constructor
 
   // get the PhotonEnergy from the parameter set
-  thePhotonEnergy =
-      theConf.getUntrackedParameter<double>("PhotonEnergy", 1.15) * eV;
+  thePhotonEnergy = theConf.getUntrackedParameter<double>("PhotonEnergy", 1.15) * eV;
 
   // number of particles in the Laser beam
-  thenParticleInGun =
-      theConf.getUntrackedParameter<int>("NumberOfPhotonsInParticleGun", 1);
+  thenParticleInGun = theConf.getUntrackedParameter<int>("NumberOfPhotonsInParticleGun", 1);
 
   // number of particles in one beam. ATTENTION: each beam contains
   // nParticleInGun with the same startpoint and direction. nParticle gives the
   // number of particles in the beam with a different startpoint. They are used
   // to simulate the gaussian beamprofile of the Laser Beams.
-  thenParticle =
-      theConf.getUntrackedParameter<int>("NumberOfPhotonsInEachBeam", 1);
+  thenParticle = theConf.getUntrackedParameter<int>("NumberOfPhotonsInEachBeam", 1);
 
   // create a messenger for this class
   //   theGunMessenger = new LaserPrimaryGeneratorMessenger(this);
 
   // create the beams in the right endcap
-  theLaserBeamsInTEC1 =
-      new LaserBeamsTEC1(thenParticleInGun, thenParticle, thePhotonEnergy);
+  theLaserBeamsInTEC1 = new LaserBeamsTEC1(thenParticleInGun, thenParticle, thePhotonEnergy);
 
   // create the beams in the left endcap
-  theLaserBeamsInTEC2 =
-      new LaserBeamsTEC2(thenParticleInGun, thenParticle, thePhotonEnergy);
+  theLaserBeamsInTEC2 = new LaserBeamsTEC2(thenParticleInGun, thenParticle, thePhotonEnergy);
 
   // create the beams to connect the TECs with TOB and TIB
-  theLaserBeamsInTECTIBTOBTEC =
-      new LaserBeamsBarrel(thenParticleInGun, thenParticle, thePhotonEnergy);
+  theLaserBeamsInTECTIBTOBTEC = new LaserBeamsBarrel(thenParticleInGun, thenParticle, thePhotonEnergy);
   // }}}
 }
 
@@ -72,9 +68,8 @@ void LaserPrimaryGeneratorAction::GeneratePrimaries(G4Event *myEvent) {
 
   // this function is called at the beginning of an Event in
   // LaserAlignment::upDate(const BeginOfEvent * myEvent)
-  LogDebug("LaserPrimaryGeneratorAction")
-      << "<LaserPrimaryGeneratorAction::GeneratePrimaries(G4Event*)>: create a "
-         "new Laser Event";
+  LogDebug("LaserPrimaryGeneratorAction") << "<LaserPrimaryGeneratorAction::GeneratePrimaries(G4Event*)>: create a "
+                                             "new Laser Event";
 
   // shoot in the right endcap
   theLaserBeamsInTEC1->GeneratePrimaries(myEvent);
@@ -102,8 +97,7 @@ void LaserPrimaryGeneratorAction::GeneratePrimaries(G4Event *myEvent) {
   // }}}
 }
 
-void LaserPrimaryGeneratorAction::setGeneratorId(G4PrimaryParticle *aParticle,
-                                                 int ID) const {
+void LaserPrimaryGeneratorAction::setGeneratorId(G4PrimaryParticle *aParticle, int ID) const {
   // {{{ SetGeneratorId(G4PrimaryParticle * aParticle, int ID) const
 
   /* *********************************************************************** */

--- a/Alignment/LaserAlignmentSimulation/src/LaserSteppingAction.cc
+++ b/Alignment/LaserAlignmentSimulation/src/LaserSteppingAction.cc
@@ -13,8 +13,7 @@
 
 LaserSteppingAction::LaserSteppingAction(edm::ParameterSet const &theConf)
     : theDebugLevel(theConf.getUntrackedParameter<int>("DebugLevel", 0)),
-      theEnergyLossScalingFactor(theConf.getUntrackedParameter<double>(
-          "EnergyLossScalingFactor", 1.0)) {}
+      theEnergyLossScalingFactor(theConf.getUntrackedParameter<double>("EnergyLossScalingFactor", 1.0)) {}
 
 LaserSteppingAction::~LaserSteppingAction() {}
 
@@ -35,40 +34,29 @@ void LaserSteppingAction::UserSteppingAction(const G4Step *myStep) {
            "AC1CMS: The Track Status = "
         << isGood;
     if (isGood == fStopAndKill)
-      LogDebug("LaserAlignmentSimulationStepping")
-          << "<LaserSteppingAction::UserSteppingAction(const G4Step *)>: "
-             "AC1CMS: Track Status = fStopAndKill ";
+      LogDebug("LaserAlignmentSimulationStepping") << "<LaserSteppingAction::UserSteppingAction(const G4Step *)>: "
+                                                      "AC1CMS: Track Status = fStopAndKill ";
 
     if (theStep->GetPreStepPoint()->GetProcessDefinedStep() != nullptr)
       LogDebug("LaserAlignmentSimulationStepping")
           << "<LaserSteppingAction::UserSteppingAction(const G4Step *)>: "
              "AC1CMS: PreStep Process  = "
-          << theStep->GetPreStepPoint()
-                 ->GetProcessDefinedStep()
-                 ->GetProcessName();
+          << theStep->GetPreStepPoint()->GetProcessDefinedStep()->GetProcessName();
     if (theStep->GetPostStepPoint()->GetProcessDefinedStep() != nullptr)
       LogDebug("LaserAlignmentSimulationStepping")
           << "<LaserSteppingAction::UserSteppingAction(const G4Step *)>: "
              "AC1CMS: PostStep Process = "
-          << theStep->GetPostStepPoint()
-                 ->GetProcessDefinedStep()
-                 ->GetProcessName();
+          << theStep->GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName();
   }
 
   // ***********************************************************************************************************
   // Set the EnergyDeposit if the photon is absorbed by a active sensor
-  if ((theStep->GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName() ==
-       "OpAbsorption")) {
-    LogDebug("LaserAlignmentStepping")
-        << "<LaserSteppingAction::UserSteppingAction(const G4Step*)>: Photon "
-           "was absorbed! ";
+  if ((theStep->GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName() == "OpAbsorption")) {
+    LogDebug("LaserAlignmentStepping") << "<LaserSteppingAction::UserSteppingAction(const G4Step*)>: Photon "
+                                          "was absorbed! ";
 
-    if (theStep->GetPreStepPoint()
-            ->GetPhysicalVolume()
-            ->GetLogicalVolume()
-            ->GetSensitiveDetector()) {
-      double EnergyLoss =
-          theEnergyLossScalingFactor * theTrack->GetTotalEnergy();
+    if (theStep->GetPreStepPoint()->GetPhysicalVolume()->GetLogicalVolume()->GetSensitiveDetector()) {
+      double EnergyLoss = theEnergyLossScalingFactor * theTrack->GetTotalEnergy();
 
       // use different energy deposit for the discs depending on the z-position
       // to simulate the variable laser power Disc 1 TEC2TEC
@@ -80,27 +68,21 @@ void LaserSteppingAction::UserSteppingAction(const G4Step *myStep) {
              theStep->GetPreStepPoint()->GetPosition().phi() < 1.295) ||
             (theStep->GetPreStepPoint()->GetPosition().phi() > 1.84 &&
              theStep->GetPreStepPoint()->GetPosition().phi() < 1.86) ||
-            (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI >
-                 3.63 &&
-             theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI <
-                 3.66) ||
-            (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI >
-                 5.20 &&
-             theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI <
-                 5.23) ||
-            (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI >
-                 5.76 &&
-             theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI <
-                 5.80)))) {
+            (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI > 3.63 &&
+             theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI < 3.66) ||
+            (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI > 5.20 &&
+             theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI < 5.23) ||
+            (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI > 5.76 &&
+             theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI < 5.80)))) {
         theStep->AddTotalEnergyDeposit(EnergyLoss);
-      } // Disc 1 TEC2TEC
+      }  // Disc 1 TEC2TEC
       // Disc 1
       else if ((theStep->GetPreStepPoint()->GetPosition().z() > 1262.5 &&
                 theStep->GetPreStepPoint()->GetPosition().z() < 1382.5) ||
                (theStep->GetPreStepPoint()->GetPosition().z() < -1262.5 &&
                 theStep->GetPreStepPoint()->GetPosition().z() > -1382.5)) {
         theStep->AddTotalEnergyDeposit(EnergyLoss / (0.2 * 0.2 * 0.2 * 0.2));
-      } // Disc 1
+      }  // Disc 1
       // Disc 2 TEC2TEC
       else if (((theStep->GetPreStepPoint()->GetPosition().z() > 1402.5 &&
                  theStep->GetPreStepPoint()->GetPosition().z() < 1522.5) ||
@@ -110,27 +92,21 @@ void LaserSteppingAction::UserSteppingAction(const G4Step *myStep) {
                   theStep->GetPreStepPoint()->GetPosition().phi() < 1.295) ||
                  (theStep->GetPreStepPoint()->GetPosition().phi() > 1.84 &&
                   theStep->GetPreStepPoint()->GetPosition().phi() < 1.86) ||
-                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI >
-                      3.63 &&
-                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI <
-                      3.66) ||
-                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI >
-                      5.20 &&
-                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI <
-                      5.23) ||
-                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI >
-                      5.76 &&
-                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI <
-                      5.80)))) {
+                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI > 3.63 &&
+                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI < 3.66) ||
+                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI > 5.20 &&
+                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI < 5.23) ||
+                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI > 5.76 &&
+                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI < 5.80)))) {
         theStep->AddTotalEnergyDeposit(EnergyLoss / (0.2));
-      } // Disc 2 TEC2TEC
+      }  // Disc 2 TEC2TEC
       // Disc 2
       else if ((theStep->GetPreStepPoint()->GetPosition().z() > 1402.5 &&
                 theStep->GetPreStepPoint()->GetPosition().z() < 1522.5) ||
                (theStep->GetPreStepPoint()->GetPosition().z() < -1402.5 &&
                 theStep->GetPreStepPoint()->GetPosition().z() > -1522.5)) {
         theStep->AddTotalEnergyDeposit(EnergyLoss / (0.2 * 0.2 * 0.2));
-      } // Disc 2
+      }  // Disc 2
       // Disc 3 TEC2TEC
       else if (((theStep->GetPreStepPoint()->GetPosition().z() > 1542.5 &&
                  theStep->GetPreStepPoint()->GetPosition().z() < 1662.5) ||
@@ -140,27 +116,21 @@ void LaserSteppingAction::UserSteppingAction(const G4Step *myStep) {
                   theStep->GetPreStepPoint()->GetPosition().phi() < 1.295) ||
                  (theStep->GetPreStepPoint()->GetPosition().phi() > 1.84 &&
                   theStep->GetPreStepPoint()->GetPosition().phi() < 1.86) ||
-                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI >
-                      3.63 &&
-                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI <
-                      3.66) ||
-                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI >
-                      5.20 &&
-                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI <
-                      5.23) ||
-                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI >
-                      5.76 &&
-                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI <
-                      5.80)))) {
+                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI > 3.63 &&
+                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI < 3.66) ||
+                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI > 5.20 &&
+                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI < 5.23) ||
+                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI > 5.76 &&
+                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI < 5.80)))) {
         theStep->AddTotalEnergyDeposit(EnergyLoss / (0.2 * 0.2));
-      } // Disc 3 TEC2TEC
+      }  // Disc 3 TEC2TEC
       // Disc 3
       else if ((theStep->GetPreStepPoint()->GetPosition().z() > 1542.5 &&
                 theStep->GetPreStepPoint()->GetPosition().z() < 1662.5) ||
                (theStep->GetPreStepPoint()->GetPosition().z() < -1542.5 &&
                 theStep->GetPreStepPoint()->GetPosition().z() > -1662.5)) {
         theStep->AddTotalEnergyDeposit(EnergyLoss / (0.2 * 0.2));
-      } // Disc 3
+      }  // Disc 3
       // Disc 4 TEC2TEC
       else if (((theStep->GetPreStepPoint()->GetPosition().z() > 1682.5 &&
                  theStep->GetPreStepPoint()->GetPosition().z() < 1802.5) ||
@@ -170,27 +140,21 @@ void LaserSteppingAction::UserSteppingAction(const G4Step *myStep) {
                   theStep->GetPreStepPoint()->GetPosition().phi() < 1.295) ||
                  (theStep->GetPreStepPoint()->GetPosition().phi() > 1.84 &&
                   theStep->GetPreStepPoint()->GetPosition().phi() < 1.86) ||
-                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI >
-                      3.63 &&
-                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI <
-                      3.66) ||
-                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI >
-                      5.20 &&
-                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI <
-                      5.23) ||
-                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI >
-                      5.76 &&
-                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI <
-                      5.80)))) {
+                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI > 3.63 &&
+                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI < 3.66) ||
+                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI > 5.20 &&
+                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI < 5.23) ||
+                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI > 5.76 &&
+                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI < 5.80)))) {
         theStep->AddTotalEnergyDeposit(EnergyLoss / (0.2 * 0.2 * 0.2));
-      } // Disc 4 TEC2TEC
+      }  // Disc 4 TEC2TEC
       // Disc 4
       else if ((theStep->GetPreStepPoint()->GetPosition().z() > 1682.5 &&
                 theStep->GetPreStepPoint()->GetPosition().z() < 1802.5) ||
                (theStep->GetPreStepPoint()->GetPosition().z() < -1682.5 &&
                 theStep->GetPreStepPoint()->GetPosition().z() > -1802.5)) {
         theStep->AddTotalEnergyDeposit(EnergyLoss / (0.2));
-      } // Disc 4
+      }  // Disc 4
       // Disc 5 TEC2TEC
       else if (((theStep->GetPreStepPoint()->GetPosition().z() > 1822.5 &&
                  theStep->GetPreStepPoint()->GetPosition().z() < 1942.5) ||
@@ -200,62 +164,56 @@ void LaserSteppingAction::UserSteppingAction(const G4Step *myStep) {
                   theStep->GetPreStepPoint()->GetPosition().phi() < 1.295) ||
                  (theStep->GetPreStepPoint()->GetPosition().phi() > 1.84 &&
                   theStep->GetPreStepPoint()->GetPosition().phi() < 1.86) ||
-                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI >
-                      3.63 &&
-                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI <
-                      3.66) ||
-                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI >
-                      5.20 &&
-                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI <
-                      5.23) ||
-                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI >
-                      5.76 &&
-                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI <
-                      5.80)))) {
+                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI > 3.63 &&
+                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI < 3.66) ||
+                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI > 5.20 &&
+                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI < 5.23) ||
+                 (theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI > 5.76 &&
+                  theStep->GetPreStepPoint()->GetPosition().phi() + 2.0 * M_PI < 5.80)))) {
         theStep->AddTotalEnergyDeposit(EnergyLoss / (0.2 * 0.2 * 0.2 * 0.2));
-      } // Disc 5 TEC2TEC
+      }  // Disc 5 TEC2TEC
       // Disc 5
       else if ((theStep->GetPreStepPoint()->GetPosition().z() > 1822.5 &&
                 theStep->GetPreStepPoint()->GetPosition().z() < 1942.5) ||
                (theStep->GetPreStepPoint()->GetPosition().z() < -1822.5 &&
                 theStep->GetPreStepPoint()->GetPosition().z() > -1942.5)) {
         theStep->AddTotalEnergyDeposit(EnergyLoss);
-      } // Disc 5
+      }  // Disc 5
       // Disc 6
       else if ((theStep->GetPreStepPoint()->GetPosition().z() > 1997.5 &&
                 theStep->GetPreStepPoint()->GetPosition().z() < 2117.5) ||
                (theStep->GetPreStepPoint()->GetPosition().z() < -1997.5 &&
                 theStep->GetPreStepPoint()->GetPosition().z() > -2117.5)) {
         theStep->AddTotalEnergyDeposit(EnergyLoss);
-      } // Disc 6
+      }  // Disc 6
       // Disc 7
       else if ((theStep->GetPreStepPoint()->GetPosition().z() > 2187.5 &&
                 theStep->GetPreStepPoint()->GetPosition().z() < 2307.5) ||
                (theStep->GetPreStepPoint()->GetPosition().z() < -2187.5 &&
                 theStep->GetPreStepPoint()->GetPosition().z() > -2307.5)) {
         theStep->AddTotalEnergyDeposit(EnergyLoss / (0.2));
-      } // Disc 7
+      }  // Disc 7
       // Disc 8
       else if ((theStep->GetPreStepPoint()->GetPosition().z() > 2392.5 &&
                 theStep->GetPreStepPoint()->GetPosition().z() < 2512.5) ||
                (theStep->GetPreStepPoint()->GetPosition().z() < -2392.5 &&
                 theStep->GetPreStepPoint()->GetPosition().z() > -2512.5)) {
         theStep->AddTotalEnergyDeposit(EnergyLoss / (0.2 * 0.2));
-      } // Disc 8
+      }  // Disc 8
       // Disc 9
       else if ((theStep->GetPreStepPoint()->GetPosition().z() > 2607.5 &&
                 theStep->GetPreStepPoint()->GetPosition().z() < 2727.5) ||
                (theStep->GetPreStepPoint()->GetPosition().z() < -2607.5 &&
                 theStep->GetPreStepPoint()->GetPosition().z() > -2727.5)) {
         theStep->AddTotalEnergyDeposit(EnergyLoss / (0.2 * 0.2 * 0.2));
-      } // Disc 9
+      }  // Disc 9
       // Beams in Barrel
       else if ((theStep->GetPreStepPoint()->GetPosition().z() > -870.0 &&
                 theStep->GetPreStepPoint()->GetPosition().z() < 1050.0) &&
                (theStep->GetPreStepPoint()->GetPosition().perp() > 500.0 &&
                 theStep->GetPreStepPoint()->GetPosition().perp() < 630.0)) {
         theStep->AddTotalEnergyDeposit(EnergyLoss / (0.2 * 0.2));
-      } // Beams in the Barrel
+      }  // Beams in the Barrel
       else {
         // apparently we are not in a detector which should be hit by a
         // LaserBeam therefore set the EnergyDeposit to zero and do not create a
@@ -270,50 +228,38 @@ void LaserSteppingAction::UserSteppingAction(const G4Step *myStep) {
   // TOB. In the current geometry this Aluminium layer is not included. This
   // should also avoid unwanted reflections (which then create hits in the TIB
   // at the wrong positions)
-  else if (((theStep->GetPreStepPoint()->GetMaterial()->GetName() ==
-             "TOB_Wafer") &&
+  else if (((theStep->GetPreStepPoint()->GetMaterial()->GetName() == "TOB_Wafer") &&
             (theStep->GetPostStepPoint()->GetMaterial()->GetName() == "Air"))) {
-    LogDebug("LaserAlignmentSimulationStepping")
-        << " AC1CMS: stepping aborted! ";
+    LogDebug("LaserAlignmentSimulationStepping") << " AC1CMS: stepping aborted! ";
     theTrack->SetTrackStatus(fStopAndKill);
   } else if ((theStep->GetPreStepPoint()->GetPosition().z() > -870.0 &&
               theStep->GetPreStepPoint()->GetPosition().z() < 1050.0) &&
              (theStep->GetPreStepPoint()->GetPosition().perp() > 630.0)) {
-    LogDebug("LaserAlignmentSimulationStepping")
-        << " AC1CMS: stepping aborted! ";
+    LogDebug("LaserAlignmentSimulationStepping") << " AC1CMS: stepping aborted! ";
     theTrack->SetTrackStatus(fStopAndKill);
   }
   // do the same for photons that a) go through a module in the inner barrel
   // detector or b) are reflected at the surface of a TIB module. The photons in
   // case b) can create hits in the TOB at the wrong z positions :-(
-  else if (((theStep->GetPreStepPoint()->GetMaterial()->GetName() ==
-             "TIB_Wafer") &&
+  else if (((theStep->GetPreStepPoint()->GetMaterial()->GetName() == "TIB_Wafer") &&
             (theStep->GetPostStepPoint()->GetMaterial()->GetName() == "Air"))) {
-    LogDebug("LaserAlignmentSimulationStepping")
-        << " AC1CMS: stepping aborted! ";
+    LogDebug("LaserAlignmentSimulationStepping") << " AC1CMS: stepping aborted! ";
     theTrack->SetTrackStatus(fStopAndKill);
   } else if ((theStep->GetPreStepPoint()->GetPosition().z() > -870.0 &&
               theStep->GetPreStepPoint()->GetPosition().z() < 1050.0) &&
              (theStep->GetPreStepPoint()->GetPosition().perp() < 500.0)) {
-    LogDebug("LaserAlignmentSimulationStepping")
-        << " AC1CMS: stepping aborted! ";
+    LogDebug("LaserAlignmentSimulationStepping") << " AC1CMS: stepping aborted! ";
     theTrack->SetTrackStatus(fStopAndKill);
   }
   // avoid reflections at Disc 1 of TEC- which enter again the Barrel Volume.
   // These Photons create hits at the wrong positions in TIB and TOB
-  else if ((((theStep->GetPreStepPoint()->GetMaterial()->GetName() ==
-              "TEC_Wafer") &&
-             (theStep->GetPostStepPoint()->GetMaterial()->GetName() ==
-              "T_Air")) ||
-            ((theStep->GetPreStepPoint()->GetMaterial()->GetName() ==
-              "TEC_Wafer") &&
-             (theStep->GetPostStepPoint()->GetMaterial()->GetName() ==
-              "Air"))) &&
-           (theStep->GetPreStepPoint()->GetMomentum().z() !=
-            theStep->GetPostStepPoint()->GetMomentum().z()) &&
+  else if ((((theStep->GetPreStepPoint()->GetMaterial()->GetName() == "TEC_Wafer") &&
+             (theStep->GetPostStepPoint()->GetMaterial()->GetName() == "T_Air")) ||
+            ((theStep->GetPreStepPoint()->GetMaterial()->GetName() == "TEC_Wafer") &&
+             (theStep->GetPostStepPoint()->GetMaterial()->GetName() == "Air"))) &&
+           (theStep->GetPreStepPoint()->GetMomentum().z() != theStep->GetPostStepPoint()->GetMomentum().z()) &&
            (theStep->GetPostStepPoint()->GetPosition().z() == -1137.25)) {
-    LogDebug("LaserAlignmentSimulationStepping")
-        << " AC1CMS: stepping aborted! photon in wrong direction";
+    LogDebug("LaserAlignmentSimulationStepping") << " AC1CMS: stepping aborted! photon in wrong direction";
     theTrack->SetTrackStatus(fStopAndKill);
   }
   // kill photons in the barrel which go in the wrong (i.e. +z) direction; they
@@ -321,28 +267,24 @@ void LaserSteppingAction::UserSteppingAction(const G4Step *myStep) {
   else if ((theStep->GetPostStepPoint()->GetPosition().z() > -1100.0) &&
            (theStep->GetPostStepPoint()->GetPosition().z() < 1100.0) &&
            (theStep->GetPostStepPoint()->GetMomentumDirection().z() > 0.8)) {
-    LogDebug("LaserAlignmentSimulationStepping")
-        << " AC1CMS: stepping aborted! photon in wrong direction";
+    LogDebug("LaserAlignmentSimulationStepping") << " AC1CMS: stepping aborted! photon in wrong direction";
     theTrack->SetTrackStatus(fStopAndKill);
   } else {
-    LogDebug("LaserAlignmentSimulationStepping")
-        << " AC1CMS: stepping continuous ... ";
+    LogDebug("LaserAlignmentSimulationStepping") << " AC1CMS: stepping continuous ... ";
   }
   // ***********************************************************************************************************
 
   // check if it is alive
   if (theTrack->GetTrackStatus() != fAlive) {
-    LogDebug("LaserAlignmentSimulationStepping")
-        << "<LaserSteppingAction::UserSteppingAction(const G4Step *)>: Track "
-           "is not alive! -> return ";
+    LogDebug("LaserAlignmentSimulationStepping") << "<LaserSteppingAction::UserSteppingAction(const G4Step *)>: Track "
+                                                    "is not alive! -> return ";
     return;
   }
 
   // check if it is a primary
   if (theTrack->GetParentID() != 0) {
-    LogDebug("LaserAlignmentSimulationStepping")
-        << "<LaserSteppingAction::UserSteppingAction(const G4Step *)>: Track "
-           "is not a primary! -> return ";
+    LogDebug("LaserAlignmentSimulationStepping") << "<LaserSteppingAction::UserSteppingAction(const G4Step *)>: Track "
+                                                    "is not a primary! -> return ";
     return;
   }
 
@@ -350,47 +292,41 @@ void LaserSteppingAction::UserSteppingAction(const G4Step *myStep) {
   if (theDebugLevel >= 4) {
     G4ParticleDefinition *theOpticalType = theTrack->GetDefinition();
     if (theOpticalType == G4OpticalPhoton::OpticalPhotonDefinition()) {
-      LogDebug("LaserAlignmentSimulationStepping")
-          << "<LaserSteppingAction::UserSteppingAction(const G4Step *)>: "
-             "Optical Photon found! ";
+      LogDebug("LaserAlignmentSimulationStepping") << "<LaserSteppingAction::UserSteppingAction(const G4Step *)>: "
+                                                      "Optical Photon found! ";
     }
 
     // check in which volume it is
 #ifdef EDM_ML_DEBUG
     G4StepPoint *thePreStepPoint = theStep->GetPreStepPoint();
-    G4VPhysicalVolume *thePreStepPhysicalVolume =
-        thePreStepPoint->GetPhysicalVolume();
+    G4VPhysicalVolume *thePreStepPhysicalVolume = thePreStepPoint->GetPhysicalVolume();
     G4String thePreStepPhysicalVolumeName = thePreStepPhysicalVolume->GetName();
     G4Material *thePreStepMaterial = thePreStepPoint->GetMaterial();
 
-    LogDebug("LaserAlignmentSimulationStepping")
-        << "<LaserSteppingAction::UserSteppingAction(const G4Step *)>: the "
-           "PreStep Position = "
-        << thePreStepPoint->GetPosition()
-        << "\n<LaserSteppingAction::UserSteppingAction(const G4Step *)>: the "
-           "PreStep Physical Volume = "
-        << thePreStepPhysicalVolumeName
-        << "\n<LaserSteppingAction::UserSteppingAction(const G4Step *)>: the "
-           "PreStep Material ="
-        << thePreStepMaterial->GetName();
+    LogDebug("LaserAlignmentSimulationStepping") << "<LaserSteppingAction::UserSteppingAction(const G4Step *)>: the "
+                                                    "PreStep Position = "
+                                                 << thePreStepPoint->GetPosition()
+                                                 << "\n<LaserSteppingAction::UserSteppingAction(const G4Step *)>: the "
+                                                    "PreStep Physical Volume = "
+                                                 << thePreStepPhysicalVolumeName
+                                                 << "\n<LaserSteppingAction::UserSteppingAction(const G4Step *)>: the "
+                                                    "PreStep Material ="
+                                                 << thePreStepMaterial->GetName();
 
     G4StepPoint *thePostStepPoint = theStep->GetPostStepPoint();
-    G4VPhysicalVolume *thePostStepPhysicalVolume =
-        thePostStepPoint->GetPhysicalVolume();
-    G4String thePostStepPhysicalVolumeName =
-        thePostStepPhysicalVolume->GetName();
+    G4VPhysicalVolume *thePostStepPhysicalVolume = thePostStepPoint->GetPhysicalVolume();
+    G4String thePostStepPhysicalVolumeName = thePostStepPhysicalVolume->GetName();
     G4Material *thePostStepMaterial = thePostStepPoint->GetMaterial();
 
-    LogDebug("LaserAlignmentSimulationStepping")
-        << "<LaserSteppingAction::UserSteppingAction(const G4Step *)>: the "
-           "PostStep Position = "
-        << thePostStepPoint->GetPosition()
-        << "\n<LaserSteppingAction::UserSteppingAction(const G4Step *)>: the "
-           "PostStep Physical Volume = "
-        << thePostStepPhysicalVolumeName
-        << "\n<LaserSteppingAction::UserSteppingAction(const G4Step *)>: the "
-           "PostStep Material = "
-        << thePostStepMaterial->GetName();
+    LogDebug("LaserAlignmentSimulationStepping") << "<LaserSteppingAction::UserSteppingAction(const G4Step *)>: the "
+                                                    "PostStep Position = "
+                                                 << thePostStepPoint->GetPosition()
+                                                 << "\n<LaserSteppingAction::UserSteppingAction(const G4Step *)>: the "
+                                                    "PostStep Physical Volume = "
+                                                 << thePostStepPhysicalVolumeName
+                                                 << "\n<LaserSteppingAction::UserSteppingAction(const G4Step *)>: the "
+                                                    "PostStep Material = "
+                                                 << thePostStepMaterial->GetName();
 #endif
   }
 }

--- a/Alignment/LaserAlignmentSimulation/src/LaserSteppingVerbose.cc
+++ b/Alignment/LaserAlignmentSimulation/src/LaserSteppingVerbose.cc
@@ -37,16 +37,14 @@ void LaserSteppingVerbose::StepInfo() {
              << " " << std::setw(10) << "Volume"
              << " " << std::setw(10) << "Process" << G4endl;
 
-      G4cout << std::setw(5) << fTrack->GetCurrentStepNumber() << " "
-             << std::setw(6) << G4BestUnit(fTrack->GetPosition().x(), "Length")
-             << std::setw(6) << G4BestUnit(fTrack->GetPosition().y(), "Length")
-             << std::setw(6) << G4BestUnit(fTrack->GetPosition().z(), "Length")
-             << std::setw(6) << G4BestUnit(fTrack->GetKineticEnergy(), "Energy")
-             << std::setw(6)
-             << G4BestUnit(fStep->GetTotalEnergyDeposit(), "Energy")
-             << std::setw(6) << G4BestUnit(fStep->GetStepLength(), "Length")
-             << std::setw(6) << G4BestUnit(fTrack->GetTrackLength(), "Length")
-             << " ";
+      G4cout << std::setw(5) << fTrack->GetCurrentStepNumber() << " " << std::setw(6)
+             << G4BestUnit(fTrack->GetPosition().x(), "Length") << std::setw(6)
+             << G4BestUnit(fTrack->GetPosition().y(), "Length") << std::setw(6)
+             << G4BestUnit(fTrack->GetPosition().z(), "Length") << std::setw(6)
+             << G4BestUnit(fTrack->GetKineticEnergy(), "Energy") << std::setw(6)
+             << G4BestUnit(fStep->GetTotalEnergyDeposit(), "Energy") << std::setw(6)
+             << G4BestUnit(fStep->GetStepLength(), "Length") << std::setw(6)
+             << G4BestUnit(fTrack->GetTrackLength(), "Length") << " ";
 
       if (fTrack->GetNextVolume() != nullptr) {
         G4cout << std::setw(10) << fTrack->GetVolume()->GetName();
@@ -55,10 +53,7 @@ void LaserSteppingVerbose::StepInfo() {
       }
 
       if (fStep->GetPostStepPoint()->GetProcessDefinedStep() != nullptr) {
-        G4cout << " " << std::setw(10)
-               << fStep->GetPostStepPoint()
-                      ->GetProcessDefinedStep()
-                      ->GetProcessName();
+        G4cout << " " << std::setw(10) << fStep->GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName();
       } else {
         G4cout << "    UserLimit";
       }
@@ -67,40 +62,27 @@ void LaserSteppingVerbose::StepInfo() {
 
       if (verboseLevel == 2) {
         // total number of secondaries
-        G4int tN2ndariesTot = fN2ndariesAtRestDoIt + fN2ndariesAlongStepDoIt +
-                              fN2ndariesPostStepDoIt;
+        G4int tN2ndariesTot = fN2ndariesAtRestDoIt + fN2ndariesAlongStepDoIt + fN2ndariesPostStepDoIt;
 
         if (tN2ndariesTot > 0) {
           G4cout << "   :---- List of Secondaries - "
-                 << "#SpawnInStep = " << std::setw(3) << tN2ndariesTot
-                 << "(Rest = " << std::setw(2) << fN2ndariesAtRestDoIt
-                 << ", Along = " << std::setw(2) << fN2ndariesAlongStepDoIt
-                 << ", Post = " << std::setw(2) << fN2ndariesPostStepDoIt
-                 << "), "
-                 << "#SpawnTotal = " << std::setw(3) << (*fSecondary).size()
-                 << " --------- " << G4endl;
+                 << "#SpawnInStep = " << std::setw(3) << tN2ndariesTot << "(Rest = " << std::setw(2)
+                 << fN2ndariesAtRestDoIt << ", Along = " << std::setw(2) << fN2ndariesAlongStepDoIt
+                 << ", Post = " << std::setw(2) << fN2ndariesPostStepDoIt << "), "
+                 << "#SpawnTotal = " << std::setw(3) << (*fSecondary).size() << " --------- " << G4endl;
 
-          for (size_t lp1 = (*fSecondary).size() - tN2ndariesTot;
-               lp1 < (*fSecondary).size(); lp1++) {
-            G4cout
-                << "   : " << std::setw(6)
-                << G4BestUnit((*fSecondary)[lp1]->GetPosition().x(), "Length")
-                << std::setw(6)
-                << G4BestUnit((*fSecondary)[lp1]->GetPosition().y(), "Length")
-                << std::setw(6)
-                << G4BestUnit((*fSecondary)[lp1]->GetPosition().z(), "Length")
-                << std::setw(6)
-                << G4BestUnit((*fSecondary)[lp1]->GetKineticEnergy(), "Energy")
-                << std::setw(10)
-                << (*fSecondary)[lp1]->GetDefinition()->GetParticleName();
+          for (size_t lp1 = (*fSecondary).size() - tN2ndariesTot; lp1 < (*fSecondary).size(); lp1++) {
+            G4cout << "   : " << std::setw(6) << G4BestUnit((*fSecondary)[lp1]->GetPosition().x(), "Length")
+                   << std::setw(6) << G4BestUnit((*fSecondary)[lp1]->GetPosition().y(), "Length") << std::setw(6)
+                   << G4BestUnit((*fSecondary)[lp1]->GetPosition().z(), "Length") << std::setw(6)
+                   << G4BestUnit((*fSecondary)[lp1]->GetKineticEnergy(), "Energy") << std::setw(10)
+                   << (*fSecondary)[lp1]->GetDefinition()->GetParticleName();
             G4cout << G4endl;
           }
 
-          G4cout
-              << "   :----------------------"
-              << "--------------------------"
-              << "-- End of Secondaries Info --------------------------------- "
-              << G4endl;
+          G4cout << "   :----------------------"
+                 << "--------------------------"
+                 << "-- End of Secondaries Info --------------------------------- " << G4endl;
         }
       }
     }
@@ -124,16 +106,14 @@ void LaserSteppingVerbose::TrackingStarted() {
            << " " << std::setw(10) << "Volume"
            << "  " << std::setw(10) << "Process " << G4endl;
 
-    G4cout << std::setw(5) << fTrack->GetCurrentStepNumber() << " "
-           << std::setw(6) << G4BestUnit(fTrack->GetPosition().x(), "Length")
-           << std::setw(6) << G4BestUnit(fTrack->GetPosition().y(), "Length")
-           << std::setw(6) << G4BestUnit(fTrack->GetPosition().z(), "Length")
-           << std::setw(6) << G4BestUnit(fTrack->GetKineticEnergy(), "Energy")
-           << std::setw(6)
-           << G4BestUnit(fStep->GetTotalEnergyDeposit(), "Energy")
-           << std::setw(6) << G4BestUnit(fStep->GetStepLength(), "Length")
-           << std::setw(6) << G4BestUnit(fTrack->GetTrackLength(), "Length")
-           << "   ";
+    G4cout << std::setw(5) << fTrack->GetCurrentStepNumber() << " " << std::setw(6)
+           << G4BestUnit(fTrack->GetPosition().x(), "Length") << std::setw(6)
+           << G4BestUnit(fTrack->GetPosition().y(), "Length") << std::setw(6)
+           << G4BestUnit(fTrack->GetPosition().z(), "Length") << std::setw(6)
+           << G4BestUnit(fTrack->GetKineticEnergy(), "Energy") << std::setw(6)
+           << G4BestUnit(fStep->GetTotalEnergyDeposit(), "Energy") << std::setw(6)
+           << G4BestUnit(fStep->GetStepLength(), "Length") << std::setw(6)
+           << G4BestUnit(fTrack->GetTrackLength(), "Length") << "   ";
 
     if (fTrack->GetNextVolume() != nullptr) {
       G4cout << std::setw(10) << fTrack->GetVolume()->GetName();

--- a/Alignment/LaserAlignmentSimulation/src/MaterialProperties.cc
+++ b/Alignment/LaserAlignmentSimulation/src/MaterialProperties.cc
@@ -14,8 +14,13 @@
 #include "G4SystemOfUnits.hh"
 
 MaterialProperties::MaterialProperties(int DebugLevel, double SiAbsLengthScale)
-    : theMaterialTable(), theMPDebugLevel(0), theSiAbsLengthScalingFactor(0),
-      theMPT(), theTECWafer(), theTOBWafer(), theTIBWafer() {
+    : theMaterialTable(),
+      theMPDebugLevel(0),
+      theSiAbsLengthScalingFactor(0),
+      theMPT(),
+      theTECWafer(),
+      theTOBWafer(),
+      theTIBWafer() {
   theMPDebugLevel = DebugLevel;
   theSiAbsLengthScalingFactor = SiAbsLengthScale;
   /* *********************************************************************** */
@@ -30,12 +35,9 @@ MaterialProperties::MaterialProperties(int DebugLevel, double SiAbsLengthScale)
   G4double theAtomicWeight = 28.09 * g / mole;
   G4double theAtomicNumber = 14.0;
 
-  theTECWafer =
-      new G4Material("TEC_Wafer", theAtomicNumber, theAtomicWeight, theDensity);
-  theTOBWafer =
-      new G4Material("TOB_Wafer", theAtomicNumber, theAtomicWeight, theDensity);
-  theTIBWafer =
-      new G4Material("TIB_Wafer", theAtomicNumber, theAtomicWeight, theDensity);
+  theTECWafer = new G4Material("TEC_Wafer", theAtomicNumber, theAtomicWeight, theDensity);
+  theTOBWafer = new G4Material("TOB_Wafer", theAtomicNumber, theAtomicWeight, theDensity);
+  theTIBWafer = new G4Material("TIB_Wafer", theAtomicNumber, theAtomicWeight, theDensity);
 
   // set the properties of the materials
   setMaterialProperties();
@@ -81,8 +83,7 @@ void MaterialProperties::setMaterialProperties() {
   //     {
   // print the materialtable
   LogDebug("SimLaserAlignment:MaterialProperties")
-      << " **** here comes the material table **** "
-      << *(G4Material::GetMaterialTable());
+      << " **** here comes the material table **** " << *(G4Material::GetMaterialTable());
   //     }
 
   // define the MateriapropertiesTable for the Sensitive Regions in the Tracker
@@ -111,22 +112,18 @@ void MaterialProperties::setMaterialProperties() {
   // Absorption Length
   // G4double AbsorptionLengthSi[nEntries] = { 198.8 * micrometer, 198.8 *
   // micrometer, 198.8 * micrometer }; ///////////////////////////////////
-  G4double AbsorptionLengthSi[nEntries] = {1136 * micrometer, 1136 * micrometer,
-                                           1136 * micrometer};
+  G4double AbsorptionLengthSi[nEntries] = {1136 * micrometer, 1136 * micrometer, 1136 * micrometer};
 
-  G4double AbsorptionLengthSiBarrel[nEntries] = {0.1 * fermi, 0.1 * fermi,
-                                                 0.1 * fermi};
+  G4double AbsorptionLengthSiBarrel[nEntries] = {0.1 * fermi, 0.1 * fermi, 0.1 * fermi};
 
   // Absorption length of the mirrors
-  G4double AbsorptionLengthMirror[nEntries] = {11.7 * cm, 0.5 * 11.7 * cm,
-                                               11.7 * cm};
+  G4double AbsorptionLengthMirror[nEntries] = {11.7 * cm, 0.5 * 11.7 * cm, 11.7 * cm};
 
   // Absorption Length for dead material in the tracker; set to small values
   // to kill the optical photons outside the TEC. Maybe this is later a problem
   // when implementing Ray 1 to connect both TECs which eachother and with TIB
   // and TOB!??
-  G4double AbsorptionLengthDead[nEntries] = {
-      0.001 * micrometer, 0.001 * micrometer, 0.001 * micrometer};
+  G4double AbsorptionLengthDead[nEntries] = {0.001 * micrometer, 0.001 * micrometer, 0.001 * micrometer};
 
   // Absorption Length of the other Materials in the Tracker
   G4double AbsorptionLengthGeneral[nEntries] = {75 * cm, 75 * cm, 75 * cm};
@@ -162,8 +159,8 @@ void MaterialProperties::setMaterialProperties() {
 
   // set the options for the materials
   {
-    for (G4MaterialTable::const_iterator theMTEntry = theMaterialTable->begin();
-         theMTEntry != theMaterialTable->end(); theMTEntry++) {
+    for (G4MaterialTable::const_iterator theMTEntry = theMaterialTable->begin(); theMTEntry != theMaterialTable->end();
+         theMTEntry++) {
       if (*theMTEntry) {
         G4Material *theMaterial = const_cast<G4Material *>(*theMTEntry);
 
@@ -175,16 +172,11 @@ void MaterialProperties::setMaterialProperties() {
 
         // properties of the TEC_Wafer
         if (theMaterial->GetName() == "TEC_Wafer") {
-          theMPT->AddProperty("FASTCOMPONENT", PhotonEnergy, Scintillation,
-                              nEntries);
-          theMPT->AddProperty("SLOWCOMPONENT", PhotonEnergy, Scintillation,
-                              nEntries);
-          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndex,
-                              nEntries);
-          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthSi,
-                              nEntries);
-          theMPT->AddProperty("EFFICIENCY", PhotonEnergy, TECEfficiency,
-                              nEntries);
+          theMPT->AddProperty("FASTCOMPONENT", PhotonEnergy, Scintillation, nEntries);
+          theMPT->AddProperty("SLOWCOMPONENT", PhotonEnergy, Scintillation, nEntries);
+          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndex, nEntries);
+          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthSi, nEntries);
+          theMPT->AddProperty("EFFICIENCY", PhotonEnergy, TECEfficiency, nEntries);
 
           theMPT->AddConstProperty("SCINTILLATIONYIELD", 12000.0 / MeV);
           theMPT->AddConstProperty("RESOLTUIONSCALE", 1.0);
@@ -198,16 +190,11 @@ void MaterialProperties::setMaterialProperties() {
 
         // properties of Silicon (used as Module Material in CMSSW)
         else if (theMaterial->GetName() == "Silicon") {
-          theMPT->AddProperty("FASTCOMPONENT", PhotonEnergy, Scintillation,
-                              nEntries);
-          theMPT->AddProperty("SLOWCOMPONENT", PhotonEnergy, Scintillation,
-                              nEntries);
-          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndex,
-                              nEntries);
-          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthSi,
-                              nEntries);
-          theMPT->AddProperty("EFFICIENCY", PhotonEnergy, TECEfficiency,
-                              nEntries);
+          theMPT->AddProperty("FASTCOMPONENT", PhotonEnergy, Scintillation, nEntries);
+          theMPT->AddProperty("SLOWCOMPONENT", PhotonEnergy, Scintillation, nEntries);
+          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndex, nEntries);
+          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthSi, nEntries);
+          theMPT->AddProperty("EFFICIENCY", PhotonEnergy, TECEfficiency, nEntries);
 
           theMPT->AddConstProperty("SCINTILLATIONYIELD", 12000.0 / MeV);
           theMPT->AddConstProperty("RESOLTUIONSCALE", 1.0);
@@ -220,20 +207,13 @@ void MaterialProperties::setMaterialProperties() {
         }
 
         // properties of the TOB_Wafer, TOB_Silicon, TIB_Wafer
-        else if ((theMaterial->GetName() == "TOB_Wafer") ||
-                 (theMaterial->GetName() == "TIB_Wafer")) {
-          theMPT->AddProperty("FASTCOMPONENT", PhotonEnergy, Scintillation,
-                              nEntries);
-          theMPT->AddProperty("SLOWCOMPONENT", PhotonEnergy, Scintillation,
-                              nEntries);
-          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndex,
-                              nEntries);
-          theMPT->AddProperty("ABSLENGTH", PhotonEnergy,
-                              AbsorptionLengthSiBarrel, nEntries);
-          theMPT->AddProperty("REFLECTIVITY", PhotonEnergy, SiReflectivity,
-                              nEntries);
-          theMPT->AddProperty("EFFICIENCY", PhotonEnergy, BarrelEfficiency,
-                              nEntries);
+        else if ((theMaterial->GetName() == "TOB_Wafer") || (theMaterial->GetName() == "TIB_Wafer")) {
+          theMPT->AddProperty("FASTCOMPONENT", PhotonEnergy, Scintillation, nEntries);
+          theMPT->AddProperty("SLOWCOMPONENT", PhotonEnergy, Scintillation, nEntries);
+          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndex, nEntries);
+          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthSiBarrel, nEntries);
+          theMPT->AddProperty("REFLECTIVITY", PhotonEnergy, SiReflectivity, nEntries);
+          theMPT->AddProperty("EFFICIENCY", PhotonEnergy, BarrelEfficiency, nEntries);
 
           theMPT->AddConstProperty("SCINTILLATIONYIELD", 12000.0 / MeV);
           theMPT->AddConstProperty("RESOLTUIONSCALE", 1.0);
@@ -248,27 +228,21 @@ void MaterialProperties::setMaterialProperties() {
         // properties of the TIB_ledge_side
         else if (theMaterial->GetName() == "TIB_ledge_side") {
           // set the refractive index
-          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndexGeneral,
-                              nEntries);
-          theMPT->AddProperty("ABSLENGTH", PhotonEnergy,
-                              AbsorptionLengthGeneral, nEntries);
+          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndexGeneral, nEntries);
+          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthGeneral, nEntries);
 
           // set the MaterialPropertiesTable
           theMaterial->SetMaterialPropertiesTable(theMPT);
         }
 
         // properties of air
-        else if ((theMaterial->GetName() == "T_Air") ||
-                 (theMaterial->GetName() == "Air")) {
+        else if ((theMaterial->GetName() == "T_Air") || (theMaterial->GetName() == "Air")) {
           // set the refractive index
-          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndexGeneral,
-                              nEntries);
+          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndexGeneral, nEntries);
           // set the reflectivity
-          theMPT->AddProperty("REFLECTIVITY", PhotonEnergy, SiReflectivity,
-                              nEntries);
+          theMPT->AddProperty("REFLECTIVITY", PhotonEnergy, SiReflectivity, nEntries);
           // set the absorptionlength
-          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthTAir,
-                              nEntries);
+          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthTAir, nEntries);
 
           // set the MaterialPropertiesTable
           theMaterial->SetMaterialPropertiesTable(theMPT);
@@ -276,18 +250,14 @@ void MaterialProperties::setMaterialProperties() {
 
         // properties of some materials in the Barrel
         // used to absorb photons to avoid hits in other TEC
-        else if ((theMaterial->GetName() == "TIB_connector") ||
-                 (theMaterial->GetName() == "TIB_cylinder") ||
+        else if ((theMaterial->GetName() == "TIB_connector") || (theMaterial->GetName() == "TIB_cylinder") ||
                  (theMaterial->GetName() == "TID_Connector")) {
           // set the refractive index
-          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndexGeneral,
-                              nEntries);
+          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndexGeneral, nEntries);
           // set the reflectivity
-          theMPT->AddProperty("REFLECTIVITY", PhotonEnergy, SiReflectivity,
-                              nEntries);
+          theMPT->AddProperty("REFLECTIVITY", PhotonEnergy, SiReflectivity, nEntries);
           // set the absorptionlength
-          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthDead,
-                              nEntries);
+          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthDead, nEntries);
 
           // set the MaterialPropertiesTable
           theMaterial->SetMaterialPropertiesTable(theMPT);
@@ -296,31 +266,24 @@ void MaterialProperties::setMaterialProperties() {
         // properties of SiO2; used for the mirrors of the Alignment Tubes
         else if (theMaterial->GetName() == "Si O_2") {
           // set the refractive index
-          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndexMirror,
-                              nEntries);
+          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndexMirror, nEntries);
           // set the absorptionlength
-          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthMirror,
-                              nEntries);
+          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthMirror, nEntries);
           // set the reflectivity
-          theMPT->AddProperty("REFLECTIVITY", PhotonEnergy, Reflectivity,
-                              nEntries);
+          theMPT->AddProperty("REFLECTIVITY", PhotonEnergy, Reflectivity, nEntries);
 
           // set the MaterialPropertiesTable
           theMaterial->SetMaterialPropertiesTable(theMPT);
         }
 
         // properties of Aluminium
-        else if ((theMaterial->GetName() == "TOB_Aluminium") ||
-                 (theMaterial->GetName() == "Aluminium")) {
+        else if ((theMaterial->GetName() == "TOB_Aluminium") || (theMaterial->GetName() == "Aluminium")) {
           // set the refractive index
-          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndexGeneral,
-                              nEntries);
+          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndexGeneral, nEntries);
           // set the reflectivity
-          theMPT->AddProperty("REFLECTIVITY", PhotonEnergy, SiReflectivity,
-                              nEntries);
+          theMPT->AddProperty("REFLECTIVITY", PhotonEnergy, SiReflectivity, nEntries);
           // set the absorptionlength
-          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthAl,
-                              nEntries);
+          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthAl, nEntries);
 
           // set the MaterialPropertiesTable
           theMaterial->SetMaterialPropertiesTable(theMPT);
@@ -329,71 +292,49 @@ void MaterialProperties::setMaterialProperties() {
         // properties of TOB_CF_Str
         else if ((theMaterial->GetName() == "TOB_CF_Str")) {
           // set the refractive index
-          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndexGeneral,
-                              nEntries);
+          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndexGeneral, nEntries);
           // set the reflectivity
-          theMPT->AddProperty("REFLECTIVITY", PhotonEnergy, SiReflectivity,
-                              nEntries);
+          theMPT->AddProperty("REFLECTIVITY", PhotonEnergy, SiReflectivity, nEntries);
           // set the absorptionlength
-          theMPT->AddProperty("ABSLENGTH", PhotonEnergy,
-                              AbsorptionLengthTOB_CF_Str, nEntries);
+          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthTOB_CF_Str, nEntries);
 
           // set the MaterialPropertiesTable
           theMaterial->SetMaterialPropertiesTable(theMPT);
         }
 
         // some other Tracker materials
-        else if ((theMaterial->GetName() == "TID_CF") ||
-                 (theMaterial->GetName() == "Nomex") ||
-                 (theMaterial->GetName() == "TOB_Nomex") ||
-                 (theMaterial->GetName() == "TID_Nomex") ||
-                 (theMaterial->GetName() == "TOB_plate_C") ||
-                 (theMaterial->GetName() == "TOB_rod") ||
-                 (theMaterial->GetName() == "TOB_cool_DS") ||
-                 (theMaterial->GetName() == "TOB_cool_SS") ||
-                 (theMaterial->GetName() == "TID_in_cable") ||
-                 (theMaterial->GetName() == "TOB_PA_rphi") ||
-                 (theMaterial->GetName() == "TOB_frame_ele") ||
-                 (theMaterial->GetName() == "TOB_PA_ster") ||
-                 (theMaterial->GetName() == "TOB_ICB") ||
-                 (theMaterial->GetName() == "TOB_CONN1") ||
-                 (theMaterial->GetName() == "TOB_CONN2") ||
-                 (theMaterial->GetName() == "TOB_CONN3") ||
-                 (theMaterial->GetName() == "TOB_rail") ||
-                 (theMaterial->GetName() == "TOB_sid_rail1") ||
+        else if ((theMaterial->GetName() == "TID_CF") || (theMaterial->GetName() == "Nomex") ||
+                 (theMaterial->GetName() == "TOB_Nomex") || (theMaterial->GetName() == "TID_Nomex") ||
+                 (theMaterial->GetName() == "TOB_plate_C") || (theMaterial->GetName() == "TOB_rod") ||
+                 (theMaterial->GetName() == "TOB_cool_DS") || (theMaterial->GetName() == "TOB_cool_SS") ||
+                 (theMaterial->GetName() == "TID_in_cable") || (theMaterial->GetName() == "TOB_PA_rphi") ||
+                 (theMaterial->GetName() == "TOB_frame_ele") || (theMaterial->GetName() == "TOB_PA_ster") ||
+                 (theMaterial->GetName() == "TOB_ICB") || (theMaterial->GetName() == "TOB_CONN1") ||
+                 (theMaterial->GetName() == "TOB_CONN2") || (theMaterial->GetName() == "TOB_CONN3") ||
+                 (theMaterial->GetName() == "TOB_rail") || (theMaterial->GetName() == "TOB_sid_rail1") ||
                  (theMaterial->GetName() == "TOB_sid_rail2")) {
           // set the refractive index
-          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndexGeneral,
-                              nEntries);
+          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndexGeneral, nEntries);
           // set the reflectivity
-          theMPT->AddProperty("REFLECTIVITY", PhotonEnergy, SiReflectivity,
-                              nEntries);
+          theMPT->AddProperty("REFLECTIVITY", PhotonEnergy, SiReflectivity, nEntries);
           // set the absorptionlength
-          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthTOBCF,
-                              nEntries);
+          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthTOBCF, nEntries);
 
           // set the MaterialPropertiesTable
           theMaterial->SetMaterialPropertiesTable(theMPT);
         }
 
         // properties of some TIB materials
-        else if ((theMaterial->GetName() == "TIB_CF") ||
-                 (theMaterial->GetName() == "TIB_cables_ax_out") ||
-                 (theMaterial->GetName() == "TIB_outer_supp") ||
-                 (theMaterial->GetName() == "TIB_PA_rphi") ||
-                 (theMaterial->GetName() == "TIB_rail") ||
-                 (theMaterial->GetName() == "TIB_sid_rail1") ||
-                 (theMaterial->GetName() == "TIB_sid_rail2") ||
-                 (theMaterial->GetName() == "TIB_mod_cool")) {
+        else if ((theMaterial->GetName() == "TIB_CF") || (theMaterial->GetName() == "TIB_cables_ax_out") ||
+                 (theMaterial->GetName() == "TIB_outer_supp") || (theMaterial->GetName() == "TIB_PA_rphi") ||
+                 (theMaterial->GetName() == "TIB_rail") || (theMaterial->GetName() == "TIB_sid_rail1") ||
+                 (theMaterial->GetName() == "TIB_sid_rail2") || (theMaterial->GetName() == "TIB_mod_cool")) {
           // set the refractive index
-          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndexGeneral,
-                              nEntries);
+          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndexGeneral, nEntries);
           // set the reflectivity
-          theMPT->AddProperty("REFLECTIVITY", PhotonEnergy, SiReflectivity,
-                              nEntries);
+          theMPT->AddProperty("REFLECTIVITY", PhotonEnergy, SiReflectivity, nEntries);
           // set the absorptionlength
-          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthTIBCF,
-                              nEntries);
+          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthTIBCF, nEntries);
 
           // set the MaterialPropertiesTable
           theMaterial->SetMaterialPropertiesTable(theMPT);
@@ -402,11 +343,9 @@ void MaterialProperties::setMaterialProperties() {
         // properties of all other materials in the detector
         else {
           // set the refractive index
-          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndexGeneral,
-                              nEntries);
+          theMPT->AddProperty("RINDEX", PhotonEnergy, RefractiveIndexGeneral, nEntries);
           // set the absorptionlength
-          theMPT->AddProperty("ABSLENGTH", PhotonEnergy,
-                              AbsorptionLengthGeneral, nEntries);
+          theMPT->AddProperty("ABSLENGTH", PhotonEnergy, AbsorptionLengthGeneral, nEntries);
 
           // set the MaterialPropertiesTable
           theMaterial->SetMaterialPropertiesTable(theMPT);
@@ -417,12 +356,11 @@ void MaterialProperties::setMaterialProperties() {
 
   // loop over the logical volumes and set the material for the sensitive
   // detectors
-  const G4LogicalVolumeStore *theLogicalVolumeStore =
-      G4LogicalVolumeStore::GetInstance();
+  const G4LogicalVolumeStore *theLogicalVolumeStore = G4LogicalVolumeStore::GetInstance();
   std::vector<G4LogicalVolume *>::const_iterator theLogicalVolume;
 
-  for (theLogicalVolume = theLogicalVolumeStore->begin();
-       theLogicalVolume != theLogicalVolumeStore->end(); theLogicalVolume++) {
+  for (theLogicalVolume = theLogicalVolumeStore->begin(); theLogicalVolume != theLogicalVolumeStore->end();
+       theLogicalVolume++) {
     if (((*theLogicalVolume)->GetName() == "TECModule0StereoActive") ||
         ((*theLogicalVolume)->GetName() == "TECModule0RphiActive") ||
         ((*theLogicalVolume)->GetName() == "TECModule1StereoActive") ||
@@ -437,15 +375,11 @@ void MaterialProperties::setMaterialProperties() {
       (*theLogicalVolume)->SetMaterial(theTECWafer);
 
       if (theMPDebugLevel > 2) {
-        std::cout << "  AC1CMS: found a logical volume: "
-                  << (*theLogicalVolume)->GetName() << std::endl;
-        std::cout << "  AC1CMS: the logical volume material = "
-                  << (*theLogicalVolume)->GetMaterial()->GetName() << std::endl;
+        std::cout << "  AC1CMS: found a logical volume: " << (*theLogicalVolume)->GetName() << std::endl;
+        std::cout << "  AC1CMS: the logical volume material = " << (*theLogicalVolume)->GetMaterial()->GetName()
+                  << std::endl;
         std::cout << "  AC1CMS: the MaterialPropertiesTable = " << std::endl;
-        (*theLogicalVolume)
-            ->GetMaterial()
-            ->GetMaterialPropertiesTable()
-            ->DumpTable();
+        (*theLogicalVolume)->GetMaterial()->GetMaterialPropertiesTable()->DumpTable();
       }
     } else if (((*theLogicalVolume)->GetName() == "TOBActiveSter0") ||
                ((*theLogicalVolume)->GetName() == "TOBActiveRphi0") ||
@@ -455,15 +389,11 @@ void MaterialProperties::setMaterialProperties() {
       (*theLogicalVolume)->SetMaterial(theTOBWafer);
 
       if (theMPDebugLevel > 2) {
-        std::cout << "  AC1CMS: found a logical volume: "
-                  << (*theLogicalVolume)->GetName() << std::endl;
-        std::cout << "  AC1CMS: the logical volume material = "
-                  << (*theLogicalVolume)->GetMaterial()->GetName() << std::endl;
+        std::cout << "  AC1CMS: found a logical volume: " << (*theLogicalVolume)->GetName() << std::endl;
+        std::cout << "  AC1CMS: the logical volume material = " << (*theLogicalVolume)->GetMaterial()->GetName()
+                  << std::endl;
         std::cout << "  AC1CMS: the MaterialPropertiesTable = " << std::endl;
-        (*theLogicalVolume)
-            ->GetMaterial()
-            ->GetMaterialPropertiesTable()
-            ->DumpTable();
+        (*theLogicalVolume)->GetMaterial()->GetMaterialPropertiesTable()->DumpTable();
       }
     } else if (((*theLogicalVolume)->GetName() == "TIBActiveSter0") ||
                ((*theLogicalVolume)->GetName() == "TIBActiveRphi0") ||
@@ -472,15 +402,11 @@ void MaterialProperties::setMaterialProperties() {
       (*theLogicalVolume)->SetMaterial(theTIBWafer);
 
       if (theMPDebugLevel > 2) {
-        std::cout << "  AC1CMS: found a logical volume: "
-                  << (*theLogicalVolume)->GetName() << std::endl;
-        std::cout << "  AC1CMS: the logical volume material = "
-                  << (*theLogicalVolume)->GetMaterial()->GetName() << std::endl;
+        std::cout << "  AC1CMS: found a logical volume: " << (*theLogicalVolume)->GetName() << std::endl;
+        std::cout << "  AC1CMS: the logical volume material = " << (*theLogicalVolume)->GetMaterial()->GetName()
+                  << std::endl;
         std::cout << "  AC1CMS: the MaterialPropertiesTable = " << std::endl;
-        (*theLogicalVolume)
-            ->GetMaterial()
-            ->GetMaterialPropertiesTable()
-            ->DumpTable();
+        (*theLogicalVolume)->GetMaterial()->GetMaterialPropertiesTable()->DumpTable();
       }
     }
   }

--- a/Alignment/LaserAlignmentSimulation/test/SimAnalyzer.cc
+++ b/Alignment/LaserAlignmentSimulation/test/SimAnalyzer.cc
@@ -26,44 +26,50 @@
 SimAnalyzer::SimAnalyzer(edm::ParameterSet const &theConf)
     : theEvents(0),
       theDebugLevel(theConf.getUntrackedParameter<int>("DebugLevel", 0)),
-      theSearchPhiTIB(
-          theConf.getUntrackedParameter<double>("SearchWindowPhiTIB", 0.05)),
-      theSearchPhiTOB(
-          theConf.getUntrackedParameter<double>("SearchWindowPhiTOB", 0.05)),
-      theSearchPhiTEC(
-          theConf.getUntrackedParameter<double>("SearchWindowPhiTEC", 0.05)),
-      theSearchZTIB(
-          theConf.getUntrackedParameter<double>("SearchWindowZTIB", 1.0)),
-      theSearchZTOB(
-          theConf.getUntrackedParameter<double>("SearchWindowZTOB", 1.0)),
-      theFile(), theCompression(theConf.getUntrackedParameter<int>(
-                     "ROOTFileCompression", 1)),
-      theFileName(theConf.getUntrackedParameter<std::string>("ROOTFileName",
-                                                             "test.root")),
-      theBarrelSimHitsX(0), theBarrelSimHitsY(0), theBarrelSimHitsZ(0),
-      theBarrelSimHitsYvsX(0), theBarrelSimHitsXvsZ(0), theBarrelSimHitsYvsZ(0),
-      theBarrelSimHitsRvsZ(0), theBarrelSimHitsPhivsX(0),
-      theBarrelSimHitsPhivsY(0), theBarrelSimHitsPhivsZ(0),
+      theSearchPhiTIB(theConf.getUntrackedParameter<double>("SearchWindowPhiTIB", 0.05)),
+      theSearchPhiTOB(theConf.getUntrackedParameter<double>("SearchWindowPhiTOB", 0.05)),
+      theSearchPhiTEC(theConf.getUntrackedParameter<double>("SearchWindowPhiTEC", 0.05)),
+      theSearchZTIB(theConf.getUntrackedParameter<double>("SearchWindowZTIB", 1.0)),
+      theSearchZTOB(theConf.getUntrackedParameter<double>("SearchWindowZTOB", 1.0)),
+      theFile(),
+      theCompression(theConf.getUntrackedParameter<int>("ROOTFileCompression", 1)),
+      theFileName(theConf.getUntrackedParameter<std::string>("ROOTFileName", "test.root")),
+      theBarrelSimHitsX(0),
+      theBarrelSimHitsY(0),
+      theBarrelSimHitsZ(0),
+      theBarrelSimHitsYvsX(0),
+      theBarrelSimHitsXvsZ(0),
+      theBarrelSimHitsYvsZ(0),
+      theBarrelSimHitsRvsZ(0),
+      theBarrelSimHitsPhivsX(0),
+      theBarrelSimHitsPhivsY(0),
+      theBarrelSimHitsPhivsZ(0),
       // the histograms for Endcap Hits
-      theEndcapSimHitsX(0), theEndcapSimHitsY(0), theEndcapSimHitsZ(0),
-      theEndcapSimHitsYvsX(0), theEndcapSimHitsXvsZ(0), theEndcapSimHitsYvsZ(0),
-      theEndcapSimHitsRvsZ(0), theEndcapSimHitsPhivsX(0),
-      theEndcapSimHitsPhivsY(0), theEndcapSimHitsPhivsZ(0),
+      theEndcapSimHitsX(0),
+      theEndcapSimHitsY(0),
+      theEndcapSimHitsZ(0),
+      theEndcapSimHitsYvsX(0),
+      theEndcapSimHitsXvsZ(0),
+      theEndcapSimHitsYvsZ(0),
+      theEndcapSimHitsRvsZ(0),
+      theEndcapSimHitsPhivsX(0),
+      theEndcapSimHitsPhivsY(0),
+      theEndcapSimHitsPhivsZ(0),
       // the histograms for all SimHits
-      theSimHitsRvsZ(0), theSimHitsPhivsZ(0) {
+      theSimHitsRvsZ(0),
+      theSimHitsPhivsZ(0) {
   // load the configuration from the ParameterSet
-  edm::LogInfo("SimAnalyzer")
-      << "==========================================================="
-      << "===                Start configuration                  ==="
-      << "    theDebugLevel                  = " << theDebugLevel
-      << "    theSearchPhiTIB                = " << theSearchPhiTIB
-      << "    theSearchPhiTOB                = " << theSearchPhiTOB
-      << "    theSearchPhiTEC                = " << theSearchPhiTEC
-      << "    theSearchZTIB                  = " << theSearchZTIB
-      << "    theSearchZTOB                  = " << theSearchZTOB
-      << "    ROOT filename                  = " << theFileName
-      << "    compression                    = " << theCompression
-      << "===========================================================";
+  edm::LogInfo("SimAnalyzer") << "==========================================================="
+                              << "===                Start configuration                  ==="
+                              << "    theDebugLevel                  = " << theDebugLevel
+                              << "    theSearchPhiTIB                = " << theSearchPhiTIB
+                              << "    theSearchPhiTOB                = " << theSearchPhiTOB
+                              << "    theSearchPhiTEC                = " << theSearchPhiTEC
+                              << "    theSearchZTIB                  = " << theSearchZTIB
+                              << "    theSearchZTOB                  = " << theSearchZTOB
+                              << "    ROOT filename                  = " << theFileName
+                              << "    compression                    = " << theCompression
+                              << "===========================================================";
 }
 
 SimAnalyzer::~SimAnalyzer() {
@@ -75,12 +81,10 @@ SimAnalyzer::~SimAnalyzer() {
   }
 }
 
-void SimAnalyzer::analyze(edm::Event const &theEvent,
-                          edm::EventSetup const &theSetup) {
-  LogDebug("SimAnalyzer")
-      << "==========================================================="
-      << "   Private analysis of event #" << theEvent.id().event()
-      << " in run #" << theEvent.id().run();
+void SimAnalyzer::analyze(edm::Event const &theEvent, edm::EventSetup const &theSetup) {
+  LogDebug("SimAnalyzer") << "==========================================================="
+                          << "   Private analysis of event #" << theEvent.id().event() << " in run #"
+                          << theEvent.id().run();
 
   // ----- check if the actual event can be used -----
   /* here we can later on add some criteria for good alignment events!? */
@@ -92,15 +96,13 @@ void SimAnalyzer::analyze(edm::Event const &theEvent,
   // do the Tracker Statistics
   trackerStatistics(theEvent, theSetup);
 
-  LogDebug("SimAnalyzer")
-      << "===========================================================";
+  LogDebug("SimAnalyzer") << "===========================================================";
 }
 
 void SimAnalyzer::beginJob() {
-  LogDebug("SimAnalyzer")
-      << "==========================================================="
-      << "===                Start beginJob()                     ==="
-      << "     creating a CMS Root Tree ...";
+  LogDebug("SimAnalyzer") << "==========================================================="
+                          << "===                Start beginJob()                     ==="
+                          << "     creating a CMS Root Tree ...";
   // creating a new file
   theFile = new TFile(theFileName.c_str(), "RECREATE", "CMS ROOT file");
 
@@ -114,14 +116,11 @@ void SimAnalyzer::beginJob() {
                          "with the RootFile");
   }
 
-  LogDebug("SimAnalyzer")
-      << "===                Done beginJob()                      ==="
-      << "===========================================================";
+  LogDebug("SimAnalyzer") << "===                Done beginJob()                      ==="
+                          << "===========================================================";
 }
 
-double SimAnalyzer::angle(double theAngle) {
-  return theAngle += (theAngle >= 0.0) ? 0.0 : 2.0 * M_PI;
-}
+double SimAnalyzer::angle(double theAngle) { return theAngle += (theAngle >= 0.0) ? 0.0 : 2.0 * M_PI; }
 
 void SimAnalyzer::closeRootFile() {
   LogDebug("SimAnalyzer") << " writing all information into a file ";
@@ -130,8 +129,7 @@ void SimAnalyzer::closeRootFile() {
 }
 
 void SimAnalyzer::initHistograms() {
-  LogDebug("SimAnalyzer")
-      << "     Start of initialisation monitor histograms ...";
+  LogDebug("SimAnalyzer") << "     Start of initialisation monitor histograms ...";
 
   // the directories in the ROOT file
   TDirectory *SimHitDir = theFile->mkdir("SimHits");
@@ -139,136 +137,113 @@ void SimAnalyzer::initHistograms() {
   TDirectory *EndcapDir = SimHitDir->mkdir("Endcap");
 
   // histograms for Barrel Hits
-  theBarrelSimHitsX = new TH1D("BarrelSimHitsX", "X Position of the SimHits",
-                               200, -100.0, 100.0);
+  theBarrelSimHitsX = new TH1D("BarrelSimHitsX", "X Position of the SimHits", 200, -100.0, 100.0);
   theBarrelSimHitsX->SetDirectory(BarrelDir);
   theBarrelSimHitsX->Sumw2();
 
-  theBarrelSimHitsY = new TH1D("BarrelSimHitsY", "Y Position of the SimHits",
-                               200, -100.0, 100.0);
+  theBarrelSimHitsY = new TH1D("BarrelSimHitsY", "Y Position of the SimHits", 200, -100.0, 100.0);
   theBarrelSimHitsY->SetDirectory(BarrelDir);
   theBarrelSimHitsY->Sumw2();
 
-  theBarrelSimHitsZ = new TH1D("BarrelSimHitsZ", "Z Position of the SimHits",
-                               240, -120.0, 120.0);
+  theBarrelSimHitsZ = new TH1D("BarrelSimHitsZ", "Z Position of the SimHits", 240, -120.0, 120.0);
   theBarrelSimHitsZ->SetDirectory(BarrelDir);
   theBarrelSimHitsZ->Sumw2();
 
   theBarrelSimHitsYvsX =
-      new TH2D("BarrelSimHitsYvsX", "Y vs X Position of the SimHits", 200,
-               -100.0, 100.0, 200, -100.0, 100.0);
+      new TH2D("BarrelSimHitsYvsX", "Y vs X Position of the SimHits", 200, -100.0, 100.0, 200, -100.0, 100.0);
   theBarrelSimHitsYvsX->SetDirectory(BarrelDir);
   theBarrelSimHitsYvsX->Sumw2();
 
   theBarrelSimHitsXvsZ =
-      new TH2D("BarrelSimHitsXvsZ", "X vs Z Position of the SimHits", 240,
-               -120.0, 120.0, 200, -100.0, 100.0);
+      new TH2D("BarrelSimHitsXvsZ", "X vs Z Position of the SimHits", 240, -120.0, 120.0, 200, -100.0, 100.0);
   theBarrelSimHitsXvsZ->SetDirectory(BarrelDir);
   theBarrelSimHitsXvsZ->Sumw2();
 
   theBarrelSimHitsYvsZ =
-      new TH2D("BarrelSimHitsYvsZ", "Y vs Z Position of the SimHits", 240,
-               -120.0, 120.0, 200, -100.0, 100.0);
+      new TH2D("BarrelSimHitsYvsZ", "Y vs Z Position of the SimHits", 240, -120.0, 120.0, 200, -100.0, 100.0);
   theBarrelSimHitsYvsZ->SetDirectory(BarrelDir);
   theBarrelSimHitsYvsZ->Sumw2();
 
   theBarrelSimHitsRvsZ =
-      new TH2D("BarrelSimHitsRvsZ", "R vs Z Position of the SimHits", 240,
-               -120.0, 120.0, 130, 0.0, 65.0);
+      new TH2D("BarrelSimHitsRvsZ", "R vs Z Position of the SimHits", 240, -120.0, 120.0, 130, 0.0, 65.0);
   theBarrelSimHitsRvsZ->SetDirectory(BarrelDir);
   theBarrelSimHitsRvsZ->Sumw2();
 
   theBarrelSimHitsPhivsX =
-      new TH2D("BarrelSimHitsPhivsX", "Phi [rad] vs X Position of the SimHits",
-               200, -100.0, 100.0, 70, 0.0, 7.0);
+      new TH2D("BarrelSimHitsPhivsX", "Phi [rad] vs X Position of the SimHits", 200, -100.0, 100.0, 70, 0.0, 7.0);
   theBarrelSimHitsPhivsX->SetDirectory(BarrelDir);
   theBarrelSimHitsPhivsX->Sumw2();
 
   theBarrelSimHitsPhivsY =
-      new TH2D("BarrelSimHitsPhivsY", "Phi [rad] vs Y Position of the SimHits",
-               200, -100.0, 100.0, 70, 0.0, 7.0);
+      new TH2D("BarrelSimHitsPhivsY", "Phi [rad] vs Y Position of the SimHits", 200, -100.0, 100.0, 70, 0.0, 7.0);
   theBarrelSimHitsPhivsY->SetDirectory(BarrelDir);
   theBarrelSimHitsPhivsY->Sumw2();
 
   theBarrelSimHitsPhivsZ =
-      new TH2D("BarrelSimHitsPhivsZ", "Phi [rad] vs Z Position of the SimHits",
-               240, -120.0, 120.0, 70, 0.0, 7.0);
+      new TH2D("BarrelSimHitsPhivsZ", "Phi [rad] vs Z Position of the SimHits", 240, -120.0, 120.0, 70, 0.0, 7.0);
   theBarrelSimHitsPhivsZ->SetDirectory(BarrelDir);
   theBarrelSimHitsPhivsZ->Sumw2();
 
   // histograms for Endcap Hits
-  theEndcapSimHitsX = new TH1D("EndcapSimHitsX", "X Position of the SimHits",
-                               200, -100.0, 100.0);
+  theEndcapSimHitsX = new TH1D("EndcapSimHitsX", "X Position of the SimHits", 200, -100.0, 100.0);
   theEndcapSimHitsX->SetDirectory(EndcapDir);
   theEndcapSimHitsX->Sumw2();
 
-  theEndcapSimHitsY = new TH1D("EndcapSimHitsY", "Y Position of the SimHits",
-                               200, -100.0, 100.0);
+  theEndcapSimHitsY = new TH1D("EndcapSimHitsY", "Y Position of the SimHits", 200, -100.0, 100.0);
   theEndcapSimHitsY->SetDirectory(EndcapDir);
   theEndcapSimHitsY->Sumw2();
 
-  theEndcapSimHitsZ = new TH1D("EndcapSimHitsZ", "Z Position of the SimHits",
-                               600, -300.0, 300.0);
+  theEndcapSimHitsZ = new TH1D("EndcapSimHitsZ", "Z Position of the SimHits", 600, -300.0, 300.0);
   theEndcapSimHitsZ->SetDirectory(EndcapDir);
   theEndcapSimHitsZ->Sumw2();
 
   theEndcapSimHitsYvsX =
-      new TH2D("EndcapSimHitsYvsX", "Y vs X Position of the SimHits", 200,
-               -100.0, 100.0, 200, -100.0, 100.0);
+      new TH2D("EndcapSimHitsYvsX", "Y vs X Position of the SimHits", 200, -100.0, 100.0, 200, -100.0, 100.0);
   theEndcapSimHitsYvsX->SetDirectory(EndcapDir);
   theEndcapSimHitsYvsX->Sumw2();
 
   theEndcapSimHitsXvsZ =
-      new TH2D("EndcapSimHitsXvsZ", "X vs Z Position of the SimHits", 600,
-               -300.0, 300.0, 200, -100.0, 100.0);
+      new TH2D("EndcapSimHitsXvsZ", "X vs Z Position of the SimHits", 600, -300.0, 300.0, 200, -100.0, 100.0);
   theEndcapSimHitsXvsZ->SetDirectory(EndcapDir);
   theEndcapSimHitsXvsZ->Sumw2();
 
   theEndcapSimHitsYvsZ =
-      new TH2D("EndcapSimHitsYvsZ", "Y vs Z Position of the SimHits", 600,
-               -300.0, 300.0, 200, -100.0, 100.0);
+      new TH2D("EndcapSimHitsYvsZ", "Y vs Z Position of the SimHits", 600, -300.0, 300.0, 200, -100.0, 100.0);
   theEndcapSimHitsYvsZ->SetDirectory(EndcapDir);
   theEndcapSimHitsYvsZ->Sumw2();
 
   theEndcapSimHitsRvsZ =
-      new TH2D("EndcapSimHitsRvsZ", "R vs Z Position of the SimHits", 600,
-               -300.0, 300.0, 1000, 0.0, 100.0);
+      new TH2D("EndcapSimHitsRvsZ", "R vs Z Position of the SimHits", 600, -300.0, 300.0, 1000, 0.0, 100.0);
   theEndcapSimHitsRvsZ->SetDirectory(EndcapDir);
   theEndcapSimHitsRvsZ->Sumw2();
 
   theEndcapSimHitsPhivsX =
-      new TH2D("EndcapSimHitsPhivsX", "Phi [rad] vs X Positon of the SimHits",
-               200, -100.0, 100.0, 70, 0.0, 7.0);
+      new TH2D("EndcapSimHitsPhivsX", "Phi [rad] vs X Positon of the SimHits", 200, -100.0, 100.0, 70, 0.0, 7.0);
   theEndcapSimHitsPhivsX->SetDirectory(EndcapDir);
   theEndcapSimHitsPhivsX->Sumw2();
 
   theEndcapSimHitsPhivsY =
-      new TH2D("EndcapSimHitsPhivsY", "Phi [rad] vs Y Position of the SimHits",
-               200, -100.0, 100.0, 70, 0.0, 7.0);
+      new TH2D("EndcapSimHitsPhivsY", "Phi [rad] vs Y Position of the SimHits", 200, -100.0, 100.0, 70, 0.0, 7.0);
   theEndcapSimHitsPhivsY->SetDirectory(EndcapDir);
   theEndcapSimHitsPhivsY->Sumw2();
 
   theEndcapSimHitsPhivsZ =
-      new TH2D("EndcapSimHitsPhivsZ", "Phi [rad] vs Z Position of the SimHits",
-               600, -300.0, 300.0, 70, 0.0, 7.0);
+      new TH2D("EndcapSimHitsPhivsZ", "Phi [rad] vs Z Position of the SimHits", 600, -300.0, 300.0, 70, 0.0, 7.0);
   theEndcapSimHitsPhivsZ->SetDirectory(EndcapDir);
   theEndcapSimHitsPhivsZ->Sumw2();
 
   // histograms for all SimHits
-  theSimHitsRvsZ = new TH2D("SimHitsRvsZ", "R vs Z Position of the SimHits",
-                            600, -300.0, 300.0, 1000, 0.0, 100.0);
+  theSimHitsRvsZ = new TH2D("SimHitsRvsZ", "R vs Z Position of the SimHits", 600, -300.0, 300.0, 1000, 0.0, 100.0);
   theSimHitsRvsZ->SetDirectory(SimHitDir);
   theSimHitsRvsZ->Sumw2();
 
   theSimHitsPhivsZ =
-      new TH2D("SimHitsPhivsZ", "Phi [rad] vs Z Position of the SimHits", 600,
-               -300.0, 300.0, 700, 0.0, 7.0);
+      new TH2D("SimHitsPhivsZ", "Phi [rad] vs Z Position of the SimHits", 600, -300.0, 300.0, 700, 0.0, 7.0);
   theSimHitsPhivsZ->SetDirectory(SimHitDir);
   theSimHitsPhivsZ->Sumw2();
 }
 
-void SimAnalyzer::trackerStatistics(edm::Event const &theEvent,
-                                    edm::EventSetup const &theSetup) {
+void SimAnalyzer::trackerStatistics(edm::Event const &theEvent, edm::EventSetup const &theSetup) {
   LogDebug("SimAnalyzer") << "<SimAnalyzer::trackerStatistics(edm::Event "
                              "const& theEvent): filling the histograms ... ";
 
@@ -287,24 +262,19 @@ void SimAnalyzer::trackerStatistics(edm::Event const &theEvent,
   std::vector<edm::Handle<edm::PSimHitContainer>> theSimHitContainers;
   theEvent.getManyByType(theSimHitContainers);
 
-  LogDebug("SimAnalyzer") << " Geometry node for TrackingGeometry is  "
-                          << &(*theTrackerGeometry) << "\n I have "
+  LogDebug("SimAnalyzer") << " Geometry node for TrackingGeometry is  " << &(*theTrackerGeometry) << "\n I have "
                           << theTrackerGeometry->dets().size() << " detectors "
-                          << "\n I have "
-                          << theTrackerGeometry->detTypes().size() << " types "
-                          << "\n theDetUnits has " << theDetUnits.size()
-                          << " dets ";
+                          << "\n I have " << theTrackerGeometry->detTypes().size() << " types "
+                          << "\n theDetUnits has " << theDetUnits.size() << " dets ";
 
   // theSimHits contains all the sim hits in this event
   std::vector<PSimHit> theSimHits;
   for (int i = 0; i < int(theSimHitContainers.size()); i++) {
-    theSimHits.insert(theSimHits.end(), theSimHitContainers.at(i)->begin(),
-                      theSimHitContainers.at(i)->end());
+    theSimHits.insert(theSimHits.end(), theSimHitContainers.at(i)->begin(), theSimHitContainers.at(i)->end());
   }
 
   // loop over the SimHits and fill the histograms
-  for (std::vector<PSimHit>::const_iterator iHit = theSimHits.begin();
-       iHit != theSimHits.end(); iHit++) {
+  for (std::vector<PSimHit>::const_iterator iHit = theSimHits.begin(); iHit != theSimHits.end(); iHit++) {
     // create a DetId from the detUnitId
     DetId theDetUnitId((*iHit).detUnitId());
 
@@ -314,121 +284,96 @@ void SimAnalyzer::trackerStatistics(edm::Event const &theEvent,
     // the detector part
     std::string thePart = "";
 
-    LogDebug("SimAnalyzer:SimHitInfo")
-        << " ============================================================ "
-        << "\n Some Information for this SimHit: "
-        << "\n"
-        << *iHit << "\n GlobalPosition = ("
-        << theDet->surface().toGlobal((*iHit).localPosition()).x() << ","
-        << theDet->surface().toGlobal((*iHit).localPosition()).y() << ","
-        << theDet->surface().toGlobal((*iHit).localPosition()).z() << ") "
-        << "\n R = "
-        << theDet->surface().toGlobal((*iHit).localPosition()).perp()
-        << "\n phi = "
-        << theDet->surface().toGlobal((*iHit).localPosition()).phi()
-        << "\n angle(phi) = "
-        << angle(theDet->surface().toGlobal((*iHit).localPosition()).phi())
-        << "\n GlobalDirection = ("
-        << theDet->surface().toGlobal((*iHit).localDirection()).x() << ","
-        << theDet->surface().toGlobal((*iHit).localDirection()).y() << ","
-        << theDet->surface().toGlobal((*iHit).localDirection()).z() << ") "
-        << "\n Total momentum = " << (*iHit).pabs()
-        << "\n ParticleType = " << (*iHit).particleType()
-        << "\n detUnitId = " << (*iHit).detUnitId();
+    LogDebug("SimAnalyzer:SimHitInfo") << " ============================================================ "
+                                       << "\n Some Information for this SimHit: "
+                                       << "\n"
+                                       << *iHit << "\n GlobalPosition = ("
+                                       << theDet->surface().toGlobal((*iHit).localPosition()).x() << ","
+                                       << theDet->surface().toGlobal((*iHit).localPosition()).y() << ","
+                                       << theDet->surface().toGlobal((*iHit).localPosition()).z() << ") "
+                                       << "\n R = " << theDet->surface().toGlobal((*iHit).localPosition()).perp()
+                                       << "\n phi = " << theDet->surface().toGlobal((*iHit).localPosition()).phi()
+                                       << "\n angle(phi) = "
+                                       << angle(theDet->surface().toGlobal((*iHit).localPosition()).phi())
+                                       << "\n GlobalDirection = ("
+                                       << theDet->surface().toGlobal((*iHit).localDirection()).x() << ","
+                                       << theDet->surface().toGlobal((*iHit).localDirection()).y() << ","
+                                       << theDet->surface().toGlobal((*iHit).localDirection()).z() << ") "
+                                       << "\n Total momentum = " << (*iHit).pabs()
+                                       << "\n ParticleType = " << (*iHit).particleType()
+                                       << "\n detUnitId = " << (*iHit).detUnitId();
 
     // select hits in Barrel and Endcaps
     switch (theDetUnitId.subdetId()) {
-    case StripSubdetector::TIB: {
-      thePart = "TIB";
-      break;
-    }
-    case StripSubdetector::TOB: {
-      thePart = "TOB";
-      break;
-    }
-    case StripSubdetector::TEC: {
-      thePart = "TEC";
-      break;
-    }
+      case StripSubdetector::TIB: {
+        thePart = "TIB";
+        break;
+      }
+      case StripSubdetector::TOB: {
+        thePart = "TOB";
+        break;
+      }
+      case StripSubdetector::TEC: {
+        thePart = "TEC";
+        break;
+      }
     }
 
     if ((thePart == "TIB") || (thePart == "TOB")) {
       theBarrelHits++;
 
       // histograms for the Barrel
-      theBarrelSimHitsX->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).x());
-      theBarrelSimHitsY->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).y());
-      theBarrelSimHitsZ->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).z());
-      theBarrelSimHitsYvsX->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).x(),
-          theDet->surface().toGlobal((*iHit).localPosition()).y());
-      theBarrelSimHitsXvsZ->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).z(),
-          theDet->surface().toGlobal((*iHit).localPosition()).x());
-      theBarrelSimHitsYvsZ->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).z(),
-          theDet->surface().toGlobal((*iHit).localPosition()).y());
-      theBarrelSimHitsRvsZ->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).z(),
-          theDet->surface().toGlobal((*iHit).localPosition()).perp());
-      theBarrelSimHitsPhivsX->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).x(),
-          angle(theDet->surface().toGlobal((*iHit).localPosition()).phi()));
-      theBarrelSimHitsPhivsY->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).y(),
-          angle(theDet->surface().toGlobal((*iHit).localPosition()).phi()));
-      theBarrelSimHitsPhivsZ->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).z(),
-          angle(theDet->surface().toGlobal((*iHit).localPosition()).phi()));
+      theBarrelSimHitsX->Fill(theDet->surface().toGlobal((*iHit).localPosition()).x());
+      theBarrelSimHitsY->Fill(theDet->surface().toGlobal((*iHit).localPosition()).y());
+      theBarrelSimHitsZ->Fill(theDet->surface().toGlobal((*iHit).localPosition()).z());
+      theBarrelSimHitsYvsX->Fill(theDet->surface().toGlobal((*iHit).localPosition()).x(),
+                                 theDet->surface().toGlobal((*iHit).localPosition()).y());
+      theBarrelSimHitsXvsZ->Fill(theDet->surface().toGlobal((*iHit).localPosition()).z(),
+                                 theDet->surface().toGlobal((*iHit).localPosition()).x());
+      theBarrelSimHitsYvsZ->Fill(theDet->surface().toGlobal((*iHit).localPosition()).z(),
+                                 theDet->surface().toGlobal((*iHit).localPosition()).y());
+      theBarrelSimHitsRvsZ->Fill(theDet->surface().toGlobal((*iHit).localPosition()).z(),
+                                 theDet->surface().toGlobal((*iHit).localPosition()).perp());
+      theBarrelSimHitsPhivsX->Fill(theDet->surface().toGlobal((*iHit).localPosition()).x(),
+                                   angle(theDet->surface().toGlobal((*iHit).localPosition()).phi()));
+      theBarrelSimHitsPhivsY->Fill(theDet->surface().toGlobal((*iHit).localPosition()).y(),
+                                   angle(theDet->surface().toGlobal((*iHit).localPosition()).phi()));
+      theBarrelSimHitsPhivsZ->Fill(theDet->surface().toGlobal((*iHit).localPosition()).z(),
+                                   angle(theDet->surface().toGlobal((*iHit).localPosition()).phi()));
     } else if (thePart == "TEC") {
       theEndcapHits++;
 
       // histograms for the Endcaps
-      theEndcapSimHitsX->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).x());
-      theEndcapSimHitsY->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).y());
-      theEndcapSimHitsZ->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).z());
-      theEndcapSimHitsYvsX->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).x(),
-          theDet->surface().toGlobal((*iHit).localPosition()).y());
-      theEndcapSimHitsXvsZ->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).z(),
-          theDet->surface().toGlobal((*iHit).localPosition()).x());
-      theEndcapSimHitsYvsZ->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).z(),
-          theDet->surface().toGlobal((*iHit).localPosition()).y());
-      theEndcapSimHitsRvsZ->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).z(),
-          theDet->surface().toGlobal((*iHit).localPosition()).perp());
-      theEndcapSimHitsPhivsX->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).x(),
-          angle(theDet->surface().toGlobal((*iHit).localPosition()).phi()));
-      theEndcapSimHitsPhivsY->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).y(),
-          angle(theDet->surface().toGlobal((*iHit).localPosition()).phi()));
-      theEndcapSimHitsPhivsZ->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).z(),
-          angle(theDet->surface().toGlobal((*iHit).localPosition()).phi()));
+      theEndcapSimHitsX->Fill(theDet->surface().toGlobal((*iHit).localPosition()).x());
+      theEndcapSimHitsY->Fill(theDet->surface().toGlobal((*iHit).localPosition()).y());
+      theEndcapSimHitsZ->Fill(theDet->surface().toGlobal((*iHit).localPosition()).z());
+      theEndcapSimHitsYvsX->Fill(theDet->surface().toGlobal((*iHit).localPosition()).x(),
+                                 theDet->surface().toGlobal((*iHit).localPosition()).y());
+      theEndcapSimHitsXvsZ->Fill(theDet->surface().toGlobal((*iHit).localPosition()).z(),
+                                 theDet->surface().toGlobal((*iHit).localPosition()).x());
+      theEndcapSimHitsYvsZ->Fill(theDet->surface().toGlobal((*iHit).localPosition()).z(),
+                                 theDet->surface().toGlobal((*iHit).localPosition()).y());
+      theEndcapSimHitsRvsZ->Fill(theDet->surface().toGlobal((*iHit).localPosition()).z(),
+                                 theDet->surface().toGlobal((*iHit).localPosition()).perp());
+      theEndcapSimHitsPhivsX->Fill(theDet->surface().toGlobal((*iHit).localPosition()).x(),
+                                   angle(theDet->surface().toGlobal((*iHit).localPosition()).phi()));
+      theEndcapSimHitsPhivsY->Fill(theDet->surface().toGlobal((*iHit).localPosition()).y(),
+                                   angle(theDet->surface().toGlobal((*iHit).localPosition()).phi()));
+      theEndcapSimHitsPhivsZ->Fill(theDet->surface().toGlobal((*iHit).localPosition()).z(),
+                                   angle(theDet->surface().toGlobal((*iHit).localPosition()).phi()));
     }
 
     // histograms for all SimHits (both Barrel and Endcaps)
     if ((thePart == "TIB") || (thePart == "TOB") || (thePart == "TEC")) {
-      theSimHitsRvsZ->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).z(),
-          theDet->surface().toGlobal((*iHit).localPosition()).perp());
-      theSimHitsPhivsZ->Fill(
-          theDet->surface().toGlobal((*iHit).localPosition()).z(),
-          angle(theDet->surface().toGlobal((*iHit).localPosition()).phi()));
+      theSimHitsRvsZ->Fill(theDet->surface().toGlobal((*iHit).localPosition()).z(),
+                           theDet->surface().toGlobal((*iHit).localPosition()).perp());
+      theSimHitsPhivsZ->Fill(theDet->surface().toGlobal((*iHit).localPosition()).z(),
+                             angle(theDet->surface().toGlobal((*iHit).localPosition()).phi()));
     }
 
-  } // end loop over SimHits
+  }  // end loop over SimHits
 
   // some statistics for this event
-  edm::LogInfo("SimAnalyzer") << "     number of SimHits = " << theBarrelHits
-                              << "/" << theEndcapHits << " (Barrel/Endcap) ";
+  edm::LogInfo("SimAnalyzer") << "     number of SimHits = " << theBarrelHits << "/" << theEndcapHits
+                              << " (Barrel/Endcap) ";
 }

--- a/Alignment/LaserAlignmentSimulation/test/SimAnalyzer.h
+++ b/Alignment/LaserAlignmentSimulation/test/SimAnalyzer.h
@@ -27,8 +27,7 @@ public:
   ~SimAnalyzer();
 
   /// this method will do the user analysis
-  virtual void analyze(edm::Event const &theEvent,
-                       edm::EventSetup const &theSetup);
+  virtual void analyze(edm::Event const &theEvent, edm::EventSetup const &theSetup);
   /// begin job
   virtual void beginJob();
 
@@ -41,8 +40,7 @@ private:
   void initHistograms();
   /// find the dets which are hit by a laser beam and fill the SimHit info into
   /// histograms
-  void trackerStatistics(edm::Event const &theEvent,
-                         edm::EventSetup const &theSetup);
+  void trackerStatistics(edm::Event const &theEvent, edm::EventSetup const &theSetup);
 
 private:
   int theEvents;

--- a/CalibCalorimetry/EcalPedestalOffsets/interface/EcalPedOffset.h
+++ b/CalibCalorimetry/EcalPedestalOffsets/interface/EcalPedOffset.h
@@ -26,7 +26,6 @@ class EEDigiCollection;
 class EcalElectronicsMapping;
 
 class EcalPedOffset : public edm::EDAnalyzer {
-
 public:
   //! Constructor
   EcalPedOffset(const edm::ParameterSet &ps);
@@ -35,8 +34,7 @@ public:
   ~EcalPedOffset() override;
 
   ///! Analyze
-  void analyze(edm::Event const &event,
-               edm::EventSetup const &eventSetup) override;
+  void analyze(edm::Event const &event, edm::EventSetup const &eventSetup) override;
 
   //! BeginRun
   void beginRun(edm::Run const &, edm::EventSetup const &eventSetup) override;
@@ -57,19 +55,14 @@ private:
   const EcalElectronicsMapping *ecalElectronicsMap_;
 
   std::string intToString(int num);
-  void readDACs(const edm::Handle<EBDigiCollection> &pDigis,
-                const std::map<int, int> &DACvalues);
-  void readDACs(const edm::Handle<EEDigiCollection> &pDigis,
-                const std::map<int, int> &DACvalues);
+  void readDACs(const edm::Handle<EBDigiCollection> &pDigis, const std::map<int, int> &DACvalues);
+  void readDACs(const edm::Handle<EEDigiCollection> &pDigis, const std::map<int, int> &DACvalues);
 
-  edm::InputTag
-      m_barrelDigiCollection; //!< secondary name given to collection of digis
-  edm::InputTag
-      m_endcapDigiCollection; //!< secondary name given to collection of digis
-  edm::InputTag
-      m_headerCollection; //!< name of module/plugin/producer making headers
+  edm::InputTag m_barrelDigiCollection;  //!< secondary name given to collection of digis
+  edm::InputTag m_endcapDigiCollection;  //!< secondary name given to collection of digis
+  edm::InputTag m_headerCollection;      //!< name of module/plugin/producer making headers
 
-  std::string m_xmlFile; //!< name of the xml file to be saved
+  std::string m_xmlFile;  //!< name of the xml file to be saved
 
   std::map<int, TPedValues *> m_pedValues;
   std::map<int, TPedResult *> m_pedResult;

--- a/CalibCalorimetry/EcalPedestalOffsets/interface/TPedValues.h
+++ b/CalibCalorimetry/EcalPedestalOffsets/interface/TPedValues.h
@@ -28,8 +28,7 @@ public:
   ~TPedValues();
 
   //! add a single value
-  void insert(const int gainId, const int crystal, const int DAC,
-              const int pedestal, const int endcapIndex);
+  void insert(const int gainId, const int crystal, const int DAC, const int pedestal, const int endcapIndex);
 
   //! calculate the offset values for all the containers
   TPedResult terminate(const int &DACstart = 0, const int &DACend = 256) const;
@@ -38,8 +37,10 @@ public:
   int checkEntries(const int &DACstart = 0, const int &DACend = 256) const;
 
   //! create a plot of the DAC pedestal trend
-  int makePlots(TFile *rootFile, const std::string &dirName,
-                const double maxSlopeAllowed, const double minSlopeAllowed,
+  int makePlots(TFile *rootFile,
+                const std::string &dirName,
+                const double maxSlopeAllowed,
+                const double minSlopeAllowed,
                 const double maxChi2OverNDF) const;
 
   //! return the index from the table

--- a/CalibCalorimetry/EcalPedestalOffsets/interface/testChannel.h
+++ b/CalibCalorimetry/EcalPedestalOffsets/interface/testChannel.h
@@ -34,7 +34,6 @@
 #include <vector>
 
 class testChannel : public edm::EDAnalyzer {
-
 public:
   //! Constructor
   testChannel(const edm::ParameterSet &ps);
@@ -48,8 +47,7 @@ public:
   void unsubscribe(void);
 
   ///! Analyze
-  void analyze(edm::Event const &event,
-               edm::EventSetup const &eventSetup) override;
+  void analyze(edm::Event const &event, edm::EventSetup const &eventSetup) override;
 
   //! BeginJob
   void beginJob() override;
@@ -60,12 +58,11 @@ public:
 private:
   int getHeaderSMId(const int headerId);
 
-  std::string m_digiCollection; //! secondary name given to collection of digis
-  std::string m_digiProducer;   //! name of module/plugin/producer making digis
-  std::string
-      m_headerProducer; //! name of module/plugin/producer making headers
+  std::string m_digiCollection;  //! secondary name given to collection of digis
+  std::string m_digiProducer;    //! name of module/plugin/producer making digis
+  std::string m_headerProducer;  //! name of module/plugin/producer making headers
 
-  std::string m_xmlFile; //! name of the xml file to be saved
+  std::string m_xmlFile;  //! name of the xml file to be saved
 
   int m_DACmin;
   int m_DACmax;

--- a/CalibCalorimetry/EcalPedestalOffsets/src/EcalPedOffset.cc
+++ b/CalibCalorimetry/EcalPedestalOffsets/src/EcalPedOffset.cc
@@ -36,48 +36,38 @@ using namespace edm;
 
 //! ctor
 EcalPedOffset::EcalPedOffset(const ParameterSet &paramSet)
-    : m_barrelDigiCollection(
-          paramSet.getParameter<edm::InputTag>("EBdigiCollection")),
-      m_endcapDigiCollection(
-          paramSet.getParameter<edm::InputTag>("EEdigiCollection")),
-      m_headerCollection(
-          paramSet.getParameter<edm::InputTag>("headerCollection")),
+    : m_barrelDigiCollection(paramSet.getParameter<edm::InputTag>("EBdigiCollection")),
+      m_endcapDigiCollection(paramSet.getParameter<edm::InputTag>("EEdigiCollection")),
+      m_headerCollection(paramSet.getParameter<edm::InputTag>("headerCollection")),
       m_xmlFile(paramSet.getParameter<std::string>("xmlFile")),
       m_DACmin(paramSet.getUntrackedParameter<int>("DACmin", 0)),
       m_DACmax(paramSet.getUntrackedParameter<int>("DACmax", 256)),
       m_RMSmax(paramSet.getUntrackedParameter<double>("RMSmax", 2)),
       m_bestPed(paramSet.getUntrackedParameter<int>("bestPed", 200)),
-      m_dbHostName(
-          paramSet.getUntrackedParameter<std::string>("dbHostName", "0")),
+      m_dbHostName(paramSet.getUntrackedParameter<std::string>("dbHostName", "0")),
       m_dbName(paramSet.getUntrackedParameter<std::string>("dbName", "0")),
       m_dbUserName(paramSet.getUntrackedParameter<std::string>("dbUserName")),
       m_dbPassword(paramSet.getUntrackedParameter<std::string>("dbPassword")),
       m_dbHostPort(paramSet.getUntrackedParameter<int>("dbHostPort", 1521)),
-      m_create_moniov(
-          paramSet.getUntrackedParameter<bool>("createMonIOV", false)),
+      m_create_moniov(paramSet.getUntrackedParameter<bool>("createMonIOV", false)),
       m_location(paramSet.getUntrackedParameter<std::string>("location", "H4")),
-      m_run(-1), m_plotting(paramSet.getParameter<std::string>("plotting")),
-      m_maxSlopeAllowed_(
-          paramSet.getUntrackedParameter<double>("maxSlopeAllowed", -29)),
-      m_minSlopeAllowed_(
-          paramSet.getUntrackedParameter<double>("minSlopeAllowed", -18)),
-      m_maxChi2OverNDFAllowed_(
-          paramSet.getUntrackedParameter<double>("maxChi2OverNDF", 5)) {
-  edm::LogInfo("EcalPedOffset")
-      << " reading "
-      << " m_DACmin: " << m_DACmin << " m_DACmax: " << m_DACmax
-      << " m_RMSmax: " << m_RMSmax << " m_bestPed: " << m_bestPed;
+      m_run(-1),
+      m_plotting(paramSet.getParameter<std::string>("plotting")),
+      m_maxSlopeAllowed_(paramSet.getUntrackedParameter<double>("maxSlopeAllowed", -29)),
+      m_minSlopeAllowed_(paramSet.getUntrackedParameter<double>("minSlopeAllowed", -18)),
+      m_maxChi2OverNDFAllowed_(paramSet.getUntrackedParameter<double>("maxChi2OverNDF", 5)) {
+  edm::LogInfo("EcalPedOffset") << " reading "
+                                << " m_DACmin: " << m_DACmin << " m_DACmax: " << m_DACmax << " m_RMSmax: " << m_RMSmax
+                                << " m_bestPed: " << m_bestPed;
 }
 
 // -----------------------------------------------------------------------------
 
 //! dtor
 EcalPedOffset::~EcalPedOffset() {
-  for (std::map<int, TPedValues *>::iterator mapIt = m_pedValues.begin();
-       mapIt != m_pedValues.end(); ++mapIt)
+  for (std::map<int, TPedValues *>::iterator mapIt = m_pedValues.begin(); mapIt != m_pedValues.end(); ++mapIt)
     delete mapIt->second;
-  for (std::map<int, TPedResult *>::iterator mapIt = m_pedResult.begin();
-       mapIt != m_pedResult.end(); ++mapIt)
+  for (std::map<int, TPedResult *>::iterator mapIt = m_pedResult.begin(); mapIt != m_pedResult.end(); ++mapIt)
     delete mapIt->second;
 }
 
@@ -109,10 +99,9 @@ void EcalPedOffset::analyze(Event const &event, EventSetup const &eventSetup) {
     m_run = event.id().run();
 
   // loop over the headers
-  for (EcalRawDataCollection::const_iterator headerItr = DCCHeaders->begin();
-       headerItr != DCCHeaders->end(); ++headerItr) {
-    EcalDCCHeaderBlock::EcalDCCEventSettings settings =
-        headerItr->getEventSettings();
+  for (EcalRawDataCollection::const_iterator headerItr = DCCHeaders->begin(); headerItr != DCCHeaders->end();
+       ++headerItr) {
+    EcalDCCHeaderBlock::EcalDCCEventSettings settings = headerItr->getEventSettings();
     int FEDid = 600 + headerItr->id();
     DACvalues[FEDid] = settings.ped_offset;
     LogDebug("EcalPedOffset") << "Found FED: " << FEDid << " in DCC header";
@@ -125,9 +114,8 @@ void EcalPedOffset::analyze(Event const &event, EventSetup const &eventSetup) {
   Handle<EBDigiCollection> barrelDigis;
   event.getByLabel(m_barrelDigiCollection, barrelDigis);
   if (!barrelDigis.isValid()) {
-    edm::LogError("EcalPedOffset")
-        << "Error! can't get the product " << m_barrelDigiCollection
-        << "; not reading barrel digis";
+    edm::LogError("EcalPedOffset") << "Error! can't get the product " << m_barrelDigiCollection
+                                   << "; not reading barrel digis";
     barrelDigisFound = false;
   }
 
@@ -142,9 +130,8 @@ void EcalPedOffset::analyze(Event const &event, EventSetup const &eventSetup) {
   Handle<EEDigiCollection> endcapDigis;
   event.getByLabel(m_endcapDigiCollection, endcapDigis);
   if (!endcapDigis.isValid()) {
-    edm::LogError("EcalPedOffset")
-        << "Error! can't get the product " << m_endcapDigiCollection
-        << "; not reading endcap digis";
+    edm::LogError("EcalPedOffset") << "Error! can't get the product " << m_endcapDigiCollection
+                                   << "; not reading endcap digis";
     endcapDigisFound = false;
   }
 
@@ -164,12 +151,10 @@ void EcalPedOffset::analyze(Event const &event, EventSetup const &eventSetup) {
 
 // -----------------------------------------------------------------------------
 
-void EcalPedOffset::readDACs(const edm::Handle<EBDigiCollection> &pDigis,
-                             const std::map<int, int> &_DACvalues) {
+void EcalPedOffset::readDACs(const edm::Handle<EBDigiCollection> &pDigis, const std::map<int, int> &_DACvalues) {
   std::map<int, int> DACvalues = _DACvalues;
   // loop over the digis
-  for (EBDigiCollection::const_iterator itdigi = pDigis->begin();
-       itdigi != pDigis->end(); ++itdigi) {
+  for (EBDigiCollection::const_iterator itdigi = pDigis->begin(); itdigi != pDigis->end(); ++itdigi) {
     int gainId = ((EBDataFrame)(*itdigi)).sample(0).gainId();
     EBDetId detId = EBDetId(itdigi->id());
     EcalElectronicsId elecId = ecalElectronicsMap_->getElectronicsId(detId);
@@ -184,38 +169,32 @@ void EcalPedOffset::readDACs(const edm::Handle<EBDigiCollection> &pDigis,
     }
 
     if (!m_pedValues.count(FEDid)) {
-      LogDebug("EcalPedOffset")
-          << "Inserting new TPedValues object for FED:" << FEDid;
+      LogDebug("EcalPedOffset") << "Inserting new TPedValues object for FED:" << FEDid;
       m_pedValues[FEDid] = new TPedValues(m_RMSmax, m_bestPed);
     }
 
     // loop over the samples
     for (int iSample = 0; iSample < EcalDataFrame::MAXSAMPLES; ++iSample) {
-      m_pedValues[FEDid]->insert(gainId, crystalId, DACvalues[FEDid],
-                                 ((EBDataFrame)(*itdigi)).sample(iSample).adc(),
-                                 crystalId);
+      m_pedValues[FEDid]->insert(
+          gainId, crystalId, DACvalues[FEDid], ((EBDataFrame)(*itdigi)).sample(iSample).adc(), crystalId);
     }
 
-  } // end loop over digis
+  }  // end loop over digis
 }
 
 // -----------------------------------------------------------------------------
 
-void EcalPedOffset::readDACs(const edm::Handle<EEDigiCollection> &pDigis,
-                             const std::map<int, int> &_DACvalues) {
+void EcalPedOffset::readDACs(const edm::Handle<EEDigiCollection> &pDigis, const std::map<int, int> &_DACvalues) {
   std::map<int, int> DACvalues = _DACvalues;
   // loop over the digis
-  for (EEDigiCollection::const_iterator itdigi = pDigis->begin();
-       itdigi != pDigis->end(); ++itdigi) {
+  for (EEDigiCollection::const_iterator itdigi = pDigis->begin(); itdigi != pDigis->end(); ++itdigi) {
     int gainId = ((EEDataFrame)(*itdigi)).sample(0).gainId();
     // int gainId = itdigi->sample(0).gainId();
     EEDetId detId = EEDetId(itdigi->id());
     EcalElectronicsId elecId = ecalElectronicsMap_->getElectronicsId(detId);
     int FEDid = 600 + elecId.dccId();
-    int crystalId =
-        25 * elecId.towerId() + 5 * elecId.stripId() + elecId.xtalId();
-    int endcapCrystalId =
-        100 * elecId.towerId() + 5 * (elecId.stripId() - 1) + elecId.xtalId();
+    int crystalId = 25 * elecId.towerId() + 5 * elecId.stripId() + elecId.xtalId();
+    int endcapCrystalId = 100 * elecId.towerId() + 5 * (elecId.stripId() - 1) + elecId.xtalId();
 
     // TODO: Behavior here
     if (DACvalues.find(FEDid) == DACvalues.end()) {
@@ -225,29 +204,26 @@ void EcalPedOffset::readDACs(const edm::Handle<EEDigiCollection> &pDigis,
     }
 
     if (!m_pedValues.count(FEDid)) {
-      LogDebug("EcalPedOffset")
-          << "Inserting new TPedValues object for FED:" << FEDid;
+      LogDebug("EcalPedOffset") << "Inserting new TPedValues object for FED:" << FEDid;
       m_pedValues[FEDid] = new TPedValues(m_RMSmax, m_bestPed);
     }
 
     // loop over the samples
     for (int iSample = 0; iSample < EcalDataFrame::MAXSAMPLES; ++iSample) {
-      m_pedValues[FEDid]->insert(gainId, crystalId, DACvalues[FEDid],
-                                 ((EEDataFrame)(*itdigi)).sample(iSample).adc(),
-                                 endcapCrystalId);
+      m_pedValues[FEDid]->insert(
+          gainId, crystalId, DACvalues[FEDid], ((EEDataFrame)(*itdigi)).sample(iSample).adc(), endcapCrystalId);
     }
 
-  } // end loop over digis
+  }  // end loop over digis
 }
 
 // -----------------------------------------------------------------------------
 
 //! perform the minimization and write results
 void EcalPedOffset::endJob() {
-  for (std::map<int, TPedValues *>::const_iterator smPeds = m_pedValues.begin();
-       smPeds != m_pedValues.end(); ++smPeds) {
-    m_pedResult[smPeds->first] =
-        new TPedResult((smPeds->second)->terminate(m_DACmin, m_DACmax));
+  for (std::map<int, TPedValues *>::const_iterator smPeds = m_pedValues.begin(); smPeds != m_pedValues.end();
+       ++smPeds) {
+    m_pedResult[smPeds->first] = new TPedResult((smPeds->second)->terminate(m_DACmin, m_DACmax));
   }
   edm::LogInfo("EcalPedOffset") << " results map size " << m_pedResult.size();
   writeXMLFiles(m_xmlFile);
@@ -269,16 +245,13 @@ void EcalPedOffset::writeDb() {
   EcalCondDBInterface *DBconnection;
   try {
     LogInfo("EcalPedOffset") << "Opening DB connection with TNS_ADMIN ...";
-    DBconnection =
-        new EcalCondDBInterface(m_dbName, m_dbUserName, m_dbPassword);
+    DBconnection = new EcalCondDBInterface(m_dbName, m_dbUserName, m_dbPassword);
   } catch (std::runtime_error &e) {
     LogError("EcalPedOffset") << e.what();
     if (!m_dbHostName.empty()) {
       try {
-        LogInfo("EcalPedOffset")
-            << "Opening DB connection without TNS_ADMIN ...";
-        DBconnection = new EcalCondDBInterface(
-            m_dbHostName, m_dbName, m_dbUserName, m_dbPassword, m_dbHostPort);
+        LogInfo("EcalPedOffset") << "Opening DB connection without TNS_ADMIN ...";
+        DBconnection = new EcalCondDBInterface(m_dbHostName, m_dbName, m_dbUserName, m_dbPassword, m_dbHostPort);
       } catch (std::runtime_error &e) {
         LogError("EcalPedOffset") << e.what();
         return;
@@ -301,7 +274,7 @@ void EcalPedOffset::writeDb() {
   runtag.setLocationDef(locdef);
   runtag.setRunTypeDef(rundef);
 
-  run_t run = m_run; // FIXME dal config file
+  run_t run = m_run;  // FIXME dal config file
   // RunIOV runiov = DBconnection->fetchRunIOV (&runtag, run);
   RunIOV runiov = DBconnection->fetchRunIOV(m_location, run);
 
@@ -312,7 +285,7 @@ void EcalPedOffset::writeDb() {
   montag.setMonVersionDef(monverdef);
   montag.setGeneralTag("CMSSW");
 
-  subrun_t subrun = 1; // hardcoded!
+  subrun_t subrun = 1;  // hardcoded!
 
   MonRunIOV moniov;
 
@@ -332,8 +305,7 @@ void EcalPedOffset::writeDb() {
       LogDebug("EcalPedOffset") << " creating a new MonRunIOV";
     } else {
       edm::LogError("EcalPedOffset") << " no MonRunIOV existing in the DB";
-      edm::LogError("EcalPedOffset")
-          << " the result will not be stored into the DB";
+      edm::LogError("EcalPedOffset") << " the result will not be stored into the DB";
       if (DBconnection) {
         delete DBconnection;
       }
@@ -349,14 +321,14 @@ void EcalPedOffset::writeDb() {
   // fill the table
 
   // loop over the super-modules
-  for (std::map<int, TPedResult *>::const_iterator result = m_pedResult.begin();
-       result != m_pedResult.end(); ++result) {
+  for (std::map<int, TPedResult *>::const_iterator result = m_pedResult.begin(); result != m_pedResult.end();
+       ++result) {
     // loop over the crystals
     for (int xtal = 0; xtal < 1700; ++xtal) {
       DBtable.setDACG1(result->second->m_DACvalue[2][xtal]);
       DBtable.setDACG6(result->second->m_DACvalue[1][xtal]);
       DBtable.setDACG12(result->second->m_DACvalue[0][xtal]);
-      DBtable.setTaskStatus(true); // FIXME to be set correctly
+      DBtable.setTaskStatus(true);  // FIXME to be set correctly
 
       // fill the table
       if (DBconnection) {
@@ -372,11 +344,9 @@ void EcalPedOffset::writeDb() {
             eid = eid + 10000 * (fedid - 600);
             ecid = DBconnection->getEcalLogicID("EE_elec_crystal_number", eid);
           } else if (fedid >= 610 && fedid <= 627) {
-            ecid = DBconnection->getEcalLogicID("EB_crystal_number",
-                                                fedid - 610 + 19, eid);
+            ecid = DBconnection->getEcalLogicID("EB_crystal_number", fedid - 610 + 19, eid);
           } else if (fedid >= 628 && fedid <= 645) {
-            ecid = DBconnection->getEcalLogicID("EB_crystal_number",
-                                                fedid - 628 + 1, eid);
+            ecid = DBconnection->getEcalLogicID("EB_crystal_number", fedid - 628 + 1, eid);
           } else if (fedid >= 646 && fedid <= 654) {
             // Add the FEDid part in for DB
             eid = eid + 10000 * (fedid - 600);
@@ -389,8 +359,8 @@ void EcalPedOffset::writeDb() {
           edm::LogError("EcalPedOffset") << e.what();
         }
       }
-    } // loop over the crystals
-  }   // loop over the super-modules
+    }  // loop over the crystals
+  }    // loop over the super-modules
 
   // insert the map of tables in the database
   if (DBconnection) {
@@ -414,8 +384,7 @@ void EcalPedOffset::writeDb() {
 //! write the m_pedResults to XML files
 void EcalPedOffset::writeXMLFiles(std::string fileName) {
   // loop over the super-modules
-  for (std::map<int, TPedResult *>::const_iterator smRes = m_pedResult.begin();
-       smRes != m_pedResult.end(); ++smRes) {
+  for (std::map<int, TPedResult *>::const_iterator smRes = m_pedResult.begin(); smRes != m_pedResult.end(); ++smRes) {
     std::string thisSMFileName = fileName;
     // open the output stream
     thisSMFileName += "_";
@@ -439,12 +408,9 @@ void EcalPedOffset::writeXMLFiles(std::string fileName) {
       if (crystalNumber == 0)
         continue;
       xml_outfile << "  <PEDESTAL_OFFSET>\n";
-      xml_outfile << "    <HIGH>" << ((smRes->second)->m_DACvalue)[0][xtal]
-                  << "</HIGH>\n";
-      xml_outfile << "    <MED>" << ((smRes->second)->m_DACvalue)[1][xtal]
-                  << "</MED>\n";
-      xml_outfile << "    <LOW>" << ((smRes->second)->m_DACvalue)[2][xtal]
-                  << "</LOW>\n";
+      xml_outfile << "    <HIGH>" << ((smRes->second)->m_DACvalue)[0][xtal] << "</HIGH>\n";
+      xml_outfile << "    <MED>" << ((smRes->second)->m_DACvalue)[1][xtal] << "</MED>\n";
+      xml_outfile << "    <LOW>" << ((smRes->second)->m_DACvalue)[2][xtal] << "</LOW>\n";
       xml_outfile << "    <CRYSTAL> " << crystalNumber << " </CRYSTAL>\n";
       xml_outfile << "  </PEDESTAL_OFFSET>" << std::endl;
     }
@@ -453,7 +419,7 @@ void EcalPedOffset::writeXMLFiles(std::string fileName) {
     xml_outfile << " </PEDESTAL_OFFSET_RELEASE>" << std::endl;
     xml_outfile << "</offsets>" << std::endl;
     xml_outfile.close();
-  } // loop over the super-modules
+  }  // loop over the super-modules
 }
 
 // -----------------------------------------------------------------------------
@@ -470,14 +436,13 @@ void EcalPedOffset::makePlots() {
   TFile *rootFile = new TFile(m_plotting.c_str(), "RECREATE");
 
   // loop over the supermodules
-  for (std::map<int, TPedValues *>::const_iterator smPeds = m_pedValues.begin();
-       smPeds != m_pedValues.end(); ++smPeds) {
+  for (std::map<int, TPedValues *>::const_iterator smPeds = m_pedValues.begin(); smPeds != m_pedValues.end();
+       ++smPeds) {
     // make a folder in the ROOT file
     char folderName[120];
     sprintf(folderName, "FED%02d", smPeds->first);
     rootFile->mkdir(folderName);
-    smPeds->second->makePlots(rootFile, folderName, m_maxSlopeAllowed_,
-                              m_minSlopeAllowed_, m_maxChi2OverNDFAllowed_);
+    smPeds->second->makePlots(rootFile, folderName, m_maxSlopeAllowed_, m_minSlopeAllowed_, m_maxChi2OverNDFAllowed_);
   }
 
   rootFile->Close();
@@ -490,10 +455,9 @@ void EcalPedOffset::makePlots() {
 
 // convert an int to a string
 std::string EcalPedOffset::intToString(int num) {
-
   // outputs the number into the string stream and then flushes
   // the buffer (makes sure the output is put into the stream)
   std::ostringstream myStream;
   myStream << num << std::flush;
-  return (myStream.str()); // returns the string form of the stringstream object
+  return (myStream.str());  // returns the string form of the stringstream object
 }

--- a/CalibCalorimetry/EcalPedestalOffsets/src/TPedValues.cc
+++ b/CalibCalorimetry/EcalPedestalOffsets/src/TPedValues.cc
@@ -13,8 +13,7 @@ void reset(double vett[256]) {
     vett[i] = 0.;
 }
 
-TPedValues::TPedValues(double RMSmax, int bestPedestal)
-    : m_bestPedestal(bestPedestal), m_RMSmax(RMSmax) {
+TPedValues::TPedValues(double RMSmax, int bestPedestal) : m_bestPedestal(bestPedestal), m_RMSmax(RMSmax) {
   LogDebug("EcalPedOffset") << "entering TPedValues ctor ...";
   for (int i = 0; i < 1700; ++i)
     endcapCrystalNumbers[i] = 0;
@@ -36,29 +35,24 @@ TPedValues::TPedValues(const TPedValues &orig) {
 
 TPedValues::~TPedValues() {}
 
-void TPedValues::insert(const int gainId, const int crystal, const int DAC,
-                        const int pedestal, const int endcapIndex) {
+void TPedValues::insert(const int gainId, const int crystal, const int DAC, const int pedestal, const int endcapIndex) {
   //  assert (gainId > 0) ;
   //  assert (gainId < 4) ;
   if (gainId <= 0 || gainId >= 4) {
-    edm::LogWarning("EcalPedOffset")
-        << "WARNING : TPedValues : gainId " << gainId
-        << " does not exist, entry skipped";
+    edm::LogWarning("EcalPedOffset") << "WARNING : TPedValues : gainId " << gainId << " does not exist, entry skipped";
     return;
   }
   //  assert (crystal > 0) ;
   //  assert (crystal <= 1700) ;
   if (crystal <= 0 || crystal > 1700) {
-    edm::LogWarning("EcalPedOffset")
-        << "WARNING : TPedValues : crystal " << crystal
-        << " does not exist, entry skipped";
+    edm::LogWarning("EcalPedOffset") << "WARNING : TPedValues : crystal " << crystal
+                                     << " does not exist, entry skipped";
     return;
   }
   //  assert (DAC >= 0) ;
   //  assert (DAC < 256) ;
   if (DAC < 0 || DAC >= 256) {
-    edm::LogWarning("EcalPedOffset") << "WARNING : TPedValues : DAC value "
-                                     << DAC << " is out range, entry skipped";
+    edm::LogWarning("EcalPedOffset") << "WARNING : TPedValues : DAC value " << DAC << " is out range, entry skipped";
     return;
   }
   m_entries[gainId - 1][crystal - 1][DAC].insert(pedestal);
@@ -92,7 +86,7 @@ TPedResult TPedValues::terminate(const int &DACstart, const int &DACend) const {
           delta = fabs(average - m_bestPedestal);
           dummyBestDAC = DAC;
         }
-      } //! loop over DAC values
+      }  //! loop over DAC values
 
       bestDAC.m_DACvalue[gainId - 1][crystal] = dummyBestDAC;
 
@@ -106,13 +100,12 @@ TPedResult TPedValues::terminate(const int &DACstart, const int &DACend) const {
           gainHuman = 1;
         else
           gainHuman = -1;
-        edm::LogError("EcalPedOffset")
-            << " TPedValues :  cannot find best DAC value for channel: "
-            << endcapCrystalNumbers[crystal] << " gain: " << gainHuman;
+        edm::LogError("EcalPedOffset") << " TPedValues :  cannot find best DAC value for channel: "
+                                       << endcapCrystalNumbers[crystal] << " gain: " << gainHuman;
       }
 
-    } // loop over crystals
-  }   // loop over gains
+    }  // loop over crystals
+  }    // loop over gains
   return bestDAC;
 }
 
@@ -148,15 +141,17 @@ int TPedValues::checkEntries(const int &DACstart, const int &DACend) const {
                                 << "\t" << gainId //FIXME
                                 << "\t" << crystal << std::endl ; //FIXME
         */
-      } //! loop over DAC values
-    }   // loop over crystals
-  }     // loop over gains
+      }  //! loop over DAC values
+    }    // loop over crystals
+  }      // loop over gains
   return returnCode;
 }
 
 //! create a plot of the DAC pedestal trend
-int TPedValues::makePlots(TFile *rootFile, const std::string &dirName,
-                          const double maxSlope, const double minSlope,
+int TPedValues::makePlots(TFile *rootFile,
+                          const std::string &dirName,
+                          const double maxSlope,
+                          const double minSlope,
                           const double maxChi2OverNDF) const {
   using namespace std;
   // prepare the ROOT file
@@ -187,7 +182,7 @@ int TPedValues::makePlots(TFile *rootFile, const std::string &dirName,
           asseY.push_back(average);
           sigmaY.push_back(rms);
         }
-      } // loop over DAC values
+      }  // loop over DAC values
       if (!asseX.empty()) {
         int lastBin = 0;
         while (lastBin < (int)asseX.size() - 1 && asseY[lastBin + 1] > 0 &&
@@ -198,11 +193,9 @@ int TPedValues::makePlots(TFile *rootFile, const std::string &dirName,
         int kinkPt = 64;
         if (fitRangeEnd < 66)
           kinkPt = fitRangeEnd - 4;
-        TGraphErrors graph(asseX.size(), &(*asseX.begin()), &(*asseY.begin()),
-                           &(*sigmaX.begin()), &(*sigmaY.begin()));
+        TGraphErrors graph(asseX.size(), &(*asseX.begin()), &(*asseY.begin()), &(*sigmaX.begin()), &(*sigmaY.begin()));
         char funct[120];
-        sprintf(funct, "(x<%d)*([0]*x+[1])+(x>=%d)*([2]*x+[3])", kinkPt,
-                kinkPt);
+        sprintf(funct, "(x<%d)*([0]*x+[1])+(x>=%d)*([2]*x+[3])", kinkPt, kinkPt);
         TF1 fitFunction("fitFunction", funct, asseX[0], fitRangeEnd);
         fitFunction.SetLineColor(2);
 
@@ -225,19 +218,14 @@ int TPedValues::makePlots(TFile *rootFile, const std::string &dirName,
         double slope1 = fitFunction.GetParameter(0);
         double slope2 = fitFunction.GetParameter(2);
 
-        if (fitFunction.GetChisquare() / fitFunction.GetNDF() >
-                maxChi2OverNDF ||
-            fitFunction.GetChisquare() / fitFunction.GetNDF() < 0 ||
-            slope1 > 0 || slope2 > 0 ||
-            ((slope1 < -29 || slope1 > -18) && slope1 < 0) ||
-            ((slope2 < -29 || slope2 > -18) && slope2 < 0)) {
-          edm::LogError("EcalPedOffset")
-              << "TPedValues : TGraph for channel:" << endcapCrystalNumbers[xtl]
-              << " gain:" << gainHuman << " is not linear;"
-              << "  slope of line1:" << fitFunction.GetParameter(0)
-              << " slope of line2:" << fitFunction.GetParameter(2)
-              << " reduced chi-squared:"
-              << fitFunction.GetChisquare() / fitFunction.GetNDF();
+        if (fitFunction.GetChisquare() / fitFunction.GetNDF() > maxChi2OverNDF ||
+            fitFunction.GetChisquare() / fitFunction.GetNDF() < 0 || slope1 > 0 || slope2 > 0 ||
+            ((slope1 < -29 || slope1 > -18) && slope1 < 0) || ((slope2 < -29 || slope2 > -18) && slope2 < 0)) {
+          edm::LogError("EcalPedOffset") << "TPedValues : TGraph for channel:" << endcapCrystalNumbers[xtl]
+                                         << " gain:" << gainHuman << " is not linear;"
+                                         << "  slope of line1:" << fitFunction.GetParameter(0)
+                                         << " slope of line2:" << fitFunction.GetParameter(2) << " reduced chi-squared:"
+                                         << fitFunction.GetChisquare() / fitFunction.GetNDF();
         }
         // LogDebug("EcalPedOffset") << "TPedValues : TGraph for channel:" <<
         // xtl+1 << " gain:"
@@ -245,18 +233,15 @@ int TPedValues::makePlots(TFile *rootFile, const std::string &dirName,
         //  asseX.back()
         //  << " and front+1 is:" << asseX.front()+1;
         if ((asseX.back() - asseX.front() + 1) != asseX.size())
-          edm::LogError("EcalPedOffset")
-              << "TPedValues : Pedestal average not found "
-              << "for all DAC values scanned in channel:"
-              << endcapCrystalNumbers[xtl] << " gain:" << gainHuman;
+          edm::LogError("EcalPedOffset") << "TPedValues : Pedestal average not found "
+                                         << "for all DAC values scanned in channel:" << endcapCrystalNumbers[xtl]
+                                         << " gain:" << gainHuman;
       }
-    } // loop over the gains
-  }   // (loop over the crystals)
+    }  // loop over the gains
+  }    // (loop over the crystals)
 
   return 0;
 }
 
 // Look up the crystal number in the EE schema and return it
-int TPedValues::getCrystalNumber(int xtal) const {
-  return endcapCrystalNumbers[xtal];
-}
+int TPedValues::getCrystalNumber(int xtal) const { return endcapCrystalNumbers[xtal]; }

--- a/CalibCalorimetry/EcalPedestalOffsets/src/TSinglePedEntry.cc
+++ b/CalibCalorimetry/EcalPedestalOffsets/src/TSinglePedEntry.cc
@@ -3,8 +3,7 @@
 #include <cmath>
 #include <iostream>
 
-TSinglePedEntry::TSinglePedEntry()
-    : m_pedestalSqSum(0), m_pedestalSum(0), m_entries(0) {
+TSinglePedEntry::TSinglePedEntry() : m_pedestalSqSum(0), m_pedestalSum(0), m_entries(0) {
   //  std::cout << "[TSinglePedEntry][ctor]" << std::endl ;
 }
 
@@ -43,7 +42,6 @@ double TSinglePedEntry::RMSSq() const {
   if (!m_entries)
     return -1;
   double num = 1. / static_cast<double>(m_entries);
-  double output =
-      m_pedestalSqSum * num - m_pedestalSum * num * m_pedestalSum * num;
+  double output = m_pedestalSqSum * num - m_pedestalSum * num * m_pedestalSum * num;
   return output;
 }

--- a/CalibFormats/CaloObjects/interface/CaloSamples.h
+++ b/CalibFormats/CaloObjects/interface/CaloSamples.h
@@ -62,9 +62,9 @@ public:
     preciseData_.resize(preciseSize_, 0.);
   }
 
-  bool isBlank() const; // are the samples blank (zero?)
+  bool isBlank() const;  // are the samples blank (zero?)
 
-  void setBlank(); // keep id, presamples, size but zero out data
+  void setBlank();  // keep id, presamples, size but zero out data
 
   /// get the size
   int preciseSize() const {
@@ -88,7 +88,7 @@ public:
 private:
   DetId id_;
   int size_, presamples_;
-  std::vector<double> data_; //
+  std::vector<double> data_;  //
   float deltaTprecise_;
   std::vector<float> preciseData_;
   int preciseSize_, precisePresamples_;

--- a/CalibFormats/CaloObjects/interface/CaloTSamples.h
+++ b/CalibFormats/CaloObjects/interface/CaloTSamples.h
@@ -17,8 +17,7 @@ public:
 
   CaloTSamples<Ttype, Tsize>();
   CaloTSamples<Ttype, Tsize>(const CaloTSamples<Ttype, Tsize> &cs);
-  CaloTSamples<Ttype, Tsize>(const DetId &id, uint32_t size = 0,
-                             uint32_t pre = 0);
+  CaloTSamples<Ttype, Tsize>(const DetId &id, uint32_t size = 0, uint32_t pre = 0);
   ~CaloTSamples<Ttype, Tsize>() override;
 
   CaloTSamples<Ttype, Tsize> &operator=(const CaloTSamples<Ttype, Tsize> &cs);

--- a/CalibFormats/CaloObjects/interface/CaloTSamples.icc
+++ b/CalibFormats/CaloObjects/interface/CaloTSamples.icc
@@ -4,12 +4,10 @@
 #include "CalibFormats/CaloObjects/interface/CaloTSamples.h"
 
 template <class Ttype, uint32_t Tsize>
-CaloTSamples<Ttype, Tsize>::CaloTSamples()
-    : CaloTSamplesBase<Ttype>(m_data, Tsize) {}
+CaloTSamples<Ttype, Tsize>::CaloTSamples() : CaloTSamplesBase<Ttype>(m_data, Tsize) {}
 
 template <class Ttype, uint32_t Tsize>
-CaloTSamples<Ttype, Tsize>::CaloTSamples(const CaloTSamples<Ttype, Tsize> &cs)
-    : CaloTSamplesBase<Ttype>(cs) {
+CaloTSamples<Ttype, Tsize>::CaloTSamples(const CaloTSamples<Ttype, Tsize> &cs) : CaloTSamplesBase<Ttype>(cs) {
   if (&cs != this) {
     for (uint32_t i(0); i != Tsize; ++i) {
       m_data[i] = cs.m_data[i];
@@ -18,16 +16,14 @@ CaloTSamples<Ttype, Tsize>::CaloTSamples(const CaloTSamples<Ttype, Tsize> &cs)
 }
 
 template <class Ttype, uint32_t Tsize>
-CaloTSamples<Ttype, Tsize>::CaloTSamples(const DetId &id, uint32_t size,
-                                         uint32_t pre)
+CaloTSamples<Ttype, Tsize>::CaloTSamples(const DetId &id, uint32_t size, uint32_t pre)
     : CaloTSamplesBase<Ttype>(m_data, Tsize, id, size, pre) {}
 
 template <class Ttype, uint32_t Tsize>
 CaloTSamples<Ttype, Tsize>::~CaloTSamples() {}
 
 template <class Ttype, uint32_t Tsize>
-CaloTSamples<Ttype, Tsize> &CaloTSamples<Ttype, Tsize>::
-operator=(const CaloTSamples<Ttype, Tsize> &cs) {
+CaloTSamples<Ttype, Tsize> &CaloTSamples<Ttype, Tsize>::operator=(const CaloTSamples<Ttype, Tsize> &cs) {
   CaloTSamplesBase<Ttype>::operator=(cs);
   std::copy(cs.m_data, cs.m_data + Tsize, m_data);
   return *this;

--- a/CalibFormats/CaloObjects/interface/CaloTSamplesBase.h
+++ b/CalibFormats/CaloObjects/interface/CaloTSamplesBase.h
@@ -5,14 +5,14 @@
 #include <cassert>
 #include <ostream>
 
-template <class Ttype> class CaloTSamplesBase {
+template <class Ttype>
+class CaloTSamplesBase {
 public:
   CaloTSamplesBase<Ttype>(Ttype *mydata, uint32_t size);
 
   CaloTSamplesBase<Ttype>(const CaloTSamplesBase<Ttype> &cs);
 
-  CaloTSamplesBase<Ttype>(Ttype *mydata, uint32_t length, const DetId &id,
-                          uint32_t size, uint32_t pre);
+  CaloTSamplesBase<Ttype>(Ttype *mydata, uint32_t length, const DetId &id, uint32_t size, uint32_t pre);
 
   virtual ~CaloTSamplesBase<Ttype>();
 

--- a/CalibFormats/CaloObjects/interface/CaloTSamplesBase.icc
+++ b/CalibFormats/CaloObjects/interface/CaloTSamplesBase.icc
@@ -4,8 +4,7 @@
 #include "CalibFormats/CaloObjects/interface/CaloTSamplesBase.h"
 
 template <class Ttype>
-CaloTSamplesBase<Ttype>::CaloTSamplesBase(Ttype *mydata, uint32_t length)
-    : m_id(0), m_size(0), m_pre(0) {
+CaloTSamplesBase<Ttype>::CaloTSamplesBase(Ttype *mydata, uint32_t length) : m_id(0), m_size(0), m_pre(0) {
   std::fill(mydata, mydata + length, 0);
 }
 
@@ -19,34 +18,38 @@ CaloTSamplesBase<Ttype>::CaloTSamplesBase(const CaloTSamplesBase<Ttype> &cs) {
 }
 
 template <class Ttype>
-CaloTSamplesBase<Ttype>::CaloTSamplesBase(Ttype *mydata, uint32_t length,
-                                          const DetId &id, uint32_t size,
-                                          uint32_t pre)
+CaloTSamplesBase<Ttype>::CaloTSamplesBase(Ttype *mydata, uint32_t length, const DetId &id, uint32_t size, uint32_t pre)
     : m_id(id), m_size(size), m_pre(pre) {
   assert(length >= size);
   assert(pre <= size);
   std::fill(mydata, mydata + length, 0);
 }
 
-template <class Ttype> CaloTSamplesBase<Ttype>::~CaloTSamplesBase() {}
+template <class Ttype>
+CaloTSamplesBase<Ttype>::~CaloTSamplesBase() {}
 
-template <class Ttype> void CaloTSamplesBase<Ttype>::setZero() {
+template <class Ttype>
+void CaloTSamplesBase<Ttype>::setZero() {
   std::fill(data(0), data(0) + capacity(), 0);
 }
 
-template <class Ttype> DetId CaloTSamplesBase<Ttype>::id() const {
+template <class Ttype>
+DetId CaloTSamplesBase<Ttype>::id() const {
   return m_id;
 }
 
-template <class Ttype> uint32_t CaloTSamplesBase<Ttype>::size() const {
+template <class Ttype>
+uint32_t CaloTSamplesBase<Ttype>::size() const {
   return m_size;
 }
 
-template <class Ttype> uint32_t CaloTSamplesBase<Ttype>::pre() const {
+template <class Ttype>
+uint32_t CaloTSamplesBase<Ttype>::pre() const {
   return m_pre;
 }
 
-template <class Ttype> bool CaloTSamplesBase<Ttype>::zero() const {
+template <class Ttype>
+bool CaloTSamplesBase<Ttype>::zero() const {
   for (uint32_t i(0); i != capacity(); ++i) {
     if (0 != (*cdata(i)))
       return false;
@@ -54,7 +57,8 @@ template <class Ttype> bool CaloTSamplesBase<Ttype>::zero() const {
   return true;
 }
 
-template <class Ttype> Ttype &CaloTSamplesBase<Ttype>::operator[](uint32_t i) {
+template <class Ttype>
+Ttype &CaloTSamplesBase<Ttype>::operator[](uint32_t i) {
   assert(capacity() > i);
   return *data(i);
 }
@@ -66,8 +70,7 @@ const Ttype &CaloTSamplesBase<Ttype>::operator[](uint32_t i) const {
 }
 
 template <class Ttype>
-CaloTSamplesBase<Ttype> &CaloTSamplesBase<Ttype>::
-operator=(const CaloTSamplesBase<Ttype> &cs) {
+CaloTSamplesBase<Ttype> &CaloTSamplesBase<Ttype>::operator=(const CaloTSamplesBase<Ttype> &cs) {
   if (&cs != this) {
     m_id = cs.m_id;
     m_size = cs.m_size;
@@ -93,8 +96,7 @@ CaloTSamplesBase<Ttype> &CaloTSamplesBase<Ttype>::operator+=(Ttype value) {
 }
 
 template <class Ttype>
-CaloTSamplesBase<Ttype> &CaloTSamplesBase<Ttype>::
-operator+=(const CaloTSamplesBase<Ttype> &cs) {
+CaloTSamplesBase<Ttype> &CaloTSamplesBase<Ttype>::operator+=(const CaloTSamplesBase<Ttype> &cs) {
   assert(m_size == cs.size());
   assert(capacity() == cs.capacity());
 

--- a/CalibFormats/CaloObjects/interface/IntegerCaloSamples.h
+++ b/CalibFormats/CaloObjects/interface/IntegerCaloSamples.h
@@ -37,7 +37,7 @@ public:
 
 private:
   DetId id_;
-  uint32_t data_[MAXSAMPLES]; //
+  uint32_t data_[MAXSAMPLES];  //
   int size_, presamples_;
 };
 

--- a/CalibFormats/CaloObjects/src/CaloSamples.cc
+++ b/CalibFormats/CaloObjects/src/CaloSamples.cc
@@ -3,20 +3,27 @@
 #include <cmath>
 #include <iostream>
 
-CaloSamples::CaloSamples()
-    : id_(), size_(0), presamples_(0), preciseSize_(0), precisePresamples_(0) {
-  setBlank();
-}
+CaloSamples::CaloSamples() : id_(), size_(0), presamples_(0), preciseSize_(0), precisePresamples_(0) { setBlank(); }
 
 CaloSamples::CaloSamples(const DetId &id, int size)
-    : id_(id), size_(size), presamples_(0), data_(size_, 0.0),
-      deltaTprecise_(0.0f), preciseSize_(0), precisePresamples_(0) {
+    : id_(id),
+      size_(size),
+      presamples_(0),
+      data_(size_, 0.0),
+      deltaTprecise_(0.0f),
+      preciseSize_(0),
+      precisePresamples_(0) {
   setBlank();
 }
 
 CaloSamples::CaloSamples(const DetId &id, int size, int presize)
-    : id_(id), size_(size), presamples_(0), data_(size_, 0.0),
-      deltaTprecise_(0.0f), preciseSize_(presize), precisePresamples_(0) {
+    : id_(id),
+      size_(size),
+      presamples_(0),
+      data_(size_, 0.0),
+      deltaTprecise_(0.0f),
+      preciseSize_(presize),
+      precisePresamples_(0) {
   setBlank();
 }
 
@@ -28,8 +35,7 @@ void CaloSamples::setPresamples(int pre) { presamples_ = pre; }
 CaloSamples &CaloSamples::scale(double value) {
   for (int i = 0; i < size_; i++)
     data_[i] *= value;
-  for (std::vector<float>::iterator j = preciseData_.begin();
-       j != preciseData_.end(); ++j)
+  for (std::vector<float>::iterator j = preciseData_.begin(); j != preciseData_.end(); ++j)
     (*j) *= value;
   return (*this);
 }
@@ -37,15 +43,13 @@ CaloSamples &CaloSamples::scale(double value) {
 CaloSamples &CaloSamples::operator+=(double value) {
   for (int i = 0; i < size_; i++)
     data_[i] += value;
-  for (std::vector<float>::iterator j = preciseData_.begin();
-       j != preciseData_.end(); ++j)
-    (*j) += value * deltaTprecise_ / 25.0; // note that the scale is conserved!
+  for (std::vector<float>::iterator j = preciseData_.begin(); j != preciseData_.end(); ++j)
+    (*j) += value * deltaTprecise_ / 25.0;  // note that the scale is conserved!
   return (*this);
 }
 
 CaloSamples &CaloSamples::operator+=(const CaloSamples &other) {
-  if (size_ != other.size_ || presamples_ != other.presamples_ ||
-      preciseSize_ != other.preciseSize_) {
+  if (size_ != other.size_ || presamples_ != other.presamples_ || preciseSize_ != other.preciseSize_) {
     edm::LogError("CaloHitResponse") << "Mismatched calo signals ";
   }
   int i;
@@ -79,7 +83,7 @@ CaloSamples &CaloSamples::offsetTime(double offset) {
   return (*this);
 }
 
-bool CaloSamples::isBlank() const // are the samples blank (zero?)
+bool CaloSamples::isBlank() const  // are the samples blank (zero?)
 {
   for (int i(0); i != size_; ++i) {
     if (1.e-6 < fabs(data_[i]))
@@ -88,7 +92,7 @@ bool CaloSamples::isBlank() const // are the samples blank (zero?)
   return true;
 }
 
-void CaloSamples::setBlank() // keep id, presamples, size but zero out data
+void CaloSamples::setBlank()  // keep id, presamples, size but zero out data
 {
   std::fill(data_.begin(), data_.end(), (double)0.0);
   std::fill(preciseData_.begin(), preciseData_.end(), (double)0.0);
@@ -105,10 +109,8 @@ std::ostream &operator<<(std::ostream &s, const CaloSamples &samples) {
   s << '\n';
   for (int i = 0; i < samples.size(); i++) {
     s << i << ":" << samples[i] << " precise:";
-    int precise_start(i * preciseStep),
-        precise_end(precise_start + preciseStep);
-    for (int j(precise_start);
-         ((j < precise_end) && (j < samples.preciseSize())); ++j)
+    int precise_start(i * preciseStep), precise_end(precise_start + preciseStep);
+    for (int j(precise_start); ((j < precise_end) && (j < samples.preciseSize())); ++j)
       s << " " << samples.preciseAt(j);
     s << std::endl;
   }

--- a/CalibFormats/CaloObjects/src/IntegerCaloSamples.cc
+++ b/CalibFormats/CaloObjects/src/IntegerCaloSamples.cc
@@ -5,8 +5,7 @@ IntegerCaloSamples::IntegerCaloSamples() : id_(), size_(0), presamples_(0) {
     data_[i] = 0;
 }
 
-IntegerCaloSamples::IntegerCaloSamples(const DetId &id, int size)
-    : id_(id), size_(size), presamples_(0) {
+IntegerCaloSamples::IntegerCaloSamples(const DetId &id, int size) : id_(id), size_(size), presamples_(0) {
   for (int i = 0; i < MAXSAMPLES; i++)
     data_[i] = 0;
 }

--- a/CalibFormats/CaloObjects/src/classes.h
+++ b/CalibFormats/CaloObjects/src/classes.h
@@ -2,9 +2,9 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 
 namespace CalibFormats_CaloObjects {
-struct dictionary {
-  CaloSamples cs;
-  CaloSamplesCollection vcs;
-  edm::Wrapper<CaloSamplesCollection> wcvs;
-};
-} // namespace CalibFormats_CaloObjects
+  struct dictionary {
+    CaloSamples cs;
+    CaloSamplesCollection vcs;
+    edm::Wrapper<CaloSamplesCollection> wcvs;
+  };
+}  // namespace CalibFormats_CaloObjects

--- a/CalibMuon/CSCCalibration/interface/CSCBadChambersConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCBadChambersConditions.h
@@ -17,8 +17,7 @@
 #include "CondFormats/DataRecord/interface/CSCBadChambersRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCBadChambersConditions : public edm::ESProducer,
-                                 public edm::EventSetupRecordIntervalFinder {
+class CSCBadChambersConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCBadChambersConditions(const edm::ParameterSet &);
   ~CSCBadChambersConditions() override;
@@ -61,7 +60,6 @@ inline CSCBadChambers *CSCBadChambersConditions::prefillBadChambers() {
   }
 
   while (!newdata.eof()) {
-
     newdata >> new_chambers;
     if (new_chambers != old_chamber) {
       new_badchambers.push_back(new_chambers);
@@ -72,8 +70,7 @@ inline CSCBadChambers *CSCBadChambersConditions::prefillBadChambers() {
   }
   newdata.close();
 
-  CSCBadChambers *cndbbadchambers =
-      new CSCBadChambers(new_nrlines, new_badchambers);
+  CSCBadChambers *cndbbadchambers = new CSCBadChambers(new_nrlines, new_badchambers);
 
   // std::cout <<"numberOfBadChambers "<<new_nrlines<<std::endl;
 

--- a/CalibMuon/CSCCalibration/interface/CSCBadStripsConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCBadStripsConditions.h
@@ -17,8 +17,7 @@
 #include "CondFormats/DataRecord/interface/CSCBadStripsRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCBadStripsConditions : public edm::ESProducer,
-                               public edm::EventSetupRecordIntervalFinder {
+class CSCBadStripsConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCBadStripsConditions(const edm::ParameterSet &);
   ~CSCBadStripsConditions() override;
@@ -67,12 +66,12 @@ inline CSCBadStrips *CSCBadStripsConditions::prefillBadStrips() {
   std::ifstream newdata1;
   std::ifstream newdata2;
 
-  newdata1.open("badstrips1.dat", std::ios::in); // chambercontainer
+  newdata1.open("badstrips1.dat", std::ios::in);  // chambercontainer
   if (!newdata1) {
     std::cerr << "Error: badstrips1.dat -> no such file!" << std::endl;
     exit(1);
   }
-  newdata2.open("badstrips2.dat", std::ios::in); // channelcontainer
+  newdata2.open("badstrips2.dat", std::ios::in);  // channelcontainer
   if (!newdata2) {
     std::cerr << "Error: badstrips2.dat -> no such file!" << std::endl;
     exit(1);

--- a/CalibMuon/CSCCalibration/interface/CSCBadWiresConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCBadWiresConditions.h
@@ -17,8 +17,7 @@
 #include "CondFormats/DataRecord/interface/CSCBadWiresRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCBadWiresConditions : public edm::ESProducer,
-                              public edm::EventSetupRecordIntervalFinder {
+class CSCBadWiresConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCBadWiresConditions(const edm::ParameterSet &);
   ~CSCBadWiresConditions() override;
@@ -72,7 +71,7 @@ inline CSCBadWires *CSCBadWiresConditions::prefillBadWires() {
     std::cerr << "Error: badwires1.dat -> no such file!" << std::endl;
     exit(1);
   }
-  newdata2.open("badwires2.dat", std::ios::in); // channelcontainer
+  newdata2.open("badwires2.dat", std::ios::in);  // channelcontainer
   if (!newdata2) {
     std::cerr << "Error: badwires2.dat -> no such file!" << std::endl;
     exit(1);

--- a/CalibMuon/CSCCalibration/interface/CSCChannelMapperBase.h
+++ b/CalibMuon/CSCCalibration/interface/CSCChannelMapperBase.h
@@ -56,21 +56,13 @@ public:
   int geomWireChannel(const CSCDetId &id, int iraw) const { return iraw; }
 
   /// Alias for rawStripChannel
-  int rawCathodeChannel(const CSCDetId &id, int igeom) const {
-    return rawStripChannel(id, igeom);
-  }
+  int rawCathodeChannel(const CSCDetId &id, int igeom) const { return rawStripChannel(id, igeom); }
   /// Alias for rawWireChannel
-  int rawAnodeChannel(const CSCDetId &id, int igeom) const {
-    return rawWireChannel(id, igeom);
-  }
+  int rawAnodeChannel(const CSCDetId &id, int igeom) const { return rawWireChannel(id, igeom); }
   /// Alias for geomStripChannel
-  int geomCathodeChannel(const CSCDetId &id, int iraw) const {
-    return geomStripChannel(id, iraw);
-  }
+  int geomCathodeChannel(const CSCDetId &id, int iraw) const { return geomStripChannel(id, iraw); }
   /// Alias for geomWireChannel
-  int geomAnodeChannel(const CSCDetId &id, int iraw) const {
-    return geomWireChannel(id, iraw);
-  }
+  int geomAnodeChannel(const CSCDetId &id, int iraw) const { return geomWireChannel(id, iraw); }
 
   /// Offline conversion of a strip (geometric labelling) back to channel
   /// (At present this just has to convert the 48 strips of ME1A to 16 ganged

--- a/CalibMuon/CSCCalibration/interface/CSCChannelMapperESProducer.h
+++ b/CalibMuon/CSCCalibration/interface/CSCChannelMapperESProducer.h
@@ -9,7 +9,6 @@
 #include "CalibMuon/CSCCalibration/interface/CSCChannelMapperRecord.h"
 
 class CSCChannelMapperESProducer : public edm::ESProducer {
-
 public:
   typedef std::unique_ptr<CSCChannelMapperBase> BSP_TYPE;
 

--- a/CalibMuon/CSCCalibration/interface/CSCChannelMapperFactory.h
+++ b/CalibMuon/CSCCalibration/interface/CSCChannelMapperFactory.h
@@ -4,7 +4,6 @@
 #include "CalibMuon/CSCCalibration/interface/CSCChannelMapperBase.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 
-typedef edmplugin::PluginFactory<CSCChannelMapperBase *(void)>
-    CSCChannelMapperFactory;
+typedef edmplugin::PluginFactory<CSCChannelMapperBase *(void)> CSCChannelMapperFactory;
 
 #endif

--- a/CalibMuon/CSCCalibration/interface/CSCChannelMapperRecord.h
+++ b/CalibMuon/CSCCalibration/interface/CSCChannelMapperRecord.h
@@ -3,8 +3,6 @@
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 
-class CSCChannelMapperRecord
-    : public edm::eventsetup::EventSetupRecordImplementation<
-          CSCChannelMapperRecord> {};
+class CSCChannelMapperRecord : public edm::eventsetup::EventSetupRecordImplementation<CSCChannelMapperRecord> {};
 
 #endif

--- a/CalibMuon/CSCCalibration/interface/CSCConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCConditions.h
@@ -64,20 +64,16 @@ public:
   float pedestalSigma(const CSCDetId &detId, int channel) const;
 
   /// crosstalk slope for left and right
-  float crosstalkSlope(const CSCDetId &detId, int channel,
-                       bool leftRight) const;
+  float crosstalkSlope(const CSCDetId &detId, int channel, bool leftRight) const;
   /// crosstalk intercept for left and right
-  float crosstalkIntercept(const CSCDetId &detId, int channel,
-                           bool leftRight) const;
+  float crosstalkIntercept(const CSCDetId &detId, int channel, bool leftRight) const;
 
   /// raw noise matrix (unscaled short int elements)
-  const CSCDBNoiseMatrix::Item &noiseMatrix(const CSCDetId &detId,
-                                            int channel) const;
+  const CSCDBNoiseMatrix::Item &noiseMatrix(const CSCDetId &detId, int channel) const;
 
   /// fill vector (dim 12, must be allocated by caller) with noise matrix
   /// elements (scaled to float)
-  void noiseMatrixElements(const CSCDetId &id, int channel,
-                           std::vector<float> &me) const;
+  void noiseMatrixElements(const CSCDetId &id, int channel, std::vector<float> &me) const;
 
   /// fill vector (dim 4, must be allocated by caller) with crosstalk sl, il,
   /// sr, ir
@@ -162,22 +158,22 @@ private:
 
   // logical flags controlling some conditions data usage
 
-  bool readBadChannels_;      // flag whether or not to even attempt reading bad
-                              // channel info from db
-  bool readBadChambers_;      // flag whether or not to even attempt reading bad
-                              // chamber info from db
-  bool useTimingCorrections_; // flag whether or not to even attempt reading
-                              // timing correction info from db
-  bool useGasGainCorrections_; // flag whether or not to even attempt reading
-                               // gas-gain correction info from db
+  bool readBadChannels_;        // flag whether or not to even attempt reading bad
+                                // channel info from db
+  bool readBadChambers_;        // flag whether or not to even attempt reading bad
+                                // chamber info from db
+  bool useTimingCorrections_;   // flag whether or not to even attempt reading
+                                // timing correction info from db
+  bool useGasGainCorrections_;  // flag whether or not to even attempt reading
+                                // gas-gain correction info from db
 
   // Cache bad channel content for current CSC layer
   CSCDetId idOfBadChannelWords_;
   std::bitset<112> badStripWord_;
   std::bitset<112> badWireWord_;
 
-  mutable float theAverageGain; // average over entire system, subject to some
-                                // constraints!
+  mutable float theAverageGain;  // average over entire system, subject to some
+                                 // constraints!
 
   edm::ESWatcher<CSCDBGainsRcd> gainsWatcher_;
   //@@ remove until we have real information to use

--- a/CalibMuon/CSCCalibration/interface/CSCCrosstalkConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCCrosstalkConditions.h
@@ -16,8 +16,7 @@
 #include "CondFormats/DataRecord/interface/CSCcrosstalkRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCCrosstalkConditions : public edm::ESProducer,
-                               public edm::EventSetupRecordIntervalFinder {
+class CSCCrosstalkConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCCrosstalkConditions(const edm::ParameterSet &);
   ~CSCCrosstalkConditions() override;

--- a/CalibMuon/CSCCalibration/interface/CSCCrosstalkDBConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCCrosstalkDBConditions.h
@@ -17,8 +17,7 @@
 #include "CondFormats/DataRecord/interface/CSCDBCrosstalkRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCCrosstalkDBConditions : public edm::ESProducer,
-                                 public edm::EventSetupRecordIntervalFinder {
+class CSCCrosstalkDBConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCCrosstalkDBConditions(const edm::ParameterSet &);
   ~CSCCrosstalkDBConditions() override;
@@ -77,8 +76,7 @@ inline CSCDBCrosstalk *CSCCrosstalkDBConditions::prefillDBCrosstalk() {
   }
 
   while (!dbdata.eof()) {
-    dbdata >> db_index >> db_slope_right >> db_intercept_right >>
-        db_slope_left >> db_intercept_left;
+    dbdata >> db_index >> db_slope_right >> db_intercept_right >> db_slope_left >> db_intercept_left;
     db_index_id.push_back(db_index);
     db_slope_r.push_back(db_slope_right);
     db_slope_l.push_back(db_slope_left);
@@ -96,8 +94,7 @@ inline CSCDBCrosstalk *CSCCrosstalkDBConditions::prefillDBCrosstalk() {
   }
 
   while (!newdata.eof()) {
-    newdata >> new_index >> new_slope_right >> new_intercept_right >>
-        new_slope_left >> new_intercept_left;
+    newdata >> new_index >> new_slope_right >> new_intercept_right >> new_slope_left >> new_intercept_left;
     new_index_id.push_back(new_index);
     new_slope_r.push_back(new_slope_right);
     new_slope_l.push_back(new_slope_left);
@@ -113,14 +110,10 @@ inline CSCDBCrosstalk *CSCCrosstalkDBConditions::prefillDBCrosstalk() {
   cndbcrosstalk->factor_intercept = int(INTERCEPT_FACTOR);
 
   for (int i = 0; i < MAX_SIZE; ++i) {
-    itemvector[i].xtalk_slope_right =
-        (short int)(db_slope_r[i] * SLOPE_FACTOR + 0.5);
-    itemvector[i].xtalk_intercept_right =
-        (short int)(db_intercept_r[i] * INTERCEPT_FACTOR + 0.5);
-    itemvector[i].xtalk_slope_left =
-        (short int)(db_slope_l[i] * SLOPE_FACTOR + 0.5);
-    itemvector[i].xtalk_intercept_left =
-        (short int)(db_intercept_l[i] * INTERCEPT_FACTOR + 0.5);
+    itemvector[i].xtalk_slope_right = (short int)(db_slope_r[i] * SLOPE_FACTOR + 0.5);
+    itemvector[i].xtalk_intercept_right = (short int)(db_intercept_r[i] * INTERCEPT_FACTOR + 0.5);
+    itemvector[i].xtalk_slope_left = (short int)(db_slope_l[i] * SLOPE_FACTOR + 0.5);
+    itemvector[i].xtalk_intercept_left = (short int)(db_intercept_l[i] * INTERCEPT_FACTOR + 0.5);
   }
 
   for (int i = 0; i < MAX_SIZE; ++i) {
@@ -128,19 +121,13 @@ inline CSCDBCrosstalk *CSCCrosstalkDBConditions::prefillDBCrosstalk() {
     for (unsigned int k = 0; k < new_index_id.size() - 1; k++) {
       if (counter == new_index_id[k]) {
         if ((short int)(fabs(new_slope_r[k] * SLOPE_FACTOR + 0.5)) < MAX_SHORT)
-          itemvector[counter].xtalk_slope_right =
-              int(new_slope_r[k] * SLOPE_FACTOR + 0.5);
-        if ((short int)(fabs(new_intercept_r[k] * INTERCEPT_FACTOR + 0.5)) <
-            MAX_SHORT)
-          itemvector[counter].xtalk_intercept_right =
-              int(new_intercept_r[k] * INTERCEPT_FACTOR + 0.5);
+          itemvector[counter].xtalk_slope_right = int(new_slope_r[k] * SLOPE_FACTOR + 0.5);
+        if ((short int)(fabs(new_intercept_r[k] * INTERCEPT_FACTOR + 0.5)) < MAX_SHORT)
+          itemvector[counter].xtalk_intercept_right = int(new_intercept_r[k] * INTERCEPT_FACTOR + 0.5);
         if ((short int)(fabs(new_slope_l[k] * SLOPE_FACTOR + 0.5)) < MAX_SHORT)
-          itemvector[counter].xtalk_slope_left =
-              int(new_slope_l[k] * SLOPE_FACTOR + 0.5);
-        if ((short int)(fabs(new_intercept_l[k] * INTERCEPT_FACTOR + 0.5)) <
-            MAX_SHORT)
-          itemvector[counter].xtalk_intercept_left =
-              int(new_intercept_l[k] * INTERCEPT_FACTOR + 0.5);
+          itemvector[counter].xtalk_slope_left = int(new_slope_l[k] * SLOPE_FACTOR + 0.5);
+        if ((short int)(fabs(new_intercept_l[k] * INTERCEPT_FACTOR + 0.5)) < MAX_SHORT)
+          itemvector[counter].xtalk_intercept_left = int(new_intercept_l[k] * INTERCEPT_FACTOR + 0.5);
         itemvector[i] = itemvector[counter];
         // std::cout<<" counter "<<counter <<" dbindex "<<new_index_id[k]<<"
         // dbslope " <<db_slope_r[k]<<" new slope "<<new_slope_r[k]<<std::endl;

--- a/CalibMuon/CSCCalibration/interface/CSCDBL1TPParametersConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCDBL1TPParametersConditions.h
@@ -17,9 +17,7 @@
 #include "CondFormats/DataRecord/interface/CSCDBL1TPParametersRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCDBL1TPParametersConditions
-    : public edm::ESProducer,
-      public edm::EventSetupRecordIntervalFinder {
+class CSCDBL1TPParametersConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCDBL1TPParametersConditions(const edm::ParameterSet &);
   ~CSCDBL1TPParametersConditions();
@@ -32,8 +30,7 @@ public:
 
 private:
   // ----------member data ---------------------------
-  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
-                      const edm::IOVSyncValue &, edm::ValidityInterval &);
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &, edm::ValidityInterval &);
 };
 
 #include <fstream>
@@ -41,17 +38,15 @@ private:
 #include <vector>
 
 // to workaround plugin library
-inline CSCDBL1TPParameters *
-CSCDBL1TPParametersConditions::prefillCSCDBL1TPParameters() {
-
+inline CSCDBL1TPParameters *CSCDBL1TPParametersConditions::prefillCSCDBL1TPParameters() {
   CSCDBL1TPParameters *cnl1tp = new CSCDBL1TPParameters();
 
   cnl1tp->setAlctFifoTbins(16);
   cnl1tp->setAlctFifoPretrig(10);
   cnl1tp->setAlctDriftDelay(2);
-  cnl1tp->setAlctNplanesHitPretrig(3); // was 2, new is 3
+  cnl1tp->setAlctNplanesHitPretrig(3);  // was 2, new is 3
   cnl1tp->setAlctNplanesHitPattern(4);
-  cnl1tp->setAlctNplanesHitAccelPretrig(3); // was 2, new is 3
+  cnl1tp->setAlctNplanesHitAccelPretrig(3);  // was 2, new is 3
   cnl1tp->setAlctNplanesHitAccelPattern(4);
   cnl1tp->setAlctTrigMode(2);
   cnl1tp->setAlctAccelMode(0);
@@ -59,9 +54,9 @@ CSCDBL1TPParametersConditions::prefillCSCDBL1TPParameters() {
 
   cnl1tp->setClctFifoTbins(12);
   cnl1tp->setClctFifoPretrig(7);
-  cnl1tp->setClctHitPersist(4); // was 6, new is 4
+  cnl1tp->setClctHitPersist(4);  // was 6, new is 4
   cnl1tp->setClctDriftDelay(2);
-  cnl1tp->setClctNplanesHitPretrig(3); // was 2, new is 3
+  cnl1tp->setClctNplanesHitPretrig(3);  // was 2, new is 3
   cnl1tp->setClctNplanesHitPattern(4);
   cnl1tp->setClctPidThreshPretrig(2);
   cnl1tp->setClctMinSeparation(10);

--- a/CalibMuon/CSCCalibration/interface/CSCFakeCrosstalkConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakeCrosstalkConditions.h
@@ -16,8 +16,7 @@
 #include "CondFormats/DataRecord/interface/CSCcrosstalkRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCFakeCrosstalkConditions : public edm::ESProducer,
-                                   public edm::EventSetupRecordIntervalFinder {
+class CSCFakeCrosstalkConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCFakeCrosstalkConditions(const edm::ParameterSet &);
   ~CSCFakeCrosstalkConditions() override;

--- a/CalibMuon/CSCCalibration/interface/CSCFakeDBCrosstalk.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakeDBCrosstalk.h
@@ -17,8 +17,7 @@
 #include "CondFormats/DataRecord/interface/CSCDBCrosstalkRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCFakeDBCrosstalk : public edm::ESProducer,
-                           public edm::EventSetupRecordIntervalFinder {
+class CSCFakeDBCrosstalk : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCFakeDBCrosstalk(const edm::ParameterSet &);
   ~CSCFakeDBCrosstalk() override;
@@ -46,7 +45,7 @@ inline CSCDBCrosstalk *CSCFakeDBCrosstalk::prefillDBCrosstalk() {
   int seed;
   float mean, min;
   int ii, jj, iii, jjj;
-  const int MAX_SIZE = 217728; // or 252288 for ME4/2 chambers
+  const int MAX_SIZE = 217728;  // or 252288 for ME4/2 chambers
   const int SLOPE_FACTOR = 10000000;
   const int INTERCEPT_FACTOR = 100000;
 
@@ -63,29 +62,13 @@ inline CSCDBCrosstalk *CSCFakeDBCrosstalk::prefillDBCrosstalk() {
 
   for (int i = 0; i < MAX_SIZE; i++) {
     cndbcrosstalk->crosstalk[i].xtalk_slope_right =
-        (short int)((-((double)rand() / ((double)(RAND_MAX) + (double)(1))) /
-                         10000 +
-                     mean) *
-                        SLOPE_FACTOR +
-                    0.5);
+        (short int)((-((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 10000 + mean) * SLOPE_FACTOR + 0.5);
     cndbcrosstalk->crosstalk[i].xtalk_intercept_right =
-        (short int)((((double)rand() / ((double)(RAND_MAX) + (double)(1))) /
-                         100 +
-                     min) *
-                        INTERCEPT_FACTOR +
-                    0.5);
+        (short int)((((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 100 + min) * INTERCEPT_FACTOR + 0.5);
     cndbcrosstalk->crosstalk[i].xtalk_slope_left =
-        (short int)((-((double)rand() / ((double)(RAND_MAX) + (double)(1))) /
-                         10000 +
-                     mean) *
-                        SLOPE_FACTOR +
-                    0.5);
+        (short int)((-((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 10000 + mean) * SLOPE_FACTOR + 0.5);
     cndbcrosstalk->crosstalk[i].xtalk_intercept_left =
-        (short int)((((double)rand() / ((double)(RAND_MAX) + (double)(1))) /
-                         100 +
-                     min) *
-                        INTERCEPT_FACTOR +
-                    0.5);
+        (short int)((((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 100 + min) * INTERCEPT_FACTOR + 0.5);
 
     // 80 strips per chamber
     if (i < 34561 && i % 80 == 0) {

--- a/CalibMuon/CSCCalibration/interface/CSCFakeDBGains.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakeDBGains.h
@@ -17,8 +17,7 @@
 #include "CondFormats/DataRecord/interface/CSCDBGainsRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCFakeDBGains : public edm::ESProducer,
-                       public edm::EventSetupRecordIntervalFinder {
+class CSCFakeDBGains : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCFakeDBGains(const edm::ParameterSet &);
   ~CSCFakeDBGains() override;
@@ -45,7 +44,7 @@ private:
 inline CSCDBGains *CSCFakeDBGains::prefillDBGains() {
   int seed;
   float mean;
-  const int MAX_SIZE = 217728; // or 252288 for ME4/2 chambers
+  const int MAX_SIZE = 217728;  // or 252288 for ME4/2 chambers
   const int FACTOR = 1000;
 
   CSCDBGains *cndbgains = new CSCDBGains();
@@ -58,8 +57,7 @@ inline CSCDBGains *CSCFakeDBGains::prefillDBGains() {
 
   for (int i = 0; i < MAX_SIZE; i++) {
     cndbgains->gains[i].gain_slope =
-        (short int)(((double)rand() / ((double)(RAND_MAX) + (double)(1))) +
-                    mean * FACTOR + 0.5);
+        (short int)(((double)rand() / ((double)(RAND_MAX) + (double)(1))) + mean * FACTOR + 0.5);
   }
   return cndbgains;
 }

--- a/CalibMuon/CSCCalibration/interface/CSCFakeDBNoiseMatrix.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakeDBNoiseMatrix.h
@@ -17,8 +17,7 @@
 #include "CondFormats/DataRecord/interface/CSCDBNoiseMatrixRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCFakeDBNoiseMatrix : public edm::ESProducer,
-                             public edm::EventSetupRecordIntervalFinder {
+class CSCFakeDBNoiseMatrix : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCFakeDBNoiseMatrix(const edm::ParameterSet &);
   ~CSCFakeDBNoiseMatrix() override;
@@ -44,7 +43,7 @@ private:
 // to workaround plugin library
 inline CSCDBNoiseMatrix *CSCFakeDBNoiseMatrix::prefillDBNoiseMatrix() {
   int seed;
-  const int MAX_SIZE = 252288; // or 252288 for ME4/2 chambers
+  const int MAX_SIZE = 252288;  // or 252288 for ME4/2 chambers
   const int FACTOR = 1000;
 
   CSCDBNoiseMatrix *cndbmatrix = new CSCDBNoiseMatrix();

--- a/CalibMuon/CSCCalibration/interface/CSCFakeDBPedestals.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakeDBPedestals.h
@@ -17,8 +17,7 @@
 #include "CondFormats/DataRecord/interface/CSCDBPedestalsRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCFakeDBPedestals : public edm::ESProducer,
-                           public edm::EventSetupRecordIntervalFinder {
+class CSCFakeDBPedestals : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCFakeDBPedestals(const edm::ParameterSet &);
   ~CSCFakeDBPedestals() override;
@@ -44,7 +43,7 @@ private:
 inline CSCDBPedestals *CSCFakeDBPedestals::prefillDBPedestals() {
   int seed;
   float meanped, meanrms;
-  const int MAX_SIZE = 217728; // or 252288 for ME4/2 chambers
+  const int MAX_SIZE = 217728;  // or 252288 for ME4/2 chambers
   const int PED_FACTOR = 10;
   const int RMS_FACTOR = 1000;
 
@@ -59,12 +58,9 @@ inline CSCDBPedestals *CSCFakeDBPedestals::prefillDBPedestals() {
 
   for (int i = 0; i < MAX_SIZE; i++) {
     cndbpedestals->pedestals[i].ped =
-        (short int)(((double)rand() / ((double)(RAND_MAX) + (double)(1))) *
-                        100 +
-                    meanped * PED_FACTOR + 0.5);
+        (short int)(((double)rand() / ((double)(RAND_MAX) + (double)(1))) * 100 + meanped * PED_FACTOR + 0.5);
     cndbpedestals->pedestals[i].rms =
-        (short int)(((double)rand() / ((double)(RAND_MAX) + (double)(1))) +
-                    meanrms * RMS_FACTOR + 0.5);
+        (short int)(((double)rand() / ((double)(RAND_MAX) + (double)(1))) + meanrms * RMS_FACTOR + 0.5);
   }
   return cndbpedestals;
 }

--- a/CalibMuon/CSCCalibration/interface/CSCFakeGainsConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakeGainsConditions.h
@@ -17,8 +17,7 @@
 #include "CondFormats/DataRecord/interface/CSCGainsRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCFakeGainsConditions : public edm::ESProducer,
-                               public edm::EventSetupRecordIntervalFinder {
+class CSCFakeGainsConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCFakeGainsConditions(const edm::ParameterSet &);
   ~CSCFakeGainsConditions() override;

--- a/CalibMuon/CSCCalibration/interface/CSCFakeNoiseMatrixConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakeNoiseMatrixConditions.h
@@ -16,9 +16,7 @@
 #include "CondFormats/DataRecord/interface/CSCNoiseMatrixRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCFakeNoiseMatrixConditions
-    : public edm::ESProducer,
-      public edm::EventSetupRecordIntervalFinder {
+class CSCFakeNoiseMatrixConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCFakeNoiseMatrixConditions(const edm::ParameterSet &);
   ~CSCFakeNoiseMatrixConditions() override;

--- a/CalibMuon/CSCCalibration/interface/CSCFakePedestalsConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCFakePedestalsConditions.h
@@ -17,8 +17,7 @@
 #include "CondFormats/DataRecord/interface/CSCPedestalsRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCFakePedestalsConditions : public edm::ESProducer,
-                                   public edm::EventSetupRecordIntervalFinder {
+class CSCFakePedestalsConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCFakePedestalsConditions(const edm::ParameterSet &);
   ~CSCFakePedestalsConditions() override;

--- a/CalibMuon/CSCCalibration/interface/CSCGainsConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCGainsConditions.h
@@ -16,8 +16,7 @@
 #include "CondFormats/DataRecord/interface/CSCGainsRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCGainsConditions : public edm::ESProducer,
-                           public edm::EventSetupRecordIntervalFinder {
+class CSCGainsConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCGainsConditions(const edm::ParameterSet &);
   ~CSCGainsConditions() override;

--- a/CalibMuon/CSCCalibration/interface/CSCGainsDBConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCGainsDBConditions.h
@@ -17,8 +17,7 @@
 #include "CondFormats/DataRecord/interface/CSCDBGainsRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCGainsDBConditions : public edm::ESProducer,
-                             public edm::EventSetupRecordIntervalFinder {
+class CSCGainsDBConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCGainsDBConditions(const edm::ParameterSet &);
   ~CSCGainsDBConditions() override;
@@ -50,7 +49,7 @@ inline CSCDBGains *CSCGainsDBConditions::prefillDBGains() {
   CSCDBGains *cndbgains = new CSCDBGains();
 
   int db_index;
-  float db_gainslope; // db_intercpt, db_chisq;
+  float db_gainslope;  // db_intercpt, db_chisq;
   std::vector<int> db_index_id;
   std::vector<float> db_slope;
   std::vector<float> db_intercept;

--- a/CalibMuon/CSCCalibration/interface/CSCGasGainCorrectionDBConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCGasGainCorrectionDBConditions.h
@@ -18,15 +18,12 @@
 #include "DataFormats/MuonDetId/interface/CSCIndexer.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCGasGainCorrectionDBConditions
-    : public edm::ESProducer,
-      public edm::EventSetupRecordIntervalFinder {
+class CSCGasGainCorrectionDBConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCGasGainCorrectionDBConditions(const edm::ParameterSet &);
   ~CSCGasGainCorrectionDBConditions() override;
 
-  inline static CSCDBGasGainCorrection *
-  prefillDBGasGainCorrection(bool isForMC, std::string dataCorrFileName);
+  inline static CSCDBGasGainCorrection *prefillDBGasGainCorrection(bool isForMC, std::string dataCorrFileName);
 
   typedef std::unique_ptr<CSCDBGasGainCorrection> ReturnType;
 
@@ -53,9 +50,8 @@ private:
 #include <vector>
 
 // to workaround plugin library
-inline CSCDBGasGainCorrection *
-CSCGasGainCorrectionDBConditions::prefillDBGasGainCorrection(
-    bool isMC, std::string filename) {
+inline CSCDBGasGainCorrection *CSCGasGainCorrectionDBConditions::prefillDBGasGainCorrection(bool isMC,
+                                                                                            std::string filename) {
   if (isMC)
     printf("\n Generating fake DB constants for MC\n");
   else {
@@ -68,8 +64,7 @@ CSCGasGainCorrectionDBConditions::prefillDBGasGainCorrection(
 
   CSCDBGasGainCorrection *cndbGasGainCorr = new CSCDBGasGainCorrection();
 
-  CSCDBGasGainCorrection::GasGainContainer &itemvector =
-      cndbGasGainCorr->gasGainCorr;
+  CSCDBGasGainCorrection::GasGainContainer &itemvector = cndbGasGainCorr->gasGainCorr;
   itemvector.resize(MAX_SIZE);
 
   // Filling corrections for MC is very simple
@@ -112,20 +107,24 @@ CSCGasGainCorrectionDBConditions::prefillDBGasGainCorrection(
 
   FILE *fin = fopen(filename.data(), "r");
 
-  int linecounter =
-      0; // set the line counter to the first serial number in the file....
+  int linecounter = 0;  // set the line counter to the first serial number in the file....
 
   while (!feof(fin)) {
     // note space at end of format string to convert last \n
-    int check =
-        fscanf(fin, "%d %d %d %d %d %d %d %d %d %f %f %f \n",
-               &gains[linecounter].gas_gain_index, &gains[linecounter].endcap,
-               &gains[linecounter].station, &gains[linecounter].ring,
-               &gains[linecounter].chamber, &gains[linecounter].layer,
-               &gains[linecounter].hvsegment, &gains[linecounter].cfeb,
-               &gains[linecounter].nentries, &gains[linecounter].mean,
-               &gains[linecounter].truncated_mean,
-               &gains[linecounter].gas_gain_correction);
+    int check = fscanf(fin,
+                       "%d %d %d %d %d %d %d %d %d %f %f %f \n",
+                       &gains[linecounter].gas_gain_index,
+                       &gains[linecounter].endcap,
+                       &gains[linecounter].station,
+                       &gains[linecounter].ring,
+                       &gains[linecounter].chamber,
+                       &gains[linecounter].layer,
+                       &gains[linecounter].hvsegment,
+                       &gains[linecounter].cfeb,
+                       &gains[linecounter].nentries,
+                       &gains[linecounter].mean,
+                       &gains[linecounter].truncated_mean,
+                       &gains[linecounter].gas_gain_correction);
 
     if (check != 12) {
       printf("The input file format is not as expected\n");
@@ -138,8 +137,7 @@ CSCGasGainCorrectionDBConditions::prefillDBGasGainCorrection(
   fclose(fin);
 
   if (linecounter == MAX_SIZE) {
-    std::cout << "Total number of gas gains read in = " << linecounter
-              << std::endl;
+    std::cout << "Total number of gas gains read in = " << linecounter << std::endl;
   } else {
     std::cout << "ERROR:  Total number of gas-gains read in = " << linecounter
               << " while total number expected = " << MAX_SIZE << std::endl;
@@ -147,15 +145,13 @@ CSCGasGainCorrectionDBConditions::prefillDBGasGainCorrection(
 
   // Fill the chip corrections with values from the file
   for (int i = 0; i < MAX_SIZE; i++) {
-
     itemvector[i].gainCorr = 0.;
 
     if (gains[i].gas_gain_correction > 0.) {
       itemvector[i].gainCorr = gains[i].gas_gain_correction;
     } else {
       // if there is no value, this should be fixed...
-      std::cout << "ERROR:  gas_gain_correction < 0 for index "
-                << gains[i].gas_gain_index << std::endl;
+      std::cout << "ERROR:  gas_gain_correction < 0 for index " << gains[i].gas_gain_index << std::endl;
     }
   }
 

--- a/CalibMuon/CSCCalibration/interface/CSCIndexerBase.h
+++ b/CalibMuon/CSCCalibration/interface/CSCIndexerBase.h
@@ -63,16 +63,16 @@
 
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 #include <boost/tuple/tuple.hpp>
-#include <utility> // for pair
+#include <utility>  // for pair
 #include <vector>
 
 class CSCIndexerBase {
 public:
   typedef uint16_t IndexType;
   typedef uint32_t LongIndexType;
-  typedef boost::tuple<CSCDetId,  // id
-                       IndexType, // HV segment
-                       IndexType  // chip
+  typedef boost::tuple<CSCDetId,   // id
+                       IndexType,  // HV segment
+                       IndexType   // chip
                        >
       GasGainIndexType;
 
@@ -102,7 +102,7 @@ public:
    * How many physical rings are there in station 'is'=1, 2, 3, 4 ?
    */
   IndexType ringsInStation(IndexType is) const {
-    const IndexType nrins[5] = {0, 3, 2, 2, 2}; // physical rings per station
+    const IndexType nrins[5] = {0, 3, 2, 2, 2};  // physical rings per station
     return nrins[is];
   }
 
@@ -119,7 +119,7 @@ public:
    * ME1a).
    */
   IndexType offlineRingsInStation(IndexType is) const {
-    const IndexType nrings[5] = {0, 4, 2, 2, 2}; // offline rings per station
+    const IndexType nrings[5] = {0, 4, 2, 2, 2};  // offline rings per station
     return nrings[is];
   }
 
@@ -128,8 +128,7 @@ public:
    * Works for ME1a (ring 4 of ME1) too.
    */
   IndexType chambersInRingOfStation(IndexType is, IndexType ir) const {
-    const IndexType nCinR[16] = {36, 36, 36, 36, 18, 36, 0, 0, 18,
-                                 36, 0,  0,  18, 36, 0,  0}; // chambers in ring
+    const IndexType nCinR[16] = {36, 36, 36, 36, 18, 36, 0, 0, 18, 36, 0, 0, 18, 36, 0, 0};  // chambers in ring
     return nCinR[(is - 1) * 4 + ir - 1];
   }
 
@@ -138,16 +137,14 @@ public:
    * with ring 'ir' and station 'is'.
    * Works for ME1a (ring 4 of ME1) too.
    */
-  virtual IndexType stripChannelsPerOfflineLayer(IndexType is,
-                                                 IndexType ir) const = 0;
+  virtual IndexType stripChannelsPerOfflineLayer(IndexType is, IndexType ir) const = 0;
 
   /**
    * Number of strip readout channels per layer in an online chamber
    * with ring 'ir' and station 'is'.
    * Works for ME1a (ring 4 of ME1) too.
    */
-  virtual IndexType stripChannelsPerOnlineLayer(IndexType is,
-                                                IndexType ir) const = 0;
+  virtual IndexType stripChannelsPerOnlineLayer(IndexType is, IndexType ir) const = 0;
 
   /**
    * Number of Buckeye chips per layer in an online chamber
@@ -179,11 +176,9 @@ public:
    * \warning: Considers both ME1a and ME1b to be part of one whole ME11 chamber
    *          (result would be the same for is=1 and ir=1 or 4).
    */
-  IndexType startChamberIndexInEndcap(IndexType ie, IndexType is,
-                                      IndexType ir) const {
-    const IndexType nschin[32] = {
-        1,   37,  73,  1,   109, 127, 0, 0, 163, 181, 0, 0, 217, 469, 0, 0,
-        235, 271, 307, 235, 343, 361, 0, 0, 397, 415, 0, 0, 451, 505, 0, 0};
+  IndexType startChamberIndexInEndcap(IndexType ie, IndexType is, IndexType ir) const {
+    const IndexType nschin[32] = {1,   37,  73,  1,   109, 127, 0, 0, 163, 181, 0, 0, 217, 469, 0, 0,
+                                  235, 271, 307, 235, 343, 361, 0, 0, 397, 415, 0, 0, 451, 505, 0, 0};
     return nschin[(ie - 1) * 16 + (is - 1) * 4 + ir - 1];
   }
 
@@ -195,10 +190,8 @@ public:
    * the output is the same for input {is=1, ir=1} and {is=1, ir=4}, i.e.
    * chamberIndex for ME1/1a is the same as for ME1/1b.
    */
-  IndexType chamberIndex(IndexType ie, IndexType is, IndexType ir,
-                         IndexType ic) const {
-    return startChamberIndexInEndcap(ie, is, ir) + ic -
-           1; // -1 so start index _is_ ic=1
+  IndexType chamberIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic) const {
+    return startChamberIndexInEndcap(ie, is, ir) + ic - 1;  // -1 so start index _is_ ic=1
   }
 
   /**
@@ -226,8 +219,7 @@ public:
    * the output is the same for input {is=1, ir=1} and {is=1, ir=4}, i.e.
    * layerIndex for ME1/1a is the same as for ME1/1b.
    */
-  IndexType layerIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic,
-                       IndexType il) const {
+  IndexType layerIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic, IndexType il) const {
     const IndexType layersInChamber = 6;
     return (chamberIndex(ie, is, ir, ic) - 1) * layersInChamber + il;
   }
@@ -243,8 +235,7 @@ public:
    * layerIndex for ME1/1a is the same as for ME1/1b.
    */
   IndexType layerIndex(const CSCDetId &id) const {
-    return layerIndex(id.endcap(), id.station(), id.ring(), id.chamber(),
-                      id.layer());
+    return layerIndex(id.endcap(), id.station(), id.ring(), id.chamber(), id.layer());
   }
   //@}
 
@@ -275,8 +266,7 @@ public:
    * Endcap label range 1-2, Station label range 1-4, Ring label range 1-4
    * (4=ME1a)
    */
-  virtual LongIndexType stripChannelStart(IndexType ie, IndexType is,
-                                          IndexType ir) const = 0;
+  virtual LongIndexType stripChannelStart(IndexType ie, IndexType is, IndexType ir) const = 0;
 
   /**
    * Linear index for strip channel istrip in layer 'il' of chamber 'ic' of ring
@@ -285,12 +275,9 @@ public:
    * \warning: You must input labels within hardware ranges. No trapping on
    * out-of-range values!
    */
-  LongIndexType stripChannelIndex(IndexType ie, IndexType is, IndexType ir,
-                                  IndexType ic, IndexType il,
-                                  IndexType istrip) const {
-    return stripChannelStart(ie, is, ir) +
-           ((ic - 1) * 6 + il - 1) * stripChannelsPerLayer(is, ir) +
-           (istrip - 1);
+  LongIndexType stripChannelIndex(
+      IndexType ie, IndexType is, IndexType ir, IndexType ic, IndexType il, IndexType istrip) const {
+    return stripChannelStart(ie, is, ir) + ((ic - 1) * 6 + il - 1) * stripChannelsPerLayer(is, ir) + (istrip - 1);
   }
 
   /**
@@ -300,8 +287,7 @@ public:
    * out-of-range values!
    */
   LongIndexType stripChannelIndex(const CSCDetId &id, IndexType istrip) const {
-    return stripChannelIndex(id.endcap(), id.station(), id.ring(), id.chamber(),
-                             id.layer(), istrip);
+    return stripChannelIndex(id.endcap(), id.station(), id.ring(), id.chamber(), id.layer(), istrip);
   }
   //@}
 
@@ -322,8 +308,7 @@ public:
    * Endcap label range 1-2, Station label range 1-4, Ring label range 1-4
    * (4=ME1a)
    */
-  virtual IndexType chipStart(IndexType ie, IndexType is,
-                              IndexType ir) const = 0;
+  virtual IndexType chipStart(IndexType ie, IndexType is, IndexType ir) const = 0;
 
   /**
    * Linear index for Buckeye chip 'ichip' in layer 'il' of chamber 'ic' of ring
@@ -334,10 +319,8 @@ public:
    * still be treated the same as ir=1, but ichip must be 5 for it to make
    * sense!
    */
-  IndexType chipIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic,
-                      IndexType il, IndexType ichip) const {
-    return chipStart(ie, is, ir) +
-           ((ic - 1) * 6 + il - 1) * chipsPerLayer(is, ir) + (ichip - 1);
+  IndexType chipIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic, IndexType il, IndexType ichip) const {
+    return chipStart(ie, is, ir) + ((ic - 1) * 6 + il - 1) * chipsPerLayer(is, ir) + (ichip - 1);
   }
 
   /**
@@ -349,8 +332,7 @@ public:
    * ME11 id, but ichip must be 5 for it to make sense!
    */
   IndexType chipIndex(const CSCDetId &id, IndexType ichip) const {
-    return chipIndex(id.endcap(), id.station(), id.ring(), id.chamber(),
-                     id.layer(), ichip);
+    return chipIndex(id.endcap(), id.station(), id.ring(), id.chamber(), id.layer(), ichip);
   }
 
   /**
@@ -376,8 +358,7 @@ public:
    * single HV segment
    */
   IndexType hvSegmentsPerLayer(IndexType is, IndexType ir) const {
-    const IndexType nSinL[16] = {1, 3, 3, 1, 3, 5, 0, 0,
-                                 3, 5, 0, 0, 3, 5, 0, 0};
+    const IndexType nSinL[16] = {1, 3, 3, 1, 3, 5, 0, 0, 3, 5, 0, 0, 3, 5, 0, 0};
     return nSinL[(is - 1) * 4 + ir - 1];
   }
 
@@ -417,8 +398,7 @@ public:
    * ir=1 upgraded:  ME1a has 3 own chips, which are appended to the end of the
    * index range, ME1b still keeps 5 chips with chip #5 index unused.
    */
-  virtual IndexType sectorStart(IndexType ie, IndexType is,
-                                IndexType ir) const = 0;
+  virtual IndexType sectorStart(IndexType ie, IndexType is, IndexType ir) const = 0;
 
   /**
    * Linear index for Gas gain sector, based on the HV segment# and the chip#
@@ -432,11 +412,14 @@ public:
    * still be treated the same as ir=1, but ichip must be 5 for it to make
    * sense!
    */
-  IndexType gasGainIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic,
-                         IndexType il, IndexType ihvsegment,
+  IndexType gasGainIndex(IndexType ie,
+                         IndexType is,
+                         IndexType ir,
+                         IndexType ic,
+                         IndexType il,
+                         IndexType ihvsegment,
                          IndexType ichip) const {
-    return sectorStart(ie, is, ir) +
-           ((ic - 1) * 6 + il - 1) * sectorsPerLayer(is, ir) +
+    return sectorStart(ie, is, ir) + ((ic - 1) * 6 + il - 1) * sectorsPerLayer(is, ir) +
            (ihvsegment - 1) * chipsPerLayer(is, ir) + (ichip - 1);
   }
 
@@ -450,11 +433,14 @@ public:
    * same as whole ME11 id, but istrip must be a h/w strip number in 64-80 in
    * that case!
    */
-  IndexType gasGainIndex(const CSCDetId &id, IndexType istrip,
-                         IndexType iwire) const {
-    return gasGainIndex(
-        id.endcap(), id.station(), id.ring(), id.chamber(), id.layer(),
-        hvSegmentIndex(id.station(), id.ring(), iwire), chipIndex(istrip));
+  IndexType gasGainIndex(const CSCDetId &id, IndexType istrip, IndexType iwire) const {
+    return gasGainIndex(id.endcap(),
+                        id.station(),
+                        id.ring(),
+                        id.chamber(),
+                        id.layer(),
+                        hvSegmentIndex(id.station(), id.ring(), iwire),
+                        chipIndex(istrip));
   }
 
   /**
@@ -470,10 +456,8 @@ public:
    * provide ME1a id in ganged case, it would still be treated the same as whole
    * ME11 id, but ichip must be 5 for it to make sense!
    */
-  IndexType gasGainIndex(IndexType ihvsegment, IndexType ichip,
-                         const CSCDetId &id) const {
-    return gasGainIndex(id.endcap(), id.station(), id.ring(), id.chamber(),
-                        id.layer(), ihvsegment, ichip);
+  IndexType gasGainIndex(IndexType ihvsegment, IndexType ichip, const CSCDetId &id) const {
+    return gasGainIndex(id.endcap(), id.station(), id.ring(), id.chamber(), id.layer(), ihvsegment, ichip);
   }
   //@}
 
@@ -504,8 +488,7 @@ public:
    * channel in range 65-80. <br> If ME1/1a is unganged then an ME1/1a strip
    * index returns ME1/1a CSCDetId + channel in range 1-48.
    */
-  virtual std::pair<CSCDetId, IndexType>
-  detIdFromStripChannelIndex(LongIndexType ichi) const = 0;
+  virtual std::pair<CSCDetId, IndexType> detIdFromStripChannelIndex(LongIndexType ichi) const = 0;
 
   /**
    * CSCDetId + chip within chamber from conditions data chip index.
@@ -515,8 +498,7 @@ public:
    * chip=5. <br> If ME1/1a is unganged then an ME1/1a chip index returns ME1/1a
    * CSCDetId + chip# in range 1-3.
    */
-  virtual std::pair<CSCDetId, IndexType>
-  detIdFromChipIndex(IndexType ichi) const = 0;
+  virtual std::pair<CSCDetId, IndexType> detIdFromChipIndex(IndexType ichi) const = 0;
 
   /**
    * CSCDetId + HV segment + chip within chamber from conditions data gas gain

--- a/CalibMuon/CSCCalibration/interface/CSCIndexerESProducer.h
+++ b/CalibMuon/CSCCalibration/interface/CSCIndexerESProducer.h
@@ -9,7 +9,6 @@
 #include "CalibMuon/CSCCalibration/interface/CSCIndexerRecord.h"
 
 class CSCIndexerESProducer : public edm::ESProducer {
-
 public:
   typedef std::unique_ptr<CSCIndexerBase> BSP_TYPE;
 

--- a/CalibMuon/CSCCalibration/interface/CSCIndexerPostls1.h
+++ b/CalibMuon/CSCCalibration/interface/CSCIndexerPostls1.h
@@ -71,10 +71,8 @@ public:
    *
    * Assume ME1a has 48 unganged readout channels.
    */
-  IndexType stripChannelsPerOfflineLayer(IndexType is,
-                                         IndexType ir) const override {
-    const IndexType nSC[16] = {64, 80, 64, 48, 80, 80, 0, 0,
-                               80, 80, 0,  0,  80, 80, 0, 0};
+  IndexType stripChannelsPerOfflineLayer(IndexType is, IndexType ir) const override {
+    const IndexType nSC[16] = {64, 80, 64, 48, 80, 80, 0, 0, 80, 80, 0, 0, 80, 80, 0, 0};
     return nSC[(is - 1) * 4 + ir - 1];
   }
 
@@ -85,10 +83,8 @@ public:
    * Assume ME1a has 48 unganged readout channels.
    * Online chambers ME1a and ME1b are separate.
    */
-  IndexType stripChannelsPerOnlineLayer(IndexType is,
-                                        IndexType ir) const override {
-    const IndexType nSC[16] = {64, 80, 64, 48, 80, 80, 0, 0,
-                               80, 80, 0,  0,  80, 80, 0, 0};
+  IndexType stripChannelsPerOnlineLayer(IndexType is, IndexType ir) const override {
+    const IndexType nSC[16] = {64, 80, 64, 48, 80, 80, 0, 0, 80, 80, 0, 0, 80, 80, 0, 0};
     return nSC[(is - 1) * 4 + ir - 1];
   }
 
@@ -101,8 +97,7 @@ public:
    * chambers with 3 and 4 CFEBs respectively
    */
   IndexType chipsPerOnlineLayer(IndexType is, IndexType ir) const override {
-    const IndexType nCinL[16] = {4, 5, 4, 3, 5, 5, 0, 0,
-                                 5, 5, 0, 0, 5, 5, 0, 0};
+    const IndexType nCinL[16] = {4, 5, 4, 3, 5, 5, 0, 0, 5, 5, 0, 0, 5, 5, 0, 0};
     return nCinL[(is - 1) * 4 + ir - 1];
   }
 
@@ -123,8 +118,7 @@ public:
    * indices wide ranges.
    */
   IndexType stripChannelsPerLayer(IndexType is, IndexType ir) const override {
-    const IndexType nSCinC[16] = {80, 80, 64, 48, 80, 80, 0, 0,
-                                  80, 80, 0,  0,  80, 80, 0, 0};
+    const IndexType nSCinC[16] = {80, 80, 64, 48, 80, 80, 0, 0, 80, 80, 0, 0, 80, 80, 0, 0};
     return nSCinC[(is - 1) * 4 + ir - 1];
   }
 
@@ -138,8 +132,7 @@ public:
    * WARNING: ME1a channels are  NOT  considered the last 16 of the 80 total in
    * each layer of an ME11 chamber!
    */
-  LongIndexType stripChannelStart(IndexType ie, IndexType is,
-                                  IndexType ir) const override {
+  LongIndexType stripChannelStart(IndexType ie, IndexType is, IndexType ir) const override {
     // These are in the ranges 1-217728 (CSCs 2008), 217729-252288 (ME42), and
     // 252289-273024 (unganged ME1a) There are 1-108884 channels per endcap
     // (CSCs 2008), 17280 channels per endcap (ME42), and 10368 channels per
@@ -148,11 +141,9 @@ public:
     // of -z (ME42) is 217728 + 1 + 17280          = 235009 Start of +z
     // (unganged ME1a) is 252288 + 1         = 252289 Start of -z (unganged
     // ME1a) is 252288 + 1 + 10368 = 262657
-    const LongIndexType nStart[32] = {
-        1,      17281,  34561,  252289, 48385,  57025,  0, 0,
-        74305,  82945,  0,      0,      100225, 217729, 0, 0,
-        108865, 126145, 143425, 262657, 157249, 165889, 0, 0,
-        183169, 191809, 0,      0,      209089, 235009, 0, 0};
+    const LongIndexType nStart[32] = {1, 17281,  34561,  252289, 48385, 57025,  0,      0,      74305,  82945,  0,
+                                      0, 100225, 217729, 0,      0,     108865, 126145, 143425, 262657, 157249, 165889,
+                                      0, 0,      183169, 191809, 0,     0,      209089, 235009, 0,      0};
     return nStart[(ie - 1) * 16 + (is - 1) * 4 + ir - 1];
   }
   //@}
@@ -175,8 +166,7 @@ public:
    * chip #5 are ignored in the unganged case.
    */
   IndexType chipsPerLayer(IndexType is, IndexType ir) const override {
-    const IndexType nCinL[16] = {5, 5, 4, 3, 5, 5, 0, 0,
-                                 5, 5, 0, 0, 5, 5, 0, 0};
+    const IndexType nCinL[16] = {5, 5, 4, 3, 5, 5, 0, 0, 5, 5, 0, 0, 5, 5, 0, 0};
     return nCinL[(is - 1) * 4 + ir - 1];
   }
 
@@ -197,10 +187,8 @@ public:
     // channels (CSCs 2008) is 6804 + 1 = 6805 Start of +z (ME42) is 13608 + 1 =
     // 13609 Start of -z (ME42) is 13608 + 1 + 1080 = 14689 Start of +z (ME1a)
     // is 15768 + 1 = 15769 Start of -z (ME1a) is 15768 + 1 + 648 = 16417
-    const IndexType nStart[32] = {
-        1, 1081, 2161,  15769, 3025, 3565, 0,     0,     4645,  5185, 0,
-        0, 6265, 13609, 0,     0,    6805, 7885,  8965,  16417, 9829, 10369,
-        0, 0,    11449, 11989, 0,    0,    13069, 14689, 0,     0};
+    const IndexType nStart[32] = {1,    1081, 2161, 15769, 3025, 3565,  0, 0, 4645,  5185,  0, 0, 6265,  13609, 0, 0,
+                                  6805, 7885, 8965, 16417, 9829, 10369, 0, 0, 11449, 11989, 0, 0, 13069, 14689, 0, 0};
     return nStart[(ie - 1) * 16 + (is - 1) * 4 + ir - 1];
   }
   //@}
@@ -218,8 +206,7 @@ public:
    * the end of the index range, ME1b still keeps 5 chips with the chip #5 index
    * being unused.
    */
-  IndexType sectorStart(IndexType ie, IndexType is,
-                        IndexType ir) const override {
+  IndexType sectorStart(IndexType ie, IndexType is, IndexType ir) const override {
     // There are 36 chambers * 6 layers * 5 CFEB's * 1 HV segment = 1080
     // gas-gain sectors in ME1/1 (non-upgraded) There are 36 chambers * 6 layers
     // * 3 CFEB's * 1 HV segment = 648 gas-gain sectors in ME1/1a (upgraded)
@@ -232,23 +219,14 @@ public:
     // Start of -z (ME42) is 45144 + 1 + 5400 = 50545
     // Start of +z (ME1a) is 45144 + 1 + 2*5400 = 55945
     // Start of -z (ME42) is 45144 + 1 + 2*5400 + 648 = 56593
-    const IndexType nStart[32] = {
-        1,     1081,
-        4321,  55945, // ME+1/1,ME+1/2,ME+1/3,ME+1/a
-        6913,  8533,
-        0,     0, // ME+2/1,ME+2/2
-        13933, 15553,
-        0,     0, // ME+3/1,ME+3/2
-        20953, 45145,
-        0,     0, // ME+4/1,ME+4/2 (note, ME+4/2 index follows ME-4/1...)
-        22573, 23653,
-        26893, 56593, // ME-1/1,ME-1/2,ME-1/3,ME+1/a
-        29485, 31105,
-        0,     0, // ME-2/1,ME-2/2
-        36505, 38125,
-        0,     0, // ME-3/1,ME-3/2
-        43525, 50545,
-        0,     0}; // ME-4/1,ME-4/2 (note, ME-4/2 index follows ME+4/2...)
+    const IndexType nStart[32] = {1,     1081,  4321,  55945,  // ME+1/1,ME+1/2,ME+1/3,ME+1/a
+                                  6913,  8533,  0,     0,      // ME+2/1,ME+2/2
+                                  13933, 15553, 0,     0,      // ME+3/1,ME+3/2
+                                  20953, 45145, 0,     0,      // ME+4/1,ME+4/2 (note, ME+4/2 index follows ME-4/1...)
+                                  22573, 23653, 26893, 56593,  // ME-1/1,ME-1/2,ME-1/3,ME+1/a
+                                  29485, 31105, 0,     0,      // ME-2/1,ME-2/2
+                                  36505, 38125, 0,     0,      // ME-3/1,ME-3/2
+                                  43525, 50545, 0,     0};     // ME-4/1,ME-4/2 (note, ME-4/2 index follows ME+4/2...)
     return nStart[(ie - 1) * 16 + (is - 1) * 4 + ir - 1];
   }
   //@}
@@ -256,12 +234,9 @@ public:
   /**
    *  Decode CSCDetId from various indexes and labels
    */
-  std::pair<CSCDetId, IndexType>
-  detIdFromStripChannelIndex(LongIndexType ichi) const override;
-  std::pair<CSCDetId, IndexType>
-  detIdFromChipIndex(IndexType ichi) const override;
-  CSCIndexerBase::GasGainIndexType
-  detIdFromGasGainIndex(IndexType igg) const override;
+  std::pair<CSCDetId, IndexType> detIdFromStripChannelIndex(LongIndexType ichi) const override;
+  std::pair<CSCDetId, IndexType> detIdFromChipIndex(IndexType ichi) const override;
+  CSCIndexerBase::GasGainIndexType detIdFromGasGainIndex(IndexType igg) const override;
 
   /**
    * Build index used internally in online CSC conditions databases (the 'Igor

--- a/CalibMuon/CSCCalibration/interface/CSCIndexerRecord.h
+++ b/CalibMuon/CSCCalibration/interface/CSCIndexerRecord.h
@@ -3,8 +3,6 @@
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 
-class CSCIndexerRecord
-    : public edm::eventsetup::EventSetupRecordImplementation<CSCIndexerRecord> {
-};
+class CSCIndexerRecord : public edm::eventsetup::EventSetupRecordImplementation<CSCIndexerRecord> {};
 
 #endif

--- a/CalibMuon/CSCCalibration/interface/CSCIndexerStartup.h
+++ b/CalibMuon/CSCCalibration/interface/CSCIndexerStartup.h
@@ -36,7 +36,6 @@
 #include <CalibMuon/CSCCalibration/interface/CSCIndexerBase.h>
 
 class CSCIndexerStartup : public CSCIndexerBase {
-
 public:
   ~CSCIndexerStartup() override;
 
@@ -69,10 +68,8 @@ public:
    *
    * Assume ME1a has 16 ganged readout channels.
    */
-  IndexType stripChannelsPerOfflineLayer(IndexType is,
-                                         IndexType ir) const override {
-    const IndexType nSC[16] = {64, 80, 64, 16, 80, 80, 0, 0,
-                               80, 80, 0,  0,  80, 80, 0, 0};
+  IndexType stripChannelsPerOfflineLayer(IndexType is, IndexType ir) const override {
+    const IndexType nSC[16] = {64, 80, 64, 16, 80, 80, 0, 0, 80, 80, 0, 0, 80, 80, 0, 0};
     return nSC[(is - 1) * 4 + ir - 1];
   }
 
@@ -84,10 +81,8 @@ public:
    * Assume ME1a has 16 ganged readout channels. Online chamber has 64+16=80
    * channels.
    */
-  IndexType stripChannelsPerOnlineLayer(IndexType is,
-                                        IndexType ir) const override {
-    const IndexType nSC[16] = {80, 80, 64, 80, 80, 80, 0, 0,
-                               80, 80, 0,  0,  80, 80, 0, 0};
+  IndexType stripChannelsPerOnlineLayer(IndexType is, IndexType ir) const override {
+    const IndexType nSC[16] = {80, 80, 64, 80, 80, 80, 0, 0, 80, 80, 0, 0, 80, 80, 0, 0};
     return nSC[(is - 1) * 4 + ir - 1];
   }
 
@@ -100,8 +95,7 @@ public:
    * chips
    */
   IndexType chipsPerOnlineLayer(IndexType is, IndexType ir) const override {
-    const IndexType nCinL[16] = {5, 5, 4, 5, 5, 5, 0, 0,
-                                 5, 5, 0, 0, 5, 5, 0, 0};
+    const IndexType nCinL[16] = {5, 5, 4, 5, 5, 5, 0, 0, 5, 5, 0, 0, 5, 5, 0, 0};
     return nCinL[(is - 1) * 4 + ir - 1];
   }
 
@@ -122,8 +116,7 @@ public:
    * hardware channels numbering is implemented.
    */
   IndexType stripChannelsPerLayer(IndexType is, IndexType ir) const override {
-    const IndexType nSCinC[16] = {80, 80, 64, 80, 80, 80, 0, 0,
-                                  80, 80, 0,  0,  80, 80, 0, 0};
+    const IndexType nSCinC[16] = {80, 80, 64, 80, 80, 80, 0, 0, 80, 80, 0, 0, 80, 80, 0, 0};
     return nSCinC[(is - 1) * 4 + ir - 1];
   }
 
@@ -137,18 +130,15 @@ public:
    * of an ME11 chamber, their start index here defaults to the start index of
    * ME1a.
    */
-  LongIndexType stripChannelStart(IndexType ie, IndexType is,
-                                  IndexType ir) const override {
+  LongIndexType stripChannelStart(IndexType ie, IndexType is, IndexType ir) const override {
     // These are in the ranges 1-217728 (CSCs 2008) and 217729-252288 (ME42).
     // There are 1-108884 channels per endcap (CSCs 2008) and 17280 channels per
     // endcap (ME42). Start of -z channels (CSCs 2008) is 108864 + 1 = 108865
     // Start of +z (ME42) is 217728 + 1 = 217729
     // Start of -z (ME42) is 217728 + 1 + 17280 = 235009
-    const LongIndexType nStart[32] = {
-        1,      17281,  34561,  1,      48385,  57025,  0, 0,
-        74305,  82945,  0,      0,      100225, 217729, 0, 0,
-        108865, 126145, 143425, 108865, 157249, 165889, 0, 0,
-        183169, 191809, 0,      0,      209089, 235009, 0, 0};
+    const LongIndexType nStart[32] = {1, 17281,  34561,  1,      48385, 57025,  0,      0,      74305,  82945,  0,
+                                      0, 100225, 217729, 0,      0,     108865, 126145, 143425, 108865, 157249, 165889,
+                                      0, 0,      183169, 191809, 0,     0,      209089, 235009, 0,      0};
     return nStart[(ie - 1) * 16 + (is - 1) * 4 + ir - 1];
   }
   //@}
@@ -168,8 +158,7 @@ public:
    * Considers ME42 as standard 5 chip per layer chambers.
    */
   IndexType chipsPerLayer(IndexType is, IndexType ir) const override {
-    const IndexType nCinL[16] = {5, 5, 4, 5, 5, 5, 0, 0,
-                                 5, 5, 0, 0, 5, 5, 0, 0};
+    const IndexType nCinL[16] = {5, 5, 4, 5, 5, 5, 0, 0, 5, 5, 0, 0, 5, 5, 0, 0};
     return nCinL[(is - 1) * 4 + ir - 1];
   }
 
@@ -189,10 +178,8 @@ public:
     // endcap (ME42). Start of -z channels (CSCs 2008) is 6804 + 1 = 6805 Start
     // of +z (ME42) is 13608 + 1 = 13609 Start of -z (ME42) is 13608 + 1 + 1080
     // = 14689
-    const IndexType nStart[32] = {1,     1081,  2161, 1,    3025,  3565,  0, 0,
-                                  4645,  5185,  0,    0,    6265,  13609, 0, 0,
-                                  6805,  7885,  8965, 6805, 9829,  10369, 0, 0,
-                                  11449, 11989, 0,    0,    13069, 14689, 0, 0};
+    const IndexType nStart[32] = {1,    1081, 2161, 1,    3025, 3565,  0, 0, 4645,  5185,  0, 0, 6265,  13609, 0, 0,
+                                  6805, 7885, 8965, 6805, 9829, 10369, 0, 0, 11449, 11989, 0, 0, 13069, 14689, 0, 0};
     return nStart[(ie - 1) * 16 + (is - 1) * 4 + ir - 1];
   }
   //@}
@@ -210,8 +197,7 @@ public:
    * ME11 chamber, and an input ir=4 in this case would give the same result as
    * ir=1
    */
-  IndexType sectorStart(IndexType ie, IndexType is,
-                        IndexType ir) const override {
+  IndexType sectorStart(IndexType ie, IndexType is, IndexType ir) const override {
     // There are 36 chambers * 6 layers * 5 CFEB's * 1 HV segment = 1080
     // gas-gain sectors in ME1/1 There are 36*6*5*3 = 3240 gas-gain sectors in
     // ME1/2 There are 36*6*4*3 = 2592 gas-gain sectors in ME1/3 There are
@@ -219,23 +205,22 @@ public:
     // gas-gain sectors in ME[2-4]/2 Start of -z channels (CSCs 2008) is 22572 +
     // 1 = 22573 Start of +z (ME42) is 45144 + 1 = 45145 Start of -z (ME42) is
     // 45144 + 1 + 5400 = 50545
-    const IndexType nStart[32] = {
-        1,     1081,  4321,
-        1, // ME+1/1,ME+1/2,ME+1/3,ME+1/4
-        6913,  8533,  0,
-        0, // ME+2/1,ME+2/2,
-        13933, 15553, 0,
-        0, // ME+3/1,ME+3/2,
-        20953, 45145, 0,
-        0, // ME+4/1,ME+4/2,ME+4/3 (note, ME+4/2 index follows ME-4/1...)
-        22573, 23653, 26893,
-        22573, // ME-1/1,ME-1/2,ME-1/3, ME-1/4
-        29485, 31105, 0,
-        0, // ME-2/1,ME-2/2,ME-2/3
-        36505, 38125, 0,
-        0, // ME-3/1,ME-3/2,ME-3/3
-        43525, 50545, 0,
-        0}; // ME-4/1,ME-4/2,ME-4/3 (note, ME-4/2 index follows ME+4/2...)
+    const IndexType nStart[32] = {1,     1081,  4321,
+                                  1,  // ME+1/1,ME+1/2,ME+1/3,ME+1/4
+                                  6913,  8533,  0,
+                                  0,  // ME+2/1,ME+2/2,
+                                  13933, 15553, 0,
+                                  0,  // ME+3/1,ME+3/2,
+                                  20953, 45145, 0,
+                                  0,  // ME+4/1,ME+4/2,ME+4/3 (note, ME+4/2 index follows ME-4/1...)
+                                  22573, 23653, 26893,
+                                  22573,  // ME-1/1,ME-1/2,ME-1/3, ME-1/4
+                                  29485, 31105, 0,
+                                  0,  // ME-2/1,ME-2/2,ME-2/3
+                                  36505, 38125, 0,
+                                  0,  // ME-3/1,ME-3/2,ME-3/3
+                                  43525, 50545, 0,
+                                  0};  // ME-4/1,ME-4/2,ME-4/3 (note, ME-4/2 index follows ME+4/2...)
     return nStart[(ie - 1) * 16 + (is - 1) * 4 + ir - 1];
   }
   //@}
@@ -243,10 +228,8 @@ public:
   /**
    *  Decode CSCDetId from various indexes and labels
    */
-  std::pair<CSCDetId, IndexType>
-  detIdFromStripChannelIndex(LongIndexType ichi) const override;
-  std::pair<CSCDetId, IndexType>
-  detIdFromChipIndex(IndexType ichi) const override;
+  std::pair<CSCDetId, IndexType> detIdFromStripChannelIndex(LongIndexType ichi) const override;
+  std::pair<CSCDetId, IndexType> detIdFromChipIndex(IndexType ichi) const override;
   GasGainIndexType detIdFromGasGainIndex(IndexType igg) const override;
 
   /**

--- a/CalibMuon/CSCCalibration/interface/CSCL1TPParametersConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCL1TPParametersConditions.h
@@ -17,8 +17,7 @@
 #include "CondFormats/DataRecord/interface/CSCL1TPParametersRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCL1TPParametersConditions : public edm::ESProducer,
-                                    public edm::EventSetupRecordIntervalFinder {
+class CSCL1TPParametersConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCL1TPParametersConditions(const edm::ParameterSet &);
   ~CSCL1TPParametersConditions() override;
@@ -42,17 +41,15 @@ private:
 #include <vector>
 
 // to workaround plugin library
-inline CSCL1TPParameters *
-CSCL1TPParametersConditions::prefillCSCL1TPParameters() {
-
+inline CSCL1TPParameters *CSCL1TPParametersConditions::prefillCSCL1TPParameters() {
   CSCL1TPParameters *cnl1tp = new CSCL1TPParameters();
 
   cnl1tp->setAlctFifoTbins(16);
   cnl1tp->setAlctFifoPretrig(10);
   cnl1tp->setAlctDriftDelay(2);
-  cnl1tp->setAlctNplanesHitPretrig(3); // was 2, new is 3
+  cnl1tp->setAlctNplanesHitPretrig(3);  // was 2, new is 3
   cnl1tp->setAlctNplanesHitPattern(4);
-  cnl1tp->setAlctNplanesHitAccelPretrig(3); // was 2, new is 3
+  cnl1tp->setAlctNplanesHitAccelPretrig(3);  // was 2, new is 3
   cnl1tp->setAlctNplanesHitAccelPattern(4);
   cnl1tp->setAlctTrigMode(2);
   cnl1tp->setAlctAccelMode(0);
@@ -60,9 +57,9 @@ CSCL1TPParametersConditions::prefillCSCL1TPParameters() {
 
   cnl1tp->setClctFifoTbins(12);
   cnl1tp->setClctFifoPretrig(7);
-  cnl1tp->setClctHitPersist(4); // was 6, new is 4
+  cnl1tp->setClctHitPersist(4);  // was 6, new is 4
   cnl1tp->setClctDriftDelay(2);
-  cnl1tp->setClctNplanesHitPretrig(3); // was 2, new is 3
+  cnl1tp->setClctNplanesHitPretrig(3);  // was 2, new is 3
   cnl1tp->setClctNplanesHitPattern(4);
   cnl1tp->setClctPidThreshPretrig(2);
   cnl1tp->setClctMinSeparation(10);

--- a/CalibMuon/CSCCalibration/interface/CSCNoiseMatrixConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCNoiseMatrixConditions.h
@@ -16,8 +16,7 @@
 #include "CondFormats/DataRecord/interface/CSCNoiseMatrixRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCNoiseMatrixConditions : public edm::ESProducer,
-                                 public edm::EventSetupRecordIntervalFinder {
+class CSCNoiseMatrixConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCNoiseMatrixConditions(const edm::ParameterSet &);
   ~CSCNoiseMatrixConditions() override;

--- a/CalibMuon/CSCCalibration/interface/CSCNoiseMatrixDBConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCNoiseMatrixDBConditions.h
@@ -17,8 +17,7 @@
 #include "CondFormats/DataRecord/interface/CSCDBNoiseMatrixRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCNoiseMatrixDBConditions : public edm::ESProducer,
-                                   public edm::EventSetupRecordIntervalFinder {
+class CSCNoiseMatrixDBConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCNoiseMatrixDBConditions(const edm::ParameterSet &);
   ~CSCNoiseMatrixDBConditions() override;
@@ -96,9 +95,8 @@ inline CSCDBNoiseMatrix *CSCNoiseMatrixDBConditions::prefillDBNoiseMatrix() {
   }
 
   while (!dbdata.eof()) {
-    dbdata >> db_index >> db_elm33 >> db_elm34 >> db_elm44 >> db_elm35 >>
-        db_elm45 >> db_elm55 >> db_elm46 >> db_elm56 >> db_elm66 >> db_elm57 >>
-        db_elm67 >> db_elm77;
+    dbdata >> db_index >> db_elm33 >> db_elm34 >> db_elm44 >> db_elm35 >> db_elm45 >> db_elm55 >> db_elm46 >>
+        db_elm56 >> db_elm66 >> db_elm57 >> db_elm67 >> db_elm77;
     db_index_id.push_back(db_index);
     db_elem33.push_back(db_elm33);
     db_elem34.push_back(db_elm34);
@@ -124,9 +122,8 @@ inline CSCDBNoiseMatrix *CSCNoiseMatrixDBConditions::prefillDBNoiseMatrix() {
   }
 
   while (!newdata.eof()) {
-    newdata >> new_index >> new_elm33 >> new_elm34 >> new_elm44 >> new_elm35 >>
-        new_elm45 >> new_elm55 >> new_elm46 >> new_elm56 >> new_elm66 >>
-        new_elm57 >> new_elm67 >> new_elm77;
+    newdata >> new_index >> new_elm33 >> new_elm34 >> new_elm44 >> new_elm35 >> new_elm45 >> new_elm55 >> new_elm46 >>
+        new_elm56 >> new_elm66 >> new_elm57 >> new_elm67 >> new_elm77;
     // new_cham_id.push_back(new_chamber_id);
     new_index_id.push_back(new_index);
     new_elem33.push_back(new_elm33);

--- a/CalibMuon/CSCCalibration/interface/CSCPedestalsDBConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCPedestalsDBConditions.h
@@ -17,8 +17,7 @@
 #include "CondFormats/DataRecord/interface/CSCDBPedestalsRcd.h"
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-class CSCPedestalsDBConditions : public edm::ESProducer,
-                                 public edm::EventSetupRecordIntervalFinder {
+class CSCPedestalsDBConditions : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   CSCPedestalsDBConditions(const edm::ParameterSet &);
   ~CSCPedestalsDBConditions() override;

--- a/CalibMuon/CSCCalibration/plugins/CSCBadChambersConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCBadChambersConditions.cc
@@ -5,8 +5,7 @@
 #include "CondFormats/CSCObjects/interface/CSCBadChambers.h"
 #include "CondFormats/DataRecord/interface/CSCBadChambersRcd.h"
 
-CSCBadChambersConditions::CSCBadChambersConditions(
-    const edm::ParameterSet &iConfig) {
+CSCBadChambersConditions::CSCBadChambersConditions(const edm::ParameterSet &iConfig) {
   // the following line is needed to tell the framework what
   // data is being produced
   setWhatProduced(this, &CSCBadChambersConditions::produceBadChambers);
@@ -15,7 +14,6 @@ CSCBadChambersConditions::CSCBadChambersConditions(
 }
 
 CSCBadChambersConditions::~CSCBadChambersConditions() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -25,15 +23,13 @@ CSCBadChambersConditions::~CSCBadChambersConditions() {
 //
 
 // ------------ method called to produce the data  ------------
-CSCBadChambersConditions::ReturnType
-CSCBadChambersConditions::produceBadChambers(const CSCBadChambersRcd &iRecord) {
+CSCBadChambersConditions::ReturnType CSCBadChambersConditions::produceBadChambers(const CSCBadChambersRcd &iRecord) {
   // need a new object so to not be deleted at exit
   return CSCBadChambersConditions::ReturnType(prefillBadChambers());
 }
 
-void CSCBadChambersConditions::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCBadChambersConditions::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                              const edm::IOVSyncValue &,
+                                              edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCBadStripsConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCBadStripsConditions.cc
@@ -5,8 +5,7 @@
 #include "CondFormats/CSCObjects/interface/CSCBadStrips.h"
 #include "CondFormats/DataRecord/interface/CSCBadStripsRcd.h"
 
-CSCBadStripsConditions::CSCBadStripsConditions(
-    const edm::ParameterSet &iConfig) {
+CSCBadStripsConditions::CSCBadStripsConditions(const edm::ParameterSet &iConfig) {
   // the following line is needed to tell the framework what
   // data is being produced
   setWhatProduced(this, &CSCBadStripsConditions::produceBadStrips);
@@ -15,7 +14,6 @@ CSCBadStripsConditions::CSCBadStripsConditions(
 }
 
 CSCBadStripsConditions::~CSCBadStripsConditions() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -25,15 +23,13 @@ CSCBadStripsConditions::~CSCBadStripsConditions() {
 //
 
 // ------------ method called to produce the data  ------------
-CSCBadStripsConditions::ReturnType
-CSCBadStripsConditions::produceBadStrips(const CSCBadStripsRcd &iRecord) {
+CSCBadStripsConditions::ReturnType CSCBadStripsConditions::produceBadStrips(const CSCBadStripsRcd &iRecord) {
   // need a new object so to not be deleted at exit
   return CSCBadStripsConditions::ReturnType(prefillBadStrips());
 }
 
-void CSCBadStripsConditions::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCBadStripsConditions::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                            const edm::IOVSyncValue &,
+                                            edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCBadWiresConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCBadWiresConditions.cc
@@ -14,7 +14,6 @@ CSCBadWiresConditions::CSCBadWiresConditions(const edm::ParameterSet &iConfig) {
 }
 
 CSCBadWiresConditions::~CSCBadWiresConditions() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -24,15 +23,13 @@ CSCBadWiresConditions::~CSCBadWiresConditions() {
 //
 
 // ------------ method called to produce the data  ------------
-CSCBadWiresConditions::ReturnType
-CSCBadWiresConditions::produceBadWires(const CSCBadWiresRcd &iRecord) {
+CSCBadWiresConditions::ReturnType CSCBadWiresConditions::produceBadWires(const CSCBadWiresRcd &iRecord) {
   // need a new object so to not be deleted at exit
   return CSCBadWiresConditions::ReturnType(prefillBadWires());
 }
 
-void CSCBadWiresConditions::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCBadWiresConditions::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                           const edm::IOVSyncValue &,
+                                           edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCChannelMapperESProducer.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCChannelMapperESProducer.cc
@@ -5,8 +5,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-CSCChannelMapperESProducer::CSCChannelMapperESProducer(
-    const edm::ParameterSet &pset) {
+CSCChannelMapperESProducer::CSCChannelMapperESProducer(const edm::ParameterSet &pset) {
   algoName = pset.getParameter<std::string>("AlgoName");
 
   LogTrace("CSCChannelMapperESProducer") << " will produce: " << algoName;
@@ -16,12 +15,10 @@ CSCChannelMapperESProducer::CSCChannelMapperESProducer(
 
 CSCChannelMapperESProducer::~CSCChannelMapperESProducer() {}
 
-CSCChannelMapperESProducer::BSP_TYPE
-CSCChannelMapperESProducer::produce(const CSCChannelMapperRecord &) {
+CSCChannelMapperESProducer::BSP_TYPE CSCChannelMapperESProducer::produce(const CSCChannelMapperRecord &) {
   LogTrace("CSCChannelMapperESProducer") << " producing: " << algoName;
 
-  return CSCChannelMapperESProducer::BSP_TYPE(
-      CSCChannelMapperFactory::get()->create(algoName));
+  return CSCChannelMapperESProducer::BSP_TYPE(CSCChannelMapperFactory::get()->create(algoName));
 }
 
 // define this as a plug-in

--- a/CalibMuon/CSCCalibration/plugins/CSCChipSpeedCorrectionDBConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCChipSpeedCorrectionDBConditions.cc
@@ -5,23 +5,19 @@
 #include "CondFormats/CSCObjects/interface/CSCDBChipSpeedCorrection.h"
 #include "CondFormats/DataRecord/interface/CSCDBChipSpeedCorrectionRcd.h"
 
-CSCChipSpeedCorrectionDBConditions::CSCChipSpeedCorrectionDBConditions(
-    const edm::ParameterSet &iConfig) {
+CSCChipSpeedCorrectionDBConditions::CSCChipSpeedCorrectionDBConditions(const edm::ParameterSet &iConfig) {
   // the following line is needed to tell the framework what
   // data is being produced
   isForMC = iConfig.getUntrackedParameter<bool>("isForMC", true);
-  dataCorrFileName = iConfig.getUntrackedParameter<std::string>(
-      "dataCorrFileName", "empty.txt");
+  dataCorrFileName = iConfig.getUntrackedParameter<std::string>("dataCorrFileName", "empty.txt");
   dataOffset = 170.;
   // added by Zhen (changed since 1_2_0)
-  setWhatProduced(
-      this, &CSCChipSpeedCorrectionDBConditions::produceDBChipSpeedCorrection);
+  setWhatProduced(this, &CSCChipSpeedCorrectionDBConditions::produceDBChipSpeedCorrection);
   findingRecord<CSCDBChipSpeedCorrectionRcd>();
   // now do what ever other initialization is needed
 }
 
 CSCChipSpeedCorrectionDBConditions::~CSCChipSpeedCorrectionDBConditions() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -31,17 +27,15 @@ CSCChipSpeedCorrectionDBConditions::~CSCChipSpeedCorrectionDBConditions() {
 //
 
 // ------------ method called to produce the data  ------------
-CSCChipSpeedCorrectionDBConditions::ReturnType
-CSCChipSpeedCorrectionDBConditions::produceDBChipSpeedCorrection(
+CSCChipSpeedCorrectionDBConditions::ReturnType CSCChipSpeedCorrectionDBConditions::produceDBChipSpeedCorrection(
     const CSCDBChipSpeedCorrectionRcd &iRecord) {
   // need a new object so to not be deleted at exit
   return CSCChipSpeedCorrectionDBConditions::ReturnType(
       prefillDBChipSpeedCorrection(isForMC, dataCorrFileName, dataOffset));
 }
 
-void CSCChipSpeedCorrectionDBConditions::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCChipSpeedCorrectionDBConditions::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                                        const edm::IOVSyncValue &,
+                                                        edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCCrosstalkConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCCrosstalkConditions.cc
@@ -4,7 +4,6 @@
 #include "CalibMuon/CSCCalibration/interface/CSCCrosstalkConditions.h"
 
 CSCcrosstalk *CSCCrosstalkConditions::prefillCrosstalk() {
-
   float mean, min, minchi;
   int seed;
   int old_chamber_id, old_strip, new_chamber_id, new_strip;
@@ -48,9 +47,8 @@ CSCcrosstalk *CSCCrosstalkConditions::prefillCrosstalk() {
   }
 
   while (!olddata.eof()) {
-    olddata >> old_chamber_id >> old_strip >> old_slope_right >>
-        old_intercept_right >> old_chi2_right >> old_slope_left >>
-        old_intercept_left >> old_chi2_left;
+    olddata >> old_chamber_id >> old_strip >> old_slope_right >> old_intercept_right >> old_chi2_right >>
+        old_slope_left >> old_intercept_left >> old_chi2_left;
     old_cham_id.push_back(old_chamber_id);
     old_strips.push_back(old_strip);
     old_slope_r.push_back(old_slope_right);
@@ -71,9 +69,8 @@ CSCcrosstalk *CSCCrosstalkConditions::prefillCrosstalk() {
   }
 
   while (!newdata.eof()) {
-    newdata >> new_chamber_id >> new_strip >> new_slope_right >>
-        new_intercept_right >> new_chi2_right >> new_slope_left >>
-        new_intercept_left >> new_chi2_left;
+    newdata >> new_chamber_id >> new_strip >> new_slope_right >> new_intercept_right >> new_chi2_right >>
+        new_slope_left >> new_intercept_left >> new_chi2_left;
     new_cham_id.push_back(new_chamber_id);
     new_strips.push_back(new_strip);
     new_slope_r.push_back(new_slope_right);
@@ -86,10 +83,8 @@ CSCcrosstalk *CSCCrosstalkConditions::prefillCrosstalk() {
   }
   newdata.close();
 
-  for (int iendcap = detId.minEndcapId(); iendcap <= detId.maxEndcapId();
-       iendcap++) {
-    for (int istation = detId.minStationId(); istation <= detId.maxStationId();
-         istation++) {
+  for (int iendcap = detId.minEndcapId(); iendcap <= detId.maxEndcapId(); iendcap++) {
+    for (int istation = detId.minStationId(); istation <= detId.maxStationId(); istation++) {
       max_ring = detId.maxRingId();
       // station 4 ring 4 not there(36 chambers*2 missing)
       // 3 rings max this way of counting (ME1a & b)
@@ -124,56 +119,36 @@ CSCcrosstalk *CSCCrosstalkConditions::prefillCrosstalk() {
         // station 1 ring 3 has 64 strips per layer instead of 80(minus & plus
         // side!!!)
 
-        for (int ichamber = detId.minChamberId(); ichamber <= max_cham;
-             ichamber++) {
-
-          for (int ilayer = detId.minLayerId(); ilayer <= detId.maxLayerId();
-               ilayer++) {
+        for (int ichamber = detId.minChamberId(); ichamber <= max_cham; ichamber++) {
+          for (int ilayer = detId.minLayerId(); ilayer <= detId.maxLayerId(); ilayer++) {
             // station 1 ring 3 has 64 strips per layer instead of 80
             if (istation == 1 && iring == 3)
               max_istrip = 64;
 
             std::vector<CSCcrosstalk::Item> itemvector;
             itemvector.resize(max_istrip);
-            id_layer = 100000 * iendcap + 10000 * istation + 1000 * iring +
-                       10 * ichamber + ilayer;
+            id_layer = 100000 * iendcap + 10000 * istation + 1000 * iring + 10 * ichamber + ilayer;
 
             for (int istrip = 0; istrip < max_istrip; istrip++) {
               // create fake values
               itemvector[istrip].xtalk_slope_right =
-                  -((double)rand() / ((double)(RAND_MAX) + (double)(1))) /
-                      10000 +
-                  mean;
+                  -((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 10000 + mean;
               itemvector[istrip].xtalk_intercept_right =
-                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 100 +
-                  min;
-              itemvector[istrip].xtalk_chi2_right =
-                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) +
-                  minchi;
+                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 100 + min;
+              itemvector[istrip].xtalk_chi2_right = ((double)rand() / ((double)(RAND_MAX) + (double)(1))) + minchi;
               itemvector[istrip].xtalk_slope_left =
-                  -((double)rand() / ((double)(RAND_MAX) + (double)(1))) /
-                      10000 +
-                  mean;
+                  -((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 10000 + mean;
               itemvector[istrip].xtalk_intercept_left =
-                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 100 +
-                  min;
-              itemvector[istrip].xtalk_chi2_left =
-                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) +
-                  minchi;
+                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 100 + min;
+              itemvector[istrip].xtalk_chi2_left = ((double)rand() / ((double)(RAND_MAX) + (double)(1))) + minchi;
               cncrosstalk->crosstalk[id_layer] = itemvector;
 
               if (istrip == 0) {
                 itemvector[istrip].xtalk_slope_right =
-                    -((double)rand() / ((double)(RAND_MAX) + (double)(1))) /
-                        10000 +
-                    mean;
+                    -((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 10000 + mean;
                 itemvector[istrip].xtalk_intercept_right =
-                    ((double)rand() / ((double)(RAND_MAX) + (double)(1))) /
-                        100 +
-                    min;
-                itemvector[istrip].xtalk_chi2_right =
-                    ((double)rand() / ((double)(RAND_MAX) + (double)(1))) +
-                    minchi;
+                    ((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 100 + min;
+                itemvector[istrip].xtalk_chi2_right = ((double)rand() / ((double)(RAND_MAX) + (double)(1))) + minchi;
                 itemvector[istrip].xtalk_slope_left = 0.0;
                 itemvector[istrip].xtalk_intercept_left = 0.0;
                 itemvector[istrip].xtalk_chi2_left = 0.0;
@@ -185,16 +160,10 @@ CSCcrosstalk *CSCCrosstalkConditions::prefillCrosstalk() {
                 itemvector[istrip].xtalk_intercept_right = 0.0;
                 itemvector[istrip].xtalk_chi2_right = 0.0;
                 itemvector[istrip].xtalk_slope_left =
-                    -((double)rand() / ((double)(RAND_MAX) + (double)(1))) /
-                        10000 +
-                    mean;
+                    -((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 10000 + mean;
                 itemvector[istrip].xtalk_intercept_left =
-                    ((double)rand() / ((double)(RAND_MAX) + (double)(1))) /
-                        100 +
-                    min;
-                itemvector[istrip].xtalk_chi2_left =
-                    ((double)rand() / ((double)(RAND_MAX) + (double)(1))) +
-                    minchi;
+                    ((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 100 + min;
+                itemvector[istrip].xtalk_chi2_left = ((double)rand() / ((double)(RAND_MAX) + (double)(1))) + minchi;
                 cncrosstalk->crosstalk[id_layer] = itemvector;
               }
             }
@@ -304,8 +273,7 @@ CSCcrosstalk *CSCCrosstalkConditions::prefillCrosstalk() {
   return cncrosstalk;
 }
 
-CSCCrosstalkConditions::CSCCrosstalkConditions(
-    const edm::ParameterSet &iConfig) {
+CSCCrosstalkConditions::CSCCrosstalkConditions(const edm::ParameterSet &iConfig) {
   // the following line is needed to tell the framework what
   // data is being produced
   // added by Zhen (changed since 1_2_0)
@@ -315,7 +283,6 @@ CSCCrosstalkConditions::CSCCrosstalkConditions(
 }
 
 CSCCrosstalkConditions::~CSCCrosstalkConditions() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -325,15 +292,13 @@ CSCCrosstalkConditions::~CSCCrosstalkConditions() {
 //
 
 // ------------ method called to produce the data  ------------
-CSCCrosstalkConditions::ReturnType
-CSCCrosstalkConditions::produceCrosstalk(const CSCcrosstalkRcd &iRecord) {
+CSCCrosstalkConditions::ReturnType CSCCrosstalkConditions::produceCrosstalk(const CSCcrosstalkRcd &iRecord) {
   // Added by Zhen, need a new object so to not be deleted at exit
   return CSCCrosstalkConditions::ReturnType(prefillCrosstalk());
 }
 
-void CSCCrosstalkConditions::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCCrosstalkConditions::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                            const edm::IOVSyncValue &,
+                                            edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCCrosstalkDBConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCCrosstalkDBConditions.cc
@@ -5,8 +5,7 @@
 #include "CondFormats/CSCObjects/interface/CSCDBCrosstalk.h"
 #include "CondFormats/DataRecord/interface/CSCDBCrosstalkRcd.h"
 
-CSCCrosstalkDBConditions::CSCCrosstalkDBConditions(
-    const edm::ParameterSet &iConfig) {
+CSCCrosstalkDBConditions::CSCCrosstalkDBConditions(const edm::ParameterSet &iConfig) {
   // the following line is needed to tell the framework what
   // data is being produced
   // added by Zhen (changed since 1_2_0)
@@ -16,7 +15,6 @@ CSCCrosstalkDBConditions::CSCCrosstalkDBConditions(
 }
 
 CSCCrosstalkDBConditions::~CSCCrosstalkDBConditions() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -26,15 +24,13 @@ CSCCrosstalkDBConditions::~CSCCrosstalkDBConditions() {
 //
 
 // ------------ method called to produce the data  ------------
-CSCCrosstalkDBConditions::ReturnType
-CSCCrosstalkDBConditions::produceDBCrosstalk(const CSCDBCrosstalkRcd &iRecord) {
+CSCCrosstalkDBConditions::ReturnType CSCCrosstalkDBConditions::produceDBCrosstalk(const CSCDBCrosstalkRcd &iRecord) {
   // need a new object so to not be deleted at exit
   return CSCCrosstalkDBConditions::ReturnType(prefillDBCrosstalk());
 }
 
-void CSCCrosstalkDBConditions::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCCrosstalkDBConditions::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                              const edm::IOVSyncValue &,
+                                              edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCFakeCrosstalkConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCFakeCrosstalkConditions.cc
@@ -3,7 +3,6 @@
 #include "CalibMuon/CSCCalibration/interface/CSCFakeCrosstalkConditions.h"
 
 CSCcrosstalk *CSCFakeCrosstalkConditions::prefillCrosstalk() {
-
   const CSCDetId &detId = CSCDetId();
   CSCcrosstalk *cncrosstalk = new CSCcrosstalk();
 
@@ -13,10 +12,8 @@ CSCcrosstalk *CSCFakeCrosstalkConditions::prefillCrosstalk() {
   mean = -0.0009, min = 0.035, minchi = 1.5, M = 1000;
 
   // endcap=1 to 2,station=1 to 4, ring=1 to 4,chamber=1 to 36,layer=1 to 6
-  for (int iendcap = detId.minEndcapId(); iendcap <= detId.maxEndcapId();
-       iendcap++) {
-    for (int istation = detId.minStationId(); istation <= detId.maxStationId();
-         istation++) {
+  for (int iendcap = detId.minEndcapId(); iendcap <= detId.maxEndcapId(); iendcap++) {
+    for (int istation = detId.minStationId(); istation <= detId.maxStationId(); istation++) {
       max_ring = detId.maxRingId();
       // station 4 ring 4 not there(36 chambers*2 missing)
       // 3 rings max this way of counting (ME1a & b)
@@ -51,56 +48,36 @@ CSCcrosstalk *CSCFakeCrosstalkConditions::prefillCrosstalk() {
         // station 1 ring 3 has 64 strips per layer instead of 80(minus & plus
         // side!!!)
 
-        for (int ichamber = detId.minChamberId(); ichamber <= max_cham;
-             ichamber++) {
-
-          for (int ilayer = detId.minLayerId(); ilayer <= detId.maxLayerId();
-               ilayer++) {
+        for (int ichamber = detId.minChamberId(); ichamber <= max_cham; ichamber++) {
+          for (int ilayer = detId.minLayerId(); ilayer <= detId.maxLayerId(); ilayer++) {
             // station 1 ring 3 has 64 strips per layer instead of 80
             if (istation == 1 && iring == 3)
               max_istrip = 64;
 
             std::vector<CSCcrosstalk::Item> itemvector;
             itemvector.resize(max_istrip);
-            id_layer = 100000 * iendcap + 10000 * istation + 1000 * iring +
-                       10 * ichamber + ilayer;
+            id_layer = 100000 * iendcap + 10000 * istation + 1000 * iring + 10 * ichamber + ilayer;
 
             for (int istrip = 0; istrip < max_istrip; istrip++) {
               // create fake values
               itemvector[istrip].xtalk_slope_right =
-                  -((double)rand() / ((double)(RAND_MAX) + (double)(1))) /
-                      10000 +
-                  mean;
+                  -((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 10000 + mean;
               itemvector[istrip].xtalk_intercept_right =
-                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 100 +
-                  min;
-              itemvector[istrip].xtalk_chi2_right =
-                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) +
-                  minchi;
+                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 100 + min;
+              itemvector[istrip].xtalk_chi2_right = ((double)rand() / ((double)(RAND_MAX) + (double)(1))) + minchi;
               itemvector[istrip].xtalk_slope_left =
-                  -((double)rand() / ((double)(RAND_MAX) + (double)(1))) /
-                      10000 +
-                  mean;
+                  -((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 10000 + mean;
               itemvector[istrip].xtalk_intercept_left =
-                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 100 +
-                  min;
-              itemvector[istrip].xtalk_chi2_left =
-                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) +
-                  minchi;
+                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 100 + min;
+              itemvector[istrip].xtalk_chi2_left = ((double)rand() / ((double)(RAND_MAX) + (double)(1))) + minchi;
               cncrosstalk->crosstalk[id_layer] = itemvector;
 
               if (istrip == 0) {
                 itemvector[istrip].xtalk_slope_right =
-                    -((double)rand() / ((double)(RAND_MAX) + (double)(1))) /
-                        10000 +
-                    mean;
+                    -((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 10000 + mean;
                 itemvector[istrip].xtalk_intercept_right =
-                    ((double)rand() / ((double)(RAND_MAX) + (double)(1))) /
-                        100 +
-                    min;
-                itemvector[istrip].xtalk_chi2_right =
-                    ((double)rand() / ((double)(RAND_MAX) + (double)(1))) +
-                    minchi;
+                    ((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 100 + min;
+                itemvector[istrip].xtalk_chi2_right = ((double)rand() / ((double)(RAND_MAX) + (double)(1))) + minchi;
                 itemvector[istrip].xtalk_slope_left = 0.0;
                 itemvector[istrip].xtalk_intercept_left = 0.0;
                 itemvector[istrip].xtalk_chi2_left = 0.0;
@@ -112,16 +89,10 @@ CSCcrosstalk *CSCFakeCrosstalkConditions::prefillCrosstalk() {
                 itemvector[istrip].xtalk_intercept_right = 0.0;
                 itemvector[istrip].xtalk_chi2_right = 0.0;
                 itemvector[istrip].xtalk_slope_left =
-                    -((double)rand() / ((double)(RAND_MAX) + (double)(1))) /
-                        10000 +
-                    mean;
+                    -((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 10000 + mean;
                 itemvector[istrip].xtalk_intercept_left =
-                    ((double)rand() / ((double)(RAND_MAX) + (double)(1))) /
-                        100 +
-                    min;
-                itemvector[istrip].xtalk_chi2_left =
-                    ((double)rand() / ((double)(RAND_MAX) + (double)(1))) +
-                    minchi;
+                    ((double)rand() / ((double)(RAND_MAX) + (double)(1))) / 100 + min;
+                itemvector[istrip].xtalk_chi2_left = ((double)rand() / ((double)(RAND_MAX) + (double)(1))) + minchi;
                 cncrosstalk->crosstalk[id_layer] = itemvector;
               }
             }
@@ -133,8 +104,7 @@ CSCcrosstalk *CSCFakeCrosstalkConditions::prefillCrosstalk() {
   return cncrosstalk;
 }
 
-CSCFakeCrosstalkConditions::CSCFakeCrosstalkConditions(
-    const edm::ParameterSet &iConfig) {
+CSCFakeCrosstalkConditions::CSCFakeCrosstalkConditions(const edm::ParameterSet &iConfig) {
   // the following line is needed to tell the framework what
   // data is being produced
   setWhatProduced(this, &CSCFakeCrosstalkConditions::produceCrosstalk);
@@ -143,7 +113,6 @@ CSCFakeCrosstalkConditions::CSCFakeCrosstalkConditions(
 }
 
 CSCFakeCrosstalkConditions::~CSCFakeCrosstalkConditions() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -153,14 +122,12 @@ CSCFakeCrosstalkConditions::~CSCFakeCrosstalkConditions() {
 //
 
 // ------------ method called to produce the data  ------------
-CSCFakeCrosstalkConditions::ReturnType
-CSCFakeCrosstalkConditions::produceCrosstalk(const CSCcrosstalkRcd &iRecord) {
+CSCFakeCrosstalkConditions::ReturnType CSCFakeCrosstalkConditions::produceCrosstalk(const CSCcrosstalkRcd &iRecord) {
   return CSCFakeCrosstalkConditions::ReturnType(prefillCrosstalk());
 }
 
-void CSCFakeCrosstalkConditions::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCFakeCrosstalkConditions::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                                const edm::IOVSyncValue &,
+                                                edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCFakeDBCrosstalk.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCFakeDBCrosstalk.cc
@@ -13,14 +13,12 @@ CSCFakeDBCrosstalk::CSCFakeDBCrosstalk(const edm::ParameterSet &iConfig) {
 CSCFakeDBCrosstalk::~CSCFakeDBCrosstalk() {}
 
 // ------------ method called to produce the data  ------------
-CSCFakeDBCrosstalk::Pointer
-CSCFakeDBCrosstalk::produceDBCrosstalk(const CSCDBCrosstalkRcd &iRecord) {
+CSCFakeDBCrosstalk::Pointer CSCFakeDBCrosstalk::produceDBCrosstalk(const CSCDBCrosstalkRcd &iRecord) {
   return CSCFakeDBCrosstalk::Pointer(prefillDBCrosstalk());
 }
 
-void CSCFakeDBCrosstalk::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCFakeDBCrosstalk::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                        const edm::IOVSyncValue &,
+                                        edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCFakeDBGains.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCFakeDBGains.cc
@@ -13,14 +13,12 @@ CSCFakeDBGains::CSCFakeDBGains(const edm::ParameterSet &iConfig) {
 CSCFakeDBGains::~CSCFakeDBGains() {}
 
 // ------------ method called to produce the data  ------------
-CSCFakeDBGains::Pointer
-CSCFakeDBGains::produceDBGains(const CSCDBGainsRcd &iRecord) {
+CSCFakeDBGains::Pointer CSCFakeDBGains::produceDBGains(const CSCDBGainsRcd &iRecord) {
   return CSCFakeDBGains::Pointer(prefillDBGains());
 }
 
-void CSCFakeDBGains::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCFakeDBGains::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                    const edm::IOVSyncValue &,
+                                    edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCFakeDBNoiseMatrix.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCFakeDBNoiseMatrix.cc
@@ -12,14 +12,12 @@ CSCFakeDBNoiseMatrix::CSCFakeDBNoiseMatrix(const edm::ParameterSet &iConfig) {
 CSCFakeDBNoiseMatrix::~CSCFakeDBNoiseMatrix() {}
 
 // ------------ method called to produce the data  ------------
-CSCFakeDBNoiseMatrix::Pointer
-CSCFakeDBNoiseMatrix::produceDBNoiseMatrix(const CSCDBNoiseMatrixRcd &iRecord) {
+CSCFakeDBNoiseMatrix::Pointer CSCFakeDBNoiseMatrix::produceDBNoiseMatrix(const CSCDBNoiseMatrixRcd &iRecord) {
   return CSCFakeDBNoiseMatrix::Pointer(prefillDBNoiseMatrix());
 }
 
-void CSCFakeDBNoiseMatrix::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCFakeDBNoiseMatrix::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                          const edm::IOVSyncValue &,
+                                          edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCFakeDBPedestals.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCFakeDBPedestals.cc
@@ -4,7 +4,6 @@
 #include "CondFormats/DataRecord/interface/CSCDBPedestalsRcd.h"
 
 CSCFakeDBPedestals::CSCFakeDBPedestals(const edm::ParameterSet &iConfig) {
-
   // the following line is needed to tell the framework what
   // data is being produced
   setWhatProduced(this, &CSCFakeDBPedestals::produceDBPedestals);
@@ -14,15 +13,13 @@ CSCFakeDBPedestals::CSCFakeDBPedestals(const edm::ParameterSet &iConfig) {
 CSCFakeDBPedestals::~CSCFakeDBPedestals() {}
 
 // ------------ method called to produce the data  ------------
-CSCFakeDBPedestals::Pointer
-CSCFakeDBPedestals::produceDBPedestals(const CSCDBPedestalsRcd &iRecord) {
+CSCFakeDBPedestals::Pointer CSCFakeDBPedestals::produceDBPedestals(const CSCDBPedestalsRcd &iRecord) {
   Pointer cndbPedestals(prefillDBPedestals());
   return cndbPedestals;
 }
 
-void CSCFakeDBPedestals::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCFakeDBPedestals::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                        const edm::IOVSyncValue &,
+                                        edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCFakeGainsConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCFakeGainsConditions.cc
@@ -12,10 +12,8 @@ CSCGains *CSCFakeGainsConditions::prefillGains() {
 
   // endcap=1 to 2,station=1 to 4, ring=1 to 4,chamber=1 to 36,layer=1 to 6
 
-  for (int iendcap = detId.minEndcapId(); iendcap <= detId.maxEndcapId();
-       iendcap++) {
-    for (int istation = detId.minStationId(); istation <= detId.maxStationId();
-         istation++) {
+  for (int iendcap = detId.minEndcapId(); iendcap <= detId.maxEndcapId(); iendcap++) {
+    for (int istation = detId.minStationId(); istation <= detId.maxStationId(); istation++) {
       max_ring = detId.maxRingId();
       // station 4 ring 4 not there(36 chambers*2 missing)
       // 3 rings max this way of counting (ME1a & b)
@@ -48,30 +46,23 @@ CSCGains *CSCFakeGainsConditions::prefillGains() {
         if (istation == 4 && iring == 1)
           max_cham = 18;
 
-        for (int ichamber = detId.minChamberId(); ichamber <= max_cham;
-             ichamber++) {
-          for (int ilayer = detId.minLayerId(); ilayer <= detId.maxLayerId();
-               ilayer++) {
+        for (int ichamber = detId.minChamberId(); ichamber <= max_cham; ichamber++) {
+          for (int ilayer = detId.minLayerId(); ilayer <= detId.maxLayerId(); ilayer++) {
             // station 1 ring 3 has 64 strips per layer instead of 80
             if (istation == 1 && iring == 3)
               max_istrip = 64;
 
             std::vector<CSCGains::Item> itemvector;
             itemvector.resize(max_istrip);
-            id_layer = 100000 * iendcap + 10000 * istation + 1000 * iring +
-                       10 * ichamber + ilayer;
+            id_layer = 100000 * iendcap + 10000 * istation + 1000 * iring + 10 * ichamber + ilayer;
 
             for (int istrip = 0; istrip < max_istrip; istrip++) {
               // itemvector[istrip].gain_slope    = 7.55;
               // itemvector[istrip].gain_intercept= -10.00;
               // itemvector[istrip].gain_chi2     = 2.00;
-              itemvector[istrip].gain_slope =
-                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) + mean;
-              itemvector[istrip].gain_intercept =
-                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) + min;
-              itemvector[istrip].gain_chi2 =
-                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) +
-                  minchi;
+              itemvector[istrip].gain_slope = ((double)rand() / ((double)(RAND_MAX) + (double)(1))) + mean;
+              itemvector[istrip].gain_intercept = ((double)rand() / ((double)(RAND_MAX) + (double)(1))) + min;
+              itemvector[istrip].gain_chi2 = ((double)rand() / ((double)(RAND_MAX) + (double)(1))) + minchi;
               cngains->gains[id_layer] = itemvector;
             }
           }
@@ -82,8 +73,7 @@ CSCGains *CSCFakeGainsConditions::prefillGains() {
   return cngains;
 }
 
-CSCFakeGainsConditions::CSCFakeGainsConditions(
-    const edm::ParameterSet &iConfig) {
+CSCFakeGainsConditions::CSCFakeGainsConditions(const edm::ParameterSet &iConfig) {
   // the following line is needed to tell the framework what
   // data is being produced
   setWhatProduced(this, &CSCFakeGainsConditions::produceGains);
@@ -92,7 +82,6 @@ CSCFakeGainsConditions::CSCFakeGainsConditions(
 }
 
 CSCFakeGainsConditions::~CSCFakeGainsConditions() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -102,14 +91,12 @@ CSCFakeGainsConditions::~CSCFakeGainsConditions() {
 //
 
 // ------------ method called to produce the data  ------------
-CSCFakeGainsConditions::ReturnType
-CSCFakeGainsConditions::produceGains(const CSCGainsRcd &iRecord) {
+CSCFakeGainsConditions::ReturnType CSCFakeGainsConditions::produceGains(const CSCGainsRcd &iRecord) {
   return CSCFakeGainsConditions::ReturnType(prefillGains());
 }
 
-void CSCFakeGainsConditions::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCFakeGainsConditions::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                            const edm::IOVSyncValue &,
+                                            edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCFakeNoiseMatrixConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCFakeNoiseMatrixConditions.cc
@@ -2,17 +2,14 @@
 #include "CalibMuon/CSCCalibration/interface/CSCFakeNoiseMatrixConditions.h"
 
 CSCNoiseMatrix *CSCFakeNoiseMatrixConditions::prefillNoiseMatrix() {
-
   const CSCDetId &detId = CSCDetId();
   CSCNoiseMatrix *cnmatrix = new CSCNoiseMatrix();
 
   int max_istrip, id_layer, max_ring, max_cham;
   // endcap=1 to 2,station=1 to 4, ring=1 to 4,chamber=1 to 36,layer=1 to 6
 
-  for (int iendcap = detId.minEndcapId(); iendcap <= detId.maxEndcapId();
-       iendcap++) {
-    for (int istation = detId.minStationId(); istation <= detId.maxStationId();
-         istation++) {
+  for (int iendcap = detId.minEndcapId(); iendcap <= detId.maxEndcapId(); iendcap++) {
+    for (int istation = detId.minStationId(); istation <= detId.maxStationId(); istation++) {
       max_ring = detId.maxRingId();
       // station 4 ring 4 not there(36 chambers*2 missing)
       // 3 rings max this way of counting (ME1a & b)
@@ -45,21 +42,17 @@ CSCNoiseMatrix *CSCFakeNoiseMatrixConditions::prefillNoiseMatrix() {
         if (istation == 4 && iring == 1)
           max_cham = 18;
 
-        for (int ichamber = detId.minChamberId(); ichamber <= max_cham;
-             ichamber++) {
-          for (int ilayer = detId.minLayerId(); ilayer <= detId.maxLayerId();
-               ilayer++) {
+        for (int ichamber = detId.minChamberId(); ichamber <= max_cham; ichamber++) {
+          for (int ilayer = detId.minLayerId(); ilayer <= detId.maxLayerId(); ilayer++) {
             // station 1 ring 3 has 64 strips per layer instead of 80
             if (istation == 1 && iring == 3)
               max_istrip = 64;
 
             std::vector<CSCNoiseMatrix::Item> itemvector;
             itemvector.resize(max_istrip);
-            id_layer = 100000 * iendcap + 10000 * istation + 1000 * iring +
-                       10 * ichamber + ilayer;
+            id_layer = 100000 * iendcap + 10000 * istation + 1000 * iring + 10 * ichamber + ilayer;
 
             for (int istrip = 0; istrip < max_istrip; istrip++) {
-
               if (istation == 1 && iring == 1) {
                 itemvector[istrip].elem33 = 7.86675;
                 itemvector[istrip].elem34 = 2.07075;
@@ -196,9 +189,7 @@ CSCNoiseMatrix *CSCFakeNoiseMatrixConditions::prefillNoiseMatrix() {
   return cnmatrix;
 }
 
-CSCFakeNoiseMatrixConditions::CSCFakeNoiseMatrixConditions(
-    const edm::ParameterSet &iConfig) {
-
+CSCFakeNoiseMatrixConditions::CSCFakeNoiseMatrixConditions(const edm::ParameterSet &iConfig) {
   // tell the framework what data is being produced
   setWhatProduced(this, &CSCFakeNoiseMatrixConditions::produceNoiseMatrix);
 
@@ -217,15 +208,13 @@ CSCFakeNoiseMatrixConditions::~CSCFakeNoiseMatrixConditions() {
 //
 
 // ------------ method called to produce the data  ------------
-CSCFakeNoiseMatrixConditions::ReturnType
-CSCFakeNoiseMatrixConditions::produceNoiseMatrix(
+CSCFakeNoiseMatrixConditions::ReturnType CSCFakeNoiseMatrixConditions::produceNoiseMatrix(
     const CSCNoiseMatrixRcd &iRecord) {
   return CSCFakeNoiseMatrixConditions::ReturnType(prefillNoiseMatrix());
 }
 
-void CSCFakeNoiseMatrixConditions::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCFakeNoiseMatrixConditions::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                                  const edm::IOVSyncValue &,
+                                                  edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCFakePedestalsConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCFakePedestalsConditions.cc
@@ -12,10 +12,8 @@ CSCPedestals *CSCFakePedestalsConditions::prefillPedestals() {
 
   // endcap=1 to 2,station=1 to 4, ring=1 to 4,chamber=1 to 36,layer=1 to 6
 
-  for (int iendcap = detId.minEndcapId(); iendcap <= detId.maxEndcapId();
-       iendcap++) {
-    for (int istation = detId.minStationId(); istation <= detId.maxStationId();
-         istation++) {
+  for (int iendcap = detId.minEndcapId(); iendcap <= detId.maxEndcapId(); iendcap++) {
+    for (int istation = detId.minStationId(); istation <= detId.maxStationId(); istation++) {
       max_ring = detId.maxRingId();
       // station 4 ring 4 not there(36 chambers*2 missing)
       // 3 rings max this way of counting (ME1a & b)
@@ -48,26 +46,19 @@ CSCPedestals *CSCFakePedestalsConditions::prefillPedestals() {
         if (istation == 4 && iring == 1)
           max_cham = 18;
 
-        for (int ichamber = detId.minChamberId(); ichamber <= max_cham;
-             ichamber++) {
-          for (int ilayer = detId.minLayerId(); ilayer <= detId.maxLayerId();
-               ilayer++) {
+        for (int ichamber = detId.minChamberId(); ichamber <= max_cham; ichamber++) {
+          for (int ilayer = detId.minLayerId(); ilayer <= detId.maxLayerId(); ilayer++) {
             // station 1 ring 3 has 64 strips per layer instead of 80
             if (istation == 1 && iring == 3)
               max_istrip = 64;
 
             std::vector<CSCPedestals::Item> itemvector;
             itemvector.resize(max_istrip);
-            id_layer = 100000 * iendcap + 10000 * istation + 1000 * iring +
-                       10 * ichamber + ilayer;
+            id_layer = 100000 * iendcap + 10000 * istation + 1000 * iring + 10 * ichamber + ilayer;
 
             for (int istrip = 0; istrip < max_istrip; istrip++) {
-              itemvector[istrip].ped =
-                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) * 100 +
-                  meanped;
-              itemvector[istrip].rms =
-                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) +
-                  meanrms;
+              itemvector[istrip].ped = ((double)rand() / ((double)(RAND_MAX) + (double)(1))) * 100 + meanped;
+              itemvector[istrip].rms = ((double)rand() / ((double)(RAND_MAX) + (double)(1))) + meanrms;
               cnpedestals->pedestals[id_layer] = itemvector;
             }
           }
@@ -78,8 +69,7 @@ CSCPedestals *CSCFakePedestalsConditions::prefillPedestals() {
   return cnpedestals;
 }
 
-CSCFakePedestalsConditions::CSCFakePedestalsConditions(
-    const edm::ParameterSet &iConfig) {
+CSCFakePedestalsConditions::CSCFakePedestalsConditions(const edm::ParameterSet &iConfig) {
   // the following line is needed to tell the framework what
   // data is being produced
   setWhatProduced(this, &CSCFakePedestalsConditions::producePedestals);
@@ -88,7 +78,6 @@ CSCFakePedestalsConditions::CSCFakePedestalsConditions(
 }
 
 CSCFakePedestalsConditions::~CSCFakePedestalsConditions() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -98,14 +87,12 @@ CSCFakePedestalsConditions::~CSCFakePedestalsConditions() {
 //
 
 // ------------ method called to produce the data  ------------
-CSCFakePedestalsConditions::ReturnType
-CSCFakePedestalsConditions::producePedestals(const CSCPedestalsRcd &iRecord) {
+CSCFakePedestalsConditions::ReturnType CSCFakePedestalsConditions::producePedestals(const CSCPedestalsRcd &iRecord) {
   return CSCFakePedestalsConditions::ReturnType(prefillPedestals());
 }
 
-void CSCFakePedestalsConditions::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCFakePedestalsConditions::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                                const edm::IOVSyncValue &,
+                                                edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCGainsConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCGainsConditions.cc
@@ -4,7 +4,6 @@
 #include "CalibMuon/CSCCalibration/interface/CSCGainsConditions.h"
 
 CSCGains *CSCGainsConditions::prefillGains() {
-
   float mean, min, minchi;
   int seed;
   int old_chamber_id, old_strip, new_chamber_id, new_strip;
@@ -39,8 +38,7 @@ CSCGains *CSCGainsConditions::prefillGains() {
   }
 
   while (!olddata.eof()) {
-    olddata >> old_chamber_id >> old_strip >> old_gainslope >> old_intercpt >>
-        old_chisq;
+    olddata >> old_chamber_id >> old_strip >> old_gainslope >> old_intercpt >> old_chisq;
     old_cham_id.push_back(old_chamber_id);
     old_strips.push_back(old_strip);
     old_slope.push_back(old_gainslope);
@@ -58,8 +56,7 @@ CSCGains *CSCGainsConditions::prefillGains() {
   }
 
   while (!newdata.eof()) {
-    newdata >> new_chamber_id >> new_strip >> new_gainslope >> new_intercpt >>
-        new_chisq;
+    newdata >> new_chamber_id >> new_strip >> new_gainslope >> new_intercpt >> new_chisq;
     new_cham_id.push_back(new_chamber_id);
     new_strips.push_back(new_strip);
     new_slope.push_back(new_gainslope);
@@ -70,10 +67,8 @@ CSCGains *CSCGainsConditions::prefillGains() {
   newdata.close();
 
   // endcap=1 to 2,station=1 to 4, ring=1 to 4,chamber=1 to 36,layer=1 to 6
-  for (int iendcap = detId.minEndcapId(); iendcap <= detId.maxEndcapId();
-       iendcap++) {
-    for (int istation = detId.minStationId(); istation <= detId.maxStationId();
-         istation++) {
+  for (int iendcap = detId.minEndcapId(); iendcap <= detId.maxEndcapId(); iendcap++) {
+    for (int istation = detId.minStationId(); istation <= detId.maxStationId(); istation++) {
       max_ring = detId.maxRingId();
       // station 4 ring 4 not there(36 chambers*2 missing)
       // 3 rings max this way of counting (ME1a & b)
@@ -106,27 +101,20 @@ CSCGains *CSCGainsConditions::prefillGains() {
         if (istation == 4 && iring == 1)
           max_cham = 18;
 
-        for (int ichamber = detId.minChamberId(); ichamber <= max_cham;
-             ichamber++) {
-          for (int ilayer = detId.minLayerId(); ilayer <= detId.maxLayerId();
-               ilayer++) {
+        for (int ichamber = detId.minChamberId(); ichamber <= max_cham; ichamber++) {
+          for (int ilayer = detId.minLayerId(); ilayer <= detId.maxLayerId(); ilayer++) {
             // station 1 ring 3 has 64 strips per layer instead of 80
             if (istation == 1 && iring == 3)
               max_istrip = 64;
 
             std::vector<CSCGains::Item> itemvector;
             itemvector.resize(max_istrip);
-            id_layer = 100000 * iendcap + 10000 * istation + 1000 * iring +
-                       10 * ichamber + ilayer;
+            id_layer = 100000 * iendcap + 10000 * istation + 1000 * iring + 10 * ichamber + ilayer;
 
             for (int istrip = 0; istrip < max_istrip; istrip++) {
-              itemvector[istrip].gain_slope =
-                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) + mean;
-              itemvector[istrip].gain_intercept =
-                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) + min;
-              itemvector[istrip].gain_chi2 =
-                  ((double)rand() / ((double)(RAND_MAX) + (double)(1))) +
-                  minchi;
+              itemvector[istrip].gain_slope = ((double)rand() / ((double)(RAND_MAX) + (double)(1))) + mean;
+              itemvector[istrip].gain_intercept = ((double)rand() / ((double)(RAND_MAX) + (double)(1))) + min;
+              itemvector[istrip].gain_chi2 = ((double)rand() / ((double)(RAND_MAX) + (double)(1))) + minchi;
               cngains->gains[id_layer] = itemvector;
             }
           }
@@ -225,7 +213,6 @@ CSCGainsConditions::CSCGainsConditions(const edm::ParameterSet &iConfig) {
 }
 
 CSCGainsConditions::~CSCGainsConditions() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -235,15 +222,13 @@ CSCGainsConditions::~CSCGainsConditions() {
 //
 
 // ------------ method called to produce the data  ------------
-CSCGainsConditions::ReturnType
-CSCGainsConditions::produceGains(const CSCGainsRcd &iRecord) {
+CSCGainsConditions::ReturnType CSCGainsConditions::produceGains(const CSCGainsRcd &iRecord) {
   // Added by Zhen, need a new object so to not be deleted at exit
   return CSCGainsConditions::ReturnType(prefillGains());
 }
 
-void CSCGainsConditions::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCGainsConditions::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                        const edm::IOVSyncValue &,
+                                        edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCGainsDBConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCGainsDBConditions.cc
@@ -15,7 +15,6 @@ CSCGainsDBConditions::CSCGainsDBConditions(const edm::ParameterSet &iConfig) {
 }
 
 CSCGainsDBConditions::~CSCGainsDBConditions() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -25,15 +24,13 @@ CSCGainsDBConditions::~CSCGainsDBConditions() {
 //
 
 // ------------ method called to produce the data  ------------
-CSCGainsDBConditions::ReturnType
-CSCGainsDBConditions::produceDBGains(const CSCDBGainsRcd &iRecord) {
+CSCGainsDBConditions::ReturnType CSCGainsDBConditions::produceDBGains(const CSCDBGainsRcd &iRecord) {
   // need a new object so to not be deleted at exit
   return CSCGainsDBConditions::ReturnType(prefillDBGains());
 }
 
-void CSCGainsDBConditions::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCGainsDBConditions::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                          const edm::IOVSyncValue &,
+                                          edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCGasGainCorrectionDBConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCGasGainCorrectionDBConditions.cc
@@ -5,22 +5,18 @@
 #include "CondFormats/CSCObjects/interface/CSCDBGasGainCorrection.h"
 #include "CondFormats/DataRecord/interface/CSCDBGasGainCorrectionRcd.h"
 
-CSCGasGainCorrectionDBConditions::CSCGasGainCorrectionDBConditions(
-    const edm::ParameterSet &iConfig) {
+CSCGasGainCorrectionDBConditions::CSCGasGainCorrectionDBConditions(const edm::ParameterSet &iConfig) {
   // the following line is needed to tell the framework what
   // data is being produced
   isForMC = iConfig.getUntrackedParameter<bool>("isForMC", true);
-  dataCorrFileName = iConfig.getUntrackedParameter<std::string>(
-      "dataCorrFileName", "empty.txt");
+  dataCorrFileName = iConfig.getUntrackedParameter<std::string>("dataCorrFileName", "empty.txt");
   // added by Zhen (changed since 1_2_0)
-  setWhatProduced(
-      this, &CSCGasGainCorrectionDBConditions::produceDBGasGainCorrection);
+  setWhatProduced(this, &CSCGasGainCorrectionDBConditions::produceDBGasGainCorrection);
   findingRecord<CSCDBGasGainCorrectionRcd>();
   // now do what ever other initialization is needed
 }
 
 CSCGasGainCorrectionDBConditions::~CSCGasGainCorrectionDBConditions() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -30,17 +26,14 @@ CSCGasGainCorrectionDBConditions::~CSCGasGainCorrectionDBConditions() {
 //
 
 // ------------ method called to produce the data  ------------
-CSCGasGainCorrectionDBConditions::ReturnType
-CSCGasGainCorrectionDBConditions::produceDBGasGainCorrection(
+CSCGasGainCorrectionDBConditions::ReturnType CSCGasGainCorrectionDBConditions::produceDBGasGainCorrection(
     const CSCDBGasGainCorrectionRcd &iRecord) {
   // need a new object so to not be deleted at exit
-  return CSCGasGainCorrectionDBConditions::ReturnType(
-      prefillDBGasGainCorrection(isForMC, dataCorrFileName));
+  return CSCGasGainCorrectionDBConditions::ReturnType(prefillDBGasGainCorrection(isForMC, dataCorrFileName));
 }
 
-void CSCGasGainCorrectionDBConditions::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCGasGainCorrectionDBConditions::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                                      const edm::IOVSyncValue &,
+                                                      edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCIndexerESProducer.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCIndexerESProducer.cc
@@ -15,12 +15,10 @@ CSCIndexerESProducer::CSCIndexerESProducer(const edm::ParameterSet &pset) {
 
 CSCIndexerESProducer::~CSCIndexerESProducer() {}
 
-CSCIndexerESProducer::BSP_TYPE
-CSCIndexerESProducer::produce(const CSCIndexerRecord &) {
+CSCIndexerESProducer::BSP_TYPE CSCIndexerESProducer::produce(const CSCIndexerRecord &) {
   LogTrace("CSCIndexerESProducer") << " producing: " << algoName;
 
-  return CSCIndexerESProducer::BSP_TYPE(
-      CSCIndexerFactory::get()->create(algoName));
+  return CSCIndexerESProducer::BSP_TYPE(CSCIndexerFactory::get()->create(algoName));
 }
 
 // define this as a plug-in

--- a/CalibMuon/CSCCalibration/plugins/CSCL1TPParameters.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCL1TPParameters.cc
@@ -5,8 +5,7 @@
 #include "CondFormats/CSCObjects/interface/CSCL1TPParameters.h"
 #include "CondFormats/DataRecord/interface/CSCL1TPParametersRcd.h"
 
-CSCL1TPParametersConditions::CSCL1TPParametersConditions(
-    const edm::ParameterSet &iConfig) {
+CSCL1TPParametersConditions::CSCL1TPParametersConditions(const edm::ParameterSet &iConfig) {
   // the following line is needed to tell the framework what
   // data is being produced
   // added by Zhen (changed since 1_2_0)
@@ -16,7 +15,6 @@ CSCL1TPParametersConditions::CSCL1TPParametersConditions(
 }
 
 CSCL1TPParametersConditions::~CSCL1TPParametersConditions() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -26,16 +24,14 @@ CSCL1TPParametersConditions::~CSCL1TPParametersConditions() {
 //
 
 // ------------ method called to produce the data  ------------
-CSCL1TPParametersConditions::ReturnType
-CSCL1TPParametersConditions::produceCSCL1TPParameters(
+CSCL1TPParametersConditions::ReturnType CSCL1TPParametersConditions::produceCSCL1TPParameters(
     const CSCL1TPParametersRcd &iRecord) {
   // need a new object so to not be deleted at exit
   return CSCL1TPParametersConditions::ReturnType(prefillCSCL1TPParameters());
 }
 
-void CSCL1TPParametersConditions::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCL1TPParametersConditions::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                                 const edm::IOVSyncValue &,
+                                                 edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCNoiseMatrixConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCNoiseMatrixConditions.cc
@@ -4,7 +4,6 @@
 #include "CalibMuon/CSCCalibration/interface/CSCNoiseMatrixConditions.h"
 
 CSCNoiseMatrix *CSCNoiseMatrixConditions::prefillNoiseMatrix() {
-
   int old_chamber_id, old_strip, new_chamber_id, new_strip;
   float old_elm33, old_elm34, old_elm44, old_elm35, old_elm45, old_elm55;
   float old_elm46, old_elm56, old_elm66, old_elm57, old_elm67, old_elm77;
@@ -55,9 +54,8 @@ CSCNoiseMatrix *CSCNoiseMatrixConditions::prefillNoiseMatrix() {
   }
 
   while (!olddata.eof()) {
-    olddata >> old_chamber_id >> old_strip >> old_elm33 >> old_elm34 >>
-        old_elm44 >> old_elm35 >> old_elm45 >> old_elm55 >> old_elm46 >>
-        old_elm56 >> old_elm66 >> old_elm57 >> old_elm67 >> old_elm77;
+    olddata >> old_chamber_id >> old_strip >> old_elm33 >> old_elm34 >> old_elm44 >> old_elm35 >> old_elm45 >>
+        old_elm55 >> old_elm46 >> old_elm56 >> old_elm66 >> old_elm57 >> old_elm67 >> old_elm77;
     old_cham_id.push_back(old_chamber_id);
     old_strips.push_back(old_strip);
     old_elem33.push_back(old_elm33);
@@ -85,9 +83,8 @@ CSCNoiseMatrix *CSCNoiseMatrixConditions::prefillNoiseMatrix() {
   }
 
   while (!newdata.eof()) {
-    newdata >> new_chamber_id >> new_strip >> new_elm33 >> new_elm34 >>
-        new_elm44 >> new_elm35 >> new_elm45 >> new_elm55 >> new_elm46 >>
-        new_elm56 >> new_elm66 >> new_elm57 >> new_elm67 >> new_elm77;
+    newdata >> new_chamber_id >> new_strip >> new_elm33 >> new_elm34 >> new_elm44 >> new_elm35 >> new_elm45 >>
+        new_elm55 >> new_elm46 >> new_elm56 >> new_elm66 >> new_elm57 >> new_elm67 >> new_elm77;
     new_cham_id.push_back(new_chamber_id);
     new_strips.push_back(new_strip);
     new_elem33.push_back(new_elm33);
@@ -108,10 +105,8 @@ CSCNoiseMatrix *CSCNoiseMatrixConditions::prefillNoiseMatrix() {
 
   // endcap=1 to 2,station=1 to 4, ring=1 to 4,chamber=1 to 36,layer=1 to 6
 
-  for (int iendcap = detId.minEndcapId(); iendcap <= detId.maxEndcapId();
-       iendcap++) {
-    for (int istation = detId.minStationId(); istation <= detId.maxStationId();
-         istation++) {
+  for (int iendcap = detId.minEndcapId(); iendcap <= detId.maxEndcapId(); iendcap++) {
+    for (int istation = detId.minStationId(); istation <= detId.maxStationId(); istation++) {
       max_ring = detId.maxRingId();
       // station 4 ring 4 not there(36 chambers*2 missing)
       // 3 rings max this way of counting (ME1a & b)
@@ -144,21 +139,17 @@ CSCNoiseMatrix *CSCNoiseMatrixConditions::prefillNoiseMatrix() {
         if (istation == 4 && iring == 1)
           max_cham = 18;
 
-        for (int ichamber = detId.minChamberId(); ichamber <= max_cham;
-             ichamber++) {
-          for (int ilayer = detId.minLayerId(); ilayer <= detId.maxLayerId();
-               ilayer++) {
+        for (int ichamber = detId.minChamberId(); ichamber <= max_cham; ichamber++) {
+          for (int ilayer = detId.minLayerId(); ilayer <= detId.maxLayerId(); ilayer++) {
             // station 1 ring 3 has 64 strips per layer instead of 80
             if (istation == 1 && iring == 3)
               max_istrip = 64;
 
             std::vector<CSCNoiseMatrix::Item> itemvector;
             itemvector.resize(max_istrip);
-            id_layer = 100000 * iendcap + 10000 * istation + 1000 * iring +
-                       10 * ichamber + ilayer;
+            id_layer = 100000 * iendcap + 10000 * istation + 1000 * iring + 10 * ichamber + ilayer;
 
             for (int istrip = 0; istrip < max_istrip; istrip++) {
-
               if (istation == 1 && iring == 1) {
                 itemvector[istrip].elem33 = 7.86675;
                 itemvector[istrip].elem34 = 2.07075;
@@ -428,8 +419,7 @@ CSCNoiseMatrix *CSCNoiseMatrixConditions::prefillNoiseMatrix() {
   return cnmatrix;
 }
 
-CSCNoiseMatrixConditions::CSCNoiseMatrixConditions(
-    const edm::ParameterSet &iConfig) {
+CSCNoiseMatrixConditions::CSCNoiseMatrixConditions(const edm::ParameterSet &iConfig) {
   // the following line is needed to tell the framework what
   // data is being produced
   // added by Zhen (changed since 1_2_0)
@@ -439,7 +429,6 @@ CSCNoiseMatrixConditions::CSCNoiseMatrixConditions(
 }
 
 CSCNoiseMatrixConditions::~CSCNoiseMatrixConditions() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -449,15 +438,13 @@ CSCNoiseMatrixConditions::~CSCNoiseMatrixConditions() {
 //
 
 // ------------ method called to produce the data  ------------
-CSCNoiseMatrixConditions::ReturnType
-CSCNoiseMatrixConditions::produceNoiseMatrix(const CSCNoiseMatrixRcd &iRecord) {
+CSCNoiseMatrixConditions::ReturnType CSCNoiseMatrixConditions::produceNoiseMatrix(const CSCNoiseMatrixRcd &iRecord) {
   // Added by Zhen, need a new object so to not be deleted at exit
   return CSCNoiseMatrixConditions::ReturnType(prefillNoiseMatrix());
 }
 
-void CSCNoiseMatrixConditions::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCNoiseMatrixConditions::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                              const edm::IOVSyncValue &,
+                                              edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCNoiseMatrixDBConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCNoiseMatrixDBConditions.cc
@@ -5,8 +5,7 @@
 #include "CondFormats/CSCObjects/interface/CSCDBNoiseMatrix.h"
 #include "CondFormats/DataRecord/interface/CSCDBNoiseMatrixRcd.h"
 
-CSCNoiseMatrixDBConditions::CSCNoiseMatrixDBConditions(
-    const edm::ParameterSet &iConfig) {
+CSCNoiseMatrixDBConditions::CSCNoiseMatrixDBConditions(const edm::ParameterSet &iConfig) {
   // the following line is needed to tell the framework what
   // data is being produced
   // added by Zhen (changed since 1_2_0)
@@ -16,7 +15,6 @@ CSCNoiseMatrixDBConditions::CSCNoiseMatrixDBConditions(
 }
 
 CSCNoiseMatrixDBConditions::~CSCNoiseMatrixDBConditions() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -26,16 +24,14 @@ CSCNoiseMatrixDBConditions::~CSCNoiseMatrixDBConditions() {
 //
 
 // ------------ method called to produce the data  ------------
-CSCNoiseMatrixDBConditions::ReturnType
-CSCNoiseMatrixDBConditions::produceDBNoiseMatrix(
+CSCNoiseMatrixDBConditions::ReturnType CSCNoiseMatrixDBConditions::produceDBNoiseMatrix(
     const CSCDBNoiseMatrixRcd &iRecord) {
   // need a new object so to not be deleted at exit
   return CSCNoiseMatrixDBConditions::ReturnType(prefillDBNoiseMatrix());
 }
 
-void CSCNoiseMatrixDBConditions::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCNoiseMatrixDBConditions::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                                const edm::IOVSyncValue &,
+                                                edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/CSCPedestalsDBConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCPedestalsDBConditions.cc
@@ -5,8 +5,7 @@
 #include "CondFormats/CSCObjects/interface/CSCDBPedestals.h"
 #include "CondFormats/DataRecord/interface/CSCDBPedestalsRcd.h"
 
-CSCPedestalsDBConditions::CSCPedestalsDBConditions(
-    const edm::ParameterSet &iConfig) {
+CSCPedestalsDBConditions::CSCPedestalsDBConditions(const edm::ParameterSet &iConfig) {
   // the following line is needed to tell the framework what
   // data is being produced
   // added by Zhen (changed since 1_2_0)
@@ -16,7 +15,6 @@ CSCPedestalsDBConditions::CSCPedestalsDBConditions(
 }
 
 CSCPedestalsDBConditions::~CSCPedestalsDBConditions() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -26,15 +24,13 @@ CSCPedestalsDBConditions::~CSCPedestalsDBConditions() {
 //
 
 // ------------ method called to produce the data  ------------
-CSCPedestalsDBConditions::ReturnType
-CSCPedestalsDBConditions::produceDBPedestals(const CSCDBPedestalsRcd &iRecord) {
+CSCPedestalsDBConditions::ReturnType CSCPedestalsDBConditions::produceDBPedestals(const CSCDBPedestalsRcd &iRecord) {
   // need a new object so to not be deleted at exit
   return CSCPedestalsDBConditions::ReturnType(prefillDBPedestals());
 }
 
-void CSCPedestalsDBConditions::setIntervalFor(
-    const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue &,
-    edm::ValidityInterval &oValidity) {
-  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),
-                                    edm::IOVSyncValue::endOfTime());
+void CSCPedestalsDBConditions::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                                              const edm::IOVSyncValue &,
+                                              edm::ValidityInterval &oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
 }

--- a/CalibMuon/CSCCalibration/plugins/modules.cc
+++ b/CalibMuon/CSCCalibration/plugins/modules.cc
@@ -9,7 +9,5 @@
 DEFINE_EDM_PLUGIN(CSCIndexerFactory, CSCIndexerStartup, "CSCIndexerStartup");
 DEFINE_EDM_PLUGIN(CSCIndexerFactory, CSCIndexerPostls1, "CSCIndexerPostls1");
 
-DEFINE_EDM_PLUGIN(CSCChannelMapperFactory, CSCChannelMapperStartup,
-                  "CSCChannelMapperStartup");
-DEFINE_EDM_PLUGIN(CSCChannelMapperFactory, CSCChannelMapperPostls1,
-                  "CSCChannelMapperPostls1");
+DEFINE_EDM_PLUGIN(CSCChannelMapperFactory, CSCChannelMapperStartup, "CSCChannelMapperStartup");
+DEFINE_EDM_PLUGIN(CSCChannelMapperFactory, CSCChannelMapperPostls1, "CSCChannelMapperPostls1");

--- a/CalibMuon/CSCCalibration/src/CSCChannelMapperPostls1.cc
+++ b/CalibMuon/CSCCalibration/src/CSCChannelMapperPostls1.cc
@@ -1,8 +1,6 @@
 #include "CalibMuon/CSCCalibration/interface/CSCChannelMapperPostls1.h"
 
-int CSCChannelMapperPostls1::rawStripChannel(const CSCDetId &id,
-                                             int igeo) const {
-
+int CSCChannelMapperPostls1::rawStripChannel(const CSCDetId &id, int igeo) const {
   // Translate a geometry-oriented strip channel in range 1-80, igeo,
   // into corresponding raw channel.
 
@@ -15,16 +13,15 @@ int CSCChannelMapperPostls1::rawStripChannel(const CSCDetId &id,
 
   if (me1a && zplus) {
     iraw = 49 - iraw;
-  } // 1-48 -> 48-1
+  }  // 1-48 -> 48-1
   if (me1b && !zplus) {
     iraw = 65 - iraw;
-  } // 1-64 -> 64-1
+  }  // 1-64 -> 64-1
 
   return iraw;
 }
 
-int CSCChannelMapperPostls1::geomStripChannel(const CSCDetId &id,
-                                              int iraw) const {
+int CSCChannelMapperPostls1::geomStripChannel(const CSCDetId &id, int iraw) const {
   // Translate a raw strip channel in range 1-80, iraw,  into
   // corresponding geometry-oriented channel in which increasing
   // channel number <-> strip number increasing with +ve local x.
@@ -37,16 +34,15 @@ int CSCChannelMapperPostls1::geomStripChannel(const CSCDetId &id,
 
   if (me1a && zplus) {
     igeo = 49 - igeo;
-  } // 1-48 -> 48-1
+  }  // 1-48 -> 48-1
   if (me1b && !zplus) {
     igeo = 65 - igeo;
-  } // 1-64 -> 64-1
+  }  // 1-64 -> 64-1
 
   return igeo;
 }
 
-int CSCChannelMapperPostls1::channelFromStrip(const CSCDetId &id,
-                                              int strip) const {
+int CSCChannelMapperPostls1::channelFromStrip(const CSCDetId &id, int strip) const {
   // This just returns the electronics channel label to which a given strip is
   // connected In all chambers (including upgraded ME1A) this is just a direct
   // 1-1 correspondence.

--- a/CalibMuon/CSCCalibration/src/CSCChannelMapperStartup.cc
+++ b/CalibMuon/CSCCalibration/src/CSCChannelMapperStartup.cc
@@ -1,8 +1,6 @@
 #include "CalibMuon/CSCCalibration/interface/CSCChannelMapperStartup.h"
 
-int CSCChannelMapperStartup::rawStripChannel(const CSCDetId &id,
-                                             int igeo) const {
-
+int CSCChannelMapperStartup::rawStripChannel(const CSCDetId &id, int igeo) const {
   // Translate a geometry-oriented strip channel in range 1-80, igeo,
   // into corresponding raw channel.
 
@@ -15,19 +13,18 @@ int CSCChannelMapperStartup::rawStripChannel(const CSCDetId &id,
 
   if (me1a && zplus) {
     iraw = 17 - iraw;
-  } // 1-16 -> 16-1
+  }  // 1-16 -> 16-1
   if (me1b && !zplus) {
     iraw = 65 - iraw;
-  } // 1-64 -> 64-1
+  }  // 1-64 -> 64-1
   if (me1a) {
     iraw += 64;
-  } // set 1-16 to 65-80
+  }  // set 1-16 to 65-80
 
   return iraw;
 }
 
-int CSCChannelMapperStartup::geomStripChannel(const CSCDetId &id,
-                                              int iraw) const {
+int CSCChannelMapperStartup::geomStripChannel(const CSCDetId &id, int iraw) const {
   // Translate a raw strip channel in range 1-80, iraw,  into
   // corresponding geometry-oriented channel in which increasing
   // channel number <-> strip number increasing with +ve local x.
@@ -40,20 +37,19 @@ int CSCChannelMapperStartup::geomStripChannel(const CSCDetId &id,
   bool me1b = me11 && (iraw <= 64);
 
   if (me1a)
-    igeo -= 64; // 65-80 -> 1-16
+    igeo -= 64;  // 65-80 -> 1-16
   // if ( me1a ) igeo %= 64; // 65-80 -> 1-16
   if (me1a && zplus) {
     igeo = 17 - igeo;
-  } // 65-80 -> 16-1
+  }  // 65-80 -> 16-1
   if (me1b && !zplus) {
     igeo = 65 - igeo;
-  } // 1-64 -> 64-1
+  }  // 1-64 -> 64-1
 
   return igeo;
 }
 
-int CSCChannelMapperStartup::channelFromStrip(const CSCDetId &id,
-                                              int strip) const {
+int CSCChannelMapperStartup::channelFromStrip(const CSCDetId &id, int strip) const {
   // This just returns the electronics channel label to which a given strip is
   // connected In all chambers but ME1A this is just a direct 1-1
   // correspondence. In ME1A the 48 strips are ganged into 16 channels:
@@ -61,7 +57,7 @@ int CSCChannelMapperStartup::channelFromStrip(const CSCDetId &id,
   int ichan = strip;
   bool me1a = (id.station() == 1) && (id.ring() == 4);
   if (me1a && strip > 16)
-    ichan = (strip - 1) % 16 + 1; // gang the 48 to 16
+    ichan = (strip - 1) % 16 + 1;  // gang the 48 to 16
   return ichan;
 }
 

--- a/CalibMuon/CSCCalibration/src/CSCConditions.cc
+++ b/CalibMuon/CSCCalibration/src/CSCConditions.cc
@@ -35,12 +35,25 @@
 #include "CondFormats/CSCObjects/interface/CSCBadWires.h"
 
 CSCConditions::CSCConditions(const edm::ParameterSet &ps)
-    : theGains(), theCrosstalk(), thePedestals(), theNoiseMatrix(),
-      theBadStrips(), theBadWires(), theBadChambers(), theChipCorrections(),
-      theChamberTimingCorrections(), theGasGainCorrections(), indexer_(nullptr),
-      mapper_(nullptr), readBadChannels_(false), readBadChambers_(false),
-      useTimingCorrections_(false), useGasGainCorrections_(false),
-      idOfBadChannelWords_(CSCDetId()), badStripWord_(0), badWireWord_(0),
+    : theGains(),
+      theCrosstalk(),
+      thePedestals(),
+      theNoiseMatrix(),
+      theBadStrips(),
+      theBadWires(),
+      theBadChambers(),
+      theChipCorrections(),
+      theChamberTimingCorrections(),
+      theGasGainCorrections(),
+      indexer_(nullptr),
+      mapper_(nullptr),
+      readBadChannels_(false),
+      readBadChambers_(false),
+      useTimingCorrections_(false),
+      useGasGainCorrections_(false),
+      idOfBadChannelWords_(CSCDetId()),
+      badStripWord_(0),
+      badWireWord_(0),
       theAverageGain(-1.0) {
   readBadChannels_ = ps.getParameter<bool>("readBadChannels");
   readBadChambers_ = ps.getParameter<bool>("readBadChambers");
@@ -87,8 +100,8 @@ void CSCConditions::initializeEvent(const edm::EventSetup &es) {
   }
 
   // Has GainsRcd changed?
-  if (gainsWatcher_.check(es)) { // Yes...
-    theAverageGain = -1.0;       // ...reset, so next access will recalculate it
+  if (gainsWatcher_.check(es)) {  // Yes...
+    theAverageGain = -1.0;        // ...reset, so next access will recalculate it
   }
 
   if (readBadChambers()) {
@@ -104,13 +117,11 @@ void CSCConditions::initializeEvent(const edm::EventSetup &es) {
 }
 
 void CSCConditions::fillBadChannelWords(const CSCDetId &id) {
-
   // input CSCDetId is expected to be an offline value i.e. different for ME1/1A
   // and ME1/1B
 
   // Only update content if necessary
   if (id != idOfBadChannelWords()) {
-
     // store offline CSCDetId for the two bad channel words
     setIdOfBadChannelWords(id);
 
@@ -130,7 +141,6 @@ void CSCConditions::fillBadChannelWords(const CSCDetId &id) {
 /// Next function private
 
 void CSCConditions::fillBadStripWord(const CSCDetId &id) {
-
   // Input CSCDetId is expected to be a 'raw' value
 
   // Find linear index of chamber for input CSCDetId
@@ -145,35 +155,31 @@ void CSCConditions::fillBadStripWord(const CSCDetId &id) {
   // channels, and the index within vector<BadChannel> where this chamber's bad
   // channels start.
 
-  for (size_t i = 0; i < theBadStrips->chambers.size();
-       ++i) { // loop over bad chambers
+  for (size_t i = 0; i < theBadStrips->chambers.size(); ++i) {  // loop over bad chambers
     int indexc = theBadStrips->chambers[i].chamber_index;
     if (indexc != inputIndex)
-      continue; // next iteration if not a match
+      continue;  // next iteration if not a match
 
     int start = theBadStrips->chambers[i].pointer;
     int nbad = theBadStrips->chambers[i].bad_channels;
 
-    for (int j = start - 1; j < start - 1 + nbad;
-         ++j) { // bad channels in this chamber
-      short lay = theBadStrips->channels[j].layer; // value 1-6
+    for (int j = start - 1; j < start - 1 + nbad; ++j) {  // bad channels in this chamber
+      short lay = theBadStrips->channels[j].layer;        // value 1-6
       if (lay != inputLayer)
         continue;
 
-      short chan = theBadStrips->channels[j]
-                       .channel; // value 1-80 (->112 for unganged ME1/1A)
+      short chan = theBadStrips->channels[j].channel;  // value 1-80 (->112 for unganged ME1/1A)
       // Flags so far unused (and unset in conditins data)
       //    short f1 = theBadStrips->channels[j].flag1;
       //    short f2 = theBadStrips->channels[j].flag2;
       //    short f3 = theBadStrips->channels[j].flag3;
-      badStripWord_.set(chan - 1, true); // set bit 0-79 (111) in 80 (112)-bit
-                                         // bitset representing this layer
-    }                                    // j
-  }                                      // i
+      badStripWord_.set(chan - 1, true);  // set bit 0-79 (111) in 80 (112)-bit
+                                          // bitset representing this layer
+    }                                     // j
+  }                                       // i
 }
 
 void CSCConditions::fillBadWireWord(const CSCDetId &id) {
-
   // Input CSCDetId is expected to be a 'raw' value
 
   // Find linear index of chamber for input CSCDetId
@@ -182,31 +188,28 @@ void CSCConditions::fillBadWireWord(const CSCDetId &id) {
 
   // unpack what we've read from theBadWires
 
-  for (size_t i = 0; i < theBadWires->chambers.size();
-       ++i) { // loop over bad chambers
+  for (size_t i = 0; i < theBadWires->chambers.size(); ++i) {  // loop over bad chambers
     int indexc = theBadWires->chambers[i].chamber_index;
 
     if (indexc != inputIndex)
-      continue; // next iteration if not a match
+      continue;  // next iteration if not a match
 
     int start = theBadWires->chambers[i].pointer;
     int nbad = theBadWires->chambers[i].bad_channels;
 
-    for (int j = start - 1; j < start - 1 + nbad;
-         ++j) { // bad channels in this chamber
-      short lay = theBadWires->channels[j].layer; // value 1-6
+    for (int j = start - 1; j < start - 1 + nbad; ++j) {  // bad channels in this chamber
+      short lay = theBadWires->channels[j].layer;         // value 1-6
       if (lay != inputLayer)
         continue;
 
-      short chan = theBadWires->channels[j].channel; // value 1-112
+      short chan = theBadWires->channels[j].channel;  // value 1-112
       //    short f1 = theBadWires->channels[j].flag1;
       //    short f2 = theBadWires->channels[j].flag2;
       //    short f3 = theBadWires->channels[j].flag3;
-      badWireWord_.set(
-          chan - 1,
-          true); // set bit 0-111 in 112-bit bitset representing this layer
-    }            // j
-  }              // i
+      badWireWord_.set(chan - 1,
+                       true);  // set bit 0-111 in 112-bit bitset representing this layer
+    }                          // j
+  }                            // i
 }
 
 bool CSCConditions::isInBadChamber(const CSCDetId &id) const {
@@ -227,8 +230,7 @@ float CSCConditions::gain(const CSCDetId &id, int geomChannel) const {
   assert(theGains.isValid());
   CSCDetId idraw = mapper_->rawCSCDetId(id);
   int iraw = mapper_->rawStripChannel(id, geomChannel);
-  int index =
-      indexer_->stripChannelIndex(idraw, iraw) - 1; // NOTE THE MINUS ONE!
+  int index = indexer_->stripChannelIndex(idraw, iraw) - 1;  // NOTE THE MINUS ONE!
   return float(theGains->gain(index)) / theGains->scale();
 }
 
@@ -236,8 +238,7 @@ float CSCConditions::pedestal(const CSCDetId &id, int geomChannel) const {
   assert(thePedestals.isValid());
   CSCDetId idraw = mapper_->rawCSCDetId(id);
   int iraw = mapper_->rawStripChannel(id, geomChannel);
-  int index =
-      indexer_->stripChannelIndex(idraw, iraw) - 1; // NOTE THE MINUS ONE!
+  int index = indexer_->stripChannelIndex(idraw, iraw) - 1;  // NOTE THE MINUS ONE!
   return float(thePedestals->pedestal(index)) / thePedestals->scale_ped();
 }
 
@@ -245,39 +246,31 @@ float CSCConditions::pedestalSigma(const CSCDetId &id, int geomChannel) const {
   assert(thePedestals.isValid());
   CSCDetId idraw = mapper_->rawCSCDetId(id);
   int iraw = mapper_->rawStripChannel(id, geomChannel);
-  int index =
-      indexer_->stripChannelIndex(idraw, iraw) - 1; // NOTE THE MINUS ONE!
+  int index = indexer_->stripChannelIndex(idraw, iraw) - 1;  // NOTE THE MINUS ONE!
   return float(thePedestals->pedestal_rms(index)) / thePedestals->scale_rms();
 }
 
-float CSCConditions::crosstalkIntercept(const CSCDetId &id, int geomChannel,
-                                        bool leftRight) const {
+float CSCConditions::crosstalkIntercept(const CSCDetId &id, int geomChannel, bool leftRight) const {
   assert(theCrosstalk.isValid());
   CSCDetId idraw = mapper_->rawCSCDetId(id);
   int iraw = mapper_->rawStripChannel(id, geomChannel);
-  int index =
-      indexer_->stripChannelIndex(idraw, iraw) - 1; // NOTE THE MINUS ONE!
+  int index = indexer_->stripChannelIndex(idraw, iraw) - 1;  // NOTE THE MINUS ONE!
   // resistive fraction is at the peak, where t=0
-  return leftRight
-             ? float(theCrosstalk->rinter(index)) / theCrosstalk->iscale()
-             : float(theCrosstalk->linter(index)) / theCrosstalk->iscale();
+  return leftRight ? float(theCrosstalk->rinter(index)) / theCrosstalk->iscale()
+                   : float(theCrosstalk->linter(index)) / theCrosstalk->iscale();
 }
 
-float CSCConditions::crosstalkSlope(const CSCDetId &id, int geomChannel,
-                                    bool leftRight) const {
+float CSCConditions::crosstalkSlope(const CSCDetId &id, int geomChannel, bool leftRight) const {
   assert(theCrosstalk.isValid());
   CSCDetId idraw = mapper_->rawCSCDetId(id);
   int iraw = mapper_->rawStripChannel(id, geomChannel);
-  int index =
-      indexer_->stripChannelIndex(idraw, iraw) - 1; // NOTE THE MINUS ONE!
+  int index = indexer_->stripChannelIndex(idraw, iraw) - 1;  // NOTE THE MINUS ONE!
   // resistive fraction is at the peak, where t=0
-  return leftRight
-             ? float(theCrosstalk->rslope(index)) / theCrosstalk->sscale()
-             : float(theCrosstalk->lslope(index)) / theCrosstalk->sscale();
+  return leftRight ? float(theCrosstalk->rslope(index)) / theCrosstalk->sscale()
+                   : float(theCrosstalk->lslope(index)) / theCrosstalk->sscale();
 }
 
-const CSCDBNoiseMatrix::Item &
-CSCConditions::noiseMatrix(const CSCDetId &id, int geomChannel) const {
+const CSCDBNoiseMatrix::Item &CSCConditions::noiseMatrix(const CSCDetId &id, int geomChannel) const {
   //@@ BEWARE - THIS FUNCTION DOES NOT APPLY SCALE FACTOR USED IN PACKING VALUES
   // IN CONDITIONS DATA
   //@@ MAY BE AN ERROR? WHO WOULD WANT ACCESS WITHOUT IT?
@@ -285,16 +278,13 @@ CSCConditions::noiseMatrix(const CSCDetId &id, int geomChannel) const {
   assert(theNoiseMatrix.isValid());
   CSCDetId idraw = mapper_->rawCSCDetId(id);
   int iraw = mapper_->rawStripChannel(id, geomChannel);
-  int index =
-      indexer_->stripChannelIndex(idraw, iraw) - 1; // NOTE THE MINUS ONE!
+  int index = indexer_->stripChannelIndex(idraw, iraw) - 1;  // NOTE THE MINUS ONE!
   return theNoiseMatrix->item(index);
 }
 
-void CSCConditions::noiseMatrixElements(const CSCDetId &id, int geomChannel,
-                                        std::vector<float> &me) const {
+void CSCConditions::noiseMatrixElements(const CSCDetId &id, int geomChannel, std::vector<float> &me) const {
   assert(me.size() > 11);
-  const CSCDBNoiseMatrix::Item &item =
-      noiseMatrix(id, geomChannel); // i.e. the function above
+  const CSCDBNoiseMatrix::Item &item = noiseMatrix(id, geomChannel);  // i.e. the function above
   me[0] = float(item.elem33) / theNoiseMatrix->scale();
   me[1] = float(item.elem34) / theNoiseMatrix->scale();
   me[2] = float(item.elem35) / theNoiseMatrix->scale();
@@ -309,13 +299,11 @@ void CSCConditions::noiseMatrixElements(const CSCDetId &id, int geomChannel,
   me[11] = float(item.elem77) / theNoiseMatrix->scale();
 }
 
-void CSCConditions::crossTalk(const CSCDetId &id, int geomChannel,
-                              std::vector<float> &ct) const {
+void CSCConditions::crossTalk(const CSCDetId &id, int geomChannel, std::vector<float> &ct) const {
   assert(theCrosstalk.isValid());
   CSCDetId idraw = mapper_->rawCSCDetId(id);
   int iraw = mapper_->rawStripChannel(id, geomChannel);
-  int index =
-      indexer_->stripChannelIndex(idraw, iraw) - 1; // NOTE THE MINUS ONE!
+  int index = indexer_->stripChannelIndex(idraw, iraw) - 1;  // NOTE THE MINUS ONE!
 
   ct[0] = float(theCrosstalk->lslope(index)) / theCrosstalk->sscale();
   ct[1] = float(theCrosstalk->linter(index)) / theCrosstalk->iscale();
@@ -328,11 +316,9 @@ float CSCConditions::chipCorrection(const CSCDetId &id, int geomChannel) const {
     assert(theChipCorrections.isValid());
     CSCDetId idraw = mapper_->rawCSCDetId(id);
     int iraw = mapper_->rawStripChannel(id, geomChannel);
-    int ichip =
-        indexer_->chipIndex(iraw); // converts 1-80 to 1-5 (chip#, CFEB#)
-    int index = indexer_->chipIndex(idraw, ichip) - 1; // NOTE THE MINUS ONE!
-    return float(theChipCorrections->value(index)) /
-           theChipCorrections->scale();
+    int ichip = indexer_->chipIndex(iraw);              // converts 1-80 to 1-5 (chip#, CFEB#)
+    int index = indexer_->chipIndex(idraw, ichip) - 1;  // NOTE THE MINUS ONE!
+    return float(theChipCorrections->value(index)) / theChipCorrections->scale();
   } else
     return 0;
 }
@@ -340,12 +326,10 @@ float CSCConditions::chamberTimingCorrection(const CSCDetId &id) const {
   if (useTimingCorrections()) {
     assert(theChamberTimingCorrections.isValid());
     CSCDetId idraw = mapper_->rawCSCDetId(id);
-    int index = indexer_->chamberIndex(idraw) - 1; // NOTE THE MINUS ONE!
+    int index = indexer_->chamberIndex(idraw) - 1;  // NOTE THE MINUS ONE!
     return float(
-        theChamberTimingCorrections->item(index).cfeb_tmb_skew_delay * 1. /
-            theChamberTimingCorrections->precision() +
-        theChamberTimingCorrections->item(index).cfeb_timing_corr * 1. /
-            theChamberTimingCorrections->precision() +
+        theChamberTimingCorrections->item(index).cfeb_tmb_skew_delay * 1. / theChamberTimingCorrections->precision() +
+        theChamberTimingCorrections->item(index).cfeb_timing_corr * 1. / theChamberTimingCorrections->precision() +
         (theChamberTimingCorrections->item(index).cfeb_cable_delay * 25.));
   } else
     return 0;
@@ -354,7 +338,7 @@ float CSCConditions::anodeBXoffset(const CSCDetId &id) const {
   if (useTimingCorrections()) {
     assert(theChamberTimingCorrections.isValid());
     CSCDetId idraw = mapper_->rawCSCDetId(id);
-    int index = indexer_->chamberIndex(idraw) - 1; // NOTE THE MINUS ONE!
+    int index = indexer_->chamberIndex(idraw) - 1;  // NOTE THE MINUS ONE!
     return float(theChamberTimingCorrections->item(index).anode_bx_offset * 1. /
                  theChamberTimingCorrections->precision());
   } else
@@ -366,15 +350,14 @@ float CSCConditions::anodeBXoffset(const CSCDetId &id) const {
 /// is between 6 or 9 otherwise fix it to 7.5.
 /// These values came from Dominique and Stan,
 float CSCConditions::averageGain() const {
-
-  const float loEdge = 5.0;          // consider gains above this
-  const float hiEdge = 10.0;         // consider gains below this
-  const float loLimit = 6.0;         // lowest acceptable average gain
-  const float hiLimit = 9.0;         // highest acceptable average gain
-  const float expectedAverage = 7.5; // default average gain
+  const float loEdge = 5.0;           // consider gains above this
+  const float hiEdge = 10.0;          // consider gains below this
+  const float loLimit = 6.0;          // lowest acceptable average gain
+  const float hiLimit = 9.0;          // highest acceptable average gain
+  const float expectedAverage = 7.5;  // default average gain
 
   if (theAverageGain > 0.)
-    return theAverageGain; // only recalculate if necessary
+    return theAverageGain;  // only recalculate if necessary
 
   int n_strip = 0;
   float gain_tot = 0.;
@@ -404,14 +387,12 @@ float CSCConditions::averageGain() const {
   return theAverageGain;
 }
 //
-float CSCConditions::gasGainCorrection(const CSCDetId &id, int geomChannel,
-                                       int iwiregroup) const {
+float CSCConditions::gasGainCorrection(const CSCDetId &id, int geomChannel, int iwiregroup) const {
   if (useGasGainCorrections()) {
     assert(theGasGainCorrections.isValid());
     CSCDetId idraw = mapper_->rawCSCDetId(id);
     int iraw = mapper_->rawStripChannel(id, geomChannel);
-    int index = indexer_->gasGainIndex(idraw, iraw, iwiregroup) -
-                1; // NOTE THE MINUS ONE!
+    int index = indexer_->gasGainIndex(idraw, iraw, iwiregroup) - 1;  // NOTE THE MINUS ONE!
     return float(theGasGainCorrections->value(index));
   } else {
     return 1.;

--- a/CalibMuon/CSCCalibration/src/CSCIndexerBase.cc
+++ b/CalibMuon/CSCCalibration/src/CSCIndexerBase.cc
@@ -1,8 +1,7 @@
 #include "CalibMuon/CSCCalibration/interface/CSCIndexerBase.h"
 
 CSCIndexerBase::CSCIndexerBase()
-    : chamberLabel_(
-          271) // # of physical chambers per endcap + 1. Includes ME42.
+    : chamberLabel_(271)  // # of physical chambers per endcap + 1. Includes ME42.
 {
   // Fill the member vector which permits decoding of the linear chamber index.
   // Beware that the ME42 indices 235-270 within this vector do NOT correspond
@@ -23,8 +22,7 @@ CSCIndexerBase::CSCIndexerBase()
 
 CSCIndexerBase::~CSCIndexerBase() {}
 
-CSCIndexerBase::IndexType
-CSCIndexerBase::chamberLabelFromChamberIndex(IndexType ici) const {
+CSCIndexerBase::IndexType CSCIndexerBase::chamberLabelFromChamberIndex(IndexType ici) const {
   // This is just for cross-checking
 
   // Expected range of input range argument is 1-540.
@@ -32,35 +30,32 @@ CSCIndexerBase::chamberLabelFromChamberIndex(IndexType ici) const {
 
   if (ici > 468) {
     // ME42
-    ici -= 234;    // now in range 235-306
-    if (ici > 270) // -z
+    ici -= 234;     // now in range 235-306
+    if (ici > 270)  // -z
     {
-      ici -= 36; // now in range 235-270
+      ici -= 36;  // now in range 235-270
     }
-  } else // in range 1-468
+  } else  // in range 1-468
   {
-    if (ici > 234) // -z
+    if (ici > 234)  // -z
     {
-      ici -= 234; // now in range 1-234
+      ici -= 234;  // now in range 1-234
     }
   }
   return chamberLabel_[ici];
 }
 
-CSCIndexerBase::IndexType
-CSCIndexerBase::hvSegmentIndex(IndexType is, IndexType ir,
-                               IndexType iwire) const {
-  IndexType hvSegment = 1; // There is only one HV segment in ME1/1
+CSCIndexerBase::IndexType CSCIndexerBase::hvSegmentIndex(IndexType is, IndexType ir, IndexType iwire) const {
+  IndexType hvSegment = 1;  // There is only one HV segment in ME1/1
 
-  if (is > 2 && ir == 1) // HV segments are the same in ME3/1 and ME4/1
+  if (is > 2 && ir == 1)  // HV segments are the same in ME3/1 and ME4/1
   {
     if (iwire >= 33 && iwire <= 64) {
       hvSegment = 2;
     } else if (iwire >= 65 && iwire <= 96) {
       hvSegment = 3;
     }
-  } else if (is > 1 &&
-             ir == 2) // HV segments are the same in ME2/2, ME3/2, and ME4/2
+  } else if (is > 1 && ir == 2)  // HV segments are the same in ME2/2, ME3/2, and ME4/2
   {
     if (iwire >= 17 && iwire <= 28) {
       hvSegment = 2;
@@ -93,8 +88,7 @@ CSCIndexerBase::hvSegmentIndex(IndexType is, IndexType ir,
   return hvSegment;
 }
 
-CSCDetId CSCIndexerBase::detIdFromChamberLabel(IndexType ie,
-                                               IndexType label) const {
+CSCDetId CSCIndexerBase::detIdFromChamberLabel(IndexType ie, IndexType label) const {
   IndexType is = label / 1000;
   label -= is * 1000;
   IndexType ir = label / 100;
@@ -111,18 +105,18 @@ CSCDetId CSCIndexerBase::detIdFromChamberIndex(IndexType ici) const {
   IndexType ie = 1;
   if (ici > 468) {
     // ME42
-    ici -= 234;    // now in range 235-306
-    if (ici > 270) // -z
+    ici -= 234;     // now in range 235-306
+    if (ici > 270)  // -z
     {
       ie = 2;
-      ici -= 36; // now in range 235-270
+      ici -= 36;  // now in range 235-270
     }
-  } else // in range 1-468
+  } else  // in range 1-468
   {
-    if (ici > 234) // -z
+    if (ici > 234)  // -z
     {
       ie = 2;
-      ici -= 234; // now in range 1-234
+      ici -= 234;  // now in range 1-234
     }
   }
 

--- a/CalibMuon/CSCCalibration/src/CSCIndexerPostls1.cc
+++ b/CalibMuon/CSCCalibration/src/CSCIndexerPostls1.cc
@@ -2,22 +2,18 @@
 
 CSCIndexerPostls1::~CSCIndexerPostls1() {}
 
-std::pair<CSCDetId, CSCIndexerBase::IndexType>
-CSCIndexerPostls1::detIdFromStripChannelIndex(LongIndexType isi) const {
-  const LongIndexType lastnonme1a = 252288; // channels with ME42 installed
-  const LongIndexType lastpluszme1a =
-      262656; // last unganged ME1a +z channel = 252288 + 10368
-  const LongIndexType lastnonme42 =
-      217728; // channels in 2008 installed chambers
-  const LongIndexType lastplusznonme42 = 108864; // = 217728/2
-  const LongIndexType firstme13 = 34561;         // First channel of ME13
-  const LongIndexType lastme13 = 48384;          // Last channel of ME13
+std::pair<CSCDetId, CSCIndexerBase::IndexType> CSCIndexerPostls1::detIdFromStripChannelIndex(LongIndexType isi) const {
+  const LongIndexType lastnonme1a = 252288;       // channels with ME42 installed
+  const LongIndexType lastpluszme1a = 262656;     // last unganged ME1a +z channel = 252288 + 10368
+  const LongIndexType lastnonme42 = 217728;       // channels in 2008 installed chambers
+  const LongIndexType lastplusznonme42 = 108864;  // = 217728/2
+  const LongIndexType firstme13 = 34561;          // First channel of ME13
+  const LongIndexType lastme13 = 48384;           // Last channel of ME13
 
   const IndexType lastnonme42layer = 2808;
-  const IndexType lastplusznonme42layer = 1404; // = 2808/2
-  const IndexType firstme13layer =
-      433; // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
-  const IndexType lastme13layer = 648; // = 108*6
+  const IndexType lastplusznonme42layer = 1404;  // = 2808/2
+  const IndexType firstme13layer = 433;          // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
+  const IndexType lastme13layer = 648;           // = 108*6
 
   bool me1a = false;
 
@@ -39,22 +35,22 @@ CSCIndexerPostls1::detIdFromStripChannelIndex(LongIndexType isi) const {
       ie = 2;
       isi -= lastplusznonme42;
     }
-    if (isi > lastme13) // after ME13
+    if (isi > lastme13)  // after ME13
     {
       istart = lastme13;
       layerOffset = lastme13layer;
-    } else if (isi >= firstme13) // ME13
+    } else if (isi >= firstme13)  // ME13
     {
       istart = firstme13 - 1;
       layerOffset = firstme13layer - 1;
       nchan = 64;
     }
-  } else if (isi <= lastnonme1a) // ME42 chambers
+  } else if (isi <= lastnonme1a)  // ME42 chambers
   {
     istart = lastnonme42;
     layerOffset = lastnonme42layer;
     // don't care about ie, as ME42 stretch of indices is uniform
-  } else // Unganged ME1a channels
+  } else  // Unganged ME1a channels
   {
     me1a = true;
     if (isi > lastpluszme1a)
@@ -64,13 +60,13 @@ CSCIndexerPostls1::detIdFromStripChannelIndex(LongIndexType isi) const {
     // layerOffset stays 0, as we want to map them onto ME1b's layer indices
   }
 
-  isi -= istart; // remove earlier group(s)
+  isi -= istart;  // remove earlier group(s)
   IndexType ichan = (isi - 1) % nchan + 1;
   IndexType ili = (isi - 1) / nchan + 1;
-  ili += layerOffset; // add appropriate offset for earlier group(s)
+  ili += layerOffset;  // add appropriate offset for earlier group(s)
   if (ie != 1)
-    ili += lastplusznonme42layer; // add offset to -z endcap; ME42 doesn't need
-                                  // this.
+    ili += lastplusznonme42layer;  // add offset to -z endcap; ME42 doesn't need
+                                   // this.
 
   CSCDetId id = detIdFromLayerIndex(ili);
 
@@ -81,22 +77,18 @@ CSCIndexerPostls1::detIdFromStripChannelIndex(LongIndexType isi) const {
   return std::make_pair(id, ichan);
 }
 
-std::pair<CSCDetId, CSCIndexerBase::IndexType>
-CSCIndexerPostls1::detIdFromChipIndex(IndexType ici) const {
-  const LongIndexType lastnonme1a =
-      15768; // chips in chambers with ME42 installed
-  const LongIndexType lastpluszme1a =
-      16416; // last unganged ME1a +z chip = 15768 + 648 = 16416
-  const LongIndexType lastnonme42 = 13608; // chips in 2008 installed chambers
-  const LongIndexType lastplusznonme42 = 6804; // = 13608/2
-  const LongIndexType firstme13 = 2161;        // First channel of ME13
-  const LongIndexType lastme13 = 3024;         // Last channel of ME13
+std::pair<CSCDetId, CSCIndexerBase::IndexType> CSCIndexerPostls1::detIdFromChipIndex(IndexType ici) const {
+  const LongIndexType lastnonme1a = 15768;      // chips in chambers with ME42 installed
+  const LongIndexType lastpluszme1a = 16416;    // last unganged ME1a +z chip = 15768 + 648 = 16416
+  const LongIndexType lastnonme42 = 13608;      // chips in 2008 installed chambers
+  const LongIndexType lastplusznonme42 = 6804;  // = 13608/2
+  const LongIndexType firstme13 = 2161;         // First channel of ME13
+  const LongIndexType lastme13 = 3024;          // Last channel of ME13
 
   const IndexType lastnonme42layer = 2808;
-  const IndexType lastplusznonme42layer = 1404; // = 2808/2
-  const IndexType firstme13layer =
-      433; // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
-  const IndexType lastme13layer = 648; // = 108*6
+  const IndexType lastplusznonme42layer = 1404;  // = 2808/2
+  const IndexType firstme13layer = 433;          // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
+  const IndexType lastme13layer = 648;           // = 108*6
 
   bool me1a = false;
 
@@ -117,22 +109,22 @@ CSCIndexerPostls1::detIdFromChipIndex(IndexType ici) const {
       ie = 2;
       ici -= lastplusznonme42;
     }
-    if (ici > lastme13) // after ME13
+    if (ici > lastme13)  // after ME13
     {
       istart = lastme13;
       layerOffset = lastme13layer;
-    } else if (ici >= firstme13) // ME13
+    } else if (ici >= firstme13)  // ME13
     {
       istart = firstme13 - 1;
       layerOffset = firstme13layer - 1;
       nchipPerLayer = 4;
     }
-  } else if (ici <= lastnonme1a) // ME42 chambers
+  } else if (ici <= lastnonme1a)  // ME42 chambers
   {
     istart = lastnonme42;
     layerOffset = lastnonme42layer;
     // don't care about ie, as ME42 stratch of indices is uniform
-  } else // Unganged ME1a channels
+  } else  // Unganged ME1a channels
   {
     me1a = true;
     if (ici > lastpluszme1a)
@@ -142,13 +134,13 @@ CSCIndexerPostls1::detIdFromChipIndex(IndexType ici) const {
     // layerOffset stays 0, as we want to map them onto ME1b's layer indices
   }
 
-  ici -= istart; // remove earlier group(s)
+  ici -= istart;  // remove earlier group(s)
   IndexType ichip = (ici - 1) % nchipPerLayer + 1;
   IndexType ili = (ici - 1) / nchipPerLayer + 1;
-  ili += layerOffset; // add appropriate offset for earlier group(s)
+  ili += layerOffset;  // add appropriate offset for earlier group(s)
   if (ie != 1)
-    ili += lastplusznonme42layer; // add offset to -z endcap; ME42 doesn't need
-                                  // this.
+    ili += lastplusznonme42layer;  // add offset to -z endcap; ME42 doesn't need
+                                   // this.
 
   CSCDetId id = detIdFromLayerIndex(ili);
 
@@ -169,28 +161,20 @@ int CSCIndexerPostls1::dbIndex(const CSCDetId &id, int &channel) const {
   return ec * 100000 + st * 10000 + rg * 1000 + ch * 10 + la;
 }
 
-CSCIndexerBase::GasGainIndexType
-CSCIndexerPostls1::detIdFromGasGainIndex(IndexType igg) const {
+CSCIndexerBase::GasGainIndexType CSCIndexerPostls1::detIdFromGasGainIndex(IndexType igg) const {
   const int n_types = 20;
-  const IndexType type_starts[n_types] = {
-      1,     1081,  4321,  6913,  8533,  13933, 15553, 20953, 22573, 23653,
-      26893, 29485, 31105, 36505, 38125, 43525, 45145, 50545, 55945, 56593};
+  const IndexType type_starts[n_types] = {1,     1081,  4321,  6913,  8533,  13933, 15553, 20953, 22573, 23653,
+                                          26893, 29485, 31105, 36505, 38125, 43525, 45145, 50545, 55945, 56593};
   //+1/1 +1/2  +1/3  +2/1  +2/2  +3/1   +3/2   +4/1   -1/1   -1/2   -1/3   -2/1
   //-2/2   -3/1   -3/2   -4/1   +4/2   -4/2   +1/4   -1/4
 
-  const int endcaps[n_types] = {1, 1, 1, 1, 1, 1, 1, 1, 2, 2,
-                                2, 2, 2, 2, 2, 2, 1, 2, 1, 2};
-  const int stations[n_types] = {1, 1, 1, 2, 2, 3, 3, 4, 1, 1,
-                                 1, 2, 2, 3, 3, 4, 4, 4, 1, 1};
-  const int rings[n_types] = {1, 2, 3, 1, 2, 1, 2, 1, 1, 2,
-                              3, 1, 2, 1, 2, 1, 2, 2, 4, 4};
+  const int endcaps[n_types] = {1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 1, 2, 1, 2};
+  const int stations[n_types] = {1, 1, 1, 2, 2, 3, 3, 4, 1, 1, 1, 2, 2, 3, 3, 4, 4, 4, 1, 1};
+  const int rings[n_types] = {1, 2, 3, 1, 2, 1, 2, 1, 1, 2, 3, 1, 2, 1, 2, 1, 2, 2, 4, 4};
 
   // determine chamber type
   std::vector<IndexType> v_type_starts(type_starts, type_starts + n_types);
-  int type =
-      int(std::upper_bound(v_type_starts.begin(), v_type_starts.end(), igg) -
-          v_type_starts.begin()) -
-      1;
+  int type = int(std::upper_bound(v_type_starts.begin(), v_type_starts.end(), igg) - v_type_starts.begin()) - 1;
 
   // determine factors for #HVsectors and #chips
   int sectors_per_layer = sectorsPerLayer(stations[type], rings[type]);
@@ -198,8 +182,7 @@ CSCIndexerPostls1::detIdFromGasGainIndex(IndexType igg) const {
 
   IndexType igg_chamber_etc = igg - type_starts[type] + 1;
 
-  IndexType igg_chamber_and_layer =
-      (igg_chamber_etc - 1) / sectors_per_layer + 1;
+  IndexType igg_chamber_and_layer = (igg_chamber_etc - 1) / sectors_per_layer + 1;
 
   // extract chamber & layer
   int chamber = (igg_chamber_and_layer - 1) / 6 + 1;

--- a/CalibMuon/CSCCalibration/src/CSCIndexerStartup.cc
+++ b/CalibMuon/CSCCalibration/src/CSCIndexerStartup.cc
@@ -2,19 +2,16 @@
 
 CSCIndexerStartup::~CSCIndexerStartup() {}
 
-std::pair<CSCDetId, CSCIndexerBase::IndexType>
-CSCIndexerStartup::detIdFromStripChannelIndex(LongIndexType isi) const {
-  const LongIndexType lastnonme42 =
-      217728; // channels in 2008 installed chambers
-  const LongIndexType lastplusznonme42 = 108864; // = 217728/2
-  const LongIndexType firstme13 = 34561;         // First channel of ME13
-  const LongIndexType lastme13 = 48384;          // Last channel of ME13
+std::pair<CSCDetId, CSCIndexerBase::IndexType> CSCIndexerStartup::detIdFromStripChannelIndex(LongIndexType isi) const {
+  const LongIndexType lastnonme42 = 217728;       // channels in 2008 installed chambers
+  const LongIndexType lastplusznonme42 = 108864;  // = 217728/2
+  const LongIndexType firstme13 = 34561;          // First channel of ME13
+  const LongIndexType lastme13 = 48384;           // Last channel of ME13
 
   const IndexType lastnonme42layer = 2808;
-  const IndexType lastplusznonme42layer = 1404; // = 2808/2
-  const IndexType firstme13layer =
-      433; // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
-  const IndexType lastme13layer = 648; // = 108*6
+  const IndexType lastplusznonme42layer = 1404;  // = 2808/2
+  const IndexType firstme13layer = 433;          // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
+  const IndexType lastme13layer = 648;           // = 108*6
 
   // All chambers but ME13 have 80 channels
   IndexType nchan = 80;
@@ -26,51 +23,49 @@ CSCIndexerStartup::detIdFromStripChannelIndex(LongIndexType isi) const {
   LongIndexType istart = 0;
   IndexType layerOffset = 0;
 
-  if (isi <= lastnonme42) // Chambers as of 2008 Installation
+  if (isi <= lastnonme42)  // Chambers as of 2008 Installation
   {
     if (isi > lastplusznonme42) {
       ie = 2;
       isi -= lastplusznonme42;
     }
-    if (isi > lastme13) // after ME13
+    if (isi > lastme13)  // after ME13
     {
       istart = lastme13;
       layerOffset = lastme13layer;
-    } else if (isi >= firstme13) // ME13
+    } else if (isi >= firstme13)  // ME13
     {
       istart = firstme13 - 1;
       layerOffset = firstme13layer - 1;
       nchan = 64;
     }
-  } else // ME42 chambers
+  } else  // ME42 chambers
   {
     istart = lastnonme42;
     layerOffset = lastnonme42layer;
   }
 
-  isi -= istart; // remove earlier group(s)
+  isi -= istart;  // remove earlier group(s)
   IndexType ichan = (isi - 1) % nchan + 1;
   IndexType ili = (isi - 1) / nchan + 1;
-  ili += layerOffset; // add appropriate offset for earlier group(s)
+  ili += layerOffset;  // add appropriate offset for earlier group(s)
   if (ie != 1)
-    ili += lastplusznonme42layer; // add offset to -z endcap; ME42 doesn't need
-                                  // this.
+    ili += lastplusznonme42layer;  // add offset to -z endcap; ME42 doesn't need
+                                   // this.
 
   return std::pair<CSCDetId, IndexType>(detIdFromLayerIndex(ili), ichan);
 }
 
-std::pair<CSCDetId, CSCIndexerBase::IndexType>
-CSCIndexerStartup::detIdFromChipIndex(IndexType ici) const {
-  const LongIndexType lastnonme42 = 13608; // chips in 2008 installed chambers
-  const LongIndexType lastplusznonme42 = 6804; // = 13608/2
-  const LongIndexType firstme13 = 2161;        // First channel of ME13
-  const LongIndexType lastme13 = 3024;         // Last channel of ME13
+std::pair<CSCDetId, CSCIndexerBase::IndexType> CSCIndexerStartup::detIdFromChipIndex(IndexType ici) const {
+  const LongIndexType lastnonme42 = 13608;      // chips in 2008 installed chambers
+  const LongIndexType lastplusznonme42 = 6804;  // = 13608/2
+  const LongIndexType firstme13 = 2161;         // First channel of ME13
+  const LongIndexType lastme13 = 3024;          // Last channel of ME13
 
   const IndexType lastnonme42layer = 2808;
-  const IndexType lastplusznonme42layer = 1404; // = 2808/2
-  const IndexType firstme13layer =
-      433; // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
-  const IndexType lastme13layer = 648; // = 108*6
+  const IndexType lastplusznonme42layer = 1404;  // = 2808/2
+  const IndexType firstme13layer = 433;          // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
+  const IndexType lastme13layer = 648;           // = 108*6
 
   // All chambers but ME13 have 5 chips/layer
   IndexType nchipPerLayer = 5;
@@ -82,35 +77,35 @@ CSCIndexerStartup::detIdFromChipIndex(IndexType ici) const {
   LongIndexType istart = 0;
   IndexType layerOffset = 0;
 
-  if (ici <= lastnonme42) // Chambers as of 2008 Installation
+  if (ici <= lastnonme42)  // Chambers as of 2008 Installation
   {
     if (ici > lastplusznonme42) {
       ie = 2;
       ici -= lastplusznonme42;
     }
-    if (ici > lastme13) // after ME13
+    if (ici > lastme13)  // after ME13
     {
       istart = lastme13;
       layerOffset = lastme13layer;
-    } else if (ici >= firstme13) // ME13
+    } else if (ici >= firstme13)  // ME13
     {
       istart = firstme13 - 1;
       layerOffset = firstme13layer - 1;
       nchipPerLayer = 4;
     }
-  } else // ME42 chambers
+  } else  // ME42 chambers
   {
     istart = lastnonme42;
     layerOffset = lastnonme42layer;
   }
 
-  ici -= istart; // remove earlier group(s)
+  ici -= istart;  // remove earlier group(s)
   IndexType ichip = (ici - 1) % nchipPerLayer + 1;
   IndexType ili = (ici - 1) / nchipPerLayer + 1;
-  ili += layerOffset; // add appropriate offset for earlier group(s)
+  ili += layerOffset;  // add appropriate offset for earlier group(s)
   if (ie != 1)
-    ili += lastplusznonme42layer; // add offset to -z endcap; ME42 doesn't need
-                                  // this.
+    ili += lastplusznonme42layer;  // add offset to -z endcap; ME42 doesn't need
+                                   // this.
 
   return std::pair<CSCDetId, IndexType>(detIdFromLayerIndex(ili), ichip);
 }
@@ -126,33 +121,41 @@ int CSCIndexerStartup::dbIndex(const CSCDetId &id, int &channel) const {
   if (st == 1 && rg == 4) {
     rg = 1;
     if (channel <= 16)
-      channel += 64; // no trapping for any bizarreness
+      channel += 64;  // no trapping for any bizarreness
   }
   return ec * 100000 + st * 10000 + rg * 1000 + ch * 10 + la;
 }
 
-CSCIndexerBase::GasGainIndexType
-CSCIndexerStartup::detIdFromGasGainIndex(IndexType igg) const {
+CSCIndexerBase::GasGainIndexType CSCIndexerStartup::detIdFromGasGainIndex(IndexType igg) const {
   const int n_types = 18;
-  const IndexType type_starts[n_types] = {
-      1,     1081,  4321,  6913,  8533,  13933, 15553, 20953, 22573,
-      23653, 26893, 29485, 31105, 36505, 38125, 43525, 45145, 50545};
+  const IndexType type_starts[n_types] = {1,
+                                          1081,
+                                          4321,
+                                          6913,
+                                          8533,
+                                          13933,
+                                          15553,
+                                          20953,
+                                          22573,
+                                          23653,
+                                          26893,
+                                          29485,
+                                          31105,
+                                          36505,
+                                          38125,
+                                          43525,
+                                          45145,
+                                          50545};
   //+1/1 +1/2  +1/3  +2/1  +2/2  +3/1   +3/2   +4/1   -1/1   -1/2   -1/3   -2/1
   //-2/2   -3/1   -3/2   -4/1   +4/2   -4/2
 
-  const int endcaps[n_types] = {1, 1, 1, 1, 1, 1, 1, 1, 2,
-                                2, 2, 2, 2, 2, 2, 2, 1, 2};
-  const int stations[n_types] = {1, 1, 1, 2, 2, 3, 3, 4, 1,
-                                 1, 1, 2, 2, 3, 3, 4, 4, 4};
-  const int rings[n_types] = {1, 2, 3, 1, 2, 1, 2, 1, 1,
-                              2, 3, 1, 2, 1, 2, 1, 2, 2};
+  const int endcaps[n_types] = {1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 1, 2};
+  const int stations[n_types] = {1, 1, 1, 2, 2, 3, 3, 4, 1, 1, 1, 2, 2, 3, 3, 4, 4, 4};
+  const int rings[n_types] = {1, 2, 3, 1, 2, 1, 2, 1, 1, 2, 3, 1, 2, 1, 2, 1, 2, 2};
 
   // determine chamber type
   std::vector<IndexType> v_type_starts(type_starts, type_starts + n_types);
-  int type =
-      int(std::upper_bound(v_type_starts.begin(), v_type_starts.end(), igg) -
-          v_type_starts.begin()) -
-      1;
+  int type = int(std::upper_bound(v_type_starts.begin(), v_type_starts.end(), igg) - v_type_starts.begin()) - 1;
 
   // determine factors for #HVsectors and #chips
   int sectors_per_layer = sectorsPerLayer(stations[type], rings[type]);
@@ -160,8 +163,7 @@ CSCIndexerStartup::detIdFromGasGainIndex(IndexType igg) const {
 
   IndexType igg_chamber_etc = igg - type_starts[type] + 1;
 
-  IndexType igg_chamber_and_layer =
-      (igg_chamber_etc - 1) / sectors_per_layer + 1;
+  IndexType igg_chamber_and_layer = (igg_chamber_etc - 1) / sectors_per_layer + 1;
 
   // extract chamber & layer
   int chamber = (igg_chamber_and_layer - 1) / 6 + 1;

--- a/CalibMuon/CSCCalibration/src/ES_CSCChannelMapperBase.cc
+++ b/CalibMuon/CSCCalibration/src/ES_CSCChannelMapperBase.cc
@@ -1,4 +1,4 @@
 #include "CalibMuon/CSCCalibration/interface/CSCChannelMapperBase.h"
 #include "FWCore/Utilities/interface/typelookup.h"
 
-TYPELOOKUP_DATA_REG(CSCChannelMapperBase); // registers the type
+TYPELOOKUP_DATA_REG(CSCChannelMapperBase);  // registers the type

--- a/CalibMuon/CSCCalibration/src/ES_CSCIndexerBase.cc
+++ b/CalibMuon/CSCCalibration/src/ES_CSCIndexerBase.cc
@@ -1,4 +1,4 @@
 #include "CalibMuon/CSCCalibration/interface/CSCIndexerBase.h"
 #include "FWCore/Utilities/interface/typelookup.h"
 
-TYPELOOKUP_DATA_REG(CSCIndexerBase); // registers the type
+TYPELOOKUP_DATA_REG(CSCIndexerBase);  // registers the type

--- a/CalibMuon/CSCCalibration/test/old_indexers/CSCIndexerOldPostls1.cc
+++ b/CalibMuon/CSCCalibration/test/old_indexers/CSCIndexerOldPostls1.cc
@@ -6,8 +6,7 @@ void CSCIndexerOldPostls1::fillChamberLabel() const {
   // Logically const since initializes cache only,
   // Beware that the ME42 indices 235-270 within this vector do NOT correspond
   // to their 'real' linear indices (which are 469-504 for +z)
-  chamberLabel.resize(
-      271); // one more than #chambers per endcap. Includes ME42.
+  chamberLabel.resize(271);  // one more than #chambers per endcap. Includes ME42.
   IndexType count = 0;
   chamberLabel[count] = 0;
 
@@ -22,18 +21,17 @@ void CSCIndexerOldPostls1::fillChamberLabel() const {
   }
 }
 
-CSCIndexerOldPostls1::IndexType
-CSCIndexerOldPostls1::hvSegmentIndex(IndexType is, IndexType ir,
-                                     IndexType iwire) const {
-  IndexType hvSegment = 1; // There is only one HV segment in ME1/1
+CSCIndexerOldPostls1::IndexType CSCIndexerOldPostls1::hvSegmentIndex(IndexType is,
+                                                                     IndexType ir,
+                                                                     IndexType iwire) const {
+  IndexType hvSegment = 1;  // There is only one HV segment in ME1/1
 
-  if (is > 2 && ir == 1) { // HV segments are the same in ME3/1 and ME4/1
+  if (is > 2 && ir == 1) {  // HV segments are the same in ME3/1 and ME4/1
     if (iwire >= 33 && iwire <= 64)
       hvSegment = 2;
     else if (iwire >= 65 && iwire <= 96)
       hvSegment = 3;
-  } else if (is > 1 &&
-             ir == 2) { // HV segments are the same in ME2/2, ME3/2, and ME4/2
+  } else if (is > 1 && ir == 2) {  // HV segments are the same in ME2/2, ME3/2, and ME4/2
     if (iwire >= 17 && iwire <= 28)
       hvSegment = 2;
     else if (iwire >= 29 && iwire <= 40)
@@ -63,7 +61,6 @@ CSCIndexerOldPostls1::hvSegmentIndex(IndexType is, IndexType ir,
 }
 
 CSCDetId CSCIndexerOldPostls1::detIdFromChamberIndex_OLD(IndexType ici) const {
-
   // Will not work as is for ME42
   // ============================
 
@@ -107,15 +104,15 @@ CSCDetId CSCIndexerOldPostls1::detIdFromChamberIndex(IndexType ici) const {
   IndexType ie = 1;
   if (ici > 468) {
     // ME42
-    ici -= 234;      // now in range 235-306
-    if (ici > 270) { // -z
+    ici -= 234;       // now in range 235-306
+    if (ici > 270) {  // -z
       ie = 2;
-      ici -= 36; // now in range 235-270
+      ici -= 36;  // now in range 235-270
     }
-  } else {           // in range 1-468
-    if (ici > 234) { // -z
+  } else {            // in range 1-468
+    if (ici > 234) {  // -z
       ie = 2;
-      ici -= 234; // now in range 1-234
+      ici -= 234;  // now in range 1-234
     }
   }
   if (chamberLabel.empty())
@@ -124,8 +121,7 @@ CSCDetId CSCIndexerOldPostls1::detIdFromChamberIndex(IndexType ici) const {
   return detIdFromChamberLabel(ie, label);
 }
 
-CSCIndexerOldPostls1::IndexType
-CSCIndexerOldPostls1::chamberLabelFromChamberIndex(IndexType ici) const {
+CSCIndexerOldPostls1::IndexType CSCIndexerOldPostls1::chamberLabelFromChamberIndex(IndexType ici) const {
   // This is just for cross-checking
 
   // Expected range of input range argument is 1-540.
@@ -133,13 +129,13 @@ CSCIndexerOldPostls1::chamberLabelFromChamberIndex(IndexType ici) const {
 
   if (ici > 468) {
     // ME42
-    ici -= 234;      // now in range 235-306
-    if (ici > 270) { // -z
-      ici -= 36;     // now in range 235-270
+    ici -= 234;       // now in range 235-306
+    if (ici > 270) {  // -z
+      ici -= 36;      // now in range 235-270
     }
-  } else {           // in range 1-468
-    if (ici > 234) { // -z
-      ici -= 234;    // now in range 1-234
+  } else {            // in range 1-468
+    if (ici > 234) {  // -z
+      ici -= 234;     // now in range 1-234
     }
   }
   if (chamberLabel.empty())
@@ -147,9 +143,7 @@ CSCIndexerOldPostls1::chamberLabelFromChamberIndex(IndexType ici) const {
   return chamberLabel[ici];
 }
 
-CSCDetId CSCIndexerOldPostls1::detIdFromChamberLabel(IndexType ie,
-                                                     IndexType label) const {
-
+CSCDetId CSCIndexerOldPostls1::detIdFromChamberLabel(IndexType ie, IndexType label) const {
   IndexType is = label / 1000;
   label -= is * 1000;
   IndexType ir = label / 100;
@@ -160,7 +154,6 @@ CSCDetId CSCIndexerOldPostls1::detIdFromChamberLabel(IndexType ie,
 }
 
 CSCDetId CSCIndexerOldPostls1::detIdFromLayerIndex(IndexType ili) const {
-
   IndexType il = (ili - 1) % 6 + 1;
   IndexType ici = (ili - 1) / 6 + 1;
   CSCDetId id = detIdFromChamberIndex(ici);
@@ -168,23 +161,19 @@ CSCDetId CSCIndexerOldPostls1::detIdFromLayerIndex(IndexType ili) const {
   return CSCDetId(id.endcap(), id.station(), id.ring(), id.chamber(), il);
 }
 
-std::pair<CSCDetId, CSCIndexerOldPostls1::IndexType>
-CSCIndexerOldPostls1::detIdFromStripChannelIndex(LongIndexType isi) const {
-
-  const LongIndexType lastnonme1a = 252288; // channels with ME42 installed
-  const LongIndexType lastpluszme1a =
-      262656; // last unganged ME1a +z channel = 252288 + 10368
-  const LongIndexType lastnonme42 =
-      217728; // channels in 2008 installed chambers
-  const LongIndexType lastplusznonme42 = 108864; // = 217728/2
-  const LongIndexType firstme13 = 34561;         // First channel of ME13
-  const LongIndexType lastme13 = 48384;          // Last channel of ME13
+std::pair<CSCDetId, CSCIndexerOldPostls1::IndexType> CSCIndexerOldPostls1::detIdFromStripChannelIndex(
+    LongIndexType isi) const {
+  const LongIndexType lastnonme1a = 252288;       // channels with ME42 installed
+  const LongIndexType lastpluszme1a = 262656;     // last unganged ME1a +z channel = 252288 + 10368
+  const LongIndexType lastnonme42 = 217728;       // channels in 2008 installed chambers
+  const LongIndexType lastplusznonme42 = 108864;  // = 217728/2
+  const LongIndexType firstme13 = 34561;          // First channel of ME13
+  const LongIndexType lastme13 = 48384;           // Last channel of ME13
 
   const IndexType lastnonme42layer = 2808;
-  const IndexType lastplusznonme42layer = 1404; // = 2808/2
-  const IndexType firstme13layer =
-      433; // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
-  const IndexType lastme13layer = 648; // = 108*6
+  const IndexType lastplusznonme42layer = 1404;  // = 2808/2
+  const IndexType firstme13layer = 433;          // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
+  const IndexType lastme13layer = 648;           // = 108*6
 
   bool me1a = false;
 
@@ -208,21 +197,21 @@ CSCIndexerOldPostls1::detIdFromStripChannelIndex(LongIndexType isi) const {
       isi -= lastplusznonme42;
     }
 
-    if (isi > lastme13) { // after ME13
+    if (isi > lastme13) {  // after ME13
       istart = lastme13;
       layerOffset = lastme13layer;
-    } else if (isi >= firstme13) { // ME13
+    } else if (isi >= firstme13) {  // ME13
       istart = firstme13 - 1;
       layerOffset = firstme13layer - 1;
       nchan = 64;
     }
-  } else if (isi <= lastnonme1a) { // ME42 chambers
+  } else if (isi <= lastnonme1a) {  // ME42 chambers
 
     istart = lastnonme42;
     layerOffset = lastnonme42layer;
 
     // don't care about ie, as ME42 stratch of indices is uniform
-  } else { // Unganged ME1a channels
+  } else {  // Unganged ME1a channels
 
     me1a = true;
     if (isi > lastpluszme1a)
@@ -232,13 +221,13 @@ CSCIndexerOldPostls1::detIdFromStripChannelIndex(LongIndexType isi) const {
     // layerOffset stays 0, as we want to map them onto ME1b's layer indices
   }
 
-  isi -= istart; // remove earlier group(s)
+  isi -= istart;  // remove earlier group(s)
   IndexType ichan = (isi - 1) % nchan + 1;
   IndexType ili = (isi - 1) / nchan + 1;
-  ili += layerOffset; // add appropriate offset for earlier group(s)
+  ili += layerOffset;  // add appropriate offset for earlier group(s)
   if (ie != 1)
-    ili += lastplusznonme42layer; // add offset to -z endcap; ME42 doesn't need
-                                  // this.
+    ili += lastplusznonme42layer;  // add offset to -z endcap; ME42 doesn't need
+                                   // this.
 
   CSCDetId id = detIdFromLayerIndex(ili);
 
@@ -249,23 +238,18 @@ CSCIndexerOldPostls1::detIdFromStripChannelIndex(LongIndexType isi) const {
   return std::make_pair(id, ichan);
 }
 
-std::pair<CSCDetId, CSCIndexerOldPostls1::IndexType>
-CSCIndexerOldPostls1::detIdFromChipIndex(IndexType ici) const {
-
-  const LongIndexType lastnonme1a =
-      15768; // chips in chambers with ME42 installed
-  const LongIndexType lastpluszme1a =
-      16416; // last unganged ME1a +z chip = 15768 + 648 = 16416
-  const LongIndexType lastnonme42 = 13608; // chips in 2008 installed chambers
-  const LongIndexType lastplusznonme42 = 6804; // = 13608/2
-  const LongIndexType firstme13 = 2161;        // First channel of ME13
-  const LongIndexType lastme13 = 3024;         // Last channel of ME13
+std::pair<CSCDetId, CSCIndexerOldPostls1::IndexType> CSCIndexerOldPostls1::detIdFromChipIndex(IndexType ici) const {
+  const LongIndexType lastnonme1a = 15768;      // chips in chambers with ME42 installed
+  const LongIndexType lastpluszme1a = 16416;    // last unganged ME1a +z chip = 15768 + 648 = 16416
+  const LongIndexType lastnonme42 = 13608;      // chips in 2008 installed chambers
+  const LongIndexType lastplusznonme42 = 6804;  // = 13608/2
+  const LongIndexType firstme13 = 2161;         // First channel of ME13
+  const LongIndexType lastme13 = 3024;          // Last channel of ME13
 
   const IndexType lastnonme42layer = 2808;
-  const IndexType lastplusznonme42layer = 1404; // = 2808/2
-  const IndexType firstme13layer =
-      433; // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
-  const IndexType lastme13layer = 648; // = 108*6
+  const IndexType lastplusznonme42layer = 1404;  // = 2808/2
+  const IndexType firstme13layer = 433;          // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
+  const IndexType lastme13layer = 648;           // = 108*6
 
   bool me1a = false;
 
@@ -288,21 +272,21 @@ CSCIndexerOldPostls1::detIdFromChipIndex(IndexType ici) const {
       ici -= lastplusznonme42;
     }
 
-    if (ici > lastme13) { // after ME13
+    if (ici > lastme13) {  // after ME13
       istart = lastme13;
       layerOffset = lastme13layer;
-    } else if (ici >= firstme13) { // ME13
+    } else if (ici >= firstme13) {  // ME13
       istart = firstme13 - 1;
       layerOffset = firstme13layer - 1;
       nchipPerLayer = 4;
     }
-  } else if (ici <= lastnonme1a) { // ME42 chambers
+  } else if (ici <= lastnonme1a) {  // ME42 chambers
 
     istart = lastnonme42;
     layerOffset = lastnonme42layer;
 
     // don't care about ie, as ME42 stratch of indices is uniform
-  } else { // Unganged ME1a channels
+  } else {  // Unganged ME1a channels
 
     me1a = true;
     if (ici > lastpluszme1a)
@@ -312,13 +296,13 @@ CSCIndexerOldPostls1::detIdFromChipIndex(IndexType ici) const {
     // layerOffset stays 0, as we want to map them onto ME1b's layer indices
   }
 
-  ici -= istart; // remove earlier group(s)
+  ici -= istart;  // remove earlier group(s)
   IndexType ichip = (ici - 1) % nchipPerLayer + 1;
   IndexType ili = (ici - 1) / nchipPerLayer + 1;
-  ili += layerOffset; // add appropriate offset for earlier group(s)
+  ili += layerOffset;  // add appropriate offset for earlier group(s)
   if (ie != 1)
-    ili += lastplusznonme42layer; // add offset to -z endcap; ME42 doesn't need
-                                  // this.
+    ili += lastplusznonme42layer;  // add offset to -z endcap; ME42 doesn't need
+                                   // this.
 
   CSCDetId id = detIdFromLayerIndex(ili);
 
@@ -329,28 +313,20 @@ CSCIndexerOldPostls1::detIdFromChipIndex(IndexType ici) const {
   return std::make_pair(id, ichip);
 }
 
-CSCIndexerOldPostls1::GasGainTuple
-CSCIndexerOldPostls1::detIdFromGasGainIndex(IndexType igg) const {
+CSCIndexerOldPostls1::GasGainTuple CSCIndexerOldPostls1::detIdFromGasGainIndex(IndexType igg) const {
   const int n_types = 20;
-  const IndexType type_starts[n_types] = {
-      1,     1081,  4321,  6913,  8533,  13933, 15553, 20953, 22573, 23653,
-      26893, 29485, 31105, 36505, 38125, 43525, 45145, 50545, 55945, 56593};
+  const IndexType type_starts[n_types] = {1,     1081,  4321,  6913,  8533,  13933, 15553, 20953, 22573, 23653,
+                                          26893, 29485, 31105, 36505, 38125, 43525, 45145, 50545, 55945, 56593};
   //+1/1 +1/2  +1/3  +2/1  +2/2  +3/1   +3/2   +4/1   -1/1   -1/2   -1/3   -2/1
   //-2/2   -3/1   -3/2   -4/1   +4/2   -4/2   +1/4   -1/4
 
-  const int endcaps[n_types] = {1, 1, 1, 1, 1, 1, 1, 1, 2, 2,
-                                2, 2, 2, 2, 2, 2, 1, 2, 1, 2};
-  const int stations[n_types] = {1, 1, 1, 2, 2, 3, 3, 4, 1, 1,
-                                 1, 2, 2, 3, 3, 4, 4, 4, 1, 1};
-  const int rings[n_types] = {1, 2, 3, 1, 2, 1, 2, 1, 1, 2,
-                              3, 1, 2, 1, 2, 1, 2, 2, 4, 4};
+  const int endcaps[n_types] = {1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 1, 2, 1, 2};
+  const int stations[n_types] = {1, 1, 1, 2, 2, 3, 3, 4, 1, 1, 1, 2, 2, 3, 3, 4, 4, 4, 1, 1};
+  const int rings[n_types] = {1, 2, 3, 1, 2, 1, 2, 1, 1, 2, 3, 1, 2, 1, 2, 1, 2, 2, 4, 4};
 
   // determine chamber type
   std::vector<IndexType> v_type_starts(type_starts, type_starts + n_types);
-  int type =
-      int(std::upper_bound(v_type_starts.begin(), v_type_starts.end(), igg) -
-          v_type_starts.begin()) -
-      1;
+  int type = int(std::upper_bound(v_type_starts.begin(), v_type_starts.end(), igg) - v_type_starts.begin()) - 1;
 
   // determine factors for #HVsectors and #chips
   int sectors_per_layer = sectorsPerLayer(stations[type], rings[type]);
@@ -358,8 +334,7 @@ CSCIndexerOldPostls1::detIdFromGasGainIndex(IndexType igg) const {
 
   IndexType igg_chamber_etc = igg - type_starts[type] + 1;
 
-  IndexType igg_chamber_and_layer =
-      (igg_chamber_etc - 1) / sectors_per_layer + 1;
+  IndexType igg_chamber_and_layer = (igg_chamber_etc - 1) / sectors_per_layer + 1;
 
   // extract chamber & layer
   int chamber = (igg_chamber_and_layer - 1) / 6 + 1;

--- a/CalibMuon/CSCCalibration/test/old_indexers/CSCIndexerOldPostls1.h
+++ b/CalibMuon/CSCCalibration/test/old_indexers/CSCIndexerOldPostls1.h
@@ -52,18 +52,17 @@
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 #include <boost/tuple/tuple.hpp>
 #include <iosfwd>
-#include <utility> // for pair
+#include <utility>  // for pair
 #include <vector>
 
 class CSCIndexerOldPostls1 {
-
 public:
   typedef uint16_t IndexType;
   typedef uint32_t LongIndexType;
 
-  typedef boost::tuple<CSCDetId,  // id
-                       IndexType, // HV segment
-                       IndexType  // chip
+  typedef boost::tuple<CSCDetId,   // id
+                       IndexType,  // HV segment
+                       IndexType   // chip
                        >
       GasGainTuple;
 
@@ -83,11 +82,9 @@ public:
    * WARNING: Considers both ME1a and ME1b to be part of one ME11 chamber
    *          (result would be the same for is=1 and ir=1 or 4).
    */
-  IndexType startChamberIndexInEndcap(IndexType ie, IndexType is,
-                                      IndexType ir) const {
-    const IndexType nschin[32] = {
-        1,   37,  73,  1,   109, 127, 0, 0, 163, 181, 0, 0, 217, 469, 0, 0,
-        235, 271, 307, 235, 343, 361, 0, 0, 397, 415, 0, 0, 451, 505, 0, 0};
+  IndexType startChamberIndexInEndcap(IndexType ie, IndexType is, IndexType ir) const {
+    const IndexType nschin[32] = {1,   37,  73,  1,   109, 127, 0, 0, 163, 181, 0, 0, 217, 469, 0, 0,
+                                  235, 271, 307, 235, 343, 361, 0, 0, 397, 415, 0, 0, 451, 505, 0, 0};
     return nschin[(ie - 1) * 16 + (is - 1) * 4 + ir - 1];
   }
 
@@ -98,10 +95,8 @@ public:
    * WARNING: Considers both ME1a and ME1b to be part of one ME11 chamber
    *          (result would be the same for is=1 and ir=1 or 4).
    */
-  IndexType chamberIndex(IndexType ie, IndexType is, IndexType ir,
-                         IndexType ic) const {
-    return startChamberIndexInEndcap(ie, is, ir) + ic -
-           1; // -1 so start index _is_ ic=1
+  IndexType chamberIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic) const {
+    return startChamberIndexInEndcap(ie, is, ir) + ic - 1;  // -1 so start index _is_ ic=1
   }
 
   /**
@@ -127,8 +122,7 @@ public:
    * chamber (result would be the same for is=1 and ir=1 or 4).
    */
   IndexType layerIndex(const CSCDetId &id) const {
-    return layerIndex(id.endcap(), id.station(), id.ring(), id.chamber(),
-                      id.layer());
+    return layerIndex(id.endcap(), id.station(), id.ring(), id.chamber(), id.layer());
   }
 
   /**
@@ -138,8 +132,7 @@ public:
    * WARNING: Considers both ME1a and ME1b to share layers of single ME11
    * chamber (result would be the same for is=1 and ir=1 or 4).
    */
-  IndexType layerIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic,
-                       IndexType il) const {
+  IndexType layerIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic, IndexType il) const {
     return (chamberIndex(ie, is, ir, ic) - 1) * 6 + il;
   }
 
@@ -152,7 +145,7 @@ public:
    * - Includes ME42 so claims 2 rings in station 4.
    */
   IndexType ringsInStation(IndexType is) const {
-    const IndexType nrings[5] = {0, 3, 2, 2, 2}; // rings per station
+    const IndexType nrings[5] = {0, 3, 2, 2, 2};  // rings per station
     return nrings[is];
   }
 
@@ -165,7 +158,7 @@ public:
    * - Includes ME42 so claims 2 rings in station 4.
    */
   IndexType offlineRingsInStation(IndexType is) const {
-    const IndexType nrings[5] = {0, 4, 2, 2, 2}; // rings per station
+    const IndexType nrings[5] = {0, 4, 2, 2, 2};  // rings per station
     return nrings[is];
   }
 
@@ -175,8 +168,7 @@ public:
    * Works for ME1a (virtual ring 4 of ME1) too.
    */
   IndexType chambersInRingOfStation(IndexType is, IndexType ir) const {
-    const IndexType nCinR[16] = {36, 36, 36, 36, 18, 36, 0, 0, 18,
-                                 36, 0,  0,  18, 36, 0,  0}; // chambers in ring
+    const IndexType nCinR[16] = {36, 36, 36, 36, 18, 36, 0, 0, 18, 36, 0, 0, 18, 36, 0, 0};  // chambers in ring
     return nCinR[(is - 1) * 4 + ir - 1];
   }
 
@@ -192,8 +184,7 @@ public:
    * are ignored in the unganged case.
    */
   IndexType stripChannelsPerLayer(IndexType is, IndexType ir) const {
-    const IndexType nSCinC[16] = {80, 80, 64, 48, 80, 80, 0, 0,
-                                  80, 80, 0,  0,  80, 80, 0, 0};
+    const IndexType nSCinC[16] = {80, 80, 64, 48, 80, 80, 0, 0, 80, 80, 0, 0, 80, 80, 0, 0};
     return nSCinC[(is - 1) * 4 + ir - 1];
   }
 
@@ -206,8 +197,7 @@ public:
    * WARNING: ME1a channels are  NOT  considered the last 16 of the 80 total in
    * each layer of an ME11 chamber!
    */
-  LongIndexType stripChannelStart(IndexType ie, IndexType is,
-                                  IndexType ir) const {
+  LongIndexType stripChannelStart(IndexType ie, IndexType is, IndexType ir) const {
     // These are in the ranges 1-217728 (CSCs 2008), 217729-252288 (ME42), and
     // 252289-273024 (unganged ME1a) There are 1-108884 channels per endcap
     // (CSCs 2008), 17280 channels per endcap (ME42), and 10368 channels per
@@ -216,11 +206,9 @@ public:
     // of -z (ME42) is 217728 + 1 + 17280          = 235009 Start of +z
     // (unganged ME1a) is 252288 + 1         = 252289 Start of -z (unganged
     // ME1a) is 252288 + 1 + 10368 = 262657
-    const LongIndexType nStart[32] = {
-        1,      17281,  34561,  252289, 48385,  57025,  0, 0,
-        74305,  82945,  0,      0,      100225, 217729, 0, 0,
-        108865, 126145, 143425, 262657, 157249, 165889, 0, 0,
-        183169, 191809, 0,      0,      209089, 235009, 0, 0};
+    const LongIndexType nStart[32] = {1, 17281,  34561,  252289, 48385, 57025,  0,      0,      74305,  82945,  0,
+                                      0, 100225, 217729, 0,      0,     108865, 126145, 143425, 262657, 157249, 165889,
+                                      0, 0,      183169, 191809, 0,     0,      209089, 235009, 0,      0};
     return nStart[(ie - 1) * 16 + (is - 1) * 4 + ir - 1];
   }
 
@@ -235,12 +223,9 @@ public:
    * WARNING: Use at your own risk! You must input labels within hardware
    * ranges. No trapping on out-of-range values!
    */
-  LongIndexType stripChannelIndex(IndexType ie, IndexType is, IndexType ir,
-                                  IndexType ic, IndexType il,
-                                  IndexType istrip) const {
-    return stripChannelStart(ie, is, ir) +
-           ((ic - 1) * 6 + il - 1) * stripChannelsPerLayer(is, ir) +
-           (istrip - 1);
+  LongIndexType stripChannelIndex(
+      IndexType ie, IndexType is, IndexType ir, IndexType ic, IndexType il, IndexType istrip) const {
+    return stripChannelStart(ie, is, ir) + ((ic - 1) * 6 + il - 1) * stripChannelsPerLayer(is, ir) + (istrip - 1);
   }
 
   /**
@@ -253,8 +238,7 @@ public:
    * No trapping on out-of-range values!
    */
   LongIndexType stripChannelIndex(const CSCDetId &id, IndexType istrip) const {
-    return stripChannelIndex(id.endcap(), id.station(), id.ring(), id.chamber(),
-                             id.layer(), istrip);
+    return stripChannelIndex(id.endcap(), id.station(), id.ring(), id.chamber(), id.layer(), istrip);
   }
 
   /**
@@ -272,8 +256,7 @@ public:
    * chip #5 are ignored in the unganged case.
    */
   IndexType chipsPerLayer(IndexType is, IndexType ir) const {
-    const IndexType nCinL[16] = {5, 5, 4, 3, 5, 5, 0, 0,
-                                 5, 5, 0, 0, 5, 5, 0, 0};
+    const IndexType nCinL[16] = {5, 5, 4, 3, 5, 5, 0, 0, 5, 5, 0, 0, 5, 5, 0, 0};
     return nCinL[(is - 1) * 4 + ir - 1];
   }
 
@@ -288,17 +271,14 @@ public:
    * an ME11 chamber,
    */
   IndexType chipStart(IndexType ie, IndexType is, IndexType ir) const {
-
     // These are in the ranges 1-13608 (CSCs 2008) and 13609-15768 (ME42) and
     // 15769-17064 (ME1a). There are 1-6804 chips per endcap (CSCs 2008) and
     // 1080 chips per endcap (ME42) and 648 chips per endcap (ME1a). Start of -z
     // channels (CSCs 2008) is 6804 + 1 = 6805 Start of +z (ME42) is 13608 + 1 =
     // 13609 Start of -z (ME42) is 13608 + 1 + 1080 = 14689 Start of +z (ME1a)
     // is 15768 + 1 = 15769 Start of -z (ME1a) is 15768 + 1 + 648 = 16417
-    const IndexType nStart[32] = {
-        1, 1081, 2161,  15769, 3025, 3565, 0,     0,     4645,  5185, 0,
-        0, 6265, 13609, 0,     0,    6805, 7885,  8965,  16417, 9829, 10369,
-        0, 0,    11449, 11989, 0,    0,    13069, 14689, 0,     0};
+    const IndexType nStart[32] = {1,    1081, 2161, 15769, 3025, 3565,  0, 0, 4645,  5185,  0, 0, 6265,  13609, 0, 0,
+                                  6805, 7885, 8965, 16417, 9829, 10369, 0, 0, 11449, 11989, 0, 0, 13069, 14689, 0, 0};
     return nStart[(ie - 1) * 16 + (is - 1) * 4 + ir - 1];
   }
 
@@ -311,13 +291,11 @@ public:
    * WARNING: Use at your own risk! You must input labels within hardware
    * ranges. No trapping on out-of-range values!
    */
-  IndexType chipIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic,
-                      IndexType il, IndexType ichip) const {
+  IndexType chipIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic, IndexType il, IndexType ichip) const {
     // printf("ME%d/%d/%d/%d layer %d  chip %d chipindex
     // %d\n",ie,is,ir,ic,il,ichip,chipStart(ie,is,ir)+( (ic-1)*6 + il - 1
     // )*chipsPerLayer(is,ir) + (ichip-1));
-    return chipStart(ie, is, ir) +
-           ((ic - 1) * 6 + il - 1) * chipsPerLayer(is, ir) + (ichip - 1);
+    return chipStart(ie, is, ir) + ((ic - 1) * 6 + il - 1) * chipsPerLayer(is, ir) + (ichip - 1);
   }
 
   /**
@@ -329,8 +307,7 @@ public:
    * No trapping on out-of-range values!
    */
   IndexType chipIndex(const CSCDetId &id, IndexType ichip) const {
-    return chipIndex(id.endcap(), id.station(), id.ring(), id.chamber(),
-                     id.layer(), ichip);
+    return chipIndex(id.endcap(), id.station(), id.ring(), id.chamber(), id.layer(), ichip);
   }
 
   /**
@@ -355,8 +332,7 @@ public:
    * same single HV segment
    */
   IndexType hvSegmentsPerLayer(IndexType is, IndexType ir) const {
-    const IndexType nSinL[16] = {1, 3, 3, 1, 3, 5, 0, 0,
-                                 3, 5, 0, 0, 3, 5, 0, 0};
+    const IndexType nSinL[16] = {1, 3, 3, 1, 3, 5, 0, 0, 3, 5, 0, 0, 3, 5, 0, 0};
     return nSinL[(is - 1) * 4 + ir - 1];
   }
 
@@ -403,23 +379,14 @@ public:
     // Start of -z (ME42) is 45144 + 1 + 5400 = 50545
     // Start of +z (ME1a) is 45144 + 1 + 2*5400 = 55945
     // Start of -z (ME42) is 45144 + 1 + 2*5400 + 648 = 56593
-    const IndexType nStart[32] = {
-        1,     1081,
-        4321,  55945, // ME+1/1,ME+1/2,ME+1/3,ME+1/a
-        6913,  8533,
-        0,     0, // ME+2/1,ME+2/2
-        13933, 15553,
-        0,     0, // ME+3/1,ME+3/2
-        20953, 45145,
-        0,     0, // ME+4/1,ME+4/2 (note, ME+4/2 index follows ME-4/1...)
-        22573, 23653,
-        26893, 56593, // ME-1/1,ME-1/2,ME-1/3,ME+1/a
-        29485, 31105,
-        0,     0, // ME-2/1,ME-2/2
-        36505, 38125,
-        0,     0, // ME-3/1,ME-3/2
-        43525, 50545,
-        0,     0}; // ME-4/1,ME-4/2 (note, ME-4/2 index follows ME+4/2...)
+    const IndexType nStart[32] = {1,     1081,  4321,  55945,  // ME+1/1,ME+1/2,ME+1/3,ME+1/a
+                                  6913,  8533,  0,     0,      // ME+2/1,ME+2/2
+                                  13933, 15553, 0,     0,      // ME+3/1,ME+3/2
+                                  20953, 45145, 0,     0,      // ME+4/1,ME+4/2 (note, ME+4/2 index follows ME-4/1...)
+                                  22573, 23653, 26893, 56593,  // ME-1/1,ME-1/2,ME-1/3,ME+1/a
+                                  29485, 31105, 0,     0,      // ME-2/1,ME-2/2
+                                  36505, 38125, 0,     0,      // ME-3/1,ME-3/2
+                                  43525, 50545, 0,     0};     // ME-4/1,ME-4/2 (note, ME-4/2 index follows ME+4/2...)
     return nStart[(ie - 1) * 16 + (is - 1) * 4 + ir - 1];
   }
 
@@ -433,11 +400,14 @@ public:
    * ranges (e.g., 'id' must correspond to a specific layer 1-6). No trapping on
    * out-of-range values!
    */
-  IndexType gasGainIndex(const CSCDetId &id, IndexType istrip,
-                         IndexType iwire) const {
-    return gasGainIndex(
-        id.endcap(), id.station(), id.ring(), id.chamber(), id.layer(),
-        hvSegmentIndex(id.station(), id.ring(), iwire), chipIndex(istrip));
+  IndexType gasGainIndex(const CSCDetId &id, IndexType istrip, IndexType iwire) const {
+    return gasGainIndex(id.endcap(),
+                        id.station(),
+                        id.ring(),
+                        id.chamber(),
+                        id.layer(),
+                        hvSegmentIndex(id.station(), id.ring(), iwire),
+                        chipIndex(istrip));
   }
 
   /**
@@ -450,10 +420,8 @@ public:
    * WARNING: Use at your own risk! You must input labels within hardware
    * ranges. No trapping on out-of-range values!
    */
-  IndexType gasGainIndex(IndexType ihvsegment, IndexType ichip,
-                         const CSCDetId &id) const {
-    return gasGainIndex(id.endcap(), id.station(), id.ring(), id.chamber(),
-                        id.layer(), ihvsegment, ichip);
+  IndexType gasGainIndex(IndexType ihvsegment, IndexType ichip, const CSCDetId &id) const {
+    return gasGainIndex(id.endcap(), id.station(), id.ring(), id.chamber(), id.layer(), ihvsegment, ichip);
   }
 
   /**
@@ -466,11 +434,14 @@ public:
    * WARNING: Use at your own risk! You must input labels within hardware
    * ranges. No trapping on out-of-range values!
    */
-  IndexType gasGainIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic,
-                         IndexType il, IndexType ihvsegment,
+  IndexType gasGainIndex(IndexType ie,
+                         IndexType is,
+                         IndexType ir,
+                         IndexType ic,
+                         IndexType il,
+                         IndexType ihvsegment,
                          IndexType ichip) const {
-    return sectorStart(ie, is, ir) +
-           ((ic - 1) * 6 + il - 1) * sectorsPerLayer(is, ir) +
+    return sectorStart(ie, is, ir) + ((ic - 1) * 6 + il - 1) * sectorsPerLayer(is, ir) +
            (ihvsegment - 1) * chipsPerLayer(is, ir) + (ichip - 1);
   }
 
@@ -481,13 +452,11 @@ public:
   CSCDetId detIdFromChamberIndex(IndexType ici) const;
   CSCDetId detIdFromChamberIndex_OLD(IndexType ici) const;
   CSCDetId detIdFromChamberLabel(IndexType ie, IndexType icl) const;
-  std::pair<CSCDetId, IndexType>
-  detIdFromStripChannelIndex(LongIndexType ichi) const;
+  std::pair<CSCDetId, IndexType> detIdFromStripChannelIndex(LongIndexType ichi) const;
   std::pair<CSCDetId, IndexType> detIdFromChipIndex(IndexType ichi) const;
   GasGainTuple detIdFromGasGainIndex(IndexType igg) const;
 
-  IndexType
-      chamberLabelFromChamberIndex(IndexType) const; // just for cross-checks
+  IndexType chamberLabelFromChamberIndex(IndexType) const;  // just for cross-checks
 
   /**
    * Build index used internally in online CSC conditions databases (the 'Igor
@@ -502,11 +471,10 @@ public:
   int dbIndex(const CSCDetId &id, int &channel);
 
 private:
-  void fillChamberLabel() const; // const so it can be called in const function
-                                 // detIdFromChamberIndex
+  void fillChamberLabel() const;  // const so it can be called in const function
+                                  // detIdFromChamberIndex
 
-  mutable std::vector<IndexType>
-      chamberLabel; // mutable so can be filled by fillChamberLabel
+  mutable std::vector<IndexType> chamberLabel;  // mutable so can be filled by fillChamberLabel
 };
 
 #endif

--- a/CalibMuon/CSCCalibration/test/old_indexers/CSCIndexerOldStartup.cc
+++ b/CalibMuon/CSCCalibration/test/old_indexers/CSCIndexerOldStartup.cc
@@ -6,8 +6,7 @@ void CSCIndexerOldStartup::fillChamberLabel() const {
   // Logically const since initializes cache only,
   // Beware that the ME42 indices 235-270 within this vector do NOT correspond
   // to their 'real' linear indices (which are 469-504 for +z)
-  chamberLabel.resize(
-      271); // one more than #chambers per endcap. Includes ME42.
+  chamberLabel.resize(271);  // one more than #chambers per endcap. Includes ME42.
   IndexType count = 0;
   chamberLabel[count] = 0;
 
@@ -23,7 +22,6 @@ void CSCIndexerOldStartup::fillChamberLabel() const {
 }
 
 CSCDetId CSCIndexerOldStartup::detIdFromChamberIndex_OLD(IndexType ici) const {
-
   // Will not work as is for ME42
   // ============================
 
@@ -67,15 +65,15 @@ CSCDetId CSCIndexerOldStartup::detIdFromChamberIndex(IndexType ici) const {
   IndexType ie = 1;
   if (ici > 468) {
     // ME42
-    ici -= 234;      // now in range 235-306
-    if (ici > 270) { // -z
+    ici -= 234;       // now in range 235-306
+    if (ici > 270) {  // -z
       ie = 2;
-      ici -= 36; // now in range 235-270
+      ici -= 36;  // now in range 235-270
     }
-  } else {           // in range 1-468
-    if (ici > 234) { // -z
+  } else {            // in range 1-468
+    if (ici > 234) {  // -z
       ie = 2;
-      ici -= 234; // now in range 1-234
+      ici -= 234;  // now in range 1-234
     }
   }
   if (chamberLabel.empty())
@@ -84,8 +82,7 @@ CSCDetId CSCIndexerOldStartup::detIdFromChamberIndex(IndexType ici) const {
   return detIdFromChamberLabel(ie, label);
 }
 
-CSCIndexerOldStartup::IndexType
-CSCIndexerOldStartup::chamberLabelFromChamberIndex(IndexType ici) const {
+CSCIndexerOldStartup::IndexType CSCIndexerOldStartup::chamberLabelFromChamberIndex(IndexType ici) const {
   // This is just for cross-checking
 
   // Expected range of input range argument is 1-540.
@@ -93,13 +90,13 @@ CSCIndexerOldStartup::chamberLabelFromChamberIndex(IndexType ici) const {
 
   if (ici > 468) {
     // ME42
-    ici -= 234;      // now in range 235-306
-    if (ici > 270) { // -z
-      ici -= 36;     // now in range 235-270
+    ici -= 234;       // now in range 235-306
+    if (ici > 270) {  // -z
+      ici -= 36;      // now in range 235-270
     }
-  } else {           // in range 1-468
-    if (ici > 234) { // -z
-      ici -= 234;    // now in range 1-234
+  } else {            // in range 1-468
+    if (ici > 234) {  // -z
+      ici -= 234;     // now in range 1-234
     }
   }
   if (chamberLabel.empty())
@@ -107,9 +104,7 @@ CSCIndexerOldStartup::chamberLabelFromChamberIndex(IndexType ici) const {
   return chamberLabel[ici];
 }
 
-CSCDetId CSCIndexerOldStartup::detIdFromChamberLabel(IndexType ie,
-                                                     IndexType label) const {
-
+CSCDetId CSCIndexerOldStartup::detIdFromChamberLabel(IndexType ie, IndexType label) const {
   IndexType is = label / 1000;
   label -= is * 1000;
   IndexType ir = label / 100;
@@ -120,7 +115,6 @@ CSCDetId CSCIndexerOldStartup::detIdFromChamberLabel(IndexType ie,
 }
 
 CSCDetId CSCIndexerOldStartup::detIdFromLayerIndex(IndexType ili) const {
-
   IndexType il = (ili - 1) % 6 + 1;
   IndexType ici = (ili - 1) / 6 + 1;
   CSCDetId id = detIdFromChamberIndex(ici);
@@ -128,20 +122,17 @@ CSCDetId CSCIndexerOldStartup::detIdFromLayerIndex(IndexType ili) const {
   return CSCDetId(id.endcap(), id.station(), id.ring(), id.chamber(), il);
 }
 
-std::pair<CSCDetId, CSCIndexerOldStartup::IndexType>
-CSCIndexerOldStartup::detIdFromStripChannelIndex(LongIndexType isi) const {
-
-  const LongIndexType lastnonme42 =
-      217728; // channels in 2008 installed chambers
-  const LongIndexType lastplusznonme42 = 108864; // = 217728/2
-  const LongIndexType firstme13 = 34561;         // First channel of ME13
-  const LongIndexType lastme13 = 48384;          // Last channel of ME13
+std::pair<CSCDetId, CSCIndexerOldStartup::IndexType> CSCIndexerOldStartup::detIdFromStripChannelIndex(
+    LongIndexType isi) const {
+  const LongIndexType lastnonme42 = 217728;       // channels in 2008 installed chambers
+  const LongIndexType lastplusznonme42 = 108864;  // = 217728/2
+  const LongIndexType firstme13 = 34561;          // First channel of ME13
+  const LongIndexType lastme13 = 48384;           // Last channel of ME13
 
   const IndexType lastnonme42layer = 2808;
-  const IndexType lastplusznonme42layer = 1404; // = 2808/2
-  const IndexType firstme13layer =
-      433; // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
-  const IndexType lastme13layer = 648; // = 108*6
+  const IndexType lastplusznonme42layer = 1404;  // = 2808/2
+  const IndexType firstme13layer = 433;          // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
+  const IndexType lastme13layer = 648;           // = 108*6
 
   // All chambers but ME13 have 80 channels
   IndexType nchan = 80;
@@ -161,10 +152,10 @@ CSCIndexerOldStartup::detIdFromStripChannelIndex(LongIndexType isi) const {
       isi -= lastplusznonme42;
     }
 
-    if (isi > lastme13) { // after ME13
+    if (isi > lastme13) {  // after ME13
       istart = lastme13;
       layerOffset = lastme13layer;
-    } else if (isi >= firstme13) { // ME13
+    } else if (isi >= firstme13) {  // ME13
       istart = firstme13 - 1;
       layerOffset = firstme13layer - 1;
       nchan = 64;
@@ -176,30 +167,27 @@ CSCIndexerOldStartup::detIdFromStripChannelIndex(LongIndexType isi) const {
     layerOffset = lastnonme42layer;
   }
 
-  isi -= istart; // remove earlier group(s)
+  isi -= istart;  // remove earlier group(s)
   IndexType ichan = (isi - 1) % nchan + 1;
   IndexType ili = (isi - 1) / nchan + 1;
-  ili += layerOffset; // add appropriate offset for earlier group(s)
+  ili += layerOffset;  // add appropriate offset for earlier group(s)
   if (ie != 1)
-    ili += lastplusznonme42layer; // add offset to -z endcap; ME42 doesn't need
-                                  // this.
+    ili += lastplusznonme42layer;  // add offset to -z endcap; ME42 doesn't need
+                                   // this.
 
   return std::pair<CSCDetId, IndexType>(detIdFromLayerIndex(ili), ichan);
 }
 
-std::pair<CSCDetId, CSCIndexerOldStartup::IndexType>
-CSCIndexerOldStartup::detIdFromChipIndex(IndexType ici) const {
-
-  const LongIndexType lastnonme42 = 13608; // chips in 2008 installed chambers
-  const LongIndexType lastplusznonme42 = 6804; // = 13608/2
-  const LongIndexType firstme13 = 2161;        // First channel of ME13
-  const LongIndexType lastme13 = 3024;         // Last channel of ME13
+std::pair<CSCDetId, CSCIndexerOldStartup::IndexType> CSCIndexerOldStartup::detIdFromChipIndex(IndexType ici) const {
+  const LongIndexType lastnonme42 = 13608;      // chips in 2008 installed chambers
+  const LongIndexType lastplusznonme42 = 6804;  // = 13608/2
+  const LongIndexType firstme13 = 2161;         // First channel of ME13
+  const LongIndexType lastme13 = 3024;          // Last channel of ME13
 
   const IndexType lastnonme42layer = 2808;
-  const IndexType lastplusznonme42layer = 1404; // = 2808/2
-  const IndexType firstme13layer =
-      433; // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
-  const IndexType lastme13layer = 648; // = 108*6
+  const IndexType lastplusznonme42layer = 1404;  // = 2808/2
+  const IndexType firstme13layer = 433;          // = 72*6 + 1 (ME13 chambers are 72-108 in range 1-234)
+  const IndexType lastme13layer = 648;           // = 108*6
 
   // All chambers but ME13 have 5 chips/layer
   IndexType nchipPerLayer = 5;
@@ -219,10 +207,10 @@ CSCIndexerOldStartup::detIdFromChipIndex(IndexType ici) const {
       ici -= lastplusznonme42;
     }
 
-    if (ici > lastme13) { // after ME13
+    if (ici > lastme13) {  // after ME13
       istart = lastme13;
       layerOffset = lastme13layer;
-    } else if (ici >= firstme13) { // ME13
+    } else if (ici >= firstme13) {  // ME13
       istart = firstme13 - 1;
       layerOffset = firstme13layer - 1;
       nchipPerLayer = 4;
@@ -234,13 +222,13 @@ CSCIndexerOldStartup::detIdFromChipIndex(IndexType ici) const {
     layerOffset = lastnonme42layer;
   }
 
-  ici -= istart; // remove earlier group(s)
+  ici -= istart;  // remove earlier group(s)
   IndexType ichip = (ici - 1) % nchipPerLayer + 1;
   IndexType ili = (ici - 1) / nchipPerLayer + 1;
-  ili += layerOffset; // add appropriate offset for earlier group(s)
+  ili += layerOffset;  // add appropriate offset for earlier group(s)
   if (ie != 1)
-    ili += lastplusznonme42layer; // add offset to -z endcap; ME42 doesn't need
-                                  // this.
+    ili += lastplusznonme42layer;  // add offset to -z endcap; ME42 doesn't need
+                                   // this.
 
   return std::pair<CSCDetId, IndexType>(detIdFromLayerIndex(ili), ichip);
 }
@@ -256,7 +244,7 @@ int CSCIndexerOldStartup::dbIndex(const CSCDetId &id, int &channel) {
   if (st == 1 && rg == 4) {
     rg = 1;
     if (channel <= 16)
-      channel += 64; // no trapping for any bizarreness
+      channel += 64;  // no trapping for any bizarreness
   }
   return ec * 100000 + st * 10000 + rg * 1000 + ch * 10 + la;
 }

--- a/CalibMuon/CSCCalibration/test/old_indexers/CSCIndexerOldStartup.h
+++ b/CalibMuon/CSCCalibration/test/old_indexers/CSCIndexerOldStartup.h
@@ -44,11 +44,10 @@
 
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 #include <iosfwd>
-#include <utility> // for pair
+#include <utility>  // for pair
 #include <vector>
 
 class CSCIndexerOldStartup {
-
 public:
   //  typedef unsigned short int IndexType;
   //  typedef unsigned       int LongIndexType;
@@ -85,19 +84,16 @@ public:
    */
 
   IndexType layerIndex(const CSCDetId &id) const {
-    return layerIndex(id.endcap(), id.station(), id.ring(), id.chamber(),
-                      id.layer());
+    return layerIndex(id.endcap(), id.station(), id.ring(), id.chamber(), id.layer());
   }
 
   /**
    * Starting index for first chamber in ring 'ir' of station 'is' in endcap
    * 'ie', in range 1-468 (CSCs 2008) or 469-540 (ME42).
    */
-  IndexType startChamberIndexInEndcap(IndexType ie, IndexType is,
-                                      IndexType ir) const {
-    const IndexType nschin[24] = {1,   37,  73,  109, 127, 0,   163, 181,
-                                  0,   217, 469, 0,   235, 271, 307, 343,
-                                  361, 0,   397, 415, 0,   451, 505, 0};
+  IndexType startChamberIndexInEndcap(IndexType ie, IndexType is, IndexType ir) const {
+    const IndexType nschin[24] = {1,   37,  73,  109, 127, 0, 163, 181, 0, 217, 469, 0,
+                                  235, 271, 307, 343, 361, 0, 397, 415, 0, 451, 505, 0};
     return nschin[(ie - 1) * 12 + (is - 1) * 3 + ir - 1];
   }
 
@@ -105,18 +101,15 @@ public:
    * Linear index for chamber 'ic' in ring 'ir' of station 'is' in endcap 'ie',
    * in range 1-468 (CSCs 2008) or 469-540 (ME42)
    */
-  IndexType chamberIndex(IndexType ie, IndexType is, IndexType ir,
-                         IndexType ic) const {
-    return startChamberIndexInEndcap(ie, is, ir) + ic -
-           1; // -1 so start index _is_ ic=1
+  IndexType chamberIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic) const {
+    return startChamberIndexInEndcap(ie, is, ir) + ic - 1;  // -1 so start index _is_ ic=1
   }
 
   /**
    * Linear index for layer 'il' of chamber 'ic' in ring 'ir' of station 'is' in
    * endcap 'ie', in range 1-2808 (CSCs 2008) or 2809-3240 (ME42).
    */
-  IndexType layerIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic,
-                       IndexType il) const {
+  IndexType layerIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic, IndexType il) const {
     const IndexType layersInChamber = 6;
     return (chamberIndex(ie, is, ir, ic) - 1) * layersInChamber + il;
   }
@@ -128,7 +121,7 @@ public:
    * CSC installation 2008.
    */
   IndexType ringsInStation(IndexType is) const {
-    const IndexType nrins[5] = {0, 3, 2, 2, 2}; // rings per station
+    const IndexType nrins[5] = {0, 3, 2, 2, 2};  // rings per station
     return nrins[is];
   }
 
@@ -138,9 +131,9 @@ public:
    * Works for ME1a (ring 4 of ME1) too.
    */
   IndexType chambersInRingOfStation(IndexType is, IndexType ir) const {
-    IndexType nc = 36; // most rings have 36 chambers
+    IndexType nc = 36;  // most rings have 36 chambers
     if (is > 1 && ir < 2)
-      nc = 18; // but 21, 31, 41 have 18
+      nc = 18;  // but 21, 31, 41 have 18
     return nc;
   }
 
@@ -167,18 +160,14 @@ public:
    * WARNING: ME1a channels are the last 16 of the 80 total in each layer of an
    * ME11 chamber, and an input ir=4 is invalid and will give nonsense.
    */
-  LongIndexType stripChannelStart(IndexType ie, IndexType is,
-                                  IndexType ir) const {
-
+  LongIndexType stripChannelStart(IndexType ie, IndexType is, IndexType ir) const {
     // These are in the ranges 1-217728 (CSCs 2008) and 217729-252288 (ME42).
     // There are 1-108884 channels per endcap (CSCs 2008) and 17280 channels per
     // endcap (ME42). Start of -z channels (CSCs 2008) is 108864 + 1 = 108865
     // Start of +z (ME42) is 217728 + 1 = 217729
     // Start of -z (ME42) is 217728 + 1 + 17280 = 235009
-    const LongIndexType nStart[24] = {
-        1,      17281,  34561,  48385,  57025,  0,      74305,  82945,
-        0,      100225, 217729, 0,      108865, 126145, 143425, 157249,
-        165889, 0,      183169, 191809, 0,      209089, 235009, 0};
+    const LongIndexType nStart[24] = {1,      17281,  34561,  48385,  57025,  0, 74305,  82945,  0, 100225, 217729, 0,
+                                      108865, 126145, 143425, 157249, 165889, 0, 183169, 191809, 0, 209089, 235009, 0};
     return nStart[(ie - 1) * 12 + (is - 1) * 3 + ir - 1];
   }
 
@@ -191,12 +180,9 @@ public:
    * WARNING: Use at your own risk! You must input labels within hardware
    * ranges. No trapping on out-of-range values!
    */
-  LongIndexType stripChannelIndex(IndexType ie, IndexType is, IndexType ir,
-                                  IndexType ic, IndexType il,
-                                  IndexType istrip) const {
-    return stripChannelStart(ie, is, ir) +
-           ((ic - 1) * 6 + il - 1) * stripChannelsPerLayer(is, ir) +
-           (istrip - 1);
+  LongIndexType stripChannelIndex(
+      IndexType ie, IndexType is, IndexType ir, IndexType ic, IndexType il, IndexType istrip) const {
+    return stripChannelStart(ie, is, ir) + ((ic - 1) * 6 + il - 1) * stripChannelsPerLayer(is, ir) + (istrip - 1);
   }
 
   /**
@@ -209,8 +195,7 @@ public:
    */
 
   LongIndexType stripChannelIndex(const CSCDetId &id, IndexType istrip) const {
-    return stripChannelIndex(id.endcap(), id.station(), id.ring(), id.chamber(),
-                             id.layer(), istrip);
+    return stripChannelIndex(id.endcap(), id.station(), id.ring(), id.chamber(), id.layer(), istrip);
   }
 
   /**
@@ -237,15 +222,13 @@ public:
    * an ME11 chamber, and an input ir=4 is invalid and will give nonsense.
    */
   IndexType chipStart(IndexType ie, IndexType is, IndexType ir) const {
-
     // These are in the ranges 1-13608 (CSCs 2008) and 13609-15768 (ME42).
     // There are 1-6804 chips per endcap (CSCs 2008) and 1080 channels per
     // endcap (ME42). Start of -z channels (CSCs 2008) is 6804 + 1 = 6805 Start
     // of +z (ME42) is 13608 + 1 = 13609 Start of -z (ME42) is 13608 + 1 + 1080
     // = 14689
-    const IndexType nStart[24] = {
-        1,    1081, 2161, 3025, 3565,  0, 4645,  5185,  0, 6265,  13609, 0,
-        6805, 7885, 8965, 9829, 10369, 0, 11449, 11989, 0, 13069, 14689, 0};
+    const IndexType nStart[24] = {1,    1081, 2161, 3025, 3565,  0, 4645,  5185,  0, 6265,  13609, 0,
+                                  6805, 7885, 8965, 9829, 10369, 0, 11449, 11989, 0, 13069, 14689, 0};
 
     return nStart[(ie - 1) * 12 + (is - 1) * 3 + ir - 1];
   }
@@ -259,13 +242,11 @@ public:
    * WARNING: Use at your own risk! You must input labels within hardware
    * ranges. No trapping on out-of-range values!
    */
-  IndexType chipIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic,
-                      IndexType il, IndexType ichip) const {
+  IndexType chipIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic, IndexType il, IndexType ichip) const {
     // printf("ME%d/%d/%d/%d layer %d  chip %d chipindex
     // %d\n",ie,is,ir,ic,il,ichip,chipStart(ie,is,ir)+( (ic-1)*6 + il - 1
     // )*chipsPerLayer(is,ir) + (ichip-1));
-    return chipStart(ie, is, ir) +
-           ((ic - 1) * 6 + il - 1) * chipsPerLayer(is, ir) + (ichip - 1);
+    return chipStart(ie, is, ir) + ((ic - 1) * 6 + il - 1) * chipsPerLayer(is, ir) + (ichip - 1);
   }
 
   /**
@@ -278,8 +259,7 @@ public:
    */
 
   IndexType chipIndex(const CSCDetId &id, IndexType ichip) const {
-    return chipIndex(id.endcap(), id.station(), id.ring(), id.chamber(),
-                     id.layer(), ichip);
+    return chipIndex(id.endcap(), id.station(), id.ring(), id.chamber(), id.layer(), ichip);
   }
 
   /**
@@ -327,18 +307,16 @@ public:
    * station, ring, and wire. No trapping on out-of-range values!
    */
   IndexType hvSegmentIndex(IndexType is, IndexType ir, IndexType iwire) const {
+    IndexType hvSegment = 1;  // There is only one HV segment in ME1/1
 
-    IndexType hvSegment = 1; // There is only one HV segment in ME1/1
-
-    if (is > 2 && ir == 1) { // HV segments are the same in ME3/1 and ME4/1
+    if (is > 2 && ir == 1) {  // HV segments are the same in ME3/1 and ME4/1
       if (iwire >= 33 && iwire <= 64) {
         hvSegment = 2;
       } else if (iwire >= 65 && iwire <= 96) {
         hvSegment = 3;
       }
 
-    } else if (is > 1 &&
-               ir == 2) { // HV segments are the same in ME2/2, ME3/2, and ME4/2
+    } else if (is > 1 && ir == 2) {  // HV segments are the same in ME2/2, ME3/2, and ME4/2
       if (iwire >= 17 && iwire <= 28) {
         hvSegment = 2;
       } else if (iwire >= 29 && iwire <= 40) {
@@ -391,23 +369,21 @@ public:
     // gas-gain sectors in ME[2-4]/2 Start of -z channels (CSCs 2008) is 22572 +
     // 1 = 22573 Start of +z (ME42) is 45144 + 1 = 45145 Start of -z (ME42) is
     // 45144 + 1 + 5400 = 50545
-    const IndexType nStart[24] = {
-        1,     1081,
-        4321, // ME+1/1,ME+1/2,ME+1/3
-        6913,  8533,
-        0, // ME+2/1,ME+2/2,ME+2/3
-        13933, 15553,
-        0, // ME+3/1,ME+3/2,ME+3/3
-        20953, 45145,
-        0, // ME+4/1,ME+4/2,ME+4/3 (note, ME+4/2 index follows ME-4/1...)
-        22573, 23653,
-        26893, // ME-1/1,ME-1/2,ME-1/3
-        29485, 31105,
-        0, // ME-2/1,ME-2/2,ME-2/3
-        36505, 38125,
-        0, // ME-3/1,ME-3/2,ME-3/3
-        43525, 50545,
-        0}; // ME-4/1,ME-4/2,ME-4/3 (note, ME-4/2 index follows ME+4/2...)
+    const IndexType nStart[24] = {1,     1081,
+                                  4321,  // ME+1/1,ME+1/2,ME+1/3
+                                  6913,  8533,
+                                  0,  // ME+2/1,ME+2/2,ME+2/3
+                                  13933, 15553,
+                                  0,  // ME+3/1,ME+3/2,ME+3/3
+                                  20953, 45145,
+                                  0,  // ME+4/1,ME+4/2,ME+4/3 (note, ME+4/2 index follows ME-4/1...)
+                                  22573, 23653,
+                                  26893,  // ME-1/1,ME-1/2,ME-1/3
+                                  29485, 31105,
+                                  0,  // ME-2/1,ME-2/2,ME-2/3
+                                  36505, 38125,
+                                  0,                 // ME-3/1,ME-3/2,ME-3/3
+                                  43525, 50545, 0};  // ME-4/1,ME-4/2,ME-4/3 (note, ME-4/2 index follows ME+4/2...)
     return nStart[(ie - 1) * 12 + (is - 1) * 3 + ir - 1];
   }
 
@@ -423,11 +399,14 @@ public:
    * still be treated the same as ir=1, but ichip must be 5 for it to make
    * sense!
    */
-  IndexType gasGainIndex(IndexType ie, IndexType is, IndexType ir, IndexType ic,
-                         IndexType il, IndexType ihvsegment,
+  IndexType gasGainIndex(IndexType ie,
+                         IndexType is,
+                         IndexType ir,
+                         IndexType ic,
+                         IndexType il,
+                         IndexType ihvsegment,
                          IndexType ichip) const {
-    return sectorStart(ie, is, ir) +
-           ((ic - 1) * 6 + il - 1) * sectorsPerLayer(is, ir) +
+    return sectorStart(ie, is, ir) + ((ic - 1) * 6 + il - 1) * sectorsPerLayer(is, ir) +
            (ihvsegment - 1) * chipsPerLayer(is, ir) + (ichip - 1);
   }
 
@@ -441,11 +420,14 @@ public:
    * same as whole ME11 id, but istrip must be a h/w strip number in 64-80 in
    * that case!
    */
-  IndexType gasGainIndex(const CSCDetId &id, IndexType istrip,
-                         IndexType iwire) const {
-    return gasGainIndex(
-        id.endcap(), id.station(), id.ring(), id.chamber(), id.layer(),
-        hvSegmentIndex(id.station(), id.ring(), iwire), chipIndex(istrip));
+  IndexType gasGainIndex(const CSCDetId &id, IndexType istrip, IndexType iwire) const {
+    return gasGainIndex(id.endcap(),
+                        id.station(),
+                        id.ring(),
+                        id.chamber(),
+                        id.layer(),
+                        hvSegmentIndex(id.station(), id.ring(), iwire),
+                        chipIndex(istrip));
   }
 
   /**
@@ -461,10 +443,8 @@ public:
    * provide ME1a id in ganged case, it would still be treated the same as whole
    * ME11 id, but ichip must be 5 for it to make sense!
    */
-  IndexType gasGainIndex(IndexType ihvsegment, IndexType ichip,
-                         const CSCDetId &id) const {
-    return gasGainIndex(id.endcap(), id.station(), id.ring(), id.chamber(),
-                        id.layer(), ihvsegment, ichip);
+  IndexType gasGainIndex(IndexType ihvsegment, IndexType ichip, const CSCDetId &id) const {
+    return gasGainIndex(id.endcap(), id.station(), id.ring(), id.chamber(), id.layer(), ihvsegment, ichip);
   }
 
   /**
@@ -474,12 +454,10 @@ public:
   CSCDetId detIdFromChamberIndex(IndexType ici) const;
   CSCDetId detIdFromChamberIndex_OLD(IndexType ici) const;
   CSCDetId detIdFromChamberLabel(IndexType ie, IndexType icl) const;
-  std::pair<CSCDetId, IndexType>
-  detIdFromStripChannelIndex(LongIndexType ichi) const;
+  std::pair<CSCDetId, IndexType> detIdFromStripChannelIndex(LongIndexType ichi) const;
   std::pair<CSCDetId, IndexType> detIdFromChipIndex(IndexType ichi) const;
 
-  IndexType
-      chamberLabelFromChamberIndex(IndexType) const; // just for cross-checks
+  IndexType chamberLabelFromChamberIndex(IndexType) const;  // just for cross-checks
 
   /**
    * Build index used internally in online CSC conditions databases (the 'Igor
@@ -492,11 +470,10 @@ public:
   int dbIndex(const CSCDetId &id, int &channel);
 
 private:
-  void fillChamberLabel() const; // const so it can be called in const function
-                                 // detIdFromChamberIndex
+  void fillChamberLabel() const;  // const so it can be called in const function
+                                  // detIdFromChamberIndex
 
-  mutable std::vector<IndexType>
-      chamberLabel; // mutable so can be filled by fillChamberLabel
+  mutable std::vector<IndexType> chamberLabel;  // mutable so can be filled by fillChamberLabel
 };
 
 #endif

--- a/CalibMuon/CSCCalibration/test/stubs/CSCBadChambersHandler.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCBadChambersHandler.cc
@@ -6,24 +6,20 @@
 #include "CondFormats/CSCObjects/interface/CSCBadChambers.h"
 
 popcon::CSCBadChambersImpl::CSCBadChambersImpl(const edm::ParameterSet &pset)
-    : m_name(pset.getUntrackedParameter<std::string>("name",
-                                                     "CSCBadChambersImpl")) {}
+    : m_name(pset.getUntrackedParameter<std::string>("name", "CSCBadChambersImpl")) {}
 
 popcon::CSCBadChambersImpl::~CSCBadChambersImpl() {}
 
 void popcon::CSCBadChambersImpl::getNewObjects() {
-
   std::cout << "------- CSC src - > getNewObjects\n" << m_name;
 
   // fill object from file
-  CSCBadChambers *cnbadchambers =
-      CSCBadChambersConditions::prefillBadChambers();
+  CSCBadChambers *cnbadchambers = CSCBadChambersConditions::prefillBadChambers();
 
   // check whats already inside of database
 
   std::cerr << "got offlineInfo" << std::endl;
-  std::cerr << tagInfo().name << " , last object valid since "
-            << tagInfo().lastInterval.first << std::endl;
+  std::cerr << tagInfo().name << " , last object valid since " << tagInfo().lastInterval.first << std::endl;
 
   unsigned int snc;
 
@@ -32,6 +28,5 @@ void popcon::CSCBadChambersImpl::getNewObjects() {
 
   m_to_transfer.push_back(std::make_pair(cnbadchambers, snc));
 
-  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n"
-            << std::endl;
+  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n" << std::endl;
 }

--- a/CalibMuon/CSCCalibration/test/stubs/CSCBadChambersHandler.h
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCBadChambersHandler.h
@@ -16,17 +16,16 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 namespace popcon {
-class CSCBadChambersImpl : public popcon::PopConSourceHandler<CSCBadChambers> {
+  class CSCBadChambersImpl : public popcon::PopConSourceHandler<CSCBadChambers> {
+  public:
+    void getNewObjects();
+    std::string id() const { return m_name; }
+    ~CSCBadChambersImpl();
 
-public:
-  void getNewObjects();
-  std::string id() const { return m_name; }
-  ~CSCBadChambersImpl();
+    CSCBadChambersImpl(const edm::ParameterSet &pset);
 
-  CSCBadChambersImpl(const edm::ParameterSet &pset);
-
-private:
-  std::string m_name;
-};
-} // namespace popcon
+  private:
+    std::string m_name;
+  };
+}  // namespace popcon
 #endif

--- a/CalibMuon/CSCCalibration/test/stubs/CSCBadChambersPopConAnalyzer.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCBadChambersPopConAnalyzer.cc
@@ -2,7 +2,6 @@
 #include "CondCore/PopCon/interface/PopConAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef popcon::PopConAnalyzer<popcon::CSCBadChambersImpl>
-    CSCBadChambersPopConAnalyzer;
+typedef popcon::PopConAnalyzer<popcon::CSCBadChambersImpl> CSCBadChambersPopConAnalyzer;
 
 DEFINE_FWK_MODULE(CSCBadChambersPopConAnalyzer);

--- a/CalibMuon/CSCCalibration/test/stubs/CSCBadStripsHandler.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCBadStripsHandler.cc
@@ -6,13 +6,11 @@
 #include "CondFormats/CSCObjects/interface/CSCBadStrips.h"
 
 popcon::CSCBadStripsImpl::CSCBadStripsImpl(const edm::ParameterSet &pset)
-    : m_name(pset.getUntrackedParameter<std::string>("name",
-                                                     "CSCBadStripsImpl")) {}
+    : m_name(pset.getUntrackedParameter<std::string>("name", "CSCBadStripsImpl")) {}
 
 popcon::CSCBadStripsImpl::~CSCBadStripsImpl() {}
 
 void popcon::CSCBadStripsImpl::getNewObjects() {
-
   std::cout << "------- CSC src - > getNewObjects\n" << m_name;
 
   // fill object from file
@@ -21,8 +19,7 @@ void popcon::CSCBadStripsImpl::getNewObjects() {
   // check whats already inside of database
 
   std::cerr << "got offlineInfo" << std::endl;
-  std::cerr << tagInfo().name << " , last object valid since "
-            << tagInfo().lastInterval.first << std::endl;
+  std::cerr << tagInfo().name << " , last object valid since " << tagInfo().lastInterval.first << std::endl;
 
   unsigned int snc;
 
@@ -31,6 +28,5 @@ void popcon::CSCBadStripsImpl::getNewObjects() {
 
   m_to_transfer.push_back(std::make_pair(cnbadstrips, snc));
 
-  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n"
-            << std::endl;
+  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n" << std::endl;
 }

--- a/CalibMuon/CSCCalibration/test/stubs/CSCBadStripsHandler.h
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCBadStripsHandler.h
@@ -16,17 +16,16 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 namespace popcon {
-class CSCBadStripsImpl : public popcon::PopConSourceHandler<CSCBadStrips> {
+  class CSCBadStripsImpl : public popcon::PopConSourceHandler<CSCBadStrips> {
+  public:
+    void getNewObjects();
+    std::string id() const { return m_name; }
+    ~CSCBadStripsImpl();
 
-public:
-  void getNewObjects();
-  std::string id() const { return m_name; }
-  ~CSCBadStripsImpl();
+    CSCBadStripsImpl(const edm::ParameterSet &pset);
 
-  CSCBadStripsImpl(const edm::ParameterSet &pset);
-
-private:
-  std::string m_name;
-};
-} // namespace popcon
+  private:
+    std::string m_name;
+  };
+}  // namespace popcon
 #endif

--- a/CalibMuon/CSCCalibration/test/stubs/CSCBadStripsPopConAnalyzer.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCBadStripsPopConAnalyzer.cc
@@ -2,7 +2,6 @@
 #include "CondCore/PopCon/interface/PopConAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef popcon::PopConAnalyzer<popcon::CSCBadStripsImpl>
-    CSCBadStripsPopConAnalyzer;
+typedef popcon::PopConAnalyzer<popcon::CSCBadStripsImpl> CSCBadStripsPopConAnalyzer;
 
 DEFINE_FWK_MODULE(CSCBadStripsPopConAnalyzer);

--- a/CalibMuon/CSCCalibration/test/stubs/CSCBadWiresHandler.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCBadWiresHandler.cc
@@ -6,13 +6,11 @@
 #include "CondFormats/CSCObjects/interface/CSCBadWires.h"
 
 popcon::CSCBadWiresImpl::CSCBadWiresImpl(const edm::ParameterSet &pset)
-    : m_name(
-          pset.getUntrackedParameter<std::string>("name", "CSCBadWiresImpl")) {}
+    : m_name(pset.getUntrackedParameter<std::string>("name", "CSCBadWiresImpl")) {}
 
 popcon::CSCBadWiresImpl::~CSCBadWiresImpl() {}
 
 void popcon::CSCBadWiresImpl::getNewObjects() {
-
   std::cout << "------- CSC src - > getNewObjects\n" << m_name;
 
   // fill object from file
@@ -21,8 +19,7 @@ void popcon::CSCBadWiresImpl::getNewObjects() {
   // check whats already inside of database
 
   std::cerr << "got offlineInfo" << std::endl;
-  std::cerr << tagInfo().name << " , last object valid since "
-            << tagInfo().lastInterval.first << std::endl;
+  std::cerr << tagInfo().name << " , last object valid since " << tagInfo().lastInterval.first << std::endl;
 
   unsigned int snc;
 
@@ -31,6 +28,5 @@ void popcon::CSCBadWiresImpl::getNewObjects() {
 
   m_to_transfer.push_back(std::make_pair(cnbadwires, snc));
 
-  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n"
-            << std::endl;
+  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n" << std::endl;
 }

--- a/CalibMuon/CSCCalibration/test/stubs/CSCBadWiresHandler.h
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCBadWiresHandler.h
@@ -16,17 +16,16 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 namespace popcon {
-class CSCBadWiresImpl : public popcon::PopConSourceHandler<CSCBadWires> {
+  class CSCBadWiresImpl : public popcon::PopConSourceHandler<CSCBadWires> {
+  public:
+    void getNewObjects();
+    std::string id() const { return m_name; }
+    ~CSCBadWiresImpl();
 
-public:
-  void getNewObjects();
-  std::string id() const { return m_name; }
-  ~CSCBadWiresImpl();
+    CSCBadWiresImpl(const edm::ParameterSet &pset);
 
-  CSCBadWiresImpl(const edm::ParameterSet &pset);
-
-private:
-  std::string m_name;
-};
-} // namespace popcon
+  private:
+    std::string m_name;
+  };
+}  // namespace popcon
 #endif

--- a/CalibMuon/CSCCalibration/test/stubs/CSCBadWiresPopConAnalyzer.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCBadWiresPopConAnalyzer.cc
@@ -2,7 +2,6 @@
 #include "CondCore/PopCon/interface/PopConAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef popcon::PopConAnalyzer<popcon::CSCBadWiresImpl>
-    CSCBadWiresPopConAnalyzer;
+typedef popcon::PopConAnalyzer<popcon::CSCBadWiresImpl> CSCBadWiresPopConAnalyzer;
 
 DEFINE_FWK_MODULE(CSCBadWiresPopConAnalyzer);

--- a/CalibMuon/CSCCalibration/test/stubs/CSCChipSpeedCorrectionPopConAnalyzer.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCChipSpeedCorrectionPopConAnalyzer.cc
@@ -2,7 +2,6 @@
 #include "CondCore/PopCon/interface/PopConAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef popcon::PopConAnalyzer<popcon::CSCDBChipSpeedCorrectionImpl>
-    CSCDBChipSpeedCorrectionPopConAnalyzer;
+typedef popcon::PopConAnalyzer<popcon::CSCDBChipSpeedCorrectionImpl> CSCDBChipSpeedCorrectionPopConAnalyzer;
 
 DEFINE_FWK_MODULE(CSCDBChipSpeedCorrectionPopConAnalyzer);

--- a/CalibMuon/CSCCalibration/test/stubs/CSCCrosstalkHandler.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCCrosstalkHandler.cc
@@ -3,8 +3,7 @@
 #include <iostream>
 
 popcon::CSCDBCrosstalkImpl::CSCDBCrosstalkImpl(const edm::ParameterSet &pset)
-    : m_name(pset.getUntrackedParameter<std::string>("name",
-                                                     "CSCDBCrosstalkImpl")) {}
+    : m_name(pset.getUntrackedParameter<std::string>("name", "CSCDBCrosstalkImpl")) {}
 
 popcon::CSCDBCrosstalkImpl::~CSCDBCrosstalkImpl() {}
 
@@ -12,7 +11,6 @@ popcon::CSCDBCrosstalkImpl::~CSCDBCrosstalkImpl() {}
 #include "CondFormats/CSCObjects/interface/CSCDBCrosstalk.h"
 
 void popcon::CSCDBCrosstalkImpl::getNewObjects() {
-
   std::cout << "CSCCrosstalkHandler - time before filling object:" << std::endl;
   std::cout << "------- CSC src - > getNewObjects\n" << m_name;
 
@@ -26,8 +24,7 @@ void popcon::CSCDBCrosstalkImpl::getNewObjects() {
   // check whats already inside of database
 
   std::cerr << "got offlineInfo" << std::endl;
-  std::cerr << tagInfo().name << " , last object valid since "
-            << tagInfo().lastInterval.first << std::endl;
+  std::cerr << tagInfo().name << " , last object valid since " << tagInfo().lastInterval.first << std::endl;
 
   unsigned int snc;
 
@@ -36,8 +33,6 @@ void popcon::CSCDBCrosstalkImpl::getNewObjects() {
 
   m_to_transfer.push_back(std::make_pair(cncrosstalk, snc));
 
-  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n"
-            << std::endl;
-  std::cout << "CSCCrosstalkHandler - time before writing into DB:"
-            << std::endl;
+  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n" << std::endl;
+  std::cout << "CSCCrosstalkHandler - time before writing into DB:" << std::endl;
 }

--- a/CalibMuon/CSCCalibration/test/stubs/CSCCrosstalkHandler.h
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCCrosstalkHandler.h
@@ -16,17 +16,16 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 namespace popcon {
-class CSCDBCrosstalkImpl : public popcon::PopConSourceHandler<CSCDBCrosstalk> {
+  class CSCDBCrosstalkImpl : public popcon::PopConSourceHandler<CSCDBCrosstalk> {
+  public:
+    void getNewObjects();
+    std::string id() const { return m_name; }
+    ~CSCDBCrosstalkImpl();
 
-public:
-  void getNewObjects();
-  std::string id() const { return m_name; }
-  ~CSCDBCrosstalkImpl();
+    CSCDBCrosstalkImpl(const edm::ParameterSet &pset);
 
-  CSCDBCrosstalkImpl(const edm::ParameterSet &pset);
-
-private:
-  std::string m_name;
-};
-} // namespace popcon
+  private:
+    std::string m_name;
+  };
+}  // namespace popcon
 #endif

--- a/CalibMuon/CSCCalibration/test/stubs/CSCCrosstalkPopConAnalyzer.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCCrosstalkPopConAnalyzer.cc
@@ -2,7 +2,6 @@
 #include "CondCore/PopCon/interface/PopConAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef popcon::PopConAnalyzer<popcon::CSCDBCrosstalkImpl>
-    CSCCrosstalkPopConAnalyzer;
+typedef popcon::PopConAnalyzer<popcon::CSCDBCrosstalkImpl> CSCCrosstalkPopConAnalyzer;
 
 DEFINE_FWK_MODULE(CSCCrosstalkPopConAnalyzer);

--- a/CalibMuon/CSCCalibration/test/stubs/CSCDBChipSpeedCorrectionHandler.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCDBChipSpeedCorrectionHandler.cc
@@ -5,22 +5,17 @@
 #include "CalibMuon/CSCCalibration/interface/CSCChipSpeedCorrectionDBConditions.h"
 #include "CondFormats/CSCObjects/interface/CSCDBChipSpeedCorrection.h"
 
-popcon::CSCDBChipSpeedCorrectionImpl::CSCDBChipSpeedCorrectionImpl(
-    const edm::ParameterSet &pset) {
-  m_name = (pset.getUntrackedParameter<std::string>(
-      "name", "CSCDBChipSpeedCorrectionImpl"));
+popcon::CSCDBChipSpeedCorrectionImpl::CSCDBChipSpeedCorrectionImpl(const edm::ParameterSet &pset) {
+  m_name = (pset.getUntrackedParameter<std::string>("name", "CSCDBChipSpeedCorrectionImpl"));
   isForMC = (pset.getUntrackedParameter<bool>("isForMC", true));
-  dataCorrFileName = (pset.getUntrackedParameter<std::string>(
-      "dataCorrFileName", "empty.txt"));
+  dataCorrFileName = (pset.getUntrackedParameter<std::string>("dataCorrFileName", "empty.txt"));
   dataOffset = 170.;
 }
 
 popcon::CSCDBChipSpeedCorrectionImpl::~CSCDBChipSpeedCorrectionImpl() {}
 
 void popcon::CSCDBChipSpeedCorrectionImpl::getNewObjects() {
-
-  std::cout << "CSCChipSpeedCorrectionHandler - time before filling object:"
-            << std::endl;
+  std::cout << "CSCChipSpeedCorrectionHandler - time before filling object:" << std::endl;
   std::cout << "------- CSC src - > getNewObjects\n" << m_name;
 
   // fill object from file
@@ -28,19 +23,16 @@ void popcon::CSCDBChipSpeedCorrectionImpl::getNewObjects() {
   // string dataCorrFileName=
   // iConfig.getUntrackedParameter<std::string>("dataCorrFileName","empty.txt");
   CSCDBChipSpeedCorrection *cnchipspeed =
-      CSCChipSpeedCorrectionDBConditions::prefillDBChipSpeedCorrection(
-          isForMC, dataCorrFileName, dataOffset);
+      CSCChipSpeedCorrectionDBConditions::prefillDBChipSpeedCorrection(isForMC, dataCorrFileName, dataOffset);
   // std::cout << "chipspeed size " << cnchipspeed->chipspeed.size() <<
   // std::endl;
 
-  std::cout << "CSCChipSpeedCorrectionHandler - time after filling object:"
-            << std::endl;
+  std::cout << "CSCChipSpeedCorrectionHandler - time after filling object:" << std::endl;
 
   // check whats already inside of database
 
   std::cerr << "got offlineInfo" << std::endl;
-  std::cerr << tagInfo().name << " , last object valid since "
-            << tagInfo().lastInterval.first << std::endl;
+  std::cerr << tagInfo().name << " , last object valid since " << tagInfo().lastInterval.first << std::endl;
 
   unsigned int snc;
   std::cout << "Source implementation test ::getNewObjects : enter since ? \n";
@@ -49,8 +41,6 @@ void popcon::CSCDBChipSpeedCorrectionImpl::getNewObjects() {
 
   m_to_transfer.push_back(std::make_pair(cnchipspeed, snc));
 
-  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n"
-            << std::endl;
-  std::cout << "CSCChipSpeedCorrectionHandler - time before writing into DB:"
-            << std::endl;
+  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n" << std::endl;
+  std::cout << "CSCChipSpeedCorrectionHandler - time before writing into DB:" << std::endl;
 }

--- a/CalibMuon/CSCCalibration/test/stubs/CSCDBChipSpeedCorrectionHandler.h
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCDBChipSpeedCorrectionHandler.h
@@ -16,20 +16,18 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 namespace popcon {
-class CSCDBChipSpeedCorrectionImpl
-    : public popcon::PopConSourceHandler<CSCDBChipSpeedCorrection> {
+  class CSCDBChipSpeedCorrectionImpl : public popcon::PopConSourceHandler<CSCDBChipSpeedCorrection> {
+  public:
+    void getNewObjects();
+    std::string id() const { return m_name; }
+    ~CSCDBChipSpeedCorrectionImpl();
+    CSCDBChipSpeedCorrectionImpl(const edm::ParameterSet &pset);
 
-public:
-  void getNewObjects();
-  std::string id() const { return m_name; }
-  ~CSCDBChipSpeedCorrectionImpl();
-  CSCDBChipSpeedCorrectionImpl(const edm::ParameterSet &pset);
-
-private:
-  std::string m_name;
-  bool isForMC;
-  std::string dataCorrFileName;
-  float dataOffset;
-};
-} // namespace popcon
+  private:
+    std::string m_name;
+    bool isForMC;
+    std::string dataCorrFileName;
+    float dataOffset;
+  };
+}  // namespace popcon
 #endif

--- a/CalibMuon/CSCCalibration/test/stubs/CSCDBGasGainCorrectionHandler.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCDBGasGainCorrectionHandler.cc
@@ -5,21 +5,16 @@
 #include "CalibMuon/CSCCalibration/interface/CSCGasGainCorrectionDBConditions.h"
 #include "CondFormats/CSCObjects/interface/CSCDBGasGainCorrection.h"
 
-popcon::CSCDBGasGainCorrectionImpl::CSCDBGasGainCorrectionImpl(
-    const edm::ParameterSet &pset) {
-  m_name = (pset.getUntrackedParameter<std::string>(
-      "name", "CSCDBGasGainCorrectionImpl"));
+popcon::CSCDBGasGainCorrectionImpl::CSCDBGasGainCorrectionImpl(const edm::ParameterSet &pset) {
+  m_name = (pset.getUntrackedParameter<std::string>("name", "CSCDBGasGainCorrectionImpl"));
   isForMC = (pset.getUntrackedParameter<bool>("isForMC", true));
-  dataCorrFileName = (pset.getUntrackedParameter<std::string>(
-      "dataCorrFileName", "empty.txt"));
+  dataCorrFileName = (pset.getUntrackedParameter<std::string>("dataCorrFileName", "empty.txt"));
 }
 
 popcon::CSCDBGasGainCorrectionImpl::~CSCDBGasGainCorrectionImpl() {}
 
 void popcon::CSCDBGasGainCorrectionImpl::getNewObjects() {
-
-  std::cout << "CSCGasGainCorrectionHandler - time before filling object:"
-            << std::endl;
+  std::cout << "CSCGasGainCorrectionHandler - time before filling object:" << std::endl;
   std::cout << "------- CSC src - > getNewObjects\n" << m_name;
 
   // fill object from file
@@ -27,17 +22,14 @@ void popcon::CSCDBGasGainCorrectionImpl::getNewObjects() {
   // string dataCorrFileName=
   // iConfig.getUntrackedParameter<std::string>("dataCorrFileName","empty.txt");
   CSCDBGasGainCorrection *cngasgain =
-      CSCGasGainCorrectionDBConditions::prefillDBGasGainCorrection(
-          isForMC, dataCorrFileName);
+      CSCGasGainCorrectionDBConditions::prefillDBGasGainCorrection(isForMC, dataCorrFileName);
 
-  std::cout << "CSCGasGainCorrectionHandler - time after filling object:"
-            << std::endl;
+  std::cout << "CSCGasGainCorrectionHandler - time after filling object:" << std::endl;
 
   // check whats already inside of database
 
   std::cerr << "got offlineInfo" << std::endl;
-  std::cerr << tagInfo().name << " , last object valid since "
-            << tagInfo().lastInterval.first << std::endl;
+  std::cerr << tagInfo().name << " , last object valid since " << tagInfo().lastInterval.first << std::endl;
 
   unsigned int snc;
   std::cout << "Source implementation test ::getNewObjects : enter since ? \n";
@@ -46,8 +38,6 @@ void popcon::CSCDBGasGainCorrectionImpl::getNewObjects() {
 
   m_to_transfer.push_back(std::make_pair(cngasgain, snc));
 
-  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n"
-            << std::endl;
-  std::cout << "CSCGasGainCorrectionHandler - time before writing into DB:"
-            << std::endl;
+  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n" << std::endl;
+  std::cout << "CSCGasGainCorrectionHandler - time before writing into DB:" << std::endl;
 }

--- a/CalibMuon/CSCCalibration/test/stubs/CSCDBGasGainCorrectionHandler.h
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCDBGasGainCorrectionHandler.h
@@ -16,19 +16,17 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 namespace popcon {
-class CSCDBGasGainCorrectionImpl
-    : public popcon::PopConSourceHandler<CSCDBGasGainCorrection> {
+  class CSCDBGasGainCorrectionImpl : public popcon::PopConSourceHandler<CSCDBGasGainCorrection> {
+  public:
+    void getNewObjects();
+    std::string id() const { return m_name; }
+    ~CSCDBGasGainCorrectionImpl();
+    CSCDBGasGainCorrectionImpl(const edm::ParameterSet &pset);
 
-public:
-  void getNewObjects();
-  std::string id() const { return m_name; }
-  ~CSCDBGasGainCorrectionImpl();
-  CSCDBGasGainCorrectionImpl(const edm::ParameterSet &pset);
-
-private:
-  std::string m_name;
-  bool isForMC;
-  std::string dataCorrFileName;
-};
-} // namespace popcon
+  private:
+    std::string m_name;
+    bool isForMC;
+    std::string dataCorrFileName;
+  };
+}  // namespace popcon
 #endif

--- a/CalibMuon/CSCCalibration/test/stubs/CSCDBL1TPParametersHandler.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCDBL1TPParametersHandler.cc
@@ -2,10 +2,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <iostream>
 
-popcon::CSCDBL1TPParametersImpl::CSCDBL1TPParametersImpl(
-    const edm::ParameterSet &pset)
-    : m_name(pset.getUntrackedParameter<std::string>(
-          "name", "CSCDBL1TPParametersImpl")) {}
+popcon::CSCDBL1TPParametersImpl::CSCDBL1TPParametersImpl(const edm::ParameterSet &pset)
+    : m_name(pset.getUntrackedParameter<std::string>("name", "CSCDBL1TPParametersImpl")) {}
 
 popcon::CSCDBL1TPParametersImpl::~CSCDBL1TPParametersImpl() {}
 
@@ -13,23 +11,18 @@ popcon::CSCDBL1TPParametersImpl::~CSCDBL1TPParametersImpl() {}
 #include "CondFormats/CSCObjects/interface/CSCDBL1TPParameters.h"
 
 void popcon::CSCDBL1TPParametersImpl::getNewObjects() {
-
-  std::cout << "CSCDBL1TPParametersHandler - time before filling object:"
-            << std::endl;
+  std::cout << "CSCDBL1TPParametersHandler - time before filling object:" << std::endl;
   std::cout << "------- CSC src - > getNewObjects\n" << m_name;
 
   // fill object from file
-  CSCDBL1TPParameters *cnl1tp =
-      CSCDBL1TPParametersConditions::prefillCSCDBL1TPParameters();
+  CSCDBL1TPParameters *cnl1tp = CSCDBL1TPParametersConditions::prefillCSCDBL1TPParameters();
 
-  std::cout << "CSCDBL1TPParametersHandler - time after filling object:"
-            << std::endl;
+  std::cout << "CSCDBL1TPParametersHandler - time after filling object:" << std::endl;
 
   // check whats already inside of database
 
   std::cerr << "got offlineInfo" << std::endl;
-  std::cerr << tagInfo().name << " , last object valid since "
-            << tagInfo().lastInterval.first << std::endl;
+  std::cerr << tagInfo().name << " , last object valid since " << tagInfo().lastInterval.first << std::endl;
 
   unsigned int snc;
 
@@ -38,8 +31,6 @@ void popcon::CSCDBL1TPParametersImpl::getNewObjects() {
 
   m_to_transfer.push_back(std::make_pair(cnl1tp, snc));
 
-  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n"
-            << std::endl;
-  std::cout << "CSCDBL1TPParametersHandler - time before writing into DB:"
-            << std::endl;
+  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n" << std::endl;
+  std::cout << "CSCDBL1TPParametersHandler - time before writing into DB:" << std::endl;
 }

--- a/CalibMuon/CSCCalibration/test/stubs/CSCDBL1TPParametersHandler.h
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCDBL1TPParametersHandler.h
@@ -16,18 +16,16 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 namespace popcon {
-class CSCDBL1TPParametersImpl
-    : public popcon::PopConSourceHandler<CSCDBL1TPParameters> {
+  class CSCDBL1TPParametersImpl : public popcon::PopConSourceHandler<CSCDBL1TPParameters> {
+  public:
+    void getNewObjects();
+    std::string id() const { return m_name; }
+    ~CSCDBL1TPParametersImpl();
 
-public:
-  void getNewObjects();
-  std::string id() const { return m_name; }
-  ~CSCDBL1TPParametersImpl();
+    CSCDBL1TPParametersImpl(const edm::ParameterSet &pset);
 
-  CSCDBL1TPParametersImpl(const edm::ParameterSet &pset);
-
-private:
-  std::string m_name;
-};
-} // namespace popcon
+  private:
+    std::string m_name;
+  };
+}  // namespace popcon
 #endif

--- a/CalibMuon/CSCCalibration/test/stubs/CSCDBL1TPParametersPopConAnalyzer.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCDBL1TPParametersPopConAnalyzer.cc
@@ -2,7 +2,6 @@
 #include "CondCore/PopCon/interface/PopConAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef popcon::PopConAnalyzer<popcon::CSCDBL1TPParametersImpl>
-    CSCDBL1TPParametersPopConAnalyzer;
+typedef popcon::PopConAnalyzer<popcon::CSCDBL1TPParametersImpl> CSCDBL1TPParametersPopConAnalyzer;
 
 DEFINE_FWK_MODULE(CSCDBL1TPParametersPopConAnalyzer);

--- a/CalibMuon/CSCCalibration/test/stubs/CSCFakeCrosstalkPopConAnalyzer.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCFakeCrosstalkPopConAnalyzer.cc
@@ -2,7 +2,6 @@
 #include "CondCore/PopCon/interface/PopConAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef popcon::PopConAnalyzer<popcon::CSCFakeDBCrosstalkImpl>
-    CSCFakeCrosstalkPopConAnalyzer;
+typedef popcon::PopConAnalyzer<popcon::CSCFakeDBCrosstalkImpl> CSCFakeCrosstalkPopConAnalyzer;
 
 DEFINE_FWK_MODULE(CSCFakeCrosstalkPopConAnalyzer);

--- a/CalibMuon/CSCCalibration/test/stubs/CSCFakeDBCrosstalkHandler.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCFakeDBCrosstalkHandler.cc
@@ -5,15 +5,12 @@
 #include "CalibMuon/CSCCalibration/interface/CSCFakeDBCrosstalk.h"
 #include "CondFormats/CSCObjects/interface/CSCDBCrosstalk.h"
 
-popcon::CSCFakeDBCrosstalkImpl::CSCFakeDBCrosstalkImpl(
-    const edm::ParameterSet &pset)
-    : m_name(pset.getUntrackedParameter<std::string>(
-          "name", "CSCFakeDBCrosstalkImpl")) {}
+popcon::CSCFakeDBCrosstalkImpl::CSCFakeDBCrosstalkImpl(const edm::ParameterSet &pset)
+    : m_name(pset.getUntrackedParameter<std::string>("name", "CSCFakeDBCrosstalkImpl")) {}
 
 popcon::CSCFakeDBCrosstalkImpl::~CSCFakeDBCrosstalkImpl() {}
 
 void popcon::CSCFakeDBCrosstalkImpl::getNewObjects() {
-
   std::cout << "------- CSC src - > getNewObjects\n" << m_name;
 
   // fill object from file
@@ -24,8 +21,7 @@ void popcon::CSCFakeDBCrosstalkImpl::getNewObjects() {
   // check whats already inside of database
 
   std::cerr << "got offlineInfo" << std::endl;
-  std::cerr << tagInfo().name << " , last object valid since "
-            << tagInfo().lastInterval.first << std::endl;
+  std::cerr << tagInfo().name << " , last object valid since " << tagInfo().lastInterval.first << std::endl;
 
   unsigned int snc;
 
@@ -34,6 +30,5 @@ void popcon::CSCFakeDBCrosstalkImpl::getNewObjects() {
 
   m_to_transfer.push_back(std::make_pair(cncrosstalk, snc));
 
-  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n"
-            << std::endl;
+  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n" << std::endl;
 }

--- a/CalibMuon/CSCCalibration/test/stubs/CSCFakeDBCrosstalkHandler.h
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCFakeDBCrosstalkHandler.h
@@ -16,18 +16,16 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 namespace popcon {
-class CSCFakeDBCrosstalkImpl
-    : public popcon::PopConSourceHandler<CSCDBCrosstalk> {
+  class CSCFakeDBCrosstalkImpl : public popcon::PopConSourceHandler<CSCDBCrosstalk> {
+  public:
+    void getNewObjects();
+    std::string id() const { return m_name; }
+    ~CSCFakeDBCrosstalkImpl();
 
-public:
-  void getNewObjects();
-  std::string id() const { return m_name; }
-  ~CSCFakeDBCrosstalkImpl();
+    CSCFakeDBCrosstalkImpl(const edm::ParameterSet &pset);
 
-  CSCFakeDBCrosstalkImpl(const edm::ParameterSet &pset);
-
-private:
-  std::string m_name;
-};
-} // namespace popcon
+  private:
+    std::string m_name;
+  };
+}  // namespace popcon
 #endif

--- a/CalibMuon/CSCCalibration/test/stubs/CSCFakeDBGainsHandler.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCFakeDBGainsHandler.cc
@@ -6,13 +6,11 @@
 #include "CondFormats/CSCObjects/interface/CSCDBGains.h"
 
 popcon::CSCFakeDBGainsImpl::CSCFakeDBGainsImpl(const edm::ParameterSet &pset)
-    : m_name(pset.getUntrackedParameter<std::string>("name",
-                                                     "CSCFakeDBGainsImpl")) {}
+    : m_name(pset.getUntrackedParameter<std::string>("name", "CSCFakeDBGainsImpl")) {}
 
 popcon::CSCFakeDBGainsImpl::~CSCFakeDBGainsImpl() {}
 
 void popcon::CSCFakeDBGainsImpl::getNewObjects() {
-
   std::cout << "------- CSC src - > getNewObjects\n" << m_name;
 
   // fill object from file
@@ -22,8 +20,7 @@ void popcon::CSCFakeDBGainsImpl::getNewObjects() {
   // check whats already inside of database
 
   std::cerr << "got offlineInfo" << std::endl;
-  std::cerr << tagInfo().name << " , last object valid since "
-            << tagInfo().lastInterval.first << std::endl;
+  std::cerr << tagInfo().name << " , last object valid since " << tagInfo().lastInterval.first << std::endl;
 
   unsigned int snc;
 
@@ -32,6 +29,5 @@ void popcon::CSCFakeDBGainsImpl::getNewObjects() {
 
   m_to_transfer.push_back(std::make_pair(cngains, snc));
 
-  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n"
-            << std::endl;
+  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n" << std::endl;
 }

--- a/CalibMuon/CSCCalibration/test/stubs/CSCFakeDBGainsHandler.h
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCFakeDBGainsHandler.h
@@ -16,17 +16,16 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 namespace popcon {
-class CSCFakeDBGainsImpl : public popcon::PopConSourceHandler<CSCDBGains> {
+  class CSCFakeDBGainsImpl : public popcon::PopConSourceHandler<CSCDBGains> {
+  public:
+    void getNewObjects();
+    std::string id() const { return m_name; }
+    ~CSCFakeDBGainsImpl();
 
-public:
-  void getNewObjects();
-  std::string id() const { return m_name; }
-  ~CSCFakeDBGainsImpl();
+    CSCFakeDBGainsImpl(const edm::ParameterSet &pset);
 
-  CSCFakeDBGainsImpl(const edm::ParameterSet &pset);
-
-private:
-  std::string m_name;
-};
-} // namespace popcon
+  private:
+    std::string m_name;
+  };
+}  // namespace popcon
 #endif

--- a/CalibMuon/CSCCalibration/test/stubs/CSCFakeDBNoiseMatrixHandler.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCFakeDBNoiseMatrixHandler.cc
@@ -5,15 +5,12 @@
 #include "CalibMuon/CSCCalibration/interface/CSCFakeDBNoiseMatrix.h"
 #include "CondFormats/CSCObjects/interface/CSCDBNoiseMatrix.h"
 
-popcon::CSCFakeDBNoiseMatrixImpl::CSCFakeDBNoiseMatrixImpl(
-    const edm::ParameterSet &pset)
-    : m_name(pset.getUntrackedParameter<std::string>(
-          "name", "CSCFakeDBNoiseMatrixImpl")) {}
+popcon::CSCFakeDBNoiseMatrixImpl::CSCFakeDBNoiseMatrixImpl(const edm::ParameterSet &pset)
+    : m_name(pset.getUntrackedParameter<std::string>("name", "CSCFakeDBNoiseMatrixImpl")) {}
 
 popcon::CSCFakeDBNoiseMatrixImpl::~CSCFakeDBNoiseMatrixImpl() {}
 
 void popcon::CSCFakeDBNoiseMatrixImpl::getNewObjects() {
-
   std::cout << "------- CSC src - > getNewObjects\n" << m_name;
 
   // fill object from file
@@ -23,8 +20,7 @@ void popcon::CSCFakeDBNoiseMatrixImpl::getNewObjects() {
   // check whats already inside of database
 
   std::cerr << "got offlineInfo" << std::endl;
-  std::cerr << tagInfo().name << " , last object valid since "
-            << tagInfo().lastInterval.first << std::endl;
+  std::cerr << tagInfo().name << " , last object valid since " << tagInfo().lastInterval.first << std::endl;
 
   unsigned int snc;
 
@@ -33,6 +29,5 @@ void popcon::CSCFakeDBNoiseMatrixImpl::getNewObjects() {
 
   m_to_transfer.push_back(std::make_pair(cnmatrix, snc));
 
-  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n"
-            << std::endl;
+  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n" << std::endl;
 }

--- a/CalibMuon/CSCCalibration/test/stubs/CSCFakeDBNoiseMatrixHandler.h
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCFakeDBNoiseMatrixHandler.h
@@ -16,18 +16,16 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 namespace popcon {
-class CSCFakeDBNoiseMatrixImpl
-    : public popcon::PopConSourceHandler<CSCDBNoiseMatrix> {
+  class CSCFakeDBNoiseMatrixImpl : public popcon::PopConSourceHandler<CSCDBNoiseMatrix> {
+  public:
+    void getNewObjects();
+    std::string id() const { return m_name; }
+    ~CSCFakeDBNoiseMatrixImpl();
 
-public:
-  void getNewObjects();
-  std::string id() const { return m_name; }
-  ~CSCFakeDBNoiseMatrixImpl();
+    CSCFakeDBNoiseMatrixImpl(const edm::ParameterSet &pset);
 
-  CSCFakeDBNoiseMatrixImpl(const edm::ParameterSet &pset);
-
-private:
-  std::string m_name;
-};
-} // namespace popcon
+  private:
+    std::string m_name;
+  };
+}  // namespace popcon
 #endif

--- a/CalibMuon/CSCCalibration/test/stubs/CSCFakeDBPedestalsHandler.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCFakeDBPedestalsHandler.cc
@@ -5,15 +5,12 @@
 #include "CalibMuon/CSCCalibration/interface/CSCFakeDBPedestals.h"
 #include "CondFormats/CSCObjects/interface/CSCDBPedestals.h"
 
-popcon::CSCFakeDBPedestalsImpl::CSCFakeDBPedestalsImpl(
-    const edm::ParameterSet &pset)
-    : m_name(pset.getUntrackedParameter<std::string>(
-          "name", "CSCFakeDBPedestalsImpl")) {}
+popcon::CSCFakeDBPedestalsImpl::CSCFakeDBPedestalsImpl(const edm::ParameterSet &pset)
+    : m_name(pset.getUntrackedParameter<std::string>("name", "CSCFakeDBPedestalsImpl")) {}
 
 popcon::CSCFakeDBPedestalsImpl::~CSCFakeDBPedestalsImpl() {}
 
 void popcon::CSCFakeDBPedestalsImpl::getNewObjects() {
-
   std::cout << "------- CSC src - > getNewObjects\n" << m_name;
 
   // fill object from file
@@ -23,8 +20,7 @@ void popcon::CSCFakeDBPedestalsImpl::getNewObjects() {
   // check whats already inside of database
 
   std::cerr << "got offlineInfo" << std::endl;
-  std::cerr << tagInfo().name << " , last object valid since "
-            << tagInfo().lastInterval.first << std::endl;
+  std::cerr << tagInfo().name << " , last object valid since " << tagInfo().lastInterval.first << std::endl;
 
   unsigned int snc;
 
@@ -33,6 +29,5 @@ void popcon::CSCFakeDBPedestalsImpl::getNewObjects() {
 
   m_to_transfer.push_back(std::make_pair(cnpedestals, snc));
 
-  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n"
-            << std::endl;
+  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n" << std::endl;
 }

--- a/CalibMuon/CSCCalibration/test/stubs/CSCFakeDBPedestalsHandler.h
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCFakeDBPedestalsHandler.h
@@ -16,18 +16,16 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 namespace popcon {
-class CSCFakeDBPedestalsImpl
-    : public popcon::PopConSourceHandler<CSCDBPedestals> {
+  class CSCFakeDBPedestalsImpl : public popcon::PopConSourceHandler<CSCDBPedestals> {
+  public:
+    void getNewObjects();
+    std::string id() const { return m_name; }
+    ~CSCFakeDBPedestalsImpl();
 
-public:
-  void getNewObjects();
-  std::string id() const { return m_name; }
-  ~CSCFakeDBPedestalsImpl();
+    CSCFakeDBPedestalsImpl(const edm::ParameterSet &pset);
 
-  CSCFakeDBPedestalsImpl(const edm::ParameterSet &pset);
-
-private:
-  std::string m_name;
-};
-} // namespace popcon
+  private:
+    std::string m_name;
+  };
+}  // namespace popcon
 #endif

--- a/CalibMuon/CSCCalibration/test/stubs/CSCFakeGainsPopConAnalyzer.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCFakeGainsPopConAnalyzer.cc
@@ -2,7 +2,6 @@
 #include "CondCore/PopCon/interface/PopConAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef popcon::PopConAnalyzer<popcon::CSCFakeDBGainsImpl>
-    CSCFakeGainsPopConAnalyzer;
+typedef popcon::PopConAnalyzer<popcon::CSCFakeDBGainsImpl> CSCFakeGainsPopConAnalyzer;
 
 DEFINE_FWK_MODULE(CSCFakeGainsPopConAnalyzer);

--- a/CalibMuon/CSCCalibration/test/stubs/CSCFakeNoiseMatrixPopConAnalyzer.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCFakeNoiseMatrixPopConAnalyzer.cc
@@ -2,7 +2,6 @@
 #include "CondCore/PopCon/interface/PopConAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef popcon::PopConAnalyzer<popcon::CSCFakeDBNoiseMatrixImpl>
-    CSCFakeNoiseMatrixPopConAnalyzer;
+typedef popcon::PopConAnalyzer<popcon::CSCFakeDBNoiseMatrixImpl> CSCFakeNoiseMatrixPopConAnalyzer;
 
 DEFINE_FWK_MODULE(CSCFakeNoiseMatrixPopConAnalyzer);

--- a/CalibMuon/CSCCalibration/test/stubs/CSCFakePedestalsPopConAnalyzer.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCFakePedestalsPopConAnalyzer.cc
@@ -2,7 +2,6 @@
 #include "CondCore/PopCon/interface/PopConAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef popcon::PopConAnalyzer<popcon::CSCFakeDBPedestalsImpl>
-    CSCFakePedestalsPopConAnalyzer;
+typedef popcon::PopConAnalyzer<popcon::CSCFakeDBPedestalsImpl> CSCFakePedestalsPopConAnalyzer;
 
 DEFINE_FWK_MODULE(CSCFakePedestalsPopConAnalyzer);

--- a/CalibMuon/CSCCalibration/test/stubs/CSCGainsHandler.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCGainsHandler.cc
@@ -6,13 +6,11 @@
 #include "CondFormats/CSCObjects/interface/CSCDBGains.h"
 
 popcon::CSCDBGainsImpl::CSCDBGainsImpl(const edm::ParameterSet &pset)
-    : m_name(
-          pset.getUntrackedParameter<std::string>("name", "CSCDBGainsImpl")) {}
+    : m_name(pset.getUntrackedParameter<std::string>("name", "CSCDBGainsImpl")) {}
 
 popcon::CSCDBGainsImpl::~CSCDBGainsImpl() {}
 
 void popcon::CSCDBGainsImpl::getNewObjects() {
-
   std::cout << "CSCGainsHandler - time before filling object:" << std::endl;
   std::cout << "------- CSC src - > getNewObjects\n" << m_name;
 
@@ -24,8 +22,7 @@ void popcon::CSCDBGainsImpl::getNewObjects() {
 
   // check whats already inside of database
   std::cerr << "got offlineInfo" << std::endl;
-  std::cerr << tagInfo().name << " , last object valid since "
-            << tagInfo().lastInterval.first << std::endl;
+  std::cerr << tagInfo().name << " , last object valid since " << tagInfo().lastInterval.first << std::endl;
 
   unsigned int snc;
 
@@ -34,8 +31,7 @@ void popcon::CSCDBGainsImpl::getNewObjects() {
 
   m_to_transfer.push_back(std::make_pair(cngains, snc));
 
-  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n"
-            << std::endl;
+  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n" << std::endl;
 
   std::cout << "CSCGainsHandler - time before writing into DB:" << std::endl;
 }

--- a/CalibMuon/CSCCalibration/test/stubs/CSCGainsHandler.h
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCGainsHandler.h
@@ -16,17 +16,16 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 namespace popcon {
-class CSCDBGainsImpl : public popcon::PopConSourceHandler<CSCDBGains> {
+  class CSCDBGainsImpl : public popcon::PopConSourceHandler<CSCDBGains> {
+  public:
+    void getNewObjects();
+    std::string id() const { return m_name; }
+    ~CSCDBGainsImpl();
 
-public:
-  void getNewObjects();
-  std::string id() const { return m_name; }
-  ~CSCDBGainsImpl();
+    CSCDBGainsImpl(const edm::ParameterSet &pset);
 
-  CSCDBGainsImpl(const edm::ParameterSet &pset);
-
-private:
-  std::string m_name;
-};
-} // namespace popcon
+  private:
+    std::string m_name;
+  };
+}  // namespace popcon
 #endif

--- a/CalibMuon/CSCCalibration/test/stubs/CSCGasGainCorrectionPopConAnalyzer.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCGasGainCorrectionPopConAnalyzer.cc
@@ -2,7 +2,6 @@
 #include "CondCore/PopCon/interface/PopConAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef popcon::PopConAnalyzer<popcon::CSCDBGasGainCorrectionImpl>
-    CSCDBGasGainCorrectionPopConAnalyzer;
+typedef popcon::PopConAnalyzer<popcon::CSCDBGasGainCorrectionImpl> CSCDBGasGainCorrectionPopConAnalyzer;
 
 DEFINE_FWK_MODULE(CSCDBGasGainCorrectionPopConAnalyzer);

--- a/CalibMuon/CSCCalibration/test/stubs/CSCIndexerAnalyzer.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCIndexerAnalyzer.cc
@@ -27,15 +27,13 @@ CSCIndexerAnalyzer::CSCIndexerAnalyzer(const edm::ParameterSet &pset) {}
 
 CSCIndexerAnalyzer::~CSCIndexerAnalyzer() {}
 
-void CSCIndexerAnalyzer::analyze(const edm::Event &ev,
-                                 const edm::EventSetup &esu) {
-  const int evalues[10] = {1, 2, 1, 2, 1, 2, 1, 2, 1, 2};   // endcap 1=+z, 2=-z
-  const int svalues[10] = {1, 1, 1, 1, 4, 4, 4, 4, 4, 4};   // station 1-4
-  const int rvalues[10] = {1, 1, 4, 4, 2, 2, 2, 2, 2, 2};   // ring 1-4
-  const int cvalues[10] = {1, 1, 1, 1, 1, 1, 36, 36, 1, 1}; // chamber 1-18/36
-  const int lvalues[10] = {1, 1, 1, 1, 1, 1, 1, 1, 6, 6};   // layer 1-6
-  const int tvalues[10] = {1, 1, 1, 1,  1,
-                           1, 1, 1, 80, 80}; // strip 1-80 (16, 48 64)
+void CSCIndexerAnalyzer::analyze(const edm::Event &ev, const edm::EventSetup &esu) {
+  const int evalues[10] = {1, 2, 1, 2, 1, 2, 1, 2, 1, 2};    // endcap 1=+z, 2=-z
+  const int svalues[10] = {1, 1, 1, 1, 4, 4, 4, 4, 4, 4};    // station 1-4
+  const int rvalues[10] = {1, 1, 4, 4, 2, 2, 2, 2, 2, 2};    // ring 1-4
+  const int cvalues[10] = {1, 1, 1, 1, 1, 1, 36, 36, 1, 1};  // chamber 1-18/36
+  const int lvalues[10] = {1, 1, 1, 1, 1, 1, 1, 1, 6, 6};    // layer 1-6
+  const int tvalues[10] = {1, 1, 1, 1, 1, 1, 1, 1, 80, 80};  // strip 1-80 (16, 48 64)
 
   const CSCIndexerRecord &irec = esu.get<CSCIndexerRecord>();
   edm::ESHandle<CSCIndexerBase> indexer_;
@@ -43,8 +41,7 @@ void CSCIndexerAnalyzer::analyze(const edm::Event &ev,
 
   algoName = indexer_->name();
 
-  std::cout << "CSCIndexerAnalyzer: analyze sees algorithm " << algoName
-            << " in Event Setup" << std::endl;
+  std::cout << "CSCIndexerAnalyzer: analyze sees algorithm " << algoName << " in Event Setup" << std::endl;
 
   for (int i = 0; i < 10; ++i) {
     int ie = evalues[i];
@@ -54,11 +51,9 @@ void CSCIndexerAnalyzer::analyze(const edm::Event &ev,
     int il = lvalues[i];
     int istrip = tvalues[i];
 
-    std::cout << "CSCIndexerAnalyzer: calling " << algoName
-              << "::stripChannelIndex(" << ie << "," << is << "," << ir << ","
-              << ic << "," << il << "," << istrip << ") = "
-              << indexer_->stripChannelIndex(ie, is, ir, ic, il, istrip)
-              << std::endl;
+    std::cout << "CSCIndexerAnalyzer: calling " << algoName << "::stripChannelIndex(" << ie << "," << is << "," << ir
+              << "," << ic << "," << il << "," << istrip
+              << ") = " << indexer_->stripChannelIndex(ie, is, ir, ic, il, istrip) << std::endl;
   }
 }
 

--- a/CalibMuon/CSCCalibration/test/stubs/CSCIndexerAnalyzer2.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCIndexerAnalyzer2.cc
@@ -16,12 +16,11 @@
 #include <CalibMuon/CSCCalibration/interface/CSCIndexerRecord.h>
 
 #include <cmath>
-#include <iomanip> // for setw() etc.
+#include <iomanip>  // for setw() etc.
 #include <string>
 #include <vector>
 
 class CSCIndexerAnalyzer2 : public edm::EDAnalyzer {
-
 public:
   explicit CSCIndexerAnalyzer2(const edm::ParameterSet &);
   ~CSCIndexerAnalyzer2();
@@ -40,16 +39,16 @@ private:
 };
 
 CSCIndexerAnalyzer2::CSCIndexerAnalyzer2(const edm::ParameterSet &iConfig)
-    : dashedLineWidth_(146), dashedLine_(std::string(dashedLineWidth_, '-')),
-      myName_("CSCIndexerAnalyzer2"), algoName_("UNKNOWN") {
+    : dashedLineWidth_(146),
+      dashedLine_(std::string(dashedLineWidth_, '-')),
+      myName_("CSCIndexerAnalyzer2"),
+      algoName_("UNKNOWN") {
   std::cout << dashedLine_ << std::endl;
   std::cout << "Welcome to " << myName_ << std::endl;
   std::cout << dashedLine_ << std::endl;
-  std::cout << "At present my CSCIndexer algorithm is    " << myAlgo()
-            << std::endl;
+  std::cout << "At present my CSCIndexer algorithm is    " << myAlgo() << std::endl;
   std::cout << dashedLine_ << std::endl;
-  std::cout << "I will build the CSC geometry, then iterate over all layers."
-            << std::endl;
+  std::cout << "I will build the CSC geometry, then iterate over all layers." << std::endl;
   std::cout << "From each CSCDetId I will build the associated linear index, "
                "including ME1a layers."
             << std::endl;
@@ -71,15 +70,13 @@ CSCIndexerAnalyzer2::CSCIndexerAnalyzer2(const edm::ParameterSet &iConfig)
   std::cout << "If any of these tests fail, you will see assert failure "
                "messages in the output."
             << std::endl;
-  std::cout << "If there are no such failures then the tests passed."
-            << std::endl;
+  std::cout << "If there are no such failures then the tests passed." << std::endl;
   std::cout << dashedLine_ << std::endl;
 }
 
 CSCIndexerAnalyzer2::~CSCIndexerAnalyzer2() {}
 
-void CSCIndexerAnalyzer2::analyze(const edm::Event &iEvent,
-                                  const edm::EventSetup &iSetup) {
+void CSCIndexerAnalyzer2::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   CSCDetId testCSCDetId;
 
   const double dPi = Geom::pi();
@@ -107,8 +104,7 @@ void CSCIndexerAnalyzer2::analyze(const edm::Event &iEvent,
   algoName_ = theIndexer->name();
 
   std::cout << dashedLine_ << std::endl;
-  std::cout << "Found CSCIndexer algorithm    " << myAlgo()
-            << "    in EventSetup" << std::endl;
+  std::cout << "Found CSCIndexer algorithm    " << myAlgo() << "    in EventSetup" << std::endl;
   std::cout << dashedLine_ << std::endl;
 
   bool ganged = 1;
@@ -128,23 +124,22 @@ void CSCIndexerAnalyzer2::analyze(const edm::Event &iEvent,
 
   // Iterate over the DetUnits in the CSCGeometry
   for (const auto &it : pDD->detUnits()) {
-
     // Check each DetUnit really is a CSC layer
     auto layer = dynamic_cast<const CSCLayer *>(it);
 
     if (layer) {
-      ++icountAll; // how many layers we see
+      ++icountAll;  // how many layers we see
 
       // Get DetId in various ways
 
       DetId detId = layer->geographicalId();
-      int id = detId(); // or detId.rawId()
+      int id = detId();  // or detId.rawId()
       CSCDetId cscDetId = layer->id();
 
       // There is going to be a lot of messing with field width (and precision)
       // so save input values...
-      int iw = std::cout.width();     // save current width
-      int ip = std::cout.precision(); // save current precision
+      int iw = std::cout.width();      // save current width
+      int ip = std::cout.precision();  // save current precision
 
       short ie = CSCDetId::endcap(id);
       short is = CSCDetId::station(id);
@@ -154,34 +149,27 @@ void CSCIndexerAnalyzer2::analyze(const edm::Event &iEvent,
 
       ++icount;
 
-      std::cout << std::setw(4) << icount << std::setw(12) << id << std::oct
-                << std::setw(12) << id << std::dec << std::setw(iw) << "   E"
-                << ie << " S" << is << " R" << ir << " C" << std::setw(2) << ic
+      std::cout << std::setw(4) << icount << std::setw(12) << id << std::oct << std::setw(12) << id << std::dec
+                << std::setw(iw) << "   E" << ie << " S" << is << " R" << ir << " C" << std::setw(2) << ic
                 << std::setw(iw) << " L" << il;
 
       unsigned cind = theIndexer->chamberIndex(ie, is, ir, ic);
       unsigned lind = theIndexer->layerIndex(ie, is, ir, ic, il);
-      unsigned scind =
-          theIndexer->startChamberIndexInEndcap(ie, is, ir) + ic - 1;
+      unsigned scind = theIndexer->startChamberIndexInEndcap(ie, is, ir) + ic - 1;
       unsigned cind2 = theIndexer->chamberIndex(cscDetId);
       unsigned lind2 = theIndexer->layerIndex(cscDetId);
 
-      std::cout << std::setw(12) << lind << std::setw(12) << lind2
-                << std::setw(12) << scind << std::setw(12)
+      std::cout << std::setw(12) << lind << std::setw(12) << lind2 << std::setw(12) << scind << std::setw(12)
                 << theIndexer->chamberLabelFromChamberIndex(scind) << "     ";
 
       // Index a few strips
       unsigned short nchan = theIndexer->stripChannelsPerOnlineLayer(is, ir);
       unsigned int sc1 = theIndexer->stripChannelIndex(ie, is, ir, ic, il, 1);
-      unsigned int scm =
-          theIndexer->stripChannelIndex(ie, is, ir, ic, il, nchan / 2);
-      unsigned int scn =
-          theIndexer->stripChannelIndex(ie, is, ir, ic, il, nchan);
+      unsigned int scm = theIndexer->stripChannelIndex(ie, is, ir, ic, il, nchan / 2);
+      unsigned int scn = theIndexer->stripChannelIndex(ie, is, ir, ic, il, nchan);
 
-      std::cout << "      1  " << std::setw(6) << sc1 << "      "
-                << std::setw(2) << nchan / 2 << "  " << std::setw(6) << scm
-                << "      " << std::setw(2) << nchan << "  " << std::setw(6)
-                << scn << std::endl;
+      std::cout << "      1  " << std::setw(6) << sc1 << "      " << std::setw(2) << nchan / 2 << "  " << std::setw(6)
+                << scm << "      " << std::setw(2) << nchan << "  " << std::setw(6) << scn << std::endl;
 
       // Reset the values we changed
       std::cout << std::setprecision(ip) << std::setw(iw);
@@ -196,8 +184,7 @@ void CSCIndexerAnalyzer2::analyze(const edm::Event &iEvent,
 
       // Build CSCDetId from layer index and check it is same as original
 
-      CSCDetId cscDetId2 =
-          theIndexer->detIdFromLayerIndex(lind); // folds ME1/1a into ME1/1
+      CSCDetId cscDetId2 = theIndexer->detIdFromLayerIndex(lind);  // folds ME1/1a into ME1/1
 
       testCSCDetId = cscDetId;
 
@@ -209,18 +196,17 @@ void CSCIndexerAnalyzer2::analyze(const edm::Event &iEvent,
       // Build CSCDetId from the strip-channel index for strip "nchan" and check
       // it matches Ganged ME1/1a returns ME1/1 CSCDetId and channel 65-80
 
-      std::pair<CSCDetId, unsigned short int> p =
-          theIndexer->detIdFromStripChannelIndex(scn);
+      std::pair<CSCDetId, unsigned short int> p = theIndexer->detIdFromStripChannelIndex(scn);
       CSCDetId cscDetId3 = p.first;
       unsigned short iscn = p.second;
 
       if (ir == 4 && ganged)
-        iscn -= 64; // reset ganged ME1a channel from 65-80 to 1-16
+        iscn -= 64;  // reset ganged ME1a channel from 65-80 to 1-16
 
       assert(iscn == nchan);
 
       if (ir == 4 && !ganged)
-        testCSCDetId = cscDetId; // unganged ME1/1a needs its own CSCDetId
+        testCSCDetId = cscDetId;  // unganged ME1/1a needs its own CSCDetId
 
       assert(cscDetId3 == testCSCDetId);
 
@@ -231,10 +217,7 @@ void CSCIndexerAnalyzer2::analyze(const edm::Event &iEvent,
       const GeomDet *gd = pDD->idToDet(detId);
       assert(gd == layer);
     } else {
-      std::cout
-          << myName()
-          << ": something wrong ... could not dynamic_cast Det* to CSCLayer* "
-          << std::endl;
+      std::cout << myName() << ": something wrong ... could not dynamic_cast Det* to CSCLayer* " << std::endl;
     }
   }
 

--- a/CalibMuon/CSCCalibration/test/stubs/CSCL1TPParametersHandler.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCL1TPParametersHandler.cc
@@ -2,11 +2,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <iostream>
 
-popcon::CSCL1TPParametersImpl::CSCL1TPParametersImpl(
-    const edm::ParameterSet &pset)
-    : m_name(pset.getUntrackedParameter<std::string>("name",
-                                                     "CSCL1TPParametersImpl")) {
-}
+popcon::CSCL1TPParametersImpl::CSCL1TPParametersImpl(const edm::ParameterSet &pset)
+    : m_name(pset.getUntrackedParameter<std::string>("name", "CSCL1TPParametersImpl")) {}
 
 popcon::CSCL1TPParametersImpl::~CSCL1TPParametersImpl() {}
 
@@ -14,23 +11,18 @@ popcon::CSCL1TPParametersImpl::~CSCL1TPParametersImpl() {}
 #include "CondFormats/CSCObjects/interface/CSCL1TPParameters.h"
 
 void popcon::CSCL1TPParametersImpl::getNewObjects() {
-
-  std::cout << "CSCL1TPParametersHandler - time before filling object:"
-            << std::endl;
+  std::cout << "CSCL1TPParametersHandler - time before filling object:" << std::endl;
   std::cout << "------- CSC src - > getNewObjects\n" << m_name;
 
   // fill object from file
-  CSCL1TPParameters *cnl1tp =
-      CSCL1TPParametersConditions::prefillCSCL1TPParameters();
+  CSCL1TPParameters *cnl1tp = CSCL1TPParametersConditions::prefillCSCL1TPParameters();
 
-  std::cout << "CSCL1TPParametersHandler - time after filling object:"
-            << std::endl;
+  std::cout << "CSCL1TPParametersHandler - time after filling object:" << std::endl;
 
   // check whats already inside of database
 
   std::cerr << "got offlineInfo" << std::endl;
-  std::cerr << tagInfo().name << " , last object valid since "
-            << tagInfo().lastInterval.first << std::endl;
+  std::cerr << tagInfo().name << " , last object valid since " << tagInfo().lastInterval.first << std::endl;
 
   unsigned int snc;
 
@@ -39,8 +31,6 @@ void popcon::CSCL1TPParametersImpl::getNewObjects() {
 
   m_to_transfer.push_back(std::make_pair(cnl1tp, snc));
 
-  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n"
-            << std::endl;
-  std::cout << "CSCL1TPParametersHandler - time before writing into DB:"
-            << std::endl;
+  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n" << std::endl;
+  std::cout << "CSCL1TPParametersHandler - time before writing into DB:" << std::endl;
 }

--- a/CalibMuon/CSCCalibration/test/stubs/CSCL1TPParametersHandler.h
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCL1TPParametersHandler.h
@@ -16,18 +16,16 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 namespace popcon {
-class CSCL1TPParametersImpl
-    : public popcon::PopConSourceHandler<CSCL1TPParameters> {
+  class CSCL1TPParametersImpl : public popcon::PopConSourceHandler<CSCL1TPParameters> {
+  public:
+    void getNewObjects();
+    std::string id() const { return m_name; }
+    ~CSCL1TPParametersImpl();
 
-public:
-  void getNewObjects();
-  std::string id() const { return m_name; }
-  ~CSCL1TPParametersImpl();
+    CSCL1TPParametersImpl(const edm::ParameterSet &pset);
 
-  CSCL1TPParametersImpl(const edm::ParameterSet &pset);
-
-private:
-  std::string m_name;
-};
-} // namespace popcon
+  private:
+    std::string m_name;
+  };
+}  // namespace popcon
 #endif

--- a/CalibMuon/CSCCalibration/test/stubs/CSCL1TPParametersPopConAnalyzer.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCL1TPParametersPopConAnalyzer.cc
@@ -2,7 +2,6 @@
 #include "CondCore/PopCon/interface/PopConAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef popcon::PopConAnalyzer<popcon::CSCL1TPParametersImpl>
-    CSCL1TPParametersPopConAnalyzer;
+typedef popcon::PopConAnalyzer<popcon::CSCL1TPParametersImpl> CSCL1TPParametersPopConAnalyzer;
 
 DEFINE_FWK_MODULE(CSCL1TPParametersPopConAnalyzer);

--- a/CalibMuon/CSCCalibration/test/stubs/CSCMapperTestPostls1.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCMapperTestPostls1.cc
@@ -27,39 +27,33 @@ CSCMapperTestPostls1::CSCMapperTestPostls1(const edm::ParameterSet &pset) {}
 
 CSCMapperTestPostls1::~CSCMapperTestPostls1() {}
 
-void CSCMapperTestPostls1::analyze(const edm::Event &ev,
-                                   const edm::EventSetup &esu) {
-  const int egeo[] = {1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2}; // endcap 1=+z, 2=-z
-  const int sgeo[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // station 1-4
-  const int rgeo[] = {1, 1, 1, 4, 4, 4, 1, 1, 1, 4, 4, 4}; // ring 1-4
-  const int cgeo[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // chamber 1-18/36
-  const int lgeo[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // layer 1-6
-  const int tgeo[] = {1, 32, 64, 1, 24, 48,
-                      1, 32, 64, 1, 24, 48}; // strip 1-80 (16, 48 64)
+void CSCMapperTestPostls1::analyze(const edm::Event &ev, const edm::EventSetup &esu) {
+  const int egeo[] = {1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2};          // endcap 1=+z, 2=-z
+  const int sgeo[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};          // station 1-4
+  const int rgeo[] = {1, 1, 1, 4, 4, 4, 1, 1, 1, 4, 4, 4};          // ring 1-4
+  const int cgeo[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};          // chamber 1-18/36
+  const int lgeo[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};          // layer 1-6
+  const int tgeo[] = {1, 32, 64, 1, 24, 48, 1, 32, 64, 1, 24, 48};  // strip 1-80 (16, 48 64)
 
-  const int eraw[] = {1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2}; // endcap 1=+z, 2=-z
-  const int sraw[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // station 1-4
-  const int rraw[] = {1, 1, 1, 4, 4, 4, 1, 1, 1, 4, 4, 4}; // ring 1-4
-  const int craw[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // chamber 1-18/36
-  const int lraw[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // layer 1-6
-  const int traw[] = {1, 32, 64, 1, 24, 48,
-                      1, 32, 64, 1, 24, 48}; // strip 1-80 (16, 48 64)
+  const int eraw[] = {1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2};          // endcap 1=+z, 2=-z
+  const int sraw[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};          // station 1-4
+  const int rraw[] = {1, 1, 1, 4, 4, 4, 1, 1, 1, 4, 4, 4};          // ring 1-4
+  const int craw[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};          // chamber 1-18/36
+  const int lraw[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};          // layer 1-6
+  const int traw[] = {1, 32, 64, 1, 24, 48, 1, 32, 64, 1, 24, 48};  // strip 1-80 (16, 48 64)
 
-  const int estrip[] = {1, 1, 1, 1, 1, 1,
-                        2, 2, 2, 2, 2, 2}; // endcap 1=+z, 2=-z
-  const int sstrip[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // station 1-4
-  const int rstrip[] = {1, 1, 1, 4, 4, 4, 1, 1, 1, 4, 4, 4}; // ring 1-4
-  const int cstrip[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // chamber 1-18/36
-  const int lstrip[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // layer 1-6
-  const int tstrip[] = {1, 32, 64, 1, 24, 48,
-                        1, 32, 64, 1, 24, 48}; // strip 1-80 (16, 48 64)
+  const int estrip[] = {1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2};          // endcap 1=+z, 2=-z
+  const int sstrip[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};          // station 1-4
+  const int rstrip[] = {1, 1, 1, 4, 4, 4, 1, 1, 1, 4, 4, 4};          // ring 1-4
+  const int cstrip[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};          // chamber 1-18/36
+  const int lstrip[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};          // layer 1-6
+  const int tstrip[] = {1, 32, 64, 1, 24, 48, 1, 32, 64, 1, 24, 48};  // strip 1-80 (16, 48 64)
 
-  const int edetid[] = {1, 1, 1, 1, 1, 1,
-                        2, 2, 2, 2, 2, 2}; // endcap 1=+z, 2=-z
-  const int sdetid[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // station 1-4
-  const int rdetid[] = {1, 1, 1, 4, 4, 4, 1, 1, 1, 4, 4, 4}; // ring 1-4
-  const int cdetid[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // chamber 1-18/36
-  const int ldetid[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // layer 1-6
+  const int edetid[] = {1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2};  // endcap 1=+z, 2=-z
+  const int sdetid[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};  // station 1-4
+  const int rdetid[] = {1, 1, 1, 4, 4, 4, 1, 1, 1, 4, 4, 4};  // ring 1-4
+  const int cdetid[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};  // chamber 1-18/36
+  const int ldetid[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};  // layer 1-6
 
   const CSCChannelMapperRecord &irec = esu.get<CSCChannelMapperRecord>();
   edm::ESHandle<CSCChannelMapperBase> mapper_;
@@ -67,8 +61,7 @@ void CSCMapperTestPostls1::analyze(const edm::Event &ev,
 
   algoName = mapper_->name();
 
-  std::cout << "CSCMapperTestPostls1: analyze sees algorithm " << algoName
-            << " in Event Setup" << std::endl;
+  std::cout << "CSCMapperTestPostls1: analyze sees algorithm " << algoName << " in Event Setup" << std::endl;
 
   size_t isiz = 12;
 
@@ -88,9 +81,8 @@ void CSCMapperTestPostls1::analyze(const edm::Event &ev,
     CSCDetId id(ie, is, ir, ic, il);
     int iraw = mapper_->rawStripChannel(id, igeo);
 
-    std::cout << std::setw(2) << ie << std::setw(4) << is << std::setw(4) << ir
-              << std::setw(4) << ic << std::setw(4) << il << std::setw(7)
-              << igeo << std::setw(7) << iraw << std::endl;
+    std::cout << std::setw(2) << ie << std::setw(4) << is << std::setw(4) << ir << std::setw(4) << ic << std::setw(4)
+              << il << std::setw(7) << igeo << std::setw(7) << iraw << std::endl;
   }
 
   std::cout << "\n" << algoName << "::geomStripChannel for:" << std::endl;
@@ -109,9 +101,8 @@ void CSCMapperTestPostls1::analyze(const edm::Event &ev,
     CSCDetId id(ie, is, ir, ic, il);
     int iraw = mapper_->geomStripChannel(id, igeo);
 
-    std::cout << std::setw(2) << ie << std::setw(4) << is << std::setw(4) << ir
-              << std::setw(4) << ic << std::setw(4) << il << std::setw(7)
-              << igeo << std::setw(7) << iraw << std::endl;
+    std::cout << std::setw(2) << ie << std::setw(4) << is << std::setw(4) << ir << std::setw(4) << ic << std::setw(4)
+              << il << std::setw(7) << igeo << std::setw(7) << iraw << std::endl;
   }
 
   std::cout << "\n" << algoName << "::channelFromStrip for:" << std::endl;
@@ -129,9 +120,8 @@ void CSCMapperTestPostls1::analyze(const edm::Event &ev,
     CSCDetId id(ie, is, ir, ic, il);
     int ichan = mapper_->channelFromStrip(id, istrip);
 
-    std::cout << std::setw(2) << ie << std::setw(4) << is << std::setw(4) << ir
-              << std::setw(4) << ic << std::setw(4) << il << std::setw(7)
-              << istrip << std::setw(7) << ichan << std::endl;
+    std::cout << std::setw(2) << ie << std::setw(4) << is << std::setw(4) << ir << std::setw(4) << ic << std::setw(4)
+              << il << std::setw(7) << istrip << std::setw(7) << ichan << std::endl;
   }
 
   std::cout << "\n" << algoName << "::rawCSCDetId for:" << std::endl;

--- a/CalibMuon/CSCCalibration/test/stubs/CSCMapperTestStartup.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCMapperTestStartup.cc
@@ -27,39 +27,33 @@ CSCMapperTestStartup::CSCMapperTestStartup(const edm::ParameterSet &pset) {}
 
 CSCMapperTestStartup::~CSCMapperTestStartup() {}
 
-void CSCMapperTestStartup::analyze(const edm::Event &ev,
-                                   const edm::EventSetup &esu) {
-  const int egeo[] = {1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2}; // endcap 1=+z, 2=-z
-  const int sgeo[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // station 1-4
-  const int rgeo[] = {1, 1, 1, 4, 4, 4, 1, 1, 1, 4, 4, 4}; // ring 1-4
-  const int cgeo[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // chamber 1-18/36
-  const int lgeo[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // layer 1-6
-  const int tgeo[] = {1, 32, 64, 1, 8, 16,
-                      1, 32, 64, 1, 8, 16}; // strip 1-80 (16, 48 64)
+void CSCMapperTestStartup::analyze(const edm::Event &ev, const edm::EventSetup &esu) {
+  const int egeo[] = {1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2};        // endcap 1=+z, 2=-z
+  const int sgeo[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};        // station 1-4
+  const int rgeo[] = {1, 1, 1, 4, 4, 4, 1, 1, 1, 4, 4, 4};        // ring 1-4
+  const int cgeo[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};        // chamber 1-18/36
+  const int lgeo[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};        // layer 1-6
+  const int tgeo[] = {1, 32, 64, 1, 8, 16, 1, 32, 64, 1, 8, 16};  // strip 1-80 (16, 48 64)
 
-  const int eraw[] = {1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2}; // endcap 1=+z, 2=-z
-  const int sraw[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // station 1-4
-  const int rraw[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // ring 1-3
-  const int craw[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // chamber 1-18/36
-  const int lraw[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // layer 1-6
-  const int traw[] = {1, 32, 64, 65, 72, 80,
-                      1, 32, 64, 65, 72, 80}; // strip 1-80 (16, 48 64)
+  const int eraw[] = {1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2};            // endcap 1=+z, 2=-z
+  const int sraw[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};            // station 1-4
+  const int rraw[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};            // ring 1-3
+  const int craw[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};            // chamber 1-18/36
+  const int lraw[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};            // layer 1-6
+  const int traw[] = {1, 32, 64, 65, 72, 80, 1, 32, 64, 65, 72, 80};  // strip 1-80 (16, 48 64)
 
-  const int estrip[] = {1, 1, 1, 1, 1, 1,
-                        2, 2, 2, 2, 2, 2}; // endcap 1=+z, 2=-z
-  const int sstrip[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // station 1-4
-  const int rstrip[] = {1, 1, 1, 4, 4, 4, 1, 1, 1, 4, 4, 4}; // ring 1-3
-  const int cstrip[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // chamber 1-18/36
-  const int lstrip[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // layer 1-6
-  const int tstrip[] = {1, 32, 64, 65, 72, 80,
-                        1, 32, 64, 65, 72, 80}; // strip 1-80 (16, 48 64)
+  const int estrip[] = {1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2};            // endcap 1=+z, 2=-z
+  const int sstrip[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};            // station 1-4
+  const int rstrip[] = {1, 1, 1, 4, 4, 4, 1, 1, 1, 4, 4, 4};            // ring 1-3
+  const int cstrip[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};            // chamber 1-18/36
+  const int lstrip[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};            // layer 1-6
+  const int tstrip[] = {1, 32, 64, 65, 72, 80, 1, 32, 64, 65, 72, 80};  // strip 1-80 (16, 48 64)
 
-  const int edetid[] = {1, 1, 1, 1, 1, 1,
-                        2, 2, 2, 2, 2, 2}; // endcap 1=+z, 2=-z
-  const int sdetid[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // station 1-4
-  const int rdetid[] = {1, 1, 1, 4, 4, 4, 1, 1, 1, 4, 4, 4}; // ring 1-3
-  const int cdetid[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // chamber 1-18/36
-  const int ldetid[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}; // layer 1-6
+  const int edetid[] = {1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2};  // endcap 1=+z, 2=-z
+  const int sdetid[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};  // station 1-4
+  const int rdetid[] = {1, 1, 1, 4, 4, 4, 1, 1, 1, 4, 4, 4};  // ring 1-3
+  const int cdetid[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};  // chamber 1-18/36
+  const int ldetid[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};  // layer 1-6
 
   const CSCChannelMapperRecord &irec = esu.get<CSCChannelMapperRecord>();
   edm::ESHandle<CSCChannelMapperBase> mapper_;
@@ -67,8 +61,7 @@ void CSCMapperTestStartup::analyze(const edm::Event &ev,
 
   algoName = mapper_->name();
 
-  std::cout << "CSCMapperTestStartup: analyze sees algorithm " << algoName
-            << " in Event Setup" << std::endl;
+  std::cout << "CSCMapperTestStartup: analyze sees algorithm " << algoName << " in Event Setup" << std::endl;
 
   size_t isiz = 12;
 
@@ -88,9 +81,8 @@ void CSCMapperTestStartup::analyze(const edm::Event &ev,
     CSCDetId id(ie, is, ir, ic, il);
     int iraw = mapper_->rawStripChannel(id, igeo);
 
-    std::cout << std::setw(2) << ie << std::setw(4) << is << std::setw(4) << ir
-              << std::setw(4) << ic << std::setw(4) << il << std::setw(7)
-              << igeo << std::setw(7) << iraw << std::endl;
+    std::cout << std::setw(2) << ie << std::setw(4) << is << std::setw(4) << ir << std::setw(4) << ic << std::setw(4)
+              << il << std::setw(7) << igeo << std::setw(7) << iraw << std::endl;
   }
 
   std::cout << "\n" << algoName << "::geomStripChannel for:" << std::endl;
@@ -109,9 +101,8 @@ void CSCMapperTestStartup::analyze(const edm::Event &ev,
     CSCDetId id(ie, is, ir, ic, il);
     int iraw = mapper_->geomStripChannel(id, igeo);
 
-    std::cout << std::setw(2) << ie << std::setw(4) << is << std::setw(4) << ir
-              << std::setw(4) << ic << std::setw(4) << il << std::setw(7)
-              << igeo << std::setw(7) << iraw << std::endl;
+    std::cout << std::setw(2) << ie << std::setw(4) << is << std::setw(4) << ir << std::setw(4) << ic << std::setw(4)
+              << il << std::setw(7) << igeo << std::setw(7) << iraw << std::endl;
   }
 
   std::cout << "\n" << algoName << "::channelFromStrip for:" << std::endl;
@@ -129,9 +120,8 @@ void CSCMapperTestStartup::analyze(const edm::Event &ev,
     CSCDetId id(ie, is, ir, ic, il);
     int ichan = mapper_->channelFromStrip(id, istrip);
 
-    std::cout << std::setw(2) << ie << std::setw(4) << is << std::setw(4) << ir
-              << std::setw(4) << ic << std::setw(4) << il << std::setw(7)
-              << istrip << std::setw(7) << ichan << std::endl;
+    std::cout << std::setw(2) << ie << std::setw(4) << is << std::setw(4) << ir << std::setw(4) << ic << std::setw(4)
+              << il << std::setw(7) << istrip << std::setw(7) << ichan << std::endl;
   }
 
   std::cout << "\n" << algoName << "::rawCSCDetId for:" << std::endl;

--- a/CalibMuon/CSCCalibration/test/stubs/CSCNoiseMatrixHandler.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCNoiseMatrixHandler.cc
@@ -5,32 +5,25 @@
 #include "CalibMuon/CSCCalibration/interface/CSCNoiseMatrixDBConditions.h"
 #include "CondFormats/CSCObjects/interface/CSCDBNoiseMatrix.h"
 
-popcon::CSCDBNoiseMatrixImpl::CSCDBNoiseMatrixImpl(
-    const edm::ParameterSet &pset)
-    : m_name(pset.getUntrackedParameter<std::string>("name",
-                                                     "CSCDBNoiseMatrixImpl")) {}
+popcon::CSCDBNoiseMatrixImpl::CSCDBNoiseMatrixImpl(const edm::ParameterSet &pset)
+    : m_name(pset.getUntrackedParameter<std::string>("name", "CSCDBNoiseMatrixImpl")) {}
 
 popcon::CSCDBNoiseMatrixImpl::~CSCDBNoiseMatrixImpl() {}
 
 void popcon::CSCDBNoiseMatrixImpl::getNewObjects() {
-
-  std::cout << "CSCNoiseMatrixHandler - time before filling object:"
-            << std::endl;
+  std::cout << "CSCNoiseMatrixHandler - time before filling object:" << std::endl;
   std::cout << "------- CSC src - > getNewObjects\n" << m_name;
 
   // fill object from file
-  CSCDBNoiseMatrix *cndbmatrix =
-      CSCNoiseMatrixDBConditions::prefillDBNoiseMatrix();
+  CSCDBNoiseMatrix *cndbmatrix = CSCNoiseMatrixDBConditions::prefillDBNoiseMatrix();
   // std::cout << "crosstalk size " << cndbmatrix->matrix.size() << std::endl;
 
-  std::cout << "CSCNoiseMatrixHandler - time after filling object:"
-            << std::endl;
+  std::cout << "CSCNoiseMatrixHandler - time after filling object:" << std::endl;
 
   // check whats already inside of database
 
   std::cerr << "got offlineInfo" << std::endl;
-  std::cerr << tagInfo().name << " , last object valid since "
-            << tagInfo().lastInterval.first << std::endl;
+  std::cerr << tagInfo().name << " , last object valid since " << tagInfo().lastInterval.first << std::endl;
 
   unsigned int snc;
 
@@ -39,8 +32,6 @@ void popcon::CSCDBNoiseMatrixImpl::getNewObjects() {
 
   m_to_transfer.push_back(std::make_pair(cndbmatrix, snc));
 
-  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n"
-            << std::endl;
-  std::cout << "CSCNoiseMatrixHandler - time before writing into DB:"
-            << std::endl;
+  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n" << std::endl;
+  std::cout << "CSCNoiseMatrixHandler - time before writing into DB:" << std::endl;
 }

--- a/CalibMuon/CSCCalibration/test/stubs/CSCNoiseMatrixHandler.h
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCNoiseMatrixHandler.h
@@ -16,17 +16,15 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 namespace popcon {
-class CSCDBNoiseMatrixImpl
-    : public popcon::PopConSourceHandler<CSCDBNoiseMatrix> {
+  class CSCDBNoiseMatrixImpl : public popcon::PopConSourceHandler<CSCDBNoiseMatrix> {
+  public:
+    void getNewObjects();
+    std::string id() const { return m_name; }
+    ~CSCDBNoiseMatrixImpl();
+    CSCDBNoiseMatrixImpl(const edm::ParameterSet &pset);
 
-public:
-  void getNewObjects();
-  std::string id() const { return m_name; }
-  ~CSCDBNoiseMatrixImpl();
-  CSCDBNoiseMatrixImpl(const edm::ParameterSet &pset);
-
-private:
-  std::string m_name;
-};
-} // namespace popcon
+  private:
+    std::string m_name;
+  };
+}  // namespace popcon
 #endif

--- a/CalibMuon/CSCCalibration/test/stubs/CSCNoiseMatrixPopConAnalyzer.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCNoiseMatrixPopConAnalyzer.cc
@@ -2,7 +2,6 @@
 #include "CondCore/PopCon/interface/PopConAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef popcon::PopConAnalyzer<popcon::CSCDBNoiseMatrixImpl>
-    CSCNoiseMatrixPopConAnalyzer;
+typedef popcon::PopConAnalyzer<popcon::CSCDBNoiseMatrixImpl> CSCNoiseMatrixPopConAnalyzer;
 
 DEFINE_FWK_MODULE(CSCNoiseMatrixPopConAnalyzer);

--- a/CalibMuon/CSCCalibration/test/stubs/CSCPedestalsHandler.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCPedestalsHandler.cc
@@ -6,13 +6,11 @@
 #include "CondFormats/CSCObjects/interface/CSCDBPedestals.h"
 
 popcon::CSCDBPedestalsImpl::CSCDBPedestalsImpl(const edm::ParameterSet &pset)
-    : m_name(pset.getUntrackedParameter<std::string>("name",
-                                                     "CSCDBPedestalsImpl")) {}
+    : m_name(pset.getUntrackedParameter<std::string>("name", "CSCDBPedestalsImpl")) {}
 
 popcon::CSCDBPedestalsImpl::~CSCDBPedestalsImpl() {}
 
 void popcon::CSCDBPedestalsImpl::getNewObjects() {
-
   std::cout << "CSCPedestalsHandler - time before filling object:" << std::endl;
   std::cout << "------- CSC src - > getNewObjects\n" << m_name;
 
@@ -26,8 +24,7 @@ void popcon::CSCDBPedestalsImpl::getNewObjects() {
   // check whats already inside of database
 
   std::cerr << "got offlineInfo" << std::endl;
-  std::cerr << tagInfo().name << " , last object valid since "
-            << tagInfo().lastInterval.first << std::endl;
+  std::cerr << tagInfo().name << " , last object valid since " << tagInfo().lastInterval.first << std::endl;
 
   unsigned int snc;
   std::cout << "Source implementation test ::getNewObjects : enter since ? \n";
@@ -36,8 +33,6 @@ void popcon::CSCDBPedestalsImpl::getNewObjects() {
 
   m_to_transfer.push_back(std::make_pair(cnpedestals, snc));
 
-  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n"
-            << std::endl;
-  std::cout << "CSCPedestalsHandler - time before writing into DB:"
-            << std::endl;
+  std::cout << "------- " << m_name << "CSC src - > getNewObjects -----------\n" << std::endl;
+  std::cout << "CSCPedestalsHandler - time before writing into DB:" << std::endl;
 }

--- a/CalibMuon/CSCCalibration/test/stubs/CSCPedestalsHandler.h
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCPedestalsHandler.h
@@ -16,16 +16,15 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 namespace popcon {
-class CSCDBPedestalsImpl : public popcon::PopConSourceHandler<CSCDBPedestals> {
+  class CSCDBPedestalsImpl : public popcon::PopConSourceHandler<CSCDBPedestals> {
+  public:
+    void getNewObjects();
+    std::string id() const { return m_name; }
+    ~CSCDBPedestalsImpl();
+    CSCDBPedestalsImpl(const edm::ParameterSet &pset);
 
-public:
-  void getNewObjects();
-  std::string id() const { return m_name; }
-  ~CSCDBPedestalsImpl();
-  CSCDBPedestalsImpl(const edm::ParameterSet &pset);
-
-private:
-  std::string m_name;
-};
-} // namespace popcon
+  private:
+    std::string m_name;
+  };
+}  // namespace popcon
 #endif

--- a/CalibMuon/CSCCalibration/test/stubs/CSCPedestalsPopConAnalyzer.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCPedestalsPopConAnalyzer.cc
@@ -2,7 +2,6 @@
 #include "CondCore/PopCon/interface/PopConAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef popcon::PopConAnalyzer<popcon::CSCDBPedestalsImpl>
-    CSCPedestalsPopConAnalyzer;
+typedef popcon::PopConAnalyzer<popcon::CSCDBPedestalsImpl> CSCPedestalsPopConAnalyzer;
 
 DEFINE_FWK_MODULE(CSCPedestalsPopConAnalyzer);

--- a/CalibMuon/CSCCalibration/test/stubs/Compare.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/Compare.cc
@@ -169,8 +169,7 @@ Compare::Compare(const edm::ParameterSet &iConfig)
   }
 
   while (!olddata1.eof()) {
-    olddata1 >> old_index >> old_xtalk_left >> old_int_left >>
-        old_xtalk_right >> old_int_right;
+    olddata1 >> old_index >> old_xtalk_left >> old_int_left >> old_xtalk_right >> old_int_right;
     old_index_id.push_back(old_index);
     old_Rxtalk.push_back(old_xtalk_right);
     old_Rint.push_back(old_int_right);
@@ -189,8 +188,7 @@ Compare::Compare(const edm::ParameterSet &iConfig)
   }
 
   while (!newdata1.eof()) {
-    newdata1 >> new_index >> new_xtalk_left >> new_int_left >>
-        new_xtalk_right >> new_int_right;
+    newdata1 >> new_index >> new_xtalk_left >> new_int_left >> new_xtalk_right >> new_int_right;
     new_index_id.push_back(new_index);
     new_Rxtalk.push_back(new_xtalk_right);
     new_Rint.push_back(new_int_right);
@@ -222,9 +220,8 @@ Compare::Compare(const edm::ParameterSet &iConfig)
         diffXtalkL[k] = old_Lxtalk[i] / 10000000. - new_Lxtalk[k];
         diffIntR[k] = old_Rint[i] / 100000. - new_Rint[k];
         diffIntL[k] = old_Rint[i] / 100000. - new_Rint[k];
-        myXtalkFile << counter << "  " << diffXtalkL[k] << "  " << diffIntL[k]
-                    << "  " << diffXtalkR[k] << "  " << diffIntR[k] << "  "
-                    << std::endl;
+        myXtalkFile << counter << "  " << diffXtalkL[k] << "  " << diffIntL[k] << "  " << diffXtalkR[k] << "  "
+                    << diffIntR[k] << "  " << std::endl;
       }
     }
   }
@@ -305,8 +302,7 @@ Compare::Compare(const edm::ParameterSet &iConfig)
   std::cout << "Comparing NOISE MATRIX, please wait!" << std::endl;
 
   old_index = 0;
-  float old_elem33, old_elem34, old_elem35, old_elem44, old_elem45, old_elem46,
-      old_elem55, old_elem56;
+  float old_elem33, old_elem34, old_elem35, old_elem44, old_elem45, old_elem46, old_elem55, old_elem56;
   float old_elem57, old_elem66, old_elem67, old_elem77;
   old_index_id.clear();
   std::vector<float> old_el33;
@@ -323,8 +319,7 @@ Compare::Compare(const edm::ParameterSet &iConfig)
   std::vector<float> old_el77;
 
   new_index = 0;
-  float new_elem33, new_elem34, new_elem35, new_elem44, new_elem45, new_elem46,
-      new_elem55, new_elem56;
+  float new_elem33, new_elem34, new_elem35, new_elem44, new_elem45, new_elem46, new_elem55, new_elem56;
   float new_elem57, new_elem66, new_elem67, new_elem77;
   new_index_id.clear();
   std::vector<float> new_el33;
@@ -381,9 +376,8 @@ Compare::Compare(const edm::ParameterSet &iConfig)
   }
 
   while (!olddata3.eof()) {
-    olddata3 >> old_index >> old_elem33 >> old_elem34 >> old_elem44 >>
-        old_elem35 >> old_elem45 >> old_elem55 >> old_elem46 >> old_elem56 >>
-        old_elem66 >> old_elem57 >> old_elem67 >> old_elem77;
+    olddata3 >> old_index >> old_elem33 >> old_elem34 >> old_elem44 >> old_elem35 >> old_elem45 >> old_elem55 >>
+        old_elem46 >> old_elem56 >> old_elem66 >> old_elem57 >> old_elem67 >> old_elem77;
     old_index_id.push_back(old_index);
     old_el33.push_back(old_elem33);
     old_el34.push_back(old_elem34);
@@ -410,9 +404,8 @@ Compare::Compare(const edm::ParameterSet &iConfig)
   }
 
   while (!newdata3.eof()) {
-    newdata3 >> new_index >> new_elem33 >> new_elem34 >> new_elem44 >>
-        new_elem35 >> new_elem45 >> new_elem55 >> new_elem46 >> new_elem56 >>
-        new_elem66 >> new_elem57 >> new_elem67 >> new_elem77;
+    newdata3 >> new_index >> new_elem33 >> new_elem34 >> new_elem44 >> new_elem35 >> new_elem45 >> new_elem55 >>
+        new_elem46 >> new_elem56 >> new_elem66 >> new_elem57 >> new_elem67 >> new_elem77;
     new_index_id.push_back(new_index);
     new_el33.push_back(new_elem33);
     new_el34.push_back(new_elem34);
@@ -487,13 +480,10 @@ Compare::Compare(const edm::ParameterSet &iConfig)
         diff_el66[k] = old_el66[i] / 1000. - new_el66[k];
         diff_el67[k] = old_el67[i] / 1000. - new_el67[k];
         diff_el77[k] = old_el77[i] / 1000. - new_el77[k];
-        myMatrixFile << counter << "  " << diff_el33[k] << "  " << diff_el34[k]
-                     << "  " << diff_el35[k] << "  " << diff_el44[k] << "  "
-                     << diff_el45[k] << "  " << diff_el46[k] << "  "
-                     << diff_el55[k] << "  " << diff_el56[k] << "  "
-                     << diff_el57[k] << "  " << diff_el66[k] << "  "
-                     << diff_el67[k] << "  " << diff_el77[k] << "  "
-                     << std::endl;
+        myMatrixFile << counter << "  " << diff_el33[k] << "  " << diff_el34[k] << "  " << diff_el35[k] << "  "
+                     << diff_el44[k] << "  " << diff_el45[k] << "  " << diff_el46[k] << "  " << diff_el55[k] << "  "
+                     << diff_el56[k] << "  " << diff_el57[k] << "  " << diff_el66[k] << "  " << diff_el67[k] << "  "
+                     << diff_el77[k] << "  " << std::endl;
       }
     }
   }
@@ -501,7 +491,6 @@ Compare::Compare(const edm::ParameterSet &iConfig)
 }
 
 Compare::~Compare() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }

--- a/CalibMuon/CSCCalibration/test/testCSCIndexer.cc
+++ b/CalibMuon/CSCCalibration/test/testCSCIndexer.cc
@@ -49,30 +49,21 @@ public:
   virtual IndexType gasGainIndex(int hvseg, int chit, CSCDetId &id) = 0;
 };
 
-template <class INDEXER> class IndexerAdapter : public IndexerAdapterBase {
+template <class INDEXER>
+class IndexerAdapter : public IndexerAdapterBase {
   INDEXER indexer;
 
 public:
   int ringsInStation(int s) { return indexer.ringsInStation(s); }
-  int chambersInRingOfStation(int s, int r) {
-    return indexer.chambersInRingOfStation(s, r);
-  }
-  int stripChannelsPerLayer(int s, int r) {
-    return indexer.stripChannelsPerLayer(s, r);
-  }
+  int chambersInRingOfStation(int s, int r) { return indexer.chambersInRingOfStation(s, r); }
+  int stripChannelsPerLayer(int s, int r) { return indexer.stripChannelsPerLayer(s, r); }
   int chipsPerLayer(int s, int r) { return indexer.chipsPerLayer(s, r); }
   int sectorsPerLayer(int s, int r) { return indexer.sectorsPerLayer(s, r); }
   int chamberIndex(CSCDetId &id) { return indexer.chamberIndex(id); }
   IndexType layerIndex(CSCDetId &id) { return indexer.layerIndex(id); }
-  LongIndexType stripChannelIndex(CSCDetId &id, int strip) {
-    return indexer.stripChannelIndex(id, strip);
-  }
-  IndexType chipIndex(CSCDetId &id, int chip) {
-    return indexer.chipIndex(id, chip);
-  }
-  IndexType gasGainIndex(int hvseg, int chip, CSCDetId &id) {
-    return indexer.gasGainIndex(hvseg, chip, id);
-  }
+  LongIndexType stripChannelIndex(CSCDetId &id, int strip) { return indexer.stripChannelIndex(id, strip); }
+  IndexType chipIndex(CSCDetId &id, int chip) { return indexer.chipIndex(id, chip); }
+  IndexType gasGainIndex(int hvseg, int chip, CSCDetId &id) { return indexer.gasGainIndex(hvseg, chip, id); }
 };
 
 class testCSCIndexer : public CppUnit::TestFixture {
@@ -223,9 +214,9 @@ void testCSCIndexer::testChamber() {
     IndexType ii = indexer_->chamberIndex(id);
 
     if (i != ii)
-      cout << " BAD CHAMBER INDEX: " << i << " != " << ii << " \t   (" << ie
-           << " " << is << " " << ir << " " << ic << ")" << endl;
-    CPPUNIT_ASSERT(i == ii); // loop-back index test
+      cout << " BAD CHAMBER INDEX: " << i << " != " << ii << " \t   (" << ie << " " << is << " " << ir << " " << ic
+           << ")" << endl;
+    CPPUNIT_ASSERT(i == ii);  // loop-back index test
     CPPUNIT_ASSERT(ie >= 1 && ie <= 2);
     CPPUNIT_ASSERT(is >= 1 && is <= 4);
     CPPUNIT_ASSERT(ir >= 1 && ir <= indexer_->offlineRingsInStation(is));
@@ -246,9 +237,9 @@ void testCSCIndexer::testLayer() {
     IndexType ii = indexer_->layerIndex(id);
 
     if (i != ii)
-      cout << " BAD LAYER INDEX: " << i << " != " << ii << " \t   (" << ie
-           << " " << is << " " << ir << " " << ic << " " << il << ")" << endl;
-    CPPUNIT_ASSERT(i == ii); // loop-back index test
+      cout << " BAD LAYER INDEX: " << i << " != " << ii << " \t   (" << ie << " " << is << " " << ir << " " << ic << " "
+           << il << ")" << endl;
+    CPPUNIT_ASSERT(i == ii);  // loop-back index test
     CPPUNIT_ASSERT(ie >= 1 && ie <= 2);
     CPPUNIT_ASSERT(is >= 1 && is <= 4);
     CPPUNIT_ASSERT(ir >= 1 && ir <= indexer_->offlineRingsInStation(is));
@@ -262,8 +253,7 @@ void testCSCIndexer::testStripChannel() {
   // std::endl;
 
   for (LongIndexType i = 1; i <= indexer_->maxStripChannelIndex(); ++i) {
-    std::pair<CSCDetId, CSCIndexerBase::IndexType> t =
-        indexer_->detIdFromStripChannelIndex(i);
+    std::pair<CSCDetId, CSCIndexerBase::IndexType> t = indexer_->detIdFromStripChannelIndex(i);
     CSCDetId id = t.first;
     int ie = id.endcap();
     int is = id.station();
@@ -274,10 +264,9 @@ void testCSCIndexer::testStripChannel() {
     LongIndexType ii = indexer_->stripChannelIndex(id, st);
 
     if (i != ii)
-      cout << " BAD STRIPCHANNEL INDEX: " << i << " != " << ii << " \t   ("
-           << ie << " " << is << " " << ir << " " << ic << " " << il << ") "
-           << st << endl;
-    CPPUNIT_ASSERT(i == ii); // loop-back index test
+      cout << " BAD STRIPCHANNEL INDEX: " << i << " != " << ii << " \t   (" << ie << " " << is << " " << ir << " " << ic
+           << " " << il << ") " << st << endl;
+    CPPUNIT_ASSERT(i == ii);  // loop-back index test
     CPPUNIT_ASSERT(ie >= 1 && ie <= 2);
     CPPUNIT_ASSERT(is >= 1 && is <= 4);
     CPPUNIT_ASSERT(ir >= 1 && ir <= indexer_->offlineRingsInStation(is));
@@ -302,9 +291,9 @@ void testCSCIndexer::testChip() {
     IndexType ii = indexer_->chipIndex(id, ch);
 
     if (i != ii)
-      cout << " BAD CHIP INDEX: " << i << " != " << ii << " \t   (" << ie << " "
-           << is << " " << ir << " " << ic << " " << il << ") " << ch << endl;
-    CPPUNIT_ASSERT(i == ii); // loop-back index test
+      cout << " BAD CHIP INDEX: " << i << " != " << ii << " \t   (" << ie << " " << is << " " << ir << " " << ic << " "
+           << il << ") " << ch << endl;
+    CPPUNIT_ASSERT(i == ii);  // loop-back index test
     CPPUNIT_ASSERT(ie >= 1 && ie <= 2);
     CPPUNIT_ASSERT(is >= 1 && is <= 4);
     CPPUNIT_ASSERT(ir >= 1 && ir <= indexer_->offlineRingsInStation(is));
@@ -330,10 +319,9 @@ void testCSCIndexer::testGasGain() {
     IndexType ii = indexer_->gasGainIndex(hv, ch, id);
 
     if (i != ii)
-      cout << " BAD GASGAIN INDEX: " << i << " != " << ii << " \t   (" << ie
-           << " " << is << " " << ir << " " << ic << " " << il << ") " << hv
-           << " " << ch << endl;
-    CPPUNIT_ASSERT(i == ii); // loop-back index test
+      cout << " BAD GASGAIN INDEX: " << i << " != " << ii << " \t   (" << ie << " " << is << " " << ir << " " << ic
+           << " " << il << ") " << hv << " " << ch << endl;
+    CPPUNIT_ASSERT(i == ii);  // loop-back index test
     CPPUNIT_ASSERT(ie >= 1 && ie <= 2);
     CPPUNIT_ASSERT(is >= 1 && is <= 4);
     CPPUNIT_ASSERT(ir >= 1 && ir <= indexer_->offlineRingsInStation(is));
@@ -348,16 +336,14 @@ void testCSCIndexer::testStartupChamberME1a() {
   modeStartup();
   const CSCDetId id_me1a(1, 1, 4, 1);
   const CSCDetId id_me1b(1, 1, 1, 1);
-  CPPUNIT_ASSERT(indexer_->chamberIndex(id_me1a) ==
-                 indexer_->chamberIndex(id_me1b));
+  CPPUNIT_ASSERT(indexer_->chamberIndex(id_me1a) == indexer_->chamberIndex(id_me1b));
 }
 
 void testCSCIndexer::testStartupLayerME1a() {
   modeStartup();
   const CSCDetId id_me1a(1, 1, 4, 1, 2);
   const CSCDetId id_me1b(1, 1, 1, 1, 2);
-  CPPUNIT_ASSERT(indexer_->layerIndex(id_me1a) ==
-                 indexer_->layerIndex(id_me1b));
+  CPPUNIT_ASSERT(indexer_->layerIndex(id_me1a) == indexer_->layerIndex(id_me1b));
 }
 
 void testCSCIndexer::testStartupStripChannelME1a() {
@@ -365,8 +351,7 @@ void testCSCIndexer::testStartupStripChannelME1a() {
   const CSCDetId id_me1a(1, 1, 4, 1, 2);
   const CSCDetId id_me1b(1, 1, 1, 1, 2);
   const IndexType istrip = 66;
-  CPPUNIT_ASSERT(indexer_->stripChannelIndex(id_me1a, istrip) ==
-                 indexer_->stripChannelIndex(id_me1b, istrip));
+  CPPUNIT_ASSERT(indexer_->stripChannelIndex(id_me1a, istrip) == indexer_->stripChannelIndex(id_me1b, istrip));
 }
 
 void testCSCIndexer::testStartupChipME1a() {
@@ -374,8 +359,7 @@ void testCSCIndexer::testStartupChipME1a() {
   const CSCDetId id_me1a(1, 1, 4, 1, 2);
   const CSCDetId id_me1b(1, 1, 1, 1, 2);
   const IndexType ichip = 5;
-  CPPUNIT_ASSERT(indexer_->chipIndex(id_me1a, ichip) ==
-                 indexer_->chipIndex(id_me1b, ichip));
+  CPPUNIT_ASSERT(indexer_->chipIndex(id_me1a, ichip) == indexer_->chipIndex(id_me1b, ichip));
 }
 
 void testCSCIndexer::testStartupGasGainME1a() {
@@ -384,8 +368,7 @@ void testCSCIndexer::testStartupGasGainME1a() {
   const CSCDetId id_me1b(1, 1, 1, 1, 2);
   const IndexType istrip = 66;
   const IndexType iwire = 4;
-  CPPUNIT_ASSERT(indexer_->gasGainIndex(id_me1a, istrip, iwire) ==
-                 indexer_->gasGainIndex(id_me1b, istrip, iwire));
+  CPPUNIT_ASSERT(indexer_->gasGainIndex(id_me1a, istrip, iwire) == indexer_->gasGainIndex(id_me1b, istrip, iwire));
 }
 
 void testCSCIndexer::testAgainstOldCode() {
@@ -401,40 +384,32 @@ void testCSCIndexer::testAgainstOldCode() {
         int cmax = indexer_->chambersInRingOfStation(s, r);
         CPPUNIT_ASSERT(cmax == indexer_old_->chambersInRingOfStation(s, r));
 
-        CPPUNIT_ASSERT(indexer_->stripChannelsPerLayer(s, r) ==
-                       indexer_old_->stripChannelsPerLayer(s, r));
+        CPPUNIT_ASSERT(indexer_->stripChannelsPerLayer(s, r) == indexer_old_->stripChannelsPerLayer(s, r));
         int stripmax = indexer_->stripChannelsPerOnlineLayer(s, r);
 
-        CPPUNIT_ASSERT(indexer_->chipsPerLayer(s, r) ==
-                       indexer_old_->chipsPerLayer(s, r));
+        CPPUNIT_ASSERT(indexer_->chipsPerLayer(s, r) == indexer_old_->chipsPerLayer(s, r));
         int chipmax = indexer_->chipsPerOnlineLayer(s, r);
 
-        CPPUNIT_ASSERT(indexer_->sectorsPerLayer(s, r) ==
-                       indexer_old_->sectorsPerLayer(s, r));
+        CPPUNIT_ASSERT(indexer_->sectorsPerLayer(s, r) == indexer_old_->sectorsPerLayer(s, r));
         int hvsegmax = indexer_->sectorsPerOnlineLayer(s, r);
 
         for (int c = 1; c <= cmax; ++c) {
           CSCDetId cid(e, s, r, c);
-          CPPUNIT_ASSERT(indexer_->chamberIndex(cid) ==
-                         indexer_old_->chamberIndex(cid));
+          CPPUNIT_ASSERT(indexer_->chamberIndex(cid) == indexer_old_->chamberIndex(cid));
 
           for (int l = 1; l <= 6; ++l) {
             CSCDetId id(e, s, r, c, l);
-            CPPUNIT_ASSERT(indexer_->layerIndex(id) ==
-                           indexer_old_->layerIndex(id));
+            CPPUNIT_ASSERT(indexer_->layerIndex(id) == indexer_old_->layerIndex(id));
 
             for (int strip = 1; strip <= stripmax; ++strip) {
-              CPPUNIT_ASSERT(indexer_->stripChannelIndex(id, strip) ==
-                             indexer_old_->stripChannelIndex(id, strip));
+              CPPUNIT_ASSERT(indexer_->stripChannelIndex(id, strip) == indexer_old_->stripChannelIndex(id, strip));
             }
 
             for (int chip = 1; chip <= chipmax; ++chip) {
-              CPPUNIT_ASSERT(indexer_->chipIndex(id, chip) ==
-                             indexer_old_->chipIndex(id, chip));
+              CPPUNIT_ASSERT(indexer_->chipIndex(id, chip) == indexer_old_->chipIndex(id, chip));
 
               for (int hvseg = 1; hvseg <= hvsegmax; ++hvseg) {
-                CPPUNIT_ASSERT(indexer_->gasGainIndex(hvseg, chip, id) ==
-                               indexer_old_->gasGainIndex(hvseg, chip, id));
+                CPPUNIT_ASSERT(indexer_->gasGainIndex(hvseg, chip, id) == indexer_old_->gasGainIndex(hvseg, chip, id));
               }
             }
           }

--- a/Calibration/TkAlCaRecoProducers/interface/AlcaBeamSpotFromDB.h
+++ b/Calibration/TkAlCaRecoProducers/interface/AlcaBeamSpotFromDB.h
@@ -20,16 +20,14 @@ ________________________________________________________________**/
 #include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class AlcaBeamSpotFromDB
-    : public edm::one::EDProducer<edm::EndLuminosityBlockProducer> {
+class AlcaBeamSpotFromDB : public edm::one::EDProducer<edm::EndLuminosityBlockProducer> {
 public:
   explicit AlcaBeamSpotFromDB(const edm::ParameterSet &);
   ~AlcaBeamSpotFromDB() override;
 
 private:
   void beginJob() final;
-  void endLuminosityBlockProduce(edm::LuminosityBlock &lumiSeg,
-                                 const edm::EventSetup &iSetup) final;
+  void endLuminosityBlockProduce(edm::LuminosityBlock &lumiSeg, const edm::EventSetup &iSetup) final;
   void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) final;
   void endJob() final;
 };

--- a/Calibration/TkAlCaRecoProducers/interface/AlcaBeamSpotHarvester.h
+++ b/Calibration/TkAlCaRecoProducers/interface/AlcaBeamSpotHarvester.h
@@ -27,10 +27,8 @@ public:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void beginRun(const edm::Run &, const edm::EventSetup &) override;
   void endRun(const edm::Run &, const edm::EventSetup &) override;
-  void beginLuminosityBlock(const edm::LuminosityBlock &,
-                            const edm::EventSetup &) override;
-  void endLuminosityBlock(const edm::LuminosityBlock &,
-                          const edm::EventSetup &) override;
+  void beginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) override;
+  void endLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) override;
 
 protected:
 private:

--- a/Calibration/TkAlCaRecoProducers/interface/AlcaBeamSpotManager.h
+++ b/Calibration/TkAlCaRecoProducers/interface/AlcaBeamSpotManager.h
@@ -24,26 +24,18 @@ public:
   void reset(void);
   void readLumi(const edm::LuminosityBlock &);
   void createWeightedPayloads(void);
-  const std::map<edm::LuminosityBlockNumber_t,
-                 std::pair<edm::Timestamp, reco::BeamSpot>> &
-  getPayloads(void) {
+  const std::map<edm::LuminosityBlockNumber_t, std::pair<edm::Timestamp, reco::BeamSpot>> &getPayloads(void) {
     return beamSpotMap_;
   }
 
-  typedef std::map<edm::LuminosityBlockNumber_t,
-                   std::pair<edm::Timestamp, reco::BeamSpot>>::iterator
-      bsMap_iterator;
+  typedef std::map<edm::LuminosityBlockNumber_t, std::pair<edm::Timestamp, reco::BeamSpot>>::iterator bsMap_iterator;
 
 private:
   reco::BeamSpot weight(const bsMap_iterator &begin, const bsMap_iterator &end);
-  void weight(double &mean, double &meanError, const double &val,
-              const double &valError);
-  std::pair<float, float> delta(const float &x, const float &xError,
-                                const float &nextX, const float &nextXError);
+  void weight(double &mean, double &meanError, const double &val, const double &valError);
+  std::pair<float, float> delta(const float &x, const float &xError, const float &nextX, const float &nextXError);
   float deltaSig(const float &num, const float &den);
-  std::map<edm::LuminosityBlockNumber_t,
-           std::pair<edm::Timestamp, reco::BeamSpot>>
-      beamSpotMap_;
+  std::map<edm::LuminosityBlockNumber_t, std::pair<edm::Timestamp, reco::BeamSpot>> beamSpotMap_;
 
   std::string beamSpotOutputBase_;
   std::string beamSpotModuleName_;

--- a/Calibration/TkAlCaRecoProducers/interface/AlcaBeamSpotProducer.h
+++ b/Calibration/TkAlCaRecoProducers/interface/AlcaBeamSpotProducer.h
@@ -22,26 +22,22 @@ ________________________________________________________________**/
 #include "RecoVertex/BeamSpotProducer/interface/BeamFitter.h"
 
 class AlcaBeamSpotProducer
-    : public edm::one::EDProducer<edm::EndLuminosityBlockProducer,
-                                  edm::one::WatchLuminosityBlocks> {
+    : public edm::one::EDProducer<edm::EndLuminosityBlockProducer, edm::one::WatchLuminosityBlocks> {
 public:
   explicit AlcaBeamSpotProducer(const edm::ParameterSet &);
   ~AlcaBeamSpotProducer() override;
 
 private:
-  void beginLuminosityBlock(edm::LuminosityBlock const &lumiSeg,
-                            const edm::EventSetup &iSetup) final;
-  void endLuminosityBlock(edm::LuminosityBlock const &lumiSeg,
-                          const edm::EventSetup &iSetup) final;
-  void endLuminosityBlockProduce(edm::LuminosityBlock &lumiSeg,
-                                 const edm::EventSetup &iSetup) final;
+  void beginLuminosityBlock(edm::LuminosityBlock const &lumiSeg, const edm::EventSetup &iSetup) final;
+  void endLuminosityBlock(edm::LuminosityBlock const &lumiSeg, const edm::EventSetup &iSetup) final;
+  void endLuminosityBlockProduce(edm::LuminosityBlock &lumiSeg, const edm::EventSetup &iSetup) final;
   void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) final;
 
   int ftotalevents;
   int fitNLumi_;
   int resetFitNLumi_;
-  int countEvt_;  // counter
-  int countLumi_; // counter
+  int countEvt_;   // counter
+  int countLumi_;  // counter
   int ftmprun0, ftmprun;
   int beginLumiOfBSFit_;
   int endLumiOfBSFit_;

--- a/Calibration/TkAlCaRecoProducers/interface/CalibrationTrackSelector.h
+++ b/Calibration/TkAlCaRecoProducers/interface/CalibrationTrackSelector.h
@@ -6,14 +6,13 @@
 #include <vector>
 
 namespace edm {
-class Event;
-class ParameterSet;
-} // namespace edm
+  class Event;
+  class ParameterSet;
+}  // namespace edm
 
 class TrackingRecHit;
 
 class CalibrationTrackSelector {
-
 public:
   typedef std::vector<const reco::Track *> Tracks;
 
@@ -40,9 +39,7 @@ private:
 
   /// compare two tracks in pt (used by theNHighestPtTracks)
   struct ComparePt {
-    bool operator()(const reco::Track *t1, const reco::Track *t2) const {
-      return t1->pt() > t2->pt();
-    }
+    bool operator()(const reco::Track *t1, const reco::Track *t2) const { return t1->pt() > t2->pt(); }
   };
   ComparePt ptComparator;
 
@@ -50,16 +47,14 @@ private:
   const int seedOnlyFromAbove_;
   const bool applyIsolation_, chargeCheck_;
   const int nHighestPt_, minMultiplicity_, maxMultiplicity_;
-  const bool multiplicityOnInput_; /// if true, cut min/maxMultiplicity on input
-                                   /// instead of on final result
-  const double ptMin_, ptMax_, etaMin_, etaMax_, phiMin_, phiMax_, nHitMin_,
-      nHitMax_, chi2nMax_;
+  const bool multiplicityOnInput_;  /// if true, cut min/maxMultiplicity on input
+                                    /// instead of on final result
+  const double ptMin_, ptMax_, etaMin_, etaMax_, phiMin_, phiMax_, nHitMin_, nHitMax_, chi2nMax_;
   const double minHitChargeStrip_, minHitIsolation_;
   const edm::InputTag rphirecHitsTag_;
   const edm::InputTag matchedrecHitsTag_;
   const unsigned int nHitMin2D_;
-  const int minHitsinTIB_, minHitsinTOB_, minHitsinTID_, minHitsinTEC_,
-      minHitsinBPIX_, minHitsinFPIX_;
+  const int minHitsinTIB_, minHitsinTOB_, minHitsinTID_, minHitsinTEC_, minHitsinBPIX_, minHitsinFPIX_;
 };
 
 #endif

--- a/Calibration/TkAlCaRecoProducers/plugins/AlcaBeamSpotFromDB.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/AlcaBeamSpotFromDB.cc
@@ -28,19 +28,16 @@ ________________________________________________________________**/
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 
 AlcaBeamSpotFromDB::AlcaBeamSpotFromDB(const edm::ParameterSet &iConfig) {
-
   produces<reco::BeamSpot, edm::Transition::EndLuminosityBlock>("alcaBeamSpot");
 }
 
 AlcaBeamSpotFromDB::~AlcaBeamSpotFromDB() {}
 
 //--------------------------------------------------------------------------------------------------
-void AlcaBeamSpotFromDB::produce(edm::Event &iEvent,
-                                 const edm::EventSetup &iSetup) {}
+void AlcaBeamSpotFromDB::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {}
 
 //--------------------------------------------------------------------------------------------------
-void AlcaBeamSpotFromDB::endLuminosityBlockProduce(
-    edm::LuminosityBlock &lumiSeg, const edm::EventSetup &iSetup) {
+void AlcaBeamSpotFromDB::endLuminosityBlockProduce(edm::LuminosityBlock &lumiSeg, const edm::EventSetup &iSetup) {
   // read DB object
   edm::ESHandle<BeamSpotObjects> beamhandle;
   iSetup.get<BeamSpotObjectsRcd>().get(beamhandle);
@@ -58,8 +55,8 @@ void AlcaBeamSpotFromDB::endLuminosityBlockProduce(
 
   reco::BeamSpot aSpot;
   // this assume beam width same in x and y
-  aSpot = reco::BeamSpot(apoint, spotDB->GetSigmaZ(), spotDB->Getdxdz(),
-                         spotDB->Getdydz(), spotDB->GetBeamWidthX(), matrix);
+  aSpot = reco::BeamSpot(
+      apoint, spotDB->GetSigmaZ(), spotDB->Getdxdz(), spotDB->Getdydz(), spotDB->GetBeamWidthX(), matrix);
   aSpot.setBeamWidthY(spotDB->GetBeamWidthY());
   aSpot.setEmittanceX(spotDB->GetEmittanceX());
   aSpot.setEmittanceY(spotDB->GetEmittanceY());

--- a/Calibration/TkAlCaRecoProducers/plugins/AlcaBeamSpotHarvester.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/AlcaBeamSpotHarvester.cc
@@ -37,25 +37,18 @@ using namespace reco;
 
 //--------------------------------------------------------------------------------------------------
 AlcaBeamSpotHarvester::AlcaBeamSpotHarvester(const edm::ParameterSet &iConfig)
-    : beamSpotOutputBase_(
-          iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters")
-              .getUntrackedParameter<std::string>("BeamSpotOutputBase")),
-      outputrecordName_(
-          iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters")
-              .getUntrackedParameter<std::string>("outputRecordName",
-                                                  "BeamSpotObjectsRcd")),
-      sigmaZValue_(
-          iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters")
-              .getUntrackedParameter<double>("SigmaZValue")),
-      sigmaZCut_(
-          iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters")
-              .getUntrackedParameter<double>("SigmaZCut")),
+    : beamSpotOutputBase_(iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters")
+                              .getUntrackedParameter<std::string>("BeamSpotOutputBase")),
+      outputrecordName_(iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters")
+                            .getUntrackedParameter<std::string>("outputRecordName", "BeamSpotObjectsRcd")),
+      sigmaZValue_(iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters")
+                       .getUntrackedParameter<double>("SigmaZValue")),
+      sigmaZCut_(iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters")
+                     .getUntrackedParameter<double>("SigmaZCut")),
       dumpTxt_(
-          iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters")
-              .getUntrackedParameter<bool>("DumpTxt")),
-      outTxtFileName_(
-          iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters")
-              .getUntrackedParameter<std::string>("TxtFileName")),
+          iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters").getUntrackedParameter<bool>("DumpTxt")),
+      outTxtFileName_(iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters")
+                          .getUntrackedParameter<std::string>("TxtFileName")),
       theAlcaBeamSpotManager_(iConfig, consumesCollector()) {}
 
 //--------------------------------------------------------------------------------------------------
@@ -68,8 +61,7 @@ void AlcaBeamSpotHarvester::beginJob() {}
 void AlcaBeamSpotHarvester::endJob() {}
 
 //--------------------------------------------------------------------------------------------------
-void AlcaBeamSpotHarvester::analyze(const edm::Event &iEvent,
-                                    const edm::EventSetup &) {
+void AlcaBeamSpotHarvester::analyze(const edm::Event &iEvent, const edm::EventSetup &) {
   //  edm::LogInfo("AlcaBeamSpotHarvester")
   //      << "Lumi: " << iEvent.luminosityBlock()
   //      << " Time: " << iEvent.time().unixTime()
@@ -77,33 +69,25 @@ void AlcaBeamSpotHarvester::analyze(const edm::Event &iEvent,
 }
 
 //--------------------------------------------------------------------------------------------------
-void AlcaBeamSpotHarvester::beginRun(const edm::Run &,
-                                     const edm::EventSetup &) {
-  theAlcaBeamSpotManager_.reset();
-}
+void AlcaBeamSpotHarvester::beginRun(const edm::Run &, const edm::EventSetup &) { theAlcaBeamSpotManager_.reset(); }
 
 //--------------------------------------------------------------------------------------------------
-void AlcaBeamSpotHarvester::endRun(const edm::Run &iRun,
-                                   const edm::EventSetup &) {
+void AlcaBeamSpotHarvester::endRun(const edm::Run &iRun, const edm::EventSetup &) {
   theAlcaBeamSpotManager_.createWeightedPayloads();
-  std::map<edm::LuminosityBlockNumber_t,
-           std::pair<edm::Timestamp, reco::BeamSpot>>
-      beamSpotMap = theAlcaBeamSpotManager_.getPayloads();
+  std::map<edm::LuminosityBlockNumber_t, std::pair<edm::Timestamp, reco::BeamSpot>> beamSpotMap =
+      theAlcaBeamSpotManager_.getPayloads();
   Service<cond::service::PoolDBOutputService> poolDbService;
   //  cond::ExportIOVUtilities utilities;
 
-  std::string outTxt =
-      Form("%s_Run%d.txt", outTxtFileName_.c_str(), iRun.id().run());
+  std::string outTxt = Form("%s_Run%d.txt", outTxtFileName_.c_str(), iRun.id().run());
   std::ofstream outFile;
   outFile.open(outTxt.c_str(), std::ios::app);
 
   if (poolDbService.isAvailable()) {
-    for (AlcaBeamSpotManager::bsMap_iterator it = beamSpotMap.begin();
-         it != beamSpotMap.end(); it++) {
+    for (AlcaBeamSpotManager::bsMap_iterator it = beamSpotMap.begin(); it != beamSpotMap.end(); it++) {
       BeamSpotObjects *aBeamSpot = new BeamSpotObjects();
       aBeamSpot->SetType(it->second.second.type());
-      aBeamSpot->SetPosition(it->second.second.x0(), it->second.second.y0(),
-                             it->second.second.z0());
+      aBeamSpot->SetPosition(it->second.second.x0(), it->second.second.y0(), it->second.second.z0());
       if (sigmaZValue_ == -1) {
         aBeamSpot->SetSigmaZ(it->second.second.sigmaZ());
       } else {
@@ -143,29 +127,25 @@ void AlcaBeamSpotHarvester::endRun(const edm::Run &iRun,
         currentBS.beamspot = it->second.second;
         currentBS.run = iRun.id().run();
         currentBS.beginLumiOfFit = it->first;
-        currentBS.endLumiOfFit = it->first; // endLumi = initLumi
+        currentBS.endLumiOfFit = it->first;  // endLumi = initLumi
 
         std::time_t lumi_t_begin = it->second.first.unixTime();
-        std::time_t lumi_t_end =
-            it->second.first.unixTime(); // begin time == end time
-        strftime(currentBS.beginTimeOfFit, sizeof currentBS.beginTimeOfFit,
-                 "%Y.%m.%d %H:%M:%S GMT", gmtime(&lumi_t_begin));
-        strftime(currentBS.endTimeOfFit, sizeof currentBS.endTimeOfFit,
-                 "%Y.%m.%d %H:%M:%S GMT", gmtime(&lumi_t_end));
+        std::time_t lumi_t_end = it->second.first.unixTime();  // begin time == end time
+        strftime(
+            currentBS.beginTimeOfFit, sizeof currentBS.beginTimeOfFit, "%Y.%m.%d %H:%M:%S GMT", gmtime(&lumi_t_begin));
+        strftime(currentBS.endTimeOfFit, sizeof currentBS.endTimeOfFit, "%Y.%m.%d %H:%M:%S GMT", gmtime(&lumi_t_end));
 
         currentBS.reftime[0] = lumi_t_begin;
         currentBS.reftime[1] = lumi_t_end;
       }
       if (poolDbService->isNewTagRequest(outputrecordName_)) {
-        edm::LogInfo("AlcaBeamSpotHarvester")
-            << "new tag requested" << std::endl;
+        edm::LogInfo("AlcaBeamSpotHarvester") << "new tag requested" << std::endl;
         // poolDbService->createNewIOV<BeamSpotObjects>(aBeamSpot,
         // poolDbService->beginOfTime(),poolDbService->endOfTime(),"BeamSpotObjectsRcd");
         // poolDbService->createNewIOV<BeamSpotObjects>(aBeamSpot,
         // poolDbService->currentTime(),
         // poolDbService->endOfTime(),"BeamSpotObjectsRcd");
-        poolDbService->writeOne<BeamSpotObjects>(aBeamSpot, thisIOV,
-                                                 outputrecordName_);
+        poolDbService->writeOne<BeamSpotObjects>(aBeamSpot, thisIOV, outputrecordName_);
         if (dumpTxt_ && beamSpotOutputBase_ == "lumibased") {
           beamspot::dumpBeamSpotTxt(outFile, currentBS);
 
@@ -178,12 +158,10 @@ void AlcaBeamSpotHarvester::endRun(const edm::Run &iRun,
           }
         }
       } else {
-        edm::LogInfo("AlcaBeamSpotHarvester")
-            << "no new tag requested, appending IOV" << std::endl;
+        edm::LogInfo("AlcaBeamSpotHarvester") << "no new tag requested, appending IOV" << std::endl;
         // poolDbService->appendSinceTime<BeamSpotObjects>(aBeamSpot,
         // poolDbService->currentTime(),"BeamSpotObjectsRcd");
-        poolDbService->writeOne<BeamSpotObjects>(aBeamSpot, thisIOV,
-                                                 outputrecordName_);
+        poolDbService->writeOne<BeamSpotObjects>(aBeamSpot, thisIOV, outputrecordName_);
         if (dumpTxt_ && beamSpotOutputBase_ == "lumibased") {
           beamspot::dumpBeamSpotTxt(outFile, currentBS);
         }
@@ -215,12 +193,10 @@ void AlcaBeamSpotHarvester::endRun(const edm::Run &iRun,
 }
 
 //--------------------------------------------------------------------------------------------------
-void AlcaBeamSpotHarvester::beginLuminosityBlock(const edm::LuminosityBlock &,
-                                                 const edm::EventSetup &) {}
+void AlcaBeamSpotHarvester::beginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) {}
 
 //--------------------------------------------------------------------------------------------------
-void AlcaBeamSpotHarvester::endLuminosityBlock(
-    const edm::LuminosityBlock &iLumi, const edm::EventSetup &) {
+void AlcaBeamSpotHarvester::endLuminosityBlock(const edm::LuminosityBlock &iLumi, const edm::EventSetup &) {
   theAlcaBeamSpotManager_.readLumi(iLumi);
 }
 

--- a/Calibration/TkAlCaRecoProducers/plugins/AlcaBeamSpotProducer.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/AlcaBeamSpotProducer.cc
@@ -33,21 +33,15 @@
 //--------------------------------------------------------------------------------------------------
 AlcaBeamSpotProducer::AlcaBeamSpotProducer(const edm::ParameterSet &iConfig) {
   // get parameter
-  write2DB_ =
-      iConfig.getParameter<edm::ParameterSet>("AlcaBeamSpotProducerParameters")
-          .getParameter<bool>("WriteToDB");
+  write2DB_ = iConfig.getParameter<edm::ParameterSet>("AlcaBeamSpotProducerParameters").getParameter<bool>("WriteToDB");
   runallfitters_ =
-      iConfig.getParameter<edm::ParameterSet>("AlcaBeamSpotProducerParameters")
-          .getParameter<bool>("RunAllFitters");
-  fitNLumi_ =
-      iConfig.getParameter<edm::ParameterSet>("AlcaBeamSpotProducerParameters")
-          .getUntrackedParameter<int>("fitEveryNLumi", -1);
-  resetFitNLumi_ =
-      iConfig.getParameter<edm::ParameterSet>("AlcaBeamSpotProducerParameters")
-          .getUntrackedParameter<int>("resetEveryNLumi", -1);
+      iConfig.getParameter<edm::ParameterSet>("AlcaBeamSpotProducerParameters").getParameter<bool>("RunAllFitters");
+  fitNLumi_ = iConfig.getParameter<edm::ParameterSet>("AlcaBeamSpotProducerParameters")
+                  .getUntrackedParameter<int>("fitEveryNLumi", -1);
+  resetFitNLumi_ = iConfig.getParameter<edm::ParameterSet>("AlcaBeamSpotProducerParameters")
+                       .getUntrackedParameter<int>("resetEveryNLumi", -1);
   runbeamwidthfit_ =
-      iConfig.getParameter<edm::ParameterSet>("AlcaBeamSpotProducerParameters")
-          .getParameter<bool>("RunBeamWidthFit");
+      iConfig.getParameter<edm::ParameterSet>("AlcaBeamSpotProducerParameters").getParameter<bool>("RunBeamWidthFit");
 
   theBeamFitter = new BeamFitter(iConfig, consumesCollector());
   theBeamFitter->resetTrkVector();
@@ -68,21 +62,18 @@ AlcaBeamSpotProducer::AlcaBeamSpotProducer(const edm::ParameterSet &iConfig) {
 AlcaBeamSpotProducer::~AlcaBeamSpotProducer() { delete theBeamFitter; }
 
 //--------------------------------------------------------------------------------------------------
-void AlcaBeamSpotProducer::produce(edm::Event &iEvent,
-                                   const edm::EventSetup &iSetup) {
+void AlcaBeamSpotProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   ftotalevents++;
   theBeamFitter->readEvent(iEvent);
   ftmprun = iEvent.id().run();
 }
 
 //--------------------------------------------------------------------------------------------------
-void AlcaBeamSpotProducer::beginLuminosityBlock(
-    edm::LuminosityBlock const &lumiSeg, const edm::EventSetup &iSetup) {
+void AlcaBeamSpotProducer::beginLuminosityBlock(edm::LuminosityBlock const &lumiSeg, const edm::EventSetup &iSetup) {
   const edm::TimeValue_t fbegintimestamp = lumiSeg.beginTime().value();
   const std::time_t ftmptime = fbegintimestamp >> 32;
 
-  if (countLumi_ == 0 ||
-      (resetFitNLumi_ > 0 && countLumi_ % resetFitNLumi_ == 0)) {
+  if (countLumi_ == 0 || (resetFitNLumi_ > 0 && countLumi_ % resetFitNLumi_ == 0)) {
     ftmprun0 = lumiSeg.run();
     ftmprun = ftmprun0;
     beginLumiOfBSFit_ = lumiSeg.luminosityBlock();
@@ -93,12 +84,10 @@ void AlcaBeamSpotProducer::beginLuminosityBlock(
 }
 
 //--------------------------------------------------------------------------------------------------
-void AlcaBeamSpotProducer::endLuminosityBlock(
-    edm::LuminosityBlock const &lumiSeg, const edm::EventSetup &iSetup) {}
+void AlcaBeamSpotProducer::endLuminosityBlock(edm::LuminosityBlock const &lumiSeg, const edm::EventSetup &iSetup) {}
 
 //--------------------------------------------------------------------------------------------------
-void AlcaBeamSpotProducer::endLuminosityBlockProduce(
-    edm::LuminosityBlock &lumiSeg, const edm::EventSetup &iSetup) {
+void AlcaBeamSpotProducer::endLuminosityBlockProduce(edm::LuminosityBlock &lumiSeg, const edm::EventSetup &iSetup) {
   const edm::TimeValue_t fendtimestamp = lumiSeg.endTime().value();
   const std::time_t fendtime = fendtimestamp >> 32;
   refBStime[1] = fendtime;
@@ -120,26 +109,24 @@ void AlcaBeamSpotProducer::endLuminosityBlockProduce(
   reco::BeamSpot bs;
   if (theBeamFitter->runPVandTrkFitter()) {
     bs = theBeamFitter->getBeamSpot();
-    edm::LogInfo("AlcaBeamSpotProducer")
-        << "\n RESULTS OF DEFAULT FIT " << std::endl
-        << " for runs: " << ftmprun0 << " - " << ftmprun << std::endl
-        << " for lumi blocks : " << LSRange.first << " - " << LSRange.second
-        << std::endl
-        << " lumi counter # " << countLumi_ << std::endl
-        << bs << std::endl
-        << "fit done. \n"
-        << std::endl;
-  } else { // Fill in empty beam spot if beamfit fails
+    edm::LogInfo("AlcaBeamSpotProducer") << "\n RESULTS OF DEFAULT FIT " << std::endl
+                                         << " for runs: " << ftmprun0 << " - " << ftmprun << std::endl
+                                         << " for lumi blocks : " << LSRange.first << " - " << LSRange.second
+                                         << std::endl
+                                         << " lumi counter # " << countLumi_ << std::endl
+                                         << bs << std::endl
+                                         << "fit done. \n"
+                                         << std::endl;
+  } else {  // Fill in empty beam spot if beamfit fails
     bs.setType(reco::BeamSpot::Fake);
-    edm::LogInfo("AlcaBeamSpotProducer")
-        << "\n Empty Beam spot fit" << std::endl
-        << " for runs: " << ftmprun0 << " - " << ftmprun << std::endl
-        << " for lumi blocks : " << LSRange.first << " - " << LSRange.second
-        << std::endl
-        << " lumi counter # " << countLumi_ << std::endl
-        << bs << std::endl
-        << "fit failed \n"
-        << std::endl;
+    edm::LogInfo("AlcaBeamSpotProducer") << "\n Empty Beam spot fit" << std::endl
+                                         << " for runs: " << ftmprun0 << " - " << ftmprun << std::endl
+                                         << " for lumi blocks : " << LSRange.first << " - " << LSRange.second
+                                         << std::endl
+                                         << " lumi counter # " << countLumi_ << std::endl
+                                         << bs << std::endl
+                                         << "fit failed \n"
+                                         << std::endl;
   }
 
   auto result = std::make_unique<reco::BeamSpot>();
@@ -148,10 +135,8 @@ void AlcaBeamSpotProducer::endLuminosityBlockProduce(
 
   if (resetFitNLumi_ > 0 && countLumi_ % resetFitNLumi_ == 0) {
     std::vector<BSTrkParameters> theBSvector = theBeamFitter->getBSvector();
-    edm::LogInfo("AlcaBeamSpotProducer")
-        << "Total number of tracks accumulated = " << theBSvector.size()
-        << std::endl
-        << "Reset track collection for beam fit" << std::endl;
+    edm::LogInfo("AlcaBeamSpotProducer") << "Total number of tracks accumulated = " << theBSvector.size() << std::endl
+                                         << "Reset track collection for beam fit" << std::endl;
     theBeamFitter->resetTrkVector();
     theBeamFitter->resetLSRange();
     theBeamFitter->resetCutFlow();

--- a/Calibration/TkAlCaRecoProducers/plugins/CalibrationTrackSelectorFromDetIdList.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/CalibrationTrackSelectorFromDetIdList.cc
@@ -40,8 +40,7 @@ Tracker DetIds
 // class decleration
 //
 
-class dso_hidden CalibrationTrackSelectorFromDetIdList final
-    : public edm::stream::EDProducer<> {
+class dso_hidden CalibrationTrackSelectorFromDetIdList final : public edm::stream::EDProducer<> {
 public:
   explicit CalibrationTrackSelectorFromDetIdList(const edm::ParameterSet &);
   ~CalibrationTrackSelectorFromDetIdList() override;
@@ -50,10 +49,9 @@ private:
   void beginRun(edm::Run const &run, const edm::EventSetup &) override;
   void produce(edm::Event &, const edm::EventSetup &) override;
   edm::EDGetTokenT<reco::TrackCollection> m_label;
-  TrackCandidate
-  makeCandidate(const reco::Track &tk,
-                std::vector<const TrackingRecHit *>::iterator hitsBegin,
-                std::vector<const TrackingRecHit *>::iterator hitsEnd);
+  TrackCandidate makeCandidate(const reco::Track &tk,
+                               std::vector<const TrackingRecHit *>::iterator hitsBegin,
+                               std::vector<const TrackingRecHit *>::iterator hitsEnd);
 
   std::vector<DetIdSelector> detidsels_;
   bool m_verbose;
@@ -62,36 +60,29 @@ private:
   edm::ESHandle<MagneticField> theMagField;
 };
 
-CalibrationTrackSelectorFromDetIdList::CalibrationTrackSelectorFromDetIdList(
-    const edm::ParameterSet &iConfig)
+CalibrationTrackSelectorFromDetIdList::CalibrationTrackSelectorFromDetIdList(const edm::ParameterSet &iConfig)
     : detidsels_() {
+  std::vector<edm::ParameterSet> selconfigs = iConfig.getParameter<std::vector<edm::ParameterSet>>("selections");
 
-  std::vector<edm::ParameterSet> selconfigs =
-      iConfig.getParameter<std::vector<edm::ParameterSet>>("selections");
-
-  for (std::vector<edm::ParameterSet>::const_iterator selconfig =
-           selconfigs.begin();
-       selconfig != selconfigs.end(); ++selconfig) {
+  for (std::vector<edm::ParameterSet>::const_iterator selconfig = selconfigs.begin(); selconfig != selconfigs.end();
+       ++selconfig) {
     DetIdSelector selection(*selconfig);
     detidsels_.push_back(selection);
   }
 
   m_verbose = iConfig.getUntrackedParameter<bool>("verbose");
-  m_label = consumes<reco::TrackCollection>(
-      iConfig.getParameter<edm::InputTag>("Input"));
+  m_label = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("Input"));
   produces<TrackCandidateCollection>();
 }
 
-CalibrationTrackSelectorFromDetIdList::
-    ~CalibrationTrackSelectorFromDetIdList() {}
+CalibrationTrackSelectorFromDetIdList::~CalibrationTrackSelectorFromDetIdList() {}
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void CalibrationTrackSelectorFromDetIdList::produce(
-    edm::Event &iEvent, const edm::EventSetup &iSetup) {
+void CalibrationTrackSelectorFromDetIdList::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
   using namespace std;
 
@@ -103,7 +94,6 @@ void CalibrationTrackSelectorFromDetIdList::produce(
 
   // loop on tracks
   for (auto &trk : tracks) {
-
     std::vector<const TrackingRecHit *> hits;
 
     bool saveTrack(false);
@@ -113,8 +103,7 @@ void CalibrationTrackSelectorFromDetIdList::produce(
 
       for (const auto &detidsel : detidsels_) {
         if (detidsel.isSelected(detid)) {
-          LogDebug("CalibrationTrackSelectorFromDetIdList")
-              << "Selected by selection " << detid;
+          LogDebug("CalibrationTrackSelectorFromDetIdList") << "Selected by selection " << detid;
           saveTrack = true;
           break;
         }
@@ -135,28 +124,21 @@ TrackCandidate CalibrationTrackSelectorFromDetIdList::makeCandidate(
     const reco::Track &tk,
     std::vector<const TrackingRecHit *>::iterator hitsBegin,
     std::vector<const TrackingRecHit *>::iterator hitsEnd) {
-
   PropagationDirection pdir = tk.seedDirection();
   PTrajectoryStateOnDet state;
   if (pdir == anyDirection)
-    throw cms::Exception("UnimplementedFeature")
-        << "Cannot work with tracks that have 'anyDirecton' \n";
+    throw cms::Exception("UnimplementedFeature") << "Cannot work with tracks that have 'anyDirecton' \n";
 
-  if ((pdir == alongMomentum) ==
-      ((tk.outerPosition() - tk.innerPosition()).Dot(tk.momentum()) >= 0)) {
+  if ((pdir == alongMomentum) == ((tk.outerPosition() - tk.innerPosition()).Dot(tk.momentum()) >= 0)) {
     // use inner state
     TrajectoryStateOnSurface originalTsosIn(
-        trajectoryStateTransform::innerStateOnSurface(tk, *theGeometry,
-                                                      &*theMagField));
-    state = trajectoryStateTransform::persistentState(originalTsosIn,
-                                                      DetId(tk.innerDetId()));
+        trajectoryStateTransform::innerStateOnSurface(tk, *theGeometry, &*theMagField));
+    state = trajectoryStateTransform::persistentState(originalTsosIn, DetId(tk.innerDetId()));
   } else {
     // use outer state
     TrajectoryStateOnSurface originalTsosOut(
-        trajectoryStateTransform::outerStateOnSurface(tk, *theGeometry,
-                                                      &*theMagField));
-    state = trajectoryStateTransform::persistentState(originalTsosOut,
-                                                      DetId(tk.outerDetId()));
+        trajectoryStateTransform::outerStateOnSurface(tk, *theGeometry, &*theMagField));
+    state = trajectoryStateTransform::persistentState(originalTsosOut, DetId(tk.outerDetId()));
   }
   TrajectorySeed seed(state, TrackCandidate::RecHitContainer(), pdir);
   TrackCandidate::RecHitContainer ownHits;
@@ -170,8 +152,7 @@ TrackCandidate CalibrationTrackSelectorFromDetIdList::makeCandidate(
   return cand;
 }
 
-void CalibrationTrackSelectorFromDetIdList::beginRun(
-    edm::Run const &run, const edm::EventSetup &iSetup) {
+void CalibrationTrackSelectorFromDetIdList::beginRun(edm::Run const &run, const edm::EventSetup &iSetup) {
   iSetup.get<TrackerDigiGeometryRecord>().get(theGeometry);
   iSetup.get<IdealMagneticFieldRecord>().get(theMagField);
 
@@ -180,8 +161,7 @@ void CalibrationTrackSelectorFromDetIdList::beginRun(
       auto theDetIds = theGeometry.product()->detIds();
       for (const auto &theDet : theDetIds) {
         if (detidsel.isSelected(theDet)) {
-          LogDebug("CalibrationTrackSelectorFromDetIdList")
-              << "detid: " << theDet.rawId() << " is taken" << std::endl;
+          LogDebug("CalibrationTrackSelectorFromDetIdList") << "detid: " << theDet.rawId() << " is taken" << std::endl;
         }
       }
     }

--- a/Calibration/TkAlCaRecoProducers/plugins/CalibrationTrackSelectorModule.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/CalibrationTrackSelectorModule.cc
@@ -13,30 +13,23 @@
 #include "CommonTools/RecoAlgos/interface/TrackSelector.h"
 
 struct SiStripCalTrackConfigSelector {
-
   typedef std::vector<const reco::Track *> container;
   typedef container::const_iterator const_iterator;
   typedef reco::TrackCollection collection;
 
-  SiStripCalTrackConfigSelector(const edm::ParameterSet &cfg,
-                                edm::ConsumesCollector &&iC)
-      : theBaseSelector(cfg) {
+  SiStripCalTrackConfigSelector(const edm::ParameterSet &cfg, edm::ConsumesCollector &&iC) : theBaseSelector(cfg) {
     // TODO Wrap the BaseSelector into its own PSet
-    theBaseSwitch = cfg.getParameter<bool>("applyBasicCuts") ||
-                    cfg.getParameter<bool>("minHitsPerSubDet") ||
-                    cfg.getParameter<bool>("applyNHighestPt") ||
-                    cfg.getParameter<bool>("applyMultiplicityFilter");
+    theBaseSwitch = cfg.getParameter<bool>("applyBasicCuts") || cfg.getParameter<bool>("minHitsPerSubDet") ||
+                    cfg.getParameter<bool>("applyNHighestPt") || cfg.getParameter<bool>("applyMultiplicityFilter");
   }
 
   const_iterator begin() const { return theSelectedTracks.begin(); }
   const_iterator end() const { return theSelectedTracks.end(); }
   size_t size() const { return theSelectedTracks.size(); }
 
-  void select(const edm::Handle<reco::TrackCollection> &c,
-              const edm::Event &evt, const edm::EventSetup & /*dummy*/) {
+  void select(const edm::Handle<reco::TrackCollection> &c, const edm::Event &evt, const edm::EventSetup & /*dummy*/) {
     theSelectedTracks.clear();
-    for (reco::TrackCollection::const_iterator i = c.product()->begin();
-         i != c.product()->end(); ++i) {
+    for (reco::TrackCollection::const_iterator i = c.product()->begin(); i != c.product()->end(); ++i) {
       theSelectedTracks.push_back(&*i);
     }
     // might add EvetSetup to the select(...) method of the Selectors
@@ -51,7 +44,6 @@ private:
   CalibrationTrackSelector theBaseSelector;
 };
 
-typedef ObjectSelectorStream<SiStripCalTrackConfigSelector>
-    CalibrationTrackSelectorModule;
+typedef ObjectSelectorStream<SiStripCalTrackConfigSelector> CalibrationTrackSelectorModule;
 
 DEFINE_FWK_MODULE(CalibrationTrackSelectorModule);

--- a/Calibration/TkAlCaRecoProducers/plugins/PCLMetadataWriter.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/PCLMetadataWriter.cc
@@ -23,14 +23,11 @@ using namespace std;
 using namespace edm;
 
 PCLMetadataWriter::PCLMetadataWriter(const edm::ParameterSet &pSet) {
-
   readFromDB = pSet.getParameter<bool>("readFromDB");
 
-  vector<ParameterSet> recordsToMap =
-      pSet.getParameter<vector<ParameterSet>>("recordsToMap");
-  for (vector<ParameterSet>::const_iterator recordPset = recordsToMap.begin();
-       recordPset != recordsToMap.end(); ++recordPset) {
-
+  vector<ParameterSet> recordsToMap = pSet.getParameter<vector<ParameterSet>>("recordsToMap");
+  for (vector<ParameterSet>::const_iterator recordPset = recordsToMap.begin(); recordPset != recordsToMap.end();
+       ++recordPset) {
     // record is the key which identifies one set of metadata in
     // DropBoxMetadataRcd (not necessarily a record in the strict framework
     // sense)
@@ -39,8 +36,7 @@ PCLMetadataWriter::PCLMetadataWriter(const edm::ParameterSet &pSet) {
     map<string, string> jrInfo;
     if (!readFromDB) {
       vector<string> paramKeys = (*recordPset).getParameterNames();
-      for (vector<string>::const_iterator key = paramKeys.begin();
-           key != paramKeys.end(); ++key) {
+      for (vector<string>::const_iterator key = paramKeys.begin(); key != paramKeys.end(); ++key) {
         jrInfo["Source"] = "AlcaHarvesting";
         jrInfo["FileClass"] = "ALCA";
         if (*key != "record") {
@@ -54,15 +50,11 @@ PCLMetadataWriter::PCLMetadataWriter(const edm::ParameterSet &pSet) {
 
 PCLMetadataWriter::~PCLMetadataWriter() {}
 
-void PCLMetadataWriter::analyze(const edm::Event &event,
-                                const edm::EventSetup &eSetup) {}
+void PCLMetadataWriter::analyze(const edm::Event &event, const edm::EventSetup &eSetup) {}
 
-void PCLMetadataWriter::beginRun(const edm::Run &run,
-                                 const edm::EventSetup &eSetup) {}
+void PCLMetadataWriter::beginRun(const edm::Run &run, const edm::EventSetup &eSetup) {}
 
-void PCLMetadataWriter::endRun(const edm::Run &run,
-                               const edm::EventSetup &eSetup) {
-
+void PCLMetadataWriter::endRun(const edm::Run &run, const edm::EventSetup &eSetup) {
   const DropBoxMetadata *metadata = nullptr;
 
   if (readFromDB) {
@@ -82,10 +74,9 @@ void PCLMetadataWriter::endRun(const edm::Run &run,
       string filename = poolDbService->session().connectionString();
 
       // loop over all records
-      for (map<string, map<string, string>>::const_iterator recordAndMap =
-               recordMap.begin();
-           recordAndMap != recordMap.end(); ++recordAndMap) {
-
+      for (map<string, map<string, string>>::const_iterator recordAndMap = recordMap.begin();
+           recordAndMap != recordMap.end();
+           ++recordAndMap) {
         string record = (*recordAndMap).first;
 
         // this is the map of metadata that we write in the JR

--- a/Calibration/TkAlCaRecoProducers/src/AlcaBeamSpotManager.cc
+++ b/Calibration/TkAlCaRecoProducers/src/AlcaBeamSpotManager.cc
@@ -20,24 +20,18 @@ using namespace std;
 AlcaBeamSpotManager::AlcaBeamSpotManager(void) {}
 
 //--------------------------------------------------------------------------------------------------
-AlcaBeamSpotManager::AlcaBeamSpotManager(const ParameterSet &iConfig,
-                                         edm::ConsumesCollector &&iC)
-    : beamSpotOutputBase_(
-          iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters")
-              .getUntrackedParameter<std::string>("BeamSpotOutputBase")),
-      beamSpotModuleName_(
-          iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters")
-              .getUntrackedParameter<std::string>("BeamSpotModuleName")),
-      beamSpotLabel_(
-          iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters")
-              .getUntrackedParameter<std::string>("BeamSpotLabel")),
-      sigmaZCut_(
-          iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters")
-              .getUntrackedParameter<double>("SigmaZCut")) {
+AlcaBeamSpotManager::AlcaBeamSpotManager(const ParameterSet &iConfig, edm::ConsumesCollector &&iC)
+    : beamSpotOutputBase_(iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters")
+                              .getUntrackedParameter<std::string>("BeamSpotOutputBase")),
+      beamSpotModuleName_(iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters")
+                              .getUntrackedParameter<std::string>("BeamSpotModuleName")),
+      beamSpotLabel_(iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters")
+                         .getUntrackedParameter<std::string>("BeamSpotLabel")),
+      sigmaZCut_(iConfig.getParameter<ParameterSet>("AlcaBeamSpotHarvesterParameters")
+                     .getUntrackedParameter<double>("SigmaZCut")) {
   edm::InputTag beamSpotTag_(beamSpotModuleName_, beamSpotLabel_);
   beamSpotToken_ = iC.consumes<reco::BeamSpot, edm::InLumi>(beamSpotTag_);
-  LogInfo("AlcaBeamSpotManager")
-      << "Output base: " << beamSpotOutputBase_ << std::endl;
+  LogInfo("AlcaBeamSpotManager") << "Output base: " << beamSpotOutputBase_ << std::endl;
   reset();
 }
 
@@ -48,22 +42,18 @@ AlcaBeamSpotManager::~AlcaBeamSpotManager(void) {}
 void AlcaBeamSpotManager::reset(void) { beamSpotMap_.clear(); }
 //--------------------------------------------------------------------------------------------------
 void AlcaBeamSpotManager::readLumi(const LuminosityBlock &iLumi) {
-
   Handle<BeamSpot> beamSpotHandle;
   iLumi.getByToken(beamSpotToken_, beamSpotHandle);
 
-  if (beamSpotHandle.isValid()) { // check the product
-    std::pair<edm::Timestamp, reco::BeamSpot> time_bs(iLumi.beginTime(),
-                                                      *beamSpotHandle);
+  if (beamSpotHandle.isValid()) {  // check the product
+    std::pair<edm::Timestamp, reco::BeamSpot> time_bs(iLumi.beginTime(), *beamSpotHandle);
     beamSpotMap_[iLumi.luminosityBlock()] = time_bs;
     const BeamSpot *aBeamSpot = &beamSpotMap_[iLumi.luminosityBlock()].second;
     aBeamSpot = beamSpotHandle.product();
-    LogInfo("AlcaBeamSpotManager")
-        << "Lumi: " << iLumi.luminosityBlock() << std::endl;
+    LogInfo("AlcaBeamSpotManager") << "Lumi: " << iLumi.luminosityBlock() << std::endl;
     LogInfo("AlcaBeamSpotManager") << *aBeamSpot << std::endl;
   } else {
-    LogInfo("AlcaBeamSpotManager")
-        << "Lumi: " << iLumi.luminosityBlock() << std::endl;
+    LogInfo("AlcaBeamSpotManager") << "Lumi: " << iLumi.luminosityBlock() << std::endl;
     LogInfo("AlcaBeamSpotManager") << "   BS is not valid!" << std::endl;
   }
 }
@@ -71,15 +61,12 @@ void AlcaBeamSpotManager::readLumi(const LuminosityBlock &iLumi) {
 //--------------------------------------------------------------------------------------------------
 void AlcaBeamSpotManager::createWeightedPayloads(void) {
   vector<bsMap_iterator> listToErase;
-  for (bsMap_iterator it = beamSpotMap_.begin(); it != beamSpotMap_.end();
-       it++) {
-    if (it->second.second.type() != BeamSpot::Tracker ||
-        it->second.second.sigmaZ() < sigmaZCut_) {
+  for (bsMap_iterator it = beamSpotMap_.begin(); it != beamSpotMap_.end(); it++) {
+    if (it->second.second.type() != BeamSpot::Tracker || it->second.second.sigmaZ() < sigmaZCut_) {
       listToErase.push_back(it);
     }
   }
-  for (vector<bsMap_iterator>::iterator it = listToErase.begin();
-       it != listToErase.end(); it++) {
+  for (vector<bsMap_iterator>::iterator it = listToErase.begin(); it != listToErase.end(); it++) {
     beamSpotMap_.erase(*it);
   }
   if (beamSpotMap_.size() <= 1) {
@@ -101,40 +88,36 @@ void AlcaBeamSpotManager::createWeightedPayloads(void) {
     reco::BeamSpot currentBSObj;
     reco::BeamSpot nextBSObj;
 
-    map<LuminosityBlockNumber_t, std::pair<edm::Timestamp, BeamSpot>>
-        tmpBeamSpotMap_;
+    map<LuminosityBlockNumber_t, std::pair<edm::Timestamp, BeamSpot>> tmpBeamSpotMap_;
     bool docreate = true;
-    bool endOfRun = false; // Added
-    bool docheck = true;   // Added
+    bool endOfRun = false;  // Added
+    bool docheck = true;    // Added
     bool foundShift = false;
-    long countlumi = 0;  // Added
-    string tmprun = "";  // Added
-    long maxNlumis = 20; // Added
+    long countlumi = 0;   // Added
+    string tmprun = "";   // Added
+    long maxNlumis = 20;  // Added
     //    if weighted:
     //        maxNlumis = 999999999
 
     unsigned int iteration = 0;
     // while(nextNextBS!=beamSpotMap_.end()){
     while (nextBS != beamSpotMap_.end()) {
-      LogInfo("AlcaBeamSpotManager") << "Iteration: " << iteration
-                                     << " size: " << beamSpotMap_.size() << "\n"
+      LogInfo("AlcaBeamSpotManager") << "Iteration: " << iteration << " size: " << beamSpotMap_.size() << "\n"
                                      << "Lumi: " << currentBS->first << "\n"
                                      << currentBS->second.second << "\n"
                                      << nextBS->first << "\n"
                                      << nextBS->second.second << endl;
       if (nextNextBS != beamSpotMap_.end())
-        LogInfo("AlcaBeamSpotManager") << nextNextBS->first << "\n"
-                                       << nextNextBS->second.second << endl;
+        LogInfo("AlcaBeamSpotManager") << nextNextBS->first << "\n" << nextNextBS->second.second << endl;
 
       if (docreate) {
         firstBS = currentBS;
-        docreate = false; // Added
+        docreate = false;  // Added
       }
       // if(iteration >= beamSpotMap_.size()-3){
       if (iteration >= beamSpotMap_.size() - 2) {
-        LogInfo("AlcaBeamSpotManager")
-            << "Reached lumi " << currentBS->first
-            << " now close payload because end of data has been reached.";
+        LogInfo("AlcaBeamSpotManager") << "Reached lumi " << currentBS->first
+                                       << " now close payload because end of data has been reached.";
         docreate = true;
         endOfRun = true;
       }
@@ -185,179 +168,144 @@ void AlcaBeamSpotManager::createWeightedPayloads(void) {
         nextBSObj = nextBS->second.second;
 
         // check movements in X
-        adelta1 = delta(currentBSObj.x0(), currentBSObj.x0Error(),
-                        nextBSObj.x0(), nextBSObj.x0Error());
+        adelta1 = delta(currentBSObj.x0(), currentBSObj.x0Error(), nextBSObj.x0(), nextBSObj.x0Error());
         adelta2 = pair<float, float>(0., 1.e9);
         if (nextNextBS->second.second.type() != -1) {
-          adelta2 = delta(nextBS->second.second.x0(), nextBSObj.x0Error(),
+          adelta2 = delta(nextBS->second.second.x0(),
+                          nextBSObj.x0Error(),
                           nextNextBS->second.second.x0(),
                           nextNextBS->second.second.x0Error());
         }
-        bool deltaX = (deltaSig(adelta1.first, adelta1.second) > 3.5 &&
-                       adelta1.first >= limit)
-                          ? true
-                          : false;
+        bool deltaX = (deltaSig(adelta1.first, adelta1.second) > 3.5 && adelta1.first >= limit) ? true : false;
         if (iteration < beamSpotMap_.size() - 2) {
-          if (!deltaX && adelta1.first * adelta2.first > 0. &&
-              fabs(adelta1.first + adelta2.first) >= limit) {
+          if (!deltaX && adelta1.first * adelta2.first > 0. && fabs(adelta1.first + adelta2.first) >= limit) {
             LogInfo("AlcaBeamSpotManager")
-                << " positive, " << (adelta1.first + adelta2.first)
-                << " limit=" << limit << endl;
+                << " positive, " << (adelta1.first + adelta2.first) << " limit=" << limit << endl;
             deltaX = true;
-          } else if (deltaX && adelta1.first * adelta2.first < 0 &&
-                     adelta2.first != 0 &&
-                     fabs(adelta1.first / adelta2.first) > 0.33 &&
-                     fabs(adelta1.first / adelta2.first) < 3) {
-            LogInfo("AlcaBeamSpotManager")
-                << " negative, " << adelta1.first / adelta2.first << endl;
+          } else if (deltaX && adelta1.first * adelta2.first < 0 && adelta2.first != 0 &&
+                     fabs(adelta1.first / adelta2.first) > 0.33 && fabs(adelta1.first / adelta2.first) < 3) {
+            LogInfo("AlcaBeamSpotManager") << " negative, " << adelta1.first / adelta2.first << endl;
             deltaX = false;
           }
         }
 
         // calculating all deltas
-        adelta1dxdz = delta(currentBSObj.dxdz(), currentBSObj.dxdzError(),
-                            nextBSObj.dxdz(), nextBSObj.dxdzError());
+        adelta1dxdz = delta(currentBSObj.dxdz(), currentBSObj.dxdzError(), nextBSObj.dxdz(), nextBSObj.dxdzError());
         adelta2dxdz = pair<float, float>(0., 1.e9);
-        adelta1dydz = delta(currentBSObj.dydz(), currentBSObj.dydzError(),
-                            nextBSObj.dydz(), nextBSObj.dydzError());
+        adelta1dydz = delta(currentBSObj.dydz(), currentBSObj.dydzError(), nextBSObj.dydz(), nextBSObj.dydzError());
         adelta2dydz = pair<float, float>(0., 1.e9);
-        adelta1widthX =
-            delta(currentBSObj.BeamWidthX(), currentBSObj.BeamWidthXError(),
-                  nextBSObj.BeamWidthX(), nextBSObj.BeamWidthXError());
+        adelta1widthX = delta(currentBSObj.BeamWidthX(),
+                              currentBSObj.BeamWidthXError(),
+                              nextBSObj.BeamWidthX(),
+                              nextBSObj.BeamWidthXError());
         adelta2widthX = pair<float, float>(0., 1.e9);
-        adelta1widthY =
-            delta(currentBSObj.BeamWidthY(), currentBSObj.BeamWidthYError(),
-                  nextBSObj.BeamWidthY(), nextBSObj.BeamWidthYError());
+        adelta1widthY = delta(currentBSObj.BeamWidthY(),
+                              currentBSObj.BeamWidthYError(),
+                              nextBSObj.BeamWidthY(),
+                              nextBSObj.BeamWidthYError());
         adelta2widthY = pair<float, float>(0., 1.e9);
-        adelta1z0 = delta(currentBSObj.z0(), currentBSObj.z0Error(),
-                          nextBSObj.z0(), nextBSObj.z0Error());
+        adelta1z0 = delta(currentBSObj.z0(), currentBSObj.z0Error(), nextBSObj.z0(), nextBSObj.z0Error());
         adelta1sigmaZ =
-            delta(currentBSObj.sigmaZ(), currentBSObj.sigmaZ0Error(),
-                  nextBSObj.sigmaZ(), nextBSObj.sigmaZ0Error());
+            delta(currentBSObj.sigmaZ(), currentBSObj.sigmaZ0Error(), nextBSObj.sigmaZ(), nextBSObj.sigmaZ0Error());
 
         // check movements in Y
-        adelta1 = delta(currentBSObj.y0(), currentBSObj.y0Error(),
-                        nextBSObj.y0(), nextBSObj.y0Error());
+        adelta1 = delta(currentBSObj.y0(), currentBSObj.y0Error(), nextBSObj.y0(), nextBSObj.y0Error());
         adelta2 = pair<float, float>(0., 1.e9);
         if (nextNextBS->second.second.type() != BeamSpot::Unknown) {
-          adelta2 = delta(nextBSObj.y0(), nextBSObj.y0Error(),
-                          nextNextBS->second.second.y0(),
-                          nextNextBS->second.second.y0Error());
-          adelta2dxdz = delta(nextBSObj.dxdz(), nextBSObj.dxdzError(),
+          adelta2 = delta(
+              nextBSObj.y0(), nextBSObj.y0Error(), nextNextBS->second.second.y0(), nextNextBS->second.second.y0Error());
+          adelta2dxdz = delta(nextBSObj.dxdz(),
+                              nextBSObj.dxdzError(),
                               nextNextBS->second.second.dxdz(),
                               nextNextBS->second.second.dxdzError());
-          adelta2dydz = delta(nextBSObj.dydz(), nextBSObj.dydzError(),
+          adelta2dydz = delta(nextBSObj.dydz(),
+                              nextBSObj.dydzError(),
                               nextNextBS->second.second.dydz(),
                               nextNextBS->second.second.dydzError());
-          adelta2widthX =
-              delta(nextBSObj.BeamWidthX(), nextBSObj.BeamWidthXError(),
-                    nextNextBS->second.second.BeamWidthX(),
-                    nextNextBS->second.second.BeamWidthXError());
-          adelta2widthY =
-              delta(nextBSObj.BeamWidthY(), nextBSObj.BeamWidthYError(),
-                    nextNextBS->second.second.BeamWidthY(),
-                    nextNextBS->second.second.BeamWidthYError());
+          adelta2widthX = delta(nextBSObj.BeamWidthX(),
+                                nextBSObj.BeamWidthXError(),
+                                nextNextBS->second.second.BeamWidthX(),
+                                nextNextBS->second.second.BeamWidthXError());
+          adelta2widthY = delta(nextBSObj.BeamWidthY(),
+                                nextBSObj.BeamWidthYError(),
+                                nextNextBS->second.second.BeamWidthY(),
+                                nextNextBS->second.second.BeamWidthYError());
         }
-        bool deltaY = (deltaSig(adelta1.first, adelta1.second) > 3.5 &&
-                       adelta1.first >= limit)
-                          ? true
-                          : false;
+        bool deltaY = (deltaSig(adelta1.first, adelta1.second) > 3.5 && adelta1.first >= limit) ? true : false;
         if (iteration < beamSpotMap_.size() - 2) {
-          if (!deltaY && adelta1.first * adelta2.first > 0. &&
-              fabs(adelta1.first + adelta2.first) >= limit) {
+          if (!deltaY && adelta1.first * adelta2.first > 0. && fabs(adelta1.first + adelta2.first) >= limit) {
             LogInfo("AlcaBeamSpotManager")
-                << " positive, " << (adelta1.first + adelta2.first)
-                << " limit=" << limit << endl;
+                << " positive, " << (adelta1.first + adelta2.first) << " limit=" << limit << endl;
             deltaY = true;
-          } else if (deltaY && adelta1.first * adelta2.first < 0 &&
-                     adelta2.first != 0 &&
-                     fabs(adelta1.first / adelta2.first) > 0.33 &&
-                     fabs(adelta1.first / adelta2.first) < 3) {
-            LogInfo("AlcaBeamSpotManager")
-                << " negative, " << adelta1.first / adelta2.first << endl;
+          } else if (deltaY && adelta1.first * adelta2.first < 0 && adelta2.first != 0 &&
+                     fabs(adelta1.first / adelta2.first) > 0.33 && fabs(adelta1.first / adelta2.first) < 3) {
+            LogInfo("AlcaBeamSpotManager") << " negative, " << adelta1.first / adelta2.first << endl;
             deltaY = false;
           }
         }
 
         limit = currentBSObj.sigmaZ() / 2.;
-        bool deltaZ = (deltaSig(adelta1z0.first, adelta1z0.second) > 3.5 &&
-                       fabs(adelta1z0.first) >= limit)
-                          ? true
-                          : false;
-        adelta = delta(currentBSObj.sigmaZ(), currentBSObj.sigmaZ0Error(),
-                       nextBSObj.sigmaZ(), nextBSObj.sigmaZ0Error());
-        bool deltasigmaZ =
-            (deltaSig(adelta.first, adelta.second) > 5.0) ? true : false;
+        bool deltaZ =
+            (deltaSig(adelta1z0.first, adelta1z0.second) > 3.5 && fabs(adelta1z0.first) >= limit) ? true : false;
+        adelta =
+            delta(currentBSObj.sigmaZ(), currentBSObj.sigmaZ0Error(), nextBSObj.sigmaZ(), nextBSObj.sigmaZ0Error());
+        bool deltasigmaZ = (deltaSig(adelta.first, adelta.second) > 5.0) ? true : false;
         bool deltadxdz = false;
         bool deltadydz = false;
         bool deltawidthX = false;
         bool deltawidthY = false;
 
         if (iteration < beamSpotMap_.size() - 2) {
-
-          adelta = delta(currentBSObj.dxdz(), currentBSObj.dxdzError(),
-                         nextBSObj.dxdz(), nextBSObj.dxdzError());
-          deltadxdz =
-              (deltaSig(adelta.first, adelta.second) > 5.0) ? true : false;
-          if (deltadxdz && (adelta1dxdz.first * adelta2dxdz.first) < 0 &&
-              adelta2dxdz.first != 0 &&
-              fabs(adelta1dxdz.first / adelta2dxdz.first) > 0.33 &&
-              fabs(adelta1dxdz.first / adelta2dxdz.first) < 3) {
+          adelta = delta(currentBSObj.dxdz(), currentBSObj.dxdzError(), nextBSObj.dxdz(), nextBSObj.dxdzError());
+          deltadxdz = (deltaSig(adelta.first, adelta.second) > 5.0) ? true : false;
+          if (deltadxdz && (adelta1dxdz.first * adelta2dxdz.first) < 0 && adelta2dxdz.first != 0 &&
+              fabs(adelta1dxdz.first / adelta2dxdz.first) > 0.33 && fabs(adelta1dxdz.first / adelta2dxdz.first) < 3) {
             deltadxdz = false;
           }
 
-          adelta = delta(currentBSObj.dydz(), currentBSObj.dydzError(),
-                         nextBSObj.dydz(), nextBSObj.dydzError());
-          deltadydz =
-              (deltaSig(adelta.first, adelta.second) > 5.0) ? true : false;
-          if (deltadydz && (adelta1dydz.first * adelta2dydz.first) < 0 &&
-              adelta2dydz.first != 0 &&
-              fabs(adelta1dydz.first / adelta2dydz.first) > 0.33 &&
-              fabs(adelta1dydz.first / adelta2dydz.first) < 3) {
+          adelta = delta(currentBSObj.dydz(), currentBSObj.dydzError(), nextBSObj.dydz(), nextBSObj.dydzError());
+          deltadydz = (deltaSig(adelta.first, adelta.second) > 5.0) ? true : false;
+          if (deltadydz && (adelta1dydz.first * adelta2dydz.first) < 0 && adelta2dydz.first != 0 &&
+              fabs(adelta1dydz.first / adelta2dydz.first) > 0.33 && fabs(adelta1dydz.first / adelta2dydz.first) < 3) {
             deltadydz = false;
           }
 
-          adelta =
-              delta(currentBSObj.BeamWidthX(), currentBSObj.BeamWidthXError(),
-                    nextBSObj.BeamWidthX(), nextBSObj.BeamWidthXError());
-          deltawidthX =
-              (deltaSig(adelta.first, adelta.second) > 5.0) ? true : false;
-          if (deltawidthX && (adelta1widthX.first * adelta2widthX.first) < 0 &&
-              adelta2widthX.first != 0 &&
+          adelta = delta(currentBSObj.BeamWidthX(),
+                         currentBSObj.BeamWidthXError(),
+                         nextBSObj.BeamWidthX(),
+                         nextBSObj.BeamWidthXError());
+          deltawidthX = (deltaSig(adelta.first, adelta.second) > 5.0) ? true : false;
+          if (deltawidthX && (adelta1widthX.first * adelta2widthX.first) < 0 && adelta2widthX.first != 0 &&
               fabs(adelta1widthX.first / adelta2widthX.first) > 0.33 &&
               fabs(adelta1widthX.first / adelta2widthX.first) < 3) {
             deltawidthX = false;
           }
 
-          adelta =
-              delta(currentBSObj.BeamWidthY(), currentBSObj.BeamWidthYError(),
-                    nextBSObj.BeamWidthY(), nextBSObj.BeamWidthYError());
-          deltawidthY =
-              (deltaSig(adelta.first, adelta.second) > 5.0) ? true : false;
-          if (deltawidthY && (adelta1widthY.first * adelta2widthY.first) < 0 &&
-              adelta2widthY.first != 0 &&
+          adelta = delta(currentBSObj.BeamWidthY(),
+                         currentBSObj.BeamWidthYError(),
+                         nextBSObj.BeamWidthY(),
+                         nextBSObj.BeamWidthYError());
+          deltawidthY = (deltaSig(adelta.first, adelta.second) > 5.0) ? true : false;
+          if (deltawidthY && (adelta1widthY.first * adelta2widthY.first) < 0 && adelta2widthY.first != 0 &&
               fabs(adelta1widthY.first / adelta2widthY.first) > 0.33 &&
               fabs(adelta1widthY.first / adelta2widthY.first) < 3) {
             deltawidthY = false;
           }
         }
-        if (deltaX || deltaY || deltaZ || deltasigmaZ || deltadxdz ||
-            deltadydz || deltawidthX || deltawidthY) {
+        if (deltaX || deltaY || deltaZ || deltasigmaZ || deltadxdz || deltadydz || deltawidthX || deltawidthY) {
           docreate = true;
           foundShift = true;
-          LogInfo("AlcaBeamSpotManager")
-              << "close payload because of movement in"
-              << " X=" << deltaX << ", Y=" << deltaY << ", Z=" << deltaZ
-              << ", sigmaZ=" << deltasigmaZ << ", dxdz=" << deltadxdz
-              << ", dydz=" << deltadydz << ", widthX=" << deltawidthX
-              << ", widthY=" << deltawidthY << endl;
+          LogInfo("AlcaBeamSpotManager") << "close payload because of movement in"
+                                         << " X=" << deltaX << ", Y=" << deltaY << ", Z=" << deltaZ
+                                         << ", sigmaZ=" << deltasigmaZ << ", dxdz=" << deltadxdz
+                                         << ", dydz=" << deltadydz << ", widthX=" << deltawidthX
+                                         << ", widthY=" << deltawidthY << endl;
         }
       }
       if (docreate) {
         std::pair<edm::Timestamp, reco::BeamSpot> thepair;
         if (foundShift) {
-          thepair =
-              std::make_pair(currentBS->second.first, weight(firstBS, nextBS));
+          thepair = std::make_pair(currentBS->second.first, weight(firstBS, nextBS));
           tmpBeamSpotMap_[firstBS->first] = thepair;
           if (endOfRun) {
             // if we're here, then we need to found a shift in the last LS
@@ -365,13 +313,11 @@ void AlcaBeamSpotManager::createWeightedPayloads(void) {
             thepair = std::make_pair(nextBS->second.first, nextBSObj);
             tmpBeamSpotMap_[nextBS->first] = thepair;
           }
-        } else if (!foundShift && !endOfRun) { // maxLS reached
-          thepair =
-              std::make_pair(currentBS->second.first, weight(firstBS, nextBS));
+        } else if (!foundShift && !endOfRun) {  // maxLS reached
+          thepair = std::make_pair(currentBS->second.first, weight(firstBS, nextBS));
           tmpBeamSpotMap_[firstBS->first] = thepair;
-        } else { // end of run with no shift detectred in last LS
-          thepair = std::make_pair(currentBS->second.first,
-                                   weight(firstBS, beamSpotMap_.end()));
+        } else {  // end of run with no shift detectred in last LS
+          thepair = std::make_pair(currentBS->second.first, weight(firstBS, beamSpotMap_.end()));
           tmpBeamSpotMap_[firstBS->first] = thepair;
         }
         firstBS = nextBS;
@@ -391,21 +337,17 @@ void AlcaBeamSpotManager::createWeightedPayloads(void) {
     beamSpotMap_ = tmpBeamSpotMap_;
   } else if (beamSpotOutputBase_ == "runbased") {
     LuminosityBlockNumber_t firstLumi = beamSpotMap_.begin()->first;
-    std::pair<edm::Timestamp, reco::BeamSpot> thepair(
-        beamSpotMap_.begin()->second.first,
-        weight(beamSpotMap_.begin(), beamSpotMap_.end()));
+    std::pair<edm::Timestamp, reco::BeamSpot> thepair(beamSpotMap_.begin()->second.first,
+                                                      weight(beamSpotMap_.begin(), beamSpotMap_.end()));
     beamSpotMap_.clear();
     beamSpotMap_[firstLumi] = thepair;
   } else {
-    LogInfo("AlcaBeamSpotManager")
-        << "Unrecognized BeamSpotOutputBase parameter: " << beamSpotOutputBase_
-        << endl;
+    LogInfo("AlcaBeamSpotManager") << "Unrecognized BeamSpotOutputBase parameter: " << beamSpotOutputBase_ << endl;
   }
 }
 
 //--------------------------------------------------------------------------------------------------
-BeamSpot AlcaBeamSpotManager::weight(const bsMap_iterator &begin,
-                                     const bsMap_iterator &end) {
+BeamSpot AlcaBeamSpotManager::weight(const bsMap_iterator &begin, const bsMap_iterator &end) {
   double x, xError = 0;
   double y, yError = 0;
   double z, zError = 0;
@@ -414,25 +356,18 @@ BeamSpot AlcaBeamSpotManager::weight(const bsMap_iterator &begin,
   double dydz, dydzError = 0;
   double widthX, widthXError = 0;
   double widthY, widthYError = 0;
-  LogInfo("AlcaBeamSpotManager")
-      << "Weighted BeamSpot will span lumi " << begin->first << " to "
-      << end->first << endl;
+  LogInfo("AlcaBeamSpotManager") << "Weighted BeamSpot will span lumi " << begin->first << " to " << end->first << endl;
 
   BeamSpot::BeamType type = BeamSpot::Unknown;
   for (bsMap_iterator it = begin; it != end; it++) {
     weight(x, xError, it->second.second.x0(), it->second.second.x0Error());
     weight(y, yError, it->second.second.y0(), it->second.second.y0Error());
     weight(z, zError, it->second.second.z0(), it->second.second.z0Error());
-    weight(sigmaZ, sigmaZError, it->second.second.sigmaZ(),
-           it->second.second.sigmaZ0Error());
-    weight(dxdz, dxdzError, it->second.second.dxdz(),
-           it->second.second.dxdzError());
-    weight(dydz, dydzError, it->second.second.dydz(),
-           it->second.second.dydzError());
-    weight(widthX, widthXError, it->second.second.BeamWidthX(),
-           it->second.second.BeamWidthXError());
-    weight(widthY, widthYError, it->second.second.BeamWidthY(),
-           it->second.second.BeamWidthYError());
+    weight(sigmaZ, sigmaZError, it->second.second.sigmaZ(), it->second.second.sigmaZ0Error());
+    weight(dxdz, dxdzError, it->second.second.dxdz(), it->second.second.dxdzError());
+    weight(dydz, dydzError, it->second.second.dydz(), it->second.second.dydzError());
+    weight(widthX, widthXError, it->second.second.BeamWidthX(), it->second.second.BeamWidthXError());
+    weight(widthY, widthYError, it->second.second.BeamWidthY(), it->second.second.BeamWidthYError());
     if (it->second.second.type() == BeamSpot::Tracker) {
       type = BeamSpot::Tracker;
     }
@@ -446,17 +381,14 @@ BeamSpot AlcaBeamSpotManager::weight(const bsMap_iterator &begin,
   error(4, 4) = dxdzError * dxdzError;
   error(5, 5) = dydzError * dydzError;
   error(6, 6) = widthXError * widthXError;
-  BeamSpot weightedBeamSpot(bsPosition, sigmaZ, dxdz, dydz, widthX, error,
-                            type);
+  BeamSpot weightedBeamSpot(bsPosition, sigmaZ, dxdz, dydz, widthX, error, type);
   weightedBeamSpot.setBeamWidthY(widthY);
-  LogInfo("AlcaBeamSpotManager") << "Weighted BeamSpot will be:" << '\n'
-                                 << weightedBeamSpot << endl;
+  LogInfo("AlcaBeamSpotManager") << "Weighted BeamSpot will be:" << '\n' << weightedBeamSpot << endl;
   return weightedBeamSpot;
 }
 
 //--------------------------------------------------------------------------------------------------
-void AlcaBeamSpotManager::weight(double &mean, double &meanError,
-                                 const double &val, const double &valError) {
+void AlcaBeamSpotManager::weight(double &mean, double &meanError, const double &val, const double &valError) {
   double tmpError = 0;
   if (meanError < 1e-8) {
     tmpError = 1 / (valError * valError);
@@ -474,8 +406,7 @@ pair<float, float> AlcaBeamSpotManager::delta(const float &x,
                                               const float &xError,
                                               const float &nextX,
                                               const float &nextXError) {
-  return pair<float, float>(x - nextX,
-                            sqrt(pow(xError, 2) + pow(nextXError, 2)));
+  return pair<float, float>(x - nextX, sqrt(pow(xError, 2) + pow(nextXError, 2)));
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/Calibration/TkAlCaRecoProducers/src/CalibrationTrackSelector.cc
+++ b/Calibration/TkAlCaRecoProducers/src/CalibrationTrackSelector.cc
@@ -25,8 +25,7 @@ const int kFPIX = PixelSubdetector::PixelEndcap;
 CalibrationTrackSelector::CalibrationTrackSelector(const edm::ParameterSet &cfg)
     : applyBasicCuts_(cfg.getParameter<bool>("applyBasicCuts")),
       applyNHighestPt_(cfg.getParameter<bool>("applyNHighestPt")),
-      applyMultiplicityFilter_(
-          cfg.getParameter<bool>("applyMultiplicityFilter")),
+      applyMultiplicityFilter_(cfg.getParameter<bool>("applyMultiplicityFilter")),
       seedOnlyFromAbove_(cfg.getParameter<int>("seedOnlyFrom")),
       applyIsolation_(cfg.getParameter<bool>("applyIsolationCut")),
       chargeCheck_(cfg.getParameter<bool>("applyChargeCheck")),
@@ -50,53 +49,38 @@ CalibrationTrackSelector::CalibrationTrackSelector(const edm::ParameterSet &cfg)
       nHitMin2D_(cfg.getParameter<unsigned int>("nHitMin2D")),
       // Ugly to use the same getParameter 6 times, but this allows const cut
       // variables...
-      minHitsinTIB_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet")
-                        .getParameter<int>("inTIB")),
-      minHitsinTOB_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet")
-                        .getParameter<int>("inTOB")),
-      minHitsinTID_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet")
-                        .getParameter<int>("inTID")),
-      minHitsinTEC_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet")
-                        .getParameter<int>("inTEC")),
-      minHitsinBPIX_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet")
-                         .getParameter<int>("inBPIX")),
-      minHitsinFPIX_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet")
-                         .getParameter<int>("inFPIX")) {
-
+      minHitsinTIB_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inTIB")),
+      minHitsinTOB_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inTOB")),
+      minHitsinTID_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inTID")),
+      minHitsinTEC_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inTEC")),
+      minHitsinBPIX_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inBPIX")),
+      minHitsinFPIX_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inFPIX")) {
   if (applyBasicCuts_)
     edm::LogInfo("CalibrationTrackSelector")
         << "applying basic track cuts ..."
-        << "\nptmin,ptmax:     " << ptMin_ << "," << ptMax_
-        << "\netamin,etamax:   " << etaMin_ << "," << etaMax_
-        << "\nphimin,phimax:   " << phiMin_ << "," << phiMax_
-        << "\nnhitmin,nhitmax: " << nHitMin_ << "," << nHitMax_
-        << "\nnhitmin2D:       " << nHitMin2D_
-        << "\nchi2nmax:        " << chi2nMax_;
+        << "\nptmin,ptmax:     " << ptMin_ << "," << ptMax_ << "\netamin,etamax:   " << etaMin_ << "," << etaMax_
+        << "\nphimin,phimax:   " << phiMin_ << "," << phiMax_ << "\nnhitmin,nhitmax: " << nHitMin_ << "," << nHitMax_
+        << "\nnhitmin2D:       " << nHitMin2D_ << "\nchi2nmax:        " << chi2nMax_;
 
   if (applyNHighestPt_)
-    edm::LogInfo("CalibrationTrackSelector")
-        << "filter N tracks with highest Pt N=" << nHighestPt_;
+    edm::LogInfo("CalibrationTrackSelector") << "filter N tracks with highest Pt N=" << nHighestPt_;
 
   if (applyMultiplicityFilter_)
     edm::LogInfo("CalibrationTrackSelector")
-        << "apply multiplicity filter N>= " << minMultiplicity_
-        << "and N<= " << maxMultiplicity_ << " on "
+        << "apply multiplicity filter N>= " << minMultiplicity_ << "and N<= " << maxMultiplicity_ << " on "
         << (multiplicityOnInput_ ? "input" : "output");
 
   if (applyIsolation_)
     edm::LogInfo("CalibrationTrackSelector")
-        << "only retain tracks isolated at least by " << minHitIsolation_
-        << " cm from other rechits";
+        << "only retain tracks isolated at least by " << minHitIsolation_ << " cm from other rechits";
 
   if (chargeCheck_)
     edm::LogInfo("CalibrationTrackSelector")
-        << "only retain hits with at least " << minHitChargeStrip_
-        << " ADC counts of total cluster charge";
+        << "only retain hits with at least " << minHitChargeStrip_ << " ADC counts of total cluster charge";
 
   edm::LogInfo("CalibrationTrackSelector")
-      << "Minimum number of hits in TIB/TID/TOB/TEC/BPIX/FPIX = "
-      << minHitsinTIB_ << "/" << minHitsinTID_ << "/" << minHitsinTOB_ << "/"
-      << minHitsinTEC_ << "/" << minHitsinBPIX_ << "/" << minHitsinFPIX_;
+      << "Minimum number of hits in TIB/TID/TOB/TEC/BPIX/FPIX = " << minHitsinTIB_ << "/" << minHitsinTID_ << "/"
+      << minHitsinTOB_ << "/" << minHitsinTEC_ << "/" << minHitsinBPIX_ << "/" << minHitsinFPIX_;
 }
 
 // destructor -----------------------------------------------------------------
@@ -105,14 +89,11 @@ CalibrationTrackSelector::~CalibrationTrackSelector() {}
 
 // do selection ---------------------------------------------------------------
 
-CalibrationTrackSelector::Tracks
-CalibrationTrackSelector::select(const Tracks &tracks,
-                                 const edm::Event &evt) const {
-
+CalibrationTrackSelector::Tracks CalibrationTrackSelector::select(const Tracks &tracks, const edm::Event &evt) const {
   if (applyMultiplicityFilter_ && multiplicityOnInput_ &&
       (tracks.size() < static_cast<unsigned int>(minMultiplicity_) ||
        tracks.size() > static_cast<unsigned int>(maxMultiplicity_))) {
-    return Tracks(); // empty collection
+    return Tracks();  // empty collection
   }
 
   Tracks result = tracks;
@@ -128,7 +109,6 @@ CalibrationTrackSelector::select(const Tracks &tracks,
   if (applyMultiplicityFilter_ && !multiplicityOnInput_) {
     if (result.size() < static_cast<unsigned int>(minMultiplicity_) ||
         result.size() > static_cast<unsigned int>(maxMultiplicity_)) {
-
       result.clear();
     }
   }
@@ -141,9 +121,8 @@ CalibrationTrackSelector::select(const Tracks &tracks,
 
 // make basic cuts ------------------------------------------------------------
 
-CalibrationTrackSelector::Tracks
-CalibrationTrackSelector::basicCuts(const Tracks &tracks,
-                                    const edm::Event &evt) const {
+CalibrationTrackSelector::Tracks CalibrationTrackSelector::basicCuts(const Tracks &tracks,
+                                                                     const edm::Event &evt) const {
   Tracks result;
 
   for (Tracks::const_iterator it = tracks.begin(); it != tracks.end(); ++it) {
@@ -157,9 +136,8 @@ CalibrationTrackSelector::basicCuts(const Tracks &tracks,
     // edm::LogDebug("CalibrationTrackSelector") << " pt,eta,phi,nhit: "
     //  <<pt<<","<<eta<<","<<phi<<","<<nhit;
 
-    if (pt > ptMin_ && pt < ptMax_ && eta > etaMin_ && eta < etaMax_ &&
-        phi > phiMin_ && phi < phiMax_ && nhit >= nHitMin_ &&
-        nhit <= nHitMax_ && chi2n < chi2nMax_) {
+    if (pt > ptMin_ && pt < ptMax_ && eta > etaMin_ && eta < etaMax_ && phi > phiMin_ && phi < phiMax_ &&
+        nhit >= nHitMin_ && nhit <= nHitMax_ && chi2n < chi2nMax_) {
       if (this->detailedHitsCheck(trackp, evt))
         result.push_back(trackp);
     }
@@ -170,13 +148,11 @@ CalibrationTrackSelector::basicCuts(const Tracks &tracks,
 
 //-----------------------------------------------------------------------------
 
-bool CalibrationTrackSelector::detailedHitsCheck(const reco::Track *trackp,
-                                                 const edm::Event &evt) const {
+bool CalibrationTrackSelector::detailedHitsCheck(const reco::Track *trackp, const edm::Event &evt) const {
   // checking hit requirements beyond simple number of valid hits
 
-  if (minHitsinTIB_ || minHitsinTOB_ || minHitsinTID_ || minHitsinTEC_ ||
-      minHitsinFPIX_ || minHitsinBPIX_ || nHitMin2D_ || chargeCheck_ ||
-      applyIsolation_) { // any detailed hit cut is active, so have to check
+  if (minHitsinTIB_ || minHitsinTOB_ || minHitsinTID_ || minHitsinTEC_ || minHitsinFPIX_ || minHitsinBPIX_ ||
+      nHitMin2D_ || chargeCheck_ || applyIsolation_) {  // any detailed hit cut is active, so have to check
 
     int nhitinTIB = 0, nhitinTOB = 0, nhitinTID = 0;
     int nhitinTEC = 0, nhitinBPIX = 0, nhitinFPIX = 0;
@@ -184,7 +160,6 @@ bool CalibrationTrackSelector::detailedHitsCheck(const reco::Track *trackp,
     unsigned int thishit = 0;
 
     for (auto const &hit : trackp->recHits()) {
-
       thishit++;
       int type = hit->geographicalId().subdetId();
 
@@ -195,22 +170,19 @@ bool CalibrationTrackSelector::detailedHitsCheck(const reco::Track *trackp,
       // seedOnlyFrom = 1 is TIB-TOB-TEC tracks only
       // seedOnlyFrom = 2 is TOB-TEC tracks only
       if (seedOnlyFromAbove_ == 1 && thishit == 1 &&
-          (type == int(StripSubdetector::TOB) ||
-           type == int(StripSubdetector::TEC)))
+          (type == int(StripSubdetector::TOB) || type == int(StripSubdetector::TEC)))
         return false;
 
-      if (seedOnlyFromAbove_ == 2 && thishit == 1 &&
-          type == int(StripSubdetector::TIB))
+      if (seedOnlyFromAbove_ == 2 && thishit == 1 && type == int(StripSubdetector::TIB))
         return false;
 
       if (!hit->isValid())
-        continue; // only real hits count as in trackp->numberOfValidHits()
+        continue;  // only real hits count as in trackp->numberOfValidHits()
       const DetId detId(hit->geographicalId());
       if (detId.det() != DetId::Tracker) {
         edm::LogError("DetectorMismatch")
             << "@SUB=CalibrationTrackSelector::detailedHitsCheck"
-            << "DetId.det() != DetId::Tracker (=" << DetId::Tracker << "), but "
-            << detId.det() << ".";
+            << "DetId.det() != DetId::Tracker (=" << DetId::Tracker << "), but " << detId.det() << ".";
       }
       if (chargeCheck_ && !(this->isOkCharge(hit)))
         return false;
@@ -232,12 +204,11 @@ bool CalibrationTrackSelector::detailedHitsCheck(const reco::Track *trackp,
       // reason:
       if (nHit2D < nHitMin2D_ && this->isHit2D(*hit))
         ++nHit2D;
-    } // end loop on hits
-    return (nhitinTIB >= minHitsinTIB_ && nhitinTOB >= minHitsinTOB_ &&
-            nhitinTID >= minHitsinTID_ && nhitinTEC >= minHitsinTEC_ &&
-            nhitinBPIX >= minHitsinBPIX_ && nhitinFPIX >= minHitsinFPIX_ &&
+    }  // end loop on hits
+    return (nhitinTIB >= minHitsinTIB_ && nhitinTOB >= minHitsinTOB_ && nhitinTID >= minHitsinTID_ &&
+            nhitinTEC >= minHitsinTEC_ && nhitinBPIX >= minHitsinBPIX_ && nhitinFPIX >= minHitsinFPIX_ &&
             nHit2D >= nHitMin2D_);
-  } else { // no cuts set, so we are just fine and can avoid loop on hits
+  } else {  // no cuts set, so we are just fine and can avoid loop on hits
     return true;
   }
 }
@@ -246,32 +217,30 @@ bool CalibrationTrackSelector::detailedHitsCheck(const reco::Track *trackp,
 
 bool CalibrationTrackSelector::isHit2D(const TrackingRecHit &hit) const {
   if (hit.dimension() < 2) {
-    return false; // some (muon...) stuff really has RecHit1D
+    return false;  // some (muon...) stuff really has RecHit1D
   } else {
     const DetId detId(hit.geographicalId());
     if (detId.det() == DetId::Tracker) {
       if (detId.subdetId() == kBPIX || detId.subdetId() == kFPIX) {
-        return true; // pixel is always 2D
-      } else {       // should be SiStrip now
+        return true;  // pixel is always 2D
+      } else {        // should be SiStrip now
         if (dynamic_cast<const SiStripRecHit2D *>(&hit))
-          return false; // normal hit
+          return false;  // normal hit
         else if (dynamic_cast<const SiStripMatchedRecHit2D *>(&hit))
-          return true; // matched is 2D
+          return true;  // matched is 2D
         else if (dynamic_cast<const ProjectedSiStripRecHit2D *>(&hit))
-          return false; // crazy hit...
+          return false;  // crazy hit...
         else {
-          edm::LogError("UnkownType")
-              << "@SUB=CalibrationTrackSelector::isHit2D"
-              << "Tracker hit not in pixel and neither SiStripRecHit2D nor "
-              << "SiStripMatchedRecHit2D nor ProjectedSiStripRecHit2D.";
+          edm::LogError("UnkownType") << "@SUB=CalibrationTrackSelector::isHit2D"
+                                      << "Tracker hit not in pixel and neither SiStripRecHit2D nor "
+                                      << "SiStripMatchedRecHit2D nor ProjectedSiStripRecHit2D.";
           return false;
         }
       }
-    } else { // not tracker??
-      edm::LogWarning("DetectorMismatch")
-          << "@SUB=CalibrationTrackSelector::isHit2D"
-          << "Hit not in tracker with 'official' dimension >=2.";
-      return true; // dimension() >= 2 so accept that...
+    } else {  // not tracker??
+      edm::LogWarning("DetectorMismatch") << "@SUB=CalibrationTrackSelector::isHit2D"
+                                          << "Hit not in tracker with 'official' dimension >=2.";
+      return true;  // dimension() >= 2 so accept that...
     }
   }
   // never reached...
@@ -279,27 +248,22 @@ bool CalibrationTrackSelector::isHit2D(const TrackingRecHit &hit) const {
 
 //-----------------------------------------------------------------------------
 
-bool CalibrationTrackSelector::isOkCharge(
-    const TrackingRecHit *therechit) const {
+bool CalibrationTrackSelector::isOkCharge(const TrackingRecHit *therechit) const {
   float charge1 = 0;
   float charge2 = 0;
-  const SiStripMatchedRecHit2D *matchedhit =
-      dynamic_cast<const SiStripMatchedRecHit2D *>(therechit);
+  const SiStripMatchedRecHit2D *matchedhit = dynamic_cast<const SiStripMatchedRecHit2D *>(therechit);
   const SiStripRecHit2D *hit = dynamic_cast<const SiStripRecHit2D *>(therechit);
-  const ProjectedSiStripRecHit2D *unmatchedhit =
-      dynamic_cast<const ProjectedSiStripRecHit2D *>(therechit);
+  const ProjectedSiStripRecHit2D *unmatchedhit = dynamic_cast<const ProjectedSiStripRecHit2D *>(therechit);
 
   if (matchedhit) {
     const SiStripCluster &monocluster = matchedhit->monoCluster();
-    const std::vector<uint16_t> amplitudesmono(monocluster.amplitudes().begin(),
-                                               monocluster.amplitudes().end());
+    const std::vector<uint16_t> amplitudesmono(monocluster.amplitudes().begin(), monocluster.amplitudes().end());
     for (size_t ia = 0; ia < amplitudesmono.size(); ++ia) {
       charge1 += amplitudesmono[ia];
     }
 
     const SiStripCluster &stereocluster = matchedhit->stereoCluster();
-    const std::vector<uint16_t> amplitudesstereo(
-        stereocluster.amplitudes().begin(), stereocluster.amplitudes().end());
+    const std::vector<uint16_t> amplitudesstereo(stereocluster.amplitudes().begin(), stereocluster.amplitudes().end());
     for (size_t ia = 0; ia < amplitudesstereo.size(); ++ia) {
       charge2 += amplitudesstereo[ia];
     }
@@ -308,10 +272,8 @@ bool CalibrationTrackSelector::isOkCharge(
     if (charge1 < minHitChargeStrip_ || charge2 < minHitChargeStrip_)
       return false;
   } else if (hit) {
-
     const SiStripCluster *cluster = &*(hit->cluster());
-    const std::vector<uint16_t> amplitudes(cluster->amplitudes().begin(),
-                                           cluster->amplitudes().end());
+    const std::vector<uint16_t> amplitudes(cluster->amplitudes().begin(), cluster->amplitudes().end());
     for (size_t ia = 0; ia < amplitudes.size(); ++ia) {
       charge1 += amplitudes[ia];
     }
@@ -319,11 +281,9 @@ bool CalibrationTrackSelector::isOkCharge(
     if (charge1 < minHitChargeStrip_)
       return false;
   } else if (unmatchedhit) {
-
     const SiStripRecHit2D &orighit = unmatchedhit->originalHit();
     const SiStripCluster *origcluster = &*(orighit.cluster());
-    const std::vector<uint16_t> amplitudes(origcluster->amplitudes().begin(),
-                                           origcluster->amplitudes().end());
+    const std::vector<uint16_t> amplitudes(origcluster->amplitudes().begin(), origcluster->amplitudes().end());
     for (size_t ia = 0; ia < amplitudes.size(); ++ia) {
       charge1 += amplitudes[ia];
     }
@@ -336,9 +296,7 @@ bool CalibrationTrackSelector::isOkCharge(
 
 //-----------------------------------------------------------------------------
 
-bool CalibrationTrackSelector::isIsolated(const TrackingRecHit *therechit,
-                                          const edm::Event &evt) const {
-
+bool CalibrationTrackSelector::isIsolated(const TrackingRecHit *therechit, const edm::Event &evt) const {
   // edm::ESHandle<TrackerGeometry> tracker;
   edm::Handle<SiStripRecHit2DCollection> rphirecHits;
   edm::Handle<SiStripMatchedRecHit2DCollection> matchedrecHits;
@@ -356,28 +314,24 @@ bool CalibrationTrackSelector::isIsolated(const TrackingRecHit *therechit,
   // FIXME: instead of looping the full hit collection, we should explore the
   // features of SiStripRecHit2DCollection::rangeRphi = rphirecHits.get(idet)
   // and loop only from rangeRphi.first until rangeRphi.second
-  for (istripSt = stripcollSt.data().begin();
-       istripSt != stripcollSt.data().end(); ++istripSt) {
+  for (istripSt = stripcollSt.data().begin(); istripSt != stripcollSt.data().end(); ++istripSt) {
     const SiStripRecHit2D *aHit = &*(istripSt);
     DetId mydet1 = aHit->geographicalId();
     if (idet.rawId() != mydet1.rawId())
       continue;
-    float theDistance =
-        (therechit->localPosition() - aHit->localPosition()).mag();
+    float theDistance = (therechit->localPosition() - aHit->localPosition()).mag();
     // std::cout << "theDistance1 = " << theDistance << "\n";
     if (theDistance > 0.001 && theDistance < minHitIsolation_)
       return false;
   }
 
   // FIXME: see above
-  for (istripStm = stripcollStm.data().begin();
-       istripStm != stripcollStm.data().end(); ++istripStm) {
+  for (istripStm = stripcollStm.data().begin(); istripStm != stripcollStm.data().end(); ++istripStm) {
     const SiStripMatchedRecHit2D *aHit = &*(istripStm);
     DetId mydet2 = aHit->geographicalId();
     if (idet.rawId() != mydet2.rawId())
       continue;
-    float theDistance =
-        (therechit->localPosition() - aHit->localPosition()).mag();
+    float theDistance = (therechit->localPosition() - aHit->localPosition()).mag();
     // std::cout << "theDistance1 = " << theDistance << "\n";
     if (theDistance > 0.001 && theDistance < minHitIsolation_)
       return false;
@@ -386,8 +340,7 @@ bool CalibrationTrackSelector::isIsolated(const TrackingRecHit *therechit,
 }
 //-----------------------------------------------------------------------------
 
-CalibrationTrackSelector::Tracks
-CalibrationTrackSelector::theNHighestPtTracks(const Tracks &tracks) const {
+CalibrationTrackSelector::Tracks CalibrationTrackSelector::theNHighestPtTracks(const Tracks &tracks) const {
   Tracks sortedTracks = tracks;
   Tracks result;
 
@@ -396,8 +349,7 @@ CalibrationTrackSelector::theNHighestPtTracks(const Tracks &tracks) const {
 
   // copy theTrackMult highest pt tracks to result vector
   int n = 0;
-  for (Tracks::const_iterator it = sortedTracks.begin();
-       it != sortedTracks.end(); ++it) {
+  for (Tracks::const_iterator it = sortedTracks.begin(); it != sortedTracks.end(); ++it) {
     if (n < nHighestPt_) {
       result.push_back(*it);
       n++;

--- a/Calibration/TkAlCaRecoProducers/test/DQMRootFileReader.cc
+++ b/Calibration/TkAlCaRecoProducers/test/DQMRootFileReader.cc
@@ -59,8 +59,7 @@ DQMRootFileReader::DQMRootFileReader(const edm::ParameterSet &iConfig) {
   // get hold of back-end interface
   dbe = edm::Service<DQMStore>().operator->();
 
-  filename = iConfig.getUntrackedParameter<std::string>("RootFileName",
-                                                        "test_playback.root");
+  filename = iConfig.getUntrackedParameter<std::string>("RootFileName", "test_playback.root");
 }
 
 DQMRootFileReader::~DQMRootFileReader() {
@@ -79,8 +78,7 @@ void DQMRootFileReader::endJob(void) {
 //
 
 // ------------ method called to produce the data  ------------
-void DQMRootFileReader::analyze(const edm::Event &iEvent,
-                                const edm::EventSetup &iSetup) {
+void DQMRootFileReader::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // NOTE: this is here just because we need it after the beginRun of
   // MEtoEDMCoverter which calls a Reset on all MEs.
   dbe->open(filename, false, "", "", DQMStore::OpenRunDirs::StripRunDirs);


### PR DESCRIPTION

Applying code-format for CMSSW category alca.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/195//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Fixes the code-formats suggested by #26630 (see #26686)
