### PR TITLE
Running code-format for l1

### DIFF
--- a/EventFilter/DTTFRawToDigi/interface/DTTFFEDReader.h
+++ b/EventFilter/DTTFRawToDigi/interface/DTTFFEDReader.h
@@ -29,7 +29,6 @@
 #include <string>
 
 class DTTFFEDReader : public edm::stream::EDProducer<> {
-
 public:
   /// Constructor
   DTTFFEDReader(const edm::ParameterSet &pset);

--- a/EventFilter/DTTFRawToDigi/interface/DTTFFEDSim.h
+++ b/EventFilter/DTTFRawToDigi/interface/DTTFFEDSim.h
@@ -27,7 +27,6 @@
 #include <string>
 
 class DTTFFEDSim : public edm::stream::EDProducer<> {
-
 public:
   /// Constructor
   DTTFFEDSim(const edm::ParameterSet &pset);

--- a/EventFilter/DTTFRawToDigi/src/DTTFFEDReader.cc
+++ b/EventFilter/DTTFRawToDigi/src/DTTFFEDReader.cc
@@ -24,7 +24,6 @@
 using namespace std;
 
 DTTFFEDReader::DTTFFEDReader(const edm::ParameterSet &pset) {
-
   produces<L1MuDTChambPhContainer>();
   produces<L1MuDTChambThContainer>();
   produces<L1MuDTTrackContainer>("DATA");
@@ -39,7 +38,6 @@ DTTFFEDReader::DTTFFEDReader(const edm::ParameterSet &pset) {
 DTTFFEDReader::~DTTFFEDReader() {}
 
 void DTTFFEDReader::produce(edm::Event &e, const edm::EventSetup &c) {
-
   unique_ptr<L1MuDTChambPhContainer> phi_product(new L1MuDTChambPhContainer);
   unique_ptr<L1MuDTChambThContainer> the_product(new L1MuDTChambThContainer);
   unique_ptr<L1MuDTTrackContainer> tra_product(new L1MuDTTrackContainer);
@@ -60,11 +58,10 @@ void DTTFFEDReader::produce(edm::Event &e, const edm::EventSetup &c) {
   e.put(std::move(tra_product), "DATA");
 }
 
-bool DTTFFEDReader::fillRawData(
-    edm::Event &e, L1MuDTChambPhContainer::Phi_Container &phi_data,
-    L1MuDTChambThContainer::The_Container &the_data,
-    L1MuDTTrackContainer::TrackContainer &tra_data) {
-
+bool DTTFFEDReader::fillRawData(edm::Event &e,
+                                L1MuDTChambPhContainer::Phi_Container &phi_data,
+                                L1MuDTChambThContainer::The_Container &the_data,
+                                L1MuDTTrackContainer::TrackContainer &tra_data) {
   analyse(e);
 
   phi_data = p_data();
@@ -86,7 +83,6 @@ void DTTFFEDReader::analyse(edm::Event &e) {
 
 // process data
 void DTTFFEDReader::process(edm::Event &e) {
-
   // Container
   vector<int> DTTFWordContainer;
   vector<int>::iterator DTTFiterator;
@@ -119,15 +115,14 @@ void DTTFFEDReader::process(edm::Event &e) {
   *dataWord2 = *((int *)LineFED);
   LineFED += 4;
   *dataWord1 = *((int *)LineFED);
-  int lines = 1; // already counting header
+  int lines = 1;  // already counting header
 
-  BOEevTy = ((*dataWord1) & 0xFF000000) >> 24; // positions 57 ->64
-  DTTFId = ((*dataWord2) & 0x000FFF00) >> 8;   // positions 9 ->20
+  BOEevTy = ((*dataWord1) & 0xFF000000) >> 24;  // positions 57 ->64
+  DTTFId = ((*dataWord2) & 0x000FFF00) >> 8;    // positions 9 ->20
 
   if ((BOEevTy != 0x50) || (DTTFId != 0x030C)) {
     if (verbose_)
-      edm::LogWarning("dttf_unpacker")
-          << "Not a DTTF header " << hex << *dataWord1;
+      edm::LogWarning("dttf_unpacker") << "Not a DTTF header " << hex << *dataWord1;
     delete dataWord1;
     delete dataWord2;
     return;
@@ -146,7 +141,6 @@ void DTTFFEDReader::process(edm::Event &e) {
   lines++;
 
   while (chkEOE != 0xA00) {
-
     dt_crc::calcCRC(*dataWord1, *dataWord2, newCRC);
 
     DTTFWord = *dataWord1;
@@ -163,30 +157,28 @@ void DTTFFEDReader::process(edm::Event &e) {
 
     if (lines > 3026) {
       if (verbose_)
-        edm::LogWarning("dttf_unpacker")
-            << "Warning : number of DTTF lines > 3026 "; // 3026 = 1(header) +
-                                                         // 3024(max # PHTF-ETTF
-                                                         // 64 bits words) +
-                                                         // 1(trailer)
+        edm::LogWarning("dttf_unpacker") << "Warning : number of DTTF lines > 3026 ";  // 3026 = 1(header) +
+                                                                                       // 3024(max # PHTF-ETTF
+                                                                                       // 64 bits words) +
+                                                                                       // 1(trailer)
       delete dataWord1;
       delete dataWord2;
       return;
     }
 
-  } // end while-Data loop
+  }  // end while-Data loop
 
   //--> Trailer
 
-  evtLgth = ((*dataWord1) & 0x00FFFFFF);   // positions 33 ->56
-  CRC = ((*dataWord2) & 0xFFFF0000) >> 16; // positions 17 ->32
+  evtLgth = ((*dataWord1) & 0x00FFFFFF);    // positions 33 ->56
+  CRC = ((*dataWord2) & 0xFFFF0000) >> 16;  // positions 17 ->32
 
   dt_crc::calcCRC(*dataWord1, (*dataWord2) & 0xFFFF, newCRC);
 
   if (newCRC != CRC) {
     if (verbose_)
-      edm::LogWarning("dttf_unpacker")
-          << "Calculated CRC " << hex << newCRC
-          << " differs from CRC in trailer " << hex << CRC;
+      edm::LogWarning("dttf_unpacker") << "Calculated CRC " << hex << newCRC << " differs from CRC in trailer " << hex
+                                       << CRC;
     delete dataWord1;
     delete dataWord2;
     return;
@@ -194,9 +186,7 @@ void DTTFFEDReader::process(edm::Event &e) {
 
   if (lines != evtLgth) {
     if (verbose_)
-      edm::LogWarning("dttf_unpacker")
-          << "Number of words read != event length " << dec << lines << " "
-          << evtLgth;
+      edm::LogWarning("dttf_unpacker") << "Number of words read != event length " << dec << lines << " " << evtLgth;
     delete dataWord1;
     delete dataWord2;
     return;
@@ -204,9 +194,7 @@ void DTTFFEDReader::process(edm::Event &e) {
 
   // --> analyse event
 
-  for (DTTFiterator = DTTFWordContainer.begin();
-       DTTFiterator != DTTFWordContainer.end(); DTTFiterator++) {
-
+  for (DTTFiterator = DTTFWordContainer.begin(); DTTFiterator != DTTFWordContainer.end(); DTTFiterator++) {
     DTTFChan = ((*DTTFiterator) & 0xFF000000) >> 24;
     DTTFiterator++;
     bitsID = ((*DTTFiterator) & 0xF0000000) >> 28;
@@ -223,7 +211,6 @@ void DTTFFEDReader::process(edm::Event &e) {
 
     // Input
     if (wheelID != 0 && bitsID <= 0x9) {
-
       int wheelPh = (abs(wheelID) - 1) * wheelID / abs(wheelID);
       int stationID = 0;
       int ra = 0;
@@ -245,7 +232,6 @@ void DTTFFEDReader::process(edm::Event &e) {
       }
 
       if (stationID != 3) {
-
         ts2tag = (bitsID)&0x1;
         tsqual = (~(*DTTFiterator) & 0x07) - 1;
         ba = (~(*DTTFiterator) & 0x1FF8) >> 3;
@@ -255,7 +241,6 @@ void DTTFFEDReader::process(edm::Event &e) {
         if (ra > 0x7FF)
           ra -= 0x1000;
       } else {
-
         ts2tag = (bitsID)&0x1;
         tsqual = (~(*DTTFiterator) & 0x07) - 1;
         ra = (~(*DTTFiterator) & 0x7FF8) >> 3;
@@ -264,25 +249,21 @@ void DTTFFEDReader::process(edm::Event &e) {
       }
 
       if (tsqual != 7 && wheelID != -1) {
-        phiSegments.push_back(L1MuDTChambPhDigi(bxID + ts2tag, wheelPh,
-                                                sectorID, stationID, ra, ba,
-                                                tsqual, ts2tag, 0));
+        phiSegments.push_back(
+            L1MuDTChambPhDigi(bxID + ts2tag, wheelPh, sectorID, stationID, ra, ba, tsqual, ts2tag, 0));
       }
     }
     // Input
 
     // Input
     if (wheelID == 0 && bitsID <= 0x4) {
-
       int wheelTh = bitsID - 2;
 
       int posALL, posBTI[7];
 
       if (wheelTh == -2 || wheelTh == -1 ||
           (wheelTh == 0 &&
-           (sectorID == 0 || sectorID == 3 || sectorID == 4 || sectorID == 7 ||
-            sectorID == 8 || sectorID == 11))) {
-
+           (sectorID == 0 || sectorID == 3 || sectorID == 4 || sectorID == 7 || sectorID == 8 || sectorID == 11))) {
         posALL = ~(*DTTFiterator) & 0x7F;
         posBTI[0] = ~(*DTTFiterator) & 0x01;
         posBTI[1] = (~(*DTTFiterator) & 0x02) >> 1;
@@ -293,8 +274,7 @@ void DTTFFEDReader::process(edm::Event &e) {
         posBTI[6] = (~(*DTTFiterator) & 0x40) >> 6;
 
         if (posALL) {
-          theSegments.push_back(
-              L1MuDTChambThDigi(bxID, wheelTh, sectorID, 1, posBTI));
+          theSegments.push_back(L1MuDTChambThDigi(bxID, wheelTh, sectorID, 1, posBTI));
         }
 
         posALL = ~(*DTTFiterator) & 0x3F80;
@@ -307,8 +287,7 @@ void DTTFFEDReader::process(edm::Event &e) {
         posBTI[6] = (~(*DTTFiterator) & 0x2000) >> 13;
 
         if (posALL) {
-          theSegments.push_back(
-              L1MuDTChambThDigi(bxID, wheelTh, sectorID, 2, posBTI));
+          theSegments.push_back(L1MuDTChambThDigi(bxID, wheelTh, sectorID, 2, posBTI));
         }
 
         posALL = ~(*DTTFiterator) & 0x1FC000;
@@ -321,13 +300,11 @@ void DTTFFEDReader::process(edm::Event &e) {
         posBTI[6] = (~(*DTTFiterator) & 0x100000) >> 20;
 
         if (posALL) {
-          theSegments.push_back(
-              L1MuDTChambThDigi(bxID, wheelTh, sectorID, 3, posBTI));
+          theSegments.push_back(L1MuDTChambThDigi(bxID, wheelTh, sectorID, 3, posBTI));
         }
       }
 
       else {
-
         posALL = ~(*DTTFiterator) & 0x7F;
         posBTI[6] = ~(*DTTFiterator) & 0x01;
         posBTI[5] = (~(*DTTFiterator) & 0x02) >> 1;
@@ -338,8 +315,7 @@ void DTTFFEDReader::process(edm::Event &e) {
         posBTI[0] = (~(*DTTFiterator) & 0x40) >> 6;
 
         if (posALL) {
-          theSegments.push_back(
-              L1MuDTChambThDigi(bxID, wheelTh, sectorID, 1, posBTI));
+          theSegments.push_back(L1MuDTChambThDigi(bxID, wheelTh, sectorID, 1, posBTI));
         }
 
         posALL = ~(*DTTFiterator) & 0x3F80;
@@ -352,8 +328,7 @@ void DTTFFEDReader::process(edm::Event &e) {
         posBTI[0] = (~(*DTTFiterator) & 0x2000) >> 13;
 
         if (posALL) {
-          theSegments.push_back(
-              L1MuDTChambThDigi(bxID, wheelTh, sectorID, 2, posBTI));
+          theSegments.push_back(L1MuDTChambThDigi(bxID, wheelTh, sectorID, 2, posBTI));
         }
 
         posALL = ~(*DTTFiterator) & 0x1FC000;
@@ -366,8 +341,7 @@ void DTTFFEDReader::process(edm::Event &e) {
         posBTI[0] = (~(*DTTFiterator) & 0x100000) >> 20;
 
         if (posALL) {
-          theSegments.push_back(
-              L1MuDTChambThDigi(bxID, wheelTh, sectorID, 3, posBTI));
+          theSegments.push_back(L1MuDTChambThDigi(bxID, wheelTh, sectorID, 3, posBTI));
         }
       }
     }
@@ -375,7 +349,6 @@ void DTTFFEDReader::process(edm::Event &e) {
 
     // Addresses
     if (wheelID != 0 && bitsID >= 0xA && bitsID <= 0xB) {
-
       int candID = bitsID - 0xA;
 
       addr4[candID] = ((*DTTFiterator) & 0x0F);
@@ -387,7 +360,6 @@ void DTTFFEDReader::process(edm::Event &e) {
 
     // Output
     if (wheelID != 0 && bitsID >= 0xC) {
-
       int muonID = 0;
       int pt = 0;
       int ch = 0;
@@ -401,16 +373,28 @@ void DTTFFEDReader::process(edm::Event &e) {
       pt = (~(*DTTFiterator) & 0x1F000) >> 12;
 
       if (qual != 0) {
-        dtTracks.push_back(L1MuDTTrackCand(
-            0, phi, 0, pt, ch, 1, 0, qual, bxID, wheelID, sectorID, muonID,
-            addr1[muonID], addr2[muonID], addr3[muonID], addr4[muonID]));
+        dtTracks.push_back(L1MuDTTrackCand(0,
+                                           phi,
+                                           0,
+                                           pt,
+                                           ch,
+                                           1,
+                                           0,
+                                           qual,
+                                           bxID,
+                                           wheelID,
+                                           sectorID,
+                                           muonID,
+                                           addr1[muonID],
+                                           addr2[muonID],
+                                           addr3[muonID],
+                                           addr4[muonID]));
       }
     }
     // Output
 
     // Output
     if (wheelID == 0 && bitsID >= 0x8) {
-
       int wheelTh = bitsID & 0x7;
 
       int etaALL;
@@ -418,21 +402,18 @@ void DTTFFEDReader::process(edm::Event &e) {
       etaALL = ~(*DTTFiterator) & 0x007F;
       if (etaALL) {
         etTrack[bxID + 1][sectorID][wheelTh][0] = (*DTTFiterator) & 0x003F;
-        efTrack[bxID + 1][sectorID][wheelTh][0] =
-            (~(*DTTFiterator) & 0x0040) >> 6;
+        efTrack[bxID + 1][sectorID][wheelTh][0] = (~(*DTTFiterator) & 0x0040) >> 6;
       }
 
       etaALL = (~(*DTTFiterator) & 0x3F80) >> 7;
       if (etaALL) {
-        etTrack[bxID + 1][sectorID][wheelTh][1] =
-            ((*DTTFiterator) & 0x1F80) >> 7;
-        efTrack[bxID + 1][sectorID][wheelTh][1] =
-            (~(*DTTFiterator) & 0x2000) >> 13;
+        etTrack[bxID + 1][sectorID][wheelTh][1] = ((*DTTFiterator) & 0x1F80) >> 7;
+        efTrack[bxID + 1][sectorID][wheelTh][1] = (~(*DTTFiterator) & 0x2000) >> 13;
       }
     }
     // Output
 
-  } // end for-loop container content
+  }  // end for-loop container content
 
   delete dataWord1;
   delete dataWord2;
@@ -440,9 +421,7 @@ void DTTFFEDReader::process(edm::Event &e) {
 }
 
 void DTTFFEDReader::match() {
-
-  for (L1MuDTTrackContainer::TrackIterator i = dtTracks.begin();
-       i != dtTracks.end(); i++) {
+  for (L1MuDTTrackContainer::TrackIterator i = dtTracks.begin(); i != dtTracks.end(); i++) {
     int bxTh = i->bx() + 1;
     int sectorTh = i->scNum();
     int wheelTh = i->whNum() + 3;
@@ -458,17 +437,11 @@ void DTTFFEDReader::match() {
 }
 
 // access data
-const L1MuDTChambPhContainer::Phi_Container &DTTFFEDReader::p_data() {
-  return phiSegments;
-}
+const L1MuDTChambPhContainer::Phi_Container &DTTFFEDReader::p_data() { return phiSegments; }
 
-const L1MuDTChambThContainer::The_Container &DTTFFEDReader::t_data() {
-  return theSegments;
-}
+const L1MuDTChambThContainer::The_Container &DTTFFEDReader::t_data() { return theSegments; }
 
-const L1MuDTTrackContainer::TrackContainer &DTTFFEDReader::k_data() {
-  return dtTracks;
-}
+const L1MuDTTrackContainer::TrackContainer &DTTFFEDReader::k_data() { return dtTracks; }
 
 void DTTFFEDReader::clear() {
   phiSegments.clear();
@@ -490,7 +463,6 @@ void DTTFFEDReader::clear() {
 }
 
 int DTTFFEDReader::channel(int wheel, int sector, int bx) {
-
   // wheel  :  -3 -2 -1 +1 +2 +3 <=> PHTF's : N2, N1, N0, P0, P1, P2
   //                           0 <=> ETTF
   // sector :  0 -> 11
@@ -517,7 +489,6 @@ int DTTFFEDReader::channel(int wheel, int sector, int bx) {
 }
 
 int DTTFFEDReader::bxNr(int channel) {
-
   int myChannel = channel;
 
   if (myChannel > 127)
@@ -533,7 +504,6 @@ int DTTFFEDReader::bxNr(int channel) {
 }
 
 int DTTFFEDReader::sector(int channel) {
-
   int myChannel = channel;
 
   if (myChannel > 127)
@@ -547,7 +517,6 @@ int DTTFFEDReader::sector(int channel) {
 }
 
 int DTTFFEDReader::wheel(int channel) {
-
   int myChannel = channel;
 
   if (myChannel > 127)

--- a/EventFilter/DTTFRawToDigi/src/DTTFFEDSim.cc
+++ b/EventFilter/DTTFRawToDigi/src/DTTFFEDSim.cc
@@ -24,7 +24,6 @@
 using namespace std;
 
 DTTFFEDSim::DTTFFEDSim(const edm::ParameterSet &pset) : eventNum(0) {
-
   produces<FEDRawDataCollection>();
 
   DTDigiInputTag = pset.getParameter<edm::InputTag>("DTDigi_Source");
@@ -38,7 +37,6 @@ DTTFFEDSim::DTTFFEDSim(const edm::ParameterSet &pset) : eventNum(0) {
 DTTFFEDSim::~DTTFFEDSim() {}
 
 void DTTFFEDSim::produce(edm::Event &e, const edm::EventSetup &c) {
-
   FEDRawDataCollection data;
 
   if (!fillRawData(e, data))
@@ -50,7 +48,6 @@ void DTTFFEDSim::produce(edm::Event &e, const edm::EventSetup &c) {
 }
 
 bool DTTFFEDSim::fillRawData(edm::Event &e, FEDRawDataCollection &data) {
-
   eventNum = e.id().event();
 
   int lines = 2;
@@ -68,7 +65,7 @@ bool DTTFFEDSim::fillRawData(edm::Event &e, FEDRawDataCollection &data) {
   lines += trtrig->bxSize(-1, 1) * 3;
 
   FEDRawData &dttfdata = data.FEDData(0x30C);
-  dttfdata.resize(lines * 8); // size in bytes
+  dttfdata.resize(lines * 8);  // size in bytes
   unsigned char *LineFED = dttfdata.data();
 
   int *dataWord1 = new int;
@@ -88,7 +85,7 @@ bool DTTFFEDSim::fillRawData(edm::Event &e, FEDRawDataCollection &data) {
 
   //--> DTTF data
 
-  int TS1Id[4], TS2Id[4]; // word identifier for TS #1,#2 for stations
+  int TS1Id[4], TS2Id[4];  // word identifier for TS #1,#2 for stations
   TS1Id[0] = 0x0E;
   TS2Id[0] = 0x1E;
   TS1Id[1] = 0x2E;
@@ -101,10 +98,8 @@ bool DTTFFEDSim::fillRawData(edm::Event &e, FEDRawDataCollection &data) {
   // Input
   L1MuDTChambPhContainer::Phi_iterator tsphi;
 
-  for (tsphi = phtrig->getContainer()->begin();
-       tsphi != phtrig->getContainer()->end(); tsphi++) {
+  for (tsphi = phtrig->getContainer()->begin(); tsphi != phtrig->getContainer()->end(); tsphi++) {
     if (tsphi->code() != 7) {
-
       int wheelID = tsphi->whNum() + 1;
       if (wheelID <= 0)
         wheelID -= 2;
@@ -119,13 +114,10 @@ bool DTTFFEDSim::fillRawData(edm::Event &e, FEDRawDataCollection &data) {
       *dataWord1 = ((channelNr & 0xFF) << 24) + 0x00FFFFFF;
 
       if (stationID != 2) {
-        *dataWord2 = ((TSId & 0x0FF) << 24) + (~(tsphi->code() + 1) & 0x007) +
-                     ((~tsphi->phiB() & 0x3FF) << 3) +
+        *dataWord2 = ((TSId & 0x0FF) << 24) + (~(tsphi->code() + 1) & 0x007) + ((~tsphi->phiB() & 0x3FF) << 3) +
                      ((~tsphi->phi() & 0xFFF) << 13);
       } else {
-        *dataWord2 = ((TSId & 0xFFFFF) << 12) +
-                     (~(tsphi->code() + 1) & 0x00007) +
-                     ((~tsphi->phi() & 0x00FFF) << 3);
+        *dataWord2 = ((TSId & 0xFFFFF) << 12) + (~(tsphi->code() + 1) & 0x00007) + ((~tsphi->phi() & 0x00FFF) << 3);
       }
 
       dt_crc::calcCRC(*dataWord1, *dataWord2, newCRC);
@@ -141,9 +133,7 @@ bool DTTFFEDSim::fillRawData(edm::Event &e, FEDRawDataCollection &data) {
   // Input
   L1MuDTChambThContainer::The_iterator tsthe;
 
-  for (tsthe = thtrig->getContainer()->begin();
-       tsthe != thtrig->getContainer()->end(); tsthe++) {
-
+  for (tsthe = thtrig->getContainer()->begin(); tsthe != thtrig->getContainer()->end(); tsthe++) {
     int wheelTh = tsthe->whNum();
     int sectorID = tsthe->scNum();
 
@@ -159,8 +149,8 @@ bool DTTFFEDSim::fillRawData(edm::Event &e, FEDRawDataCollection &data) {
     int stationID = tsthe->stNum() - 1;
     for (int bti = 0; bti < 7; bti++)
       if (wheelTh == -2 || wheelTh == -1 ||
-          (wheelTh == 0 && (sectorID == 0 || sectorID == 3 || sectorID == 4 ||
-                            sectorID == 7 || sectorID == 8 || sectorID == 11)))
+          (wheelTh == 0 &&
+           (sectorID == 0 || sectorID == 3 || sectorID == 4 || sectorID == 7 || sectorID == 8 || sectorID == 11)))
         *dataWord2 -= (tsthe->position(bti) & 0x1) << (stationID * 7 + bti);
       else
         *dataWord2 -= (tsthe->position(6 - bti) & 0x1) << (stationID * 7 + bti);
@@ -177,9 +167,7 @@ bool DTTFFEDSim::fillRawData(edm::Event &e, FEDRawDataCollection &data) {
   // Output
   L1MuDTTrackContainer::Trackiterator tstrk;
 
-  for (tstrk = trtrig->getContainer()->begin();
-       tstrk != trtrig->getContainer()->end(); tstrk++) {
-
+  for (tstrk = trtrig->getContainer()->begin(); tstrk != trtrig->getContainer()->end(); tstrk++) {
     int channelNr = channel(tstrk->whNum(), tstrk->scNum(), tstrk->bx());
     if (channelNr == 255)
       continue;
@@ -187,10 +175,8 @@ bool DTTFFEDSim::fillRawData(edm::Event &e, FEDRawDataCollection &data) {
 
     *dataWord1 = ((channelNr & 0xFF) << 24) + 0x00FFFFFF;
 
-    *dataWord2 = ((TSId & 0xFFFF) << 16) + (tstrk->stNum(4) & 0x0000F) +
-                 ((tstrk->stNum(3) & 0x0000F) << 4) +
-                 ((tstrk->stNum(2) & 0x0000F) << 8) +
-                 ((tstrk->stNum(1) & 0x00003) << 12);
+    *dataWord2 = ((TSId & 0xFFFF) << 16) + (tstrk->stNum(4) & 0x0000F) + ((tstrk->stNum(3) & 0x0000F) << 4) +
+                 ((tstrk->stNum(2) & 0x0000F) << 8) + ((tstrk->stNum(1) & 0x00003) << 12);
 
     dt_crc::calcCRC(*dataWord1, *dataWord2, newCRC);
 
@@ -203,10 +189,8 @@ bool DTTFFEDSim::fillRawData(edm::Event &e, FEDRawDataCollection &data) {
 
     *dataWord1 = ((channelNr & 0xFF) << 24) + 0x00FFFFFF;
 
-    *dataWord2 = ((TSId & 0xFFFE) << 16) + (~tstrk->quality_packed() & 0x0007) +
-                 ((tstrk->phi_packed() & 0x00FF) << 3) +
-                 ((~tstrk->charge_packed() & 0x0001) << 11) +
-                 ((~tstrk->pt_packed() & 0x001F) << 12);
+    *dataWord2 = ((TSId & 0xFFFE) << 16) + (~tstrk->quality_packed() & 0x0007) + ((tstrk->phi_packed() & 0x00FF) << 3) +
+                 ((~tstrk->charge_packed() & 0x0001) << 11) + ((~tstrk->pt_packed() & 0x001F) << 12);
 
     dt_crc::calcCRC(*dataWord1, *dataWord2, newCRC);
 
@@ -226,11 +210,9 @@ bool DTTFFEDSim::fillRawData(edm::Event &e, FEDRawDataCollection &data) {
     *dataWord2 = (TSId & 0xFFFFC) << 12;
 
     if (tstrk->TrkTag() == 0) {
-      *dataWord2 += 0x3F80 + (tstrk->eta_packed() & 0x003F) +
-                    ((~tstrk->finehalo_packed() & 0x0001) << 6);
+      *dataWord2 += 0x3F80 + (tstrk->eta_packed() & 0x003F) + ((~tstrk->finehalo_packed() & 0x0001) << 6);
     } else {
-      *dataWord2 += 0x007F + ((tstrk->eta_packed() & 0x003F) << 7) +
-                    ((~tstrk->finehalo_packed() & 0x0001) << 13);
+      *dataWord2 += 0x007F + ((tstrk->eta_packed() & 0x003F) << 7) + ((~tstrk->finehalo_packed() & 0x0001) << 13);
     }
 
     dt_crc::calcCRC(*dataWord1, *dataWord2, newCRC);
@@ -262,7 +244,6 @@ bool DTTFFEDSim::fillRawData(edm::Event &e, FEDRawDataCollection &data) {
 }
 
 int DTTFFEDSim::channel(int wheel, int sector, int bx) {
-
   // wheel  :  -3 -2 -1 +1 +2 +3 <=> PHTF's : N2, N1, N0, P0, P1, P2
   //                           0 <=> ETTF
   // sector :  0 -> 11
@@ -289,7 +270,6 @@ int DTTFFEDSim::channel(int wheel, int sector, int bx) {
 }
 
 int DTTFFEDSim::bxNr(int channel) {
-
   int myChannel = channel;
 
   if (myChannel > 127)
@@ -305,7 +285,6 @@ int DTTFFEDSim::bxNr(int channel) {
 }
 
 int DTTFFEDSim::sector(int channel) {
-
   int myChannel = channel;
 
   if (myChannel > 127)
@@ -319,7 +298,6 @@ int DTTFFEDSim::sector(int channel) {
 }
 
 int DTTFFEDSim::wheel(int channel) {
-
   int myChannel = channel;
 
   if (myChannel > 127)

--- a/L1Trigger/DTTraco/interface/DTTracoCand.h
+++ b/L1Trigger/DTTraco/interface/DTTracoCand.h
@@ -36,7 +36,6 @@ class DTTracoChip;
 //              ---------------------
 
 class DTTracoCand {
-
 public:
   /// Constructor
   DTTracoCand() {}
@@ -104,12 +103,12 @@ public:
   void print() const;
 
 private:
-  DTTracoChip *_traco; // Parent DTTracoChip
+  DTTracoChip *_traco;  // Parent DTTracoChip
 
-  const DTBtiTrigData *_btitr; // Associated BTI trigger
+  const DTBtiTrigData *_btitr;  // Associated BTI trigger
 
   // Other variables
-  BitArray<7> _dataword; // the word on which sorting is done
+  BitArray<7> _dataword;  // the word on which sorting is done
   int _step;
   int _position;
   int _usable;

--- a/L1Trigger/DTTraco/interface/DTTracoCard.h
+++ b/L1Trigger/DTTraco/interface/DTTracoCard.h
@@ -56,7 +56,6 @@ typedef std::map<DTTracoId, DTConfigTraco> ConfTracoMap;
 typedef DTCache<DTTracoTrigData, std::vector<DTTracoTrigData>> TRACOCache;
 
 class DTTracoCard : public TRACOCache, public DTGeomSupplier {
-
 public:
   /// Constructor
   // DTTracoCard(DTTrigGeom*, DTBtiCard*, DTTSTheta*,edm::ParameterSet&);
@@ -81,9 +80,7 @@ public:
   DTTracoChip *getTRACO(int n) const;
 
   /// Returns the required DTTracoChip. Return 0 if it doesn't exist
-  DTTracoChip *getTRACO(const DTTracoId &tracoid) const {
-    return getTRACO(tracoid.traco());
-  }
+  DTTracoChip *getTRACO(const DTTracoId &tracoid) const { return getTRACO(tracoid.traco()); }
 
   /// Returns the active TRACO list
   std::vector<DTTracoChip *> tracoList();
@@ -127,9 +124,7 @@ private:
   DTTracoChip *activeGetTRACO(int);
 
   /// Returns the required DTTracoChip. Create it if it doesn't exist
-  DTTracoChip *activeGetTRACO(const DTTracoId &tracoid) {
-    return activeGetTRACO(tracoid.traco());
-  }
+  DTTracoChip *activeGetTRACO(const DTTracoId &tracoid) { return activeGetTRACO(tracoid.traco()); }
 
   /// clear the TRACO map
   void localClear();
@@ -142,7 +137,7 @@ private:
   DTTSTheta *_tstheta;
 
   TRACOContainer _tracomap;
-  ConfTracoMap _conf_traco_map; // bti configuration map for this chamber
+  ConfTracoMap _conf_traco_map;  // bti configuration map for this chamber
 
   const DTConfigLUTs *_conf_luts;
 

--- a/L1Trigger/DTTraco/interface/DTTracoChip.h
+++ b/L1Trigger/DTTraco/interface/DTTracoChip.h
@@ -51,7 +51,6 @@ class DTTracoTrigData;
 //              ---------------------
 
 class DTTracoChip {
-
 public:
   /// Constructor
   // DTTracoChip(DTTracoCard* card, int n);
@@ -154,9 +153,7 @@ public:
   void setFlag(int step, int ext = 0);
 
   /// return overlap flag
-  inline int ovlFlag(int step) {
-    return _flag[step - DTConfigTraco::NSTEPF].element(1);
-  }
+  inline int ovlFlag(int step) { return _flag[step - DTConfigTraco::NSTEPF].element(1); }
 
 private:
   /// Get the best inner/outer candidate
@@ -172,12 +169,10 @@ private:
   int AdjBtiLTSuppressed(DTTracoCand *candidate);
 
   /// Check correlation and store correlated trigger
-  int storeCorr(DTTracoTrig *tctrig, DTTracoCand *inner, DTTracoCand *outer,
-                int tkn);
+  int storeCorr(DTTracoTrig *tctrig, DTTracoCand *inner, DTTracoCand *outer, int tkn);
 
   /// Store uncorrelated trigger
-  int storeUncorr(DTTracoTrig *tctrig, DTTracoCand *inner, DTTracoCand *outer,
-                  int tkn);
+  int storeUncorr(DTTracoTrig *tctrig, DTTracoCand *inner, DTTracoCand *outer, int tkn);
 
   /// Check if a trigger is inside the angular acceptance window
   int insideAngWindow(DTTracoTrig *) const;
@@ -200,14 +195,11 @@ private:
   int _dd;
 
   // input data
-  std::vector<DTTracoCand>
-      _innerCand[DTConfigTraco::NSTEPL - DTConfigTraco::NSTEPF + 1];
-  std::vector<DTTracoCand>
-      _outerCand[DTConfigTraco::NSTEPL - DTConfigTraco::NSTEPF + 1];
+  std::vector<DTTracoCand> _innerCand[DTConfigTraco::NSTEPL - DTConfigTraco::NSTEPF + 1];
+  std::vector<DTTracoCand> _outerCand[DTConfigTraco::NSTEPL - DTConfigTraco::NSTEPF + 1];
 
   // output data
-  std::vector<DTTracoTrig *>
-      _tracotrig[DTConfigTraco::NSTEPL - DTConfigTraco::NSTEPF + 1];
+  std::vector<DTTracoTrig *> _tracotrig[DTConfigTraco::NSTEPL - DTConfigTraco::NSTEPF + 1];
 
   // internal use variables: SV 11V04 lts suppression if to bx+1, bx=array index
   BitArray<DTConfigTraco::NSTEPL + 2> _bxlts;

--- a/L1Trigger/DTTraco/interface/DTTracoLUTs.h
+++ b/L1Trigger/DTTraco/interface/DTTracoLUTs.h
@@ -31,7 +31,6 @@
 typedef std::vector<unsigned short int> LUT;
 
 class DTTracoLUTs {
-
 public:
   //    typedef static std::vector<unsigned short int> LUT;
 
@@ -64,8 +63,8 @@ public:
   inline int size_phiLUT(int i) const { return phi_lut[i].size(); }
 
 private:
-  LUT phi_lut[3]; // phi rad: elem.0: inner; elem.1: outer; elem.2: corr.
-  LUT psi_lut;    // psi
+  LUT phi_lut[3];  // phi rad: elem.0: inner; elem.1: outer; elem.2: corr.
+  LUT psi_lut;     // psi
   std::string _testfile;
 };
 

--- a/L1Trigger/DTTraco/interface/DTTracoTrig.h
+++ b/L1Trigger/DTTraco/interface/DTTracoTrig.h
@@ -38,7 +38,6 @@ class DTTracoChip;
 //              ---------------------
 
 class DTTracoTrig : public DTTrigData {
-
 public:
   /// Constructors
   DTTracoTrig();
@@ -56,14 +55,10 @@ public:
   inline void setParent(DTTracoChip *parent) { _tparent = parent; }
 
   /// Add a BTI trigger to the list
-  inline void addDTBtiTrig(const DTBtiTrigData *btitrig) {
-    _btitrig.push_back(btitrig);
-  }
+  inline void addDTBtiTrig(const DTBtiTrigData *btitrig) { _btitrig.push_back(btitrig); }
 
   /// Set trigger preview parameters
-  inline void setPV(int first, int code, int K, int io) {
-    _data.setPV(first, code, K, io);
-  }
+  inline void setPV(int first, int code, int K, int io) { _data.setPV(first, code, K, io); }
 
   /// Set trigger preview correlation bit
   inline void setPVCorr(int ic) { _data.setPVCorr(ic); }
@@ -93,9 +88,7 @@ public:
   inline void setX(int x) { _data.setX(x); }
 
   /// Set trigger angles
-  inline void setAngles(int psi, int psir, int dpsir) {
-    _data.setAngles(psi, psir, dpsir);
-  }
+  inline void setAngles(int psi, int psir, int dpsir) { _data.setAngles(psi, psir, dpsir); }
 
   /// Reset all variables but preview
   inline void resetVar() { _data.resetVar(); }

--- a/L1Trigger/DTTraco/interface/DTTracoTrigData.h
+++ b/L1Trigger/DTTraco/interface/DTTracoTrigData.h
@@ -35,7 +35,6 @@
 typedef unsigned char myint8;
 
 class DTTracoTrigData : public DTTrigData {
-
 public:
   // public methods
 
@@ -215,7 +214,7 @@ public:
 
 private:
   // parent TRACO
-  DTTracoId _tracoid; // this is 4 bytes
+  DTTracoId _tracoid;  // this is 4 bytes
 
   // step number
   myint8 _step;

--- a/L1Trigger/DTTraco/interface/Lut.h
+++ b/L1Trigger/DTTraco/interface/Lut.h
@@ -24,12 +24,11 @@
 
 #define ANGRESOL 512.0
 #define POSRESOL 4096.0
-#define SL_D 23.5      //(cm)SL Distance
-#define CELL_PITCH 4.2 //(cm)Wire Distance
-#define SL_DIFF 11.75  // (cm )Distance of SL from station center
+#define SL_D 23.5       //(cm)SL Distance
+#define CELL_PITCH 4.2  //(cm)Wire Distance
+#define SL_DIFF 11.75   // (cm )Distance of SL from station center
 
 class Lut {
-
 public:
   Lut(){};
   Lut(const DTConfigLUTs *conf, int ntc, float SL_shift);
@@ -47,13 +46,13 @@ public:
   void DSPtoIEEE32(short DSPmantissa, short DSPexp, float *f);
 
 public:
-  float m_d;   // distance vertex - normal
-  float m_Xcn; // Distance correlator - normal
-  int m_ST;    // TRACO BTIC parameter
-  int m_wheel; // Wheel sign (+1 or -1)
+  float m_d;    // distance vertex - normal
+  float m_Xcn;  // Distance correlator - normal
+  int m_ST;     // TRACO BTIC parameter
+  int m_wheel;  // Wheel sign (+1 or -1)
 
 private:
-  float m_pitch_d_ST; //=pitch/ST private:
+  float m_pitch_d_ST;  //=pitch/ST private:
 
   const DTConfigLUTs *_conf_luts;
 };

--- a/L1Trigger/DTTraco/src/DTTracoCand.cc
+++ b/L1Trigger/DTTraco/src/DTTracoCand.cc
@@ -36,10 +36,8 @@
 //----------------
 // Constructors --
 //----------------
-DTTracoCand::DTTracoCand(DTTracoChip *tc, const DTBtiTrigData *btitr, int pos,
-                         int step)
+DTTracoCand::DTTracoCand(DTTracoChip *tc, const DTBtiTrigData *btitr, int pos, int step)
     : _traco(tc), _btitr(btitr), _step(step), _position(pos), _usable(1) {
-
   if (pos < 1 || pos > 4 * DTConfigTraco::NBTITC) {
     std::cout << "DTTracoCand::DTTracoCand: wrong position: " << pos;
     std::cout << ", dummy coordinates set!" << std::endl;
@@ -55,10 +53,8 @@ DTTracoCand::DTTracoCand(DTTracoChip *tc, const DTBtiTrigData *btitr, int pos,
   // X in local TRACO frame (position conversion): Xtr = Xbti + BTIC*(i+4 or
   // o-4)
   int lstep = tc->BTIC();
-  _tcX = btitr->X() + lstep * ((pos <= DTConfigTraco::NBTITC) *
-                                   (pos - 1 + DTConfigTraco::NBTITC) + // inner
-                               (pos > DTConfigTraco::NBTITC) *
-                                   (pos - 1 - DTConfigTraco::NBTITC)); // outer
+  _tcX = btitr->X() + lstep * ((pos <= DTConfigTraco::NBTITC) * (pos - 1 + DTConfigTraco::NBTITC) +  // inner
+                               (pos > DTConfigTraco::NBTITC) * (pos - 1 - DTConfigTraco::NBTITC));   // outer
 
   // NEWGEO add phi sl offset to inner positions
   if (btitr->btiSL() == 1)
@@ -91,8 +87,12 @@ DTTracoCand::DTTracoCand(DTTracoChip *tc, const DTBtiTrigData *btitr, int pos,
 }
 
 DTTracoCand::DTTracoCand(const DTTracoCand &tccand)
-    : _traco(tccand._traco), _btitr(tccand._btitr), _step(tccand._step),
-      _position(tccand._position), _usable(tccand._usable), _tcX(tccand._tcX),
+    : _traco(tccand._traco),
+      _btitr(tccand._btitr),
+      _step(tccand._step),
+      _position(tccand._position),
+      _usable(tccand._usable),
+      _tcX(tccand._tcX),
       _tcK(tccand._tcK) {}
 
 //--------------

--- a/L1Trigger/DTTraco/src/DTTracoCard.cc
+++ b/L1Trigger/DTTraco/src/DTTracoCard.cc
@@ -45,8 +45,7 @@
 // Constructors --
 //----------------
 
-DTTracoCard::DTTracoCard(DTTrigGeom *geo, DTBtiCard *bticard,
-                         DTTSTheta *tstheta)
+DTTracoCard::DTTracoCard(DTTrigGeom *geo, DTBtiCard *bticard, DTTSTheta *tstheta)
     : DTGeomSupplier(geo), _bticard(bticard), _tstheta(tstheta) {}
 
 //--------------
@@ -60,7 +59,6 @@ DTTracoCard::~DTTracoCard() { localClear(); }
 //--------------
 
 void DTTracoCard::clearCache() {
-
   TRACOCache::clearCache();
   localClear();
 }
@@ -92,7 +90,6 @@ void DTTracoCard::localClear() {
 }
 
 void DTTracoCard::loadTRACO() {
-
   localClear();
 
   if (debug()) {
@@ -139,8 +136,7 @@ void DTTracoCard::loadTRACO() {
       continue;
 
     if (debug())
-      std::cout << "Bti trigger assigned to traco " << ntc << " (maxtc "
-                << maxtc << ")" << std::endl;
+      std::cout << "Bti trigger assigned to traco " << ntc << " (maxtc " << maxtc << ")" << std::endl;
 
     // TRACO information
     DTTracoId tracoid = DTTracoId(wheel(), station(), sector(), ntc);
@@ -159,9 +155,8 @@ void DTTracoCard::loadTRACO() {
       if (!_flag_acc || (K >= CL && K <= CH))
         activeGetTRACO(ntc)->add_btiT(step, pos, &(*p));
       else if (debug())
-        std::cout << "ATTENTION: in TRACO n. " << ntc << " bti pos " << pos
-                  << " trigger K= " << K << " outside acceptance " << CL
-                  << "<K<" << CH << std::endl;
+        std::cout << "ATTENTION: in TRACO n. " << ntc << " bti pos " << pos << " trigger K= " << K
+                  << " outside acceptance " << CL << "<K<" << CH << std::endl;
     }
 
     // Load slave TRACO plane
@@ -182,10 +177,8 @@ void DTTracoCard::loadTRACO() {
           activeGetTRACO(ntc - 1)->add_btiT(step, pos + 8 - 4 * (-1), &(*p));
         } else {
           if (debug()) {
-            std::cout << "ATTENTION: in TRACO n. " << ntc - 1 << " bti pos "
-                      << pos + 8 - 4 * (-1) << " trigger K= " << K
-                      << " outside acceptance " << LL << "<K<" << LH
-                      << std::endl;
+            std::cout << "ATTENTION: in TRACO n. " << ntc - 1 << " bti pos " << pos + 8 - 4 * (-1)
+                      << " trigger K= " << K << " outside acceptance " << LL << "<K<" << LH << std::endl;
           }
         }
       }
@@ -196,10 +189,8 @@ void DTTracoCard::loadTRACO() {
           activeGetTRACO(ntc)->add_btiT(step, pos + 8 - 4 * (0), &(*p));
         } else {
           if (debug())
-            std::cout << "ATTENTION: in TRACO n. " << ntc << " bti pos "
-                      << pos + 8 - 4 * (0) << " trigger K= " << K
-                      << " outside acceptance " << CL << "<K<" << CH
-                      << std::endl;
+            std::cout << "ATTENTION: in TRACO n. " << ntc << " bti pos " << pos + 8 - 4 * (0) << " trigger K= " << K
+                      << " outside acceptance " << CL << "<K<" << CH << std::endl;
         }
       }
 
@@ -209,21 +200,18 @@ void DTTracoCard::loadTRACO() {
           activeGetTRACO(ntc + 1)->add_btiT(step, pos + 8 - 4 * (+1), &(*p));
         } else {
           if (debug())
-            std::cout << "ATTENTION: in TRACO n. " << ntc + 1 << " bti pos "
-                      << pos + 8 - 4 * (+1) << " trigger K= " << K
-                      << " outside acceptance " << RL << "<K<" << RH
-                      << std::endl;
+            std::cout << "ATTENTION: in TRACO n. " << ntc + 1 << " bti pos " << pos + 8 - 4 * (+1)
+                      << " trigger K= " << K << " outside acceptance " << RL << "<K<" << RH << std::endl;
         }
       }
     }
 
     // Filter Theta BTIs -> this is done in DTBtiChip
 
-  } // end loop on bti trigs
+  }  // end loop on bti trigs
 }
 
 void DTTracoCard::runTRACO() {
-
   if (debug()) {
     std::cout << "DTTracoCard:runTRACO called for wheel=" << wheel();
     std::cout << ", station=" << station();
@@ -233,12 +221,9 @@ void DTTracoCard::runTRACO() {
 
   // run TRACO algorithm on all non-empty TRACO
   if (!_tracomap.empty()) {
-
     if (debug()) {
-      std::cout << "===================================================="
-                << std::endl;
-      std::cout << "              TRACO triggers                        "
-                << std::endl;
+      std::cout << "====================================================" << std::endl;
+      std::cout << "              TRACO triggers                        " << std::endl;
     }
 
     TRACO_iter ptraco;
@@ -278,13 +263,11 @@ void DTTracoCard::runTRACO() {
       }
     }
     if (debug())
-      std::cout << "===================================================="
-                << std::endl;
+      std::cout << "====================================================" << std::endl;
   }
 }
 
 DTTracoChip *DTTracoCard::activeGetTRACO(int n) {
-
   // the traco identifier
   DTChamberId sid = geom()->statId();
   DTTracoId _id = DTTracoId(sid, n);
@@ -308,7 +291,6 @@ DTTracoChip *DTTracoCard::getTRACO(int n) const {
 }
 
 std::vector<DTTracoChip *> DTTracoCard::tracoList() {
-
   std::vector<DTTracoChip *> blist;
 
   if (size() < 1)
@@ -322,14 +304,11 @@ std::vector<DTTracoChip *> DTTracoCard::tracoList() {
 
 DTTracoTrig *DTTracoCard::storeTrigger(DTTracoTrigData td) {
   DTTracoId tracoid = td.parentId();
-  if (!(tracoid.wheel() == wheel() && tracoid.sector() == sector() &&
-        tracoid.station() == station()))
+  if (!(tracoid.wheel() == wheel() && tracoid.sector() == sector() && tracoid.station() == station()))
     return nullptr;
   std::cout << "DTTracoChip::trigger: trigger not belonging to this card! ";
-  std::cout << "card=(" << wheel() << "," << station() << "," << sector()
-            << ") ";
-  std::cout << "trig=(" << tracoid.wheel() << "," << tracoid.station() << ","
-            << tracoid.sector() << ")";
+  std::cout << "card=(" << wheel() << "," << station() << "," << sector() << ") ";
+  std::cout << "trig=(" << tracoid.wheel() << "," << tracoid.station() << "," << tracoid.sector() << ")";
   // get the appropriate Traco
   DTTracoChip *traco = activeGetTRACO(tracoid.traco());
   // create a new trigger in the Traco
@@ -371,20 +350,16 @@ std::endl; return LocalPoint(0,0,0);
 
 LocalPoint DTTracoCard::localPosition(const DTTrigData *tr) const {
   // NEWGEO
-  DTTracoTrigData *trig =
-      dynamic_cast<DTTracoTrigData *>(const_cast<DTTrigData *>(tr));
+  DTTracoTrigData *trig = dynamic_cast<DTTracoTrigData *>(const_cast<DTTrigData *>(tr));
   if (!trig) {
-    std::cout << "DTTracoCard::localPosition called with wrong argument!"
-              << std::endl;
+    std::cout << "DTTracoCard::localPosition called with wrong argument!" << std::endl;
     return LocalPoint(0, 0, 0);
   }
   float x = geom()->localPosition(trig->parentId()).x();
   float y = geom()->localPosition(trig->parentId()).y();
   float z = geom()->localPosition(trig->parentId()).z();
 
-  float trig_pos =
-      geom()->cellPitch() *
-      ((float)trig->X() / (float)(config_traco(trig->parentId())->BTIC()));
+  float trig_pos = geom()->cellPitch() * ((float)trig->X() / (float)(config_traco(trig->parentId())->BTIC()));
 
   //  10/7/06 May be not needed anymore in new geometry
   //   if(geom()->posFE(1)==1)
@@ -395,9 +370,9 @@ LocalPoint DTTracoCard::localPosition(const DTTrigData *tr) const {
   // If not correlated get the position of the SL instead of the chamber center
   // z axis toward vertex
   if (trig->posIn() == 0) {
-    z -= 0.5 * geom()->distSL(); // no inner ==> only outer
+    z -= 0.5 * geom()->distSL();  // no inner ==> only outer
   } else if (trig->posOut() == 0) {
-    z += 0.5 * geom()->distSL(); // no outer ==> only inner
+    z += 0.5 * geom()->distSL();  // no outer ==> only inner
   }
   return LocalPoint(x, y, z);
 }
@@ -427,23 +402,20 @@ std::endl; return LocalVector(0,0,0);
 
 LocalVector DTTracoCard::localDirection(const DTTrigData *tr) const {
   // NEWGEO
-  DTTracoTrigData *trig =
-      dynamic_cast<DTTracoTrigData *>(const_cast<DTTrigData *>(tr));
+  DTTracoTrigData *trig = dynamic_cast<DTTracoTrigData *>(const_cast<DTTrigData *>(tr));
   if (!trig) {
-    std::cout << "DTtracoCard::localDirection called with wrong argument!"
-              << std::endl;
+    std::cout << "DTtracoCard::localDirection called with wrong argument!" << std::endl;
     return LocalVector(0, 0, 0);
   }
 
   // FE position
   // int FE = geom()->posFE(3);
 
-  float psi = atan((float)(trig->K()) * geom()->cellPitch() /
-                   (geom()->distSL() * config_traco(trig->parentId())->BTIC()));
+  float psi =
+      atan((float)(trig->K()) * geom()->cellPitch() / (geom()->distSL() * config_traco(trig->parentId())->BTIC()));
 
   if (config_traco(trig->parentId())->debug() == 4)
-    std::cout << "K " << trig->K() << " == psi " << psi << " in FE frame "
-              << std::endl;
+    std::cout << "K " << trig->K() << " == psi " << psi << " in FE frame " << std::endl;
 
   // (xd,yd,zd) in chamber frame
   float xd = -sin(psi);
@@ -456,8 +428,7 @@ LocalVector DTTracoCard::localDirection(const DTTrigData *tr) const {
   //}
 
   if (config_traco(trig->parentId())->debug() == 4)
-    std::cout << "Direction in chamber frame is (" << xd << "," << yd << ","
-              << zd << ")" << std::endl;
+    std::cout << "Direction in chamber frame is (" << xd << "," << yd << "," << zd << ")" << std::endl;
 
   return LocalVector(xd, yd, zd);
 }
@@ -466,9 +437,8 @@ DTConfigTraco *DTTracoCard::config_traco(const DTTracoId &tracoid) const {
   // loop on map to find traco
   ConfTracoMap::const_iterator titer = _conf_traco_map.find(tracoid);
   if (titer == _conf_traco_map.end()) {
-    std::cout << "DTTracoCard::config_traco : TRACO (" << tracoid.wheel() << ","
-              << tracoid.sector() << "," << tracoid.station() << ","
-              << tracoid.traco() << ") not found, return 0" << std::endl;
+    std::cout << "DTTracoCard::config_traco : TRACO (" << tracoid.wheel() << "," << tracoid.sector() << ","
+              << tracoid.station() << "," << tracoid.traco() << ") not found, return 0" << std::endl;
     return nullptr;
   }
 

--- a/L1Trigger/DTTraco/src/DTTracoChip.cc
+++ b/L1Trigger/DTTraco/src/DTTracoChip.cc
@@ -44,15 +44,12 @@
 // Constructors --
 //----------------
 
-DTTracoChip::DTTracoChip(DTTracoCard *card, int n, DTConfigTraco *conf)
-    : _card(card), _config(conf) {
-
+DTTracoChip::DTTracoChip(DTTracoCard *card, int n, DTConfigTraco *conf) : _card(card), _config(conf) {
   _geom = _card->geom();
 
   // n=traco number 1,2,...
   if (config()->debug() == 4) {
-    std::cout << "DTTracoChip constructor called for TRACO number " << n
-              << std::endl;
+    std::cout << "DTTracoChip constructor called for TRACO number " << n << std::endl;
   }
 
   // set acceptances from CMSSW geometry
@@ -72,8 +69,7 @@ DTTracoChip::DTTracoChip(DTTracoCard *card, int n, DTConfigTraco *conf)
 
   // Flags for LTS
   _bxlts.zero();
-  for (int is = 0; is < DTConfigTraco::NSTEPL - DTConfigTraco::NSTEPF + 1;
-       is++) {
+  for (int is = 0; is < DTConfigTraco::NSTEPL - DTConfigTraco::NSTEPF + 1; is++) {
     _flag[is].zero();
   }
 
@@ -89,8 +85,7 @@ DTTracoChip::DTTracoChip(DTTracoCard *card, int n, DTConfigTraco *conf)
 
   // offset from geometry (x1-x3 FE view): converted from cm to ST units (0.9999
   // for rounding)
-  _ibtioff = static_cast<int>(config()->BTIC() / (_geom->cellPitch()) *
-                              (_geom->phiSLOffset() / 0.9999));
+  _ibtioff = static_cast<int>(config()->BTIC() / (_geom->cellPitch()) * (_geom->phiSLOffset() / 0.9999));
 
   // 091030 SV lut parameters from DB
   // SV 08/12/12 : added flag for computing luts from DB parameters
@@ -99,16 +94,8 @@ DTTracoChip::DTTracoChip(DTTracoCard *card, int n, DTConfigTraco *conf)
     // int traco = int(fmod( double(n-1),4.));
     // 110208 SV for TRACO hardware bug included SL_shift
     // SL shift
-    float xBTI1_3 =
-        _geom
-            ->localPosition(DTBtiId(
-                DTSuperLayerId(sid.wheel(), sid.station(), sid.sector(), 3), 1))
-            .x();
-    float xBTI1_1 =
-        _geom
-            ->localPosition(DTBtiId(
-                DTSuperLayerId(sid.wheel(), sid.station(), sid.sector(), 1), 1))
-            .x();
+    float xBTI1_3 = _geom->localPosition(DTBtiId(DTSuperLayerId(sid.wheel(), sid.station(), sid.sector(), 3), 1)).x();
+    float xBTI1_1 = _geom->localPosition(DTBtiId(DTSuperLayerId(sid.wheel(), sid.station(), sid.sector(), 1), 1)).x();
     float SL_shift = xBTI1_3 - xBTI1_1;
 
     _lutsCCB = new Lut(_card->config_luts(), n, SL_shift);
@@ -158,8 +145,7 @@ DTTracoChip::DTTracoChip(DTTracoCard *card, int n, DTConfigTraco *conf)
 }
 
 DTTracoChip::DTTracoChip(const DTTracoChip &traco)
-    : _geom(traco._geom), _id(traco._id), _card(traco._card),
-      _luts(traco._luts) {
+    : _geom(traco._geom), _id(traco._id), _card(traco._card), _luts(traco._luts) {
   int i = 0;
   for (i = 0; i < DTConfigTraco::NSTEPL - DTConfigTraco::NSTEPF; i++) {
     _innerCand[i].reserve(DTConfigTraco::NBTITC);
@@ -173,14 +159,12 @@ DTTracoChip::DTTracoChip(const DTTracoChip &traco)
     }
     _tracotrig[i].reserve(2);
     std::vector<DTTracoTrig *>::const_iterator p1;
-    for (p1 = traco._tracotrig[i].begin(); p1 < traco._tracotrig[i].end();
-         p1++) {
+    for (p1 = traco._tracotrig[i].begin(); p1 < traco._tracotrig[i].end(); p1++) {
       _tracotrig[i].push_back(*p1);
     }
   }
   _bxlts = traco._bxlts;
-  for (int is = 0; is < DTConfigTraco::NSTEPL - DTConfigTraco::NSTEPF + 1;
-       is++) {
+  for (int is = 0; is < DTConfigTraco::NSTEPL - DTConfigTraco::NSTEPF + 1; is++) {
     _flag[is] = traco._flag[is];
   }
 }
@@ -217,25 +201,21 @@ DTTracoChip &DTTracoChip::operator=(const DTTracoChip &traco) {
     for (i = 0; i < DTConfigTraco::NSTEPL - DTConfigTraco::NSTEPF; i++) {
       _innerCand[i].reserve(DTConfigTraco::NBTITC);
       std::vector<DTTracoCand>::const_iterator p;
-      for (p = traco._innerCand[i].begin(); p < traco._innerCand[i].end();
-           p++) {
+      for (p = traco._innerCand[i].begin(); p < traco._innerCand[i].end(); p++) {
         _innerCand[i].push_back(*p);
       }
       _outerCand[i].reserve(3 * DTConfigTraco::NBTITC);
-      for (p = traco._outerCand[i].begin(); p < traco._outerCand[i].end();
-           p++) {
+      for (p = traco._outerCand[i].begin(); p < traco._outerCand[i].end(); p++) {
         _outerCand[i].push_back(*p);
       }
       _tracotrig[i].reserve(2);
       std::vector<DTTracoTrig *>::const_iterator p1;
-      for (p1 = traco._tracotrig[i].begin(); p1 < traco._tracotrig[i].end();
-           p1++) {
+      for (p1 = traco._tracotrig[i].begin(); p1 < traco._tracotrig[i].end(); p1++) {
         _tracotrig[i].push_back(*p1);
       }
     }
     _bxlts = traco._bxlts;
-    for (int is = 0; is < DTConfigTraco::NSTEPL - DTConfigTraco::NSTEPF + 1;
-         is++) {
+    for (int is = 0; is < DTConfigTraco::NSTEPL - DTConfigTraco::NSTEPF + 1; is++) {
       _flag[is] = traco._flag[is];
     }
   }
@@ -243,10 +223,8 @@ DTTracoChip &DTTracoChip::operator=(const DTTracoChip &traco) {
 }
 
 void DTTracoChip::clear() {
-
   std::vector<DTTracoTrig *>::iterator p1;
-  for (int is = 0; is < DTConfigTraco::NSTEPL - DTConfigTraco::NSTEPF + 1;
-       is++) {
+  for (int is = 0; is < DTConfigTraco::NSTEPL - DTConfigTraco::NSTEPF + 1; is++) {
     for (p1 = _tracotrig[is].begin(); p1 < _tracotrig[is].end(); p1++) {
       delete (*p1);
     }
@@ -259,21 +237,17 @@ void DTTracoChip::clear() {
 }
 
 void DTTracoChip::run() {
-
   // Debugging...
   if (config()->debug() > 1) {
-    std::cout << "DTTracoChip::run: Processing TRACO " << _id.traco()
-              << std::endl;
+    std::cout << "DTTracoChip::run: Processing TRACO " << _id.traco() << std::endl;
   }
   // End debugging
 
-  int maxtc = static_cast<int>(
-      ceil(float(geom()->nCell(1)) / float(DTConfigTraco::NBTITC)));
+  int maxtc = static_cast<int>(ceil(float(geom()->nCell(1)) / float(DTConfigTraco::NBTITC)));
 
   if (_id.traco() < 1 || _id.traco() > maxtc) {
     if (config()->debug() == 4)
-      std::cout << "DTTracoChip::run: wrong TRACO number " << _id.traco()
-                << std::endl;
+      std::cout << "DTTracoChip::run: wrong TRACO number " << _id.traco() << std::endl;
     return;
   }
 
@@ -285,15 +259,13 @@ void DTTracoChip::run() {
     }
 
     // skip if no cand. at this step
-    if (_innerCand[is - DTConfigTraco::NSTEPF].empty() &&
-        _outerCand[is - DTConfigTraco::NSTEPF].empty())
+    if (_innerCand[is - DTConfigTraco::NSTEPF].empty() && _outerCand[is - DTConfigTraco::NSTEPF].empty())
       continue;
 
     // Debugging...
     if (config()->debug() == 4) {
       std::cout << " --> "
-                << _innerCand[is - DTConfigTraco::NSTEPF].size() +
-                       _outerCand[is - DTConfigTraco::NSTEPF].size();
+                << _innerCand[is - DTConfigTraco::NSTEPF].size() + _outerCand[is - DTConfigTraco::NSTEPF].size();
       std::cout << " candidates " << std::endl;
     }
     // End debugging
@@ -303,15 +275,13 @@ void DTTracoChip::run() {
 
     // check if there is a H in bx for LVALIDIFH flag
     if (config()->LVALIDIFH()) {
-      for (unsigned int e = 0;
-           e < _innerCand[is - DTConfigTraco::NSTEPF].size(); e++) {
+      for (unsigned int e = 0; e < _innerCand[is - DTConfigTraco::NSTEPF].size(); e++) {
         if (_innerCand[is - DTConfigTraco::NSTEPF][e].BtiTrig()->code() == 8) {
           _flag[is - DTConfigTraco::NSTEPF].set(9);
           break;
         }
       }
-      for (unsigned int e = 0;
-           e < _outerCand[is - DTConfigTraco::NSTEPF].size(); e++) {
+      for (unsigned int e = 0; e < _outerCand[is - DTConfigTraco::NSTEPF].size(); e++) {
         if (_outerCand[is - DTConfigTraco::NSTEPF][e].BtiTrig()->code() == 8) {
           _flag[is - DTConfigTraco::NSTEPF].set(9);
           break;
@@ -323,22 +293,18 @@ void DTTracoChip::run() {
     // for(int itk=0; itk < DTConfigTraco::NMAXCAND; itk++){
     // FIX this hardcoded 2!!
     for (int itk = 0; itk < 2; itk++) {
-
       // Get the best inner and outer segments
       if (config()->debug() == 4)
         std::cout << "Inner:" << std::endl;
-      DTTracoCand *inner =
-          bestCand(itk, _innerCand[is - DTConfigTraco::NSTEPF]);
+      DTTracoCand *inner = bestCand(itk, _innerCand[is - DTConfigTraco::NSTEPF]);
       if (config()->debug() == 4)
         std::cout << "Outer:" << std::endl;
-      DTTracoCand *outer =
-          bestCand(itk, _outerCand[is - DTConfigTraco::NSTEPF]);
+      DTTracoCand *outer = bestCand(itk, _outerCand[is - DTConfigTraco::NSTEPF]);
 
       // debug
       if (config()->debug() > 1) {
         if (inner || outer)
-          std::cout << "Best candidates for track " << itk + 1
-                    << " are:" << std::endl;
+          std::cout << "Best candidates for track " << itk + 1 << " are:" << std::endl;
         if (inner) {
           std::cout << "inner->";
           inner->print();
@@ -375,7 +341,7 @@ void DTTracoChip::run() {
 
       // skip if no TRACO trigger has been created with this trigger
       if (!tct)
-        break; // something nasty happened. Go to next step
+        break;  // something nasty happened. Go to next step
 
       // try a correlation between segments
       int stored = 0;
@@ -397,35 +363,29 @@ void DTTracoChip::run() {
         // break;-> II track is computed even if no I track found...
       }
 
-    } // end loop on first/second track
+    }  // end loop on first/second track
 
     // Inhibit second track at previous bunch crossing
     if (config()->debug() == 4)
       std::cout << "Checking overlap I-II track..." << std::endl;
-    if (!_tracotrig[is - DTConfigTraco::NSTEPF].empty() &&
-        is > DTConfigTraco::NSTEPF &&
-        (_tracotrig[is - DTConfigTraco::NSTEPF])[0]
-            ->isFirst()) {                      // I track at bx
-      if (nTrig(is - 1) > 0) {                  // there is a track at bx-1
-        if (!(trigger(is - 1, 1)->isFirst()) || // trig 1 is II track
-            (nTrig(is - 1) == 2 &&
-             !(trigger(is - 1, 2)->isFirst()))) { // trig 2 is II track
+    if (!_tracotrig[is - DTConfigTraco::NSTEPF].empty() && is > DTConfigTraco::NSTEPF &&
+        (_tracotrig[is - DTConfigTraco::NSTEPF])[0]->isFirst()) {        // I track at bx
+      if (nTrig(is - 1) > 0) {                                           // there is a track at bx-1
+        if (!(trigger(is - 1, 1)->isFirst()) ||                          // trig 1 is II track
+            (nTrig(is - 1) == 2 && !(trigger(is - 1, 2)->isFirst()))) {  // trig 2 is II track
           raiseOverlap(is);
           if (config()->debug() == 4) {
-            std::cout << "II track at step " << std::hex << is - 1 << std::dec
-                      << "marked rej." << std::endl;
-            std::cout << "I track overlap flag at step " << std::hex << is
-                      << std::dec << " setted" << std::endl;
+            std::cout << "II track at step " << std::hex << is - 1 << std::dec << "marked rej." << std::endl;
+            std::cout << "I track overlap flag at step " << std::hex << is << std::dec << " setted" << std::endl;
           }
         }
       }
     }
     // debug...
-    for (int isd = 0; isd <= DTConfigTraco::NSTEPL - DTConfigTraco::NSTEPF + 1;
-         isd++)
+    for (int isd = 0; isd <= DTConfigTraco::NSTEPL - DTConfigTraco::NSTEPF + 1; isd++)
       if (config()->debug() == 4) {
-        std::cout << "overlap flag step = " << isd + DTConfigTraco::NSTEPF
-                  << "  " << _flag[isd].element(1) << std::endl;
+        std::cout << "overlap flag step = " << isd + DTConfigTraco::NSTEPF << "  " << _flag[isd].element(1)
+                  << std::endl;
       }
     // debugging...
     if (config()->debug() > 0) {
@@ -434,17 +394,16 @@ void DTTracoChip::run() {
           trigger(is, cc)->print();
         }
       }
-    } // end debugging
-  }   // end loop on step
+    }  // end debugging
+  }    // end loop on step
 }
 
 void DTTracoChip::raiseOverlap(int step) {
-  _flag[step - DTConfigTraco::NSTEPF].set(1);     // overlap flag raised
-  _flag[step - DTConfigTraco::NSTEPF - 1].set(2); // mark II rej.
+  _flag[step - DTConfigTraco::NSTEPF].set(1);      // overlap flag raised
+  _flag[step - DTConfigTraco::NSTEPF - 1].set(2);  // mark II rej.
 }
 
 void DTTracoChip::setFlag(int step, int ext) {
-
   if (ext == 0) {
     // this is the original: flags from card
     DTTracoChip *prevTraco = _card->getTRACO(_id.traco() - 1);
@@ -465,7 +424,7 @@ void DTTracoChip::setFlag(int step, int ext) {
     // SV III/03: flags from input EXT: only for testing purpose
     for (int i = 0; i < 6; i++) {
       int ibit = ext >> i;
-      if (ibit & 0x01) // bit i+1 -> flag 3,4,5,6 : IL,IR,OL,OR
+      if (ibit & 0x01)  // bit i+1 -> flag 3,4,5,6 : IL,IR,OL,OR
         _flag[step - DTConfigTraco::NSTEPF].set(i + 1 + 2);
     }
   }
@@ -481,13 +440,11 @@ void DTTracoChip::setFlag(int step, int ext) {
     std::cout << _flag[step - DTConfigTraco::NSTEPF].element(6) << "  ";
     std::cout << _flag[step - DTConfigTraco::NSTEPF].element(7) << "  ";
     std::cout << _flag[step - DTConfigTraco::NSTEPF].element(8) << "  ";
-    std::cout << _flag[step - DTConfigTraco::NSTEPF].element(9) << "  "
-              << std::endl;
-  } // end debugging
+    std::cout << _flag[step - DTConfigTraco::NSTEPF].element(9) << "  " << std::endl;
+  }  // end debugging
 }
 
 DTTracoCand *DTTracoChip::bestCand(int itk, std::vector<DTTracoCand> &tclist) {
-
   // Return if no candidates
   if (tclist.empty())
     return nullptr;
@@ -495,9 +452,8 @@ DTTracoCand *DTTracoChip::bestCand(int itk, std::vector<DTTracoCand> &tclist) {
   // stl function: sort in Ktc ascending or descending order according
   // to user request comparing by default with user-defined <
   // NB don't reverse if candidates are two with same K
-  stable_sort(tclist.begin(), tclist.end()); // 0=K ascending, 1=K descending
-  if (config()->sortKascend(itk) &&
-      !(tclist.size() == 2 && tclist[0].K() == tclist[1].K())) {
+  stable_sort(tclist.begin(), tclist.end());  // 0=K ascending, 1=K descending
+  if (config()->sortKascend(itk) && !(tclist.size() == 2 && tclist[0].K() == tclist[1].K())) {
     reverse(tclist.begin(), tclist.end());
     if (config()->debug() == 4)
       std::cout << "Reversing order of sorted candidate list..." << std::endl;
@@ -513,20 +469,16 @@ DTTracoCand *DTTracoChip::bestCand(int itk, std::vector<DTTracoCand> &tclist) {
 
   // debugging...
   if (config()->debug() == 4) {
-    std::cout << "DTTracoChip::findBest - Looking for track number " << itk + 1
-              << std::endl;
-    std::cout << "Sorted std::vector of usable track candidates is:"
-              << std::endl;
+    std::cout << "DTTracoChip::findBest - Looking for track number " << itk + 1 << std::endl;
+    std::cout << "Sorted std::vector of usable track candidates is:" << std::endl;
     int i = 1;
-    for (std::vector<DTTracoCand>::iterator p = tclist.begin();
-         p < tclist.end(); p++) {
+    for (std::vector<DTTracoCand>::iterator p = tclist.begin(); p < tclist.end(); p++) {
       if ((*p).usable()) {
         std::cout << " DTTracoChip Candidate # " << i++;
         (*p).print();
       }
     }
-    std::cout << "--------------------------------------------------"
-              << std::endl;
+    std::cout << "--------------------------------------------------" << std::endl;
   }
   // end debugging
 
@@ -539,8 +491,7 @@ DTTracoCand *DTTracoChip::bestCand(int itk, std::vector<DTTracoCand> &tclist) {
     // candidate must be usable and not suppressed by LTS
     if (AdjBtiLTSuppressed(&(*p)))
       if (config()->debug() == 4)
-        std::cout << "Candidate # " << i
-                  << " supp. because next to H in adiacent Tracos" << std::endl;
+        std::cout << "Candidate # " << i << " supp. because next to H in adiacent Tracos" << std::endl;
     if ((*p).usable() && !AdjBtiLTSuppressed(&(*p))) {
       // check if preference to HTRIG is set and return first trigger
       if (!config()->prefHtrig(itk))
@@ -554,8 +505,7 @@ DTTracoCand *DTTracoChip::bestCand(int itk, std::vector<DTTracoCand> &tclist) {
   return bestltrig;
 }
 
-void DTTracoChip::DoAdjBtiLts(DTTracoCand *candidate,
-                              std::vector<DTTracoCand> &tclist) {
+void DTTracoChip::DoAdjBtiLts(DTTracoCand *candidate, std::vector<DTTracoCand> &tclist) {
   // If requested, do suppression of LTRIG on BTI close to selected HTRIG in
   // same traco
   // if(!(config()->adjBtiLts()) && candidate->BtiTrig()->code()==8) {
@@ -563,18 +513,16 @@ void DTTracoChip::DoAdjBtiLts(DTTracoCand *candidate,
   if (candidate->BtiTrig()->code() == 8) {
     std::vector<DTTracoCand>::iterator p;
     for (p = tclist.begin(); p < tclist.end(); p++) {
-      if ((*p).BtiTrig()->code() < 8 &&
-          abs((*p).BtiTrig()->btiNumber() - candidate->BtiTrig()->btiNumber()) <
-              2) {
+      if ((*p).BtiTrig()->code() < 8 && abs((*p).BtiTrig()->btiNumber() - candidate->BtiTrig()->btiNumber()) < 2) {
         (*p).setUsed();
         if (config()->debug() == 4) {
           std::cout << "Candidate :";
           (*p).print();
           std::cout << "Suppressed because adiacent to H trig" << std::endl;
-        } // end debug
-      }   // end if
-    }     // end candidate loop
-  }       // end if H
+        }  // end debug
+      }    // end if
+    }      // end candidate loop
+  }        // end if H
 }
 
 int DTTracoChip::AdjBtiLTSuppressed(DTTracoCand *candidate) {
@@ -582,11 +530,9 @@ int DTTracoChip::AdjBtiLTSuppressed(DTTracoCand *candidate) {
   // if(!(config()->adjBtiLts()) && candidate->BtiTrig()->code()<8) {
   // SV: Ltrig always suppressed in hardware if Htrig in adj traco!
   if (candidate->BtiTrig()->code() < 8) {
-    if (_flag[candidate->step() - DTConfigTraco::NSTEPF].element(3) &&
-        candidate->position() == 1)
+    if (_flag[candidate->step() - DTConfigTraco::NSTEPF].element(3) && candidate->position() == 1)
       return 1;
-    if (_flag[candidate->step() - DTConfigTraco::NSTEPF].element(4) &&
-        candidate->position() == DTConfigTraco::NBTITC)
+    if (_flag[candidate->step() - DTConfigTraco::NSTEPF].element(4) && candidate->position() == DTConfigTraco::NBTITC)
       return 1;
     if (_flag[candidate->step() - DTConfigTraco::NSTEPF].element(5) &&
         candidate->position() == DTConfigTraco::NBTITC + 1)
@@ -599,9 +545,7 @@ int DTTracoChip::AdjBtiLTSuppressed(DTTracoCand *candidate) {
   return 0;
 }
 
-DTTracoTrig *DTTracoChip::setPV(int itk, DTTracoCand *inner,
-                                DTTracoCand *outer) {
-
+DTTracoTrig *DTTracoChip::setPV(int itk, DTTracoCand *inner, DTTracoCand *outer) {
   // debugging...
   if (config()->debug() == 4) {
     std::cout << "DTTracoChip::setPV called for candidates : " << std::endl;
@@ -609,8 +553,7 @@ DTTracoTrig *DTTracoChip::setPV(int itk, DTTracoCand *inner,
       inner->print();
     if (outer)
       outer->print();
-    std::cout << "--------------------------------------------------"
-              << std::endl;
+    std::cout << "--------------------------------------------------" << std::endl;
   }
   // end debugging
 
@@ -631,7 +574,7 @@ DTTracoTrig *DTTracoChip::setPV(int itk, DTTracoCand *inner,
       candidate = inner;
     } else if (inner->BtiTrig()->code() < 8 && outer->BtiTrig()->code() == 8) {
       candidate = outer;
-    } else { // for same quality tracks, pref. to in/out selection
+    } else {  // for same quality tracks, pref. to in/out selection
       if (!config()->prefInner(itk)) {
         candidate = inner;
       } else {
@@ -653,7 +596,7 @@ DTTracoTrig *DTTracoChip::setPV(int itk, DTTracoCand *inner,
   } else if (inner != nullptr && outer == nullptr) {
     candidate = inner;
   } else {
-    return nullptr; // no candidates
+    return nullptr;  // no candidates
   }
 
   // create new trigger with this candidate
@@ -669,7 +612,7 @@ DTTracoTrig *DTTracoChip::setPV(int itk, DTTracoCand *inner,
   int ioflag = 0;
   if (candidate->position() > 4)
     ioflag = 1;
-  tct->setPV(first, cod, K, ioflag); // this is already BTI_K-KRAD
+  tct->setPV(first, cod, K, ioflag);  // this is already BTI_K-KRAD
 
   if (config()->debug() == 4) {
     std::cout << "Selected candidate stored for preview is: ";
@@ -678,9 +621,7 @@ DTTracoTrig *DTTracoChip::setPV(int itk, DTTracoCand *inner,
   return tct;
 }
 
-int DTTracoChip::storeCorr(DTTracoTrig *tctrig, DTTracoCand *inner,
-                           DTTracoCand *outer, int tkn) {
-
+int DTTracoChip::storeCorr(DTTracoTrig *tctrig, DTTracoCand *inner, DTTracoCand *outer, int tkn) {
   // Bunch crossing
   int is = tctrig->step();
 
@@ -691,8 +632,7 @@ int DTTracoChip::storeCorr(DTTracoTrig *tctrig, DTTracoCand *inner,
       inner->print();
     if (outer)
       outer->print();
-    std::cout << "--------------------------------------------------"
-              << std::endl;
+    std::cout << "--------------------------------------------------" << std::endl;
   }
   // End debugging
 
@@ -727,13 +667,11 @@ int DTTracoChip::storeCorr(DTTracoTrig *tctrig, DTTracoCand *inner,
   int kd1 = abs(kcor / 16 - kq1 / 16);
   int kd2 = abs(kcor / 16 - kq2 / 16);
 
-  icor = kd1 <= config()->TcKToll(tkn) && kd2 <= config()->TcKToll(tkn) &&
-         xcor > 0;
+  icor = kd1 <= config()->TcKToll(tkn) && kd2 <= config()->TcKToll(tkn) && xcor > 0;
 
   // Debugging...
   if (config()->debug() == 4) {
-    std::cout
-        << "*************************************************************";
+    std::cout << "*************************************************************";
     std::cout << std::endl;
     std::cout << " shift = " << shift;
     std::cout << " xq1 = " << xq1;
@@ -746,10 +684,9 @@ int DTTracoChip::storeCorr(DTTracoTrig *tctrig, DTTracoCand *inner,
     std::cout << " kd2 = " << kd2;
     std::cout << " icor = " << icor;
     std::cout << std::endl;
-    std::cout
-        << "*************************************************************";
+    std::cout << "*************************************************************";
     std::cout << std::endl;
-  } // End debugging
+  }  // End debugging
 
   //}//end if TcBxLts....
 
@@ -784,13 +721,12 @@ int DTTracoChip::storeCorr(DTTracoTrig *tctrig, DTTracoCand *inner,
       tctrig->resetVar();
     }
     // SV 1/IV/04 BUG FIX: check LTS after angle cut...
-    else if (tctrig->qdec() == 4 && // cut only LL
-             config()->TcBxLts()) { // BX LTS is  enabled or
+    else if (tctrig->qdec() == 4 &&  // cut only LL
+             config()->TcBxLts()) {  // BX LTS is  enabled or
       // reset codes, K, X and angles
-      if (tkn == 0 && _bxlts.element(is)) // I track : there is H -4,+1
+      if (tkn == 0 && _bxlts.element(is))  // I track : there is H -4,+1
         tctrig->resetVar();
-      if (tkn == 1 &&
-          _bxlts.element(is + 1)) // II track : there is H -4,+1 1 bx later
+      if (tkn == 1 && _bxlts.element(is + 1))  // II track : there is H -4,+1 1 bx later
         tctrig->resetVar();
     } else {
       // set links to BTI triggers
@@ -800,34 +736,27 @@ int DTTracoChip::storeCorr(DTTracoTrig *tctrig, DTTracoCand *inner,
 
     // Debugging...
     if (config()->debug() > 1) {
-      std::cout
-          << "*************************************************************";
+      std::cout << "*************************************************************";
       std::cout << std::endl;
-      std::cout
-          << "               Correlation was successfull:                  ";
+      std::cout << "               Correlation was successfull:                  ";
       std::cout << std::endl;
       std::cout << " Code = " << tctrig->code();
       std::cout << " K = " << tctrig->K();
       std::cout << " X = " << tctrig->X();
       std::cout << std::endl;
-      std::cout
-          << "*************************************************************";
+      std::cout << "*************************************************************";
       std::cout << std::endl;
     }
     // End debugging
 
   } else {
-
     // Debugging...
     if (config()->debug() > 1) {
-      std::cout
-          << "*************************************************************";
+      std::cout << "*************************************************************";
       std::cout << std::endl;
-      std::cout
-          << "               No correlation possible                       ";
+      std::cout << "               No correlation possible                       ";
       std::cout << std::endl;
-      std::cout
-          << "*************************************************************";
+      std::cout << "*************************************************************";
       std::cout << std::endl;
     }
     // End debugging
@@ -836,22 +765,18 @@ int DTTracoChip::storeCorr(DTTracoTrig *tctrig, DTTracoCand *inner,
   return icor;
 }
 
-int DTTracoChip::storeUncorr(DTTracoTrig *tctrig, DTTracoCand *inner,
-                             DTTracoCand *outer, int tkn) {
-
+int DTTracoChip::storeUncorr(DTTracoTrig *tctrig, DTTracoCand *inner, DTTracoCand *outer, int tkn) {
   // Bunch crossing
   int is = tctrig->step();
 
   // Debugging...
   if (config()->debug() == 4) {
-    std::cout << "DTTracoChip::storeUncorr called with candidates: "
-              << std::endl;
+    std::cout << "DTTracoChip::storeUncorr called with candidates: " << std::endl;
     if (inner)
       inner->print();
     if (outer)
       outer->print();
-    std::cout << "--------------------------------------------------"
-              << std::endl;
+    std::cout << "--------------------------------------------------" << std::endl;
   }
 
   // End debugging
@@ -869,7 +794,7 @@ int DTTracoChip::storeUncorr(DTTracoTrig *tctrig, DTTracoCand *inner,
     } else if (inner->BtiTrig()->code() < 8 && outer->BtiTrig()->code() == 8) {
       candidate = outer;
       // if(config()->TcReuse(0)) inner->setUnused(); // reusable
-    } else { // for the same quality triggers:
+    } else {  // for the same quality triggers:
       if (!config()->prefInner(tkn)) {
         candidate = inner;
         // if(config()->TcReuse(1))  outer->setUnused(); // reusable
@@ -877,7 +802,7 @@ int DTTracoChip::storeUncorr(DTTracoTrig *tctrig, DTTracoCand *inner,
         candidate = outer;
         // if(config()->TcReuse(0))  inner->setUnused(); // reusable
       }
-    } // end else
+    }  // end else
     /*
         } else {//no Htrig preference
           if(!config()->prefInner(tkn)) {
@@ -894,7 +819,7 @@ int DTTracoChip::storeUncorr(DTTracoTrig *tctrig, DTTracoCand *inner,
   } else if (inner != nullptr && outer == nullptr) {
     candidate = inner;
   } else {
-    return 0; // no candidates
+    return 0;  // no candidates
   }
 
   // SV *** FOR TESTBEAM OR TEST BENCH PURPOSE ***
@@ -911,11 +836,11 @@ int DTTracoChip::storeUncorr(DTTracoTrig *tctrig, DTTracoCand *inner,
     if (config()->LVALIDIFH() && _flag[is - DTConfigTraco::NSTEPF].element(9)) {
       if (config()->debug() > 1)
         std::cout << "Low accepted because LVALIDIFH on...." << std::endl;
-    } else { // LVALIDIFH==0 or there isn't H in traco in bx : check theta!
+    } else {  // LVALIDIFH==0 or there isn't H in traco in bx : check theta!
       // theta check
       if (!config()->singleLenab(tkn)) {
         // LTF: single LTRIG not always en. Check cond.:
-        if (config()->singleLflag(tkn) == 1 || // always discarded
+        if (config()->singleLflag(tkn) == 1 ||  // always discarded
             (config()->singleLflag(tkn) == 2 && !(_card->TSTh()->nHTrig(is))) ||
             (config()->singleLflag(tkn) == 0 && !(_card->TSTh()->nTrig(is)))) {
           // SV --> for TESTS version
@@ -928,9 +853,9 @@ int DTTracoChip::storeUncorr(DTTracoTrig *tctrig, DTTracoCand *inner,
           return 0;
         }
         //       ^-------- trigger is suppressed and will not be stored
-      } // end theta
+      }  // end theta
 
-    } // end else
+    }  // end else
     // REUSE : mark candidates reusable HERE! SV BUG FIX 6IV04
     if (candidate == inner && config()->TcReuse(1) && outer)
       outer->setUnused();
@@ -939,24 +864,22 @@ int DTTracoChip::storeUncorr(DTTracoTrig *tctrig, DTTracoCand *inner,
 
     // LTS suppression
     if (config()->TcBxLts()) {
-      if ((tkn == 0 && _bxlts.element(is)) // I track : there is H -4,+1
-          ||
-          (tkn == 1 &&
-           _bxlts.element(is + 1))) { // II track : there is H -4,+1 1 bx later
+      if ((tkn == 0 && _bxlts.element(is))            // I track : there is H -4,+1
+          || (tkn == 1 && _bxlts.element(is + 1))) {  // II track : there is H -4,+1 1 bx later
         tctrig->resetVar();
         if (config()->debug() > 1)
           std::cout << "Low trigger suppressed because H in next 4 bx "
                     << " and LTS flag on...." << std::endl;
-        return 1; // trigger is suppressed but preview will be stored
+        return 1;  // trigger is suppressed but preview will be stored
       }
-    } // end lts
+    }  // end lts
 
     //    } //end else
-  } // Low trigs
+  }  // Low trigs
 
   // Preview Htmsk not implemented: awaiting decision
   // --> implemented in priority selector by SV
-  else { // HTRIG
+  else {  // HTRIG
     // if(config()->singleHflag(tkn)==1 && thTr==0 )  //this is for testing
     if (config()->singleHflag(tkn) == 1 && !(_card->TSTh()->nTrig(is)))
       return 0;
@@ -981,7 +904,7 @@ int DTTracoChip::storeUncorr(DTTracoTrig *tctrig, DTTracoCand *inner,
   // correlation wasn't successfull
   // set the preview correlation bit.
   tctrig->setPVCorr(0);
-  if (candidate->BtiTrig()->btiSL() == 1) { // inner track
+  if (candidate->BtiTrig()->btiSL() == 1) {  // inner track
     tctrig->setCodeIn(candidate->BtiTrig()->code());
     tctrig->setCodeOut(0);
     // tctrig->setPosIn(candidate->position());
@@ -991,7 +914,7 @@ int DTTracoChip::storeUncorr(DTTracoTrig *tctrig, DTTracoCand *inner,
     // SV store also equation
     tctrig->setEqIn(candidate->BtiTrig()->eq() + 1);
     tctrig->setEqOut(0);
-  } else { // outer track
+  } else {  // outer track
     tctrig->setCodeIn(0);
     tctrig->setCodeOut(candidate->BtiTrig()->code());
     tctrig->setPosIn(0);
@@ -1020,18 +943,15 @@ int DTTracoChip::storeUncorr(DTTracoTrig *tctrig, DTTracoCand *inner,
 
   // Debugging...
   if (config()->debug() > 1) {
-    std::cout
-        << "*************************************************************";
+    std::cout << "*************************************************************";
     std::cout << std::endl;
-    std::cout
-        << "               Single trigger stored:                        ";
+    std::cout << "               Single trigger stored:                        ";
     std::cout << std::endl;
     std::cout << " Code = " << tctrig->code();
     std::cout << " K = " << tctrig->K();
     std::cout << " X = " << tctrig->X();
     std::cout << std::endl;
-    std::cout
-        << "*************************************************************";
+    std::cout << "*************************************************************";
     std::cout << std::endl;
   }
   // End debugging
@@ -1040,7 +960,6 @@ int DTTracoChip::storeUncorr(DTTracoTrig *tctrig, DTTracoCand *inner,
 }
 
 void DTTracoChip::add_btiT(int step, int pos, const DTBtiTrigData *btitrig) {
-
   if (pos < 1 || pos > 4 * DTConfigTraco::NBTITC) {
     std::cout << "DTTracoChip::add_btiT: wrong position: " << pos;
     std::cout << "trigger not added!" << std::endl;
@@ -1067,8 +986,7 @@ void DTTracoChip::add_btiT(int step, int pos, const DTBtiTrigData *btitrig) {
     // check K inside acceptance
     if (btitrig->K() < _PSIMIN[pos - 1] || btitrig->K() > _PSIMAX[pos - 1]) {
       if (config()->debug() > 1) {
-        std::cout << "In TRACO num. " << number() << " BTI trig. in pos " << pos
-                  << " outside K acceptance (";
+        std::cout << "In TRACO num. " << number() << " BTI trig. in pos " << pos << " outside K acceptance (";
         std::cout << _PSIMIN[pos - 1] << "-->";
         std::cout << _PSIMAX[pos - 1] << ") - Not added" << std::endl;
       }
@@ -1078,16 +996,14 @@ void DTTracoChip::add_btiT(int step, int pos, const DTBtiTrigData *btitrig) {
 
   // Store trigger candidate
   if (pos <= DTConfigTraco::NBTITC) {
-    _innerCand[step - DTConfigTraco::NSTEPF].push_back(
-        DTTracoCand(this, btitrig, pos, step));
+    _innerCand[step - DTConfigTraco::NSTEPF].push_back(DTTracoCand(this, btitrig, pos, step));
   } else {
-    _outerCand[step - DTConfigTraco::NSTEPF].push_back(
-        DTTracoCand(this, btitrig, pos, step));
+    _outerCand[step - DTConfigTraco::NSTEPF].push_back(DTTracoCand(this, btitrig, pos, step));
   }
 
   // Fill array for BX LTS
   if (btitrig->code() == 8) {
-    for (int is = step - 4; is < step; is++) { // set flag for 4 previous BX
+    for (int is = step - 4; is < step; is++) {  // set flag for 4 previous BX
       if (is > 0 && is <= DTConfigTraco::NSTEPL)
         _bxlts.set(is);
     }
@@ -1102,10 +1018,9 @@ void DTTracoChip::add_btiT(int step, int pos, const DTBtiTrigData *btitrig) {
   // Debugging
   if (config()->debug() > 1) {
     std::cout << "BTI Trigger added at step " << step;
-    std::cout << " to TRACO " << _id.traco() << " at position " << pos
-              << std::endl;
+    std::cout << " to TRACO " << _id.traco() << " at position " << pos << std::endl;
     btitrig->print();
-  } // End debugging
+  }  // End debugging
 }
 
 void DTTracoChip::addTrig(int step, DTTracoTrig *tctrig) {
@@ -1145,8 +1060,7 @@ DTTracoTrig *DTTracoChip::trigger(int step, unsigned n) const {
     std::cout << " empty pointer returned!" << std::endl;
     return nullptr;
   }
-  std::vector<DTTracoTrig *>::const_iterator p =
-      _tracotrig[step - DTConfigTraco::NSTEPF].begin() + n - 1;
+  std::vector<DTTracoTrig *>::const_iterator p = _tracotrig[step - DTConfigTraco::NSTEPF].begin() + n - 1;
   return *p;
 }
 
@@ -1161,8 +1075,7 @@ DTTracoTrigData DTTracoChip::triggerData(int step, unsigned n) const {
     std::cout << " dummy trigger returned!" << std::endl;
     return DTTracoTrigData();
   }
-  std::vector<DTTracoTrig *>::const_iterator p =
-      _tracotrig[step - DTConfigTraco::NSTEPF].begin() + n - 1;
+  std::vector<DTTracoTrig *>::const_iterator p = _tracotrig[step - DTConfigTraco::NSTEPF].begin() + n - 1;
   return (*p)->data();
 }
 
@@ -1223,29 +1136,26 @@ int DTTracoChip::edgeBTI(int step, int io, int lr) const {
   if (io == 1) {
     if (!_innerCand[step - DTConfigTraco::NSTEPF].empty()) {
       // SV 24/IX/03 fix: only HTRIG accepted
-      for (p = _innerCand[step - DTConfigTraco::NSTEPF].begin();
-           p < _innerCand[step - DTConfigTraco::NSTEPF].end(); p++) {
+      for (p = _innerCand[step - DTConfigTraco::NSTEPF].begin(); p < _innerCand[step - DTConfigTraco::NSTEPF].end();
+           p++) {
         if (lr == 1 && (*p).position() == 1 && (*p).BtiTrig()->code() == 8)
           return 1;
-        if (lr == 2 && (*p).position() == DTConfigTraco::NBTITC &&
-            (*p).BtiTrig()->code() == 8)
+        if (lr == 2 && (*p).position() == DTConfigTraco::NBTITC && (*p).BtiTrig()->code() == 8)
           return 1;
       }
     }
   } else {
     if (!_outerCand[step - DTConfigTraco::NSTEPF].empty()) {
-      for (p = _outerCand[step - DTConfigTraco::NSTEPF].begin();
-           p < _outerCand[step - DTConfigTraco::NSTEPF].end(); p++) {
+      for (p = _outerCand[step - DTConfigTraco::NSTEPF].begin(); p < _outerCand[step - DTConfigTraco::NSTEPF].end();
+           p++) {
         // SV: is the following correct???FIX if using _card to set _flag
         // if(lr==1 && (*p).position()==DTConfigTraco::NBTITC+1)return 1; //or
         // pos=8?? if(lr==2 && (*p).position()==DTConfigTraco::NBTITC*4)return
         // 1;
         // //or pos=13?? SV 24/IX/03 fix
-        if (lr == 1 && (*p).position() == DTConfigTraco::NBTITC * 3 + 1 &&
-            (*p).BtiTrig()->code() == 8)
+        if (lr == 1 && (*p).position() == DTConfigTraco::NBTITC * 3 + 1 && (*p).BtiTrig()->code() == 8)
           return 1;
-        if (lr == 2 && (*p).position() == DTConfigTraco::NBTITC * 2 &&
-            (*p).BtiTrig()->code() == 8)
+        if (lr == 2 && (*p).position() == DTConfigTraco::NBTITC * 2 && (*p).BtiTrig()->code() == 8)
           return 1;
       }
     }
@@ -1254,7 +1164,6 @@ int DTTracoChip::edgeBTI(int step, int io, int lr) const {
 }
 
 void DTTracoChip::calculateAngles(DTTracoTrig *tct) {
-
   int ipsi = 0;
   int iphir = 0;
   int idpsir = 0;
@@ -1301,11 +1210,11 @@ void DTTracoChip::calculateAngles(DTTracoTrig *tct) {
 
     int flag = 0;
     int qual = tct->data().qdec();
-    if (qual == 3 || qual == 1) // case 0:outer
+    if (qual == 3 || qual == 1)  // case 0:outer
       flag = 0;
-    if (qual == 2 || qual == 0) // case 1:inner
+    if (qual == 2 || qual == 0)  // case 1:inner
       flag = 1;
-    if (qual == 6 || qual == 5 || qual == 4) // case 2:correlated
+    if (qual == 6 || qual == 5 || qual == 4)  // case 2:correlated
       flag = 2;
 
     iphir = _lutsCCB->get_x((tct->X() + 512 * flag));
@@ -1319,8 +1228,8 @@ void DTTracoChip::calculateAngles(DTTracoTrig *tct) {
     // psi
     //  float fpsi = atan( (float)(tct->K()) * _geom->cellPitch() /
     //		     (_geom->distSL() * config()->ST()) );
-    float fpsi = atan(_card->localDirection(&td).x() / // e.g. x>0 and
-                      _card->localDirection(&td).z()); //      z<0 => fpsi<0
+    float fpsi = atan(_card->localDirection(&td).x() /  // e.g. x>0 and
+                      _card->localDirection(&td).z());  //      z<0 => fpsi<0
 
     // Change sign in case of wheel<0 or wheel==0 and station == 1,4,5,8,9,12
     int mywh = tct->ChamberId().wheel();
@@ -1347,8 +1256,7 @@ void DTTracoChip::calculateAngles(DTTracoTrig *tct) {
       fpsir -= 1.0;
     iphir = (int)fpsir;
     // if outside range set to lower edge
-    if (iphir >= DTConfigTraco::RESOLPSIR / 2 ||
-        iphir < -DTConfigTraco::RESOLPSIR / 2)
+    if (iphir >= DTConfigTraco::RESOLPSIR / 2 || iphir < -DTConfigTraco::RESOLPSIR / 2)
       iphir = -DTConfigTraco::RESOLPSIR / 2;
 
     // Delta(psi_r)
@@ -1369,9 +1277,8 @@ void DTTracoChip::calculateAngles(DTTracoTrig *tct) {
     std::cout << " ipsi = " << ipsi << " iphir = " << iphir;
     std::cout << " idpsir = " << idpsir << std::endl;
     if (_card->lutFromDBFlag() == 1)
-      std::cout << "Angles are calculated from LUT parameters from DB!"
-                << std::endl;
-  } // end debugging
+      std::cout << "Angles are calculated from LUT parameters from DB!" << std::endl;
+  }  // end debugging
 }
 
 int DTTracoChip::insideAngWindow(DTTracoTrig *tctrig) const {
@@ -1382,18 +1289,16 @@ int DTTracoChip::insideAngWindow(DTTracoTrig *tctrig) const {
   BitArray<10> bendAng;
   bendAng.assign(0, 10, tctrig->DeltaPsiR());
   // bendAng.print();
-  if (bendAng.element(9)) // negativo!
+  if (bendAng.element(9))  // negativo!
     bendAng.twoComplement();
   int bendAngINT = bendAng.read(0, 9);
   // std::cout<<"abs bend angle int ="<< bendAngINT <<std::endl;
 
-  if (config()->BendingAngleCut() != -1 &&
-      bendAngINT > 2 * (config()->BendingAngleCut())) {
+  if (config()->BendingAngleCut() != -1 && bendAngINT > 2 * (config()->BendingAngleCut())) {
     int absBendAng = tctrig->DeltaPsiR() & 0x1FF;
     if (config()->debug() == 4)
-      std::cout << "Attention: abs(bendAng)=" << absBendAng << " > "
-                << 2 * config()->BendingAngleCut() << "!! reject trigger"
-                << std::endl;
+      std::cout << "Attention: abs(bendAng)=" << absBendAng << " > " << 2 * config()->BendingAngleCut()
+                << "!! reject trigger" << std::endl;
     return 0;
   }
   return 1;
@@ -1427,22 +1332,19 @@ void DTTracoChip::setTracoAcceptances() {
       float Xin_max = 2. * DTConfig::NBTITC * K0 + shiftSL;
       float Xout_min = i * K0;
       float Xout_max = Xout_min + K0;
-      _PSIMAX[DTConfig::NBTITC + i] =
-          int(2. * h / distsl * (Xin_max - Xout_min) + K0 + 1.01);
-      _PSIMIN[DTConfig::NBTITC + i] =
-          int(2. * h / distsl * (Xin_min - Xout_max) + K0);
+      _PSIMAX[DTConfig::NBTITC + i] = int(2. * h / distsl * (Xin_max - Xout_min) + K0 + 1.01);
+      _PSIMIN[DTConfig::NBTITC + i] = int(2. * h / distsl * (Xin_min - Xout_max) + K0);
     }
   }
 
   // debugging
   if (config()->debug() == 4) {
     // if(wheel()==2&&station()==3&&sector()==1){ // only 1 chamber
-    std::cout << "Acceptance of mt ports for offset (cell unit) "
-              << _geom->phiSLOffset() / pitch << std::endl;
+    std::cout << "Acceptance of mt ports for offset (cell unit) " << _geom->phiSLOffset() / pitch << std::endl;
     for (int i = 0; i < 4 * DTConfig::NBTITC; i++) {
       std::cout << "Port " << i + 1 << " : ";
       std::cout << _PSIMIN[i] << " --> " << _PSIMAX[i] << std::endl;
     }
     //}
-  } // end debugging
+  }  // end debugging
 }

--- a/L1Trigger/DTTraco/src/DTTracoLUTs.cc
+++ b/L1Trigger/DTTraco/src/DTTracoLUTs.cc
@@ -49,7 +49,6 @@ DTTracoLUTs::DTTracoLUTs(string testfile) : _testfile(testfile) {}
 //--------------
 
 DTTracoLUTs::~DTTracoLUTs() {
-
   psi_lut.clear();
   for (int k = 0; k < 3; k++)
     phi_lut[k].clear();
@@ -63,7 +62,6 @@ DTTracoLUTs::~DTTracoLUTs() {
 // reset look-up tables
 //
 void DTTracoLUTs::reset() {
-
   psi_lut.clear();
   for (int k = 0; k < 3; k++)
     phi_lut[k].clear();
@@ -73,7 +71,6 @@ void DTTracoLUTs::reset() {
 // load look-up tables for traco
 //
 int DTTracoLUTs::load() {
-
   // get file name in current directory
   string ang_file = _testfile + ".anglut";
   string pos_file = _testfile + ".poslut";
@@ -89,12 +86,12 @@ int DTTracoLUTs::load() {
   // read file for PSI values --->   psi is 10 bits, 9+sign(10,11...16),
   // resolution 9 bits,
   for (int u = 0; u < 1024; u++) {
-    int word = filePSI.readHex(); // read a 16 bits word
+    int word = filePSI.readHex();  // read a 16 bits word
     // int psi = word & 0x01FF;    //bits  0,1,...8
     // int sgn = word & 0x0200;    //bit 9
     // if(sgn)
     // psi = -psi;
-    psi_lut.push_back(word); // positive value
+    psi_lut.push_back(word);  // positive value
   }
   filePSI.close();
 
@@ -105,8 +102,7 @@ int DTTracoLUTs::load() {
 
   // read file for PHI values    --->  phi is 12 bits, 11+sign(12..16),
   // resolution 12 bits
-  for (int y = 0; y < 3;
-       y++) { // 3 series of values: I-outer, II-innner, III-correlated
+  for (int y = 0; y < 3; y++) {  // 3 series of values: I-outer, II-innner, III-correlated
     for (int h = 0; h < 512; h++) {
       int phi = filePHI.readHex();
       // phi &= 0x0FFF;                //get 12 bits
@@ -115,7 +111,7 @@ int DTTracoLUTs::load() {
       // sgn &= 0x01;
       // if(sgn==1)                    //negative value
       // phi = -phi;
-      phi_lut[y].push_back(phi); // positive value
+      phi_lut[y].push_back(phi);  // positive value
     }
   }
   filePHI.close();
@@ -126,7 +122,6 @@ int DTTracoLUTs::load() {
 // print look-up tables for EMU
 //
 void DTTracoLUTs::print() const {
-
   cout << endl;
   cout << "L1 barrel Traco look-up tables :" << endl;
   cout << "====================================================" << endl;
@@ -137,15 +132,15 @@ void DTTracoLUTs::print() const {
   for (int x = 0; x < 1024; x++)
     cout << "K=" << x << " ---> " << hex << psi_lut[x] << dec << endl;
   for (int m = 0; m < 512; m++)
-    cout << "X=" << m << " ---> " << hex << (phi_lut[0])[m] << "  "
-         << (phi_lut[1])[m] << "  " << (phi_lut[2])[m] << "  " << dec << endl;
+    cout << "X=" << m << " ---> " << hex << (phi_lut[0])[m] << "  " << (phi_lut[1])[m] << "  " << (phi_lut[2])[m]
+         << "  " << dec << endl;
 }
 
 //
 // get phi radial value for a given position
 //
 unsigned short int DTTracoLUTs::getPhiRad(int pos, int flag) const {
-  unsigned short int phi = (phi_lut[flag])[pos] & 0xFFF; // 12 bits
+  unsigned short int phi = (phi_lut[flag])[pos] & 0xFFF;  // 12 bits
   // int sgn = (phi_lut[flag])[pos]  &  0x800;     //bit 12 for sign
   // if(sgn)
   // phi = - phi;
@@ -157,9 +152,8 @@ unsigned short int DTTracoLUTs::getPhiRad(int pos, int flag) const {
 // get psi value for a given angle
 //
 unsigned short int DTTracoLUTs::getPsi(int ang) const {
-
-  unsigned short int ipsi = (psi_lut)[ang + 512]; // scritto in complemento a
-                                                  // due
+  unsigned short int ipsi = (psi_lut)[ang + 512];  // scritto in complemento a
+                                                   // due
   /*
     //debug: try with formula
     float fpsi = atan( ((float)(ang) * 4.2) /(18 * 1.3 * 30 ));
@@ -181,8 +175,7 @@ unsigned short int DTTracoLUTs::getBendAng(int pos, int ang, int flag) const {
   // bendAng = psi - phi  : psi ha risoluzione 12, phi 9, quindi devo riportarli
   // alla stessa risoluzione con : phi/8 (scarto i 3 bit meno significativi). Il
   // risultato ha risoluzione 10 bits.
-  unsigned short int BendAng =
-      ((psi_lut)[ang + 512] - ((phi_lut[flag])[pos] / 8)) & 0x3FF; // 10 bits
+  unsigned short int BendAng = ((psi_lut)[ang + 512] - ((phi_lut[flag])[pos] / 8)) & 0x3FF;  // 10 bits
 
   // cout << "Bending angle is:" << hex << BendAng << endl;
   // cout << "Abs of bending angle is:" << hex << abs(BendAng) << endl;

--- a/L1Trigger/DTTraco/src/DTTracoTrig.cc
+++ b/L1Trigger/DTTraco/src/DTTracoTrig.cc
@@ -36,14 +36,12 @@ using namespace std;
 // Constructors --
 //----------------
 DTTracoTrig::DTTracoTrig() {
-
   // reserve the appropriate amount of space for vectors
   _btitrig.reserve(2);
   clear();
 }
 
 DTTracoTrig::DTTracoTrig(DTTracoChip *tparent, int step) : _tparent(tparent) {
-
   // reserve the appropriate amount of space for vectors
   _btitrig.reserve(2);
   clear();
@@ -53,9 +51,7 @@ DTTracoTrig::DTTracoTrig(DTTracoChip *tparent, int step) : _tparent(tparent) {
   _data.setParent(tparent->id());
 }
 
-DTTracoTrig::DTTracoTrig(DTTracoChip *parent, DTTracoTrigData data)
-    : _tparent(parent), _data(data) {
-
+DTTracoTrig::DTTracoTrig(DTTracoChip *parent, DTTracoTrigData data) : _tparent(parent), _data(data) {
   // reserve the appropriate amount of space for vectors
   _btitrig.reserve(2);
 }
@@ -70,12 +66,9 @@ bool DTTracoTrig::operator==(const DTTracoTrig &tt) const {
     return true;
 
   if (!(isFirst() == tt.isFirst()) || !(pvK() == tt.pvK()) ||
-      ((fmod(double(pvCode()), 8.) == 0) ^
-       (fmod(double(tt.pvCode()), 8.) == 0)) ||
-      !(pvCorr() == tt.pvCorr()) || !(psiR() == tt.psiR()) ||
-      !(DeltaPsiR() == tt.DeltaPsiR()) || !(qdec() == tt.qdec()) ||
+      ((fmod(double(pvCode()), 8.) == 0) ^ (fmod(double(tt.pvCode()), 8.) == 0)) || !(pvCorr() == tt.pvCorr()) ||
+      !(psiR() == tt.psiR()) || !(DeltaPsiR() == tt.DeltaPsiR()) || !(qdec() == tt.qdec()) ||
       !(data().pvIO() == tt.data().pvIO())) {
-
     cout << "fs:" << isFirst() << "," << tt.isFirst() << endl;
     cout << "pvCode:" << pvCode() << "," << tt.pvCode() << endl;
     cout << "pvK:" << pvK() << "," << tt.pvK() << endl;

--- a/L1Trigger/DTTraco/src/DTTracoTrigData.cc
+++ b/L1Trigger/DTTraco/src/DTTracoTrigData.cc
@@ -32,10 +32,7 @@ using namespace std;
 //----------------
 // Constructors --
 //----------------
-DTTracoTrigData::DTTracoTrigData(DTTracoId tracoid, int step)
-    : _tracoid(tracoid), _step(step) {
-  clear();
-}
+DTTracoTrigData::DTTracoTrigData(DTTracoId tracoid, int step) : _tracoid(tracoid), _step(step) { clear(); }
 
 //--------------
 // Operations --
@@ -44,22 +41,22 @@ DTTracoTrigData::DTTracoTrigData(DTTracoId tracoid, int step)
 int DTTracoTrigData::qdec() const {
   // This is consistent with memo
   if (_codeIn == 8 && _codeOut == 8)
-    return 6; // HH
+    return 6;  // HH
   if (_codeIn == 8 && _codeOut == 0)
-    return 2; // Hinner
+    return 2;  // Hinner
   if (_codeIn == 0 && _codeOut == 8)
-    return 3; // Houter
+    return 3;  // Houter
   if (_codeIn > 0 && _codeOut == 8)
-    return 5; // LH
+    return 5;  // LH
   if (_codeIn == 8 && _codeOut > 0)
-    return 5; // HL
+    return 5;  // HL
   if (_codeIn > 0 && _codeOut > 0)
-    return 4; // LL
+    return 4;  // LL
   if (_codeIn > 0 && _codeOut == 0)
-    return 0; // Linner
+    return 0;  // Linner
   if (_codeIn == 0 && _codeOut > 0)
-    return 1; // Louter
-  return 7;   // null
+    return 1;  // Louter
+  return 7;    // null
 }
 
 void DTTracoTrigData::print() const {
@@ -72,11 +69,9 @@ void DTTracoTrigData::print() const {
        << " step: " << step();
 
   cout << dec << " code=" << code() << " K=" << K() << " X=" << X();
-  cout << dec << " PVcode=" << pvCode() << " PVk=" << pvK()
-       << " qdec=" << qdec();
+  cout << dec << " PVcode=" << pvCode() << " PVk=" << pvK() << " qdec=" << qdec();
   cout << " qdec=" << qdec();
-  cout << hex << " psiR=" << psiR() << "  DeltaPsiR=" << DeltaPsiR() << dec
-       << endl;
+  cout << hex << " psiR=" << psiR() << "  DeltaPsiR=" << DeltaPsiR() << dec << endl;
   if (isFirst())
     cout << " I trk";
   if (!isFirst())

--- a/L1Trigger/DTTraco/src/Lut.cc
+++ b/L1Trigger/DTTraco/src/Lut.cc
@@ -12,7 +12,6 @@
 //----------------
 
 Lut::Lut(const DTConfigLUTs *conf, int ntc, float SL_shift) : _conf_luts(conf) {
-
   // set parameters from configuration
   m_d = _conf_luts->D();
   m_ST = _conf_luts->BTIC();
@@ -48,7 +47,6 @@ void Lut::setForTestBeam(int station, int board, int traco) {
   float tracoPos[50];
 
   if (nStat == 1) {
-
     tracoPos[0] = -120.19;
     tracoPos[1] = -103.39;
     tracoPos[2] = -86.59;
@@ -124,15 +122,15 @@ int Lut::get_x(int addr) const {
   int i;
   float a, b, x;
 
-  if (addr <= 511) // LUT outer
+  if (addr <= 511)  // LUT outer
   {
     i = addr;
     b = m_d + SL_DIFF;
-  } else if (addr <= 1023) // LUT inner
+  } else if (addr <= 1023)  // LUT inner
   {
     i = addr - 512;
     b = m_d - SL_DIFF;
-  } else // LUT correlati
+  } else  // LUT correlati
   {
     i = addr - 1024;
     b = m_d;
@@ -429,13 +427,13 @@ void IEEE32toDSP(float f, short *DSPmantissa, short *DSPexp) {
     // pl = (long*) (&f);
     if ((pl & 0x80000000) != 0)
       sign = true;
-    lm = (0x800000 | (pl & 0x7FFFFF)); // [1][23bit mantissa]
-    lm >>= 9;                          // reduce to 15bits
+    lm = (0x800000 | (pl & 0x7FFFFF));  // [1][23bit mantissa]
+    lm >>= 9;                           // reduce to 15bits
     lm &= 0x7FFF;
     *DSPexp = ((pl >> 23) & 0xFF) - 126;
     *DSPmantissa = (short)lm;
     if (sign)
-      *DSPmantissa = -*DSPmantissa; // convert negative value in 2.s
+      *DSPmantissa = -*DSPmantissa;  // convert negative value in 2.s
     // complement
   }
   return;

--- a/L1Trigger/DTTriggerServerPhi/interface/DTChambPhSegm.h
+++ b/L1Trigger/DTTriggerServerPhi/interface/DTChambPhSegm.h
@@ -39,7 +39,6 @@
 typedef unsigned char myint8;
 
 class DTChambPhSegm : public DTTrigData {
-
 public:
   /// Constructor
   DTChambPhSegm(DTChamberId, int);
@@ -60,7 +59,6 @@ public:
   DTChambPhSegm &operator=(const DTChambPhSegm &);
   /// Associate a TRACO trigger
   inline void setTracoTrig(const DTTracoTrigData *tracotrig, int isFirst) {
-
     m_tracotrig = tracotrig;
     m_isFirst = isFirst;
   }

--- a/L1Trigger/DTTriggerServerPhi/interface/DTTSCand.h
+++ b/L1Trigger/DTTriggerServerPhi/interface/DTTSCand.h
@@ -33,7 +33,6 @@ class DTConfigTSPhi;
 //              ---------------------
 
 class DTTSCand {
-
 public:
   /// Constructor
   DTTSCand(DTTSS *, const DTTracoTrigData *, int, int);
@@ -100,9 +99,7 @@ public:
   inline int isFirst() const { return _dataword.element(14) == 0; }
 
   /// Return HTRIG/LTRIG bit
-  inline int isHtrig() const {
-    return _tctrig->pvCode() == 8 || _tctrig->pvCode() == 80;
-  }
+  inline int isHtrig() const { return _tctrig->pvCode() == 8 || _tctrig->pvCode() == 80; }
   /// Return Inner/Outer bit
   inline int isInner() const { return _tctrig->pvCode() > 8; }
 
@@ -113,39 +110,23 @@ public:
   inline int isCarry() const { return _isCarry; }
 
   /// Return if HH or HL
-  inline int isHHorHL() const {
-    return _tctrig->pvCorr() && _tctrig->pvCode() == 80;
-  }
+  inline int isHHorHL() const { return _tctrig->pvCorr() && _tctrig->pvCode() == 80; }
 
   /// Return if LH
-  inline int isLH() const {
-    return _tctrig->pvCorr() && _tctrig->pvCode() == 8;
-  }
+  inline int isLH() const { return _tctrig->pvCorr() && _tctrig->pvCode() == 8; }
 
   /// Return if LL
-  inline int isLL() const {
-    return _tctrig->pvCorr() && !(_tctrig->pvCode() == 8) &&
-           !(_tctrig->pvCode() == 80);
-  }
+  inline int isLL() const { return _tctrig->pvCorr() && !(_tctrig->pvCode() == 8) && !(_tctrig->pvCode() == 80); }
   /// Return if H inner
-  inline int isH0() const {
-    return !_tctrig->pvCorr() && _tctrig->pvCode() == 80;
-  }
+  inline int isH0() const { return !_tctrig->pvCorr() && _tctrig->pvCode() == 80; }
 
   /// Return if H outer
-  inline int is0H() const {
-    return !_tctrig->pvCorr() && _tctrig->pvCode() == 8;
-  }
+  inline int is0H() const { return !_tctrig->pvCorr() && _tctrig->pvCode() == 8; }
 
   /// Return if L inner
-  inline int isL0() const {
-    return !_tctrig->pvCorr() && _tctrig->pvCode() < 80 &&
-           _tctrig->pvCode() > 8;
-  }
+  inline int isL0() const { return !_tctrig->pvCorr() && _tctrig->pvCode() < 80 && _tctrig->pvCode() > 8; }
   /// Return if L outer
-  inline int is0L() const {
-    return !_tctrig->pvCorr() && _tctrig->pvCode() < 8;
-  }
+  inline int is0L() const { return !_tctrig->pvCorr() && _tctrig->pvCode() < 8; }
 
   /// Return an uint16 with the content of the data word (for debugging)
   inline unsigned dataword() const { return _dataword.dataWord(0) & 0x1ff; }
@@ -166,13 +147,13 @@ public:
 private:
   DTTSS *_tss;
   const DTTracoTrigData *_tctrig;
-  BitArray<15> _dataword; // the word on which sorting is done. reserve space
-                          // enough for Preview and full data
+  BitArray<15> _dataword;  // the word on which sorting is done. reserve space
+                           // enough for Preview and full data
   // SM double TSM  BitArray<9> _datawordbk; // the word on which sorting is
   // done (back-up mode)
-  int _tcPos; // TRACO position in TSS
+  int _tcPos;  // TRACO position in TSS
   // SM double TSM   int _bkmod;            // TSM back-up mode flag
-  int _isCarry; // info for TSM
+  int _isCarry;  // info for TSM
 };
 
 #endif

--- a/L1Trigger/DTTriggerServerPhi/interface/DTTSM.h
+++ b/L1Trigger/DTTriggerServerPhi/interface/DTTSM.h
@@ -36,7 +36,6 @@ class DTTrigGeom;
 //              ---------------------
 
 class DTTSM {
-
 public:
   ///  Constructor
   // SM double TSM

--- a/L1Trigger/DTTriggerServerPhi/interface/DTTSPhi.h
+++ b/L1Trigger/DTTriggerServerPhi/interface/DTTSPhi.h
@@ -51,7 +51,6 @@ typedef std::vector<DTChambPhSegm> DTChambPhVector;
 typedef DTCache<DTChambPhSegm, DTChambPhVector> DTTSPhiManager;
 
 class DTTSPhi : public DTTSPhiManager, public DTGeomSupplier {
-
 public:
   /// Constructor
   DTTSPhi(DTTrigGeom *, DTTracoCard *);
@@ -118,8 +117,7 @@ private:
   std::vector<DTTSM *> _tsm[DTConfigTSPhi::NSTEPL - DTConfigTSPhi::NSTEPF + 1];
 
   // Input data
-  std::vector<DTTSCand *>
-      _tctrig[DTConfigTSPhi::NSTEPL - DTConfigTSPhi::NSTEPF + 1];
+  std::vector<DTTSCand *> _tctrig[DTConfigTSPhi::NSTEPL - DTConfigTSPhi::NSTEPF + 1];
 };
 
 #endif

--- a/L1Trigger/DTTriggerServerPhi/interface/DTTSS.h
+++ b/L1Trigger/DTTriggerServerPhi/interface/DTTSS.h
@@ -34,7 +34,6 @@ class DTConfigTSPhi;
 //              ---------------------
 
 class DTTSS {
-
 public:
   /// Constructor
   DTTSS(int);

--- a/L1Trigger/DTTriggerServerPhi/src/DTChambPhSegm.cc
+++ b/L1Trigger/DTTriggerServerPhi/src/DTChambPhSegm.cc
@@ -32,19 +32,13 @@
 //----------------
 // Constructors --
 //----------------
-DTChambPhSegm::DTChambPhSegm(DTChamberId chamberid, int step)
-    : m_chamberid(chamberid), m_step(step) {
-  clear();
-}
+DTChambPhSegm::DTChambPhSegm(DTChamberId chamberid, int step) : m_chamberid(chamberid), m_step(step) { clear(); }
 
-DTChambPhSegm::DTChambPhSegm(DTChamberId chamberid, int step,
-                             const DTTracoTrigData *tracotrig, int isfirst)
-    : m_chamberid(chamberid), m_step(step), m_isFirst(isfirst),
-      m_tracotrig(tracotrig) {}
+DTChambPhSegm::DTChambPhSegm(DTChamberId chamberid, int step, const DTTracoTrigData *tracotrig, int isfirst)
+    : m_chamberid(chamberid), m_step(step), m_isFirst(isfirst), m_tracotrig(tracotrig) {}
 
 DTChambPhSegm::DTChambPhSegm(const DTChambPhSegm &seg)
-    : m_chamberid(seg.m_chamberid), m_step(seg.m_step),
-      m_isFirst(seg.m_isFirst), m_tracotrig(seg.m_tracotrig) {}
+    : m_chamberid(seg.m_chamberid), m_step(seg.m_step), m_isFirst(seg.m_isFirst), m_tracotrig(seg.m_tracotrig) {}
 
 //--------------
 // Destructor --
@@ -72,15 +66,13 @@ void DTChambPhSegm::clear() {
 
 void DTChambPhSegm::print() const {
   std::cout << "TP at step " << step() << ", in wheel " << wheel();
-  std::cout << ", station " << station() << ", sector " << sector()
-            << std::endl;
-  std::cout << "TSS "
-            << (tracoTrig()->tracoNumber() - 1) / DTConfigTSPhi::NTCTSS + 1;
+  std::cout << ", station " << station() << ", sector " << sector() << std::endl;
+  std::cout << "TSS " << (tracoTrig()->tracoNumber() - 1) / DTConfigTSPhi::NTCTSS + 1;
   std::cout << ", TRACO " << tracoNumber() << " : " << std::endl;
   std::cout << "  -->  code " << oldCode() << ", K " << K();
   std::cout << ", X " << X() << ", position mask " << posMask() << std::endl;
-  std::cout << "inner bti equation=" << tracoTrig()->eqIn()
-            << "    outer bti equation=" << tracoTrig()->eqOut() << std::endl;
+  std::cout << "inner bti equation=" << tracoTrig()->eqIn() << "    outer bti equation=" << tracoTrig()->eqOut()
+            << std::endl;
   std::cout << "        psi " << psi() << ", psiR " << psiR();
   std::cout << ", DeltaPsiR " << DeltaPsiR() << std::endl;
 }

--- a/L1Trigger/DTTriggerServerPhi/src/DTTSCand.cc
+++ b/L1Trigger/DTTriggerServerPhi/src/DTTSCand.cc
@@ -35,19 +35,17 @@
 
 DTTSCand::DTTSCand(DTTSS *tss, const DTTracoTrigData *tctrig, int ifs, int pos)
     : _tss(tss), _tctrig(tctrig), _tcPos(pos), _isCarry(0) {
-
-  _dataword.one(); // reset dataword to 0x1ff
+  _dataword.one();  // reset dataword to 0x1ff
 
   // SM sector collector Set bit 14 instead of 8, for 1st/2nd track to allow
   // extra space
   //      if(ifs==1)_dataword.unset(8); // set bit 8 (0=first, 1=second tracks)
   if (ifs == 1)
-    _dataword.unset(14); // set bit 14 (0=first, 1=second tracks)
+    _dataword.unset(14);  // set bit 14 (0=first, 1=second tracks)
 }
 
 DTTSCand::DTTSCand(const DTTSCand &tscand)
-    : _tss(tscand._tss), _tctrig(tscand._tctrig), _tcPos(tscand._tcPos),
-      _isCarry(tscand._isCarry) {}
+    : _tss(tscand._tss), _tctrig(tscand._tctrig), _tcPos(tscand._tcPos), _isCarry(tscand._isCarry) {}
 
 DTTSCand::DTTSCand() {}
 
@@ -79,13 +77,11 @@ void DTTSCand::clear() {
 
 void DTTSCand::setBitsTss() {
   // first/second track already set. Set other 3 bits
-  int itk = _dataword.element(14); // first tracks 0, second tracks 1
+  int itk = _dataword.element(14);  // first tracks 0, second tracks 1
 
   clearBits();
-  if (_tctrig->pvK() > 32 ||
-      _tctrig->pvK() < 0) { // Check K within 5 bits range
-    std::cout << "DTTSCand::setBitsTss() pvK outside valid range: "
-              << _tctrig->pvK();
+  if (_tctrig->pvK() > 32 || _tctrig->pvK() < 0) {  // Check K within 5 bits range
+    std::cout << "DTTSCand::setBitsTss() pvK outside valid range: " << _tctrig->pvK();
     std::cout << " deltaPsiR set to 31" << std::endl;
   } else {
     // assign preview in dataword (common to any other assignment)
@@ -96,40 +92,40 @@ void DTTSCand::setBitsTss() {
     int posI = -1;
     int posC = -1;
     switch (config()->TssMasking(itk)) {
-    case 123: // H/L, In/Out, Corr/NotC
-      posH = 7;
-      posI = 6;
-      posC = 5;
-      break;
-    case 132: // H/L, Corr/NotC, In/Out
-      posH = 7;
-      posI = 5;
-      posC = 6;
-      break;
-    case 213: // In/Out, H/L, Corr/NotC
-      posH = 6;
-      posI = 7;
-      posC = 5;
-      break;
-    case 231: // In/Out, Corr/NotC, H/L
-      posH = 5;
-      posI = 7;
-      posC = 6;
-      break;
-    case 312: // Corr/NotC, H/L, In/Out
-      posH = 6;
-      posI = 5;
-      posC = 7;
-      break;
-    case 321: // Corr/NotC, In/Out, H/L
-      posH = 5;
-      posI = 6;
-      posC = 7;
-      break;
-    default:
-      std::cout << "DTTSCand::DTTSCand(): masking not correct: ";
-      std::cout << config()->TssMasking(itk);
-      std::cout << " All bits set to 1" << std::endl;
+      case 123:  // H/L, In/Out, Corr/NotC
+        posH = 7;
+        posI = 6;
+        posC = 5;
+        break;
+      case 132:  // H/L, Corr/NotC, In/Out
+        posH = 7;
+        posI = 5;
+        posC = 6;
+        break;
+      case 213:  // In/Out, H/L, Corr/NotC
+        posH = 6;
+        posI = 7;
+        posC = 5;
+        break;
+      case 231:  // In/Out, Corr/NotC, H/L
+        posH = 5;
+        posI = 7;
+        posC = 6;
+        break;
+      case 312:  // Corr/NotC, H/L, In/Out
+        posH = 6;
+        posI = 5;
+        posC = 7;
+        break;
+      case 321:  // Corr/NotC, In/Out, H/L
+        posH = 5;
+        posI = 6;
+        posC = 7;
+        break;
+      default:
+        std::cout << "DTTSCand::DTTSCand(): masking not correct: ";
+        std::cout << config()->TssMasking(itk);
+        std::cout << " All bits set to 1" << std::endl;
     }
     // Masking:
     bool enaH = config()->TssHtrigEna(itk);
@@ -167,40 +163,38 @@ void DTTSCand::setBitsBkmod() {
     _dataword.unset(a2);
     _dataword.unset(a1);
     _dataword.unset(a0);
-  } // 1-000
+  }  // 1-000
   if (_tctrig->qdec() == 5) {
     _dataword.unset(a2);
     _dataword.unset(a1);
-  } // 1-001
+  }  // 1-001
   if (_tctrig->qdec() == 4) {
     _dataword.unset(a2);
     _dataword.unset(a0);
-  } // 1-010
+  }  // 1-010
   if (_tctrig->qdec() == 3) {
     _dataword.unset(a1);
-  } // 1-101
+  }  // 1-101
   if (_tctrig->qdec() == 2) {
     _dataword.unset(a1);
     _dataword.unset(a0);
-  } // 1-100
+  }  // 1-100
 
   if (_tctrig->qdec() == 0) {
     _dataword.unset(a0);
-  } // 1-110
+  }  // 1-110
 
   //    std::cout << " set Bits TSM back up " << _dataword.print() << std::endl;
 }
 
 void DTTSCand::setBitsTsm() {
   // first/second track already set. Set other 3 bits
-  int itk = _dataword.element(14); // first tracks 0, second tracks 1
+  int itk = _dataword.element(14);  // first tracks 0, second tracks 1
 
   clearBits();
 
-  if (_tctrig->pvK() > 31 ||
-      _tctrig->pvK() < 0) { // Check K within 5 bits range
-    std::cout << "DTTSCand::setBitsTsm pvK outside valid range: "
-              << _tctrig->pvK();
+  if (_tctrig->pvK() > 31 || _tctrig->pvK() < 0) {  // Check K within 5 bits range
+    std::cout << "DTTSCand::setBitsTsm pvK outside valid range: " << _tctrig->pvK();
     std::cout << " deltaPsiR set to 31" << std::endl;
   } else {
     // SM double TSM
@@ -213,58 +207,58 @@ void DTTSCand::setBitsTsm() {
     int posI = -1;
     int posC = -1;
     switch (config()->TsmMasking(itk)) {
-    case 123: // H/L, In/Out, Corr/NotC
-      posH = 7;
-      posI = 6;
-      posC = 5;
-      break;
-    case 132: // H/L, Corr/NotC, In/Out
-      posH = 7;
-      posI = 5;
-      posC = 6;
-      break;
-    case 213: // In/Out, H/L, Corr/NotC
-      posH = 6;
-      posI = 7;
-      posC = 5;
-      break;
-    case 231: // In/Out, Corr/NotC, H/L
-      posH = 5;
-      posI = 7;
-      posC = 6;
-      break;
-    case 312: // Corr/NotC, H/L, In/Out
-      posH = 6;
-      posI = 5;
-      posC = 7;
-      break;
-    case 321: // Corr/NotC, In/Out, H/L
-      posH = 5;
-      posI = 6;
-      posC = 7;
-      break;
-    default:
-      std::cout << "DTTSCand::DTTSCand(): masking not correct: ";
-      std::cout << config()->TssMasking(itk);
-      std::cout << " All bits set to 1" << std::endl;
+      case 123:  // H/L, In/Out, Corr/NotC
+        posH = 7;
+        posI = 6;
+        posC = 5;
+        break;
+      case 132:  // H/L, Corr/NotC, In/Out
+        posH = 7;
+        posI = 5;
+        posC = 6;
+        break;
+      case 213:  // In/Out, H/L, Corr/NotC
+        posH = 6;
+        posI = 7;
+        posC = 5;
+        break;
+      case 231:  // In/Out, Corr/NotC, H/L
+        posH = 5;
+        posI = 7;
+        posC = 6;
+        break;
+      case 312:  // Corr/NotC, H/L, In/Out
+        posH = 6;
+        posI = 5;
+        posC = 7;
+        break;
+      case 321:  // Corr/NotC, In/Out, H/L
+        posH = 5;
+        posI = 6;
+        posC = 7;
+        break;
+      default:
+        std::cout << "DTTSCand::DTTSCand(): masking not correct: ";
+        std::cout << config()->TssMasking(itk);
+        std::cout << " All bits set to 1" << std::endl;
 
-      // Masking:
-      bool enaH = config()->TsmHtrigEna(itk);
-      bool enaI = config()->TsmInOutEna(itk);
-      bool enaC = config()->TsmCorrEna(itk);
-      if (isCarry()) {
-        // Special setting for carry
-        enaH = config()->TsmHtrigEnaCarry();
-        enaI = config()->TsmInOutEnaCarry();
-        enaC = config()->TsmCorrEnaCarry();
-      }
-      // Bits set to 0 give higher priority:
-      if (isHtrig() && enaH && posH > 0)
-        _dataword.unset(posH);
-      if (isInner() && enaI && posI > 0)
-        _dataword.unset(posI);
-      if (isCorr() && enaC && posC > 0)
-        _dataword.unset(posC);
+        // Masking:
+        bool enaH = config()->TsmHtrigEna(itk);
+        bool enaI = config()->TsmInOutEna(itk);
+        bool enaC = config()->TsmCorrEna(itk);
+        if (isCarry()) {
+          // Special setting for carry
+          enaH = config()->TsmHtrigEnaCarry();
+          enaI = config()->TsmInOutEnaCarry();
+          enaC = config()->TsmCorrEnaCarry();
+        }
+        // Bits set to 0 give higher priority:
+        if (isHtrig() && enaH && posH > 0)
+          _dataword.unset(posH);
+        if (isInner() && enaI && posI > 0)
+          _dataword.unset(posI);
+        if (isCorr() && enaC && posC > 0)
+          _dataword.unset(posC);
     }
   }
 }

--- a/L1Trigger/DTTriggerServerPhi/src/DTTSM.cc
+++ b/L1Trigger/DTTriggerServerPhi/src/DTTSM.cc
@@ -62,15 +62,13 @@ void DTTSM::clear() {
 }
 
 void DTTSM::run(int bkmod) {
-
   if (config()->debug()) {
     std::cout << "DTTSM::run: Processing DTTSM: ";
-    std::cout << nFirstT() << " first & " << nSecondT() << " second tracks"
-              << std::endl;
+    std::cout << nFirstT() << " first & " << nSecondT() << " second tracks" << std::endl;
   }
 
   if (nFirstT() < 1)
-    return; // skip if no first tracks
+    return;  // skip if no first tracks
   //
   // SORT 1
   //
@@ -90,7 +88,7 @@ void DTTSM::run(int bkmod) {
     _outcand.push_back(first);
   }
   if (nSecondT() < 1)
-    return; // skip if no second tracks
+    return;  // skip if no second tracks
 
   //
   // SORT 2
@@ -99,8 +97,7 @@ void DTTSM::run(int bkmod) {
   // debugging
   if (config()->debug()) {
     std::vector<DTTSCand *>::const_iterator p;
-    std::cout << "Vector of second tracks (including carry) in DTTSM: "
-              << std::endl;
+    std::cout << "Vector of second tracks (including carry) in DTTSM: " << std::endl;
     for (p = _incand[1].begin(); p != _incand[1].end(); p++) {
       (*p)->print();
     }
@@ -109,7 +106,6 @@ void DTTSM::run(int bkmod) {
 
   DTTSCand *second = sortTSM2(bkmod);
   if (second != nullptr) {
-
     _outcand.push_back(second);
   }
 }
@@ -122,15 +118,13 @@ DTTSCand *DTTSM::sortTSM1(int bkmod) {
   for (p = _incand[0].begin(); p != _incand[0].end(); p++) {
     DTTSCand *curr = (*p);
 
-    if (bkmod == 1) {     // NORMAL mode ---> sorting on dataword
-      curr->setBitsTss(); // maybe not necessary, as they are the same as for
-                          // TSS in the default
-    } else if (bkmod ==
-               0) { //  { // BACKUP mode ---> sorting on modified dataword
+    if (bkmod == 1) {         // NORMAL mode ---> sorting on dataword
+      curr->setBitsTss();     // maybe not necessary, as they are the same as for
+                              // TSS in the default
+    } else if (bkmod == 0) {  //  { // BACKUP mode ---> sorting on modified dataword
       curr->setBitsBkmod();
     } else {
-      std::cout << "DTTSM::sortTSM1:  bkmod not properly assigned!"
-                << std::endl;
+      std::cout << "DTTSM::sortTSM1:  bkmod not properly assigned!" << std::endl;
     }
 
     if (best == nullptr) {
@@ -142,11 +136,11 @@ DTTSCand *DTTSM::sortTSM1(int bkmod) {
       carry = curr;
     } else if ((*curr) < (*carry)) {
       carry = curr;
-    } // else { }
+    }  // else { }
   }
 
   // Ghost 1 suppression: use carry only if not suppressed
-  if (carry != nullptr) { // A carry is present
+  if (carry != nullptr) {  // A carry is present
 
     // Carry enabled if correlated and TRACO is next to best
     bool inner_or_corr;
@@ -156,26 +150,25 @@ DTTSCand *DTTSM::sortTSM1(int bkmod) {
       inner_or_corr = carry->isInner();
     }
 
-    if (config()->TsmGhost1Flag() < 2) { // Carry isn't always suppressed
+    if (config()->TsmGhost1Flag() < 2) {  // Carry isn't always suppressed
       // check if adjacent DTTracoChips
-      int adj =
-          (carry->tssNumber() == best->tssNumber() + 1 && // next DTTracoChip
-           best->TcPos() == DTConfigTSPhi::NTCTSS && carry->TcPos() == 1) ||
-          (carry->tssNumber() == best->tssNumber() - 1 && // prev DTTracoChip
-           best->TcPos() == 1 && carry->TcPos() == DTConfigTSPhi::NTCTSS) ||
-          (carry->tssNumber() == best->tssNumber() && // same DTTracoChip
-           abs(carry->TcPos() - best->TcPos()) == 1);
+      int adj = (carry->tssNumber() == best->tssNumber() + 1 &&  // next DTTracoChip
+                 best->TcPos() == DTConfigTSPhi::NTCTSS && carry->TcPos() == 1) ||
+                (carry->tssNumber() == best->tssNumber() - 1 &&  // prev DTTracoChip
+                 best->TcPos() == 1 && carry->TcPos() == DTConfigTSPhi::NTCTSS) ||
+                (carry->tssNumber() == best->tssNumber() &&  // same DTTracoChip
+                 abs(carry->TcPos() - best->TcPos()) == 1);
 
-      if (config()->TsmGhost1Flag() == 0 || // Carry always enabled
-                                            //       carry->isInner() || //
-                                            //       Carry is inner
-          inner_or_corr ||                  // Carry is inner or corr
-          !adj) {                           // Carry not adj. to best
+      if (config()->TsmGhost1Flag() == 0 ||  // Carry always enabled
+                                             //       carry->isInner() || //
+                                             //       Carry is inner
+          inner_or_corr ||                   // Carry is inner or corr
+          !adj) {                            // Carry not adj. to best
         // add carry to second tracks to for sort 2
-        carry->setSecondTrack(); // change value of first/second track bit
+        carry->setSecondTrack();  // change value of first/second track bit
         // NEW DESIGN: DTTSM is not configurable!
         // carry->setBitsTsm();     // set quality bits as for second tracks
-        _incand[1].push_back(carry); // add to list of second tracks
+        _incand[1].push_back(carry);  // add to list of second tracks
       }
     }
   }
@@ -184,7 +177,6 @@ DTTSCand *DTTSM::sortTSM1(int bkmod) {
 }
 
 DTTSCand *DTTSM::sortTSM2(int bkmod) {
-
   // If second tracks are always suppressed skip processing
   if (config()->TsmGhost2Flag() == 3)
     return nullptr;
@@ -223,31 +215,27 @@ DTTSCand *DTTSM::sortTSM2(int bkmod) {
       inner_or_corr = curr->isInner();
     }
 
-    if (config()->TsmGhost2Flag() != 0) { // 2nd tracks not always enabled
+    if (config()->TsmGhost2Flag() != 0) {  // 2nd tracks not always enabled
       if (
           //! curr->isInner() &&                // outer track
-          !inner_or_corr && // outer and not corr
-          (curr->tssNumber() == best->tssNumber() &&
-           curr->TcPos() == best->TcPos())) { // same correlator of 1st track
-        if (config()->TsmGhost2Flag() == 2 || // do not look to corr bit of 1st
-            ((!best->isCorr()) &&
-             config()->TsmGhost2Flag() != 4) || // skip if best is not corr
+          !inner_or_corr &&                                                              // outer and not corr
+          (curr->tssNumber() == best->tssNumber() && curr->TcPos() == best->TcPos())) {  // same correlator of 1st track
+        if (config()->TsmGhost2Flag() == 2 ||                         // do not look to corr bit of 1st
+            ((!best->isCorr()) && config()->TsmGhost2Flag() != 4) ||  // skip if best is not corr
             ((!best->isCorr()) && best->isInner() &&
-             config()->TsmGhost2Flag() ==
-                 4)) // skip only if best is inner and not corr
+             config()->TsmGhost2Flag() == 4))  // skip only if best is inner and not corr
         {
-          continue; // skip track
+          continue;  // skip track
         }
       }
     }
 
     // added DBSM
     // SM double TSM    if ( bkmod == 1 ) { // NORMAL mode ---> sorting with <
-    if (bkmod == 1) {     // NORMAL mode ---> sorting on dataword
-      curr->setBitsTss(); // maybe not necessary, as they are the same as for
-                          // TSS in the default
-    } else if (bkmod ==
-               0) { //  { // BACKUP mode ---> sorting on modified dataword
+    if (bkmod == 1) {         // NORMAL mode ---> sorting on dataword
+      curr->setBitsTss();     // maybe not necessary, as they are the same as for
+                              // TSS in the default
+    } else if (bkmod == 0) {  //  { // BACKUP mode ---> sorting on modified dataword
       curr->setBitsBkmod();
     } else {
       std::cout << " DTTSM::sortTSM2 bkmod not properly assigned!" << std::endl;
@@ -312,7 +300,6 @@ const DTTracoTrigData *DTTSM::getTracoT(int ifs, unsigned n) const {
 }
 
 DTTSCand *DTTSM::getTrack(int n) const {
-
   if (n < 1 || n > nTracks()) {
     std::cout << "DTTSM::getTrack: requested track not present: " << n;
     std::cout << " empty pointer returned!" << std::endl;

--- a/L1Trigger/DTTriggerServerPhi/src/DTTSPhi.cc
+++ b/L1Trigger/DTTriggerServerPhi/src/DTTSPhi.cc
@@ -41,21 +41,16 @@
 //----------------
 // Constructors --
 //----------------
-DTTSPhi::DTTSPhi(DTTrigGeom *geom, DTTracoCard *tracocard)
-    : DTGeomSupplier(geom), _tracocard(tracocard) {
-
+DTTSPhi::DTTSPhi(DTTrigGeom *geom, DTTracoCard *tracocard) : DTGeomSupplier(geom), _tracocard(tracocard) {
   // reserve the appropriate amount of space for vectors
   int i = 0;
-  for (i = 0; i < DTConfigTSPhi::NSTEPL - DTConfigTSPhi::NSTEPF + 1;
-       i++) { // SM add + 1
+  for (i = 0; i < DTConfigTSPhi::NSTEPL - DTConfigTSPhi::NSTEPF + 1; i++) {  // SM add + 1
     _tss[i].reserve(DTConfigTSPhi::NTSSTSM);
     // DBSM-doubleTSM
     _tsm[i].reserve(DTConfigTSPhi::NTSMD);
   }
 
-  for (int is = 0; is < DTConfigTSPhi::NSTEPL - DTConfigTSPhi::NSTEPF + 1;
-       is++) {
-
+  for (int is = 0; is < DTConfigTSPhi::NSTEPL - DTConfigTSPhi::NSTEPF + 1; is++) {
     // create DTTSSs
     for (int itss = 1; itss <= DTConfigTSPhi::NTSSTSM; itss++) {
       DTTSS *tss = new DTTSS(itss);
@@ -74,11 +69,9 @@ DTTSPhi::DTTSPhi(DTTrigGeom *geom, DTTracoCard *tracocard)
 // Destructor --
 //--------------
 DTTSPhi::~DTTSPhi() {
-
   std::vector<DTTSS *>::iterator ptss;
   std::vector<DTTSM *>::iterator ptsm;
-  for (int is = 0; is < DTConfigTSPhi::NSTEPL - DTConfigTSPhi::NSTEPF + 1;
-       is++) {
+  for (int is = 0; is < DTConfigTSPhi::NSTEPL - DTConfigTSPhi::NSTEPF + 1; is++) {
     // clear TSSs
     for (ptss = _tss[is].begin(); ptss != _tss[is].end(); ptss++) {
       delete (*ptss);
@@ -101,8 +94,7 @@ DTTSPhi::~DTTSPhi() {
 //--------------
 
 void DTTSPhi::localClear() {
-  for (int is = 0; is < DTConfigTSPhi::NSTEPL - DTConfigTSPhi::NSTEPF + 1;
-       is++) {
+  for (int is = 0; is < DTConfigTSPhi::NSTEPL - DTConfigTSPhi::NSTEPF + 1; is++) {
     // clear buffer
     std::vector<DTTSCand *>::iterator p1;
     for (p1 = _tctrig[is].begin(); p1 != _tctrig[is].end(); p1++) {
@@ -123,13 +115,10 @@ void DTTSPhi::localClear() {
 }
 
 void DTTSPhi::setConfig(const DTConfigManager *conf) {
-
   DTChamberId sid = ChamberId();
   _config = conf->getDTConfigTSPhi(sid);
 
-  for (int is = 0; is < DTConfigTSPhi::NSTEPL - DTConfigTSPhi::NSTEPF + 1;
-       is++) {
-
+  for (int is = 0; is < DTConfigTSPhi::NSTEPL - DTConfigTSPhi::NSTEPF + 1; is++) {
     // set TSS config
     std::vector<DTTSS *>::iterator ptss;
     for (ptss = _tss[is].begin(); ptss != _tss[is].end(); ptss++) {
@@ -144,7 +133,6 @@ void DTTSPhi::setConfig(const DTConfigManager *conf) {
 }
 
 void DTTSPhi::loadTSPhi() {
-
   // clear DTTSSs and DTTSM
   localClear();
 
@@ -158,9 +146,7 @@ void DTTSPhi::loadTSPhi() {
   std::vector<DTTracoTrigData>::const_iterator p;
   std::vector<DTTracoTrigData>::const_iterator pend = _tracocard->end();
   for (p = _tracocard->begin(); p != pend; p++) {
-
-    if (config()->usedTraco(
-            p->tracoNumber()) /*|| config()->usedTraco(p->tracoNumber())==1*/) {
+    if (config()->usedTraco(p->tracoNumber()) /*|| config()->usedTraco(p->tracoNumber())==1*/) {
       int step = p->step();
       int fs = (p->isFirst()) ? 1 : 2;
 
@@ -199,7 +185,7 @@ void DTTSPhi::addTracoT(int step, const DTTracoTrigData *tracotrig, int ifs) {
 
   // TSM status check (if it is the case, reject TRACO triggers related to
   // broken TSMData)
-  if (config()->TsmStatus().element(itss) == 0) { // TSMD broken
+  if (config()->TsmStatus().element(itss) == 0) {  // TSMD broken
     return;
   }
 
@@ -222,33 +208,28 @@ void DTTSPhi::addTracoT(int step, const DTTracoTrigData *tracotrig, int ifs) {
       std::cout << " (second track)";
     }
     std::cout << " from TRACO " << tracotrig->tracoNumber();
-    std::cout << " to TSS " << tss->number() << ", position=" << pos
-              << std::endl;
+    std::cout << " to TSS " << tss->number() << ", position=" << pos << std::endl;
     tracotrig->print();
   }
   // end debugging
 }
 
 void DTTSPhi::runTSPhi() {
-
-  DTTSCand *secondPrevBx = nullptr; // new DTTSCand;
+  DTTSCand *secondPrevBx = nullptr;  // new DTTSCand;
 
   bool existSecondPrevBx = false;
-  int itsmd = 1; // initialize it to 1, default value if not in back up mode
-  int ntsm[DTConfigTSPhi::NSTEPL + 1 - DTConfigTSPhi::NSTEPF]
-          [DTConfigTSPhi::NTSMD];
+  int itsmd = 1;  // initialize it to 1, default value if not in back up mode
+  int ntsm[DTConfigTSPhi::NSTEPL + 1 - DTConfigTSPhi::NSTEPF][DTConfigTSPhi::NTSMD];
   int i_tsmd;
 
   for (int is = DTConfigTSPhi::NSTEPF; is < DTConfigTSPhi::NSTEPL + 1; is++) {
     // loop on DTTSSs
     int ntss = 0;
     i_tsmd = 0;
-    ntsm[is - DTConfigTSPhi::NSTEPF][0] =
-        0; // counter to make sector collector run if at least a tsm
+    ntsm[is - DTConfigTSPhi::NSTEPF][0] = 0;  // counter to make sector collector run if at least a tsm
     ntsm[is - DTConfigTSPhi::NSTEPF][1] = 0;
     std::vector<DTTSS *>::iterator p;
-    for (p = _tss[is - DTConfigTSPhi::NSTEPF].begin();
-         p < _tss[is - DTConfigTSPhi::NSTEPF].end(); p++) {
+    for (p = _tss[is - DTConfigTSPhi::NSTEPF].begin(); p < _tss[is - DTConfigTSPhi::NSTEPF].end(); p++) {
       if ((*p)->nTracoT(1) > 0) {
         // run DTTSS algorithm on non-empty DTTSSs
         (*p)->run();
@@ -257,12 +238,11 @@ void DTTSPhi::runTSPhi() {
           for (int it = 1; it <= (*p)->nTracks(); it++) {
             //--- SM double TSM    get the corresponding tsm data
             int bkmod = config()->TsmStatus().element(0);
-            if (bkmod == 0) {               // we are in back-up mode
-              int my_itss = (*p)->number(); // metodo di DTTSS che ritorna itss
+            if (bkmod == 0) {                // we are in back-up mode
+              int my_itss = (*p)->number();  // metodo di DTTSS che ritorna itss
               int ntsstsmd = config()->TSSinTSMD(station(), sector());
               if (ntsstsmd < 2 || ntsstsmd > DTConfigTSPhi::NTSSTSMD) {
-                std::cout << " DTTSPhi::addTracoT - wrong TSMD: " << ntsstsmd
-                          << std::endl;
+                std::cout << " DTTSPhi::addTracoT - wrong TSMD: " << ntsstsmd << std::endl;
               }
 
               // Get the appropriate TSMD
@@ -270,40 +250,34 @@ void DTTSPhi::runTSPhi() {
               if (config()->debug()) {
                 std::cout << " DTTSPhi::addTracoT: itsmd = (my_itss -1 ) / "
                              "ntsstsmd + 1  ---> my_itss = "
-                          << my_itss << "  ntsstsmd = " << ntsstsmd
-                          << "  itsmd = " << itsmd << std::endl;
+                          << my_itss << "  ntsstsmd = " << ntsstsmd << "  itsmd = " << itsmd << std::endl;
               }
             } else if (bkmod == 1) {
-              itsmd =
-                  1; // initialize it to 1, default value if not in back up mode
+              itsmd = 1;  // initialize it to 1, default value if not in back up mode
             }
             if (itsmd > 2)
-              std::cout << "****** >DTTSPhi::RunTSPhi wrong  itsmd = " << itsmd
-                        << std::endl;
+              std::cout << "****** >DTTSPhi::RunTSPhi wrong  itsmd = " << itsmd << std::endl;
             DTTSM *tsm = getDTTSM(is, itsmd);
             tsm->addCand((*p)->getTrack(it));
           }
           ntss++;
-        } // end loop on output DTTSS tracks
+        }  // end loop on output DTTSS tracks
       }
-    } // end loop on DTTSSs
+    }  // end loop on DTTSSs
 
     // at least a DTTSS with signal. Run DTTSM
 
     std::vector<DTTSM *>::iterator p_tsm;
 
-    for (p_tsm = _tsm[is - DTConfigTSPhi::NSTEPF].begin();
-         p_tsm < _tsm[is - DTConfigTSPhi::NSTEPF].end(); p_tsm++) {
-
+    for (p_tsm = _tsm[is - DTConfigTSPhi::NSTEPF].begin(); p_tsm < _tsm[is - DTConfigTSPhi::NSTEPF].end(); p_tsm++) {
       // Run TSM sorting if at least a first track
 
-      i_tsmd = (*p_tsm)->number() -
-               1; // returns itsmd (0 in default, 0 or 1 when bkmode )
+      i_tsmd = (*p_tsm)->number() - 1;  // returns itsmd (0 in default, 0 or 1 when bkmode )
 
       if ((*p_tsm)->nCand(1) > 0) {
         int bkmod = config()->TsmStatus().element(0);
 
-        (*p_tsm)->run(bkmod); // bkmod 1 normal, 0 backup
+        (*p_tsm)->run(bkmod);  // bkmod 1 normal, 0 backup
         // Run TSM for current BX in case of 1st Tracks
         // Run TSM for previous BX for second tracks, to check whether there is
         // a pile up Tells whether a second track at previous BX exists
@@ -312,146 +286,105 @@ void DTTSPhi::runTSPhi() {
           // We have a first track. Store it if code is > 0
 
           if ((*p_tsm)->getTrack(1)->tracoTr()->code() > 0) {
-
             DTTSCand *first = (*p_tsm)->getTrack(1);
-            if (config()->TsmGetCarryFlag() ==
-                0) { //  get 1st tk at current BX and ignore any 2nd tk at
-                     //  previous BX
+            if (config()->TsmGetCarryFlag() == 0) {  //  get 1st tk at current BX and ignore any 2nd tk at
+                                                     //  previous BX
 
-              _cache.push_back(DTChambPhSegm(
-                  ChamberId(), is, (*p_tsm)->getTrack(1)->tracoTr(), 1));
-              ntsm[is - DTConfigTSPhi::NSTEPF]
-                  [i_tsmd]++; // SM increment ntsm at current BX
+              _cache.push_back(DTChambPhSegm(ChamberId(), is, (*p_tsm)->getTrack(1)->tracoTr(), 1));
+              ntsm[is - DTConfigTSPhi::NSTEPF][i_tsmd]++;  // SM increment ntsm at current BX
               if (config()->debug())
-                std::cout << "ntsm = "
-                          << ntsm[is - DTConfigTSPhi::NSTEPF][i_tsmd]
-                          << " is = " << is << " i_tsmd = " << i_tsmd
-                          << std::endl;
-              if ((*p_tsm)->nTracks() > 1) { // there is a 2nd tk
-                if ((*p_tsm)->getTrack(2)->tracoTr()->code() >
-                    0) { // check if its code > 0
+                std::cout << "ntsm = " << ntsm[is - DTConfigTSPhi::NSTEPF][i_tsmd] << " is = " << is
+                          << " i_tsmd = " << i_tsmd << std::endl;
+              if ((*p_tsm)->nTracks() > 1) {                         // there is a 2nd tk
+                if ((*p_tsm)->getTrack(2)->tracoTr()->code() > 0) {  // check if its code > 0
                   ntsm[is - DTConfigTSPhi::NSTEPF][i_tsmd]++;
                   if (config()->debug())
-                    std::cout
-                        << "ntsm = " << ntsm[is - DTConfigTSPhi::NSTEPF][i_tsmd]
-                        << " is = " << is << " i_tsmd = " << i_tsmd
-                        << std::endl;
+                    std::cout << "ntsm = " << ntsm[is - DTConfigTSPhi::NSTEPF][i_tsmd] << " is = " << is
+                              << " i_tsmd = " << i_tsmd << std::endl;
 
-                  secondPrevBx =
-                      (*p_tsm)->getTrack(2); // assign second tk of previous BX
+                  secondPrevBx = (*p_tsm)->getTrack(2);  // assign second tk of previous BX
                 }
               }
-            } else if (config()->TsmGetCarryFlag() ==
-                       1) { // compare with 2nd tk in previous BX and get the tk
-                            // with better quality
+            } else if (config()->TsmGetCarryFlag() == 1) {  // compare with 2nd tk in previous BX and get the tk
+                                                            // with better quality
               existSecondPrevBx =
-                  ((is - 1 - DTConfigTSPhi::NSTEPF >= 0) &&
-                   (ntsm[is - 1 - DTConfigTSPhi::NSTEPF][i_tsmd] > 1) &&
+                  ((is - 1 - DTConfigTSPhi::NSTEPF >= 0) && (ntsm[is - 1 - DTConfigTSPhi::NSTEPF][i_tsmd] > 1) &&
                    (secondPrevBx->tracoTr()->code() > 0));
               if ((!existSecondPrevBx) ||
-                  !((secondPrevBx->isCorr() && secondPrevBx->isHtrig() &&
-                     secondPrevBx->isInner()) ||
-                    (secondPrevBx->isCorr() && secondPrevBx->isHtrig() &&
-                     !secondPrevBx->isInner()) ||
-                    (!secondPrevBx->isCorr() && secondPrevBx->isHtrig() &&
-                     secondPrevBx->isInner())) ||
+                  !((secondPrevBx->isCorr() && secondPrevBx->isHtrig() && secondPrevBx->isInner()) ||
+                    (secondPrevBx->isCorr() && secondPrevBx->isHtrig() && !secondPrevBx->isInner()) ||
+                    (!secondPrevBx->isCorr() && secondPrevBx->isHtrig() && secondPrevBx->isInner())) ||
 
-                  ((secondPrevBx->isCorr() && secondPrevBx->isHtrig() &&
-                    secondPrevBx->isInner()) &&
+                  ((secondPrevBx->isCorr() && secondPrevBx->isHtrig() && secondPrevBx->isInner()) &&
                    (first->isCorr() && first->isHtrig() && first->isInner())) ||
 
-                  ((secondPrevBx->isCorr() && secondPrevBx->isHtrig() &&
-                    !secondPrevBx->isInner()) &&
+                  ((secondPrevBx->isCorr() && secondPrevBx->isHtrig() && !secondPrevBx->isInner()) &&
                    ((first->isCorr() && first->isHtrig() && first->isInner()) ||
-                    (first->isCorr() && first->isHtrig() &&
-                     !first->isInner()))) ||
+                    (first->isCorr() && first->isHtrig() && !first->isInner()))) ||
 
-                  ((!secondPrevBx->isCorr() && secondPrevBx->isHtrig() &&
-                    secondPrevBx->isInner()) &&
-                   !((!first->isCorr() && first->isHtrig() &&
-                      !first->isInner()) ||
-                     (!first->isCorr() && !first->isHtrig() &&
-                      first->isInner()) ||
-                     (!first->isCorr() && !first->isHtrig() &&
-                      !first->isInner()) ||
-                     (first->isCorr() && !first->isHtrig() &&
-                      !first->isInner()) ||
-                     (first->isCorr() && !first->isHtrig() &&
-                      first->isInner())))) {
+                  ((!secondPrevBx->isCorr() && secondPrevBx->isHtrig() && secondPrevBx->isInner()) &&
+                   !((!first->isCorr() && first->isHtrig() && !first->isInner()) ||
+                     (!first->isCorr() && !first->isHtrig() && first->isInner()) ||
+                     (!first->isCorr() && !first->isHtrig() && !first->isInner()) ||
+                     (first->isCorr() && !first->isHtrig() && !first->isInner()) ||
+                     (first->isCorr() && !first->isHtrig() && first->isInner())))) {
                 // SM sector collector
-                ntsm[is - DTConfigTSPhi::NSTEPF]
-                    [i_tsmd]++; // SM increment ntsm at current BX. I need to
-                                // know if there is at least a first track from
-                                // TSM to run Sect Coll
+                ntsm[is - DTConfigTSPhi::NSTEPF][i_tsmd]++;  // SM increment ntsm at current BX. I need to
+                                                             // know if there is at least a first track from
+                                                             // TSM to run Sect Coll
 
-                _cache.push_back(DTChambPhSegm(
-                    ChamberId(), is, (*p_tsm)->getTrack(1)->tracoTr(), 1));
+                _cache.push_back(DTChambPhSegm(ChamberId(), is, (*p_tsm)->getTrack(1)->tracoTr(), 1));
                 //		(*p_tsm)->getTrack(1)->print();
 
-                if ((*p_tsm)->nTracks() > 1) { // there is a 2nd tk
+                if ((*p_tsm)->nTracks() > 1) {  // there is a 2nd tk
                   ntsm[is - DTConfigTSPhi::NSTEPF][i_tsmd]++;
-                  if ((*p_tsm)->getTrack(2)->tracoTr()->code() >
-                      0) { // check if its code > 0
-                    secondPrevBx =
-                        (*p_tsm)->getTrack(2); // assign second previous BX
+                  if ((*p_tsm)->getTrack(2)->tracoTr()->code() > 0) {  // check if its code > 0
+                    secondPrevBx = (*p_tsm)->getTrack(2);              // assign second previous BX
                   }
                 }
-              } else { // if 2nd tk prev BX is better than first present BX skip
-                       // the event and get 2nd prev BX
-                ntsm[is - 1 - DTConfigTSPhi::NSTEPF]
-                    [i_tsmd]++; // SM increment ntsm at previous BX.
-                _cache.push_back(DTChambPhSegm(ChamberId(), is - 1,
-                                               secondPrevBx->tracoTr(), 2));
+              } else {  // if 2nd tk prev BX is better than first present BX skip
+                        // the event and get 2nd prev BX
+                ntsm[is - 1 - DTConfigTSPhi::NSTEPF][i_tsmd]++;  // SM increment ntsm at previous BX.
+                _cache.push_back(DTChambPhSegm(ChamberId(), is - 1, secondPrevBx->tracoTr(), 2));
                 // secondPrevBx->print();
               }
             }
 
-            else if (config()->TsmGetCarryFlag() ==
-                     2) { // neglect first tk if it is a low uncorrelated
-                          // trigger
+            else if (config()->TsmGetCarryFlag() == 2) {  // neglect first tk if it is a low uncorrelated
+                                                          // trigger
               existSecondPrevBx =
-                  ((is - 1 - DTConfigTSPhi::NSTEPF >= 0) &&
-                   (ntsm[is - 1 - DTConfigTSPhi::NSTEPF][i_tsmd] > 1) &&
+                  ((is - 1 - DTConfigTSPhi::NSTEPF >= 0) && (ntsm[is - 1 - DTConfigTSPhi::NSTEPF][i_tsmd] > 1) &&
                    (secondPrevBx->tracoTr()->code() > 0));
               if ((!existSecondPrevBx) || first->isHtrig() || first->isCorr()) {
-                ntsm[is - DTConfigTSPhi::NSTEPF]
-                    [i_tsmd]++; // SM increment ntsm at current BX.
+                ntsm[is - DTConfigTSPhi::NSTEPF][i_tsmd]++;  // SM increment ntsm at current BX.
                 // SM sector collector: Load DTSectColl with output of DTTSM
-                _cache.push_back(DTChambPhSegm(
-                    ChamberId(), is, (*p_tsm)->getTrack(1)->tracoTr(), 1));
+                _cache.push_back(DTChambPhSegm(ChamberId(), is, (*p_tsm)->getTrack(1)->tracoTr(), 1));
                 //		(*p_tsm)->getTrack(1)->print();
 
-                if ((*p_tsm)->nTracks() > 1) { // there is a 2nd tk
+                if ((*p_tsm)->nTracks() > 1) {  // there is a 2nd tk
                   ntsm[is - DTConfigTSPhi::NSTEPF][i_tsmd]++;
-                  if ((*p_tsm)->getTrack(2)->tracoTr()->code() >
-                      0) { // check if its code > 0
-                    secondPrevBx = (*p_tsm)->getTrack(
-                        2); // assign second tk of previous BX
+                  if ((*p_tsm)->getTrack(2)->tracoTr()->code() > 0) {  // check if its code > 0
+                    secondPrevBx = (*p_tsm)->getTrack(2);              // assign second tk of previous BX
                   }
                 }
               } else {
-                ntsm[is - 1 - DTConfigTSPhi::NSTEPF]
-                    [i_tsmd]++; // SM increment ntsm at previous BX.
-                _cache.push_back(DTChambPhSegm(ChamberId(), is - 1,
-                                               secondPrevBx->tracoTr(), 2));
+                ntsm[is - 1 - DTConfigTSPhi::NSTEPF][i_tsmd]++;  // SM increment ntsm at previous BX.
+                _cache.push_back(DTChambPhSegm(ChamberId(), is - 1, secondPrevBx->tracoTr(), 2));
                 //		secondPrevBx->print();
               }
             }
           }
         }
 
-      } else if (((*p_tsm)->nCand(1) == 0) &&
-                 (is - 1 - DTConfigTSPhi::NSTEPF >= 0) &&
+      } else if (((*p_tsm)->nCand(1) == 0) && (is - 1 - DTConfigTSPhi::NSTEPF >= 0) &&
                  ntsm[is - 1 - DTConfigTSPhi::NSTEPF][i_tsmd] >
-                     0) { // it means that the last BX with sort 2 was not the
-                          // previous one
+                     0) {  // it means that the last BX with sort 2 was not the
+                           // previous one
         existSecondPrevBx =
-            ((is - 1 - DTConfigTSPhi::NSTEPF >= 0) &&
-             (ntsm[is - 1 - DTConfigTSPhi::NSTEPF][i_tsmd] > 1) &&
+            ((is - 1 - DTConfigTSPhi::NSTEPF >= 0) && (ntsm[is - 1 - DTConfigTSPhi::NSTEPF][i_tsmd] > 1) &&
              (secondPrevBx->tracoTr()->code() > 0));
         if (existSecondPrevBx) {
-          _cache.push_back(
-              DTChambPhSegm(ChamberId(), is - 1, secondPrevBx->tracoTr(), 2));
+          _cache.push_back(DTChambPhSegm(ChamberId(), is - 1, secondPrevBx->tracoTr(), 2));
 
           //	  secondPrevBx->print();
         }
@@ -459,28 +392,24 @@ void DTTSPhi::runTSPhi() {
     }
     //---
 
-  } // end loop on step
+  }  // end loop on step
   // debugging...
   if (config()->debug()) {
     if (!_cache.empty()) {
-      std::cout << "===================================================="
-                << std::endl;
-      std::cout << "                  Phi segments                     "
-                << std::endl;
+      std::cout << "====================================================" << std::endl;
+      std::cout << "                  Phi segments                     " << std::endl;
       std::vector<DTChambPhSegm>::const_iterator p;
       for (p = _cache.begin(); p < _cache.end(); p++) {
         p->print();
       }
-      std::cout << "===================================================="
-                << std::endl;
+      std::cout << "====================================================" << std::endl;
     }
   }
   //  end debugging
 }
 
 void DTTSPhi::ignoreSecondTrack(int step, int tracon) {
-
-  int itsmd = 1; // initialize it to default
+  int itsmd = 1;  // initialize it to default
 
   if (step < DTConfigTSPhi::NSTEPF || step > DTConfigTSPhi::NSTEPL) {
     std::cout << "DTTSPhi::ignoreSecondTrack: step out of range: " << step;
@@ -497,7 +426,7 @@ void DTTSPhi::ignoreSecondTrack(int step, int tracon) {
   tss->ignoreSecondTrack();
 
   int bkmod = config()->TsmStatus().element(0);
-  if (bkmod == 0) { // we are in back-up mode
+  if (bkmod == 0) {  // we are in back-up mode
 
     int ntsstsmd = config()->TSSinTSMD(station(), sector());
     // Get the appropriate TSMD
@@ -521,8 +450,7 @@ DTTSS *DTTSPhi::getDTTSS(int step, unsigned n) const {
     return nullptr;
   }
 
-  std::vector<DTTSS *>::const_iterator p =
-      _tss[step - DTConfigTSPhi::NSTEPF].begin() + n - 1;
+  std::vector<DTTSS *>::const_iterator p = _tss[step - DTConfigTSPhi::NSTEPF].begin() + n - 1;
   return *p;
 }
 
@@ -538,14 +466,13 @@ DTTSM *DTTSPhi::getDTTSM(int step, unsigned n) const {
     std::cout << " empty pointer returned!" << std::endl;
     return nullptr;
   }
-  std::vector<DTTSM *>::const_iterator p_tsm =
-      _tsm[step - DTConfigTSPhi::NSTEPF].begin() + n - 1;
+  std::vector<DTTSM *>::const_iterator p_tsm = _tsm[step - DTConfigTSPhi::NSTEPF].begin() + n - 1;
   return *p_tsm;
 }
 
 int DTTSPhi::nSegm(int step) {
   int n = 0;
-  std::vector<DTChambPhSegm>::const_iterator p; // p=0;
+  std::vector<DTChambPhSegm>::const_iterator p;  // p=0;
   for (p = begin(); p < end(); p++) {
     if (p->step() == step)
       n++;
@@ -554,11 +481,10 @@ int DTTSPhi::nSegm(int step) {
 }
 
 const DTChambPhSegm *DTTSPhi::segment(int step, unsigned n) {
-  std::vector<DTChambPhSegm>::const_iterator p; // p=0;
+  std::vector<DTChambPhSegm>::const_iterator p;  // p=0;
   for (p = begin(); p < end(); p++) {
-    if (p->step() == step &&
-        ((n == 1 && p->isFirst()) || (n == 2 && !p->isFirst())))
-      return &(*p); // p;
+    if (p->step() == step && ((n == 1 && p->isFirst()) || (n == 2 && !p->isFirst())))
+      return &(*p);  // p;
   }
   return nullptr;
 }
@@ -569,20 +495,17 @@ LocalPoint DTTSPhi::localPosition(const DTTrigData *tr) const {
   // dynamic_cast<DTChambPhSegm*>(const_cast<DTTrigData*>(tr));
   const DTChambPhSegm *trig = dynamic_cast<const DTChambPhSegm *>(tr);
   if (!trig) {
-    std::cout << "DTTSPhi::LocalPosition called with wrong argument!"
-              << std::endl;
+    std::cout << "DTTSPhi::LocalPosition called with wrong argument!" << std::endl;
     return LocalPoint(0, 0, 0);
   }
   return _tracocard->localPosition(trig->tracoTrig());
 }
 
 LocalVector DTTSPhi::localDirection(const DTTrigData *tr) const {
-  DTChambPhSegm *trig =
-      dynamic_cast<DTChambPhSegm *>(const_cast<DTTrigData *>(tr));
+  DTChambPhSegm *trig = dynamic_cast<DTChambPhSegm *>(const_cast<DTTrigData *>(tr));
   //  const DTChambPhSegm* trig = dynamic_cast<const DTChambPhSegm*>(tr);
   if (!trig) {
-    std::cout << "DTTSPhi::LocalDirection called with wrong argument!"
-              << std::endl;
+    std::cout << "DTTSPhi::LocalDirection called with wrong argument!" << std::endl;
     return LocalVector(0, 0, 0);
   }
   return _tracocard->localDirection(trig->tracoTrig());

--- a/L1Trigger/DTTriggerServerPhi/src/DTTSS.cc
+++ b/L1Trigger/DTTriggerServerPhi/src/DTTSS.cc
@@ -34,7 +34,6 @@
 // Constructors --
 //----------------
 DTTSS::DTTSS(int n) : _n(n), _ignoreSecondTrack(0) {
-
   // reserve the appropriate amount of space for vectors
   //_tctrig[0].reserve(DTConfigTSPhi::NTCTSS);
   //_tctrig[1].reserve(DTConfigTSPhi::NTCTSS);
@@ -67,15 +66,13 @@ void DTTSS::clear() {
 }
 
 void DTTSS::run() {
-
   if (config()->debug()) {
     std::cout << "DTTSS::run: Processing DTTSS number " << _n << " : ";
-    std::cout << nFirstT() << " first & " << nSecondT() << " second tracks"
-              << std::endl;
+    std::cout << nFirstT() << " first & " << nSecondT() << " second tracks" << std::endl;
   }
 
   if (nFirstT() < 1)
-    return; // skip if no first tracks
+    return;  // skip if no first tracks
   //
   // SORT 1
   //
@@ -95,15 +92,14 @@ void DTTSS::run() {
   }
 
   if (nSecondT() < 1)
-    return; // skip if no second tracks
+    return;  // skip if no second tracks
   //
   // SORT 2
   //
   // debugging
   if (config()->debug()) {
     std::vector<DTTSCand *>::const_iterator p;
-    std::cout << "Vector of second tracks (including carry) in DTTSS: "
-              << std::endl;
+    std::cout << "Vector of second tracks (including carry) in DTTSS: " << std::endl;
     for (p = _tctrig[1].begin(); p != _tctrig[1].end(); p++) {
       (*p)->print();
     }
@@ -117,7 +113,6 @@ void DTTSS::run() {
 }
 
 DTTSCand *DTTSS::sortTSS1() {
-
   // Do a sort 1
   DTTSCand *best = nullptr;
   DTTSCand *carry = nullptr;
@@ -145,7 +140,7 @@ DTTSCand *DTTSS::sortTSS1() {
 
   // Ghost 1 suppression: use carry only if not suppressed
 
-  if (carry != nullptr) { // A carry is present
+  if (carry != nullptr) {  // A carry is present
 
     // Carry enabled if correlated and TRACO is next to best
     bool inner_or_corr;
@@ -155,17 +150,16 @@ DTTSCand *DTTSS::sortTSS1() {
     } else {
       inner_or_corr = carry->isInner();
     }
-    if (config()->TssGhost1Flag() < 2 &&
-        (                                     // Carry isn't always suppressed
-            config()->TssGhost1Flag() == 0 || // Carry always enabled
-            //       carry->isInner() ||                    // Carry is inner
-            inner_or_corr ||                          // carry is inner or corr
-            abs(carry->TcPos() - best->TcPos()) != 1) // Carry not adj. to best
+    if (config()->TssGhost1Flag() < 2 && (                                      // Carry isn't always suppressed
+                                             config()->TssGhost1Flag() == 0 ||  // Carry always enabled
+                                             //       carry->isInner() ||                    // Carry is inner
+                                             inner_or_corr ||                           // carry is inner or corr
+                                             abs(carry->TcPos() - best->TcPos()) != 1)  // Carry not adj. to best
     ) {
       // add carry to second tracks for sort 2
-      carry->setSecondTrack();     // change value of first/second track bit
-      carry->setBitsTss();         // set quality bits as for second tracks
-      _tctrig[1].push_back(carry); // add to list of second tracks
+      carry->setSecondTrack();      // change value of first/second track bit
+      carry->setBitsTss();          // set quality bits as for second tracks
+      _tctrig[1].push_back(carry);  // add to list of second tracks
     } else {
       _logWord1[1 + carry->TcPos()] = 'g';
     }
@@ -191,7 +185,6 @@ DTTSCand *DTTSS::sortTSS1() {
 }
 
 DTTSCand *DTTSS::sortTSS2() {
-
   // Check if there are second tracks
   if (nTracks() < 1) {
     std::cout << "DTTSS::DTTSSsort2: called with no first track.";
@@ -210,7 +203,7 @@ DTTSCand *DTTSS::sortTSS2() {
     std::vector<DTTSCand *>::iterator p;
     for (p = _tctrig[1].begin(); p != _tctrig[1].end(); p++)
       if (!(*p)->isCarry())
-        _logWord2[1 + (*p)->TcPos()] = 'o'; // out of time
+        _logWord2[1 + (*p)->TcPos()] = 'o';  // out of time
     return nullptr;
   }
 
@@ -239,7 +232,7 @@ DTTSCand *DTTSS::sortTSS2() {
         continue;
     }
     // ghost 2 suppression: skip track if suppressed
-    if (config()->TssGhost2Flag() != 0) { // 2nd tracks not always enabled
+    if (config()->TssGhost2Flag() != 0) {  // 2nd tracks not always enabled
 
       bool inner_or_corr;
       if (config()->TssGhost2Corr()) {
@@ -251,18 +244,16 @@ DTTSCand *DTTSS::sortTSS2() {
 
       if (
           //! curr->isInner() &&               // outer track
-          !inner_or_corr &&                   // outer and not corr
-          curr->TcPos() == best->TcPos()) {   // same correlator of 1st track
-        if (config()->TssGhost2Flag() == 2 || // do not look to corr bit of 1st
-            ((!best->isCorr()) &&
-             config()->TssGhost2Flag() != 4) || // skip if best is not corr
+          !inner_or_corr &&                                           // outer and not corr
+          curr->TcPos() == best->TcPos()) {                           // same correlator of 1st track
+        if (config()->TssGhost2Flag() == 2 ||                         // do not look to corr bit of 1st
+            ((!best->isCorr()) && config()->TssGhost2Flag() != 4) ||  // skip if best is not corr
             ((!best->isCorr()) && best->isInner() &&
-             config()->TssGhost2Flag() ==
-                 4)) // skip only if best is inner and not corr
+             config()->TssGhost2Flag() == 4))  // skip only if best is inner and not corr
         {
           _logWord2[1 + curr->TcPos()] = 'G';
           // 	  std::cout << " skip sort 2 in TSS" << std::endl;
-          continue; // skip track
+          continue;  // skip track
         }
       }
     }
@@ -345,15 +336,15 @@ DTTSCand *DTTSS::getCarry() const {
 std::string DTTSS::logWord(int n) const {
   std::string lw = "";
   switch (n) {
-  case 1:
-    lw = _logWord1;
-    break;
-  case 2:
-    lw = _logWord2;
-    break;
-  default:
-    std::cout << "DTTSS::logWord: requested track not present: " << n;
-    std::cout << " empty string returned!" << std::endl;
+    case 1:
+      lw = _logWord1;
+      break;
+    case 2:
+      lw = _logWord2;
+      break;
+    default:
+      std::cout << "DTTSS::logWord: requested track not present: " << n;
+      std::cout << " empty string returned!" << std::endl;
   }
   return lw;
 }

--- a/L1Trigger/DTUtilities/interface/DTCache.h
+++ b/L1Trigger/DTUtilities/interface/DTCache.h
@@ -19,8 +19,8 @@
 
 #include <vector>
 
-template <class T, class Coll = std::vector<T>> class DTCache {
-
+template <class T, class Coll = std::vector<T>>
+class DTCache {
 public:
   typedef T my_type;
   typedef Coll my_collection;

--- a/L1Trigger/DTUtilities/interface/DTGeomSupplier.h
+++ b/L1Trigger/DTUtilities/interface/DTGeomSupplier.h
@@ -40,7 +40,6 @@
 //              ---------------------
 
 class DTGeomSupplier {
-
 public:
   ///  Constructor
   DTGeomSupplier(DTTrigGeom *geom) : _geom(geom) {}
@@ -73,14 +72,10 @@ public:
   virtual LocalVector localDirection(const DTTrigData *) const = 0;
 
   /// CMS position in chamber of a trigger-data object
-  inline GlobalPoint CMSPosition(const DTTrigData *trig) const {
-    return _geom->toGlobal(localPosition(trig));
-  }
+  inline GlobalPoint CMSPosition(const DTTrigData *trig) const { return _geom->toGlobal(localPosition(trig)); }
 
   /// CMS direction in chamber of a trigger -data object
-  inline GlobalVector CMSDirection(const DTTrigData *trig) const {
-    return _geom->toGlobal(localDirection(trig));
-  }
+  inline GlobalVector CMSDirection(const DTTrigData *trig) const { return _geom->toGlobal(localDirection(trig)); }
 
   /// Print a trigger-data object with also local and global position/direction
   virtual void print(const DTTrigData *trig) const;

--- a/L1Trigger/DTUtilities/interface/DTTPGLutFile.h
+++ b/L1Trigger/DTUtilities/interface/DTTPGLutFile.h
@@ -33,7 +33,6 @@
 //              ---------------------
 
 class DTTPGLutFile {
-
 public:
   /// constructor
   DTTPGLutFile(const std::string name = "");
@@ -75,8 +74,8 @@ public:
   std::string readString();
 
 private:
-  std::ifstream m_fin; // input file stream
-  std::string m_file;  // file name
+  std::ifstream m_fin;  // input file stream
+  std::string m_file;   // file name
 };
 
 #endif

--- a/L1Trigger/DTUtilities/interface/DTTrigData.h
+++ b/L1Trigger/DTUtilities/interface/DTTrigData.h
@@ -33,7 +33,6 @@
 //              ---------------------
 
 class DTTrigData {
-
 public:
   ///  Constructor
   DTTrigData() {}

--- a/L1Trigger/DTUtilities/interface/DTTrigGeom.h
+++ b/L1Trigger/DTUtilities/interface/DTTrigGeom.h
@@ -39,7 +39,6 @@
 //              ---------------------
 
 class DTTrigGeom {
-
 public:
   /// Constructor
   DTTrigGeom(const DTChamber *stat, bool debug);
@@ -86,9 +85,7 @@ public:
   float ZSL(int) const;
 
   /// Number of BTIs in a required superlayer (i.e. nCells in lay 1)
-  inline int nCell(int sl) const {
-    return (sl > 0 && sl <= 3) * _NCELL[sl - 1];
-  }
+  inline int nCell(int sl) const { return (sl > 0 && sl <= 3) * _NCELL[sl - 1]; }
 
   // NEWGEOmetry update
   /// Staggering of first wire of layer respect to default: obsolete 19/6/06
@@ -110,24 +107,16 @@ public:
   // Local and global position of a trigger object
 
   /// Go to CMS coordinate system for a point
-  GlobalPoint toGlobal(const LocalPoint p) const {
-    return _stat->surface().toGlobal(p);
-  }
+  GlobalPoint toGlobal(const LocalPoint p) const { return _stat->surface().toGlobal(p); }
 
   /// Go to CMS coordinate system for a vector
-  GlobalVector toGlobal(const LocalVector v) const {
-    return _stat->surface().toGlobal(v);
-  }
+  GlobalVector toGlobal(const LocalVector v) const { return _stat->surface().toGlobal(v); }
 
   /// Go to Local coordinate system for a point
-  LocalPoint toLocal(const GlobalPoint p) const {
-    return _stat->surface().toLocal(p);
-  }
+  LocalPoint toLocal(const GlobalPoint p) const { return _stat->surface().toLocal(p); }
 
   /// Go to Local coordinate system for a vector
-  LocalVector toLocal(const GlobalVector v) const {
-    return _stat->surface().toLocal(v);
-  }
+  LocalVector toLocal(const GlobalVector v) const { return _stat->surface().toLocal(v); }
 
   /*!
       \verbatim
@@ -185,14 +174,10 @@ public:
   LocalPoint localPosition(const DTTracoId) const;
 
   /// CMS position of a BTI
-  inline GlobalPoint CMSPosition(const DTBtiId obj) const {
-    return toGlobal(localPosition(obj));
-  }
+  inline GlobalPoint CMSPosition(const DTBtiId obj) const { return toGlobal(localPosition(obj)); }
 
   /// CMS position of a TRACO
-  inline GlobalPoint CMSPosition(const DTTracoId obj) const {
-    return toGlobal(localPosition(obj));
-  }
+  inline GlobalPoint CMSPosition(const DTTracoId obj) const { return toGlobal(localPosition(obj)); }
 
   /// Dump the geometry
   void dumpGeom() const;
@@ -206,14 +191,14 @@ private:
   void getGeom();
 
 private:
-  const DTChamber *_stat; // Pointer to the chamber
+  const DTChamber *_stat;  // Pointer to the chamber
 
   // geometrical parameters
-  float _PHICH;  // angle of normal to the chamber in CMS frame (rad)
-  float _H;      // height of a cell (cm)
-  float _PITCH;  // width of a cell (cm)
-  float _ZSL[3]; // Z coordinate of SL centers
-  int _NCELL[3]; // number of cells (BTI) in SL each SL
+  float _PHICH;   // angle of normal to the chamber in CMS frame (rad)
+  float _H;       // height of a cell (cm)
+  float _PITCH;   // width of a cell (cm)
+  float _ZSL[3];  // Z coordinate of SL centers
+  int _NCELL[3];  // number of cells (BTI) in SL each SL
   bool _debug;
 };
 

--- a/L1Trigger/DTUtilities/src/DTGeomSupplier.cc
+++ b/L1Trigger/DTUtilities/src/DTGeomSupplier.cc
@@ -3,8 +3,6 @@
 
 void DTGeomSupplier::print(const DTTrigData *trig) const {
   trig->print();
-  std::cout << " Local (pos)(dir): " << localPosition(trig)
-            << localDirection(trig) << std::endl;
-  std::cout << " CMS (pos)(dir): " << CMSPosition(trig) << CMSDirection(trig)
-            << std::endl;
+  std::cout << " Local (pos)(dir): " << localPosition(trig) << localDirection(trig) << std::endl;
+  std::cout << " CMS (pos)(dir): " << CMSPosition(trig) << CMSDirection(trig) << std::endl;
 }

--- a/L1Trigger/DTUtilities/src/DTTPGLutFile.cc
+++ b/L1Trigger/DTUtilities/src/DTTPGLutFile.cc
@@ -53,13 +53,11 @@ DTTPGLutFile::~DTTPGLutFile() {}
 //--------------
 
 DTTPGLutFile &DTTPGLutFile::operator=(const DTTPGLutFile &lut) {
-
   m_file = lut.m_file;
   return *this;
 }
 
 int DTTPGLutFile::open() {
-
   const char *file_name = m_file.c_str();
   m_fin.open(file_name, ios::in);
   if (!m_fin) {
@@ -71,28 +69,24 @@ int DTTPGLutFile::open() {
 }
 
 void DTTPGLutFile::ignoreLines(int n) {
-
   char buf[256];
   for (int i = 0; i < n; i++)
     m_fin.getline(buf, 256);
 }
 
 int DTTPGLutFile::readInteger() {
-
   int tmp = 0;
   m_fin >> tmp;
   return tmp;
 }
 
 int DTTPGLutFile::readHex() {
-
   int tmp = 0;
   m_fin >> hex >> tmp;
   return tmp;
 }
 
 string DTTPGLutFile::readString() {
-
   string tmp;
   m_fin >> tmp;
   return tmp;

--- a/L1Trigger/DTUtilities/src/DTTrigGeom.cc
+++ b/L1Trigger/DTUtilities/src/DTTrigGeom.cc
@@ -49,11 +49,7 @@ using namespace std;
 // Constructors --
 //----------------
 
-DTTrigGeom::DTTrigGeom(const DTChamber *stat, bool debug)
-    : _stat(stat), _debug(debug) {
-
-  getGeom();
-}
+DTTrigGeom::DTTrigGeom(const DTChamber *stat, bool debug) : _stat(stat), _debug(debug) { getGeom(); }
 
 //--------------
 // Destructor --
@@ -205,13 +201,11 @@ int DTTrigGeom::posFE(int sl) const {
 }
 
 void DTTrigGeom::setGeom(const DTChamber *stat) {
-
   _stat = stat;
   getGeom();
 }
 
 void DTTrigGeom::getGeom() {
-
   // Geometrical constants of chamber
   // Cell width (cm)
   _PITCH = 4.2;
@@ -225,13 +219,13 @@ void DTTrigGeom::getGeom() {
   DTLayer const *l1[3];
   int i = 0;
   for (i = 0; i < 3; i++) {
-    if (station() == 4 && i == 1) { // No theta SL in MB4
+    if (station() == 4 && i == 1) {  // No theta SL in MB4
       _ZSL[i] = -999;
       _NCELL[i] = 0;
     } else {
       sl[i] = _stat->superLayer(DTSuperLayerId(statId(), i + 1));
       l1[i] = sl[i]->layer(DTLayerId(statId(), i + 1, 1));
-      _ZSL[i] = _stat->surface().toLocal(sl[i]->position()).z(); // - 1.5 * _H;
+      _ZSL[i] = _stat->surface().toLocal(sl[i]->position()).z();  // - 1.5 * _H;
       // LocalPoint posInLayer=l1[i]->layType()->getWire(1)->positionInLayer();
       const DTTopology &tp = l1[i]->specificTopology();
       float posX = tp.wirePosition(tp.firstChannel());
@@ -242,22 +236,19 @@ void DTTrigGeom::getGeom() {
 
   // debugging
   if (_debug) {
-    std::cout << setiosflags(std::ios::showpoint | std::ios::fixed)
-              << std::setw(4) << std::setprecision(1);
+    std::cout << setiosflags(std::ios::showpoint | std::ios::fixed) << std::setw(4) << std::setprecision(1);
     std::cout << "Identification: wheel=" << wheel();
     std::cout << ", station=" << station();
     std::cout << ", sector=" << sector() << std::endl;
     GlobalPoint pp = _stat->toGlobal(LocalPoint(0, 0, 0));
-    std::cout << "Position: Mag=" << pp.mag()
-              << "cm, Phi=" << pp.phi() * 180 / 3.14159;
+    std::cout << "Position: Mag=" << pp.mag() << "cm, Phi=" << pp.phi() * 180 / 3.14159;
     std::cout << " deg, Z=" << pp.z() << " cm" << std::endl;
     std::cout << "Rotation: ANGLE=" << phiCh() * 180 / 3.14159 << std::endl;
     // if(wheel()==2&&sector()==2){ // only 1 sector-wheel
     std::cout << "Z of superlayers: phi=" << ZSL(1) << ", ";
     std::cout << ZSL(3) << " theta=" << ZSL(2);
     std::cout << " (DeltaY = " << distSL() << ")" << std::endl;
-    std::cout << " ncell: sl 1 " << nCell(1) << " sl 2 " << nCell(2) << " sl 3 "
-              << nCell(3) << std::endl;
+    std::cout << " ncell: sl 1 " << nCell(1) << " sl 2 " << nCell(2) << " sl 3 " << nCell(3) << std::endl;
     //}
   }
   // end debugging
@@ -277,14 +268,12 @@ void DTTrigGeom::dumpGeom() const {
   std::cout << ", station=" << station();
   std::cout << ", sector=" << sector() << std::endl;
   GlobalPoint pp = _stat->toGlobal(LocalPoint(0, 0, 0));
-  std::cout << "Position: Mag=" << pp.mag()
-            << "cm, Phi=" << pp.phi() * 180 / 3.14159;
+  std::cout << "Position: Mag=" << pp.mag() << "cm, Phi=" << pp.phi() * 180 / 3.14159;
   std::cout << " deg, Z=" << pp.z() << " cm" << std::endl;
   std::cout << "Rotation: ANGLE=" << phiCh() * 180 / 3.14159 << std::endl;
   std::cout << "Z of superlayers: phi=" << ZSL(1) << ", ";
   std::cout << ZSL(3) << " theta=" << ZSL(2) << std::endl;
-  std::cout << "Number of cells: SL1=" << nCell(1) << " SL2=" << nCell(2)
-            << " SL3=" << nCell(3) << std::endl;
+  std::cout << "Number of cells: SL1=" << nCell(1) << " SL2=" << nCell(2) << " SL3=" << nCell(3) << std::endl;
   std::cout << "First wire positions:" << std::endl;
   int ii = 0;
   int jj = 0;
@@ -304,32 +293,27 @@ void DTTrigGeom::dumpGeom() const {
 
   std::cout << "First BTI position:";
   std::cout << " SL1:" << localPosition(DTBtiId(statId(), 1, 1)) << std::endl;
-  std::cout << " Position: R=" << gp1.perp()
-            << "cm, Phi=" << gp1.phi() * 180 / 3.14159 << " deg, Z=" << gp1.z()
+  std::cout << " Position: R=" << gp1.perp() << "cm, Phi=" << gp1.phi() * 180 / 3.14159 << " deg, Z=" << gp1.z()
             << " cm" << std::endl;
 
   if (station() != 4) {
     GlobalPoint gp2 = CMSPosition(DTBtiId(statId(), 2, 1));
     std::cout << " SL2:" << localPosition(DTBtiId(statId(), 2, 1)) << std::endl;
-    std::cout << " Position: R=" << gp2.perp()
-              << "cm, Phi=" << gp2.phi() * 180 / 3.14159
-              << " deg, Z=" << gp2.z() << " cm" << std::endl;
+    std::cout << " Position: R=" << gp2.perp() << "cm, Phi=" << gp2.phi() * 180 / 3.14159 << " deg, Z=" << gp2.z()
+              << " cm" << std::endl;
   }
 
   GlobalPoint gp3 = CMSPosition(DTBtiId(statId(), 3, 1));
   std::cout << " SL3:" << localPosition(DTBtiId(statId(), 3, 1)) << std::endl;
-  std::cout << " Position: R=" << gp3.perp()
-            << "cm, Phi=" << gp3.phi() * 180 / 3.14159 << " deg, Z=" << gp3.z()
+  std::cout << " Position: R=" << gp3.perp() << "cm, Phi=" << gp3.phi() * 180 / 3.14159 << " deg, Z=" << gp3.z()
             << " cm" << std::endl;
 
   std::cout << "First TRACO position:";
   std::cout << localPosition(DTTracoId(statId(), 1)) << std::endl;
-  std::cout << "******************************************************"
-            << std::endl;
+  std::cout << "******************************************************" << std::endl;
 }
 
 void DTTrigGeom::dumpLUT(short int btic) {
-
   // chamber id
   int wh = wheel();
   int st = station();
@@ -366,12 +350,8 @@ void DTTrigGeom::dumpLUT(short int btic) {
   fout << "\t" << se;
 
   // SL shift
-  float xBTI1_3 =
-      localPosition(DTBtiId(DTSuperLayerId(wheel(), station(), sector(), 3), 1))
-          .x();
-  float xBTI1_1 =
-      localPosition(DTBtiId(DTSuperLayerId(wheel(), station(), sector(), 1), 1))
-          .x();
+  float xBTI1_3 = localPosition(DTBtiId(DTSuperLayerId(wheel(), station(), sector(), 3), 1)).x();
+  float xBTI1_1 = localPosition(DTBtiId(DTSuperLayerId(wheel(), station(), sector(), 1), 1)).x();
   float SL_shift = xBTI1_3 - xBTI1_1;
   //  std::cout << " SL shift " << SL_shift << std::endl;
 
@@ -396,8 +376,7 @@ void DTTrigGeom::dumpLUT(short int btic) {
     // 110208 SV comment: this was inserted for a TRACO hardware bug
     if (SL_shift > 0)
       xcn = xcn + SL_shift;
-    xcn_sign = static_cast<int>(pp.y() / fabs(pp.y())) *
-               static_cast<int>(traco_1.y() / fabs(traco_1.y()));
+    xcn_sign = static_cast<int>(pp.y() / fabs(pp.y())) * static_cast<int>(traco_1.y() / fabs(traco_1.y()));
     if (station() == 2 || (station() == 4 && sector() == 1))
       xcn_sign = -xcn_sign;
     xcn = xcn * xcn_sign;
@@ -409,8 +388,7 @@ void DTTrigGeom::dumpLUT(short int btic) {
     float yn = m * xn;
 
     d = sqrt(xn * xn + yn * yn);
-    xcn = sqrt((xn - traco_1.x()) * (xn - traco_1.x()) +
-               (yn - traco_1.y()) * (yn - traco_1.y()));
+    xcn = sqrt((xn - traco_1.x()) * (xn - traco_1.x()) + (yn - traco_1.y()) * (yn - traco_1.y()));
     // 110208 SV comment: this was inserted for a TRACO hardware bug
     if (SL_shift > 0)
       xcn = xcn + SL_shift;
@@ -428,11 +406,9 @@ void DTTrigGeom::dumpLUT(short int btic) {
   fout << "\tA8";
   // short int btic = 31;
   // cout << "CHECK BTIC " << btic << endl;
-  short int Low_byte =
-      (btic & 0x00FF); // output in hex bytes format with zero padding
+  short int Low_byte = (btic & 0x00FF);  // output in hex bytes format with zero padding
   short int High_byte = (btic >> 8 & 0x00FF);
-  fout << setw(2) << setfill('0') << hex << High_byte << setw(2) << setfill('0')
-       << Low_byte;
+  fout << setw(2) << setfill('0') << hex << High_byte << setw(2) << setfill('0') << Low_byte;
 
   // convert parameters from IEE32 float to DSP float format
   short int DSPmantissa = 0;
@@ -440,36 +416,28 @@ void DTTrigGeom::dumpLUT(short int btic) {
 
   // d parameter conversion and dump
   IEEE32toDSP(d, DSPmantissa, DSPexp);
-  Low_byte =
-      (DSPmantissa & 0x00FF); // output in hex bytes format with zero padding
+  Low_byte = (DSPmantissa & 0x00FF);  // output in hex bytes format with zero padding
   High_byte = (DSPmantissa >> 8 & 0x00FF);
-  fout << setw(2) << setfill('0') << hex << High_byte << setw(2) << setfill('0')
-       << Low_byte;
+  fout << setw(2) << setfill('0') << hex << High_byte << setw(2) << setfill('0') << Low_byte;
   Low_byte = (DSPexp & 0x00FF);
   High_byte = (DSPexp >> 8 & 0x00FF);
-  fout << setw(2) << setfill('0') << High_byte << setw(2) << setfill('0')
-       << Low_byte;
+  fout << setw(2) << setfill('0') << High_byte << setw(2) << setfill('0') << Low_byte;
 
   // xnc parameter conversion and dump
   DSPmantissa = 0;
   DSPexp = 0;
   IEEE32toDSP(xcn, DSPmantissa, DSPexp);
-  Low_byte =
-      (DSPmantissa & 0x00FF); // output in hex bytes format with zero padding
+  Low_byte = (DSPmantissa & 0x00FF);  // output in hex bytes format with zero padding
   High_byte = (DSPmantissa >> 8 & 0x00FF);
-  fout << setw(2) << setfill('0') << hex << High_byte << setw(2) << setfill('0')
-       << Low_byte;
+  fout << setw(2) << setfill('0') << hex << High_byte << setw(2) << setfill('0') << Low_byte;
   Low_byte = (DSPexp & 0x00FF);
   High_byte = (DSPexp >> 8 & 0x00FF);
-  fout << setw(2) << setfill('0') << High_byte << setw(2) << setfill('0')
-       << Low_byte;
+  fout << setw(2) << setfill('0') << High_byte << setw(2) << setfill('0') << Low_byte;
 
   // sign bits
-  Low_byte =
-      (xcn_sign & 0x00FF); // output in hex bytes format with zero padding
+  Low_byte = (xcn_sign & 0x00FF);  // output in hex bytes format with zero padding
   High_byte = (xcn_sign >> 8 & 0x00FF);
-  fout << setw(2) << setfill('0') << hex << High_byte << setw(2) << setfill('0')
-       << Low_byte << dec << "\n";
+  fout << setw(2) << setfill('0') << hex << High_byte << setw(2) << setfill('0') << Low_byte << dec << "\n";
 
   fout.close();
 
@@ -511,8 +479,7 @@ complement
 // A.Gozzelino May 11th 2012: bug fix in method IEEE32toDSP
 //******************
 
-void DTTrigGeom::IEEE32toDSP(float f, short int &DSPmantissa,
-                             short int &DSPexp) {
+void DTTrigGeom::IEEE32toDSP(float f, short int &DSPmantissa, short int &DSPexp) {
   long int lm;
   long int pl = 0;
 
@@ -526,13 +493,13 @@ void DTTrigGeom::IEEE32toDSP(float f, short int &DSPmantissa,
 
     if ((pl & 0x80000000) != 0)
       sign = true;
-    lm = (0x800000 | (pl & 0x7FFFFF)); // [1][23bit mantissa]
-    lm >>= 9;                          // reduce to 15bits
+    lm = (0x800000 | (pl & 0x7FFFFF));  // [1][23bit mantissa]
+    lm >>= 9;                           // reduce to 15bits
     lm &= 0x7FFF;
     DSPexp = ((pl >> 23) & 0xFF) - 126;
     DSPmantissa = (short)lm;
     if (sign)
-      DSPmantissa = -DSPmantissa; // convert negative value in 2.s complement
+      DSPmantissa = -DSPmantissa;  // convert negative value in 2.s complement
   }
   return;
 }
@@ -591,8 +558,7 @@ LocalPoint DTTrigGeom::localPosition(const DTBtiId id) const {
   // LocalPoint posInLayer1(localX+xt,yt,0); //Correction now y is left I of
   // first cell of layer 1 y=0 and z in the middle of SL,
   LocalPoint posInLayer1(localX + xt, 0, zt);
-  LocalPoint posInChamber =
-      _stat->surface().toLocal(lay->toGlobal(posInLayer1));
+  LocalPoint posInChamber = _stat->surface().toLocal(lay->toGlobal(posInLayer1));
   // GlobalPoint posInCMS = lay->toGlobal(posInLayer1);
 
   /* cout <<endl;
@@ -614,9 +580,7 @@ LocalPoint DTTrigGeom::localPosition(const DTTracoId id) const {
   */
   // NEWGEO
   // position of first BTI in sl 3 on X
-  float x =
-      localPosition(DTBtiId(DTSuperLayerId(wheel(), station(), sector(), 3), 1))
-          .x();
+  float x = localPosition(DTBtiId(DTSuperLayerId(wheel(), station(), sector(), 3), 1)).x();
   // 10/7/06 May be not needed anymore in new geometry
   //   if(posFE(3)==1)
   //     x -= (id.traco()-2)*DTConfig::NBTITC * cellPitch();

--- a/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerFDL.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerFDL.h
@@ -39,7 +39,6 @@ class L1GlobalTriggerPSB;
 
 // class declaration
 class L1GlobalTriggerFDL {
-
 public:
   /// constructor
   L1GlobalTriggerFDL();
@@ -48,18 +47,23 @@ public:
   virtual ~L1GlobalTriggerFDL();
 
   /// run the FDL
-  void run(edm::Event &iEvent, const std::vector<int> &prescaleFactorsAlgoTrig,
+  void run(edm::Event &iEvent,
+           const std::vector<int> &prescaleFactorsAlgoTrig,
            const std::vector<int> &prescaleFactorsTechTrig,
            const std::vector<unsigned int> &triggerMaskAlgoTrig,
            const std::vector<unsigned int> &triggerMaskTechTrig,
            const std::vector<unsigned int> &triggerMaskVetoAlgoTrig,
            const std::vector<unsigned int> &triggerMaskVetoTechTrig,
-           const std::vector<L1GtBoard> &boardMaps, const int totalBxInEvent,
-           const int iBxInEvent, const unsigned int numberPhysTriggers,
+           const std::vector<L1GtBoard> &boardMaps,
+           const int totalBxInEvent,
+           const int iBxInEvent,
+           const unsigned int numberPhysTriggers,
            const unsigned int numberTechnicalTriggers,
            const unsigned int numberDaqPartitions,
-           const L1GlobalTriggerGTL *ptrGTL, const L1GlobalTriggerPSB *ptrPSB,
-           const int pfAlgoSetIndex, const int pfTechSetIndex,
+           const L1GlobalTriggerGTL *ptrGTL,
+           const L1GlobalTriggerPSB *ptrPSB,
+           const int pfAlgoSetIndex,
+           const int pfTechSetIndex,
            const bool algorithmTriggersUnprescaled,
            const bool algorithmTriggersUnmasked,
            const bool technicalTriggersUnprescaled,
@@ -69,7 +73,8 @@ public:
   /// fill the FDL block in the L1 GT DAQ record for iBxInEvent
   void fillDaqFdlBlock(const int iBxInEvent,
                        const boost::uint16_t &activeBoardsGtDaq,
-                       const int recordLength0, const int recordLength1,
+                       const int recordLength0,
+                       const int recordLength1,
                        const unsigned int altNrBxBoardDaq,
                        const std::vector<L1GtBoard> &boardMaps,
                        L1GlobalTriggerReadoutRecord *gtDaqReadoutRecord);
@@ -77,7 +82,8 @@ public:
   /// fill the FDL block in the L1 GT EVM record for iBxInEvent
   void fillEvmFdlBlock(const int iBxInEvent,
                        const boost::uint16_t &activeBoardsGtEvm,
-                       const int recordLength0, const int recordLength1,
+                       const int recordLength0,
+                       const int recordLength1,
                        const unsigned int altNrBxBoardEvm,
                        const std::vector<L1GtBoard> &boardMaps,
                        L1GlobalTriggerEvmReadoutRecord *gtEvmReadoutRecord);

--- a/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerFunctions.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerFunctions.h
@@ -20,9 +20,7 @@ bool hexStringToInt64(const std::string &, std::vector<unsigned long long> &);
 /// the third parameter of stringToNumber should be
 /// one of std::hex, std::dec or std::oct
 template <class T>
-bool stringToNumber(T &tmpl, const std::string &str,
-                    std::ios_base &(*f)(std::ios_base &)) {
-
+bool stringToNumber(T &tmpl, const std::string &str, std::ios_base &(*f)(std::ios_base &)) {
   std::istringstream iss(str);
   return !(iss >> f >> tmpl).fail();
 }

--- a/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerGTL.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerGTL.h
@@ -43,7 +43,6 @@ class L1GtEtaPhiConversions;
 
 // class declaration
 class L1GlobalTriggerGTL {
-
 public:
   // constructors
   L1GlobalTriggerGTL(const edm::InputTag &mutag, edm::ConsumesCollector &&iC);
@@ -53,22 +52,29 @@ public:
 
 public:
   /// receive data from Global Muon Trigger
-  void receiveGmtObjectData(edm::Event &, const edm::InputTag &,
-                            const int iBxInEvent, const bool receiveMu,
-                            const int nrL1Mu);
+  void receiveGmtObjectData(
+      edm::Event &, const edm::InputTag &, const int iBxInEvent, const bool receiveMu, const int nrL1Mu);
 
   /// initialize the class (mainly reserve)
   void init(const int nrL1Mu, const int numberPhysTriggers);
 
   /// run the GTL
-  void run(edm::Event &iEvent, const edm::EventSetup &evSetup,
+  void run(edm::Event &iEvent,
+           const edm::EventSetup &evSetup,
            const L1GlobalTriggerPSB *ptrGtPSB,
-           const bool produceL1GtObjectMapRecord, const int iBxInEvent,
+           const bool produceL1GtObjectMapRecord,
+           const int iBxInEvent,
            L1GlobalTriggerObjectMapRecord *gtObjectMapRecord,
-           const unsigned int numberPhysTriggers, const int nrL1Mu,
-           const int nrL1NoIsoEG, const int nrL1IsoEG, const int nrL1CenJet,
-           const int nrL1ForJet, const int nrL1TauJet, const int nrL1JetCounts,
-           const int ifMuEtaNumberBits, const int ifCaloEtaNumberBits);
+           const unsigned int numberPhysTriggers,
+           const int nrL1Mu,
+           const int nrL1NoIsoEG,
+           const int nrL1IsoEG,
+           const int nrL1CenJet,
+           const int nrL1ForJet,
+           const int nrL1TauJet,
+           const int nrL1JetCounts,
+           const int ifMuEtaNumberBits,
+           const int ifCaloEtaNumberBits);
 
   /// clear GTL
   void reset();
@@ -77,21 +83,17 @@ public:
   void printGmtData(const int iBxInEvent) const;
 
   /// return decision
-  inline const std::bitset<L1GlobalTriggerReadoutSetup::NumberPhysTriggers> &
-  getDecisionWord() const {
+  inline const std::bitset<L1GlobalTriggerReadoutSetup::NumberPhysTriggers> &getDecisionWord() const {
     return m_gtlDecisionWord;
   }
 
   /// return algorithm OR decision
-  inline const std::bitset<L1GlobalTriggerReadoutSetup::NumberPhysTriggers> &
-  getAlgorithmOR() const {
+  inline const std::bitset<L1GlobalTriggerReadoutSetup::NumberPhysTriggers> &getAlgorithmOR() const {
     return m_gtlAlgorithmOR;
   }
 
   /// return global muon trigger candidate
-  inline const std::vector<const L1MuGMTCand *> *getCandL1Mu() const {
-    return m_candL1Mu;
-  }
+  inline const std::vector<const L1MuGMTCand *> *getCandL1Mu() const { return m_candL1Mu; }
 
 public:
   inline void setVerbosity(const int verbosity) { m_verbosity = verbosity; }
@@ -117,12 +119,10 @@ private:
   std::vector<const L1MuGMTCand *> *m_candL1Mu;
 
   std::bitset<L1GlobalTriggerReadoutSetup::NumberPhysTriggers> m_gtlAlgorithmOR;
-  std::bitset<L1GlobalTriggerReadoutSetup::NumberPhysTriggers>
-      m_gtlDecisionWord;
+  std::bitset<L1GlobalTriggerReadoutSetup::NumberPhysTriggers> m_gtlDecisionWord;
 
   // cache of maps
-  std::vector<L1GtAlgorithmEvaluation::ConditionEvaluationMap>
-      m_conditionResultMaps;
+  std::vector<L1GtAlgorithmEvaluation::ConditionEvaluationMap> m_conditionResultMaps;
 
 private:
   /// verbosity level

--- a/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerPSB.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerPSB.h
@@ -56,7 +56,6 @@ class L1GlobalTriggerReadoutRecord;
 
 // class declaration
 class L1GlobalTriggerPSB {
-
 public:
   // constructor
   L1GlobalTriggerPSB(const edm::InputTag &caloTag,
@@ -68,48 +67,68 @@ public:
 
 public:
   /// initialize the class (mainly reserve)
-  void init(const int nrL1NoIsoEG, const int nrL1IsoEG, const int nrL1CenJet,
-            const int nrL1ForJet, const int nrL1TauJet,
+  void init(const int nrL1NoIsoEG,
+            const int nrL1IsoEG,
+            const int nrL1CenJet,
+            const int nrL1ForJet,
+            const int nrL1TauJet,
             const int numberTechnicalTriggers);
 
   /// receive Global Calorimeter Trigger objects
-  void receiveGctObjectData(
-      edm::Event &iEvent, const edm::InputTag &caloGctInputTag,
-      const int iBxInEvent, const bool receiveNoIsoEG, const int nrL1NoIsoEG,
-      const bool receiveIsoEG, const int nrL1IsoEG, const bool receiveCenJet,
-      const int nrL1CenJet, const bool receiveForJet, const int nrL1ForJet,
-      const bool receiveTauJet, const int nrL1TauJet, const bool receiveETM,
-      const bool receiveETT, const bool receiveHTT, const bool receiveHTM,
-      const bool receiveJetCounts, const bool receiveHfBitCounts,
-      const bool receiveHfRingEtSums);
+  void receiveGctObjectData(edm::Event &iEvent,
+                            const edm::InputTag &caloGctInputTag,
+                            const int iBxInEvent,
+                            const bool receiveNoIsoEG,
+                            const int nrL1NoIsoEG,
+                            const bool receiveIsoEG,
+                            const int nrL1IsoEG,
+                            const bool receiveCenJet,
+                            const int nrL1CenJet,
+                            const bool receiveForJet,
+                            const int nrL1ForJet,
+                            const bool receiveTauJet,
+                            const int nrL1TauJet,
+                            const bool receiveETM,
+                            const bool receiveETT,
+                            const bool receiveHTT,
+                            const bool receiveHTM,
+                            const bool receiveJetCounts,
+                            const bool receiveHfBitCounts,
+                            const bool receiveHfRingEtSums);
 
   /// receive CASTOR objects
   void receiveCastorData(edm::Event &iEvent,
                          const edm::InputTag &castorInputTag,
-                         const int iBxInEvent, const bool receiveCastor,
+                         const int iBxInEvent,
+                         const bool receiveCastor,
                          const bool readFromPsb);
 
   /// receive BPTX objects
-  void receiveBptxData(edm::Event &iEvent, const edm::InputTag &bptxInputTag,
-                       const int iBxInEvent, const bool receiveBptx,
+  void receiveBptxData(edm::Event &iEvent,
+                       const edm::InputTag &bptxInputTag,
+                       const int iBxInEvent,
+                       const bool receiveBptx,
                        const bool readFromPsb);
 
   /// receive External objects
   void receiveExternalData(edm::Event &iEvent,
                            const std::vector<edm::InputTag> &externalInputTags,
-                           const int iBxInEvent, const bool receiveExternal,
+                           const int iBxInEvent,
+                           const bool receiveExternal,
                            const bool readFromPsb);
 
   /// receive technical trigger
-  void receiveTechnicalTriggers(
-      edm::Event &iEvent,
-      const std::vector<edm::InputTag> &technicalTriggersInputTags,
-      const int iBxInEvent, const bool receiveTechTr, const int nrL1TechTr);
+  void receiveTechnicalTriggers(edm::Event &iEvent,
+                                const std::vector<edm::InputTag> &technicalTriggersInputTags,
+                                const int iBxInEvent,
+                                const bool receiveTechTr,
+                                const int nrL1TechTr);
 
   /// fill the content of active PSB boards
   void fillPsbBlock(edm::Event &iEvent,
                     const boost::uint16_t &activeBoardsGtDaq,
-                    const int recordLength0, const int recordLength1,
+                    const int recordLength0,
+                    const int recordLength1,
                     const unsigned int altNrBxBoardDaq,
                     const std::vector<L1GtBoard> &boardMaps,
                     const int iBxInEvent,
@@ -122,29 +141,19 @@ public:
   void printGctObjectData(const int iBxInEvent) const;
 
   /// pointer to NoIsoEG data list
-  inline const std::vector<const L1GctCand *> *getCandL1NoIsoEG() const {
-    return m_candL1NoIsoEG;
-  }
+  inline const std::vector<const L1GctCand *> *getCandL1NoIsoEG() const { return m_candL1NoIsoEG; }
 
   /// pointer to IsoEG data list
-  inline const std::vector<const L1GctCand *> *getCandL1IsoEG() const {
-    return m_candL1IsoEG;
-  }
+  inline const std::vector<const L1GctCand *> *getCandL1IsoEG() const { return m_candL1IsoEG; }
 
   /// pointer to CenJet data list
-  inline const std::vector<const L1GctCand *> *getCandL1CenJet() const {
-    return m_candL1CenJet;
-  }
+  inline const std::vector<const L1GctCand *> *getCandL1CenJet() const { return m_candL1CenJet; }
 
   /// pointer to ForJet data list
-  inline const std::vector<const L1GctCand *> *getCandL1ForJet() const {
-    return m_candL1ForJet;
-  }
+  inline const std::vector<const L1GctCand *> *getCandL1ForJet() const { return m_candL1ForJet; }
 
   /// pointer to TauJet data list
-  inline const std::vector<const L1GctCand *> *getCandL1TauJet() const {
-    return m_candL1TauJet;
-  }
+  inline const std::vector<const L1GctCand *> *getCandL1TauJet() const { return m_candL1TauJet; }
 
   /// pointer to ETM data list
   inline const L1GctEtMiss *getCandL1ETM() const { return m_candETM; }
@@ -159,24 +168,16 @@ public:
   inline const L1GctHtMiss *getCandL1HTM() const { return m_candHTM; }
 
   /// pointer to JetCounts data list
-  inline const L1GctJetCounts *getCandL1JetCounts() const {
-    return m_candJetCounts;
-  }
+  inline const L1GctJetCounts *getCandL1JetCounts() const { return m_candJetCounts; }
 
   /// pointer to HfBitCounts data list
-  inline const L1GctHFBitCounts *getCandL1HfBitCounts() const {
-    return m_candHfBitCounts;
-  }
+  inline const L1GctHFBitCounts *getCandL1HfBitCounts() const { return m_candHfBitCounts; }
 
   /// pointer to HfRingEtSums data list
-  inline const L1GctHFRingEtSums *getCandL1HfRingEtSums() const {
-    return m_candHfRingEtSums;
-  }
+  inline const L1GctHFRingEtSums *getCandL1HfRingEtSums() const { return m_candHfRingEtSums; }
 
   /// pointer to technical trigger bits
-  inline const std::vector<bool> *getGtTechnicalTriggers() const {
-    return &m_gtTechnicalTriggers;
-  }
+  inline const std::vector<bool> *getGtTechnicalTriggers() const { return &m_gtTechnicalTriggers; }
 
 public:
   inline void setVerbosity(const int verbosity) { m_verbosity = verbosity; }

--- a/L1Trigger/GlobalTrigger/interface/L1GtAlgorithmEvaluation.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GtAlgorithmEvaluation.h
@@ -36,17 +36,16 @@
 //   how to hash std::string, using a "template specialization"
 namespace __gnu_cxx {
 
-/**
+  /**
  Explicit template specialization of hash of a string class,
  which just uses the internal char* representation as a wrapper.
  */
-template <> struct hash<std::string> {
-  size_t operator()(const std::string &x) const {
-    return hash<const char *>()(x.c_str());
-  }
-};
+  template <>
+  struct hash<std::string> {
+    size_t operator()(const std::string &x) const { return hash<const char *>()(x.c_str()); }
+  };
 
-} // namespace __gnu_cxx
+}  // namespace __gnu_cxx
 // end hash map
 
 // user include files
@@ -63,7 +62,6 @@ class L1GtConditionEvaluation;
 
 // class interface
 class L1GtAlgorithmEvaluation {
-
 public:
   typedef L1GtLogicParser::TokenRPN TokenRPN;
   typedef std::vector<TokenRPN> RpnVector;
@@ -83,8 +81,7 @@ public:
 
   // typedef std::map<std::string, L1GtConditionEvaluation*>
   // ConditionEvaluationMap;
-  typedef __gnu_cxx ::hash_map<std::string, L1GtConditionEvaluation *>
-      ConditionEvaluationMap;
+  typedef __gnu_cxx ::hash_map<std::string, L1GtConditionEvaluation *> ConditionEvaluationMap;
   typedef ConditionEvaluationMap::const_iterator CItEvalMap;
   typedef ConditionEvaluationMap::iterator ItEvalMap;
 
@@ -92,23 +89,16 @@ public:
   /// get / set the result of the algorithm
   inline bool gtAlgoResult() const { return m_algoResult; }
 
-  inline void setGtAlgoResult(const bool algoResult) {
-    m_algoResult = algoResult;
-  }
+  inline void setGtAlgoResult(const bool algoResult) { m_algoResult = algoResult; }
 
   /// evaluate an algorithm
-  void evaluateAlgorithm(const int chipNumber,
-                         const std::vector<ConditionEvaluationMap> &);
+  void evaluateAlgorithm(const int chipNumber, const std::vector<ConditionEvaluationMap> &);
 
   /// get all the object combinations evaluated to true in the conditions
   /// from the algorithm
-  inline std::vector<CombinationsInCond> &gtAlgoCombinationVector() {
-    return m_algoCombinationVector;
-  }
+  inline std::vector<CombinationsInCond> &gtAlgoCombinationVector() { return m_algoCombinationVector; }
 
-  inline std::vector<L1GtLogicParser::OperandToken> &operandTokenVector() {
-    return m_operandTokenVector;
-  }
+  inline std::vector<L1GtLogicParser::OperandToken> &operandTokenVector() { return m_operandTokenVector; }
 
   void print(std::ostream &myCout) const;
 

--- a/L1Trigger/GlobalTrigger/interface/L1GtBptxCondition.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GtBptxCondition.h
@@ -30,7 +30,6 @@ class L1GtBptxTemplate;
 
 // class declaration
 class L1GtBptxCondition : public L1GtConditionEvaluation {
-
 public:
   /// constructors
   ///     default
@@ -57,18 +56,14 @@ public:
 
 public:
   ///   get / set the pointer to a L1GtCondition
-  inline const L1GtBptxTemplate *gtBptxTemplate() const {
-    return m_gtBptxTemplate;
-  }
+  inline const L1GtBptxTemplate *gtBptxTemplate() const { return m_gtBptxTemplate; }
 
   void setGtBptxTemplate(const L1GtBptxTemplate *);
 
   ///   get / set the result
   inline const bool conditionResult() const { return m_conditionResult; }
 
-  inline void setConditionResult(const bool result) {
-    m_conditionResult = result;
-  }
+  inline void setConditionResult(const bool result) { m_conditionResult = result; }
 
 private:
   /// copy function for copy constructor and operator=

--- a/L1Trigger/GlobalTrigger/interface/L1GtCaloCondition.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GtCaloCondition.h
@@ -33,17 +33,20 @@ class L1GlobalTriggerPSB;
 
 // class declaration
 class L1GtCaloCondition : public L1GtConditionEvaluation {
-
 public:
   /// constructors
   ///     default
   L1GtCaloCondition();
 
   ///     from base template condition (from event setup usually)
-  L1GtCaloCondition(const L1GtCondition *, const L1GlobalTriggerPSB *,
-                    const int nrL1NoIsoEG, const int nrL1IsoEG,
-                    const int nrL1CenJet, const int nrL1ForJet,
-                    const int nrL1TauJet, const int ifCaloEtaNumberBits);
+  L1GtCaloCondition(const L1GtCondition *,
+                    const L1GlobalTriggerPSB *,
+                    const int nrL1NoIsoEG,
+                    const int nrL1IsoEG,
+                    const int nrL1CenJet,
+                    const int nrL1ForJet,
+                    const int nrL1TauJet,
+                    const int ifCaloEtaNumberBits);
 
   // copy constructor
   L1GtCaloCondition(const L1GtCaloCondition &);
@@ -63,9 +66,7 @@ public:
 
 public:
   ///   get / set the pointer to a L1GtCondition
-  inline const L1GtCaloTemplate *gtCaloTemplate() const {
-    return m_gtCaloTemplate;
-  }
+  inline const L1GtCaloTemplate *gtCaloTemplate() const { return m_gtCaloTemplate; }
 
   void setGtCaloTemplate(const L1GtCaloTemplate *);
 
@@ -75,16 +76,12 @@ public:
   void setGtPSB(const L1GlobalTriggerPSB *);
 
   ///   get / set the number of bits for eta of calorimeter objects
-  inline const int gtIfCaloEtaNumberBits() const {
-    return m_ifCaloEtaNumberBits;
-  }
+  inline const int gtIfCaloEtaNumberBits() const { return m_ifCaloEtaNumberBits; }
 
   void setGtIfCaloEtaNumberBits(const int &);
 
   ///   get / set maximum number of bins for the delta phi scales
-  inline const int gtCorrParDeltaPhiNrBins() const {
-    return m_corrParDeltaPhiNrBins;
-  }
+  inline const int gtCorrParDeltaPhiNrBins() const { return m_corrParDeltaPhiNrBins; }
 
   void setGtCorrParDeltaPhiNrBins(const int &);
 
@@ -96,8 +93,7 @@ private:
   const L1GctCand *getCandidate(const int indexCand) const;
 
   /// function to check a single object if it matches a condition
-  const bool checkObjectParameter(const int iCondition,
-                                  const L1GctCand &cand) const;
+  const bool checkObjectParameter(const int iCondition, const L1GctCand &cand) const;
 
 private:
   /// pointer to a L1GtCaloTemplate

--- a/L1Trigger/GlobalTrigger/interface/L1GtCastorCondition.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GtCastorCondition.h
@@ -30,7 +30,6 @@ class L1GtCastorTemplate;
 
 // class declaration
 class L1GtCastorCondition : public L1GtConditionEvaluation {
-
 public:
   /// constructors
   ///     default
@@ -57,18 +56,14 @@ public:
 
 public:
   ///   get / set the pointer to a L1GtCondition
-  inline const L1GtCastorTemplate *gtCastorTemplate() const {
-    return m_gtCastorTemplate;
-  }
+  inline const L1GtCastorTemplate *gtCastorTemplate() const { return m_gtCastorTemplate; }
 
   void setGtCastorTemplate(const L1GtCastorTemplate *);
 
   ///   get / set the result
   inline const bool conditionResult() const { return m_conditionResult; }
 
-  inline void setConditionResult(const bool result) {
-    m_conditionResult = result;
-  }
+  inline void setConditionResult(const bool result) { m_conditionResult = result; }
 
 private:
   /// copy function for copy constructor and operator=

--- a/L1Trigger/GlobalTrigger/interface/L1GtConditionEvaluation.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GtConditionEvaluation.h
@@ -36,11 +36,9 @@
 
 // class interface
 class L1GtConditionEvaluation {
-
 public:
   /// constructor
-  L1GtConditionEvaluation()
-      : m_condMaxNumberObjects(0), m_condLastResult(false), m_verbosity(0) {}
+  L1GtConditionEvaluation() : m_condMaxNumberObjects(0), m_condLastResult(false), m_verbosity(0) {}
 
   /// destructor
   virtual ~L1GtConditionEvaluation() {}
@@ -58,9 +56,7 @@ public:
   inline bool condLastResult() const { return m_condLastResult; }
 
   /// call evaluateCondition and save last result
-  inline void evaluateConditionStoreResult() {
-    m_condLastResult = evaluateCondition();
-  }
+  inline void evaluateConditionStoreResult() { m_condLastResult = evaluateCondition(); }
 
   /// the core function to check if the condition matches
   virtual const bool evaluateCondition() const = 0;
@@ -75,9 +71,7 @@ public:
   }
 
   /// get all the object combinations evaluated to true in the condition
-  inline CombinationsInCond const &getCombinationsInCond() const {
-    return m_combinationsInCond;
-  }
+  inline CombinationsInCond const &getCombinationsInCond() const { return m_combinationsInCond; }
 
   /// print condition
   virtual void print(std::ostream &myCout) const;
@@ -86,15 +80,12 @@ public:
 
 protected:
   /// get all the object combinations (to fill it...)
-  inline CombinationsInCond &combinationsInCond() const {
-    return m_combinationsInCond;
-  }
+  inline CombinationsInCond &combinationsInCond() const { return m_combinationsInCond; }
 
   /// check if a value is greater than a threshold or
   /// greater-or-equal depending on the value of the condGEqValue flag
   template <class Type1, class Type2>
-  const bool checkThreshold(const Type1 &threshold, const Type2 &value,
-                            const bool condGEqValue) const;
+  const bool checkThreshold(const Type1 &threshold, const Type2 &value, const bool condGEqValue) const;
 
   /// check if a bit with a given number is set in a mask
   template <class Type1>
@@ -120,9 +111,9 @@ protected:
 // check if a value is greater than a threshold or
 // greater-or-equal depending on the value of the condGEqValue flag
 template <class Type1, class Type2>
-const bool L1GtConditionEvaluation::checkThreshold(
-    const Type1 &threshold, const Type2 &value, const bool condGEqValue) const {
-
+const bool L1GtConditionEvaluation::checkThreshold(const Type1 &threshold,
+                                                   const Type2 &value,
+                                                   const bool condGEqValue) const {
   // if (value > 0) {
   //    LogTrace("L1GlobalTrigger") << "  threshold check for condGEqValue = "
   //        << condGEqValue << "\n    hex: " << std::hex << "threshold = " <<
@@ -134,7 +125,6 @@ const bool L1GtConditionEvaluation::checkThreshold(
 
   if (condGEqValue) {
     if (value >= threshold) {
-
       // LogTrace("L1GlobalTrigger") << "    condGEqValue: value >= threshold"
       //    << std::endl;
 
@@ -144,9 +134,7 @@ const bool L1GtConditionEvaluation::checkThreshold(
     return false;
 
   } else {
-
     if (value == threshold) {
-
       // LogTrace("L1GlobalTrigger") << "    condGEqValue: value = threshold"
       //    << std::endl;
 
@@ -159,20 +147,14 @@ const bool L1GtConditionEvaluation::checkThreshold(
 
 // check if a bit with a given number is set in a mask
 template <class Type1>
-const bool
-L1GtConditionEvaluation::checkBit(const Type1 &mask,
-                                  const unsigned int bitNumber) const {
-
+const bool L1GtConditionEvaluation::checkBit(const Type1 &mask, const unsigned int bitNumber) const {
   boost::uint64_t oneBit = 1ULL;
 
   if (bitNumber >= (sizeof(oneBit) * 8)) {
-
     if (m_verbosity) {
-
-      LogTrace("L1GlobalTrigger")
-          << "    checkBit "
-          << "\n     Bit number = " << bitNumber
-          << " larger than maximum allowed " << sizeof(oneBit) * 8 << std::endl;
+      LogTrace("L1GlobalTrigger") << "    checkBit "
+                                  << "\n     Bit number = " << bitNumber << " larger than maximum allowed "
+                                  << sizeof(oneBit) * 8 << std::endl;
     }
 
     return false;

--- a/L1Trigger/GlobalTrigger/interface/L1GtCorrelationCondition.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GtCorrelationCondition.h
@@ -32,16 +32,20 @@ class L1GtEtaPhiConversions;
 
 // class declaration
 class L1GtCorrelationCondition : public L1GtConditionEvaluation {
-
 public:
   /// constructors
   ///     default
   L1GtCorrelationCondition();
 
   ///     from base template condition (from event setup usually)
-  L1GtCorrelationCondition(const L1GtCondition *, const L1GtCondition *,
-                           const L1GtCondition *, const int, const int,
-                           const int, const int, const L1GlobalTriggerGTL *,
+  L1GtCorrelationCondition(const L1GtCondition *,
+                           const L1GtCondition *,
+                           const L1GtCondition *,
+                           const int,
+                           const int,
+                           const int,
+                           const int,
+                           const L1GlobalTriggerGTL *,
                            const L1GlobalTriggerPSB *,
                            const L1GtEtaPhiConversions *);
 
@@ -68,9 +72,7 @@ public:
   void setGtNrBinsPhi(const unsigned int);
 
   ///   get / set the pointer to a L1GtCondition
-  inline const L1GtCorrelationTemplate *gtCorrelationTemplate() const {
-    return m_gtCorrelationTemplate;
-  }
+  inline const L1GtCorrelationTemplate *gtCorrelationTemplate() const { return m_gtCorrelationTemplate; }
 
   void setGtCorrelationTemplate(const L1GtCorrelationTemplate *);
 

--- a/L1Trigger/GlobalTrigger/interface/L1GtEnergySumCondition.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GtEnergySumCondition.h
@@ -31,7 +31,6 @@ class L1GlobalTriggerPSB;
 
 // class declaration
 class L1GtEnergySumCondition : public L1GtConditionEvaluation {
-
 public:
   /// constructors
   ///     default
@@ -58,9 +57,7 @@ public:
 
 public:
   ///   get / set the pointer to a L1GtCondition
-  inline const L1GtEnergySumTemplate *gtEnergySumTemplate() const {
-    return m_gtEnergySumTemplate;
-  }
+  inline const L1GtEnergySumTemplate *gtEnergySumTemplate() const { return m_gtEnergySumTemplate; }
 
   void setGtEnergySumTemplate(const L1GtEnergySumTemplate *);
 

--- a/L1Trigger/GlobalTrigger/interface/L1GtEtaPhiConversions.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GtEtaPhiConversions.h
@@ -34,7 +34,6 @@ class L1MuTriggerScales;
 
 // class interface
 class L1GtEtaPhiConversions {
-
 public:
   /// constructor
   L1GtEtaPhiConversions();
@@ -45,8 +44,7 @@ public:
 public:
   /// return the index of a pair in the vector m_gtObjectPairVec, to be used to
   /// extract the number of phi bins, the conversion of the indices, etc
-  const unsigned int gtObjectPairIndex(const L1GtObject &,
-                                       const L1GtObject &) const;
+  const unsigned int gtObjectPairIndex(const L1GtObject &, const L1GtObject &) const;
 
   /// convert the phi index initialIndex for an object from pair pairIndex, with
   /// position of object in pair positionPair to common scale for the L1GtObject
@@ -61,25 +59,21 @@ public:
   /// converted index returned by reference
   /// method return true, if initial index within scale size
   /// otherwise (hardware error), return false
-  const bool convertEtaIndex(const L1GtObject &,
-                             const unsigned int initialIndex,
-                             unsigned int &convertedIndex) const;
+  const bool convertEtaIndex(const L1GtObject &, const unsigned int initialIndex, unsigned int &convertedIndex) const;
 
   /// return the number of phi bins for a GT object
   const unsigned int gtObjectNrBinsPhi(const L1GtObject &) const;
 
   /// return the number of phi bins for a pair of GT objects, according to
   /// conversion rules
-  const unsigned int gtObjectNrBinsPhi(const L1GtObject &,
-                                       const L1GtObject &) const;
+  const unsigned int gtObjectNrBinsPhi(const L1GtObject &, const L1GtObject &) const;
 
   /// return the number of phi bins for a pair of GT objects, according to
   /// conversion rules, when the index of the pair is used
   const unsigned int gtObjectNrBinsPhi(const unsigned int) const;
 
   /// perform all scale conversions
-  void convertL1Scales(const L1CaloGeometry *, const L1MuTriggerScales *,
-                       const int, const int);
+  void convertL1Scales(const L1CaloGeometry *, const L1MuTriggerScales *, const int, const int);
 
   inline void setVerbosity(const int verbosity) { m_verbosity = verbosity; }
 

--- a/L1Trigger/GlobalTrigger/interface/L1GtExternalCondition.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GtExternalCondition.h
@@ -30,7 +30,6 @@ class L1GtExternalTemplate;
 
 // class declaration
 class L1GtExternalCondition : public L1GtConditionEvaluation {
-
 public:
   /// constructors
   ///     default
@@ -57,18 +56,14 @@ public:
 
 public:
   ///   get / set the pointer to a L1GtCondition
-  inline const L1GtExternalTemplate *gtExternalTemplate() const {
-    return m_gtExternalTemplate;
-  }
+  inline const L1GtExternalTemplate *gtExternalTemplate() const { return m_gtExternalTemplate; }
 
   void setGtExternalTemplate(const L1GtExternalTemplate *);
 
   ///   get / set the result
   inline const bool conditionResult() const { return m_conditionResult; }
 
-  inline void setConditionResult(const bool result) {
-    m_conditionResult = result;
-  }
+  inline void setConditionResult(const bool result) { m_conditionResult = result; }
 
 private:
   /// copy function for copy constructor and operator=

--- a/L1Trigger/GlobalTrigger/interface/L1GtHfBitCountsCondition.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GtHfBitCountsCondition.h
@@ -30,7 +30,6 @@ class L1GlobalTriggerPSB;
 
 // class declaration
 class L1GtHfBitCountsCondition : public L1GtConditionEvaluation {
-
 public:
   /// constructors
   ///     default
@@ -57,9 +56,7 @@ public:
 
 public:
   ///   get / set the pointer to a L1GtCondition
-  inline const L1GtHfBitCountsTemplate *gtHfBitCountsTemplate() const {
-    return m_gtHfBitCountsTemplate;
-  }
+  inline const L1GtHfBitCountsTemplate *gtHfBitCountsTemplate() const { return m_gtHfBitCountsTemplate; }
 
   void setGtHfBitCountsTemplate(const L1GtHfBitCountsTemplate *);
 

--- a/L1Trigger/GlobalTrigger/interface/L1GtHfRingEtSumsCondition.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GtHfRingEtSumsCondition.h
@@ -30,7 +30,6 @@ class L1GlobalTriggerPSB;
 
 // class declaration
 class L1GtHfRingEtSumsCondition : public L1GtConditionEvaluation {
-
 public:
   /// constructors
   ///     default
@@ -57,9 +56,7 @@ public:
 
 public:
   ///   get / set the pointer to a L1GtCondition
-  inline const L1GtHfRingEtSumsTemplate *gtHfRingEtSumsTemplate() const {
-    return m_gtHfRingEtSumsTemplate;
-  }
+  inline const L1GtHfRingEtSumsTemplate *gtHfRingEtSumsTemplate() const { return m_gtHfRingEtSumsTemplate; }
 
   void setGtHfRingEtSumsTemplate(const L1GtHfRingEtSumsTemplate *);
 

--- a/L1Trigger/GlobalTrigger/interface/L1GtJetCountsCondition.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GtJetCountsCondition.h
@@ -31,15 +31,13 @@ class L1GlobalTriggerPSB;
 
 // class declaration
 class L1GtJetCountsCondition : public L1GtConditionEvaluation {
-
 public:
   /// constructors
   ///     default
   L1GtJetCountsCondition();
 
   ///     from base template condition (from event setup usually)
-  L1GtJetCountsCondition(const L1GtCondition *, const L1GlobalTriggerPSB *,
-                         const int nrL1JetCounts);
+  L1GtJetCountsCondition(const L1GtCondition *, const L1GlobalTriggerPSB *, const int nrL1JetCounts);
 
   // copy constructor
   L1GtJetCountsCondition(const L1GtJetCountsCondition &);
@@ -59,9 +57,7 @@ public:
 
 public:
   ///   get / set the pointer to a L1GtCondition
-  inline const L1GtJetCountsTemplate *gtJetCountsTemplate() const {
-    return m_gtJetCountsTemplate;
-  }
+  inline const L1GtJetCountsTemplate *gtJetCountsTemplate() const { return m_gtJetCountsTemplate; }
 
   void setGtJetCountsTemplate(const L1GtJetCountsTemplate *);
 

--- a/L1Trigger/GlobalTrigger/interface/L1GtMuonCondition.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GtMuonCondition.h
@@ -33,15 +33,13 @@ class L1GlobalTriggerGTL;
 
 // class declaration
 class L1GtMuonCondition : public L1GtConditionEvaluation {
-
 public:
   /// constructors
   ///     default
   L1GtMuonCondition();
 
   ///     from base template condition (from event setup usually)
-  L1GtMuonCondition(const L1GtCondition *, const L1GlobalTriggerGTL *,
-                    const int nrL1Mu, const int ifMuEtaNumberBits);
+  L1GtMuonCondition(const L1GtCondition *, const L1GlobalTriggerGTL *, const int nrL1Mu, const int ifMuEtaNumberBits);
 
   // copy constructor
   L1GtMuonCondition(const L1GtMuonCondition &);
@@ -61,9 +59,7 @@ public:
 
 public:
   ///   get / set the pointer to a L1GtCondition
-  inline const L1GtMuonTemplate *gtMuonTemplate() const {
-    return m_gtMuonTemplate;
-  }
+  inline const L1GtMuonTemplate *gtMuonTemplate() const { return m_gtMuonTemplate; }
 
   void setGtMuonTemplate(const L1GtMuonTemplate *);
 
@@ -78,9 +74,7 @@ public:
   void setGtIfMuEtaNumberBits(const int &);
 
   ///   get / set maximum number of bins for the delta phi scales
-  inline const int gtCorrParDeltaPhiNrBins() const {
-    return m_corrParDeltaPhiNrBins;
-  }
+  inline const int gtCorrParDeltaPhiNrBins() const { return m_corrParDeltaPhiNrBins; }
 
   void setGtCorrParDeltaPhiNrBins(const int &);
 
@@ -92,8 +86,7 @@ private:
   const L1MuGMTCand *getCandidate(const int indexCand) const;
 
   /// function to check a single object if it matches a condition
-  const bool checkObjectParameter(const int iCondition,
-                                  const L1MuGMTCand &cand) const;
+  const bool checkObjectParameter(const int iCondition, const L1MuGMTCand &cand) const;
 
 private:
   /// pointer to a L1GtMuonTemplate

--- a/L1Trigger/GlobalTrigger/plugins/CompareToObjectMapRecord.cc
+++ b/L1Trigger/GlobalTrigger/plugins/CompareToObjectMapRecord.cc
@@ -33,18 +33,14 @@
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-CompareToObjectMapRecord::CompareToObjectMapRecord(
-    const edm::ParameterSet &pset)
+CompareToObjectMapRecord::CompareToObjectMapRecord(const edm::ParameterSet &pset)
     : m_l1GtObjectMapTag(pset.getParameter<edm::InputTag>("L1GtObjectMapTag")),
-      m_l1GtObjectMapsTag(
-          pset.getParameter<edm::InputTag>("L1GtObjectMapsTag")),
+      m_l1GtObjectMapsTag(pset.getParameter<edm::InputTag>("L1GtObjectMapsTag")),
       verbose_(pset.getUntrackedParameter<bool>("verbose", false)) {}
 
 CompareToObjectMapRecord::~CompareToObjectMapRecord() {}
 
-void CompareToObjectMapRecord::analyze(edm::Event const &event,
-                                       edm::EventSetup const &es) {
-
+void CompareToObjectMapRecord::analyze(edm::Event const &event, edm::EventSetup const &es) {
   // Read in the data in the old format
   edm::Handle<L1GlobalTriggerObjectMapRecord> gtObjectMapRecord;
   event.getByLabel(m_l1GtObjectMapTag, gtObjectMapRecord);
@@ -56,8 +52,7 @@ void CompareToObjectMapRecord::analyze(edm::Event const &event,
   // In the new format the names are not in the event data,
   // They are in the ParameterSet registry
   edm::pset::Registry *psetRegistry = edm::pset::Registry::instance();
-  edm::ParameterSet const *pset =
-      psetRegistry->getMapped(gtObjectMaps->namesParameterSetID());
+  edm::ParameterSet const *pset = psetRegistry->getMapped(gtObjectMaps->namesParameterSetID());
   if (pset == nullptr) {
     cms::Exception ex("L1GlobalTrigger");
     ex << "Could not find L1 trigger names ParameterSet in the registry";
@@ -67,13 +62,11 @@ void CompareToObjectMapRecord::analyze(edm::Event const &event,
 
   // First compare the algorithm bit numbers
   std::vector<int> algoBitNumbers1;
-  std::vector<L1GlobalTriggerObjectMap> const &vectorInRecord =
-      gtObjectMapRecord->gtObjectMap();
+  std::vector<L1GlobalTriggerObjectMap> const &vectorInRecord = gtObjectMapRecord->gtObjectMap();
   algoBitNumbers1.reserve(vectorInRecord.size());
-  for (std::vector<L1GlobalTriggerObjectMap>::const_iterator
-           i = vectorInRecord.begin(),
-           iEnd = vectorInRecord.end();
-       i != iEnd; ++i) {
+  for (std::vector<L1GlobalTriggerObjectMap>::const_iterator i = vectorInRecord.begin(), iEnd = vectorInRecord.end();
+       i != iEnd;
+       ++i) {
     algoBitNumbers1.push_back(i->algoBitNumber());
     if (verbose_) {
       // This will print out all the data from the
@@ -93,15 +86,13 @@ void CompareToObjectMapRecord::analyze(edm::Event const &event,
   }
 
   // Now test the algorithm names
-  std::vector<std::string> algoNames2 =
-      pset->getParameter<std::vector<std::string>>("@algorithmNames");
+  std::vector<std::string> algoNames2 = pset->getParameter<std::vector<std::string>>("@algorithmNames");
 
   // In the ParameterSet, the algorithm names are referenced by position
   // in the vector. If the bit number for a position in the vector is
   // not assigned, then the algorithm name should be an empty string.
   for (int i = 0; i < static_cast<int>(algoNames2.size()); ++i) {
-    if (!std::binary_search(algoBitNumbers1.begin(), algoBitNumbers1.end(),
-                            i)) {
+    if (!std::binary_search(algoBitNumbers1.begin(), algoBitNumbers1.end(), i)) {
       if (algoNames2[i] != std::string("")) {
         cms::Exception ex("L1GlobalTrigger");
         ex << "Undefined algorithm should have empty name";
@@ -112,12 +103,10 @@ void CompareToObjectMapRecord::analyze(edm::Event const &event,
   }
 
   // Main loop over algorithms
-  for (std::vector<int>::const_iterator iBit = algoBitNumbers1.begin(),
-                                        endBits = algoBitNumbers1.end();
-       iBit != endBits; ++iBit) {
-
-    L1GlobalTriggerObjectMap const *objMap =
-        gtObjectMapRecord->getObjectMap(*iBit);
+  for (std::vector<int>::const_iterator iBit = algoBitNumbers1.begin(), endBits = algoBitNumbers1.end();
+       iBit != endBits;
+       ++iBit) {
+    L1GlobalTriggerObjectMap const *objMap = gtObjectMapRecord->getObjectMap(*iBit);
     const std::string &algoName1 = objMap->algoName();
 
     if (algoName1 != algoNames2.at(*iBit)) {
@@ -135,11 +124,9 @@ void CompareToObjectMapRecord::analyze(edm::Event const &event,
       throw ex;
     }
 
-    std::vector<L1GtLogicParser::OperandToken> const &operandTokens1 =
-        objMap->operandTokenVector();
+    std::vector<L1GtLogicParser::OperandToken> const &operandTokens1 = objMap->operandTokenVector();
 
-    L1GlobalTriggerObjectMaps::ConditionsInAlgorithm conditions2 =
-        gtObjectMaps->getConditionsInAlgorithm(*iBit);
+    L1GlobalTriggerObjectMaps::ConditionsInAlgorithm conditions2 = gtObjectMaps->getConditionsInAlgorithm(*iBit);
     if (conditions2.nConditions() != operandTokens1.size()) {
       cms::Exception ex("L1GlobalTrigger");
       ex << "Number of conditions does not match";
@@ -148,28 +135,21 @@ void CompareToObjectMapRecord::analyze(edm::Event const &event,
     }
 
     std::vector<std::string> conditionNames2;
-    conditionNames2 =
-        pset->getParameter<std::vector<std::string>>(algoNames2.at(*iBit));
+    conditionNames2 = pset->getParameter<std::vector<std::string>>(algoNames2.at(*iBit));
 
     // Print out data from L1GlobalTriggerObjectMaps and ParameterSet registry
     if (verbose_) {
-      std::cout << *iBit << "  " << algoNames2[*iBit] << "  "
-                << gtObjectMaps->algorithmResult(*iBit) << "\n";
+      std::cout << *iBit << "  " << algoNames2[*iBit] << "  " << gtObjectMaps->algorithmResult(*iBit) << "\n";
 
-      for (unsigned j = 0; j < gtObjectMaps->getNumberOfConditions(*iBit);
-           ++j) {
-        L1GlobalTriggerObjectMaps::ConditionsInAlgorithm conditions =
-            gtObjectMaps->getConditionsInAlgorithm(*iBit);
-        std::cout << "    " << j << "  " << conditionNames2[j] << "  "
-                  << conditions.getConditionResult(j) << "\n";
+      for (unsigned j = 0; j < gtObjectMaps->getNumberOfConditions(*iBit); ++j) {
+        L1GlobalTriggerObjectMaps::ConditionsInAlgorithm conditions = gtObjectMaps->getConditionsInAlgorithm(*iBit);
+        std::cout << "    " << j << "  " << conditionNames2[j] << "  " << conditions.getConditionResult(j) << "\n";
         L1GlobalTriggerObjectMaps::CombinationsInCondition combinations =
             gtObjectMaps->getCombinationsInCondition(*iBit, j);
         for (unsigned m = 0; m < combinations.nCombinations(); ++m) {
           std::cout << "    ";
           for (unsigned n = 0; n < combinations.nObjectsPerCombination(); ++n) {
-            std::cout << "  "
-                      << static_cast<unsigned>(
-                             combinations.getObjectIndex(m, n));
+            std::cout << "  " << static_cast<unsigned>(combinations.getObjectIndex(m, n));
           }
           std::cout << "\n";
         }
@@ -178,11 +158,10 @@ void CompareToObjectMapRecord::analyze(edm::Event const &event,
 
     // Loop over conditions
     unsigned iCondition = 0;
-    for (std::vector<L1GtLogicParser::OperandToken>::const_iterator
-             iToken1 = operandTokens1.begin(),
-             endTokens1 = operandTokens1.end();
-         iToken1 != endTokens1; ++iToken1, ++iCondition) {
-
+    for (std::vector<L1GtLogicParser::OperandToken>::const_iterator iToken1 = operandTokens1.begin(),
+                                                                    endTokens1 = operandTokens1.end();
+         iToken1 != endTokens1;
+         ++iToken1, ++iCondition) {
       // Compare condition numbers
       if (iToken1->tokenNumber != static_cast<int>(iCondition)) {
         cms::Exception ex("L1GlobalTrigger");
@@ -211,8 +190,7 @@ void CompareToObjectMapRecord::analyze(edm::Event const &event,
       L1GlobalTriggerObjectMaps::CombinationsInCondition combinations2 =
           gtObjectMaps->getCombinationsInCondition(*iBit, iCondition);
 
-      CombinationsInCond const *combinations1 =
-          objMap->getCombinationsInCond(iToken1->tokenNumber);
+      CombinationsInCond const *combinations1 = objMap->getCombinationsInCond(iToken1->tokenNumber);
       if (combinations1->size() != combinations2.nCombinations()) {
         cms::Exception ex("L1GlobalTrigger");
         ex << "The number of combinations in a condition does not match";
@@ -220,9 +198,9 @@ void CompareToObjectMapRecord::analyze(edm::Event const &event,
         throw ex;
       }
 
-      for (CombinationsInCond::const_iterator iCombo = combinations1->begin(),
-                                              endCombos = combinations1->end();
-           iCombo != endCombos; ++iCombo) {
+      for (CombinationsInCond::const_iterator iCombo = combinations1->begin(), endCombos = combinations1->end();
+           iCombo != endCombos;
+           ++iCombo) {
         if (iCombo->size() != combinations2.nObjectsPerCombination()) {
           cms::Exception ex("L1GlobalTrigger");
           ex << "The number of indexes in a combination does not match";
@@ -230,13 +208,10 @@ void CompareToObjectMapRecord::analyze(edm::Event const &event,
           throw ex;
         }
 
-        for (std::vector<int>::const_iterator iIndex = iCombo->begin(),
-                                              endIndexes = iCombo->end();
-             iIndex != endIndexes; ++iIndex) {
-
-          if (*iIndex !=
-              combinations2.getObjectIndex(iCombo - combinations1->begin(),
-                                           iIndex - iCombo->begin())) {
+        for (std::vector<int>::const_iterator iIndex = iCombo->begin(), endIndexes = iCombo->end();
+             iIndex != endIndexes;
+             ++iIndex) {
+          if (*iIndex != combinations2.getObjectIndex(iCombo - combinations1->begin(), iIndex - iCombo->begin())) {
             cms::Exception ex("L1GlobalTrigger");
             ex << "Object index does not match";
             ex.addContext("Calling CompareToObjectMapRecord::analyze");

--- a/L1Trigger/GlobalTrigger/plugins/CompareToObjectMapRecord.h
+++ b/L1Trigger/GlobalTrigger/plugins/CompareToObjectMapRecord.h
@@ -25,7 +25,6 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 
 class CompareToObjectMapRecord : public edm::EDAnalyzer {
-
 public:
   explicit CompareToObjectMapRecord(const edm::ParameterSet &pset);
   ~CompareToObjectMapRecord() override;

--- a/L1Trigger/GlobalTrigger/plugins/ConvertObjectMapRecord.cc
+++ b/L1Trigger/GlobalTrigger/plugins/ConvertObjectMapRecord.cc
@@ -32,17 +32,14 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 ConvertObjectMapRecord::ConvertObjectMapRecord(const edm::ParameterSet &pset)
-    : m_l1GtObjectMapToken(consumes<L1GlobalTriggerObjectMapRecord>(
-          pset.getParameter<edm::InputTag>("L1GtObjectMapTag"))) {
-
+    : m_l1GtObjectMapToken(
+          consumes<L1GlobalTriggerObjectMapRecord>(pset.getParameter<edm::InputTag>("L1GtObjectMapTag"))) {
   produces<L1GlobalTriggerObjectMaps>();
 }
 
 ConvertObjectMapRecord::~ConvertObjectMapRecord() {}
 
-void ConvertObjectMapRecord::produce(edm::Event &event,
-                                     const edm::EventSetup &es) {
-
+void ConvertObjectMapRecord::produce(edm::Event &event, const edm::EventSetup &es) {
   // Read in the existing object from the data
   edm::Handle<L1GlobalTriggerObjectMapRecord> gtObjectMapRecord;
   event.getByToken(m_l1GtObjectMapToken, gtObjectMapRecord);
@@ -52,18 +49,15 @@ void ConvertObjectMapRecord::produce(edm::Event &event,
   }
 
   // Create the new object we are going to copy the information to
-  std::unique_ptr<L1GlobalTriggerObjectMaps> gtObjectMaps(
-      new L1GlobalTriggerObjectMaps);
+  std::unique_ptr<L1GlobalTriggerObjectMaps> gtObjectMaps(new L1GlobalTriggerObjectMaps);
 
   // get the algorithm bit numbers and sort them
   std::vector<int> algoBitNumbers;
-  std::vector<L1GlobalTriggerObjectMap> const &vectorInRecord =
-      gtObjectMapRecord->gtObjectMap();
+  std::vector<L1GlobalTriggerObjectMap> const &vectorInRecord = gtObjectMapRecord->gtObjectMap();
   algoBitNumbers.reserve(vectorInRecord.size());
-  for (std::vector<L1GlobalTriggerObjectMap>::const_iterator
-           i = vectorInRecord.begin(),
-           iEnd = vectorInRecord.end();
-       i != iEnd; ++i) {
+  for (std::vector<L1GlobalTriggerObjectMap>::const_iterator i = vectorInRecord.begin(), iEnd = vectorInRecord.end();
+       i != iEnd;
+       ++i) {
     algoBitNumbers.push_back(i->algoBitNumber());
   }
   edm::sort_all(algoBitNumbers);
@@ -89,29 +83,23 @@ void ConvertObjectMapRecord::produce(edm::Event &event,
   unsigned startIndexOfConditions = 0;
   unsigned nIndexes = 0;
 
-  for (std::vector<int>::const_iterator iBit = algoBitNumbers.begin(),
-                                        endBits = algoBitNumbers.end();
-       iBit != endBits; ++iBit) {
-    L1GlobalTriggerObjectMap const *objMap =
-        gtObjectMapRecord->getObjectMap(*iBit);
+  for (std::vector<int>::const_iterator iBit = algoBitNumbers.begin(), endBits = algoBitNumbers.end(); iBit != endBits;
+       ++iBit) {
+    L1GlobalTriggerObjectMap const *objMap = gtObjectMapRecord->getObjectMap(*iBit);
 
-    gtObjectMaps->pushBackAlgorithm(startIndexOfConditions,
-                                    objMap->algoBitNumber(),
-                                    objMap->algoGtlResult());
+    gtObjectMaps->pushBackAlgorithm(startIndexOfConditions, objMap->algoBitNumber(), objMap->algoGtlResult());
 
     savedNames.at(static_cast<unsigned>(*iBit)) = objMap->algoName();
 
-    std::vector<L1GtLogicParser::OperandToken> const &operandTokens =
-        objMap->operandTokenVector();
+    std::vector<L1GtLogicParser::OperandToken> const &operandTokens = objMap->operandTokenVector();
 
     startIndexOfConditions += operandTokens.size();
 
     int tokenCounter = 0;
-    for (std::vector<L1GtLogicParser::OperandToken>::const_iterator
-             iToken = operandTokens.begin(),
-             endTokens = operandTokens.end();
-         iToken != endTokens; ++iToken, ++tokenCounter) {
-
+    for (std::vector<L1GtLogicParser::OperandToken>::const_iterator iToken = operandTokens.begin(),
+                                                                    endTokens = operandTokens.end();
+         iToken != endTokens;
+         ++iToken, ++tokenCounter) {
       if (tokenCounter != iToken->tokenNumber) {
         cms::Exception ex("L1GlobalTrigger");
         ex << "Token numbers not sequential";
@@ -119,14 +107,12 @@ void ConvertObjectMapRecord::produce(edm::Event &event,
         throw ex;
       }
 
-      CombinationsInCond const *combos =
-          objMap->getCombinationsInCond(iToken->tokenNumber);
-      for (CombinationsInCond::const_iterator iCombo = combos->begin(),
-                                              endCombos = combos->end();
-           iCombo != endCombos; ++iCombo) {
-        for (std::vector<int>::const_iterator iIndex = iCombo->begin(),
-                                              endIndexes = iCombo->end();
-             iIndex != endIndexes; ++iIndex) {
+      CombinationsInCond const *combos = objMap->getCombinationsInCond(iToken->tokenNumber);
+      for (CombinationsInCond::const_iterator iCombo = combos->begin(), endCombos = combos->end(); iCombo != endCombos;
+           ++iCombo) {
+        for (std::vector<int>::const_iterator iIndex = iCombo->begin(), endIndexes = iCombo->end();
+             iIndex != endIndexes;
+             ++iIndex) {
           ++nIndexes;
         }
       }
@@ -136,42 +122,35 @@ void ConvertObjectMapRecord::produce(edm::Event &event,
   gtObjectMaps->reserveForObjectIndexes(nIndexes);
 
   edm::ParameterSet namesPset;
-  namesPset.addParameter<std::vector<std::string>>(
-      std::string("@algorithmNames"), savedNames);
+  namesPset.addParameter<std::vector<std::string>>(std::string("@algorithmNames"), savedNames);
 
   // Now loop a second time and fill the condition and index
   // information.
   unsigned startIndexOfCombinations = 0;
-  for (std::vector<int>::const_iterator iBit = algoBitNumbers.begin(),
-                                        endBits = algoBitNumbers.end();
-       iBit != endBits; ++iBit) {
-    L1GlobalTriggerObjectMap const *objMap =
-        gtObjectMapRecord->getObjectMap(*iBit);
+  for (std::vector<int>::const_iterator iBit = algoBitNumbers.begin(), endBits = algoBitNumbers.end(); iBit != endBits;
+       ++iBit) {
+    L1GlobalTriggerObjectMap const *objMap = gtObjectMapRecord->getObjectMap(*iBit);
 
-    std::vector<L1GtLogicParser::OperandToken> const &operandTokens =
-        objMap->operandTokenVector();
+    std::vector<L1GtLogicParser::OperandToken> const &operandTokens = objMap->operandTokenVector();
 
     savedNames.clear();
     if (savedNames.capacity() < operandTokens.size()) {
       savedNames.reserve(operandTokens.size());
     }
 
-    for (std::vector<L1GtLogicParser::OperandToken>::const_iterator
-             iToken = operandTokens.begin(),
-             endTokens = operandTokens.end();
-         iToken != endTokens; ++iToken) {
-
+    for (std::vector<L1GtLogicParser::OperandToken>::const_iterator iToken = operandTokens.begin(),
+                                                                    endTokens = operandTokens.end();
+         iToken != endTokens;
+         ++iToken) {
       savedNames.push_back(iToken->tokenName);
 
       unsigned short nObjectsPerCombination = 0;
       bool first = true;
       unsigned nIndexesInCombination = 0;
 
-      CombinationsInCond const *combos =
-          objMap->getCombinationsInCond(iToken->tokenNumber);
-      for (CombinationsInCond::const_iterator iCombo = combos->begin(),
-                                              endCombos = combos->end();
-           iCombo != endCombos; ++iCombo) {
+      CombinationsInCond const *combos = objMap->getCombinationsInCond(iToken->tokenNumber);
+      for (CombinationsInCond::const_iterator iCombo = combos->begin(), endCombos = combos->end(); iCombo != endCombos;
+           ++iCombo) {
         if (first) {
           if (iCombo->size() > std::numeric_limits<unsigned short>::max()) {
             cms::Exception ex("L1GlobalTrigger");
@@ -190,12 +169,10 @@ void ConvertObjectMapRecord::produce(edm::Event &event,
           }
         }
 
-        for (std::vector<int>::const_iterator iIndex = iCombo->begin(),
-                                              endIndexes = iCombo->end();
-             iIndex != endIndexes; ++iIndex) {
-
-          if (*iIndex < 0 ||
-              *iIndex > std::numeric_limits<unsigned char>::max()) {
+        for (std::vector<int>::const_iterator iIndex = iCombo->begin(), endIndexes = iCombo->end();
+             iIndex != endIndexes;
+             ++iIndex) {
+          if (*iIndex < 0 || *iIndex > std::numeric_limits<unsigned char>::max()) {
             cms::Exception ex("L1GlobalTrigger");
             ex << "object index too large, out of range";
             ex.addContext("Calling ConvertObjectMapRecord::produce");
@@ -205,13 +182,10 @@ void ConvertObjectMapRecord::produce(edm::Event &event,
           ++nIndexesInCombination;
         }
       }
-      gtObjectMaps->pushBackCondition(startIndexOfCombinations,
-                                      nObjectsPerCombination,
-                                      iToken->tokenResult);
+      gtObjectMaps->pushBackCondition(startIndexOfCombinations, nObjectsPerCombination, iToken->tokenResult);
       startIndexOfCombinations += nIndexesInCombination;
     }
-    namesPset.addParameter<std::vector<std::string>>(objMap->algoName(),
-                                                     savedNames);
+    namesPset.addParameter<std::vector<std::string>>(objMap->algoName(), savedNames);
   }
   namesPset.registerIt();
   gtObjectMaps->setNamesParameterSetID(namesPset.id());

--- a/L1Trigger/GlobalTrigger/plugins/ConvertObjectMapRecord.h
+++ b/L1Trigger/GlobalTrigger/plugins/ConvertObjectMapRecord.h
@@ -26,7 +26,6 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 
 class ConvertObjectMapRecord : public edm::stream::EDProducer<> {
-
 public:
   explicit ConvertObjectMapRecord(const edm::ParameterSet &pset);
   ~ConvertObjectMapRecord() override;

--- a/L1Trigger/GlobalTrigger/plugins/L1GTPrescaler.cc
+++ b/L1Trigger/GlobalTrigger/plugins/L1GTPrescaler.cc
@@ -35,12 +35,9 @@ private:
 };
 
 L1GTPrescaler::L1GTPrescaler(edm::ParameterSet const &config)
-    : m_l1ResultsToken(consumes<L1GlobalTriggerReadoutRecord>(
-          config.getParameter<edm::InputTag>("l1Results"))),
-      m_algoPrescales(make_array<double, 128>(
-          config.getParameter<std::vector<double>>("l1AlgoPrescales"))),
-      m_techPrescales(make_array<double, 64>(
-          config.getParameter<std::vector<double>>("l1TechPrescales"))) {
+    : m_l1ResultsToken(consumes<L1GlobalTriggerReadoutRecord>(config.getParameter<edm::InputTag>("l1Results"))),
+      m_algoPrescales(make_array<double, 128>(config.getParameter<std::vector<double>>("l1AlgoPrescales"))),
+      m_techPrescales(make_array<double, 64>(config.getParameter<std::vector<double>>("l1TechPrescales"))) {
   m_algoCounters.fill(0);
   m_techCounters.fill(0);
   produces<L1GlobalTriggerReadoutRecord>();
@@ -49,9 +46,8 @@ L1GTPrescaler::L1GTPrescaler(edm::ParameterSet const &config)
 bool L1GTPrescaler::filter(edm::Event &event, edm::EventSetup const &setup) {
   edm::Handle<L1GlobalTriggerReadoutRecord> handle;
   event.getByToken(m_l1ResultsToken, handle);
-  auto algoWord = handle->decisionWord(); // make a copy of the L1 algo results
-  auto techWord =
-      handle->technicalTriggerWord(); // make a copy of the L1 tech results
+  auto algoWord = handle->decisionWord();          // make a copy of the L1 algo results
+  auto techWord = handle->technicalTriggerWord();  // make a copy of the L1 tech results
   bool finalOr = false;
 
   for (unsigned int i = 0; i < 128; ++i) {
@@ -85,8 +81,7 @@ bool L1GTPrescaler::filter(edm::Event &event, edm::EventSetup const &setup) {
   }
 
   // make a copy of the L1GlobalTriggerReadoutRecord, and set the new decisions
-  std::unique_ptr<L1GlobalTriggerReadoutRecord> result(
-      new L1GlobalTriggerReadoutRecord(*handle));
+  std::unique_ptr<L1GlobalTriggerReadoutRecord> result(new L1GlobalTriggerReadoutRecord(*handle));
   result->setDecisionWord(algoWord);
   result->setTechnicalTriggerWord(techWord);
   result->setDecision(finalOr);
@@ -95,8 +90,7 @@ bool L1GTPrescaler::filter(edm::Event &event, edm::EventSetup const &setup) {
   return finalOr;
 }
 
-void L1GTPrescaler::fillDescriptions(
-    edm::ConfigurationDescriptions &descriptions) {
+void L1GTPrescaler::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("l1Results", edm::InputTag("gtDigis"));
   desc.add<std::vector<double>>("l1AlgoPrescales", std::vector<double>(128, 1));

--- a/L1Trigger/GlobalTrigger/plugins/L1GlobalTrigger.cc
+++ b/L1Trigger/GlobalTrigger/plugins/L1GlobalTrigger.cc
@@ -90,92 +90,59 @@ L1GlobalTrigger::L1GlobalTrigger(const edm::ParameterSet &parSet)
     : m_muGmtInputTag(parSet.getParameter<edm::InputTag>("GmtInputTag")),
       m_caloGctInputTag(parSet.getParameter<edm::InputTag>("GctInputTag")),
       m_castorInputTag(parSet.getParameter<edm::InputTag>("CastorInputTag")),
-      m_technicalTriggersInputTags(
-          parSet.getParameter<std::vector<edm::InputTag>>(
-              "TechnicalTriggersInputTags")),
+      m_technicalTriggersInputTags(parSet.getParameter<std::vector<edm::InputTag>>("TechnicalTriggersInputTags")),
       m_produceL1GtDaqRecord(parSet.getParameter<bool>("ProduceL1GtDaqRecord")),
       m_produceL1GtEvmRecord(parSet.getParameter<bool>("ProduceL1GtEvmRecord")),
-      m_produceL1GtObjectMapRecord(
-          parSet.getParameter<bool>("ProduceL1GtObjectMapRecord")),
-      m_writePsbL1GtDaqRecord(
-          parSet.getParameter<bool>("WritePsbL1GtDaqRecord")),
-      m_readTechnicalTriggerRecords(
-          parSet.getParameter<bool>("ReadTechnicalTriggerRecords")),
+      m_produceL1GtObjectMapRecord(parSet.getParameter<bool>("ProduceL1GtObjectMapRecord")),
+      m_writePsbL1GtDaqRecord(parSet.getParameter<bool>("WritePsbL1GtDaqRecord")),
+      m_readTechnicalTriggerRecords(parSet.getParameter<bool>("ReadTechnicalTriggerRecords")),
       m_emulateBxInEvent(parSet.getParameter<int>("EmulateBxInEvent")),
       m_recordLength(parSet.getParameter<std::vector<int>>("RecordLength")),
-      m_alternativeNrBxBoardDaq(
-          parSet.getParameter<unsigned int>("AlternativeNrBxBoardDaq")),
-      m_alternativeNrBxBoardEvm(
-          parSet.getParameter<unsigned int>("AlternativeNrBxBoardEvm")),
+      m_alternativeNrBxBoardDaq(parSet.getParameter<unsigned int>("AlternativeNrBxBoardDaq")),
+      m_alternativeNrBxBoardEvm(parSet.getParameter<unsigned int>("AlternativeNrBxBoardEvm")),
       m_psBstLengthBytes(parSet.getParameter<int>("BstLengthBytes")),
-      m_algorithmTriggersUnprescaled(
-          parSet.getParameter<bool>("AlgorithmTriggersUnprescaled")),
-      m_algorithmTriggersUnmasked(
-          parSet.getParameter<bool>("AlgorithmTriggersUnmasked")),
-      m_technicalTriggersUnprescaled(
-          parSet.getParameter<bool>("TechnicalTriggersUnprescaled")),
-      m_technicalTriggersUnmasked(
-          parSet.getParameter<bool>("TechnicalTriggersUnmasked")),
-      m_technicalTriggersVetoUnmasked(
-          parSet.getParameter<bool>("TechnicalTriggersVetoUnmasked")),
+      m_algorithmTriggersUnprescaled(parSet.getParameter<bool>("AlgorithmTriggersUnprescaled")),
+      m_algorithmTriggersUnmasked(parSet.getParameter<bool>("AlgorithmTriggersUnmasked")),
+      m_technicalTriggersUnprescaled(parSet.getParameter<bool>("TechnicalTriggersUnprescaled")),
+      m_technicalTriggersUnmasked(parSet.getParameter<bool>("TechnicalTriggersUnmasked")),
+      m_technicalTriggersVetoUnmasked(parSet.getParameter<bool>("TechnicalTriggersVetoUnmasked")),
       m_verbosity(parSet.getUntrackedParameter<int>("Verbosity", 0)),
       m_isDebugEnabled(edm::isDebugEnabled())
 
 {
-
   if (m_verbosity) {
-
     LogDebug("L1GlobalTrigger") << std::endl;
 
-    LogTrace("L1GlobalTrigger")
-        << "\nInput tag for muon collection from GMT:         "
-        << m_muGmtInputTag
-        << "\nInput tag for calorimeter collections from GCT: "
-        << m_caloGctInputTag
-        << "\nInput tag for CASTOR record:                    "
-        << m_castorInputTag
-        << "\nInput tag for technical triggers:               " << std::endl;
+    LogTrace("L1GlobalTrigger") << "\nInput tag for muon collection from GMT:         " << m_muGmtInputTag
+                                << "\nInput tag for calorimeter collections from GCT: " << m_caloGctInputTag
+                                << "\nInput tag for CASTOR record:                    " << m_castorInputTag
+                                << "\nInput tag for technical triggers:               " << std::endl;
 
     // loop over all producers of technical trigger records
-    for (std::vector<edm::InputTag>::const_iterator it =
-             m_technicalTriggersInputTags.begin();
-         it != m_technicalTriggersInputTags.end(); it++) {
+    for (std::vector<edm::InputTag>::const_iterator it = m_technicalTriggersInputTags.begin();
+         it != m_technicalTriggersInputTags.end();
+         it++) {
       LogTrace("L1GlobalTrigger") << "\n  " << (*it) << std::endl;
     }
 
     LogTrace("L1GlobalTrigger")
-        << "\nProduce the L1 GT DAQ readout record:           "
-        << m_produceL1GtDaqRecord
-        << "\nProduce the L1 GT EVM readout record:           "
-        << m_produceL1GtEvmRecord
-        << "\nProduce the L1 GT Object Map record:            "
-        << m_produceL1GtObjectMapRecord << " \n"
-        << "\nWrite Psb content to L1 GT DAQ Record:          "
-        << m_writePsbL1GtDaqRecord << " \n"
-        << "\nRead technical trigger records:                 "
-        << m_readTechnicalTriggerRecords << " \n"
-        << "\nNumber of BxInEvent to be emulated:             "
-        << m_emulateBxInEvent
-        << "\nNumber of BXs corresponding to alternative 0:   "
-        << m_recordLength.at(0)
-        << "\nNumber of BXs corresponding to alternative 1:   "
-        << m_recordLength.at(1) << " \n"
-        << "\nAlternative for number of BX in GT DAQ record:   0x" << std::hex
-        << m_alternativeNrBxBoardDaq
-        << "\nAlternative for number of BX in GT EVM record:   0x" << std::hex
-        << m_alternativeNrBxBoardEvm << std::dec << " \n"
-        << "\nLength of BST message [bytes]:                  "
-        << m_psBstLengthBytes << "\n"
-        << "\nRun algorithm triggers unprescaled:             "
-        << m_algorithmTriggersUnprescaled
-        << "\nRun algorithm triggers unmasked (all enabled):  "
-        << m_algorithmTriggersUnmasked << "\n"
-        << "\nRun technical triggers unprescaled:             "
-        << m_technicalTriggersUnprescaled
-        << "\nRun technical triggers unmasked (all enabled):  "
-        << m_technicalTriggersUnmasked
-        << "\nRun technical triggers veto unmasked (no veto): "
-        << m_technicalTriggersUnmasked << "\n"
+        << "\nProduce the L1 GT DAQ readout record:           " << m_produceL1GtDaqRecord
+        << "\nProduce the L1 GT EVM readout record:           " << m_produceL1GtEvmRecord
+        << "\nProduce the L1 GT Object Map record:            " << m_produceL1GtObjectMapRecord << " \n"
+        << "\nWrite Psb content to L1 GT DAQ Record:          " << m_writePsbL1GtDaqRecord << " \n"
+        << "\nRead technical trigger records:                 " << m_readTechnicalTriggerRecords << " \n"
+        << "\nNumber of BxInEvent to be emulated:             " << m_emulateBxInEvent
+        << "\nNumber of BXs corresponding to alternative 0:   " << m_recordLength.at(0)
+        << "\nNumber of BXs corresponding to alternative 1:   " << m_recordLength.at(1) << " \n"
+        << "\nAlternative for number of BX in GT DAQ record:   0x" << std::hex << m_alternativeNrBxBoardDaq
+        << "\nAlternative for number of BX in GT EVM record:   0x" << std::hex << m_alternativeNrBxBoardEvm << std::dec
+        << " \n"
+        << "\nLength of BST message [bytes]:                  " << m_psBstLengthBytes << "\n"
+        << "\nRun algorithm triggers unprescaled:             " << m_algorithmTriggersUnprescaled
+        << "\nRun algorithm triggers unmasked (all enabled):  " << m_algorithmTriggersUnmasked << "\n"
+        << "\nRun technical triggers unprescaled:             " << m_technicalTriggersUnprescaled
+        << "\nRun technical triggers unmasked (all enabled):  " << m_technicalTriggersUnmasked
+        << "\nRun technical triggers veto unmasked (no veto): " << m_technicalTriggersUnmasked << "\n"
         << std::endl;
   }
 
@@ -183,32 +150,25 @@ L1GlobalTrigger::L1GlobalTrigger(const edm::ParameterSet &parSet)
     m_emulateBxInEvent = m_emulateBxInEvent - 1;
 
     if (m_verbosity) {
-      edm::LogWarning("L1GlobalTrigger")
-          << "\nWARNING: Number of bunch crossing to be emulated rounded to: "
-          << m_emulateBxInEvent
-          << "\n         The number must be an odd number!\n"
-          << std::endl;
+      edm::LogWarning("L1GlobalTrigger") << "\nWARNING: Number of bunch crossing to be emulated rounded to: "
+                                         << m_emulateBxInEvent << "\n         The number must be an odd number!\n"
+                                         << std::endl;
     }
   }
 
-  int requiredRecordLength =
-      std::max(m_recordLength.at(0), m_recordLength.at(1));
-  if ((m_emulateBxInEvent >= 0) &&
-      (m_emulateBxInEvent < requiredRecordLength)) {
-
+  int requiredRecordLength = std::max(m_recordLength.at(0), m_recordLength.at(1));
+  if ((m_emulateBxInEvent >= 0) && (m_emulateBxInEvent < requiredRecordLength)) {
     m_emulateBxInEvent = requiredRecordLength;
 
     if (m_verbosity) {
-      edm::LogWarning("L1GlobalTrigger")
-          << "\nWARNING: Number of bunch crossing required to be emulated ( "
-          << m_emulateBxInEvent << " BX) smaller as required in RecordLength:"
-          << "\n  Number of BXs corresponding to alternative 0:   "
-          << m_recordLength.at(0)
-          << "\n  Number of BXs corresponding to alternative 1:   "
-          << m_recordLength.at(1) << "\nEmulating " << requiredRecordLength
-          << " BX!"
-          << "\n"
-          << std::endl;
+      edm::LogWarning("L1GlobalTrigger") << "\nWARNING: Number of bunch crossing required to be emulated ( "
+                                         << m_emulateBxInEvent << " BX) smaller as required in RecordLength:"
+                                         << "\n  Number of BXs corresponding to alternative 0:   "
+                                         << m_recordLength.at(0)
+                                         << "\n  Number of BXs corresponding to alternative 1:   "
+                                         << m_recordLength.at(1) << "\nEmulating " << requiredRecordLength << " BX!"
+                                         << "\n"
+                                         << std::endl;
     }
   }
 
@@ -226,8 +186,7 @@ L1GlobalTrigger::L1GlobalTrigger(const edm::ParameterSet &parSet)
   }
 
   // create new PSBs
-  m_gtPSB = new L1GlobalTriggerPSB(
-      m_caloGctInputTag, m_technicalTriggersInputTags, consumesCollector());
+  m_gtPSB = new L1GlobalTriggerPSB(m_caloGctInputTag, m_technicalTriggersInputTags, consumesCollector());
   m_gtPSB->setVerbosity(m_verbosity);
 
   // create new GTL
@@ -288,7 +247,6 @@ L1GlobalTrigger::L1GlobalTrigger(const edm::ParameterSet &parSet)
 
 // destructor
 L1GlobalTrigger::~L1GlobalTrigger() {
-
   delete m_gtPSB;
   delete m_gtGTL;
   delete m_gtFDL;
@@ -297,19 +255,15 @@ L1GlobalTrigger::~L1GlobalTrigger() {
 // member functions
 
 // method called to produce the data
-void L1GlobalTrigger::produce(edm::Event &iEvent,
-                              const edm::EventSetup &evSetup) {
-
+void L1GlobalTrigger::produce(edm::Event &iEvent, const edm::EventSetup &evSetup) {
   // process event iEvent
 
   // get / update the stable parameters from the EventSetup
   // local cache & check on cacheIdentifier
 
-  unsigned long long l1GtStableParCacheID =
-      evSetup.get<L1GtStableParametersRcd>().cacheIdentifier();
+  unsigned long long l1GtStableParCacheID = evSetup.get<L1GtStableParametersRcd>().cacheIdentifier();
 
   if (m_l1GtStableParCacheID != l1GtStableParCacheID) {
-
     edm::ESHandle<L1GtStableParameters> l1GtStablePar;
     evSetup.get<L1GtStableParametersRcd>().get(l1GtStablePar);
     m_l1GtStablePar = l1GtStablePar.product();
@@ -321,7 +275,7 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
     m_numberTechnicalTriggers = m_l1GtStablePar->gtNumberTechnicalTriggers();
 
     // number of DAQ partitions
-    m_numberDaqPartitions = 8; // FIXME add it to stable parameters
+    m_numberDaqPartitions = 8;  // FIXME add it to stable parameters
 
     // number of objects of each type
     m_nrL1Mu = static_cast<int>(m_l1GtStablePar->gtNumberL1Mu());
@@ -337,17 +291,14 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
 
     // ... the rest of the objects are global
 
-    m_ifMuEtaNumberBits =
-        static_cast<int>(m_l1GtStablePar->gtIfMuEtaNumberBits());
-    m_ifCaloEtaNumberBits =
-        static_cast<int>(m_l1GtStablePar->gtIfCaloEtaNumberBits());
+    m_ifMuEtaNumberBits = static_cast<int>(m_l1GtStablePar->gtIfMuEtaNumberBits());
+    m_ifCaloEtaNumberBits = static_cast<int>(m_l1GtStablePar->gtIfCaloEtaNumberBits());
 
     // (re)initialize L1GlobalTriggerGTL
     m_gtGTL->init(m_nrL1Mu, m_numberPhysTriggers);
 
     // (re)initialize L1GlobalTriggerPSB
-    m_gtPSB->init(m_nrL1NoIsoEG, m_nrL1IsoEG, m_nrL1CenJet, m_nrL1ForJet,
-                  m_nrL1TauJet, m_numberTechnicalTriggers);
+    m_gtPSB->init(m_nrL1NoIsoEG, m_nrL1IsoEG, m_nrL1CenJet, m_nrL1ForJet, m_nrL1TauJet, m_numberTechnicalTriggers);
 
     //
     m_l1GtStableParCacheID = l1GtStableParCacheID;
@@ -356,11 +307,9 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
   // get / update the parameters from the EventSetup
   // local cache & check on cacheIdentifier
 
-  unsigned long long l1GtParCacheID =
-      evSetup.get<L1GtParametersRcd>().cacheIdentifier();
+  unsigned long long l1GtParCacheID = evSetup.get<L1GtParametersRcd>().cacheIdentifier();
 
   if (m_l1GtParCacheID != l1GtParCacheID) {
-
     edm::ESHandle<L1GtParameters> l1GtPar;
     evSetup.get<L1GtParametersRcd>().get(l1GtPar);
     m_l1GtPar = l1GtPar.product();
@@ -390,7 +339,6 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
   int recordLength1 = m_recordLength.at(1);
 
   if ((recordLength0 < 0) || (recordLength1 < 0)) {
-
     // take them from event setup
     // FIXME implement later - temporary solution
 
@@ -399,20 +347,18 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
   }
 
   if (m_verbosity) {
-
-    LogDebug("L1GlobalTrigger")
-        << "\nTotal number of BX to emulate in the GT readout record: "
-        << m_emulateBxInEvent << " = "
-        << "[" << minBxInEvent << ", " << maxBxInEvent << "] BX\n"
-        << "\nNumber of BX for alternative 0:  " << recordLength0
-        << "\nNumber of BX for alternative 1:  " << recordLength1
-        << "\nActive boards in L1 GT DAQ record (hex format) = " << std::hex
-        << std::setw(sizeof(m_activeBoardsGtDaq) * 2) << std::setfill('0')
-        << m_activeBoardsGtDaq << std::dec << std::setfill(' ')
-        << "\nActive boards in L1 GT EVM record (hex format) = " << std::hex
-        << std::setw(sizeof(m_activeBoardsGtEvm) * 2) << std::setfill('0')
-        << m_activeBoardsGtEvm << std::dec << std::setfill(' ') << "\n"
-        << std::endl;
+    LogDebug("L1GlobalTrigger") << "\nTotal number of BX to emulate in the GT readout record: " << m_emulateBxInEvent
+                                << " = "
+                                << "[" << minBxInEvent << ", " << maxBxInEvent << "] BX\n"
+                                << "\nNumber of BX for alternative 0:  " << recordLength0
+                                << "\nNumber of BX for alternative 1:  " << recordLength1
+                                << "\nActive boards in L1 GT DAQ record (hex format) = " << std::hex
+                                << std::setw(sizeof(m_activeBoardsGtDaq) * 2) << std::setfill('0')
+                                << m_activeBoardsGtDaq << std::dec << std::setfill(' ')
+                                << "\nActive boards in L1 GT EVM record (hex format) = " << std::hex
+                                << std::setw(sizeof(m_activeBoardsGtEvm) * 2) << std::setfill('0')
+                                << m_activeBoardsGtEvm << std::dec << std::setfill(' ') << "\n"
+                                << std::endl;
   }
 
   // get / update the board maps from the EventSetup
@@ -420,11 +366,9 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
 
   typedef std::vector<L1GtBoard>::const_iterator CItBoardMaps;
 
-  unsigned long long l1GtBMCacheID =
-      evSetup.get<L1GtBoardMapsRcd>().cacheIdentifier();
+  unsigned long long l1GtBMCacheID = evSetup.get<L1GtBoardMapsRcd>().cacheIdentifier();
 
   if (m_l1GtBMCacheID != l1GtBMCacheID) {
-
     edm::ESHandle<L1GtBoardMaps> l1GtBM;
     evSetup.get<L1GtBoardMapsRcd>().get(l1GtBM);
     m_l1GtBM = l1GtBM.product();
@@ -438,11 +382,9 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
   // get / update the prescale factors from the EventSetup
   // local cache & check on cacheIdentifier
 
-  unsigned long long l1GtPfAlgoCacheID =
-      evSetup.get<L1GtPrescaleFactorsAlgoTrigRcd>().cacheIdentifier();
+  unsigned long long l1GtPfAlgoCacheID = evSetup.get<L1GtPrescaleFactorsAlgoTrigRcd>().cacheIdentifier();
 
   if (m_l1GtPfAlgoCacheID != l1GtPfAlgoCacheID) {
-
     edm::ESHandle<L1GtPrescaleFactors> l1GtPfAlgo;
     evSetup.get<L1GtPrescaleFactorsAlgoTrigRcd>().get(l1GtPfAlgo);
     m_l1GtPfAlgo = l1GtPfAlgo.product();
@@ -452,11 +394,9 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
     m_l1GtPfAlgoCacheID = l1GtPfAlgoCacheID;
   }
 
-  unsigned long long l1GtPfTechCacheID =
-      evSetup.get<L1GtPrescaleFactorsTechTrigRcd>().cacheIdentifier();
+  unsigned long long l1GtPfTechCacheID = evSetup.get<L1GtPrescaleFactorsTechTrigRcd>().cacheIdentifier();
 
   if (m_l1GtPfTechCacheID != l1GtPfTechCacheID) {
-
     edm::ESHandle<L1GtPrescaleFactors> l1GtPfTech;
     evSetup.get<L1GtPrescaleFactorsTechTrigRcd>().get(l1GtPfTech);
     m_l1GtPfTech = l1GtPfTech.product();
@@ -469,11 +409,9 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
   // get / update the trigger mask from the EventSetup
   // local cache & check on cacheIdentifier
 
-  unsigned long long l1GtTmAlgoCacheID =
-      evSetup.get<L1GtTriggerMaskAlgoTrigRcd>().cacheIdentifier();
+  unsigned long long l1GtTmAlgoCacheID = evSetup.get<L1GtTriggerMaskAlgoTrigRcd>().cacheIdentifier();
 
   if (m_l1GtTmAlgoCacheID != l1GtTmAlgoCacheID) {
-
     edm::ESHandle<L1GtTriggerMask> l1GtTmAlgo;
     evSetup.get<L1GtTriggerMaskAlgoTrigRcd>().get(l1GtTmAlgo);
     m_l1GtTmAlgo = l1GtTmAlgo.product();
@@ -483,11 +421,9 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
     m_l1GtTmAlgoCacheID = l1GtTmAlgoCacheID;
   }
 
-  unsigned long long l1GtTmTechCacheID =
-      evSetup.get<L1GtTriggerMaskTechTrigRcd>().cacheIdentifier();
+  unsigned long long l1GtTmTechCacheID = evSetup.get<L1GtTriggerMaskTechTrigRcd>().cacheIdentifier();
 
   if (m_l1GtTmTechCacheID != l1GtTmTechCacheID) {
-
     edm::ESHandle<L1GtTriggerMask> l1GtTmTech;
     evSetup.get<L1GtTriggerMaskTechTrigRcd>().get(l1GtTmTech);
     m_l1GtTmTech = l1GtTmTech.product();
@@ -497,11 +433,9 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
     m_l1GtTmTechCacheID = l1GtTmTechCacheID;
   }
 
-  unsigned long long l1GtTmVetoAlgoCacheID =
-      evSetup.get<L1GtTriggerMaskVetoAlgoTrigRcd>().cacheIdentifier();
+  unsigned long long l1GtTmVetoAlgoCacheID = evSetup.get<L1GtTriggerMaskVetoAlgoTrigRcd>().cacheIdentifier();
 
   if (m_l1GtTmVetoAlgoCacheID != l1GtTmVetoAlgoCacheID) {
-
     edm::ESHandle<L1GtTriggerMask> l1GtTmVetoAlgo;
     evSetup.get<L1GtTriggerMaskVetoAlgoTrigRcd>().get(l1GtTmVetoAlgo);
     m_l1GtTmVetoAlgo = l1GtTmVetoAlgo.product();
@@ -511,11 +445,9 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
     m_l1GtTmVetoAlgoCacheID = l1GtTmVetoAlgoCacheID;
   }
 
-  unsigned long long l1GtTmVetoTechCacheID =
-      evSetup.get<L1GtTriggerMaskVetoTechTrigRcd>().cacheIdentifier();
+  unsigned long long l1GtTmVetoTechCacheID = evSetup.get<L1GtTriggerMaskVetoTechTrigRcd>().cacheIdentifier();
 
   if (m_l1GtTmVetoTechCacheID != l1GtTmVetoTechCacheID) {
-
     edm::ESHandle<L1GtTriggerMask> l1GtTmVetoTech;
     evSetup.get<L1GtTriggerMaskVetoTechTrigRcd>().get(l1GtTmVetoTech);
     m_l1GtTmVetoTech = l1GtTmVetoTech.product();
@@ -560,12 +492,9 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
 
   bool receiveTechTr = false;
 
-  for (CItBoardMaps itBoard = boardMaps.begin(); itBoard != boardMaps.end();
-       ++itBoard) {
-
+  for (CItBoardMaps itBoard = boardMaps.begin(); itBoard != boardMaps.end(); ++itBoard) {
     int iPosition = itBoard->gtPositionDaqRecord();
     if (iPosition > 0) {
-
       int iActiveBit = itBoard->gtBitDaqActiveBoards();
       bool activeBoard = false;
 
@@ -577,127 +506,122 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
       // 0)
       //               in the record and ActiveBoardsMap, and active
       if ((iActiveBit < 0) || activeBoard) {
-
         switch (itBoard->gtBoardType()) {
-
-        case GTFE: {
-          daqNrGtfeBoards++;
-        }
-
-        break;
-        case FDL: {
-          daqNrFdlBoards++;
-        }
-
-        break;
-        case PSB: {
-          daqNrPsbBoards++;
-
-          // get the objects coming to this PSB
-          std::vector<L1GtPsbQuad> quadInPsb = itBoard->gtQuadInPsb();
-          for (std::vector<L1GtPsbQuad>::const_iterator itQuad =
-                   quadInPsb.begin();
-               itQuad != quadInPsb.end(); ++itQuad) {
-
-            switch (*itQuad) {
-
-            case TechTr: {
-              receiveTechTr = true;
-            }
-
-            break;
-            case NoIsoEGQ: {
-              receiveNoIsoEG = true;
-            }
-
-            break;
-            case IsoEGQ: {
-              receiveIsoEG = true;
-            }
-
-            break;
-            case CenJetQ: {
-              receiveCenJet = true;
-            }
-
-            break;
-            case ForJetQ: {
-              receiveForJet = true;
-            }
-
-            break;
-            case TauJetQ: {
-              receiveTauJet = true;
-            }
-
-            break;
-            case ESumsQ: {
-              receiveETM = true;
-              receiveETT = true;
-              receiveHTT = true;
-              receiveHTM = true;
-            }
-
-            break;
-            case JetCountsQ: {
-              receiveJetCounts = true;
-            }
-
-            break;
-            case CastorQ: {
-              // obsolete
-            }
-
-            break;
-            case BptxQ: {
-              // obsolete
-            }
-
-            break;
-            case GtExternalQ: {
-              receiveExternal = true;
-            }
-
-            break;
-            case HfQ: {
-              receiveHfBitCounts = true;
-              receiveHfRingEtSums = true;
-            }
-
-            break;
-              // FIXME add MIP/Iso bits
-            default: {
-              // do nothing
-            }
-
-            break;
-            }
+          case GTFE: {
+            daqNrGtfeBoards++;
           }
 
-        }
+          break;
+          case FDL: {
+            daqNrFdlBoards++;
+          }
 
-        break;
-        case GMT: {
-          daqNrGmtBoards++;
-          receiveMu = true;
-        }
+          break;
+          case PSB: {
+            daqNrPsbBoards++;
 
-        break;
-        case TCS: {
-          daqNrTcsBoards++;
-        }
+            // get the objects coming to this PSB
+            std::vector<L1GtPsbQuad> quadInPsb = itBoard->gtQuadInPsb();
+            for (std::vector<L1GtPsbQuad>::const_iterator itQuad = quadInPsb.begin(); itQuad != quadInPsb.end();
+                 ++itQuad) {
+              switch (*itQuad) {
+                case TechTr: {
+                  receiveTechTr = true;
+                }
 
-        break;
-        case TIM: {
-          daqNrTimBoards++;
-        }
+                break;
+                case NoIsoEGQ: {
+                  receiveNoIsoEG = true;
+                }
 
-        break;
-        default: {
-          // do nothing, all blocks are given in GtBoardType enum
-        }
+                break;
+                case IsoEGQ: {
+                  receiveIsoEG = true;
+                }
 
-        break;
+                break;
+                case CenJetQ: {
+                  receiveCenJet = true;
+                }
+
+                break;
+                case ForJetQ: {
+                  receiveForJet = true;
+                }
+
+                break;
+                case TauJetQ: {
+                  receiveTauJet = true;
+                }
+
+                break;
+                case ESumsQ: {
+                  receiveETM = true;
+                  receiveETT = true;
+                  receiveHTT = true;
+                  receiveHTM = true;
+                }
+
+                break;
+                case JetCountsQ: {
+                  receiveJetCounts = true;
+                }
+
+                break;
+                case CastorQ: {
+                  // obsolete
+                }
+
+                break;
+                case BptxQ: {
+                  // obsolete
+                }
+
+                break;
+                case GtExternalQ: {
+                  receiveExternal = true;
+                }
+
+                break;
+                case HfQ: {
+                  receiveHfBitCounts = true;
+                  receiveHfRingEtSums = true;
+                }
+
+                break;
+                  // FIXME add MIP/Iso bits
+                default: {
+                  // do nothing
+                }
+
+                break;
+              }
+            }
+
+          }
+
+          break;
+          case GMT: {
+            daqNrGmtBoards++;
+            receiveMu = true;
+          }
+
+          break;
+          case TCS: {
+            daqNrTcsBoards++;
+          }
+
+          break;
+          case TIM: {
+            daqNrTimBoards++;
+          }
+
+          break;
+          default: {
+            // do nothing, all blocks are given in GtBoardType enum
+          }
+
+          break;
         }
       }
     }
@@ -706,8 +630,7 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
   // produce the L1GlobalTriggerReadoutRecord now, after we found how many
   // BxInEvent the record has and how many boards are active
   std::unique_ptr<L1GlobalTriggerReadoutRecord> gtDaqReadoutRecord(
-      new L1GlobalTriggerReadoutRecord(m_emulateBxInEvent, daqNrFdlBoards,
-                                       daqNrPsbBoards));
+      new L1GlobalTriggerReadoutRecord(m_emulateBxInEvent, daqNrFdlBoards, daqNrPsbBoards));
 
   // * produce the L1GlobalTriggerEvmReadoutRecord
   std::unique_ptr<L1GlobalTriggerEvmReadoutRecord> gtEvmReadoutRecord(
@@ -715,8 +638,7 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
   // daqNrFdlBoards OK, just reserve memory at this point
 
   // * produce the L1GlobalTriggerObjectMapRecord
-  std::unique_ptr<L1GlobalTriggerObjectMapRecord> gtObjectMapRecord(
-      new L1GlobalTriggerObjectMapRecord());
+  std::unique_ptr<L1GlobalTriggerObjectMapRecord> gtObjectMapRecord(new L1GlobalTriggerObjectMapRecord());
 
   // fill the boards not depending on the BxInEvent in the L1 GT DAQ record
   // GMT, PSB and FDL depend on BxInEvent
@@ -728,24 +650,18 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
   if ((bxCross & 0xFFF) == bxCross) {
     bxCrossHw = static_cast<boost::uint16_t>(bxCross);
   } else {
-    bxCrossHw = 0; // Bx number too large, set to 0!
+    bxCrossHw = 0;  // Bx number too large, set to 0!
     if (m_verbosity) {
-
-      LogDebug("L1GlobalTrigger")
-          << "\nBunch cross number [hex] = " << std::hex << bxCross
-          << "\n  larger than 12 bits. Set to 0! \n"
-          << std::dec << std::endl;
+      LogDebug("L1GlobalTrigger") << "\nBunch cross number [hex] = " << std::hex << bxCross
+                                  << "\n  larger than 12 bits. Set to 0! \n"
+                                  << std::dec << std::endl;
     }
   }
 
   if (m_produceL1GtDaqRecord) {
-
-    for (CItBoardMaps itBoard = boardMaps.begin(); itBoard != boardMaps.end();
-         ++itBoard) {
-
+    for (CItBoardMaps itBoard = boardMaps.begin(); itBoard != boardMaps.end(); ++itBoard) {
       int iPosition = itBoard->gtPositionDaqRecord();
       if (iPosition > 0) {
-
         int iActiveBit = itBoard->gtBitDaqActiveBoards();
         bool activeBoard = false;
 
@@ -757,59 +673,53 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
         // 0)
         //               in the record and ActiveBoardsMap, and active
         if ((iActiveBit < 0) || activeBoard) {
-
           switch (itBoard->gtBoardType()) {
+            case GTFE: {
+              L1GtfeWord gtfeWordValue;
 
-          case GTFE: {
-            L1GtfeWord gtfeWordValue;
+              gtfeWordValue.setBoardId(itBoard->gtBoardId());
 
-            gtfeWordValue.setBoardId(itBoard->gtBoardId());
+              // cast int to boost::uint16_t
+              // there are normally 3 or 5 BxInEvent
+              gtfeWordValue.setRecordLength(static_cast<boost::uint16_t>(recordLength0));
 
-            // cast int to boost::uint16_t
-            // there are normally 3 or 5 BxInEvent
-            gtfeWordValue.setRecordLength(
-                static_cast<boost::uint16_t>(recordLength0));
+              gtfeWordValue.setRecordLength1(static_cast<boost::uint16_t>(recordLength1));
 
-            gtfeWordValue.setRecordLength1(
-                static_cast<boost::uint16_t>(recordLength1));
+              // bunch crossing
+              gtfeWordValue.setBxNr(bxCrossHw);
 
-            // bunch crossing
-            gtfeWordValue.setBxNr(bxCrossHw);
+              // set the list of active boards
+              gtfeWordValue.setActiveBoards(m_activeBoardsGtDaq);
 
-            // set the list of active boards
-            gtfeWordValue.setActiveBoards(m_activeBoardsGtDaq);
+              // set alternative for number of BX per board
+              gtfeWordValue.setAltNrBxBoard(static_cast<boost::uint16_t>(m_alternativeNrBxBoardDaq));
 
-            // set alternative for number of BX per board
-            gtfeWordValue.setAltNrBxBoard(
-                static_cast<boost::uint16_t>(m_alternativeNrBxBoardDaq));
+              // set the TOTAL_TRIGNR as read from iEvent
+              // TODO check again - PTC stuff
 
-            // set the TOTAL_TRIGNR as read from iEvent
-            // TODO check again - PTC stuff
+              gtfeWordValue.setTotalTriggerNr(static_cast<boost::uint32_t>(iEvent.id().event()));
 
-            gtfeWordValue.setTotalTriggerNr(
-                static_cast<boost::uint32_t>(iEvent.id().event()));
+              // ** fill L1GtfeWord in GT DAQ record
 
-            // ** fill L1GtfeWord in GT DAQ record
+              gtDaqReadoutRecord->setGtfeWord(gtfeWordValue);
+            }
 
-            gtDaqReadoutRecord->setGtfeWord(gtfeWordValue);
-          }
+            break;
+            case TCS: {
+              // nothing
+            }
 
-          break;
-          case TCS: {
-            // nothing
-          }
+            break;
+            case TIM: {
+              // nothing
+            }
 
-          break;
-          case TIM: {
-            // nothing
-          }
+            break;
+            default: {
+              // do nothing, all blocks are given in GtBoardType enum
+            }
 
-          break;
-          default: {
-            // do nothing, all blocks are given in GtBoardType enum
-          }
-
-          break;
+            break;
           }
         }
       }
@@ -821,7 +731,6 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
   int evmNrFdlBoards = 0;
 
   if (m_produceL1GtEvmRecord) {
-
     // get the length of the BST message from parameter set or from event setup
 
     int bstLengthBytes = 0;
@@ -836,18 +745,12 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
     }
 
     if (m_verbosity) {
-
-      LogTrace("L1GlobalTrigger")
-          << "\n Length of BST message (in bytes): " << bstLengthBytes << "\n"
-          << std::endl;
+      LogTrace("L1GlobalTrigger") << "\n Length of BST message (in bytes): " << bstLengthBytes << "\n" << std::endl;
     }
 
-    for (CItBoardMaps itBoard = boardMaps.begin(); itBoard != boardMaps.end();
-         ++itBoard) {
-
+    for (CItBoardMaps itBoard = boardMaps.begin(); itBoard != boardMaps.end(); ++itBoard) {
       int iPosition = itBoard->gtPositionEvmRecord();
       if (iPosition > 0) {
-
         int iActiveBit = itBoard->gtBitEvmActiveBoards();
         bool activeBoard = false;
 
@@ -859,104 +762,94 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
         // 0)
         //               in the record and ActiveBoardsMap, and active
         if ((iActiveBit < 0) || activeBoard) {
-
           switch (itBoard->gtBoardType()) {
+            case GTFE: {
+              L1GtfeExtWord gtfeWordValue(bstLengthBytes);
 
-          case GTFE: {
-            L1GtfeExtWord gtfeWordValue(bstLengthBytes);
+              gtfeWordValue.setBoardId(itBoard->gtBoardId());
 
-            gtfeWordValue.setBoardId(itBoard->gtBoardId());
+              // cast int to boost::uint16_t
+              // there are normally 3 or 5 BxInEvent
+              gtfeWordValue.setRecordLength(static_cast<boost::uint16_t>(recordLength0));
 
-            // cast int to boost::uint16_t
-            // there are normally 3 or 5 BxInEvent
-            gtfeWordValue.setRecordLength(
-                static_cast<boost::uint16_t>(recordLength0));
+              gtfeWordValue.setRecordLength1(static_cast<boost::uint16_t>(recordLength1));
 
-            gtfeWordValue.setRecordLength1(
-                static_cast<boost::uint16_t>(recordLength1));
+              // bunch crossing
+              gtfeWordValue.setBxNr(bxCrossHw);
 
-            // bunch crossing
-            gtfeWordValue.setBxNr(bxCrossHw);
+              // set the list of active boards
+              gtfeWordValue.setActiveBoards(m_activeBoardsGtEvm);
 
-            // set the list of active boards
-            gtfeWordValue.setActiveBoards(m_activeBoardsGtEvm);
+              // set alternative for number of BX per board
+              gtfeWordValue.setAltNrBxBoard(static_cast<boost::uint16_t>(m_alternativeNrBxBoardEvm));
 
-            // set alternative for number of BX per board
-            gtfeWordValue.setAltNrBxBoard(
-                static_cast<boost::uint16_t>(m_alternativeNrBxBoardEvm));
+              // set the TOTAL_TRIGNR as read from iEvent
+              // TODO check again - PTC stuff
 
-            // set the TOTAL_TRIGNR as read from iEvent
-            // TODO check again - PTC stuff
+              gtfeWordValue.setTotalTriggerNr(static_cast<boost::uint32_t>(iEvent.id().event()));
 
-            gtfeWordValue.setTotalTriggerNr(
-                static_cast<boost::uint32_t>(iEvent.id().event()));
+              // set the GPS time to the value read from Timestamp
+              edm::TimeValue_t evTime = iEvent.time().value();
 
-            // set the GPS time to the value read from Timestamp
-            edm::TimeValue_t evTime = iEvent.time().value();
+              gtfeWordValue.setGpsTime(evTime);
 
-            gtfeWordValue.setGpsTime(evTime);
+              // LogDebug("L1GlobalTrigger")
+              //<< "\nEvent timestamp value [hex] = " << std::hex << evTime
+              //<< "\nBST retrieved value [hex]   = " << gtfeWordValue.gpsTime()
+              //<< std::dec << std::endl;
 
-            // LogDebug("L1GlobalTrigger")
-            //<< "\nEvent timestamp value [hex] = " << std::hex << evTime
-            //<< "\nBST retrieved value [hex]   = " << gtfeWordValue.gpsTime()
-            //<< std::dec << std::endl;
+              // source of BST message: DDDD simulated data
+              boost::uint16_t bstSourceVal = 0xDDDD;
+              gtfeWordValue.setBstSource(bstSourceVal);
 
-            // source of BST message: DDDD simulated data
-            boost::uint16_t bstSourceVal = 0xDDDD;
-            gtfeWordValue.setBstSource(bstSourceVal);
+              // ** fill L1GtfeWord in GT EVM record
 
-            // ** fill L1GtfeWord in GT EVM record
+              gtEvmReadoutRecord->setGtfeWord(gtfeWordValue);
+            }
 
-            gtEvmReadoutRecord->setGtfeWord(gtfeWordValue);
-          }
+            break;
+            case FDL: {
+              evmNrFdlBoards++;
+            }
 
-          break;
-          case FDL: {
-            evmNrFdlBoards++;
-          }
+            break;
+            case TCS: {
+              L1TcsWord tcsWordValue;
 
-          break;
-          case TCS: {
+              tcsWordValue.setBoardId(itBoard->gtBoardId());
 
-            L1TcsWord tcsWordValue;
+              // bunch crossing
+              tcsWordValue.setBxNr(bxCrossHw);
 
-            tcsWordValue.setBoardId(itBoard->gtBoardId());
+              boost::uint16_t trigType = 0x5;  // 0101 simulated event
+              tcsWordValue.setTriggerType(trigType);
 
-            // bunch crossing
-            tcsWordValue.setBxNr(bxCrossHw);
+              // luminosity segment number
+              tcsWordValue.setLuminositySegmentNr(static_cast<boost::uint16_t>(iEvent.luminosityBlock()));
 
-            boost::uint16_t trigType = 0x5; // 0101 simulated event
-            tcsWordValue.setTriggerType(trigType);
+              // set the Event_Nr as read from iEvent
+              tcsWordValue.setEventNr(static_cast<boost::uint32_t>(iEvent.id().event()));
 
-            // luminosity segment number
-            tcsWordValue.setLuminositySegmentNr(
-                static_cast<boost::uint16_t>(iEvent.luminosityBlock()));
+              // orbit number
+              tcsWordValue.setOrbitNr(static_cast<boost::uint64_t>(iEvent.orbitNumber()));
 
-            // set the Event_Nr as read from iEvent
-            tcsWordValue.setEventNr(
-                static_cast<boost::uint32_t>(iEvent.id().event()));
+              // ** fill L1TcsWord in the EVM record
 
-            // orbit number
-            tcsWordValue.setOrbitNr(
-                static_cast<boost::uint64_t>(iEvent.orbitNumber()));
+              gtEvmReadoutRecord->setTcsWord(tcsWordValue);
 
-            // ** fill L1TcsWord in the EVM record
+            }
 
-            gtEvmReadoutRecord->setTcsWord(tcsWordValue);
+            break;
+            case TIM: {
+              // nothing
+            }
 
-          }
+            break;
+            default: {
+              // do nothing, all blocks are given in GtBoardType enum
+            }
 
-          break;
-          case TIM: {
-            // nothing
-          }
-
-          break;
-          default: {
-            // do nothing, all blocks are given in GtBoardType enum
-          }
-
-          break;
+            break;
           }
         }
       }
@@ -964,38 +857,47 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
   }
 
   // get the prescale factor set used in the actual luminosity segment
-  int pfAlgoSetIndex = 0; // FIXME
-  const std::vector<int> &prescaleFactorsAlgoTrig =
-      (*m_prescaleFactorsAlgoTrig).at(pfAlgoSetIndex);
+  int pfAlgoSetIndex = 0;  // FIXME
+  const std::vector<int> &prescaleFactorsAlgoTrig = (*m_prescaleFactorsAlgoTrig).at(pfAlgoSetIndex);
 
-  int pfTechSetIndex = 0; // FIXME
-  const std::vector<int> &prescaleFactorsTechTrig =
-      (*m_prescaleFactorsTechTrig).at(pfTechSetIndex);
+  int pfTechSetIndex = 0;  // FIXME
+  const std::vector<int> &prescaleFactorsTechTrig = (*m_prescaleFactorsTechTrig).at(pfTechSetIndex);
 
   //
 
   // loop over BxInEvent
-  for (int iBxInEvent = minBxInEvent; iBxInEvent <= maxBxInEvent;
-       ++iBxInEvent) {
-
+  for (int iBxInEvent = minBxInEvent; iBxInEvent <= maxBxInEvent; ++iBxInEvent) {
     // * receive GCT object data via PSBs
     // LogDebug("L1GlobalTrigger")
     //<< "\nL1GlobalTrigger : receiving PSB data for bx = " << iBxInEvent <<
     //"\n"
     //<< std::endl;
 
-    m_gtPSB->receiveGctObjectData(
-        iEvent, m_caloGctInputTag, iBxInEvent, receiveNoIsoEG, m_nrL1NoIsoEG,
-        receiveIsoEG, m_nrL1IsoEG, receiveCenJet, m_nrL1CenJet, receiveForJet,
-        m_nrL1ForJet, receiveTauJet, m_nrL1TauJet, receiveETM, receiveETT,
-        receiveHTT, receiveHTM, receiveJetCounts, receiveHfBitCounts,
-        receiveHfRingEtSums);
+    m_gtPSB->receiveGctObjectData(iEvent,
+                                  m_caloGctInputTag,
+                                  iBxInEvent,
+                                  receiveNoIsoEG,
+                                  m_nrL1NoIsoEG,
+                                  receiveIsoEG,
+                                  m_nrL1IsoEG,
+                                  receiveCenJet,
+                                  m_nrL1CenJet,
+                                  receiveForJet,
+                                  m_nrL1ForJet,
+                                  receiveTauJet,
+                                  m_nrL1TauJet,
+                                  receiveETM,
+                                  receiveETT,
+                                  receiveHTT,
+                                  receiveHTM,
+                                  receiveJetCounts,
+                                  receiveHfBitCounts,
+                                  receiveHfRingEtSums);
 
     /// receive technical trigger
     if (m_readTechnicalTriggerRecords) {
-      m_gtPSB->receiveTechnicalTriggers(iEvent, m_technicalTriggersInputTags,
-                                        iBxInEvent, receiveTechTr,
-                                        m_numberTechnicalTriggers);
+      m_gtPSB->receiveTechnicalTriggers(
+          iEvent, m_technicalTriggersInputTags, iBxInEvent, receiveTechTr, m_numberTechnicalTriggers);
     }
 
     if (receiveExternal) {
@@ -1003,9 +905,14 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
     }
 
     if (m_produceL1GtDaqRecord && m_writePsbL1GtDaqRecord) {
-      m_gtPSB->fillPsbBlock(iEvent, m_activeBoardsGtDaq, recordLength0,
-                            recordLength1, m_alternativeNrBxBoardDaq, boardMaps,
-                            iBxInEvent, gtDaqReadoutRecord.get());
+      m_gtPSB->fillPsbBlock(iEvent,
+                            m_activeBoardsGtDaq,
+                            recordLength0,
+                            recordLength1,
+                            m_alternativeNrBxBoardDaq,
+                            boardMaps,
+                            iBxInEvent,
+                            gtDaqReadoutRecord.get());
     }
 
     // * receive GMT object data via GTL
@@ -1014,19 +921,29 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
     //"\n"
     //<< std::endl;
 
-    m_gtGTL->receiveGmtObjectData(iEvent, m_muGmtInputTag, iBxInEvent,
-                                  receiveMu, m_nrL1Mu);
+    m_gtGTL->receiveGmtObjectData(iEvent, m_muGmtInputTag, iBxInEvent, receiveMu, m_nrL1Mu);
 
     // * run GTL
     // LogDebug("L1GlobalTrigger")
     //<< "\nL1GlobalTrigger : running GTL for bx = " << iBxInEvent << "\n"
     //<< std::endl;
 
-    m_gtGTL->run(iEvent, evSetup, m_gtPSB, m_produceL1GtObjectMapRecord,
-                 iBxInEvent, gtObjectMapRecord.get(), m_numberPhysTriggers,
-                 m_nrL1Mu, m_nrL1NoIsoEG, m_nrL1IsoEG, m_nrL1CenJet,
-                 m_nrL1ForJet, m_nrL1TauJet, m_nrL1JetCounts,
-                 m_ifMuEtaNumberBits, m_ifCaloEtaNumberBits);
+    m_gtGTL->run(iEvent,
+                 evSetup,
+                 m_gtPSB,
+                 m_produceL1GtObjectMapRecord,
+                 iBxInEvent,
+                 gtObjectMapRecord.get(),
+                 m_numberPhysTriggers,
+                 m_nrL1Mu,
+                 m_nrL1NoIsoEG,
+                 m_nrL1IsoEG,
+                 m_nrL1CenJet,
+                 m_nrL1ForJet,
+                 m_nrL1TauJet,
+                 m_nrL1JetCounts,
+                 m_ifMuEtaNumberBits,
+                 m_ifCaloEtaNumberBits);
 
     // LogDebug("L1GlobalTrigger")
     //<< "\n AlgorithmOR\n" << m_gtGTL->getAlgorithmOR() << "\n"
@@ -1037,26 +954,47 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
     //<< "\nL1GlobalTrigger : running FDL for bx = " << iBxInEvent << "\n"
     //<< std::endl;
 
-    m_gtFDL->run(iEvent, prescaleFactorsAlgoTrig, prescaleFactorsTechTrig,
-                 m_triggerMaskAlgoTrig, m_triggerMaskTechTrig,
-                 m_triggerMaskVetoAlgoTrig, m_triggerMaskVetoTechTrig,
-                 boardMaps, m_emulateBxInEvent, iBxInEvent,
-                 m_numberPhysTriggers, m_numberTechnicalTriggers,
-                 m_numberDaqPartitions, m_gtGTL, m_gtPSB, pfAlgoSetIndex,
-                 pfTechSetIndex, m_algorithmTriggersUnprescaled,
-                 m_algorithmTriggersUnmasked, m_technicalTriggersUnprescaled,
-                 m_technicalTriggersUnmasked, m_technicalTriggersVetoUnmasked);
+    m_gtFDL->run(iEvent,
+                 prescaleFactorsAlgoTrig,
+                 prescaleFactorsTechTrig,
+                 m_triggerMaskAlgoTrig,
+                 m_triggerMaskTechTrig,
+                 m_triggerMaskVetoAlgoTrig,
+                 m_triggerMaskVetoTechTrig,
+                 boardMaps,
+                 m_emulateBxInEvent,
+                 iBxInEvent,
+                 m_numberPhysTriggers,
+                 m_numberTechnicalTriggers,
+                 m_numberDaqPartitions,
+                 m_gtGTL,
+                 m_gtPSB,
+                 pfAlgoSetIndex,
+                 pfTechSetIndex,
+                 m_algorithmTriggersUnprescaled,
+                 m_algorithmTriggersUnmasked,
+                 m_technicalTriggersUnprescaled,
+                 m_technicalTriggersUnmasked,
+                 m_technicalTriggersVetoUnmasked);
 
     if (m_produceL1GtDaqRecord && (daqNrFdlBoards > 0)) {
-      m_gtFDL->fillDaqFdlBlock(iBxInEvent, m_activeBoardsGtDaq, recordLength0,
-                               recordLength1, m_alternativeNrBxBoardDaq,
-                               boardMaps, gtDaqReadoutRecord.get());
+      m_gtFDL->fillDaqFdlBlock(iBxInEvent,
+                               m_activeBoardsGtDaq,
+                               recordLength0,
+                               recordLength1,
+                               m_alternativeNrBxBoardDaq,
+                               boardMaps,
+                               gtDaqReadoutRecord.get());
     }
 
     if (m_produceL1GtEvmRecord && (evmNrFdlBoards > 0)) {
-      m_gtFDL->fillEvmFdlBlock(iBxInEvent, m_activeBoardsGtEvm, recordLength0,
-                               recordLength1, m_alternativeNrBxBoardEvm,
-                               boardMaps, gtEvmReadoutRecord.get());
+      m_gtFDL->fillEvmFdlBlock(iBxInEvent,
+                               m_activeBoardsGtEvm,
+                               recordLength0,
+                               recordLength1,
+                               m_alternativeNrBxBoardEvm,
+                               boardMaps,
+                               gtEvmReadoutRecord.get());
     }
 
     // reset
@@ -1068,7 +1006,6 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
   }
 
   if (receiveMu) {
-
     // LogDebug("L1GlobalTrigger")
     //<< "\n**** "
     //<< "\n  Persistent reference for L1MuGMTReadoutCollection with input tag:
@@ -1084,53 +1021,42 @@ void L1GlobalTrigger::produce(edm::Event &iEvent,
 
     if (!gmtRcHandle.isValid()) {
       if (m_verbosity) {
-        edm::LogWarning("L1GlobalTrigger")
-            << "\nWarning: L1MuGMTReadoutCollection with input tag "
-            << m_muGmtInputTag
-            << "\nrequested in configuration, but not found in the event.\n"
-            << std::endl;
+        edm::LogWarning("L1GlobalTrigger") << "\nWarning: L1MuGMTReadoutCollection with input tag " << m_muGmtInputTag
+                                           << "\nrequested in configuration, but not found in the event.\n"
+                                           << std::endl;
       }
     } else {
-
       gtDaqReadoutRecord->setMuCollectionRefProd(gmtRcHandle);
     }
   }
 
   if (m_verbosity && m_isDebugEnabled) {
-
     std::ostringstream myCoutStream;
     gtDaqReadoutRecord->print(myCoutStream);
-    LogTrace("L1GlobalTrigger")
-        << "\n The following L1 GT DAQ readout record was produced:\n"
-        << myCoutStream.str() << "\n"
-        << std::endl;
+    LogTrace("L1GlobalTrigger") << "\n The following L1 GT DAQ readout record was produced:\n"
+                                << myCoutStream.str() << "\n"
+                                << std::endl;
 
     myCoutStream.str("");
     myCoutStream.clear();
 
     gtEvmReadoutRecord->print(myCoutStream);
-    LogTrace("L1GlobalTrigger")
-        << "\n The following L1 GT EVM readout record was produced:\n"
-        << myCoutStream.str() << "\n"
-        << std::endl;
+    LogTrace("L1GlobalTrigger") << "\n The following L1 GT EVM readout record was produced:\n"
+                                << myCoutStream.str() << "\n"
+                                << std::endl;
 
     myCoutStream.str("");
     myCoutStream.clear();
 
-    const std::vector<L1GlobalTriggerObjectMap> objMapVec =
-        gtObjectMapRecord->gtObjectMap();
+    const std::vector<L1GlobalTriggerObjectMap> objMapVec = gtObjectMapRecord->gtObjectMap();
 
-    for (std::vector<L1GlobalTriggerObjectMap>::const_iterator it =
-             objMapVec.begin();
-         it != objMapVec.end(); ++it) {
-
+    for (std::vector<L1GlobalTriggerObjectMap>::const_iterator it = objMapVec.begin(); it != objMapVec.end(); ++it) {
       (*it).print(myCoutStream);
     }
 
-    LogDebug("L1GlobalTrigger")
-        << "Test gtObjectMapRecord in L1GlobalTrigger \n\n"
-        << myCoutStream.str() << "\n\n"
-        << std::endl;
+    LogDebug("L1GlobalTrigger") << "Test gtObjectMapRecord in L1GlobalTrigger \n\n"
+                                << myCoutStream.str() << "\n\n"
+                                << std::endl;
 
     myCoutStream.str("");
     myCoutStream.clear();

--- a/L1Trigger/GlobalTrigger/plugins/L1GlobalTrigger.h
+++ b/L1Trigger/GlobalTrigger/plugins/L1GlobalTrigger.h
@@ -53,7 +53,6 @@ class L1GtTriggerMask;
 
 // class declaration
 class L1GlobalTrigger : public edm::stream::EDProducer<> {
-
 public:
   explicit L1GlobalTrigger(const edm::ParameterSet &);
   ~L1GlobalTrigger() override;

--- a/L1Trigger/GlobalTrigger/src/L1GlobalTriggerFDL.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GlobalTriggerFDL.cc
@@ -42,10 +42,11 @@
 
 // constructor
 L1GlobalTriggerFDL::L1GlobalTriggerFDL()
-    : // logical switches
-      m_firstEv(true), m_firstEvLumiSegment(true), m_firstEvRun(true),
+    :  // logical switches
+      m_firstEv(true),
+      m_firstEvLumiSegment(true),
+      m_firstEvRun(true),
       m_isDebugEnabled(edm::isDebugEnabled()) {
-
   // create empty FDL word
   m_gtFdlWord = new L1GtFdlWord();
 
@@ -54,7 +55,6 @@ L1GlobalTriggerFDL::L1GlobalTriggerFDL()
 
 // destructor
 L1GlobalTriggerFDL::~L1GlobalTriggerFDL() {
-
   reset();
   delete m_gtFdlWord;
 }
@@ -62,27 +62,30 @@ L1GlobalTriggerFDL::~L1GlobalTriggerFDL() {
 // Operations
 
 // run FDL
-void L1GlobalTriggerFDL::run(
-    edm::Event &iEvent, const std::vector<int> &prescaleFactorsAlgoTrig,
-    const std::vector<int> &prescaleFactorsTechTrig,
-    const std::vector<unsigned int> &triggerMaskAlgoTrig,
-    const std::vector<unsigned int> &triggerMaskTechTrig,
-    const std::vector<unsigned int> &triggerMaskVetoAlgoTrig,
-    const std::vector<unsigned int> &triggerMaskVetoTechTrig,
-    const std::vector<L1GtBoard> &boardMaps, const int totalBxInEvent,
-    const int iBxInEvent, const unsigned int numberPhysTriggers,
-    const unsigned int numberTechnicalTriggers,
-    const unsigned int numberDaqPartitions, const L1GlobalTriggerGTL *ptrGTL,
-    const L1GlobalTriggerPSB *ptrPSB, const int pfAlgoSetIndex,
-    const int pfTechSetIndex, const bool algorithmTriggersUnprescaled,
-    const bool algorithmTriggersUnmasked,
-    const bool technicalTriggersUnprescaled,
-    const bool technicalTriggersUnmasked,
-    const bool technicalTriggersVetoUnmasked) {
-
+void L1GlobalTriggerFDL::run(edm::Event &iEvent,
+                             const std::vector<int> &prescaleFactorsAlgoTrig,
+                             const std::vector<int> &prescaleFactorsTechTrig,
+                             const std::vector<unsigned int> &triggerMaskAlgoTrig,
+                             const std::vector<unsigned int> &triggerMaskTechTrig,
+                             const std::vector<unsigned int> &triggerMaskVetoAlgoTrig,
+                             const std::vector<unsigned int> &triggerMaskVetoTechTrig,
+                             const std::vector<L1GtBoard> &boardMaps,
+                             const int totalBxInEvent,
+                             const int iBxInEvent,
+                             const unsigned int numberPhysTriggers,
+                             const unsigned int numberTechnicalTriggers,
+                             const unsigned int numberDaqPartitions,
+                             const L1GlobalTriggerGTL *ptrGTL,
+                             const L1GlobalTriggerPSB *ptrPSB,
+                             const int pfAlgoSetIndex,
+                             const int pfTechSetIndex,
+                             const bool algorithmTriggersUnprescaled,
+                             const bool algorithmTriggersUnmasked,
+                             const bool technicalTriggersUnprescaled,
+                             const bool technicalTriggersUnmasked,
+                             const bool technicalTriggersVetoUnmasked) {
   // FIXME get rid of bitset in GTL in order to use only EventSetup
-  const unsigned int numberPhysTriggersSet =
-      L1GlobalTriggerReadoutSetup::NumberPhysTriggers;
+  const unsigned int numberPhysTriggersSet = L1GlobalTriggerReadoutSetup::NumberPhysTriggers;
 
   // get gtlDecisionWord from GTL
   std::bitset<numberPhysTriggersSet> gtlDecisionWord = ptrGTL->getAlgorithmOR();
@@ -91,7 +94,6 @@ void L1GlobalTriggerFDL::run(
   DecisionWord algoDecisionWord(numberPhysTriggers);
 
   for (unsigned int iBit = 0; iBit < numberPhysTriggers; ++iBit) {
-
     bool bitValue = gtlDecisionWord.test(iBit);
     algoDecisionWord[iBit] = bitValue;
   }
@@ -99,12 +101,10 @@ void L1GlobalTriggerFDL::run(
   // prescale counters are reset at the beginning of the luminosity segment
 
   if (m_firstEv) {
-
     // prescale counters: numberPhysTriggers counters per bunch cross
     m_prescaleCounterAlgoTrig.reserve(numberPhysTriggers * totalBxInEvent);
 
     for (int iBxInEvent = 0; iBxInEvent <= totalBxInEvent; ++iBxInEvent) {
-
       m_prescaleCounterAlgoTrig.push_back(prescaleFactorsAlgoTrig);
     }
 
@@ -112,7 +112,6 @@ void L1GlobalTriggerFDL::run(
     m_prescaleCounterTechTrig.reserve(numberTechnicalTriggers * totalBxInEvent);
 
     for (int iBxInEvent = 0; iBxInEvent <= totalBxInEvent; ++iBxInEvent) {
-
       m_prescaleCounterTechTrig.push_back(prescaleFactorsTechTrig);
     }
 
@@ -121,7 +120,6 @@ void L1GlobalTriggerFDL::run(
 
   // TODO FIXME find the beginning of the luminosity segment
   if (m_firstEvLumiSegment) {
-
     m_prescaleCounterAlgoTrig.clear();
     for (int iBxInEvent = 0; iBxInEvent <= totalBxInEvent; ++iBxInEvent) {
       m_prescaleCounterAlgoTrig.push_back(prescaleFactorsAlgoTrig);
@@ -141,19 +139,13 @@ void L1GlobalTriggerFDL::run(
   int inBxInEvent = totalBxInEvent / 2 + iBxInEvent;
 
   for (unsigned int iBit = 0; iBit < numberPhysTriggers; ++iBit) {
-
-    if ((!algorithmTriggersUnprescaled) &&
-        (prescaleFactorsAlgoTrig.at(iBit) != 1)) {
-
+    if ((!algorithmTriggersUnprescaled) && (prescaleFactorsAlgoTrig.at(iBit) != 1)) {
       bool bitValue = algoDecisionWord.at(iBit);
       if (bitValue) {
-
         (m_prescaleCounterAlgoTrig.at(inBxInEvent).at(iBit))--;
         if (m_prescaleCounterAlgoTrig.at(inBxInEvent).at(iBit) == 0) {
-
           // bit already true in algoDecisionWord, just reset counter
-          m_prescaleCounterAlgoTrig.at(inBxInEvent).at(iBit) =
-              prescaleFactorsAlgoTrig.at(iBit);
+          m_prescaleCounterAlgoTrig.at(inBxInEvent).at(iBit) = prescaleFactorsAlgoTrig.at(iBit);
 
           // LogTrace("L1GlobalTrigger")
           //<< "\nPrescaled algorithm: " << iBit << ". Reset counter to "
@@ -161,7 +153,6 @@ void L1GlobalTriggerFDL::run(
           //<< std::endl;
 
         } else {
-
           // change bit to false
           algoDecisionWord[iBit] = false;
           ;
@@ -186,19 +177,13 @@ void L1GlobalTriggerFDL::run(
   // prescale the technical trigger, if necessary
 
   for (unsigned int iBit = 0; iBit < numberTechnicalTriggers; ++iBit) {
-
-    if ((!technicalTriggersUnprescaled) &&
-        (prescaleFactorsTechTrig.at(iBit) != 1)) {
-
+    if ((!technicalTriggersUnprescaled) && (prescaleFactorsTechTrig.at(iBit) != 1)) {
       bool bitValue = techDecisionWord.at(iBit);
       if (bitValue) {
-
         (m_prescaleCounterTechTrig.at(inBxInEvent).at(iBit))--;
         if (m_prescaleCounterTechTrig.at(inBxInEvent).at(iBit) == 0) {
-
           // bit already true in techDecisionWord, just reset counter
-          m_prescaleCounterTechTrig.at(inBxInEvent).at(iBit) =
-              prescaleFactorsTechTrig.at(iBit);
+          m_prescaleCounterTechTrig.at(inBxInEvent).at(iBit) = prescaleFactorsTechTrig.at(iBit);
 
           // LogTrace("L1GlobalTrigger")
           //<< "\nPrescaled algorithm: " << iBit << ". Reset counter to "
@@ -206,7 +191,6 @@ void L1GlobalTriggerFDL::run(
           //<< std::endl;
 
         } else {
-
           // change bit to false
           techDecisionWord[iBit] = false;
 
@@ -229,7 +213,6 @@ void L1GlobalTriggerFDL::run(
   boost::uint16_t finalOrValue = 0;
 
   for (unsigned int iDaq = 0; iDaq < numberDaqPartitions; ++iDaq) {
-
     bool daqPartitionFinalOR = false;
 
     // starts with technical trigger veto mask to minimize computation
@@ -239,11 +222,8 @@ void L1GlobalTriggerFDL::run(
 
     // vetoTechTrig can change only when using trigger veto masks
     if (!technicalTriggersVetoUnmasked) {
-
       for (unsigned int iBit = 0; iBit < numberTechnicalTriggers; ++iBit) {
-
-        int triggerMaskVetoTechTrigBit =
-            triggerMaskVetoTechTrig[iBit] & (1 << iDaq);
+        int triggerMaskVetoTechTrigBit = triggerMaskVetoTechTrig[iBit] & (1 << iDaq);
         // LogTrace("L1GlobalTrigger")
         //<< "\nTechnical trigger bit: " << iBit
         //<< " mask = " << triggerMaskVetoTechTrigBit
@@ -251,7 +231,6 @@ void L1GlobalTriggerFDL::run(
         //<< std::endl;
 
         if (triggerMaskVetoTechTrigBit && techDecisionWord[iBit]) {
-
           daqPartitionFinalOR = false;
           vetoTechTrig = true;
 
@@ -268,12 +247,10 @@ void L1GlobalTriggerFDL::run(
     // apply algorithm and technical trigger masks only if no veto from
     // technical trigger
     if (!vetoTechTrig) {
-
       // algorithm trigger mask
       bool algoFinalOr = false;
 
       for (unsigned int iBit = 0; iBit < numberPhysTriggers; ++iBit) {
-
         bool iBitDecision = false;
 
         int triggerMaskAlgoTrigBit = -1;
@@ -308,7 +285,6 @@ void L1GlobalTriggerFDL::run(
       bool techFinalOr = false;
 
       for (unsigned int iBit = 0; iBit < numberTechnicalTriggers; ++iBit) {
-
         bool iBitDecision = false;
 
         int triggerMaskTechTrigBit = -1;
@@ -324,7 +300,6 @@ void L1GlobalTriggerFDL::run(
         //<< std::endl;
 
         if (triggerMaskTechTrigBit) {
-
           iBitDecision = false;
 
           // LogTrace("L1GlobalTrigger")
@@ -340,13 +315,11 @@ void L1GlobalTriggerFDL::run(
       daqPartitionFinalOR = algoFinalOr || techFinalOr;
 
     } else {
-
-      daqPartitionFinalOR = false; // vetoTechTrig
+      daqPartitionFinalOR = false;  // vetoTechTrig
     }
 
     // push it in finalOrValue
-    boost::uint16_t daqPartitionFinalORValue =
-        static_cast<boost::uint16_t>(daqPartitionFinalOR);
+    boost::uint16_t daqPartitionFinalORValue = static_cast<boost::uint16_t>(daqPartitionFinalOR);
 
     finalOrValue = finalOrValue | (daqPartitionFinalORValue << iDaq);
   }
@@ -354,11 +327,8 @@ void L1GlobalTriggerFDL::run(
   // fill everything we know in the L1GtFdlWord
 
   typedef std::vector<L1GtBoard>::const_iterator CItBoardMaps;
-  for (CItBoardMaps itBoard = boardMaps.begin(); itBoard != boardMaps.end();
-       ++itBoard) {
-
+  for (CItBoardMaps itBoard = boardMaps.begin(); itBoard != boardMaps.end(); ++itBoard) {
     if ((itBoard->gtBoardType() == FDL)) {
-
       m_gtFdlWord->setBoardId(itBoard->gtBoardId());
 
       // BxInEvent
@@ -373,20 +343,18 @@ void L1GlobalTriggerFDL::run(
       if ((bxCross & 0xFFF) == bxCross) {
         bxCrossHw = static_cast<boost::uint16_t>(bxCross);
       } else {
-        bxCrossHw = 0; // Bx number too large, set to 0!
+        bxCrossHw = 0;  // Bx number too large, set to 0!
         if (m_verbosity) {
-          LogDebug("L1GlobalTrigger")
-              << "\nBunch cross number [hex] = " << std::hex << bxCross
-              << "\n  larger than 12 bits. Set to 0! \n"
-              << std::dec << std::endl;
+          LogDebug("L1GlobalTrigger") << "\nBunch cross number [hex] = " << std::hex << bxCross
+                                      << "\n  larger than 12 bits. Set to 0! \n"
+                                      << std::dec << std::endl;
         }
       }
 
       m_gtFdlWord->setBxNr(bxCrossHw);
 
       // set event number since last L1 reset generated in FDL
-      m_gtFdlWord->setEventNr(
-          static_cast<boost::uint32_t>(iEvent.id().event()));
+      m_gtFdlWord->setEventNr(static_cast<boost::uint32_t>(iEvent.id().event()));
 
       // technical trigger decision word
       m_gtFdlWord->setGtTechnicalTriggerWord(techDecisionWord);
@@ -395,10 +363,8 @@ void L1GlobalTriggerFDL::run(
       m_gtFdlWord->setGtDecisionWord(algoDecisionWord);
 
       // index of prescale factor set - technical triggers and algo
-      m_gtFdlWord->setGtPrescaleFactorIndexTech(
-          static_cast<boost::uint16_t>(pfTechSetIndex));
-      m_gtFdlWord->setGtPrescaleFactorIndexAlgo(
-          static_cast<boost::uint16_t>(pfAlgoSetIndex));
+      m_gtFdlWord->setGtPrescaleFactorIndexTech(static_cast<boost::uint16_t>(pfTechSetIndex));
+      m_gtFdlWord->setGtPrescaleFactorIndexAlgo(static_cast<boost::uint16_t>(pfAlgoSetIndex));
 
       // NoAlgo bit FIXME
 
@@ -406,12 +372,10 @@ void L1GlobalTriggerFDL::run(
       m_gtFdlWord->setFinalOR(finalOrValue);
 
       // orbit number
-      m_gtFdlWord->setOrbitNr(
-          static_cast<boost::uint32_t>(iEvent.orbitNumber()));
+      m_gtFdlWord->setOrbitNr(static_cast<boost::uint32_t>(iEvent.orbitNumber()));
 
       // luminosity segment number
-      m_gtFdlWord->setLumiSegmentNr(
-          static_cast<boost::uint16_t>(iEvent.luminosityBlock()));
+      m_gtFdlWord->setLumiSegmentNr(static_cast<boost::uint16_t>(iEvent.luminosityBlock()));
 
       // local bunch crossing - set identical with absolute BxNr
       m_gtFdlWord->setLocalBxNr(bxCrossHw);
@@ -420,19 +384,17 @@ void L1GlobalTriggerFDL::run(
 }
 
 // fill the FDL block in the L1 GT DAQ record for iBxInEvent
-void L1GlobalTriggerFDL::fillDaqFdlBlock(
-    const int iBxInEvent, const boost::uint16_t &activeBoardsGtDaq,
-    const int recordLength0, const int recordLength1,
-    const unsigned int altNrBxBoardDaq, const std::vector<L1GtBoard> &boardMaps,
-    L1GlobalTriggerReadoutRecord *gtDaqReadoutRecord) {
-
+void L1GlobalTriggerFDL::fillDaqFdlBlock(const int iBxInEvent,
+                                         const boost::uint16_t &activeBoardsGtDaq,
+                                         const int recordLength0,
+                                         const int recordLength1,
+                                         const unsigned int altNrBxBoardDaq,
+                                         const std::vector<L1GtBoard> &boardMaps,
+                                         L1GlobalTriggerReadoutRecord *gtDaqReadoutRecord) {
   typedef std::vector<L1GtBoard>::const_iterator CItBoardMaps;
-  for (CItBoardMaps itBoard = boardMaps.begin(); itBoard != boardMaps.end();
-       ++itBoard) {
-
+  for (CItBoardMaps itBoard = boardMaps.begin(); itBoard != boardMaps.end(); ++itBoard) {
     int iPosition = itBoard->gtPositionDaqRecord();
     if (iPosition > 0) {
-
       int iActiveBit = itBoard->gtBitDaqActiveBoards();
       bool activeBoard = false;
       bool writeBoard = false;
@@ -459,7 +421,6 @@ void L1GlobalTriggerFDL::fillDaqFdlBlock(
       }
 
       if (activeBoard && writeBoard && (itBoard->gtBoardType() == FDL)) {
-
         gtDaqReadoutRecord->setGtFdlWord(*m_gtFdlWord);
       }
     }
@@ -467,19 +428,17 @@ void L1GlobalTriggerFDL::fillDaqFdlBlock(
 }
 
 // fill the FDL block in the L1 GT EVM record for iBxInEvent
-void L1GlobalTriggerFDL::fillEvmFdlBlock(
-    const int iBxInEvent, const boost::uint16_t &activeBoardsGtEvm,
-    const int recordLength0, const int recordLength1,
-    const unsigned int altNrBxBoardEvm, const std::vector<L1GtBoard> &boardMaps,
-    L1GlobalTriggerEvmReadoutRecord *gtEvmReadoutRecord) {
-
+void L1GlobalTriggerFDL::fillEvmFdlBlock(const int iBxInEvent,
+                                         const boost::uint16_t &activeBoardsGtEvm,
+                                         const int recordLength0,
+                                         const int recordLength1,
+                                         const unsigned int altNrBxBoardEvm,
+                                         const std::vector<L1GtBoard> &boardMaps,
+                                         L1GlobalTriggerEvmReadoutRecord *gtEvmReadoutRecord) {
   typedef std::vector<L1GtBoard>::const_iterator CItBoardMaps;
-  for (CItBoardMaps itBoard = boardMaps.begin(); itBoard != boardMaps.end();
-       ++itBoard) {
-
+  for (CItBoardMaps itBoard = boardMaps.begin(); itBoard != boardMaps.end(); ++itBoard) {
     int iPosition = itBoard->gtPositionEvmRecord();
     if (iPosition > 0) {
-
       int iActiveBit = itBoard->gtBitEvmActiveBoards();
       bool activeBoard = false;
 
@@ -488,7 +447,6 @@ void L1GlobalTriggerFDL::fillEvmFdlBlock(
       }
 
       if (activeBoard && (itBoard->gtBoardType() == FDL)) {
-
         gtEvmReadoutRecord->setGtFdlWord(*m_gtFdlWord);
       }
     }
@@ -497,7 +455,6 @@ void L1GlobalTriggerFDL::fillEvmFdlBlock(
 
 // clear FDL
 void L1GlobalTriggerFDL::reset() {
-
   m_gtFdlWord->reset();
 
   // do NOT reset the prescale counters

--- a/L1Trigger/GlobalTrigger/src/L1GlobalTriggerFunctions.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GlobalTriggerFunctions.cc
@@ -13,30 +13,22 @@
 int factorial(int n) { return (n <= 0) ? 1 : (n * factorial(n - 1)); }
 
 // hex string to a vector of 64-bit integers
-bool hexStringToInt64(const std::string &hexString,
-                      std::vector<unsigned long long> &vecInt64) {
-
+bool hexStringToInt64(const std::string &hexString, std::vector<unsigned long long> &vecInt64) {
   int iVec = 0;
   size_t initialPos = 0;
   unsigned long long iValue = 0ULL;
 
   do {
-
     iValue = 0ULL;
 
-    if (stringToNumber<unsigned long long>(
-            iValue, hexString.substr(initialPos, 16), std::hex)) {
-
-      LogTrace("L1GlobalTrigger")
-          << "\n  String " << hexString.substr(initialPos, 16)
-          << " converted to hex value 0x" << std::hex << iValue << std::dec
-          << std::endl;
+    if (stringToNumber<unsigned long long>(iValue, hexString.substr(initialPos, 16), std::hex)) {
+      LogTrace("L1GlobalTrigger") << "\n  String " << hexString.substr(initialPos, 16) << " converted to hex value 0x"
+                                  << std::hex << iValue << std::dec << std::endl;
 
       vecInt64[iVec] = iValue;
     } else {
-      LogTrace("L1GlobalTrigger")
-          << "\nstringToNumber failed to convert string "
-          << hexString.substr(initialPos, 16) << std::endl;
+      LogTrace("L1GlobalTrigger") << "\nstringToNumber failed to convert string " << hexString.substr(initialPos, 16)
+                                  << std::endl;
 
       return false;
     }

--- a/L1Trigger/GlobalTrigger/src/L1GlobalTriggerGTL.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GlobalTriggerGTL.cc
@@ -74,11 +74,8 @@
 // forward declarations
 
 // constructor
-L1GlobalTriggerGTL::L1GlobalTriggerGTL(const edm::InputTag &m_muGmtInputTag,
-                                       edm::ConsumesCollector &&iC)
-    : m_candL1Mu(new std::vector<const L1MuGMTCand *>),
-      m_isDebugEnabled(edm::isDebugEnabled()) {
-
+L1GlobalTriggerGTL::L1GlobalTriggerGTL(const edm::InputTag &m_muGmtInputTag, edm::ConsumesCollector &&iC)
+    : m_candL1Mu(new std::vector<const L1MuGMTCand *>), m_isDebugEnabled(edm::isDebugEnabled()) {
   m_gtlAlgorithmOR.reset();
   m_gtlDecisionWord.reset();
 
@@ -96,7 +93,6 @@ L1GlobalTriggerGTL::L1GlobalTriggerGTL(const edm::InputTag &m_muGmtInputTag,
 
 // destructor
 L1GlobalTriggerGTL::~L1GlobalTriggerGTL() {
-
   reset();
   delete m_candL1Mu;
   delete m_gtEtaPhiConversions;
@@ -104,7 +100,6 @@ L1GlobalTriggerGTL::~L1GlobalTriggerGTL() {
 
 // operations
 void L1GlobalTriggerGTL::init(const int nrL1Mu, const int numberPhysTriggers) {
-
   m_candL1Mu->reserve(nrL1Mu);
 
   // FIXME move from bitset to std::vector<bool> to be able to use
@@ -118,39 +113,34 @@ void L1GlobalTriggerGTL::init(const int nrL1Mu, const int numberPhysTriggers) {
 }
 
 // receive data from Global Muon Trigger
-void L1GlobalTriggerGTL::receiveGmtObjectData(
-    edm::Event &iEvent, const edm::InputTag &muGmtInputTag,
-    const int iBxInEvent, const bool receiveMu, const int nrL1Mu) {
-
+void L1GlobalTriggerGTL::receiveGmtObjectData(edm::Event &iEvent,
+                                              const edm::InputTag &muGmtInputTag,
+                                              const int iBxInEvent,
+                                              const bool receiveMu,
+                                              const int nrL1Mu) {
   if (m_verbosity) {
-    LogDebug("L1GlobalTrigger")
-        << "\n**** L1GlobalTriggerGTL receiving muon data for BxInEvent = "
-        << iBxInEvent << "\n     from input tag " << muGmtInputTag << "\n"
-        << std::endl;
+    LogDebug("L1GlobalTrigger") << "\n**** L1GlobalTriggerGTL receiving muon data for BxInEvent = " << iBxInEvent
+                                << "\n     from input tag " << muGmtInputTag << "\n"
+                                << std::endl;
   }
 
   reset();
 
   // get data from Global Muon Trigger
   if (receiveMu) {
-
     edm::Handle<std::vector<L1MuGMTCand>> muonData;
     iEvent.getByLabel(muGmtInputTag, muonData);
 
     if (!muonData.isValid()) {
       if (m_verbosity) {
-        edm::LogWarning("L1GlobalTrigger")
-            << "\nWarning: std::vector<L1MuGMTCand> with input tag "
-            << muGmtInputTag
-            << "\nrequested in configuration, but not found in the event.\n"
-            << std::endl;
+        edm::LogWarning("L1GlobalTrigger") << "\nWarning: std::vector<L1MuGMTCand> with input tag " << muGmtInputTag
+                                           << "\nrequested in configuration, but not found in the event.\n"
+                                           << std::endl;
       }
     } else {
-
       std::vector<L1MuGMTCand>::const_iterator itMuon;
       for (itMuon = muonData->begin(); itMuon != muonData->end(); itMuon++) {
         if ((*itMuon).bx() == iBxInEvent) {
-
           (*m_candL1Mu).push_back(&(*itMuon));
           // LogTrace("L1GlobalTrigger") << (*itMuon)
           //        << std::endl;
@@ -165,23 +155,28 @@ void L1GlobalTriggerGTL::receiveGmtObjectData(
 }
 
 // run GTL
-void L1GlobalTriggerGTL::run(
-    edm::Event &iEvent, const edm::EventSetup &evSetup,
-    const L1GlobalTriggerPSB *ptrGtPSB, const bool produceL1GtObjectMapRecord,
-    const int iBxInEvent, L1GlobalTriggerObjectMapRecord *gtObjectMapRecord,
-    const unsigned int numberPhysTriggers, const int nrL1Mu,
-    const int nrL1NoIsoEG, const int nrL1IsoEG, const int nrL1CenJet,
-    const int nrL1ForJet, const int nrL1TauJet, const int nrL1JetCounts,
-    const int ifMuEtaNumberBits, const int ifCaloEtaNumberBits) {
-
+void L1GlobalTriggerGTL::run(edm::Event &iEvent,
+                             const edm::EventSetup &evSetup,
+                             const L1GlobalTriggerPSB *ptrGtPSB,
+                             const bool produceL1GtObjectMapRecord,
+                             const int iBxInEvent,
+                             L1GlobalTriggerObjectMapRecord *gtObjectMapRecord,
+                             const unsigned int numberPhysTriggers,
+                             const int nrL1Mu,
+                             const int nrL1NoIsoEG,
+                             const int nrL1IsoEG,
+                             const int nrL1CenJet,
+                             const int nrL1ForJet,
+                             const int nrL1TauJet,
+                             const int nrL1JetCounts,
+                             const int ifMuEtaNumberBits,
+                             const int ifCaloEtaNumberBits) {
   // get / update the trigger menu from the EventSetup
   // local cache & check on cacheIdentifier
 
-  unsigned long long l1GtMenuCacheID =
-      evSetup.get<L1GtTriggerMenuRcd>().cacheIdentifier();
+  unsigned long long l1GtMenuCacheID = evSetup.get<L1GtTriggerMenuRcd>().cacheIdentifier();
 
   if (m_l1GtMenuCacheID != l1GtMenuCacheID) {
-
     edm::ESHandle<L1GtTriggerMenu> l1GtMenu;
     evSetup.get<L1GtTriggerMenuRcd>().get(l1GtMenu);
     m_l1GtMenu = l1GtMenu.product();
@@ -191,14 +186,11 @@ void L1GlobalTriggerGTL::run(
   const std::vector<ConditionMap> &conditionMap = m_l1GtMenu->gtConditionMap();
   const AlgorithmMap &algorithmMap = m_l1GtMenu->gtAlgorithmMap();
 
-  const std::vector<std::vector<L1GtMuonTemplate>> &corrMuon =
-      m_l1GtMenu->corMuonTemplate();
+  const std::vector<std::vector<L1GtMuonTemplate>> &corrMuon = m_l1GtMenu->corMuonTemplate();
 
-  const std::vector<std::vector<L1GtCaloTemplate>> &corrCalo =
-      m_l1GtMenu->corCaloTemplate();
+  const std::vector<std::vector<L1GtCaloTemplate>> &corrCalo = m_l1GtMenu->corCaloTemplate();
 
-  const std::vector<std::vector<L1GtEnergySumTemplate>> &corrEnergySum =
-      m_l1GtMenu->corEnergySumTemplate();
+  const std::vector<std::vector<L1GtEnergySumTemplate>> &corrEnergySum = m_l1GtMenu->corEnergySumTemplate();
 
   // conversion needed for correlation conditions
   // done in the condition loop when the first correlation template is in the
@@ -207,11 +199,9 @@ void L1GlobalTriggerGTL::run(
 
   // get / update the calorimeter geometry from the EventSetup
   // local cache & check on cacheIdentifier
-  unsigned long long l1CaloGeometryCacheID =
-      evSetup.get<L1CaloGeometryRecord>().cacheIdentifier();
+  unsigned long long l1CaloGeometryCacheID = evSetup.get<L1CaloGeometryRecord>().cacheIdentifier();
 
   if (m_l1CaloGeometryCacheID != l1CaloGeometryCacheID) {
-
     edm::ESHandle<L1CaloGeometry> l1CaloGeometry;
     evSetup.get<L1CaloGeometryRecord>().get(l1CaloGeometry);
     m_l1CaloGeometry = l1CaloGeometry.product();
@@ -222,11 +212,9 @@ void L1GlobalTriggerGTL::run(
 
   // get / update the eta and phi muon trigger scales from the EventSetup
   // local cache & check on cacheIdentifier
-  unsigned long long l1MuTriggerScalesCacheID =
-      evSetup.get<L1MuTriggerScalesRcd>().cacheIdentifier();
+  unsigned long long l1MuTriggerScalesCacheID = evSetup.get<L1MuTriggerScalesRcd>().cacheIdentifier();
 
   if (m_l1MuTriggerScalesCacheID != l1MuTriggerScalesCacheID) {
-
     edm::ESHandle<L1MuTriggerScales> l1MuTriggerScales;
     evSetup.get<L1MuTriggerScalesRcd>().get(l1MuTriggerScales);
     m_l1MuTriggerScales = l1MuTriggerScales.product();
@@ -238,8 +226,7 @@ void L1GlobalTriggerGTL::run(
   if (convertScale) {
     m_gtEtaPhiConversions->setVerbosity(m_verbosity);
     m_gtEtaPhiConversions->convertL1Scales(
-        m_l1CaloGeometry, m_l1MuTriggerScales, ifCaloEtaNumberBits,
-        ifMuEtaNumberBits);
+        m_l1CaloGeometry, m_l1MuTriggerScales, ifCaloEtaNumberBits, ifMuEtaNumberBits);
 
     // print the conversions if DEBUG and verbosity enabled
 
@@ -268,350 +255,332 @@ void L1GlobalTriggerGTL::run(
 
   int iChip = -1;
 
-  for (std::vector<ConditionMap>::const_iterator itCondOnChip =
-           conditionMap.begin();
-       itCondOnChip != conditionMap.end(); itCondOnChip++) {
-
+  for (std::vector<ConditionMap>::const_iterator itCondOnChip = conditionMap.begin();
+       itCondOnChip != conditionMap.end();
+       itCondOnChip++) {
     iChip++;
 
     // L1GtAlgorithmEvaluation::ConditionEvaluationMap cMapResults;
     // L1GtAlgorithmEvaluation::ConditionEvaluationMap
     // cMapResults((*itCondOnChip).size()); // hash map
-    L1GtAlgorithmEvaluation::ConditionEvaluationMap &cMapResults =
-        m_conditionResultMaps[iChip];
+    L1GtAlgorithmEvaluation::ConditionEvaluationMap &cMapResults = m_conditionResultMaps[iChip];
 
-    for (CItCond itCond = itCondOnChip->begin(); itCond != itCondOnChip->end();
-         itCond++) {
-
+    for (CItCond itCond = itCondOnChip->begin(); itCond != itCondOnChip->end(); itCond++) {
       // evaluate condition
       switch ((itCond->second)->condCategory()) {
-      case CondMuon: {
-
-        L1GtMuonCondition *muCondition = new L1GtMuonCondition(
-            itCond->second, this, nrL1Mu, ifMuEtaNumberBits);
-
-        muCondition->setVerbosity(m_verbosity);
-        muCondition->setGtCorrParDeltaPhiNrBins(
-            (m_gtEtaPhiConversions->gtObjectNrBinsPhi(Mu)) / 2 + 1);
-        muCondition->evaluateConditionStoreResult();
-
-        cMapResults[itCond->first] = muCondition;
-
-        if (m_verbosity && m_isDebugEnabled) {
-          std::ostringstream myCout;
-          muCondition->print(myCout);
-
-          LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
-        }
-
-        // delete muCondition;
-
-      } break;
-      case CondCalo: {
-
-        L1GtCaloCondition *caloCondition = new L1GtCaloCondition(
-            itCond->second, ptrGtPSB, nrL1NoIsoEG, nrL1IsoEG, nrL1CenJet,
-            nrL1ForJet, nrL1TauJet, ifCaloEtaNumberBits);
-
-        caloCondition->setVerbosity(m_verbosity);
-        caloCondition->setGtCorrParDeltaPhiNrBins(
-            (m_gtEtaPhiConversions->gtObjectNrBinsPhi(
-                ((itCond->second)->objectType())[0])) /
-                2 +
-            1);
-        caloCondition->evaluateConditionStoreResult();
-
-        cMapResults[itCond->first] = caloCondition;
-
-        if (m_verbosity && m_isDebugEnabled) {
-          std::ostringstream myCout;
-          caloCondition->print(myCout);
-
-          LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
-        }
-        //                    delete caloCondition;
-
-      } break;
-      case CondEnergySum: {
-        L1GtEnergySumCondition *eSumCondition =
-            new L1GtEnergySumCondition(itCond->second, ptrGtPSB);
-
-        eSumCondition->setVerbosity(m_verbosity);
-        eSumCondition->evaluateConditionStoreResult();
-
-        cMapResults[itCond->first] = eSumCondition;
-
-        if (m_verbosity && m_isDebugEnabled) {
-          std::ostringstream myCout;
-          eSumCondition->print(myCout);
-
-          LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
-        }
-        //                    delete eSumCondition;
-
-      } break;
-      case CondJetCounts: {
-        L1GtJetCountsCondition *jcCondition =
-            new L1GtJetCountsCondition(itCond->second, ptrGtPSB, nrL1JetCounts);
-
-        jcCondition->setVerbosity(m_verbosity);
-        jcCondition->evaluateConditionStoreResult();
-
-        cMapResults[itCond->first] = jcCondition;
-
-        if (m_verbosity && m_isDebugEnabled) {
-          std::ostringstream myCout;
-          jcCondition->print(myCout);
-
-          LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
-        }
-
-        //                  delete jcCondition;
-
-      } break;
-      case CondHfBitCounts: {
-        L1GtHfBitCountsCondition *bcCondition =
-            new L1GtHfBitCountsCondition(itCond->second, ptrGtPSB);
-
-        bcCondition->setVerbosity(m_verbosity);
-        bcCondition->evaluateConditionStoreResult();
-
-        cMapResults[itCond->first] = bcCondition;
-
-        if (m_isDebugEnabled) {
-          std::ostringstream myCout;
-          bcCondition->print(myCout);
-
-          LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
-        }
-
-        //                  delete bcCondition;
-
-      } break;
-      case CondHfRingEtSums: {
-        L1GtHfRingEtSumsCondition *etCondition =
-            new L1GtHfRingEtSumsCondition(itCond->second, ptrGtPSB);
-
-        etCondition->setVerbosity(m_verbosity);
-        etCondition->evaluateConditionStoreResult();
-
-        cMapResults[itCond->first] = etCondition;
-
-        if (m_verbosity && m_isDebugEnabled) {
-          std::ostringstream myCout;
-          etCondition->print(myCout);
-
-          LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
-        }
-
-        //                  delete etCondition;
-
-      } break;
-      case CondCastor: {
-        bool castorCondResult = false;
-
-        // FIXME need a solution to read CASTOR
-        // if (castorConditionFlag) {
-        //    castorCondResult = castorData->conditionResult(itCond->first);
-        //}
-
-        L1GtCastorCondition *castorCondition =
-            new L1GtCastorCondition(itCond->second, castorCondResult);
-
-        castorCondition->setVerbosity(m_verbosity);
-        castorCondition->evaluateConditionStoreResult();
-
-        cMapResults[itCond->first] = castorCondition;
-
-        if (m_verbosity && m_isDebugEnabled) {
-          std::ostringstream myCout;
-          castorCondition->print(myCout);
-
-          LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
-        }
-
-        //                  delete castorCondition;
-
-      } break;
-      case CondBptx: {
-        bool bptxCondResult = true;
-
-        // FIXME need a solution to read BPTX with real value
-
-        L1GtBptxCondition *bptxCondition =
-            new L1GtBptxCondition(itCond->second, bptxCondResult);
-
-        bptxCondition->setVerbosity(m_verbosity);
-        bptxCondition->evaluateConditionStoreResult();
-
-        cMapResults[itCond->first] = bptxCondition;
-
-        if (m_verbosity && m_isDebugEnabled) {
-          std::ostringstream myCout;
-          bptxCondition->print(myCout);
-
-          LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
-        }
-
-        //                  delete bptxCondition;
-
-      } break;
-      case CondExternal: {
-        bool externalCondResult = true;
-
-        // FIXME need a solution to read External with real value
-
-        L1GtExternalCondition *externalCondition =
-            new L1GtExternalCondition(itCond->second, externalCondResult);
-
-        externalCondition->setVerbosity(m_verbosity);
-        externalCondition->evaluateConditionStoreResult();
-
-        cMapResults[itCond->first] = externalCondition;
-
-        if (m_verbosity && m_isDebugEnabled) {
-          std::ostringstream myCout;
-          externalCondition->print(myCout);
-
-          LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
-        }
-
-        //                  delete externalCondition;
-
-      } break;
-      case CondCorrelation: {
-
-        // get first the sub-conditions
-        const L1GtCorrelationTemplate *corrTemplate =
-            static_cast<const L1GtCorrelationTemplate *>(itCond->second);
-        const L1GtConditionCategory cond0Categ = corrTemplate->cond0Category();
-        const L1GtConditionCategory cond1Categ = corrTemplate->cond1Category();
-        const int cond0Ind = corrTemplate->cond0Index();
-        const int cond1Ind = corrTemplate->cond1Index();
-
-        const L1GtCondition *cond0Condition = nullptr;
-        const L1GtCondition *cond1Condition = nullptr;
-
-        // maximum number of objects received for evaluation of Type1s condition
-        int cond0NrL1Objects = 0;
-        int cond1NrL1Objects = 0;
-
-        int cond0EtaBits = 0;
-        int cond1EtaBits = 0;
-
-        switch (cond0Categ) {
         case CondMuon: {
-          cond0Condition = &((corrMuon[iChip])[cond0Ind]);
-          cond0NrL1Objects = nrL1Mu;
-          cond0EtaBits = ifMuEtaNumberBits;
-        } break;
-        case CondCalo: {
-          cond0Condition = &((corrCalo[iChip])[cond0Ind]);
+          L1GtMuonCondition *muCondition = new L1GtMuonCondition(itCond->second, this, nrL1Mu, ifMuEtaNumberBits);
 
-          switch ((cond0Condition->objectType())[0]) {
-          case NoIsoEG:
-            cond0NrL1Objects = nrL1NoIsoEG;
-            break;
-          case IsoEG:
-            cond0NrL1Objects = nrL1IsoEG;
-            break;
-          case CenJet:
-            cond0NrL1Objects = nrL1CenJet;
-            break;
-          case ForJet:
-            cond0NrL1Objects = nrL1ForJet;
-            break;
-          case TauJet:
-            cond0NrL1Objects = nrL1TauJet;
-            break;
-          default:
-            cond0NrL1Objects = 0;
-            break;
+          muCondition->setVerbosity(m_verbosity);
+          muCondition->setGtCorrParDeltaPhiNrBins((m_gtEtaPhiConversions->gtObjectNrBinsPhi(Mu)) / 2 + 1);
+          muCondition->evaluateConditionStoreResult();
+
+          cMapResults[itCond->first] = muCondition;
+
+          if (m_verbosity && m_isDebugEnabled) {
+            std::ostringstream myCout;
+            muCondition->print(myCout);
+
+            LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
           }
 
-          cond0EtaBits = ifCaloEtaNumberBits;
-        } break;
-        case CondEnergySum: {
-          cond0Condition = &((corrEnergySum[iChip])[cond0Ind]);
-          cond0NrL1Objects = 1;
-        } break;
-        default: {
-          // do nothing, should not arrive here
-        } break;
-        }
+          // delete muCondition;
 
-        switch (cond1Categ) {
-        case CondMuon: {
-          cond1Condition = &((corrMuon[iChip])[cond1Ind]);
-          cond1NrL1Objects = nrL1Mu;
-          cond1EtaBits = ifMuEtaNumberBits;
         } break;
         case CondCalo: {
-          cond1Condition = &((corrCalo[iChip])[cond1Ind]);
+          L1GtCaloCondition *caloCondition = new L1GtCaloCondition(
+              itCond->second, ptrGtPSB, nrL1NoIsoEG, nrL1IsoEG, nrL1CenJet, nrL1ForJet, nrL1TauJet, ifCaloEtaNumberBits);
 
-          switch ((cond1Condition->objectType())[0]) {
-          case NoIsoEG:
-            cond1NrL1Objects = nrL1NoIsoEG;
-            break;
-          case IsoEG:
-            cond1NrL1Objects = nrL1IsoEG;
-            break;
-          case CenJet:
-            cond1NrL1Objects = nrL1CenJet;
-            break;
-          case ForJet:
-            cond1NrL1Objects = nrL1ForJet;
-            break;
-          case TauJet:
-            cond1NrL1Objects = nrL1TauJet;
-            break;
-          default:
-            cond1NrL1Objects = 0;
-            break;
+          caloCondition->setVerbosity(m_verbosity);
+          caloCondition->setGtCorrParDeltaPhiNrBins(
+              (m_gtEtaPhiConversions->gtObjectNrBinsPhi(((itCond->second)->objectType())[0])) / 2 + 1);
+          caloCondition->evaluateConditionStoreResult();
+
+          cMapResults[itCond->first] = caloCondition;
+
+          if (m_verbosity && m_isDebugEnabled) {
+            std::ostringstream myCout;
+            caloCondition->print(myCout);
+
+            LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
           }
+          //                    delete caloCondition;
 
-          cond1EtaBits = ifCaloEtaNumberBits;
         } break;
         case CondEnergySum: {
-          cond1Condition = &((corrEnergySum[iChip])[cond1Ind]);
-          cond1NrL1Objects = 1;
+          L1GtEnergySumCondition *eSumCondition = new L1GtEnergySumCondition(itCond->second, ptrGtPSB);
+
+          eSumCondition->setVerbosity(m_verbosity);
+          eSumCondition->evaluateConditionStoreResult();
+
+          cMapResults[itCond->first] = eSumCondition;
+
+          if (m_verbosity && m_isDebugEnabled) {
+            std::ostringstream myCout;
+            eSumCondition->print(myCout);
+
+            LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
+          }
+          //                    delete eSumCondition;
+
+        } break;
+        case CondJetCounts: {
+          L1GtJetCountsCondition *jcCondition = new L1GtJetCountsCondition(itCond->second, ptrGtPSB, nrL1JetCounts);
+
+          jcCondition->setVerbosity(m_verbosity);
+          jcCondition->evaluateConditionStoreResult();
+
+          cMapResults[itCond->first] = jcCondition;
+
+          if (m_verbosity && m_isDebugEnabled) {
+            std::ostringstream myCout;
+            jcCondition->print(myCout);
+
+            LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
+          }
+
+          //                  delete jcCondition;
+
+        } break;
+        case CondHfBitCounts: {
+          L1GtHfBitCountsCondition *bcCondition = new L1GtHfBitCountsCondition(itCond->second, ptrGtPSB);
+
+          bcCondition->setVerbosity(m_verbosity);
+          bcCondition->evaluateConditionStoreResult();
+
+          cMapResults[itCond->first] = bcCondition;
+
+          if (m_isDebugEnabled) {
+            std::ostringstream myCout;
+            bcCondition->print(myCout);
+
+            LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
+          }
+
+          //                  delete bcCondition;
+
+        } break;
+        case CondHfRingEtSums: {
+          L1GtHfRingEtSumsCondition *etCondition = new L1GtHfRingEtSumsCondition(itCond->second, ptrGtPSB);
+
+          etCondition->setVerbosity(m_verbosity);
+          etCondition->evaluateConditionStoreResult();
+
+          cMapResults[itCond->first] = etCondition;
+
+          if (m_verbosity && m_isDebugEnabled) {
+            std::ostringstream myCout;
+            etCondition->print(myCout);
+
+            LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
+          }
+
+          //                  delete etCondition;
+
+        } break;
+        case CondCastor: {
+          bool castorCondResult = false;
+
+          // FIXME need a solution to read CASTOR
+          // if (castorConditionFlag) {
+          //    castorCondResult = castorData->conditionResult(itCond->first);
+          //}
+
+          L1GtCastorCondition *castorCondition = new L1GtCastorCondition(itCond->second, castorCondResult);
+
+          castorCondition->setVerbosity(m_verbosity);
+          castorCondition->evaluateConditionStoreResult();
+
+          cMapResults[itCond->first] = castorCondition;
+
+          if (m_verbosity && m_isDebugEnabled) {
+            std::ostringstream myCout;
+            castorCondition->print(myCout);
+
+            LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
+          }
+
+          //                  delete castorCondition;
+
+        } break;
+        case CondBptx: {
+          bool bptxCondResult = true;
+
+          // FIXME need a solution to read BPTX with real value
+
+          L1GtBptxCondition *bptxCondition = new L1GtBptxCondition(itCond->second, bptxCondResult);
+
+          bptxCondition->setVerbosity(m_verbosity);
+          bptxCondition->evaluateConditionStoreResult();
+
+          cMapResults[itCond->first] = bptxCondition;
+
+          if (m_verbosity && m_isDebugEnabled) {
+            std::ostringstream myCout;
+            bptxCondition->print(myCout);
+
+            LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
+          }
+
+          //                  delete bptxCondition;
+
+        } break;
+        case CondExternal: {
+          bool externalCondResult = true;
+
+          // FIXME need a solution to read External with real value
+
+          L1GtExternalCondition *externalCondition = new L1GtExternalCondition(itCond->second, externalCondResult);
+
+          externalCondition->setVerbosity(m_verbosity);
+          externalCondition->evaluateConditionStoreResult();
+
+          cMapResults[itCond->first] = externalCondition;
+
+          if (m_verbosity && m_isDebugEnabled) {
+            std::ostringstream myCout;
+            externalCondition->print(myCout);
+
+            LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
+          }
+
+          //                  delete externalCondition;
+
+        } break;
+        case CondCorrelation: {
+          // get first the sub-conditions
+          const L1GtCorrelationTemplate *corrTemplate = static_cast<const L1GtCorrelationTemplate *>(itCond->second);
+          const L1GtConditionCategory cond0Categ = corrTemplate->cond0Category();
+          const L1GtConditionCategory cond1Categ = corrTemplate->cond1Category();
+          const int cond0Ind = corrTemplate->cond0Index();
+          const int cond1Ind = corrTemplate->cond1Index();
+
+          const L1GtCondition *cond0Condition = nullptr;
+          const L1GtCondition *cond1Condition = nullptr;
+
+          // maximum number of objects received for evaluation of Type1s condition
+          int cond0NrL1Objects = 0;
+          int cond1NrL1Objects = 0;
+
+          int cond0EtaBits = 0;
+          int cond1EtaBits = 0;
+
+          switch (cond0Categ) {
+            case CondMuon: {
+              cond0Condition = &((corrMuon[iChip])[cond0Ind]);
+              cond0NrL1Objects = nrL1Mu;
+              cond0EtaBits = ifMuEtaNumberBits;
+            } break;
+            case CondCalo: {
+              cond0Condition = &((corrCalo[iChip])[cond0Ind]);
+
+              switch ((cond0Condition->objectType())[0]) {
+                case NoIsoEG:
+                  cond0NrL1Objects = nrL1NoIsoEG;
+                  break;
+                case IsoEG:
+                  cond0NrL1Objects = nrL1IsoEG;
+                  break;
+                case CenJet:
+                  cond0NrL1Objects = nrL1CenJet;
+                  break;
+                case ForJet:
+                  cond0NrL1Objects = nrL1ForJet;
+                  break;
+                case TauJet:
+                  cond0NrL1Objects = nrL1TauJet;
+                  break;
+                default:
+                  cond0NrL1Objects = 0;
+                  break;
+              }
+
+              cond0EtaBits = ifCaloEtaNumberBits;
+            } break;
+            case CondEnergySum: {
+              cond0Condition = &((corrEnergySum[iChip])[cond0Ind]);
+              cond0NrL1Objects = 1;
+            } break;
+            default: {
+              // do nothing, should not arrive here
+            } break;
+          }
+
+          switch (cond1Categ) {
+            case CondMuon: {
+              cond1Condition = &((corrMuon[iChip])[cond1Ind]);
+              cond1NrL1Objects = nrL1Mu;
+              cond1EtaBits = ifMuEtaNumberBits;
+            } break;
+            case CondCalo: {
+              cond1Condition = &((corrCalo[iChip])[cond1Ind]);
+
+              switch ((cond1Condition->objectType())[0]) {
+                case NoIsoEG:
+                  cond1NrL1Objects = nrL1NoIsoEG;
+                  break;
+                case IsoEG:
+                  cond1NrL1Objects = nrL1IsoEG;
+                  break;
+                case CenJet:
+                  cond1NrL1Objects = nrL1CenJet;
+                  break;
+                case ForJet:
+                  cond1NrL1Objects = nrL1ForJet;
+                  break;
+                case TauJet:
+                  cond1NrL1Objects = nrL1TauJet;
+                  break;
+                default:
+                  cond1NrL1Objects = 0;
+                  break;
+              }
+
+              cond1EtaBits = ifCaloEtaNumberBits;
+            } break;
+            case CondEnergySum: {
+              cond1Condition = &((corrEnergySum[iChip])[cond1Ind]);
+              cond1NrL1Objects = 1;
+            } break;
+            default: {
+              // do nothing, should not arrive here
+            } break;
+          }
+
+          L1GtCorrelationCondition *correlationCond = new L1GtCorrelationCondition(itCond->second,
+                                                                                   cond0Condition,
+                                                                                   cond1Condition,
+                                                                                   cond0NrL1Objects,
+                                                                                   cond1NrL1Objects,
+                                                                                   cond0EtaBits,
+                                                                                   cond1EtaBits,
+                                                                                   this,
+                                                                                   ptrGtPSB,
+                                                                                   m_gtEtaPhiConversions);
+
+          correlationCond->setVerbosity(m_verbosity);
+          correlationCond->evaluateConditionStoreResult();
+
+          cMapResults[itCond->first] = correlationCond;
+
+          if (m_verbosity && m_isDebugEnabled) {
+            std::ostringstream myCout;
+            correlationCond->print(myCout);
+
+            LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
+          }
+
+          //                  delete correlationCond;
+
+        } break;
+        case CondNull: {
+          // do nothing
+
         } break;
         default: {
-          // do nothing, should not arrive here
+          // do nothing
+
         } break;
-        }
-
-        L1GtCorrelationCondition *correlationCond =
-            new L1GtCorrelationCondition(
-                itCond->second, cond0Condition, cond1Condition,
-                cond0NrL1Objects, cond1NrL1Objects, cond0EtaBits, cond1EtaBits,
-                this, ptrGtPSB, m_gtEtaPhiConversions);
-
-        correlationCond->setVerbosity(m_verbosity);
-        correlationCond->evaluateConditionStoreResult();
-
-        cMapResults[itCond->first] = correlationCond;
-
-        if (m_verbosity && m_isDebugEnabled) {
-          std::ostringstream myCout;
-          correlationCond->print(myCout);
-
-          LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
-        }
-
-        //                  delete correlationCond;
-
-      } break;
-      case CondNull: {
-
-        // do nothing
-
-      } break;
-      default: {
-
-        // do nothing
-
-      } break;
       }
     }
   }
@@ -623,12 +592,9 @@ void L1GlobalTriggerGTL::run(
   if (produceL1GtObjectMapRecord && (iBxInEvent == 0))
     objMapVec.reserve(numberPhysTriggers);
 
-  for (CItAlgo itAlgo = algorithmMap.begin(); itAlgo != algorithmMap.end();
-       itAlgo++) {
-
+  for (CItAlgo itAlgo = algorithmMap.begin(); itAlgo != algorithmMap.end(); itAlgo++) {
     L1GtAlgorithmEvaluation gtAlg(itAlgo->second);
-    gtAlg.evaluateAlgorithm((itAlgo->second).algoChipNumber(),
-                            m_conditionResultMaps);
+    gtAlg.evaluateAlgorithm((itAlgo->second).algoChipNumber(), m_conditionResultMaps);
 
     int algBitNumber = (itAlgo->second).algoBitNumber();
     bool algResult = gtAlg.gtAlgoResult();
@@ -647,7 +613,6 @@ void L1GlobalTriggerGTL::run(
 
     // object maps only for BxInEvent = 0
     if (produceL1GtObjectMapRecord && (iBxInEvent == 0)) {
-
       // set object map
       L1GlobalTriggerObjectMap objMap;
 
@@ -678,13 +643,11 @@ void L1GlobalTriggerGTL::run(
   // then loop over conditions in the map
   // delete the conditions created with new, zero pointer, do not clear map,
   // keep the vector as is...
-  for (std::vector<L1GtAlgorithmEvaluation::ConditionEvaluationMap>::iterator
-           itCondOnChip = m_conditionResultMaps.begin();
-       itCondOnChip != m_conditionResultMaps.end(); itCondOnChip++) {
-
-    for (L1GtAlgorithmEvaluation::ItEvalMap itCond = itCondOnChip->begin();
-         itCond != itCondOnChip->end(); itCond++) {
-
+  for (std::vector<L1GtAlgorithmEvaluation::ConditionEvaluationMap>::iterator itCondOnChip =
+           m_conditionResultMaps.begin();
+       itCondOnChip != m_conditionResultMaps.end();
+       itCondOnChip++) {
+    for (L1GtAlgorithmEvaluation::ItEvalMap itCond = itCondOnChip->begin(); itCond != itCondOnChip->end(); itCond++) {
       delete itCond->second;
       itCond->second = nullptr;
     }
@@ -693,7 +656,6 @@ void L1GlobalTriggerGTL::run(
 
 // clear GTL
 void L1GlobalTriggerGTL::reset() {
-
   m_candL1Mu->clear();
 
   m_gtlDecisionWord.reset();
@@ -702,19 +664,12 @@ void L1GlobalTriggerGTL::reset() {
 
 // print Global Muon Trigger data received by GTL
 void L1GlobalTriggerGTL::printGmtData(const int iBxInEvent) const {
-
-  LogTrace("L1GlobalTrigger")
-      << "\nL1GlobalTrigger: GMT data received for BxInEvent = " << iBxInEvent
-      << std::endl;
+  LogTrace("L1GlobalTrigger") << "\nL1GlobalTrigger: GMT data received for BxInEvent = " << iBxInEvent << std::endl;
 
   int nrL1Mu = m_candL1Mu->size();
-  LogTrace("L1GlobalTrigger") << "Number of GMT muons = " << nrL1Mu << "\n"
-                              << std::endl;
+  LogTrace("L1GlobalTrigger") << "Number of GMT muons = " << nrL1Mu << "\n" << std::endl;
 
-  for (std::vector<const L1MuGMTCand *>::const_iterator iter =
-           m_candL1Mu->begin();
-       iter != m_candL1Mu->end(); iter++) {
-
+  for (std::vector<const L1MuGMTCand *>::const_iterator iter = m_candL1Mu->begin(); iter != m_candL1Mu->end(); iter++) {
     LogTrace("L1GlobalTrigger") << *(*iter) << std::endl;
   }
 

--- a/L1Trigger/GlobalTrigger/src/L1GlobalTriggerPSB.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GlobalTriggerPSB.cc
@@ -46,30 +46,29 @@
 // forward declarations
 
 // constructor
-L1GlobalTriggerPSB::L1GlobalTriggerPSB(
-    const edm::InputTag &m_caloGctInputTag,
-    const std::vector<edm::InputTag> &m_technicalTriggersInputTags,
-    edm::ConsumesCollector &&iC)
+L1GlobalTriggerPSB::L1GlobalTriggerPSB(const edm::InputTag &m_caloGctInputTag,
+                                       const std::vector<edm::InputTag> &m_technicalTriggersInputTags,
+                                       edm::ConsumesCollector &&iC)
     : m_candL1NoIsoEG(new std::vector<const L1GctCand *>),
       m_candL1IsoEG(new std::vector<const L1GctCand *>),
       m_candL1CenJet(new std::vector<const L1GctCand *>),
       m_candL1ForJet(new std::vector<const L1GctCand *>),
-      m_candL1TauJet(new std::vector<const L1GctCand *>), m_candETM(nullptr),
-      m_candETT(nullptr), m_candHTT(nullptr), m_candHTM(nullptr),
-      m_candJetCounts(nullptr), m_candHfBitCounts(nullptr),
-      m_candHfRingEtSums(nullptr), m_isDebugEnabled(edm::isDebugEnabled())
+      m_candL1TauJet(new std::vector<const L1GctCand *>),
+      m_candETM(nullptr),
+      m_candETT(nullptr),
+      m_candHTT(nullptr),
+      m_candHTM(nullptr),
+      m_candJetCounts(nullptr),
+      m_candHfBitCounts(nullptr),
+      m_candHfRingEtSums(nullptr),
+      m_isDebugEnabled(edm::isDebugEnabled())
 
 {
-  iC.consumes<L1GctEmCandCollection>(
-      edm::InputTag(m_caloGctInputTag.label(), "nonIsoEm", ""));
-  iC.consumes<L1GctEmCandCollection>(
-      edm::InputTag(m_caloGctInputTag.label(), "isoEm", ""));
-  iC.consumes<L1GctJetCandCollection>(
-      edm::InputTag(m_caloGctInputTag.label(), "cenJets", ""));
-  iC.consumes<L1GctJetCandCollection>(
-      edm::InputTag(m_caloGctInputTag.label(), "forJets", ""));
-  iC.consumes<L1GctJetCandCollection>(
-      edm::InputTag(m_caloGctInputTag.label(), "tauJets", ""));
+  iC.consumes<L1GctEmCandCollection>(edm::InputTag(m_caloGctInputTag.label(), "nonIsoEm", ""));
+  iC.consumes<L1GctEmCandCollection>(edm::InputTag(m_caloGctInputTag.label(), "isoEm", ""));
+  iC.consumes<L1GctJetCandCollection>(edm::InputTag(m_caloGctInputTag.label(), "cenJets", ""));
+  iC.consumes<L1GctJetCandCollection>(edm::InputTag(m_caloGctInputTag.label(), "forJets", ""));
+  iC.consumes<L1GctJetCandCollection>(edm::InputTag(m_caloGctInputTag.label(), "tauJets", ""));
   iC.consumes<L1GctEtMissCollection>(m_caloGctInputTag);
   iC.consumes<L1GctEtTotalCollection>(m_caloGctInputTag);
   iC.consumes<L1GctEtHadCollection>(m_caloGctInputTag);
@@ -78,9 +77,9 @@ L1GlobalTriggerPSB::L1GlobalTriggerPSB(
   iC.consumes<L1GctHFBitCountsCollection>(m_caloGctInputTag);
   iC.consumes<L1GctHFRingEtSumsCollection>(m_caloGctInputTag);
 
-  for (std::vector<edm::InputTag>::const_iterator it =
-           m_technicalTriggersInputTags.begin();
-       it != m_technicalTriggersInputTags.end(); it++) {
+  for (std::vector<edm::InputTag>::const_iterator it = m_technicalTriggersInputTags.begin();
+       it != m_technicalTriggersInputTags.end();
+       it++) {
     iC.consumes<L1GtTechnicalTriggerRecord>((*it));
   }
   // empty
@@ -88,7 +87,6 @@ L1GlobalTriggerPSB::L1GlobalTriggerPSB(
 
 // destructor
 L1GlobalTriggerPSB::~L1GlobalTriggerPSB() {
-
   reset();
 
   delete m_candL1NoIsoEG;
@@ -99,11 +97,12 @@ L1GlobalTriggerPSB::~L1GlobalTriggerPSB() {
 }
 
 // operations
-void L1GlobalTriggerPSB::init(const int nrL1NoIsoEG, const int nrL1IsoEG,
-                              const int nrL1CenJet, const int nrL1ForJet,
+void L1GlobalTriggerPSB::init(const int nrL1NoIsoEG,
+                              const int nrL1IsoEG,
+                              const int nrL1CenJet,
+                              const int nrL1ForJet,
                               const int nrL1TauJet,
                               const int numberTechnicalTriggers) {
-
   m_candL1NoIsoEG->reserve(nrL1NoIsoEG);
   m_candL1IsoEG->reserve(nrL1IsoEG);
   m_candL1CenJet->reserve(nrL1CenJet);
@@ -116,16 +115,26 @@ void L1GlobalTriggerPSB::init(const int nrL1NoIsoEG, const int nrL1IsoEG,
 
 // receive input data
 
-void L1GlobalTriggerPSB::receiveGctObjectData(
-    edm::Event &iEvent, const edm::InputTag &caloGctInputTag,
-    const int iBxInEvent, const bool receiveNoIsoEG, const int nrL1NoIsoEG,
-    const bool receiveIsoEG, const int nrL1IsoEG, const bool receiveCenJet,
-    const int nrL1CenJet, const bool receiveForJet, const int nrL1ForJet,
-    const bool receiveTauJet, const int nrL1TauJet, const bool receiveETM,
-    const bool receiveETT, const bool receiveHTT, const bool receiveHTM,
-    const bool receiveJetCounts, const bool receiveHfBitCounts,
-    const bool receiveHfRingEtSums) {
-
+void L1GlobalTriggerPSB::receiveGctObjectData(edm::Event &iEvent,
+                                              const edm::InputTag &caloGctInputTag,
+                                              const int iBxInEvent,
+                                              const bool receiveNoIsoEG,
+                                              const int nrL1NoIsoEG,
+                                              const bool receiveIsoEG,
+                                              const int nrL1IsoEG,
+                                              const bool receiveCenJet,
+                                              const int nrL1CenJet,
+                                              const bool receiveForJet,
+                                              const int nrL1ForJet,
+                                              const bool receiveTauJet,
+                                              const int nrL1TauJet,
+                                              const bool receiveETM,
+                                              const bool receiveETT,
+                                              const bool receiveHTT,
+                                              const bool receiveHTM,
+                                              const bool receiveJetCounts,
+                                              const bool receiveHfBitCounts,
+                                              const bool receiveHfRingEtSums) {
   // LogDebug("L1GlobalTrigger")
   //        << "\n**** L1GlobalTriggerPSB receiving calorimeter data for
   //        BxInEvent = "
@@ -138,26 +147,20 @@ void L1GlobalTriggerPSB::receiveGctObjectData(
   bool warningEnabled = edm::isWarningEnabled();
 
   if (receiveNoIsoEG) {
-
     // get GCT NoIsoEG
     edm::Handle<L1GctEmCandCollection> emCands;
     iEvent.getByLabel(caloGctInputTag.label(), "nonIsoEm", emCands);
 
     if (!emCands.isValid()) {
       if (warningEnabled) {
-        warningsStream
-            << "\nWarning: L1GctEmCandCollection with input label "
-            << caloGctInputTag.label() << " and instance \"nonIsoEm\" \n"
-            << "requested in configuration, but not found in the event.\n"
-            << std::endl;
+        warningsStream << "\nWarning: L1GctEmCandCollection with input label " << caloGctInputTag.label()
+                       << " and instance \"nonIsoEm\" \n"
+                       << "requested in configuration, but not found in the event.\n"
+                       << std::endl;
       }
     } else {
-
-      for (L1GctEmCandCollection::const_iterator it = emCands->begin();
-           it != emCands->end(); it++) {
-
+      for (L1GctEmCandCollection::const_iterator it = emCands->begin(); it != emCands->end(); it++) {
         if ((*it).bx() == iBxInEvent) {
-
           (*m_candL1NoIsoEG).push_back(&(*it));
           // LogTrace("L1GlobalTrigger") << "NoIsoEG:  " << (*it) << std::endl;
         }
@@ -166,26 +169,20 @@ void L1GlobalTriggerPSB::receiveGctObjectData(
   }
 
   if (receiveIsoEG) {
-
     // get GCT IsoEG
     edm::Handle<L1GctEmCandCollection> isoEmCands;
     iEvent.getByLabel(caloGctInputTag.label(), "isoEm", isoEmCands);
 
     if (!isoEmCands.isValid()) {
       if (warningEnabled) {
-        warningsStream
-            << "\nWarning: L1GctEmCandCollection with input label "
-            << caloGctInputTag.label() << " and instance \"isoEm\" \n"
-            << "requested in configuration, but not found in the event.\n"
-            << std::endl;
+        warningsStream << "\nWarning: L1GctEmCandCollection with input label " << caloGctInputTag.label()
+                       << " and instance \"isoEm\" \n"
+                       << "requested in configuration, but not found in the event.\n"
+                       << std::endl;
       }
     } else {
-
-      for (L1GctEmCandCollection::const_iterator it = isoEmCands->begin();
-           it != isoEmCands->end(); it++) {
-
+      for (L1GctEmCandCollection::const_iterator it = isoEmCands->begin(); it != isoEmCands->end(); it++) {
         if ((*it).bx() == iBxInEvent) {
-
           (*m_candL1IsoEG).push_back(&(*it));
           // LogTrace("L1GlobalTrigger") << "IsoEG:    " <<  (*it) << std::endl;
         }
@@ -194,26 +191,20 @@ void L1GlobalTriggerPSB::receiveGctObjectData(
   }
 
   if (receiveCenJet) {
-
     // get GCT CenJet
     edm::Handle<L1GctJetCandCollection> cenJets;
     iEvent.getByLabel(caloGctInputTag.label(), "cenJets", cenJets);
 
     if (!cenJets.isValid()) {
       if (warningEnabled) {
-        warningsStream
-            << "\nWarning: L1GctJetCandCollection with input label "
-            << caloGctInputTag.label() << " and instance \"cenJets\" \n"
-            << "requested in configuration, but not found in the event.\n"
-            << std::endl;
+        warningsStream << "\nWarning: L1GctJetCandCollection with input label " << caloGctInputTag.label()
+                       << " and instance \"cenJets\" \n"
+                       << "requested in configuration, but not found in the event.\n"
+                       << std::endl;
       }
     } else {
-
-      for (L1GctJetCandCollection::const_iterator it = cenJets->begin();
-           it != cenJets->end(); it++) {
-
+      for (L1GctJetCandCollection::const_iterator it = cenJets->begin(); it != cenJets->end(); it++) {
         if ((*it).bx() == iBxInEvent) {
-
           (*m_candL1CenJet).push_back(&(*it));
           // LogTrace("L1GlobalTrigger") << "CenJet    " <<  (*it) << std::endl;
         }
@@ -222,26 +213,20 @@ void L1GlobalTriggerPSB::receiveGctObjectData(
   }
 
   if (receiveForJet) {
-
     // get GCT ForJet
     edm::Handle<L1GctJetCandCollection> forJets;
     iEvent.getByLabel(caloGctInputTag.label(), "forJets", forJets);
 
     if (!forJets.isValid()) {
       if (warningEnabled) {
-        warningsStream
-            << "\nWarning: L1GctJetCandCollection with input label "
-            << caloGctInputTag.label() << " and instance \"forJets\" \n"
-            << "requested in configuration, but not found in the event.\n"
-            << std::endl;
+        warningsStream << "\nWarning: L1GctJetCandCollection with input label " << caloGctInputTag.label()
+                       << " and instance \"forJets\" \n"
+                       << "requested in configuration, but not found in the event.\n"
+                       << std::endl;
       }
     } else {
-
-      for (L1GctJetCandCollection::const_iterator it = forJets->begin();
-           it != forJets->end(); it++) {
-
+      for (L1GctJetCandCollection::const_iterator it = forJets->begin(); it != forJets->end(); it++) {
         if ((*it).bx() == iBxInEvent) {
-
           (*m_candL1ForJet).push_back(&(*it));
           // LogTrace("L1GlobalTrigger") << "ForJet    " <<  (*it) << std::endl;
         }
@@ -250,26 +235,20 @@ void L1GlobalTriggerPSB::receiveGctObjectData(
   }
 
   if (receiveTauJet) {
-
     // get GCT TauJet
     edm::Handle<L1GctJetCandCollection> tauJets;
     iEvent.getByLabel(caloGctInputTag.label(), "tauJets", tauJets);
 
     if (!tauJets.isValid()) {
       if (warningEnabled) {
-        warningsStream
-            << "\nWarning: L1GctJetCandCollection with input label "
-            << caloGctInputTag.label() << " and instance \"tauJets\" \n"
-            << "requested in configuration, but not found in the event.\n"
-            << std::endl;
+        warningsStream << "\nWarning: L1GctJetCandCollection with input label " << caloGctInputTag.label()
+                       << " and instance \"tauJets\" \n"
+                       << "requested in configuration, but not found in the event.\n"
+                       << std::endl;
       }
     } else {
-
-      for (L1GctJetCandCollection::const_iterator it = tauJets->begin();
-           it != tauJets->end(); it++) {
-
+      for (L1GctJetCandCollection::const_iterator it = tauJets->begin(); it != tauJets->end(); it++) {
         if ((*it).bx() == iBxInEvent) {
-
           (*m_candL1TauJet).push_back(&(*it));
           // LogTrace("L1GlobalTrigger") << "TauJet    " <<  (*it) << std::endl;
         }
@@ -279,25 +258,18 @@ void L1GlobalTriggerPSB::receiveGctObjectData(
 
   // get GCT ETM
   if (receiveETM) {
-
     edm::Handle<L1GctEtMissCollection> missEtColl;
     iEvent.getByLabel(caloGctInputTag, missEtColl);
 
     if (!missEtColl.isValid()) {
       if (warningEnabled) {
-        warningsStream
-            << "\nWarning: L1GctEtMissCollection with input tag "
-            << caloGctInputTag
-            << "\nrequested in configuration, but not found in the event.\n"
-            << std::endl;
+        warningsStream << "\nWarning: L1GctEtMissCollection with input tag " << caloGctInputTag
+                       << "\nrequested in configuration, but not found in the event.\n"
+                       << std::endl;
       }
     } else {
-
-      for (L1GctEtMissCollection::const_iterator it = missEtColl->begin();
-           it != missEtColl->end(); it++) {
-
+      for (L1GctEtMissCollection::const_iterator it = missEtColl->begin(); it != missEtColl->end(); it++) {
         if ((*it).bx() == iBxInEvent) {
-
           m_candETM = &(*it);
           // LogTrace("L1GlobalTrigger") << "ETM      " << (*it) << std::endl;
         }
@@ -307,25 +279,18 @@ void L1GlobalTriggerPSB::receiveGctObjectData(
 
   // get GCT ETT
   if (receiveETT) {
-
     edm::Handle<L1GctEtTotalCollection> sumEtColl;
     iEvent.getByLabel(caloGctInputTag, sumEtColl);
 
     if (!sumEtColl.isValid()) {
       if (warningEnabled) {
-        warningsStream
-            << "\nWarning: L1GctEtTotalCollection with input tag "
-            << caloGctInputTag
-            << "\nrequested in configuration, but not found in the event.\n"
-            << std::endl;
+        warningsStream << "\nWarning: L1GctEtTotalCollection with input tag " << caloGctInputTag
+                       << "\nrequested in configuration, but not found in the event.\n"
+                       << std::endl;
       }
     } else {
-
-      for (L1GctEtTotalCollection::const_iterator it = sumEtColl->begin();
-           it != sumEtColl->end(); it++) {
-
+      for (L1GctEtTotalCollection::const_iterator it = sumEtColl->begin(); it != sumEtColl->end(); it++) {
         if ((*it).bx() == iBxInEvent) {
-
           m_candETT = &(*it);
           // LogTrace("L1GlobalTrigger") << "ETT      " << (*it) << std::endl;
         }
@@ -335,25 +300,18 @@ void L1GlobalTriggerPSB::receiveGctObjectData(
 
   // get GCT HTT
   if (receiveHTT) {
-
     edm::Handle<L1GctEtHadCollection> sumHtColl;
     iEvent.getByLabel(caloGctInputTag, sumHtColl);
 
     if (!sumHtColl.isValid()) {
       if (warningEnabled) {
-        warningsStream
-            << "\nWarning: L1GctEtHadCollection with input tag "
-            << caloGctInputTag
-            << "\nrequested in configuration, but not found in the event.\n"
-            << std::endl;
+        warningsStream << "\nWarning: L1GctEtHadCollection with input tag " << caloGctInputTag
+                       << "\nrequested in configuration, but not found in the event.\n"
+                       << std::endl;
       }
     } else {
-
-      for (L1GctEtHadCollection::const_iterator it = sumHtColl->begin();
-           it != sumHtColl->end(); it++) {
-
+      for (L1GctEtHadCollection::const_iterator it = sumHtColl->begin(); it != sumHtColl->end(); it++) {
         if ((*it).bx() == iBxInEvent) {
-
           m_candHTT = &(*it);
           // LogTrace("L1GlobalTrigger") << "HTT      "  << (*it) << std::endl;
         }
@@ -363,25 +321,18 @@ void L1GlobalTriggerPSB::receiveGctObjectData(
 
   // get GCT HTM
   if (receiveHTM) {
-
     edm::Handle<L1GctHtMissCollection> missHtColl;
     iEvent.getByLabel(caloGctInputTag, missHtColl);
 
     if (!missHtColl.isValid()) {
       if (warningEnabled) {
-        warningsStream
-            << "\nWarning: L1GctHtMissCollection with input tag "
-            << caloGctInputTag
-            << "\nrequested in configuration, but not found in the event.\n"
-            << std::endl;
+        warningsStream << "\nWarning: L1GctHtMissCollection with input tag " << caloGctInputTag
+                       << "\nrequested in configuration, but not found in the event.\n"
+                       << std::endl;
       }
     } else {
-
-      for (L1GctHtMissCollection::const_iterator it = missHtColl->begin();
-           it != missHtColl->end(); it++) {
-
+      for (L1GctHtMissCollection::const_iterator it = missHtColl->begin(); it != missHtColl->end(); it++) {
         if ((*it).bx() == iBxInEvent) {
-
           m_candHTM = &(*it);
           // LogTrace("L1GlobalTrigger") << "HTM      " << (*it) << std::endl;
         }
@@ -391,25 +342,18 @@ void L1GlobalTriggerPSB::receiveGctObjectData(
 
   // get GCT JetCounts
   if (receiveJetCounts) {
-
     edm::Handle<L1GctJetCountsCollection> jetCountColl;
     iEvent.getByLabel(caloGctInputTag, jetCountColl);
 
     if (!jetCountColl.isValid()) {
       if (warningEnabled) {
-        warningsStream
-            << "\nWarning: L1GctJetCountsCollection with input tag "
-            << caloGctInputTag
-            << "\nrequested in configuration, but not found in the event.\n"
-            << std::endl;
+        warningsStream << "\nWarning: L1GctJetCountsCollection with input tag " << caloGctInputTag
+                       << "\nrequested in configuration, but not found in the event.\n"
+                       << std::endl;
       }
     } else {
-
-      for (L1GctJetCountsCollection::const_iterator it = jetCountColl->begin();
-           it != jetCountColl->end(); it++) {
-
+      for (L1GctJetCountsCollection::const_iterator it = jetCountColl->begin(); it != jetCountColl->end(); it++) {
         if ((*it).bx() == iBxInEvent) {
-
           m_candJetCounts = &(*it);
           // LogTrace("L1GlobalTrigger") << (*it) << std::endl;
         }
@@ -419,26 +363,19 @@ void L1GlobalTriggerPSB::receiveGctObjectData(
 
   // get GCT HfBitCounts
   if (receiveHfBitCounts) {
-
     edm::Handle<L1GctHFBitCountsCollection> hfBitCountsColl;
     iEvent.getByLabel(caloGctInputTag, hfBitCountsColl);
 
     if (!hfBitCountsColl.isValid()) {
       if (warningEnabled) {
-        warningsStream
-            << "\nWarning: L1GctHFBitCountsCollection with input tag "
-            << caloGctInputTag
-            << "\nrequested in configuration, but not found in the event.\n"
-            << std::endl;
+        warningsStream << "\nWarning: L1GctHFBitCountsCollection with input tag " << caloGctInputTag
+                       << "\nrequested in configuration, but not found in the event.\n"
+                       << std::endl;
       }
     } else {
-
-      for (L1GctHFBitCountsCollection::const_iterator it =
-               hfBitCountsColl->begin();
-           it != hfBitCountsColl->end(); it++) {
-
+      for (L1GctHFBitCountsCollection::const_iterator it = hfBitCountsColl->begin(); it != hfBitCountsColl->end();
+           it++) {
         if ((*it).bx() == iBxInEvent) {
-
           m_candHfBitCounts = &(*it);
           // LogTrace("L1GlobalTrigger") << "L1GctHFBitCountsCollection: "
           //<< (*it) << std::endl;
@@ -449,26 +386,18 @@ void L1GlobalTriggerPSB::receiveGctObjectData(
 
   // get GCT HfRingEtSums
   if (receiveHfRingEtSums) {
-
     edm::Handle<L1GctHFRingEtSumsCollection> hfRingEtSums;
     iEvent.getByLabel(caloGctInputTag, hfRingEtSums);
 
     if (!hfRingEtSums.isValid()) {
       if (warningEnabled) {
-        warningsStream
-            << "\nWarning: L1GctHFRingEtSumsCollection with input tag "
-            << caloGctInputTag
-            << "\nrequested in configuration, but not found in the event.\n"
-            << std::endl;
+        warningsStream << "\nWarning: L1GctHFRingEtSumsCollection with input tag " << caloGctInputTag
+                       << "\nrequested in configuration, but not found in the event.\n"
+                       << std::endl;
       }
     } else {
-
-      for (L1GctHFRingEtSumsCollection::const_iterator it =
-               hfRingEtSums->begin();
-           it != hfRingEtSums->end(); it++) {
-
+      for (L1GctHFRingEtSumsCollection::const_iterator it = hfRingEtSums->begin(); it != hfRingEtSums->end(); it++) {
         if ((*it).bx() == iBxInEvent) {
-
           m_candHfRingEtSums = &(*it);
           // LogTrace("L1GlobalTrigger") << "L1GctHFRingEtSumsCollection: "
           //<< (*it) << std::endl;
@@ -484,12 +413,10 @@ void L1GlobalTriggerPSB::receiveGctObjectData(
   }
 
   if (m_verbosity && m_isDebugEnabled) {
-
-    LogDebug("L1GlobalTrigger")
-        << "\n**** L1GlobalTriggerPSB receiving calorimeter data for BxInEvent "
-           "= "
-        << iBxInEvent << "\n     from " << caloGctInputTag << "\n"
-        << std::endl;
+    LogDebug("L1GlobalTrigger") << "\n**** L1GlobalTriggerPSB receiving calorimeter data for BxInEvent "
+                                   "= "
+                                << iBxInEvent << "\n     from " << caloGctInputTag << "\n"
+                                << std::endl;
 
     printGctObjectData(iBxInEvent);
   }
@@ -501,7 +428,6 @@ void L1GlobalTriggerPSB::receiveCastorData(edm::Event &iEvent,
                                            const int iBxInEvent,
                                            const bool receiveCastor,
                                            const bool readFromPsb) {
-
   // get the CASTOR record
 
   // bool castorConditionFlag = true;
@@ -551,18 +477,20 @@ void L1GlobalTriggerPSB::receiveBptxData(edm::Event &iEvent,
 // receive External objects
 //   from a GT record with ExternalInputTag - if readFromPsb is true
 //   otherwise, generate them from randomly
-void L1GlobalTriggerPSB::receiveExternalData(
-    edm::Event &iEvent, const std::vector<edm::InputTag> &externalInputTags,
-    const int iBxInEvent, const bool receiveExternal, const bool readFromPsb) {}
+void L1GlobalTriggerPSB::receiveExternalData(edm::Event &iEvent,
+                                             const std::vector<edm::InputTag> &externalInputTags,
+                                             const int iBxInEvent,
+                                             const bool receiveExternal,
+                                             const bool readFromPsb) {}
 
 // receive technical triggers
 // each L1GtTechnicalTriggerRecord can have more than one technical trigger bit,
 // such that a single producer per system can be used (if desired)
-void L1GlobalTriggerPSB::receiveTechnicalTriggers(
-    edm::Event &iEvent,
-    const std::vector<edm::InputTag> &technicalTriggersInputTags,
-    const int iBxInEvent, const bool receiveTechTr, const int nrL1TechTr) {
-
+void L1GlobalTriggerPSB::receiveTechnicalTriggers(edm::Event &iEvent,
+                                                  const std::vector<edm::InputTag> &technicalTriggersInputTags,
+                                                  const int iBxInEvent,
+                                                  const bool receiveTechTr,
+                                                  const int nrL1TechTr) {
   std::ostringstream warningsStream;
   bool warningEnabled = edm::isWarningEnabled();
 
@@ -570,34 +498,27 @@ void L1GlobalTriggerPSB::receiveTechnicalTriggers(
   m_gtTechnicalTriggers = std::vector<bool>(nrL1TechTr, false);
 
   if (receiveTechTr) {
-
     // get the technical trigger bits from the records and write them in
     // the decision word for technical triggers
 
     // loop over all producers of technical trigger records
-    for (std::vector<edm::InputTag>::const_iterator it =
-             technicalTriggersInputTags.begin();
-         it != technicalTriggersInputTags.end(); it++) {
-
+    for (std::vector<edm::InputTag>::const_iterator it = technicalTriggersInputTags.begin();
+         it != technicalTriggersInputTags.end();
+         it++) {
       edm::Handle<L1GtTechnicalTriggerRecord> techTrigRecord;
       iEvent.getByLabel((*it), techTrigRecord);
 
       if (!techTrigRecord.isValid()) {
         if (warningEnabled) {
-          warningsStream
-              << "\nWarning: L1GtTechnicalTriggerRecord with input tag "
-              << (*it)
-              << "\nrequested in configuration, but not found in the event.\n"
-              << std::endl;
+          warningsStream << "\nWarning: L1GtTechnicalTriggerRecord with input tag " << (*it)
+                         << "\nrequested in configuration, but not found in the event.\n"
+                         << std::endl;
         }
       } else {
-
-        const std::vector<L1GtTechnicalTrigger> &ttVec =
-            techTrigRecord->gtTechnicalTrigger();
+        const std::vector<L1GtTechnicalTrigger> &ttVec = techTrigRecord->gtTechnicalTrigger();
         size_t ttVecSize = ttVec.size();
 
         for (size_t iTT = 0; iTT < ttVecSize; ++iTT) {
-
           const L1GtTechnicalTrigger &ttBxRecord = ttVec[iTT];
           int ttBxInEvent = ttBxRecord.bxInEvent();
 
@@ -608,12 +529,9 @@ void L1GlobalTriggerPSB::receiveTechnicalTriggers(
             m_gtTechnicalTriggers.at(ttBitNumber) = ttResult;
 
             if (m_verbosity) {
-              LogTrace("L1GlobalTrigger")
-                  << "Add for BxInEvent " << iBxInEvent
-                  << " the technical trigger produced by " << (*it)
-                  << " : name " << (ttBxRecord.gtTechnicalTriggerName())
-                  << " , bit number " << ttBitNumber << " and result "
-                  << ttResult << std::endl;
+              LogTrace("L1GlobalTrigger") << "Add for BxInEvent " << iBxInEvent << " the technical trigger produced by "
+                                          << (*it) << " : name " << (ttBxRecord.gtTechnicalTriggerName())
+                                          << " , bit number " << ttBitNumber << " and result " << ttResult << std::endl;
             }
           }
         }
@@ -628,19 +546,16 @@ void L1GlobalTriggerPSB::receiveTechnicalTriggers(
   }
 
   if (m_verbosity && m_isDebugEnabled) {
-    LogDebug("L1GlobalTrigger")
-        << "\n**** L1GlobalTriggerPSB receiving technical triggers: "
-        << std::endl;
+    LogDebug("L1GlobalTrigger") << "\n**** L1GlobalTriggerPSB receiving technical triggers: " << std::endl;
 
-    int sizeW64 = 64; // 64 bits words
+    int sizeW64 = 64;  // 64 bits words
     int iBit = 0;
 
     std::ostringstream myCout;
 
-    for (std::vector<bool>::reverse_iterator ritBit =
-             m_gtTechnicalTriggers.rbegin();
-         ritBit != m_gtTechnicalTriggers.rend(); ++ritBit) {
-
+    for (std::vector<bool>::reverse_iterator ritBit = m_gtTechnicalTriggers.rbegin();
+         ritBit != m_gtTechnicalTriggers.rend();
+         ++ritBit) {
       myCout << (*ritBit ? '1' : '0');
 
       if ((((iBit + 1) % 16) == (sizeW64 % 16)) && (iBit != 63)) {
@@ -655,12 +570,14 @@ void L1GlobalTriggerPSB::receiveTechnicalTriggers(
 }
 
 // fill the content of active PSB boards
-void L1GlobalTriggerPSB::fillPsbBlock(
-    edm::Event &iEvent, const boost::uint16_t &activeBoardsGtDaq,
-    const int recordLength0, const int recordLength1,
-    const unsigned int altNrBxBoardDaq, const std::vector<L1GtBoard> &boardMaps,
-    const int iBxInEvent, L1GlobalTriggerReadoutRecord *gtDaqReadoutRecord) {
-
+void L1GlobalTriggerPSB::fillPsbBlock(edm::Event &iEvent,
+                                      const boost::uint16_t &activeBoardsGtDaq,
+                                      const int recordLength0,
+                                      const int recordLength1,
+                                      const unsigned int altNrBxBoardDaq,
+                                      const std::vector<L1GtBoard> &boardMaps,
+                                      const int iBxInEvent,
+                                      L1GlobalTriggerReadoutRecord *gtDaqReadoutRecord) {
   // fill in emulator the same bunch crossing (12 bits - hardwired number of
   // bits...) and the same local bunch crossing for all boards
   int bxCross = iEvent.bunchCrossing();
@@ -668,13 +585,11 @@ void L1GlobalTriggerPSB::fillPsbBlock(
   if ((bxCross & 0xFFF) == bxCross) {
     bxCrossHw = static_cast<boost::uint16_t>(bxCross);
   } else {
-    bxCrossHw = 0; // Bx number too large, set to 0!
+    bxCrossHw = 0;  // Bx number too large, set to 0!
     if (m_verbosity) {
-
-      LogDebug("L1GlobalTrigger")
-          << "\nBunch cross number [hex] = " << std::hex << bxCross
-          << "\n  larger than 12 bits. Set to 0! \n"
-          << std::dec << std::endl;
+      LogDebug("L1GlobalTrigger") << "\nBunch cross number [hex] = " << std::hex << bxCross
+                                  << "\n  larger than 12 bits. Set to 0! \n"
+                                  << std::dec << std::endl;
     }
   }
 
@@ -683,12 +598,9 @@ void L1GlobalTriggerPSB::fillPsbBlock(
   // loop over PSB blocks in the GT DAQ record and fill them
   // with the content of the object list
 
-  for (CItBoardMaps itBoard = boardMaps.begin(); itBoard != boardMaps.end();
-       ++itBoard) {
-
+  for (CItBoardMaps itBoard = boardMaps.begin(); itBoard != boardMaps.end(); ++itBoard) {
     int iPosition = itBoard->gtPositionDaqRecord();
     if (iPosition > 0) {
-
       int iActiveBit = itBoard->gtBitDaqActiveBoards();
       bool activeBoard = false;
       bool writeBoard = false;
@@ -730,7 +642,6 @@ void L1GlobalTriggerPSB::fillPsbBlock(
       //    << std::endl;
 
       if (activeBoard && writeBoard && (itBoard->gtBoardType() == PSB)) {
-
         L1GtPsbWord psbWordValue;
 
         // set board ID
@@ -744,8 +655,7 @@ void L1GlobalTriggerPSB::fillPsbBlock(
         psbWordValue.setBxNr(bxNrValue);
 
         // set event number since last L1 reset generated in PSB
-        psbWordValue.setEventNr(
-            static_cast<boost::uint32_t>(iEvent.id().event()));
+        psbWordValue.setEventNr(static_cast<boost::uint32_t>(iEvent.id().event()));
 
         // set local bunch cross number of the actual bx
         // set identical to bxCrossHw - other solution?
@@ -764,248 +674,256 @@ void L1GlobalTriggerPSB::fillPsbBlock(
         boost::uint16_t bDataVal = 0;
 
         int iCable = -1;
-        for (std::vector<L1GtPsbQuad>::const_iterator itQuad =
-                 quadInPsb.begin();
-             itQuad != quadInPsb.end(); ++itQuad) {
-
+        for (std::vector<L1GtPsbQuad>::const_iterator itQuad = quadInPsb.begin(); itQuad != quadInPsb.end(); ++itQuad) {
           iCable++;
 
           int iAB = (nrCables - iCable - 1) * nrObjRow;
 
           switch (*itQuad) {
+            case TechTr: {
+              // LogTrace("L1GlobalTrigger")
+              //<< "\nL1GlobalTriggerPSB: write TechTr for BxInEvent = "
+              //<< iBxInEvent
+              //<< "\n PSB " << std::hex << itBoard->gtBoardId() << std::dec
+              //<< " Cable " << iCable << " Quad " << (*itQuad)
+              //<< std::endl;
 
-          case TechTr: {
+              // order: 16-bit words
+              int bitsPerWord = 16;
 
-            // LogTrace("L1GlobalTrigger")
-            //<< "\nL1GlobalTriggerPSB: write TechTr for BxInEvent = "
-            //<< iBxInEvent
-            //<< "\n PSB " << std::hex << itBoard->gtBoardId() << std::dec
-            //<< " Cable " << iCable << " Quad " << (*itQuad)
-            //<< std::endl;
+              //
+              int iPair = 0;
+              aDataVal = 0;
 
-            // order: 16-bit words
-            int bitsPerWord = 16;
+              int iBit = 0;
+              boost::uint16_t bitVal = 0;
 
-            //
-            int iPair = 0;
-            aDataVal = 0;
+              for (int i = 0; i < bitsPerWord; ++i) {
+                if (m_gtTechnicalTriggers[iBit]) {
+                  bitVal = 1;
+                } else {
+                  bitVal = 0;
+                }
 
-            int iBit = 0;
-            boost::uint16_t bitVal = 0;
-
-            for (int i = 0; i < bitsPerWord; ++i) {
-              if (m_gtTechnicalTriggers[iBit]) {
-                bitVal = 1;
-              } else {
-                bitVal = 0;
-              }
-
-              aDataVal = aDataVal | (bitVal << i);
-              iBit++;
-            }
-            psbWordValue.setAData(aDataVal, iAB + iPair);
-
-            //
-            bDataVal = 0;
-
-            for (int i = 0; i < bitsPerWord; ++i) {
-              if (m_gtTechnicalTriggers[iBit]) {
-                bitVal = 1;
-              } else {
-                bitVal = 0;
-              }
-
-              bDataVal = bDataVal | (bitVal << i);
-              iBit++;
-            }
-            psbWordValue.setBData(bDataVal, iAB + iPair);
-
-            //
-            iPair = 1;
-            aDataVal = 0;
-
-            for (int i = 0; i < bitsPerWord; ++i) {
-              if (m_gtTechnicalTriggers[iBit]) {
-                bitVal = 1;
-              } else {
-                bitVal = 0;
-              }
-
-              aDataVal = aDataVal | (bitVal << i);
-              iBit++;
-            }
-            psbWordValue.setAData(aDataVal, iAB + iPair);
-
-            bDataVal = 0;
-
-            for (int i = 0; i < bitsPerWord; ++i) {
-              if (m_gtTechnicalTriggers[iBit]) {
-                bitVal = 1;
-              } else {
-                bitVal = 0;
-              }
-
-              bDataVal = bDataVal | (bitVal << i);
-              iBit++;
-            }
-            psbWordValue.setBData(bDataVal, iAB + iPair);
-          }
-
-          break;
-          case NoIsoEGQ: {
-
-            // LogTrace("L1GlobalTrigger")
-            //<< "\nL1GlobalTriggerPSB: write NoIsoEGQ for BxInEvent = "
-            //<< iBxInEvent
-            //<< "\n PSB " << std::hex << itBoard->gtBoardId() << std::dec
-            //<< " Cable " << iCable << " Quad " << (*itQuad)
-            //<< std::endl;
-
-            int recL1NoIsoEG = m_candL1NoIsoEG->size();
-            for (int iPair = 0; iPair < nrObjRow; ++iPair) {
-              if (iPair < recL1NoIsoEG) {
-                aDataVal = (static_cast<const L1GctEmCand *>(
-                                (*m_candL1NoIsoEG)[iPair]))
-                               ->raw();
-              } else {
-                aDataVal = 0;
+                aDataVal = aDataVal | (bitVal << i);
+                iBit++;
               }
               psbWordValue.setAData(aDataVal, iAB + iPair);
 
-              if ((iPair + nrObjRow) < recL1NoIsoEG) {
-                bDataVal = (static_cast<const L1GctEmCand *>(
-                                (*m_candL1NoIsoEG)[iPair + nrObjRow]))
-                               ->raw();
-              } else {
-                bDataVal = 0;
+              //
+              bDataVal = 0;
+
+              for (int i = 0; i < bitsPerWord; ++i) {
+                if (m_gtTechnicalTriggers[iBit]) {
+                  bitVal = 1;
+                } else {
+                  bitVal = 0;
+                }
+
+                bDataVal = bDataVal | (bitVal << i);
+                iBit++;
               }
               psbWordValue.setBData(bDataVal, iAB + iPair);
-            }
-          }
 
-          break;
-          case IsoEGQ: {
+              //
+              iPair = 1;
+              aDataVal = 0;
 
-            // LogTrace("L1GlobalTrigger")
-            //<< "\nL1GlobalTriggerPSB: write IsoEGQ for BxInEvent = "
-            //<< iBxInEvent
-            //<< "\n PSB " << std::hex << itBoard->gtBoardId() << std::dec
-            //<< " Cable " << iCable << " Quad " << (*itQuad)
-            //<< std::endl;
+              for (int i = 0; i < bitsPerWord; ++i) {
+                if (m_gtTechnicalTriggers[iBit]) {
+                  bitVal = 1;
+                } else {
+                  bitVal = 0;
+                }
 
-            int recL1IsoEG = m_candL1IsoEG->size();
-            for (int iPair = 0; iPair < nrObjRow; ++iPair) {
-              if (iPair < recL1IsoEG) {
-                aDataVal =
-                    (static_cast<const L1GctEmCand *>((*m_candL1IsoEG)[iPair]))
-                        ->raw();
-              } else {
-                aDataVal = 0;
+                aDataVal = aDataVal | (bitVal << i);
+                iBit++;
               }
               psbWordValue.setAData(aDataVal, iAB + iPair);
 
-              if ((iPair + nrObjRow) < recL1IsoEG) {
-                bDataVal = (static_cast<const L1GctEmCand *>(
-                                (*m_candL1IsoEG)[iPair + nrObjRow]))
-                               ->raw();
-              } else {
-                bDataVal = 0;
+              bDataVal = 0;
+
+              for (int i = 0; i < bitsPerWord; ++i) {
+                if (m_gtTechnicalTriggers[iBit]) {
+                  bitVal = 1;
+                } else {
+                  bitVal = 0;
+                }
+
+                bDataVal = bDataVal | (bitVal << i);
+                iBit++;
               }
               psbWordValue.setBData(bDataVal, iAB + iPair);
             }
 
-          }
+            break;
+            case NoIsoEGQ: {
+              // LogTrace("L1GlobalTrigger")
+              //<< "\nL1GlobalTriggerPSB: write NoIsoEGQ for BxInEvent = "
+              //<< iBxInEvent
+              //<< "\n PSB " << std::hex << itBoard->gtBoardId() << std::dec
+              //<< " Cable " << iCable << " Quad " << (*itQuad)
+              //<< std::endl;
 
-          break;
-          case CenJetQ: {
+              int recL1NoIsoEG = m_candL1NoIsoEG->size();
+              for (int iPair = 0; iPair < nrObjRow; ++iPair) {
+                if (iPair < recL1NoIsoEG) {
+                  aDataVal = (static_cast<const L1GctEmCand *>((*m_candL1NoIsoEG)[iPair]))->raw();
+                } else {
+                  aDataVal = 0;
+                }
+                psbWordValue.setAData(aDataVal, iAB + iPair);
 
-            // LogTrace("L1GlobalTrigger")
-            //<< "\nL1GlobalTriggerPSB: write CenJetQ for BxInEvent = "
-            //<< iBxInEvent
-            //<< "\n PSB " << std::hex << itBoard->gtBoardId() << std::dec
-            //<< " Cable " << iCable << " Quad " << (*itQuad)
-            //<< std::endl;
-
-            int recL1CenJet = m_candL1CenJet->size();
-            for (int iPair = 0; iPair < nrObjRow; ++iPair) {
-              if (iPair < recL1CenJet) {
-                aDataVal = (static_cast<const L1GctJetCand *>(
-                                (*m_candL1CenJet)[iPair]))
-                               ->raw();
-              } else {
-                aDataVal = 0;
+                if ((iPair + nrObjRow) < recL1NoIsoEG) {
+                  bDataVal = (static_cast<const L1GctEmCand *>((*m_candL1NoIsoEG)[iPair + nrObjRow]))->raw();
+                } else {
+                  bDataVal = 0;
+                }
+                psbWordValue.setBData(bDataVal, iAB + iPair);
               }
-              psbWordValue.setAData(aDataVal, iAB + iPair);
-
-              if ((iPair + nrObjRow) < recL1CenJet) {
-                bDataVal = (static_cast<const L1GctJetCand *>(
-                                (*m_candL1CenJet)[iPair + nrObjRow]))
-                               ->raw();
-              } else {
-                bDataVal = 0;
-              }
-              psbWordValue.setBData(bDataVal, iAB + iPair);
-            }
-          }
-
-          break;
-          case ForJetQ: {
-
-            // LogTrace("L1GlobalTrigger")
-            //<< "\nL1GlobalTriggerPSB: write ForJetQ for BxInEvent = "
-            //<< iBxInEvent
-            //<< "\n PSB " << std::hex << itBoard->gtBoardId() << std::dec
-            //<< " Cable " << iCable << " Quad " << (*itQuad)
-            //<< std::endl;
-
-            int recL1ForJet = m_candL1ForJet->size();
-            for (int iPair = 0; iPair < nrObjRow; ++iPair) {
-              if (iPair < recL1ForJet) {
-                aDataVal = (static_cast<const L1GctJetCand *>(
-                                (*m_candL1ForJet)[iPair]))
-                               ->raw();
-              } else {
-                aDataVal = 0;
-              }
-              psbWordValue.setAData(aDataVal, iAB + iPair);
-
-              if ((iPair + nrObjRow) < recL1ForJet) {
-                bDataVal = (static_cast<const L1GctJetCand *>(
-                                (*m_candL1ForJet)[iPair + nrObjRow]))
-                               ->raw();
-              } else {
-                bDataVal = 0;
-              }
-              psbWordValue.setBData(bDataVal, iAB + iPair);
             }
 
-          }
+            break;
+            case IsoEGQ: {
+              // LogTrace("L1GlobalTrigger")
+              //<< "\nL1GlobalTriggerPSB: write IsoEGQ for BxInEvent = "
+              //<< iBxInEvent
+              //<< "\n PSB " << std::hex << itBoard->gtBoardId() << std::dec
+              //<< " Cable " << iCable << " Quad " << (*itQuad)
+              //<< std::endl;
 
-          break;
-          case TauJetQ: {
+              int recL1IsoEG = m_candL1IsoEG->size();
+              for (int iPair = 0; iPair < nrObjRow; ++iPair) {
+                if (iPair < recL1IsoEG) {
+                  aDataVal = (static_cast<const L1GctEmCand *>((*m_candL1IsoEG)[iPair]))->raw();
+                } else {
+                  aDataVal = 0;
+                }
+                psbWordValue.setAData(aDataVal, iAB + iPair);
 
-            // LogTrace("L1GlobalTrigger")
-            //<< "\nL1GlobalTriggerPSB: write TauJetQ for BxInEvent = "
-            //<< iBxInEvent
-            //<< "\n PSB " << std::hex << itBoard->gtBoardId() << std::dec
-            //<< " Cable " << iCable << " Quad " << (*itQuad)
-            //<< std::endl;
+                if ((iPair + nrObjRow) < recL1IsoEG) {
+                  bDataVal = (static_cast<const L1GctEmCand *>((*m_candL1IsoEG)[iPair + nrObjRow]))->raw();
+                } else {
+                  bDataVal = 0;
+                }
+                psbWordValue.setBData(bDataVal, iAB + iPair);
+              }
 
-            int recL1TauJet = m_candL1TauJet->size();
-            for (int iPair = 0; iPair < nrObjRow; ++iPair) {
-              if (iPair < recL1TauJet) {
-                aDataVal = (static_cast<const L1GctJetCand *>(
-                                (*m_candL1TauJet)[iPair]))
-                               ->raw();
+            }
+
+            break;
+            case CenJetQ: {
+              // LogTrace("L1GlobalTrigger")
+              //<< "\nL1GlobalTriggerPSB: write CenJetQ for BxInEvent = "
+              //<< iBxInEvent
+              //<< "\n PSB " << std::hex << itBoard->gtBoardId() << std::dec
+              //<< " Cable " << iCable << " Quad " << (*itQuad)
+              //<< std::endl;
+
+              int recL1CenJet = m_candL1CenJet->size();
+              for (int iPair = 0; iPair < nrObjRow; ++iPair) {
+                if (iPair < recL1CenJet) {
+                  aDataVal = (static_cast<const L1GctJetCand *>((*m_candL1CenJet)[iPair]))->raw();
+                } else {
+                  aDataVal = 0;
+                }
+                psbWordValue.setAData(aDataVal, iAB + iPair);
+
+                if ((iPair + nrObjRow) < recL1CenJet) {
+                  bDataVal = (static_cast<const L1GctJetCand *>((*m_candL1CenJet)[iPair + nrObjRow]))->raw();
+                } else {
+                  bDataVal = 0;
+                }
+                psbWordValue.setBData(bDataVal, iAB + iPair);
+              }
+            }
+
+            break;
+            case ForJetQ: {
+              // LogTrace("L1GlobalTrigger")
+              //<< "\nL1GlobalTriggerPSB: write ForJetQ for BxInEvent = "
+              //<< iBxInEvent
+              //<< "\n PSB " << std::hex << itBoard->gtBoardId() << std::dec
+              //<< " Cable " << iCable << " Quad " << (*itQuad)
+              //<< std::endl;
+
+              int recL1ForJet = m_candL1ForJet->size();
+              for (int iPair = 0; iPair < nrObjRow; ++iPair) {
+                if (iPair < recL1ForJet) {
+                  aDataVal = (static_cast<const L1GctJetCand *>((*m_candL1ForJet)[iPair]))->raw();
+                } else {
+                  aDataVal = 0;
+                }
+                psbWordValue.setAData(aDataVal, iAB + iPair);
+
+                if ((iPair + nrObjRow) < recL1ForJet) {
+                  bDataVal = (static_cast<const L1GctJetCand *>((*m_candL1ForJet)[iPair + nrObjRow]))->raw();
+                } else {
+                  bDataVal = 0;
+                }
+                psbWordValue.setBData(bDataVal, iAB + iPair);
+              }
+
+            }
+
+            break;
+            case TauJetQ: {
+              // LogTrace("L1GlobalTrigger")
+              //<< "\nL1GlobalTriggerPSB: write TauJetQ for BxInEvent = "
+              //<< iBxInEvent
+              //<< "\n PSB " << std::hex << itBoard->gtBoardId() << std::dec
+              //<< " Cable " << iCable << " Quad " << (*itQuad)
+              //<< std::endl;
+
+              int recL1TauJet = m_candL1TauJet->size();
+              for (int iPair = 0; iPair < nrObjRow; ++iPair) {
+                if (iPair < recL1TauJet) {
+                  aDataVal = (static_cast<const L1GctJetCand *>((*m_candL1TauJet)[iPair]))->raw();
+                } else {
+                  aDataVal = 0;
+                }
+                psbWordValue.setAData(aDataVal, iAB + iPair);
+
+                if ((iPair + nrObjRow) < recL1TauJet) {
+                  bDataVal = (static_cast<const L1GctJetCand *>((*m_candL1TauJet)[iPair + nrObjRow]))->raw();
+                } else {
+                  bDataVal = 0;
+                }
+                psbWordValue.setBData(bDataVal, iAB + iPair);
+
+                // LogTrace("L1GlobalTrigger")
+                //        << "\n aDataVal[" << (iAB + iPair)
+                //        << "] = 0x" << std::hex << aDataVal << std::dec
+                //        << " (object " << iPair << ")"
+                //        << "\n bDataVal[" << (iAB + iPair)
+                //        << "] = 0x" << std::hex << bDataVal << std::dec
+                //        << " (object " << (iPair + nrObjRow) << ")"
+                //        << std::endl;
+              }
+
+            }
+
+            break;
+            case ESumsQ: {
+              // LogTrace("L1GlobalTrigger")
+              //<< "\nL1GlobalTriggerPSB: write ESumsQ for BxInEvent = "
+              //<< iBxInEvent
+              //<< "\n PSB " << std::hex << itBoard->gtBoardId() << std::dec
+              //<< " Cable " << iCable << " Quad " << (*itQuad)
+              //<< std::endl;
+
+              // order: ETT, ETM et, HTT, ETM phi... hardcoded here
+              int iPair = 0;
+
+              if (m_candETT) {
+                aDataVal = m_candETT->raw();
               } else {
                 aDataVal = 0;
               }
               psbWordValue.setAData(aDataVal, iAB + iPair);
 
-              if ((iPair + nrObjRow) < recL1TauJet) {
-                bDataVal = (static_cast<const L1GctJetCand *>(
-                                (*m_candL1TauJet)[iPair + nrObjRow]))
-                               ->raw();
+              if (m_candHTT) {
+                bDataVal = m_candHTT->raw();
               } else {
                 bDataVal = 0;
               }
@@ -1014,325 +932,267 @@ void L1GlobalTriggerPSB::fillPsbBlock(
               // LogTrace("L1GlobalTrigger")
               //        << "\n aDataVal[" << (iAB + iPair)
               //        << "] = 0x" << std::hex << aDataVal << std::dec
-              //        << " (object " << iPair << ")"
               //        << "\n bDataVal[" << (iAB + iPair)
               //        << "] = 0x" << std::hex << bDataVal << std::dec
-              //        << " (object " << (iPair + nrObjRow) << ")"
               //        << std::endl;
-            }
+              //
+              iPair = 1;
+              if (m_candETM) {
+                // bits 0:15
+                aDataVal = m_candETM->raw() & 0x0000FFFF;
 
-          }
+                // LogTrace("L1GlobalTrigger") << std::hex
+                //        << "\n ETM et        = "
+                //        << m_candETM->et()
+                //        << "\n ETM overFlow  = "
+                //       << m_candETM->overFlow() << std::dec
+                //       << std::endl;
+              } else {
+                aDataVal = 0;
+              }
+              psbWordValue.setAData(aDataVal, iAB + iPair);
 
-          break;
-          case ESumsQ: {
+              if (m_candETM) {
+                // bits 16:31
+                bDataVal = (m_candETM->raw() & 0xFFFF0000) >> 16;
 
-            // LogTrace("L1GlobalTrigger")
-            //<< "\nL1GlobalTriggerPSB: write ESumsQ for BxInEvent = "
-            //<< iBxInEvent
-            //<< "\n PSB " << std::hex << itBoard->gtBoardId() << std::dec
-            //<< " Cable " << iCable << " Quad " << (*itQuad)
-            //<< std::endl;
+                // LogTrace("L1GlobalTrigger") << std::hex
+                //        << "\n ETM phi  = " << m_candETM->phi()
+                //        << std::dec << std::endl;
 
-            // order: ETT, ETM et, HTT, ETM phi... hardcoded here
-            int iPair = 0;
+              } else {
+                bDataVal = 0;
+              }
+              psbWordValue.setBData(bDataVal, iAB + iPair);
 
-            if (m_candETT) {
-              aDataVal = m_candETT->raw();
-            } else {
-              aDataVal = 0;
-            }
-            psbWordValue.setAData(aDataVal, iAB + iPair);
+              // FIXME add HTM
 
-            if (m_candHTT) {
-              bDataVal = m_candHTT->raw();
-            } else {
-              bDataVal = 0;
-            }
-            psbWordValue.setBData(bDataVal, iAB + iPair);
-
-            // LogTrace("L1GlobalTrigger")
-            //        << "\n aDataVal[" << (iAB + iPair)
-            //        << "] = 0x" << std::hex << aDataVal << std::dec
-            //        << "\n bDataVal[" << (iAB + iPair)
-            //        << "] = 0x" << std::hex << bDataVal << std::dec
-            //        << std::endl;
-            //
-            iPair = 1;
-            if (m_candETM) {
-              // bits 0:15
-              aDataVal = m_candETM->raw() & 0x0000FFFF;
-
-              // LogTrace("L1GlobalTrigger") << std::hex
-              //        << "\n ETM et        = "
-              //        << m_candETM->et()
-              //        << "\n ETM overFlow  = "
-              //       << m_candETM->overFlow() << std::dec
+              // LogTrace("L1GlobalTrigger")
+              //        << "\n aDataVal[" << (iAB + iPair)
+              //        << "] = 0x" << std::hex << aDataVal << std::dec
+              //       << "\n bDataVal[" << (iAB + iPair)
+              //        << "] = 0x" << std::hex << bDataVal << std::dec
               //       << std::endl;
-            } else {
+
+            }
+
+            break;
+            case JetCountsQ: {
+              // LogTrace("L1GlobalTrigger")
+              //<< "\nL1GlobalTriggerPSB: write JetCountsQ for BxInEvent = "
+              //<< iBxInEvent
+              //<< "\n PSB " << std::hex << itBoard->gtBoardId() << std::dec
+              //<< " Cable " << iCable << " Quad " << (*itQuad)
+              //<< std::endl;
+
+              // order: 3 JetCounts per 16-bits word ... hardcoded here
+              int jetCountsBits = 5;  // FIXME get it from event setup
+              int countsPerWord = 3;
+
+              //
+              int iPair = 0;
               aDataVal = 0;
-            }
-            psbWordValue.setAData(aDataVal, iAB + iPair);
-
-            if (m_candETM) {
-
-              // bits 16:31
-              bDataVal = (m_candETM->raw() & 0xFFFF0000) >> 16;
-
-              // LogTrace("L1GlobalTrigger") << std::hex
-              //        << "\n ETM phi  = " << m_candETM->phi()
-              //        << std::dec << std::endl;
-
-            } else {
               bDataVal = 0;
-            }
-            psbWordValue.setBData(bDataVal, iAB + iPair);
 
-            // FIXME add HTM
+              int iCount = 0;
 
-            // LogTrace("L1GlobalTrigger")
-            //        << "\n aDataVal[" << (iAB + iPair)
-            //        << "] = 0x" << std::hex << aDataVal << std::dec
-            //       << "\n bDataVal[" << (iAB + iPair)
-            //        << "] = 0x" << std::hex << bDataVal << std::dec
-            //       << std::endl;
+              if (m_candJetCounts) {
+                for (int i = 0; i < countsPerWord; ++i) {
+                  aDataVal = aDataVal | ((m_candJetCounts->count(iCount)) << (jetCountsBits * i));
+                  iCount++;
+                }
 
-          }
+                //
 
-          break;
-          case JetCountsQ: {
-
-            // LogTrace("L1GlobalTrigger")
-            //<< "\nL1GlobalTriggerPSB: write JetCountsQ for BxInEvent = "
-            //<< iBxInEvent
-            //<< "\n PSB " << std::hex << itBoard->gtBoardId() << std::dec
-            //<< " Cable " << iCable << " Quad " << (*itQuad)
-            //<< std::endl;
-
-            // order: 3 JetCounts per 16-bits word ... hardcoded here
-            int jetCountsBits = 5; // FIXME get it from event setup
-            int countsPerWord = 3;
-
-            //
-            int iPair = 0;
-            aDataVal = 0;
-            bDataVal = 0;
-
-            int iCount = 0;
-
-            if (m_candJetCounts) {
-
-              for (int i = 0; i < countsPerWord; ++i) {
-                aDataVal = aDataVal | ((m_candJetCounts->count(iCount))
-                                       << (jetCountsBits * i));
-                iCount++;
+                for (int i = 0; i < countsPerWord; ++i) {
+                  bDataVal = bDataVal | ((m_candJetCounts->count(iCount)) << (jetCountsBits * i));
+                  iCount++;
+                }
               }
+
+              psbWordValue.setAData(aDataVal, iAB + iPair);
+              psbWordValue.setBData(bDataVal, iAB + iPair);
 
               //
+              iPair = 1;
+              aDataVal = 0;
+              bDataVal = 0;
 
-              for (int i = 0; i < countsPerWord; ++i) {
-                bDataVal = bDataVal | ((m_candJetCounts->count(iCount))
-                                       << (jetCountsBits * i));
-                iCount++;
+              if (m_candJetCounts) {
+                for (int i = 0; i < countsPerWord; ++i) {
+                  aDataVal = aDataVal | ((m_candJetCounts->count(iCount)) << (jetCountsBits * i));
+                  iCount++;
+                }
+
+                //
+
+                for (int i = 0; i < countsPerWord; ++i) {
+                  bDataVal = bDataVal | ((m_candJetCounts->count(iCount)) << (jetCountsBits * i));
+                  iCount++;
+                }
               }
+
+              psbWordValue.setAData(aDataVal, iAB + iPair);
+              psbWordValue.setBData(bDataVal, iAB + iPair);
             }
 
-            psbWordValue.setAData(aDataVal, iAB + iPair);
-            psbWordValue.setBData(bDataVal, iAB + iPair);
+            break;
+              // FIXME add MIP/Iso bits
+            case HfQ: {
+              // LogTrace("L1GlobalTrigger")
+              //<< "\nL1GlobalTriggerPSB: write HfQ for BxInEvent = "
+              //<< iBxInEvent
+              //<< "\n PSB " << std::hex << itBoard->gtBoardId() << std::dec
+              //<< " Cable " << iCable << " Quad " << (*itQuad)
+              //<< std::endl;
 
-            //
-            iPair = 1;
-            aDataVal = 0;
-            bDataVal = 0;
+              // FIXME get it from event setup?
+              // 3 bits per Hf index
+              // order hardcoded here
+              // HfBitCounts first, followed by HfRingEtSum
+              int hfBits = 3;
 
-            if (m_candJetCounts) {
-              for (int i = 0; i < countsPerWord; ++i) {
-                aDataVal = aDataVal | ((m_candJetCounts->count(iCount))
-                                       << (jetCountsBits * i));
-                iCount++;
-              }
+              L1GctHFBitCounts hfBitCounts;
+              int nHfBitCounts = hfBitCounts.nCounts();
+
+              L1GctHFRingEtSums hfRingEtSums;
+              int nHfRingEtSums = hfRingEtSums.nSums();
 
               //
+              int iPair = 0;
+              aDataVal = 0;
+              bDataVal = 0;
 
-              for (int i = 0; i < countsPerWord; ++i) {
-                bDataVal = bDataVal | ((m_candJetCounts->count(iCount))
-                                       << (jetCountsBits * i));
-                iCount++;
-              }
-            }
-
-            psbWordValue.setAData(aDataVal, iAB + iPair);
-            psbWordValue.setBData(bDataVal, iAB + iPair);
-          }
-
-          break;
-            // FIXME add MIP/Iso bits
-          case HfQ: {
-
-            // LogTrace("L1GlobalTrigger")
-            //<< "\nL1GlobalTriggerPSB: write HfQ for BxInEvent = "
-            //<< iBxInEvent
-            //<< "\n PSB " << std::hex << itBoard->gtBoardId() << std::dec
-            //<< " Cable " << iCable << " Quad " << (*itQuad)
-            //<< std::endl;
-
-            // FIXME get it from event setup?
-            // 3 bits per Hf index
-            // order hardcoded here
-            // HfBitCounts first, followed by HfRingEtSum
-            int hfBits = 3;
-
-            L1GctHFBitCounts hfBitCounts;
-            int nHfBitCounts = hfBitCounts.nCounts();
-
-            L1GctHFRingEtSums hfRingEtSums;
-            int nHfRingEtSums = hfRingEtSums.nSums();
-
-            //
-            int iPair = 0;
-            aDataVal = 0;
-            bDataVal = 0;
-
-            // sizeof return in multiple of 8 bits
-            int hfPerWord = sizeof(aDataVal) * 8 / hfBits;
-            // LogTrace("L1GlobalTrigger")
-            //<< "\n nHfBitCounts  = " << nHfBitCounts
-            //<< "\n nHfRingEtSums = " << nHfRingEtSums
-            //<< "\n hfPerWord     = " << hfPerWord
-            //<< std::endl;
-
-            int iHf = 0;
-            bool aDataFlag = true;
-            bool bDataFlag = false;
-
-            if (m_candHfBitCounts) {
-
-              for (int i = 0; i < nHfBitCounts; ++i) {
-
-                if (aDataFlag) {
-                  if (iHf < hfPerWord) {
-                    // aData (cycle 0) for iPair 0 (object 0)
-                    aDataVal = aDataVal | ((m_candHfBitCounts->bitCount(i))
-                                           << (hfBits * iHf));
-                    iHf++;
-                    // LogTrace("L1GlobalTrigger")
-                    //        << "\n Added HfBitCounts index " << i << " to "
-                    //        << " aDataVal[" << (iAB + iPair) << "]"
-                    //        << std::endl;
-                  } else {
-                    aDataFlag = false;
-                    bDataFlag = true;
-                    iHf = 0;
-                  }
-                }
-
-                if (bDataFlag) {
-                  if (iHf < hfPerWord) {
-                    // bData (cycle 1) for iPair 0 (object 2)
-                    bDataVal = bDataVal | ((m_candHfBitCounts->bitCount(i))
-                                           << (hfBits * iHf));
-                    iHf++;
-                    // LogTrace("L1GlobalTrigger")
-                    //        << "\n Added HfBitCounts index " << i << " to "
-                    //        << " bDataVal[" << (iAB + iPair) << "]"
-                    //       << std::endl;
-                  } else {
-                    aDataFlag = false;
-                    bDataFlag = false;
-                    iHf = 0;
-                  }
-                }
-              }
-            } else {
-              iHf = nHfBitCounts % hfPerWord;
+              // sizeof return in multiple of 8 bits
+              int hfPerWord = sizeof(aDataVal) * 8 / hfBits;
               // LogTrace("L1GlobalTrigger")
-              //        << "\n No HfBitCounts collection - skip "
-              //        << iHf*hfBits << " bits "
-              //        << std::endl;
-            }
+              //<< "\n nHfBitCounts  = " << nHfBitCounts
+              //<< "\n nHfRingEtSums = " << nHfRingEtSums
+              //<< "\n hfPerWord     = " << hfPerWord
+              //<< std::endl;
 
-            if (aDataFlag && bDataFlag) {
-              LogTrace("L1GlobalTrigger")
-                  << "\n HfBitCounts collection filled aData and bData ["
-                  << (iAB + iPair) << "]"
-                  << "\n HfRingEtSums collection has no space to be written"
-                  << std::endl;
-            }
+              int iHf = 0;
+              bool aDataFlag = true;
+              bool bDataFlag = false;
 
-            if (m_candHfRingEtSums) {
+              if (m_candHfBitCounts) {
+                for (int i = 0; i < nHfBitCounts; ++i) {
+                  if (aDataFlag) {
+                    if (iHf < hfPerWord) {
+                      // aData (cycle 0) for iPair 0 (object 0)
+                      aDataVal = aDataVal | ((m_candHfBitCounts->bitCount(i)) << (hfBits * iHf));
+                      iHf++;
+                      // LogTrace("L1GlobalTrigger")
+                      //        << "\n Added HfBitCounts index " << i << " to "
+                      //        << " aDataVal[" << (iAB + iPair) << "]"
+                      //        << std::endl;
+                    } else {
+                      aDataFlag = false;
+                      bDataFlag = true;
+                      iHf = 0;
+                    }
+                  }
 
-              for (int i = 0; i < nHfRingEtSums; ++i) {
-
-                if (aDataFlag) {
-                  if (iHf < hfPerWord) {
-                    // aData (cycle 0) for iPair 0 (object 0)
-                    aDataVal = aDataVal | ((m_candHfRingEtSums->etSum(i))
-                                           << (hfBits * iHf));
-                    iHf++;
-                    // LogTrace("L1GlobalTrigger")
-                    //        << "\n Added HfRingEtSums index " << i << " to "
-                    //        << " aDataVal[" << (iAB + iPair) << "]"
-                    //       << std::endl;
-                  } else {
-                    aDataFlag = false;
-                    bDataFlag = true;
-                    iHf = 0;
+                  if (bDataFlag) {
+                    if (iHf < hfPerWord) {
+                      // bData (cycle 1) for iPair 0 (object 2)
+                      bDataVal = bDataVal | ((m_candHfBitCounts->bitCount(i)) << (hfBits * iHf));
+                      iHf++;
+                      // LogTrace("L1GlobalTrigger")
+                      //        << "\n Added HfBitCounts index " << i << " to "
+                      //        << " bDataVal[" << (iAB + iPair) << "]"
+                      //       << std::endl;
+                    } else {
+                      aDataFlag = false;
+                      bDataFlag = false;
+                      iHf = 0;
+                    }
                   }
                 }
-
-                if (bDataFlag) {
-                  if (iHf < hfPerWord) {
-                    // bData (cycle 1) for iPair 0 (object 2)
-                    bDataVal = bDataVal | ((m_candHfRingEtSums->etSum(i))
-                                           << (hfBits * iHf));
-                    iHf++;
-                    // LogTrace("L1GlobalTrigger")
-                    //        << "\n Added HfRingEtSums index " << i << " to "
-                    //        << " bDataVal[" << (iAB + iPair) << "]"
-                    //        << std::endl;
-                  } else {
-                    aDataFlag = false;
-                    bDataFlag = false;
-                    iHf = 0;
-                  }
-                }
+              } else {
+                iHf = nHfBitCounts % hfPerWord;
+                // LogTrace("L1GlobalTrigger")
+                //        << "\n No HfBitCounts collection - skip "
+                //        << iHf*hfBits << " bits "
+                //        << std::endl;
               }
-            } else {
-              iHf = nHfRingEtSums % hfPerWord;
+
+              if (aDataFlag && bDataFlag) {
+                LogTrace("L1GlobalTrigger")
+                    << "\n HfBitCounts collection filled aData and bData [" << (iAB + iPair) << "]"
+                    << "\n HfRingEtSums collection has no space to be written" << std::endl;
+              }
+
+              if (m_candHfRingEtSums) {
+                for (int i = 0; i < nHfRingEtSums; ++i) {
+                  if (aDataFlag) {
+                    if (iHf < hfPerWord) {
+                      // aData (cycle 0) for iPair 0 (object 0)
+                      aDataVal = aDataVal | ((m_candHfRingEtSums->etSum(i)) << (hfBits * iHf));
+                      iHf++;
+                      // LogTrace("L1GlobalTrigger")
+                      //        << "\n Added HfRingEtSums index " << i << " to "
+                      //        << " aDataVal[" << (iAB + iPair) << "]"
+                      //       << std::endl;
+                    } else {
+                      aDataFlag = false;
+                      bDataFlag = true;
+                      iHf = 0;
+                    }
+                  }
+
+                  if (bDataFlag) {
+                    if (iHf < hfPerWord) {
+                      // bData (cycle 1) for iPair 0 (object 2)
+                      bDataVal = bDataVal | ((m_candHfRingEtSums->etSum(i)) << (hfBits * iHf));
+                      iHf++;
+                      // LogTrace("L1GlobalTrigger")
+                      //        << "\n Added HfRingEtSums index " << i << " to "
+                      //        << " bDataVal[" << (iAB + iPair) << "]"
+                      //        << std::endl;
+                    } else {
+                      aDataFlag = false;
+                      bDataFlag = false;
+                      iHf = 0;
+                    }
+                  }
+                }
+              } else {
+                iHf = nHfRingEtSums % hfPerWord;
+                // LogTrace("L1GlobalTrigger")
+                //        << "\n No HfRingEtSums collection - skip "
+                //        << iHf*hfBits << " bits "
+                //        << std::endl;
+              }
+
+              psbWordValue.setAData(aDataVal, iAB + iPair);
+              psbWordValue.setBData(bDataVal, iAB + iPair);
+
               // LogTrace("L1GlobalTrigger")
-              //        << "\n No HfRingEtSums collection - skip "
-              //        << iHf*hfBits << " bits "
-              //        << std::endl;
+              //        << "\n aDataVal[" << iAB + iPair
+              //        << "] = 0x" << std::hex << aDataVal << std::dec
+              //        << "\n bDataVal[" << (iAB + iPair)
+              //        << "] = 0x" << std::hex << bDataVal << std::dec
+              //       << std::endl;
+
+              if (aDataFlag && bDataFlag) {
+                LogTrace("L1GlobalTrigger") << "\n aData and bData [" << (iAB + iPair) << "] full"
+                                            << "\n HfRingEtSums collection has not enough space to be "
+                                               "written"
+                                            << std::endl;
+              }
+
             }
 
-            psbWordValue.setAData(aDataVal, iAB + iPair);
-            psbWordValue.setBData(bDataVal, iAB + iPair);
-
-            // LogTrace("L1GlobalTrigger")
-            //        << "\n aDataVal[" << iAB + iPair
-            //        << "] = 0x" << std::hex << aDataVal << std::dec
-            //        << "\n bDataVal[" << (iAB + iPair)
-            //        << "] = 0x" << std::hex << bDataVal << std::dec
-            //       << std::endl;
-
-            if (aDataFlag && bDataFlag) {
-              LogTrace("L1GlobalTrigger")
-                  << "\n aData and bData [" << (iAB + iPair) << "] full"
-                  << "\n HfRingEtSums collection has not enough space to be "
-                     "written"
-                  << std::endl;
+            break;
+            default: {
+              // do nothing
             }
 
-          }
+            break;
+          }  // end switch (*itQuad)
 
-          break;
-          default: {
-            // do nothing
-          }
-
-          break;
-          } // end switch (*itQuad)
-
-        } // end for: (itQuad)
+        }  // end for: (itQuad)
 
         // ** fill L1PsbWord in GT DAQ record
 
@@ -1342,17 +1202,16 @@ void L1GlobalTriggerPSB::fillPsbBlock(
 
         gtDaqReadoutRecord->setGtPsbWord(psbWordValue);
 
-      } // end if (active && PSB)
+      }  // end if (active && PSB)
 
-    } // end if (iPosition)
+    }  // end if (iPosition)
 
-  } // end for (itBoard
+  }  // end for (itBoard
 }
 
 // clear PSB
 
 void L1GlobalTriggerPSB::reset() {
-
   m_candL1NoIsoEG->clear();
   m_candL1IsoEG->clear();
   m_candL1CenJet->clear();
@@ -1374,88 +1233,69 @@ void L1GlobalTriggerPSB::reset() {
 // print Global Calorimeter Trigger data
 // use int to bitset conversion to print
 void L1GlobalTriggerPSB::printGctObjectData(const int iBxInEvent) const {
-
-  LogTrace("L1GlobalTrigger")
-      << "\nL1GlobalTrigger: GCT data [hex] received by PSBs for BxInEvent = "
-      << iBxInEvent << "\n"
-      << std::endl;
+  LogTrace("L1GlobalTrigger") << "\nL1GlobalTrigger: GCT data [hex] received by PSBs for BxInEvent = " << iBxInEvent
+                              << "\n"
+                              << std::endl;
 
   std::vector<const L1GctCand *>::const_iterator iterConst;
 
   LogTrace("L1GlobalTrigger") << "   GCT NoIsoEG " << std::endl;
-  for (iterConst = m_candL1NoIsoEG->begin();
-       iterConst != m_candL1NoIsoEG->end(); iterConst++) {
-
-    LogTrace("L1GlobalTrigger")
-        << std::hex << "Rank = " << (*iterConst)->rank()
-        << " Eta index = " << (*iterConst)->etaIndex()
-        << " Phi index = " << (*iterConst)->phiIndex() << std::dec << std::endl;
+  for (iterConst = m_candL1NoIsoEG->begin(); iterConst != m_candL1NoIsoEG->end(); iterConst++) {
+    LogTrace("L1GlobalTrigger") << std::hex << "Rank = " << (*iterConst)->rank()
+                                << " Eta index = " << (*iterConst)->etaIndex()
+                                << " Phi index = " << (*iterConst)->phiIndex() << std::dec << std::endl;
   }
 
   LogTrace("L1GlobalTrigger") << "   GCT IsoEG " << std::endl;
-  for (iterConst = m_candL1IsoEG->begin(); iterConst != m_candL1IsoEG->end();
-       iterConst++) {
-    LogTrace("L1GlobalTrigger")
-        << std::hex << "Rank = " << (*iterConst)->rank()
-        << " Eta index = " << (*iterConst)->etaIndex()
-        << " Phi index = " << (*iterConst)->phiIndex() << std::dec << std::endl;
+  for (iterConst = m_candL1IsoEG->begin(); iterConst != m_candL1IsoEG->end(); iterConst++) {
+    LogTrace("L1GlobalTrigger") << std::hex << "Rank = " << (*iterConst)->rank()
+                                << " Eta index = " << (*iterConst)->etaIndex()
+                                << " Phi index = " << (*iterConst)->phiIndex() << std::dec << std::endl;
   }
 
   LogTrace("L1GlobalTrigger") << "   GCT CenJet " << std::endl;
-  for (iterConst = m_candL1CenJet->begin(); iterConst != m_candL1CenJet->end();
-       iterConst++) {
-    LogTrace("L1GlobalTrigger")
-        << std::hex << "Rank = " << (*iterConst)->rank()
-        << " Eta index = " << (*iterConst)->etaIndex()
-        << " Phi index = " << (*iterConst)->phiIndex() << std::dec << std::endl;
+  for (iterConst = m_candL1CenJet->begin(); iterConst != m_candL1CenJet->end(); iterConst++) {
+    LogTrace("L1GlobalTrigger") << std::hex << "Rank = " << (*iterConst)->rank()
+                                << " Eta index = " << (*iterConst)->etaIndex()
+                                << " Phi index = " << (*iterConst)->phiIndex() << std::dec << std::endl;
   }
 
   LogTrace("L1GlobalTrigger") << "   GCT ForJet " << std::endl;
-  for (iterConst = m_candL1ForJet->begin(); iterConst != m_candL1ForJet->end();
-       iterConst++) {
-    LogTrace("L1GlobalTrigger")
-        << std::hex << "Rank = " << (*iterConst)->rank()
-        << " Eta index = " << (*iterConst)->etaIndex()
-        << " Phi index = " << (*iterConst)->phiIndex() << std::dec << std::endl;
+  for (iterConst = m_candL1ForJet->begin(); iterConst != m_candL1ForJet->end(); iterConst++) {
+    LogTrace("L1GlobalTrigger") << std::hex << "Rank = " << (*iterConst)->rank()
+                                << " Eta index = " << (*iterConst)->etaIndex()
+                                << " Phi index = " << (*iterConst)->phiIndex() << std::dec << std::endl;
   }
 
   LogTrace("L1GlobalTrigger") << "   GCT TauJet " << std::endl;
-  for (iterConst = m_candL1TauJet->begin(); iterConst != m_candL1TauJet->end();
-       iterConst++) {
-    LogTrace("L1GlobalTrigger")
-        << std::hex << "Rank = " << (*iterConst)->rank()
-        << " Eta index = " << (*iterConst)->etaIndex()
-        << " Phi index = " << (*iterConst)->phiIndex() << std::dec << std::endl;
+  for (iterConst = m_candL1TauJet->begin(); iterConst != m_candL1TauJet->end(); iterConst++) {
+    LogTrace("L1GlobalTrigger") << std::hex << "Rank = " << (*iterConst)->rank()
+                                << " Eta index = " << (*iterConst)->etaIndex()
+                                << " Phi index = " << (*iterConst)->phiIndex() << std::dec << std::endl;
   }
 
   LogTrace("L1GlobalTrigger") << "   GCT ETM " << std::endl;
   if (m_candETM) {
-    LogTrace("L1GlobalTrigger")
-        << std::hex << "ET  = " << m_candETM->et() << std::dec << std::endl;
+    LogTrace("L1GlobalTrigger") << std::hex << "ET  = " << m_candETM->et() << std::dec << std::endl;
 
-    LogTrace("L1GlobalTrigger")
-        << std::hex << "phi = " << m_candETM->phi() << std::dec << std::endl;
+    LogTrace("L1GlobalTrigger") << std::hex << "phi = " << m_candETM->phi() << std::dec << std::endl;
   }
 
   LogTrace("L1GlobalTrigger") << "   GCT ETT " << std::endl;
   if (m_candETT) {
-    LogTrace("L1GlobalTrigger")
-        << std::hex << "ET  = " << m_candETT->et() << std::dec << std::endl;
+    LogTrace("L1GlobalTrigger") << std::hex << "ET  = " << m_candETT->et() << std::dec << std::endl;
   }
 
   LogTrace("L1GlobalTrigger") << "   GCT HTT " << std::endl;
   if (m_candHTT) {
-    LogTrace("L1GlobalTrigger")
-        << std::hex << "ET  = " << m_candHTT->et() << std::dec << std::endl;
+    LogTrace("L1GlobalTrigger") << std::hex << "ET  = " << m_candHTT->et() << std::dec << std::endl;
   }
 
   LogTrace("L1GlobalTrigger") << "   GCT HTM " << std::endl;
   if (m_candHTM) {
-    LogTrace("L1GlobalTrigger")
-        << std::hex << "ET  = " << m_candHTM->et() << std::dec << std::endl;
+    LogTrace("L1GlobalTrigger") << std::hex << "ET  = " << m_candHTM->et() << std::dec << std::endl;
 
-    LogTrace("L1GlobalTrigger")
-        << std::hex << "phi = " << m_candHTM->phi() << std::dec << std::endl;
+    LogTrace("L1GlobalTrigger") << std::hex << "phi = " << m_candHTM->phi() << std::dec << std::endl;
   }
 
   LogTrace("L1GlobalTrigger") << "   GCT JetCounts " << std::endl;

--- a/L1Trigger/GlobalTrigger/src/L1GtAlgorithmEvaluation.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GtAlgorithmEvaluation.cc
@@ -41,27 +41,22 @@
 
 /// constructor from an algorithm from event setup
 L1GtAlgorithmEvaluation::L1GtAlgorithmEvaluation(const L1GtAlgorithm &alg)
-    : m_algoResult(false), m_logicalExpression(alg.algoLogicalExpression()),
-      m_rpnVector(alg.algoRpnVector()) {
-
+    : m_algoResult(false), m_logicalExpression(alg.algoLogicalExpression()), m_rpnVector(alg.algoRpnVector()) {
   // the rest is properly initialized by default
 }
 
 // methods
 
 /// evaluate an algorithm
-void L1GtAlgorithmEvaluation::evaluateAlgorithm(
-    const int chipNumber,
-    const std::vector<ConditionEvaluationMap> &conditionResultMaps) {
-
+void L1GtAlgorithmEvaluation::evaluateAlgorithm(const int chipNumber,
+                                                const std::vector<ConditionEvaluationMap> &conditionResultMaps) {
   // set result to false if there is no expression
   if (m_rpnVector.empty()) {
     m_algoResult = false;
 
     // it should never be happen
-    throw cms::Exception("FailModule")
-        << "\nEmpty RPN vector for the logical expression = "
-        << m_logicalExpression << std::endl;
+    throw cms::Exception("FailModule") << "\nEmpty RPN vector for the logical expression = " << m_logicalExpression
+                                       << std::endl;
   }
 
   // reserve memory
@@ -77,90 +72,80 @@ void L1GtAlgorithmEvaluation::evaluateAlgorithm(
 
   int opNumber = 0;
 
-  for (RpnVector::const_iterator it = m_rpnVector.begin();
-       it != m_rpnVector.end(); it++) {
-
+  for (RpnVector::const_iterator it = m_rpnVector.begin(); it != m_rpnVector.end(); it++) {
     // LogTrace("L1GlobalTrigger")
     //<< "\nit->operation = " << it->operation
     //<< "\nit->operand =   '" << it->operand << "'\n"
     //<< std::endl;
 
     switch (it->operation) {
+      case L1GtLogicParser::OP_OPERAND: {
+        CItEvalMap itCond = (conditionResultMaps.at(chipNumber)).find(it->operand);
+        if (itCond != (conditionResultMaps[chipNumber]).end()) {
+          if (nullptr == itCond->second) {
+            // it should never be happen, only valid conditions are in the maps
+            throw cms::Exception("FailModule")
+                << "\nCondition " << (it->operand) << " NULL pointer found in condition map" << std::endl;
+          }
 
-    case L1GtLogicParser::OP_OPERAND: {
+          //
+          bool condResult = (itCond->second)->condLastResult();
 
-      CItEvalMap itCond =
-          (conditionResultMaps.at(chipNumber)).find(it->operand);
-      if (itCond != (conditionResultMaps[chipNumber]).end()) {
+          resultStack.push(condResult);
 
-        if (nullptr == itCond->second) {
-          // it should never be happen, only valid conditions are in the maps
+          // only conditions are added to /counted in m_operandTokenVector
+          // opNumber is the index of the condition in the logical expression
+          OperandToken opToken;
+          opToken.tokenName = it->operand;
+          opToken.tokenNumber = opNumber;
+          opToken.tokenResult = condResult;
+
+          m_operandTokenVector.push_back(opToken);
+          opNumber++;
+
+          //
+          CombinationsInCond const &combInCondition = (itCond->second)->getCombinationsInCond();
+          m_algoCombinationVector.push_back(combInCondition);
+
+        } else {
+          // it should never be happen, all conditions are in the maps
           throw cms::Exception("FailModule")
-              << "\nCondition " << (it->operand)
-              << " NULL pointer found in condition map" << std::endl;
+              << "\nCondition " << (it->operand) << " not found in condition map" << std::endl;
         }
 
-        //
-        bool condResult = (itCond->second)->condLastResult();
-
-        resultStack.push(condResult);
-
-        // only conditions are added to /counted in m_operandTokenVector
-        // opNumber is the index of the condition in the logical expression
-        OperandToken opToken;
-        opToken.tokenName = it->operand;
-        opToken.tokenNumber = opNumber;
-        opToken.tokenResult = condResult;
-
-        m_operandTokenVector.push_back(opToken);
-        opNumber++;
-
-        //
-        CombinationsInCond const &combInCondition =
-            (itCond->second)->getCombinationsInCond();
-        m_algoCombinationVector.push_back(combInCondition);
-
-      } else {
-
-        // it should never be happen, all conditions are in the maps
-        throw cms::Exception("FailModule")
-            << "\nCondition " << (it->operand) << " not found in condition map"
-            << std::endl;
       }
 
-    }
+      break;
+      case L1GtLogicParser::OP_NOT: {
+        b1 = resultStack.top();
+        resultStack.pop();      // pop the top
+        resultStack.push(!b1);  // and push the result
+      }
 
-    break;
-    case L1GtLogicParser::OP_NOT: {
-      b1 = resultStack.top();
-      resultStack.pop();     // pop the top
-      resultStack.push(!b1); // and push the result
-    }
+      break;
+      case L1GtLogicParser::OP_OR: {
+        b1 = resultStack.top();
+        resultStack.pop();
+        b2 = resultStack.top();
+        resultStack.pop();
+        resultStack.push(b1 || b2);
+      }
 
-    break;
-    case L1GtLogicParser::OP_OR: {
-      b1 = resultStack.top();
-      resultStack.pop();
-      b2 = resultStack.top();
-      resultStack.pop();
-      resultStack.push(b1 || b2);
-    }
+      break;
+      case L1GtLogicParser::OP_AND: {
+        b1 = resultStack.top();
+        resultStack.pop();
+        b2 = resultStack.top();
+        resultStack.pop();
+        resultStack.push(b1 && b2);
+      }
 
-    break;
-    case L1GtLogicParser::OP_AND: {
-      b1 = resultStack.top();
-      resultStack.pop();
-      b2 = resultStack.top();
-      resultStack.pop();
-      resultStack.push(b1 && b2);
-    }
+      break;
+      default: {
+        // should not arrive here
+      }
 
-    break;
-    default: {
-      // should not arrive here
-    }
-
-    break;
+      break;
     }
   }
 
@@ -173,13 +158,11 @@ void L1GtAlgorithmEvaluation::evaluateAlgorithm(
 
 // print algorithm evaluation
 void L1GtAlgorithmEvaluation::print(std::ostream &myCout) const {
-
   myCout << std::endl;
 
   myCout << "    Algorithm result:          " << m_algoResult << std::endl;
 
-  myCout << "    CombinationVector size:    " << m_algoCombinationVector.size()
-         << std::endl;
+  myCout << "    CombinationVector size:    " << m_algoCombinationVector.size() << std::endl;
 
   int operandTokenVectorSize = m_operandTokenVector.size();
 
@@ -191,11 +174,8 @@ void L1GtAlgorithmEvaluation::print(std::ostream &myCout) const {
     myCout << std::endl;
 
     for (int i = 0; i < operandTokenVectorSize; ++i) {
-
-      myCout << "      " << std::setw(5)
-             << (m_operandTokenVector[i]).tokenNumber << "\t" << std::setw(25)
-             << (m_operandTokenVector[i]).tokenName << "\t"
-             << (m_operandTokenVector[i]).tokenResult << std::endl;
+      myCout << "      " << std::setw(5) << (m_operandTokenVector[i]).tokenNumber << "\t" << std::setw(25)
+             << (m_operandTokenVector[i]).tokenName << "\t" << (m_operandTokenVector[i]).tokenResult << std::endl;
     }
   }
 

--- a/L1Trigger/GlobalTrigger/src/L1GtBptxCondition.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GtBptxCondition.cc
@@ -26,18 +26,13 @@
 
 // constructors
 //     default
-L1GtBptxCondition::L1GtBptxCondition() : L1GtConditionEvaluation() {
-
-  m_conditionResult = false;
-}
+L1GtBptxCondition::L1GtBptxCondition() : L1GtConditionEvaluation() { m_conditionResult = false; }
 
 //     from base template condition (from event setup usually)
-L1GtBptxCondition::L1GtBptxCondition(const L1GtCondition *bptxTemplate,
-                                     const bool result)
+L1GtBptxCondition::L1GtBptxCondition(const L1GtCondition *bptxTemplate, const bool result)
     : L1GtConditionEvaluation(),
       m_gtBptxTemplate(static_cast<const L1GtBptxTemplate *>(bptxTemplate)),
       m_conditionResult(result) {
-
   // maximum number of objects received for the evaluation of the condition
   // no object
   m_condMaxNumberObjects = 0;
@@ -45,7 +40,6 @@ L1GtBptxCondition::L1GtBptxCondition(const L1GtCondition *bptxTemplate,
 
 // copy constructor
 void L1GtBptxCondition::copy(const L1GtBptxCondition &cp) {
-
   m_gtBptxTemplate = cp.gtBptxTemplate();
   m_conditionResult = cp.conditionResult();
 
@@ -56,15 +50,10 @@ void L1GtBptxCondition::copy(const L1GtBptxCondition &cp) {
   m_verbosity = cp.m_verbosity;
 }
 
-L1GtBptxCondition::L1GtBptxCondition(const L1GtBptxCondition &cp)
-    : L1GtConditionEvaluation() {
-
-  copy(cp);
-}
+L1GtBptxCondition::L1GtBptxCondition(const L1GtBptxCondition &cp) : L1GtConditionEvaluation() { copy(cp); }
 
 // destructor
 L1GtBptxCondition::~L1GtBptxCondition() {
-
   // empty
 }
 
@@ -75,14 +64,9 @@ L1GtBptxCondition &L1GtBptxCondition::operator=(const L1GtBptxCondition &cp) {
 }
 
 // methods
-void L1GtBptxCondition::setGtBptxTemplate(
-    const L1GtBptxTemplate *bptxTemplate) {
-
-  m_gtBptxTemplate = bptxTemplate;
-}
+void L1GtBptxCondition::setGtBptxTemplate(const L1GtBptxTemplate *bptxTemplate) { m_gtBptxTemplate = bptxTemplate; }
 
 const bool L1GtBptxCondition::evaluateCondition() const {
-
   // clear the m_combinationsInCond vector
   (combinationsInCond()).clear();
 
@@ -91,7 +75,6 @@ const bool L1GtBptxCondition::evaluateCondition() const {
 }
 
 void L1GtBptxCondition::print(std::ostream &myCout) const {
-
   m_gtBptxTemplate->print(myCout);
   L1GtConditionEvaluation::print(myCout);
 }

--- a/L1Trigger/GlobalTrigger/src/L1GtCaloCondition.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GtCaloCondition.cc
@@ -46,7 +46,6 @@
 // constructors
 //     default
 L1GtCaloCondition::L1GtCaloCondition() : L1GtConditionEvaluation() {
-
   m_ifCaloEtaNumberBits = -1;
   m_corrParDeltaPhiNrBins = 0;
 }
@@ -54,14 +53,16 @@ L1GtCaloCondition::L1GtCaloCondition() : L1GtConditionEvaluation() {
 //     from base template condition (from event setup usually)
 L1GtCaloCondition::L1GtCaloCondition(const L1GtCondition *caloTemplate,
                                      const L1GlobalTriggerPSB *ptrPSB,
-                                     const int nrL1NoIsoEG, const int nrL1IsoEG,
-                                     const int nrL1CenJet, const int nrL1ForJet,
+                                     const int nrL1NoIsoEG,
+                                     const int nrL1IsoEG,
+                                     const int nrL1CenJet,
+                                     const int nrL1ForJet,
                                      const int nrL1TauJet,
                                      const int ifCaloEtaNumberBits)
     : L1GtConditionEvaluation(),
       m_gtCaloTemplate(static_cast<const L1GtCaloTemplate *>(caloTemplate)),
-      m_gtPSB(ptrPSB), m_ifCaloEtaNumberBits(ifCaloEtaNumberBits) {
-
+      m_gtPSB(ptrPSB),
+      m_ifCaloEtaNumberBits(ifCaloEtaNumberBits) {
   m_corrParDeltaPhiNrBins = 0;
 
   // maximum number of objects received for the evaluation of the condition
@@ -70,30 +71,29 @@ L1GtCaloCondition::L1GtCaloCondition(const L1GtCondition *caloTemplate,
   // type for the first object
 
   switch ((m_gtCaloTemplate->objectType())[0]) {
-  case NoIsoEG:
-    m_condMaxNumberObjects = nrL1NoIsoEG;
-    break;
-  case IsoEG:
-    m_condMaxNumberObjects = nrL1IsoEG;
-    break;
-  case CenJet:
-    m_condMaxNumberObjects = nrL1CenJet;
-    break;
-  case ForJet:
-    m_condMaxNumberObjects = nrL1ForJet;
-    break;
-  case TauJet:
-    m_condMaxNumberObjects = nrL1TauJet;
-    break;
-  default:
-    m_condMaxNumberObjects = 0;
-    break;
+    case NoIsoEG:
+      m_condMaxNumberObjects = nrL1NoIsoEG;
+      break;
+    case IsoEG:
+      m_condMaxNumberObjects = nrL1IsoEG;
+      break;
+    case CenJet:
+      m_condMaxNumberObjects = nrL1CenJet;
+      break;
+    case ForJet:
+      m_condMaxNumberObjects = nrL1ForJet;
+      break;
+    case TauJet:
+      m_condMaxNumberObjects = nrL1TauJet;
+      break;
+    default:
+      m_condMaxNumberObjects = 0;
+      break;
   }
 }
 
 // copy constructor
 void L1GtCaloCondition::copy(const L1GtCaloCondition &cp) {
-
   m_gtCaloTemplate = cp.gtCaloTemplate();
   m_gtPSB = cp.gtPSB();
 
@@ -107,15 +107,10 @@ void L1GtCaloCondition::copy(const L1GtCaloCondition &cp) {
   m_verbosity = cp.m_verbosity;
 }
 
-L1GtCaloCondition::L1GtCaloCondition(const L1GtCaloCondition &cp)
-    : L1GtConditionEvaluation() {
-
-  copy(cp);
-}
+L1GtCaloCondition::L1GtCaloCondition(const L1GtCaloCondition &cp) : L1GtConditionEvaluation() { copy(cp); }
 
 // destructor
 L1GtCaloCondition::~L1GtCaloCondition() {
-
   // empty
 }
 
@@ -126,34 +121,23 @@ L1GtCaloCondition &L1GtCaloCondition::operator=(const L1GtCaloCondition &cp) {
 }
 
 // methods
-void L1GtCaloCondition::setGtCaloTemplate(const L1GtCaloTemplate *caloTempl) {
-
-  m_gtCaloTemplate = caloTempl;
-}
+void L1GtCaloCondition::setGtCaloTemplate(const L1GtCaloTemplate *caloTempl) { m_gtCaloTemplate = caloTempl; }
 
 ///   set the pointer to PSB
-void L1GtCaloCondition::setGtPSB(const L1GlobalTriggerPSB *ptrPSB) {
-
-  m_gtPSB = ptrPSB;
-}
+void L1GtCaloCondition::setGtPSB(const L1GlobalTriggerPSB *ptrPSB) { m_gtPSB = ptrPSB; }
 
 //   set the number of bits for eta of calorimeter objects
-void L1GtCaloCondition::setGtIfCaloEtaNumberBits(
-    const int &ifCaloEtaNumberBitsValue) {
-
+void L1GtCaloCondition::setGtIfCaloEtaNumberBits(const int &ifCaloEtaNumberBitsValue) {
   m_ifCaloEtaNumberBits = ifCaloEtaNumberBitsValue;
 }
 
 //   set the maximum number of bins for the delta phi scales
-void L1GtCaloCondition::setGtCorrParDeltaPhiNrBins(
-    const int &corrParDeltaPhiNrBins) {
-
+void L1GtCaloCondition::setGtCorrParDeltaPhiNrBins(const int &corrParDeltaPhiNrBins) {
   m_corrParDeltaPhiNrBins = corrParDeltaPhiNrBins;
 }
 
 // try all object permutations and check spatial correlations, if required
 const bool L1GtCaloCondition::evaluateCondition() const {
-
   // number of trigger objects in the condition
   int nObjInCond = m_gtCaloTemplate->nrObjects();
   // LogTrace("L1GlobalTrigger") << "  nObjInCond: " << nObjInCond
@@ -168,24 +152,24 @@ const bool L1GtCaloCondition::evaluateCondition() const {
   const std::vector<const L1GctCand *> *candVec;
 
   switch ((m_gtCaloTemplate->objectType())[0]) {
-  case NoIsoEG:
-    candVec = m_gtPSB->getCandL1NoIsoEG();
-    break;
-  case IsoEG:
-    candVec = m_gtPSB->getCandL1IsoEG();
-    break;
-  case CenJet:
-    candVec = m_gtPSB->getCandL1CenJet();
-    break;
-  case ForJet:
-    candVec = m_gtPSB->getCandL1ForJet();
-    break;
-  case TauJet:
-    candVec = m_gtPSB->getCandL1TauJet();
-    break;
-  default:
-    return false;
-    break;
+    case NoIsoEG:
+      candVec = m_gtPSB->getCandL1NoIsoEG();
+      break;
+    case IsoEG:
+      candVec = m_gtPSB->getCandL1IsoEG();
+      break;
+    case CenJet:
+      candVec = m_gtPSB->getCandL1CenJet();
+      break;
+    case ForJet:
+      candVec = m_gtPSB->getCandL1ForJet();
+      break;
+    case TauJet:
+      candVec = m_gtPSB->getCandL1TauJet();
+      break;
+    default:
+      return false;
+      break;
   }
 
   int numberObjects = candVec->size();
@@ -221,7 +205,6 @@ const bool L1GtCaloCondition::evaluateCondition() const {
   combinationsInCond().clear();
 
   do {
-
     if (--jumpIndex)
       continue;
 
@@ -236,7 +219,6 @@ const bool L1GtCaloCondition::evaluateCondition() const {
     // check if there is a permutation that matches object-parameter
     // requirements
     for (int i = 0; i < nObjInCond; i++) {
-
       tmpResult &= checkObjectParameter(i, *(*candVec)[index[i]]);
       objectsInComb.push_back(index[i]);
     }
@@ -244,30 +226,26 @@ const bool L1GtCaloCondition::evaluateCondition() const {
     // if permutation does not match particle conditions
     // skip spatial correlations
     if (!tmpResult) {
-
       continue;
     }
 
     if (m_gtCaloTemplate->wsc()) {
-
       // wsc requirements have always nObjInCond = 2
       // one can use directly index[0] and index[1] to compute
       // eta and phi differences
       const int ObjInWscComb = 2;
       if (nObjInCond != ObjInWscComb) {
-
         if (m_verbosity) {
           edm::LogError("L1GlobalTrigger")
               << "\n  Error: "
-              << "number of particles in condition with spatial correlation = "
-              << nObjInCond << "\n  it must be = " << ObjInWscComb << std::endl;
+              << "number of particles in condition with spatial correlation = " << nObjInCond
+              << "\n  it must be = " << ObjInWscComb << std::endl;
         }
 
         continue;
       }
 
-      L1GtCaloTemplate::CorrelationParameter corrPar =
-          *(m_gtCaloTemplate->correlationParameter());
+      L1GtCaloTemplate::CorrelationParameter corrPar = *(m_gtCaloTemplate->correlationParameter());
 
       unsigned int candDeltaEta;
       unsigned int candDeltaPhi;
@@ -282,8 +260,7 @@ const bool L1GtCaloCondition::evaluateCondition() const {
       int scaleEta = 1 << (m_ifCaloEtaNumberBits - 1);
 
       for (int i = 0; i < ObjInWscComb; ++i) {
-        signBit[i] = ((*candVec)[index[i]]->etaIndex() & scaleEta) >>
-                     (m_ifCaloEtaNumberBits - 1);
+        signBit[i] = ((*candVec)[index[i]]->etaIndex() & scaleEta) >> (m_ifCaloEtaNumberBits - 1);
         signedEta[i] = ((*candVec)[index[i]]->etaIndex()) % scaleEta;
 
         if (signBit[i] == 1) {
@@ -293,8 +270,8 @@ const bool L1GtCaloCondition::evaluateCondition() const {
 
       // compute candDeltaEta - add 1 if signs are different (due to +0/-0
       // indices)
-      candDeltaEta = static_cast<int>(std::abs(signedEta[1] - signedEta[0])) +
-                     static_cast<int>(signBit[1] ^ signBit[0]);
+      candDeltaEta =
+          static_cast<int>(std::abs(signedEta[1] - signedEta[0])) + static_cast<int>(signBit[1] ^ signBit[0]);
 
       if (!checkBit(corrPar.deltaEtaRange, candDeltaEta)) {
         continue;
@@ -304,11 +281,9 @@ const bool L1GtCaloCondition::evaluateCondition() const {
 
       // calculate absolute value of candDeltaPhi
       if ((*candVec)[index[0]]->phiIndex() > (*candVec)[index[1]]->phiIndex()) {
-        candDeltaPhi =
-            (*candVec)[index[0]]->phiIndex() - (*candVec)[index[1]]->phiIndex();
+        candDeltaPhi = (*candVec)[index[0]]->phiIndex() - (*candVec)[index[1]]->phiIndex();
       } else {
-        candDeltaPhi =
-            (*candVec)[index[1]]->phiIndex() - (*candVec)[index[0]]->phiIndex();
+        candDeltaPhi = (*candVec)[index[1]]->phiIndex() - (*candVec)[index[0]]->phiIndex();
       }
 
       // check if candDeltaPhi > 180 (via delta_phi_maxbits)
@@ -319,19 +294,16 @@ const bool L1GtCaloCondition::evaluateCondition() const {
       int iLoop = 0;
 
       while (candDeltaPhi >= m_corrParDeltaPhiNrBins) {
-
         unsigned int candDeltaPhiInitial = candDeltaPhi;
 
         // candDeltaPhi > 180 ==> take 360 - candDeltaPhi
         candDeltaPhi = (m_corrParDeltaPhiNrBins - 1) * 2 - candDeltaPhi;
         if (m_verbosity) {
-          LogTrace("L1GlobalTrigger")
-              << "    Initial candDeltaPhi = " << candDeltaPhiInitial
-              << " > m_corrParDeltaPhiNrBins = " << m_corrParDeltaPhiNrBins
-              << "  ==> candDeltaPhi rescaled to: " << candDeltaPhi
-              << " [ loop index " << iLoop << "; breaks after " << nMaxLoop
-              << " loops ]\n"
-              << std::endl;
+          LogTrace("L1GlobalTrigger") << "    Initial candDeltaPhi = " << candDeltaPhiInitial
+                                      << " > m_corrParDeltaPhiNrBins = " << m_corrParDeltaPhiNrBins
+                                      << "  ==> candDeltaPhi rescaled to: " << candDeltaPhi << " [ loop index " << iLoop
+                                      << "; breaks after " << nMaxLoop << " loops ]\n"
+                                      << std::endl;
         }
 
         iLoop++;
@@ -344,7 +316,7 @@ const bool L1GtCaloCondition::evaluateCondition() const {
         continue;
       }
 
-    } // end wsc check
+    }  // end wsc check
 
     // if we get here all checks were successful for this combination
     // set the general result for evaluateCondition to "true"
@@ -368,29 +340,28 @@ const bool L1GtCaloCondition::evaluateCondition() const {
 
 // load calo candidates
 const L1GctCand *L1GtCaloCondition::getCandidate(const int indexCand) const {
-
   // objectType() gives the type for nrObjects() only,
   // but in a CondCalo all objects have the same type
   // take type from the type of the first object
   switch ((m_gtCaloTemplate->objectType())[0]) {
-  case NoIsoEG:
-    return (*(m_gtPSB->getCandL1NoIsoEG()))[indexCand];
-    break;
-  case IsoEG:
-    return (*(m_gtPSB->getCandL1IsoEG()))[indexCand];
-    break;
-  case CenJet:
-    return (*(m_gtPSB->getCandL1CenJet()))[indexCand];
-    break;
-  case ForJet:
-    return (*(m_gtPSB->getCandL1ForJet()))[indexCand];
-    break;
-  case TauJet:
-    return (*(m_gtPSB->getCandL1TauJet()))[indexCand];
-    break;
-  default:
-    return nullptr;
-    break;
+    case NoIsoEG:
+      return (*(m_gtPSB->getCandL1NoIsoEG()))[indexCand];
+      break;
+    case IsoEG:
+      return (*(m_gtPSB->getCandL1IsoEG()))[indexCand];
+      break;
+    case CenJet:
+      return (*(m_gtPSB->getCandL1CenJet()))[indexCand];
+      break;
+    case ForJet:
+      return (*(m_gtPSB->getCandL1ForJet()))[indexCand];
+      break;
+    case TauJet:
+      return (*(m_gtPSB->getCandL1TauJet()))[indexCand];
+      break;
+    default:
+      return nullptr;
+      break;
   }
 
   return nullptr;
@@ -405,10 +376,7 @@ const L1GctCand *L1GtCaloCondition::getCandidate(const int indexCand) const {
  * @return The result of the comparison (false if a condition does not exist).
  */
 
-const bool
-L1GtCaloCondition::checkObjectParameter(const int iCondition,
-                                        const L1GctCand &cand) const {
-
+const bool L1GtCaloCondition::checkObjectParameter(const int iCondition, const L1GctCand &cand) const {
   // number of objects in condition
   int nObjInCond = m_gtCaloTemplate->nrObjects();
 
@@ -421,12 +389,10 @@ L1GtCaloCondition::checkObjectParameter(const int iCondition,
     return false;
   }
 
-  const L1GtCaloTemplate::ObjectParameter objPar =
-      (*(m_gtCaloTemplate->objectParameter()))[iCondition];
+  const L1GtCaloTemplate::ObjectParameter objPar = (*(m_gtCaloTemplate->objectParameter()))[iCondition];
 
   // check energy threshold
-  if (!checkThreshold(objPar.etThreshold, cand.rank(),
-                      m_gtCaloTemplate->condGEq())) {
+  if (!checkThreshold(objPar.etThreshold, cand.rank(), m_gtCaloTemplate->condGEq())) {
     return false;
   }
 
@@ -451,13 +417,10 @@ L1GtCaloCondition::checkObjectParameter(const int iCondition,
 }
 
 void L1GtCaloCondition::print(std::ostream &myCout) const {
-
   m_gtCaloTemplate->print(myCout);
 
-  myCout << "    Number of bits for eta of calorimeter objects = "
-         << m_ifCaloEtaNumberBits << std::endl;
-  myCout << "    Maximum number of bins for the delta phi scales = "
-         << m_corrParDeltaPhiNrBins << "\n " << std::endl;
+  myCout << "    Number of bits for eta of calorimeter objects = " << m_ifCaloEtaNumberBits << std::endl;
+  myCout << "    Maximum number of bins for the delta phi scales = " << m_corrParDeltaPhiNrBins << "\n " << std::endl;
 
   L1GtConditionEvaluation::print(myCout);
 }

--- a/L1Trigger/GlobalTrigger/src/L1GtCastorCondition.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GtCastorCondition.cc
@@ -26,19 +26,13 @@
 
 // constructors
 //     default
-L1GtCastorCondition::L1GtCastorCondition() : L1GtConditionEvaluation() {
-
-  m_conditionResult = false;
-}
+L1GtCastorCondition::L1GtCastorCondition() : L1GtConditionEvaluation() { m_conditionResult = false; }
 
 //     from base template condition (from event setup usually)
-L1GtCastorCondition::L1GtCastorCondition(const L1GtCondition *castorTemplate,
-                                         const bool result)
+L1GtCastorCondition::L1GtCastorCondition(const L1GtCondition *castorTemplate, const bool result)
     : L1GtConditionEvaluation(),
-      m_gtCastorTemplate(
-          static_cast<const L1GtCastorTemplate *>(castorTemplate)),
+      m_gtCastorTemplate(static_cast<const L1GtCastorTemplate *>(castorTemplate)),
       m_conditionResult(result) {
-
   // maximum number of objects received for the evaluation of the condition
   // no object
   m_condMaxNumberObjects = 0;
@@ -46,7 +40,6 @@ L1GtCastorCondition::L1GtCastorCondition(const L1GtCondition *castorTemplate,
 
 // copy constructor
 void L1GtCastorCondition::copy(const L1GtCastorCondition &cp) {
-
   m_gtCastorTemplate = cp.gtCastorTemplate();
   m_conditionResult = cp.conditionResult();
 
@@ -57,34 +50,25 @@ void L1GtCastorCondition::copy(const L1GtCastorCondition &cp) {
   m_verbosity = cp.m_verbosity;
 }
 
-L1GtCastorCondition::L1GtCastorCondition(const L1GtCastorCondition &cp)
-    : L1GtConditionEvaluation() {
-
-  copy(cp);
-}
+L1GtCastorCondition::L1GtCastorCondition(const L1GtCastorCondition &cp) : L1GtConditionEvaluation() { copy(cp); }
 
 // destructor
 L1GtCastorCondition::~L1GtCastorCondition() {
-
   // empty
 }
 
 // equal operator
-L1GtCastorCondition &L1GtCastorCondition::
-operator=(const L1GtCastorCondition &cp) {
+L1GtCastorCondition &L1GtCastorCondition::operator=(const L1GtCastorCondition &cp) {
   copy(cp);
   return *this;
 }
 
 // methods
-void L1GtCastorCondition::setGtCastorTemplate(
-    const L1GtCastorTemplate *castorTemplate) {
-
+void L1GtCastorCondition::setGtCastorTemplate(const L1GtCastorTemplate *castorTemplate) {
   m_gtCastorTemplate = castorTemplate;
 }
 
 const bool L1GtCastorCondition::evaluateCondition() const {
-
   // clear the m_combinationsInCond vector
   (combinationsInCond()).clear();
 
@@ -93,7 +77,6 @@ const bool L1GtCastorCondition::evaluateCondition() const {
 }
 
 void L1GtCastorCondition::print(std::ostream &myCout) const {
-
   m_gtCastorTemplate->print(myCout);
   L1GtConditionEvaluation::print(myCout);
 }

--- a/L1Trigger/GlobalTrigger/src/L1GtConditionEvaluation.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GtConditionEvaluation.cc
@@ -32,23 +32,17 @@
 
 /// print condition
 void L1GtConditionEvaluation::print(std::ostream &myCout) const {
-
   myCout << "\n  L1GtConditionEvaluation print...\n" << std::endl;
-  myCout << "  Maximum number of objects in condition: "
-         << m_condMaxNumberObjects << std::endl;
-  myCout << "  Condition result:                       " << m_condLastResult
-         << std::endl;
+  myCout << "  Maximum number of objects in condition: " << m_condMaxNumberObjects << std::endl;
+  myCout << "  Condition result:                       " << m_condLastResult << std::endl;
 
   CombinationsInCond::const_iterator itVV;
   std::ostringstream myCout1;
 
-  for (itVV = (m_combinationsInCond).begin();
-       itVV != (m_combinationsInCond).end(); itVV++) {
-
+  for (itVV = (m_combinationsInCond).begin(); itVV != (m_combinationsInCond).end(); itVV++) {
     myCout1 << "( ";
 
-    std::copy((*itVV).begin(), (*itVV).end(),
-              std::ostream_iterator<int>(myCout1, " "));
+    std::copy((*itVV).begin(), (*itVV).end(), std::ostream_iterator<int>(myCout1, " "));
 
     myCout1 << "); ";
   }

--- a/L1Trigger/GlobalTrigger/src/L1GtCorrelationCondition.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GtCorrelationCondition.cc
@@ -57,34 +57,38 @@
 //     default
 L1GtCorrelationCondition::L1GtCorrelationCondition()
     : L1GtConditionEvaluation(), m_isDebugEnabled(edm::isDebugEnabled()) {
-
   // empty
 }
 
 //     from base template condition (from event setup usually)
-L1GtCorrelationCondition::L1GtCorrelationCondition(
-    const L1GtCondition *corrTemplate, const L1GtCondition *cond0Condition,
-    const L1GtCondition *cond1Condition, const int cond0NrL1Objects,
-    const int cond1NrL1Objects, const int cond0EtaBits, const int cond1EtaBits,
-    const L1GlobalTriggerGTL *ptrGTL, const L1GlobalTriggerPSB *ptrPSB,
-    const L1GtEtaPhiConversions *etaPhiConversions)
+L1GtCorrelationCondition::L1GtCorrelationCondition(const L1GtCondition *corrTemplate,
+                                                   const L1GtCondition *cond0Condition,
+                                                   const L1GtCondition *cond1Condition,
+                                                   const int cond0NrL1Objects,
+                                                   const int cond1NrL1Objects,
+                                                   const int cond0EtaBits,
+                                                   const int cond1EtaBits,
+                                                   const L1GlobalTriggerGTL *ptrGTL,
+                                                   const L1GlobalTriggerPSB *ptrPSB,
+                                                   const L1GtEtaPhiConversions *etaPhiConversions)
     : L1GtConditionEvaluation(),
-      m_gtCorrelationTemplate(
-          static_cast<const L1GtCorrelationTemplate *>(corrTemplate)),
-      m_gtCond0(cond0Condition), m_gtCond1(cond1Condition),
+      m_gtCorrelationTemplate(static_cast<const L1GtCorrelationTemplate *>(corrTemplate)),
+      m_gtCond0(cond0Condition),
+      m_gtCond1(cond1Condition),
       m_cond0NrL1Objects(cond0NrL1Objects),
-      m_cond1NrL1Objects(cond1NrL1Objects), m_cond0EtaBits(cond0EtaBits),
-      m_cond1EtaBits(cond1EtaBits), m_gtGTL(ptrGTL), m_gtPSB(ptrPSB),
+      m_cond1NrL1Objects(cond1NrL1Objects),
+      m_cond0EtaBits(cond0EtaBits),
+      m_cond1EtaBits(cond1EtaBits),
+      m_gtGTL(ptrGTL),
+      m_gtPSB(ptrPSB),
       m_gtEtaPhiConversions(etaPhiConversions),
       m_isDebugEnabled(edm::isDebugEnabled()) {
-
-  m_condMaxNumberObjects = 2; // irrelevant for correlation conditions
+  m_condMaxNumberObjects = 2;  // irrelevant for correlation conditions
   m_nrBinsPhi = 0;
 }
 
 // copy constructor
 void L1GtCorrelationCondition::copy(const L1GtCorrelationCondition &cp) {
-
   m_gtCorrelationTemplate = cp.m_gtCorrelationTemplate;
 
   m_gtCond0 = cp.m_gtCond0;
@@ -111,54 +115,38 @@ void L1GtCorrelationCondition::copy(const L1GtCorrelationCondition &cp) {
   m_isDebugEnabled = cp.m_isDebugEnabled;
 }
 
-L1GtCorrelationCondition::L1GtCorrelationCondition(
-    const L1GtCorrelationCondition &cp)
-    : L1GtConditionEvaluation() {
+L1GtCorrelationCondition::L1GtCorrelationCondition(const L1GtCorrelationCondition &cp) : L1GtConditionEvaluation() {
   copy(cp);
 }
 
 // destructor
 L1GtCorrelationCondition::~L1GtCorrelationCondition() {
-
   // empty
 }
 
 // equal operator
-L1GtCorrelationCondition &L1GtCorrelationCondition::
-operator=(const L1GtCorrelationCondition &cp) {
+L1GtCorrelationCondition &L1GtCorrelationCondition::operator=(const L1GtCorrelationCondition &cp) {
   copy(cp);
   return *this;
 }
 
 // methods
 
-void L1GtCorrelationCondition::setGtNrBinsPhi(const unsigned int nrBins) {
-
-  m_nrBinsPhi = nrBins;
-}
+void L1GtCorrelationCondition::setGtNrBinsPhi(const unsigned int nrBins) { m_nrBinsPhi = nrBins; }
 
 //
-void L1GtCorrelationCondition::setGtCorrelationTemplate(
-    const L1GtCorrelationTemplate *corrTempl) {
-
+void L1GtCorrelationCondition::setGtCorrelationTemplate(const L1GtCorrelationTemplate *corrTempl) {
   m_gtCorrelationTemplate = corrTempl;
 }
 
 //   set the pointer to GTL
-void L1GtCorrelationCondition::setGtGTL(const L1GlobalTriggerGTL *ptrGTL) {
-
-  m_gtGTL = ptrGTL;
-}
+void L1GtCorrelationCondition::setGtGTL(const L1GlobalTriggerGTL *ptrGTL) { m_gtGTL = ptrGTL; }
 
 //   set the pointer to PSB
-void L1GtCorrelationCondition::setGtPSB(const L1GlobalTriggerPSB *ptrPSB) {
-
-  m_gtPSB = ptrPSB;
-}
+void L1GtCorrelationCondition::setGtPSB(const L1GlobalTriggerPSB *ptrPSB) { m_gtPSB = ptrPSB; }
 
 // try all object permutations and check spatial correlations, if required
 const bool L1GtCorrelationCondition::evaluateCondition() const {
-
   // std::cout << "m_isDebugEnabled = " << m_isDebugEnabled << std::endl;
   // std::cout << "m_verbosity = " << m_verbosity << std::endl;
 
@@ -172,10 +160,8 @@ const bool L1GtCorrelationCondition::evaluateCondition() const {
 
   // evaluate first the two sub-conditions (Type1s)
 
-  const L1GtConditionCategory cond0Categ =
-      m_gtCorrelationTemplate->cond0Category();
-  const L1GtConditionCategory cond1Categ =
-      m_gtCorrelationTemplate->cond1Category();
+  const L1GtConditionCategory cond0Categ = m_gtCorrelationTemplate->cond0Category();
+  const L1GtConditionCategory cond1Categ = m_gtCorrelationTemplate->cond1Category();
 
   const L1GtMuonTemplate *corrMuon = nullptr;
   const L1GtCaloTemplate *corrCalo = nullptr;
@@ -186,76 +172,78 @@ const bool L1GtCorrelationCondition::evaluateCondition() const {
   CombinationsInCond cond1Comb;
 
   switch (cond0Categ) {
-  case CondMuon: {
-    corrMuon = static_cast<const L1GtMuonTemplate *>(m_gtCond0);
-    L1GtMuonCondition muCondition(corrMuon, m_gtGTL, m_cond0NrL1Objects,
-                                  m_cond0EtaBits);
+    case CondMuon: {
+      corrMuon = static_cast<const L1GtMuonTemplate *>(m_gtCond0);
+      L1GtMuonCondition muCondition(corrMuon, m_gtGTL, m_cond0NrL1Objects, m_cond0EtaBits);
 
-    muCondition.evaluateConditionStoreResult();
-    reqObjResult = muCondition.condLastResult();
+      muCondition.evaluateConditionStoreResult();
+      reqObjResult = muCondition.condLastResult();
 
-    cond0Comb = (muCondition.getCombinationsInCond());
-    cndObjTypeVec[0] = (corrMuon->objectType())[0];
+      cond0Comb = (muCondition.getCombinationsInCond());
+      cndObjTypeVec[0] = (corrMuon->objectType())[0];
 
-    if (m_verbosity && m_isDebugEnabled) {
-      std::ostringstream myCout;
-      muCondition.print(myCout);
+      if (m_verbosity && m_isDebugEnabled) {
+        std::ostringstream myCout;
+        muCondition.print(myCout);
 
-      LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
-    }
-  } break;
-  case CondCalo: {
-    corrCalo = static_cast<const L1GtCaloTemplate *>(m_gtCond0);
+        LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
+      }
+    } break;
+    case CondCalo: {
+      corrCalo = static_cast<const L1GtCaloTemplate *>(m_gtCond0);
 
-    L1GtCaloCondition caloCondition(corrCalo, m_gtPSB, m_cond0NrL1Objects,
-                                    m_cond0NrL1Objects, m_cond0NrL1Objects,
-                                    m_cond0NrL1Objects, m_cond0NrL1Objects,
-                                    m_cond0EtaBits);
+      L1GtCaloCondition caloCondition(corrCalo,
+                                      m_gtPSB,
+                                      m_cond0NrL1Objects,
+                                      m_cond0NrL1Objects,
+                                      m_cond0NrL1Objects,
+                                      m_cond0NrL1Objects,
+                                      m_cond0NrL1Objects,
+                                      m_cond0EtaBits);
 
-    caloCondition.evaluateConditionStoreResult();
-    reqObjResult = caloCondition.condLastResult();
+      caloCondition.evaluateConditionStoreResult();
+      reqObjResult = caloCondition.condLastResult();
 
-    cond0Comb = (caloCondition.getCombinationsInCond());
-    cndObjTypeVec[0] = (corrCalo->objectType())[0];
+      cond0Comb = (caloCondition.getCombinationsInCond());
+      cndObjTypeVec[0] = (corrCalo->objectType())[0];
 
-    if (m_verbosity && m_isDebugEnabled) {
-      std::ostringstream myCout;
-      caloCondition.print(myCout);
+      if (m_verbosity && m_isDebugEnabled) {
+        std::ostringstream myCout;
+        caloCondition.print(myCout);
 
-      LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
-    }
-  } break;
-  case CondEnergySum: {
-    corrEnergySum = static_cast<const L1GtEnergySumTemplate *>(m_gtCond0);
-    L1GtEnergySumCondition eSumCondition(corrEnergySum, m_gtPSB);
+        LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
+      }
+    } break;
+    case CondEnergySum: {
+      corrEnergySum = static_cast<const L1GtEnergySumTemplate *>(m_gtCond0);
+      L1GtEnergySumCondition eSumCondition(corrEnergySum, m_gtPSB);
 
-    eSumCondition.evaluateConditionStoreResult();
-    reqObjResult = eSumCondition.condLastResult();
+      eSumCondition.evaluateConditionStoreResult();
+      reqObjResult = eSumCondition.condLastResult();
 
-    cond0Comb = (eSumCondition.getCombinationsInCond());
-    cndObjTypeVec[0] = (corrEnergySum->objectType())[0];
+      cond0Comb = (eSumCondition.getCombinationsInCond());
+      cndObjTypeVec[0] = (corrEnergySum->objectType())[0];
 
-    if (m_verbosity && m_isDebugEnabled) {
-      std::ostringstream myCout;
-      eSumCondition.print(myCout);
+      if (m_verbosity && m_isDebugEnabled) {
+        std::ostringstream myCout;
+        eSumCondition.print(myCout);
 
-      LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
-    }
-  } break;
-  default: {
-    // should not arrive here, there are no correlation conditions defined for
-    // this object
-    return false;
-  } break;
+        LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
+      }
+    } break;
+    default: {
+      // should not arrive here, there are no correlation conditions defined for
+      // this object
+      return false;
+    } break;
   }
 
   // return if first subcondition is false
   if (!reqObjResult) {
     if (m_verbosity && m_isDebugEnabled) {
-      LogTrace("L1GlobalTrigger")
-          << "\n  First sub-condition false, second sub-condition not "
-             "evaluated and not printed."
-          << std::endl;
+      LogTrace("L1GlobalTrigger") << "\n  First sub-condition false, second sub-condition not "
+                                     "evaluated and not printed."
+                                  << std::endl;
     }
     return false;
   }
@@ -264,77 +252,79 @@ const bool L1GtCorrelationCondition::evaluateCondition() const {
   reqObjResult = false;
 
   switch (cond1Categ) {
-  case CondMuon: {
-    corrMuon = static_cast<const L1GtMuonTemplate *>(m_gtCond1);
-    L1GtMuonCondition muCondition(corrMuon, m_gtGTL, m_cond1NrL1Objects,
-                                  m_cond1EtaBits);
+    case CondMuon: {
+      corrMuon = static_cast<const L1GtMuonTemplate *>(m_gtCond1);
+      L1GtMuonCondition muCondition(corrMuon, m_gtGTL, m_cond1NrL1Objects, m_cond1EtaBits);
 
-    muCondition.evaluateConditionStoreResult();
-    reqObjResult = muCondition.condLastResult();
+      muCondition.evaluateConditionStoreResult();
+      reqObjResult = muCondition.condLastResult();
 
-    cond1Comb = (muCondition.getCombinationsInCond());
-    cndObjTypeVec[1] = (corrMuon->objectType())[0];
+      cond1Comb = (muCondition.getCombinationsInCond());
+      cndObjTypeVec[1] = (corrMuon->objectType())[0];
 
-    if (m_verbosity && m_isDebugEnabled) {
-      std::ostringstream myCout;
-      muCondition.print(myCout);
+      if (m_verbosity && m_isDebugEnabled) {
+        std::ostringstream myCout;
+        muCondition.print(myCout);
 
-      LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
-    }
-  } break;
-  case CondCalo: {
-    corrCalo = static_cast<const L1GtCaloTemplate *>(m_gtCond1);
-    L1GtCaloCondition caloCondition(corrCalo, m_gtPSB, m_cond1NrL1Objects,
-                                    m_cond1NrL1Objects, m_cond1NrL1Objects,
-                                    m_cond1NrL1Objects, m_cond1NrL1Objects,
-                                    m_cond1EtaBits);
+        LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
+      }
+    } break;
+    case CondCalo: {
+      corrCalo = static_cast<const L1GtCaloTemplate *>(m_gtCond1);
+      L1GtCaloCondition caloCondition(corrCalo,
+                                      m_gtPSB,
+                                      m_cond1NrL1Objects,
+                                      m_cond1NrL1Objects,
+                                      m_cond1NrL1Objects,
+                                      m_cond1NrL1Objects,
+                                      m_cond1NrL1Objects,
+                                      m_cond1EtaBits);
 
-    caloCondition.evaluateConditionStoreResult();
-    reqObjResult = caloCondition.condLastResult();
+      caloCondition.evaluateConditionStoreResult();
+      reqObjResult = caloCondition.condLastResult();
 
-    cond1Comb = (caloCondition.getCombinationsInCond());
-    cndObjTypeVec[1] = (corrCalo->objectType())[0];
+      cond1Comb = (caloCondition.getCombinationsInCond());
+      cndObjTypeVec[1] = (corrCalo->objectType())[0];
 
-    if (m_verbosity && m_isDebugEnabled) {
-      std::ostringstream myCout;
-      caloCondition.print(myCout);
+      if (m_verbosity && m_isDebugEnabled) {
+        std::ostringstream myCout;
+        caloCondition.print(myCout);
 
-      LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
-    }
+        LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
+      }
 
-  } break;
-  case CondEnergySum: {
-    corrEnergySum = static_cast<const L1GtEnergySumTemplate *>(m_gtCond1);
-    L1GtEnergySumCondition eSumCondition(corrEnergySum, m_gtPSB);
-    eSumCondition.evaluateConditionStoreResult();
-    reqObjResult = eSumCondition.condLastResult();
+    } break;
+    case CondEnergySum: {
+      corrEnergySum = static_cast<const L1GtEnergySumTemplate *>(m_gtCond1);
+      L1GtEnergySumCondition eSumCondition(corrEnergySum, m_gtPSB);
+      eSumCondition.evaluateConditionStoreResult();
+      reqObjResult = eSumCondition.condLastResult();
 
-    cond1Comb = (eSumCondition.getCombinationsInCond());
-    cndObjTypeVec[1] = (corrEnergySum->objectType())[0];
+      cond1Comb = (eSumCondition.getCombinationsInCond());
+      cndObjTypeVec[1] = (corrEnergySum->objectType())[0];
 
-    if (m_verbosity && m_isDebugEnabled) {
-      std::ostringstream myCout;
-      eSumCondition.print(myCout);
+      if (m_verbosity && m_isDebugEnabled) {
+        std::ostringstream myCout;
+        eSumCondition.print(myCout);
 
-      LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
-    }
-  } break;
-  default: {
-    // should not arrive here, there are no correlation conditions defined for
-    // this object
-    return false;
-  } break;
+        LogTrace("L1GlobalTrigger") << myCout.str() << std::endl;
+      }
+    } break;
+    default: {
+      // should not arrive here, there are no correlation conditions defined for
+      // this object
+      return false;
+    } break;
   }
 
   // return if second sub-condition is false
   if (!reqObjResult) {
     return false;
   } else {
-    LogTrace("L1GlobalTrigger")
-        << "\n"
-        << "    Both sub-conditions true for object requirements."
-        << "    Evaluate correlation requirements.\n"
-        << std::endl;
+    LogTrace("L1GlobalTrigger") << "\n"
+                                << "    Both sub-conditions true for object requirements."
+                                << "    Evaluate correlation requirements.\n"
+                                << std::endl;
   }
 
   //
@@ -344,8 +334,7 @@ const bool L1GtCorrelationCondition::evaluateCondition() const {
 
   // get the correlation parameters
 
-  L1GtCorrelationTemplate::CorrelationParameter corrPar =
-      *(m_gtCorrelationTemplate->correlationParameter());
+  L1GtCorrelationTemplate::CorrelationParameter corrPar = *(m_gtCorrelationTemplate->correlationParameter());
 
   // convert the eta template requirements from string to 64-bit integers
   // number of 64-bit integers: string length / 16
@@ -366,12 +355,10 @@ const bool L1GtCorrelationCondition::evaluateCondition() const {
   }
 
   // get the index of L1 GT object pair
-  unsigned int objPairIndex = (m_gtEtaPhiConversions->gtObjectPairIndex(
-      cndObjTypeVec[0], cndObjTypeVec[1]));
+  unsigned int objPairIndex = (m_gtEtaPhiConversions->gtObjectPairIndex(cndObjTypeVec[0], cndObjTypeVec[1]));
 
   // get the maximum number of bins for the delta phi scales
-  unsigned int corrParDeltaPhiNrBins =
-      (m_gtEtaPhiConversions->gtObjectNrBinsPhi(objPairIndex)) / 2 + 1;
+  unsigned int corrParDeltaPhiNrBins = (m_gtEtaPhiConversions->gtObjectNrBinsPhi(objPairIndex)) / 2 + 1;
 
   // vector to store the indices of the calorimeter objects
   // from the combination evaluated in the condition
@@ -403,18 +390,14 @@ const bool L1GtCorrelationCondition::evaluateCondition() const {
   unsigned int etaIndex0Converted = 0;
   unsigned int etaIndex1Converted = 0;
 
-  LogTrace("L1GlobalTrigger")
-      << "  Sub-condition 0: std::vector<SingleCombInCond> size: "
-      << (cond0Comb.size()) << std::endl;
-  LogTrace("L1GlobalTrigger")
-      << "  Sub-condition 1: std::vector<SingleCombInCond> size: "
-      << (cond1Comb.size()) << std::endl;
+  LogTrace("L1GlobalTrigger") << "  Sub-condition 0: std::vector<SingleCombInCond> size: " << (cond0Comb.size())
+                              << std::endl;
+  LogTrace("L1GlobalTrigger") << "  Sub-condition 1: std::vector<SingleCombInCond> size: " << (cond1Comb.size())
+                              << std::endl;
 
   // loop over all combinations which produced individually "true" as Type1s
-  for (std::vector<SingleCombInCond>::const_iterator it0Comb =
-           cond0Comb.begin();
-       it0Comb != cond0Comb.end(); it0Comb++) {
-
+  for (std::vector<SingleCombInCond>::const_iterator it0Comb = cond0Comb.begin(); it0Comb != cond0Comb.end();
+       it0Comb++) {
     // Type1s: there is 1 object only, no need for a loop, index 0 should be OK
     // in (*it0Comb)[0]
     // ... but add protection to not crash
@@ -423,121 +406,112 @@ const bool L1GtCorrelationCondition::evaluateCondition() const {
     if (!(*it0Comb).empty()) {
       obj0Index = (*it0Comb)[0];
     } else {
-      LogTrace("L1GlobalTrigger") << "\n  SingleCombInCond (*it0Comb).size() "
-                                  << ((*it0Comb).size()) << std::endl;
+      LogTrace("L1GlobalTrigger") << "\n  SingleCombInCond (*it0Comb).size() " << ((*it0Comb).size()) << std::endl;
       return false;
     }
 
     bool convStatus = false;
 
     switch (cond0Categ) {
-    case CondMuon: {
-      candMuVec = m_gtGTL->getCandL1Mu();
-      phiIndex0 = (*candMuVec)[obj0Index]->phiIndex();
-      etaIndex0 = (*candMuVec)[obj0Index]->etaIndex();
+      case CondMuon: {
+        candMuVec = m_gtGTL->getCandL1Mu();
+        phiIndex0 = (*candMuVec)[obj0Index]->phiIndex();
+        etaIndex0 = (*candMuVec)[obj0Index]->etaIndex();
 
-      convStatus = m_gtEtaPhiConversions->convertPhiIndex(
-          objPairIndex, 0, phiIndex0, phiIndex0Converted);
+        convStatus = m_gtEtaPhiConversions->convertPhiIndex(objPairIndex, 0, phiIndex0, phiIndex0Converted);
 
-      if (!convStatus) {
-        // conversion failed, message written in L1GtEtaPhiConversions
-        return false;
-      }
+        if (!convStatus) {
+          // conversion failed, message written in L1GtEtaPhiConversions
+          return false;
+        }
 
-      convStatus = m_gtEtaPhiConversions->convertEtaIndex(Mu, etaIndex0,
-                                                          etaIndex0Converted);
+        convStatus = m_gtEtaPhiConversions->convertEtaIndex(Mu, etaIndex0, etaIndex0Converted);
 
-      if (!convStatus) {
-        // conversion failed, message written in L1GtEtaPhiConversions
-        return false;
-      }
+        if (!convStatus) {
+          // conversion failed, message written in L1GtEtaPhiConversions
+          return false;
+        }
 
-    } break;
-    case CondCalo: {
-      switch (cndObjTypeVec[0]) {
-      case NoIsoEG: {
-        candCaloVec = m_gtPSB->getCandL1NoIsoEG();
       } break;
-      case IsoEG: {
-        candCaloVec = m_gtPSB->getCandL1IsoEG();
+      case CondCalo: {
+        switch (cndObjTypeVec[0]) {
+          case NoIsoEG: {
+            candCaloVec = m_gtPSB->getCandL1NoIsoEG();
+          } break;
+          case IsoEG: {
+            candCaloVec = m_gtPSB->getCandL1IsoEG();
+          } break;
+          case CenJet: {
+            candCaloVec = m_gtPSB->getCandL1CenJet();
+          } break;
+          case ForJet: {
+            candCaloVec = m_gtPSB->getCandL1ForJet();
+          } break;
+          case TauJet: {
+            candCaloVec = m_gtPSB->getCandL1TauJet();
+          } break;
+          default: {
+            // do nothing
+          } break;
+        }
+
+        phiIndex0 = (*candCaloVec)[obj0Index]->phiIndex();
+        etaIndex0 = (*candCaloVec)[obj0Index]->etaIndex();
+
+        convStatus = m_gtEtaPhiConversions->convertPhiIndex(objPairIndex, 0, phiIndex0, phiIndex0Converted);
+
+        if (!convStatus) {
+          // conversion failed, message written in L1GtEtaPhiConversions
+          return false;
+        }
+
+        convStatus = m_gtEtaPhiConversions->convertEtaIndex(cndObjTypeVec[0], etaIndex0, etaIndex0Converted);
+
+        if (!convStatus) {
+          // conversion failed, message written in L1GtEtaPhiConversions
+          return false;
+        }
       } break;
-      case CenJet: {
-        candCaloVec = m_gtPSB->getCandL1CenJet();
-      } break;
-      case ForJet: {
-        candCaloVec = m_gtPSB->getCandL1ForJet();
-      } break;
-      case TauJet: {
-        candCaloVec = m_gtPSB->getCandL1TauJet();
+      case CondEnergySum: {
+        switch (cndObjTypeVec[0]) {
+          case ETM: {
+            candETM = m_gtPSB->getCandL1ETM();
+            phiIndex0 = candETM->phi();
+
+            convStatus = m_gtEtaPhiConversions->convertPhiIndex(objPairIndex, 0, phiIndex0, phiIndex0Converted);
+
+            if (!convStatus) {
+              // conversion failed, message written in L1GtEtaPhiConversions
+              return false;
+            }
+
+          } break;
+          case HTM: {
+            candHTM = m_gtPSB->getCandL1HTM();
+            phiIndex0 = candHTM->phi();
+
+            convStatus = m_gtEtaPhiConversions->convertPhiIndex(objPairIndex, 0, phiIndex0, phiIndex0Converted);
+
+            if (!convStatus) {
+              // conversion failed, message written in L1GtEtaPhiConversions
+              return false;
+            }
+
+          } break;
+          default:
+            // do nothing
+            break;
+        }
       } break;
       default: {
-        // do nothing
-      } break;
-      }
-
-      phiIndex0 = (*candCaloVec)[obj0Index]->phiIndex();
-      etaIndex0 = (*candCaloVec)[obj0Index]->etaIndex();
-
-      convStatus = m_gtEtaPhiConversions->convertPhiIndex(
-          objPairIndex, 0, phiIndex0, phiIndex0Converted);
-
-      if (!convStatus) {
-        // conversion failed, message written in L1GtEtaPhiConversions
+        // should not arrive here, there are no correlation conditions defined for
+        // this object
         return false;
-      }
-
-      convStatus = m_gtEtaPhiConversions->convertEtaIndex(
-          cndObjTypeVec[0], etaIndex0, etaIndex0Converted);
-
-      if (!convStatus) {
-        // conversion failed, message written in L1GtEtaPhiConversions
-        return false;
-      }
-    } break;
-    case CondEnergySum: {
-      switch (cndObjTypeVec[0]) {
-      case ETM: {
-        candETM = m_gtPSB->getCandL1ETM();
-        phiIndex0 = candETM->phi();
-
-        convStatus = m_gtEtaPhiConversions->convertPhiIndex(
-            objPairIndex, 0, phiIndex0, phiIndex0Converted);
-
-        if (!convStatus) {
-          // conversion failed, message written in L1GtEtaPhiConversions
-          return false;
-        }
-
       } break;
-      case HTM: {
-        candHTM = m_gtPSB->getCandL1HTM();
-        phiIndex0 = candHTM->phi();
-
-        convStatus = m_gtEtaPhiConversions->convertPhiIndex(
-            objPairIndex, 0, phiIndex0, phiIndex0Converted);
-
-        if (!convStatus) {
-          // conversion failed, message written in L1GtEtaPhiConversions
-          return false;
-        }
-
-      } break;
-      default:
-        // do nothing
-        break;
-      }
-    } break;
-    default: {
-      // should not arrive here, there are no correlation conditions defined for
-      // this object
-      return false;
-    } break;
     }
 
-    for (std::vector<SingleCombInCond>::const_iterator it1Comb =
-             cond1Comb.begin();
-         it1Comb != cond1Comb.end(); it1Comb++) {
-
+    for (std::vector<SingleCombInCond>::const_iterator it1Comb = cond1Comb.begin(); it1Comb != cond1Comb.end();
+         it1Comb++) {
       // Type1s: there is 1 object only, no need for a loop (*it1Comb)[0]
       // ... but add protection to not crash
       int obj1Index = -1;
@@ -545,126 +519,115 @@ const bool L1GtCorrelationCondition::evaluateCondition() const {
       if (!(*it1Comb).empty()) {
         obj1Index = (*it1Comb)[0];
       } else {
-        LogTrace("L1GlobalTrigger") << "\n  SingleCombInCond (*it1Comb).size() "
-                                    << ((*it1Comb).size()) << std::endl;
+        LogTrace("L1GlobalTrigger") << "\n  SingleCombInCond (*it1Comb).size() " << ((*it1Comb).size()) << std::endl;
         return false;
       }
 
       switch (cond1Categ) {
-      case CondMuon: {
-        candMuVec = m_gtGTL->getCandL1Mu();
-        phiIndex1 = (*candMuVec)[obj1Index]->phiIndex();
-        etaIndex1 = (*candMuVec)[obj1Index]->etaIndex();
+        case CondMuon: {
+          candMuVec = m_gtGTL->getCandL1Mu();
+          phiIndex1 = (*candMuVec)[obj1Index]->phiIndex();
+          etaIndex1 = (*candMuVec)[obj1Index]->etaIndex();
 
-        convStatus = m_gtEtaPhiConversions->convertPhiIndex(
-            objPairIndex, 1, phiIndex1, phiIndex1Converted);
+          convStatus = m_gtEtaPhiConversions->convertPhiIndex(objPairIndex, 1, phiIndex1, phiIndex1Converted);
 
-        if (!convStatus) {
-          // conversion failed, message written in L1GtEtaPhiConversions
-          return false;
-        }
+          if (!convStatus) {
+            // conversion failed, message written in L1GtEtaPhiConversions
+            return false;
+          }
 
-        convStatus = m_gtEtaPhiConversions->convertEtaIndex(
-            cndObjTypeVec[1], etaIndex1, etaIndex1Converted);
-
-        if (!convStatus) {
-          // conversion failed, message written in L1GtEtaPhiConversions
-          return false;
-        }
-      } break;
-      case CondCalo: {
-        switch (cndObjTypeVec[1]) {
-        case NoIsoEG:
-          candCaloVec = m_gtPSB->getCandL1NoIsoEG();
-          break;
-        case IsoEG:
-          candCaloVec = m_gtPSB->getCandL1IsoEG();
-          break;
-        case CenJet:
-          candCaloVec = m_gtPSB->getCandL1CenJet();
-          break;
-        case ForJet:
-          candCaloVec = m_gtPSB->getCandL1ForJet();
-          break;
-        case TauJet:
-          candCaloVec = m_gtPSB->getCandL1TauJet();
-          break;
-        default:
-          // do nothing
-          break;
-        }
-
-        phiIndex1 = (*candCaloVec)[obj1Index]->phiIndex();
-        etaIndex1 = (*candCaloVec)[obj1Index]->etaIndex();
-
-        convStatus = m_gtEtaPhiConversions->convertPhiIndex(
-            objPairIndex, 1, phiIndex1, phiIndex1Converted);
-
-        if (!convStatus) {
-          // conversion failed, message written in L1GtEtaPhiConversions
-          return false;
-        }
-
-        convStatus = m_gtEtaPhiConversions->convertEtaIndex(
-            cndObjTypeVec[1], etaIndex1, etaIndex1Converted);
-
-        if (!convStatus) {
-          // conversion failed, message written in L1GtEtaPhiConversions
-          return false;
-        }
-
-      } break;
-      case CondEnergySum: {
-        switch (cndObjTypeVec[1]) {
-        case ETM: {
-          candETM = m_gtPSB->getCandL1ETM();
-          phiIndex1 = candETM->phi();
-
-          convStatus = m_gtEtaPhiConversions->convertPhiIndex(
-              objPairIndex, 1, phiIndex1, phiIndex1Converted);
+          convStatus = m_gtEtaPhiConversions->convertEtaIndex(cndObjTypeVec[1], etaIndex1, etaIndex1Converted);
 
           if (!convStatus) {
             // conversion failed, message written in L1GtEtaPhiConversions
             return false;
           }
         } break;
-        case HTM: {
-          candHTM = m_gtPSB->getCandL1HTM();
-          phiIndex1 = candHTM->phi();
+        case CondCalo: {
+          switch (cndObjTypeVec[1]) {
+            case NoIsoEG:
+              candCaloVec = m_gtPSB->getCandL1NoIsoEG();
+              break;
+            case IsoEG:
+              candCaloVec = m_gtPSB->getCandL1IsoEG();
+              break;
+            case CenJet:
+              candCaloVec = m_gtPSB->getCandL1CenJet();
+              break;
+            case ForJet:
+              candCaloVec = m_gtPSB->getCandL1ForJet();
+              break;
+            case TauJet:
+              candCaloVec = m_gtPSB->getCandL1TauJet();
+              break;
+            default:
+              // do nothing
+              break;
+          }
 
-          convStatus = m_gtEtaPhiConversions->convertPhiIndex(
-              objPairIndex, 1, phiIndex1, phiIndex1Converted);
+          phiIndex1 = (*candCaloVec)[obj1Index]->phiIndex();
+          etaIndex1 = (*candCaloVec)[obj1Index]->etaIndex();
+
+          convStatus = m_gtEtaPhiConversions->convertPhiIndex(objPairIndex, 1, phiIndex1, phiIndex1Converted);
 
           if (!convStatus) {
             // conversion failed, message written in L1GtEtaPhiConversions
             return false;
           }
+
+          convStatus = m_gtEtaPhiConversions->convertEtaIndex(cndObjTypeVec[1], etaIndex1, etaIndex1Converted);
+
+          if (!convStatus) {
+            // conversion failed, message written in L1GtEtaPhiConversions
+            return false;
+          }
+
         } break;
-        default:
-          // do nothing
-          break;
-        }
-      } break;
-      default: {
-        // should not arrive here, there are no correlation conditions defined
-        // for this object
-        return false;
-      } break;
+        case CondEnergySum: {
+          switch (cndObjTypeVec[1]) {
+            case ETM: {
+              candETM = m_gtPSB->getCandL1ETM();
+              phiIndex1 = candETM->phi();
+
+              convStatus = m_gtEtaPhiConversions->convertPhiIndex(objPairIndex, 1, phiIndex1, phiIndex1Converted);
+
+              if (!convStatus) {
+                // conversion failed, message written in L1GtEtaPhiConversions
+                return false;
+              }
+            } break;
+            case HTM: {
+              candHTM = m_gtPSB->getCandL1HTM();
+              phiIndex1 = candHTM->phi();
+
+              convStatus = m_gtEtaPhiConversions->convertPhiIndex(objPairIndex, 1, phiIndex1, phiIndex1Converted);
+
+              if (!convStatus) {
+                // conversion failed, message written in L1GtEtaPhiConversions
+                return false;
+              }
+            } break;
+            default:
+              // do nothing
+              break;
+          }
+        } break;
+        default: {
+          // should not arrive here, there are no correlation conditions defined
+          // for this object
+          return false;
+        } break;
       }
 
       if (m_verbosity && m_isDebugEnabled) {
-        LogTrace("L1GlobalTrigger")
-            << "    Correlation pair ["
-            << l1GtObjectEnumToString(cndObjTypeVec[0]) << ", "
-            << l1GtObjectEnumToString(cndObjTypeVec[1])
-            << "] with collection indices [" << obj0Index << ", " << obj1Index
-            << "] "
-            << " has: \n      phi indices = [" << phiIndex0 << ", " << phiIndex1
-            << "] converted to [" << phiIndex0Converted << ", "
-            << phiIndex1Converted << "] \n      eta indices [" << etaIndex0
-            << ", " << etaIndex1 << "] converted to [" << etaIndex0Converted
-            << ", " << etaIndex1Converted << "] \n"
-            << std::endl;
+        LogTrace("L1GlobalTrigger") << "    Correlation pair [" << l1GtObjectEnumToString(cndObjTypeVec[0]) << ", "
+                                    << l1GtObjectEnumToString(cndObjTypeVec[1]) << "] with collection indices ["
+                                    << obj0Index << ", " << obj1Index << "] "
+                                    << " has: \n      phi indices = [" << phiIndex0 << ", " << phiIndex1
+                                    << "] converted to [" << phiIndex0Converted << ", " << phiIndex1Converted
+                                    << "] \n      eta indices [" << etaIndex0 << ", " << etaIndex1 << "] converted to ["
+                                    << etaIndex0Converted << ", " << etaIndex1Converted << "] \n"
+                                    << std::endl;
       }
 
       // the conversions were successful, need to evaluate requirements now
@@ -690,19 +653,16 @@ const bool L1GtCorrelationCondition::evaluateCondition() const {
       int iLoop = 0;
 
       while (candDeltaPhi >= corrParDeltaPhiNrBins) {
-
         unsigned int candDeltaPhiInitial = candDeltaPhi;
 
         // candDeltaPhi > 180 ==> take 360 - candDeltaPhi
         candDeltaPhi = (corrParDeltaPhiNrBins - 1) * 2 - candDeltaPhi;
         if (m_verbosity) {
-          LogTrace("L1GlobalTrigger")
-              << "    Initial candDeltaPhi = " << candDeltaPhiInitial
-              << " > corrParDeltaPhiNrBins = " << corrParDeltaPhiNrBins
-              << "  ==> candDeltaPhi rescaled to: " << candDeltaPhi
-              << " [ loop index " << iLoop << "; breaks after " << nMaxLoop
-              << " loops ]\n"
-              << std::endl;
+          LogTrace("L1GlobalTrigger") << "    Initial candDeltaPhi = " << candDeltaPhiInitial
+                                      << " > corrParDeltaPhiNrBins = " << corrParDeltaPhiNrBins
+                                      << "  ==> candDeltaPhi rescaled to: " << candDeltaPhi << " [ loop index " << iLoop
+                                      << "; breaks after " << nMaxLoop << " loops ]\n"
+                                      << std::endl;
         }
 
         iLoop++;
@@ -715,21 +675,17 @@ const bool L1GtCorrelationCondition::evaluateCondition() const {
       // ...now check for each 64-bit integer against template requirements
       bool indResult = true;
 
-      for (size_t iDeltaPhi = 0; iDeltaPhi < deltaPhiRangeConv.size();
-           ++iDeltaPhi) {
+      for (size_t iDeltaPhi = 0; iDeltaPhi < deltaPhiRangeConv.size(); ++iDeltaPhi) {
         if (!checkBit(deltaPhiRangeConv[iDeltaPhi], candDeltaPhi)) {
           indResult = false;
         }
       }
 
       if (!indResult) {
-
         if (m_verbosity && m_isDebugEnabled) {
-          LogTrace("L1GlobalTrigger")
-              << "      object delta phi = " << candDeltaPhi
-              << " fails delta phi requirements."
-              << "\n      Pair fails correlation condition.\n"
-              << std::endl;
+          LogTrace("L1GlobalTrigger") << "      object delta phi = " << candDeltaPhi << " fails delta phi requirements."
+                                      << "\n      Pair fails correlation condition.\n"
+                                      << std::endl;
         }
 
         reqEtaPhiResult = false;
@@ -737,9 +693,8 @@ const bool L1GtCorrelationCondition::evaluateCondition() const {
 
       } else {
         if (m_verbosity && m_isDebugEnabled) {
-          LogTrace("L1GlobalTrigger")
-              << "      object delta phi = " << candDeltaPhi
-              << " passes delta phi requirements." << std::endl;
+          LogTrace("L1GlobalTrigger") << "      object delta phi = " << candDeltaPhi
+                                      << " passes delta phi requirements." << std::endl;
         }
       }
 
@@ -758,21 +713,17 @@ const bool L1GtCorrelationCondition::evaluateCondition() const {
       // ...now check for each 64-bit integer against template requirements
       indResult = true;
 
-      for (size_t iDeltaEta = 0; iDeltaEta < deltaEtaRangeConv.size();
-           ++iDeltaEta) {
+      for (size_t iDeltaEta = 0; iDeltaEta < deltaEtaRangeConv.size(); ++iDeltaEta) {
         if (!checkBit(deltaEtaRangeConv[iDeltaEta], candDeltaEta)) {
           indResult = false;
         }
       }
 
       if (!indResult) {
-
         if (m_verbosity && m_isDebugEnabled) {
-          LogTrace("L1GlobalTrigger")
-              << "      object delta eta = " << candDeltaEta
-              << " fails delta eta requirements."
-              << "\n      Pair fails correlation condition.\n"
-              << std::endl;
+          LogTrace("L1GlobalTrigger") << "      object delta eta = " << candDeltaEta << " fails delta eta requirements."
+                                      << "\n      Pair fails correlation condition.\n"
+                                      << std::endl;
         }
 
         reqEtaPhiResult = false;
@@ -780,11 +731,10 @@ const bool L1GtCorrelationCondition::evaluateCondition() const {
 
       } else {
         if (m_verbosity && m_isDebugEnabled) {
-          LogTrace("L1GlobalTrigger")
-              << "      object delta eta = " << candDeltaEta
-              << " passes delta eta requirements."
-              << "\n      Pair passes correlation condition.\n"
-              << std::endl;
+          LogTrace("L1GlobalTrigger") << "      object delta eta = " << candDeltaEta
+                                      << " passes delta eta requirements."
+                                      << "\n      Pair passes correlation condition.\n"
+                                      << std::endl;
         }
 
         reqEtaPhiResult = true;
@@ -800,7 +750,6 @@ const bool L1GtCorrelationCondition::evaluateCondition() const {
       // set the general result for evaluateCondition to "true"
 
       if (reqEtaPhiResult) {
-
         condResult = true;
         (combinationsInCond()).push_back(objectsInComb);
       }
@@ -808,19 +757,16 @@ const bool L1GtCorrelationCondition::evaluateCondition() const {
   }
 
   if (m_verbosity && m_isDebugEnabled && condResult) {
-    LogTrace("L1GlobalTrigger")
-        << (combinationsInCond()).size() << " correlation pair(s) ["
-        << l1GtObjectEnumToString(cndObjTypeVec[0]) << ", "
-        << l1GtObjectEnumToString(cndObjTypeVec[1])
-        << "] pass(es) the correlation condition.\n"
-        << std::endl;
+    LogTrace("L1GlobalTrigger") << (combinationsInCond()).size() << " correlation pair(s) ["
+                                << l1GtObjectEnumToString(cndObjTypeVec[0]) << ", "
+                                << l1GtObjectEnumToString(cndObjTypeVec[1]) << "] pass(es) the correlation condition.\n"
+                                << std::endl;
   }
 
   return condResult;
 }
 
 void L1GtCorrelationCondition::print(std::ostream &myCout) const {
-
   m_gtCorrelationTemplate->print(myCout);
   L1GtConditionEvaluation::print(myCout);
 }

--- a/L1Trigger/GlobalTrigger/src/L1GtEnergySumCondition.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GtEnergySumCondition.cc
@@ -38,20 +38,16 @@
 // constructors
 //     default
 L1GtEnergySumCondition::L1GtEnergySumCondition() : L1GtConditionEvaluation() {
-
   // empty
 }
 
 //     from base template condition (from event setup usually)
-L1GtEnergySumCondition::L1GtEnergySumCondition(
-    const L1GtCondition *eSumTemplate, const L1GlobalTriggerPSB *ptrPSB)
+L1GtEnergySumCondition::L1GtEnergySumCondition(const L1GtCondition *eSumTemplate, const L1GlobalTriggerPSB *ptrPSB)
     : L1GtConditionEvaluation(),
-      m_gtEnergySumTemplate(
-          static_cast<const L1GtEnergySumTemplate *>(eSumTemplate)),
+      m_gtEnergySumTemplate(static_cast<const L1GtEnergySumTemplate *>(eSumTemplate)),
       m_gtPSB(ptrPSB)
 
 {
-
   // maximum number of objects received for the evaluation of the condition
   // energy sums are global quantities - one object per event
 
@@ -60,7 +56,6 @@ L1GtEnergySumCondition::L1GtEnergySumCondition(
 
 // copy constructor
 void L1GtEnergySumCondition::copy(const L1GtEnergySumCondition &cp) {
-
   m_gtEnergySumTemplate = cp.gtEnergySumTemplate();
   m_gtPSB = cp.gtPSB();
 
@@ -71,41 +66,31 @@ void L1GtEnergySumCondition::copy(const L1GtEnergySumCondition &cp) {
   m_verbosity = cp.m_verbosity;
 }
 
-L1GtEnergySumCondition::L1GtEnergySumCondition(const L1GtEnergySumCondition &cp)
-    : L1GtConditionEvaluation() {
-
+L1GtEnergySumCondition::L1GtEnergySumCondition(const L1GtEnergySumCondition &cp) : L1GtConditionEvaluation() {
   copy(cp);
 }
 
 // destructor
 L1GtEnergySumCondition::~L1GtEnergySumCondition() {
-
   // empty
 }
 
 // equal operator
-L1GtEnergySumCondition &L1GtEnergySumCondition::
-operator=(const L1GtEnergySumCondition &cp) {
+L1GtEnergySumCondition &L1GtEnergySumCondition::operator=(const L1GtEnergySumCondition &cp) {
   copy(cp);
   return *this;
 }
 
 // methods
-void L1GtEnergySumCondition::setGtEnergySumTemplate(
-    const L1GtEnergySumTemplate *eSumTempl) {
-
+void L1GtEnergySumCondition::setGtEnergySumTemplate(const L1GtEnergySumTemplate *eSumTempl) {
   m_gtEnergySumTemplate = eSumTempl;
 }
 
 ///   set the pointer to PSB
-void L1GtEnergySumCondition::setGtPSB(const L1GlobalTriggerPSB *ptrPSB) {
-
-  m_gtPSB = ptrPSB;
-}
+void L1GtEnergySumCondition::setGtPSB(const L1GlobalTriggerPSB *ptrPSB) { m_gtPSB = ptrPSB; }
 
 // try all object permutations and check spatial correlations, if required
 const bool L1GtEnergySumCondition::evaluateCondition() const {
-
   // number of trigger objects in the condition
   // in fact, there is only one object
   int iCondition = 0;
@@ -131,66 +116,65 @@ const bool L1GtEnergySumCondition::evaluateCondition() const {
   bool candOverflow = false;
 
   switch ((m_gtEnergySumTemplate->objectType())[0]) {
-  case ETT: {
-    const L1GctEtTotal *cand1 = m_gtPSB->getCandL1ETT();
+    case ETT: {
+      const L1GctEtTotal *cand1 = m_gtPSB->getCandL1ETT();
 
-    if (cand1 == nullptr) {
-      return false;
+      if (cand1 == nullptr) {
+        return false;
+      }
+
+      candEt = cand1->et();
+      candOverflow = cand1->overFlow();
+
+      break;
     }
+    case ETM: {
+      const L1GctEtMiss *cand2 = m_gtPSB->getCandL1ETM();
 
-    candEt = cand1->et();
-    candOverflow = cand1->overFlow();
+      if (cand2 == nullptr) {
+        return false;
+      }
 
-    break;
-  }
-  case ETM: {
-    const L1GctEtMiss *cand2 = m_gtPSB->getCandL1ETM();
+      candEt = cand2->et();
+      candPhi = cand2->phi();
+      candOverflow = cand2->overFlow();
 
-    if (cand2 == nullptr) {
-      return false;
+      break;
     }
+    case HTT: {
+      const L1GctEtHad *cand3 = m_gtPSB->getCandL1HTT();
 
-    candEt = cand2->et();
-    candPhi = cand2->phi();
-    candOverflow = cand2->overFlow();
+      if (cand3 == nullptr) {
+        return false;
+      }
 
-    break;
-  }
-  case HTT: {
-    const L1GctEtHad *cand3 = m_gtPSB->getCandL1HTT();
+      candEt = cand3->et();
+      candOverflow = cand3->overFlow();
 
-    if (cand3 == nullptr) {
-      return false;
+      break;
     }
+    case HTM: {
+      const L1GctHtMiss *cand4 = m_gtPSB->getCandL1HTM();
 
-    candEt = cand3->et();
-    candOverflow = cand3->overFlow();
+      if (cand4 == nullptr) {
+        return false;
+      }
 
-    break;
-  }
-  case HTM: {
-    const L1GctHtMiss *cand4 = m_gtPSB->getCandL1HTM();
+      candEt = cand4->et();
+      candPhi = cand4->phi();
+      candOverflow = cand4->overFlow();
 
-    if (cand4 == nullptr) {
-      return false;
+      break;
     }
+    default: {
+      // should not arrive here
+      return false;
 
-    candEt = cand4->et();
-    candPhi = cand4->phi();
-    candOverflow = cand4->overFlow();
-
-    break;
-  }
-  default: {
-    // should not arrive here
-    return false;
-
-    break;
-  }
+      break;
+    }
   }
 
-  const L1GtEnergySumTemplate::ObjectParameter objPar =
-      (*(m_gtEnergySumTemplate->objectParameter()))[iCondition];
+  const L1GtEnergySumTemplate::ObjectParameter objPar = (*(m_gtEnergySumTemplate->objectParameter()))[iCondition];
 
   // check energy threshold and overflow
   // overflow evaluation:
@@ -225,31 +209,25 @@ const bool L1GtEnergySumCondition::evaluateCondition() const {
 
   if (!candOverflow) {
     if ((m_gtEnergySumTemplate->objectType())[0] == ETM) {
-
       // phi bitmask is saved in two uint64_t (see parser)
       if (candPhi < 64) {
         if (!checkBit(objPar.phiRange0Word, candPhi)) {
-
           return false;
         }
       } else {
         if (!checkBit(objPar.phiRange1Word, candPhi - 64)) {
-
           return false;
         }
       }
 
     } else if ((m_gtEnergySumTemplate->objectType())[0] == HTM) {
-
       // phi bitmask is in the first word for HTM
       if (candPhi < 64) {
         if (!checkBit(objPar.phiRange0Word, candPhi)) {
-
           return false;
         }
       } else {
         if (!checkBit(objPar.phiRange1Word, candPhi - 64)) {
-
           return false;
         }
       }
@@ -271,7 +249,6 @@ const bool L1GtEnergySumCondition::evaluateCondition() const {
 }
 
 void L1GtEnergySumCondition::print(std::ostream &myCout) const {
-
   m_gtEnergySumTemplate->print(myCout);
   L1GtConditionEvaluation::print(myCout);
 }

--- a/L1Trigger/GlobalTrigger/src/L1GtEtaPhiConversions.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GtEtaPhiConversions.cc
@@ -36,10 +36,13 @@
 
 // constructor
 L1GtEtaPhiConversions::L1GtEtaPhiConversions()
-    : m_nrBinsPhiMu(0), m_nrBinsPhiJetEg(0), m_nrBinsPhiEtm(0),
-      m_nrBinsPhiHtm(0), m_nrBinsEtaCommon(0), m_verbosity(0),
+    : m_nrBinsPhiMu(0),
+      m_nrBinsPhiJetEg(0),
+      m_nrBinsPhiEtm(0),
+      m_nrBinsPhiHtm(0),
+      m_nrBinsEtaCommon(0),
+      m_verbosity(0),
       m_isDebugEnabled(edm::isDebugEnabled()) {
-
   // prepare the pairs of L1GtObjects, reserve (by hand) memory for vectors
   // the index of the pair in m_gtObjectPairVec is used to extract
   // the information from the other vectors, so the push_back must be done
@@ -423,20 +426,16 @@ L1GtEtaPhiConversions::L1GtEtaPhiConversions()
   // m_verbosity can not be used here, as L1GtEtaPhiConversions is called
   // in L1GlobalTriggerGTL constructor,  where m_verbosity is not yet set
   if (m_isDebugEnabled) {
-    LogTrace("L1GlobalTrigger")
-        << "\nm_gtObjectPairVec size: " << (m_gtObjectPairVec.size())
-        << std::endl;
+    LogTrace("L1GlobalTrigger") << "\nm_gtObjectPairVec size: " << (m_gtObjectPairVec.size()) << std::endl;
 
     unsigned int iPair = 0;
 
-    for (std::vector<std::pair<L1GtObject, L1GtObject>>::const_iterator cIter =
-             m_gtObjectPairVec.begin();
-         cIter != m_gtObjectPairVec.end(); ++cIter) {
-      LogTrace("L1GlobalTrigger")
-          << "m_gtObjectPairVec vector element ["
-          << l1GtObjectEnumToString((*cIter).first) << ", "
-          << l1GtObjectEnumToString((*cIter).second)
-          << "], \t\tpair index =  " << iPair << std::endl;
+    for (std::vector<std::pair<L1GtObject, L1GtObject>>::const_iterator cIter = m_gtObjectPairVec.begin();
+         cIter != m_gtObjectPairVec.end();
+         ++cIter) {
+      LogTrace("L1GlobalTrigger") << "m_gtObjectPairVec vector element [" << l1GtObjectEnumToString((*cIter).first)
+                                  << ", " << l1GtObjectEnumToString((*cIter).second) << "], \t\tpair index =  " << iPair
+                                  << std::endl;
 
       iPair++;
     }
@@ -445,16 +444,12 @@ L1GtEtaPhiConversions::L1GtEtaPhiConversions()
 
 // destructor
 L1GtEtaPhiConversions::~L1GtEtaPhiConversions() {
-
   // do nothing
 }
 
 // methods
 
-const unsigned int
-L1GtEtaPhiConversions::gtObjectPairIndex(const L1GtObject &obj0,
-                                         const L1GtObject &obj1) const {
-
+const unsigned int L1GtEtaPhiConversions::gtObjectPairIndex(const L1GtObject &obj0, const L1GtObject &obj1) const {
   std::pair<L1GtObject, L1GtObject> gtObjPair;
   gtObjPair = std::make_pair(obj0, obj1);
 
@@ -463,14 +458,12 @@ L1GtEtaPhiConversions::gtObjectPairIndex(const L1GtObject &obj0,
   //        << (l1GtObjectEnumToString(obj1)) << "]\n" << std::endl;
 
   unsigned int iPair = 0;
-  for (std::vector<std::pair<L1GtObject, L1GtObject>>::const_iterator cIter =
-           m_gtObjectPairVec.begin();
-       cIter != m_gtObjectPairVec.end(); ++cIter) {
-
+  for (std::vector<std::pair<L1GtObject, L1GtObject>>::const_iterator cIter = m_gtObjectPairVec.begin();
+       cIter != m_gtObjectPairVec.end();
+       ++cIter) {
     if (*cIter == gtObjPair) {
-      LogTrace("L1GlobalTrigger")
-          << "\n  Index for pair [" << l1GtObjectEnumToString(obj0) << ", "
-          << l1GtObjectEnumToString(obj1) << "] = " << iPair << std::endl;
+      LogTrace("L1GlobalTrigger") << "\n  Index for pair [" << l1GtObjectEnumToString(obj0) << ", "
+                                  << l1GtObjectEnumToString(obj1) << "] = " << iPair << std::endl;
 
       return iPair;
     }
@@ -485,10 +478,10 @@ L1GtEtaPhiConversions::gtObjectPairIndex(const L1GtObject &obj0,
   return m_gtObjectPairVec.size();
 }
 
-const bool L1GtEtaPhiConversions::convertPhiIndex(
-    const unsigned int pairIndex, const unsigned int positionPair,
-    const unsigned int initialIndex, unsigned int &convertedIndex) const {
-
+const bool L1GtEtaPhiConversions::convertPhiIndex(const unsigned int pairIndex,
+                                                  const unsigned int positionPair,
+                                                  const unsigned int initialIndex,
+                                                  unsigned int &convertedIndex) const {
   unsigned int newIndex = badIndex;
   bool conversionStatus = false;
 
@@ -496,127 +489,103 @@ const bool L1GtEtaPhiConversions::convertPhiIndex(
   // could be outside the scale size if there are hardware errors
   // or wrong scale conversions
   if (initialIndex >= (*(m_pairPhiConvVec.at(pairIndex))).size()) {
-
     conversionStatus = false;
 
     if (m_verbosity && m_isDebugEnabled) {
-      LogTrace("L1GlobalTrigger")
-          << (positionPair ? "    Second" : "\n  First") << " object from pair "
-          << pairIndex << ": initial phi index " << initialIndex
-          << " >= " << ((*(m_pairPhiConvVec.at(pairIndex))).size())
-          << " Conversion failed." << std::endl;
+      LogTrace("L1GlobalTrigger") << (positionPair ? "    Second" : "\n  First") << " object from pair " << pairIndex
+                                  << ": initial phi index " << initialIndex
+                                  << " >= " << ((*(m_pairPhiConvVec.at(pairIndex))).size()) << " Conversion failed."
+                                  << std::endl;
     }
   } else {
     if (m_verbosity && m_isDebugEnabled) {
-      LogTrace("L1GlobalTrigger")
-          << (positionPair ? "    Second" : "\n  First") << " object from pair "
-          << pairIndex << ": initial phi index " << initialIndex
-          << " within scale size "
-          << ((*(m_pairPhiConvVec.at(pairIndex))).size()) << std::endl;
+      LogTrace("L1GlobalTrigger") << (positionPair ? "    Second" : "\n  First") << " object from pair " << pairIndex
+                                  << ": initial phi index " << initialIndex << " within scale size "
+                                  << ((*(m_pairPhiConvVec.at(pairIndex))).size()) << std::endl;
     }
   }
 
   // convert the index
   switch (positionPair) {
-  case 0: {
-    if (m_pairConvertPhiFirstGtObject.at(pairIndex)) {
+    case 0: {
+      if (m_pairConvertPhiFirstGtObject.at(pairIndex)) {
+        newIndex = (*(m_pairPhiConvVec.at(pairIndex))).at(initialIndex);
 
-      newIndex = (*(m_pairPhiConvVec.at(pairIndex))).at(initialIndex);
+        if (newIndex != badIndex) {
+          conversionStatus = true;
 
-      if (newIndex != badIndex) {
+          if (m_verbosity && m_isDebugEnabled) {
+            LogTrace("L1GlobalTrigger") << (positionPair ? "    Second" : "\n  First") << " object from pair "
+                                        << pairIndex << ": initial phi index " << initialIndex << " converted to "
+                                        << newIndex << std::endl;
+          }
 
-        conversionStatus = true;
+        } else {
+          conversionStatus = false;
 
-        if (m_verbosity && m_isDebugEnabled) {
-          LogTrace("L1GlobalTrigger")
-              << (positionPair ? "    Second" : "\n  First")
-              << " object from pair " << pairIndex << ": initial phi index "
-              << initialIndex << " converted to " << newIndex << std::endl;
+          if (m_verbosity && m_isDebugEnabled) {
+            LogTrace("L1GlobalTrigger") << (positionPair ? "    Second" : "\n  First") << " object from pair "
+                                        << pairIndex << ": converted phi index " << newIndex << "is equal to badIndex "
+                                        << badIndex << " Conversion failed." << std::endl;
+          }
         }
 
       } else {
-
-        conversionStatus = false;
-
-        if (m_verbosity && m_isDebugEnabled) {
-          LogTrace("L1GlobalTrigger")
-              << (positionPair ? "    Second" : "\n  First")
-              << " object from pair " << pairIndex << ": converted phi index "
-              << newIndex << "is equal to badIndex " << badIndex
-              << " Conversion failed." << std::endl;
-        }
-      }
-
-    } else {
-      newIndex = initialIndex;
-      conversionStatus = true;
-
-      if (m_verbosity && m_isDebugEnabled) {
-        LogTrace("L1GlobalTrigger")
-            << (positionPair ? "    Second" : "\n  First")
-            << " object from pair " << pairIndex << ": initial phi index "
-            << initialIndex << " not requested to be converted, return index "
-            << newIndex << std::endl;
-      }
-    }
-  }
-
-  break;
-  case 1: {
-    if (m_pairConvertPhiFirstGtObject.at(pairIndex)) {
-
-      newIndex = initialIndex;
-      conversionStatus = true;
-
-      if (m_verbosity && m_isDebugEnabled) {
-        LogTrace("L1GlobalTrigger")
-            << (positionPair ? "    Second" : "\n  First")
-            << " object from pair " << pairIndex << ": initial phi index "
-            << initialIndex
-            << " not requested to be converted, return index, return index "
-            << newIndex << std::endl;
-      }
-    } else {
-
-      newIndex = (*(m_pairPhiConvVec.at(pairIndex))).at(initialIndex);
-
-      if (newIndex != badIndex) {
-
+        newIndex = initialIndex;
         conversionStatus = true;
 
         if (m_verbosity && m_isDebugEnabled) {
-          LogTrace("L1GlobalTrigger")
-              << (positionPair ? "    Second" : "\n  First")
-              << " object from pair " << pairIndex << ": initial phi index "
-              << initialIndex << " converted to " << newIndex << std::endl;
-        }
-
-      } else {
-
-        conversionStatus = false;
-
-        if (m_verbosity && m_isDebugEnabled) {
-          LogTrace("L1GlobalTrigger")
-              << (positionPair ? "    Second" : "\n  First")
-              << " object from pair " << pairIndex << ": converted phi index "
-              << newIndex << "is equal to badIndex " << badIndex
-              << " Conversion failed." << std::endl;
+          LogTrace("L1GlobalTrigger") << (positionPair ? "    Second" : "\n  First") << " object from pair "
+                                      << pairIndex << ": initial phi index " << initialIndex
+                                      << " not requested to be converted, return index " << newIndex << std::endl;
         }
       }
     }
 
-  }
+    break;
+    case 1: {
+      if (m_pairConvertPhiFirstGtObject.at(pairIndex)) {
+        newIndex = initialIndex;
+        conversionStatus = true;
 
-  break;
-  default: {
+        if (m_verbosity && m_isDebugEnabled) {
+          LogTrace("L1GlobalTrigger") << (positionPair ? "    Second" : "\n  First") << " object from pair "
+                                      << pairIndex << ": initial phi index " << initialIndex
+                                      << " not requested to be converted, return index, return index " << newIndex
+                                      << std::endl;
+        }
+      } else {
+        newIndex = (*(m_pairPhiConvVec.at(pairIndex))).at(initialIndex);
 
-    // should not happen (programming error)
-    throw cms::Exception("FailModule")
-        << "\n  Wrong position in the object pair " << positionPair
-        << "\n  Programming error - position must be either 0 or 1..."
-        << std::endl;
+        if (newIndex != badIndex) {
+          conversionStatus = true;
 
-  } break;
+          if (m_verbosity && m_isDebugEnabled) {
+            LogTrace("L1GlobalTrigger") << (positionPair ? "    Second" : "\n  First") << " object from pair "
+                                        << pairIndex << ": initial phi index " << initialIndex << " converted to "
+                                        << newIndex << std::endl;
+          }
+
+        } else {
+          conversionStatus = false;
+
+          if (m_verbosity && m_isDebugEnabled) {
+            LogTrace("L1GlobalTrigger") << (positionPair ? "    Second" : "\n  First") << " object from pair "
+                                        << pairIndex << ": converted phi index " << newIndex << "is equal to badIndex "
+                                        << badIndex << " Conversion failed." << std::endl;
+          }
+        }
+      }
+
+    }
+
+    break;
+    default: {
+      // should not happen (programming error)
+      throw cms::Exception("FailModule") << "\n  Wrong position in the object pair " << positionPair
+                                         << "\n  Programming error - position must be either 0 or 1..." << std::endl;
+
+    } break;
   }
 
   //
@@ -624,190 +593,160 @@ const bool L1GtEtaPhiConversions::convertPhiIndex(
   return conversionStatus;
 }
 
-const bool
-L1GtEtaPhiConversions::convertEtaIndex(const L1GtObject &gtObject,
-                                       const unsigned int initialIndex,
-                                       unsigned int &convertedIndex) const {
-
+const bool L1GtEtaPhiConversions::convertEtaIndex(const L1GtObject &gtObject,
+                                                  const unsigned int initialIndex,
+                                                  unsigned int &convertedIndex) const {
   unsigned int newIndex = badIndex;
   bool conversionStatus = false;
 
   switch (gtObject) {
-
-  case Mu: {
-
-    // check if initial index is within the scale size
-    // could be outside the scale size if there are hardware errors
-    // or wrong scale conversions
-    if (initialIndex >= m_lutEtaMuToCommonCalo.size()) {
-
-      conversionStatus = false;
-
-      if (m_verbosity && m_isDebugEnabled) {
-        LogTrace("L1GlobalTrigger")
-            << "    L1 GT object " << (l1GtObjectEnumToString(gtObject))
-            << " has initial eta index " << initialIndex
-            << " >= " << (m_lutEtaMuToCommonCalo.size())
-            << " scale size. Conversion failed." << std::endl;
-      }
-    } else {
-
-      // convert the index
-      newIndex = m_lutEtaMuToCommonCalo[initialIndex];
-
-      if (newIndex != badIndex) {
-
-        conversionStatus = true;
-
-        if (m_verbosity && m_isDebugEnabled) {
-          LogTrace("L1GlobalTrigger")
-              << "    L1 GT object " << (l1GtObjectEnumToString(gtObject))
-              << " initial eta index " << initialIndex << " (within scale size "
-              << (m_lutEtaMuToCommonCalo.size()) << ") converted to "
-              << newIndex << std::endl;
-        }
-
-      } else {
-
+    case Mu: {
+      // check if initial index is within the scale size
+      // could be outside the scale size if there are hardware errors
+      // or wrong scale conversions
+      if (initialIndex >= m_lutEtaMuToCommonCalo.size()) {
         conversionStatus = false;
 
         if (m_verbosity && m_isDebugEnabled) {
-          LogTrace("L1GlobalTrigger")
-              << "    L1 GT object " << (l1GtObjectEnumToString(gtObject))
-              << " initial eta index " << initialIndex << " (within scale size "
-              << (m_lutEtaMuToCommonCalo.size()) << ") converted to badIndex"
-              << newIndex << " Conversion failed." << std::endl;
+          LogTrace("L1GlobalTrigger") << "    L1 GT object " << (l1GtObjectEnumToString(gtObject))
+                                      << " has initial eta index " << initialIndex
+                                      << " >= " << (m_lutEtaMuToCommonCalo.size()) << " scale size. Conversion failed."
+                                      << std::endl;
         }
-      }
-    }
-
-  } break;
-
-  case NoIsoEG:
-  case IsoEG:
-  case CenJet:
-  case TauJet: {
-
-    // check if initial index is within the scale size
-    // could be outside the scale size if there are hardware errors
-    // or wrong scale conversions
-    if (initialIndex >= m_lutEtaCentralToCommonCalo.size()) {
-
-      conversionStatus = false;
-
-      if (m_verbosity && m_isDebugEnabled) {
-        LogTrace("L1GlobalTrigger")
-            << "    L1 GT object " << (l1GtObjectEnumToString(gtObject))
-            << " has initial eta index " << initialIndex
-            << " >= " << (m_lutEtaCentralToCommonCalo.size())
-            << " scale size. Conversion failed." << std::endl;
-      }
-    } else {
-
-      // convert the index
-      newIndex = m_lutEtaCentralToCommonCalo[initialIndex];
-
-      if (newIndex != badIndex) {
-
-        conversionStatus = true;
-
-        if (m_verbosity && m_isDebugEnabled) {
-          LogTrace("L1GlobalTrigger")
-              << "    L1 GT object " << (l1GtObjectEnumToString(gtObject))
-              << " initial eta index " << initialIndex << " (within scale size "
-              << (m_lutEtaMuToCommonCalo.size()) << ") converted to "
-              << newIndex << std::endl;
-        }
-
       } else {
+        // convert the index
+        newIndex = m_lutEtaMuToCommonCalo[initialIndex];
 
+        if (newIndex != badIndex) {
+          conversionStatus = true;
+
+          if (m_verbosity && m_isDebugEnabled) {
+            LogTrace("L1GlobalTrigger") << "    L1 GT object " << (l1GtObjectEnumToString(gtObject))
+                                        << " initial eta index " << initialIndex << " (within scale size "
+                                        << (m_lutEtaMuToCommonCalo.size()) << ") converted to " << newIndex
+                                        << std::endl;
+          }
+
+        } else {
+          conversionStatus = false;
+
+          if (m_verbosity && m_isDebugEnabled) {
+            LogTrace("L1GlobalTrigger") << "    L1 GT object " << (l1GtObjectEnumToString(gtObject))
+                                        << " initial eta index " << initialIndex << " (within scale size "
+                                        << (m_lutEtaMuToCommonCalo.size()) << ") converted to badIndex" << newIndex
+                                        << " Conversion failed." << std::endl;
+          }
+        }
+      }
+
+    } break;
+
+    case NoIsoEG:
+    case IsoEG:
+    case CenJet:
+    case TauJet: {
+      // check if initial index is within the scale size
+      // could be outside the scale size if there are hardware errors
+      // or wrong scale conversions
+      if (initialIndex >= m_lutEtaCentralToCommonCalo.size()) {
         conversionStatus = false;
 
         if (m_verbosity && m_isDebugEnabled) {
-          LogTrace("L1GlobalTrigger")
-              << "    L1 GT object " << (l1GtObjectEnumToString(gtObject))
-              << " initial eta index " << initialIndex << " (within scale size "
-              << (m_lutEtaCentralToCommonCalo.size())
-              << ") converted to badIndex" << newIndex << " Conversion failed."
-              << std::endl;
+          LogTrace("L1GlobalTrigger") << "    L1 GT object " << (l1GtObjectEnumToString(gtObject))
+                                      << " has initial eta index " << initialIndex
+                                      << " >= " << (m_lutEtaCentralToCommonCalo.size())
+                                      << " scale size. Conversion failed." << std::endl;
         }
-      }
-    }
-
-  } break;
-
-  case ForJet: {
-
-    // check if initial index is within the scale size
-    // could be outside the scale size if there are hardware errors
-    // or wrong scale conversions
-    if (initialIndex >= m_lutEtaForJetToCommonCalo.size()) {
-
-      conversionStatus = false;
-
-      if (m_verbosity && m_isDebugEnabled) {
-        LogTrace("L1GlobalTrigger")
-            << "    L1 GT object " << (l1GtObjectEnumToString(gtObject))
-            << " has initial eta index " << initialIndex
-            << " >= " << (m_lutEtaForJetToCommonCalo.size())
-            << " scale size. Conversion failed." << std::endl;
-      }
-    } else {
-
-      // convert the index
-      newIndex = m_lutEtaForJetToCommonCalo[initialIndex];
-
-      if (newIndex != badIndex) {
-
-        conversionStatus = true;
-
-        if (m_verbosity && m_isDebugEnabled) {
-          LogTrace("L1GlobalTrigger")
-              << "    L1 GT object " << (l1GtObjectEnumToString(gtObject))
-              << " initial eta index " << initialIndex << " (within scale size "
-              << (m_lutEtaMuToCommonCalo.size()) << ") converted to "
-              << newIndex << std::endl;
-        }
-
       } else {
+        // convert the index
+        newIndex = m_lutEtaCentralToCommonCalo[initialIndex];
 
+        if (newIndex != badIndex) {
+          conversionStatus = true;
+
+          if (m_verbosity && m_isDebugEnabled) {
+            LogTrace("L1GlobalTrigger") << "    L1 GT object " << (l1GtObjectEnumToString(gtObject))
+                                        << " initial eta index " << initialIndex << " (within scale size "
+                                        << (m_lutEtaMuToCommonCalo.size()) << ") converted to " << newIndex
+                                        << std::endl;
+          }
+
+        } else {
+          conversionStatus = false;
+
+          if (m_verbosity && m_isDebugEnabled) {
+            LogTrace("L1GlobalTrigger") << "    L1 GT object " << (l1GtObjectEnumToString(gtObject))
+                                        << " initial eta index " << initialIndex << " (within scale size "
+                                        << (m_lutEtaCentralToCommonCalo.size()) << ") converted to badIndex" << newIndex
+                                        << " Conversion failed." << std::endl;
+          }
+        }
+      }
+
+    } break;
+
+    case ForJet: {
+      // check if initial index is within the scale size
+      // could be outside the scale size if there are hardware errors
+      // or wrong scale conversions
+      if (initialIndex >= m_lutEtaForJetToCommonCalo.size()) {
         conversionStatus = false;
 
         if (m_verbosity && m_isDebugEnabled) {
-          LogTrace("L1GlobalTrigger")
-              << "    L1 GT object " << (l1GtObjectEnumToString(gtObject))
-              << " initial eta index " << initialIndex << " (within scale size "
-              << (m_lutEtaForJetToCommonCalo.size())
-              << ") converted to badIndex" << newIndex << " Conversion failed."
-              << std::endl;
+          LogTrace("L1GlobalTrigger") << "    L1 GT object " << (l1GtObjectEnumToString(gtObject))
+                                      << " has initial eta index " << initialIndex
+                                      << " >= " << (m_lutEtaForJetToCommonCalo.size())
+                                      << " scale size. Conversion failed." << std::endl;
+        }
+      } else {
+        // convert the index
+        newIndex = m_lutEtaForJetToCommonCalo[initialIndex];
+
+        if (newIndex != badIndex) {
+          conversionStatus = true;
+
+          if (m_verbosity && m_isDebugEnabled) {
+            LogTrace("L1GlobalTrigger") << "    L1 GT object " << (l1GtObjectEnumToString(gtObject))
+                                        << " initial eta index " << initialIndex << " (within scale size "
+                                        << (m_lutEtaMuToCommonCalo.size()) << ") converted to " << newIndex
+                                        << std::endl;
+          }
+
+        } else {
+          conversionStatus = false;
+
+          if (m_verbosity && m_isDebugEnabled) {
+            LogTrace("L1GlobalTrigger") << "    L1 GT object " << (l1GtObjectEnumToString(gtObject))
+                                        << " initial eta index " << initialIndex << " (within scale size "
+                                        << (m_lutEtaForJetToCommonCalo.size()) << ") converted to badIndex" << newIndex
+                                        << " Conversion failed." << std::endl;
+          }
         }
       }
-    }
-  } break;
+    } break;
 
-  case ETM:
-  case ETT:
-  case HTT:
-  case HTM:
-  case JetCounts:
-  case HfBitCounts:
-  case HfRingEtSums:
-  case TechTrig:
-  case Castor:
-  case BPTX:
-  case GtExternal:
-  case ObjNull: {
+    case ETM:
+    case ETT:
+    case HTT:
+    case HTM:
+    case JetCounts:
+    case HfBitCounts:
+    case HfRingEtSums:
+    case TechTrig:
+    case Castor:
+    case BPTX:
+    case GtExternal:
+    case ObjNull: {
+      // no conversions needed, there is no eta quantity for these objects
+      conversionStatus = false;
+    } break;
 
-    // no conversions needed, there is no eta quantity for these objects
-    conversionStatus = false;
-  } break;
-
-  default: {
-    edm::LogInfo("L1GtObject") << "\n  '" << (l1GtObjectEnumToString(gtObject))
-                               << "' is not a recognized L1GtObject. "
-                               << "\n Conversion failed. " << std::endl;
-    conversionStatus = false;
-  } break;
+    default: {
+      edm::LogInfo("L1GtObject") << "\n  '" << (l1GtObjectEnumToString(gtObject))
+                                 << "' is not a recognized L1GtObject. "
+                                 << "\n Conversion failed. " << std::endl;
+      conversionStatus = false;
+    } break;
   }
 
   //
@@ -816,60 +755,54 @@ L1GtEtaPhiConversions::convertEtaIndex(const L1GtObject &gtObject,
   return conversionStatus;
 }
 
-const unsigned int
-L1GtEtaPhiConversions::gtObjectNrBinsPhi(const L1GtObject &gtObject) const {
-
+const unsigned int L1GtEtaPhiConversions::gtObjectNrBinsPhi(const L1GtObject &gtObject) const {
   switch (gtObject) {
+    case Mu: {
+      return m_nrBinsPhiMu;
+    } break;
 
-  case Mu: {
-    return m_nrBinsPhiMu;
-  } break;
+    case NoIsoEG:
+    case IsoEG:
+    case CenJet:
+    case ForJet:
+    case TauJet: {
+      return m_nrBinsPhiJetEg;
+    } break;
 
-  case NoIsoEG:
-  case IsoEG:
-  case CenJet:
-  case ForJet:
-  case TauJet: {
-    return m_nrBinsPhiJetEg;
-  } break;
+    case ETM: {
+      return m_nrBinsPhiEtm;
+    } break;
 
-  case ETM: {
-    return m_nrBinsPhiEtm;
-  } break;
+    case ETT:
+    case HTT: {
+      return 0;
+    } break;
 
-  case ETT:
-  case HTT: {
-    return 0;
-  } break;
+    case HTM: {
+      return m_nrBinsPhiHtm;
+    } break;
 
-  case HTM: {
-    return m_nrBinsPhiHtm;
-  } break;
+    case JetCounts:
+    case HfBitCounts:
+    case HfRingEtSums:
+    case TechTrig:
+    case Castor:
+    case BPTX:
+    case GtExternal:
+    case ObjNull: {
+      return 0;
+    } break;
 
-  case JetCounts:
-  case HfBitCounts:
-  case HfRingEtSums:
-  case TechTrig:
-  case Castor:
-  case BPTX:
-  case GtExternal:
-  case ObjNull: {
-    return 0;
-  } break;
-
-  default: {
-    edm::LogInfo("L1GtObject") << "\n  '" << (l1GtObjectEnumToString(gtObject))
-                               << "' is not a recognized L1GtObject. "
-                               << "\n Return 0 bins.";
-    return 0;
-  } break;
+    default: {
+      edm::LogInfo("L1GtObject") << "\n  '" << (l1GtObjectEnumToString(gtObject))
+                                 << "' is not a recognized L1GtObject. "
+                                 << "\n Return 0 bins.";
+      return 0;
+    } break;
   }
 }
 
-const unsigned int
-L1GtEtaPhiConversions::gtObjectNrBinsPhi(const L1GtObject &obj0,
-                                         const L1GtObject &obj1) const {
-
+const unsigned int L1GtEtaPhiConversions::gtObjectNrBinsPhi(const L1GtObject &obj0, const L1GtObject &obj1) const {
   std::pair<L1GtObject, L1GtObject> gtObjPair;
   gtObjPair = std::make_pair(obj0, obj1);
 
@@ -878,15 +811,13 @@ L1GtEtaPhiConversions::gtObjectNrBinsPhi(const L1GtObject &obj0,
   //        << (l1GtObjectEnumToString(obj1)) << "]\n" << std::endl;
 
   int iPair = 0;
-  for (std::vector<std::pair<L1GtObject, L1GtObject>>::const_iterator cIter =
-           m_gtObjectPairVec.begin();
-       cIter != m_gtObjectPairVec.end(); ++cIter) {
-
+  for (std::vector<std::pair<L1GtObject, L1GtObject>>::const_iterator cIter = m_gtObjectPairVec.begin();
+       cIter != m_gtObjectPairVec.end();
+       ++cIter) {
     if (*cIter == gtObjPair) {
-      LogTrace("L1GlobalTrigger")
-          << "\n  gtObjectNrBinsPhi [" << l1GtObjectEnumToString(obj0) << ", "
-          << l1GtObjectEnumToString(obj1)
-          << "] = " << (*(m_pairNrPhiBinsVec.at(iPair))) << std::endl;
+      LogTrace("L1GlobalTrigger") << "\n  gtObjectNrBinsPhi [" << l1GtObjectEnumToString(obj0) << ", "
+                                  << l1GtObjectEnumToString(obj1) << "] = " << (*(m_pairNrPhiBinsVec.at(iPair)))
+                                  << std::endl;
 
       return *(m_pairNrPhiBinsVec.at(iPair));
     }
@@ -897,24 +828,20 @@ L1GtEtaPhiConversions::gtObjectNrBinsPhi(const L1GtObject &obj0,
   return 0;
 }
 
-const unsigned int
-L1GtEtaPhiConversions::gtObjectNrBinsPhi(const unsigned int pairIndex) const {
-
+const unsigned int L1GtEtaPhiConversions::gtObjectNrBinsPhi(const unsigned int pairIndex) const {
   if (m_verbosity && m_isDebugEnabled) {
-    LogTrace("L1GlobalTrigger")
-        << "\n  gtObjectNrBinsPhi for L1 GT object pair index " << pairIndex
-        << " = " << (*(m_pairNrPhiBinsVec.at(pairIndex))) << std::endl;
+    LogTrace("L1GlobalTrigger") << "\n  gtObjectNrBinsPhi for L1 GT object pair index " << pairIndex << " = "
+                                << (*(m_pairNrPhiBinsVec.at(pairIndex))) << std::endl;
   }
 
   return *(m_pairNrPhiBinsVec.at(pairIndex));
 }
 
 // perform all conversions
-void L1GtEtaPhiConversions::convertL1Scales(
-    const L1CaloGeometry *l1CaloGeometry,
-    const L1MuTriggerScales *l1MuTriggerScales, const int ifCaloEtaNumberBits,
-    const int ifMuEtaNumberBits) {
-
+void L1GtEtaPhiConversions::convertL1Scales(const L1CaloGeometry *l1CaloGeometry,
+                                            const L1MuTriggerScales *l1MuTriggerScales,
+                                            const int ifCaloEtaNumberBits,
+                                            const int ifMuEtaNumberBits) {
   // no bullet-proof method, depends on binning ...
   // decide "by hand / by eyes" which object converts to which object
 
@@ -924,7 +851,7 @@ void L1GtEtaPhiConversions::convertL1Scales(
 
   // number of bins for all phi scales used
 
-  m_nrBinsPhiMu = 144; // FIXME ask Ivan for size() ...
+  m_nrBinsPhiMu = 144;  // FIXME ask Ivan for size() ...
   // m_nrBinsPhiMu = m_l1MuTriggerScales->getPhiScale()->size();
 
   m_nrBinsPhiJetEg = m_l1CaloGeometry->numberGctEmJetPhiBins();
@@ -946,33 +873,26 @@ void L1GtEtaPhiConversions::convertL1Scales(
   m_lutPhiMuToHtm.resize(m_nrBinsPhiMu, badIndex);
 
   for (unsigned int phiMuInd = 0; phiMuInd < m_nrBinsPhiMu; ++phiMuInd) {
-
-    double phiMuLowEdge =
-        m_l1MuTriggerScales->getPhiScale()->getLowEdge(phiMuInd);
-    double phiMuHighEdge =
-        m_l1MuTriggerScales->getPhiScale()->getHighEdge(phiMuInd);
+    double phiMuLowEdge = m_l1MuTriggerScales->getPhiScale()->getLowEdge(phiMuInd);
+    double phiMuHighEdge = m_l1MuTriggerScales->getPhiScale()->getHighEdge(phiMuInd);
 
     // to avoid precision problems, add a small quantity to phiMuLowEdge
-    double phiMuLowEdgeSmallShiftRight =
-        phiMuLowEdge + (phiMuHighEdge - phiMuLowEdge) / 100.;
+    double phiMuLowEdgeSmallShiftRight = phiMuLowEdge + (phiMuHighEdge - phiMuLowEdge) / 100.;
 
     // phi Mu -> (*Jet, EG)
 
     unsigned int nrBins = m_nrBinsPhiJetEg;
 
     for (unsigned int iBin = nrBins;; --iBin) {
-
       double phiLowEdge = m_l1CaloGeometry->emJetPhiBinLowEdge(iBin);
       double phiHighEdge = m_l1CaloGeometry->emJetPhiBinHighEdge(iBin);
 
       if (phiMuLowEdgeSmallShiftRight >= phiLowEdge) {
         m_lutPhiMuToJetEg[phiMuInd] = iBin % nrBins;
 
-        LogTrace("L1GlobalTrigger")
-            << " phiMuIndex \t" << phiMuInd << " [ " << phiMuLowEdge << " \t, "
-            << phiMuHighEdge << "] \t==>\t phiMuJetEG \t"
-            << m_lutPhiMuToJetEg[phiMuInd] << " [ " << phiLowEdge << "\t, "
-            << phiHighEdge << " ]" << std::endl;
+        LogTrace("L1GlobalTrigger") << " phiMuIndex \t" << phiMuInd << " [ " << phiMuLowEdge << " \t, " << phiMuHighEdge
+                                    << "] \t==>\t phiMuJetEG \t" << m_lutPhiMuToJetEg[phiMuInd] << " [ " << phiLowEdge
+                                    << "\t, " << phiHighEdge << " ]" << std::endl;
 
         break;
       }
@@ -983,18 +903,15 @@ void L1GtEtaPhiConversions::convertL1Scales(
     nrBins = m_nrBinsPhiEtm;
 
     for (unsigned int iBin = nrBins;; --iBin) {
-
       double phiLowEdge = m_l1CaloGeometry->etSumPhiBinLowEdge(iBin);
       double phiHighEdge = m_l1CaloGeometry->etSumPhiBinHighEdge(iBin);
 
       if (phiMuLowEdgeSmallShiftRight >= phiLowEdge) {
         m_lutPhiMuToEtm[phiMuInd] = iBin % nrBins;
 
-        LogTrace("L1GlobalTrigger")
-            << " phiMuIndex \t" << phiMuInd << " [ " << phiMuLowEdge << " \t, "
-            << phiMuHighEdge << "] \t==>\t phiMuToEtm \t"
-            << m_lutPhiMuToEtm[phiMuInd] << " [ " << phiLowEdge << "\t, "
-            << phiHighEdge << " ]" << std::endl;
+        LogTrace("L1GlobalTrigger") << " phiMuIndex \t" << phiMuInd << " [ " << phiMuLowEdge << " \t, " << phiMuHighEdge
+                                    << "] \t==>\t phiMuToEtm \t" << m_lutPhiMuToEtm[phiMuInd] << " [ " << phiLowEdge
+                                    << "\t, " << phiHighEdge << " ]" << std::endl;
 
         break;
       }
@@ -1005,18 +922,15 @@ void L1GtEtaPhiConversions::convertL1Scales(
     nrBins = m_nrBinsPhiHtm;
 
     for (unsigned int iBin = nrBins;; --iBin) {
-
       double phiLowEdge = m_l1CaloGeometry->htSumPhiBinLowEdge(iBin);
       double phiHighEdge = m_l1CaloGeometry->htSumPhiBinHighEdge(iBin);
 
       if (phiMuLowEdgeSmallShiftRight >= phiLowEdge) {
         m_lutPhiMuToHtm[phiMuInd] = iBin % nrBins;
 
-        LogTrace("L1GlobalTrigger")
-            << " phiMuIndex \t" << phiMuInd << " [ " << phiMuLowEdge << " \t, "
-            << phiMuHighEdge << "] \t==>\t phiMuToHtm \t"
-            << m_lutPhiMuToHtm[phiMuInd] << " [ " << phiLowEdge << "\t, "
-            << phiHighEdge << " ]" << std::endl;
+        LogTrace("L1GlobalTrigger") << " phiMuIndex \t" << phiMuInd << " [ " << phiMuLowEdge << " \t, " << phiMuHighEdge
+                                    << "] \t==>\t phiMuToHtm \t" << m_lutPhiMuToHtm[phiMuInd] << " [ " << phiLowEdge
+                                    << "\t, " << phiHighEdge << " ]" << std::endl;
 
         break;
       }
@@ -1028,11 +942,9 @@ void L1GtEtaPhiConversions::convertL1Scales(
   if (m_verbosity && m_isDebugEnabled) {
     LogTrace("L1GlobalTrigger") << "Mu phi conversions" << std::endl;
     for (unsigned int iBin = 0; iBin < m_nrBinsPhiMu; ++iBin) {
-      LogTrace("L1GlobalTrigger")
-          << "  Mu phiIndex \t" << iBin << "\t converted to index:"
-          << "\t Jet-EG \t" << m_lutPhiMuToJetEg.at(iBin) << "\t ETM \t"
-          << m_lutPhiMuToEtm.at(iBin) << "\t HTM \t" << m_lutPhiMuToHtm.at(iBin)
-          << std::endl;
+      LogTrace("L1GlobalTrigger") << "  Mu phiIndex \t" << iBin << "\t converted to index:"
+                                  << "\t Jet-EG \t" << m_lutPhiMuToJetEg.at(iBin) << "\t ETM \t"
+                                  << m_lutPhiMuToEtm.at(iBin) << "\t HTM \t" << m_lutPhiMuToHtm.at(iBin) << std::endl;
     }
     LogTrace("L1GlobalTrigger") << std::endl;
   }
@@ -1048,31 +960,26 @@ void L1GtEtaPhiConversions::convertL1Scales(
   m_lutPhiEtmToHtm.resize(m_nrBinsPhiEtm, badIndex);
 
   for (unsigned int phiEtmInd = 0; phiEtmInd < m_nrBinsPhiEtm; ++phiEtmInd) {
-
     double phiEtmLowEdge = m_l1CaloGeometry->etSumPhiBinLowEdge(phiEtmInd);
     double phiEtmHighEdge = m_l1CaloGeometry->etSumPhiBinHighEdge(phiEtmInd);
 
     // to avoid precision problems, add a small quantity to phiEtmLowEdge
-    double phiEtmLowEdgeSmallShiftRight =
-        phiEtmLowEdge + (phiEtmHighEdge - phiEtmLowEdge) / 100.;
+    double phiEtmLowEdgeSmallShiftRight = phiEtmLowEdge + (phiEtmHighEdge - phiEtmLowEdge) / 100.;
 
     // phi ETM -> (*Jet, EG)
 
     unsigned int nrBins = m_nrBinsPhiJetEg;
 
     for (unsigned int iBin = nrBins;; --iBin) {
-
       double phiLowEdge = m_l1CaloGeometry->emJetPhiBinLowEdge(iBin);
       double phiHighEdge = m_l1CaloGeometry->emJetPhiBinHighEdge(iBin);
 
       if (phiEtmLowEdgeSmallShiftRight >= phiLowEdge) {
         m_lutPhiEtmToJetEg[phiEtmInd] = iBin % nrBins;
 
-        LogTrace("L1GlobalTrigger")
-            << " phiEtmIndex \t" << phiEtmInd << " [ " << phiEtmLowEdge
-            << " \t, " << phiEtmHighEdge << "] \t==>\t phiEtmJetEG \t"
-            << m_lutPhiEtmToJetEg[phiEtmInd] << " [ " << phiLowEdge << "\t, "
-            << phiHighEdge << " ]" << std::endl;
+        LogTrace("L1GlobalTrigger") << " phiEtmIndex \t" << phiEtmInd << " [ " << phiEtmLowEdge << " \t, "
+                                    << phiEtmHighEdge << "] \t==>\t phiEtmJetEG \t" << m_lutPhiEtmToJetEg[phiEtmInd]
+                                    << " [ " << phiLowEdge << "\t, " << phiHighEdge << " ]" << std::endl;
 
         break;
       }
@@ -1083,18 +990,15 @@ void L1GtEtaPhiConversions::convertL1Scales(
     nrBins = m_nrBinsPhiHtm;
 
     for (unsigned int iBin = nrBins;; --iBin) {
-
       double phiLowEdge = m_l1CaloGeometry->htSumPhiBinLowEdge(iBin);
       double phiHighEdge = m_l1CaloGeometry->htSumPhiBinHighEdge(iBin);
 
       if (phiEtmLowEdgeSmallShiftRight >= phiLowEdge) {
         m_lutPhiEtmToHtm[phiEtmInd] = iBin % nrBins;
 
-        LogTrace("L1GlobalTrigger")
-            << " phiEtmIndex \t" << phiEtmInd << " [ " << phiEtmLowEdge
-            << " \t, " << phiEtmHighEdge << "] \t==>\t phiEtmToHtm \t"
-            << m_lutPhiEtmToHtm[phiEtmInd] << " [ " << phiLowEdge << "\t, "
-            << phiHighEdge << " ]" << std::endl;
+        LogTrace("L1GlobalTrigger") << " phiEtmIndex \t" << phiEtmInd << " [ " << phiEtmLowEdge << " \t, "
+                                    << phiEtmHighEdge << "] \t==>\t phiEtmToHtm \t" << m_lutPhiEtmToHtm[phiEtmInd]
+                                    << " [ " << phiLowEdge << "\t, " << phiHighEdge << " ]" << std::endl;
 
         break;
       }
@@ -1111,29 +1015,24 @@ void L1GtEtaPhiConversions::convertL1Scales(
   m_lutPhiHtmToJetEg.resize(m_nrBinsPhiHtm, badIndex);
 
   for (unsigned int phiHtmInd = 0; phiHtmInd < m_nrBinsPhiHtm; ++phiHtmInd) {
-
     double phiHtmLowEdge = m_l1CaloGeometry->htSumPhiBinLowEdge(phiHtmInd);
     double phiHtmHighEdge = m_l1CaloGeometry->htSumPhiBinHighEdge(phiHtmInd);
 
     // to avoid precision problems, add a small quantity to phiHtmLowEdge
-    double phiHtmLowEdgeSmallShiftRight =
-        phiHtmLowEdge + (phiHtmHighEdge - phiHtmLowEdge) / 100.;
+    double phiHtmLowEdgeSmallShiftRight = phiHtmLowEdge + (phiHtmHighEdge - phiHtmLowEdge) / 100.;
 
     unsigned int nrBins = m_nrBinsPhiJetEg;
 
     for (unsigned int iBin = nrBins;; --iBin) {
-
       double phiLowEdge = m_l1CaloGeometry->emJetPhiBinLowEdge(iBin);
       double phiHighEdge = m_l1CaloGeometry->emJetPhiBinHighEdge(iBin);
 
       if (phiHtmLowEdgeSmallShiftRight >= phiLowEdge) {
         m_lutPhiHtmToJetEg[phiHtmInd] = iBin % nrBins;
 
-        LogTrace("L1GlobalTrigger")
-            << " phiHtmIndex \t" << phiHtmInd << " [ " << phiHtmLowEdge
-            << " \t, " << phiHtmHighEdge << "] \t==>\t phiHtmJetEG \t"
-            << m_lutPhiHtmToJetEg[phiHtmInd] << " [ " << phiLowEdge << "\t, "
-            << phiHighEdge << " ]" << std::endl;
+        LogTrace("L1GlobalTrigger") << " phiHtmIndex \t" << phiHtmInd << " [ " << phiHtmLowEdge << " \t, "
+                                    << phiHtmHighEdge << "] \t==>\t phiHtmJetEG \t" << m_lutPhiHtmToJetEg[phiHtmInd]
+                                    << " [ " << phiLowEdge << "\t, " << phiHighEdge << " ]" << std::endl;
 
         break;
       }
@@ -1165,14 +1064,11 @@ void L1GtEtaPhiConversions::convertL1Scales(
   // Jet/IsoEG/NoIsoEG positive bins][ForJet positive bins]
   //
 
-  unsigned int nrGctCentralEtaBinsPerHalf =
-      m_l1CaloGeometry->numberGctCentralEtaBinsPerHalf();
+  unsigned int nrGctCentralEtaBinsPerHalf = m_l1CaloGeometry->numberGctCentralEtaBinsPerHalf();
 
-  unsigned int nrGctForwardEtaBinsPerHalf =
-      m_l1CaloGeometry->numberGctForwardEtaBinsPerHalf();
+  unsigned int nrGctForwardEtaBinsPerHalf = m_l1CaloGeometry->numberGctForwardEtaBinsPerHalf();
 
-  unsigned int nrGctTotalEtaBinsPerHalf =
-      nrGctCentralEtaBinsPerHalf + nrGctForwardEtaBinsPerHalf;
+  unsigned int nrGctTotalEtaBinsPerHalf = nrGctCentralEtaBinsPerHalf + nrGctForwardEtaBinsPerHalf;
 
   m_nrBinsEtaCommon = 2 * nrGctTotalEtaBinsPerHalf;
 
@@ -1187,31 +1083,23 @@ void L1GtEtaPhiConversions::convertL1Scales(
                               << std::endl;
 
   m_lutEtaCentralToCommonCalo.clear();
-  m_lutEtaCentralToCommonCalo.resize(
-      (nrGctCentralEtaBinsPerHalf | (1 << (ifCaloEtaNumberBits - 1))),
-      badIndex);
+  m_lutEtaCentralToCommonCalo.resize((nrGctCentralEtaBinsPerHalf | (1 << (ifCaloEtaNumberBits - 1))), badIndex);
 
   for (unsigned int etaInd = 0; etaInd < nrGctCentralEtaBinsPerHalf; ++etaInd) {
-
     // for positive values, the index is etaInd
-    unsigned int globalIndex = m_l1CaloGeometry->globalEtaIndex(
-        m_l1CaloGeometry->etaBinCenter(etaInd, true));
+    unsigned int globalIndex = m_l1CaloGeometry->globalEtaIndex(m_l1CaloGeometry->etaBinCenter(etaInd, true));
     m_lutEtaCentralToCommonCalo[etaInd] = globalIndex;
 
-    LogTrace("L1GlobalTrigger")
-        << " etaIndex " << etaInd << "\t [hex: " << std::hex << etaInd << "] "
-        << std::dec << " ==> etaIndexGlobal " << globalIndex << std::endl;
+    LogTrace("L1GlobalTrigger") << " etaIndex " << etaInd << "\t [hex: " << std::hex << etaInd << "] " << std::dec
+                                << " ==> etaIndexGlobal " << globalIndex << std::endl;
 
     // for negative values, one adds (binary) 1 as MSB to the index
     unsigned int etaIndNeg = etaInd | (1 << (ifCaloEtaNumberBits - 1));
-    globalIndex = m_l1CaloGeometry->globalEtaIndex(
-        m_l1CaloGeometry->etaBinCenter(etaIndNeg, true));
+    globalIndex = m_l1CaloGeometry->globalEtaIndex(m_l1CaloGeometry->etaBinCenter(etaIndNeg, true));
     m_lutEtaCentralToCommonCalo[etaIndNeg] = globalIndex;
 
-    LogTrace("L1GlobalTrigger")
-        << " etaIndex " << etaIndNeg << "\t [hex: " << std::hex << etaIndNeg
-        << "] " << std::dec << " ==> etaIndexGlobal " << globalIndex
-        << std::endl;
+    LogTrace("L1GlobalTrigger") << " etaIndex " << etaIndNeg << "\t [hex: " << std::hex << etaIndNeg << "] " << std::dec
+                                << " ==> etaIndexGlobal " << globalIndex << std::endl;
   }
 
   //
@@ -1219,36 +1107,26 @@ void L1GtEtaPhiConversions::convertL1Scales(
   // central / forward calorimeter eta scale
   //
 
-  LogTrace("L1GlobalTrigger")
-      << " \nEta conversion: ForJet to a common calorimeter scale\n"
-      << std::endl;
+  LogTrace("L1GlobalTrigger") << " \nEta conversion: ForJet to a common calorimeter scale\n" << std::endl;
 
   m_lutEtaForJetToCommonCalo.clear();
-  m_lutEtaForJetToCommonCalo.resize(
-      (nrGctForwardEtaBinsPerHalf | (1 << (ifCaloEtaNumberBits - 1))),
-      badIndex);
+  m_lutEtaForJetToCommonCalo.resize((nrGctForwardEtaBinsPerHalf | (1 << (ifCaloEtaNumberBits - 1))), badIndex);
 
   for (unsigned int etaInd = 0; etaInd < nrGctForwardEtaBinsPerHalf; ++etaInd) {
-
     // for positive values, the index is etaInd
-    unsigned int globalIndex = m_l1CaloGeometry->globalEtaIndex(
-        m_l1CaloGeometry->etaBinCenter(etaInd, false));
+    unsigned int globalIndex = m_l1CaloGeometry->globalEtaIndex(m_l1CaloGeometry->etaBinCenter(etaInd, false));
     m_lutEtaForJetToCommonCalo[etaInd] = globalIndex;
 
-    LogTrace("L1GlobalTrigger")
-        << " etaIndex " << etaInd << "\t [hex: " << std::hex << etaInd << "] "
-        << std::dec << " ==> etaIndexGlobal " << globalIndex << std::endl;
+    LogTrace("L1GlobalTrigger") << " etaIndex " << etaInd << "\t [hex: " << std::hex << etaInd << "] " << std::dec
+                                << " ==> etaIndexGlobal " << globalIndex << std::endl;
 
     // for negative values, one adds (binary) 1 as MSB to the index
     unsigned int etaIndNeg = etaInd | (1 << (ifCaloEtaNumberBits - 1));
-    globalIndex = m_l1CaloGeometry->globalEtaIndex(
-        m_l1CaloGeometry->etaBinCenter(etaIndNeg, false));
+    globalIndex = m_l1CaloGeometry->globalEtaIndex(m_l1CaloGeometry->etaBinCenter(etaIndNeg, false));
     m_lutEtaForJetToCommonCalo[etaIndNeg] = globalIndex;
 
-    LogTrace("L1GlobalTrigger")
-        << " etaIndex " << etaIndNeg << "\t [hex: " << std::hex << etaIndNeg
-        << "] " << std::dec << " ==> etaIndexGlobal " << globalIndex
-        << std::endl;
+    LogTrace("L1GlobalTrigger") << " etaIndex " << etaIndNeg << "\t [hex: " << std::hex << etaIndNeg << "] " << std::dec
+                                << " ==> etaIndexGlobal " << globalIndex << std::endl;
   }
 
   //
@@ -1256,35 +1134,24 @@ void L1GtEtaPhiConversions::convertL1Scales(
   // central / forward calorimeter eta scale
   //
 
-  LogDebug("L1GlobalTrigger")
-      << " \nEta conversion: Mu to a common calorimeter scale\n"
-      << std::endl;
+  LogDebug("L1GlobalTrigger") << " \nEta conversion: Mu to a common calorimeter scale\n" << std::endl;
 
   // eta scale defined for positive values - need to be symmetrized
-  unsigned int nrBinsEtaMuPerHalf =
-      m_l1MuTriggerScales->getGMTEtaScale()->getNBins();
-  LogTrace("L1GlobalTrigger")
-      << " \nnrBinsEtaMuPerHalf = " << nrBinsEtaMuPerHalf << "\n"
-      << std::endl;
+  unsigned int nrBinsEtaMuPerHalf = m_l1MuTriggerScales->getGMTEtaScale()->getNBins();
+  LogTrace("L1GlobalTrigger") << " \nnrBinsEtaMuPerHalf = " << nrBinsEtaMuPerHalf << "\n" << std::endl;
 
   m_lutEtaMuToCommonCalo.clear();
-  m_lutEtaMuToCommonCalo.resize(
-      (nrBinsEtaMuPerHalf | (1 << (ifMuEtaNumberBits - 1))), badIndex);
+  m_lutEtaMuToCommonCalo.resize((nrBinsEtaMuPerHalf | (1 << (ifMuEtaNumberBits - 1))), badIndex);
 
   for (unsigned int etaMuInd = 0; etaMuInd < nrBinsEtaMuPerHalf; ++etaMuInd) {
-
-    double etaMuLowEdge =
-        m_l1MuTriggerScales->getGMTEtaScale()->getValue(etaMuInd);
-    double etaMuHighEdge =
-        m_l1MuTriggerScales->getGMTEtaScale()->getValue(etaMuInd + 1);
+    double etaMuLowEdge = m_l1MuTriggerScales->getGMTEtaScale()->getValue(etaMuInd);
+    double etaMuHighEdge = m_l1MuTriggerScales->getGMTEtaScale()->getValue(etaMuInd + 1);
 
     // to avoid precision problems, add a small quantity to etaMuLowEdge
-    double etaMuLowEdgeSmallShiftRight =
-        etaMuLowEdge + (etaMuHighEdge - etaMuLowEdge) / 100.;
+    double etaMuLowEdgeSmallShiftRight = etaMuLowEdge + (etaMuHighEdge - etaMuLowEdge) / 100.;
 
     // positive values
     for (unsigned int iBin = m_nrBinsEtaCommon;; --iBin) {
-
       double etaLowEdge = m_l1CaloGeometry->globalEtaBinLowEdge(iBin);
 
       double etaHighEdge = 0.0;
@@ -1297,11 +1164,9 @@ void L1GtEtaPhiConversions::convertL1Scales(
       if (etaMuLowEdgeSmallShiftRight >= etaLowEdge) {
         m_lutEtaMuToCommonCalo[etaMuInd] = iBin % m_nrBinsEtaCommon;
 
-        LogTrace("L1GlobalTrigger")
-            << " etaMuIndex \t" << etaMuInd << "\t [ " << etaMuLowEdge << ", \t"
-            << etaMuHighEdge << "] ==> etaMuJetEG \t"
-            << m_lutEtaMuToCommonCalo[etaMuInd] << "\t [ " << etaLowEdge
-            << ", \t" << etaHighEdge << " ]" << std::endl;
+        LogTrace("L1GlobalTrigger") << " etaMuIndex \t" << etaMuInd << "\t [ " << etaMuLowEdge << ", \t"
+                                    << etaMuHighEdge << "] ==> etaMuJetEG \t" << m_lutEtaMuToCommonCalo[etaMuInd]
+                                    << "\t [ " << etaLowEdge << ", \t" << etaHighEdge << " ]" << std::endl;
 
         break;
       }
@@ -1310,20 +1175,14 @@ void L1GtEtaPhiConversions::convertL1Scales(
     // for negative values, one adds (binary) 1 as MSB to the index
     unsigned int etaMuIndNeg = etaMuInd | (1 << (ifMuEtaNumberBits - 1));
     m_lutEtaMuToCommonCalo[etaMuIndNeg] =
-        m_lutEtaMuToCommonCalo[0] -
-        (m_lutEtaMuToCommonCalo[etaMuInd] - m_lutEtaMuToCommonCalo[0] + 1);
+        m_lutEtaMuToCommonCalo[0] - (m_lutEtaMuToCommonCalo[etaMuInd] - m_lutEtaMuToCommonCalo[0] + 1);
 
-    LogTrace("L1GlobalTrigger")
-        << " etaMuIndexNeg \t" << etaMuIndNeg << "\t [ "
-        << (-1.0 * etaMuLowEdge) << ", \t" << (-1.0 * etaMuHighEdge)
-        << "] ==> etaMuJetEG \t" << m_lutEtaMuToCommonCalo[etaMuIndNeg]
-        << "\t [ "
-        << m_l1CaloGeometry->globalEtaBinLowEdge(
-               m_lutEtaMuToCommonCalo[etaMuIndNeg])
-        << ", \t"
-        << m_l1CaloGeometry->globalEtaBinLowEdge(
-               m_lutEtaMuToCommonCalo[etaMuIndNeg] + 1)
-        << " ]" << std::endl;
+    LogTrace("L1GlobalTrigger") << " etaMuIndexNeg \t" << etaMuIndNeg << "\t [ " << (-1.0 * etaMuLowEdge) << ", \t"
+                                << (-1.0 * etaMuHighEdge) << "] ==> etaMuJetEG \t"
+                                << m_lutEtaMuToCommonCalo[etaMuIndNeg] << "\t [ "
+                                << m_l1CaloGeometry->globalEtaBinLowEdge(m_lutEtaMuToCommonCalo[etaMuIndNeg]) << ", \t"
+                                << m_l1CaloGeometry->globalEtaBinLowEdge(m_lutEtaMuToCommonCalo[etaMuIndNeg] + 1)
+                                << " ]" << std::endl;
   }
 
   if (m_verbosity && m_isDebugEnabled) {
@@ -1334,7 +1193,6 @@ void L1GtEtaPhiConversions::convertL1Scales(
 
 // print all the performed conversions
 void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
-
   // force a page break before each group
   myCout << "<p style=\"page-break-before: always\">&nbsp;</p>";
 
@@ -1353,8 +1211,7 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
          << std::endl;
 
   size_t lutPhiMuToJetEgSize = m_lutPhiMuToJetEg.size();
-  myCout << "Size of look-up table = " << lutPhiMuToJetEgSize << "\n"
-         << std::endl;
+  myCout << "Size of look-up table = " << lutPhiMuToJetEgSize << "\n" << std::endl;
 
   myCout << "|  *Initial Phi Hardware Index*  "
          << "||  *Initial Phi Range*  ||"
@@ -1363,13 +1220,9 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
          << "\n"
          << "|  *hex*  |  *dec*  | ^|^|  *hex*  |  *dec*  |^|^|" << std::endl;
 
-  for (unsigned int indexToConv = 0; indexToConv < lutPhiMuToJetEgSize;
-       ++indexToConv) {
-
-    double lowEdgeToConv =
-        m_l1MuTriggerScales->getPhiScale()->getLowEdge(indexToConv);
-    double highEdgeToConv =
-        m_l1MuTriggerScales->getPhiScale()->getHighEdge(indexToConv);
+  for (unsigned int indexToConv = 0; indexToConv < lutPhiMuToJetEgSize; ++indexToConv) {
+    double lowEdgeToConv = m_l1MuTriggerScales->getPhiScale()->getLowEdge(indexToConv);
+    double highEdgeToConv = m_l1MuTriggerScales->getPhiScale()->getHighEdge(indexToConv);
 
     unsigned int convIndex = m_lutPhiMuToJetEg[indexToConv];
 
@@ -1385,15 +1238,12 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
       highEdgeToConv = 0.;
     }
 
-    myCout << "|  0x" << std::setw(3) << std::hex << std::left << indexToConv
-           << "  |  " << std::dec << std::setw(3) << std::left << indexToConv
-           << "  |[ " << std::setw(10) << std::left << (rad2deg(lowEdgeToConv))
-           << ",  |" << std::setw(10) << std::left << (rad2deg(highEdgeToConv))
-           << " )  |  0x" << std::setw(6) << std::hex << std::left << convIndex
-           << " |  " << std::dec << std::setw(6) << convIndex << "  |[ "
-           << std::setw(10) << std::left << (rad2deg(convLowEdge)) << ",  |"
-           << std::setw(10) << std::left << (rad2deg(convHighEdge)) << " )  |"
-           << std::right << std::endl;
+    myCout << "|  0x" << std::setw(3) << std::hex << std::left << indexToConv << "  |  " << std::dec << std::setw(3)
+           << std::left << indexToConv << "  |[ " << std::setw(10) << std::left << (rad2deg(lowEdgeToConv)) << ",  |"
+           << std::setw(10) << std::left << (rad2deg(highEdgeToConv)) << " )  |  0x" << std::setw(6) << std::hex
+           << std::left << convIndex << " |  " << std::dec << std::setw(6) << convIndex << "  |[ " << std::setw(10)
+           << std::left << (rad2deg(convLowEdge)) << ",  |" << std::setw(10) << std::left << (rad2deg(convHighEdge))
+           << " )  |" << std::right << std::endl;
   }
 
   // phi Mu -> ETM
@@ -1404,8 +1254,7 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
   myCout << "\n---+++Phi conversion for muons to ETM phi scale \n" << std::endl;
 
   size_t lutPhiMuToEtmSize = m_lutPhiMuToEtm.size();
-  myCout << "Size of look-up table = " << lutPhiMuToEtmSize << "\n"
-         << std::endl;
+  myCout << "Size of look-up table = " << lutPhiMuToEtmSize << "\n" << std::endl;
 
   myCout << "|  *Initial Phi Hardware Index*  "
          << "||  *Initial Phi Range*  ||"
@@ -1414,13 +1263,9 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
          << "\n"
          << "|  *hex*  |  *dec*  | ^|^|  *hex*  |  *dec*  |^|^|" << std::endl;
 
-  for (unsigned int indexToConv = 0; indexToConv < lutPhiMuToEtmSize;
-       ++indexToConv) {
-
-    double lowEdgeToConv =
-        m_l1MuTriggerScales->getPhiScale()->getLowEdge(indexToConv);
-    double highEdgeToConv =
-        m_l1MuTriggerScales->getPhiScale()->getHighEdge(indexToConv);
+  for (unsigned int indexToConv = 0; indexToConv < lutPhiMuToEtmSize; ++indexToConv) {
+    double lowEdgeToConv = m_l1MuTriggerScales->getPhiScale()->getLowEdge(indexToConv);
+    double highEdgeToConv = m_l1MuTriggerScales->getPhiScale()->getHighEdge(indexToConv);
 
     unsigned int convIndex = m_lutPhiMuToEtm[indexToConv];
 
@@ -1436,15 +1281,12 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
       highEdgeToConv = 0.;
     }
 
-    myCout << "|  0x" << std::setw(3) << std::hex << std::left << indexToConv
-           << "  |  " << std::dec << std::setw(3) << std::left << indexToConv
-           << "  |[ " << std::setw(10) << std::left << (rad2deg(lowEdgeToConv))
-           << ",  |" << std::setw(10) << std::left << (rad2deg(highEdgeToConv))
-           << " )  |  0x" << std::setw(6) << std::hex << std::left << convIndex
-           << " |  " << std::dec << std::setw(6) << convIndex << "  |[ "
-           << std::setw(10) << std::left << (rad2deg(convLowEdge)) << ",  |"
-           << std::setw(10) << std::left << (rad2deg(convHighEdge)) << " )  |"
-           << std::right << std::endl;
+    myCout << "|  0x" << std::setw(3) << std::hex << std::left << indexToConv << "  |  " << std::dec << std::setw(3)
+           << std::left << indexToConv << "  |[ " << std::setw(10) << std::left << (rad2deg(lowEdgeToConv)) << ",  |"
+           << std::setw(10) << std::left << (rad2deg(highEdgeToConv)) << " )  |  0x" << std::setw(6) << std::hex
+           << std::left << convIndex << " |  " << std::dec << std::setw(6) << convIndex << "  |[ " << std::setw(10)
+           << std::left << (rad2deg(convLowEdge)) << ",  |" << std::setw(10) << std::left << (rad2deg(convHighEdge))
+           << " )  |" << std::right << std::endl;
   }
 
   // phi Mu -> HTM
@@ -1455,8 +1297,7 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
   myCout << "\n---+++Phi conversion for muons to HTM phi scale \n" << std::endl;
 
   size_t lutPhiMuToHtmSize = m_lutPhiMuToHtm.size();
-  myCout << "Size of look-up table = " << lutPhiMuToHtmSize << "\n"
-         << std::endl;
+  myCout << "Size of look-up table = " << lutPhiMuToHtmSize << "\n" << std::endl;
 
   myCout << "|  *Initial Phi Hardware Index*  "
          << "||  *Initial Phi Range*  ||"
@@ -1465,13 +1306,9 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
          << "\n"
          << "|  *hex*  |  *dec*  | ^|^|  *hex*  |  *dec*  |^|^|" << std::endl;
 
-  for (unsigned int indexToConv = 0; indexToConv < lutPhiMuToHtmSize;
-       ++indexToConv) {
-
-    double lowEdgeToConv =
-        m_l1MuTriggerScales->getPhiScale()->getLowEdge(indexToConv);
-    double highEdgeToConv =
-        m_l1MuTriggerScales->getPhiScale()->getHighEdge(indexToConv);
+  for (unsigned int indexToConv = 0; indexToConv < lutPhiMuToHtmSize; ++indexToConv) {
+    double lowEdgeToConv = m_l1MuTriggerScales->getPhiScale()->getLowEdge(indexToConv);
+    double highEdgeToConv = m_l1MuTriggerScales->getPhiScale()->getHighEdge(indexToConv);
 
     unsigned int convIndex = m_lutPhiMuToHtm[indexToConv];
 
@@ -1487,15 +1324,12 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
       highEdgeToConv = 0.;
     }
 
-    myCout << "|  0x" << std::setw(3) << std::hex << std::left << indexToConv
-           << "  |  " << std::dec << std::setw(3) << std::left << indexToConv
-           << "  |[ " << std::setw(10) << std::left << (rad2deg(lowEdgeToConv))
-           << ",  |" << std::setw(10) << std::left << (rad2deg(highEdgeToConv))
-           << " )  |  0x" << std::setw(6) << std::hex << std::left << convIndex
-           << " |  " << std::dec << std::setw(6) << convIndex << "  |[ "
-           << std::setw(10) << std::left << (rad2deg(convLowEdge)) << ",  |"
-           << std::setw(10) << std::left << (rad2deg(convHighEdge)) << " )  |"
-           << std::right << std::endl;
+    myCout << "|  0x" << std::setw(3) << std::hex << std::left << indexToConv << "  |  " << std::dec << std::setw(3)
+           << std::left << indexToConv << "  |[ " << std::setw(10) << std::left << (rad2deg(lowEdgeToConv)) << ",  |"
+           << std::setw(10) << std::left << (rad2deg(highEdgeToConv)) << " )  |  0x" << std::setw(6) << std::hex
+           << std::left << convIndex << " |  " << std::dec << std::setw(6) << convIndex << "  |[ " << std::setw(10)
+           << std::left << (rad2deg(convLowEdge)) << ",  |" << std::setw(10) << std::left << (rad2deg(convHighEdge))
+           << " )  |" << std::right << std::endl;
   }
 
   // phi ETM -> (*Jet, EG)
@@ -1508,8 +1342,7 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
          << std::endl;
 
   size_t lutPhiEtmToJetEgSize = m_lutPhiEtmToJetEg.size();
-  myCout << "Size of look-up table = " << lutPhiEtmToJetEgSize << "\n"
-         << std::endl;
+  myCout << "Size of look-up table = " << lutPhiEtmToJetEgSize << "\n" << std::endl;
 
   myCout << "|  *Initial Phi Hardware Index*  "
          << "||  *Initial Phi Range*  ||"
@@ -1518,9 +1351,7 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
          << "\n"
          << "|  *hex*  |  *dec*  | ^|^|  *hex*  |  *dec*  |^|^|" << std::endl;
 
-  for (unsigned int indexToConv = 0; indexToConv < lutPhiEtmToJetEgSize;
-       ++indexToConv) {
-
+  for (unsigned int indexToConv = 0; indexToConv < lutPhiEtmToJetEgSize; ++indexToConv) {
     double lowEdgeToConv = m_l1CaloGeometry->etSumPhiBinLowEdge(indexToConv);
     double highEdgeToConv = m_l1CaloGeometry->etSumPhiBinHighEdge(indexToConv);
 
@@ -1538,15 +1369,12 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
       highEdgeToConv = 0.;
     }
 
-    myCout << "|  0x" << std::setw(3) << std::hex << std::left << indexToConv
-           << "  |  " << std::dec << std::setw(3) << std::left << indexToConv
-           << "  |[ " << std::setw(10) << std::left << (rad2deg(lowEdgeToConv))
-           << ",  |" << std::setw(10) << std::left << (rad2deg(highEdgeToConv))
-           << " )  |  0x" << std::setw(6) << std::hex << std::left << convIndex
-           << " |  " << std::dec << std::setw(6) << convIndex << "  |[ "
-           << std::setw(10) << std::left << (rad2deg(convLowEdge)) << ",  |"
-           << std::setw(10) << std::left << (rad2deg(convHighEdge)) << " )  |"
-           << std::right << std::endl;
+    myCout << "|  0x" << std::setw(3) << std::hex << std::left << indexToConv << "  |  " << std::dec << std::setw(3)
+           << std::left << indexToConv << "  |[ " << std::setw(10) << std::left << (rad2deg(lowEdgeToConv)) << ",  |"
+           << std::setw(10) << std::left << (rad2deg(highEdgeToConv)) << " )  |  0x" << std::setw(6) << std::hex
+           << std::left << convIndex << " |  " << std::dec << std::setw(6) << convIndex << "  |[ " << std::setw(10)
+           << std::left << (rad2deg(convLowEdge)) << ",  |" << std::setw(10) << std::left << (rad2deg(convHighEdge))
+           << " )  |" << std::right << std::endl;
   }
 
   // phi ETM -> HTM
@@ -1557,8 +1385,7 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
   myCout << "\n---+++Phi conversion for ETM to HTM phi scale \n" << std::endl;
 
   size_t lutPhiEtmToHtmSize = m_lutPhiEtmToHtm.size();
-  myCout << "Size of look-up table = " << lutPhiEtmToHtmSize << "\n"
-         << std::endl;
+  myCout << "Size of look-up table = " << lutPhiEtmToHtmSize << "\n" << std::endl;
 
   myCout << "|  *Initial Phi Hardware Index*  "
          << "||  *Initial Phi Range*  ||"
@@ -1567,9 +1394,7 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
          << "\n"
          << "|  *hex*  |  *dec*  | ^|^|  *hex*  |  *dec*  |^|^|" << std::endl;
 
-  for (unsigned int indexToConv = 0; indexToConv < lutPhiEtmToHtmSize;
-       ++indexToConv) {
-
+  for (unsigned int indexToConv = 0; indexToConv < lutPhiEtmToHtmSize; ++indexToConv) {
     double lowEdgeToConv = m_l1CaloGeometry->etSumPhiBinLowEdge(indexToConv);
     double highEdgeToConv = m_l1CaloGeometry->etSumPhiBinHighEdge(indexToConv);
 
@@ -1587,15 +1412,12 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
       highEdgeToConv = 0.;
     }
 
-    myCout << "|  0x" << std::setw(3) << std::hex << std::left << indexToConv
-           << "  |  " << std::dec << std::setw(3) << std::left << indexToConv
-           << "  |[ " << std::setw(10) << std::left << (rad2deg(lowEdgeToConv))
-           << ",  |" << std::setw(10) << std::left << (rad2deg(highEdgeToConv))
-           << " )  |  0x" << std::setw(6) << std::hex << std::left << convIndex
-           << " |  " << std::dec << std::setw(6) << convIndex << "  |[ "
-           << std::setw(10) << std::left << (rad2deg(convLowEdge)) << ",  |"
-           << std::setw(10) << std::left << (rad2deg(convHighEdge)) << " )  |"
-           << std::right << std::endl;
+    myCout << "|  0x" << std::setw(3) << std::hex << std::left << indexToConv << "  |  " << std::dec << std::setw(3)
+           << std::left << indexToConv << "  |[ " << std::setw(10) << std::left << (rad2deg(lowEdgeToConv)) << ",  |"
+           << std::setw(10) << std::left << (rad2deg(highEdgeToConv)) << " )  |  0x" << std::setw(6) << std::hex
+           << std::left << convIndex << " |  " << std::dec << std::setw(6) << convIndex << "  |[ " << std::setw(10)
+           << std::left << (rad2deg(convLowEdge)) << ",  |" << std::setw(10) << std::left << (rad2deg(convHighEdge))
+           << " )  |" << std::right << std::endl;
   }
 
   // phi HTM -> (*Jet, EG)
@@ -1608,8 +1430,7 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
          << std::endl;
 
   size_t lutPhiHtmToJetEgSize = m_lutPhiHtmToJetEg.size();
-  myCout << "Size of look-up table = " << lutPhiHtmToJetEgSize << "\n"
-         << std::endl;
+  myCout << "Size of look-up table = " << lutPhiHtmToJetEgSize << "\n" << std::endl;
 
   myCout << "|  *Initial Phi Hardware Index*  "
          << "||  *Initial Phi Range*  ||"
@@ -1618,9 +1439,7 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
          << "\n"
          << "|  *hex*  |  *dec*  | ^|^|  *hex*  |  *dec*  |^|^|" << std::endl;
 
-  for (unsigned int indexToConv = 0; indexToConv < lutPhiHtmToJetEgSize;
-       ++indexToConv) {
-
+  for (unsigned int indexToConv = 0; indexToConv < lutPhiHtmToJetEgSize; ++indexToConv) {
     double lowEdgeToConv = m_l1CaloGeometry->htSumPhiBinLowEdge(indexToConv);
     double highEdgeToConv = m_l1CaloGeometry->htSumPhiBinHighEdge(indexToConv);
 
@@ -1638,15 +1457,12 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
       highEdgeToConv = 0.;
     }
 
-    myCout << "|  0x" << std::setw(3) << std::hex << std::left << indexToConv
-           << "  |  " << std::dec << std::setw(3) << std::left << indexToConv
-           << "  |[ " << std::setw(10) << std::left << (rad2deg(lowEdgeToConv))
-           << ",  |" << std::setw(10) << std::left << (rad2deg(highEdgeToConv))
-           << " )  |  0x" << std::setw(6) << std::hex << std::left << convIndex
-           << " |  " << std::dec << std::setw(6) << convIndex << "  |[ "
-           << std::setw(10) << std::left << (rad2deg(convLowEdge)) << ",  |"
-           << std::setw(10) << std::left << (rad2deg(convHighEdge)) << " )  |"
-           << std::right << std::endl;
+    myCout << "|  0x" << std::setw(3) << std::hex << std::left << indexToConv << "  |  " << std::dec << std::setw(3)
+           << std::left << indexToConv << "  |[ " << std::setw(10) << std::left << (rad2deg(lowEdgeToConv)) << ",  |"
+           << std::setw(10) << std::left << (rad2deg(highEdgeToConv)) << " )  |  0x" << std::setw(6) << std::hex
+           << std::left << convIndex << " |  " << std::dec << std::setw(6) << convIndex << "  |[ " << std::setw(10)
+           << std::left << (rad2deg(convLowEdge)) << ",  |" << std::setw(10) << std::left << (rad2deg(convHighEdge))
+           << " )  |" << std::right << std::endl;
   }
 
   //
@@ -1664,8 +1480,7 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
          << std::endl;
 
   size_t lutEtaCentralToCommonCaloSize = m_lutEtaCentralToCommonCalo.size();
-  myCout << "Size of look-up table = " << lutEtaCentralToCommonCaloSize << "\n"
-         << std::endl;
+  myCout << "Size of look-up table = " << lutEtaCentralToCommonCaloSize << "\n" << std::endl;
 
   myCout << "|  *Initial Eta Hardware Index*  "
          << "||  *Initial Eta Range*  ||"
@@ -1674,16 +1489,11 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
          << "\n"
          << "|  *hex*  |  *dec*  | ^|^|  *hex*  |  *dec*  |^|^|" << std::endl;
 
-  for (unsigned int indexToConv = 0;
-       indexToConv < lutEtaCentralToCommonCaloSize; ++indexToConv) {
-
-    double lowEdgeToConv =
-        m_l1CaloGeometry->globalEtaBinLowEdge(m_l1CaloGeometry->globalEtaIndex(
-            m_l1CaloGeometry->etaBinCenter(indexToConv, true)));
+  for (unsigned int indexToConv = 0; indexToConv < lutEtaCentralToCommonCaloSize; ++indexToConv) {
+    double lowEdgeToConv = m_l1CaloGeometry->globalEtaBinLowEdge(
+        m_l1CaloGeometry->globalEtaIndex(m_l1CaloGeometry->etaBinCenter(indexToConv, true)));
     double highEdgeToConv = m_l1CaloGeometry->globalEtaBinLowEdge(
-        m_l1CaloGeometry->globalEtaIndex(
-            m_l1CaloGeometry->etaBinCenter(indexToConv, true)) +
-        1);
+        m_l1CaloGeometry->globalEtaIndex(m_l1CaloGeometry->etaBinCenter(indexToConv, true)) + 1);
 
     unsigned int convIndex = m_lutEtaCentralToCommonCalo[indexToConv];
 
@@ -1699,14 +1509,11 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
       highEdgeToConv = 0.;
     }
 
-    myCout << "|  0x" << std::setw(3) << std::hex << std::left << indexToConv
-           << "  |  " << std::dec << std::setw(3) << std::left << indexToConv
-           << "  |[ " << std::setw(10) << std::left << lowEdgeToConv << ",  |"
-           << std::setw(10) << std::left << highEdgeToConv << " )  |  0x"
-           << std::setw(6) << std::hex << std::left << convIndex << " |  "
-           << std::dec << std::setw(6) << convIndex << "  |[ " << std::setw(10)
-           << std::left << convLowEdge << ",  |" << std::setw(10) << std::left
-           << convHighEdge << " )  |" << std::right << std::endl;
+    myCout << "|  0x" << std::setw(3) << std::hex << std::left << indexToConv << "  |  " << std::dec << std::setw(3)
+           << std::left << indexToConv << "  |[ " << std::setw(10) << std::left << lowEdgeToConv << ",  |"
+           << std::setw(10) << std::left << highEdgeToConv << " )  |  0x" << std::setw(6) << std::hex << std::left
+           << convIndex << " |  " << std::dec << std::setw(6) << convIndex << "  |[ " << std::setw(10) << std::left
+           << convLowEdge << ",  |" << std::setw(10) << std::left << convHighEdge << " )  |" << std::right << std::endl;
   }
 
   // ForJet to a common central / forward calorimeter eta scale
@@ -1719,8 +1526,7 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
          << std::endl;
 
   size_t lutEtaForJetToCommonCaloSize = m_lutEtaForJetToCommonCalo.size();
-  myCout << "Size of look-up table = " << lutEtaForJetToCommonCaloSize << "\n"
-         << std::endl;
+  myCout << "Size of look-up table = " << lutEtaForJetToCommonCaloSize << "\n" << std::endl;
 
   myCout << "|  *Initial Eta Hardware Index*  "
          << "||  *Initial Eta Range*  ||"
@@ -1729,16 +1535,11 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
          << "\n"
          << "|  *hex*  |  *dec*  | ^|^|  *hex*  |  *dec*  |^|^|" << std::endl;
 
-  for (unsigned int indexToConv = 0; indexToConv < lutEtaForJetToCommonCaloSize;
-       ++indexToConv) {
-
-    double lowEdgeToConv =
-        m_l1CaloGeometry->globalEtaBinLowEdge(m_l1CaloGeometry->globalEtaIndex(
-            m_l1CaloGeometry->etaBinCenter(indexToConv, false)));
+  for (unsigned int indexToConv = 0; indexToConv < lutEtaForJetToCommonCaloSize; ++indexToConv) {
+    double lowEdgeToConv = m_l1CaloGeometry->globalEtaBinLowEdge(
+        m_l1CaloGeometry->globalEtaIndex(m_l1CaloGeometry->etaBinCenter(indexToConv, false)));
     double highEdgeToConv = m_l1CaloGeometry->globalEtaBinLowEdge(
-        m_l1CaloGeometry->globalEtaIndex(
-            m_l1CaloGeometry->etaBinCenter(indexToConv, false)) +
-        1);
+        m_l1CaloGeometry->globalEtaIndex(m_l1CaloGeometry->etaBinCenter(indexToConv, false)) + 1);
 
     unsigned int convIndex = m_lutEtaForJetToCommonCalo[indexToConv];
 
@@ -1754,14 +1555,11 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
       highEdgeToConv = 0.;
     }
 
-    myCout << "|  0x" << std::setw(3) << std::hex << std::left << indexToConv
-           << "  |  " << std::dec << std::setw(3) << std::left << indexToConv
-           << "  |[ " << std::setw(10) << std::left << lowEdgeToConv << ",  |"
-           << std::setw(10) << std::left << highEdgeToConv << " )  |  0x"
-           << std::setw(6) << std::hex << std::left << convIndex << " |  "
-           << std::dec << std::setw(6) << convIndex << "  |[ " << std::setw(10)
-           << std::left << convLowEdge << ",  |" << std::setw(10) << std::left
-           << convHighEdge << " )  |" << std::right << std::endl;
+    myCout << "|  0x" << std::setw(3) << std::hex << std::left << indexToConv << "  |  " << std::dec << std::setw(3)
+           << std::left << indexToConv << "  |[ " << std::setw(10) << std::left << lowEdgeToConv << ",  |"
+           << std::setw(10) << std::left << highEdgeToConv << " )  |  0x" << std::setw(6) << std::hex << std::left
+           << convIndex << " |  " << std::dec << std::setw(6) << convIndex << "  |[ " << std::setw(10) << std::left
+           << convLowEdge << ",  |" << std::setw(10) << std::left << convHighEdge << " )  |" << std::right << std::endl;
   }
 
   // Mu to a common central / forward calorimeter eta scale
@@ -1774,11 +1572,9 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
          << std::endl;
 
   size_t lutEtaMuToCommonCaloSize = m_lutEtaMuToCommonCalo.size();
-  myCout << "Size of look-up table = " << lutEtaMuToCommonCaloSize << "\n"
-         << std::endl;
+  myCout << "Size of look-up table = " << lutEtaMuToCommonCaloSize << "\n" << std::endl;
 
-  unsigned int nrBinsEtaMuPerHalf =
-      m_l1MuTriggerScales->getGMTEtaScale()->getNBins();
+  unsigned int nrBinsEtaMuPerHalf = m_l1MuTriggerScales->getGMTEtaScale()->getNBins();
 
   myCout << "|  *Initial Eta Hardware Index*  "
          << "||  *Initial Eta Range*  ||"
@@ -1787,9 +1583,7 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
          << "\n"
          << "|  *hex*  |  *dec*  | ^|^|  *hex*  |  *dec*  |^|^|" << std::endl;
 
-  for (unsigned int indexToConv = 0; indexToConv < lutEtaMuToCommonCaloSize;
-       ++indexToConv) {
-
+  for (unsigned int indexToConv = 0; indexToConv < lutEtaMuToCommonCaloSize; ++indexToConv) {
     // Mu scale defined for positive values only, need to be symmetrized
     unsigned int iBinOffset = 0;
     double etaSign = 1.;
@@ -1799,12 +1593,8 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
       etaSign = -1.;
     }
 
-    double lowEdgeToConv =
-        etaSign * m_l1MuTriggerScales->getGMTEtaScale()->getValue(indexToConv -
-                                                                  iBinOffset);
-    double highEdgeToConv =
-        etaSign * m_l1MuTriggerScales->getGMTEtaScale()->getValue(
-                      indexToConv + 1 - iBinOffset);
+    double lowEdgeToConv = etaSign * m_l1MuTriggerScales->getGMTEtaScale()->getValue(indexToConv - iBinOffset);
+    double highEdgeToConv = etaSign * m_l1MuTriggerScales->getGMTEtaScale()->getValue(indexToConv + 1 - iBinOffset);
 
     unsigned int convIndex = m_lutEtaMuToCommonCalo[indexToConv];
 
@@ -1820,20 +1610,16 @@ void L1GtEtaPhiConversions::print(std::ostream &myCout) const {
       highEdgeToConv = 0.;
     }
 
-    myCout << "|  0x" << std::setw(3) << std::hex << std::left << indexToConv
-           << "  |  " << std::dec << std::setw(3) << std::left << indexToConv
-           << "  |[ " << std::setw(10) << std::left << lowEdgeToConv << ",  |"
-           << std::setw(10) << std::left << highEdgeToConv << " )  |  0x"
-           << std::setw(6) << std::hex << std::left << convIndex << " |  "
-           << std::dec << std::setw(6) << convIndex << "  |[ " << std::setw(10)
-           << std::left << convLowEdge << ",  |" << std::setw(10) << std::left
-           << convHighEdge << " )  |" << std::right << std::endl;
+    myCout << "|  0x" << std::setw(3) << std::hex << std::left << indexToConv << "  |  " << std::dec << std::setw(3)
+           << std::left << indexToConv << "  |[ " << std::setw(10) << std::left << lowEdgeToConv << ",  |"
+           << std::setw(10) << std::left << highEdgeToConv << " )  |  0x" << std::setw(6) << std::hex << std::left
+           << convIndex << " |  " << std::dec << std::setw(6) << convIndex << "  |[ " << std::setw(10) << std::left
+           << convLowEdge << ",  |" << std::setw(10) << std::left << convHighEdge << " )  |" << std::right << std::endl;
   }
 }
 
 // convert phi from rad (-pi, pi] to deg (0, 360)
 const double L1GtEtaPhiConversions::rad2deg(const double &phiRad) const {
-
   if (phiRad < 0.) {
     return (phiRad * PiConversion) + 360.;
   } else {

--- a/L1Trigger/GlobalTrigger/src/L1GtExternalCondition.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GtExternalCondition.cc
@@ -26,19 +26,13 @@
 
 // constructors
 //     default
-L1GtExternalCondition::L1GtExternalCondition() : L1GtConditionEvaluation() {
-
-  m_conditionResult = false;
-}
+L1GtExternalCondition::L1GtExternalCondition() : L1GtConditionEvaluation() { m_conditionResult = false; }
 
 //     from base template condition (from event setup usually)
-L1GtExternalCondition::L1GtExternalCondition(
-    const L1GtCondition *externalTemplate, const bool result)
+L1GtExternalCondition::L1GtExternalCondition(const L1GtCondition *externalTemplate, const bool result)
     : L1GtConditionEvaluation(),
-      m_gtExternalTemplate(
-          static_cast<const L1GtExternalTemplate *>(externalTemplate)),
+      m_gtExternalTemplate(static_cast<const L1GtExternalTemplate *>(externalTemplate)),
       m_conditionResult(result) {
-
   // maximum number of objects received for the evaluation of the condition
   // no object
   m_condMaxNumberObjects = 0;
@@ -46,7 +40,6 @@ L1GtExternalCondition::L1GtExternalCondition(
 
 // copy constructor
 void L1GtExternalCondition::copy(const L1GtExternalCondition &cp) {
-
   m_gtExternalTemplate = cp.gtExternalTemplate();
   m_conditionResult = cp.conditionResult();
 
@@ -57,34 +50,25 @@ void L1GtExternalCondition::copy(const L1GtExternalCondition &cp) {
   m_verbosity = cp.m_verbosity;
 }
 
-L1GtExternalCondition::L1GtExternalCondition(const L1GtExternalCondition &cp)
-    : L1GtConditionEvaluation() {
-
-  copy(cp);
-}
+L1GtExternalCondition::L1GtExternalCondition(const L1GtExternalCondition &cp) : L1GtConditionEvaluation() { copy(cp); }
 
 // destructor
 L1GtExternalCondition::~L1GtExternalCondition() {
-
   // empty
 }
 
 // equal operator
-L1GtExternalCondition &L1GtExternalCondition::
-operator=(const L1GtExternalCondition &cp) {
+L1GtExternalCondition &L1GtExternalCondition::operator=(const L1GtExternalCondition &cp) {
   copy(cp);
   return *this;
 }
 
 // methods
-void L1GtExternalCondition::setGtExternalTemplate(
-    const L1GtExternalTemplate *externalTemplate) {
-
+void L1GtExternalCondition::setGtExternalTemplate(const L1GtExternalTemplate *externalTemplate) {
   m_gtExternalTemplate = externalTemplate;
 }
 
 const bool L1GtExternalCondition::evaluateCondition() const {
-
   // clear the m_combinationsInCond vector
   (combinationsInCond()).clear();
 
@@ -93,7 +77,6 @@ const bool L1GtExternalCondition::evaluateCondition() const {
 }
 
 void L1GtExternalCondition::print(std::ostream &myCout) const {
-
   m_gtExternalTemplate->print(myCout);
   L1GtConditionEvaluation::print(myCout);
 }

--- a/L1Trigger/GlobalTrigger/src/L1GtHfBitCountsCondition.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GtHfBitCountsCondition.cc
@@ -34,20 +34,15 @@
 
 // constructors
 //     default
-L1GtHfBitCountsCondition::L1GtHfBitCountsCondition()
-    : L1GtConditionEvaluation() {
-
+L1GtHfBitCountsCondition::L1GtHfBitCountsCondition() : L1GtConditionEvaluation() {
   // empty
 }
 
 //     from base template condition (from event setup usually)
-L1GtHfBitCountsCondition::L1GtHfBitCountsCondition(
-    const L1GtCondition *bcTemplate, const L1GlobalTriggerPSB *ptrPSB)
+L1GtHfBitCountsCondition::L1GtHfBitCountsCondition(const L1GtCondition *bcTemplate, const L1GlobalTriggerPSB *ptrPSB)
     : L1GtConditionEvaluation(),
-      m_gtHfBitCountsTemplate(
-          static_cast<const L1GtHfBitCountsTemplate *>(bcTemplate)),
+      m_gtHfBitCountsTemplate(static_cast<const L1GtHfBitCountsTemplate *>(bcTemplate)),
       m_gtPSB(ptrPSB) {
-
   // maximum number of objects received for the evaluation of the condition
   // no objects, in fact, just a count
   m_condMaxNumberObjects = 1;
@@ -55,7 +50,6 @@ L1GtHfBitCountsCondition::L1GtHfBitCountsCondition(
 
 // copy constructor
 void L1GtHfBitCountsCondition::copy(const L1GtHfBitCountsCondition &cp) {
-
   m_gtHfBitCountsTemplate = cp.gtHfBitCountsTemplate();
   m_gtPSB = cp.gtPSB();
 
@@ -66,42 +60,31 @@ void L1GtHfBitCountsCondition::copy(const L1GtHfBitCountsCondition &cp) {
   m_verbosity = cp.m_verbosity;
 }
 
-L1GtHfBitCountsCondition::L1GtHfBitCountsCondition(
-    const L1GtHfBitCountsCondition &cp)
-    : L1GtConditionEvaluation() {
-
+L1GtHfBitCountsCondition::L1GtHfBitCountsCondition(const L1GtHfBitCountsCondition &cp) : L1GtConditionEvaluation() {
   copy(cp);
 }
 
 // destructor
 L1GtHfBitCountsCondition::~L1GtHfBitCountsCondition() {
-
   // empty
 }
 
 // equal operator
-L1GtHfBitCountsCondition &L1GtHfBitCountsCondition::
-operator=(const L1GtHfBitCountsCondition &cp) {
+L1GtHfBitCountsCondition &L1GtHfBitCountsCondition::operator=(const L1GtHfBitCountsCondition &cp) {
   copy(cp);
   return *this;
 }
 
 // methods
-void L1GtHfBitCountsCondition::setGtHfBitCountsTemplate(
-    const L1GtHfBitCountsTemplate *bcTemplate) {
-
+void L1GtHfBitCountsCondition::setGtHfBitCountsTemplate(const L1GtHfBitCountsTemplate *bcTemplate) {
   m_gtHfBitCountsTemplate = bcTemplate;
 }
 
 ///   set the pointer to PSB
-void L1GtHfBitCountsCondition::setGtPSB(const L1GlobalTriggerPSB *ptrPSB) {
-
-  m_gtPSB = ptrPSB;
-}
+void L1GtHfBitCountsCondition::setGtPSB(const L1GlobalTriggerPSB *ptrPSB) { m_gtPSB = ptrPSB; }
 
 // try all object permutations and check spatial correlations, if required
 const bool L1GtHfBitCountsCondition::evaluateCondition() const {
-
   // number of trigger objects in the condition
   // no objects, in fact, just a count
   int iCondition = 0;
@@ -125,28 +108,23 @@ const bool L1GtHfBitCountsCondition::evaluateCondition() const {
     return false;
   }
 
-  const L1GtHfBitCountsTemplate::ObjectParameter objPar =
-      (*(m_gtHfBitCountsTemplate->objectParameter()))[iCondition];
+  const L1GtHfBitCountsTemplate::ObjectParameter objPar = (*(m_gtHfBitCountsTemplate->objectParameter()))[iCondition];
 
   // FIXME ask GCT to provide a method to retrieve it
   const unsigned int numberL1HfBitCounts = 4;
 
   const unsigned int cIndex = objPar.countIndex;
   if (cIndex >= numberL1HfBitCounts) {
-
-    edm::LogError("L1GlobalTrigger")
-        << "\nL1GtHfBitCountsCondition error: countIndex " << cIndex
-        << "greater than GCT maximum index = " << numberL1HfBitCounts
-        << "\n  ==> condResult = false " << std::endl;
+    edm::LogError("L1GlobalTrigger") << "\nL1GtHfBitCountsCondition error: countIndex " << cIndex
+                                     << "greater than GCT maximum index = " << numberL1HfBitCounts
+                                     << "\n  ==> condResult = false " << std::endl;
     return false;
   }
 
   const unsigned int countValue = bitCounts->bitCount(cIndex);
 
   // check countThreshold
-  if (!checkThreshold(objPar.countThreshold, countValue,
-                      m_gtHfBitCountsTemplate->condGEq())) {
-
+  if (!checkThreshold(objPar.countThreshold, countValue, m_gtHfBitCountsTemplate->condGEq())) {
     return false;
   }
 
@@ -164,7 +142,6 @@ const bool L1GtHfBitCountsCondition::evaluateCondition() const {
 }
 
 void L1GtHfBitCountsCondition::print(std::ostream &myCout) const {
-
   m_gtHfBitCountsTemplate->print(myCout);
   L1GtConditionEvaluation::print(myCout);
 }

--- a/L1Trigger/GlobalTrigger/src/L1GtHfRingEtSumsCondition.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GtHfRingEtSumsCondition.cc
@@ -34,20 +34,15 @@
 
 // constructors
 //     default
-L1GtHfRingEtSumsCondition::L1GtHfRingEtSumsCondition()
-    : L1GtConditionEvaluation() {
-
+L1GtHfRingEtSumsCondition::L1GtHfRingEtSumsCondition() : L1GtConditionEvaluation() {
   // empty
 }
 
 //     from base template condition (from event setup usually)
-L1GtHfRingEtSumsCondition::L1GtHfRingEtSumsCondition(
-    const L1GtCondition *etTemplate, const L1GlobalTriggerPSB *ptrPSB)
+L1GtHfRingEtSumsCondition::L1GtHfRingEtSumsCondition(const L1GtCondition *etTemplate, const L1GlobalTriggerPSB *ptrPSB)
     : L1GtConditionEvaluation(),
-      m_gtHfRingEtSumsTemplate(
-          static_cast<const L1GtHfRingEtSumsTemplate *>(etTemplate)),
+      m_gtHfRingEtSumsTemplate(static_cast<const L1GtHfRingEtSumsTemplate *>(etTemplate)),
       m_gtPSB(ptrPSB) {
-
   // maximum number of objects received for the evaluation of the condition
   // no objects, in fact, just a number
   m_condMaxNumberObjects = 1;
@@ -55,7 +50,6 @@ L1GtHfRingEtSumsCondition::L1GtHfRingEtSumsCondition(
 
 // copy constructor
 void L1GtHfRingEtSumsCondition::copy(const L1GtHfRingEtSumsCondition &cp) {
-
   m_gtHfRingEtSumsTemplate = cp.gtHfRingEtSumsTemplate();
   m_gtPSB = cp.gtPSB();
 
@@ -66,42 +60,31 @@ void L1GtHfRingEtSumsCondition::copy(const L1GtHfRingEtSumsCondition &cp) {
   m_verbosity = cp.m_verbosity;
 }
 
-L1GtHfRingEtSumsCondition::L1GtHfRingEtSumsCondition(
-    const L1GtHfRingEtSumsCondition &cp)
-    : L1GtConditionEvaluation() {
-
+L1GtHfRingEtSumsCondition::L1GtHfRingEtSumsCondition(const L1GtHfRingEtSumsCondition &cp) : L1GtConditionEvaluation() {
   copy(cp);
 }
 
 // destructor
 L1GtHfRingEtSumsCondition::~L1GtHfRingEtSumsCondition() {
-
   // empty
 }
 
 // equal operator
-L1GtHfRingEtSumsCondition &L1GtHfRingEtSumsCondition::
-operator=(const L1GtHfRingEtSumsCondition &cp) {
+L1GtHfRingEtSumsCondition &L1GtHfRingEtSumsCondition::operator=(const L1GtHfRingEtSumsCondition &cp) {
   copy(cp);
   return *this;
 }
 
 // methods
-void L1GtHfRingEtSumsCondition::setGtHfRingEtSumsTemplate(
-    const L1GtHfRingEtSumsTemplate *etTemplate) {
-
+void L1GtHfRingEtSumsCondition::setGtHfRingEtSumsTemplate(const L1GtHfRingEtSumsTemplate *etTemplate) {
   m_gtHfRingEtSumsTemplate = etTemplate;
 }
 
 ///   set the pointer to PSB
-void L1GtHfRingEtSumsCondition::setGtPSB(const L1GlobalTriggerPSB *ptrPSB) {
-
-  m_gtPSB = ptrPSB;
-}
+void L1GtHfRingEtSumsCondition::setGtPSB(const L1GlobalTriggerPSB *ptrPSB) { m_gtPSB = ptrPSB; }
 
 // try all object permutations and check spatial correlations, if required
 const bool L1GtHfRingEtSumsCondition::evaluateCondition() const {
-
   // number of trigger objects in the condition
   // no objects, in fact, just a number
   int iCondition = 0;
@@ -125,28 +108,23 @@ const bool L1GtHfRingEtSumsCondition::evaluateCondition() const {
     return false;
   }
 
-  const L1GtHfRingEtSumsTemplate::ObjectParameter objPar =
-      (*(m_gtHfRingEtSumsTemplate->objectParameter()))[iCondition];
+  const L1GtHfRingEtSumsTemplate::ObjectParameter objPar = (*(m_gtHfRingEtSumsTemplate->objectParameter()))[iCondition];
 
   // FIXME ask GCT to provide a method to retrieve it
   const unsigned int numberL1HfRingEtSums = 4;
 
   const unsigned int cIndex = objPar.etSumIndex;
   if (cIndex >= numberL1HfRingEtSums) {
-
-    edm::LogError("L1GlobalTrigger")
-        << "\nL1GtHfRingEtSumsCondition error: etSumIndex " << cIndex
-        << "greater than GCT maximum index = " << numberL1HfRingEtSums
-        << "\n  ==> condResult = false " << std::endl;
+    edm::LogError("L1GlobalTrigger") << "\nL1GtHfRingEtSumsCondition error: etSumIndex " << cIndex
+                                     << "greater than GCT maximum index = " << numberL1HfRingEtSums
+                                     << "\n  ==> condResult = false " << std::endl;
     return false;
   }
 
   const unsigned int etSumValue = etSumCand->etSum(cIndex);
 
   // check countThreshold
-  if (!checkThreshold(objPar.etSumThreshold, etSumValue,
-                      m_gtHfRingEtSumsTemplate->condGEq())) {
-
+  if (!checkThreshold(objPar.etSumThreshold, etSumValue, m_gtHfRingEtSumsTemplate->condGEq())) {
     return false;
   }
 
@@ -164,7 +142,6 @@ const bool L1GtHfRingEtSumsCondition::evaluateCondition() const {
 }
 
 void L1GtHfRingEtSumsCondition::print(std::ostream &myCout) const {
-
   m_gtHfRingEtSumsTemplate->print(myCout);
   L1GtConditionEvaluation::print(myCout);
 }

--- a/L1Trigger/GlobalTrigger/src/L1GtJetCountsCondition.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GtJetCountsCondition.cc
@@ -35,7 +35,6 @@
 // constructors
 //     default
 L1GtJetCountsCondition::L1GtJetCountsCondition() : L1GtConditionEvaluation() {
-
   // empty
 }
 
@@ -44,10 +43,9 @@ L1GtJetCountsCondition::L1GtJetCountsCondition(const L1GtCondition *jcTemplate,
                                                const L1GlobalTriggerPSB *ptrPSB,
                                                const int nrL1JetCounts)
     : L1GtConditionEvaluation(),
-      m_gtJetCountsTemplate(
-          static_cast<const L1GtJetCountsTemplate *>(jcTemplate)),
-      m_gtPSB(ptrPSB), m_numberL1JetCounts(nrL1JetCounts) {
-
+      m_gtJetCountsTemplate(static_cast<const L1GtJetCountsTemplate *>(jcTemplate)),
+      m_gtPSB(ptrPSB),
+      m_numberL1JetCounts(nrL1JetCounts) {
   // maximum number of objects received for the evaluation of the condition
   // no objects, in fact, just a number
   m_condMaxNumberObjects = 1;
@@ -55,7 +53,6 @@ L1GtJetCountsCondition::L1GtJetCountsCondition(const L1GtCondition *jcTemplate,
 
 // copy constructor
 void L1GtJetCountsCondition::copy(const L1GtJetCountsCondition &cp) {
-
   m_gtJetCountsTemplate = cp.gtJetCountsTemplate();
   m_gtPSB = cp.gtPSB();
 
@@ -66,41 +63,31 @@ void L1GtJetCountsCondition::copy(const L1GtJetCountsCondition &cp) {
   m_verbosity = cp.m_verbosity;
 }
 
-L1GtJetCountsCondition::L1GtJetCountsCondition(const L1GtJetCountsCondition &cp)
-    : L1GtConditionEvaluation() {
-
+L1GtJetCountsCondition::L1GtJetCountsCondition(const L1GtJetCountsCondition &cp) : L1GtConditionEvaluation() {
   copy(cp);
 }
 
 // destructor
 L1GtJetCountsCondition::~L1GtJetCountsCondition() {
-
   // empty
 }
 
 // equal operator
-L1GtJetCountsCondition &L1GtJetCountsCondition::
-operator=(const L1GtJetCountsCondition &cp) {
+L1GtJetCountsCondition &L1GtJetCountsCondition::operator=(const L1GtJetCountsCondition &cp) {
   copy(cp);
   return *this;
 }
 
 // methods
-void L1GtJetCountsCondition::setGtJetCountsTemplate(
-    const L1GtJetCountsTemplate *jcTemplate) {
-
+void L1GtJetCountsCondition::setGtJetCountsTemplate(const L1GtJetCountsTemplate *jcTemplate) {
   m_gtJetCountsTemplate = jcTemplate;
 }
 
 ///   set the pointer to PSB
-void L1GtJetCountsCondition::setGtPSB(const L1GlobalTriggerPSB *ptrPSB) {
-
-  m_gtPSB = ptrPSB;
-}
+void L1GtJetCountsCondition::setGtPSB(const L1GlobalTriggerPSB *ptrPSB) { m_gtPSB = ptrPSB; }
 
 // try all object permutations and check spatial correlations, if required
 const bool L1GtJetCountsCondition::evaluateCondition() const {
-
   // number of trigger objects in the condition
   // in fact, there is only one object
   int iCondition = 0;
@@ -124,26 +111,21 @@ const bool L1GtJetCountsCondition::evaluateCondition() const {
     return false;
   }
 
-  const L1GtJetCountsTemplate::ObjectParameter objPar =
-      (*(m_gtJetCountsTemplate->objectParameter()))[iCondition];
+  const L1GtJetCountsTemplate::ObjectParameter objPar = (*(m_gtJetCountsTemplate->objectParameter()))[iCondition];
 
   unsigned int cIndex = objPar.countIndex;
 
   if (cIndex >= m_numberL1JetCounts) {
-
-    edm::LogError("L1GlobalTrigger")
-        << "\nL1GtJetCountsCondition error: countIndex " << cIndex
-        << "greater than maximum allowed count = " << m_numberL1JetCounts
-        << "\n  ==> condResult = false " << std::endl;
+    edm::LogError("L1GlobalTrigger") << "\nL1GtJetCountsCondition error: countIndex " << cIndex
+                                     << "greater than maximum allowed count = " << m_numberL1JetCounts
+                                     << "\n  ==> condResult = false " << std::endl;
     return false;
   }
 
   unsigned int countValue = jetCounts->count(cIndex);
 
   // check countThreshold
-  if (!checkThreshold(objPar.countThreshold, countValue,
-                      m_gtJetCountsTemplate->condGEq())) {
-
+  if (!checkThreshold(objPar.countThreshold, countValue, m_gtJetCountsTemplate->condGEq())) {
     return false;
   }
 
@@ -162,7 +144,6 @@ const bool L1GtJetCountsCondition::evaluateCondition() const {
 }
 
 void L1GtJetCountsCondition::print(std::ostream &myCout) const {
-
   m_gtJetCountsTemplate->print(myCout);
   L1GtConditionEvaluation::print(myCout);
 }

--- a/L1Trigger/GlobalTrigger/src/L1GtMuonCondition.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GtMuonCondition.cc
@@ -41,7 +41,6 @@
 // constructors
 //     default
 L1GtMuonCondition::L1GtMuonCondition() : L1GtConditionEvaluation() {
-
   // empty
 }
 
@@ -52,14 +51,14 @@ L1GtMuonCondition::L1GtMuonCondition(const L1GtCondition *muonTemplate,
                                      const int ifMuEtaNumberBits)
     : L1GtConditionEvaluation(),
       m_gtMuonTemplate(static_cast<const L1GtMuonTemplate *>(muonTemplate)),
-      m_gtGTL(ptrGTL), m_ifMuEtaNumberBits(ifMuEtaNumberBits) {
+      m_gtGTL(ptrGTL),
+      m_ifMuEtaNumberBits(ifMuEtaNumberBits) {
   m_corrParDeltaPhiNrBins = 0;
   m_condMaxNumberObjects = nrL1Mu;
 }
 
 // copy constructor
 void L1GtMuonCondition::copy(const L1GtMuonCondition &cp) {
-
   m_gtMuonTemplate = cp.gtMuonTemplate();
   m_gtGTL = cp.gtGTL();
 
@@ -73,14 +72,10 @@ void L1GtMuonCondition::copy(const L1GtMuonCondition &cp) {
   m_verbosity = cp.m_verbosity;
 }
 
-L1GtMuonCondition::L1GtMuonCondition(const L1GtMuonCondition &cp)
-    : L1GtConditionEvaluation() {
-  copy(cp);
-}
+L1GtMuonCondition::L1GtMuonCondition(const L1GtMuonCondition &cp) : L1GtConditionEvaluation() { copy(cp); }
 
 // destructor
 L1GtMuonCondition::~L1GtMuonCondition() {
-
   // empty
 }
 
@@ -91,34 +86,23 @@ L1GtMuonCondition &L1GtMuonCondition::operator=(const L1GtMuonCondition &cp) {
 }
 
 // methods
-void L1GtMuonCondition::setGtMuonTemplate(const L1GtMuonTemplate *muonTempl) {
-
-  m_gtMuonTemplate = muonTempl;
-}
+void L1GtMuonCondition::setGtMuonTemplate(const L1GtMuonTemplate *muonTempl) { m_gtMuonTemplate = muonTempl; }
 
 ///   set the pointer to GTL
-void L1GtMuonCondition::setGtGTL(const L1GlobalTriggerGTL *ptrGTL) {
-
-  m_gtGTL = ptrGTL;
-}
+void L1GtMuonCondition::setGtGTL(const L1GlobalTriggerGTL *ptrGTL) { m_gtGTL = ptrGTL; }
 
 //   set the number of bits for eta of muon objects
-void L1GtMuonCondition::setGtIfMuEtaNumberBits(
-    const int &ifMuEtaNumberBitsValue) {
-
+void L1GtMuonCondition::setGtIfMuEtaNumberBits(const int &ifMuEtaNumberBitsValue) {
   m_ifMuEtaNumberBits = ifMuEtaNumberBitsValue;
 }
 
 //   set the maximum number of bins for the delta phi scales
-void L1GtMuonCondition::setGtCorrParDeltaPhiNrBins(
-    const int &corrParDeltaPhiNrBins) {
-
+void L1GtMuonCondition::setGtCorrParDeltaPhiNrBins(const int &corrParDeltaPhiNrBins) {
   m_corrParDeltaPhiNrBins = corrParDeltaPhiNrBins;
 }
 
 // try all object permutations and check spatial correlations, if required
 const bool L1GtMuonCondition::evaluateCondition() const {
-
   // number of trigger objects in the condition
   int nObjInCond = m_gtMuonTemplate->nrObjects();
 
@@ -158,7 +142,6 @@ const bool L1GtMuonCondition::evaluateCondition() const {
   (combinationsInCond()).clear();
 
   do {
-
     if (--jumpIndex)
       continue;
 
@@ -173,7 +156,6 @@ const bool L1GtMuonCondition::evaluateCondition() const {
     // check if there is a permutation that matches object-parameter
     // requirements
     for (int i = 0; i < nObjInCond; i++) {
-
       tmpResult &= checkObjectParameter(i, *(*candVec)[index[i]]);
       objectsInComb.push_back(index[i]);
     }
@@ -181,20 +163,17 @@ const bool L1GtMuonCondition::evaluateCondition() const {
     // if permutation does not match particle conditions
     // skip charge correlation and spatial correlations
     if (!tmpResult) {
-
       continue;
     }
 
     // get the correlation parameters (chargeCorrelation included here also)
-    L1GtMuonTemplate::CorrelationParameter corrPar =
-        *(m_gtMuonTemplate->correlationParameter());
+    L1GtMuonTemplate::CorrelationParameter corrPar = *(m_gtMuonTemplate->correlationParameter());
 
     // charge_correlation consists of 3 relevant bits (D2, D1, D0)
     unsigned int chargeCorr = corrPar.chargeCorrelation;
 
     // charge ignore bit (D0) not set?
     if ((chargeCorr & 1) == 0) {
-
       for (int i = 0; i < nObjInCond; i++) {
         // check valid charge - skip if invalid charge
         bool chargeValid = (*candVec)[index[i]]->charge_valid();
@@ -209,22 +188,20 @@ const bool L1GtMuonCondition::evaluateCondition() const {
         continue;
       }
 
-      if (nObjInCond == 1) { // one object condition
+      if (nObjInCond == 1) {  // one object condition
 
         // D2..enable pos, D1..enable neg
         if (!(((chargeCorr & 4) != 0 && (*candVec)[index[0]]->charge() > 0) ||
               ((chargeCorr & 2) != 0 && (*candVec)[index[0]]->charge() < 0))) {
-
           continue;
         }
 
-      } else { // more objects condition
+      } else {  // more objects condition
 
         // find out if signs are equal
         bool equalSigns = true;
         for (int i = 0; i < nObjInCond - 1; i++) {
-          if ((*candVec)[index[i]]->charge() !=
-              (*candVec)[index[i + 1]]->charge()) {
+          if ((*candVec)[index[i]]->charge() != (*candVec)[index[i + 1]]->charge()) {
             equalSigns = false;
             break;
           }
@@ -233,9 +210,7 @@ const bool L1GtMuonCondition::evaluateCondition() const {
         // two or three particle condition
         if (nObjInCond == 2 || nObjInCond == 3) {
           // D2..enable equal, D1..enable not equal
-          if (!(((chargeCorr & 4) != 0 && equalSigns) ||
-                ((chargeCorr & 2) != 0 && !equalSigns))) {
-
+          if (!(((chargeCorr & 4) != 0 && equalSigns) || ((chargeCorr & 2) != 0 && !equalSigns))) {
             continue;
           }
         }
@@ -252,27 +227,22 @@ const bool L1GtMuonCondition::evaluateCondition() const {
           }
 
           // D2..enable equal, D1..enable pairs
-          if (!(((chargeCorr & 4) != 0 && equalSigns) ||
-                ((chargeCorr & 2) != 0 && posCount == 2))) {
-
+          if (!(((chargeCorr & 4) != 0 && equalSigns) || ((chargeCorr & 2) != 0 && posCount == 2))) {
             continue;
           }
         }
       }
-    } // end signchecks
+    }  // end signchecks
 
     if (m_gtMuonTemplate->wsc()) {
-
       // wsc requirements have always nObjInCond = 2
       // one can use directly index[0] and index[1] to compute
       // eta and phi differences
       const int ObjInWscComb = 2;
       if (nObjInCond != ObjInWscComb) {
-
-        edm::LogError("L1GlobalTrigger")
-            << "\n  Error: "
-            << "number of particles in condition with spatial correlation = "
-            << nObjInCond << "\n  it must be = " << ObjInWscComb << std::endl;
+        edm::LogError("L1GlobalTrigger") << "\n  Error: "
+                                         << "number of particles in condition with spatial correlation = " << nObjInCond
+                                         << "\n  it must be = " << ObjInWscComb << std::endl;
         // TODO Perhaps I should throw here an exception,
         // since something is really wrong if nObjInCond != ObjInWscComb (=2)
         continue;
@@ -291,8 +261,7 @@ const bool L1GtMuonCondition::evaluateCondition() const {
       int scaleEta = 1 << (m_ifMuEtaNumberBits - 1);
 
       for (int i = 0; i < ObjInWscComb; ++i) {
-        signBit[i] = ((*candVec)[index[i]]->etaIndex() & scaleEta) >>
-                     (m_ifMuEtaNumberBits - 1);
+        signBit[i] = ((*candVec)[index[i]]->etaIndex() & scaleEta) >> (m_ifMuEtaNumberBits - 1);
         signedEta[i] = ((*candVec)[index[i]]->etaIndex()) % scaleEta;
 
         if (signBit[i] == 1) {
@@ -302,8 +271,8 @@ const bool L1GtMuonCondition::evaluateCondition() const {
 
       // compute candDeltaEta - add 1 if signs are different (due to +0/-0
       // indices)
-      candDeltaEta = static_cast<int>(std::abs(signedEta[1] - signedEta[0])) +
-                     static_cast<int>(signBit[1] ^ signBit[0]);
+      candDeltaEta =
+          static_cast<int>(std::abs(signedEta[1] - signedEta[0])) + static_cast<int>(signBit[1] ^ signBit[0]);
 
       if (!checkBit(corrPar.deltaEtaRange, candDeltaEta)) {
         continue;
@@ -313,11 +282,9 @@ const bool L1GtMuonCondition::evaluateCondition() const {
 
       // calculate absolute value of candDeltaPhi
       if ((*candVec)[index[0]]->phiIndex() > (*candVec)[index[1]]->phiIndex()) {
-        candDeltaPhi =
-            (*candVec)[index[0]]->phiIndex() - (*candVec)[index[1]]->phiIndex();
+        candDeltaPhi = (*candVec)[index[0]]->phiIndex() - (*candVec)[index[1]]->phiIndex();
       } else {
-        candDeltaPhi =
-            (*candVec)[index[1]]->phiIndex() - (*candVec)[index[0]]->phiIndex();
+        candDeltaPhi = (*candVec)[index[1]]->phiIndex() - (*candVec)[index[0]]->phiIndex();
       }
 
       // check if candDeltaPhi > 180 (via delta_phi_maxbits)
@@ -328,19 +295,16 @@ const bool L1GtMuonCondition::evaluateCondition() const {
       int iLoop = 0;
 
       while (candDeltaPhi >= m_corrParDeltaPhiNrBins) {
-
         unsigned int candDeltaPhiInitial = candDeltaPhi;
 
         // candDeltaPhi > 180 ==> take 360 - candDeltaPhi
         candDeltaPhi = (m_corrParDeltaPhiNrBins - 1) * 2 - candDeltaPhi;
         if (m_verbosity) {
-          LogTrace("L1GlobalTrigger")
-              << "    Initial candDeltaPhi = " << candDeltaPhiInitial
-              << " > m_corrParDeltaPhiNrBins = " << m_corrParDeltaPhiNrBins
-              << "  ==> candDeltaPhi rescaled to: " << candDeltaPhi
-              << " [ loop index " << iLoop << "; breaks after " << nMaxLoop
-              << " loops ]\n"
-              << std::endl;
+          LogTrace("L1GlobalTrigger") << "    Initial candDeltaPhi = " << candDeltaPhiInitial
+                                      << " > m_corrParDeltaPhiNrBins = " << m_corrParDeltaPhiNrBins
+                                      << "  ==> candDeltaPhi rescaled to: " << candDeltaPhi << " [ loop index " << iLoop
+                                      << "; breaks after " << nMaxLoop << " loops ]\n"
+                                      << std::endl;
         }
 
         iLoop++;
@@ -360,7 +324,7 @@ const bool L1GtMuonCondition::evaluateCondition() const {
         }
       }
 
-    } // end wsc check
+    }  // end wsc check
 
     // if we get here all checks were successfull for this combination
     // set the general result for evaluateCondition to "true"
@@ -383,7 +347,6 @@ const bool L1GtMuonCondition::evaluateCondition() const {
 
 // load muon candidates
 const L1MuGMTCand *L1GtMuonCondition::getCandidate(const int indexCand) const {
-
   return (*(m_gtGTL->getCandL1Mu()))[indexCand];
 }
 
@@ -396,10 +359,7 @@ const L1MuGMTCand *L1GtMuonCondition::getCandidate(const int indexCand) const {
  * @return The result of the comparison (false if a condition does not exist).
  */
 
-const bool
-L1GtMuonCondition::checkObjectParameter(const int iCondition,
-                                        const L1MuGMTCand &cand) const {
-
+const bool L1GtMuonCondition::checkObjectParameter(const int iCondition, const L1MuGMTCand &cand) const {
   // number of objects in condition
   int nObjInCond = m_gtMuonTemplate->nrObjects();
 
@@ -412,8 +372,7 @@ L1GtMuonCondition::checkObjectParameter(const int iCondition,
     return false;
   }
 
-  const L1GtMuonTemplate::ObjectParameter objPar =
-      (*(m_gtMuonTemplate->objectParameter()))[iCondition];
+  const L1GtMuonTemplate::ObjectParameter objPar = (*(m_gtMuonTemplate->objectParameter()))[iCondition];
 
   // using the logic table from GTL-9U-module.pdf
   // "Truth table for Isolation bit"
@@ -440,29 +399,21 @@ L1GtMuonCondition::checkObjectParameter(const int iCondition,
   //   value >= high pt threshold & isolated muon:
   //       OK, trigger
 
-  if (!checkThreshold(objPar.ptHighThreshold, cand.ptIndex(),
-                      m_gtMuonTemplate->condGEq())) {
-
-    if (!checkThreshold(objPar.ptLowThreshold, cand.ptIndex(),
-                        m_gtMuonTemplate->condGEq())) {
-
+  if (!checkThreshold(objPar.ptHighThreshold, cand.ptIndex(), m_gtMuonTemplate->condGEq())) {
+    if (!checkThreshold(objPar.ptLowThreshold, cand.ptIndex(), m_gtMuonTemplate->condGEq())) {
       return false;
     } else {
-
       // check isolation
       if (!cand.isol()) {
         if (objPar.requestIso || objPar.enableIso) {
-
           return false;
         }
       }
     }
 
   } else {
-
     if (!cand.isol()) {
       if (objPar.requestIso) {
-
         return false;
       }
     }
@@ -479,17 +430,12 @@ L1GtMuonCondition::checkObjectParameter(const int iCondition,
   // for phiLow >= phiHigh takes [phiLow, phiHigh] over zero angle!
 
   if (objPar.phiHigh >= objPar.phiLow) {
-
-    if (!((objPar.phiLow <= cand.phiIndex()) &&
-          (cand.phiIndex() <= objPar.phiHigh))) {
-
+    if (!((objPar.phiLow <= cand.phiIndex()) && (cand.phiIndex() <= objPar.phiHigh))) {
       return false;
     }
 
-  } else { // go over zero angle!!
-    if (!((objPar.phiLow <= cand.phiIndex()) ||
-          (cand.phiIndex() <= objPar.phiHigh))) {
-
+  } else {  // go over zero angle!!
+    if (!((objPar.phiLow <= cand.phiIndex()) || (cand.phiIndex() <= objPar.phiHigh))) {
       return false;
     }
   }
@@ -515,7 +461,6 @@ L1GtMuonCondition::checkObjectParameter(const int iCondition,
   // check mip
   if (objPar.enableMip) {
     if (!cand.mip()) {
-
       return false;
     }
   }
@@ -529,13 +474,10 @@ L1GtMuonCondition::checkObjectParameter(const int iCondition,
 }
 
 void L1GtMuonCondition::print(std::ostream &myCout) const {
-
   m_gtMuonTemplate->print(myCout);
 
-  myCout << "    Number of bits for eta of muon objects = "
-         << m_ifMuEtaNumberBits << std::endl;
-  myCout << "    Maximum number of bins for the delta phi scales = "
-         << m_corrParDeltaPhiNrBins << "\n " << std::endl;
+  myCout << "    Number of bits for eta of muon objects = " << m_ifMuEtaNumberBits << std::endl;
+  myCout << "    Maximum number of bins for the delta phi scales = " << m_corrParDeltaPhiNrBins << "\n " << std::endl;
 
   L1GtConditionEvaluation::print(myCout);
 }

--- a/L1Trigger/L1ExtraFromDigis/interface/L1ExtraParticleMapProd.h
+++ b/L1Trigger/L1ExtraFromDigis/interface/L1ExtraParticleMapProd.h
@@ -47,105 +47,93 @@ public:
 private:
   // Adds Refs to the objects in handle to the outputRefs vector.
   template <class TCollection>
-  void
-  addToVectorRefs(const edm::Handle<TCollection> &handle,          // input
-                  std::vector<edm::Ref<TCollection>> &vectorRefs); // output
+  void addToVectorRefs(const edm::Handle<TCollection> &handle,           // input
+                       std::vector<edm::Ref<TCollection>> &vectorRefs);  // output
 
   template <class TCollection>
-  void evaluateSingleObjectTrigger(
-      const std::vector<edm::Ref<TCollection>> &inputRefs, // input
-      const double &etThreshold,                           // input
-      bool &decision,                                      // output
-      std::vector<edm::Ref<TCollection>> &outputRefs);     // output
+  void evaluateSingleObjectTrigger(const std::vector<edm::Ref<TCollection>> &inputRefs,  // input
+                                   const double &etThreshold,                            // input
+                                   bool &decision,                                       // output
+                                   std::vector<edm::Ref<TCollection>> &outputRefs);      // output
 
   template <class TCollection>
-  void evaluateDoubleSameObjectTrigger(
-      const std::vector<edm::Ref<TCollection>> &inputRefs, // input
-      const double &etThreshold,                           // input
-      bool &decision,                                      // output
-      std::vector<edm::Ref<TCollection>> &outputRefs,      // output
-      l1extra::L1ParticleMap::L1IndexComboVector &combos,  // output
-      bool combinedWithGlobalObject = false); // if true, add entry for
-                                              // HT or MET to particle combos
+  void evaluateDoubleSameObjectTrigger(const std::vector<edm::Ref<TCollection>> &inputRefs,  // input
+                                       const double &etThreshold,                            // input
+                                       bool &decision,                                       // output
+                                       std::vector<edm::Ref<TCollection>> &outputRefs,       // output
+                                       l1extra::L1ParticleMap::L1IndexComboVector &combos,   // output
+                                       bool combinedWithGlobalObject = false);               // if true, add entry for
+  // HT or MET to particle combos
 
   template <class TCollection>
-  void evaluateTripleSameObjectTrigger(
-      const std::vector<edm::Ref<TCollection>> &inputRefs, // input
-      const double &etThreshold,                           // input
-      bool &decision,                                      // output
-      std::vector<edm::Ref<TCollection>> &outputRefs,      // output
-      l1extra::L1ParticleMap::L1IndexComboVector &combos); // output
+  void evaluateTripleSameObjectTrigger(const std::vector<edm::Ref<TCollection>> &inputRefs,  // input
+                                       const double &etThreshold,                            // input
+                                       bool &decision,                                       // output
+                                       std::vector<edm::Ref<TCollection>> &outputRefs,       // output
+                                       l1extra::L1ParticleMap::L1IndexComboVector &combos);  // output
 
   template <class TCollection1, class TCollection2>
-  void evaluateDoublePlusSingleObjectTrigger(
-      const std::vector<edm::Ref<TCollection1>> &inputRefs1, // input
-      const std::vector<edm::Ref<TCollection2>> &inputRefs2, // input
-      const double &etThreshold1,                            // input
-      const double &etThreshold2,                            // input
-      bool &decision,                                        // output
-      std::vector<edm::Ref<TCollection1>> &outputRefs1,      // output
-      std::vector<edm::Ref<TCollection2>> &outputRefs2,      // output
-      l1extra::L1ParticleMap::L1IndexComboVector &combos);   // output
+  void evaluateDoublePlusSingleObjectTrigger(const std::vector<edm::Ref<TCollection1>> &inputRefs1,  // input
+                                             const std::vector<edm::Ref<TCollection2>> &inputRefs2,  // input
+                                             const double &etThreshold1,                             // input
+                                             const double &etThreshold2,                             // input
+                                             bool &decision,                                         // output
+                                             std::vector<edm::Ref<TCollection1>> &outputRefs1,       // output
+                                             std::vector<edm::Ref<TCollection2>> &outputRefs2,       // output
+                                             l1extra::L1ParticleMap::L1IndexComboVector &combos);    // output
 
   template <class TCollection>
-  void evaluateQuadSameObjectTrigger(
-      const std::vector<edm::Ref<TCollection>> &inputRefs, // input
-      const double &etThreshold,                           // input
-      bool &decision,                                      // output
-      std::vector<edm::Ref<TCollection>> &outputRefs,      // output
-      l1extra::L1ParticleMap::L1IndexComboVector &combos); // output
+  void evaluateQuadSameObjectTrigger(const std::vector<edm::Ref<TCollection>> &inputRefs,  // input
+                                     const double &etThreshold,                            // input
+                                     bool &decision,                                       // output
+                                     std::vector<edm::Ref<TCollection>> &outputRefs,       // output
+                                     l1extra::L1ParticleMap::L1IndexComboVector &combos);  // output
 
   template <class TCollection1, class TCollection2>
-  void evaluateDoubleDifferentObjectTrigger(
-      const std::vector<edm::Ref<TCollection1>> &inputRefs1, // input
-      const std::vector<edm::Ref<TCollection2>> &inputRefs2, // input
-      const double &etThreshold1,                            // input
-      const double &etThreshold2,                            // input
-      bool &decision,                                        // output
-      std::vector<edm::Ref<TCollection1>> &outputRefs1,      // output
-      std::vector<edm::Ref<TCollection2>> &outputRefs2,      // output
-      l1extra::L1ParticleMap::L1IndexComboVector &combos);   // output
+  void evaluateDoubleDifferentObjectTrigger(const std::vector<edm::Ref<TCollection1>> &inputRefs1,  // input
+                                            const std::vector<edm::Ref<TCollection2>> &inputRefs2,  // input
+                                            const double &etThreshold1,                             // input
+                                            const double &etThreshold2,                             // input
+                                            bool &decision,                                         // output
+                                            std::vector<edm::Ref<TCollection1>> &outputRefs1,       // output
+                                            std::vector<edm::Ref<TCollection2>> &outputRefs2,       // output
+                                            l1extra::L1ParticleMap::L1IndexComboVector &combos);    // output
 
   template <class TCollection>
-  void evaluateDoubleDifferentObjectSameTypeTrigger(
-      const std::vector<edm::Ref<TCollection>> &inputRefs1, // input
-      const std::vector<edm::Ref<TCollection>> &inputRefs2, // input
-      const double &etThreshold1,                           // input
-      const double &etThreshold2,                           // input
-      bool &decision,                                       // output
-      std::vector<edm::Ref<TCollection>> &outputRefs,       // output
-      l1extra::L1ParticleMap::L1IndexComboVector &combos);  // output
+  void evaluateDoubleDifferentObjectSameTypeTrigger(const std::vector<edm::Ref<TCollection>> &inputRefs1,  // input
+                                                    const std::vector<edm::Ref<TCollection>> &inputRefs2,  // input
+                                                    const double &etThreshold1,                            // input
+                                                    const double &etThreshold2,                            // input
+                                                    bool &decision,                                        // output
+                                                    std::vector<edm::Ref<TCollection>> &outputRefs,        // output
+                                                    l1extra::L1ParticleMap::L1IndexComboVector &combos);   // output
 
-  void evaluateDoubleDifferentCaloObjectTrigger(
-      const l1extra::L1EmParticleVectorRef &inputRefs1,    // input
-      const l1extra::L1JetParticleVectorRef &inputRefs2,   // input
-      const double &etThreshold1,                          // input
-      const double &etThreshold2,                          // input
-      bool &decision,                                      // output
-      l1extra::L1EmParticleVectorRef &outputRefs1,         // output
-      l1extra::L1JetParticleVectorRef &outputRefs2,        // output
-      l1extra::L1ParticleMap::L1IndexComboVector &combos); // output
+  void evaluateDoubleDifferentCaloObjectTrigger(const l1extra::L1EmParticleVectorRef &inputRefs1,     // input
+                                                const l1extra::L1JetParticleVectorRef &inputRefs2,    // input
+                                                const double &etThreshold1,                           // input
+                                                const double &etThreshold2,                           // input
+                                                bool &decision,                                       // output
+                                                l1extra::L1EmParticleVectorRef &outputRefs1,          // output
+                                                l1extra::L1JetParticleVectorRef &outputRefs2,         // output
+                                                l1extra::L1ParticleMap::L1IndexComboVector &combos);  // output
 
-  void evaluateJetGapJetTrigger(
-      const l1extra::L1JetParticleVectorRef &inputRefs,    // input
-      const double &etThreshold,                           // input
-      bool &decision,                                      // output
-      l1extra::L1JetParticleVectorRef &outputRefs,         // output
-      l1extra::L1ParticleMap::L1IndexComboVector &combos); // output
+  void evaluateJetGapJetTrigger(const l1extra::L1JetParticleVectorRef &inputRefs,     // input
+                                const double &etThreshold,                            // input
+                                bool &decision,                                       // output
+                                l1extra::L1JetParticleVectorRef &outputRefs,          // output
+                                l1extra::L1ParticleMap::L1IndexComboVector &combos);  // output
 
-  void evaluateForwardRapidityGap(
-      const l1extra::L1JetParticleVectorRef &inputRefs, // input
-      const double &etThreshold,                        // input
-      bool &decision);                                  // output
+  void evaluateForwardRapidityGap(const l1extra::L1JetParticleVectorRef &inputRefs,  // input
+                                  const double &etThreshold,                         // input
+                                  bool &decision);                                   // output
 
-  void evaluateDoubleExclusiveIsoEG(
-      const l1extra::L1EmParticleVectorRef &inputRefs1,    // input
-      const l1extra::L1JetParticleVectorRef &inputRefs2,   // input
-      const double &etThreshold1,                          // input
-      const double &etThreshold2,                          // input
-      bool &decision,                                      // output
-      l1extra::L1EmParticleVectorRef &outputRefs1,         // output
-      l1extra::L1ParticleMap::L1IndexComboVector &combos); // output
+  void evaluateDoubleExclusiveIsoEG(const l1extra::L1EmParticleVectorRef &inputRefs1,     // input
+                                    const l1extra::L1JetParticleVectorRef &inputRefs2,    // input
+                                    const double &etThreshold1,                           // input
+                                    const double &etThreshold2,                           // input
+                                    bool &decision,                                       // output
+                                    l1extra::L1EmParticleVectorRef &outputRefs1,          // output
+                                    l1extra::L1ParticleMap::L1IndexComboVector &combos);  // output
 
   // ----------member data ---------------------------
   edm::InputTag muonSource_;
@@ -160,8 +148,7 @@ private:
   double singleThresholds_[l1extra::L1ParticleMap::kNumOfL1TriggerTypes];
   int prescales_[l1extra::L1ParticleMap::kNumOfL1TriggerTypes];
   int prescaleCounters_[l1extra::L1ParticleMap::kNumOfL1TriggerTypes];
-  std::pair<double, double>
-      doubleThresholds_[l1extra::L1ParticleMap::kNumOfL1TriggerTypes];
+  std::pair<double, double> doubleThresholds_[l1extra::L1ParticleMap::kNumOfL1TriggerTypes];
 };
 
 #endif

--- a/L1Trigger/L1ExtraFromDigis/src/L1ExtraParticleMapProd.cc
+++ b/L1Trigger/L1ExtraFromDigis/src/L1ExtraParticleMapProd.cc
@@ -42,8 +42,7 @@ static const int kDefault = -1;
 L1ExtraParticleMapProd::L1ExtraParticleMapProd(const edm::ParameterSet &iConfig)
     : muonSource_(iConfig.getParameter<edm::InputTag>("muonSource")),
       isoEmSource_(iConfig.getParameter<edm::InputTag>("isolatedEmSource")),
-      nonIsoEmSource_(
-          iConfig.getParameter<edm::InputTag>("nonIsolatedEmSource")),
+      nonIsoEmSource_(iConfig.getParameter<edm::InputTag>("nonIsolatedEmSource")),
       cenJetSource_(iConfig.getParameter<edm::InputTag>("centralJetSource")),
       forJetSource_(iConfig.getParameter<edm::InputTag>("forwardJetSource")),
       tauJetSource_(iConfig.getParameter<edm::InputTag>("tauJetSource")),
@@ -66,515 +65,282 @@ L1ExtraParticleMapProd::L1ExtraParticleMapProd(const edm::ParameterSet &iConfig)
 
   // Single object triggers, 5 thresholds each
 
-  singleThresholds_[L1ParticleMap::kSingleMu3] =
-      iConfig.getParameter<double>("L1_SingleMu3_thresh");
-  prescales_[L1ParticleMap::kSingleMu3] =
-      iConfig.getParameter<int>("L1_SingleMu3_prescale");
-  singleThresholds_[L1ParticleMap::kSingleMu5] =
-      iConfig.getParameter<double>("L1_SingleMu5_thresh");
-  prescales_[L1ParticleMap::kSingleMu5] =
-      iConfig.getParameter<int>("L1_SingleMu5_prescale");
-  singleThresholds_[L1ParticleMap::kSingleMu7] =
-      iConfig.getParameter<double>("L1_SingleMu7_thresh");
-  prescales_[L1ParticleMap::kSingleMu7] =
-      iConfig.getParameter<int>("L1_SingleMu7_prescale");
-  singleThresholds_[L1ParticleMap::kSingleMu10] =
-      iConfig.getParameter<double>("L1_SingleMu10_thresh");
-  prescales_[L1ParticleMap::kSingleMu10] =
-      iConfig.getParameter<int>("L1_SingleMu10_prescale");
-  singleThresholds_[L1ParticleMap::kSingleMu14] =
-      iConfig.getParameter<double>("L1_SingleMu14_thresh");
-  prescales_[L1ParticleMap::kSingleMu14] =
-      iConfig.getParameter<int>("L1_SingleMu14_prescale");
-  singleThresholds_[L1ParticleMap::kSingleMu20] =
-      iConfig.getParameter<double>("L1_SingleMu20_thresh");
-  prescales_[L1ParticleMap::kSingleMu20] =
-      iConfig.getParameter<int>("L1_SingleMu20_prescale");
-  singleThresholds_[L1ParticleMap::kSingleMu25] =
-      iConfig.getParameter<double>("L1_SingleMu25_thresh");
-  prescales_[L1ParticleMap::kSingleMu25] =
-      iConfig.getParameter<int>("L1_SingleMu25_prescale");
+  singleThresholds_[L1ParticleMap::kSingleMu3] = iConfig.getParameter<double>("L1_SingleMu3_thresh");
+  prescales_[L1ParticleMap::kSingleMu3] = iConfig.getParameter<int>("L1_SingleMu3_prescale");
+  singleThresholds_[L1ParticleMap::kSingleMu5] = iConfig.getParameter<double>("L1_SingleMu5_thresh");
+  prescales_[L1ParticleMap::kSingleMu5] = iConfig.getParameter<int>("L1_SingleMu5_prescale");
+  singleThresholds_[L1ParticleMap::kSingleMu7] = iConfig.getParameter<double>("L1_SingleMu7_thresh");
+  prescales_[L1ParticleMap::kSingleMu7] = iConfig.getParameter<int>("L1_SingleMu7_prescale");
+  singleThresholds_[L1ParticleMap::kSingleMu10] = iConfig.getParameter<double>("L1_SingleMu10_thresh");
+  prescales_[L1ParticleMap::kSingleMu10] = iConfig.getParameter<int>("L1_SingleMu10_prescale");
+  singleThresholds_[L1ParticleMap::kSingleMu14] = iConfig.getParameter<double>("L1_SingleMu14_thresh");
+  prescales_[L1ParticleMap::kSingleMu14] = iConfig.getParameter<int>("L1_SingleMu14_prescale");
+  singleThresholds_[L1ParticleMap::kSingleMu20] = iConfig.getParameter<double>("L1_SingleMu20_thresh");
+  prescales_[L1ParticleMap::kSingleMu20] = iConfig.getParameter<int>("L1_SingleMu20_prescale");
+  singleThresholds_[L1ParticleMap::kSingleMu25] = iConfig.getParameter<double>("L1_SingleMu25_thresh");
+  prescales_[L1ParticleMap::kSingleMu25] = iConfig.getParameter<int>("L1_SingleMu25_prescale");
 
-  singleThresholds_[L1ParticleMap::kSingleIsoEG5] =
-      iConfig.getParameter<double>("L1_SingleIsoEG5_thresh");
-  prescales_[L1ParticleMap::kSingleIsoEG5] =
-      iConfig.getParameter<int>("L1_SingleIsoEG5_prescale");
-  singleThresholds_[L1ParticleMap::kSingleIsoEG8] =
-      iConfig.getParameter<double>("L1_SingleIsoEG8_thresh");
-  prescales_[L1ParticleMap::kSingleIsoEG8] =
-      iConfig.getParameter<int>("L1_SingleIsoEG8_prescale");
-  singleThresholds_[L1ParticleMap::kSingleIsoEG10] =
-      iConfig.getParameter<double>("L1_SingleIsoEG10_thresh");
-  prescales_[L1ParticleMap::kSingleIsoEG10] =
-      iConfig.getParameter<int>("L1_SingleIsoEG10_prescale");
-  singleThresholds_[L1ParticleMap::kSingleIsoEG12] =
-      iConfig.getParameter<double>("L1_SingleIsoEG12_thresh");
-  prescales_[L1ParticleMap::kSingleIsoEG12] =
-      iConfig.getParameter<int>("L1_SingleIsoEG12_prescale");
-  singleThresholds_[L1ParticleMap::kSingleIsoEG15] =
-      iConfig.getParameter<double>("L1_SingleIsoEG15_thresh");
-  prescales_[L1ParticleMap::kSingleIsoEG15] =
-      iConfig.getParameter<int>("L1_SingleIsoEG15_prescale");
-  singleThresholds_[L1ParticleMap::kSingleIsoEG20] =
-      iConfig.getParameter<double>("L1_SingleIsoEG20_thresh");
-  prescales_[L1ParticleMap::kSingleIsoEG20] =
-      iConfig.getParameter<int>("L1_SingleIsoEG20_prescale");
-  singleThresholds_[L1ParticleMap::kSingleIsoEG25] =
-      iConfig.getParameter<double>("L1_SingleIsoEG25_thresh");
-  prescales_[L1ParticleMap::kSingleIsoEG25] =
-      iConfig.getParameter<int>("L1_SingleIsoEG25_prescale");
+  singleThresholds_[L1ParticleMap::kSingleIsoEG5] = iConfig.getParameter<double>("L1_SingleIsoEG5_thresh");
+  prescales_[L1ParticleMap::kSingleIsoEG5] = iConfig.getParameter<int>("L1_SingleIsoEG5_prescale");
+  singleThresholds_[L1ParticleMap::kSingleIsoEG8] = iConfig.getParameter<double>("L1_SingleIsoEG8_thresh");
+  prescales_[L1ParticleMap::kSingleIsoEG8] = iConfig.getParameter<int>("L1_SingleIsoEG8_prescale");
+  singleThresholds_[L1ParticleMap::kSingleIsoEG10] = iConfig.getParameter<double>("L1_SingleIsoEG10_thresh");
+  prescales_[L1ParticleMap::kSingleIsoEG10] = iConfig.getParameter<int>("L1_SingleIsoEG10_prescale");
+  singleThresholds_[L1ParticleMap::kSingleIsoEG12] = iConfig.getParameter<double>("L1_SingleIsoEG12_thresh");
+  prescales_[L1ParticleMap::kSingleIsoEG12] = iConfig.getParameter<int>("L1_SingleIsoEG12_prescale");
+  singleThresholds_[L1ParticleMap::kSingleIsoEG15] = iConfig.getParameter<double>("L1_SingleIsoEG15_thresh");
+  prescales_[L1ParticleMap::kSingleIsoEG15] = iConfig.getParameter<int>("L1_SingleIsoEG15_prescale");
+  singleThresholds_[L1ParticleMap::kSingleIsoEG20] = iConfig.getParameter<double>("L1_SingleIsoEG20_thresh");
+  prescales_[L1ParticleMap::kSingleIsoEG20] = iConfig.getParameter<int>("L1_SingleIsoEG20_prescale");
+  singleThresholds_[L1ParticleMap::kSingleIsoEG25] = iConfig.getParameter<double>("L1_SingleIsoEG25_thresh");
+  prescales_[L1ParticleMap::kSingleIsoEG25] = iConfig.getParameter<int>("L1_SingleIsoEG25_prescale");
 
-  singleThresholds_[L1ParticleMap::kSingleEG5] =
-      iConfig.getParameter<double>("L1_SingleEG5_thresh");
-  prescales_[L1ParticleMap::kSingleEG5] =
-      iConfig.getParameter<int>("L1_SingleEG5_prescale");
-  singleThresholds_[L1ParticleMap::kSingleEG8] =
-      iConfig.getParameter<double>("L1_SingleEG8_thresh");
-  prescales_[L1ParticleMap::kSingleEG8] =
-      iConfig.getParameter<int>("L1_SingleEG8_prescale");
-  singleThresholds_[L1ParticleMap::kSingleEG10] =
-      iConfig.getParameter<double>("L1_SingleEG10_thresh");
-  prescales_[L1ParticleMap::kSingleEG10] =
-      iConfig.getParameter<int>("L1_SingleEG10_prescale");
-  singleThresholds_[L1ParticleMap::kSingleEG12] =
-      iConfig.getParameter<double>("L1_SingleEG12_thresh");
-  prescales_[L1ParticleMap::kSingleEG12] =
-      iConfig.getParameter<int>("L1_SingleEG12_prescale");
-  singleThresholds_[L1ParticleMap::kSingleEG15] =
-      iConfig.getParameter<double>("L1_SingleEG15_thresh");
-  prescales_[L1ParticleMap::kSingleEG15] =
-      iConfig.getParameter<int>("L1_SingleEG15_prescale");
-  singleThresholds_[L1ParticleMap::kSingleEG20] =
-      iConfig.getParameter<double>("L1_SingleEG20_thresh");
-  prescales_[L1ParticleMap::kSingleEG20] =
-      iConfig.getParameter<int>("L1_SingleEG20_prescale");
-  singleThresholds_[L1ParticleMap::kSingleEG25] =
-      iConfig.getParameter<double>("L1_SingleEG25_thresh");
-  prescales_[L1ParticleMap::kSingleEG25] =
-      iConfig.getParameter<int>("L1_SingleEG25_prescale");
+  singleThresholds_[L1ParticleMap::kSingleEG5] = iConfig.getParameter<double>("L1_SingleEG5_thresh");
+  prescales_[L1ParticleMap::kSingleEG5] = iConfig.getParameter<int>("L1_SingleEG5_prescale");
+  singleThresholds_[L1ParticleMap::kSingleEG8] = iConfig.getParameter<double>("L1_SingleEG8_thresh");
+  prescales_[L1ParticleMap::kSingleEG8] = iConfig.getParameter<int>("L1_SingleEG8_prescale");
+  singleThresholds_[L1ParticleMap::kSingleEG10] = iConfig.getParameter<double>("L1_SingleEG10_thresh");
+  prescales_[L1ParticleMap::kSingleEG10] = iConfig.getParameter<int>("L1_SingleEG10_prescale");
+  singleThresholds_[L1ParticleMap::kSingleEG12] = iConfig.getParameter<double>("L1_SingleEG12_thresh");
+  prescales_[L1ParticleMap::kSingleEG12] = iConfig.getParameter<int>("L1_SingleEG12_prescale");
+  singleThresholds_[L1ParticleMap::kSingleEG15] = iConfig.getParameter<double>("L1_SingleEG15_thresh");
+  prescales_[L1ParticleMap::kSingleEG15] = iConfig.getParameter<int>("L1_SingleEG15_prescale");
+  singleThresholds_[L1ParticleMap::kSingleEG20] = iConfig.getParameter<double>("L1_SingleEG20_thresh");
+  prescales_[L1ParticleMap::kSingleEG20] = iConfig.getParameter<int>("L1_SingleEG20_prescale");
+  singleThresholds_[L1ParticleMap::kSingleEG25] = iConfig.getParameter<double>("L1_SingleEG25_thresh");
+  prescales_[L1ParticleMap::kSingleEG25] = iConfig.getParameter<int>("L1_SingleEG25_prescale");
 
-  singleThresholds_[L1ParticleMap::kSingleJet15] =
-      iConfig.getParameter<double>("L1_SingleJet15_thresh");
-  prescales_[L1ParticleMap::kSingleJet15] =
-      iConfig.getParameter<int>("L1_SingleJet15_prescale");
-  singleThresholds_[L1ParticleMap::kSingleJet20] =
-      iConfig.getParameter<double>("L1_SingleJet20_thresh");
-  prescales_[L1ParticleMap::kSingleJet20] =
-      iConfig.getParameter<int>("L1_SingleJet20_prescale");
-  singleThresholds_[L1ParticleMap::kSingleJet30] =
-      iConfig.getParameter<double>("L1_SingleJet30_thresh");
-  prescales_[L1ParticleMap::kSingleJet30] =
-      iConfig.getParameter<int>("L1_SingleJet30_prescale");
-  singleThresholds_[L1ParticleMap::kSingleJet50] =
-      iConfig.getParameter<double>("L1_SingleJet50_thresh");
-  prescales_[L1ParticleMap::kSingleJet50] =
-      iConfig.getParameter<int>("L1_SingleJet50_prescale");
-  singleThresholds_[L1ParticleMap::kSingleJet70] =
-      iConfig.getParameter<double>("L1_SingleJet70_thresh");
-  prescales_[L1ParticleMap::kSingleJet70] =
-      iConfig.getParameter<int>("L1_SingleJet70_prescale");
-  singleThresholds_[L1ParticleMap::kSingleJet100] =
-      iConfig.getParameter<double>("L1_SingleJet100_thresh");
-  prescales_[L1ParticleMap::kSingleJet100] =
-      iConfig.getParameter<int>("L1_SingleJet100_prescale");
-  singleThresholds_[L1ParticleMap::kSingleJet150] =
-      iConfig.getParameter<double>("L1_SingleJet150_thresh");
-  prescales_[L1ParticleMap::kSingleJet150] =
-      iConfig.getParameter<int>("L1_SingleJet150_prescale");
-  singleThresholds_[L1ParticleMap::kSingleJet200] =
-      iConfig.getParameter<double>("L1_SingleJet200_thresh");
-  prescales_[L1ParticleMap::kSingleJet200] =
-      iConfig.getParameter<int>("L1_SingleJet200_prescale");
+  singleThresholds_[L1ParticleMap::kSingleJet15] = iConfig.getParameter<double>("L1_SingleJet15_thresh");
+  prescales_[L1ParticleMap::kSingleJet15] = iConfig.getParameter<int>("L1_SingleJet15_prescale");
+  singleThresholds_[L1ParticleMap::kSingleJet20] = iConfig.getParameter<double>("L1_SingleJet20_thresh");
+  prescales_[L1ParticleMap::kSingleJet20] = iConfig.getParameter<int>("L1_SingleJet20_prescale");
+  singleThresholds_[L1ParticleMap::kSingleJet30] = iConfig.getParameter<double>("L1_SingleJet30_thresh");
+  prescales_[L1ParticleMap::kSingleJet30] = iConfig.getParameter<int>("L1_SingleJet30_prescale");
+  singleThresholds_[L1ParticleMap::kSingleJet50] = iConfig.getParameter<double>("L1_SingleJet50_thresh");
+  prescales_[L1ParticleMap::kSingleJet50] = iConfig.getParameter<int>("L1_SingleJet50_prescale");
+  singleThresholds_[L1ParticleMap::kSingleJet70] = iConfig.getParameter<double>("L1_SingleJet70_thresh");
+  prescales_[L1ParticleMap::kSingleJet70] = iConfig.getParameter<int>("L1_SingleJet70_prescale");
+  singleThresholds_[L1ParticleMap::kSingleJet100] = iConfig.getParameter<double>("L1_SingleJet100_thresh");
+  prescales_[L1ParticleMap::kSingleJet100] = iConfig.getParameter<int>("L1_SingleJet100_prescale");
+  singleThresholds_[L1ParticleMap::kSingleJet150] = iConfig.getParameter<double>("L1_SingleJet150_thresh");
+  prescales_[L1ParticleMap::kSingleJet150] = iConfig.getParameter<int>("L1_SingleJet150_prescale");
+  singleThresholds_[L1ParticleMap::kSingleJet200] = iConfig.getParameter<double>("L1_SingleJet200_thresh");
+  prescales_[L1ParticleMap::kSingleJet200] = iConfig.getParameter<int>("L1_SingleJet200_prescale");
 
-  singleThresholds_[L1ParticleMap::kSingleTauJet10] =
-      iConfig.getParameter<double>("L1_SingleTauJet10_thresh");
-  prescales_[L1ParticleMap::kSingleTauJet10] =
-      iConfig.getParameter<int>("L1_SingleTauJet10_prescale");
-  singleThresholds_[L1ParticleMap::kSingleTauJet20] =
-      iConfig.getParameter<double>("L1_SingleTauJet20_thresh");
-  prescales_[L1ParticleMap::kSingleTauJet20] =
-      iConfig.getParameter<int>("L1_SingleTauJet20_prescale");
-  singleThresholds_[L1ParticleMap::kSingleTauJet30] =
-      iConfig.getParameter<double>("L1_SingleTauJet30_thresh");
-  prescales_[L1ParticleMap::kSingleTauJet30] =
-      iConfig.getParameter<int>("L1_SingleTauJet30_prescale");
-  singleThresholds_[L1ParticleMap::kSingleTauJet35] =
-      iConfig.getParameter<double>("L1_SingleTauJet35_thresh");
-  prescales_[L1ParticleMap::kSingleTauJet35] =
-      iConfig.getParameter<int>("L1_SingleTauJet35_prescale");
-  singleThresholds_[L1ParticleMap::kSingleTauJet40] =
-      iConfig.getParameter<double>("L1_SingleTauJet40_thresh");
-  prescales_[L1ParticleMap::kSingleTauJet40] =
-      iConfig.getParameter<int>("L1_SingleTauJet40_prescale");
-  singleThresholds_[L1ParticleMap::kSingleTauJet60] =
-      iConfig.getParameter<double>("L1_SingleTauJet60_thresh");
-  prescales_[L1ParticleMap::kSingleTauJet60] =
-      iConfig.getParameter<int>("L1_SingleTauJet60_prescale");
-  singleThresholds_[L1ParticleMap::kSingleTauJet80] =
-      iConfig.getParameter<double>("L1_SingleTauJet80_thresh");
-  prescales_[L1ParticleMap::kSingleTauJet80] =
-      iConfig.getParameter<int>("L1_SingleTauJet80_prescale");
-  singleThresholds_[L1ParticleMap::kSingleTauJet100] =
-      iConfig.getParameter<double>("L1_SingleTauJet100_thresh");
-  prescales_[L1ParticleMap::kSingleTauJet100] =
-      iConfig.getParameter<int>("L1_SingleTauJet100_prescale");
+  singleThresholds_[L1ParticleMap::kSingleTauJet10] = iConfig.getParameter<double>("L1_SingleTauJet10_thresh");
+  prescales_[L1ParticleMap::kSingleTauJet10] = iConfig.getParameter<int>("L1_SingleTauJet10_prescale");
+  singleThresholds_[L1ParticleMap::kSingleTauJet20] = iConfig.getParameter<double>("L1_SingleTauJet20_thresh");
+  prescales_[L1ParticleMap::kSingleTauJet20] = iConfig.getParameter<int>("L1_SingleTauJet20_prescale");
+  singleThresholds_[L1ParticleMap::kSingleTauJet30] = iConfig.getParameter<double>("L1_SingleTauJet30_thresh");
+  prescales_[L1ParticleMap::kSingleTauJet30] = iConfig.getParameter<int>("L1_SingleTauJet30_prescale");
+  singleThresholds_[L1ParticleMap::kSingleTauJet35] = iConfig.getParameter<double>("L1_SingleTauJet35_thresh");
+  prescales_[L1ParticleMap::kSingleTauJet35] = iConfig.getParameter<int>("L1_SingleTauJet35_prescale");
+  singleThresholds_[L1ParticleMap::kSingleTauJet40] = iConfig.getParameter<double>("L1_SingleTauJet40_thresh");
+  prescales_[L1ParticleMap::kSingleTauJet40] = iConfig.getParameter<int>("L1_SingleTauJet40_prescale");
+  singleThresholds_[L1ParticleMap::kSingleTauJet60] = iConfig.getParameter<double>("L1_SingleTauJet60_thresh");
+  prescales_[L1ParticleMap::kSingleTauJet60] = iConfig.getParameter<int>("L1_SingleTauJet60_prescale");
+  singleThresholds_[L1ParticleMap::kSingleTauJet80] = iConfig.getParameter<double>("L1_SingleTauJet80_thresh");
+  prescales_[L1ParticleMap::kSingleTauJet80] = iConfig.getParameter<int>("L1_SingleTauJet80_prescale");
+  singleThresholds_[L1ParticleMap::kSingleTauJet100] = iConfig.getParameter<double>("L1_SingleTauJet100_thresh");
+  prescales_[L1ParticleMap::kSingleTauJet100] = iConfig.getParameter<int>("L1_SingleTauJet100_prescale");
 
-  singleThresholds_[L1ParticleMap::kHTT100] =
-      iConfig.getParameter<double>("L1_HTT100_thresh");
-  prescales_[L1ParticleMap::kHTT100] =
-      iConfig.getParameter<int>("L1_HTT100_prescale");
-  singleThresholds_[L1ParticleMap::kHTT200] =
-      iConfig.getParameter<double>("L1_HTT200_thresh");
-  prescales_[L1ParticleMap::kHTT200] =
-      iConfig.getParameter<int>("L1_HTT200_prescale");
-  singleThresholds_[L1ParticleMap::kHTT250] =
-      iConfig.getParameter<double>("L1_HTT250_thresh");
-  prescales_[L1ParticleMap::kHTT250] =
-      iConfig.getParameter<int>("L1_HTT250_prescale");
-  singleThresholds_[L1ParticleMap::kHTT300] =
-      iConfig.getParameter<double>("L1_HTT300_thresh");
-  prescales_[L1ParticleMap::kHTT300] =
-      iConfig.getParameter<int>("L1_HTT300_prescale");
-  singleThresholds_[L1ParticleMap::kHTT400] =
-      iConfig.getParameter<double>("L1_HTT400_thresh");
-  prescales_[L1ParticleMap::kHTT400] =
-      iConfig.getParameter<int>("L1_HTT400_prescale");
-  singleThresholds_[L1ParticleMap::kHTT500] =
-      iConfig.getParameter<double>("L1_HTT500_thresh");
-  prescales_[L1ParticleMap::kHTT500] =
-      iConfig.getParameter<int>("L1_HTT500_prescale");
+  singleThresholds_[L1ParticleMap::kHTT100] = iConfig.getParameter<double>("L1_HTT100_thresh");
+  prescales_[L1ParticleMap::kHTT100] = iConfig.getParameter<int>("L1_HTT100_prescale");
+  singleThresholds_[L1ParticleMap::kHTT200] = iConfig.getParameter<double>("L1_HTT200_thresh");
+  prescales_[L1ParticleMap::kHTT200] = iConfig.getParameter<int>("L1_HTT200_prescale");
+  singleThresholds_[L1ParticleMap::kHTT250] = iConfig.getParameter<double>("L1_HTT250_thresh");
+  prescales_[L1ParticleMap::kHTT250] = iConfig.getParameter<int>("L1_HTT250_prescale");
+  singleThresholds_[L1ParticleMap::kHTT300] = iConfig.getParameter<double>("L1_HTT300_thresh");
+  prescales_[L1ParticleMap::kHTT300] = iConfig.getParameter<int>("L1_HTT300_prescale");
+  singleThresholds_[L1ParticleMap::kHTT400] = iConfig.getParameter<double>("L1_HTT400_thresh");
+  prescales_[L1ParticleMap::kHTT400] = iConfig.getParameter<int>("L1_HTT400_prescale");
+  singleThresholds_[L1ParticleMap::kHTT500] = iConfig.getParameter<double>("L1_HTT500_thresh");
+  prescales_[L1ParticleMap::kHTT500] = iConfig.getParameter<int>("L1_HTT500_prescale");
 
-  singleThresholds_[L1ParticleMap::kETM10] =
-      iConfig.getParameter<double>("L1_ETM10_thresh");
-  prescales_[L1ParticleMap::kETM10] =
-      iConfig.getParameter<int>("L1_ETM10_prescale");
-  singleThresholds_[L1ParticleMap::kETM15] =
-      iConfig.getParameter<double>("L1_ETM15_thresh");
-  prescales_[L1ParticleMap::kETM15] =
-      iConfig.getParameter<int>("L1_ETM15_prescale");
-  singleThresholds_[L1ParticleMap::kETM20] =
-      iConfig.getParameter<double>("L1_ETM20_thresh");
-  prescales_[L1ParticleMap::kETM20] =
-      iConfig.getParameter<int>("L1_ETM20_prescale");
-  singleThresholds_[L1ParticleMap::kETM30] =
-      iConfig.getParameter<double>("L1_ETM30_thresh");
-  prescales_[L1ParticleMap::kETM30] =
-      iConfig.getParameter<int>("L1_ETM30_prescale");
-  singleThresholds_[L1ParticleMap::kETM40] =
-      iConfig.getParameter<double>("L1_ETM40_thresh");
-  prescales_[L1ParticleMap::kETM40] =
-      iConfig.getParameter<int>("L1_ETM40_prescale");
-  singleThresholds_[L1ParticleMap::kETM50] =
-      iConfig.getParameter<double>("L1_ETM50_thresh");
-  prescales_[L1ParticleMap::kETM50] =
-      iConfig.getParameter<int>("L1_ETM50_prescale");
-  singleThresholds_[L1ParticleMap::kETM60] =
-      iConfig.getParameter<double>("L1_ETM60_thresh");
-  prescales_[L1ParticleMap::kETM60] =
-      iConfig.getParameter<int>("L1_ETM60_prescale");
+  singleThresholds_[L1ParticleMap::kETM10] = iConfig.getParameter<double>("L1_ETM10_thresh");
+  prescales_[L1ParticleMap::kETM10] = iConfig.getParameter<int>("L1_ETM10_prescale");
+  singleThresholds_[L1ParticleMap::kETM15] = iConfig.getParameter<double>("L1_ETM15_thresh");
+  prescales_[L1ParticleMap::kETM15] = iConfig.getParameter<int>("L1_ETM15_prescale");
+  singleThresholds_[L1ParticleMap::kETM20] = iConfig.getParameter<double>("L1_ETM20_thresh");
+  prescales_[L1ParticleMap::kETM20] = iConfig.getParameter<int>("L1_ETM20_prescale");
+  singleThresholds_[L1ParticleMap::kETM30] = iConfig.getParameter<double>("L1_ETM30_thresh");
+  prescales_[L1ParticleMap::kETM30] = iConfig.getParameter<int>("L1_ETM30_prescale");
+  singleThresholds_[L1ParticleMap::kETM40] = iConfig.getParameter<double>("L1_ETM40_thresh");
+  prescales_[L1ParticleMap::kETM40] = iConfig.getParameter<int>("L1_ETM40_prescale");
+  singleThresholds_[L1ParticleMap::kETM50] = iConfig.getParameter<double>("L1_ETM50_thresh");
+  prescales_[L1ParticleMap::kETM50] = iConfig.getParameter<int>("L1_ETM50_prescale");
+  singleThresholds_[L1ParticleMap::kETM60] = iConfig.getParameter<double>("L1_ETM60_thresh");
+  prescales_[L1ParticleMap::kETM60] = iConfig.getParameter<int>("L1_ETM60_prescale");
 
-  singleThresholds_[L1ParticleMap::kETT60] =
-      iConfig.getParameter<double>("L1_ETT60_thresh");
-  prescales_[L1ParticleMap::kETT60] =
-      iConfig.getParameter<int>("L1_ETT60_prescale");
+  singleThresholds_[L1ParticleMap::kETT60] = iConfig.getParameter<double>("L1_ETT60_thresh");
+  prescales_[L1ParticleMap::kETT60] = iConfig.getParameter<int>("L1_ETT60_prescale");
 
   // AA triggers
 
-  singleThresholds_[L1ParticleMap::kDoubleMu3] =
-      iConfig.getParameter<double>("L1_DoubleMu3_thresh");
-  prescales_[L1ParticleMap::kDoubleMu3] =
-      iConfig.getParameter<int>("L1_DoubleMu3_prescale");
+  singleThresholds_[L1ParticleMap::kDoubleMu3] = iConfig.getParameter<double>("L1_DoubleMu3_thresh");
+  prescales_[L1ParticleMap::kDoubleMu3] = iConfig.getParameter<int>("L1_DoubleMu3_prescale");
 
-  singleThresholds_[L1ParticleMap::kDoubleIsoEG8] =
-      iConfig.getParameter<double>("L1_DoubleIsoEG8_thresh");
-  prescales_[L1ParticleMap::kDoubleIsoEG8] =
-      iConfig.getParameter<int>("L1_DoubleIsoEG8_prescale");
-  singleThresholds_[L1ParticleMap::kDoubleIsoEG10] =
-      iConfig.getParameter<double>("L1_DoubleIsoEG10_thresh");
-  prescales_[L1ParticleMap::kDoubleIsoEG10] =
-      iConfig.getParameter<int>("L1_DoubleIsoEG10_prescale");
+  singleThresholds_[L1ParticleMap::kDoubleIsoEG8] = iConfig.getParameter<double>("L1_DoubleIsoEG8_thresh");
+  prescales_[L1ParticleMap::kDoubleIsoEG8] = iConfig.getParameter<int>("L1_DoubleIsoEG8_prescale");
+  singleThresholds_[L1ParticleMap::kDoubleIsoEG10] = iConfig.getParameter<double>("L1_DoubleIsoEG10_thresh");
+  prescales_[L1ParticleMap::kDoubleIsoEG10] = iConfig.getParameter<int>("L1_DoubleIsoEG10_prescale");
 
-  singleThresholds_[L1ParticleMap::kDoubleEG5] =
-      iConfig.getParameter<double>("L1_DoubleEG5_thresh");
-  prescales_[L1ParticleMap::kDoubleEG5] =
-      iConfig.getParameter<int>("L1_DoubleEG5_prescale");
-  singleThresholds_[L1ParticleMap::kDoubleEG10] =
-      iConfig.getParameter<double>("L1_DoubleEG10_thresh");
-  prescales_[L1ParticleMap::kDoubleEG10] =
-      iConfig.getParameter<int>("L1_DoubleEG10_prescale");
-  singleThresholds_[L1ParticleMap::kDoubleEG15] =
-      iConfig.getParameter<double>("L1_DoubleEG15_thresh");
-  prescales_[L1ParticleMap::kDoubleEG15] =
-      iConfig.getParameter<int>("L1_DoubleEG15_prescale");
+  singleThresholds_[L1ParticleMap::kDoubleEG5] = iConfig.getParameter<double>("L1_DoubleEG5_thresh");
+  prescales_[L1ParticleMap::kDoubleEG5] = iConfig.getParameter<int>("L1_DoubleEG5_prescale");
+  singleThresholds_[L1ParticleMap::kDoubleEG10] = iConfig.getParameter<double>("L1_DoubleEG10_thresh");
+  prescales_[L1ParticleMap::kDoubleEG10] = iConfig.getParameter<int>("L1_DoubleEG10_prescale");
+  singleThresholds_[L1ParticleMap::kDoubleEG15] = iConfig.getParameter<double>("L1_DoubleEG15_thresh");
+  prescales_[L1ParticleMap::kDoubleEG15] = iConfig.getParameter<int>("L1_DoubleEG15_prescale");
 
-  singleThresholds_[L1ParticleMap::kDoubleJet70] =
-      iConfig.getParameter<double>("L1_DoubleJet70_thresh");
-  prescales_[L1ParticleMap::kDoubleJet70] =
-      iConfig.getParameter<int>("L1_DoubleJet70_prescale");
-  singleThresholds_[L1ParticleMap::kDoubleJet100] =
-      iConfig.getParameter<double>("L1_DoubleJet100_thresh");
-  prescales_[L1ParticleMap::kDoubleJet100] =
-      iConfig.getParameter<int>("L1_DoubleJet100_prescale");
+  singleThresholds_[L1ParticleMap::kDoubleJet70] = iConfig.getParameter<double>("L1_DoubleJet70_thresh");
+  prescales_[L1ParticleMap::kDoubleJet70] = iConfig.getParameter<int>("L1_DoubleJet70_prescale");
+  singleThresholds_[L1ParticleMap::kDoubleJet100] = iConfig.getParameter<double>("L1_DoubleJet100_thresh");
+  prescales_[L1ParticleMap::kDoubleJet100] = iConfig.getParameter<int>("L1_DoubleJet100_prescale");
 
-  singleThresholds_[L1ParticleMap::kDoubleTauJet20] =
-      iConfig.getParameter<double>("L1_DoubleTauJet20_thresh");
-  prescales_[L1ParticleMap::kDoubleTauJet20] =
-      iConfig.getParameter<int>("L1_DoubleTauJet20_prescale");
-  singleThresholds_[L1ParticleMap::kDoubleTauJet30] =
-      iConfig.getParameter<double>("L1_DoubleTauJet30_thresh");
-  prescales_[L1ParticleMap::kDoubleTauJet30] =
-      iConfig.getParameter<int>("L1_DoubleTauJet30_prescale");
-  singleThresholds_[L1ParticleMap::kDoubleTauJet35] =
-      iConfig.getParameter<double>("L1_DoubleTauJet35_thresh");
-  prescales_[L1ParticleMap::kDoubleTauJet35] =
-      iConfig.getParameter<int>("L1_DoubleTauJet35_prescale");
-  singleThresholds_[L1ParticleMap::kDoubleTauJet40] =
-      iConfig.getParameter<double>("L1_DoubleTauJet40_thresh");
-  prescales_[L1ParticleMap::kDoubleTauJet40] =
-      iConfig.getParameter<int>("L1_DoubleTauJet40_prescale");
+  singleThresholds_[L1ParticleMap::kDoubleTauJet20] = iConfig.getParameter<double>("L1_DoubleTauJet20_thresh");
+  prescales_[L1ParticleMap::kDoubleTauJet20] = iConfig.getParameter<int>("L1_DoubleTauJet20_prescale");
+  singleThresholds_[L1ParticleMap::kDoubleTauJet30] = iConfig.getParameter<double>("L1_DoubleTauJet30_thresh");
+  prescales_[L1ParticleMap::kDoubleTauJet30] = iConfig.getParameter<int>("L1_DoubleTauJet30_prescale");
+  singleThresholds_[L1ParticleMap::kDoubleTauJet35] = iConfig.getParameter<double>("L1_DoubleTauJet35_thresh");
+  prescales_[L1ParticleMap::kDoubleTauJet35] = iConfig.getParameter<int>("L1_DoubleTauJet35_prescale");
+  singleThresholds_[L1ParticleMap::kDoubleTauJet40] = iConfig.getParameter<double>("L1_DoubleTauJet40_thresh");
+  prescales_[L1ParticleMap::kDoubleTauJet40] = iConfig.getParameter<int>("L1_DoubleTauJet40_prescale");
 
   // AB triggers
 
-  doubleThresholds_[L1ParticleMap::kMu3_IsoEG5].first =
-      iConfig.getParameter<double>("L1_Mu3_IsoEG5_thresh1");
-  doubleThresholds_[L1ParticleMap::kMu3_IsoEG5].second =
-      iConfig.getParameter<double>("L1_Mu3_IsoEG5_thresh2");
-  prescales_[L1ParticleMap::kMu3_IsoEG5] =
-      iConfig.getParameter<int>("L1_Mu3_IsoEG5_prescale");
-  doubleThresholds_[L1ParticleMap::kMu5_IsoEG10].first =
-      iConfig.getParameter<double>("L1_Mu5_IsoEG10_thresh1");
-  doubleThresholds_[L1ParticleMap::kMu5_IsoEG10].second =
-      iConfig.getParameter<double>("L1_Mu5_IsoEG10_thresh2");
-  prescales_[L1ParticleMap::kMu5_IsoEG10] =
-      iConfig.getParameter<int>("L1_Mu5_IsoEG10_prescale");
+  doubleThresholds_[L1ParticleMap::kMu3_IsoEG5].first = iConfig.getParameter<double>("L1_Mu3_IsoEG5_thresh1");
+  doubleThresholds_[L1ParticleMap::kMu3_IsoEG5].second = iConfig.getParameter<double>("L1_Mu3_IsoEG5_thresh2");
+  prescales_[L1ParticleMap::kMu3_IsoEG5] = iConfig.getParameter<int>("L1_Mu3_IsoEG5_prescale");
+  doubleThresholds_[L1ParticleMap::kMu5_IsoEG10].first = iConfig.getParameter<double>("L1_Mu5_IsoEG10_thresh1");
+  doubleThresholds_[L1ParticleMap::kMu5_IsoEG10].second = iConfig.getParameter<double>("L1_Mu5_IsoEG10_thresh2");
+  prescales_[L1ParticleMap::kMu5_IsoEG10] = iConfig.getParameter<int>("L1_Mu5_IsoEG10_prescale");
 
-  doubleThresholds_[L1ParticleMap::kMu3_EG12].first =
-      iConfig.getParameter<double>("L1_Mu3_EG12_thresh1");
-  doubleThresholds_[L1ParticleMap::kMu3_EG12].second =
-      iConfig.getParameter<double>("L1_Mu3_EG12_thresh2");
-  prescales_[L1ParticleMap::kMu3_EG12] =
-      iConfig.getParameter<int>("L1_Mu3_EG12_prescale");
+  doubleThresholds_[L1ParticleMap::kMu3_EG12].first = iConfig.getParameter<double>("L1_Mu3_EG12_thresh1");
+  doubleThresholds_[L1ParticleMap::kMu3_EG12].second = iConfig.getParameter<double>("L1_Mu3_EG12_thresh2");
+  prescales_[L1ParticleMap::kMu3_EG12] = iConfig.getParameter<int>("L1_Mu3_EG12_prescale");
 
-  doubleThresholds_[L1ParticleMap::kMu3_Jet15].first =
-      iConfig.getParameter<double>("L1_Mu3_Jet15_thresh1");
-  doubleThresholds_[L1ParticleMap::kMu3_Jet15].second =
-      iConfig.getParameter<double>("L1_Mu3_Jet15_thresh2");
-  prescales_[L1ParticleMap::kMu3_Jet15] =
-      iConfig.getParameter<int>("L1_Mu3_Jet15_prescale");
-  doubleThresholds_[L1ParticleMap::kMu5_Jet15].first =
-      iConfig.getParameter<double>("L1_Mu5_Jet15_thresh1");
-  doubleThresholds_[L1ParticleMap::kMu5_Jet15].second =
-      iConfig.getParameter<double>("L1_Mu5_Jet15_thresh2");
-  prescales_[L1ParticleMap::kMu5_Jet15] =
-      iConfig.getParameter<int>("L1_Mu5_Jet15_prescale");
-  doubleThresholds_[L1ParticleMap::kMu3_Jet70].first =
-      iConfig.getParameter<double>("L1_Mu3_Jet70_thresh1");
-  doubleThresholds_[L1ParticleMap::kMu3_Jet70].second =
-      iConfig.getParameter<double>("L1_Mu3_Jet70_thresh2");
-  prescales_[L1ParticleMap::kMu3_Jet70] =
-      iConfig.getParameter<int>("L1_Mu3_Jet70_prescale");
-  doubleThresholds_[L1ParticleMap::kMu5_Jet20].first =
-      iConfig.getParameter<double>("L1_Mu5_Jet20_thresh1");
-  doubleThresholds_[L1ParticleMap::kMu5_Jet20].second =
-      iConfig.getParameter<double>("L1_Mu5_Jet20_thresh2");
-  prescales_[L1ParticleMap::kMu5_Jet20] =
-      iConfig.getParameter<int>("L1_Mu5_Jet20_prescale");
+  doubleThresholds_[L1ParticleMap::kMu3_Jet15].first = iConfig.getParameter<double>("L1_Mu3_Jet15_thresh1");
+  doubleThresholds_[L1ParticleMap::kMu3_Jet15].second = iConfig.getParameter<double>("L1_Mu3_Jet15_thresh2");
+  prescales_[L1ParticleMap::kMu3_Jet15] = iConfig.getParameter<int>("L1_Mu3_Jet15_prescale");
+  doubleThresholds_[L1ParticleMap::kMu5_Jet15].first = iConfig.getParameter<double>("L1_Mu5_Jet15_thresh1");
+  doubleThresholds_[L1ParticleMap::kMu5_Jet15].second = iConfig.getParameter<double>("L1_Mu5_Jet15_thresh2");
+  prescales_[L1ParticleMap::kMu5_Jet15] = iConfig.getParameter<int>("L1_Mu5_Jet15_prescale");
+  doubleThresholds_[L1ParticleMap::kMu3_Jet70].first = iConfig.getParameter<double>("L1_Mu3_Jet70_thresh1");
+  doubleThresholds_[L1ParticleMap::kMu3_Jet70].second = iConfig.getParameter<double>("L1_Mu3_Jet70_thresh2");
+  prescales_[L1ParticleMap::kMu3_Jet70] = iConfig.getParameter<int>("L1_Mu3_Jet70_prescale");
+  doubleThresholds_[L1ParticleMap::kMu5_Jet20].first = iConfig.getParameter<double>("L1_Mu5_Jet20_thresh1");
+  doubleThresholds_[L1ParticleMap::kMu5_Jet20].second = iConfig.getParameter<double>("L1_Mu5_Jet20_thresh2");
+  prescales_[L1ParticleMap::kMu5_Jet20] = iConfig.getParameter<int>("L1_Mu5_Jet20_prescale");
 
-  doubleThresholds_[L1ParticleMap::kMu5_TauJet20].first =
-      iConfig.getParameter<double>("L1_Mu5_TauJet20_thresh1");
-  doubleThresholds_[L1ParticleMap::kMu5_TauJet20].second =
-      iConfig.getParameter<double>("L1_Mu5_TauJet20_thresh2");
-  prescales_[L1ParticleMap::kMu5_TauJet20] =
-      iConfig.getParameter<int>("L1_Mu5_TauJet20_prescale");
-  doubleThresholds_[L1ParticleMap::kMu5_TauJet30].first =
-      iConfig.getParameter<double>("L1_Mu5_TauJet30_thresh1");
-  doubleThresholds_[L1ParticleMap::kMu5_TauJet30].second =
-      iConfig.getParameter<double>("L1_Mu5_TauJet30_thresh2");
-  prescales_[L1ParticleMap::kMu5_TauJet30] =
-      iConfig.getParameter<int>("L1_Mu5_TauJet30_prescale");
+  doubleThresholds_[L1ParticleMap::kMu5_TauJet20].first = iConfig.getParameter<double>("L1_Mu5_TauJet20_thresh1");
+  doubleThresholds_[L1ParticleMap::kMu5_TauJet20].second = iConfig.getParameter<double>("L1_Mu5_TauJet20_thresh2");
+  prescales_[L1ParticleMap::kMu5_TauJet20] = iConfig.getParameter<int>("L1_Mu5_TauJet20_prescale");
+  doubleThresholds_[L1ParticleMap::kMu5_TauJet30].first = iConfig.getParameter<double>("L1_Mu5_TauJet30_thresh1");
+  doubleThresholds_[L1ParticleMap::kMu5_TauJet30].second = iConfig.getParameter<double>("L1_Mu5_TauJet30_thresh2");
+  prescales_[L1ParticleMap::kMu5_TauJet30] = iConfig.getParameter<int>("L1_Mu5_TauJet30_prescale");
 
-  doubleThresholds_[L1ParticleMap::kIsoEG10_EG10].first =
-      iConfig.getParameter<double>("L1_IsoEG10_EG10_thresh1");
-  doubleThresholds_[L1ParticleMap::kIsoEG10_EG10].second =
-      iConfig.getParameter<double>("L1_IsoEG10_EG10_thresh2");
-  prescales_[L1ParticleMap::kIsoEG10_EG10] =
-      iConfig.getParameter<int>("L1_IsoEG10_EG10_prescale");
+  doubleThresholds_[L1ParticleMap::kIsoEG10_EG10].first = iConfig.getParameter<double>("L1_IsoEG10_EG10_thresh1");
+  doubleThresholds_[L1ParticleMap::kIsoEG10_EG10].second = iConfig.getParameter<double>("L1_IsoEG10_EG10_thresh2");
+  prescales_[L1ParticleMap::kIsoEG10_EG10] = iConfig.getParameter<int>("L1_IsoEG10_EG10_prescale");
 
-  doubleThresholds_[L1ParticleMap::kIsoEG10_Jet15].first =
-      iConfig.getParameter<double>("L1_IsoEG10_Jet15_thresh1");
-  doubleThresholds_[L1ParticleMap::kIsoEG10_Jet15].second =
-      iConfig.getParameter<double>("L1_IsoEG10_Jet15_thresh2");
-  prescales_[L1ParticleMap::kIsoEG10_Jet15] =
-      iConfig.getParameter<int>("L1_IsoEG10_Jet15_prescale");
-  doubleThresholds_[L1ParticleMap::kIsoEG10_Jet30].first =
-      iConfig.getParameter<double>("L1_IsoEG10_Jet30_thresh1");
-  doubleThresholds_[L1ParticleMap::kIsoEG10_Jet30].second =
-      iConfig.getParameter<double>("L1_IsoEG10_Jet30_thresh2");
-  prescales_[L1ParticleMap::kIsoEG10_Jet30] =
-      iConfig.getParameter<int>("L1_IsoEG10_Jet30_prescale");
-  doubleThresholds_[L1ParticleMap::kIsoEG10_Jet20].first =
-      iConfig.getParameter<double>("L1_IsoEG10_Jet20_thresh1");
-  doubleThresholds_[L1ParticleMap::kIsoEG10_Jet20].second =
-      iConfig.getParameter<double>("L1_IsoEG10_Jet20_thresh2");
-  prescales_[L1ParticleMap::kIsoEG10_Jet20] =
-      iConfig.getParameter<int>("L1_IsoEG10_Jet20_prescale");
-  doubleThresholds_[L1ParticleMap::kIsoEG10_Jet70].first =
-      iConfig.getParameter<double>("L1_IsoEG10_Jet70_thresh1");
-  doubleThresholds_[L1ParticleMap::kIsoEG10_Jet70].second =
-      iConfig.getParameter<double>("L1_IsoEG10_Jet70_thresh2");
-  prescales_[L1ParticleMap::kIsoEG10_Jet70] =
-      iConfig.getParameter<int>("L1_IsoEG10_Jet70_prescale");
+  doubleThresholds_[L1ParticleMap::kIsoEG10_Jet15].first = iConfig.getParameter<double>("L1_IsoEG10_Jet15_thresh1");
+  doubleThresholds_[L1ParticleMap::kIsoEG10_Jet15].second = iConfig.getParameter<double>("L1_IsoEG10_Jet15_thresh2");
+  prescales_[L1ParticleMap::kIsoEG10_Jet15] = iConfig.getParameter<int>("L1_IsoEG10_Jet15_prescale");
+  doubleThresholds_[L1ParticleMap::kIsoEG10_Jet30].first = iConfig.getParameter<double>("L1_IsoEG10_Jet30_thresh1");
+  doubleThresholds_[L1ParticleMap::kIsoEG10_Jet30].second = iConfig.getParameter<double>("L1_IsoEG10_Jet30_thresh2");
+  prescales_[L1ParticleMap::kIsoEG10_Jet30] = iConfig.getParameter<int>("L1_IsoEG10_Jet30_prescale");
+  doubleThresholds_[L1ParticleMap::kIsoEG10_Jet20].first = iConfig.getParameter<double>("L1_IsoEG10_Jet20_thresh1");
+  doubleThresholds_[L1ParticleMap::kIsoEG10_Jet20].second = iConfig.getParameter<double>("L1_IsoEG10_Jet20_thresh2");
+  prescales_[L1ParticleMap::kIsoEG10_Jet20] = iConfig.getParameter<int>("L1_IsoEG10_Jet20_prescale");
+  doubleThresholds_[L1ParticleMap::kIsoEG10_Jet70].first = iConfig.getParameter<double>("L1_IsoEG10_Jet70_thresh1");
+  doubleThresholds_[L1ParticleMap::kIsoEG10_Jet70].second = iConfig.getParameter<double>("L1_IsoEG10_Jet70_thresh2");
+  prescales_[L1ParticleMap::kIsoEG10_Jet70] = iConfig.getParameter<int>("L1_IsoEG10_Jet70_prescale");
 
   doubleThresholds_[L1ParticleMap::kIsoEG10_TauJet20].first =
       iConfig.getParameter<double>("L1_IsoEG10_TauJet20_thresh1");
   doubleThresholds_[L1ParticleMap::kIsoEG10_TauJet20].second =
       iConfig.getParameter<double>("L1_IsoEG10_TauJet20_thresh2");
-  prescales_[L1ParticleMap::kIsoEG10_TauJet20] =
-      iConfig.getParameter<int>("L1_IsoEG10_TauJet20_prescale");
+  prescales_[L1ParticleMap::kIsoEG10_TauJet20] = iConfig.getParameter<int>("L1_IsoEG10_TauJet20_prescale");
   doubleThresholds_[L1ParticleMap::kIsoEG10_TauJet30].first =
       iConfig.getParameter<double>("L1_IsoEG10_TauJet30_thresh1");
   doubleThresholds_[L1ParticleMap::kIsoEG10_TauJet30].second =
       iConfig.getParameter<double>("L1_IsoEG10_TauJet30_thresh2");
-  prescales_[L1ParticleMap::kIsoEG10_TauJet30] =
-      iConfig.getParameter<int>("L1_IsoEG10_TauJet30_prescale");
+  prescales_[L1ParticleMap::kIsoEG10_TauJet30] = iConfig.getParameter<int>("L1_IsoEG10_TauJet30_prescale");
 
-  doubleThresholds_[L1ParticleMap::kEG10_Jet15].first =
-      iConfig.getParameter<double>("L1_EG10_Jet15_thresh1");
-  doubleThresholds_[L1ParticleMap::kEG10_Jet15].second =
-      iConfig.getParameter<double>("L1_EG10_Jet15_thresh2");
-  prescales_[L1ParticleMap::kEG10_Jet15] =
-      iConfig.getParameter<int>("L1_EG10_Jet15_prescale");
-  doubleThresholds_[L1ParticleMap::kEG12_Jet20].first =
-      iConfig.getParameter<double>("L1_EG12_Jet20_thresh1");
-  doubleThresholds_[L1ParticleMap::kEG12_Jet20].second =
-      iConfig.getParameter<double>("L1_EG12_Jet20_thresh2");
-  prescales_[L1ParticleMap::kEG12_Jet20] =
-      iConfig.getParameter<int>("L1_EG12_Jet20_prescale");
-  doubleThresholds_[L1ParticleMap::kEG12_Jet70].first =
-      iConfig.getParameter<double>("L1_EG12_Jet70_thresh1");
-  doubleThresholds_[L1ParticleMap::kEG12_Jet70].second =
-      iConfig.getParameter<double>("L1_EG12_Jet70_thresh2");
-  prescales_[L1ParticleMap::kEG12_Jet70] =
-      iConfig.getParameter<int>("L1_EG12_Jet70_prescale");
+  doubleThresholds_[L1ParticleMap::kEG10_Jet15].first = iConfig.getParameter<double>("L1_EG10_Jet15_thresh1");
+  doubleThresholds_[L1ParticleMap::kEG10_Jet15].second = iConfig.getParameter<double>("L1_EG10_Jet15_thresh2");
+  prescales_[L1ParticleMap::kEG10_Jet15] = iConfig.getParameter<int>("L1_EG10_Jet15_prescale");
+  doubleThresholds_[L1ParticleMap::kEG12_Jet20].first = iConfig.getParameter<double>("L1_EG12_Jet20_thresh1");
+  doubleThresholds_[L1ParticleMap::kEG12_Jet20].second = iConfig.getParameter<double>("L1_EG12_Jet20_thresh2");
+  prescales_[L1ParticleMap::kEG12_Jet20] = iConfig.getParameter<int>("L1_EG12_Jet20_prescale");
+  doubleThresholds_[L1ParticleMap::kEG12_Jet70].first = iConfig.getParameter<double>("L1_EG12_Jet70_thresh1");
+  doubleThresholds_[L1ParticleMap::kEG12_Jet70].second = iConfig.getParameter<double>("L1_EG12_Jet70_thresh2");
+  prescales_[L1ParticleMap::kEG12_Jet70] = iConfig.getParameter<int>("L1_EG12_Jet70_prescale");
 
-  doubleThresholds_[L1ParticleMap::kEG12_TauJet40].first =
-      iConfig.getParameter<double>("L1_EG12_TauJet40_thresh1");
-  doubleThresholds_[L1ParticleMap::kEG12_TauJet40].second =
-      iConfig.getParameter<double>("L1_EG12_TauJet40_thresh2");
-  prescales_[L1ParticleMap::kEG12_TauJet40] =
-      iConfig.getParameter<int>("L1_EG12_TauJet40_prescale");
+  doubleThresholds_[L1ParticleMap::kEG12_TauJet40].first = iConfig.getParameter<double>("L1_EG12_TauJet40_thresh1");
+  doubleThresholds_[L1ParticleMap::kEG12_TauJet40].second = iConfig.getParameter<double>("L1_EG12_TauJet40_thresh2");
+  prescales_[L1ParticleMap::kEG12_TauJet40] = iConfig.getParameter<int>("L1_EG12_TauJet40_prescale");
 
-  doubleThresholds_[L1ParticleMap::kJet70_TauJet40].first =
-      iConfig.getParameter<double>("L1_Jet70_TauJet40_thresh1");
-  doubleThresholds_[L1ParticleMap::kJet70_TauJet40].second =
-      iConfig.getParameter<double>("L1_Jet70_TauJet40_thresh2");
-  prescales_[L1ParticleMap::kJet70_TauJet40] =
-      iConfig.getParameter<int>("L1_Jet70_TauJet40_prescale");
+  doubleThresholds_[L1ParticleMap::kJet70_TauJet40].first = iConfig.getParameter<double>("L1_Jet70_TauJet40_thresh1");
+  doubleThresholds_[L1ParticleMap::kJet70_TauJet40].second = iConfig.getParameter<double>("L1_Jet70_TauJet40_thresh2");
+  prescales_[L1ParticleMap::kJet70_TauJet40] = iConfig.getParameter<int>("L1_Jet70_TauJet40_prescale");
 
-  doubleThresholds_[L1ParticleMap::kMu3_HTT200].first =
-      iConfig.getParameter<double>("L1_Mu3_HTT200_thresh1");
-  doubleThresholds_[L1ParticleMap::kMu3_HTT200].second =
-      iConfig.getParameter<double>("L1_Mu3_HTT200_thresh2");
-  prescales_[L1ParticleMap::kMu3_HTT200] =
-      iConfig.getParameter<int>("L1_Mu3_HTT200_prescale");
-  doubleThresholds_[L1ParticleMap::kIsoEG10_HTT200].first =
-      iConfig.getParameter<double>("L1_IsoEG10_HTT200_thresh1");
-  doubleThresholds_[L1ParticleMap::kIsoEG10_HTT200].second =
-      iConfig.getParameter<double>("L1_IsoEG10_HTT200_thresh2");
-  prescales_[L1ParticleMap::kIsoEG10_HTT200] =
-      iConfig.getParameter<int>("L1_IsoEG10_HTT200_prescale");
-  doubleThresholds_[L1ParticleMap::kEG12_HTT200].first =
-      iConfig.getParameter<double>("L1_EG12_HTT200_thresh1");
-  doubleThresholds_[L1ParticleMap::kEG12_HTT200].second =
-      iConfig.getParameter<double>("L1_EG12_HTT200_thresh2");
-  prescales_[L1ParticleMap::kEG12_HTT200] =
-      iConfig.getParameter<int>("L1_EG12_HTT200_prescale");
-  doubleThresholds_[L1ParticleMap::kJet70_HTT200].first =
-      iConfig.getParameter<double>("L1_Jet70_HTT200_thresh1");
-  doubleThresholds_[L1ParticleMap::kJet70_HTT200].second =
-      iConfig.getParameter<double>("L1_Jet70_HTT200_thresh2");
-  prescales_[L1ParticleMap::kJet70_HTT200] =
-      iConfig.getParameter<int>("L1_Jet70_HTT200_prescale");
-  doubleThresholds_[L1ParticleMap::kTauJet40_HTT200].first =
-      iConfig.getParameter<double>("L1_TauJet40_HTT200_thresh1");
+  doubleThresholds_[L1ParticleMap::kMu3_HTT200].first = iConfig.getParameter<double>("L1_Mu3_HTT200_thresh1");
+  doubleThresholds_[L1ParticleMap::kMu3_HTT200].second = iConfig.getParameter<double>("L1_Mu3_HTT200_thresh2");
+  prescales_[L1ParticleMap::kMu3_HTT200] = iConfig.getParameter<int>("L1_Mu3_HTT200_prescale");
+  doubleThresholds_[L1ParticleMap::kIsoEG10_HTT200].first = iConfig.getParameter<double>("L1_IsoEG10_HTT200_thresh1");
+  doubleThresholds_[L1ParticleMap::kIsoEG10_HTT200].second = iConfig.getParameter<double>("L1_IsoEG10_HTT200_thresh2");
+  prescales_[L1ParticleMap::kIsoEG10_HTT200] = iConfig.getParameter<int>("L1_IsoEG10_HTT200_prescale");
+  doubleThresholds_[L1ParticleMap::kEG12_HTT200].first = iConfig.getParameter<double>("L1_EG12_HTT200_thresh1");
+  doubleThresholds_[L1ParticleMap::kEG12_HTT200].second = iConfig.getParameter<double>("L1_EG12_HTT200_thresh2");
+  prescales_[L1ParticleMap::kEG12_HTT200] = iConfig.getParameter<int>("L1_EG12_HTT200_prescale");
+  doubleThresholds_[L1ParticleMap::kJet70_HTT200].first = iConfig.getParameter<double>("L1_Jet70_HTT200_thresh1");
+  doubleThresholds_[L1ParticleMap::kJet70_HTT200].second = iConfig.getParameter<double>("L1_Jet70_HTT200_thresh2");
+  prescales_[L1ParticleMap::kJet70_HTT200] = iConfig.getParameter<int>("L1_Jet70_HTT200_prescale");
+  doubleThresholds_[L1ParticleMap::kTauJet40_HTT200].first = iConfig.getParameter<double>("L1_TauJet40_HTT200_thresh1");
   doubleThresholds_[L1ParticleMap::kTauJet40_HTT200].second =
       iConfig.getParameter<double>("L1_TauJet40_HTT200_thresh2");
-  prescales_[L1ParticleMap::kTauJet40_HTT200] =
-      iConfig.getParameter<int>("L1_TauJet40_HTT200_prescale");
+  prescales_[L1ParticleMap::kTauJet40_HTT200] = iConfig.getParameter<int>("L1_TauJet40_HTT200_prescale");
 
-  doubleThresholds_[L1ParticleMap::kMu3_ETM30].first =
-      iConfig.getParameter<double>("L1_Mu3_ETM30_thresh1");
-  doubleThresholds_[L1ParticleMap::kMu3_ETM30].second =
-      iConfig.getParameter<double>("L1_Mu3_ETM30_thresh2");
-  prescales_[L1ParticleMap::kMu3_ETM30] =
-      iConfig.getParameter<int>("L1_Mu3_ETM30_prescale");
-  doubleThresholds_[L1ParticleMap::kIsoEG10_ETM30].first =
-      iConfig.getParameter<double>("L1_IsoEG10_ETM30_thresh1");
-  doubleThresholds_[L1ParticleMap::kIsoEG10_ETM30].second =
-      iConfig.getParameter<double>("L1_IsoEG10_ETM30_thresh2");
-  prescales_[L1ParticleMap::kIsoEG10_ETM30] =
-      iConfig.getParameter<int>("L1_IsoEG10_ETM30_prescale");
-  doubleThresholds_[L1ParticleMap::kEG12_ETM30].first =
-      iConfig.getParameter<double>("L1_EG12_ETM30_thresh1");
-  doubleThresholds_[L1ParticleMap::kEG12_ETM30].second =
-      iConfig.getParameter<double>("L1_EG12_ETM30_thresh2");
-  prescales_[L1ParticleMap::kEG12_ETM30] =
-      iConfig.getParameter<int>("L1_EG12_ETM30_prescale");
-  doubleThresholds_[L1ParticleMap::kJet70_ETM40].first =
-      iConfig.getParameter<double>("L1_Jet70_ETM40_thresh1");
-  doubleThresholds_[L1ParticleMap::kJet70_ETM40].second =
-      iConfig.getParameter<double>("L1_Jet70_ETM40_thresh2");
-  prescales_[L1ParticleMap::kJet70_ETM40] =
-      iConfig.getParameter<int>("L1_Jet70_ETM40_prescale");
+  doubleThresholds_[L1ParticleMap::kMu3_ETM30].first = iConfig.getParameter<double>("L1_Mu3_ETM30_thresh1");
+  doubleThresholds_[L1ParticleMap::kMu3_ETM30].second = iConfig.getParameter<double>("L1_Mu3_ETM30_thresh2");
+  prescales_[L1ParticleMap::kMu3_ETM30] = iConfig.getParameter<int>("L1_Mu3_ETM30_prescale");
+  doubleThresholds_[L1ParticleMap::kIsoEG10_ETM30].first = iConfig.getParameter<double>("L1_IsoEG10_ETM30_thresh1");
+  doubleThresholds_[L1ParticleMap::kIsoEG10_ETM30].second = iConfig.getParameter<double>("L1_IsoEG10_ETM30_thresh2");
+  prescales_[L1ParticleMap::kIsoEG10_ETM30] = iConfig.getParameter<int>("L1_IsoEG10_ETM30_prescale");
+  doubleThresholds_[L1ParticleMap::kEG12_ETM30].first = iConfig.getParameter<double>("L1_EG12_ETM30_thresh1");
+  doubleThresholds_[L1ParticleMap::kEG12_ETM30].second = iConfig.getParameter<double>("L1_EG12_ETM30_thresh2");
+  prescales_[L1ParticleMap::kEG12_ETM30] = iConfig.getParameter<int>("L1_EG12_ETM30_prescale");
+  doubleThresholds_[L1ParticleMap::kJet70_ETM40].first = iConfig.getParameter<double>("L1_Jet70_ETM40_thresh1");
+  doubleThresholds_[L1ParticleMap::kJet70_ETM40].second = iConfig.getParameter<double>("L1_Jet70_ETM40_thresh2");
+  prescales_[L1ParticleMap::kJet70_ETM40] = iConfig.getParameter<int>("L1_Jet70_ETM40_prescale");
 
-  doubleThresholds_[L1ParticleMap::kTauJet20_ETM20].first =
-      iConfig.getParameter<double>("L1_TauJet20_ETM20_thresh1");
-  doubleThresholds_[L1ParticleMap::kTauJet20_ETM20].second =
-      iConfig.getParameter<double>("L1_TauJet20_ETM20_thresh2");
-  prescales_[L1ParticleMap::kTauJet20_ETM20] =
-      iConfig.getParameter<int>("L1_TauJet20_ETM20_prescale");
-  doubleThresholds_[L1ParticleMap::kTauJet30_ETM30].first =
-      iConfig.getParameter<double>("L1_TauJet30_ETM30_thresh1");
-  doubleThresholds_[L1ParticleMap::kTauJet30_ETM30].second =
-      iConfig.getParameter<double>("L1_TauJet30_ETM30_thresh2");
-  prescales_[L1ParticleMap::kTauJet30_ETM30] =
-      iConfig.getParameter<int>("L1_TauJet30_ETM30_prescale");
-  doubleThresholds_[L1ParticleMap::kTauJet30_ETM40].first =
-      iConfig.getParameter<double>("L1_TauJet30_ETM40_thresh1");
-  doubleThresholds_[L1ParticleMap::kTauJet30_ETM40].second =
-      iConfig.getParameter<double>("L1_TauJet30_ETM40_thresh2");
-  prescales_[L1ParticleMap::kTauJet30_ETM40] =
-      iConfig.getParameter<int>("L1_TauJet30_ETM40_prescale");
+  doubleThresholds_[L1ParticleMap::kTauJet20_ETM20].first = iConfig.getParameter<double>("L1_TauJet20_ETM20_thresh1");
+  doubleThresholds_[L1ParticleMap::kTauJet20_ETM20].second = iConfig.getParameter<double>("L1_TauJet20_ETM20_thresh2");
+  prescales_[L1ParticleMap::kTauJet20_ETM20] = iConfig.getParameter<int>("L1_TauJet20_ETM20_prescale");
+  doubleThresholds_[L1ParticleMap::kTauJet30_ETM30].first = iConfig.getParameter<double>("L1_TauJet30_ETM30_thresh1");
+  doubleThresholds_[L1ParticleMap::kTauJet30_ETM30].second = iConfig.getParameter<double>("L1_TauJet30_ETM30_thresh2");
+  prescales_[L1ParticleMap::kTauJet30_ETM30] = iConfig.getParameter<int>("L1_TauJet30_ETM30_prescale");
+  doubleThresholds_[L1ParticleMap::kTauJet30_ETM40].first = iConfig.getParameter<double>("L1_TauJet30_ETM40_thresh1");
+  doubleThresholds_[L1ParticleMap::kTauJet30_ETM40].second = iConfig.getParameter<double>("L1_TauJet30_ETM40_thresh2");
+  prescales_[L1ParticleMap::kTauJet30_ETM40] = iConfig.getParameter<int>("L1_TauJet30_ETM40_prescale");
 
-  doubleThresholds_[L1ParticleMap::kHTT100_ETM30].first =
-      iConfig.getParameter<double>("L1_HTT100_ETM30_thresh1");
-  doubleThresholds_[L1ParticleMap::kHTT100_ETM30].second =
-      iConfig.getParameter<double>("L1_HTT100_ETM30_thresh2");
-  prescales_[L1ParticleMap::kHTT100_ETM30] =
-      iConfig.getParameter<int>("L1_HTT100_ETM30_prescale");
+  doubleThresholds_[L1ParticleMap::kHTT100_ETM30].first = iConfig.getParameter<double>("L1_HTT100_ETM30_thresh1");
+  doubleThresholds_[L1ParticleMap::kHTT100_ETM30].second = iConfig.getParameter<double>("L1_HTT100_ETM30_thresh2");
+  prescales_[L1ParticleMap::kHTT100_ETM30] = iConfig.getParameter<int>("L1_HTT100_ETM30_prescale");
 
   // AAA triggers
 
-  singleThresholds_[L1ParticleMap::kTripleMu3] =
-      iConfig.getParameter<double>("L1_TripleMu3_thresh");
-  prescales_[L1ParticleMap::kTripleMu3] =
-      iConfig.getParameter<int>("L1_TripleMu3_prescale");
-  singleThresholds_[L1ParticleMap::kTripleIsoEG5] =
-      iConfig.getParameter<double>("L1_TripleIsoEG5_thresh");
-  prescales_[L1ParticleMap::kTripleIsoEG5] =
-      iConfig.getParameter<int>("L1_TripleIsoEG5_prescale");
-  singleThresholds_[L1ParticleMap::kTripleEG10] =
-      iConfig.getParameter<double>("L1_TripleEG10_thresh");
-  prescales_[L1ParticleMap::kTripleEG10] =
-      iConfig.getParameter<int>("L1_TripleEG10_prescale");
-  singleThresholds_[L1ParticleMap::kTripleJet50] =
-      iConfig.getParameter<double>("L1_TripleJet50_thresh");
-  prescales_[L1ParticleMap::kTripleJet50] =
-      iConfig.getParameter<int>("L1_TripleJet50_prescale");
-  singleThresholds_[L1ParticleMap::kTripleTauJet40] =
-      iConfig.getParameter<double>("L1_TripleTauJet40_thresh");
-  prescales_[L1ParticleMap::kTripleTauJet40] =
-      iConfig.getParameter<int>("L1_TripleTauJet40_prescale");
+  singleThresholds_[L1ParticleMap::kTripleMu3] = iConfig.getParameter<double>("L1_TripleMu3_thresh");
+  prescales_[L1ParticleMap::kTripleMu3] = iConfig.getParameter<int>("L1_TripleMu3_prescale");
+  singleThresholds_[L1ParticleMap::kTripleIsoEG5] = iConfig.getParameter<double>("L1_TripleIsoEG5_thresh");
+  prescales_[L1ParticleMap::kTripleIsoEG5] = iConfig.getParameter<int>("L1_TripleIsoEG5_prescale");
+  singleThresholds_[L1ParticleMap::kTripleEG10] = iConfig.getParameter<double>("L1_TripleEG10_thresh");
+  prescales_[L1ParticleMap::kTripleEG10] = iConfig.getParameter<int>("L1_TripleEG10_prescale");
+  singleThresholds_[L1ParticleMap::kTripleJet50] = iConfig.getParameter<double>("L1_TripleJet50_thresh");
+  prescales_[L1ParticleMap::kTripleJet50] = iConfig.getParameter<int>("L1_TripleJet50_prescale");
+  singleThresholds_[L1ParticleMap::kTripleTauJet40] = iConfig.getParameter<double>("L1_TripleTauJet40_thresh");
+  prescales_[L1ParticleMap::kTripleTauJet40] = iConfig.getParameter<int>("L1_TripleTauJet40_prescale");
 
   // AAB triggers
 
@@ -582,106 +348,82 @@ L1ExtraParticleMapProd::L1ExtraParticleMapProd(const edm::ParameterSet &iConfig)
       iConfig.getParameter<double>("L1_DoubleMu3_IsoEG5_thresh1");
   doubleThresholds_[L1ParticleMap::kDoubleMu3_IsoEG5].second =
       iConfig.getParameter<double>("L1_DoubleMu3_IsoEG5_thresh2");
-  prescales_[L1ParticleMap::kDoubleMu3_IsoEG5] =
-      iConfig.getParameter<int>("L1_DoubleMu3_IsoEG5_prescale");
-  doubleThresholds_[L1ParticleMap::kDoubleMu3_EG10].first =
-      iConfig.getParameter<double>("L1_DoubleMu3_EG10_thresh1");
-  doubleThresholds_[L1ParticleMap::kDoubleMu3_EG10].second =
-      iConfig.getParameter<double>("L1_DoubleMu3_EG10_thresh2");
-  prescales_[L1ParticleMap::kDoubleMu3_EG10] =
-      iConfig.getParameter<int>("L1_DoubleMu3_EG10_prescale");
+  prescales_[L1ParticleMap::kDoubleMu3_IsoEG5] = iConfig.getParameter<int>("L1_DoubleMu3_IsoEG5_prescale");
+  doubleThresholds_[L1ParticleMap::kDoubleMu3_EG10].first = iConfig.getParameter<double>("L1_DoubleMu3_EG10_thresh1");
+  doubleThresholds_[L1ParticleMap::kDoubleMu3_EG10].second = iConfig.getParameter<double>("L1_DoubleMu3_EG10_thresh2");
+  prescales_[L1ParticleMap::kDoubleMu3_EG10] = iConfig.getParameter<int>("L1_DoubleMu3_EG10_prescale");
   doubleThresholds_[L1ParticleMap::kDoubleIsoEG5_Mu3].first =
       iConfig.getParameter<double>("L1_DoubleIsoEG5_Mu3_thresh1");
   doubleThresholds_[L1ParticleMap::kDoubleIsoEG5_Mu3].second =
       iConfig.getParameter<double>("L1_DoubleIsoEG5_Mu3_thresh2");
-  prescales_[L1ParticleMap::kDoubleIsoEG5_Mu3] =
-      iConfig.getParameter<int>("L1_DoubleIsoEG5_Mu3_prescale");
-  doubleThresholds_[L1ParticleMap::kDoubleEG10_Mu3].first =
-      iConfig.getParameter<double>("L1_DoubleEG10_Mu3_thresh1");
-  doubleThresholds_[L1ParticleMap::kDoubleEG10_Mu3].second =
-      iConfig.getParameter<double>("L1_DoubleEG10_Mu3_thresh2");
-  prescales_[L1ParticleMap::kDoubleEG10_Mu3] =
-      iConfig.getParameter<int>("L1_DoubleEG10_Mu3_prescale");
+  prescales_[L1ParticleMap::kDoubleIsoEG5_Mu3] = iConfig.getParameter<int>("L1_DoubleIsoEG5_Mu3_prescale");
+  doubleThresholds_[L1ParticleMap::kDoubleEG10_Mu3].first = iConfig.getParameter<double>("L1_DoubleEG10_Mu3_thresh1");
+  doubleThresholds_[L1ParticleMap::kDoubleEG10_Mu3].second = iConfig.getParameter<double>("L1_DoubleEG10_Mu3_thresh2");
+  prescales_[L1ParticleMap::kDoubleEG10_Mu3] = iConfig.getParameter<int>("L1_DoubleEG10_Mu3_prescale");
 
   doubleThresholds_[L1ParticleMap::kDoubleMu3_HTT200].first =
       iConfig.getParameter<double>("L1_DoubleMu3_HTT200_thresh1");
   doubleThresholds_[L1ParticleMap::kDoubleMu3_HTT200].second =
       iConfig.getParameter<double>("L1_DoubleMu3_HTT200_thresh2");
-  prescales_[L1ParticleMap::kDoubleMu3_HTT200] =
-      iConfig.getParameter<int>("L1_DoubleMu3_HTT200_prescale");
+  prescales_[L1ParticleMap::kDoubleMu3_HTT200] = iConfig.getParameter<int>("L1_DoubleMu3_HTT200_prescale");
   doubleThresholds_[L1ParticleMap::kDoubleIsoEG5_HTT200].first =
       iConfig.getParameter<double>("L1_DoubleIsoEG5_HTT200_thresh1");
   doubleThresholds_[L1ParticleMap::kDoubleIsoEG5_HTT200].second =
       iConfig.getParameter<double>("L1_DoubleIsoEG5_HTT200_thresh2");
-  prescales_[L1ParticleMap::kDoubleIsoEG5_HTT200] =
-      iConfig.getParameter<int>("L1_DoubleIsoEG5_HTT200_prescale");
+  prescales_[L1ParticleMap::kDoubleIsoEG5_HTT200] = iConfig.getParameter<int>("L1_DoubleIsoEG5_HTT200_prescale");
   doubleThresholds_[L1ParticleMap::kDoubleEG10_HTT200].first =
       iConfig.getParameter<double>("L1_DoubleEG10_HTT200_thresh1");
   doubleThresholds_[L1ParticleMap::kDoubleEG10_HTT200].second =
       iConfig.getParameter<double>("L1_DoubleEG10_HTT200_thresh2");
-  prescales_[L1ParticleMap::kDoubleEG10_HTT200] =
-      iConfig.getParameter<int>("L1_DoubleEG10_HTT200_prescale");
+  prescales_[L1ParticleMap::kDoubleEG10_HTT200] = iConfig.getParameter<int>("L1_DoubleEG10_HTT200_prescale");
   doubleThresholds_[L1ParticleMap::kDoubleJet50_HTT200].first =
       iConfig.getParameter<double>("L1_DoubleJet50_HTT200_thresh1");
   doubleThresholds_[L1ParticleMap::kDoubleJet50_HTT200].second =
       iConfig.getParameter<double>("L1_DoubleJet50_HTT200_thresh2");
-  prescales_[L1ParticleMap::kDoubleJet50_HTT200] =
-      iConfig.getParameter<int>("L1_DoubleJet50_HTT200_prescale");
+  prescales_[L1ParticleMap::kDoubleJet50_HTT200] = iConfig.getParameter<int>("L1_DoubleJet50_HTT200_prescale");
   doubleThresholds_[L1ParticleMap::kDoubleTauJet40_HTT200].first =
       iConfig.getParameter<double>("L1_DoubleTauJet40_HTT200_thresh1");
   doubleThresholds_[L1ParticleMap::kDoubleTauJet40_HTT200].second =
       iConfig.getParameter<double>("L1_DoubleTauJet40_HTT200_thresh2");
-  prescales_[L1ParticleMap::kDoubleTauJet40_HTT200] =
-      iConfig.getParameter<int>("L1_DoubleTauJet40_HTT200_prescale");
+  prescales_[L1ParticleMap::kDoubleTauJet40_HTT200] = iConfig.getParameter<int>("L1_DoubleTauJet40_HTT200_prescale");
 
-  doubleThresholds_[L1ParticleMap::kDoubleMu3_ETM20].first =
-      iConfig.getParameter<double>("L1_DoubleMu3_ETM20_thresh1");
+  doubleThresholds_[L1ParticleMap::kDoubleMu3_ETM20].first = iConfig.getParameter<double>("L1_DoubleMu3_ETM20_thresh1");
   doubleThresholds_[L1ParticleMap::kDoubleMu3_ETM20].second =
       iConfig.getParameter<double>("L1_DoubleMu3_ETM20_thresh2");
-  prescales_[L1ParticleMap::kDoubleMu3_ETM20] =
-      iConfig.getParameter<int>("L1_DoubleMu3_ETM20_prescale");
+  prescales_[L1ParticleMap::kDoubleMu3_ETM20] = iConfig.getParameter<int>("L1_DoubleMu3_ETM20_prescale");
   doubleThresholds_[L1ParticleMap::kDoubleIsoEG5_ETM20].first =
       iConfig.getParameter<double>("L1_DoubleIsoEG5_ETM20_thresh1");
   doubleThresholds_[L1ParticleMap::kDoubleIsoEG5_ETM20].second =
       iConfig.getParameter<double>("L1_DoubleIsoEG5_ETM20_thresh2");
-  prescales_[L1ParticleMap::kDoubleIsoEG5_ETM20] =
-      iConfig.getParameter<int>("L1_DoubleIsoEG5_ETM20_prescale");
+  prescales_[L1ParticleMap::kDoubleIsoEG5_ETM20] = iConfig.getParameter<int>("L1_DoubleIsoEG5_ETM20_prescale");
   doubleThresholds_[L1ParticleMap::kDoubleEG10_ETM20].first =
       iConfig.getParameter<double>("L1_DoubleEG10_ETM20_thresh1");
   doubleThresholds_[L1ParticleMap::kDoubleEG10_ETM20].second =
       iConfig.getParameter<double>("L1_DoubleEG10_ETM20_thresh2");
-  prescales_[L1ParticleMap::kDoubleEG10_ETM20] =
-      iConfig.getParameter<int>("L1_DoubleEG10_ETM20_prescale");
+  prescales_[L1ParticleMap::kDoubleEG10_ETM20] = iConfig.getParameter<int>("L1_DoubleEG10_ETM20_prescale");
   doubleThresholds_[L1ParticleMap::kDoubleJet50_ETM20].first =
       iConfig.getParameter<double>("L1_DoubleJet50_ETM20_thresh1");
   doubleThresholds_[L1ParticleMap::kDoubleJet50_ETM20].second =
       iConfig.getParameter<double>("L1_DoubleJet50_ETM20_thresh2");
-  prescales_[L1ParticleMap::kDoubleJet50_ETM20] =
-      iConfig.getParameter<int>("L1_DoubleJet50_ETM20_prescale");
+  prescales_[L1ParticleMap::kDoubleJet50_ETM20] = iConfig.getParameter<int>("L1_DoubleJet50_ETM20_prescale");
   doubleThresholds_[L1ParticleMap::kDoubleTauJet40_ETM20].first =
       iConfig.getParameter<double>("L1_DoubleTauJet40_ETM20_thresh1");
   doubleThresholds_[L1ParticleMap::kDoubleTauJet40_ETM20].second =
       iConfig.getParameter<double>("L1_DoubleTauJet40_ETM20_thresh2");
-  prescales_[L1ParticleMap::kDoubleTauJet40_ETM20] =
-      iConfig.getParameter<int>("L1_DoubleTauJet40_ETM20_prescale");
+  prescales_[L1ParticleMap::kDoubleTauJet40_ETM20] = iConfig.getParameter<int>("L1_DoubleTauJet40_ETM20_prescale");
 
-  singleThresholds_[L1ParticleMap::kQuadJet30] =
-      iConfig.getParameter<double>("L1_QuadJet30_thresh");
-  prescales_[L1ParticleMap::kQuadJet30] =
-      iConfig.getParameter<int>("L1_QuadJet30_prescale");
+  singleThresholds_[L1ParticleMap::kQuadJet30] = iConfig.getParameter<double>("L1_QuadJet30_thresh");
+  prescales_[L1ParticleMap::kQuadJet30] = iConfig.getParameter<int>("L1_QuadJet30_prescale");
 
   // Diffractive triggers
   doubleThresholds_[L1ParticleMap::kExclusiveDoubleIsoEG4].first =
       iConfig.getParameter<double>("L1_ExclusiveDoubleIsoEG4_thresh1");
   doubleThresholds_[L1ParticleMap::kExclusiveDoubleIsoEG4].second =
-      iConfig.getParameter<double>(
-          "L1_ExclusiveDoubleIsoEG4_thresh2"); // for jet rejection
-  prescales_[L1ParticleMap::kExclusiveDoubleIsoEG4] =
-      iConfig.getParameter<int>("L1_ExclusiveDoubleIsoEG4_prescale");
+      iConfig.getParameter<double>("L1_ExclusiveDoubleIsoEG4_thresh2");  // for jet rejection
+  prescales_[L1ParticleMap::kExclusiveDoubleIsoEG4] = iConfig.getParameter<int>("L1_ExclusiveDoubleIsoEG4_prescale");
   singleThresholds_[L1ParticleMap::kExclusiveDoubleJet60] =
       iConfig.getParameter<double>("L1_ExclusiveDoubleJet60_thresh");
-  prescales_[L1ParticleMap::kExclusiveDoubleJet60] =
-      iConfig.getParameter<int>("L1_ExclusiveDoubleJet60_prescale");
+  prescales_[L1ParticleMap::kExclusiveDoubleJet60] = iConfig.getParameter<int>("L1_ExclusiveDoubleJet60_prescale");
   singleThresholds_[L1ParticleMap::kExclusiveJet25_Gap_Jet25] =
       iConfig.getParameter<double>("L1_ExclusiveJet25_Gap_Jet25_thresh");
   prescales_[L1ParticleMap::kExclusiveJet25_Gap_Jet25] =
@@ -692,13 +434,10 @@ L1ExtraParticleMapProd::L1ExtraParticleMapProd(const edm::ParameterSet &iConfig)
       iConfig.getParameter<double>("L1_IsoEG10_Jet20_ForJet10_thresh2");
   singleThresholds_[L1ParticleMap::kIsoEG10_Jet20_ForJet10] =
       iConfig.getParameter<double>("L1_IsoEG10_Jet20_ForJet10_thresh3");
-  prescales_[L1ParticleMap::kIsoEG10_Jet20_ForJet10] =
-      iConfig.getParameter<int>("L1_IsoEG10_Jet20_ForJet10_prescale");
+  prescales_[L1ParticleMap::kIsoEG10_Jet20_ForJet10] = iConfig.getParameter<int>("L1_IsoEG10_Jet20_ForJet10_prescale");
 
-  prescales_[L1ParticleMap::kMinBias_HTT10] =
-      iConfig.getParameter<int>("L1_MinBias_HTT10_prescale");
-  prescales_[L1ParticleMap::kZeroBias] =
-      iConfig.getParameter<int>("L1_ZeroBias_prescale");
+  prescales_[L1ParticleMap::kMinBias_HTT10] = iConfig.getParameter<int>("L1_MinBias_HTT10_prescale");
+  prescales_[L1ParticleMap::kZeroBias] = iConfig.getParameter<int>("L1_ZeroBias_prescale");
 
   //    // Print trigger table in Twiki table format.
   //    std::cout << "|  *Trigger Index*  |  *Trigger Name*  |  *E<sub>T</sub>
@@ -754,8 +493,7 @@ L1ExtraParticleMapProd::~L1ExtraParticleMapProd() {
 //
 
 // ------------ method called to produce the data  ------------
-void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
-                                     const edm::EventSetup &iSetup) {
+void L1ExtraParticleMapProd::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
   using namespace std;
   using namespace reco;
@@ -830,13 +568,11 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
       unsigned int qual = muItr->gmtMuonCand().quality();
 
       if (qual == 4 || qual == 5 || qual == 6 || qual == 7) {
-        inputMuonRefsSingle.push_back(
-            edm::Ref<L1MuonParticleCollection>(muHandle, i));
+        inputMuonRefsSingle.push_back(edm::Ref<L1MuonParticleCollection>(muHandle, i));
       }
 
       if (qual == 3 || qual == 5 || qual == 6 || qual == 7) {
-        inputMuonRefsDouble.push_back(
-            edm::Ref<L1MuonParticleCollection>(muHandle, i));
+        inputMuonRefsDouble.push_back(edm::Ref<L1MuonParticleCollection>(muHandle, i));
       }
     }
   }
@@ -852,83 +588,53 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
     L1JetParticleVectorRef outputJetRefsTmp;
     L1MuonParticleVectorRef outputMuonRefsTmp;
     L1EtMissParticleRefProd metRefTmp;
-    L1ParticleMap::L1IndexComboVector combosTmp; // unfilled for single objs
+    L1ParticleMap::L1IndexComboVector combosTmp;  // unfilled for single objs
 
-    if (itrig == L1ParticleMap::kSingleMu3 ||
-        itrig == L1ParticleMap::kSingleMu5 ||
-        itrig == L1ParticleMap::kSingleMu7 ||
-        itrig == L1ParticleMap::kSingleMu10 ||
-        itrig == L1ParticleMap::kSingleMu14 ||
-        itrig == L1ParticleMap::kSingleMu20 ||
+    if (itrig == L1ParticleMap::kSingleMu3 || itrig == L1ParticleMap::kSingleMu5 ||
+        itrig == L1ParticleMap::kSingleMu7 || itrig == L1ParticleMap::kSingleMu10 ||
+        itrig == L1ParticleMap::kSingleMu14 || itrig == L1ParticleMap::kSingleMu20 ||
         itrig == L1ParticleMap::kSingleMu25) {
       objectTypes.push_back(L1ParticleMap::kMuon);
 
-      evaluateSingleObjectTrigger(inputMuonRefsSingle, singleThresholds_[itrig],
-                                  decision, outputMuonRefsTmp);
-    } else if (itrig == L1ParticleMap::kSingleIsoEG5 ||
-               itrig == L1ParticleMap::kSingleIsoEG8 ||
-               itrig == L1ParticleMap::kSingleIsoEG10 ||
-               itrig == L1ParticleMap::kSingleIsoEG12 ||
-               itrig == L1ParticleMap::kSingleIsoEG15 ||
-               itrig == L1ParticleMap::kSingleIsoEG20 ||
+      evaluateSingleObjectTrigger(inputMuonRefsSingle, singleThresholds_[itrig], decision, outputMuonRefsTmp);
+    } else if (itrig == L1ParticleMap::kSingleIsoEG5 || itrig == L1ParticleMap::kSingleIsoEG8 ||
+               itrig == L1ParticleMap::kSingleIsoEG10 || itrig == L1ParticleMap::kSingleIsoEG12 ||
+               itrig == L1ParticleMap::kSingleIsoEG15 || itrig == L1ParticleMap::kSingleIsoEG20 ||
                itrig == L1ParticleMap::kSingleIsoEG25) {
       objectTypes.push_back(L1ParticleMap::kEM);
 
-      evaluateSingleObjectTrigger(inputIsoEmRefs, singleThresholds_[itrig],
-                                  decision, outputEmRefsTmp);
-    } else if (itrig == L1ParticleMap::kSingleEG5 ||
-               itrig == L1ParticleMap::kSingleEG8 ||
-               itrig == L1ParticleMap::kSingleEG10 ||
-               itrig == L1ParticleMap::kSingleEG12 ||
-               itrig == L1ParticleMap::kSingleEG15 ||
-               itrig == L1ParticleMap::kSingleEG20 ||
+      evaluateSingleObjectTrigger(inputIsoEmRefs, singleThresholds_[itrig], decision, outputEmRefsTmp);
+    } else if (itrig == L1ParticleMap::kSingleEG5 || itrig == L1ParticleMap::kSingleEG8 ||
+               itrig == L1ParticleMap::kSingleEG10 || itrig == L1ParticleMap::kSingleEG12 ||
+               itrig == L1ParticleMap::kSingleEG15 || itrig == L1ParticleMap::kSingleEG20 ||
                itrig == L1ParticleMap::kSingleEG25) {
       objectTypes.push_back(L1ParticleMap::kEM);
 
-      evaluateSingleObjectTrigger(inputRelaxedEmRefs, singleThresholds_[itrig],
-                                  decision, outputEmRefsTmp);
-    } else if (itrig == L1ParticleMap::kSingleJet15 ||
-               itrig == L1ParticleMap::kSingleJet20 ||
-               itrig == L1ParticleMap::kSingleJet30 ||
-               itrig == L1ParticleMap::kSingleJet50 ||
-               itrig == L1ParticleMap::kSingleJet70 ||
-               itrig == L1ParticleMap::kSingleJet100 ||
-               itrig == L1ParticleMap::kSingleJet150 ||
-               itrig == L1ParticleMap::kSingleJet200) {
+      evaluateSingleObjectTrigger(inputRelaxedEmRefs, singleThresholds_[itrig], decision, outputEmRefsTmp);
+    } else if (itrig == L1ParticleMap::kSingleJet15 || itrig == L1ParticleMap::kSingleJet20 ||
+               itrig == L1ParticleMap::kSingleJet30 || itrig == L1ParticleMap::kSingleJet50 ||
+               itrig == L1ParticleMap::kSingleJet70 || itrig == L1ParticleMap::kSingleJet100 ||
+               itrig == L1ParticleMap::kSingleJet150 || itrig == L1ParticleMap::kSingleJet200) {
       objectTypes.push_back(L1ParticleMap::kJet);
 
-      evaluateSingleObjectTrigger(inputJetRefs, singleThresholds_[itrig],
-                                  decision, outputJetRefsTmp);
-    } else if (itrig == L1ParticleMap::kSingleTauJet10 ||
-               itrig == L1ParticleMap::kSingleTauJet20 ||
-               itrig == L1ParticleMap::kSingleTauJet30 ||
-               itrig == L1ParticleMap::kSingleTauJet35 ||
-               itrig == L1ParticleMap::kSingleTauJet40 ||
-               itrig == L1ParticleMap::kSingleTauJet60 ||
-               itrig == L1ParticleMap::kSingleTauJet80 ||
-               itrig == L1ParticleMap::kSingleTauJet100) {
+      evaluateSingleObjectTrigger(inputJetRefs, singleThresholds_[itrig], decision, outputJetRefsTmp);
+    } else if (itrig == L1ParticleMap::kSingleTauJet10 || itrig == L1ParticleMap::kSingleTauJet20 ||
+               itrig == L1ParticleMap::kSingleTauJet30 || itrig == L1ParticleMap::kSingleTauJet35 ||
+               itrig == L1ParticleMap::kSingleTauJet40 || itrig == L1ParticleMap::kSingleTauJet60 ||
+               itrig == L1ParticleMap::kSingleTauJet80 || itrig == L1ParticleMap::kSingleTauJet100) {
       objectTypes.push_back(L1ParticleMap::kJet);
 
-      evaluateSingleObjectTrigger(inputTauRefs, singleThresholds_[itrig],
-                                  decision, outputJetRefsTmp);
-    } else if (itrig == L1ParticleMap::kHTT100 ||
-               itrig == L1ParticleMap::kHTT200 ||
-               itrig == L1ParticleMap::kHTT250 ||
-               itrig == L1ParticleMap::kHTT300 ||
-               itrig == L1ParticleMap::kHTT400 ||
-               itrig == L1ParticleMap::kHTT500) {
+      evaluateSingleObjectTrigger(inputTauRefs, singleThresholds_[itrig], decision, outputJetRefsTmp);
+    } else if (itrig == L1ParticleMap::kHTT100 || itrig == L1ParticleMap::kHTT200 || itrig == L1ParticleMap::kHTT250 ||
+               itrig == L1ParticleMap::kHTT300 || itrig == L1ParticleMap::kHTT400 || itrig == L1ParticleMap::kHTT500) {
       objectTypes.push_back(L1ParticleMap::kEtHad);
 
       if (ht >= singleThresholds_[itrig]) {
         decision = true;
         metRefTmp = L1EtMissParticleRefProd(mhtHandle);
       }
-    } else if (itrig == L1ParticleMap::kETM10 ||
-               itrig == L1ParticleMap::kETM15 ||
-               itrig == L1ParticleMap::kETM20 ||
-               itrig == L1ParticleMap::kETM30 ||
-               itrig == L1ParticleMap::kETM40 ||
-               itrig == L1ParticleMap::kETM50 ||
+    } else if (itrig == L1ParticleMap::kETM10 || itrig == L1ParticleMap::kETM15 || itrig == L1ParticleMap::kETM20 ||
+               itrig == L1ParticleMap::kETM30 || itrig == L1ParticleMap::kETM40 || itrig == L1ParticleMap::kETM50 ||
                itrig == L1ParticleMap::kETM60) {
       objectTypes.push_back(L1ParticleMap::kEtMiss);
 
@@ -947,140 +653,158 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
       objectTypes.push_back(L1ParticleMap::kMuon);
       objectTypes.push_back(L1ParticleMap::kMuon);
 
-      evaluateDoubleSameObjectTrigger(inputMuonRefsDouble,
-                                      singleThresholds_[itrig], decision,
-                                      outputMuonRefsTmp, combosTmp);
-    } else if (itrig == L1ParticleMap::kDoubleIsoEG8 ||
-               itrig == L1ParticleMap::kDoubleIsoEG10) {
+      evaluateDoubleSameObjectTrigger(
+          inputMuonRefsDouble, singleThresholds_[itrig], decision, outputMuonRefsTmp, combosTmp);
+    } else if (itrig == L1ParticleMap::kDoubleIsoEG8 || itrig == L1ParticleMap::kDoubleIsoEG10) {
       objectTypes.push_back(L1ParticleMap::kEM);
       objectTypes.push_back(L1ParticleMap::kEM);
 
-      evaluateDoubleSameObjectTrigger(inputIsoEmRefs, singleThresholds_[itrig],
-                                      decision, outputEmRefsTmp, combosTmp);
-    } else if (itrig == L1ParticleMap::kDoubleEG5 ||
-               itrig == L1ParticleMap::kDoubleEG10 ||
+      evaluateDoubleSameObjectTrigger(inputIsoEmRefs, singleThresholds_[itrig], decision, outputEmRefsTmp, combosTmp);
+    } else if (itrig == L1ParticleMap::kDoubleEG5 || itrig == L1ParticleMap::kDoubleEG10 ||
                itrig == L1ParticleMap::kDoubleEG15) {
       objectTypes.push_back(L1ParticleMap::kEM);
       objectTypes.push_back(L1ParticleMap::kEM);
 
-      evaluateDoubleSameObjectTrigger(inputRelaxedEmRefs,
-                                      singleThresholds_[itrig], decision,
-                                      outputEmRefsTmp, combosTmp);
-    } else if (itrig == L1ParticleMap::kDoubleJet70 ||
-               itrig == L1ParticleMap::kDoubleJet100) {
+      evaluateDoubleSameObjectTrigger(
+          inputRelaxedEmRefs, singleThresholds_[itrig], decision, outputEmRefsTmp, combosTmp);
+    } else if (itrig == L1ParticleMap::kDoubleJet70 || itrig == L1ParticleMap::kDoubleJet100) {
       objectTypes.push_back(L1ParticleMap::kJet);
       objectTypes.push_back(L1ParticleMap::kJet);
 
-      evaluateDoubleSameObjectTrigger(inputJetRefs, singleThresholds_[itrig],
-                                      decision, outputJetRefsTmp, combosTmp);
-    } else if (itrig == L1ParticleMap::kDoubleTauJet20 ||
-               itrig == L1ParticleMap::kDoubleTauJet30 ||
-               itrig == L1ParticleMap::kDoubleTauJet35 ||
-               itrig == L1ParticleMap::kDoubleTauJet40) {
+      evaluateDoubleSameObjectTrigger(inputJetRefs, singleThresholds_[itrig], decision, outputJetRefsTmp, combosTmp);
+    } else if (itrig == L1ParticleMap::kDoubleTauJet20 || itrig == L1ParticleMap::kDoubleTauJet30 ||
+               itrig == L1ParticleMap::kDoubleTauJet35 || itrig == L1ParticleMap::kDoubleTauJet40) {
       objectTypes.push_back(L1ParticleMap::kJet);
       objectTypes.push_back(L1ParticleMap::kJet);
 
-      evaluateDoubleSameObjectTrigger(inputTauRefs, singleThresholds_[itrig],
-                                      decision, outputJetRefsTmp, combosTmp);
-    } else if (itrig == L1ParticleMap::kMu3_IsoEG5 ||
-               itrig == L1ParticleMap::kMu5_IsoEG10) {
+      evaluateDoubleSameObjectTrigger(inputTauRefs, singleThresholds_[itrig], decision, outputJetRefsTmp, combosTmp);
+    } else if (itrig == L1ParticleMap::kMu3_IsoEG5 || itrig == L1ParticleMap::kMu5_IsoEG10) {
       objectTypes.push_back(L1ParticleMap::kMuon);
       objectTypes.push_back(L1ParticleMap::kEM);
 
-      evaluateDoubleDifferentObjectTrigger(
-          inputMuonRefsSingle, inputIsoEmRefs, doubleThresholds_[itrig].first,
-          doubleThresholds_[itrig].second, decision, outputMuonRefsTmp,
-          outputEmRefsTmp, combosTmp);
+      evaluateDoubleDifferentObjectTrigger(inputMuonRefsSingle,
+                                           inputIsoEmRefs,
+                                           doubleThresholds_[itrig].first,
+                                           doubleThresholds_[itrig].second,
+                                           decision,
+                                           outputMuonRefsTmp,
+                                           outputEmRefsTmp,
+                                           combosTmp);
     } else if (itrig == L1ParticleMap::kMu3_EG12) {
       objectTypes.push_back(L1ParticleMap::kMuon);
       objectTypes.push_back(L1ParticleMap::kEM);
 
-      evaluateDoubleDifferentObjectTrigger(
-          inputMuonRefsSingle, inputRelaxedEmRefs,
-          doubleThresholds_[itrig].first, doubleThresholds_[itrig].second,
-          decision, outputMuonRefsTmp, outputEmRefsTmp, combosTmp);
-    } else if (itrig == L1ParticleMap::kMu3_Jet15 ||
-               itrig == L1ParticleMap::kMu5_Jet15 ||
-               itrig == L1ParticleMap::kMu3_Jet70 ||
-               itrig == L1ParticleMap::kMu5_Jet20) {
+      evaluateDoubleDifferentObjectTrigger(inputMuonRefsSingle,
+                                           inputRelaxedEmRefs,
+                                           doubleThresholds_[itrig].first,
+                                           doubleThresholds_[itrig].second,
+                                           decision,
+                                           outputMuonRefsTmp,
+                                           outputEmRefsTmp,
+                                           combosTmp);
+    } else if (itrig == L1ParticleMap::kMu3_Jet15 || itrig == L1ParticleMap::kMu5_Jet15 ||
+               itrig == L1ParticleMap::kMu3_Jet70 || itrig == L1ParticleMap::kMu5_Jet20) {
       objectTypes.push_back(L1ParticleMap::kMuon);
       objectTypes.push_back(L1ParticleMap::kJet);
 
-      evaluateDoubleDifferentObjectTrigger(
-          inputMuonRefsSingle, inputJetRefs, doubleThresholds_[itrig].first,
-          doubleThresholds_[itrig].second, decision, outputMuonRefsTmp,
-          outputJetRefsTmp, combosTmp);
-    } else if (itrig == L1ParticleMap::kMu5_TauJet20 ||
-               itrig == L1ParticleMap::kMu5_TauJet30) {
+      evaluateDoubleDifferentObjectTrigger(inputMuonRefsSingle,
+                                           inputJetRefs,
+                                           doubleThresholds_[itrig].first,
+                                           doubleThresholds_[itrig].second,
+                                           decision,
+                                           outputMuonRefsTmp,
+                                           outputJetRefsTmp,
+                                           combosTmp);
+    } else if (itrig == L1ParticleMap::kMu5_TauJet20 || itrig == L1ParticleMap::kMu5_TauJet30) {
       objectTypes.push_back(L1ParticleMap::kMuon);
       objectTypes.push_back(L1ParticleMap::kJet);
 
-      evaluateDoubleDifferentObjectTrigger(
-          inputMuonRefsSingle, inputTauRefs, doubleThresholds_[itrig].first,
-          doubleThresholds_[itrig].second, decision, outputMuonRefsTmp,
-          outputJetRefsTmp, combosTmp);
+      evaluateDoubleDifferentObjectTrigger(inputMuonRefsSingle,
+                                           inputTauRefs,
+                                           doubleThresholds_[itrig].first,
+                                           doubleThresholds_[itrig].second,
+                                           decision,
+                                           outputMuonRefsTmp,
+                                           outputJetRefsTmp,
+                                           combosTmp);
     } else if (itrig == L1ParticleMap::kIsoEG10_EG10) {
       objectTypes.push_back(L1ParticleMap::kEM);
       objectTypes.push_back(L1ParticleMap::kEM);
 
-      evaluateDoubleDifferentObjectSameTypeTrigger(
-          inputIsoEmRefs, inputRelaxedEmRefs, doubleThresholds_[itrig].first,
-          doubleThresholds_[itrig].second, decision, outputEmRefsTmp,
-          combosTmp);
-    } else if (itrig == L1ParticleMap::kIsoEG10_Jet15 ||
-               itrig == L1ParticleMap::kIsoEG10_Jet30 ||
-               itrig == L1ParticleMap::kIsoEG10_Jet20 ||
-               itrig == L1ParticleMap::kIsoEG10_Jet70) {
+      evaluateDoubleDifferentObjectSameTypeTrigger(inputIsoEmRefs,
+                                                   inputRelaxedEmRefs,
+                                                   doubleThresholds_[itrig].first,
+                                                   doubleThresholds_[itrig].second,
+                                                   decision,
+                                                   outputEmRefsTmp,
+                                                   combosTmp);
+    } else if (itrig == L1ParticleMap::kIsoEG10_Jet15 || itrig == L1ParticleMap::kIsoEG10_Jet30 ||
+               itrig == L1ParticleMap::kIsoEG10_Jet20 || itrig == L1ParticleMap::kIsoEG10_Jet70) {
       objectTypes.push_back(L1ParticleMap::kEM);
       objectTypes.push_back(L1ParticleMap::kJet);
 
-      evaluateDoubleDifferentCaloObjectTrigger(
-          inputIsoEmRefs, inputJetRefs, doubleThresholds_[itrig].first,
-          doubleThresholds_[itrig].second, decision, outputEmRefsTmp,
-          outputJetRefsTmp, combosTmp);
-    } else if (itrig == L1ParticleMap::kIsoEG10_TauJet20 ||
-               itrig == L1ParticleMap::kIsoEG10_TauJet30) {
+      evaluateDoubleDifferentCaloObjectTrigger(inputIsoEmRefs,
+                                               inputJetRefs,
+                                               doubleThresholds_[itrig].first,
+                                               doubleThresholds_[itrig].second,
+                                               decision,
+                                               outputEmRefsTmp,
+                                               outputJetRefsTmp,
+                                               combosTmp);
+    } else if (itrig == L1ParticleMap::kIsoEG10_TauJet20 || itrig == L1ParticleMap::kIsoEG10_TauJet30) {
       objectTypes.push_back(L1ParticleMap::kEM);
       objectTypes.push_back(L1ParticleMap::kJet);
 
-      evaluateDoubleDifferentCaloObjectTrigger(
-          inputIsoEmRefs, inputTauRefs, doubleThresholds_[itrig].first,
-          doubleThresholds_[itrig].second, decision, outputEmRefsTmp,
-          outputJetRefsTmp, combosTmp);
-    } else if (itrig == L1ParticleMap::kEG10_Jet15 ||
-               itrig == L1ParticleMap::kEG12_Jet20 ||
+      evaluateDoubleDifferentCaloObjectTrigger(inputIsoEmRefs,
+                                               inputTauRefs,
+                                               doubleThresholds_[itrig].first,
+                                               doubleThresholds_[itrig].second,
+                                               decision,
+                                               outputEmRefsTmp,
+                                               outputJetRefsTmp,
+                                               combosTmp);
+    } else if (itrig == L1ParticleMap::kEG10_Jet15 || itrig == L1ParticleMap::kEG12_Jet20 ||
                itrig == L1ParticleMap::kEG12_Jet70) {
       objectTypes.push_back(L1ParticleMap::kEM);
       objectTypes.push_back(L1ParticleMap::kJet);
 
-      evaluateDoubleDifferentCaloObjectTrigger(
-          inputRelaxedEmRefs, inputJetRefs, doubleThresholds_[itrig].first,
-          doubleThresholds_[itrig].second, decision, outputEmRefsTmp,
-          outputJetRefsTmp, combosTmp);
+      evaluateDoubleDifferentCaloObjectTrigger(inputRelaxedEmRefs,
+                                               inputJetRefs,
+                                               doubleThresholds_[itrig].first,
+                                               doubleThresholds_[itrig].second,
+                                               decision,
+                                               outputEmRefsTmp,
+                                               outputJetRefsTmp,
+                                               combosTmp);
     } else if (itrig == L1ParticleMap::kEG12_TauJet40) {
       objectTypes.push_back(L1ParticleMap::kEM);
       objectTypes.push_back(L1ParticleMap::kJet);
 
-      evaluateDoubleDifferentCaloObjectTrigger(
-          inputRelaxedEmRefs, inputTauRefs, doubleThresholds_[itrig].first,
-          doubleThresholds_[itrig].second, decision, outputEmRefsTmp,
-          outputJetRefsTmp, combosTmp);
+      evaluateDoubleDifferentCaloObjectTrigger(inputRelaxedEmRefs,
+                                               inputTauRefs,
+                                               doubleThresholds_[itrig].first,
+                                               doubleThresholds_[itrig].second,
+                                               decision,
+                                               outputEmRefsTmp,
+                                               outputJetRefsTmp,
+                                               combosTmp);
     } else if (itrig == L1ParticleMap::kJet70_TauJet40) {
       objectTypes.push_back(L1ParticleMap::kJet);
       objectTypes.push_back(L1ParticleMap::kJet);
 
-      evaluateDoubleDifferentObjectSameTypeTrigger(
-          inputJetRefs, inputTauRefs, doubleThresholds_[itrig].first,
-          doubleThresholds_[itrig].second, decision, outputJetRefsTmp,
-          combosTmp);
+      evaluateDoubleDifferentObjectSameTypeTrigger(inputJetRefs,
+                                                   inputTauRefs,
+                                                   doubleThresholds_[itrig].first,
+                                                   doubleThresholds_[itrig].second,
+                                                   decision,
+                                                   outputJetRefsTmp,
+                                                   combosTmp);
     } else if (itrig == L1ParticleMap::kMu3_HTT200) {
       objectTypes.push_back(L1ParticleMap::kMuon);
       objectTypes.push_back(L1ParticleMap::kEtHad);
 
       if (ht >= doubleThresholds_[itrig].second) {
-        evaluateSingleObjectTrigger(inputMuonRefsSingle,
-                                    doubleThresholds_[itrig].first, decision,
-                                    outputMuonRefsTmp);
+        evaluateSingleObjectTrigger(inputMuonRefsSingle, doubleThresholds_[itrig].first, decision, outputMuonRefsTmp);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(mhtHandle);
@@ -1091,9 +815,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
       objectTypes.push_back(L1ParticleMap::kEtHad);
 
       if (ht >= doubleThresholds_[itrig].second) {
-        evaluateSingleObjectTrigger(inputIsoEmRefs,
-                                    doubleThresholds_[itrig].first, decision,
-                                    outputEmRefsTmp);
+        evaluateSingleObjectTrigger(inputIsoEmRefs, doubleThresholds_[itrig].first, decision, outputEmRefsTmp);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(mhtHandle);
@@ -1104,9 +826,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
       objectTypes.push_back(L1ParticleMap::kEtHad);
 
       if (ht >= doubleThresholds_[itrig].second) {
-        evaluateSingleObjectTrigger(inputRelaxedEmRefs,
-                                    doubleThresholds_[itrig].first, decision,
-                                    outputEmRefsTmp);
+        evaluateSingleObjectTrigger(inputRelaxedEmRefs, doubleThresholds_[itrig].first, decision, outputEmRefsTmp);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(mhtHandle);
@@ -1117,9 +837,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
       objectTypes.push_back(L1ParticleMap::kEtHad);
 
       if (ht >= doubleThresholds_[itrig].second) {
-        evaluateSingleObjectTrigger(inputJetRefs,
-                                    doubleThresholds_[itrig].first, decision,
-                                    outputJetRefsTmp);
+        evaluateSingleObjectTrigger(inputJetRefs, doubleThresholds_[itrig].first, decision, outputJetRefsTmp);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(mhtHandle);
@@ -1130,9 +848,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
       objectTypes.push_back(L1ParticleMap::kEtHad);
 
       if (ht >= doubleThresholds_[itrig].second) {
-        evaluateSingleObjectTrigger(inputTauRefs,
-                                    doubleThresholds_[itrig].first, decision,
-                                    outputJetRefsTmp);
+        evaluateSingleObjectTrigger(inputTauRefs, doubleThresholds_[itrig].first, decision, outputJetRefsTmp);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(mhtHandle);
@@ -1143,9 +859,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
       objectTypes.push_back(L1ParticleMap::kEtMiss);
 
       if (met >= doubleThresholds_[itrig].second) {
-        evaluateSingleObjectTrigger(inputMuonRefsSingle,
-                                    doubleThresholds_[itrig].first, decision,
-                                    outputMuonRefsTmp);
+        evaluateSingleObjectTrigger(inputMuonRefsSingle, doubleThresholds_[itrig].first, decision, outputMuonRefsTmp);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(metHandle);
@@ -1156,9 +870,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
       objectTypes.push_back(L1ParticleMap::kEtMiss);
 
       if (met >= doubleThresholds_[itrig].second) {
-        evaluateSingleObjectTrigger(inputIsoEmRefs,
-                                    doubleThresholds_[itrig].first, decision,
-                                    outputEmRefsTmp);
+        evaluateSingleObjectTrigger(inputIsoEmRefs, doubleThresholds_[itrig].first, decision, outputEmRefsTmp);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(metHandle);
@@ -1169,9 +881,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
       objectTypes.push_back(L1ParticleMap::kEtMiss);
 
       if (met >= doubleThresholds_[itrig].second) {
-        evaluateSingleObjectTrigger(inputRelaxedEmRefs,
-                                    doubleThresholds_[itrig].first, decision,
-                                    outputEmRefsTmp);
+        evaluateSingleObjectTrigger(inputRelaxedEmRefs, doubleThresholds_[itrig].first, decision, outputEmRefsTmp);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(metHandle);
@@ -1182,24 +892,19 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
       objectTypes.push_back(L1ParticleMap::kEtMiss);
 
       if (met >= doubleThresholds_[itrig].second) {
-        evaluateSingleObjectTrigger(inputJetRefs,
-                                    doubleThresholds_[itrig].first, decision,
-                                    outputJetRefsTmp);
+        evaluateSingleObjectTrigger(inputJetRefs, doubleThresholds_[itrig].first, decision, outputJetRefsTmp);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(metHandle);
         }
       }
-    } else if (itrig == L1ParticleMap::kTauJet20_ETM20 ||
-               itrig == L1ParticleMap::kTauJet30_ETM30 ||
+    } else if (itrig == L1ParticleMap::kTauJet20_ETM20 || itrig == L1ParticleMap::kTauJet30_ETM30 ||
                itrig == L1ParticleMap::kTauJet30_ETM40) {
       objectTypes.push_back(L1ParticleMap::kJet);
       objectTypes.push_back(L1ParticleMap::kEtMiss);
 
       if (met >= doubleThresholds_[itrig].second) {
-        evaluateSingleObjectTrigger(inputTauRefs,
-                                    doubleThresholds_[itrig].first, decision,
-                                    outputJetRefsTmp);
+        evaluateSingleObjectTrigger(inputTauRefs, doubleThresholds_[itrig].first, decision, outputJetRefsTmp);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(metHandle);
@@ -1209,8 +914,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
       objectTypes.push_back(L1ParticleMap::kEtHad);
       objectTypes.push_back(L1ParticleMap::kEtMiss);
 
-      if (ht >= doubleThresholds_[itrig].first &&
-          met >= doubleThresholds_[itrig].second) {
+      if (ht >= doubleThresholds_[itrig].first && met >= doubleThresholds_[itrig].second) {
         decision = true;
         metRefTmp = L1EtMissParticleRefProd(metHandle);
       }
@@ -1219,74 +923,85 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
       objectTypes.push_back(L1ParticleMap::kMuon);
       objectTypes.push_back(L1ParticleMap::kMuon);
 
-      evaluateTripleSameObjectTrigger(inputMuonRefsDouble,
-                                      singleThresholds_[itrig], decision,
-                                      outputMuonRefsTmp, combosTmp);
+      evaluateTripleSameObjectTrigger(
+          inputMuonRefsDouble, singleThresholds_[itrig], decision, outputMuonRefsTmp, combosTmp);
     } else if (itrig == L1ParticleMap::kTripleIsoEG5) {
       objectTypes.push_back(L1ParticleMap::kEM);
       objectTypes.push_back(L1ParticleMap::kEM);
       objectTypes.push_back(L1ParticleMap::kEM);
 
-      evaluateTripleSameObjectTrigger(inputIsoEmRefs, singleThresholds_[itrig],
-                                      decision, outputEmRefsTmp, combosTmp);
+      evaluateTripleSameObjectTrigger(inputIsoEmRefs, singleThresholds_[itrig], decision, outputEmRefsTmp, combosTmp);
     } else if (itrig == L1ParticleMap::kTripleEG10) {
       objectTypes.push_back(L1ParticleMap::kEM);
       objectTypes.push_back(L1ParticleMap::kEM);
       objectTypes.push_back(L1ParticleMap::kEM);
 
-      evaluateTripleSameObjectTrigger(inputRelaxedEmRefs,
-                                      singleThresholds_[itrig], decision,
-                                      outputEmRefsTmp, combosTmp);
+      evaluateTripleSameObjectTrigger(
+          inputRelaxedEmRefs, singleThresholds_[itrig], decision, outputEmRefsTmp, combosTmp);
     } else if (itrig == L1ParticleMap::kTripleJet50) {
       objectTypes.push_back(L1ParticleMap::kJet);
       objectTypes.push_back(L1ParticleMap::kJet);
       objectTypes.push_back(L1ParticleMap::kJet);
 
-      evaluateTripleSameObjectTrigger(inputJetRefs, singleThresholds_[itrig],
-                                      decision, outputJetRefsTmp, combosTmp);
+      evaluateTripleSameObjectTrigger(inputJetRefs, singleThresholds_[itrig], decision, outputJetRefsTmp, combosTmp);
     } else if (itrig == L1ParticleMap::kTripleTauJet40) {
       objectTypes.push_back(L1ParticleMap::kJet);
       objectTypes.push_back(L1ParticleMap::kJet);
       objectTypes.push_back(L1ParticleMap::kJet);
 
-      evaluateTripleSameObjectTrigger(inputTauRefs, singleThresholds_[itrig],
-                                      decision, outputJetRefsTmp, combosTmp);
+      evaluateTripleSameObjectTrigger(inputTauRefs, singleThresholds_[itrig], decision, outputJetRefsTmp, combosTmp);
     } else if (itrig == L1ParticleMap::kDoubleMu3_IsoEG5) {
       objectTypes.push_back(L1ParticleMap::kMuon);
       objectTypes.push_back(L1ParticleMap::kMuon);
       objectTypes.push_back(L1ParticleMap::kEM);
 
-      evaluateDoublePlusSingleObjectTrigger(
-          inputMuonRefsDouble, inputIsoEmRefs, doubleThresholds_[itrig].first,
-          doubleThresholds_[itrig].second, decision, outputMuonRefsTmp,
-          outputEmRefsTmp, combosTmp);
+      evaluateDoublePlusSingleObjectTrigger(inputMuonRefsDouble,
+                                            inputIsoEmRefs,
+                                            doubleThresholds_[itrig].first,
+                                            doubleThresholds_[itrig].second,
+                                            decision,
+                                            outputMuonRefsTmp,
+                                            outputEmRefsTmp,
+                                            combosTmp);
     } else if (itrig == L1ParticleMap::kDoubleMu3_EG10) {
       objectTypes.push_back(L1ParticleMap::kMuon);
       objectTypes.push_back(L1ParticleMap::kMuon);
       objectTypes.push_back(L1ParticleMap::kEM);
 
-      evaluateDoublePlusSingleObjectTrigger(
-          inputMuonRefsDouble, inputRelaxedEmRefs,
-          doubleThresholds_[itrig].first, doubleThresholds_[itrig].second,
-          decision, outputMuonRefsTmp, outputEmRefsTmp, combosTmp);
+      evaluateDoublePlusSingleObjectTrigger(inputMuonRefsDouble,
+                                            inputRelaxedEmRefs,
+                                            doubleThresholds_[itrig].first,
+                                            doubleThresholds_[itrig].second,
+                                            decision,
+                                            outputMuonRefsTmp,
+                                            outputEmRefsTmp,
+                                            combosTmp);
     } else if (itrig == L1ParticleMap::kDoubleIsoEG5_Mu3) {
       objectTypes.push_back(L1ParticleMap::kEM);
       objectTypes.push_back(L1ParticleMap::kEM);
       objectTypes.push_back(L1ParticleMap::kMuon);
 
-      evaluateDoublePlusSingleObjectTrigger(
-          inputIsoEmRefs, inputMuonRefsSingle, doubleThresholds_[itrig].first,
-          doubleThresholds_[itrig].second, decision, outputEmRefsTmp,
-          outputMuonRefsTmp, combosTmp);
+      evaluateDoublePlusSingleObjectTrigger(inputIsoEmRefs,
+                                            inputMuonRefsSingle,
+                                            doubleThresholds_[itrig].first,
+                                            doubleThresholds_[itrig].second,
+                                            decision,
+                                            outputEmRefsTmp,
+                                            outputMuonRefsTmp,
+                                            combosTmp);
     } else if (itrig == L1ParticleMap::kDoubleEG10_Mu3) {
       objectTypes.push_back(L1ParticleMap::kEM);
       objectTypes.push_back(L1ParticleMap::kEM);
       objectTypes.push_back(L1ParticleMap::kMuon);
 
-      evaluateDoublePlusSingleObjectTrigger(
-          inputRelaxedEmRefs, inputMuonRefsSingle,
-          doubleThresholds_[itrig].first, doubleThresholds_[itrig].second,
-          decision, outputEmRefsTmp, outputMuonRefsTmp, combosTmp);
+      evaluateDoublePlusSingleObjectTrigger(inputRelaxedEmRefs,
+                                            inputMuonRefsSingle,
+                                            doubleThresholds_[itrig].first,
+                                            doubleThresholds_[itrig].second,
+                                            decision,
+                                            outputEmRefsTmp,
+                                            outputMuonRefsTmp,
+                                            combosTmp);
     } else if (itrig == L1ParticleMap::kDoubleMu3_HTT200) {
       objectTypes.push_back(L1ParticleMap::kMuon);
       objectTypes.push_back(L1ParticleMap::kMuon);
@@ -1294,8 +1009,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
 
       if (ht >= doubleThresholds_[itrig].second) {
         evaluateDoubleSameObjectTrigger(
-            inputMuonRefsDouble, doubleThresholds_[itrig].first, decision,
-            outputMuonRefsTmp, combosTmp, true);
+            inputMuonRefsDouble, doubleThresholds_[itrig].first, decision, outputMuonRefsTmp, combosTmp, true);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(mhtHandle);
@@ -1308,8 +1022,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
 
       if (ht >= doubleThresholds_[itrig].second) {
         evaluateDoubleSameObjectTrigger(
-            inputIsoEmRefs, doubleThresholds_[itrig].first, decision,
-            outputEmRefsTmp, combosTmp, true);
+            inputIsoEmRefs, doubleThresholds_[itrig].first, decision, outputEmRefsTmp, combosTmp, true);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(mhtHandle);
@@ -1322,8 +1035,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
 
       if (ht >= doubleThresholds_[itrig].second) {
         evaluateDoubleSameObjectTrigger(
-            inputRelaxedEmRefs, doubleThresholds_[itrig].first, decision,
-            outputEmRefsTmp, combosTmp, true);
+            inputRelaxedEmRefs, doubleThresholds_[itrig].first, decision, outputEmRefsTmp, combosTmp, true);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(mhtHandle);
@@ -1336,8 +1048,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
 
       if (ht >= doubleThresholds_[itrig].second) {
         evaluateDoubleSameObjectTrigger(
-            inputJetRefs, doubleThresholds_[itrig].first, decision,
-            outputJetRefsTmp, combosTmp, true);
+            inputJetRefs, doubleThresholds_[itrig].first, decision, outputJetRefsTmp, combosTmp, true);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(mhtHandle);
@@ -1350,8 +1061,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
 
       if (ht >= doubleThresholds_[itrig].second) {
         evaluateDoubleSameObjectTrigger(
-            inputTauRefs, doubleThresholds_[itrig].first, decision,
-            outputJetRefsTmp, combosTmp, true);
+            inputTauRefs, doubleThresholds_[itrig].first, decision, outputJetRefsTmp, combosTmp, true);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(mhtHandle);
@@ -1364,8 +1074,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
 
       if (met >= doubleThresholds_[itrig].second) {
         evaluateDoubleSameObjectTrigger(
-            inputMuonRefsDouble, doubleThresholds_[itrig].first, decision,
-            outputMuonRefsTmp, combosTmp, true);
+            inputMuonRefsDouble, doubleThresholds_[itrig].first, decision, outputMuonRefsTmp, combosTmp, true);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(metHandle);
@@ -1378,8 +1087,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
 
       if (met >= doubleThresholds_[itrig].second) {
         evaluateDoubleSameObjectTrigger(
-            inputIsoEmRefs, doubleThresholds_[itrig].first, decision,
-            outputEmRefsTmp, combosTmp, true);
+            inputIsoEmRefs, doubleThresholds_[itrig].first, decision, outputEmRefsTmp, combosTmp, true);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(metHandle);
@@ -1392,8 +1100,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
 
       if (met >= doubleThresholds_[itrig].second) {
         evaluateDoubleSameObjectTrigger(
-            inputRelaxedEmRefs, doubleThresholds_[itrig].first, decision,
-            outputEmRefsTmp, combosTmp, true);
+            inputRelaxedEmRefs, doubleThresholds_[itrig].first, decision, outputEmRefsTmp, combosTmp, true);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(metHandle);
@@ -1406,8 +1113,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
 
       if (met >= doubleThresholds_[itrig].second) {
         evaluateDoubleSameObjectTrigger(
-            inputJetRefs, doubleThresholds_[itrig].first, decision,
-            outputJetRefsTmp, combosTmp, true);
+            inputJetRefs, doubleThresholds_[itrig].first, decision, outputJetRefsTmp, combosTmp, true);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(metHandle);
@@ -1420,8 +1126,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
 
       if (met >= doubleThresholds_[itrig].second) {
         evaluateDoubleSameObjectTrigger(
-            inputTauRefs, doubleThresholds_[itrig].first, decision,
-            outputJetRefsTmp, combosTmp, true);
+            inputTauRefs, doubleThresholds_[itrig].first, decision, outputJetRefsTmp, combosTmp, true);
 
         if (decision) {
           metRefTmp = L1EtMissParticleRefProd(metHandle);
@@ -1433,46 +1138,49 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
       objectTypes.push_back(L1ParticleMap::kJet);
       objectTypes.push_back(L1ParticleMap::kJet);
 
-      evaluateQuadSameObjectTrigger(inputJetRefs, singleThresholds_[itrig],
-                                    decision, outputJetRefsTmp, combosTmp);
+      evaluateQuadSameObjectTrigger(inputJetRefs, singleThresholds_[itrig], decision, outputJetRefsTmp, combosTmp);
     } else if (itrig == L1ParticleMap::kExclusiveDoubleIsoEG4) {
       objectTypes.push_back(L1ParticleMap::kEM);
       objectTypes.push_back(L1ParticleMap::kEM);
 
-      evaluateDoubleExclusiveIsoEG(inputIsoEmRefs, inputJetRefs,
+      evaluateDoubleExclusiveIsoEG(inputIsoEmRefs,
+                                   inputJetRefs,
                                    doubleThresholds_[itrig].first,
-                                   doubleThresholds_[itrig].second, decision,
-                                   outputEmRefsTmp, combosTmp);
+                                   doubleThresholds_[itrig].second,
+                                   decision,
+                                   outputEmRefsTmp,
+                                   combosTmp);
 
     } else if (itrig == L1ParticleMap::kExclusiveDoubleJet60) {
       objectTypes.push_back(L1ParticleMap::kJet);
       objectTypes.push_back(L1ParticleMap::kJet);
 
       if (inputJetRefs.size() == 2) {
-        evaluateDoubleSameObjectTrigger(inputJetRefs, singleThresholds_[itrig],
-                                        decision, outputJetRefsTmp, combosTmp);
+        evaluateDoubleSameObjectTrigger(inputJetRefs, singleThresholds_[itrig], decision, outputJetRefsTmp, combosTmp);
       }
     } else if (itrig == L1ParticleMap::kExclusiveJet25_Gap_Jet25) {
       objectTypes.push_back(L1ParticleMap::kJet);
       objectTypes.push_back(L1ParticleMap::kJet);
 
       if (inputJetRefs.size() == 2) {
-        evaluateJetGapJetTrigger(inputForJetRefs, singleThresholds_[itrig],
-                                 decision, outputJetRefsTmp, combosTmp);
+        evaluateJetGapJetTrigger(inputForJetRefs, singleThresholds_[itrig], decision, outputJetRefsTmp, combosTmp);
       }
     } else if (itrig == L1ParticleMap::kIsoEG10_Jet20_ForJet10) {
       objectTypes.push_back(L1ParticleMap::kEM);
       objectTypes.push_back(L1ParticleMap::kJet);
 
-      evaluateForwardRapidityGap(inputForJetRefs, singleThresholds_[itrig],
-                                 decision);
+      evaluateForwardRapidityGap(inputForJetRefs, singleThresholds_[itrig], decision);
 
       if (decision) {
         decision = false;
-        evaluateDoubleDifferentCaloObjectTrigger(
-            inputIsoEmRefs, inputCenJetTauJetRefs,
-            doubleThresholds_[itrig].first, doubleThresholds_[itrig].second,
-            decision, outputEmRefsTmp, outputJetRefsTmp, combosTmp);
+        evaluateDoubleDifferentCaloObjectTrigger(inputIsoEmRefs,
+                                                 inputCenJetTauJetRefs,
+                                                 doubleThresholds_[itrig].first,
+                                                 doubleThresholds_[itrig].second,
+                                                 decision,
+                                                 outputEmRefsTmp,
+                                                 outputJetRefsTmp,
+                                                 combosTmp);
       }
     } else if (itrig == L1ParticleMap::kMinBias_HTT10) {
       objectTypes.push_back(L1ParticleMap::kEtHad);
@@ -1489,7 +1197,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
     L1JetParticleVectorRef outputJetRefs;
     L1MuonParticleVectorRef outputMuonRefs;
     L1EtMissParticleRefProd metRef;
-    L1ParticleMap::L1IndexComboVector combos; // unfilled for single objs
+    L1ParticleMap::L1IndexComboVector combos;  // unfilled for single objs
 
     if (decision) {
       //	 if( prescaleCounters_[ itrig ] % prescales_[ itrig ] )
@@ -1509,9 +1217,14 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
     }
 
     // Construct a L1ParticleMap and add it to the collection.
-    mapColl->push_back(L1ParticleMap(
-        (L1ParticleMap::L1TriggerType)itrig, decision, objectTypes,
-        outputEmRefs, outputJetRefs, outputMuonRefs, metRef, combos));
+    mapColl->push_back(L1ParticleMap((L1ParticleMap::L1TriggerType)itrig,
+                                     decision,
+                                     objectTypes,
+                                     outputEmRefs,
+                                     outputJetRefs,
+                                     outputMuonRefs,
+                                     metRef,
+                                     combos));
 
     globalDecision = globalDecision || decision;
     decisionWord.push_back(decision);
@@ -1521,8 +1234,7 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
   iEvent.put(std::move(mapColl));
 
   // Make a L1GlobalTriggerReadoutRecord and put it into the event.
-  unique_ptr<L1GlobalTriggerReadoutRecord> gtRecord(
-      new L1GlobalTriggerReadoutRecord());
+  unique_ptr<L1GlobalTriggerReadoutRecord> gtRecord(new L1GlobalTriggerReadoutRecord());
   gtRecord->setDecision(globalDecision);
   gtRecord->setDecisionWord(decisionWord);
   iEvent.put(std::move(gtRecord));
@@ -1531,9 +1243,8 @@ void L1ExtraParticleMapProd::produce(edm::Event &iEvent,
 }
 
 template <class TCollection>
-void L1ExtraParticleMapProd::addToVectorRefs(
-    const edm::Handle<TCollection> &handle,         // input
-    std::vector<edm::Ref<TCollection>> &vectorRefs) // output
+void L1ExtraParticleMapProd::addToVectorRefs(const edm::Handle<TCollection> &handle,          // input
+                                             std::vector<edm::Ref<TCollection>> &vectorRefs)  // output
 {
   for (size_t i = 0; i < handle->size(); ++i) {
     vectorRefs.push_back(edm::Ref<TCollection>(handle, i));
@@ -1541,11 +1252,10 @@ void L1ExtraParticleMapProd::addToVectorRefs(
 }
 
 template <class TCollection>
-void L1ExtraParticleMapProd::evaluateSingleObjectTrigger(
-    const std::vector<edm::Ref<TCollection>> &inputRefs, // input
-    const double &etThreshold,                           // input
-    bool &decision,                                      // output
-    std::vector<edm::Ref<TCollection>> &outputRefs)      // output
+void L1ExtraParticleMapProd::evaluateSingleObjectTrigger(const std::vector<edm::Ref<TCollection>> &inputRefs,  // input
+                                                         const double &etThreshold,                            // input
+                                                         bool &decision,                                       // output
+                                                         std::vector<edm::Ref<TCollection>> &outputRefs)       // output
 {
   for (size_t i = 0; i < inputRefs.size(); ++i) {
     if (inputRefs[i].get()->et() >= etThreshold) {
@@ -1557,12 +1267,12 @@ void L1ExtraParticleMapProd::evaluateSingleObjectTrigger(
 
 template <class TCollection>
 void L1ExtraParticleMapProd::evaluateDoubleSameObjectTrigger(
-    const std::vector<edm::Ref<TCollection>> &inputRefs, // input
-    const double &etThreshold,                           // input
-    bool &decision,                                      // output
-    std::vector<edm::Ref<TCollection>> &outputRefs,      // output
-    l1extra::L1ParticleMap::L1IndexComboVector &combos,  // output
-    bool combinedWithGlobalObject)                       // input
+    const std::vector<edm::Ref<TCollection>> &inputRefs,  // input
+    const double &etThreshold,                            // input
+    bool &decision,                                       // output
+    std::vector<edm::Ref<TCollection>> &outputRefs,       // output
+    l1extra::L1ParticleMap::L1IndexComboVector &combos,   // output
+    bool combinedWithGlobalObject)                        // input
 {
   // Use i+1 < inputRefs.size() instead of i < inputRefs.size()-1
   // because i is unsigned, and if size() is 0, then RHS undefined.
@@ -1615,11 +1325,11 @@ void L1ExtraParticleMapProd::evaluateDoubleSameObjectTrigger(
 
 template <class TCollection>
 void L1ExtraParticleMapProd::evaluateTripleSameObjectTrigger(
-    const std::vector<edm::Ref<TCollection>> &inputRefs, // input
-    const double &etThreshold,                           // input
-    bool &decision,                                      // output
-    std::vector<edm::Ref<TCollection>> &outputRefs,      // output
-    l1extra::L1ParticleMap::L1IndexComboVector &combos)  // output
+    const std::vector<edm::Ref<TCollection>> &inputRefs,  // input
+    const double &etThreshold,                            // input
+    bool &decision,                                       // output
+    std::vector<edm::Ref<TCollection>> &outputRefs,       // output
+    l1extra::L1ParticleMap::L1IndexComboVector &combos)   // output
 {
   // Use i+2 < inputRefs.size() instead of i < inputRefs.size()-2
   // because i is unsigned, and if size() is 0, then RHS undefined.
@@ -1686,14 +1396,14 @@ void L1ExtraParticleMapProd::evaluateTripleSameObjectTrigger(
 
 template <class TCollection1, class TCollection2>
 void L1ExtraParticleMapProd::evaluateDoublePlusSingleObjectTrigger(
-    const std::vector<edm::Ref<TCollection1>> &inputRefs1, // input
-    const std::vector<edm::Ref<TCollection2>> &inputRefs2, // input
-    const double &etThreshold1,                            // input
-    const double &etThreshold2,                            // input
-    bool &decision,                                        // output
-    std::vector<edm::Ref<TCollection1>> &outputRefs1,      // output
-    std::vector<edm::Ref<TCollection2>> &outputRefs2,      // output
-    l1extra::L1ParticleMap::L1IndexComboVector &combos)    // output
+    const std::vector<edm::Ref<TCollection1>> &inputRefs1,  // input
+    const std::vector<edm::Ref<TCollection2>> &inputRefs2,  // input
+    const double &etThreshold1,                             // input
+    const double &etThreshold2,                             // input
+    bool &decision,                                         // output
+    std::vector<edm::Ref<TCollection1>> &outputRefs1,       // output
+    std::vector<edm::Ref<TCollection2>> &outputRefs2,       // output
+    l1extra::L1ParticleMap::L1IndexComboVector &combos)     // output
 {
   // Use i+1 < inputRefs.size() instead of i < inputRefs.size()-1
   // because i is unsigned, and if size() is 0, then RHS undefined.
@@ -1763,11 +1473,11 @@ void L1ExtraParticleMapProd::evaluateDoublePlusSingleObjectTrigger(
 
 template <class TCollection>
 void L1ExtraParticleMapProd::evaluateQuadSameObjectTrigger(
-    const std::vector<edm::Ref<TCollection>> &inputRefs, // input
-    const double &etThreshold,                           // input
-    bool &decision,                                      // output
-    std::vector<edm::Ref<TCollection>> &outputRefs,      // output
-    l1extra::L1ParticleMap::L1IndexComboVector &combos)  // output
+    const std::vector<edm::Ref<TCollection>> &inputRefs,  // input
+    const double &etThreshold,                            // input
+    bool &decision,                                       // output
+    std::vector<edm::Ref<TCollection>> &outputRefs,       // output
+    l1extra::L1ParticleMap::L1IndexComboVector &combos)   // output
 {
   // Use i+3 < inputRefs.size() instead of i < inputRefs.size()-3
   // because i is unsigned, and if size() is 0, then RHS undefined.
@@ -1850,14 +1560,14 @@ void L1ExtraParticleMapProd::evaluateQuadSameObjectTrigger(
 
 template <class TCollection1, class TCollection2>
 void L1ExtraParticleMapProd::evaluateDoubleDifferentObjectTrigger(
-    const std::vector<edm::Ref<TCollection1>> &inputRefs1, // input
-    const std::vector<edm::Ref<TCollection2>> &inputRefs2, // input
-    const double &etThreshold1,                            // input
-    const double &etThreshold2,                            // input
-    bool &decision,                                        // output
-    std::vector<edm::Ref<TCollection1>> &outputRefs1,      // output
-    std::vector<edm::Ref<TCollection2>> &outputRefs2,      // output
-    l1extra::L1ParticleMap::L1IndexComboVector &combos)    // output
+    const std::vector<edm::Ref<TCollection1>> &inputRefs1,  // input
+    const std::vector<edm::Ref<TCollection2>> &inputRefs2,  // input
+    const double &etThreshold1,                             // input
+    const double &etThreshold2,                             // input
+    bool &decision,                                         // output
+    std::vector<edm::Ref<TCollection1>> &outputRefs1,       // output
+    std::vector<edm::Ref<TCollection2>> &outputRefs2,       // output
+    l1extra::L1ParticleMap::L1IndexComboVector &combos)     // output
 {
   for (size_t i = 0; i < inputRefs1.size(); ++i) {
     const edm::Ref<TCollection1> &refi = inputRefs1[i];
@@ -1909,13 +1619,13 @@ void L1ExtraParticleMapProd::evaluateDoubleDifferentObjectTrigger(
 
 template <class TCollection>
 void L1ExtraParticleMapProd::evaluateDoubleDifferentObjectSameTypeTrigger(
-    const std::vector<edm::Ref<TCollection>> &inputRefs1, // input
-    const std::vector<edm::Ref<TCollection>> &inputRefs2, // input
-    const double &etThreshold1,                           // input
-    const double &etThreshold2,                           // input
-    bool &decision,                                       // output
-    std::vector<edm::Ref<TCollection>> &outputRefs,       // output
-    l1extra::L1ParticleMap::L1IndexComboVector &combos)   // output
+    const std::vector<edm::Ref<TCollection>> &inputRefs1,  // input
+    const std::vector<edm::Ref<TCollection>> &inputRefs2,  // input
+    const double &etThreshold1,                            // input
+    const double &etThreshold2,                            // input
+    bool &decision,                                        // output
+    std::vector<edm::Ref<TCollection>> &outputRefs,        // output
+    l1extra::L1ParticleMap::L1IndexComboVector &combos)    // output
 {
   for (size_t i = 0; i < inputRefs1.size(); ++i) {
     const edm::Ref<TCollection> &refi = inputRefs1[i];
@@ -1966,14 +1676,14 @@ void L1ExtraParticleMapProd::evaluateDoubleDifferentObjectSameTypeTrigger(
 }
 
 void L1ExtraParticleMapProd::evaluateDoubleDifferentCaloObjectTrigger(
-    const l1extra::L1EmParticleVectorRef &inputRefs1,   // input
-    const l1extra::L1JetParticleVectorRef &inputRefs2,  // input
-    const double &etThreshold1,                         // input
-    const double &etThreshold2,                         // input
-    bool &decision,                                     // output
-    l1extra::L1EmParticleVectorRef &outputRefs1,        // output
-    l1extra::L1JetParticleVectorRef &outputRefs2,       // output
-    l1extra::L1ParticleMap::L1IndexComboVector &combos) // output
+    const l1extra::L1EmParticleVectorRef &inputRefs1,    // input
+    const l1extra::L1JetParticleVectorRef &inputRefs2,   // input
+    const double &etThreshold1,                          // input
+    const double &etThreshold2,                          // input
+    bool &decision,                                      // output
+    l1extra::L1EmParticleVectorRef &outputRefs1,         // output
+    l1extra::L1JetParticleVectorRef &outputRefs2,        // output
+    l1extra::L1ParticleMap::L1IndexComboVector &combos)  // output
 {
   for (size_t i = 0; i < inputRefs1.size(); ++i) {
     const l1extra::L1EmParticleRef &refi = inputRefs1[i];
@@ -1983,10 +1693,8 @@ void L1ExtraParticleMapProd::evaluateDoubleDifferentCaloObjectTrigger(
 
         // Check for identical region only if both HW objects are non-null.
         if (refj.get()->et() >= etThreshold2 &&
-            (refi.get()->gctEmCand() == nullptr ||
-             refj.get()->gctJetCand() == nullptr ||
-             refi.get()->gctEmCand()->regionId() !=
-                 refj.get()->gctJetCand()->regionId())) {
+            (refi.get()->gctEmCand() == nullptr || refj.get()->gctJetCand() == nullptr ||
+             refi.get()->gctEmCand()->regionId() != refj.get()->gctJetCand()->regionId())) {
           decision = true;
 
           // If the two objects are already in their respective lists,
@@ -2029,12 +1737,11 @@ void L1ExtraParticleMapProd::evaluateDoubleDifferentCaloObjectTrigger(
 }
 
 // ok if both objects are above the threshold and are in opposite hemispheres
-void L1ExtraParticleMapProd::evaluateJetGapJetTrigger(
-    const l1extra::L1JetParticleVectorRef &inputRefs,   // input
-    const double &etThreshold,                          // input
-    bool &decision,                                     // output
-    l1extra::L1JetParticleVectorRef &outputRefs,        // output
-    l1extra::L1ParticleMap::L1IndexComboVector &combos) // output
+void L1ExtraParticleMapProd::evaluateJetGapJetTrigger(const l1extra::L1JetParticleVectorRef &inputRefs,    // input
+                                                      const double &etThreshold,                           // input
+                                                      bool &decision,                                      // output
+                                                      l1extra::L1JetParticleVectorRef &outputRefs,         // output
+                                                      l1extra::L1ParticleMap::L1IndexComboVector &combos)  // output
 {
   // Use i+1 < inputRefs.size() instead of i < inputRefs.size()-1
   // because i is unsigned, and if size() is 0, then RHS undefined.
@@ -2043,9 +1750,8 @@ void L1ExtraParticleMapProd::evaluateJetGapJetTrigger(
     if (refi.get()->et() >= etThreshold) {
       for (size_t j = i + 1; j < inputRefs.size(); ++j) {
         const l1extra::L1JetParticleRef &refj = inputRefs[j];
-        if ((refj.get()->et() >= etThreshold) &&
-            (((refi.get()->eta() < 0.) && (refj.get()->eta() > 0.)) ||
-             ((refi.get()->eta() > 0.) && (refj.get()->eta() < 0.)))) {
+        if ((refj.get()->et() >= etThreshold) && (((refi.get()->eta() < 0.) && (refj.get()->eta() > 0.)) ||
+                                                  ((refi.get()->eta() > 0.) && (refj.get()->eta() < 0.)))) {
           decision = true;
 
           // If the two objects are already in the list, find
@@ -2086,10 +1792,9 @@ void L1ExtraParticleMapProd::evaluateJetGapJetTrigger(
 }
 
 // veto if both forward regions see some jet with e_T > threshold
-void L1ExtraParticleMapProd::evaluateForwardRapidityGap(
-    const l1extra::L1JetParticleVectorRef &inputRefs, // input
-    const double &etThreshold,                        // input
-    bool &decision                                    // output
+void L1ExtraParticleMapProd::evaluateForwardRapidityGap(const l1extra::L1JetParticleVectorRef &inputRefs,  // input
+                                                        const double &etThreshold,                         // input
+                                                        bool &decision                                     // output
 ) {
   decision = true;
 
@@ -2097,40 +1802,35 @@ void L1ExtraParticleMapProd::evaluateForwardRapidityGap(
   for (size_t k = 0; k + 1 < inputRefs.size(); ++k) {
     const l1extra::L1JetParticleRef &refk = inputRefs[k];
     double etak = refk.get()->eta();
-    if ((refk.get()->type() == l1extra::L1JetParticle::kForward) &&
-        (refk.get()->et() >= etThreshold)) {
+    if ((refk.get()->type() == l1extra::L1JetParticle::kForward) && (refk.get()->et() >= etThreshold)) {
       for (size_t l = k + 1; l < inputRefs.size(); ++l) {
         const l1extra::L1JetParticleRef &refl = inputRefs[l];
         double etal = refl.get()->eta();
-        if ((refl.get()->type() == l1extra::L1JetParticle::kForward) &&
-            (refl.get()->et() >= etThreshold) &&
+        if ((refl.get()->type() == l1extra::L1JetParticle::kForward) && (refl.get()->et() >= etThreshold) &&
             ((etak > 0 && etal < 0) || (etak < 0 && etal > 0))) {
           decision = false;
-          return; // no need for going further -- for a faster algorithm
+          return;  // no need for going further -- for a faster algorithm
         }
       }
     }
   }
 }
 
-void L1ExtraParticleMapProd::evaluateDoubleExclusiveIsoEG(
-    const l1extra::L1EmParticleVectorRef &inputRefs1,   // input
-    const l1extra::L1JetParticleVectorRef &inputRefs2,  // input
-    const double &etThreshold1,                         // input
-    const double &etThreshold2,                         // input
-    bool &decision,                                     // output
-    l1extra::L1EmParticleVectorRef &outputRefs1,        // output
-    l1extra::L1ParticleMap::L1IndexComboVector &combos) // output
+void L1ExtraParticleMapProd::evaluateDoubleExclusiveIsoEG(const l1extra::L1EmParticleVectorRef &inputRefs1,    // input
+                                                          const l1extra::L1JetParticleVectorRef &inputRefs2,   // input
+                                                          const double &etThreshold1,                          // input
+                                                          const double &etThreshold2,                          // input
+                                                          bool &decision,                                      // output
+                                                          l1extra::L1EmParticleVectorRef &outputRefs1,         // output
+                                                          l1extra::L1ParticleMap::L1IndexComboVector &combos)  // output
 {
-  if (inputRefs1.size() == 2) { // 2 iso EG
+  if (inputRefs1.size() == 2) {  // 2 iso EG
     decision = true;
-    if (!inputRefs2.empty()) { // should veto if there are jets, with pt>thresh
+    if (!inputRefs2.empty()) {  // should veto if there are jets, with pt>thresh
       for (size_t j = 0; j < inputRefs2.size(); ++j) {
-        if (inputRefs2[j].get()->gctJetCand()->regionId() ==
-            inputRefs1[0].get()->gctEmCand()->regionId())
+        if (inputRefs2[j].get()->gctJetCand()->regionId() == inputRefs1[0].get()->gctEmCand()->regionId())
           continue;
-        if (inputRefs2[j].get()->gctJetCand()->regionId() ==
-            inputRefs1[1].get()->gctEmCand()->regionId())
+        if (inputRefs2[j].get()->gctJetCand()->regionId() == inputRefs1[1].get()->gctEmCand()->regionId())
           continue;
         if (inputRefs2[j].get()->et() > etThreshold2) {
           decision = false;
@@ -2139,10 +1839,9 @@ void L1ExtraParticleMapProd::evaluateDoubleExclusiveIsoEG(
         // break : for a faster algorithm
       }
     }
-    if (decision) { // threshold evaluation for the Exclusive double isoEG
+    if (decision) {  // threshold evaluation for the Exclusive double isoEG
       decision = false;
-      evaluateDoubleSameObjectTrigger(inputRefs1, etThreshold1, decision,
-                                      outputRefs1, combos);
+      evaluateDoubleSameObjectTrigger(inputRefs1, etThreshold1, decision, outputRefs1, combos);
     }
   }
 }

--- a/L1Trigger/L1ExtraFromDigis/src/L1ExtraParticlesProd.cc
+++ b/L1Trigger/L1ExtraFromDigis/src/L1ExtraParticlesProd.cc
@@ -58,7 +58,7 @@
 // static data member definitions
 //
 
-double const L1ExtraParticlesProd::muonMassGeV_ = 0.105658369; // PDG06
+double const L1ExtraParticlesProd::muonMassGeV_ = 0.105658369;  // PDG06
 
 //
 // constructors and destructor
@@ -68,8 +68,7 @@ L1ExtraParticlesProd::L1ExtraParticlesProd(const edm::ParameterSet &iConfig)
       muonSource_(iConfig.getParameter<edm::InputTag>("muonSource")),
       produceCaloParticles_(iConfig.getParameter<bool>("produceCaloParticles")),
       isoEmSource_(iConfig.getParameter<edm::InputTag>("isolatedEmSource")),
-      nonIsoEmSource_(
-          iConfig.getParameter<edm::InputTag>("nonIsolatedEmSource")),
+      nonIsoEmSource_(iConfig.getParameter<edm::InputTag>("nonIsolatedEmSource")),
       cenJetSource_(iConfig.getParameter<edm::InputTag>("centralJetSource")),
       forJetSource_(iConfig.getParameter<edm::InputTag>("forwardJetSource")),
       tauJetSource_(iConfig.getParameter<edm::InputTag>("tauJetSource")),
@@ -78,10 +77,8 @@ L1ExtraParticlesProd::L1ExtraParticlesProd(const edm::ParameterSet &iConfig)
       etHadSource_(iConfig.getParameter<edm::InputTag>("etHadSource")),
       etMissSource_(iConfig.getParameter<edm::InputTag>("etMissSource")),
       htMissSource_(iConfig.getParameter<edm::InputTag>("htMissSource")),
-      hfRingEtSumsSource_(
-          iConfig.getParameter<edm::InputTag>("hfRingEtSumsSource")),
-      hfRingBitCountsSource_(
-          iConfig.getParameter<edm::InputTag>("hfRingBitCountsSource")),
+      hfRingEtSumsSource_(iConfig.getParameter<edm::InputTag>("hfRingEtSumsSource")),
+      hfRingBitCountsSource_(iConfig.getParameter<edm::InputTag>("hfRingBitCountsSource")),
       centralBxOnly_(iConfig.getParameter<bool>("centralBxOnly")),
       ignoreHtMiss_(iConfig.getParameter<bool>("ignoreHtMiss")) {
   using namespace l1extra;
@@ -115,7 +112,6 @@ L1ExtraParticlesProd::L1ExtraParticlesProd(const edm::ParameterSet &iConfig)
 }
 
 L1ExtraParticlesProd::~L1ExtraParticlesProd() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -125,8 +121,7 @@ L1ExtraParticlesProd::~L1ExtraParticlesProd() {
 //
 
 // ------------ method called to produce the data  ------------
-void L1ExtraParticlesProd::produce(edm::Event &iEvent,
-                                   const edm::EventSetup &iSetup) {
+void L1ExtraParticlesProd::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
   using namespace l1extra;
   using namespace std;
@@ -150,10 +145,8 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
     vector<L1MuGMTExtendedCand> hwMuCands;
 
     if (!hwMuCollection.isValid()) {
-      LogDebug("L1ExtraParticlesProd")
-          << "\nWarning: L1MuGMTReadoutCollection with " << muonSource_
-          << "\nrequested in configuration, but not found in the event."
-          << std::endl;
+      LogDebug("L1ExtraParticlesProd") << "\nWarning: L1MuGMTReadoutCollection with " << muonSource_
+                                       << "\nrequested in configuration, but not found in the event." << std::endl;
     } else {
       if (centralBxOnly_) {
         // Get GMT candidates from central bunch crossing only
@@ -188,8 +181,7 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
 
         if (!muItr->empty()) {
           // keep x and y components non-zero and protect against roundoff.
-          double pt =
-              muPtScale->getPtScale()->getLowEdge(muItr->ptIndex()) + 1.e-6;
+          double pt = muPtScale->getPtScale()->getLowEdge(muItr->ptIndex()) + 1.e-6;
 
           // 	    cout << "L1Extra pt " << pt << endl ;
 
@@ -199,15 +191,13 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
 
           math::PtEtaPhiMLorentzVector p4(pt, eta, phi, muonMassGeV_);
 
-          muColl->push_back(
-              L1MuonParticle(muItr->charge(), p4, *muItr, muItr->bx()));
+          muColl->push_back(L1MuonParticle(muItr->charge(), p4, *muItr, muItr->bx()));
         }
       }
     }
   }
 
-  OrphanHandle<L1MuonParticleCollection> muHandle =
-      iEvent.put(std::move(muColl));
+  OrphanHandle<L1MuonParticleCollection> muHandle = iEvent.put(std::move(muColl));
 
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // ~~~~~~~~~~~~~~~~~~~~ Calorimeter ~~~~~~~~~~~~~~~~~~~~
@@ -223,14 +213,11 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
 
   unique_ptr<L1JetParticleCollection> tauJetColl(new L1JetParticleCollection);
 
-  unique_ptr<L1JetParticleCollection> isoTauJetColl(
-      new L1JetParticleCollection);
+  unique_ptr<L1JetParticleCollection> isoTauJetColl(new L1JetParticleCollection);
 
-  unique_ptr<L1EtMissParticleCollection> etMissColl(
-      new L1EtMissParticleCollection);
+  unique_ptr<L1EtMissParticleCollection> etMissColl(new L1EtMissParticleCollection);
 
-  unique_ptr<L1EtMissParticleCollection> htMissColl(
-      new L1EtMissParticleCollection);
+  unique_ptr<L1EtMissParticleCollection> htMissColl(new L1EtMissParticleCollection);
 
   unique_ptr<L1HFRingsCollection> hfRingsColl(new L1HFRingsCollection);
 
@@ -251,10 +238,8 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
     iEvent.getByLabel(isoEmSource_, hwIsoEmCands);
 
     if (!hwIsoEmCands.isValid()) {
-      LogDebug("L1ExtraParticlesProd")
-          << "\nWarning: L1GctEmCandCollection with " << isoEmSource_
-          << "\nrequested in configuration, but not found in the event."
-          << std::endl;
+      LogDebug("L1ExtraParticlesProd") << "\nWarning: L1GctEmCandCollection with " << isoEmSource_
+                                       << "\nrequested in configuration, but not found in the event." << std::endl;
     } else {
       //       cout << "HW iso EM" << endl ;
 
@@ -278,8 +263,7 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
           // 	    cout << "L1Extra et " << et << endl ;
 
           isoEmColl->push_back(L1EmParticle(
-              gctLorentzVector(et, *emItr, caloGeom, true),
-              Ref<L1GctEmCandCollection>(hwIsoEmCands, i), emItr->bx()));
+              gctLorentzVector(et, *emItr, caloGeom, true), Ref<L1GctEmCandCollection>(hwIsoEmCands, i), emItr->bx()));
         }
       }
     }
@@ -289,10 +273,8 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
     iEvent.getByLabel(nonIsoEmSource_, hwNonIsoEmCands);
 
     if (!hwNonIsoEmCands.isValid()) {
-      LogDebug("L1ExtraParticlesProd")
-          << "\nWarning: L1GctEmCandCollection with " << nonIsoEmSource_
-          << "\nrequested in configuration, but not found in the event."
-          << std::endl;
+      LogDebug("L1ExtraParticlesProd") << "\nWarning: L1GctEmCandCollection with " << nonIsoEmSource_
+                                       << "\nrequested in configuration, but not found in the event." << std::endl;
     } else {
       //       cout << "HW non-iso EM" << endl ;
       L1GctEmCandCollection::const_iterator emItr = hwNonIsoEmCands->begin();
@@ -314,9 +296,9 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
 
           // 	    cout << "L1Extra et " << et << endl ;
 
-          nonIsoEmColl->push_back(L1EmParticle(
-              gctLorentzVector(et, *emItr, caloGeom, true),
-              Ref<L1GctEmCandCollection>(hwNonIsoEmCands, i), emItr->bx()));
+          nonIsoEmColl->push_back(L1EmParticle(gctLorentzVector(et, *emItr, caloGeom, true),
+                                               Ref<L1GctEmCandCollection>(hwNonIsoEmCands, i),
+                                               emItr->bx()));
         }
       }
     }
@@ -331,10 +313,8 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
     iEvent.getByLabel(cenJetSource_, hwCenJetCands);
 
     if (!hwCenJetCands.isValid()) {
-      LogDebug("L1ExtraParticlesProd")
-          << "\nWarning: L1GctJetCandCollection with " << cenJetSource_
-          << "\nrequested in configuration, but not found in the event."
-          << std::endl;
+      LogDebug("L1ExtraParticlesProd") << "\nWarning: L1GctJetCandCollection with " << cenJetSource_
+                                       << "\nrequested in configuration, but not found in the event." << std::endl;
     } else {
       //       cout << "HW central jets" << endl ;
       L1GctJetCandCollection::const_iterator jetItr = hwCenJetCands->begin();
@@ -358,9 +338,9 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
 
           // 	    cout << "L1Extra et " << et << endl ;
 
-          cenJetColl->push_back(L1JetParticle(
-              gctLorentzVector(et, *jetItr, caloGeom, true),
-              Ref<L1GctJetCandCollection>(hwCenJetCands, i), jetItr->bx()));
+          cenJetColl->push_back(L1JetParticle(gctLorentzVector(et, *jetItr, caloGeom, true),
+                                              Ref<L1GctJetCandCollection>(hwCenJetCands, i),
+                                              jetItr->bx()));
         }
       }
     }
@@ -370,10 +350,8 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
     iEvent.getByLabel(forJetSource_, hwForJetCands);
 
     if (!hwForJetCands.isValid()) {
-      LogDebug("L1ExtraParticlesProd")
-          << "\nWarning: L1GctEmCandCollection with " << forJetSource_
-          << "\nrequested in configuration, but not found in the event."
-          << std::endl;
+      LogDebug("L1ExtraParticlesProd") << "\nWarning: L1GctEmCandCollection with " << forJetSource_
+                                       << "\nrequested in configuration, but not found in the event." << std::endl;
     } else {
       //       cout << "HW forward jets" << endl ;
       L1GctJetCandCollection::const_iterator jetItr = hwForJetCands->begin();
@@ -397,9 +375,9 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
 
           // 	    cout << "L1Extra et " << et << endl ;
 
-          forJetColl->push_back(L1JetParticle(
-              gctLorentzVector(et, *jetItr, caloGeom, false),
-              Ref<L1GctJetCandCollection>(hwForJetCands, i), jetItr->bx()));
+          forJetColl->push_back(L1JetParticle(gctLorentzVector(et, *jetItr, caloGeom, false),
+                                              Ref<L1GctJetCandCollection>(hwForJetCands, i),
+                                              jetItr->bx()));
         }
       }
     }
@@ -410,10 +388,8 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
     iEvent.getByLabel(tauJetSource_, hwTauJetCands);
 
     if (!hwTauJetCands.isValid()) {
-      LogDebug("L1ExtraParticlesProd")
-          << "\nWarning: L1GctJetCandCollection with " << tauJetSource_
-          << "\nrequested in configuration, but not found in the event."
-          << std::endl;
+      LogDebug("L1ExtraParticlesProd") << "\nWarning: L1GctJetCandCollection with " << tauJetSource_
+                                       << "\nrequested in configuration, but not found in the event." << std::endl;
     } else {
       L1GctJetCandCollection::const_iterator jetItr = hwTauJetCands->begin();
       L1GctJetCandCollection::const_iterator jetEnd = hwTauJetCands->end();
@@ -436,9 +412,9 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
 
           // 	    cout << "L1Extra et " << et << endl ;
 
-          tauJetColl->push_back(L1JetParticle(
-              gctLorentzVector(et, *jetItr, caloGeom, true),
-              Ref<L1GctJetCandCollection>(hwTauJetCands, i), jetItr->bx()));
+          tauJetColl->push_back(L1JetParticle(gctLorentzVector(et, *jetItr, caloGeom, true),
+                                              Ref<L1GctJetCandCollection>(hwTauJetCands, i),
+                                              jetItr->bx()));
         }
       }
     }
@@ -449,10 +425,8 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
     iEvent.getByLabel(isoTauJetSource_, hwIsoTauJetCands);
 
     if (!hwIsoTauJetCands.isValid()) {
-      LogDebug("L1ExtraParticlesProd")
-          << "\nWarning: L1GctJetCandCollection with " << isoTauJetSource_
-          << "\nrequested in configuration, but not found in the event."
-          << std::endl;
+      LogDebug("L1ExtraParticlesProd") << "\nWarning: L1GctJetCandCollection with " << isoTauJetSource_
+                                       << "\nrequested in configuration, but not found in the event." << std::endl;
     } else {
       L1GctJetCandCollection::const_iterator jetItr = hwIsoTauJetCands->begin();
       L1GctJetCandCollection::const_iterator jetEnd = hwIsoTauJetCands->end();
@@ -475,9 +449,9 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
 
           // 	    cout << "L1Extra et " << et << endl ;
 
-          isoTauJetColl->push_back(L1JetParticle(
-              gctLorentzVector(et, *jetItr, caloGeom, true),
-              Ref<L1GctJetCandCollection>(hwIsoTauJetCands, i), jetItr->bx()));
+          isoTauJetColl->push_back(L1JetParticle(gctLorentzVector(et, *jetItr, caloGeom, true),
+                                                 Ref<L1GctJetCandCollection>(hwIsoTauJetCands, i),
+                                                 jetItr->bx()));
         }
       }
     }
@@ -493,15 +467,11 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
     iEvent.getByLabel(etMissSource_, hwEtMissColl);
 
     if (!hwEtTotColl.isValid()) {
-      LogDebug("L1ExtraParticlesProd")
-          << "\nWarning: L1GctEtTotalCollection with " << etTotSource_
-          << "\nrequested in configuration, but not found in the event."
-          << std::endl;
+      LogDebug("L1ExtraParticlesProd") << "\nWarning: L1GctEtTotalCollection with " << etTotSource_
+                                       << "\nrequested in configuration, but not found in the event." << std::endl;
     } else if (!hwEtMissColl.isValid()) {
-      LogDebug("L1ExtraParticlesProd")
-          << "\nWarning: L1GctEtMissCollection with " << etMissSource_
-          << "\nrequested in configuration, but not found in the event."
-          << std::endl;
+      LogDebug("L1ExtraParticlesProd") << "\nWarning: L1GctEtMissCollection with " << etMissSource_
+                                       << "\nrequested in configuration, but not found in the event." << std::endl;
     } else {
       // Make a L1EtMissParticle even if either L1GctEtTotal or L1GctEtMiss
       // is missing for a given bx.  Keep track of which L1GctEtMiss objects
@@ -525,9 +495,7 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
         if (!centralBxOnly_ || bx == 0) {
           // ET bin low edge
           double etTot =
-              (hwEtTotItr->overFlow() ? (double)L1GctEtTotal::kEtTotalMaxValue
-                                      : (double)hwEtTotItr->et()) *
-                  etSumLSB +
+              (hwEtTotItr->overFlow() ? (double)L1GctEtTotal::kEtTotalMaxValue : (double)hwEtTotItr->et()) * etSumLSB +
               1.e-6;
 
           int iMiss = 0;
@@ -548,11 +516,9 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
           // If a L1GctEtMiss with the right bx is not found, itr == end.
           if (hwEtMissItr != hwEtMissEnd) {
             // ET bin low edge
-            etMiss =
-                (hwEtMissItr->overFlow() ? (double)L1GctEtMiss::kEtMissMaxValue
-                                         : (double)hwEtMissItr->et()) *
-                    etSumLSB +
-                1.e-6;
+            etMiss = (hwEtMissItr->overFlow() ? (double)L1GctEtMiss::kEtMissMaxValue : (double)hwEtMissItr->et()) *
+                         etSumLSB +
+                     1.e-6;
             // keep x and y components non-zero and
             // protect against roundoff.
 
@@ -579,10 +545,14 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
           // 		    << endl ;
           // 	     }
 
-          etMissColl->push_back(L1EtMissParticle(
-              p4, L1EtMissParticle::kMET, etTot, metRef,
-              Ref<L1GctEtTotalCollection>(hwEtTotColl, iTot),
-              Ref<L1GctHtMissCollection>(), Ref<L1GctEtHadCollection>(), bx));
+          etMissColl->push_back(L1EtMissParticle(p4,
+                                                 L1EtMissParticle::kMET,
+                                                 etTot,
+                                                 metRef,
+                                                 Ref<L1GctEtTotalCollection>(hwEtTotColl, iTot),
+                                                 Ref<L1GctHtMissCollection>(),
+                                                 Ref<L1GctEtHadCollection>(),
+                                                 bx));
         }
       }
 
@@ -601,8 +571,7 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
 
             // ET bin low edge
             double etMiss =
-                (hwEtMissItr->overFlow() ? (double)L1GctEtMiss::kEtMissMaxValue
-                                         : (double)hwEtMissItr->et()) *
+                (hwEtMissItr->overFlow() ? (double)L1GctEtMiss::kEtMissMaxValue : (double)hwEtMissItr->et()) *
                     etSumLSB +
                 1.e-6;
             // keep x and y components non-zero and
@@ -620,11 +589,14 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
             // 		       << " bx " << bx
             // 		       << endl ;
 
-            etMissColl->push_back(L1EtMissParticle(
-                p4, L1EtMissParticle::kMET, etTot,
-                Ref<L1GctEtMissCollection>(hwEtMissColl, iMiss),
-                Ref<L1GctEtTotalCollection>(), Ref<L1GctHtMissCollection>(),
-                Ref<L1GctEtHadCollection>(), bx));
+            etMissColl->push_back(L1EtMissParticle(p4,
+                                                   L1EtMissParticle::kMET,
+                                                   etTot,
+                                                   Ref<L1GctEtMissCollection>(hwEtMissColl, iMiss),
+                                                   Ref<L1GctEtTotalCollection>(),
+                                                   Ref<L1GctHtMissCollection>(),
+                                                   Ref<L1GctEtHadCollection>(),
+                                                   bx));
           }
         }
       }
@@ -650,21 +622,16 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
       iSetup.get<L1HtMissScaleRcd>().get(htMissScale);
 
       if (!hwEtHadColl.isValid()) {
-        LogDebug("L1ExtraParticlesProd")
-            << "\nWarning: L1GctEtHadCollection with " << etHadSource_
-            << "\nrequested in configuration, but not found in the event."
-            << std::endl;
+        LogDebug("L1ExtraParticlesProd") << "\nWarning: L1GctEtHadCollection with " << etHadSource_
+                                         << "\nrequested in configuration, but not found in the event." << std::endl;
       } else if (!hwHtMissColl.isValid()) {
-        LogDebug("L1ExtraParticlesProd")
-            << "\nWarning: L1GctHtMissCollection with " << htMissSource_
-            << "\nrequested in configuration, but not found in the event."
-            << std::endl;
+        LogDebug("L1ExtraParticlesProd") << "\nWarning: L1GctHtMissCollection with " << htMissSource_
+                                         << "\nrequested in configuration, but not found in the event." << std::endl;
       } else {
         // Make a L1EtMissParticle even if either L1GctEtHad or L1GctHtMiss
         // is missing for a given bx. Keep track of which L1GctHtMiss objects
         // have a corresponding L1GctHtTotal object.
-        L1GctHtMissCollection::const_iterator hwHtMissItr =
-            hwHtMissColl->begin();
+        L1GctHtMissCollection::const_iterator hwHtMissItr = hwHtMissColl->begin();
         L1GctHtMissCollection::const_iterator hwHtMissEnd = hwHtMissColl->end();
         for (; hwHtMissItr != hwHtMissEnd; ++hwHtMissItr) {
           htMissMatched.push_back(false);
@@ -673,15 +640,11 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
     }
 
     if (!hwEtHadColl.isValid()) {
-      LogDebug("L1ExtraParticlesProd")
-          << "\nWarning: L1GctEtHadCollection with " << etHadSource_
-          << "\nrequested in configuration, but not found in the event."
-          << std::endl;
+      LogDebug("L1ExtraParticlesProd") << "\nWarning: L1GctEtHadCollection with " << etHadSource_
+                                       << "\nrequested in configuration, but not found in the event." << std::endl;
     } else if (!hwHtMissColl.isValid()) {
-      LogDebug("L1ExtraParticlesProd")
-          << "\nWarning: L1GctHtMissCollection with " << htMissSource_
-          << "\nrequested in configuration, but not found in the event."
-          << std::endl;
+      LogDebug("L1ExtraParticlesProd") << "\nWarning: L1GctHtMissCollection with " << htMissSource_
+                                       << "\nrequested in configuration, but not found in the event." << std::endl;
     } else {
       L1GctEtHadCollection::const_iterator hwEtHadItr = hwEtHadColl->begin();
       L1GctEtHadCollection::const_iterator hwEtHadEnd = hwEtHadColl->end();
@@ -693,9 +656,7 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
         if (!centralBxOnly_ || bx == 0) {
           // HT bin low edge
           double htTot =
-              (hwEtHadItr->overFlow() ? (double)L1GctEtHad::kEtHadMaxValue
-                                      : (double)hwEtHadItr->et()) *
-                  htSumLSB +
+              (hwEtHadItr->overFlow() ? (double)L1GctEtHad::kEtHadMaxValue : (double)hwEtHadItr->et()) * htSumLSB +
               1.e-6;
 
           double htMiss = 0.;
@@ -704,10 +665,8 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
           Ref<L1GctHtMissCollection> mhtRef;
 
           if (!ignoreHtMiss_) {
-            L1GctHtMissCollection::const_iterator hwHtMissItr =
-                hwHtMissColl->begin();
-            L1GctHtMissCollection::const_iterator hwHtMissEnd =
-                hwHtMissColl->end();
+            L1GctHtMissCollection::const_iterator hwHtMissItr = hwHtMissColl->begin();
+            L1GctHtMissCollection::const_iterator hwHtMissEnd = hwHtMissColl->end();
 
             int iMiss = 0;
             for (; hwHtMissItr != hwHtMissEnd; ++hwHtMissItr, ++iMiss) {
@@ -720,10 +679,8 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
             // If a L1GctHtMiss with the right bx is not found, itr == end.
             if (hwHtMissItr != hwHtMissEnd) {
               // HT bin low edge
-              htMiss = htMissScale->et(hwHtMissItr->overFlow()
-                                           ? htMissScale->rankScaleMax()
-                                           : hwHtMissItr->et()) +
-                       1.e-6;
+              htMiss =
+                  htMissScale->et(hwHtMissItr->overFlow() ? htMissScale->rankScaleMax() : hwHtMissItr->et()) + 1.e-6;
               // keep x and y components non-zero and
               // protect against roundoff.
 
@@ -756,10 +713,14 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
             // 		 }
           }
 
-          htMissColl->push_back(L1EtMissParticle(
-              p4, L1EtMissParticle::kMHT, htTot, Ref<L1GctEtMissCollection>(),
-              Ref<L1GctEtTotalCollection>(), mhtRef,
-              Ref<L1GctEtHadCollection>(hwEtHadColl, iHad), bx));
+          htMissColl->push_back(L1EtMissParticle(p4,
+                                                 L1EtMissParticle::kMHT,
+                                                 htTot,
+                                                 Ref<L1GctEtMissCollection>(),
+                                                 Ref<L1GctEtTotalCollection>(),
+                                                 mhtRef,
+                                                 Ref<L1GctEtHadCollection>(hwEtHadColl, iHad),
+                                                 bx));
         }
       }
 
@@ -768,8 +729,7 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
         // a matched L1GctHtTotal object.
         double htTot = 0.;
 
-        L1GctHtMissCollection::const_iterator hwHtMissItr =
-            hwHtMissColl->begin();
+        L1GctHtMissCollection::const_iterator hwHtMissItr = hwHtMissColl->begin();
         L1GctHtMissCollection::const_iterator hwHtMissEnd = hwHtMissColl->end();
 
         int iMiss = 0;
@@ -778,10 +738,8 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
             int bx = hwHtMissItr->bx();
 
             // HT bin low edge
-            double htMiss = htMissScale->et(hwHtMissItr->overFlow()
-                                                ? htMissScale->rankScaleMax()
-                                                : hwHtMissItr->et()) +
-                            1.e-6;
+            double htMiss =
+                htMissScale->et(hwHtMissItr->overFlow() ? htMissScale->rankScaleMax() : hwHtMissItr->et()) + 1.e-6;
             // keep x and y components non-zero and
             // protect against roundoff.
 
@@ -797,11 +755,14 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
             // 		       << " bx " << bx
             // 		       << endl ;
 
-            htMissColl->push_back(L1EtMissParticle(
-                p4, L1EtMissParticle::kMHT, htTot, Ref<L1GctEtMissCollection>(),
-                Ref<L1GctEtTotalCollection>(),
-                Ref<L1GctHtMissCollection>(hwHtMissColl, iMiss),
-                Ref<L1GctEtHadCollection>(), bx));
+            htMissColl->push_back(L1EtMissParticle(p4,
+                                                   L1EtMissParticle::kMHT,
+                                                   htTot,
+                                                   Ref<L1GctEtMissCollection>(),
+                                                   Ref<L1GctEtTotalCollection>(),
+                                                   Ref<L1GctHtMissCollection>(hwHtMissColl, iMiss),
+                                                   Ref<L1GctEtHadCollection>(),
+                                                   bx));
           }
         }
       }
@@ -819,36 +780,25 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
     iSetup.get<L1HfRingEtScaleRcd>().get(hfRingEtScale);
 
     if (!hwHFEtSumsColl.isValid()) {
-      LogDebug("L1ExtraParticlesProd")
-          << "\nWarning: L1GctHFRingEtSumsCollection with "
-          << hfRingEtSumsSource_
-          << "\nrequested in configuration, but not found in the event."
-          << std::endl;
+      LogDebug("L1ExtraParticlesProd") << "\nWarning: L1GctHFRingEtSumsCollection with " << hfRingEtSumsSource_
+                                       << "\nrequested in configuration, but not found in the event." << std::endl;
     } else if (!hwHFBitCountsColl.isValid()) {
-      LogDebug("L1ExtraParticlesProd")
-          << "\nWarning: L1GctHFBitCountsCollection with "
-          << hfRingBitCountsSource_
-          << "\nrequested in configuration, but not found in the event."
-          << std::endl;
+      LogDebug("L1ExtraParticlesProd") << "\nWarning: L1GctHFBitCountsCollection with " << hfRingBitCountsSource_
+                                       << "\nrequested in configuration, but not found in the event." << std::endl;
     } else {
-      L1GctHFRingEtSumsCollection::const_iterator hwHFEtSumsItr =
-          hwHFEtSumsColl->begin();
-      L1GctHFRingEtSumsCollection::const_iterator hwHFEtSumsEnd =
-          hwHFEtSumsColl->end();
+      L1GctHFRingEtSumsCollection::const_iterator hwHFEtSumsItr = hwHFEtSumsColl->begin();
+      L1GctHFRingEtSumsCollection::const_iterator hwHFEtSumsEnd = hwHFEtSumsColl->end();
 
       int iEtSums = 0;
       for (; hwHFEtSumsItr != hwHFEtSumsEnd; ++hwHFEtSumsItr, ++iEtSums) {
         int bx = hwHFEtSumsItr->bx();
 
         if (!centralBxOnly_ || bx == 0) {
-          L1GctHFBitCountsCollection::const_iterator hwHFBitCountsItr =
-              hwHFBitCountsColl->begin();
-          L1GctHFBitCountsCollection::const_iterator hwHFBitCountsEnd =
-              hwHFBitCountsColl->end();
+          L1GctHFBitCountsCollection::const_iterator hwHFBitCountsItr = hwHFBitCountsColl->begin();
+          L1GctHFBitCountsCollection::const_iterator hwHFBitCountsEnd = hwHFBitCountsColl->end();
 
           int iBitCounts = 0;
-          for (; hwHFBitCountsItr != hwHFBitCountsEnd;
-               ++hwHFBitCountsItr, ++iBitCounts) {
+          for (; hwHFBitCountsItr != hwHFBitCountsEnd; ++hwHFBitCountsItr, ++iBitCounts) {
             if (hwHFBitCountsItr->bx() == bx) {
               break;
             }
@@ -862,14 +812,10 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
 
             // HF Et sums
             double etSums[L1HFRings::kNumRings];
-            etSums[L1HFRings::kRing1PosEta] =
-                hfRingEtScale->et(hwHFEtSumsItr->etSum(0)) + 1.e-6;
-            etSums[L1HFRings::kRing1NegEta] =
-                hfRingEtScale->et(hwHFEtSumsItr->etSum(1)) + 1.e-6;
-            etSums[L1HFRings::kRing2PosEta] =
-                hfRingEtScale->et(hwHFEtSumsItr->etSum(2)) + 1.e-6;
-            etSums[L1HFRings::kRing2NegEta] =
-                hfRingEtScale->et(hwHFEtSumsItr->etSum(3)) + 1.e-6;
+            etSums[L1HFRings::kRing1PosEta] = hfRingEtScale->et(hwHFEtSumsItr->etSum(0)) + 1.e-6;
+            etSums[L1HFRings::kRing1NegEta] = hfRingEtScale->et(hwHFEtSumsItr->etSum(1)) + 1.e-6;
+            etSums[L1HFRings::kRing2PosEta] = hfRingEtScale->et(hwHFEtSumsItr->etSum(2)) + 1.e-6;
+            etSums[L1HFRings::kRing2NegEta] = hfRingEtScale->et(hwHFEtSumsItr->etSum(3)) + 1.e-6;
             // protect against roundoff.
 
             // 	       cout << "HF Et Sums "
@@ -897,52 +843,43 @@ void L1ExtraParticlesProd::produce(edm::Event &iEvent,
             // 		    << hwHFBitCountsItr->bitCount( 3 ) << " "
             // 		    << endl ;
 
-            hfRingsColl->push_back(L1HFRings(
-                etSums, bitCounts,
-                Ref<L1GctHFRingEtSumsCollection>(hwHFEtSumsColl, iEtSums),
-                Ref<L1GctHFBitCountsCollection>(hwHFBitCountsColl, iBitCounts),
-                bx));
+            hfRingsColl->push_back(L1HFRings(etSums,
+                                             bitCounts,
+                                             Ref<L1GctHFRingEtSumsCollection>(hwHFEtSumsColl, iEtSums),
+                                             Ref<L1GctHFBitCountsCollection>(hwHFBitCountsColl, iBitCounts),
+                                             bx));
           }
         }
       }
     }
   }
 
-  OrphanHandle<L1EmParticleCollection> isoEmHandle =
-      iEvent.put(std::move(isoEmColl), "Isolated");
+  OrphanHandle<L1EmParticleCollection> isoEmHandle = iEvent.put(std::move(isoEmColl), "Isolated");
 
-  OrphanHandle<L1EmParticleCollection> nonIsoEmHandle =
-      iEvent.put(std::move(nonIsoEmColl), "NonIsolated");
+  OrphanHandle<L1EmParticleCollection> nonIsoEmHandle = iEvent.put(std::move(nonIsoEmColl), "NonIsolated");
 
-  OrphanHandle<L1JetParticleCollection> cenJetHandle =
-      iEvent.put(std::move(cenJetColl), "Central");
+  OrphanHandle<L1JetParticleCollection> cenJetHandle = iEvent.put(std::move(cenJetColl), "Central");
 
-  OrphanHandle<L1JetParticleCollection> forJetHandle =
-      iEvent.put(std::move(forJetColl), "Forward");
+  OrphanHandle<L1JetParticleCollection> forJetHandle = iEvent.put(std::move(forJetColl), "Forward");
 
-  OrphanHandle<L1JetParticleCollection> tauJetHandle =
-      iEvent.put(std::move(tauJetColl), "Tau");
+  OrphanHandle<L1JetParticleCollection> tauJetHandle = iEvent.put(std::move(tauJetColl), "Tau");
 
-  OrphanHandle<L1JetParticleCollection> IsoTauJetHandle =
-      iEvent.put(std::move(isoTauJetColl), "IsoTau");
+  OrphanHandle<L1JetParticleCollection> IsoTauJetHandle = iEvent.put(std::move(isoTauJetColl), "IsoTau");
 
-  OrphanHandle<L1EtMissParticleCollection> etMissCollHandle =
-      iEvent.put(std::move(etMissColl), "MET");
+  OrphanHandle<L1EtMissParticleCollection> etMissCollHandle = iEvent.put(std::move(etMissColl), "MET");
 
-  OrphanHandle<L1EtMissParticleCollection> htMissCollHandle =
-      iEvent.put(std::move(htMissColl), "MHT");
+  OrphanHandle<L1EtMissParticleCollection> htMissCollHandle = iEvent.put(std::move(htMissColl), "MHT");
 
-  OrphanHandle<L1HFRingsCollection> hfRingsCollHandle =
-      iEvent.put(std::move(hfRingsColl));
+  OrphanHandle<L1HFRingsCollection> hfRingsCollHandle = iEvent.put(std::move(hfRingsColl));
 }
 
 // math::XYZTLorentzVector
-math::PtEtaPhiMLorentzVector
-L1ExtraParticlesProd::gctLorentzVector(const double &et, const L1GctCand &cand,
-                                       const L1CaloGeometry *geom,
-                                       bool central) {
+math::PtEtaPhiMLorentzVector L1ExtraParticlesProd::gctLorentzVector(const double &et,
+                                                                    const L1GctCand &cand,
+                                                                    const L1CaloGeometry *geom,
+                                                                    bool central) {
   // To keep x and y components non-zero.
-  double etCorr = et + 1.e-6; // protect against roundoff, not only for et=0
+  double etCorr = et + 1.e-6;  // protect against roundoff, not only for et=0
 
   double eta = geom->etaBinCenter(cand.etaIndex(), central);
 

--- a/L1Trigger/L1ExtraFromDigis/src/L1ExtraTestAnalyzer.cc
+++ b/L1Trigger/L1ExtraFromDigis/src/L1ExtraTestAnalyzer.cc
@@ -90,8 +90,7 @@ private:
 //
 L1ExtraTestAnalyzer::L1ExtraTestAnalyzer(const edm::ParameterSet &iConfig)
     : isoEmSource_(iConfig.getParameter<edm::InputTag>("isolatedEmSource")),
-      nonIsoEmSource_(
-          iConfig.getParameter<edm::InputTag>("nonIsolatedEmSource")),
+      nonIsoEmSource_(iConfig.getParameter<edm::InputTag>("nonIsolatedEmSource")),
       cenJetSource_(iConfig.getParameter<edm::InputTag>("centralJetSource")),
       forJetSource_(iConfig.getParameter<edm::InputTag>("forwardJetSource")),
       tauJetSource_(iConfig.getParameter<edm::InputTag>("tauJetSource")),
@@ -100,11 +99,12 @@ L1ExtraTestAnalyzer::L1ExtraTestAnalyzer(const edm::ParameterSet &iConfig)
       htMissSource_(iConfig.getParameter<edm::InputTag>("htMissSource")),
       hfRingsSource_(iConfig.getParameter<edm::InputTag>("hfRingsSource")),
       gtReadoutSource_(iConfig.getParameter<edm::InputTag>("gtReadoutSource")),
-      particleMapSource_(
-          iConfig.getParameter<edm::InputTag>("particleMapSource")),
+      particleMapSource_(iConfig.getParameter<edm::InputTag>("particleMapSource")),
       file_("l1extra.root", "RECREATE"),
-      hist_("triggers", "Triggers",
-            2 * l1extra::L1ParticleMap::kNumOfL1TriggerTypes + 1, -0.75,
+      hist_("triggers",
+            "Triggers",
+            2 * l1extra::L1ParticleMap::kNumOfL1TriggerTypes + 1,
+            -0.75,
             l1extra::L1ParticleMap::kNumOfL1TriggerTypes + 0.5 - 0.75) {
   // now do what ever initialization is needed
 }
@@ -122,8 +122,7 @@ L1ExtraTestAnalyzer::~L1ExtraTestAnalyzer() {
 //
 
 // ------------ method called to produce the data  ------------
-void L1ExtraTestAnalyzer::analyze(const edm::Event &iEvent,
-                                  const edm::EventSetup &iSetup) {
+void L1ExtraTestAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
   using namespace l1extra;
 
@@ -137,11 +136,9 @@ void L1ExtraTestAnalyzer::analyze(const edm::Event &iEvent,
   iEvent.getByLabel(isoEmSource_, isoEmColl);
   cout << "Number of isolated EM " << isoEmColl->size() << endl;
 
-  for (L1EmParticleCollection::const_iterator emItr = isoEmColl->begin();
-       emItr != isoEmColl->end(); ++emItr) {
-    cout << "  p4 (" << emItr->px() << ", " << emItr->py() << ", "
-         << emItr->pz() << ", " << emItr->energy() << ") et " << emItr->et()
-         << " eta " << emItr->eta() << " phi " << emItr->phi() << endl;
+  for (L1EmParticleCollection::const_iterator emItr = isoEmColl->begin(); emItr != isoEmColl->end(); ++emItr) {
+    cout << "  p4 (" << emItr->px() << ", " << emItr->py() << ", " << emItr->pz() << ", " << emItr->energy() << ") et "
+         << emItr->et() << " eta " << emItr->eta() << " phi " << emItr->phi() << endl;
   }
 
   // Non-isolated EM particles
@@ -149,11 +146,9 @@ void L1ExtraTestAnalyzer::analyze(const edm::Event &iEvent,
   iEvent.getByLabel(nonIsoEmSource_, nonIsoEmColl);
   cout << "Number of non-isolated EM " << nonIsoEmColl->size() << endl;
 
-  for (L1EmParticleCollection::const_iterator emItr = nonIsoEmColl->begin();
-       emItr != nonIsoEmColl->end(); ++emItr) {
-    cout << "  p4 (" << emItr->px() << ", " << emItr->py() << ", "
-         << emItr->pz() << ", " << emItr->energy() << ") et " << emItr->et()
-         << " eta " << emItr->eta() << " phi " << emItr->phi() << endl;
+  for (L1EmParticleCollection::const_iterator emItr = nonIsoEmColl->begin(); emItr != nonIsoEmColl->end(); ++emItr) {
+    cout << "  p4 (" << emItr->px() << ", " << emItr->py() << ", " << emItr->pz() << ", " << emItr->energy() << ") et "
+         << emItr->et() << " eta " << emItr->eta() << " phi " << emItr->phi() << endl;
   }
 
   // Jet particles
@@ -161,33 +156,27 @@ void L1ExtraTestAnalyzer::analyze(const edm::Event &iEvent,
   iEvent.getByLabel(cenJetSource_, cenJetColl);
   cout << "Number of central jets " << cenJetColl->size() << endl;
 
-  for (L1JetParticleCollection::const_iterator jetItr = cenJetColl->begin();
-       jetItr != cenJetColl->end(); ++jetItr) {
-    cout << "  p4 (" << jetItr->px() << ", " << jetItr->py() << ", "
-         << jetItr->pz() << ", " << jetItr->energy() << ") et " << jetItr->et()
-         << " eta " << jetItr->eta() << " phi " << jetItr->phi() << endl;
+  for (L1JetParticleCollection::const_iterator jetItr = cenJetColl->begin(); jetItr != cenJetColl->end(); ++jetItr) {
+    cout << "  p4 (" << jetItr->px() << ", " << jetItr->py() << ", " << jetItr->pz() << ", " << jetItr->energy()
+         << ") et " << jetItr->et() << " eta " << jetItr->eta() << " phi " << jetItr->phi() << endl;
   }
 
   Handle<L1JetParticleCollection> forJetColl;
   iEvent.getByLabel(forJetSource_, forJetColl);
   cout << "Number of forward jets " << forJetColl->size() << endl;
 
-  for (L1JetParticleCollection::const_iterator jetItr = forJetColl->begin();
-       jetItr != forJetColl->end(); ++jetItr) {
-    cout << "  p4 (" << jetItr->px() << ", " << jetItr->py() << ", "
-         << jetItr->pz() << ", " << jetItr->energy() << ") et " << jetItr->et()
-         << " eta " << jetItr->eta() << " phi " << jetItr->phi() << endl;
+  for (L1JetParticleCollection::const_iterator jetItr = forJetColl->begin(); jetItr != forJetColl->end(); ++jetItr) {
+    cout << "  p4 (" << jetItr->px() << ", " << jetItr->py() << ", " << jetItr->pz() << ", " << jetItr->energy()
+         << ") et " << jetItr->et() << " eta " << jetItr->eta() << " phi " << jetItr->phi() << endl;
   }
 
   Handle<L1JetParticleCollection> tauColl;
   iEvent.getByLabel(tauJetSource_, tauColl);
   cout << "Number of tau jets " << tauColl->size() << endl;
 
-  for (L1JetParticleCollection::const_iterator tauItr = tauColl->begin();
-       tauItr != tauColl->end(); ++tauItr) {
-    cout << "  p4 (" << tauItr->px() << ", " << tauItr->py() << ", "
-         << tauItr->pz() << ", " << tauItr->energy() << ") et " << tauItr->et()
-         << " eta " << tauItr->eta() << " phi " << tauItr->phi() << endl;
+  for (L1JetParticleCollection::const_iterator tauItr = tauColl->begin(); tauItr != tauColl->end(); ++tauItr) {
+    cout << "  p4 (" << tauItr->px() << ", " << tauItr->py() << ", " << tauItr->pz() << ", " << tauItr->energy()
+         << ") et " << tauItr->et() << " eta " << tauItr->eta() << " phi " << tauItr->phi() << endl;
   }
 
   // Muon particles
@@ -195,44 +184,34 @@ void L1ExtraTestAnalyzer::analyze(const edm::Event &iEvent,
   iEvent.getByLabel(muonSource_, muColl);
   cout << "Number of muons " << muColl->size() << endl;
 
-  for (L1MuonParticleCollection::const_iterator muItr = muColl->begin();
-       muItr != muColl->end(); ++muItr) {
-    cout << "  q " << muItr->charge() << " p4 (" << muItr->px() << ", "
-         << muItr->py() << ", " << muItr->pz() << ", " << muItr->energy()
-         << ") et " << muItr->et() << " eta " << muItr->eta() << endl
-         << "    phi " << muItr->phi() << " iso " << muItr->isIsolated()
-         << " mip " << muItr->isMip() << " fwd " << muItr->isForward()
-         << " rpc " << muItr->isRPC() << endl;
+  for (L1MuonParticleCollection::const_iterator muItr = muColl->begin(); muItr != muColl->end(); ++muItr) {
+    cout << "  q " << muItr->charge() << " p4 (" << muItr->px() << ", " << muItr->py() << ", " << muItr->pz() << ", "
+         << muItr->energy() << ") et " << muItr->et() << " eta " << muItr->eta() << endl
+         << "    phi " << muItr->phi() << " iso " << muItr->isIsolated() << " mip " << muItr->isMip() << " fwd "
+         << muItr->isForward() << " rpc " << muItr->isRPC() << endl;
   }
 
   // MET
   Handle<L1EtMissParticleCollection> etMissColl;
   iEvent.getByLabel(etMissSource_, etMissColl);
-  cout << "MET Coll (" << etMissColl->begin()->px() << ", "
-       << etMissColl->begin()->py() << ", " << etMissColl->begin()->pz() << ", "
-       << etMissColl->begin()->energy() << ") phi "
-       << etMissColl->begin()->phi() << " EtTot "
-       << etMissColl->begin()->etTotal() << endl;
+  cout << "MET Coll (" << etMissColl->begin()->px() << ", " << etMissColl->begin()->py() << ", "
+       << etMissColl->begin()->pz() << ", " << etMissColl->begin()->energy() << ") phi " << etMissColl->begin()->phi()
+       << " EtTot " << etMissColl->begin()->etTotal() << endl;
 
   // MHT
   Handle<L1EtMissParticleCollection> htMissColl;
   iEvent.getByLabel(htMissSource_, htMissColl);
-  cout << "MHT Coll (" << htMissColl->begin()->px() << ", "
-       << htMissColl->begin()->py() << ", " << htMissColl->begin()->pz() << ", "
-       << htMissColl->begin()->energy() << ") phi "
-       << htMissColl->begin()->phi() << " HtTot "
-       << htMissColl->begin()->etTotal() << endl;
+  cout << "MHT Coll (" << htMissColl->begin()->px() << ", " << htMissColl->begin()->py() << ", "
+       << htMissColl->begin()->pz() << ", " << htMissColl->begin()->energy() << ") phi " << htMissColl->begin()->phi()
+       << " HtTot " << htMissColl->begin()->etTotal() << endl;
 
   // HF Rings
   Handle<L1HFRingsCollection> hfRingsColl;
   iEvent.getByLabel(hfRingsSource_, hfRingsColl);
   cout << "HF Rings:" << endl;
   for (int i = 0; i < L1HFRings::kNumRings; ++i) {
-    cout << "  " << i << ": et sum = "
-         << hfRingsColl->begin()->hfEtSum((L1HFRings::HFRingLabels)i)
-         << ", bit count = "
-         << hfRingsColl->begin()->hfBitCount((L1HFRings::HFRingLabels)i)
-         << endl;
+    cout << "  " << i << ": et sum = " << hfRingsColl->begin()->hfEtSum((L1HFRings::HFRingLabels)i)
+         << ", bit count = " << hfRingsColl->begin()->hfBitCount((L1HFRings::HFRingLabels)i) << endl;
   }
   cout << endl;
 

--- a/L1Trigger/L1TMuonCPPF/interface/EmulateCPPF.h
+++ b/L1Trigger/L1TMuonCPPF/interface/EmulateCPPF.h
@@ -7,15 +7,14 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class EmulateCPPF {
-
 public:
-  explicit EmulateCPPF(const edm::ParameterSet &iConfig,
-                       edm::ConsumesCollector &&iConsumes);
+  explicit EmulateCPPF(const edm::ParameterSet &iConfig, edm::ConsumesCollector &&iConsumes);
   ~EmulateCPPF();
 
   void process(
       // Input
-      const edm::Event &iEvent, const edm::EventSetup &iSetup,
+      const edm::Event &iEvent,
+      const edm::EventSetup &iSetup,
       // Output
       l1t::CPPFDigiCollection &cppf_recHit);
 
@@ -29,6 +28,6 @@ private:
   enum class CppfSource { File, EventSetup } cppfSource_;
   std::vector<RecHitProcessor::CppfItem> CppfVec_1;
   int MaxClusterSize_;
-}; // End class EmulateCPPF
+};  // End class EmulateCPPF
 
-#endif // #define L1Trigger_L1TMuonCPPF_EmulateCPPF_h
+#endif  // #define L1Trigger_L1TMuonCPPF_EmulateCPPF_h

--- a/L1Trigger/L1TMuonCPPF/interface/RecHitProcessor.h
+++ b/L1Trigger/L1TMuonCPPF/interface/RecHitProcessor.h
@@ -33,7 +33,6 @@ public:
   ~RecHitProcessor();
 
   struct CppfItem {
-
     int lb;
     int rawId;
     int strip;
@@ -49,22 +48,23 @@ public:
 
   void processLook(
       // Input
-      const edm::Event &iEvent, const edm::EventSetup &iSetup,
+      const edm::Event &iEvent,
+      const edm::EventSetup &iSetup,
       const edm::EDGetToken &recHitToken,
       std::vector<RecHitProcessor::CppfItem> &CppfVec1,
       // Output
-      l1t::CPPFDigiCollection &cppfDigis, const int MaxClusterSize) const;
+      l1t::CPPFDigiCollection &cppfDigis,
+      const int MaxClusterSize) const;
 
   void process(
       // Input
-      const edm::Event &iEvent, const edm::EventSetup &iSetup,
+      const edm::Event &iEvent,
+      const edm::EventSetup &iSetup,
       const edm::EDGetToken &recHitToken,
       // Output
       l1t::CPPFDigiCollection &cppfDigis) const;
 
-  void print(int a, int b, float c, float d) const {
-    std::cout << a << " " << b << " " << c << " " << d << std::endl;
-  };
+  void print(int a, int b, float c, float d) const { std::cout << a << " " << b << " " << c << " " << d << std::endl; };
 
   COND_SERIALIZABLE;
 

--- a/L1Trigger/L1TMuonCPPF/plugins/L1TMuonCPPFDigiProducer.cc
+++ b/L1Trigger/L1TMuonCPPF/plugins/L1TMuonCPPFDigiProducer.cc
@@ -3,10 +3,8 @@
 
 #include "L1TMuonCPPFDigiProducer.h"
 
-L1TMuonCPPFDigiProducer::L1TMuonCPPFDigiProducer(
-    const edm::ParameterSet &iConfig)
-    : cppf_emulator_(
-          std::make_unique<EmulateCPPF>(iConfig, consumesCollector()))
+L1TMuonCPPFDigiProducer::L1TMuonCPPFDigiProducer(const edm::ParameterSet &iConfig)
+    : cppf_emulator_(std::make_unique<EmulateCPPF>(iConfig, consumesCollector()))
 // cppf_emulator_(new EmulateCPPF(iConfig, consumesCollector()))
 {
   // produces<l1t::CPPFDigiCollection>("rpcDigi");
@@ -15,9 +13,7 @@ L1TMuonCPPFDigiProducer::L1TMuonCPPFDigiProducer(
 
 L1TMuonCPPFDigiProducer::~L1TMuonCPPFDigiProducer() {}
 
-void L1TMuonCPPFDigiProducer::produce(edm::Event &iEvent,
-                                      const edm::EventSetup &iSetup) {
-
+void L1TMuonCPPFDigiProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // Create pointers to the collections which will store the cppfDigis
   // auto cppf_rpcDigi = std::make_unique<l1t::CPPFDigiCollection>();
   auto cppf_recHit = std::make_unique<l1t::CPPFDigiCollection>();

--- a/L1Trigger/L1TMuonCPPF/plugins/L1TMuonCPPFDigiProducer.h
+++ b/L1Trigger/L1TMuonCPPF/plugins/L1TMuonCPPFDigiProducer.h
@@ -47,7 +47,6 @@
 
 // Class declaration
 class L1TMuonCPPFDigiProducer : public edm::stream::EDProducer<> {
-
 public:
   explicit L1TMuonCPPFDigiProducer(const edm::ParameterSet &);
   ~L1TMuonCPPFDigiProducer() override;

--- a/L1Trigger/L1TMuonCPPF/src/EmulateCPPF.cc
+++ b/L1Trigger/L1TMuonCPPF/src/EmulateCPPF.cc
@@ -7,32 +7,29 @@
 
 EmulateCPPF::EmulateCPPF(const edm::ParameterSet &iConfig,
                          edm::ConsumesCollector &&iConsumes)
-    : // rpcDigi_processors_(),
+    :  // rpcDigi_processors_(),
       recHit_processors_(),
       // rpcDigiToken_(
       // iConsumes.consumes<RPCTag::digi_collection>(iConfig.getParameter<edm::InputTag>("recHitLabel"))
       // ),
-      recHitToken_(iConsumes.consumes<RPCRecHitCollection>(
-          iConfig.getParameter<edm::InputTag>("recHitLabel"))),
-      cppfSource_(CppfSource::EventSetup), MaxClusterSize_(0) {
+      recHitToken_(iConsumes.consumes<RPCRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitLabel"))),
+      cppfSource_(CppfSource::EventSetup),
+      MaxClusterSize_(0) {
   MaxClusterSize_ = iConfig.getParameter<int>("MaxClusterSize");
 
-  const std::string cppfSource =
-      iConfig.getParameter<std::string>("cppfSource");
+  const std::string cppfSource = iConfig.getParameter<std::string>("cppfSource");
   // Look up table
   if (cppfSource == "File") {
     cppfSource_ = CppfSource::File;
     edm::FileInPath fp = iConfig.getParameter<edm::FileInPath>("cppfvecfile");
     std::ifstream inputFile(fp.fullPath().c_str(), std::ios::in);
     if (!inputFile) {
-      throw cms::Exception("No LUT")
-          << "Error: CPPF look up table file cannot not be opened";
+      throw cms::Exception("No LUT") << "Error: CPPF look up table file cannot not be opened";
       exit(1);
     }
     while (inputFile.good()) {
       RecHitProcessor::CppfItem Item;
-      inputFile >> Item.rawId >> Item.strip >> Item.lb >> Item.halfchannel >>
-          Item.int_phi >> Item.int_theta;
+      inputFile >> Item.rawId >> Item.strip >> Item.lb >> Item.halfchannel >> Item.int_phi >> Item.int_theta;
       if (inputFile.good())
         CppfVec_1.push_back(Item);
     }
@@ -45,9 +42,8 @@ EmulateCPPF::EmulateCPPF(const edm::ParameterSet &iConfig,
   }
   // Error for wrong input
   else {
-    throw cms::Exception("Invalid option")
-        << "Error: Specify in python/emulatorCppfDigis_cfi 'File' for look up  "
-           "table or 'Geo' for RPC Geometry";
+    throw cms::Exception("Invalid option") << "Error: Specify in python/emulatorCppfDigis_cfi 'File' for look up  "
+                                              "table or 'Geo' for RPC Geometry";
     exit(1);
   }
 }
@@ -58,13 +54,11 @@ void EmulateCPPF::process(const edm::Event &iEvent,
                           const edm::EventSetup &iSetup,
                           // l1t::CPPFDigiCollection& cppf_rpcDigi,
                           l1t::CPPFDigiCollection &cppf_recHit) {
-
   if (cppfSource_ == CppfSource::File) {
     // Using the look up table to fill the information
     cppf_recHit.clear();
     for (auto &recHit_processor : recHit_processors_) {
-      recHit_processor.processLook(iEvent, iSetup, recHitToken_, CppfVec_1,
-                                   cppf_recHit, MaxClusterSize_);
+      recHit_processor.processLook(iEvent, iSetup, recHitToken_, CppfVec_1, cppf_recHit, MaxClusterSize_);
       //  recHit_processors_.at(recHit_processor).processLook( iEvent, iSetup,
       //  recHitToken_, CppfVec_1, cppf_recHit );
     }
@@ -95,4 +89,4 @@ void EmulateCPPF::process(const edm::Event &iEvent,
       // recHitToken_, cppf_recHit );
     }
   }
-} // End void EmulateCPPF::process()
+}  // End void EmulateCPPF::process()

--- a/L1Trigger/L1TMuonCPPF/src/RecHitProcessor.cc
+++ b/L1Trigger/L1TMuonCPPF/src/RecHitProcessor.cc
@@ -4,12 +4,12 @@ RecHitProcessor::RecHitProcessor() {}
 
 RecHitProcessor::~RecHitProcessor() {}
 
-void RecHitProcessor::processLook(
-    const edm::Event &iEvent, const edm::EventSetup &iSetup,
-    const edm::EDGetToken &recHitToken,
-    std::vector<RecHitProcessor::CppfItem> &CppfVec1,
-    l1t::CPPFDigiCollection &cppfDigis, const int MaxClusterSize) const {
-
+void RecHitProcessor::processLook(const edm::Event &iEvent,
+                                  const edm::EventSetup &iSetup,
+                                  const edm::EDGetToken &recHitToken,
+                                  std::vector<RecHitProcessor::CppfItem> &CppfVec1,
+                                  l1t::CPPFDigiCollection &cppfDigis,
+                                  const int MaxClusterSize) const {
   edm::Handle<RPCRecHitCollection> recHits;
   iEvent.getByToken(recHitToken, recHits);
 
@@ -19,10 +19,8 @@ void RecHitProcessor::processLook(
   // The loop is over the detector container in the rpc geometry collection. We
   // are interested in the RPDdetID (inside of RPCChamber vectors),
   // specifically, the RPCrechits. to assignment the CPPFDigis.
-  for (TrackingGeometry::DetContainer::const_iterator iDet =
-           rpcGeom->dets().begin();
-       iDet < rpcGeom->dets().end(); iDet++) {
-
+  for (TrackingGeometry::DetContainer::const_iterator iDet = rpcGeom->dets().begin(); iDet < rpcGeom->dets().end();
+       iDet++) {
     //  we do a cast over the class RPCChamber to obtain the RPCroll vectors,
     //  inside of them, the RPCRechits are found. in other words, the method
     //  ->rolls() does not exist for other kind of vector within DetContainer
@@ -36,19 +34,14 @@ void RecHitProcessor::processLook(
 
     // Loop over rolls in the chamber
     for (auto &iRoll : rolls) {
-
       RPCDetId rpcId = (*iRoll).id();
 
-      typedef std::pair<RPCRecHitCollection::const_iterator,
-                        RPCRecHitCollection::const_iterator>
-          rangeRecHits;
+      typedef std::pair<RPCRecHitCollection::const_iterator, RPCRecHitCollection::const_iterator> rangeRecHits;
       rangeRecHits recHitCollection = recHits->get(rpcId);
 
       // Loop over the RPC digis
-      for (RPCRecHitCollection::const_iterator rechit_it =
-               recHitCollection.first;
-           rechit_it != recHitCollection.second; rechit_it++) {
-
+      for (RPCRecHitCollection::const_iterator rechit_it = recHitCollection.first; rechit_it != recHitCollection.second;
+           rechit_it++) {
         // const RPCDetId& rpcId = rechit_it->rpcId();
         int rawId = rpcId.rawId();
         // int station = rpcId.station();
@@ -170,10 +163,8 @@ void RecHitProcessor::processLook(
         std::vector<RecHitProcessor::CppfItem>::iterator cppf1;
         std::vector<RecHitProcessor::CppfItem>::iterator cppf;
         for (cppf1 = CppfVec1.begin(); cppf1 != CppfVec1.end(); cppf1++) {
-
           // Condition to save the CPPFDigi
           if (((*cppf1).rawId == rawId) && ((*cppf1).strip == rechitstrip)) {
-
             int old_strip = (*cppf1).strip;
             int before = 0;
             int after = 0;
@@ -193,7 +184,6 @@ void RecHitProcessor::processLook(
             cppf = cppf1;
 
             if (clustersize == 2) {
-
               if (firststrip == 1) {
                 if (before < after)
                   cppf = (cppf1 - 1);
@@ -208,14 +198,32 @@ void RecHitProcessor::processLook(
             }
             // Using the RPCGeometry
             if (Geo) {
-              std::shared_ptr<l1t::CPPFDigi> MainVariables1(new l1t::CPPFDigi(
-                  rpcId, Bx, (*cppf).int_phi, (*cppf).int_theta, isValid,
-                  (*cppf).lb, (*cppf).halfchannel, EMTFsector1, EMTFLink1,
-                  old_strip, clustersize, global_phi, global_theta));
-              std::shared_ptr<l1t::CPPFDigi> MainVariables2(new l1t::CPPFDigi(
-                  rpcId, Bx, (*cppf).int_phi, (*cppf).int_theta, isValid,
-                  (*cppf).lb, (*cppf).halfchannel, EMTFsector2, EMTFLink2,
-                  old_strip, clustersize, global_phi, global_theta));
+              std::shared_ptr<l1t::CPPFDigi> MainVariables1(new l1t::CPPFDigi(rpcId,
+                                                                              Bx,
+                                                                              (*cppf).int_phi,
+                                                                              (*cppf).int_theta,
+                                                                              isValid,
+                                                                              (*cppf).lb,
+                                                                              (*cppf).halfchannel,
+                                                                              EMTFsector1,
+                                                                              EMTFLink1,
+                                                                              old_strip,
+                                                                              clustersize,
+                                                                              global_phi,
+                                                                              global_theta));
+              std::shared_ptr<l1t::CPPFDigi> MainVariables2(new l1t::CPPFDigi(rpcId,
+                                                                              Bx,
+                                                                              (*cppf).int_phi,
+                                                                              (*cppf).int_theta,
+                                                                              isValid,
+                                                                              (*cppf).lb,
+                                                                              (*cppf).halfchannel,
+                                                                              EMTFsector2,
+                                                                              EMTFLink2,
+                                                                              old_strip,
+                                                                              clustersize,
+                                                                              global_phi,
+                                                                              global_theta));
 
               if ((EMTFsector1 > 0) && (EMTFsector2 == 0)) {
                 cppfDigis.push_back(*MainVariables1.get());
@@ -225,18 +233,36 @@ void RecHitProcessor::processLook(
               } else if ((EMTFsector1 == 0) && (EMTFsector2 == 0)) {
                 continue;
               }
-            } // Geo is true
+            }  // Geo is true
             else {
               global_phi = 0.;
               global_theta = 0.;
-              std::shared_ptr<l1t::CPPFDigi> MainVariables1(new l1t::CPPFDigi(
-                  rpcId, Bx, (*cppf).int_phi, (*cppf).int_theta, isValid,
-                  (*cppf).lb, (*cppf).halfchannel, EMTFsector1, EMTFLink1,
-                  old_strip, clustersize, global_phi, global_theta));
-              std::shared_ptr<l1t::CPPFDigi> MainVariables2(new l1t::CPPFDigi(
-                  rpcId, Bx, (*cppf).int_phi, (*cppf).int_theta, isValid,
-                  (*cppf).lb, (*cppf).halfchannel, EMTFsector2, EMTFLink2,
-                  old_strip, clustersize, global_phi, global_theta));
+              std::shared_ptr<l1t::CPPFDigi> MainVariables1(new l1t::CPPFDigi(rpcId,
+                                                                              Bx,
+                                                                              (*cppf).int_phi,
+                                                                              (*cppf).int_theta,
+                                                                              isValid,
+                                                                              (*cppf).lb,
+                                                                              (*cppf).halfchannel,
+                                                                              EMTFsector1,
+                                                                              EMTFLink1,
+                                                                              old_strip,
+                                                                              clustersize,
+                                                                              global_phi,
+                                                                              global_theta));
+              std::shared_ptr<l1t::CPPFDigi> MainVariables2(new l1t::CPPFDigi(rpcId,
+                                                                              Bx,
+                                                                              (*cppf).int_phi,
+                                                                              (*cppf).int_theta,
+                                                                              isValid,
+                                                                              (*cppf).lb,
+                                                                              (*cppf).halfchannel,
+                                                                              EMTFsector2,
+                                                                              EMTFLink2,
+                                                                              old_strip,
+                                                                              clustersize,
+                                                                              global_phi,
+                                                                              global_theta));
               if ((EMTFsector1 > 0) && (EMTFsector2 == 0)) {
                 cppfDigis.push_back(*MainVariables1.get());
               } else if ((EMTFsector1 > 0) && (EMTFsector2 > 0)) {
@@ -246,20 +272,19 @@ void RecHitProcessor::processLook(
                 continue;
               }
             }
-          } // Condition to save the CPPFDigi
-        }   // Loop over the LUTVector
-      }     // Loop over the recHits
-    }       // End loop: for (std::vector<const RPCRoll*>::const_iterator r =
-            // rolls.begin(); r != rolls.end(); ++r)
-  } // End loop: for (TrackingGeometry::DetContainer::const_iterator iDet =
-    // rpcGeom->dets().begin(); iDet < rpcGeom->dets().end(); iDet++)
+          }  // Condition to save the CPPFDigi
+        }    // Loop over the LUTVector
+      }      // Loop over the recHits
+    }        // End loop: for (std::vector<const RPCRoll*>::const_iterator r =
+             // rolls.begin(); r != rolls.end(); ++r)
+  }          // End loop: for (TrackingGeometry::DetContainer::const_iterator iDet =
+             // rpcGeom->dets().begin(); iDet < rpcGeom->dets().end(); iDet++)
 }
 
 void RecHitProcessor::process(const edm::Event &iEvent,
                               const edm::EventSetup &iSetup,
                               const edm::EDGetToken &recHitToken,
                               l1t::CPPFDigiCollection &cppfDigis) const {
-
   // Get the RPC Geometry
   edm::ESHandle<RPCGeometry> rpcGeom;
   iSetup.get<MuonGeometryRecord>().get(rpcGeom);
@@ -271,10 +296,8 @@ void RecHitProcessor::process(const edm::Event &iEvent,
   // The loop is over the detector container in the rpc geometry collection. We
   // are interested in the RPDdetID (inside of RPCChamber vectors),
   // specifically, the RPCrechits. to assignment the CPPFDigis.
-  for (TrackingGeometry::DetContainer::const_iterator iDet =
-           rpcGeom->dets().begin();
-       iDet < rpcGeom->dets().end(); iDet++) {
-
+  for (TrackingGeometry::DetContainer::const_iterator iDet = rpcGeom->dets().begin(); iDet < rpcGeom->dets().end();
+       iDet++) {
     //  we do a cast over the class RPCChamber to obtain the RPCroll vectors,
     //  inside of them, the RPCRechits are found. in other words, the method
     //  ->rolls() does not exist for other kind of vector within DetContainer
@@ -287,18 +310,13 @@ void RecHitProcessor::process(const edm::Event &iEvent,
 
     // Loop over rolls in the chamber
     for (auto &iRoll : rolls) {
-
       RPCDetId rpcId = (*iRoll).id();
 
-      typedef std::pair<RPCRecHitCollection::const_iterator,
-                        RPCRecHitCollection::const_iterator>
-          rangeRecHits;
+      typedef std::pair<RPCRecHitCollection::const_iterator, RPCRecHitCollection::const_iterator> rangeRecHits;
       rangeRecHits recHitCollection = recHits->get(rpcId);
 
-      for (RPCRecHitCollection::const_iterator rechit_it =
-               recHitCollection.first;
-           rechit_it != recHitCollection.second; rechit_it++) {
-
+      for (RPCRecHitCollection::const_iterator rechit_it = recHitCollection.first; rechit_it != recHitCollection.second;
+           rechit_it++) {
         // const RPCDetId& rpcId = rechit_it->rpcId();
         // int rawId = rpcId.rawId();
         int region = rpcId.region();
@@ -316,10 +334,8 @@ void RecHitProcessor::process(const edm::Event &iEvent,
         // Endcap region only
 
         if (region != 0) {
-
-          int int_theta = (region == -1 ? 180. * 32. / 36.5 : 0.) +
-                          (float)region * global_theta * 32. / 36.5 -
-                          8.5 * 32 / 36.5;
+          int int_theta =
+              (region == -1 ? 180. * 32. / 36.5 : 0.) + (float)region * global_theta * 32. / 36.5 - 8.5 * 32 / 36.5;
 
           if (region == 1) {
             if (global_theta < 8.5)
@@ -444,14 +460,32 @@ void RecHitProcessor::process(const edm::Event &iEvent,
           assert(0 <= int_phi && int_phi < 1250);
           assert(0 <= int_theta && int_theta < 32);
 
-          std::shared_ptr<l1t::CPPFDigi> MainVariables1(
-              new l1t::CPPFDigi(rpcId, Bx, int_phi, int_theta, isValid, lb,
-                                halfchannel, EMTFsector1, EMTFLink1, firststrip,
-                                clustersize, global_phi, global_theta));
-          std::shared_ptr<l1t::CPPFDigi> MainVariables2(
-              new l1t::CPPFDigi(rpcId, Bx, int_phi, int_theta, isValid, lb,
-                                halfchannel, EMTFsector2, EMTFLink2, firststrip,
-                                clustersize, global_phi, global_theta));
+          std::shared_ptr<l1t::CPPFDigi> MainVariables1(new l1t::CPPFDigi(rpcId,
+                                                                          Bx,
+                                                                          int_phi,
+                                                                          int_theta,
+                                                                          isValid,
+                                                                          lb,
+                                                                          halfchannel,
+                                                                          EMTFsector1,
+                                                                          EMTFLink1,
+                                                                          firststrip,
+                                                                          clustersize,
+                                                                          global_phi,
+                                                                          global_theta));
+          std::shared_ptr<l1t::CPPFDigi> MainVariables2(new l1t::CPPFDigi(rpcId,
+                                                                          Bx,
+                                                                          int_phi,
+                                                                          int_theta,
+                                                                          isValid,
+                                                                          lb,
+                                                                          halfchannel,
+                                                                          EMTFsector2,
+                                                                          EMTFLink2,
+                                                                          firststrip,
+                                                                          clustersize,
+                                                                          global_phi,
+                                                                          global_theta));
           if (int_theta == 31)
             continue;
           if ((EMTFsector1 > 0) && (EMTFsector2 == 0)) {
@@ -464,13 +498,13 @@ void RecHitProcessor::process(const edm::Event &iEvent,
           if ((EMTFsector1 == 0) && (EMTFsector2 == 0)) {
             continue;
           }
-        } // No barrel rechits
+        }  // No barrel rechits
 
-      } // End loop: for (RPCRecHitCollection::const_iterator recHit =
-        // recHitCollection.first; recHit != recHitCollection.second; recHit++)
+      }  // End loop: for (RPCRecHitCollection::const_iterator recHit =
+         // recHitCollection.first; recHit != recHitCollection.second; recHit++)
 
-    } // End loop: for (std::vector<const RPCRoll*>::const_iterator r =
-      // rolls.begin(); r != rolls.end(); ++r)
-  }   // End loop: for (TrackingGeometry::DetContainer::const_iterator iDet =
-      // rpcGeom->dets().begin(); iDet < rpcGeom->dets().end(); iDet++)
-} // End function: void RecHitProcessor::process()
+    }  // End loop: for (std::vector<const RPCRoll*>::const_iterator r =
+       // rolls.begin(); r != rolls.end(); ++r)
+  }    // End loop: for (TrackingGeometry::DetContainer::const_iterator iDet =
+       // rpcGeom->dets().begin(); iDet < rpcGeom->dets().end(); iDet++)
+}  // End function: void RecHitProcessor::process()

--- a/L1Trigger/RegionalCaloTrigger/interface/L1RCT.h
+++ b/L1Trigger/RegionalCaloTrigger/interface/L1RCT.h
@@ -18,7 +18,6 @@
 class L1RCTLookupTables;
 
 class L1RCT {
-
 public:
   L1RCT(const L1RCTLookupTables *rctLookupTables);
 
@@ -26,19 +25,17 @@ public:
   void input();
 
   // For testing accept external input
-  void
-  input(const std::vector<std::vector<std::vector<unsigned short>>> &barrelIn,
-        const std::vector<std::vector<unsigned short>> &hfIn);
+  void input(const std::vector<std::vector<std::vector<unsigned short>>> &barrelIn,
+             const std::vector<std::vector<unsigned short>> &hfIn);
 
   // Should send commands to all crates to send commands to all RCs to
   // process the input data and then send it on to the EICs and then
   // to the JSCs
   void processEvent();
 
-  void fileInput(const char *filename); // added "const" also in .cc
+  void fileInput(const char *filename);  // added "const" also in .cc
 
-  void digiInput(const EcalTrigPrimDigiCollection &ecalCollection,
-                 const HcalTrigPrimDigiCollection &hcalCollection);
+  void digiInput(const EcalTrigPrimDigiCollection &ecalCollection, const HcalTrigPrimDigiCollection &hcalCollection);
 
   void randomInput();
 
@@ -59,33 +56,23 @@ public:
 
   L1CaloEmCollection getNonisolatedEGObjects(unsigned crate);
 
-  std::vector<unsigned short> getJetRegions(unsigned crate) {
-    return crates.at(crate).getJetRegions();
-  }
+  std::vector<unsigned short> getJetRegions(unsigned crate) { return crates.at(crate).getJetRegions(); }
 
   std::vector<L1CaloRegion> getRegions(unsigned crate);
 
-  unsigned short ecalCompressedET(int crate, int card, int tower) {
-    return barrel.at(crate).at(card).at(tower) / 2;
-  }
-  unsigned short ecalFineGrainBit(int crate, int card, int tower) {
-    return barrel.at(crate).at(card).at(tower) & 1;
-  }
+  unsigned short ecalCompressedET(int crate, int card, int tower) { return barrel.at(crate).at(card).at(tower) / 2; }
+  unsigned short ecalFineGrainBit(int crate, int card, int tower) { return barrel.at(crate).at(card).at(tower) & 1; }
   unsigned short hcalCompressedET(int crate, int card, int tower) {
     return barrel.at(crate).at(card).at(tower + 32) / 2;
   }
   unsigned short hcalFineGrainBit(int crate, int card, int tower) {
     return barrel.at(crate).at(card).at(tower + 32) & 1;
   }
-  unsigned short hfCompressedET(int crate, int tower) {
-    return hf.at(crate).at(tower) / 2;
-  }
-  unsigned short hfFineGrainBit(int crate, int tower) {
-    return hf.at(crate).at(tower) & 1;
-  }
+  unsigned short hfCompressedET(int crate, int tower) { return hf.at(crate).at(tower) / 2; }
+  unsigned short hfFineGrainBit(int crate, int tower) { return hf.at(crate).at(tower) & 1; }
 
 private:
-  L1RCT(); // Do not implement this
+  L1RCT();  // Do not implement this
 
   const L1RCTLookupTables *rctLookupTables_;
 

--- a/L1Trigger/RegionalCaloTrigger/interface/L1RCTCrate.h
+++ b/L1Trigger/RegionalCaloTrigger/interface/L1RCTCrate.h
@@ -9,7 +9,6 @@
 class L1RCTLookupTables;
 
 class L1RCTCrate {
-
 public:
   L1RCTCrate(int crtNo, const L1RCTLookupTables *rctLookupTables);
 
@@ -29,8 +28,7 @@ public:
   // the RCInput to the 7 receiver cards and sends the HFInput straight
   // to the JSC for this crate.  The RCs never see the HF data.  Instead
   // the JSC acts like a primitive RC for these regions.
-  void input(const std::vector<std::vector<unsigned short>> &RCInput,
-             const std::vector<unsigned short> &HFInput);
+  void input(const std::vector<std::vector<unsigned short>> &RCInput, const std::vector<unsigned short> &HFInput);
   // The two following are methods for running the actual data processing
   // in the RCs and the EICs.  They're to be called for each card
   // from the L1RCT process method
@@ -48,23 +46,13 @@ public:
   void printEICEdges(int i) { electronCards.at(i).printEdges(); }
 
   // region sums
-  std::vector<unsigned short> getJetRegions() {
-    return jetSummaryCard.getJetRegions();
-  }
-  std::vector<unsigned short> getBarrelRegions() {
-    return jetSummaryCard.getBarrelRegions();
-  }
-  std::vector<unsigned short> getHFRegions() {
-    return jetSummaryCard.getHFRegions();
-  }
+  std::vector<unsigned short> getJetRegions() { return jetSummaryCard.getJetRegions(); }
+  std::vector<unsigned short> getBarrelRegions() { return jetSummaryCard.getBarrelRegions(); }
+  std::vector<unsigned short> getHFRegions() { return jetSummaryCard.getHFRegions(); }
 
   // e-gamma objects
-  std::vector<unsigned short> getIsolatedEGObjects() {
-    return jetSummaryCard.getIsolatedEGObjects();
-  }
-  std::vector<unsigned short> getNonisolatedEGObjects() {
-    return jetSummaryCard.getNonisolatedEGObjects();
-  }
+  std::vector<unsigned short> getIsolatedEGObjects() { return jetSummaryCard.getIsolatedEGObjects(); }
+  std::vector<unsigned short> getNonisolatedEGObjects() { return jetSummaryCard.getNonisolatedEGObjects(); }
 
   // the bits
   unsigned short getTauBits() { return jetSummaryCard.getTauBits(); }
@@ -72,9 +60,7 @@ public:
   unsigned short getOverFlowBits() { return jetSummaryCard.getOverFlowBits(); }
   unsigned short getQuietBits() { return jetSummaryCard.getQuietBits(); }
   // hf bit
-  std::vector<unsigned short> getHFFineGrainBits() {
-    return jetSummaryCard.getHFFineGrainBits();
-  }
+  std::vector<unsigned short> getHFFineGrainBits() { return jetSummaryCard.getHFFineGrainBits(); }
 
 private:
   // The seven RCs and EICs
@@ -95,4 +81,4 @@ private:
 
   // L1RCTJetCaptureCard jetCaptureCard;
 };
-#endif // L1RCTCrate_h
+#endif  // L1RCTCrate_h

--- a/L1Trigger/RegionalCaloTrigger/interface/L1RCTElectronIsolationCard.h
+++ b/L1Trigger/RegionalCaloTrigger/interface/L1RCTElectronIsolationCard.h
@@ -17,10 +17,8 @@
 class L1RCTLookupTables;
 
 class L1RCTElectronIsolationCard {
-
 public:
-  L1RCTElectronIsolationCard(int crateNumber, int cardNumber,
-                             const L1RCTLookupTables *rctLookupTables);
+  L1RCTElectronIsolationCard(int crateNumber, int cardNumber, const L1RCTLookupTables *rctLookupTables);
   ~L1RCTElectronIsolationCard();
 
   int crateNumber() { return crtNo; }
@@ -40,14 +38,15 @@ public:
   }
 
 private:
-  std::vector<unsigned short> calcElectronCandidates(const L1RCTRegion &region,
-                                                     int regionNum);
-  unsigned short calcMaxSum(unsigned short primaryEt, unsigned short northEt,
-                            unsigned short southEt, unsigned short eastEt,
+  std::vector<unsigned short> calcElectronCandidates(const L1RCTRegion &region, int regionNum);
+  unsigned short calcMaxSum(unsigned short primaryEt,
+                            unsigned short northEt,
+                            unsigned short southEt,
+                            unsigned short eastEt,
                             unsigned short westEt);
 
-  unsigned short crtNo;  // changed from int
-  unsigned short cardNo; // changed from int
+  unsigned short crtNo;   // changed from int
+  unsigned short cardNo;  // changed from int
 
   const L1RCTLookupTables *rctLookupTables_;
 

--- a/L1Trigger/RegionalCaloTrigger/interface/L1RCTJetSummaryCard.h
+++ b/L1Trigger/RegionalCaloTrigger/interface/L1RCTJetSummaryCard.h
@@ -22,12 +22,8 @@ public:
   // although, in the case of the emulator they may always be in
   // the descending order of rank
 
-  std::vector<unsigned short> getIsolatedEGObjects() {
-    return isolatedEGObjects;
-  }
-  std::vector<unsigned short> getNonisolatedEGObjects() {
-    return nonisolatedEGObjects;
-  }
+  std::vector<unsigned short> getIsolatedEGObjects() { return isolatedEGObjects; }
+  std::vector<unsigned short> getNonisolatedEGObjects() { return nonisolatedEGObjects; }
 
   // Region sums 10-bit energy (bits 0-9),overflow (bit 10)
   // bit 11 is tau bit
@@ -74,14 +70,11 @@ public:
   std::vector<unsigned short> getHFFineGrainBits() { return hfFineGrainBits; }
 
   void fillHFRegionSums(const std::vector<unsigned short> &hfRegionSums);
-  void fillRegionSums(const std::vector<unsigned short> &regSums) {
-    barrelRegions = regSums;
-  }
+  void fillRegionSums(const std::vector<unsigned short> &regSums) { barrelRegions = regSums; }
   void fillJetRegions();
 
   void fillIsolatedEGObjects(const std::vector<unsigned short> &isoElectrons);
-  void
-  fillNonIsolatedEGObjects(const std::vector<unsigned short> &nonIsoElectrons);
+  void fillNonIsolatedEGObjects(const std::vector<unsigned short> &nonIsoElectrons);
 
   void fillMIPBits(const std::vector<unsigned short> &mip);
   void fillTauBits(const std::vector<unsigned short> &tau);
@@ -99,10 +92,9 @@ private:
   std::vector<unsigned short> nonisolatedEGObjects;
   std::vector<unsigned short> jetRegions;
 
-  std::vector<unsigned short> HFRegions; // 8-bit et + fine grain?
-  std::vector<unsigned short>
-      barrelRegions; // no, this is 10-bit et, not
-                     // (activityBit)(etIn9Bits)(HE_FGBit)(etIn7Bits)
+  std::vector<unsigned short> HFRegions;      // 8-bit et + fine grain?
+  std::vector<unsigned short> barrelRegions;  // no, this is 10-bit et, not
+                                              // (activityBit)(etIn9Bits)(HE_FGBit)(etIn7Bits)
 
   unsigned short mipBits;
   unsigned short quietBits;

--- a/L1Trigger/RegionalCaloTrigger/interface/L1RCTLookupTables.h
+++ b/L1Trigger/RegionalCaloTrigger/interface/L1RCTLookupTables.h
@@ -9,47 +9,37 @@ class L1CaloHcalScale;
 class L1CaloEtScale;
 
 class L1RCTLookupTables {
-
 public:
   // constructor
 
   L1RCTLookupTables()
-      : rctParameters_(nullptr), channelMask_(nullptr), ecalScale_(nullptr),
-        hcalScale_(nullptr), etScale_(nullptr) {}
+      : rctParameters_(nullptr), channelMask_(nullptr), ecalScale_(nullptr), hcalScale_(nullptr), etScale_(nullptr) {}
 
   // this needs to be refreshed every event -- constructor inits to zero
   // to indicate that it cannot be used -- if this set function is
   // called, lookup after that call will use it.
-  void setRCTParameters(const L1RCTParameters *rctParameters) {
-    rctParameters_ = rctParameters;
-  }
+  void setRCTParameters(const L1RCTParameters *rctParameters) { rctParameters_ = rctParameters; }
   // ditto for channel mask
-  void setChannelMask(const L1RCTChannelMask *channelMask) {
-    channelMask_ = channelMask;
-  }
-  void setNoisyChannelMask(const L1RCTNoisyChannelMask *channelMask) {
-    noisyChannelMask_ = channelMask;
-  }
+  void setChannelMask(const L1RCTChannelMask *channelMask) { channelMask_ = channelMask; }
+  void setNoisyChannelMask(const L1RCTNoisyChannelMask *channelMask) { noisyChannelMask_ = channelMask; }
 
   // ditto for hcal TPG scale
-  void setHcalScale(const L1CaloHcalScale *hcalScale) {
-    hcalScale_ = hcalScale;
-  }
+  void setHcalScale(const L1CaloHcalScale *hcalScale) { hcalScale_ = hcalScale; }
   // ditto for caloEtScale
   void setL1CaloEtScale(const L1CaloEtScale *etScale) { etScale_ = etScale; }
   // ditto for ecal TPG Scale
-  void setEcalScale(const L1CaloEcalScale *ecalScale) {
-    ecalScale_ = ecalScale;
-  }
+  void setEcalScale(const L1CaloEcalScale *ecalScale) { ecalScale_ = ecalScale; }
 
   const L1RCTParameters *rctParameters() const { return rctParameters_; }
 
-  unsigned int lookup(unsigned short ecalInput, unsigned short hcalInput,
-                      unsigned short fgbit, unsigned short crtNo,
-                      unsigned short crdNo, unsigned short twrNo) const;
+  unsigned int lookup(unsigned short ecalInput,
+                      unsigned short hcalInput,
+                      unsigned short fgbit,
+                      unsigned short crtNo,
+                      unsigned short crdNo,
+                      unsigned short twrNo) const;
 
-  unsigned int lookup(unsigned short hfInput, unsigned short crtNo,
-                      unsigned short crdNo, unsigned short twrNo) const;
+  unsigned int lookup(unsigned short hfInput, unsigned short crtNo, unsigned short crdNo, unsigned short twrNo) const;
 
   unsigned int emRank(unsigned short energy) const;
   unsigned int eGammaETCode(float ecal, float hcal, int iAbsEta) const;
@@ -60,10 +50,8 @@ public:
 private:
   // helper functions
 
-  float convertEcal(unsigned short ecal, unsigned short iAbsEta,
-                    short sign) const;
-  float convertHcal(unsigned short hcal, unsigned short iAbsEta,
-                    short sign) const;
+  float convertEcal(unsigned short ecal, unsigned short iAbsEta, short sign) const;
+  float convertHcal(unsigned short hcal, unsigned short iAbsEta, short sign) const;
   unsigned long convertToInteger(float et, float lsb, int precision) const;
 
   const L1RCTParameters *rctParameters_;

--- a/L1Trigger/RegionalCaloTrigger/interface/L1RCTLutWriter.h
+++ b/L1Trigger/RegionalCaloTrigger/interface/L1RCTLutWriter.h
@@ -33,8 +33,8 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"   // why doesn't mkedanlzr
-#include "FWCore/Framework/interface/EventSetup.h" // add these??
+#include "FWCore/Framework/interface/ESHandle.h"    // why doesn't mkedanlzr
+#include "FWCore/Framework/interface/EventSetup.h"  // add these??
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class L1RCTLookupTables;
@@ -56,9 +56,7 @@ private:
   void writeRcLutFile(unsigned short card);
   void writeEicLutFile(unsigned short card);
   void writeJscLutFile();
-  void writeThresholdsFile(unsigned int eicThreshold,
-                           unsigned int jscThresholdBarrel,
-                           unsigned int jscThresholdEndcap);
+  void writeThresholdsFile(unsigned int eicThreshold, unsigned int jscThresholdBarrel, unsigned int jscThresholdEndcap);
 
   // ----------member data ---------------------------
 

--- a/L1Trigger/RegionalCaloTrigger/interface/L1RCTORCAMap.h
+++ b/L1Trigger/RegionalCaloTrigger/interface/L1RCTORCAMap.h
@@ -4,7 +4,6 @@
 #include <vector>
 
 class L1RCTORCAMap {
-
 public:
   L1RCTORCAMap();
 
@@ -13,14 +12,14 @@ public:
 
   void readData(const std::vector<unsigned> &emet,
                 const std::vector<unsigned> &hdet,
-                const std::vector<bool> &emfg, const std::vector<bool> &hdfg,
+                const std::vector<bool> &emfg,
+                const std::vector<bool> &hdfg,
                 const std::vector<unsigned> &hfet);
 
   std::vector<int> orcamap(int eta, int phi);
 
   unsigned short combine(unsigned short et, unsigned short fg);
-  std::vector<unsigned short> combVec(const std::vector<unsigned short> &et,
-                                      const std::vector<unsigned short> &fg);
+  std::vector<unsigned short> combVec(const std::vector<unsigned short> &et, const std::vector<unsigned short> &fg);
 
   void makeBarrelData();
   void makeHFData();

--- a/L1Trigger/RegionalCaloTrigger/interface/L1RCTProducer.h
+++ b/L1Trigger/RegionalCaloTrigger/interface/L1RCTProducer.h
@@ -46,8 +46,7 @@ public:
   explicit L1RCTProducer(const edm::ParameterSet &ps);
   ~L1RCTProducer() override;
   void beginRun(edm::Run const &r, const edm::EventSetup &c) final;
-  void beginLuminosityBlock(edm::LuminosityBlock const &lumiSeg,
-                            const edm::EventSetup &context) final;
+  void beginLuminosityBlock(edm::LuminosityBlock const &lumiSeg, const edm::EventSetup &context) final;
   void produce(edm::Event &e, const edm::EventSetup &c) final;
 
   void updateConfiguration(const edm::EventSetup &);
@@ -76,16 +75,7 @@ private:
   // Create a channel mask object to be updated at every Run....
   L1RCTChannelMask *fedUpdatedMask;
 
-  enum crateSection {
-    c_min,
-    ebOddFed = c_min,
-    ebEvenFed,
-    eeFed,
-    hbheFed,
-    hfFed,
-    hfFedUp,
-    c_max = hfFedUp
-  };
+  enum crateSection { c_min, ebOddFed = c_min, ebEvenFed, eeFed, hbheFed, hfFed, hfFedUp, c_max = hfFedUp };
 
   static const int crateFED[18][6];
 

--- a/L1Trigger/RegionalCaloTrigger/interface/L1RCTReceiverCard.h
+++ b/L1Trigger/RegionalCaloTrigger/interface/L1RCTReceiverCard.h
@@ -12,10 +12,8 @@
 class L1RCTLookupTables;
 
 class L1RCTReceiverCard {
-
 public:
-  L1RCTReceiverCard(int crateNumber, int cardNumber,
-                    const L1RCTLookupTables *rctLookupTables);
+  L1RCTReceiverCard(int crateNumber, int cardNumber, const L1RCTLookupTables *rctLookupTables);
   ~L1RCTReceiverCard();
 
   // Information needed to identify cards

--- a/L1Trigger/RegionalCaloTrigger/interface/L1RCTRegion.h
+++ b/L1Trigger/RegionalCaloTrigger/interface/L1RCTRegion.h
@@ -4,7 +4,6 @@
 #include <vector>
 
 class L1RCTRegion {
-
 public:
   L1RCTRegion();
   ~L1RCTRegion();

--- a/L1Trigger/RegionalCaloTrigger/interface/L1RCTTestAnalyzer.h
+++ b/L1Trigger/RegionalCaloTrigger/interface/L1RCTTestAnalyzer.h
@@ -58,8 +58,7 @@ public:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
 private:
-  static bool compareEmCands(const L1CaloEmCand &cand1,
-                             const L1CaloEmCand &cand2);
+  static bool compareEmCands(const L1CaloEmCand &cand1, const L1CaloEmCand &cand2);
 
   // ----------member data ---------------------------
   std::string m_HepMCProduct;

--- a/L1Trigger/RegionalCaloTrigger/plugins/L1RCTInputProducer.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/L1RCTInputProducer.cc
@@ -28,7 +28,8 @@ using std::cout;
 using std::endl;
 
 L1RCTInputProducer::L1RCTInputProducer(const edm::ParameterSet &conf)
-    : rctLookupTables(new L1RCTLookupTables), rct(new L1RCT(rctLookupTables)),
+    : rctLookupTables(new L1RCTLookupTables),
+      rct(new L1RCT(rctLookupTables)),
       useEcal(conf.getParameter<bool>("useEcal")),
       useHcal(conf.getParameter<bool>("useHcal")),
       ecalDigisLabel(conf.getParameter<edm::InputTag>("ecalDigisLabel")),
@@ -54,9 +55,7 @@ L1RCTInputProducer::~L1RCTInputProducer() {
     delete rctLookupTables;
 }
 
-void L1RCTInputProducer::produce(edm::Event &event,
-                                 const edm::EventSetup &eventSetup) {
-
+void L1RCTInputProducer::produce(edm::Event &event, const edm::EventSetup &eventSetup) {
   // Refresh configuration information every event
   // Hopefully, this does not take too much time
   // There should be a call back function in future to
@@ -107,38 +106,28 @@ void L1RCTInputProducer::produce(edm::Event &event,
 
   // Stuff to create
 
-  std::unique_ptr<std::vector<unsigned short>> rctCrate(
-      new std::vector<unsigned short>);
-  std::unique_ptr<std::vector<unsigned short>> rctCard(
-      new std::vector<unsigned short>);
-  std::unique_ptr<std::vector<unsigned short>> rctTower(
-      new std::vector<unsigned short>);
-  std::unique_ptr<std::vector<unsigned int>> rctEGammaET(
-      new std::vector<unsigned int>);
+  std::unique_ptr<std::vector<unsigned short>> rctCrate(new std::vector<unsigned short>);
+  std::unique_ptr<std::vector<unsigned short>> rctCard(new std::vector<unsigned short>);
+  std::unique_ptr<std::vector<unsigned short>> rctTower(new std::vector<unsigned short>);
+  std::unique_ptr<std::vector<unsigned int>> rctEGammaET(new std::vector<unsigned int>);
   std::unique_ptr<std::vector<bool>> rctHoEFGVetoBit(new std::vector<bool>);
-  std::unique_ptr<std::vector<unsigned int>> rctJetMETET(
-      new std::vector<unsigned int>);
+  std::unique_ptr<std::vector<unsigned int>> rctJetMETET(new std::vector<unsigned int>);
   std::unique_ptr<std::vector<bool>> rctTowerActivityBit(new std::vector<bool>);
   std::unique_ptr<std::vector<bool>> rctTowerMIPBit(new std::vector<bool>);
 
   for (int crate = 0; crate < 18; crate++) {
     for (int card = 0; card < 7; card++) {
       for (int tower = 0; tower < 32; tower++) {
-        unsigned short ecalCompressedET =
-            rct->ecalCompressedET(crate, card, tower);
-        unsigned short ecalFineGrainBit =
-            rct->ecalFineGrainBit(crate, card, tower);
-        unsigned short hcalCompressedET =
-            rct->hcalCompressedET(crate, card, tower);
+        unsigned short ecalCompressedET = rct->ecalCompressedET(crate, card, tower);
+        unsigned short ecalFineGrainBit = rct->ecalFineGrainBit(crate, card, tower);
+        unsigned short hcalCompressedET = rct->hcalCompressedET(crate, card, tower);
         unsigned int lutBits =
-            rctLookupTables->lookup(ecalCompressedET, hcalCompressedET,
-                                    ecalFineGrainBit, crate, card, tower);
+            rctLookupTables->lookup(ecalCompressedET, hcalCompressedET, ecalFineGrainBit, crate, card, tower);
         unsigned int eGammaETCode = lutBits & 0x0000007F;
         bool hOeFGVetoBit = (lutBits >> 7) & 0x00000001;
         unsigned int jetMETETCode = (lutBits >> 8) & 0x000001FF;
         bool activityBit = (lutBits >> 17) & 0x00000001;
-        if (eGammaETCode > 0 || jetMETETCode > 0 || hOeFGVetoBit ||
-            activityBit) {
+        if (eGammaETCode > 0 || jetMETETCode > 0 || hOeFGVetoBit || activityBit) {
           rctCrate->push_back(crate);
           rctCard->push_back(card);
           rctTower->push_back(tower);
@@ -146,29 +135,25 @@ void L1RCTInputProducer::produce(edm::Event &event,
           rctHoEFGVetoBit->push_back(hOeFGVetoBit);
           rctJetMETET->push_back(jetMETETCode);
           rctTowerActivityBit->push_back(activityBit);
-          rctTowerMIPBit->push_back(false); // FIXME: MIP bit is not yet defined
+          rctTowerMIPBit->push_back(false);  // FIXME: MIP bit is not yet defined
         }
       }
     }
   }
 
-  std::unique_ptr<std::vector<unsigned short>> rctHFCrate(
-      new std::vector<unsigned short>);
-  std::unique_ptr<std::vector<unsigned short>> rctHFRegion(
-      new std::vector<unsigned short>);
-  std::unique_ptr<std::vector<unsigned int>> rctHFET(
-      new std::vector<unsigned int>);
+  std::unique_ptr<std::vector<unsigned short>> rctHFCrate(new std::vector<unsigned short>);
+  std::unique_ptr<std::vector<unsigned short>> rctHFRegion(new std::vector<unsigned short>);
+  std::unique_ptr<std::vector<unsigned int>> rctHFET(new std::vector<unsigned int>);
   std::unique_ptr<std::vector<bool>> rctHFFG(new std::vector<bool>);
   for (int crate = 0; crate < 18; crate++) {
     for (int hfRegion = 0; hfRegion < 8; hfRegion++) {
       unsigned short hfCompressedET = rct->hfCompressedET(crate, hfRegion);
-      unsigned int hfETCode =
-          rctLookupTables->lookup(hfCompressedET, crate, 999, hfRegion);
+      unsigned int hfETCode = rctLookupTables->lookup(hfCompressedET, crate, 999, hfRegion);
       if (hfETCode > 0) {
         rctHFCrate->push_back(crate);
         rctHFRegion->push_back(hfRegion);
         rctHFET->push_back(hfETCode);
-        rctHFFG->push_back(false); // FIXME: HF FG is not yet defined
+        rctHFFG->push_back(false);  // FIXME: HF FG is not yet defined
       }
     }
   }

--- a/L1Trigger/RegionalCaloTrigger/plugins/L1RCTLutWriter.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/L1RCTLutWriter.cc
@@ -42,7 +42,6 @@ L1RCTLutWriter::L1RCTLutWriter(const edm::ParameterSet &iConfig)
 }
 
 L1RCTLutWriter::~L1RCTLutWriter() {
-
   // do anything here that needs to be done at destruction time
   // (e.g. close files, deallocate resources etc.)
 
@@ -55,9 +54,7 @@ L1RCTLutWriter::~L1RCTLutWriter() {
 //
 
 // ------------ method called to for each event  ------------
-void L1RCTLutWriter::analyze(const edm::Event &iEvent,
-                             const edm::EventSetup &iSetup) {
-
+void L1RCTLutWriter::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // get all the configuration information from the event, set it
   // in the lookuptable
   edm::ESHandle<L1RCTParameters> rctParameters;
@@ -106,9 +103,8 @@ void L1RCTLutWriter::analyze(const edm::Event &iEvent,
   L1CaloEcalScale *dummyE(nullptr);
   L1CaloHcalScale *dummyH(nullptr);
 
-  if (useDebugTpgScales_) // generate new-style scales from tpg scales
+  if (useDebugTpgScales_)  // generate new-style scales from tpg scales
   {
-
     std::cout << "Using old-style TPG scales!" << std::endl;
 
     // old version of hcal energy scale to convert input
@@ -127,35 +123,33 @@ void L1RCTLutWriter::analyze(const edm::Event &iEvent,
 
     // ECAL
     for (unsigned short ieta = 1; ieta <= L1CaloEcalScale::nBinEta; ++ieta) {
-      for (unsigned short irank = 0; irank < L1CaloEcalScale::nBinRank;
-           ++irank) {
+      for (unsigned short irank = 0; irank < L1CaloEcalScale::nBinRank; ++irank) {
         EcalSubdetector subdet = (ieta <= 17) ? EcalBarrel : EcalEndcap;
-        double etGeVPos =
-            e_tpg->getTPGInGeV(irank, EcalTrigTowerDetId(1, // +ve eta
-                                                         subdet, ieta,
-                                                         1)); // dummy phi value
+        double etGeVPos = e_tpg->getTPGInGeV(irank,
+                                             EcalTrigTowerDetId(1,  // +ve eta
+                                                                subdet,
+                                                                ieta,
+                                                                1));  // dummy phi value
         ecalScale->setBin(irank, ieta, 1, etGeVPos);
       }
     }
 
     for (unsigned short ieta = 1; ieta <= L1CaloEcalScale::nBinEta; ++ieta) {
-      for (unsigned short irank = 0; irank < L1CaloEcalScale::nBinRank;
-           ++irank) {
+      for (unsigned short irank = 0; irank < L1CaloEcalScale::nBinRank; ++irank) {
         EcalSubdetector subdet = (ieta <= 17) ? EcalBarrel : EcalEndcap;
 
-        double etGeVNeg =
-            e_tpg->getTPGInGeV(irank,
-                               EcalTrigTowerDetId(-1, // -ve eta
-                                                  subdet, ieta,
-                                                  2)); // dummy phi value
+        double etGeVNeg = e_tpg->getTPGInGeV(irank,
+                                             EcalTrigTowerDetId(-1,  // -ve eta
+                                                                subdet,
+                                                                ieta,
+                                                                2));  // dummy phi value
         ecalScale->setBin(irank, ieta, -1, etGeVNeg);
       }
     }
 
     // HCAL
     for (unsigned short ieta = 1; ieta <= L1CaloHcalScale::nBinEta; ++ieta) {
-      for (unsigned short irank = 0; irank < L1CaloHcalScale::nBinRank;
-           ++irank) {
+      for (unsigned short irank = 0; irank < L1CaloHcalScale::nBinRank; ++irank) {
         double etGeV = h_tpg->hcaletValue(ieta, irank);
 
         hcalScale->setBin(irank, ieta, 1, etGeV);
@@ -173,7 +167,6 @@ void L1RCTLutWriter::analyze(const edm::Event &iEvent,
     delete e_tpg;
 
   } else {
-
     // get energy scale to convert input from ECAL
     edm::ESHandle<L1CaloEcalScale> ecalScale;
     iSetup.get<L1CaloEcalScaleRcd>().get(ecalScale);
@@ -219,7 +212,6 @@ void L1RCTLutWriter::endJob() {}
 
 // ------------ method to write one receiver card lut file
 void L1RCTLutWriter::writeRcLutFile(unsigned short card) {
-
   // don't mess yet with name
   char filename[256];
   char command[264];
@@ -233,8 +225,7 @@ void L1RCTLutWriter::writeRcLutFile(unsigned short card) {
   }
   // open file for writing, delete any existing content
   lutFile_.open(filename, std::ios::trunc);
-  lutFile_ << "Emulator-parameter generated lut file, card " << card << " key "
-           << keyName_ << "   ";
+  lutFile_ << "Emulator-parameter generated lut file, card " << card << " key " << keyName_ << "   ";
 
   // close to append timestamp info
   lutFile_.close();
@@ -279,8 +270,7 @@ void L1RCTLutWriter::writeRcLutFile(unsigned short card) {
         // loop through 8 bits of ecal energy
         for (unsigned int ecalEt = 0; ecalEt < 256; ecalEt++) {
           // assign 10-bit (9et,1mip) sums data here!
-          unsigned long output =
-              lookupTable_->lookup(ecalEt, hcalEt, ecalfg, crate, card, tower);
+          unsigned long output = lookupTable_->lookup(ecalEt, hcalEt, ecalfg, crate, card, tower);
           unsigned short etIn9Bits = (output >> 8) & 511;
           unsigned short tauActivityBit = (output >> 17) & 1;
           data = (tauActivityBit << 9) + etIn9Bits;
@@ -296,8 +286,7 @@ void L1RCTLutWriter::writeRcLutFile(unsigned short card) {
         // loop through 8 bits of ecal energy
         for (unsigned int ecalEt = 0; ecalEt < 256; ecalEt++) {
           // assign 8-bit (7et,1veto) egamma data here!
-          unsigned long output =
-              lookupTable_->lookup(ecalEt, hcalEt, ecalfg, crate, card, tower);
+          unsigned long output = lookupTable_->lookup(ecalEt, hcalEt, ecalfg, crate, card, tower);
           unsigned short etIn7Bits = output & 127;
           unsigned short heFgVetoBit = (output >> 7) & 1;
           data = (heFgVetoBit << 7) + etIn7Bits;
@@ -324,8 +313,7 @@ void L1RCTLutWriter::writeEicLutFile(unsigned short card) {
   }
   // open file for writing, delete any existing content
   lutFile_.open(filename, std::ios::trunc);
-  lutFile_ << "Emulator-parameter generated EIC lut file, card " << card
-           << " key " << keyName_ << "   ";
+  lutFile_ << "Emulator-parameter generated EIC lut file, card " << card << " key " << keyName_ << "   ";
   // close to append timestamp info
   lutFile_.close();
   sprintf(command, "date >> %s", filename);
@@ -359,8 +347,7 @@ void L1RCTLutWriter::writeJscLutFile() {
 
   // open file; if it already existed, delete existing content
   lutFile_.open(filename, std::ios::trunc);
-  lutFile_ << "Emulator parameter-generated lut file, key " << keyName_
-           << "   ";
+  lutFile_ << "Emulator parameter-generated lut file, key " << keyName_ << "   ";
   // close to append time-stamp
   lutFile_.close();
   sprintf(command, "date >> %s", filename);
@@ -388,11 +375,11 @@ void L1RCTLutWriter::writeJscLutFile() {
         // only |ieta| matters
         data0 = lookupTable_->lookup(phi0et, 0, 999, lutbits);
         if (data0 > 0xff) {
-          data0 = 0xff; // 8-bit output energy for each phi region
+          data0 = 0xff;  // 8-bit output energy for each phi region
         }
         data1 = lookupTable_->lookup(phi1et, 0, 999, lutbits);
         if (data1 > 0xff) {
-          data1 = 0xff; // 8-bit output energy for each phi region
+          data1 = 0xff;  // 8-bit output energy for each phi region
         }
         data = (data1 << 8) + (data0);
         lutFile_ << std::hex << data << std::dec << std::endl;
@@ -425,10 +412,8 @@ void L1RCTLutWriter::writeThresholdsFile(unsigned int eicThreshold,
 
   thresholdsFile << "key is " << keyName_ << std::endl << std::endl;
   thresholdsFile << "eicIsolationThreshold " << eicThreshold << std::endl;
-  thresholdsFile << "jscQuietThresholdBarrel " << jscThresholdBarrel
-                 << std::endl;
-  thresholdsFile << "jscQuietThresholdEndcap " << jscThresholdEndcap
-                 << std::endl;
+  thresholdsFile << "jscQuietThresholdBarrel " << jscThresholdBarrel << std::endl;
+  thresholdsFile << "jscQuietThresholdEndcap " << jscThresholdEndcap << std::endl;
 
   thresholdsFile.close();
 }

--- a/L1Trigger/RegionalCaloTrigger/plugins/L1RCTProducer.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/L1RCTProducer.cc
@@ -11,19 +11,28 @@ using std::vector;
 
 using std::cout;
 using std::endl;
-const int L1RCTProducer::crateFED[18][6] = {
-    {613, 614, 603, 702, 718, 1118}, {611, 612, 602, 700, 718, 1118},
-    {627, 610, 601, 716, 722, 1122}, {625, 626, 609, 714, 722, 1122},
-    {623, 624, 608, 712, 722, 1122}, {621, 622, 607, 710, 720, 1120},
-    {619, 620, 606, 708, 720, 1120}, {617, 618, 605, 706, 720, 1120},
-    {615, 616, 604, 704, 718, 1118}, {631, 632, 648, 703, 719, 1118},
-    {629, 630, 647, 701, 719, 1118}, {645, 628, 646, 717, 723, 1122},
-    {643, 644, 654, 715, 723, 1122}, {641, 642, 653, 713, 723, 1122},
-    {639, 640, 652, 711, 721, 1120}, {637, 638, 651, 709, 721, 1120},
-    {635, 636, 650, 707, 721, 1120}, {633, 634, 649, 705, 719, 1118}};
+const int L1RCTProducer::crateFED[18][6] = {{613, 614, 603, 702, 718, 1118},
+                                            {611, 612, 602, 700, 718, 1118},
+                                            {627, 610, 601, 716, 722, 1122},
+                                            {625, 626, 609, 714, 722, 1122},
+                                            {623, 624, 608, 712, 722, 1122},
+                                            {621, 622, 607, 710, 720, 1120},
+                                            {619, 620, 606, 708, 720, 1120},
+                                            {617, 618, 605, 706, 720, 1120},
+                                            {615, 616, 604, 704, 718, 1118},
+                                            {631, 632, 648, 703, 719, 1118},
+                                            {629, 630, 647, 701, 719, 1118},
+                                            {645, 628, 646, 717, 723, 1122},
+                                            {643, 644, 654, 715, 723, 1122},
+                                            {641, 642, 653, 713, 723, 1122},
+                                            {639, 640, 652, 711, 721, 1120},
+                                            {637, 638, 651, 709, 721, 1120},
+                                            {635, 636, 650, 707, 721, 1120},
+                                            {633, 634, 649, 705, 719, 1118}};
 
 L1RCTProducer::L1RCTProducer(const edm::ParameterSet &conf)
-    : rctLookupTables(new L1RCTLookupTables), rct(new L1RCT(rctLookupTables)),
+    : rctLookupTables(new L1RCTLookupTables),
+      rct(new L1RCT(rctLookupTables)),
       useEcal(conf.getParameter<bool>("useEcal")),
       useHcal(conf.getParameter<bool>("useHcal")),
       ecalDigis(conf.getParameter<std::vector<edm::InputTag>>("ecalDigis")),
@@ -38,15 +47,13 @@ L1RCTProducer::L1RCTProducer(const edm::ParameterSet &conf)
   produces<L1CaloRegionCollection>();
 
   for (unsigned int ihc = 0; ihc < hcalDigis.size(); ihc++) {
-    consumes<edm::SortedCollection<
-        HcalTriggerPrimitiveDigi,
-        edm::StrictWeakOrdering<HcalTriggerPrimitiveDigi>>>(hcalDigis[ihc]);
+    consumes<edm::SortedCollection<HcalTriggerPrimitiveDigi, edm::StrictWeakOrdering<HcalTriggerPrimitiveDigi>>>(
+        hcalDigis[ihc]);
   }
 
   for (unsigned int iec = 0; iec < ecalDigis.size(); iec++) {
-    consumes<edm::SortedCollection<
-        EcalTriggerPrimitiveDigi,
-        edm::StrictWeakOrdering<EcalTriggerPrimitiveDigi>>>(ecalDigis[iec]);
+    consumes<edm::SortedCollection<EcalTriggerPrimitiveDigi, edm::StrictWeakOrdering<EcalTriggerPrimitiveDigi>>>(
+        ecalDigis[iec]);
   }
 }
 
@@ -59,39 +66,35 @@ L1RCTProducer::~L1RCTProducer() {
     delete fedUpdatedMask;
 }
 
-void L1RCTProducer::beginRun(edm::Run const &run,
-                             const edm::EventSetup &eventSetup) {
+void L1RCTProducer::beginRun(edm::Run const &run, const edm::EventSetup &eventSetup) {
   //  std::cout << "getFedsFromOmds is " << getFedsFromOmds << std::endl;
 
   updateConfiguration(eventSetup);
 
   int runNumber = run.run();
   updateFedVector(eventSetup, false,
-                  runNumber); // RUNINFO ONLY at beginning of run
+                  runNumber);  // RUNINFO ONLY at beginning of run
 }
 
-void L1RCTProducer::beginLuminosityBlock(edm::LuminosityBlock const &lumiSeg,
-                                         const edm::EventSetup &context) {
+void L1RCTProducer::beginLuminosityBlock(edm::LuminosityBlock const &lumiSeg, const edm::EventSetup &context) {
   // check LS number every LS, if the checkOMDS flag is set AND it's the right
   // LS, update the FED vector from OMDS can pass the flag as the bool??  but
   // only check LS number if flag is true anyhow
   if (getFedsFromOmds) {
-    unsigned int nLumi =
-        lumiSeg.luminosityBlock(); // doesn't even need the (unsigned int) cast
-                                   // because LuminosityBlockNumber_t is already
-                                   // an unsigned int
+    unsigned int nLumi = lumiSeg.luminosityBlock();  // doesn't even need the (unsigned int) cast
+                                                     // because LuminosityBlockNumber_t is already
+                                                     // an unsigned int
     // LS count starts at 1, want to be able to delay 0 LS's intuitively
     if (((nLumi - 1) == queryDelayInLS) ||
         (queryIntervalInLS > 0 &&
-         nLumi % queryIntervalInLS ==
-             0)) // to guard against problems if online DQM crashes; every 100
-                 // LS is ~20-30 minutes, not too big a load, hopefully not too
-                 // long between
+         nLumi % queryIntervalInLS == 0))  // to guard against problems if online DQM crashes; every 100
+                                           // LS is ~20-30 minutes, not too big a load, hopefully not too
+                                           // long between
     {
       int runNumber = lumiSeg.run();
       //	  std::cout << "Lumi section for this FED vector update is " <<
       // nLumi << std::endl;
-      updateFedVector(context, true, runNumber); // OMDS
+      updateFedVector(context, true, runNumber);  // OMDS
     } else if (queryIntervalInLS <= 0) {
       // don't do interval checking... cout message??
     }
@@ -133,10 +136,10 @@ void L1RCTProducer::updateConfiguration(const edm::EventSetup &eventSetup) {
   rctLookupTables->setL1CaloEtScale(s);
 }
 
-void L1RCTProducer::updateFedVector(
-    const edm::EventSetup &eventSetup, bool getFromOmds,
-    int runNumber) // eventSetup apparently doesn't include run number:
-                   // http://cmslxr.fnal.gov/lxr/source/FWCore/Framework/interface/EventSetup.h
+void L1RCTProducer::updateFedVector(const edm::EventSetup &eventSetup,
+                                    bool getFromOmds,
+                                    int runNumber)  // eventSetup apparently doesn't include run number:
+// http://cmslxr.fnal.gov/lxr/source/FWCore/Framework/interface/EventSetup.h
 {
   // list of RCT channels to mask
   edm::ESHandle<L1RCTChannelMask> channelMask;
@@ -172,9 +175,7 @@ void L1RCTProducer::updateFedVector(
 
   //   // adding fed mask into channel mask
 
-  const std::vector<int> Feds = getFromOmds
-                                    ? getFedVectorFromOmds(eventSetup)
-                                    : getFedVectorFromRunInfo(eventSetup);
+  const std::vector<int> Feds = getFromOmds ? getFedVectorFromOmds(eventSetup) : getFedVectorFromRunInfo(eventSetup);
   // so can create/initialize/assign const quantity in one line accounting for
   // if statement wikipedia says this is exactly what it's for:
   // http://en.wikipedia.org/wiki/%3F:#C.2B.2B
@@ -186,14 +187,12 @@ void L1RCTProducer::updateFedVector(
 
   bool useUpgradedHF = false;
 
-  std::vector<int> caloFeds; // pare down the feds to the interesting ones
+  std::vector<int> caloFeds;  // pare down the feds to the interesting ones
   // is this unneccesary?
   // Mike B : This will decrease the find speed so better do it
-  for (std::vector<int>::const_iterator cf = Feds.begin(); cf != Feds.end();
-       ++cf) {
+  for (std::vector<int>::const_iterator cf = Feds.begin(); cf != Feds.end(); ++cf) {
     int fedNum = *cf;
-    if ((fedNum > 600 && fedNum < 724) || fedNum == 1118 || fedNum == 1120 ||
-        fedNum == 1122)
+    if ((fedNum > 600 && fedNum < 724) || fedNum == 1118 || fedNum == 1120 || fedNum == 1122)
       caloFeds.push_back(fedNum);
 
     if (fedNum == 1118 || fedNum == 1120 || fedNum == 1122)
@@ -201,82 +200,80 @@ void L1RCTProducer::updateFedVector(
   }
 
   for (int cr = 0; cr < 18; ++cr) {
-
     for (crateSection cs = c_min; cs <= c_max; cs = crateSection(cs + 1)) {
       bool fedFound = false;
 
       // Try to find the FED
-      std::vector<int>::iterator fv =
-          std::find(caloFeds.begin(), caloFeds.end(), crateFED[cr][cs]);
+      std::vector<int>::iterator fv = std::find(caloFeds.begin(), caloFeds.end(), crateFED[cr][cs]);
       if (fv != caloFeds.end())
         fedFound = true;
 
       if (!fedFound) {
         int eta_min = 0;
         int eta_max = 0;
-        bool phi_even[2] = {false}; //, phi_odd = false;
+        bool phi_even[2] = {false};  //, phi_odd = false;
         bool ecal = false;
 
         switch (cs) {
-        case ebEvenFed:
-          eta_min = minBarrel;
-          eta_max = maxBarrel;
-          phi_even[0] = true;
-          ecal = true;
-          break;
-
-        case ebOddFed:
-          eta_min = minBarrel;
-          eta_max = maxBarrel;
-          phi_even[1] = true;
-          ecal = true;
-          break;
-
-        case eeFed:
-          eta_min = minEndcap;
-          eta_max = maxEndcap;
-          phi_even[0] = true;
-          phi_even[1] = true;
-          ecal = true;
-          break;
-
-        case hbheFed:
-          eta_min = minBarrel;
-          eta_max = maxEndcap;
-          phi_even[0] = true;
-          phi_even[1] = true;
-          ecal = false;
-          break;
-
-        case hfFed:
-          if (useUpgradedHF)
+          case ebEvenFed:
+            eta_min = minBarrel;
+            eta_max = maxBarrel;
+            phi_even[0] = true;
+            ecal = true;
             break;
 
-          eta_min = minHF;
-          eta_max = maxHF;
-
-          phi_even[0] = true;
-          phi_even[1] = true;
-          ecal = false;
-          break;
-
-        case hfFedUp:
-          if (!useUpgradedHF)
+          case ebOddFed:
+            eta_min = minBarrel;
+            eta_max = maxBarrel;
+            phi_even[1] = true;
+            ecal = true;
             break;
 
-          eta_min = minHF;
-          eta_max = maxHF;
+          case eeFed:
+            eta_min = minEndcap;
+            eta_max = maxEndcap;
+            phi_even[0] = true;
+            phi_even[1] = true;
+            ecal = true;
+            break;
 
-          phi_even[0] = true;
-          phi_even[1] = true;
-          ecal = false;
-          break;
+          case hbheFed:
+            eta_min = minBarrel;
+            eta_max = maxEndcap;
+            phi_even[0] = true;
+            phi_even[1] = true;
+            ecal = false;
+            break;
 
-        default:
-          break;
+          case hfFed:
+            if (useUpgradedHF)
+              break;
+
+            eta_min = minHF;
+            eta_max = maxHF;
+
+            phi_even[0] = true;
+            phi_even[1] = true;
+            ecal = false;
+            break;
+
+          case hfFedUp:
+            if (!useUpgradedHF)
+              break;
+
+            eta_min = minHF;
+            eta_max = maxHF;
+
+            phi_even[0] = true;
+            phi_even[1] = true;
+            ecal = false;
+            break;
+
+          default:
+            break;
         }
         for (int ieta = eta_min; ieta <= eta_max; ++ieta) {
-          if (ieta <= 28) // barrel and endcap
+          if (ieta <= 28)  // barrel and endcap
             for (int even = 0; even <= 1; even++) {
               if (phi_even[even]) {
                 if (ecal)
@@ -297,8 +294,7 @@ void L1RCTProducer::updateFedVector(
   rctLookupTables->setChannelMask(fedUpdatedMask);
 }
 
-const std::vector<int>
-L1RCTProducer::getFedVectorFromRunInfo(const edm::EventSetup &eventSetup) {
+const std::vector<int> L1RCTProducer::getFedVectorFromRunInfo(const edm::EventSetup &eventSetup) {
   //  std::cout << "Getting FED vector from standard RunInfo object" <<
   //  std::endl;
   // get FULL FED vector from RUNINFO
@@ -310,18 +306,15 @@ L1RCTProducer::getFedVectorFromRunInfo(const edm::EventSetup &eventSetup) {
   return fedvector;
 }
 
-const std::vector<int>
-L1RCTProducer::getFedVectorFromOmds(const edm::EventSetup &eventSetup) {
-
+const std::vector<int> L1RCTProducer::getFedVectorFromOmds(const edm::EventSetup &eventSetup) {
   //  std::cout << "Getting FED vector from my specific ES RunInfo object" <<
   //  std::endl;
 
   // get FULL FED vector from RunInfo object specifically created to have OMDS
   // fed vector
   edm::ESHandle<RunInfo> sum;
-  eventSetup.get<RunInfoRcd>().get(
-      "OmdsFedVector",
-      sum); // using label to get my specific instance of RunInfo
+  eventSetup.get<RunInfoRcd>().get("OmdsFedVector",
+                                   sum);  // using label to get my specific instance of RunInfo
   if (sum.isValid()) {
     const RunInfo *summary = sum.product();
     const std::vector<int> fedvector = summary->m_fed_in;
@@ -332,22 +325,17 @@ L1RCTProducer::getFedVectorFromOmds(const edm::EventSetup &eventSetup) {
   }
 }
 
-void L1RCTProducer::produce(edm::Event &event,
-                            const edm::EventSetup &eventSetup) {
-
+void L1RCTProducer::produce(edm::Event &event, const edm::EventSetup &eventSetup) {
   std::unique_ptr<L1CaloEmCollection> rctEmCands(new L1CaloEmCollection);
-  std::unique_ptr<L1CaloRegionCollection> rctRegions(
-      new L1CaloRegionCollection);
+  std::unique_ptr<L1CaloRegionCollection> rctRegions(new L1CaloRegionCollection);
 
-  if (!(ecalDigis.size() == hcalDigis.size() &&
-        hcalDigis.size() == bunchCrossings.size()))
-    throw cms::Exception("BadInput")
-        << "From what I see the number of your your ECAL input digi "
-           "collections.\n"
-        << "is different from the size of your HCAL digi input collections\n"
-        << "or the size of your BX factor collection"
-        << "They must be the same to correspond to the same Bxs\n"
-        << "It does not matter if one of them is empty\n";
+  if (!(ecalDigis.size() == hcalDigis.size() && hcalDigis.size() == bunchCrossings.size()))
+    throw cms::Exception("BadInput") << "From what I see the number of your your ECAL input digi "
+                                        "collections.\n"
+                                     << "is different from the size of your HCAL digi input collections\n"
+                                     << "or the size of your BX factor collection"
+                                     << "They must be the same to correspond to the same Bxs\n"
+                                     << "It does not matter if one of them is empty\n";
 
   // loop through and process each bx
   for (unsigned short sample = 0; sample < bunchCrossings.size(); sample++) {
@@ -395,8 +383,7 @@ void L1RCTProducer::produce(edm::Event &event,
 // print contents of (FULL) FED vector
 void L1RCTProducer::printFedVector(const std::vector<int> &fedVector) {
   std::cout << "Contents of given fedVector: ";
-  std::copy(fedVector.begin(), fedVector.end(),
-            std::ostream_iterator<int>(std::cout, ", "));
+  std::copy(fedVector.begin(), fedVector.end(), std::ostream_iterator<int>(std::cout, ", "));
   std::cout << std::endl;
 }
 
@@ -405,9 +392,7 @@ void L1RCTProducer::printUpdatedFedMask() {
   if (fedUpdatedMask != nullptr) {
     fedUpdatedMask->print(std::cout);
   } else {
-    std::cout
-        << "Trying to print contents of fedUpdatedMask, but it doesn't exist!"
-        << std::endl;
+    std::cout << "Trying to print contents of fedUpdatedMask, but it doesn't exist!" << std::endl;
   }
 }
 
@@ -446,8 +431,6 @@ void L1RCTProducer::printUpdatedFedMaskVerbose() {
     std::cout << std::endl;
   } else {
     // print error message
-    std::cout
-        << "Trying to print contents of fedUpdatedMask, but it doesn't exist!"
-        << std::endl;
+    std::cout << "Trying to print contents of fedUpdatedMask, but it doesn't exist!" << std::endl;
   }
 }

--- a/L1Trigger/RegionalCaloTrigger/plugins/L1RCTRelValAnalyzer.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/L1RCTRelValAnalyzer.cc
@@ -31,21 +31,15 @@ L1RCTRelValAnalyzer::L1RCTRelValAnalyzer(const edm::ParameterSet &iConfig)
   h_emRank = fs->make<TH1F>("emRank", "emRank", 64, 0., 64.);
   h_emIeta = fs->make<TH1F>("emOccupancyIeta", "emOccupancyIeta", 22, 0., 22.);
   h_emIphi = fs->make<TH1F>("emOccupancyIphi", "emOccupancyIphi", 18, 0., 18.);
-  h_emIsoOccIetaIphi = fs->make<TH2F>("emIsoOccupancy2D", "emIsoOccupancy2D",
-                                      22, 0., 22., 18, 0., 18.);
-  h_emNonIsoOccIetaIphi = fs->make<TH2F>(
-      "emNonIsoOccupancy2D", "emNonIsoOccupancy2D", 22, 0., 22., 18, 0., 18.);
+  h_emIsoOccIetaIphi = fs->make<TH2F>("emIsoOccupancy2D", "emIsoOccupancy2D", 22, 0., 22., 18, 0., 18.);
+  h_emNonIsoOccIetaIphi = fs->make<TH2F>("emNonIsoOccupancy2D", "emNonIsoOccupancy2D", 22, 0., 22., 18, 0., 18.);
 
   h_regionSum = fs->make<TH1F>("regionSum", "regionSum", 100, 0., 100.);
-  h_regionSumIetaIphi =
-      fs->make<TH2F>("regionSumEtWeighted2D", "regionSumEtWeighted2D", 22, 0.,
-                     22., 18, 0., 18.);
-  h_regionOccIetaIphi = fs->make<TH2F>("regionOccupancy2D", "regionOccupancy2D",
-                                       22, 0., 22., 18, 0., 18.);
+  h_regionSumIetaIphi = fs->make<TH2F>("regionSumEtWeighted2D", "regionSumEtWeighted2D", 22, 0., 22., 18, 0., 18.);
+  h_regionOccIetaIphi = fs->make<TH2F>("regionOccupancy2D", "regionOccupancy2D", 22, 0., 22., 18, 0., 18.);
 }
 
 L1RCTRelValAnalyzer::~L1RCTRelValAnalyzer() {
-
   // do anything here that needs to be done at destruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -55,8 +49,7 @@ L1RCTRelValAnalyzer::~L1RCTRelValAnalyzer() {
 //
 
 // ------------ method called to produce the data  ------------
-void L1RCTRelValAnalyzer::analyze(const edm::Event &iEvent,
-                                  const edm::EventSetup &iSetup) {
+void L1RCTRelValAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
 #ifdef THIS_IS_AN_EVENT_EXAMPLE
   Handle<ExampleData> pIn;
@@ -84,11 +77,9 @@ void L1RCTRelValAnalyzer::analyze(const edm::Event &iEvent,
       h_emIeta->Fill((*em).regionId().ieta());
       h_emIphi->Fill((*em).regionId().iphi());
       if ((*em).isolated()) {
-        h_emIsoOccIetaIphi->Fill((*em).regionId().ieta(),
-                                 (*em).regionId().iphi());
+        h_emIsoOccIetaIphi->Fill((*em).regionId().ieta(), (*em).regionId().iphi());
       } else {
-        h_emNonIsoOccIetaIphi->Fill((*em).regionId().ieta(),
-                                    (*em).regionId().iphi());
+        h_emNonIsoOccIetaIphi->Fill((*em).regionId().ieta(), (*em).regionId().iphi());
       }
     }
   }

--- a/L1Trigger/RegionalCaloTrigger/plugins/L1RCTSaveInput.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/L1RCTSaveInput.cc
@@ -44,7 +44,8 @@ using std::ostream;
 
 L1RCTSaveInput::L1RCTSaveInput(const edm::ParameterSet &conf)
     : fileName(conf.getUntrackedParameter<std::string>("rctTestInputFile")),
-      rctLookupTables(new L1RCTLookupTables), rct(new L1RCT(rctLookupTables)),
+      rctLookupTables(new L1RCTLookupTables),
+      rct(new L1RCT(rctLookupTables)),
       useEcal(conf.getParameter<bool>("useEcal")),
       useHcal(conf.getParameter<bool>("useHcal")),
       ecalDigisLabel(conf.getParameter<edm::InputTag>("ecalDigisLabel")),
@@ -64,8 +65,7 @@ L1RCTSaveInput::~L1RCTSaveInput() {
     delete rctLookupTables;
 }
 
-void L1RCTSaveInput::analyze(const edm::Event &event,
-                             const edm::EventSetup &eventSetup) {
+void L1RCTSaveInput::analyze(const edm::Event &event, const edm::EventSetup &eventSetup) {
   edm::ESHandle<L1RCTParameters> rctParameters;
   eventSetup.get<L1RCTParametersRcd>().get(rctParameters);
   const L1RCTParameters *r = rctParameters.product();
@@ -96,14 +96,14 @@ void L1RCTSaveInput::analyze(const edm::Event &event,
     // ECAL
     std::cout << "ECAL Pos " << L1CaloEcalScale::nBinRank << std::endl;
     for (unsigned short ieta = 1; ieta <= L1CaloEcalScale::nBinEta; ++ieta) {
-      for (unsigned short irank = 0; irank < L1CaloEcalScale::nBinRank;
-           ++irank) {
+      for (unsigned short irank = 0; irank < L1CaloEcalScale::nBinRank; ++irank) {
         std::cout << ieta << " " << irank;
         EcalSubdetector subdet = (ieta <= 17) ? EcalBarrel : EcalEndcap;
-        double etGeVPos =
-            e_tpg->getTPGInGeV(irank, EcalTrigTowerDetId(1, // +ve eta
-                                                         subdet, ieta,
-                                                         1)); // dummy phi value
+        double etGeVPos = e_tpg->getTPGInGeV(irank,
+                                             EcalTrigTowerDetId(1,  // +ve eta
+                                                                subdet,
+                                                                ieta,
+                                                                1));  // dummy phi value
         ecalScale->setBin(irank, ieta, 1, etGeVPos);
         std::cout << etGeVPos << ", ";
       }
@@ -113,16 +113,15 @@ void L1RCTSaveInput::analyze(const edm::Event &event,
 
     std::cout << "ECAL Neg" << std::endl;
     for (unsigned short ieta = 1; ieta <= L1CaloEcalScale::nBinEta; ++ieta) {
-      for (unsigned short irank = 0; irank < L1CaloEcalScale::nBinRank;
-           ++irank) {
+      for (unsigned short irank = 0; irank < L1CaloEcalScale::nBinRank; ++irank) {
         EcalSubdetector subdet = (ieta <= 17) ? EcalBarrel : EcalEndcap;
 
         std::cout << ieta << " " << irank;
-        double etGeVNeg =
-            e_tpg->getTPGInGeV(irank,
-                               EcalTrigTowerDetId(-1, // -ve eta
-                                                  subdet, ieta,
-                                                  2)); // dummy phi value
+        double etGeVNeg = e_tpg->getTPGInGeV(irank,
+                                             EcalTrigTowerDetId(-1,  // -ve eta
+                                                                subdet,
+                                                                ieta,
+                                                                2));  // dummy phi value
         ecalScale->setBin(irank, ieta, -1, etGeVNeg);
         std::cout << etGeVNeg << ", ";
       }
@@ -133,8 +132,7 @@ void L1RCTSaveInput::analyze(const edm::Event &event,
     // HCAL
     std::cout << "HCAL" << std::endl;
     for (unsigned short ieta = 1; ieta <= L1CaloHcalScale::nBinEta; ++ieta) {
-      for (unsigned short irank = 0; irank < L1CaloHcalScale::nBinRank;
-           ++irank) {
+      for (unsigned short irank = 0; irank < L1CaloHcalScale::nBinRank; ++irank) {
         double etGeV = h_tpg->hcaletValue(ieta, irank);
 
         hcalScale->setBin(irank, ieta, 1, etGeV);
@@ -212,11 +210,9 @@ void L1RCTSaveInput::analyze(const edm::Event &event,
           unsigned short hcal = rct->hcalCompressedET(iCrate, iCard, iTower);
           unsigned short fgbit = rct->ecalFineGrainBit(iCrate, iCard, iTower);
           unsigned short mubit = rct->hcalFineGrainBit(iCrate, iCard, iTower);
-          unsigned long lutOutput =
-              rctLookupTables->lookup(ecal, hcal, fgbit, iCrate, iCard, iTower);
-          ofs << std::hex << nEvents << "\t" << iCrate << "\t" << iCard << "\t"
-              << iTower << "\t" << ecal * 2 + fgbit << "\t" << hcal * 2 + mubit
-              << "\t" << lutOutput << std::dec << std::endl;
+          unsigned long lutOutput = rctLookupTables->lookup(ecal, hcal, fgbit, iCrate, iCard, iTower);
+          ofs << std::hex << nEvents << "\t" << iCrate << "\t" << iCard << "\t" << iTower << "\t" << ecal * 2 + fgbit
+              << "\t" << hcal * 2 + mubit << "\t" << lutOutput << std::dec << std::endl;
         }
       }
     }

--- a/L1Trigger/RegionalCaloTrigger/plugins/L1RCTTPGProvider.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/L1RCTTPGProvider.cc
@@ -11,7 +11,6 @@ L1RCTTPGProvider::L1RCTTPGProvider(const edm::ParameterSet &iConfig)
       postSamples(iConfig.getParameter<int>("postSamples")),
       hfShift(iConfig.getParameter<int>("HFShift")),
       hbShift(iConfig.getParameter<int>("HBShift")) {
-
   // Output :The new manipulated TPGs
   // make it smart - to name the collections
   // correctly
@@ -46,8 +45,7 @@ L1RCTTPGProvider::~L1RCTTPGProvider() {
 //
 
 // ------------ method called to produce the data  ------------
-void L1RCTTPGProvider::produce(edm::Event &iEvent,
-                               const edm::EventSetup &iSetup) {
+void L1RCTTPGProvider::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
   // Declare handles
   Handle<EcalTrigPrimDigiCollection> ecal;
@@ -55,75 +53,64 @@ void L1RCTTPGProvider::produce(edm::Event &iEvent,
 
   // Declare vector of collection to send for output !
 
-  std::vector<EcalTrigPrimDigiCollection> ecalColl(preSamples + 1 +
-                                                   postSamples);
-  std::vector<HcalTrigPrimDigiCollection> hcalColl(preSamples + 1 +
-                                                   postSamples);
+  std::vector<EcalTrigPrimDigiCollection> ecalColl(preSamples + 1 + postSamples);
+  std::vector<HcalTrigPrimDigiCollection> hcalColl(preSamples + 1 + postSamples);
 
   unsigned nSamples = preSamples + postSamples + 1;
 
   if (iEvent.getByLabel(ecalTPG_, ecal))
     if (ecal.isValid()) {
       // loop through all ecal digis
-      for (EcalTrigPrimDigiCollection::const_iterator ecal_it = ecal->begin();
-           ecal_it != ecal->end(); ecal_it++) {
+      for (EcalTrigPrimDigiCollection::const_iterator ecal_it = ecal->begin(); ecal_it != ecal->end(); ecal_it++) {
         short zside = ecal_it->id().zside();
         unsigned short ietaAbs = ecal_it->id().ietaAbs();
         short iphi = ecal_it->id().iphi();
         unsigned short digiSize = ecal_it->size();
         unsigned short nSOI = (unsigned short)(ecal_it->sampleOfInterest());
-        if (digiSize < nSamples || nSOI < preSamples ||
-            ((int)(digiSize - nSOI) < (int)(nSamples - preSamples))) {
+        if (digiSize < nSamples || nSOI < preSamples || ((int)(digiSize - nSOI) < (int)(nSamples - preSamples))) {
           unsigned short preLoopsZero = (unsigned short)(preSamples)-nSOI;
 
           // fill extra bx's at beginning with zeros
           for (int sample = 0; sample < preLoopsZero; sample++) {
             // fill first few with zeros
-            EcalTriggerPrimitiveDigi ecalDigi(EcalTrigTowerDetId(
-                (int)zside, EcalTriggerTower, (int)ietaAbs, (int)iphi));
+            EcalTriggerPrimitiveDigi ecalDigi(
+                EcalTrigTowerDetId((int)zside, EcalTriggerTower, (int)ietaAbs, (int)iphi));
             ecalDigi.setSize(1);
             ecalDigi.setSample(0, EcalTriggerPrimitiveSample(0, false, 0));
             ecalColl[sample].push_back(ecalDigi);
           }
 
           // loop through existing data
-          for (int sample = preLoopsZero; sample < (preLoopsZero + digiSize);
-               sample++) {
+          for (int sample = preLoopsZero; sample < (preLoopsZero + digiSize); sample++) {
             // go through data
-            EcalTriggerPrimitiveDigi ecalDigi(EcalTrigTowerDetId(
-                (int)zside, EcalTriggerTower, (int)ietaAbs, (int)iphi));
+            EcalTriggerPrimitiveDigi ecalDigi(
+                EcalTrigTowerDetId((int)zside, EcalTriggerTower, (int)ietaAbs, (int)iphi));
             ecalDigi.setSize(1);
             if (useEcalCosmicTiming && iphi >= 1 && iphi <= 36) {
               if (nSOI < (preSamples + 1)) {
-                edm::LogWarning("TooLittleData")
-                    << "ECAL data needs at least one presample "
-                    << "more than the number requested "
-                    << "to use ecal cosmic timing mod!  "
-                    << "reverting to useEcalCosmicTiming = false "
-                    << "for rest of job.";
+                edm::LogWarning("TooLittleData") << "ECAL data needs at least one presample "
+                                                 << "more than the number requested "
+                                                 << "to use ecal cosmic timing mod!  "
+                                                 << "reverting to useEcalCosmicTiming = false "
+                                                 << "for rest of job.";
                 useEcalCosmicTiming = false;
               } else {
-                ecalDigi.setSample(
-                    0,
-                    EcalTriggerPrimitiveSample(
-                        ecal_it->sample(nSOI + sample - preSamples - 1).raw()));
+                ecalDigi.setSample(0,
+                                   EcalTriggerPrimitiveSample(ecal_it->sample(nSOI + sample - preSamples - 1).raw()));
               }
             }
             // else
             if ((!useEcalCosmicTiming) || (iphi >= 37 && iphi <= 72)) {
-              ecalDigi.setSample(
-                  0, EcalTriggerPrimitiveSample(
-                         ecal_it->sample(nSOI + sample - preSamples).raw()));
+              ecalDigi.setSample(0, EcalTriggerPrimitiveSample(ecal_it->sample(nSOI + sample - preSamples).raw()));
             }
             ecalColl[sample].push_back(ecalDigi);
           }
 
           // fill extra bx's at end with zeros
-          for (unsigned int sample = (preLoopsZero + digiSize);
-               sample < nSamples; sample++) {
+          for (unsigned int sample = (preLoopsZero + digiSize); sample < nSamples; sample++) {
             // fill zeros!
-            EcalTriggerPrimitiveDigi ecalDigi(EcalTrigTowerDetId(
-                (int)zside, EcalTriggerTower, (int)ietaAbs, (int)iphi));
+            EcalTriggerPrimitiveDigi ecalDigi(
+                EcalTrigTowerDetId((int)zside, EcalTriggerTower, (int)ietaAbs, (int)iphi));
             ecalDigi.setSize(1);
             ecalDigi.setSample(0, EcalTriggerPrimitiveSample(0, false, 0));
             ecalColl[sample].push_back(ecalDigi);
@@ -134,36 +121,29 @@ void L1RCTTPGProvider::produce(edm::Event &iEvent,
             short zside = ecal_it->id().zside();
             unsigned short ietaAbs = ecal_it->id().ietaAbs();
             short iphi = ecal_it->id().iphi();
-            EcalTriggerPrimitiveDigi ecalDigi(EcalTrigTowerDetId(
-                (int)zside, EcalTriggerTower, (int)ietaAbs, (int)iphi));
+            EcalTriggerPrimitiveDigi ecalDigi(
+                EcalTrigTowerDetId((int)zside, EcalTriggerTower, (int)ietaAbs, (int)iphi));
             ecalDigi.setSize(1);
 
             if (useEcalCosmicTiming && iphi >= 1 && iphi <= 36) {
               if (nSOI < (preSamples + 1)) {
-                edm::LogWarning("TooLittleData")
-                    << "ECAL data needs at least one presample "
-                    << "more than the number requested "
-                    << "to use ecal cosmic timing mod!  "
-                    << "reverting to useEcalCosmicTiming = false "
-                    << "for rest of job.";
+                edm::LogWarning("TooLittleData") << "ECAL data needs at least one presample "
+                                                 << "more than the number requested "
+                                                 << "to use ecal cosmic timing mod!  "
+                                                 << "reverting to useEcalCosmicTiming = false "
+                                                 << "for rest of job.";
                 useEcalCosmicTiming = false;
               } else {
-                ecalDigi.setSample(
-                    0, EcalTriggerPrimitiveSample(
-                           ecal_it
-                               ->sample(ecal_it->sampleOfInterest() + sample -
-                                        preSamples - 1)
-                               .raw()));
+                ecalDigi.setSample(0,
+                                   EcalTriggerPrimitiveSample(
+                                       ecal_it->sample(ecal_it->sampleOfInterest() + sample - preSamples - 1).raw()));
               }
             }
             // else
             if ((!useEcalCosmicTiming) || (iphi >= 37 && iphi <= 72)) {
-              ecalDigi.setSample(0,
-                                 EcalTriggerPrimitiveSample(
-                                     ecal_it
-                                         ->sample(ecal_it->sampleOfInterest() +
-                                                  sample - preSamples)
-                                         .raw()));
+              ecalDigi.setSample(
+                  0,
+                  EcalTriggerPrimitiveSample(ecal_it->sample(ecal_it->sampleOfInterest() + sample - preSamples).raw()));
             }
             // push back each digi into correct "time sample" of coll
             ecalColl[sample].push_back(ecalDigi);
@@ -175,22 +155,19 @@ void L1RCTTPGProvider::produce(edm::Event &iEvent,
   if (iEvent.getByLabel(hcalTPG_, hcal))
     if (hcal.isValid()) {
       // loop through all hcal digis
-      for (HcalTrigPrimDigiCollection::const_iterator hcal_it = hcal->begin();
-           hcal_it != hcal->end(); hcal_it++) {
+      for (HcalTrigPrimDigiCollection::const_iterator hcal_it = hcal->begin(); hcal_it != hcal->end(); hcal_it++) {
         short ieta = hcal_it->id().ieta();
         short iphi = hcal_it->id().iphi();
         // loop through time samples for each digi
         unsigned short digiSize = hcal_it->size();
         // (size of each digi must be no less than nSamples)
         unsigned short nSOI = (unsigned short)(hcal_it->presamples());
-        if (digiSize < nSamples || nSOI < preSamples ||
-            ((int)(digiSize - nSOI) < (int)(nSamples - preSamples))) {
+        if (digiSize < nSamples || nSOI < preSamples || ((int)(digiSize - nSOI) < (int)(nSamples - preSamples))) {
           unsigned short preLoopsZero = (unsigned short)(preSamples)-nSOI;
           // fill extra bx's at beginning with zeros
           for (int sample = 0; sample < preLoopsZero; sample++) {
             // fill first few with zeros
-            HcalTriggerPrimitiveDigi hcalDigi(
-                HcalTrigTowerDetId((int)ieta, (int)iphi));
+            HcalTriggerPrimitiveDigi hcalDigi(HcalTrigTowerDetId((int)ieta, (int)iphi));
             hcalDigi.setSize(1);
             hcalDigi.setPresamples(0);
             hcalDigi.setSample(0, HcalTriggerPrimitiveSample(0, false, 0, 0));
@@ -198,49 +175,38 @@ void L1RCTTPGProvider::produce(edm::Event &iEvent,
           }
 
           // loop through existing data
-          for (int sample = preLoopsZero; sample < (preLoopsZero + digiSize);
-               sample++) {
+          for (int sample = preLoopsZero; sample < (preLoopsZero + digiSize); sample++) {
             // go through data
-            HcalTriggerPrimitiveDigi hcalDigi(
-                HcalTrigTowerDetId((int)ieta, (int)iphi));
+            HcalTriggerPrimitiveDigi hcalDigi(HcalTrigTowerDetId((int)ieta, (int)iphi));
             hcalDigi.setSize(1);
             hcalDigi.setPresamples(0);
 
             if (useHcalCosmicTiming && iphi >= 1 && iphi <= 36) {
               if (nSOI < (preSamples + 1)) {
-                edm::LogWarning("TooLittleData")
-                    << "HCAL data needs at least one presample "
-                    << "more than the number requested "
-                    << "to use hcal cosmic timing mod!  "
-                    << "reverting to useHcalCosmicTiming = false "
-                    << "for rest of job.";
+                edm::LogWarning("TooLittleData") << "HCAL data needs at least one presample "
+                                                 << "more than the number requested "
+                                                 << "to use hcal cosmic timing mod!  "
+                                                 << "reverting to useHcalCosmicTiming = false "
+                                                 << "for rest of job.";
                 useHcalCosmicTiming = false;
               } else {
-                hcalDigi.setSample(0, HcalTriggerPrimitiveSample(
-                                          hcal_it
-                                              ->sample(hcal_it->presamples() +
-                                                       sample - preSamples - 1)
-                                              .raw()));
+                hcalDigi.setSample(
+                    0,
+                    HcalTriggerPrimitiveSample(hcal_it->sample(hcal_it->presamples() + sample - preSamples - 1).raw()));
               }
             }
             // else
             if ((!useHcalCosmicTiming) || (iphi >= 37 && iphi <= 72)) {
-
-              hcalDigi.setSample(0, HcalTriggerPrimitiveSample(
-                                        hcal_it
-                                            ->sample(hcal_it->presamples() +
-                                                     sample - preSamples)
-                                            .raw()));
+              hcalDigi.setSample(
+                  0, HcalTriggerPrimitiveSample(hcal_it->sample(hcal_it->presamples() + sample - preSamples).raw()));
             }
             hcalColl[sample].push_back(hcalDigi);
           }
 
           // fill extra bx's at end with zeros
-          for (unsigned int sample = (preLoopsZero + digiSize);
-               sample < nSamples; sample++) {
+          for (unsigned int sample = (preLoopsZero + digiSize); sample < nSamples; sample++) {
             // fill zeros!
-            HcalTriggerPrimitiveDigi hcalDigi(
-                HcalTrigTowerDetId((int)ieta, (int)iphi));
+            HcalTriggerPrimitiveDigi hcalDigi(HcalTrigTowerDetId((int)ieta, (int)iphi));
             hcalDigi.setSize(1);
             hcalDigi.setPresamples(0);
             hcalDigi.setSample(0, HcalTriggerPrimitiveSample(0, false, 0, 0));
@@ -249,44 +215,34 @@ void L1RCTTPGProvider::produce(edm::Event &iEvent,
         } else {
           for (unsigned short sample = 0; sample < nSamples; sample++) {
             // put each (relevant) time sample into its own digi
-            HcalTriggerPrimitiveDigi hcalDigi(
-                HcalTrigTowerDetId((int)ieta, (int)iphi));
+            HcalTriggerPrimitiveDigi hcalDigi(HcalTrigTowerDetId((int)ieta, (int)iphi));
             hcalDigi.setSize(1);
             hcalDigi.setPresamples(0);
 
             if (useHcalCosmicTiming && iphi >= 1 && iphi <= 36) {
               if (nSOI < (preSamples + 1)) {
-                edm::LogWarning("TooLittleData")
-                    << "HCAL data needs at least one presample "
-                    << "more than the number requested "
-                    << "to use hcal cosmic timing mod!  "
-                    << "reverting to useHcalCosmicTiming = false "
-                    << "for rest of job.";
+                edm::LogWarning("TooLittleData") << "HCAL data needs at least one presample "
+                                                 << "more than the number requested "
+                                                 << "to use hcal cosmic timing mod!  "
+                                                 << "reverting to useHcalCosmicTiming = false "
+                                                 << "for rest of job.";
                 useHcalCosmicTiming = false;
               } else {
-                hcalDigi.setSample(0, HcalTriggerPrimitiveSample(
-                                          hcal_it
-                                              ->sample(hcal_it->presamples() +
-                                                       sample - preSamples - 1)
-                                              .raw()));
+                hcalDigi.setSample(
+                    0,
+                    HcalTriggerPrimitiveSample(hcal_it->sample(hcal_it->presamples() + sample - preSamples - 1).raw()));
               }
             }
             // else
             if ((!useHcalCosmicTiming) || (iphi >= 37 && iphi <= 72)) {
               if (ieta > -29 && ieta < 29)
-                hcalDigi.setSample(
-                    0, HcalTriggerPrimitiveSample(
-                           hcal_it
-                               ->sample(hcal_it->presamples() + sample -
-                                        preSamples + hbShift)
-                               .raw()));
+                hcalDigi.setSample(0,
+                                   HcalTriggerPrimitiveSample(
+                                       hcal_it->sample(hcal_it->presamples() + sample - preSamples + hbShift).raw()));
               if (ieta <= -29 || ieta >= 29)
-                hcalDigi.setSample(
-                    0, HcalTriggerPrimitiveSample(
-                           hcal_it
-                               ->sample(hcal_it->presamples() + sample -
-                                        preSamples + hfShift)
-                               .raw()));
+                hcalDigi.setSample(0,
+                                   HcalTriggerPrimitiveSample(
+                                       hcal_it->sample(hcal_it->presamples() + sample - preSamples + hfShift).raw()));
             }
             hcalColl[sample].push_back(hcalDigi);
           }
@@ -303,10 +259,8 @@ void L1RCTTPGProvider::produce(edm::Event &iEvent,
     sprintf(ecal_label, "ECALBxminus%d", preSamples - i);
     sprintf(hcal_label, "HCALBxminus%d", preSamples - i);
 
-    std::unique_ptr<EcalTrigPrimDigiCollection> ecalIn(
-        new EcalTrigPrimDigiCollection);
-    std::unique_ptr<HcalTrigPrimDigiCollection> hcalIn(
-        new HcalTrigPrimDigiCollection);
+    std::unique_ptr<EcalTrigPrimDigiCollection> ecalIn(new EcalTrigPrimDigiCollection);
+    std::unique_ptr<HcalTrigPrimDigiCollection> hcalIn(new HcalTrigPrimDigiCollection);
     for (unsigned int j = 0; j < ecalColl[i].size(); ++j) {
       ecalIn->push_back((ecalColl[i])[j]);
     }
@@ -317,10 +271,8 @@ void L1RCTTPGProvider::produce(edm::Event &iEvent,
     iEvent.put(std::move(hcalIn), hcal_label);
   }
 
-  std::unique_ptr<EcalTrigPrimDigiCollection> ecal0(
-      new EcalTrigPrimDigiCollection);
-  std::unique_ptr<HcalTrigPrimDigiCollection> hcal0(
-      new HcalTrigPrimDigiCollection);
+  std::unique_ptr<EcalTrigPrimDigiCollection> ecal0(new EcalTrigPrimDigiCollection);
+  std::unique_ptr<HcalTrigPrimDigiCollection> hcal0(new HcalTrigPrimDigiCollection);
   for (unsigned int j = 0; j < ecalColl[preSamples].size(); ++j)
     ecal0->push_back((ecalColl[preSamples])[j]);
   for (unsigned int j = 0; j < hcalColl[preSamples].size(); ++j)
@@ -336,10 +288,8 @@ void L1RCTTPGProvider::produce(edm::Event &iEvent,
     sprintf(ecal_label, "ECALBxplus%d", i - preSamples);
     sprintf(hcal_label, "HCALBxplus%d", i - preSamples);
 
-    std::unique_ptr<EcalTrigPrimDigiCollection> ecalIn2(
-        new EcalTrigPrimDigiCollection);
-    std::unique_ptr<HcalTrigPrimDigiCollection> hcalIn2(
-        new HcalTrigPrimDigiCollection);
+    std::unique_ptr<EcalTrigPrimDigiCollection> ecalIn2(new EcalTrigPrimDigiCollection);
+    std::unique_ptr<HcalTrigPrimDigiCollection> hcalIn2(new HcalTrigPrimDigiCollection);
 
     for (unsigned int j = 0; j < ecalColl[i].size(); ++j)
       ecalIn2->push_back((ecalColl[i])[j]);

--- a/L1Trigger/RegionalCaloTrigger/plugins/L1RCTTestAnalyzer.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/L1RCTTestAnalyzer.cc
@@ -44,41 +44,31 @@ L1RCTTestAnalyzer::L1RCTTestAnalyzer(const edm::ParameterSet &iConfig)
   emTree->Branch("emIso", &emIso);
 
   h_emRank = fs->make<TH1F>("emRank", "emRank", 64, 0., 64.);
-  h_emRankOutOfTime =
-      fs->make<TH1F>("emRankOutOfTime", "emRankOutOfTime", 64, 0., 64.);
+  h_emRankOutOfTime = fs->make<TH1F>("emRankOutOfTime", "emRankOutOfTime", 64, 0., 64.);
   h_emIeta = fs->make<TH1F>("emIeta", "emIeta", 22, 0., 22.);
   h_emIphi = fs->make<TH1F>("emIphi", "emIphi", 18, 0., 18.);
   h_emIso = fs->make<TH1F>("emIso", "emIso", 2, 0., 2.);
-  h_emRankInIetaIphi =
-      fs->make<TH2F>("emRank2D", "emRank2D", 22, 0., 22., 18, 0., 18.);
-  h_emIsoInIetaIphi =
-      fs->make<TH2F>("emIso2D", "emIso2D", 22, 0., 22., 18, 0., 18.);
-  h_emNonIsoInIetaIphi =
-      fs->make<TH2F>("emNonIso2D", "emNonIso2D", 22, 0., 22., 18, 0., 18.);
-  h_emCandTimeSample =
-      fs->make<TH1F>("emCandTimeSample", "emCandTimeSample", 5, -2., 2.);
+  h_emRankInIetaIphi = fs->make<TH2F>("emRank2D", "emRank2D", 22, 0., 22., 18, 0., 18.);
+  h_emIsoInIetaIphi = fs->make<TH2F>("emIso2D", "emIso2D", 22, 0., 22., 18, 0., 18.);
+  h_emNonIsoInIetaIphi = fs->make<TH2F>("emNonIso2D", "emNonIso2D", 22, 0., 22., 18, 0., 18.);
+  h_emCandTimeSample = fs->make<TH1F>("emCandTimeSample", "emCandTimeSample", 5, -2., 2.);
 
   h_regionSum = fs->make<TH1F>("regionSum", "regionSum", 100, 0., 100.);
   h_regionIeta = fs->make<TH1F>("regionIeta", "regionIeta", 22, 0., 22.);
   h_regionIphi = fs->make<TH1F>("regionIphi", "regionIphi", 18, 0., 18.);
   h_regionMip = fs->make<TH1F>("regionMip", "regionMipBit", 2, 0., 2.);
-  h_regionSumInIetaIphi =
-      fs->make<TH2F>("regionSum2D", "regionSum2D", 22, 0., 22., 18, 0., 18.);
-  h_regionFGInIetaIphi =
-      fs->make<TH2F>("regionFG2D", "regionFG2D", 22, 0., 22., 18, 0., 18.);
+  h_regionSumInIetaIphi = fs->make<TH2F>("regionSum2D", "regionSum2D", 22, 0., 22., 18, 0., 18.);
+  h_regionFGInIetaIphi = fs->make<TH2F>("regionFG2D", "regionFG2D", 22, 0., 22., 18, 0., 18.);
 
   h_towerMip = fs->make<TH1F>("towerMip", "towerMipBit", 2, 0., 2.);
 
-  h_ecalTimeSample =
-      fs->make<TH1F>("ecalTimeSample", "ecalTimeSample", 10, 0., 10.);
-  h_hcalTimeSample =
-      fs->make<TH1F>("hcalTimeSample", "hcalTimeSample", 10, 0., 10.);
+  h_ecalTimeSample = fs->make<TH1F>("ecalTimeSample", "ecalTimeSample", 10, 0., 10.);
+  h_hcalTimeSample = fs->make<TH1F>("hcalTimeSample", "hcalTimeSample", 10, 0., 10.);
 
   // get names of modules, producing object collections
 }
 
 L1RCTTestAnalyzer::~L1RCTTestAnalyzer() {
-
   // do anything here that needs to be done at destruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -88,8 +78,7 @@ L1RCTTestAnalyzer::~L1RCTTestAnalyzer() {
 //
 
 // ------------ method called to produce the data  ------------
-void L1RCTTestAnalyzer::analyze(const edm::Event &iEvent,
-                                const edm::EventSetup &iSetup) {
+void L1RCTTestAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
 #ifdef THIS_IS_AN_EVENT_EXAMPLE
   Handle<ExampleData> pIn;
@@ -153,14 +142,11 @@ void L1RCTTestAnalyzer::analyze(const edm::Event &iEvent,
         h_emIeta->Fill((*em).regionId().ieta());
         h_emIphi->Fill((*em).regionId().iphi());
         h_emIso->Fill((*em).isolated());
-        h_emRankInIetaIphi->Fill((*em).regionId().ieta(),
-                                 (*em).regionId().iphi(), (*em).rank());
+        h_emRankInIetaIphi->Fill((*em).regionId().ieta(), (*em).regionId().iphi(), (*em).rank());
         if ((*em).isolated()) {
-          h_emIsoInIetaIphi->Fill((*em).regionId().ieta(),
-                                  (*em).regionId().iphi());
+          h_emIsoInIetaIphi->Fill((*em).regionId().ieta(), (*em).regionId().iphi());
         } else {
-          h_emNonIsoInIetaIphi->Fill((*em).regionId().ieta(),
-                                     (*em).regionId().iphi());
+          h_emNonIsoInIetaIphi->Fill((*em).regionId().ieta(), (*em).regionId().iphi());
         }
       }
 
@@ -177,8 +163,7 @@ void L1RCTTestAnalyzer::analyze(const edm::Event &iEvent,
           } else if (card < 6) {
             rgnPhi = (card % 2);
           } else {
-            std::cout << "rgnPhi not assigned (still " << rgnPhi
-                      << ") -- Weird card number! " << card;
+            std::cout << "rgnPhi not assigned (still " << rgnPhi << ") -- Weird card number! " << card;
           }
 
           // unsigned short phi_bin = ((crate % 9) * 2) + rgnPhi;
@@ -209,7 +194,7 @@ void L1RCTTestAnalyzer::analyze(const edm::Event &iEvent,
   //    std::sort(rctEmCands->begin(),rctEmCands->end(),compareEmCands);
   //    for (em=rctEmCands->begin(); em!=rctEmCands->end(); em++)
   std::sort(myL1EmColl->begin(), myL1EmColl->end(), compareEmCands);
-  std::reverse(myL1EmColl->begin(), myL1EmColl->end()); // whoops!
+  std::reverse(myL1EmColl->begin(), myL1EmColl->end());  // whoops!
   for (em = myL1EmColl->begin(); em != myL1EmColl->end(); em++) {
     emRank.push_back((*em).rank());
     emIeta.push_back((*em).regionId().ieta());
@@ -230,10 +215,8 @@ void L1RCTTestAnalyzer::analyze(const edm::Event &iEvent,
         h_regionSum->Fill((*rgn).et());
         h_regionIeta->Fill((*rgn).gctEta());
         h_regionIphi->Fill((*rgn).gctPhi());
-        h_regionSumInIetaIphi->Fill((*rgn).gctEta(), (*rgn).gctPhi(),
-                                    (*rgn).et());
-        h_regionFGInIetaIphi->Fill((*rgn).gctEta(), (*rgn).gctPhi(),
-                                   (*rgn).fineGrain());
+        h_regionSumInIetaIphi->Fill((*rgn).gctEta(), (*rgn).gctPhi(), (*rgn).et());
+        h_regionFGInIetaIphi->Fill((*rgn).gctEta(), (*rgn).gctPhi(), (*rgn).fineGrain());
       }
       h_regionMip->Fill((*rgn).mip());
     }
@@ -250,7 +233,6 @@ void L1RCTTestAnalyzer::analyze(const edm::Event &iEvent,
   delete myL1EmColl;
 }
 
-bool L1RCTTestAnalyzer::compareEmCands(const L1CaloEmCand &cand1,
-                                       const L1CaloEmCand &cand2) {
+bool L1RCTTestAnalyzer::compareEmCands(const L1CaloEmCand &cand1, const L1CaloEmCand &cand2) {
   return (cand1.rank() < cand2.rank());
 }

--- a/L1Trigger/RegionalCaloTrigger/plugins/MaskedRctInputDigiProducer.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/MaskedRctInputDigiProducer.cc
@@ -12,8 +12,7 @@ using std::vector;
 // constructors and destructor
 //
 
-MaskedRctInputDigiProducer::MaskedRctInputDigiProducer(
-    const edm::ParameterSet &iConfig)
+MaskedRctInputDigiProducer::MaskedRctInputDigiProducer(const edm::ParameterSet &iConfig)
     : useEcal_(iConfig.getParameter<bool>("useEcal")),
       useHcal_(iConfig.getParameter<bool>("useHcal")),
       ecalDigisLabel_(iConfig.getParameter<edm::InputTag>("ecalDigisLabel")),
@@ -34,7 +33,6 @@ MaskedRctInputDigiProducer::MaskedRctInputDigiProducer(
 }
 
 MaskedRctInputDigiProducer::~MaskedRctInputDigiProducer() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -44,8 +42,7 @@ MaskedRctInputDigiProducer::~MaskedRctInputDigiProducer() {
 //
 
 // ------------ method called to produce the data  ------------
-void MaskedRctInputDigiProducer::produce(edm::Event &iEvent,
-                                         const edm::EventSetup &iSetup) {
+void MaskedRctInputDigiProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
   /* This is an event example
      //Read 'ExampleData' from the Event
@@ -85,8 +82,7 @@ void MaskedRctInputDigiProducer::produce(edm::Event &iEvent,
 
   ifstream maskFileStream(maskFile_.fullPath().c_str());
   if (!maskFileStream.is_open()) {
-    throw cms::Exception("FileInPathError")
-        << "RCT mask file not opened" << std::endl;
+    throw cms::Exception("FileInPathError") << "RCT mask file not opened" << std::endl;
     ;
   }
 
@@ -104,19 +100,16 @@ void MaskedRctInputDigiProducer::produce(edm::Event &iEvent,
   //   temp(2,std::vector<std::vector<unsigned short> >(72,std::vector<unsigned
   //   short>(28,1)));
   std::vector<std::vector<std::vector<unsigned short>>> ecalMask(
-      2, std::vector<std::vector<unsigned short>>(
-             72, std::vector<unsigned short>(28, 1)));
+      2, std::vector<std::vector<unsigned short>>(72, std::vector<unsigned short>(28, 1)));
   std::vector<std::vector<std::vector<unsigned short>>> hcalMask(
-      2, std::vector<std::vector<unsigned short>>(
-             72, std::vector<unsigned short>(28, 1)));
+      2, std::vector<std::vector<unsigned short>>(72, std::vector<unsigned short>(28, 1)));
   std::vector<std::vector<std::vector<unsigned short>>> hfMask(
-      2, std::vector<std::vector<unsigned short>>(
-             18, std::vector<unsigned short>(8, 1)));
+      2, std::vector<std::vector<unsigned short>>(18, std::vector<unsigned short>(8, 1)));
 
   // read ECAL mask first
   // loop through rct iphi
   for (int i = 1; i <= 72; i++) {
-    int phi_index = (72 + 18 - i) % 72; // transfrom from RCT coords
+    int phi_index = (72 + 18 - i) % 72;  // transfrom from RCT coords
     if (phi_index == 0) {
       phi_index = 72;
     }
@@ -127,8 +120,7 @@ void MaskedRctInputDigiProducer::produce(edm::Event &iEvent,
       } else if ((junk == "X") || (junk == "x")) {
         ecalMask.at(0).at(phi_index - 1).at(j - 1) = 0;
       } else {
-        std::cerr << "RCT mask producer: error -- unrecognized character"
-                  << std::endl;
+        std::cerr << "RCT mask producer: error -- unrecognized character" << std::endl;
       }
     }
     for (int j = 1; j <= 28; j++) {
@@ -137,8 +129,7 @@ void MaskedRctInputDigiProducer::produce(edm::Event &iEvent,
       } else if ((junk == "X") || (junk == "x")) {
         ecalMask.at(1).at(phi_index - 1).at(j - 1) = 0;
       } else {
-        std::cerr << "RCT mask producer: error -- unrecognized character"
-                  << std::endl;
+        std::cerr << "RCT mask producer: error -- unrecognized character" << std::endl;
       }
     }
   }
@@ -146,8 +137,7 @@ void MaskedRctInputDigiProducer::produce(edm::Event &iEvent,
 
   maskFileStream >> junk;
   if (junk != "HCAL:") {
-    throw cms::Exception("FileInPathError")
-        << "RCT mask producer: error reading ECAL mask" << std::endl;
+    throw cms::Exception("FileInPathError") << "RCT mask producer: error reading ECAL mask" << std::endl;
     ;
   }
 
@@ -156,7 +146,7 @@ void MaskedRctInputDigiProducer::produce(edm::Event &iEvent,
   // now read HCAL mask
   // loop through rct iphi
   for (int i = 1; i <= 72; i++) {
-    int phi_index = (72 + 18 - i) % 72; // transfrom from RCT coords
+    int phi_index = (72 + 18 - i) % 72;  // transfrom from RCT coords
     if (phi_index == 0) {
       phi_index = 72;
     }
@@ -167,8 +157,7 @@ void MaskedRctInputDigiProducer::produce(edm::Event &iEvent,
       } else if ((junk == "X") || (junk == "x")) {
         hcalMask.at(0).at(phi_index - 1).at(j - 1) = 0;
       } else {
-        std::cerr << "RCT mask producer: error -- unrecognized character"
-                  << std::endl;
+        std::cerr << "RCT mask producer: error -- unrecognized character" << std::endl;
       }
     }
     for (int j = 1; j <= 28; j++) {
@@ -177,16 +166,14 @@ void MaskedRctInputDigiProducer::produce(edm::Event &iEvent,
       } else if ((junk == "X") || (junk == "x")) {
         hcalMask.at(1).at(phi_index - 1).at(j - 1) = 0;
       } else {
-        std::cerr << "RCT mask producer: error -- unrecognized character"
-                  << std::endl;
+        std::cerr << "RCT mask producer: error -- unrecognized character" << std::endl;
       }
     }
   }
 
   maskFileStream >> junk;
   if (junk != "HF:") {
-    throw cms::Exception("FileInPathError")
-        << "RCT mask producer: error reading HCAL mask" << std::endl;
+    throw cms::Exception("FileInPathError") << "RCT mask producer: error reading HCAL mask" << std::endl;
     ;
   }
 
@@ -200,11 +187,9 @@ void MaskedRctInputDigiProducer::produce(edm::Event &iEvent,
       }
       if (junk == "-") {
       } else if ((junk == "X") || (junk == "x")) {
-        hfMask.at(0).at(i).at(j - 1) =
-            0; // just save iphi as 0-17, transform later
+        hfMask.at(0).at(i).at(j - 1) = 0;  // just save iphi as 0-17, transform later
       } else {
-        std::cerr << "RCT mask producer: error -- unrecognized character"
-                  << std::endl;
+        std::cerr << "RCT mask producer: error -- unrecognized character" << std::endl;
       }
     }
     for (int j = 1; j <= 4; j++) {
@@ -216,8 +201,7 @@ void MaskedRctInputDigiProducer::produce(edm::Event &iEvent,
       } else if ((junk == "X") || (junk == "x")) {
         hfMask.at(1).at(i).at(j - 1) = 0;
       } else {
-        std::cerr << "RCT mask producer: error -- unrecognized character"
-                  << std::endl;
+        std::cerr << "RCT mask producer: error -- unrecognized character" << std::endl;
       }
     }
   }
@@ -230,10 +214,8 @@ void MaskedRctInputDigiProducer::produce(edm::Event &iEvent,
 
   // apply mask
 
-  std::unique_ptr<EcalTrigPrimDigiCollection> maskedEcalTPs(
-      new EcalTrigPrimDigiCollection());
-  std::unique_ptr<HcalTrigPrimDigiCollection> maskedHcalTPs(
-      new HcalTrigPrimDigiCollection());
+  std::unique_ptr<EcalTrigPrimDigiCollection> maskedEcalTPs(new EcalTrigPrimDigiCollection());
+  std::unique_ptr<HcalTrigPrimDigiCollection> maskedHcalTPs(new HcalTrigPrimDigiCollection());
   maskedEcalTPs->reserve(56 * 72);
   maskedHcalTPs->reserve(56 * 72 + 18 * 8);
   int nEcalSamples = 0;
@@ -249,33 +231,26 @@ void MaskedRctInputDigiProducer::produce(edm::Event &iEvent,
     // absIeta
     //		      << ", iphi is " << iphi << std::endl;}
 
-    EcalTriggerPrimitiveDigi ecalDigi(
-        EcalTrigTowerDetId(sign, EcalTriggerTower, absIeta, iphi));
+    EcalTriggerPrimitiveDigi ecalDigi(EcalTrigTowerDetId(sign, EcalTriggerTower, absIeta, iphi));
     ecalDigi.setSize(nEcalSamples);
 
     for (int nSample = 0; nSample < nEcalSamples; nSample++) {
-
       int energy = 0;
       bool fineGrain = false;
 
       if (sign < 0) {
         // std::cout << "eta-: mask is " <<
         // ecalMask.at(0).at(iphi-1).at(absIeta-1) << std::endl;
-        energy = ecalMask.at(0).at(iphi - 1).at(absIeta - 1) *
-                 ecalColl[i].sample(nSample).compressedEt();
-        fineGrain = (ecalMask.at(0).at(iphi - 1).at(absIeta - 1) != 0) &&
-                    ecalColl[i].sample(nSample).fineGrain();
+        energy = ecalMask.at(0).at(iphi - 1).at(absIeta - 1) * ecalColl[i].sample(nSample).compressedEt();
+        fineGrain = (ecalMask.at(0).at(iphi - 1).at(absIeta - 1) != 0) && ecalColl[i].sample(nSample).fineGrain();
       } else if (sign > 0) {
         // std::cout << "eta+: mask is " <<
         // ecalMask.at(1).at(iphi-1).at(absIeta-1) << std::endl;
-        energy = ecalMask.at(1).at(iphi - 1).at(absIeta - 1) *
-                 ecalColl[i].sample(nSample).compressedEt();
-        fineGrain = (ecalMask.at(1).at(iphi - 1).at(absIeta - 1) != 0) &&
-                    ecalColl[i].sample(nSample).fineGrain();
+        energy = ecalMask.at(1).at(iphi - 1).at(absIeta - 1) * ecalColl[i].sample(nSample).compressedEt();
+        fineGrain = (ecalMask.at(1).at(iphi - 1).at(absIeta - 1) != 0) && ecalColl[i].sample(nSample).fineGrain();
       }
 
-      ecalDigi.setSample(nSample,
-                         EcalTriggerPrimitiveSample(energy, fineGrain, 0));
+      ecalDigi.setSample(nSample, EcalTriggerPrimitiveSample(energy, fineGrain, 0));
     }
     maskedEcalTPs->push_back(ecalDigi);
   }
@@ -305,21 +280,16 @@ void MaskedRctInputDigiProducer::produce(edm::Event &iEvent,
     hcalDigi.setPresamples(hcalColl[i].presamples());
 
     for (int nSample = 0; nSample < nHcalSamples; nSample++) {
-
       int energy = 0;
       bool fineGrain = false;
 
       if (absIeta < 29) {
         if (sign < 0) {
-          energy = hcalMask.at(0).at(iphi - 1).at(absIeta - 1) *
-                   hcalColl[i].sample(nSample).compressedEt();
-          fineGrain = (hcalMask.at(0).at(iphi - 1).at(absIeta - 1) != 0) &&
-                      hcalColl[i].sample(nSample).fineGrain();
+          energy = hcalMask.at(0).at(iphi - 1).at(absIeta - 1) * hcalColl[i].sample(nSample).compressedEt();
+          fineGrain = (hcalMask.at(0).at(iphi - 1).at(absIeta - 1) != 0) && hcalColl[i].sample(nSample).fineGrain();
         } else if (sign > 0) {
-          energy = hcalMask.at(1).at(iphi - 1).at(absIeta - 1) *
-                   hcalColl[i].sample(nSample).compressedEt();
-          fineGrain = (hcalMask.at(1).at(iphi - 1).at(absIeta - 1) != 0) &&
-                      hcalColl[i].sample(nSample).fineGrain();
+          energy = hcalMask.at(1).at(iphi - 1).at(absIeta - 1) * hcalColl[i].sample(nSample).compressedEt();
+          fineGrain = (hcalMask.at(1).at(iphi - 1).at(absIeta - 1) != 0) && hcalColl[i].sample(nSample).fineGrain();
         }
       } else if ((absIeta >= 29) && (absIeta <= 32)) {
         // std::cout << "hf iphi: " << iphi << std::endl;
@@ -332,26 +302,20 @@ void MaskedRctInputDigiProducer::produce(edm::Event &iEvent,
           // hfMask.at(0).at(hf_phi_index).at(absIeta-29) << std::endl; // hf
           // ieta 0-3
           energy = hfMask.at(0).at(hf_phi_index).at(absIeta - 29) *
-                   hcalColl[i]
-                       .sample(nSample)
-                       .compressedEt(); // for hf, iphi starts at 0
-          fineGrain = (hfMask.at(0).at(hf_phi_index).at(absIeta - 29) != 0) &&
-                      hcalColl[i].sample(nSample).fineGrain();
+                   hcalColl[i].sample(nSample).compressedEt();  // for hf, iphi starts at 0
+          fineGrain = (hfMask.at(0).at(hf_phi_index).at(absIeta - 29) != 0) && hcalColl[i].sample(nSample).fineGrain();
         } else if (sign > 0) {
           // std::cout << "ieta is " << ieta << ", absIeta is " << absIeta << ",
           // iphi is " << iphi << std::endl; std::cout << "eta+: mask is " <<
           // hfMask.at(1).at(hf_phi_index).at(absIeta-29) << std::endl;
-          energy = hfMask.at(1).at(hf_phi_index).at(absIeta - 29) *
-                   hcalColl[i].sample(nSample).compressedEt();
-          fineGrain = (hfMask.at(1).at(hf_phi_index).at(absIeta - 29) != 0) &&
-                      hcalColl[i].sample(nSample).fineGrain();
+          energy = hfMask.at(1).at(hf_phi_index).at(absIeta - 29) * hcalColl[i].sample(nSample).compressedEt();
+          fineGrain = (hfMask.at(1).at(hf_phi_index).at(absIeta - 29) != 0) && hcalColl[i].sample(nSample).fineGrain();
         }
         // iphi = iphi*4 + 1; // change back to original
         // std::cout << "New hf iphi = " << iphi << std::endl;
       }
 
-      hcalDigi.setSample(nSample,
-                         HcalTriggerPrimitiveSample(energy, fineGrain, 0, 0));
+      hcalDigi.setSample(nSample, HcalTriggerPrimitiveSample(energy, fineGrain, 0, 0));
 
       // if (hcalDigi.SOI_compressedEt() != 0)
       //{

--- a/L1Trigger/RegionalCaloTrigger/src/L1RCT.cc
+++ b/L1Trigger/RegionalCaloTrigger/src/L1RCT.cc
@@ -53,9 +53,10 @@ void L1RCT::makeCrates() {
 }
 
 L1RCT::L1RCT(const L1RCTLookupTables *rctLookupTables)
-    : rctLookupTables_(rctLookupTables), empty(), neighborMap(),
-      barrel(18, std::vector<std::vector<unsigned short>>(
-                     7, std::vector<unsigned short>(64))),
+    : rctLookupTables_(rctLookupTables),
+      empty(),
+      neighborMap(),
+      barrel(18, std::vector<std::vector<unsigned short>>(7, std::vector<unsigned short>(64))),
       hf(18, std::vector<unsigned short>(8)) {
   makeCrates();
 }
@@ -66,9 +67,8 @@ void L1RCT::input() {
   }
 }
 
-void L1RCT::input(
-    const std::vector<std::vector<std::vector<unsigned short>>> &barrelIn,
-    const std::vector<std::vector<unsigned short>> &hfIn) {
+void L1RCT::input(const std::vector<std::vector<std::vector<unsigned short>>> &barrelIn,
+                  const std::vector<std::vector<unsigned short>> &hfIn) {
   for (int i = 0; i < 18; i++) {
     crates.at(i).input(barrelIn.at(i), hfIn.at(i));
   }
@@ -78,7 +78,7 @@ void L1RCT::input(
 // of 18*7*64 will simply be ignored.  This *only* fills input for a single
 // event.  At the moment you cannot put a ton of data and have it be
 // read as separate events.
-void L1RCT::fileInput(const char *filename) { // added "const" also in .h
+void L1RCT::fileInput(const char *filename) {  // added "const" also in .h
   unsigned short x;
   std::ifstream instream(filename);
   if (instream) {
@@ -86,9 +86,9 @@ void L1RCT::fileInput(const char *filename) { // added "const" also in .h
       for (int j = 0; j < 7; j++) {
         for (int k = 0; k < 64; k++) {
           if (instream >> x) {
-            unsigned short bit = x / 256;    // added J.Leonard Aug. 16 06
-            unsigned short energy = x & 255; //
-            unsigned short input = energy * 2 + bit; //
+            unsigned short bit = x / 256;             // added J.Leonard Aug. 16 06
+            unsigned short energy = x & 255;          //
+            unsigned short input = energy * 2 + bit;  //
             barrel.at(i).at(j).at(k) = input;
           } else
             break;
@@ -129,9 +129,8 @@ void L1RCT::digiInput(const EcalTrigPrimDigiCollection &ecalCollection,
     // Note absIeta counts from 1-28 (not 0-27)
     unsigned short absIeta = (unsigned short)abs(ieta);
     unsigned short cal_iphi = (unsigned short)ecalCollection[i].id().iphi();
-    unsigned short iphi =
-        (72 + 18 - cal_iphi) % 72; // transform TOWERS (not regions) into local
-                                   // rct (intuitive) phi bins
+    unsigned short iphi = (72 + 18 - cal_iphi) % 72;  // transform TOWERS (not regions) into local
+                                                      // rct (intuitive) phi bins
 
     // map digis to crates, cards, and towers
     unsigned short crate = 999, card = 999, tower = 999;
@@ -140,17 +139,15 @@ void L1RCT::digiInput(const EcalTrigPrimDigiCollection &ecalCollection,
     tower = rctLookupTables_->rctParameters()->calcTower(iphi, absIeta);
 
     unsigned short energy = ecalCollection[i].compressedEt();
-    unsigned short fineGrain =
-        (unsigned short)ecalCollection[i].fineGrain(); // 0 or 1
+    unsigned short fineGrain = (unsigned short)ecalCollection[i].fineGrain();  // 0 or 1
     unsigned short ecalInput = energy * 2 + fineGrain;
 
     // put input into correct crate/card/tower of barrel
-    if ((crate < 18) && (card < 7) &&
-        (tower < 32)) { // changed 64 to 32 Sept. 19 J. Leonard, rm -1 7Nov07
-      barrel.at(crate).at(card).at(tower) = ecalInput; // rm -1
+    if ((crate < 18) && (card < 7) && (tower < 32)) {   // changed 64 to 32 Sept. 19 J. Leonard, rm -1 7Nov07
+      barrel.at(crate).at(card).at(tower) = ecalInput;  // rm -1
     } else {
-      std::cerr << "L1RCT: ecal out of range! tower = " << tower << " iphi is "
-                << iphi << " absieta is " << absIeta << std::endl;
+      std::cerr << "L1RCT: ecal out of range! tower = " << tower << " iphi is " << iphi << " absieta is " << absIeta
+                << std::endl;
     }
   }
 
@@ -185,20 +182,15 @@ void L1RCT::digiInput(const EcalTrigPrimDigiCollection &ecalCollection,
     }
     tower = rctLookupTables_->rctParameters()->calcTower(iphi, absIeta);
 
-    unsigned short energy =
-        hcalCollection[i].SOI_compressedEt(); // access only sample of interest
-    unsigned short fineGrain =
-        (unsigned short)hcalCollection[i].SOI_fineGrain();
+    unsigned short energy = hcalCollection[i].SOI_compressedEt();  // access only sample of interest
+    unsigned short fineGrain = (unsigned short)hcalCollection[i].SOI_fineGrain();
     unsigned short hcalInput = energy * 2 + fineGrain;
     if (absIeta <= 28) {
       // put input into correct crate/card/tower of barrel
-      if ((crate < 18) && (card < 7) &&
-          (tower < 32)) { // changed 64 to 32 Sept. 19 J. Leonard, rm -1 7Nov07
-        barrel.at(crate).at(card).at(tower + 32) =
-            hcalInput; // hcal towers are ecal + 32 see RC.cc; rm -1 7Nov07
+      if ((crate < 18) && (card < 7) && (tower < 32)) {        // changed 64 to 32 Sept. 19 J. Leonard, rm -1 7Nov07
+        barrel.at(crate).at(card).at(tower + 32) = hcalInput;  // hcal towers are ecal + 32 see RC.cc; rm -1 7Nov07
       } else {
-        std::cout << "L1RCT: hcal out of range!  tower = " << tower
-                  << std::endl;
+        std::cout << "L1RCT: hcal out of range!  tower = " << tower << std::endl;
       }
     } else if ((absIeta >= 29) && (absIeta <= 32)) {
       // put input into correct crate/region of HF
@@ -225,7 +217,7 @@ void L1RCT::randomInput() {
       }
     }
     for (int j = 0; j < 8; j++) {
-      hf.at(i).at(j) = rand() % 255; // changed from 1023 (10 bits)
+      hf.at(i).at(j) = rand() % 255;  // changed from 1023 (10 bits)
     }
   }
   input();
@@ -252,70 +244,53 @@ void L1RCT::shareNeighbors() {
   for (int i = 0; i < 18; i++) {
     for (int j = 0; j < 7; j++) {
       for (int k = 0; k < 2; k++) {
-
         primary = crates.at(i).getReceiverCard(j)->getRegion(k);
 
         vector<int> northIndices = neighborMap.north(i, j, k);
         if (northIndices.at(0) != -1)
-          north = crates.at(northIndices.at(0))
-                      .getReceiverCard(northIndices.at(1))
-                      ->getRegion(northIndices.at(2));
+          north = crates.at(northIndices.at(0)).getReceiverCard(northIndices.at(1))->getRegion(northIndices.at(2));
         else
           north = &empty;
 
         vector<int> southIndices = neighborMap.south(i, j, k);
         if (southIndices.at(0) != -1)
-          south = crates.at(southIndices.at(0))
-                      .getReceiverCard(southIndices.at(1))
-                      ->getRegion(southIndices.at(2));
+          south = crates.at(southIndices.at(0)).getReceiverCard(southIndices.at(1))->getRegion(southIndices.at(2));
         else
           south = &empty;
 
         vector<int> westIndices = neighborMap.west(i, j, k);
         if (westIndices.at(0) != -1)
-          west = crates.at(westIndices.at(0))
-                     .getReceiverCard(westIndices.at(1))
-                     ->getRegion(westIndices.at(2));
+          west = crates.at(westIndices.at(0)).getReceiverCard(westIndices.at(1))->getRegion(westIndices.at(2));
         else
           west = &empty;
 
         vector<int> eastIndices = neighborMap.east(i, j, k);
         if (eastIndices.at(0) != -1)
-          east = crates.at(eastIndices.at(0))
-                     .getReceiverCard(eastIndices.at(1))
-                     ->getRegion(eastIndices.at(2));
+          east = crates.at(eastIndices.at(0)).getReceiverCard(eastIndices.at(1))->getRegion(eastIndices.at(2));
         else
           east = &empty;
 
         vector<int> seIndices = neighborMap.se(i, j, k);
         if (seIndices.at(0) != -1)
-          se = crates.at(seIndices.at(0))
-                   .getReceiverCard(seIndices.at(1))
-                   ->getRegion(seIndices.at(2));
+          se = crates.at(seIndices.at(0)).getReceiverCard(seIndices.at(1))->getRegion(seIndices.at(2));
         else
           se = &empty;
 
         vector<int> swIndices = neighborMap.sw(i, j, k);
         if (swIndices.at(0) != -1)
-          sw = crates.at(swIndices.at(0))
-                   .getReceiverCard(swIndices.at(1))
-                   ->getRegion(swIndices.at(2));
+          sw = crates.at(swIndices.at(0)).getReceiverCard(swIndices.at(1))->getRegion(swIndices.at(2));
         else
           sw = &empty;
 
         vector<int> neIndices = neighborMap.ne(i, j, k);
         if (neIndices.at(0) != -1)
-          ne = crates.at(neIndices.at(0))
-                   .getReceiverCard(neIndices.at(1))
-                   ->getRegion(neIndices.at(2));
+          ne = crates.at(neIndices.at(0)).getReceiverCard(neIndices.at(1))->getRegion(neIndices.at(2));
         else
           ne = &empty;
 
         vector<int> nwIndices = neighborMap.nw(i, j, k);
         if (nwIndices.at(0) != -1)
-          nw = crates.at(nwIndices.at(0))
-                   .getReceiverCard(nwIndices.at(1))
-                   ->getRegion(nwIndices.at(2));
+          nw = crates.at(nwIndices.at(0)).getReceiverCard(nwIndices.at(1))->getRegion(nwIndices.at(2));
         else
           nw = &empty;
 
@@ -350,8 +325,7 @@ void L1RCT::print() {
 // Returns the top four isolated electrons from given crate
 // in a vector of L1CaloEmCands
 L1CaloEmCollection L1RCT::getIsolatedEGObjects(unsigned crate) {
-  std::vector<unsigned short> isoEmObjects =
-      crates.at(crate).getIsolatedEGObjects();
+  std::vector<unsigned short> isoEmObjects = crates.at(crate).getIsolatedEGObjects();
   L1CaloEmCollection isoEmCands;
   for (uint16_t i = 0; i < 4; i++) {
     unsigned rgn = ((isoEmObjects.at(i)) & 1);
@@ -359,7 +333,7 @@ L1CaloEmCollection L1RCT::getIsolatedEGObjects(unsigned crate) {
     unsigned energy = ((isoEmObjects.at(i)) / 16);
     unsigned rank = rctLookupTables_->emRank(energy);
     L1CaloEmCand isoCand(rank, rgn, crd, crate, true, i,
-                         0); // includes emcand index
+                         0);  // includes emcand index
     isoEmCands.push_back(isoCand);
   }
   return isoEmCands;
@@ -368,8 +342,7 @@ L1CaloEmCollection L1RCT::getIsolatedEGObjects(unsigned crate) {
 // Returns the top four nonisolated electrons from the given crate
 // in a vector of L1CaloEmCands
 L1CaloEmCollection L1RCT::getNonisolatedEGObjects(unsigned crate) {
-  std::vector<unsigned short> nonIsoEmObjects =
-      crates.at(crate).getNonisolatedEGObjects();
+  std::vector<unsigned short> nonIsoEmObjects = crates.at(crate).getNonisolatedEGObjects();
   L1CaloEmCollection nonIsoEmCands;
   for (uint16_t i = 0; i < 4; i++) {
     unsigned rgn = ((nonIsoEmObjects.at(i)) & 1);
@@ -377,7 +350,7 @@ L1CaloEmCollection L1RCT::getNonisolatedEGObjects(unsigned crate) {
     unsigned energy = ((nonIsoEmObjects.at(i)) / 16);
     unsigned rank = rctLookupTables_->emRank(energy);
     L1CaloEmCand nonIsoCand(rank, rgn, crd, crate, false, i,
-                            0); // includes emcand index
+                            0);  // includes emcand index
     nonIsoEmCands.push_back(nonIsoCand);
   }
   return nonIsoEmCands;
@@ -389,8 +362,7 @@ vector<L1CaloRegion> L1RCT::getRegions(unsigned crate) {
   std::bitset<14> mips((long)crates.at(crate).getMIPBits());
   std::bitset<14> quiets((long)crates.at(crate).getQuietBits());
   std::bitset<14> overflows((long)crates.at(crate).getOverFlowBits());
-  std::vector<unsigned short> barrelEnergies =
-      crates.at(crate).getBarrelRegions();
+  std::vector<unsigned short> barrelEnergies = crates.at(crate).getBarrelRegions();
   std::vector<L1CaloRegion> regionCollection;
   for (unsigned card = 0; card < 7; card++) {
     for (unsigned rgn = 0; rgn < 2; rgn++) {
@@ -399,8 +371,7 @@ vector<L1CaloRegion> L1RCT::getRegions(unsigned crate) {
       bool quiet = quiets[card * 2 + rgn];
       bool overflow = overflows[card * 2 + rgn];
       unsigned barrelEnergy = barrelEnergies.at(card * 2 + rgn);
-      L1CaloRegion region(barrelEnergy, overflow, tau, mip, quiet, crate, card,
-                          rgn);
+      L1CaloRegion region(barrelEnergy, overflow, tau, mip, quiet, crate, card, rgn);
       regionCollection.push_back(region);
     }
   }
@@ -408,11 +379,9 @@ vector<L1CaloRegion> L1RCT::getRegions(unsigned crate) {
   // hf regions
   std::vector<unsigned short> hfEnergies = crates.at(crate).getHFRegions();
   // fine grain bits -- still have to work out digi input
-  std::vector<unsigned short> hfFineGrainBits =
-      crates.at(crate).getHFFineGrainBits();
-  for (unsigned hfRgn = 0; hfRgn < 8;
-       hfRgn++) { // region number, see diagram on paper.  make sure know how hf
-                  // regions come in.
+  std::vector<unsigned short> hfFineGrainBits = crates.at(crate).getHFFineGrainBits();
+  for (unsigned hfRgn = 0; hfRgn < 8; hfRgn++) {  // region number, see diagram on paper.  make sure know how hf
+                                                  // regions come in.
     unsigned energy = hfEnergies.at(hfRgn);
     bool fineGrain = hfFineGrainBits.at(hfRgn);
     L1CaloRegion hfRegion(energy, fineGrain, crate, hfRgn);

--- a/L1Trigger/RegionalCaloTrigger/src/L1RCTCrate.cc
+++ b/L1Trigger/RegionalCaloTrigger/src/L1RCTCrate.cc
@@ -2,8 +2,7 @@
 #include "L1Trigger/RegionalCaloTrigger/interface/L1RCTLookupTables.h"
 
 L1RCTCrate::L1RCTCrate(int crtNo, const L1RCTLookupTables *rctLookupTables)
-    : jetSummaryCard(crtNo, rctLookupTables), crtNo(crtNo),
-      rctLookupTables_(rctLookupTables) {
+    : jetSummaryCard(crtNo, rctLookupTables), crtNo(crtNo), rctLookupTables_(rctLookupTables) {
   for (int i = 0; i < 7; i++) {
     L1RCTReceiverCard rc(crtNo, i, rctLookupTables);
     L1RCTElectronIsolationCard eic(crtNo, i, rctLookupTables);
@@ -55,11 +54,9 @@ void L1RCTCrate::fillJetSummaryCard() {
     mipBits.at(2 * i) = receiverCards.at(i).getMuonBitRegion(0);
     mipBits.at(2 * i + 1) = receiverCards.at(i).getMuonBitRegion(1);
     isoElectrons.at(2 * i) = electronCards.at(i).getIsoElectrons(0);
-    isoElectrons.at(2 * i + 1) =
-        electronCards.at(i).getIsoElectrons(1) + 1; // the +1 adds region info
+    isoElectrons.at(2 * i + 1) = electronCards.at(i).getIsoElectrons(1) + 1;  // the +1 adds region info
     nonIsoElectrons.at(2 * i) = electronCards.at(i).getNonIsoElectrons(0);
-    nonIsoElectrons.at(2 * i + 1) =
-        electronCards.at(i).getNonIsoElectrons(1) + 1; // +1 adds region info
+    nonIsoElectrons.at(2 * i + 1) = electronCards.at(i).getNonIsoElectrons(1) + 1;  // +1 adds region info
     barrelSums.at(2 * i) = receiverCards.at(i).getEtIn10BitsRegion(0);
     barrelSums.at(2 * i + 1) = receiverCards.at(i).getEtIn10BitsRegion(1);
     overFlowBits.at(2 * i) = receiverCards.at(i).getOverFlowBitRegion(0);

--- a/L1Trigger/RegionalCaloTrigger/src/L1RCTElectronIsolationCard.cc
+++ b/L1Trigger/RegionalCaloTrigger/src/L1RCTElectronIsolationCard.cc
@@ -5,10 +5,15 @@
 #include <iomanip>
 #include <iostream>
 
-L1RCTElectronIsolationCard::L1RCTElectronIsolationCard(
-    int crateNumber, int cardNumber, const L1RCTLookupTables *rctLookupTables)
-    : crtNo(crateNumber), cardNo(cardNumber), rctLookupTables_(rctLookupTables),
-      isoElectrons(2), nonIsoElectrons(2), regions(2) {
+L1RCTElectronIsolationCard::L1RCTElectronIsolationCard(int crateNumber,
+                                                       int cardNumber,
+                                                       const L1RCTLookupTables *rctLookupTables)
+    : crtNo(crateNumber),
+      cardNo(cardNumber),
+      rctLookupTables_(rctLookupTables),
+      isoElectrons(2),
+      nonIsoElectrons(2),
+      regions(2) {
   regions.push_back(L1RCTRegion());
   regions.push_back(L1RCTRegion());
 }
@@ -16,10 +21,8 @@ L1RCTElectronIsolationCard::L1RCTElectronIsolationCard(
 L1RCTElectronIsolationCard::~L1RCTElectronIsolationCard() { regions.clear(); }
 
 void L1RCTElectronIsolationCard::fillElectronCandidates() {
-  std::vector<unsigned short> region0Electrons =
-      calcElectronCandidates(regions.at(0), 0);
-  std::vector<unsigned short> region1Electrons =
-      calcElectronCandidates(regions.at(1), 1);
+  std::vector<unsigned short> region0Electrons = calcElectronCandidates(regions.at(0), 0);
+  std::vector<unsigned short> region1Electrons = calcElectronCandidates(regions.at(1), 1);
   isoElectrons.at(0) = region0Electrons.at(0);
   isoElectrons.at(1) = region1Electrons.at(0);
   nonIsoElectrons.at(0) = region0Electrons.at(1);
@@ -32,17 +35,14 @@ void L1RCTElectronIsolationCard::fillElectronCandidates() {
 // h/e||fg bit is not on and it is higher energy than it's direct four
 // neighbors. An electron candidate is *always* a non-isolated electron. If it
 // also passes the neighbor cuts then it is an isolated electron as well.
-std::vector<unsigned short>
-L1RCTElectronIsolationCard::calcElectronCandidates(const L1RCTRegion &region,
-                                                   int regionNum) {
-
+std::vector<unsigned short> L1RCTElectronIsolationCard::calcElectronCandidates(const L1RCTRegion &region,
+                                                                               int regionNum) {
   unsigned short nonIsoElectron = 0;
   unsigned short isoElectron = 0;
 
   // i is row and j is column
   for (int i = 0; i < 4; i++) {
     for (int j = 0; j < 4; j++) {
-
       unsigned short primaryEt = region.getEtIn7Bits(i, j);
       unsigned short primaryHE_FG = region.getHE_FGBit(i, j);
 
@@ -71,17 +71,14 @@ L1RCTElectronIsolationCard::calcElectronCandidates(const L1RCTRegion &region,
       int nRegion = regionNum;
 
       // top row of crate
-      if (nCard == 0 || nCard == 2 || nCard == 4 ||
-          (nCard == 6 && nRegion == 0)) {
+      if (nCard == 0 || nCard == 2 || nCard == 4 || (nCard == 6 && nRegion == 0)) {
         top = true;
       }
       // bottom row of crate
-      else if (nCard == 1 || nCard == 3 || nCard == 5 ||
-               (nCard == 6 && nRegion == 1)) {
-      } // top already false
+      else if (nCard == 1 || nCard == 3 || nCard == 5 || (nCard == 6 && nRegion == 1)) {
+      }  // top already false
       else {
-        std::cerr << "Error! EIC top assignment"
-                  << std::endl; // this shouldn't happen!
+        std::cerr << "Error! EIC top assignment" << std::endl;  // this shouldn't happen!
       }
 
       // The following values are used for zeroing and determining whether or
@@ -99,11 +96,11 @@ L1RCTElectronIsolationCard::calcElectronCandidates(const L1RCTRegion &region,
       // appropriate regions, those for which tp_lf bit is set to 0 in
       // Pam's JCCTest/EGWithShare.cc).
 
-      if (primaryEt > 0) // this value should maybe be customizable?
+      if (primaryEt > 0)  // this value should maybe be customizable?
       {
-        if (nCard != 6) // all cards except 6
+        if (nCard != 6)  // all cards except 6
         {
-          if (top && nCrate >= 9) // top row of regions in positive-eta crate
+          if (top && nCrate >= 9)  // top row of regions in positive-eta crate
           {
             if (westTowerEt == eastTowerEt)
               westTowerEt = 0;
@@ -113,8 +110,7 @@ L1RCTElectronIsolationCard::calcElectronCandidates(const L1RCTRegion &region,
               southTowerEt = 0;
             if (westTowerEt == northTowerEt)
               westTowerEt = 0;
-          } else if ((!top) &&
-                     nCrate < 9) // bottom row of regions in negative-eta crate
+          } else if ((!top) && nCrate < 9)  // bottom row of regions in negative-eta crate
           {
             if (eastTowerEt == westTowerEt)
               eastTowerEt = 0;
@@ -125,7 +121,7 @@ L1RCTElectronIsolationCard::calcElectronCandidates(const L1RCTRegion &region,
             if (eastTowerEt == southTowerEt)
               eastTowerEt = 0;
           }
-        } else // card 6
+        } else  // card 6
         {
           // only +eta card 6 needs to have zeroing.  Pam sez.
           // -eta card 6 does what it's supposed to even w/o zeroing.
@@ -149,27 +145,25 @@ L1RCTElectronIsolationCard::calcElectronCandidates(const L1RCTRegion &region,
       bool candidate = false;
 
       // for case where primary tower et greater than all neighbors -> candidate
-      if (primaryEt > northEt && primaryEt > southEt && primaryEt > eastEt &&
-          primaryEt > westEt && !primaryHE_FG) {
+      if (primaryEt > northEt && primaryEt > southEt && primaryEt > eastEt && primaryEt > westEt && !primaryHE_FG) {
         candidate = true;
       }
 
       // if primary et less than any neighbors (or HE_FG veto set) NOT a
       // candidate!
-      else if (primaryEt < northEt || primaryEt < southEt ||
-               primaryEt < eastEt || primaryEt < westEt || primaryHE_FG) {
-      } // candidate already false
+      else if (primaryEt < northEt || primaryEt < southEt || primaryEt < eastEt || primaryEt < westEt || primaryHE_FG) {
+      }  // candidate already false
 
-      else // Case of primary tower et being equal to any of its neighbors.
-           // This section determines which tower gets the candidate.
-           // See AboutTP.pdf document, figure on p. 4, for clarification.
-           // Zeroed values are used in this calculation.
+      else  // Case of primary tower et being equal to any of its neighbors.
+            // This section determines which tower gets the candidate.
+            // See AboutTP.pdf document, figure on p. 4, for clarification.
+            // Zeroed values are used in this calculation.
       {
         if (primaryEt > 0) {
-          if (nCrate >= 9) // positive eta
+          if (nCrate >= 9)  // positive eta
           {
-            if (top) // top row of regions in crate.  tp_lf == 0
-                     // priority order: east < south < north < west
+            if (top)  // top row of regions in crate.  tp_lf == 0
+                      // priority order: east < south < north < west
             {
               if (westTowerEt == primaryTowerEt)
                 candidate = true;
@@ -181,8 +175,8 @@ L1RCTElectronIsolationCard::calcElectronCandidates(const L1RCTRegion &region,
                 candidate = false;
             }
 
-            else // bottom row of regions in crate.  tp_lf == 1
-                 // priority order: west < north < south < east
+            else  // bottom row of regions in crate.  tp_lf == 1
+                  // priority order: west < north < south < east
             {
               if (eastTowerEt == primaryTowerEt)
                 candidate = true;
@@ -192,7 +186,7 @@ L1RCTElectronIsolationCard::calcElectronCandidates(const L1RCTRegion &region,
                 candidate = false;
               else if (westTowerEt == primaryTowerEt)
                 candidate = false;
-              if (nCard == 6) // card 6. tp_lf == 1
+              if (nCard == 6)  // card 6. tp_lf == 1
               {
                 // priority order: east < north < south < west
                 if (westTowerEt == primaryTowerEt)
@@ -205,10 +199,10 @@ L1RCTElectronIsolationCard::calcElectronCandidates(const L1RCTRegion &region,
                   candidate = false;
               }
             }
-          } else // negative eta
+          } else  // negative eta
           {
-            if (top) // top row of regions in crate.  tp_lf == 1
-                     // priority order: east < south < north < west
+            if (top)  // top row of regions in crate.  tp_lf == 1
+                      // priority order: east < south < north < west
             {
               if (westTowerEt == primaryTowerEt)
                 candidate = true;
@@ -218,8 +212,8 @@ L1RCTElectronIsolationCard::calcElectronCandidates(const L1RCTRegion &region,
                 candidate = false;
               else if (eastTowerEt == primaryTowerEt)
                 candidate = false;
-              if (nCard == 6) // card 6.  tp_lf == 0
-                              // east < south < north < west
+              if (nCard == 6)  // card 6.  tp_lf == 0
+                               // east < south < north < west
               {
                 if (westTowerEt == primaryTowerEt)
                   candidate = false;
@@ -230,8 +224,8 @@ L1RCTElectronIsolationCard::calcElectronCandidates(const L1RCTRegion &region,
                 else if (eastTowerEt == primaryTowerEt)
                   candidate = true;
               }
-            } else // bottom row of regions.  tp_lf == 0
-                   // west < north < south < east
+            } else  // bottom row of regions.  tp_lf == 0
+                    // west < north < south < east
             {
               if (eastTowerEt == primaryTowerEt)
                 candidate = true;
@@ -242,8 +236,8 @@ L1RCTElectronIsolationCard::calcElectronCandidates(const L1RCTRegion &region,
               else if (westTowerEt == primaryTowerEt)
                 candidate = false;
 
-              if (nCard == 6) // card 6.  tp_lf == 1
-                              // west < north < south < east
+              if (nCard == 6)  // card 6.  tp_lf == 1
+                               // west < north < south < east
               {
                 if (eastTowerEt == primaryTowerEt)
                   candidate = true;
@@ -257,28 +251,25 @@ L1RCTElectronIsolationCard::calcElectronCandidates(const L1RCTRegion &region,
             }
           }
         }
-      } // end of if (primary == neighbors)
+      }  // end of if (primary == neighbors)
 
       if (candidate) {
-
         // Either zeroed or non-zeroed set of values can be used here --
         // neighbor tower only zeroed if another neighbor tower of same
         // energy.  Max sum calculated from primary and only one neighbor
         // tower, and always one neighbor tower left over, so value of sum
         // is not affected.  Currently using non-zeroed.
-        unsigned short candidateEt =
-            calcMaxSum(primaryEt, northEt, southEt, eastEt, westEt);
+        unsigned short candidateEt = calcMaxSum(primaryEt, northEt, southEt, eastEt, westEt);
 
         // neighbor HE_FG veto true if neighbor has HE_FG set
-        bool neighborVeto = (nwHE_FG || northHE_FG || neHE_FG || westHE_FG ||
-                             eastHE_FG || swHE_FG || southHE_FG || seHE_FG);
+        bool neighborVeto =
+            (nwHE_FG || northHE_FG || neHE_FG || westHE_FG || eastHE_FG || swHE_FG || southHE_FG || seHE_FG);
 
         // threshold for five-tower corner quiet veto
         // int quietThreshold = 3;   // 3 - loose isolation 0 - very tight
         // isolation int quietThreshold = 7; // ECALGREN int quietThreshold = 0;
         // // HCALGREN
-        unsigned quietThreshold =
-            rctLookupTables_->rctParameters()->eicIsolationThreshold();
+        unsigned quietThreshold = rctLookupTables_->rctParameters()->eicIsolationThreshold();
 
         bool nw = false;
         bool ne = false;
@@ -333,13 +324,9 @@ L1RCTElectronIsolationCard::calcElectronCandidates(const L1RCTRegion &region,
 
   std::vector<unsigned short> candidates;
   unsigned short fullIsoElectron =
-      isoElectron * 16 +
-      cardNo *
-          2; // leaves room for last bit -- region number, added in Crate.cc
+      isoElectron * 16 + cardNo * 2;  // leaves room for last bit -- region number, added in Crate.cc
   candidates.push_back(fullIsoElectron);
-  unsigned short fullNonIsoElectron =
-      nonIsoElectron * 16 +
-      cardNo * 2; // leaves room for region info in last bit
+  unsigned short fullNonIsoElectron = nonIsoElectron * 16 + cardNo * 2;  // leaves room for region info in last bit
   candidates.push_back(fullNonIsoElectron);
 
   return candidates;
@@ -366,13 +353,11 @@ void L1RCTElectronIsolationCard::print() {
   regions.at(0).print();
 
   std::cout << "IsoElectron Candidate " << isoElectrons.at(0) << std::endl;
-  std::cout << "NonIsoElectron Candidate " << nonIsoElectrons.at(0) << std::endl
-            << std::endl;
+  std::cout << "NonIsoElectron Candidate " << nonIsoElectrons.at(0) << std::endl << std::endl;
 
   std::cout << "Region 1 Information" << std::endl;
   regions.at(1).print();
 
   std::cout << "IsoElectron Candidate " << isoElectrons.at(1) << std::endl;
-  std::cout << "NonIsoElectron Candidate " << nonIsoElectrons.at(1)
-            << std::endl;
+  std::cout << "NonIsoElectron Candidate " << nonIsoElectrons.at(1) << std::endl;
 }

--- a/L1Trigger/RegionalCaloTrigger/src/L1RCTJetSummaryCard.cc
+++ b/L1Trigger/RegionalCaloTrigger/src/L1RCTJetSummaryCard.cc
@@ -10,21 +10,27 @@ using std::vector;
 #include <bitset>
 using std::bitset;
 
-L1RCTJetSummaryCard::L1RCTJetSummaryCard(
-    int crtNo, const L1RCTLookupTables *rctLookupTables)
-    : crtNo(crtNo), rctLookupTables_(rctLookupTables), isolatedEGObjects(4),
-      nonisolatedEGObjects(4), jetRegions(22), HFRegions(8), barrelRegions(14),
-      mipBits(0), quietBits(0), tauBits(0), overFlowBits(0), hfFineGrainBits(8)
+L1RCTJetSummaryCard::L1RCTJetSummaryCard(int crtNo, const L1RCTLookupTables *rctLookupTables)
+    : crtNo(crtNo),
+      rctLookupTables_(rctLookupTables),
+      isolatedEGObjects(4),
+      nonisolatedEGObjects(4),
+      jetRegions(22),
+      HFRegions(8),
+      barrelRegions(14),
+      mipBits(0),
+      quietBits(0),
+      tauBits(0),
+      overFlowBits(0),
+      hfFineGrainBits(8)
 // quietThreshold(3)
 {}
 
-void L1RCTJetSummaryCard::fillHFRegionSums(
-    const std::vector<unsigned short> &hfRegionSums) {
+void L1RCTJetSummaryCard::fillHFRegionSums(const std::vector<unsigned short> &hfRegionSums) {
   // std::cout << "JSC.fillHFRegionSums() entered" << std::endl;
   for (int i = 0; i < 8; i++) {
     // std::cout << "filling hf region at " << i << std::endl;
-    HFRegions.at(i) =
-        rctLookupTables_->lookup((hfRegionSums.at(i) / 2), crtNo, 999, i);
+    HFRegions.at(i) = rctLookupTables_->lookup((hfRegionSums.at(i) / 2), crtNo, 999, i);
     // std::cout << "hf region " << i << " et filled" << std::endl;
     hfFineGrainBits.at(i) = (hfRegionSums.at(i) & 1);
     // std::cout << "hf region " << i << " fine grain bit filled" << std::endl;
@@ -76,8 +82,7 @@ void L1RCTJetSummaryCard::fillJetRegions() {
   }
 }
 
-void L1RCTJetSummaryCard::fillIsolatedEGObjects(
-    const std::vector<unsigned short> &isoElectrons) {
+void L1RCTJetSummaryCard::fillIsolatedEGObjects(const std::vector<unsigned short> &isoElectrons) {
   // sort(isoElectrons.begin(),isoElectrons.end());
   // reverse(isoElectrons.begin(),isoElectrons.end());
 
@@ -118,8 +123,7 @@ void L1RCTJetSummaryCard::fillIsolatedEGObjects(
   isolatedEGObjects.at(3) = sortIso.at(2);
 }
 
-void L1RCTJetSummaryCard::fillNonIsolatedEGObjects(
-    const std::vector<unsigned short> &nonIsoElectrons) {
+void L1RCTJetSummaryCard::fillNonIsolatedEGObjects(const std::vector<unsigned short> &nonIsoElectrons) {
   // sort(nonIsoElectrons.begin(),nonIsoElectrons.end());
   // reverse(nonIsoElectrons.begin(),nonIsoElectrons.end());
 
@@ -174,8 +178,7 @@ void L1RCTJetSummaryCard::fillTauBits(const std::vector<unsigned short> &tau) {
   tauBits = taus.to_ulong();
 }
 
-void L1RCTJetSummaryCard::fillOverFlowBits(
-    const std::vector<unsigned short> &overflow) {
+void L1RCTJetSummaryCard::fillOverFlowBits(const std::vector<unsigned short> &overflow) {
   bitset<14> overflows;
   for (int i = 0; i < 14; i++)
     overflows[i] = overflow.at(i);
@@ -185,22 +188,20 @@ void L1RCTJetSummaryCard::fillOverFlowBits(
 void L1RCTJetSummaryCard::fillQuietBits() {
   bitset<14> quiet;
 
-  quietThresholdBarrel =
-      rctLookupTables_->rctParameters()->jscQuietThresholdBarrel();
-  quietThresholdEndcap =
-      rctLookupTables_->rctParameters()->jscQuietThresholdEndcap();
+  quietThresholdBarrel = rctLookupTables_->rctParameters()->jscQuietThresholdBarrel();
+  quietThresholdEndcap = rctLookupTables_->rctParameters()->jscQuietThresholdEndcap();
 
   // use one threshold for barrel regions (first 8 in list, cards 0-3)
   for (int i = 0; i < 8; i++) {
     if ((barrelRegions.at(i)) > quietThresholdBarrel)
-      quiet[i] = false; // switched 0 and 1
+      quiet[i] = false;  // switched 0 and 1
     else
       quiet[i] = true;
   }
   // use second for endcap regions (last 6 in list, cards 4-6)
   for (int i = 8; i < 14; i++) {
     if ((barrelRegions.at(i)) > quietThresholdEndcap)
-      quiet[i] = false; // switched 0 and 1
+      quiet[i] = false;  // switched 0 and 1
     else
       quiet[i] = true;
   }
@@ -257,11 +258,10 @@ void L1RCTJetSummaryCard::asicCompare(std::vector<unsigned short> &array) {
   int i;
   unsigned short temp;
   for (i = 0; i < 4; i++) {
-
     unsigned short rank1 = rctLookupTables_->emRank(array.at(2 * i) >> 4);
     unsigned short rank2 = rctLookupTables_->emRank(array.at(2 * i + 1) >> 4);
 
-    if (rank1 < rank2) // currently bottom 3 bits are rgn,crd
+    if (rank1 < rank2)  // currently bottom 3 bits are rgn,crd
     {
       temp = array.at(2 * i);
       array.at(2 * i) = array.at((2 * i) + 1);
@@ -275,11 +275,9 @@ void L1RCTJetSummaryCard::print() {
   std::cout << "MIPBits " << mipBits << std::endl;
   std::cout << "QuietBits " << quietBits << std::endl;
   for (int i = 0; i < 4; i++) {
-    std::cout << "isoElectron " << i << " " << isolatedEGObjects.at(i)
-              << std::endl;
+    std::cout << "isoElectron " << i << " " << isolatedEGObjects.at(i) << std::endl;
     ;
-    std::cout << "nonIsoElectron " << i << " " << nonisolatedEGObjects.at(i)
-              << std::endl;
+    std::cout << "nonIsoElectron " << i << " " << nonisolatedEGObjects.at(i) << std::endl;
   }
   std::cout << "Jets ";
   for (int i = 0; i < 22; i++)

--- a/L1Trigger/RegionalCaloTrigger/src/L1RCTLookupTables.cc
+++ b/L1Trigger/RegionalCaloTrigger/src/L1RCTLookupTables.cc
@@ -19,29 +19,25 @@ using std::endl;
 #include "CondFormats/L1TObjects/interface/L1RCTNoisyChannelMask.h"
 #include "CondFormats/L1TObjects/interface/L1RCTParameters.h"
 
-unsigned int
-L1RCTLookupTables::lookup(unsigned short ecalInput, unsigned short hcalInput,
-                          unsigned short fgbit, unsigned short crtNo,
-                          unsigned short crdNo, unsigned short twrNo) const {
+unsigned int L1RCTLookupTables::lookup(unsigned short ecalInput,
+                                       unsigned short hcalInput,
+                                       unsigned short fgbit,
+                                       unsigned short crtNo,
+                                       unsigned short crdNo,
+                                       unsigned short twrNo) const {
   if (rctParameters_ == nullptr)
-    throw cms::Exception("L1RCTParameters Invalid")
-        << "L1RCTParameters should be set every event" << rctParameters_;
+    throw cms::Exception("L1RCTParameters Invalid") << "L1RCTParameters should be set every event" << rctParameters_;
   if (channelMask_ == nullptr)
-    throw cms::Exception("L1RCTChannelMask Invalid")
-        << "L1RCTChannelMask should be set every event" << channelMask_;
+    throw cms::Exception("L1RCTChannelMask Invalid") << "L1RCTChannelMask should be set every event" << channelMask_;
   if (noisyChannelMask_ == nullptr)
     throw cms::Exception("L1RCTNoisyChannelMask Invalid")
-        << "L1RCTNoisyChannelMask should be set every event"
-        << noisyChannelMask_;
+        << "L1RCTNoisyChannelMask should be set every event" << noisyChannelMask_;
   if (ecalInput > 0xFF)
-    throw cms::Exception("Invalid Data")
-        << "ECAL compressedET should be less than 0xFF, is " << ecalInput;
+    throw cms::Exception("Invalid Data") << "ECAL compressedET should be less than 0xFF, is " << ecalInput;
   if (hcalInput > 0xFF)
-    throw cms::Exception("Invalid Data")
-        << "HCAL compressedET should be less than 0xFF, is " << hcalInput;
+    throw cms::Exception("Invalid Data") << "HCAL compressedET should be less than 0xFF, is " << hcalInput;
   if (fgbit > 1)
-    throw cms::Exception("Invalid Data")
-        << "ECAL finegrain should be a single bit, is " << fgbit;
+    throw cms::Exception("Invalid Data") << "ECAL finegrain should be a single bit, is " << fgbit;
   short iEta = (short)rctParameters_->calcIEta(crtNo, crdNo, twrNo);
   unsigned short iAbsEta = (unsigned short)abs(iEta);
   short sign = iEta / iAbsEta;
@@ -60,12 +56,11 @@ L1RCTLookupTables::lookup(unsigned short ecalInput, unsigned short hcalInput,
 
   float ecalBeforeMask = convertEcal(ecalInput, iAbsEta, sign);
 
-  bool resetECAL =
-      (channelMask_->ecalMask[crtNo][phiSide][iAbsEta - 1]) || // channel mask
-      (noisyChannelMask_->ecalMask[crtNo][phiSide][iAbsEta - 1] &&
-       ecalBeforeMask < noisyChannelMask_->ecalThreshold) || // hot mask
-      (rctParameters_->eGammaECalScaleFactors()[iAbsEta - 1] == 0. &&
-       rctParameters_->jetMETECalScaleFactors()[iAbsEta - 1] == 0.);
+  bool resetECAL = (channelMask_->ecalMask[crtNo][phiSide][iAbsEta - 1]) ||  // channel mask
+                   (noisyChannelMask_->ecalMask[crtNo][phiSide][iAbsEta - 1] &&
+                    ecalBeforeMask < noisyChannelMask_->ecalThreshold) ||  // hot mask
+                   (rctParameters_->eGammaECalScaleFactors()[iAbsEta - 1] == 0. &&
+                    rctParameters_->jetMETECalScaleFactors()[iAbsEta - 1] == 0.);
 
   if (resetECAL) {
     ecalAfterMask = 0;
@@ -78,12 +73,11 @@ L1RCTLookupTables::lookup(unsigned short ecalInput, unsigned short hcalInput,
   // masking off hcal for channels in channel mask
   float hcalBeforeMask = convertHcal(hcalInput, iAbsEta, sign);
 
-  bool resetHCAL =
-      channelMask_->hcalMask[crtNo][phiSide][iAbsEta - 1] ||
-      (noisyChannelMask_->hcalMask[crtNo][phiSide][iAbsEta - 1] &&
-       hcalBeforeMask < noisyChannelMask_->hcalThreshold) || // hot mask
-      (rctParameters_->eGammaHCalScaleFactors()[iAbsEta - 1] == 0. &&
-       rctParameters_->jetMETHCalScaleFactors()[iAbsEta - 1] == 0.);
+  bool resetHCAL = channelMask_->hcalMask[crtNo][phiSide][iAbsEta - 1] ||
+                   (noisyChannelMask_->hcalMask[crtNo][phiSide][iAbsEta - 1] &&
+                    hcalBeforeMask < noisyChannelMask_->hcalThreshold) ||  // hot mask
+                   (rctParameters_->eGammaHCalScaleFactors()[iAbsEta - 1] == 0. &&
+                    rctParameters_->jetMETHCalScaleFactors()[iAbsEta - 1] == 0.);
 
   if (resetHCAL) {
     hcalAfterMask = 0;
@@ -107,17 +101,13 @@ L1RCTLookupTables::lookup(unsigned short ecalInput, unsigned short hcalInput,
     etIn9Bits = jetMETETCode(ecal, hcal, iAbsEta);
   }
   // Saturated input towers cause tower ET pegging at the highest value
-  if ((ecalAfterMask == 0xFF &&
-       rctParameters_->eGammaECalScaleFactors()[iAbsEta - 1] != 0.) ||
-      (hcalAfterMask == 0xFF &&
-       rctParameters_->eGammaHCalScaleFactors()[iAbsEta - 1] != 0.)) {
-    etIn7Bits = 0x7F; // egamma path
+  if ((ecalAfterMask == 0xFF && rctParameters_->eGammaECalScaleFactors()[iAbsEta - 1] != 0.) ||
+      (hcalAfterMask == 0xFF && rctParameters_->eGammaHCalScaleFactors()[iAbsEta - 1] != 0.)) {
+    etIn7Bits = 0x7F;  // egamma path
   }
-  if ((ecalAfterMask == 0xFF &&
-       rctParameters_->jetMETECalScaleFactors()[iAbsEta - 1] != 0.) ||
-      (hcalAfterMask == 0xFF &&
-       rctParameters_->jetMETHCalScaleFactors()[iAbsEta - 1] != 0.)) {
-    etIn9Bits = 0x1FF; // sums path
+  if ((ecalAfterMask == 0xFF && rctParameters_->jetMETECalScaleFactors()[iAbsEta - 1] != 0.) ||
+      (hcalAfterMask == 0xFF && rctParameters_->jetMETHCalScaleFactors()[iAbsEta - 1] != 0.)) {
+    etIn9Bits = 0x1FF;  // sums path
   }
 
   unsigned long shiftEtIn9Bits = etIn9Bits << 8;
@@ -133,8 +123,7 @@ L1RCTLookupTables::lookup(unsigned short ecalInput, unsigned short hcalInput,
   } else {
     shiftActivityBit = activityBit(ecal, hcal) << 17;
   }
-  unsigned long output =
-      etIn7Bits + shiftHE_FGBit + shiftEtIn9Bits + shiftActivityBit;
+  unsigned long output = etIn7Bits + shiftHE_FGBit + shiftEtIn9Bits + shiftActivityBit;
   return output;
 }
 
@@ -143,28 +132,23 @@ unsigned int L1RCTLookupTables::lookup(unsigned short hfInput,
                                        unsigned short crdNo,
                                        unsigned short twrNo) const {
   if (rctParameters_ == nullptr)
-    throw cms::Exception("L1RCTParameters Invalid")
-        << "L1RCTParameters should be set every event" << rctParameters_;
+    throw cms::Exception("L1RCTParameters Invalid") << "L1RCTParameters should be set every event" << rctParameters_;
   if (channelMask_ == nullptr)
-    throw cms::Exception("L1RCTChannelMask Invalid")
-        << "L1RCTChannelMask should be set every event" << channelMask_;
+    throw cms::Exception("L1RCTChannelMask Invalid") << "L1RCTChannelMask should be set every event" << channelMask_;
   if (hfInput > 0xFF)
-    throw cms::Exception("Invalid Data")
-        << "HF compressedET should be less than 0xFF, is " << hfInput;
+    throw cms::Exception("Invalid Data") << "HF compressedET should be less than 0xFF, is " << hfInput;
   short iEta = rctParameters_->calcIEta(crtNo, crdNo, twrNo);
   unsigned short iAbsEta = abs(iEta);
   short sign = (iEta / iAbsEta);
   unsigned short phiSide = twrNo / 4;
   if (iAbsEta < 29 || iAbsEta > 32)
-    throw cms::Exception("Invalid Data")
-        << "29 <= |iEta| <= 32, is " << iAbsEta;
+    throw cms::Exception("Invalid Data") << "29 <= |iEta| <= 32, is " << iAbsEta;
 
   float et = convertHcal(hfInput, iAbsEta, sign);
   ;
 
   if (channelMask_->hfMask[crtNo][phiSide][iAbsEta - 29] ||
-      (noisyChannelMask_->hfMask[crtNo][phiSide][iAbsEta - 29] &&
-       et < noisyChannelMask_->hfThreshold)) {
+      (noisyChannelMask_->hfMask[crtNo][phiSide][iAbsEta - 29] && et < noisyChannelMask_->hfThreshold)) {
     et = 0;
   }
 
@@ -173,7 +157,7 @@ unsigned int L1RCTLookupTables::lookup(unsigned short hfInput,
   float scalehf = 1.;
   if (rctParameters_->jetMETHCalScaleFactors().size() == 32) {
     scalehf = (float)rctParameters_->jetMETHCalScaleFactors()[iAbsEta - 1];
-  } // The max eta for the various scale factors is 32, check to see if used.
+  }  // The max eta for the various scale factors is 32, check to see if used.
   else if (rctParameters_->jetMETHCalScaleFactors().size() == 32 * 10) {
     int ht_bin = ((int)floor(et) / 5);
     // lowest bin (1) is 0-10GeV
@@ -182,12 +166,10 @@ unsigned int L1RCTLookupTables::lookup(unsigned short hfInput,
     // highest bin (9) is 45GeV and up
     if (ht_bin > 9)
       ht_bin = 9;
-    scalehf =
-        (float)
-            rctParameters_->jetMETHCalScaleFactors()[32 * ht_bin + iAbsEta - 1];
-  } // et-dependent scale factors (optional, of course, if set to 1)
+    scalehf = (float)rctParameters_->jetMETHCalScaleFactors()[32 * ht_bin + iAbsEta - 1];
+  }  // et-dependent scale factors (optional, of course, if set to 1)
 
-  et = scalehf * et; // Allow for scaling the HF as well e.g. zero out if needed
+  et = scalehf * et;  // Allow for scaling the HF as well e.g. zero out if needed
 
   unsigned int result = convertToInteger(et, rctParameters_->jetMETLSB(), 8);
   return result;
@@ -195,23 +177,20 @@ unsigned int L1RCTLookupTables::lookup(unsigned short hfInput,
 
 bool L1RCTLookupTables::hOeFGVetoBit(float ecal, float hcal, bool fgbit) const {
   if (rctParameters_ == nullptr)
-    throw cms::Exception("L1RCTParameters Invalid")
-        << "L1RCTParameters should be set every event" << rctParameters_;
+    throw cms::Exception("L1RCTParameters Invalid") << "L1RCTParameters should be set every event" << rctParameters_;
   bool veto = false;
-  if (ecal > rctParameters_->eMinForFGCut() &&
-      ecal < rctParameters_->eMaxForFGCut()) {
+  if (ecal > rctParameters_->eMinForFGCut() && ecal < rctParameters_->eMaxForFGCut()) {
     if (fgbit)
       veto = true;
   }
-  if (ecal >= rctParameters_->eMinForHoECut() &&
-      ecal < rctParameters_->eMaxForHoECut()) {
+  if (ecal >= rctParameters_->eMinForHoECut() && ecal < rctParameters_->eMaxForHoECut()) {
     if ((hcal / ecal) > rctParameters_->hOeCut())
       veto = true;
   }
   //  else
   if (ecal < rctParameters_->eMinForHoECut()) {
     if (hcal >= rctParameters_->hMinForHoECut())
-      veto = true; // Changed from eMinForHoECut() - JLL 2008-Feb-13
+      veto = true;  // Changed from eMinForHoECut() - JLL 2008-Feb-13
   }
   return veto;
 }
@@ -219,13 +198,11 @@ bool L1RCTLookupTables::hOeFGVetoBit(float ecal, float hcal, bool fgbit) const {
 bool L1RCTLookupTables::activityBit(float ecal, float hcal) const {
   // Redefined for upgrade as EM activity only
   if (rctParameters_ == nullptr)
-    throw cms::Exception("L1RCTParameters Invalid")
-        << "L1RCTParameters should be set every event" << rctParameters_;
+    throw cms::Exception("L1RCTParameters Invalid") << "L1RCTParameters should be set every event" << rctParameters_;
   bool aBit = false;
   if (rctParameters_->eMinForHoECut() < rctParameters_->eMaxForHoECut()) {
     // For RCT operations HoE cut and tauVeto are used
-    aBit = ((ecal > rctParameters_->eActivityCut()) ||
-            (hcal > rctParameters_->hActivityCut()));
+    aBit = ((ecal > rctParameters_->eActivityCut()) || (hcal > rctParameters_->hActivityCut()));
   } else {
     // We redefine tauVeto() for upgrade as EM activity only  --
     // both EG and Tau make it through the EIC and JSC to CTP cards
@@ -250,8 +227,7 @@ unsigned int L1RCTLookupTables::emRank(unsigned short energy) const {
 }
 
 // converts compressed ecal energy to linear (real) scale
-float L1RCTLookupTables::convertEcal(unsigned short ecal,
-                                     unsigned short iAbsEta, short sign) const {
+float L1RCTLookupTables::convertEcal(unsigned short ecal, unsigned short iAbsEta, short sign) const {
   if (ecalScale_) {
     // std::cout << "[luts] energy " << ecal << " sign " << sign
     //<< " iAbsEta " << iAbsEta << " iPhi "	<< iPhi << std::endl;
@@ -277,8 +253,7 @@ float L1RCTLookupTables::convertEcal(unsigned short ecal,
 }
 
 // converts compressed hcal energy to linear (real) scale
-float L1RCTLookupTables::convertHcal(unsigned short hcal,
-                                     unsigned short iAbsEta, short sign) const {
+float L1RCTLookupTables::convertHcal(unsigned short hcal, unsigned short iAbsEta, short sign) const {
   if (hcalScale_ != nullptr) {
     return (hcalScale_->et(hcal, iAbsEta, sign));
   } else {
@@ -289,8 +264,7 @@ float L1RCTLookupTables::convertHcal(unsigned short hcal,
 }
 
 // integerize given an LSB and set maximum value of 2^precision-1
-unsigned long L1RCTLookupTables::convertToInteger(float et, float lsb,
-                                                  int precision) const {
+unsigned long L1RCTLookupTables::convertToInteger(float et, float lsb, int precision) const {
   unsigned long etBits = (unsigned long)(et / lsb);
   unsigned long maxValue = (1 << precision) - 1;
   if (etBits > maxValue)
@@ -299,20 +273,16 @@ unsigned long L1RCTLookupTables::convertToInteger(float et, float lsb,
     return etBits;
 }
 
-unsigned int L1RCTLookupTables::eGammaETCode(float ecal, float hcal,
-                                             int iAbsEta) const {
+unsigned int L1RCTLookupTables::eGammaETCode(float ecal, float hcal, int iAbsEta) const {
   if (rctParameters_ == nullptr)
-    throw cms::Exception("L1RCTParameters Invalid")
-        << "L1RCTParameters should be set every event" << rctParameters_;
+    throw cms::Exception("L1RCTParameters Invalid") << "L1RCTParameters should be set every event" << rctParameters_;
   float etLinear = rctParameters_->EGammaTPGSum(ecal, hcal, iAbsEta);
   return convertToInteger(etLinear, rctParameters_->eGammaLSB(), 7);
 }
 
-unsigned int L1RCTLookupTables::jetMETETCode(float ecal, float hcal,
-                                             int iAbsEta) const {
+unsigned int L1RCTLookupTables::jetMETETCode(float ecal, float hcal, int iAbsEta) const {
   if (rctParameters_ == nullptr)
-    throw cms::Exception("L1RCTParameters Invalid")
-        << "L1RCTParameters should be set every event" << rctParameters_;
+    throw cms::Exception("L1RCTParameters Invalid") << "L1RCTParameters should be set every event" << rctParameters_;
   float etLinear = rctParameters_->JetMETTPGSum(ecal, hcal, iAbsEta);
   return convertToInteger(etLinear, rctParameters_->jetMETLSB(), 9);
 }

--- a/L1Trigger/RegionalCaloTrigger/src/L1RCTORCAMap.cc
+++ b/L1Trigger/RegionalCaloTrigger/src/L1RCTORCAMap.cc
@@ -13,14 +13,10 @@ L1RCTORCAMap::L1RCTORCAMap() {
   combHD = std::vector<unsigned short>(56 * 72);
 
   barrelData = std::vector<std::vector<std::vector<unsigned short>>>(
-      18, std::vector<std::vector<unsigned short>>(
-              7, std::vector<unsigned short>(64)));
-  hfData = std::vector<std::vector<unsigned short>>(
-      18, std::vector<unsigned short>(8));
+      18, std::vector<std::vector<unsigned short>>(7, std::vector<unsigned short>(64)));
+  hfData = std::vector<std::vector<unsigned short>>(18, std::vector<unsigned short>(8));
 }
-vector<std::vector<std::vector<unsigned short>>> L1RCTORCAMap::giveBarrel() {
-  return barrelData;
-}
+vector<std::vector<std::vector<unsigned short>>> L1RCTORCAMap::giveBarrel() { return barrelData; }
 
 vector<std::vector<unsigned short>> L1RCTORCAMap::giveHF() { return hfData; }
 void L1RCTORCAMap::makeHFData() {
@@ -38,10 +34,8 @@ void L1RCTORCAMap::makeBarrelData() {
   for (int phi = 0; phi < 72; phi++) {
     for (int eta = 0; eta < 56; eta++) {
       indices = orcamap(eta, phi);
-      (barrelData.at(indices.at(0))).at(indices.at(1)).at(indices.at(2)) =
-          combEM.at(phi * 56 + eta);
-      (barrelData.at(indices.at(0))).at(indices.at(1)).at(indices.at(2) + 32) =
-          combHD.at(phi * 56 + eta);
+      (barrelData.at(indices.at(0))).at(indices.at(1)).at(indices.at(2)) = combEM.at(phi * 56 + eta);
+      (barrelData.at(indices.at(0))).at(indices.at(1)).at(indices.at(2) + 32) = combHD.at(phi * 56 + eta);
     }
   }
 }
@@ -72,9 +66,8 @@ unsigned short L1RCTORCAMap::combine(unsigned short et, unsigned short fg) {
   return newfg + et;
 }
 
-vector<unsigned short>
-L1RCTORCAMap::combVec(const std::vector<unsigned short> &et,
-                      const std::vector<unsigned short> &fg) {
+vector<unsigned short> L1RCTORCAMap::combVec(const std::vector<unsigned short> &et,
+                                             const std::vector<unsigned short> &fg) {
   std::vector<unsigned short> comb(56 * 72);
   for (int i = 0; i < (int)et.size(); i++)
     comb.at(i) = combine(et.at(i), fg.at(i));

--- a/L1Trigger/RegionalCaloTrigger/src/L1RCTReceiverCard.cc
+++ b/L1Trigger/RegionalCaloTrigger/src/L1RCTReceiverCard.cc
@@ -15,11 +15,15 @@ using std::endl;
 #include <string>
 using std::string;
 
-L1RCTReceiverCard::L1RCTReceiverCard(int crateNumber, int cardNumber,
-                                     const L1RCTLookupTables *rctLookupTables)
-    : regions(2), crtNo(crateNumber), cardNo(cardNumber),
-      rctLookupTables_(rctLookupTables), etIn10Bits(2), overFlowBits(2),
-      muonBits(2), tauBits(2) {}
+L1RCTReceiverCard::L1RCTReceiverCard(int crateNumber, int cardNumber, const L1RCTLookupTables *rctLookupTables)
+    : regions(2),
+      crtNo(crateNumber),
+      cardNo(cardNumber),
+      rctLookupTables_(rctLookupTables),
+      etIn10Bits(2),
+      overFlowBits(2),
+      muonBits(2),
+      tauBits(2) {}
 
 L1RCTReceiverCard::~L1RCTReceiverCard() {}
 
@@ -65,7 +69,6 @@ void L1RCTReceiverCard::fileInput(char *filename) {
 // 19 23 27 31
 
 void L1RCTReceiverCard::fillInput(const std::vector<unsigned short> &input) {
-
   std::vector<unsigned short> ecalInput(32);
   std::vector<unsigned short> ecalFG(32);
   std::vector<unsigned short> hcalInput(32);
@@ -76,9 +79,8 @@ void L1RCTReceiverCard::fillInput(const std::vector<unsigned short> &input) {
     ecalFG.at(i) = input.at(i) & 1;
     hcalInput.at(i) = input.at(i + 32) / 2;
     hcalMuon.at(i) = input.at(i + 32) & 1;
-    unsigned long lookup =
-        rctLookupTables_->lookup(ecalInput.at(i), hcalInput.at(i), ecalFG.at(i),
-                                 crtNo, cardNo, i); // tower number 0-31 now
+    unsigned long lookup = rctLookupTables_->lookup(
+        ecalInput.at(i), hcalInput.at(i), ecalFG.at(i), crtNo, cardNo, i);  // tower number 0-31 now
     unsigned short etIn7Bits = lookup & 127;
     unsigned short etIn9Bits = (lookup >> 8) & 511;
     unsigned short HE_FGBit = (lookup >> 7) & 1;
@@ -170,24 +172,20 @@ unsigned short L1RCTReceiverCard::calcTauBit(L1RCTRegion region) {
   bitset<4> badPattern15(string("1111"));
 
   for (int i = 0; i < 4; i++) {
-    phiPattern[i] = region.getActivityBit(i, 0) ||
-                    region.getActivityBit(i, 1) ||
-                    region.getActivityBit(i, 2) || region.getActivityBit(i, 3);
-    etaPattern[i] = region.getActivityBit(0, i) ||
-                    region.getActivityBit(1, i) ||
-                    region.getActivityBit(2, i) || region.getActivityBit(3, i);
+    phiPattern[i] = region.getActivityBit(i, 0) || region.getActivityBit(i, 1) || region.getActivityBit(i, 2) ||
+                    region.getActivityBit(i, 3);
+    etaPattern[i] = region.getActivityBit(0, i) || region.getActivityBit(1, i) || region.getActivityBit(2, i) ||
+                    region.getActivityBit(3, i);
   }
 
   bool answer;
 
-  if (etaPattern != badPattern5 && etaPattern != badPattern7 &&
-      etaPattern != badPattern10 && etaPattern != badPattern11 &&
-      etaPattern != badPattern13 && etaPattern != badPattern14 &&
-      etaPattern != badPattern15 && phiPattern != badPattern5 &&
-      phiPattern != badPattern7 && phiPattern != badPattern10 &&
-      phiPattern != badPattern11 && phiPattern != badPattern13 &&
-      phiPattern != badPattern14 && phiPattern != badPattern15 &&
-      etaPattern != badPattern9 && phiPattern != badPattern9) { // adding in "9"
+  if (etaPattern != badPattern5 && etaPattern != badPattern7 && etaPattern != badPattern10 &&
+      etaPattern != badPattern11 && etaPattern != badPattern13 && etaPattern != badPattern14 &&
+      etaPattern != badPattern15 && phiPattern != badPattern5 && phiPattern != badPattern7 &&
+      phiPattern != badPattern10 && phiPattern != badPattern11 && phiPattern != badPattern13 &&
+      phiPattern != badPattern14 && phiPattern != badPattern15 && etaPattern != badPattern9 &&
+      phiPattern != badPattern9) {  // adding in "9"
     // return false;
     answer = false;
   }

--- a/L1Trigger/RegionalCaloTrigger/src/L1RCTRegion.cc
+++ b/L1Trigger/RegionalCaloTrigger/src/L1RCTRegion.cc
@@ -8,9 +8,7 @@ using std::cerr;
 using std::cout;
 using std::endl;
 
-L1RCTRegion::L1RCTRegion()
-    : totalRegionEt(36), totalRegionHE_FG(36), etIn9Bits(16), muonBit(16),
-      activityBit(16) {}
+L1RCTRegion::L1RCTRegion() : totalRegionEt(36), totalRegionHE_FG(36), etIn9Bits(16), muonBit(16), activityBit(16) {}
 
 L1RCTRegion::~L1RCTRegion() {}
 
@@ -37,20 +35,14 @@ void L1RCTRegion::setEtIn7Bits(int i, int j, unsigned short energy) {
     totalRegionEt.at(6 * (i + 1) + j + 1) = 127;
 }
 
-unsigned short L1RCTRegion::getHE_FGBit(int i, int j) const {
-  return totalRegionHE_FG.at(6 * (i + 1) + j + 1);
-}
+unsigned short L1RCTRegion::getHE_FGBit(int i, int j) const { return totalRegionHE_FG.at(6 * (i + 1) + j + 1); }
 
-void L1RCTRegion::setHE_FGBit(int i, int j, unsigned short HE_FG) {
-  totalRegionHE_FG.at(6 * (i + 1) + j + 1) = HE_FG;
-}
+void L1RCTRegion::setHE_FGBit(int i, int j, unsigned short HE_FG) { totalRegionHE_FG.at(6 * (i + 1) + j + 1) = HE_FG; }
 
 // The rest of the data stored in a region only works if i and j are
 // in the 0-3 range.  The arrays truly are 4x4 and will signal an error
 // if misused thanks to the vector function .at
-unsigned short L1RCTRegion::getEtIn9Bits(int i, int j) const {
-  return etIn9Bits.at(4 * i + j);
-}
+unsigned short L1RCTRegion::getEtIn9Bits(int i, int j) const { return etIn9Bits.at(4 * i + j); }
 
 void L1RCTRegion::setEtIn9Bits(int i, int j, unsigned short energy) {
   if (energy <= 511)
@@ -59,21 +51,13 @@ void L1RCTRegion::setEtIn9Bits(int i, int j, unsigned short energy) {
     etIn9Bits.at(4 * i + j) = 511;
 }
 
-unsigned short L1RCTRegion::getMuonBit(int i, int j) const {
-  return muonBit.at(4 * i + j);
-}
+unsigned short L1RCTRegion::getMuonBit(int i, int j) const { return muonBit.at(4 * i + j); }
 
-void L1RCTRegion::setMuonBit(int i, int j, unsigned short muon) {
-  muonBit.at(4 * i + j) = muon;
-}
+void L1RCTRegion::setMuonBit(int i, int j, unsigned short muon) { muonBit.at(4 * i + j) = muon; }
 
-void L1RCTRegion::setActivityBit(int i, int j, unsigned short activity) {
-  activityBit.at(4 * i + j) = activity;
-}
+void L1RCTRegion::setActivityBit(int i, int j, unsigned short activity) { activityBit.at(4 * i + j) = activity; }
 
-unsigned short L1RCTRegion::getActivityBit(int i, int j) const {
-  return activityBit.at(4 * i + j);
-}
+unsigned short L1RCTRegion::getActivityBit(int i, int j) const { return activityBit.at(4 * i + j); }
 
 // The following list of give and set functions are the core
 // of the work for neighbor sharing swept under the rug.
@@ -204,9 +188,7 @@ unsigned short L1RCTRegion::giveSWEt() const {
 }
 unsigned short L1RCTRegion::giveSWHE_FG() const { return getHE_FGBit(0, 3); }
 void L1RCTRegion::setSWEt(unsigned short sw) { totalRegionEt.at(30) = sw; }
-void L1RCTRegion::setSWHE_FG(unsigned short sw) {
-  totalRegionHE_FG.at(30) = sw;
-}
+void L1RCTRegion::setSWHE_FG(unsigned short sw) { totalRegionHE_FG.at(30) = sw; }
 
 unsigned short L1RCTRegion::giveSEEt() const {
   unsigned short et = getEtIn7Bits(0, 0);
@@ -217,12 +199,9 @@ unsigned short L1RCTRegion::giveSEEt() const {
 }
 unsigned short L1RCTRegion::giveSEHE_FG() const { return getHE_FGBit(0, 0); }
 void L1RCTRegion::setSEEt(unsigned short se) { totalRegionEt.at(35) = se; }
-void L1RCTRegion::setSEHE_FG(unsigned short se) {
-  totalRegionHE_FG.at(35) = se;
-}
+void L1RCTRegion::setSEHE_FG(unsigned short se) { totalRegionHE_FG.at(35) = se; }
 
 void L1RCTRegion::print() {
-
   std::cout << " 7 Bit Energies ";
   for (int i = 0; i < 4; i++) {
     std::cout << std::endl;

--- a/L1Trigger/Skimmer/src/L1Filter.cc
+++ b/L1Trigger/Skimmer/src/L1Filter.cc
@@ -45,7 +45,6 @@ L1Filter::L1Filter(const edm::ParameterSet &ps)
 L1Filter::~L1Filter() {}
 
 bool L1Filter::filter(edm::Event &iEvent, edm::EventSetup const &evSetup) {
-
   // get menu
   edm::ESHandle<L1GtTriggerMenu> menuRcd;
   evSetup.get<L1GtTriggerMenuRcd>().get(menuRcd);

--- a/L1Trigger/TextToDigi/plugins/GctDigiToPsbText.cc
+++ b/L1Trigger/TextToDigi/plugins/GctDigiToPsbText.cc
@@ -8,8 +8,7 @@ using std::setw;
 GctDigiToPsbText::GctDigiToPsbText(const edm::ParameterSet &iConfig)
     : m_gctInputLabel(iConfig.getParameter<edm::InputTag>("GctInputLabel")),
       m_textFileName(iConfig.getParameter<std::string>("TextFileName")),
-      m_hexUpperCase(
-          iConfig.getUntrackedParameter<bool>("HexUpperCase", false)) {
+      m_hexUpperCase(iConfig.getUntrackedParameter<bool>("HexUpperCase", false)) {
   /// open output text files
   for (unsigned i = 0; i < 4; i++) {
     std::stringstream fileStream;
@@ -31,9 +30,7 @@ GctDigiToPsbText::~GctDigiToPsbText() {
     m_file[i].close();
 }
 
-void GctDigiToPsbText::analyze(const edm::Event &iEvent,
-                               const edm::EventSetup &iSetup) {
-
+void GctDigiToPsbText::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // static int nevt = -1; nevt++;
 
   // get digis
@@ -73,12 +70,10 @@ void GctDigiToPsbText::analyze(const edm::Event &iEvent,
 
     // print electrons
     sstrm.str("");
-    sstrm << setw(4) << setfill('0') << std::hex
-          << (data[iIsola][cycle] & 0x7fff) + ((cbs[cycle] & 0x1) << 15);
+    sstrm << setw(4) << setfill('0') << std::hex << (data[iIsola][cycle] & 0x7fff) + ((cbs[cycle] & 0x1) << 15);
     m_file[iIsola] << sstrm.str() << std::endl;
     sstrm.str("");
-    sstrm << setw(4) << setfill('0') << std::hex
-          << (data[iNoIso][cycle] & 0x7fff) + ((cbs[cycle] & 0x1) << 15);
+    sstrm << setw(4) << setfill('0') << std::hex << (data[iNoIso][cycle] & 0x7fff) + ((cbs[cycle] & 0x1) << 15);
     m_file[iNoIso] << sstrm.str() << std::endl;
   }
 

--- a/L1Trigger/TextToDigi/plugins/GctDigiToPsbText.h
+++ b/L1Trigger/TextToDigi/plugins/GctDigiToPsbText.h
@@ -22,7 +22,6 @@
 #include "DataFormats/L1GlobalCaloTrigger/interface/L1GctCollections.h"
 
 class GctDigiToPsbText : public edm::EDAnalyzer {
-
 public:
   explicit GctDigiToPsbText(const edm::ParameterSet &);
   ~GctDigiToPsbText() override;

--- a/L1Trigger/TextToDigi/plugins/GtPsbTextToDigi.cc
+++ b/L1Trigger/TextToDigi/plugins/GtPsbTextToDigi.cc
@@ -13,8 +13,7 @@
 //#include "DataFormats/L1GlobalCaloTrigger/interface/L1GctJetCounts.h"
 
 GtPsbTextToDigi::GtPsbTextToDigi(const edm::ParameterSet &iConfig)
-    : m_fileEventOffset(
-          iConfig.getUntrackedParameter<int>("FileEventOffset", 0)),
+    : m_fileEventOffset(iConfig.getUntrackedParameter<int>("FileEventOffset", 0)),
       m_textFileName(iConfig.getParameter<std::string>("TextFileName")),
       m_nevt(0) {
   // Produces collections
@@ -59,16 +58,11 @@ GtPsbTextToDigi::~GtPsbTextToDigi() {
 
 /// Append empty digi collection
 void GtPsbTextToDigi::putEmptyDigi(edm::Event &iEvent) {
-  std::unique_ptr<L1GctEmCandCollection> gctIsolaEm(
-      new L1GctEmCandCollection());
-  std::unique_ptr<L1GctEmCandCollection> gctNoIsoEm(
-      new L1GctEmCandCollection());
-  std::unique_ptr<L1GctJetCandCollection> gctCenJets(
-      new L1GctJetCandCollection());
-  std::unique_ptr<L1GctJetCandCollection> gctForJets(
-      new L1GctJetCandCollection());
-  std::unique_ptr<L1GctJetCandCollection> gctTauJets(
-      new L1GctJetCandCollection());
+  std::unique_ptr<L1GctEmCandCollection> gctIsolaEm(new L1GctEmCandCollection());
+  std::unique_ptr<L1GctEmCandCollection> gctNoIsoEm(new L1GctEmCandCollection());
+  std::unique_ptr<L1GctJetCandCollection> gctCenJets(new L1GctJetCandCollection());
+  std::unique_ptr<L1GctJetCandCollection> gctForJets(new L1GctJetCandCollection());
+  std::unique_ptr<L1GctJetCandCollection> gctTauJets(new L1GctJetCandCollection());
   // std::unique_ptr<L1GctEtTotal>           gctEtTotal( new L1GctEtTotal () );
   for (int i = 0; i < 4; i++) {
     gctIsolaEm->push_back(L1GctEmCand(0, true));
@@ -88,18 +82,14 @@ void GtPsbTextToDigi::putEmptyDigi(edm::Event &iEvent) {
   LogDebug("GtPsbTextToDigi") << "putting empty digi (evt:" << m_nevt << ")\n";
 }
 
-void GtPsbTextToDigi::produce(edm::Event &iEvent,
-                              const edm::EventSetup &iSetup) {
-
+void GtPsbTextToDigi::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // specify clock cycle bit sequence 1 0 1 0... or 0 1 0 1...
   unsigned short cbs[2] = {1, 0};
 
   // Skip event if required
   if (m_nevt < m_fileEventOffset) {
     putEmptyDigi(iEvent);
-    LogDebug("GtPsbTextToDigi")
-        << "[GtPsbTextToDigi::produce()] skipping event " << m_nevt
-        << std::endl;
+    LogDebug("GtPsbTextToDigi") << "[GtPsbTextToDigi::produce()] skipping event " << m_nevt << std::endl;
     m_nevt++;
     return;
   } else if (m_nevt == 0 && m_fileEventOffset < 0) {
@@ -118,30 +108,22 @@ void GtPsbTextToDigi::produce(edm::Event &iEvent,
               throw cms::Exception("GtPsbTextToDigiTextFileFormatError")
                   // std::cout << "GtPsbTextToDigiTextFileFormatError"
                   << "GtPsbTextToDigi::produce : "
-                  << " found format inconsistency in file #" << ifile
-                  << "\n in skipped line:" << ievt * 2 + 1 << " cycle:" << tmp
-                  << " is different from " << cbs[cycle] << std::endl;
+                  << " found format inconsistency in file #" << ifile << "\n in skipped line:" << ievt * 2 + 1
+                  << " cycle:" << tmp << " is different from " << cbs[cycle] << std::endl;
           }
         }
       }
-      LogDebug("GtPsbTextToDigi")
-          << "[GtPsbTextToDigi::produce()] skipping input " << ievt
-          << std::endl;
+      LogDebug("GtPsbTextToDigi") << "[GtPsbTextToDigi::produce()] skipping input " << ievt << std::endl;
     }
   }
   m_nevt++;
 
   // New collections
-  std::unique_ptr<L1GctEmCandCollection> gctIsolaEm(
-      new L1GctEmCandCollection());
-  std::unique_ptr<L1GctEmCandCollection> gctNoIsoEm(
-      new L1GctEmCandCollection());
-  std::unique_ptr<L1GctJetCandCollection> gctCenJets(
-      new L1GctJetCandCollection());
-  std::unique_ptr<L1GctJetCandCollection> gctForJets(
-      new L1GctJetCandCollection());
-  std::unique_ptr<L1GctJetCandCollection> gctTauJets(
-      new L1GctJetCandCollection());
+  std::unique_ptr<L1GctEmCandCollection> gctIsolaEm(new L1GctEmCandCollection());
+  std::unique_ptr<L1GctEmCandCollection> gctNoIsoEm(new L1GctEmCandCollection());
+  std::unique_ptr<L1GctJetCandCollection> gctCenJets(new L1GctJetCandCollection());
+  std::unique_ptr<L1GctJetCandCollection> gctForJets(new L1GctJetCandCollection());
+  std::unique_ptr<L1GctJetCandCollection> gctTauJets(new L1GctJetCandCollection());
   // std::unique_ptr<L1GctEtTotal>           gctEtTotal( new L1GctEtTotal () );
 
   /// buffer
@@ -156,18 +138,15 @@ void GtPsbTextToDigi::produce(edm::Event &iEvent,
 
     // Check we're not at the end of the file
     if (m_file[ifile].eof()) {
-      LogDebug("GtPsbTextToDigi")
-          << "GtPsbTextToDigi::produce : "
-          << " unexpected end of file " << m_textFileName << ii << ".txt"
-          << std::endl;
+      LogDebug("GtPsbTextToDigi") << "GtPsbTextToDigi::produce : "
+                                  << " unexpected end of file " << m_textFileName << ii << ".txt" << std::endl;
       putEmptyDigi(iEvent);
       continue;
     }
 
     if (!m_file[ifile].good()) {
       LogDebug("GtPsbTextToDigi") << "GtPsbTextToDigi::produce : "
-                                  << " problem reading file " << m_textFileName
-                                  << ii << ".txt" << std::endl;
+                                  << " problem reading file " << m_textFileName << ii << ".txt" << std::endl;
       putEmptyDigi(iEvent);
       continue;
     }
@@ -182,10 +161,8 @@ void GtPsbTextToDigi::produce(edm::Event &iEvent,
       /// cycle debuging (temporary)
       if (false && tmp != cbs[cycle])
         std::cout << "[GtPsbTextToDigi::produce()] asserting "
-                  << " evt:" << m_nevt << " ifile:" << ifile
-                  << " cycle:" << cbs[cycle] << std::hex
-                  << " buffer:" << uLongBuffer << " tmp: " << tmp << std::dec
-                  << "\n\n"
+                  << " evt:" << m_nevt << " ifile:" << ifile << " cycle:" << cbs[cycle] << std::hex
+                  << " buffer:" << uLongBuffer << " tmp: " << tmp << std::dec << "\n\n"
                   << std::flush;
 
       if (tmp != cbs[cycle]) {
@@ -196,14 +173,13 @@ void GtPsbTextToDigi::produce(edm::Event &iEvent,
               // std::cout << "GtPsbTextToDigiTextFileFormatError "
               << "GtPsbTextToDigi::produce : "
               << " found format inconsistency in file #" << ifile
-              << "\n in line:" << (m_nevt - m_fileEventOffset) * 2 - 1
-              << " cycle:" << tmp << " is different from " << cbs[cycle]
-              << std::endl;
+              << "\n in line:" << (m_nevt - m_fileEventOffset) * 2 - 1 << " cycle:" << tmp << " is different from "
+              << cbs[cycle] << std::endl;
         }
       }
       data[ifile][cycle] = (uLongBuffer & 0x7fff);
-    } // cycle loop
-  }   // ifile loop
+    }  // cycle loop
+  }    // ifile loop
 
   /// Fill in digi collections
   unsigned iIsola, iNoIso;
@@ -235,8 +211,7 @@ void GtPsbTextToDigi::endJob() {
     match &= (m_bc0[i] == m_bc0[i + 1]);
   LogDebug("GtPsbTextToDigi") << "[GtPsbTextToDigi::endJob()] ";
   if (!match)
-    LogDebug("GtPsbTextToDigi")
-        << "did not find matching BC0 in all input files: ";
+    LogDebug("GtPsbTextToDigi") << "did not find matching BC0 in all input files: ";
   else
     LogDebug("GtPsbTextToDigi") << "detected common BC0 in all input files: ";
   for (int i = 0; i < nmem; i++)

--- a/L1Trigger/TextToDigi/plugins/RawToText.cc
+++ b/L1Trigger/TextToDigi/plugins/RawToText.cc
@@ -15,18 +15,14 @@
 RawToText::RawToText(const edm::ParameterSet &iConfig)
     : inputLabel_(iConfig.getParameter<edm::InputTag>("inputLabel")),
       fedId_(iConfig.getUntrackedParameter<int>("fedId", 745)),
-      filename_(iConfig.getUntrackedParameter<std::string>("filename",
-                                                           "slinkOutput.txt")),
+      filename_(iConfig.getUntrackedParameter<std::string>("filename", "slinkOutput.txt")),
       nevt_(0) {
-  edm::LogInfo("TextToDigi")
-      << "Creating ASCII dump " << filename_ << std::endl;
+  edm::LogInfo("TextToDigi") << "Creating ASCII dump " << filename_ << std::endl;
 }
 
 RawToText::~RawToText() {}
 
-void RawToText::analyze(const edm::Event &iEvent,
-                        const edm::EventSetup &iSetup) {
-
+void RawToText::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   nevt_++;
 
   // get raw data collection
@@ -34,13 +30,11 @@ void RawToText::analyze(const edm::Event &iEvent,
   iEvent.getByLabel(inputLabel_, feds);
   const FEDRawData &gctRcd = feds->FEDData(fedId_);
 
-  edm::LogInfo("GCT") << "Upacking FEDRawData of size " << std::dec
-                      << gctRcd.size() << std::endl;
+  edm::LogInfo("GCT") << "Upacking FEDRawData of size " << std::dec << gctRcd.size() << std::endl;
 
   // do a simple check of the raw data
   if (gctRcd.size() < 16) {
-    edm::LogWarning("Invalid Data")
-        << "Empty/invalid GCT raw data, size = " << gctRcd.size() << std::endl;
+    edm::LogWarning("Invalid Data") << "Empty/invalid GCT raw data, size = " << gctRcd.size() << std::endl;
     return;
   }
 
@@ -62,13 +56,11 @@ void RawToText::analyze(const edm::Event &iEvent,
 }
 
 void RawToText::beginJob() {
-
   // open VME file
   file_.open(filename_.c_str(), std::ios::out);
 
   if (!file_.good()) {
-    edm::LogInfo("RawToText")
-        << "Failed to open ASCII file " << filename_ << std::endl;
+    edm::LogInfo("RawToText") << "Failed to open ASCII file " << filename_ << std::endl;
   }
 }
 

--- a/L1Trigger/TextToDigi/plugins/RctDigiToRctText.cc
+++ b/L1Trigger/TextToDigi/plugins/RctDigiToRctText.cc
@@ -12,12 +12,10 @@ RctDigiToRctText::RctDigiToRctText(const edm::ParameterSet &iConfig)
     : m_rctInputLabel(iConfig.getParameter<edm::InputTag>("RctInputLabel")),
       m_textFileName(iConfig.getParameter<std::string>("TextFileName")),
       m_hexUpperCase(iConfig.getParameter<bool>("HexUpperCase")) {
-
   /// open output text files
   for (unsigned i = 0; i < NUM_RCT_CRATES; i++) {
     std::stringstream fileStream;
-    fileStream << m_textFileName << std::setw(2) << std::setfill('0') << i
-               << ".txt";
+    fileStream << m_textFileName << std::setw(2) << std::setfill('0') << i << ".txt";
     std::string fileName(fileStream.str());
     m_file[i].open(fileName.c_str(), std::ios::out);
 
@@ -39,9 +37,7 @@ RctDigiToRctText::~RctDigiToRctText() {
   fdebug.close();
 }
 
-void RctDigiToRctText::analyze(const edm::Event &iEvent,
-                               const edm::EventSetup &iSetup) {
-
+void RctDigiToRctText::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   /// count bunch crossing
   static int nevt = -1;
   nevt++;
@@ -67,9 +63,7 @@ void RctDigiToRctText::analyze(const edm::Event &iEvent,
   bool iso;
   int id;
 
-  for (L1CaloEmCollection::const_iterator iem = em->begin(); iem != em->end();
-       iem++) {
-
+  for (L1CaloEmCollection::const_iterator iem = em->begin(); iem != em->end(); iem++) {
     int crate = iem->rctCrate();
     iso = iem->isolated();
     unsigned data = iem->raw();
@@ -81,14 +75,12 @@ void RctDigiToRctText::analyze(const edm::Event &iEvent,
     /// debug
     if (crate > 17 || id > 7)
       throw cms::Exception("RctDigiToRctTextElectronIndexOutBounds")
-          << "out of bounds indices  crate:" << crate << "id:" << id
-          << std::endl;
+          << "out of bounds indices  crate:" << crate << "id:" << id << std::endl;
     if (ldebug && data != 0)
       debug_NOTEMPTY[crate] = true;
     dstrm.str("");
     dstrm << "electron "
-          << " bx:" << nevt << " crate:" << crate << " iso:" << iso
-          << " raw:" << data << " \t cand:" << *iem;
+          << " bx:" << nevt << " crate:" << crate << " iso:" << iso << " raw:" << data << " \t cand:" << *iem;
     if (debug_NOTEMPTY[crate])
       fdebug << dstrm.str() << std::endl;
   }
@@ -102,9 +94,7 @@ void RctDigiToRctText::analyze(const edm::Event &iEvent,
   unsigned short RCtau[18][7][2] = {{{0}}};
   unsigned short HF[18][4][2] = {{{0}}};
 
-  for (L1CaloRegionCollection::const_iterator irgn = rgn->begin();
-       irgn != rgn->end(); irgn++) {
-
+  for (L1CaloRegionCollection::const_iterator irgn = rgn->begin(); irgn != rgn->end(); irgn++) {
     int crate = irgn->rctCrate();
     int card = irgn->rctCard();
     int rgnidx = irgn->rctRegionIndex();
@@ -117,25 +107,22 @@ void RctDigiToRctText::analyze(const edm::Event &iEvent,
       MIPbits[crate][card][rgnidx] = irgn->mip();
       QIEbits[crate][card][rgnidx] = irgn->quiet();
       // debug info
-      dstrm << hex << "Et=" << irgn->et() << " OverFlow=" << irgn->overFlow()
-            << " tauVeto=" << irgn->tauVeto() << " mip=" << irgn->mip()
-            << " quiet=" << irgn->quiet() << " Card=" << irgn->rctCard()
-            << " Region=" << irgn->rctRegionIndex()
-            << " Crate=" << irgn->rctCrate() << dec;
+      dstrm << hex << "Et=" << irgn->et() << " OverFlow=" << irgn->overFlow() << " tauVeto=" << irgn->tauVeto()
+            << " mip=" << irgn->mip() << " quiet=" << irgn->quiet() << " Card=" << irgn->rctCard()
+            << " Region=" << irgn->rctRegionIndex() << " Crate=" << irgn->rctCrate() << dec;
       if (ldebug)
         LogDebug("Regions") << dstrm.str();
     } else {
       HF[crate][irgn->id().rctEta() - 7][irgn->id().rctPhi()] = irgn->et();
       // debug info
-      dstrm << hex << "Et=" << irgn->et() << " FGrain=" << irgn->fineGrain()
-            << " Eta=" << irgn->id().rctEta() << " Phi=" << irgn->id().rctPhi()
-            << " Crate=" << irgn->rctCrate() << dec;
+      dstrm << hex << "Et=" << irgn->et() << " FGrain=" << irgn->fineGrain() << " Eta=" << irgn->id().rctEta()
+            << " Phi=" << irgn->id().rctPhi() << " Crate=" << irgn->rctCrate() << dec;
       if (ldebug)
         LogDebug("HFRegions") << dstrm.str();
     }
 
     if (ldebug && irgn->et() != 0)
-      debug_NOTEMPTY[crate] = true; // debug
+      debug_NOTEMPTY[crate] = true;  // debug
     if (debug_NOTEMPTY[crate]) {
       fdebug << "region"
              << " bx:" << nevt << " crate:" << crate << "\t";
@@ -152,7 +139,6 @@ void RctDigiToRctText::analyze(const edm::Event &iEvent,
   /// print electrons
 
   for (unsigned crate = 0; crate < NUM_RCT_CRATES; crate++) {
-
     sstrm.str("");
     sstrm << "Crossing " << nevt << std::endl;
 
@@ -174,7 +160,6 @@ void RctDigiToRctText::analyze(const edm::Event &iEvent,
   /// print regions
 
   for (unsigned crate = 0; crate < NUM_RCT_CRATES; crate++) {
-
     /// mip bits
     sstrm.str("");
     for (int card = 0; card < 7; card++) {
@@ -184,7 +169,7 @@ void RctDigiToRctText::analyze(const edm::Event &iEvent,
     }
     m_file[crate] << sstrm.str() << std::endl;
     if (debug_NOTEMPTY[crate])
-      fdebug << sstrm.str() << std::endl; // debug
+      fdebug << sstrm.str() << std::endl;  // debug
 
     /// quiet bits
     sstrm.str("");
@@ -195,7 +180,7 @@ void RctDigiToRctText::analyze(const edm::Event &iEvent,
     }
     m_file[crate] << sstrm.str() << std::endl;
     if (debug_NOTEMPTY[crate])
-      fdebug << sstrm.str() << std::endl; // debug
+      fdebug << sstrm.str() << std::endl;  // debug
 
     /// region info
     sstrm.str("");
@@ -212,7 +197,7 @@ void RctDigiToRctText::analyze(const edm::Event &iEvent,
     }
     m_file[crate] << sstrm.str() << std::endl;
     if (debug_NOTEMPTY[crate])
-      fdebug << sstrm.str() << std::endl << std::endl; // debug
+      fdebug << sstrm.str() << std::endl << std::endl;  // debug
 
     /// HF
     sstrm.str("");
@@ -224,10 +209,10 @@ void RctDigiToRctText::analyze(const edm::Event &iEvent,
     }
     m_file[crate] << sstrm.str() << std::endl;
     if (debug_NOTEMPTY[crate])
-      fdebug << sstrm.str() << std::endl; // debug
+      fdebug << sstrm.str() << std::endl;  // debug
     sstrm << setfill(' ') << dec;
 
-  } // end crate loop
+  }  // end crate loop
 
   /// flush data to files
   for (unsigned i = 0; i < NUM_RCT_CRATES; i++)

--- a/L1Trigger/TextToDigi/plugins/RctDigiToRctText.h
+++ b/L1Trigger/TextToDigi/plugins/RctDigiToRctText.h
@@ -20,7 +20,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h" // Logger
+#include "FWCore/MessageLogger/interface/MessageLogger.h"  // Logger
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/L1CaloTrigger/interface/L1CaloCollections.h"
@@ -28,7 +28,6 @@
 const static unsigned NUM_RCT_CRATES = 18;
 
 class RctDigiToRctText : public edm::EDAnalyzer {
-
 public:
   explicit RctDigiToRctText(const edm::ParameterSet &);
   ~RctDigiToRctText() override;

--- a/L1Trigger/TextToDigi/plugins/RctDigiToSourceCardText.cc
+++ b/L1Trigger/TextToDigi/plugins/RctDigiToSourceCardText.cc
@@ -16,8 +16,8 @@ source cards for pattern tests.
 //
 //
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h" // Logger
-#include "FWCore/ServiceRegistry/interface/Service.h"     // Framework services
+#include "FWCore/MessageLogger/interface/MessageLogger.h"  // Logger
+#include "FWCore/ServiceRegistry/interface/Service.h"      // Framework services
 #include "RctDigiToSourceCardText.h"
 
 using namespace edm;
@@ -26,8 +26,7 @@ using namespace std;
 // Set constant
 const static int NUM_RCT_CRATES = 18;
 
-RctDigiToSourceCardText::RctDigiToSourceCardText(
-    const edm::ParameterSet &iConfig)
+RctDigiToSourceCardText::RctDigiToSourceCardText(const edm::ParameterSet &iConfig)
     : m_rctInputLabel(iConfig.getParameter<edm::InputTag>("RctInputLabel")),
       m_textFileName(iConfig.getParameter<std::string>("TextFileName")),
       m_nevt(0) {
@@ -37,8 +36,7 @@ RctDigiToSourceCardText::RctDigiToSourceCardText(
   if (!m_file.good()) {
     throw cms::Exception("RctDigiToSourceCardTextFileOpenError")
         << "RctDigiToSourceCardText::RctDigiToSourceCardText : "
-        << " couldn't open the file " << m_textFileName << " for writing"
-        << std::endl;
+        << " couldn't open the file " << m_textFileName << " for writing" << std::endl;
   }
 
   // Make a SC routing object
@@ -51,9 +49,7 @@ RctDigiToSourceCardText::~RctDigiToSourceCardText() {
 }
 
 // ------------ method called to for each event  ------------
-void RctDigiToSourceCardText::analyze(const edm::Event &iEvent,
-                                      const edm::EventSetup &iSetup) {
-
+void RctDigiToSourceCardText::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // get the RCT data
   Handle<L1CaloEmCollection> em;
   Handle<L1CaloRegionCollection> rgn;
@@ -77,28 +73,21 @@ void RctDigiToSourceCardText::analyze(const edm::Event &iEvent,
   unsigned numIsoEM[18] = {0};
   unsigned numNonIsoEM[18] = {0};
 
-  for (L1CaloEmCollection::const_iterator iem = em->begin(); iem != em->end();
-       iem++) {
+  for (L1CaloEmCollection::const_iterator iem = em->begin(); iem != em->end(); iem++) {
     if (iem->isolated()) {
       eIsoRank[iem->rctCrate()][numIsoEM[iem->rctCrate()]] = iem->rank();
       eIsoCardId[iem->rctCrate()][numIsoEM[iem->rctCrate()]] = iem->rctCard();
-      eIsoRegionId[iem->rctCrate()][numIsoEM[iem->rctCrate()]] =
-          iem->rctRegion();
+      eIsoRegionId[iem->rctCrate()][numIsoEM[iem->rctCrate()]] = iem->rctRegion();
       numIsoEM[iem->rctCrate()]++;
     } else {
       eNonIsoRank[iem->rctCrate()][numNonIsoEM[iem->rctCrate()]] = iem->rank();
-      eNonIsoCardId[iem->rctCrate()][numNonIsoEM[iem->rctCrate()]] =
-          iem->rctCard();
-      eNonIsoRegionId[iem->rctCrate()][numNonIsoEM[iem->rctCrate()]] =
-          iem->rctRegion();
+      eNonIsoCardId[iem->rctCrate()][numNonIsoEM[iem->rctCrate()]] = iem->rctCard();
+      eNonIsoRegionId[iem->rctCrate()][numNonIsoEM[iem->rctCrate()]] = iem->rctRegion();
       numNonIsoEM[iem->rctCrate()]++;
     }
     // Debug info
-    LogDebug("Electrons") << "Rank=" << iem->rank()
-                          << " Card=" << iem->rctCard()
-                          << " Region=" << iem->rctRegion()
-                          << " Crate=" << iem->rctCrate()
-                          << " Isolated=" << iem->isolated();
+    LogDebug("Electrons") << "Rank=" << iem->rank() << " Card=" << iem->rctCard() << " Region=" << iem->rctRegion()
+                          << " Crate=" << iem->rctCrate() << " Isolated=" << iem->isolated();
   }
 
   // Arrays to hold region variables
@@ -111,52 +100,44 @@ void RctDigiToSourceCardText::analyze(const edm::Event &iEvent,
   unsigned short Qbits[18][7][2] = {{{0}}};
 
   // Fill regions
-  for (L1CaloRegionCollection::const_iterator irgn = rgn->begin();
-       irgn != rgn->end(); irgn++) {
+  for (L1CaloRegionCollection::const_iterator irgn = rgn->begin(); irgn != rgn->end(); irgn++) {
     if (irgn->id().isHf()) {
-      HF[irgn->rctCrate()][irgn->id().rctEta() - 7][irgn->id().rctPhi()] =
-          irgn->et();
-      HFQ[irgn->rctCrate()][irgn->id().rctEta() - 7][irgn->id().rctPhi()] =
-          irgn->fineGrain();
+      HF[irgn->rctCrate()][irgn->id().rctEta() - 7][irgn->id().rctPhi()] = irgn->et();
+      HFQ[irgn->rctCrate()][irgn->id().rctEta() - 7][irgn->id().rctPhi()] = irgn->fineGrain();
       // Debug info
-      LogDebug("HFRegions")
-          << "Et=" << irgn->et() << " FineGrain=" << irgn->fineGrain()
-          << " Eta=" << irgn->id().rctEta() << " Phi=" << irgn->id().rctPhi()
-          << " Crate=" << irgn->rctCrate();
+      LogDebug("HFRegions") << "Et=" << irgn->et() << " FineGrain=" << irgn->fineGrain()
+                            << " Eta=" << irgn->id().rctEta() << " Phi=" << irgn->id().rctPhi()
+                            << " Crate=" << irgn->rctCrate();
     } else {
-      RC[irgn->rctCrate()][irgn->rctCard()][irgn->rctRegionIndex()] =
-          irgn->et();
-      RCof[irgn->rctCrate()][irgn->rctCard()][irgn->rctRegionIndex()] =
-          irgn->overFlow();
-      RCtau[irgn->rctCrate()][irgn->rctCard()][irgn->rctRegionIndex()] =
-          irgn->tauVeto();
-      MIPbits[irgn->rctCrate()][irgn->rctCard()][irgn->rctRegionIndex()] =
-          irgn->mip();
-      Qbits[irgn->rctCrate()][irgn->rctCard()][irgn->rctRegionIndex()] =
-          irgn->quiet();
+      RC[irgn->rctCrate()][irgn->rctCard()][irgn->rctRegionIndex()] = irgn->et();
+      RCof[irgn->rctCrate()][irgn->rctCard()][irgn->rctRegionIndex()] = irgn->overFlow();
+      RCtau[irgn->rctCrate()][irgn->rctCard()][irgn->rctRegionIndex()] = irgn->tauVeto();
+      MIPbits[irgn->rctCrate()][irgn->rctCard()][irgn->rctRegionIndex()] = irgn->mip();
+      Qbits[irgn->rctCrate()][irgn->rctCard()][irgn->rctRegionIndex()] = irgn->quiet();
       // Debug info
-      LogDebug("Regions") << "Et=" << irgn->et()
-                          << " OverFlow=" << irgn->overFlow()
-                          << " tauVeto=" << irgn->tauVeto()
-                          << " mip=" << irgn->mip()
-                          << " quiet=" << irgn->quiet()
-                          << " Card=" << irgn->rctCard()
-                          << " Region=" << irgn->rctRegionIndex()
-                          << " Crate=" << irgn->rctCrate();
+      LogDebug("Regions") << "Et=" << irgn->et() << " OverFlow=" << irgn->overFlow() << " tauVeto=" << irgn->tauVeto()
+                          << " mip=" << irgn->mip() << " quiet=" << irgn->quiet() << " Card=" << irgn->rctCard()
+                          << " Region=" << irgn->rctRegionIndex() << " Crate=" << irgn->rctCrate();
     }
   }
 
   for (int crate = 0; crate < NUM_RCT_CRATES; crate++) {
-
     // Logical Card ID = Source Card number
     RoutingMode = 0;
     m_scRouting.RoutingModetoLogicalCardID(logicalCardID, RoutingMode, crate);
 
     // Convert electrons to SC format
-    m_scRouting.EMUtoSTRING(
-        logicalCardID, m_nevt, eIsoRank[crate], eIsoCardId[crate],
-        eIsoRegionId[crate], eNonIsoRank[crate], eNonIsoCardId[crate],
-        eNonIsoRegionId[crate], MIPbits[crate], Qbits[crate], dataString);
+    m_scRouting.EMUtoSTRING(logicalCardID,
+                            m_nevt,
+                            eIsoRank[crate],
+                            eIsoCardId[crate],
+                            eIsoRegionId[crate],
+                            eNonIsoRank[crate],
+                            eNonIsoCardId[crate],
+                            eNonIsoRegionId[crate],
+                            MIPbits[crate],
+                            Qbits[crate],
+                            dataString);
 
     // Write electrons
     m_file << dataString;
@@ -166,8 +147,8 @@ void RctDigiToSourceCardText::analyze(const edm::Event &iEvent,
     m_scRouting.RoutingModetoLogicalCardID(logicalCardID, RoutingMode, crate);
 
     // Convert regions to SC format
-    m_scRouting.RC56HFtoSTRING(logicalCardID, m_nevt, RC[crate], RCof[crate],
-                               RCtau[crate], HF[crate], HFQ[crate], dataString);
+    m_scRouting.RC56HFtoSTRING(
+        logicalCardID, m_nevt, RC[crate], RCof[crate], RCtau[crate], HF[crate], HFQ[crate], dataString);
 
     // Write regions
     m_file << dataString;
@@ -177,8 +158,7 @@ void RctDigiToSourceCardText::analyze(const edm::Event &iEvent,
     m_scRouting.RoutingModetoLogicalCardID(logicalCardID, RoutingMode, crate);
 
     // Convert regions to SC format
-    m_scRouting.RC012toSTRING(logicalCardID, m_nevt, RC[crate], RCof[crate],
-                              RCtau[crate], dataString);
+    m_scRouting.RC012toSTRING(logicalCardID, m_nevt, RC[crate], RCof[crate], RCtau[crate], dataString);
 
     // Write regions
     m_file << dataString;
@@ -190,9 +170,15 @@ void RctDigiToSourceCardText::analyze(const edm::Event &iEvent,
       m_scRouting.RoutingModetoLogicalCardID(logicalCardID, RoutingMode, crate);
 
       // Convert regions to SC format
-      m_scRouting.RC234toSTRING(logicalCardID, m_nevt, RC[crate], RCof[crate],
-                                RCtau[crate], RC[crate + 9], RCof[crate + 9],
-                                RCtau[crate + 9], dataString);
+      m_scRouting.RC234toSTRING(logicalCardID,
+                                m_nevt,
+                                RC[crate],
+                                RCof[crate],
+                                RCtau[crate],
+                                RC[crate + 9],
+                                RCof[crate + 9],
+                                RCtau[crate + 9],
+                                dataString);
 
       // Write regions
       m_file << dataString;

--- a/L1Trigger/TextToDigi/plugins/RctInputTextToDigi.cc
+++ b/L1Trigger/TextToDigi/plugins/RctInputTextToDigi.cc
@@ -6,8 +6,10 @@
 
 RctInputTextToDigi::RctInputTextToDigi(const edm::ParameterSet &iConfig)
     : inputFile_(iConfig.getParameter<edm::FileInPath>("inputFile")),
-      inputStream_(inputFile_.fullPath().c_str()), nEvent_(0),
-      oldVersion_(false), lookupTables_(new L1RCTLookupTables) {
+      inputStream_(inputFile_.fullPath().c_str()),
+      nEvent_(0),
+      oldVersion_(false),
+      lookupTables_(new L1RCTLookupTables) {
   // register your products
   /* Examples
      produces<ExampleData2>();
@@ -29,7 +31,6 @@ RctInputTextToDigi::RctInputTextToDigi(const edm::ParameterSet &iConfig)
 }
 
 RctInputTextToDigi::~RctInputTextToDigi() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 
@@ -41,8 +42,7 @@ RctInputTextToDigi::~RctInputTextToDigi() {
 //
 
 // ------------ method called to produce the data  ------------
-void RctInputTextToDigi::produce(edm::Event &iEvent,
-                                 const edm::EventSetup &iSetup) {
+void RctInputTextToDigi::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
 
   // std::cout << std::endl << std::endl << "Event number " << nEvent_ <<
@@ -57,13 +57,11 @@ void RctInputTextToDigi::produce(edm::Event &iEvent,
   const L1RCTParameters *r = rctParameters.product();
   lookupTables_->setRCTParameters(r);
 
-  std::unique_ptr<EcalTrigPrimDigiCollection> ecalTPs(
-      new EcalTrigPrimDigiCollection());
-  std::unique_ptr<HcalTrigPrimDigiCollection> hcalTPs(
-      new HcalTrigPrimDigiCollection());
+  std::unique_ptr<EcalTrigPrimDigiCollection> ecalTPs(new EcalTrigPrimDigiCollection());
+  std::unique_ptr<HcalTrigPrimDigiCollection> hcalTPs(new HcalTrigPrimDigiCollection());
   ecalTPs->reserve(56 * 72);
-  hcalTPs->reserve(56 * 72 + 18 * 8); // includes HF
-  const int nEcalSamples = 1;         // we only use 1 sample for each
+  hcalTPs->reserve(56 * 72 + 18 * 8);  // includes HF
+  const int nEcalSamples = 1;          // we only use 1 sample for each
   const int nHcalSamples = 1;
 
   int fileEventNumber;
@@ -115,8 +113,7 @@ void RctInputTextToDigi::produce(edm::Event &iEvent,
       unsigned eAddr;
       unsigned hAddr;
 
-      inputStream_ >> std::hex >> fileEventNumber >> crate >> card >> tower >>
-          eAddr >> hAddr >> junk >> std::dec;
+      inputStream_ >> std::hex >> fileEventNumber >> crate >> card >> tower >> eAddr >> hAddr >> junk >> std::dec;
 
       if (oldVersion_) {
         tower = tower - 1;
@@ -124,7 +121,7 @@ void RctInputTextToDigi::produce(edm::Event &iEvent,
       int encodedEtEcal = (int)(eAddr >> 1);
       bool fineGrainEcal = (bool)(eAddr & 1);
       int encodedEtHcal = (int)(hAddr >> 1);
-      bool fineGrainHcal = (bool)(hAddr & 1); // mip bit
+      bool fineGrainHcal = (bool)(hAddr & 1);  // mip bit
 
       // std::cout << "Eventnumber " << fileEventNumber << "\tCrate "
       //    << crate << "\tCard " << card << "\tTower "
@@ -149,14 +146,12 @@ void RctInputTextToDigi::produce(edm::Event &iEvent,
       // args to detid are zside, type of tower, absieta, iphi
       // absieta and iphi must be between 1 and 127 inclusive
 
-      EcalTriggerPrimitiveDigi ecalDigi(
-          EcalTrigTowerDetId(zSide, EcalTriggerTower, absIeta, iPhi));
+      EcalTriggerPrimitiveDigi ecalDigi(EcalTrigTowerDetId(zSide, EcalTriggerTower, absIeta, iPhi));
       ecalDigi.setSize(nEcalSamples);
 
       // last arg is 3-bit trigger tower flag, which we don't use
       // we only use 8-bit encoded et and 1-bit fg
-      ecalDigi.setSample(
-          0, EcalTriggerPrimitiveSample(encodedEtEcal, fineGrainEcal, 0));
+      ecalDigi.setSample(0, EcalTriggerPrimitiveSample(encodedEtEcal, fineGrainEcal, 0));
       // std::cout << ecalDigi << std::endl;
       ecalTPs->push_back(ecalDigi);
 
@@ -165,8 +160,7 @@ void RctInputTextToDigi::produce(edm::Event &iEvent,
       hcalDigi.setSize(nHcalSamples);
 
       // last two arg's are slb and slb channel, which we don't need
-      hcalDigi.setSample(
-          0, HcalTriggerPrimitiveSample(encodedEtHcal, fineGrainHcal, 0, 0));
+      hcalDigi.setSample(0, HcalTriggerPrimitiveSample(encodedEtHcal, fineGrainHcal, 0, 0));
       // std::cout << hcalDigi << std::endl;
       hcalTPs->push_back(hcalDigi);
     }

--- a/L1Trigger/TextToDigi/plugins/RctTextToRctDigi.cc
+++ b/L1Trigger/TextToDigi/plugins/RctTextToRctDigi.cc
@@ -32,8 +32,8 @@ Description: Makes RCT digis from the file format specified by Pam Klabbers
 //        any way. Set to true.
 //
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h" // Logger
-#include "FWCore/ServiceRegistry/interface/Service.h"     // Framework services
+#include "FWCore/MessageLogger/interface/MessageLogger.h"  // Logger
+#include "FWCore/ServiceRegistry/interface/Service.h"      // Framework services
 #include "RctTextToRctDigi.h"
 #include <iomanip>
 
@@ -54,16 +54,14 @@ RctTextToRctDigi::RctTextToRctDigi(const edm::ParameterSet &iConfig)
   // Open the input files
   for (unsigned i = 0; i < NUM_RCT_CRATES; i++) {
     std::stringstream fileStream;
-    fileStream << m_textFileName << std::setw(2) << std::setfill('0') << i
-               << ".txt";
+    fileStream << m_textFileName << std::setw(2) << std::setfill('0') << i << ".txt";
     std::string fileName(fileStream.str());
     m_file[i].open(fileName.c_str(), std::ios::in);
 
     if (!m_file[i].good()) {
       // throw cms::Exception("RctTextToRctDigiTextFileOpenError")
       LogDebug("RctTextToRctDigi") << "RctTextToRctDigi::RctTextToRctDigi : "
-                                   << " couldn't open the file " << fileName
-                                   << "...skipping!" << std::endl;
+                                   << " couldn't open the file " << fileName << "...skipping!" << std::endl;
     }
   }
 }
@@ -85,8 +83,7 @@ void RctTextToRctDigi::putEmptyDigi(edm::Event &iEvent) {
       em->push_back(L1CaloEmCand(0, i, false));
     }
     for (unsigned j = 0; j < 14; j++)
-      rgn->push_back(
-          L1CaloRegion(0, false, false, false, false, i, j / 2, j % 2));
+      rgn->push_back(L1CaloRegion(0, false, false, false, false, i, j / 2, j % 2));
     for (unsigned j = 0; j < 8; j++)
       rgn->push_back(L1CaloRegion(0, true, i, j));
   }
@@ -111,9 +108,7 @@ void RctTextToRctDigi::bxSynchro(int &bx, int crate) {
 }
 
 // ------------ method called to produce the data  ------------
-void RctTextToRctDigi::produce(edm::Event &iEvent,
-                               const edm::EventSetup &iSetup) {
-
+void RctTextToRctDigi::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // Skip event if required
   if (m_nevt < m_fileEventOffset) {
     // string tmp;
@@ -131,7 +126,6 @@ void RctTextToRctDigi::produce(edm::Event &iEvent,
 
   // Loop over RCT crates
   for (unsigned i = 0; i < NUM_RCT_CRATES; i++) {
-
     if (!m_file[i].good()) {
       continue;
     }
@@ -139,10 +133,9 @@ void RctTextToRctDigi::produce(edm::Event &iEvent,
     // Check we're not at the end of the file
     if (m_file[i].eof()) {
       // throw cms::Exception("RctTextToRctDigiTextFileReadError")
-      LogDebug("RctTextToRctDigi")
-          << "RctTextToRctDigi::produce : "
-          << " unexpected end of file " << m_textFileName << i
-          << " adding empty collection for event !" << std::endl;
+      LogDebug("RctTextToRctDigi") << "RctTextToRctDigi::produce : "
+                                   << " unexpected end of file " << m_textFileName << i
+                                   << " adding empty collection for event !" << std::endl;
       putEmptyDigi(iEvent);
       continue;
     }
@@ -168,8 +161,7 @@ void RctTextToRctDigi::produce(edm::Event &iEvent,
       throw cms::Exception("RctTextToRctDigiTextSyncError")
           << "RctTextToRctDigi::produce : "
           << " something screwy happened "
-          << "evt:" << m_nevt << " != bx:" << BXNum << " + "
-          << m_fileEventOffset << std::endl;
+          << "evt:" << m_nevt << " != bx:" << BXNum << " + " << m_fileEventOffset << std::endl;
 
     // Buffers
     unsigned long int uLongBuffer;
@@ -204,23 +196,20 @@ void RctTextToRctDigi::produce(edm::Event &iEvent,
     for (unsigned j = 0; j < 14; j++) {
       m_file[i] >> uLongBuffer;
 
-      unsigned et =
-          uLongBuffer & 0x3ff; // put the first 10 bits of rawData into the Et
-      uLongBuffer >>=
-          10; // shift the remaining bits down to remove the 10 bits of Et
+      unsigned et = uLongBuffer & 0x3ff;  // put the first 10 bits of rawData into the Et
+      uLongBuffer >>= 10;                 // shift the remaining bits down to remove the 10 bits of Et
 
-      bool overFlow = ((uLongBuffer & 0x1) != 0); // LSB is now overflow bit
-      bool tauVeto = (((uLongBuffer & 0x2) >> 1) != 0); // 2nd bit is tauveto
+      bool overFlow = ((uLongBuffer & 0x1) != 0);        // LSB is now overflow bit
+      bool tauVeto = (((uLongBuffer & 0x2) >> 1) != 0);  // 2nd bit is tauveto
 
-      rgn->push_back(L1CaloRegion(et, overFlow, tauVeto, mipBitBuffer[j],
-                                  qBitBuffer[j], i, j / 2, j % 2));
+      rgn->push_back(L1CaloRegion(et, overFlow, tauVeto, mipBitBuffer[j], qBitBuffer[j], i, j / 2, j % 2));
     }
 
     // HF
     for (unsigned j = 0; j < 8; j++) {
       m_file[i] >> uLongBuffer;
 
-      unsigned et = uLongBuffer & 0xff; // put the first 8 bits into the Et
+      unsigned et = uLongBuffer & 0xff;  // put the first 8 bits into the Et
 
       rgn->push_back(L1CaloRegion(et, true, i, j));
     }

--- a/L1Trigger/TextToDigi/plugins/SourceCardTextToRctDigi.cc
+++ b/L1Trigger/TextToDigi/plugins/SourceCardTextToRctDigi.cc
@@ -16,8 +16,8 @@ digis for pattern tests.
 //
 //
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h" // Logger
-#include "FWCore/ServiceRegistry/interface/Service.h"     // Framework services
+#include "FWCore/MessageLogger/interface/MessageLogger.h"  // Logger
+#include "FWCore/ServiceRegistry/interface/Service.h"      // Framework services
 #include "SourceCardTextToRctDigi.h"
 
 using namespace edm;
@@ -27,8 +27,7 @@ using namespace std;
 const static unsigned NUM_LINES_PER_EVENT = 63;
 const static int NUM_RCT_CRATES = 18;
 
-SourceCardTextToRctDigi::SourceCardTextToRctDigi(
-    const edm::ParameterSet &iConfig)
+SourceCardTextToRctDigi::SourceCardTextToRctDigi(const edm::ParameterSet &iConfig)
     : m_textFileName(iConfig.getParameter<std::string>("TextFileName")),
       m_fileEventOffset(iConfig.getParameter<int>("fileEventOffset")),
       m_nevt(0) {
@@ -42,8 +41,7 @@ SourceCardTextToRctDigi::SourceCardTextToRctDigi(
   if (!m_file.good()) {
     throw cms::Exception("SourceCardTextToRctDigiTextFileOpenError")
         << "SourceCardTextToRctDigi::SourceCardTextToRctDigi : "
-        << " couldn't open the file " << m_textFileName << " for reading"
-        << std::endl;
+        << " couldn't open the file " << m_textFileName << " for reading" << std::endl;
   }
 
   // Make a SC routing object
@@ -65,8 +63,7 @@ void SourceCardTextToRctDigi::putEmptyDigi(edm::Event &iEvent) {
       em->push_back(L1CaloEmCand(0, i, false));
     }
     for (int j = 0; j < 14; j++)
-      rgn->push_back(
-          L1CaloRegion(0, false, false, false, false, i, j / 2, j % 2));
+      rgn->push_back(L1CaloRegion(0, false, false, false, false, i, j / 2, j % 2));
     for (unsigned j = 0; j < 8; j++)
       rgn->push_back(L1CaloRegion(0, true, i, j));
   }
@@ -75,8 +72,7 @@ void SourceCardTextToRctDigi::putEmptyDigi(edm::Event &iEvent) {
 }
 
 // ------------ method called to produce the data  ------------
-void SourceCardTextToRctDigi::produce(edm::Event &iEvent,
-                                      const edm::EventSetup &iSetup) {
+void SourceCardTextToRctDigi::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // Skip event if required
   if (m_nevt < m_fileEventOffset) {
     //    std::string tmp;
@@ -137,7 +133,6 @@ void SourceCardTextToRctDigi::produce(edm::Event &iEvent,
   int thisEventNumber = -1;
   // Read in file one line at a time
   for (unsigned line = 0; line < NUM_LINES_PER_EVENT; line++) {
-
     if (!getline(m_file, dataString)) {
       throw cms::Exception("SourceCardTextToRctDigiTextFileReadError")
           << "SourceCardTextToRctDigi::SourceCardTextToRctDigi : "
@@ -156,78 +151,77 @@ void SourceCardTextToRctDigi::produce(edm::Event &iEvent,
     m_scRouting.LogicalCardIDtoRoutingMode(logicalCardID, routingMode, crate);
 
     if (routingMode == 0) {
-
       // Electrons
-      m_scRouting.VHDCItoEMU(eIsoRank[crate], eIsoCardId[crate],
-                             eIsoRegionId[crate], eNonIsoRank[crate],
-                             eNonIsoCardId[crate], eNonIsoRegionId[crate],
-                             MIPbits[crate], Qbits[crate], VHDCI);
+      m_scRouting.VHDCItoEMU(eIsoRank[crate],
+                             eIsoCardId[crate],
+                             eIsoRegionId[crate],
+                             eNonIsoRank[crate],
+                             eNonIsoCardId[crate],
+                             eNonIsoRegionId[crate],
+                             MIPbits[crate],
+                             Qbits[crate],
+                             VHDCI);
 
     } else if (routingMode == 1) {
-
       // Regions
-      m_scRouting.VHDCItoRC56HF(RC[crate], RCof[crate], RCtau[crate], HF[crate],
-                                HFQ[crate], VHDCI);
+      m_scRouting.VHDCItoRC56HF(RC[crate], RCof[crate], RCtau[crate], HF[crate], HFQ[crate], VHDCI);
 
     } else if (routingMode == 2) {
-
       // Regions
       m_scRouting.VHDCItoRC012(RC[crate], RCof[crate], RCtau[crate], VHDCI);
 
     } else if (routingMode == 3) {
-
       // Regions
-      m_scRouting.VHDCItoRC234(RC[crate], RCof[crate], RCtau[crate],
-                               RC[crate + 9], RCof[crate + 9], RCtau[crate + 9],
-                               VHDCI);
+      m_scRouting.VHDCItoRC234(
+          RC[crate], RCof[crate], RCtau[crate], RC[crate + 9], RCof[crate + 9], RCtau[crate + 9], VHDCI);
 
     } else {
       // Something went wrong
-      throw cms::Exception("SourceCardtextToRctDigiError")
-          << "SourceCardTextToRctDigi::produce : "
-          << " unknown routing mode=" << routingMode << std::endl;
+      throw cms::Exception("SourceCardtextToRctDigiError") << "SourceCardTextToRctDigi::produce : "
+                                                           << " unknown routing mode=" << routingMode << std::endl;
     }
   }
 
   // Make RCT digis
   for (crate = 0; crate < NUM_RCT_CRATES; crate++) {
-
     // Make EM collections
     for (int i = 0; i < 4; i++) {
-      em->push_back(L1CaloEmCand(eIsoRank[crate][i], eIsoRegionId[crate][i],
-                                 eIsoCardId[crate][i], crate, true, i, 0));
-      em->push_back(L1CaloEmCand(eNonIsoRank[crate][i],
-                                 eNonIsoRegionId[crate][i],
-                                 eNonIsoCardId[crate][i], crate, false, i, 0));
+      em->push_back(L1CaloEmCand(eIsoRank[crate][i], eIsoRegionId[crate][i], eIsoCardId[crate][i], crate, true, i, 0));
+      em->push_back(
+          L1CaloEmCand(eNonIsoRank[crate][i], eNonIsoRegionId[crate][i], eNonIsoCardId[crate][i], crate, false, i, 0));
     }
 
     // Make region collections
-    for (int i = 0; i < 7; i++) {   // Receiver card
-      for (int j = 0; j < 2; j++) { // Region
-        rgn->push_back(L1CaloRegion::makeHBHERegion(
-            RC[crate][i][j], RCof[crate][i][j], RCtau[crate][i][j],
-            MIPbits[crate][i][j], Qbits[crate][i][j], crate, i, j));
+    for (int i = 0; i < 7; i++) {    // Receiver card
+      for (int j = 0; j < 2; j++) {  // Region
+        rgn->push_back(L1CaloRegion::makeHBHERegion(RC[crate][i][j],
+                                                    RCof[crate][i][j],
+                                                    RCtau[crate][i][j],
+                                                    MIPbits[crate][i][j],
+                                                    Qbits[crate][i][j],
+                                                    crate,
+                                                    i,
+                                                    j));
       }
     }
 
     // Make HF region collections
-    for (int i = 0; i < 4; i++) {   // Eta bin
-      for (int j = 0; j < 2; j++) { // HF0, HF1
-        rgn->push_back(L1CaloRegion::makeHFRegion(
-            HF[crate][i][j], HFQ[crate][i][j], crate,
-            i + (4 * j))); // region=eta+4*phi for eta 0-3
+    for (int i = 0; i < 4; i++) {    // Eta bin
+      for (int j = 0; j < 2; j++) {  // HF0, HF1
+        rgn->push_back(L1CaloRegion::makeHFRegion(HF[crate][i][j],
+                                                  HFQ[crate][i][j],
+                                                  crate,
+                                                  i + (4 * j)));  // region=eta+4*phi for eta 0-3
       }
     }
   }
 
   // Debug info
-  for (L1CaloEmCollection::const_iterator iem = em->begin(); iem != em->end();
-       iem++) {
+  for (L1CaloEmCollection::const_iterator iem = em->begin(); iem != em->end(); iem++) {
     LogDebug("Electrons") << (*iem);
   }
 
-  for (L1CaloRegionCollection::const_iterator irgn = rgn->begin();
-       irgn != rgn->end(); irgn++) {
+  for (L1CaloRegionCollection::const_iterator irgn = rgn->begin(); irgn != rgn->end(); irgn++) {
     LogDebug("HFRegions") << (*irgn);
   }
 

--- a/L1Trigger/TextToDigi/plugins/TextToRaw.cc
+++ b/L1Trigger/TextToDigi/plugins/TextToRaw.cc
@@ -27,20 +27,16 @@ const unsigned TextToRaw::EVT_MAX_SIZE;
 
 TextToRaw::TextToRaw(const edm::ParameterSet &iConfig)
     : fedId_(iConfig.getUntrackedParameter<int>("fedId", 745)),
-      filename_(iConfig.getUntrackedParameter<std::string>("filename",
-                                                           "slinkOutput.txt")),
-      fileEventOffset_(
-          iConfig.getUntrackedParameter<int>("FileEventOffset", 0)),
+      filename_(iConfig.getUntrackedParameter<std::string>("filename", "slinkOutput.txt")),
+      fileEventOffset_(iConfig.getUntrackedParameter<int>("FileEventOffset", 0)),
       nevt_(0) {
-  edm::LogInfo("TextToDigi")
-      << "Reading ASCII dump from " << filename_ << std::endl;
+  edm::LogInfo("TextToDigi") << "Reading ASCII dump from " << filename_ << std::endl;
 
   // register the products
   produces<FEDRawDataCollection>();
 }
 
 TextToRaw::~TextToRaw() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -70,10 +66,9 @@ void TextToRaw::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
       while (getline(file_, line) && !line.empty()) {
         iline++;
         if (iline * 4 >= EVT_MAX_SIZE)
-          throw cms::Exception("TextToRawEventSizeOverflow")
-              << "TextToRaw::produce() : "
-              << " read too many lines (" << iline << ": " << line << ")"
-              << ", maximum event size is " << EVT_MAX_SIZE << std::endl;
+          throw cms::Exception("TextToRawEventSizeOverflow") << "TextToRaw::produce() : "
+                                                             << " read too many lines (" << iline << ": " << line << ")"
+                                                             << ", maximum event size is " << EVT_MAX_SIZE << std::endl;
       }
     }
   }
@@ -82,16 +77,14 @@ void TextToRaw::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
 
   // read file
   std::string line;
-  unsigned i = 0; // count 32-bit words
+  unsigned i = 0;  // count 32-bit words
 
   // while not encountering dumb errors
   while (getline(file_, line) && !line.empty()) {
-
     // bail if we reached the EVT_MAX_SIZE
     if (i * 4 >= EVT_MAX_SIZE) {
-      throw cms::Exception("TextToRaw")
-          << "Read too many lines from file. Maximum event size is "
-          << EVT_MAX_SIZE << " lines" << std::endl;
+      throw cms::Exception("TextToRaw") << "Read too many lines from file. Maximum event size is " << EVT_MAX_SIZE
+                                        << " lines" << std::endl;
     }
 
     // convert string to int
@@ -111,9 +104,8 @@ void TextToRaw::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
 
     // bail if we reached the EVT_MAX_SIZE
     if (i >= EVT_MAX_SIZE) {
-      throw cms::Exception("TextToRaw")
-          << "Read too many lines from file. Maximum event size is "
-          << EVT_MAX_SIZE << " lines" << std::endl;
+      throw cms::Exception("TextToRaw") << "Read too many lines from file. Maximum event size is " << EVT_MAX_SIZE
+                                        << " lines" << std::endl;
     }
   }
 
@@ -141,8 +133,7 @@ void TextToRaw::beginJob() {
   // open VME file
   file_.open(filename_.c_str(), std::ios::in);
   if (!file_.good()) {
-    edm::LogInfo("TextToDigi")
-        << "Failed to open ASCII file " << filename_ << std::endl;
+    edm::LogInfo("TextToDigi") << "Failed to open ASCII file " << filename_ << std::endl;
   }
 }
 

--- a/L1Trigger/TextToDigi/plugins/TextToRaw.h
+++ b/L1Trigger/TextToDigi/plugins/TextToRaw.h
@@ -43,7 +43,7 @@ public:
   explicit TextToRaw(const edm::ParameterSet &);
   ~TextToRaw() override;
 
-private: // methods
+private:  // methods
   void beginJob() override;
   void produce(edm::Event &, const edm::EventSetup &) override;
   void endJob() override;

--- a/L1Trigger/TextToDigi/src/SourceCardRouting.cc
+++ b/L1Trigger/TextToDigi/src/SourceCardRouting.cc
@@ -4,7 +4,7 @@
 */
 
 // Prototype class definition
-#include "SourceCardRouting.h" //hh"
+#include "SourceCardRouting.h"  //hh"
 
 // File streams
 #include <iomanip>
@@ -27,13 +27,15 @@ SourceCardRouting::~SourceCardRouting() {
 // electron arrays are eIsoRank[candidate number<4]
 // muon arrays are MIPbits[rec card number<7][region<2]
 
-void SourceCardRouting::EMUtoSFP(
-    unsigned short (&eIsoRank)[4], unsigned short (&eIsoCardId)[4],
-    unsigned short (&eIsoRegionId)[4], unsigned short (&eNonIsoRank)[4],
-    unsigned short (&eNonIsoCardId)[4], unsigned short (&eNonIsoRegionId)[4],
-    unsigned short (&MIPbits)[7][2], unsigned short (&Qbits)[7][2],
-    unsigned short (&SFP)[2][4]) const {
-
+void SourceCardRouting::EMUtoSFP(unsigned short (&eIsoRank)[4],
+                                 unsigned short (&eIsoCardId)[4],
+                                 unsigned short (&eIsoRegionId)[4],
+                                 unsigned short (&eNonIsoRank)[4],
+                                 unsigned short (&eNonIsoCardId)[4],
+                                 unsigned short (&eNonIsoRegionId)[4],
+                                 unsigned short (&MIPbits)[7][2],
+                                 unsigned short (&Qbits)[7][2],
+                                 unsigned short (&SFP)[2][4]) const {
   SFP[0][0] = 0;
   SFP[1][0] = 0x8000;
 
@@ -44,22 +46,18 @@ void SourceCardRouting::EMUtoSFP(
     }
   }
 
-  SFP[0][1] = (eIsoRank[0] & 0x3f) | ((eIsoRegionId[0] & 0x01) << 6) |
-              ((eIsoCardId[0] & 0x07) << 7) | ((eIsoRank[1] & 0x7) << 10);
-  SFP[1][1] = 0x8000 | (eIsoRank[2] & 0x3f) | ((eIsoRegionId[2] & 0x01) << 6) |
-              ((eIsoCardId[2] & 0x07) << 7) | ((eIsoRank[3] & 0x7) << 10);
-  SFP[0][2] = (eNonIsoRank[0] & 0x3f) | ((eNonIsoRegionId[0] & 0x01) << 6) |
-              ((eNonIsoCardId[0] & 0x07) << 7) | ((eIsoRank[1] & 0x38) << 7) |
-              ((eIsoRegionId[1] & 0x01) << 13);
-  SFP[1][2] = 0x8000 | (eNonIsoRank[2] & 0x3f) |
-              ((eNonIsoRegionId[2] & 0x01) << 6) |
-              ((eNonIsoCardId[2] & 0x07) << 7) | ((eIsoRank[3] & 0x38) << 7) |
-              ((eIsoRegionId[3] & 0x01) << 13);
-  SFP[0][3] = (eNonIsoRank[1] & 0x3f) | ((eNonIsoRegionId[1] & 0x01) << 6) |
-              ((eNonIsoCardId[1] & 0x07) << 7) | ((eIsoCardId[1] & 0x07) << 10);
-  SFP[1][3] = 0x8000 | (eNonIsoRank[3] & 0x3f) |
-              ((eNonIsoRegionId[3] & 0x01) << 6) |
-              ((eNonIsoCardId[3] & 0x07) << 7) | ((eIsoCardId[3] & 0x07) << 10);
+  SFP[0][1] = (eIsoRank[0] & 0x3f) | ((eIsoRegionId[0] & 0x01) << 6) | ((eIsoCardId[0] & 0x07) << 7) |
+              ((eIsoRank[1] & 0x7) << 10);
+  SFP[1][1] = 0x8000 | (eIsoRank[2] & 0x3f) | ((eIsoRegionId[2] & 0x01) << 6) | ((eIsoCardId[2] & 0x07) << 7) |
+              ((eIsoRank[3] & 0x7) << 10);
+  SFP[0][2] = (eNonIsoRank[0] & 0x3f) | ((eNonIsoRegionId[0] & 0x01) << 6) | ((eNonIsoCardId[0] & 0x07) << 7) |
+              ((eIsoRank[1] & 0x38) << 7) | ((eIsoRegionId[1] & 0x01) << 13);
+  SFP[1][2] = 0x8000 | (eNonIsoRank[2] & 0x3f) | ((eNonIsoRegionId[2] & 0x01) << 6) | ((eNonIsoCardId[2] & 0x07) << 7) |
+              ((eIsoRank[3] & 0x38) << 7) | ((eIsoRegionId[3] & 0x01) << 13);
+  SFP[0][3] = (eNonIsoRank[1] & 0x3f) | ((eNonIsoRegionId[1] & 0x01) << 6) | ((eNonIsoCardId[1] & 0x07) << 7) |
+              ((eIsoCardId[1] & 0x07) << 10);
+  SFP[1][3] = 0x8000 | (eNonIsoRank[3] & 0x3f) | ((eNonIsoRegionId[3] & 0x01) << 6) | ((eNonIsoCardId[3] & 0x07) << 7) |
+              ((eIsoCardId[3] & 0x07) << 10);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -67,13 +65,15 @@ void SourceCardRouting::EMUtoSFP(
 // electron arrays are eIsoRank[candidate number<4]
 // muon arrays are MIPbits[rec card number<7][region<2]
 
-void SourceCardRouting::SFPtoEMU(
-    unsigned short (&eIsoRank)[4], unsigned short (&eIsoCardId)[4],
-    unsigned short (&eIsoRegionId)[4], unsigned short (&eNonIsoRank)[4],
-    unsigned short (&eNonIsoCardId)[4], unsigned short (&eNonIsoRegionId)[4],
-    unsigned short (&MIPbits)[7][2], unsigned short (&Qbits)[7][2],
-    unsigned short (&SFP)[2][4]) const {
-
+void SourceCardRouting::SFPtoEMU(unsigned short (&eIsoRank)[4],
+                                 unsigned short (&eIsoCardId)[4],
+                                 unsigned short (&eIsoRegionId)[4],
+                                 unsigned short (&eNonIsoRank)[4],
+                                 unsigned short (&eNonIsoCardId)[4],
+                                 unsigned short (&eNonIsoRegionId)[4],
+                                 unsigned short (&MIPbits)[7][2],
+                                 unsigned short (&Qbits)[7][2],
+                                 unsigned short (&SFP)[2][4]) const {
   for (int i = 0; i < 7; i++) {
     for (int j = 0; j < 2; j++) {
       MIPbits[i][j] = (SFP[0][0] >> ((2 * i) + j)) & 0x1;
@@ -123,19 +123,14 @@ void SourceCardRouting::RC56HFtoSFP(unsigned short (&RC)[7][2],
                                     unsigned short (&HF)[4][2],
                                     unsigned short (&HFQ)[4][2],
                                     unsigned short (&SFP)[2][4]) const {
-
-  SFP[0][0] = (RC[5][0] & 0x3ff) | ((RCof[5][0] & 0x1) << 10) |
-              ((RCtau[5][0] & 0x1) << 11) | ((HFQ[0][0] & 0x1) << 12) |
-              ((HFQ[1][0] & 0x01) << 13) | ((HF[0][0] & 0x01) << 14);
-  SFP[1][0] = 0x8000 | (RC[5][1] & 0x3ff) | ((RCof[5][1] & 0x1) << 10) |
-              ((RCtau[5][1] & 0x1) << 11) | ((HFQ[2][0] & 0x1) << 12) |
-              ((HFQ[3][0] & 0x01) << 13) | ((HF[2][0] & 0x01) << 14);
-  SFP[0][1] = (RC[6][0] & 0x3ff) | ((RCof[6][0] & 0x1) << 10) |
-              ((RCtau[6][0] & 0x1) << 11) | ((HFQ[0][1] & 0x1) << 12) |
-              ((HFQ[1][1] & 0x01) << 13) | ((HF[0][1] & 0x01) << 14);
-  SFP[1][1] = 0x8000 | (RC[6][1] & 0x3ff) | ((RCof[6][1] & 0x1) << 10) |
-              ((RCtau[6][1] & 0x1) << 11) | ((HFQ[2][1] & 0x1) << 12) |
-              ((HFQ[3][1] & 0x01) << 13) | ((HF[2][1] & 0x01) << 14);
+  SFP[0][0] = (RC[5][0] & 0x3ff) | ((RCof[5][0] & 0x1) << 10) | ((RCtau[5][0] & 0x1) << 11) |
+              ((HFQ[0][0] & 0x1) << 12) | ((HFQ[1][0] & 0x01) << 13) | ((HF[0][0] & 0x01) << 14);
+  SFP[1][0] = 0x8000 | (RC[5][1] & 0x3ff) | ((RCof[5][1] & 0x1) << 10) | ((RCtau[5][1] & 0x1) << 11) |
+              ((HFQ[2][0] & 0x1) << 12) | ((HFQ[3][0] & 0x01) << 13) | ((HF[2][0] & 0x01) << 14);
+  SFP[0][1] = (RC[6][0] & 0x3ff) | ((RCof[6][0] & 0x1) << 10) | ((RCtau[6][0] & 0x1) << 11) |
+              ((HFQ[0][1] & 0x1) << 12) | ((HFQ[1][1] & 0x01) << 13) | ((HF[0][1] & 0x01) << 14);
+  SFP[1][1] = 0x8000 | (RC[6][1] & 0x3ff) | ((RCof[6][1] & 0x1) << 10) | ((RCtau[6][1] & 0x1) << 11) |
+              ((HFQ[2][1] & 0x1) << 12) | ((HFQ[3][1] & 0x01) << 13) | ((HF[2][1] & 0x01) << 14);
   SFP[0][2] = ((HF[0][0] >> 1) & 0x7f) | ((HF[1][0] & 0xff) << 7);
   SFP[1][2] = 0x8000 | ((HF[2][0] >> 1) & 0x7f) | ((HF[3][0] & 0xff) << 7);
   SFP[0][3] = ((HF[0][1] >> 1) & 0x7f) | ((HF[1][1] & 0xff) << 7);
@@ -153,7 +148,6 @@ void SourceCardRouting::SFPtoRC56HF(unsigned short (&RC)[7][2],
                                     unsigned short (&HF)[4][2],
                                     unsigned short (&HFQ)[4][2],
                                     unsigned short (&SFP)[2][4]) const {
-
   RC[5][0] = SFP[0][0] & 0x3ff;
   RC[5][1] = SFP[1][0] & 0x3ff;
   RC[6][0] = SFP[0][1] & 0x3ff;
@@ -198,26 +192,19 @@ void SourceCardRouting::RC012toSFP(unsigned short (&RC)[7][2],
                                    unsigned short (&RCof)[7][2],
                                    unsigned short (&RCtau)[7][2],
                                    unsigned short (&SFP)[2][4]) const {
+  SFP[0][0] = (RC[0][0] & 0x3ff) | ((RCof[0][0] & 0x1) << 10) | ((RCtau[0][0] & 0x1) << 11) | ((RC[2][0] & 0x7) << 12);
+  SFP[1][0] =
+      0x8000 | (RC[0][1] & 0x3ff) | ((RCof[0][1] & 0x1) << 10) | ((RCtau[0][1] & 0x1) << 11) | ((RC[2][1] & 0x7) << 12);
 
-  SFP[0][0] = (RC[0][0] & 0x3ff) | ((RCof[0][0] & 0x1) << 10) |
-              ((RCtau[0][0] & 0x1) << 11) | ((RC[2][0] & 0x7) << 12);
-  SFP[1][0] = 0x8000 | (RC[0][1] & 0x3ff) | ((RCof[0][1] & 0x1) << 10) |
-              ((RCtau[0][1] & 0x1) << 11) | ((RC[2][1] & 0x7) << 12);
+  SFP[0][1] = (RC[1][0] & 0x3ff) | ((RCof[1][0] & 0x1) << 10) | ((RCtau[1][0] & 0x1) << 11) | ((RC[2][0] & 0x38) << 9);
+  SFP[1][1] =
+      0x8000 | (RC[1][1] & 0x3ff) | ((RCof[1][1] & 0x1) << 10) | ((RCtau[1][1] & 0x1) << 11) | ((RC[2][1] & 0x38) << 9);
 
-  SFP[0][1] = (RC[1][0] & 0x3ff) | ((RCof[1][0] & 0x1) << 10) |
-              ((RCtau[1][0] & 0x1) << 11) | ((RC[2][0] & 0x38) << 9);
-  SFP[1][1] = 0x8000 | (RC[1][1] & 0x3ff) | ((RCof[1][1] & 0x1) << 10) |
-              ((RCtau[1][1] & 0x1) << 11) | ((RC[2][1] & 0x38) << 9);
+  SFP[0][2] = (RC[0][0] & 0x3ff) | ((RCof[0][0] & 0x1) << 10) | ((RCtau[0][0] & 0x1) << 11);
+  SFP[1][2] = 0x8000 | (RC[0][1] & 0x3ff) | ((RCof[0][1] & 0x1) << 10) | ((RCtau[0][1] & 0x1) << 11);
 
-  SFP[0][2] = (RC[0][0] & 0x3ff) | ((RCof[0][0] & 0x1) << 10) |
-              ((RCtau[0][0] & 0x1) << 11);
-  SFP[1][2] = 0x8000 | (RC[0][1] & 0x3ff) | ((RCof[0][1] & 0x1) << 10) |
-              ((RCtau[0][1] & 0x1) << 11);
-
-  SFP[0][3] = (RC[1][0] & 0x3ff) | ((RCof[1][0] & 0x1) << 10) |
-              ((RCtau[1][0] & 0x1) << 11);
-  SFP[1][3] = 0x8000 | (RC[1][1] & 0x3ff) | ((RCof[1][1] & 0x1) << 10) |
-              ((RCtau[1][1] & 0x1) << 11);
+  SFP[0][3] = (RC[1][0] & 0x3ff) | ((RCof[1][0] & 0x1) << 10) | ((RCtau[1][0] & 0x1) << 11);
+  SFP[1][3] = 0x8000 | (RC[1][1] & 0x3ff) | ((RCof[1][1] & 0x1) << 10) | ((RCtau[1][1] & 0x1) << 11);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -228,15 +215,12 @@ void SourceCardRouting::SFPtoRC012(unsigned short (&RC)[7][2],
                                    unsigned short (&RCof)[7][2],
                                    unsigned short (&RCtau)[7][2],
                                    unsigned short (&SFP)[2][4]) const {
-
   RC[0][0] = SFP[0][0] & 0x3ff;
   RC[0][1] = SFP[1][0] & 0x3ff;
   RC[1][0] = SFP[0][1] & 0x3ff;
   RC[1][1] = SFP[1][1] & 0x3ff;
-  RC[2][0] = (RC[2][0] & 0x3c0) | ((SFP[0][0] & 0x7000) >> 12) |
-             ((SFP[0][1] & 0x7000) >> 9);
-  RC[2][1] = (RC[2][1] & 0x3c0) | ((SFP[1][0] & 0x7000) >> 12) |
-             ((SFP[1][1] & 0x7000) >> 9);
+  RC[2][0] = (RC[2][0] & 0x3c0) | ((SFP[0][0] & 0x7000) >> 12) | ((SFP[0][1] & 0x7000) >> 9);
+  RC[2][1] = (RC[2][1] & 0x3c0) | ((SFP[1][0] & 0x7000) >> 12) | ((SFP[1][1] & 0x7000) >> 9);
 
   RCof[0][0] = (SFP[0][0] >> 10) & 0x1;
   RCof[0][1] = (SFP[1][0] >> 10) & 0x1;
@@ -260,34 +244,24 @@ void SourceCardRouting::RC234toSFP(unsigned short (&RC)[7][2],
                                    unsigned short (&sisterRCof)[7][2],
                                    unsigned short (&sisterRCtau)[7][2],
                                    unsigned short (&SFP)[2][4]) const {
+  SFP[0][0] = (RC[3][0] & 0x3ff) | ((RCof[3][0] & 0x1) << 10) | ((RCtau[3][0] & 0x1) << 11) | ((RC[2][0] & 0x1c0) << 6);
+  SFP[1][0] = 0x8000 | (RC[3][1] & 0x3ff) | ((RCof[3][1] & 0x1) << 10) | ((RCtau[3][1] & 0x1) << 11) |
+              ((RC[2][1] & 0x1c0) << 6);
 
-  SFP[0][0] = (RC[3][0] & 0x3ff) | ((RCof[3][0] & 0x1) << 10) |
-              ((RCtau[3][0] & 0x1) << 11) | ((RC[2][0] & 0x1c0) << 6);
-  SFP[1][0] = 0x8000 | (RC[3][1] & 0x3ff) | ((RCof[3][1] & 0x1) << 10) |
-              ((RCtau[3][1] & 0x1) << 11) | ((RC[2][1] & 0x1c0) << 6);
+  SFP[0][1] = (RC[4][0] & 0x3ff) | ((RCof[4][0] & 0x1) << 10) | ((RCtau[4][0] & 0x1) << 11) |
+              ((RC[2][0] & 0x200) << 3) | ((RCof[2][0] & 0x1) << 13) | ((RCtau[2][0] & 0x1) << 14);
+  SFP[1][1] = 0x8000 | (RC[4][1] & 0x3ff) | ((RCof[4][1] & 0x1) << 10) | ((RCtau[4][1] & 0x1) << 11) |
+              ((RC[2][1] & 0x200) << 3) | ((RCof[2][1] & 0x1) << 13) | ((RCtau[2][1] & 0x1) << 14);
 
-  SFP[0][1] = (RC[4][0] & 0x3ff) | ((RCof[4][0] & 0x1) << 10) |
-              ((RCtau[4][0] & 0x1) << 11) | ((RC[2][0] & 0x200) << 3) |
-              ((RCof[2][0] & 0x1) << 13) | ((RCtau[2][0] & 0x1) << 14);
-  SFP[1][1] = 0x8000 | (RC[4][1] & 0x3ff) | ((RCof[4][1] & 0x1) << 10) |
-              ((RCtau[4][1] & 0x1) << 11) | ((RC[2][1] & 0x200) << 3) |
-              ((RCof[2][1] & 0x1) << 13) | ((RCtau[2][1] & 0x1) << 14);
-
-  SFP[0][2] = (sisterRC[3][0] & 0x3ff) | ((sisterRCof[3][0] & 0x1) << 10) |
-              ((sisterRCtau[3][0] & 0x1) << 11) |
+  SFP[0][2] = (sisterRC[3][0] & 0x3ff) | ((sisterRCof[3][0] & 0x1) << 10) | ((sisterRCtau[3][0] & 0x1) << 11) |
               ((sisterRC[2][0] & 0x1c0) << 6);
-  SFP[1][2] =
-      0x8000 | (sisterRC[3][1] & 0x3ff) | ((sisterRCof[3][1] & 0x1) << 10) |
-      ((sisterRCtau[3][1] & 0x1) << 11) | ((sisterRC[2][1] & 0x1c0) << 6);
+  SFP[1][2] = 0x8000 | (sisterRC[3][1] & 0x3ff) | ((sisterRCof[3][1] & 0x1) << 10) | ((sisterRCtau[3][1] & 0x1) << 11) |
+              ((sisterRC[2][1] & 0x1c0) << 6);
 
-  SFP[0][3] =
-      (sisterRC[4][0] & 0x3ff) | ((sisterRCof[4][0] & 0x1) << 10) |
-      ((sisterRCtau[4][0] & 0x1) << 11) | ((sisterRC[2][0] & 0x200) << 3) |
-      ((sisterRCof[2][0] & 0x1) << 13) | ((sisterRCtau[2][0] & 0x1) << 14);
-  SFP[1][3] =
-      0x8000 | (sisterRC[4][1] & 0x3ff) | ((sisterRCof[4][1] & 0x1) << 10) |
-      ((sisterRCtau[4][1] & 0x1) << 11) | ((sisterRC[2][1] & 0x200) << 3) |
-      ((sisterRCof[2][1] & 0x1) << 13) | ((sisterRCtau[2][1] & 0x1) << 14);
+  SFP[0][3] = (sisterRC[4][0] & 0x3ff) | ((sisterRCof[4][0] & 0x1) << 10) | ((sisterRCtau[4][0] & 0x1) << 11) |
+              ((sisterRC[2][0] & 0x200) << 3) | ((sisterRCof[2][0] & 0x1) << 13) | ((sisterRCtau[2][0] & 0x1) << 14);
+  SFP[1][3] = 0x8000 | (sisterRC[4][1] & 0x3ff) | ((sisterRCof[4][1] & 0x1) << 10) | ((sisterRCtau[4][1] & 0x1) << 11) |
+              ((sisterRC[2][1] & 0x200) << 3) | ((sisterRCof[2][1] & 0x1) << 13) | ((sisterRCtau[2][1] & 0x1) << 14);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -301,13 +275,10 @@ void SourceCardRouting::SFPtoRC234(unsigned short (&RC)[7][2],
                                    unsigned short (&sisterRCof)[7][2],
                                    unsigned short (&sisterRCtau)[7][2],
                                    unsigned short (&SFP)[2][4]) const {
-
-  RC[2][0] = (RC[2][0] & 0x3f) | ((SFP[0][0] & 0x7000) >> 6) |
-             ((SFP[0][1] & 0x1000) >> 3);
+  RC[2][0] = (RC[2][0] & 0x3f) | ((SFP[0][0] & 0x7000) >> 6) | ((SFP[0][1] & 0x1000) >> 3);
   RC[3][0] = SFP[0][0] & 0x3ff;
   RC[4][0] = SFP[0][1] & 0x3ff;
-  RC[2][1] = (RC[2][1] & 0x3f) | ((SFP[1][0] & 0x7000) >> 6) |
-             ((SFP[1][1] & 0x1000) >> 3);
+  RC[2][1] = (RC[2][1] & 0x3f) | ((SFP[1][0] & 0x7000) >> 6) | ((SFP[1][1] & 0x1000) >> 3);
   RC[3][1] = SFP[1][0] & 0x3ff;
   RC[4][1] = SFP[1][1] & 0x3ff;
 
@@ -325,12 +296,10 @@ void SourceCardRouting::SFPtoRC234(unsigned short (&RC)[7][2],
   RCtau[3][1] = (SFP[1][0] >> 11) & 0x1;
   RCtau[4][1] = (SFP[1][1] >> 11) & 0x1;
 
-  sisterRC[2][0] = (sisterRC[2][0] & ~0x3C0) | ((SFP[0][2] & 0x7000) >> 6) |
-                   ((SFP[0][3] & 0x1000) >> 3);
+  sisterRC[2][0] = (sisterRC[2][0] & ~0x3C0) | ((SFP[0][2] & 0x7000) >> 6) | ((SFP[0][3] & 0x1000) >> 3);
   sisterRC[3][0] = SFP[0][2] & 0x3ff;
   sisterRC[4][0] = SFP[0][3] & 0x3ff;
-  sisterRC[2][1] = (sisterRC[2][1] & ~0x3C0) | ((SFP[1][2] & 0x7000) >> 6) |
-                   ((SFP[1][3] & 0x1000) >> 3);
+  sisterRC[2][1] = (sisterRC[2][1] & ~0x3C0) | ((SFP[1][2] & 0x7000) >> 6) | ((SFP[1][3] & 0x1000) >> 3);
   sisterRC[3][1] = SFP[1][2] & 0x3ff;
   sisterRC[4][1] = SFP[1][3] & 0x3ff;
 
@@ -354,207 +323,158 @@ void SourceCardRouting::SFPtoRC234(unsigned short (&RC)[7][2],
 // VHDCI arrays are VHDCI[VHDCI<2][cycle<2]
 // SFP arrays are SFP[cycle<2][sfp number<4]
 
-void SourceCardRouting::SFPtoVHDCI(int RoutingMode, unsigned short (&SFP)[2][4],
-                                   unsigned long (&VHDCI)[2][2]) const {
-
+void SourceCardRouting::SFPtoVHDCI(int RoutingMode, unsigned short (&SFP)[2][4], unsigned long (&VHDCI)[2][2]) const {
   unsigned short sfp_reverse[2][4] = {{0}};
 
   for (int i = 0; i < 2; i++) {
     for (int j = 0; j < 4; j++) {
       for (int k = 0; k < 16; k++) {
-        sfp_reverse[i][j] =
-            sfp_reverse[i][j] | (((SFP[i][j] >> k) & 0x01) << (15 - k));
+        sfp_reverse[i][j] = sfp_reverse[i][j] | (((SFP[i][j] >> k) & 0x01) << (15 - k));
       }
       // std::cout <<hex<< SFP[i][j]<<'\t'<<sfp_reverse[i][j]<<std::endl;
     }
   }
 
   switch (RoutingMode) {
-  case 0:
-    VHDCI[0][0] = (SFP[0][1] & 0x3ff) | ((SFP[0][1] & 0x1c00) << 1) |
-                  ((SFP[0][2] & 0x3c00) << 4) | ((SFP[0][3] & 0x1c00) << 8) |
-                  ((SFP[0][0] & 0xff) << 22);
-    VHDCI[0][1] = (SFP[1][1] & 0x3ff) | ((SFP[1][1] & 0x1c00) << 1) |
-                  ((SFP[1][2] & 0x3c00) << 4) | ((SFP[1][3] & 0x1c00) << 8) |
-                  ((SFP[1][0] & 0xff) << 22);
-    VHDCI[1][0] = (SFP[0][2] & 0x3ff) | ((SFP[0][3] & 0x3ff) << 11) |
-                  ((SFP[0][0] & 0x3f00) << 14);
-    VHDCI[1][1] = (SFP[1][2] & 0x3ff) | ((SFP[1][3] & 0x3ff) << 11) |
-                  ((SFP[1][0] & 0x3f00) << 14);
-    break;
-  case 1:
-    VHDCI[0][0] = (SFP[0][0] & 0xfff) | ((SFP[0][1] & 0x7) << 12) |
-                  ((SFP[0][2] & 0x80) << 10) | ((SFP[0][0] & 0x4000) << 4) |
-                  ((sfp_reverse[0][1] & 0xc) << 17) |
-                  ((sfp_reverse[0][0] & 0xc) << 19) |
-                  ((sfp_reverse[0][1] & 0x1ff0) << 19);
-    VHDCI[0][1] = (SFP[1][0] & 0xfff) | ((SFP[1][1] & 0x7) << 12) |
-                  ((SFP[1][2] & 0x80) << 10) | ((SFP[1][0] & 0x4000) << 4) |
-                  ((sfp_reverse[1][1] & 0xc) << 17) |
-                  ((sfp_reverse[1][0] & 0xc) << 19) |
-                  ((sfp_reverse[1][1] & 0x1ff0) << 19);
+    case 0:
+      VHDCI[0][0] = (SFP[0][1] & 0x3ff) | ((SFP[0][1] & 0x1c00) << 1) | ((SFP[0][2] & 0x3c00) << 4) |
+                    ((SFP[0][3] & 0x1c00) << 8) | ((SFP[0][0] & 0xff) << 22);
+      VHDCI[0][1] = (SFP[1][1] & 0x3ff) | ((SFP[1][1] & 0x1c00) << 1) | ((SFP[1][2] & 0x3c00) << 4) |
+                    ((SFP[1][3] & 0x1c00) << 8) | ((SFP[1][0] & 0xff) << 22);
+      VHDCI[1][0] = (SFP[0][2] & 0x3ff) | ((SFP[0][3] & 0x3ff) << 11) | ((SFP[0][0] & 0x3f00) << 14);
+      VHDCI[1][1] = (SFP[1][2] & 0x3ff) | ((SFP[1][3] & 0x3ff) << 11) | ((SFP[1][0] & 0x3f00) << 14);
+      break;
+    case 1:
+      VHDCI[0][0] = (SFP[0][0] & 0xfff) | ((SFP[0][1] & 0x7) << 12) | ((SFP[0][2] & 0x80) << 10) |
+                    ((SFP[0][0] & 0x4000) << 4) | ((sfp_reverse[0][1] & 0xc) << 17) |
+                    ((sfp_reverse[0][0] & 0xc) << 19) | ((sfp_reverse[0][1] & 0x1ff0) << 19);
+      VHDCI[0][1] = (SFP[1][0] & 0xfff) | ((SFP[1][1] & 0x7) << 12) | ((SFP[1][2] & 0x80) << 10) |
+                    ((SFP[1][0] & 0x4000) << 4) | ((sfp_reverse[1][1] & 0xc) << 17) |
+                    ((sfp_reverse[1][0] & 0xc) << 19) | ((sfp_reverse[1][1] & 0x1ff0) << 19);
 
-    VHDCI[1][0] = (SFP[0][1] & 0x4000) | ((SFP[0][3] & 0x80) << 24);
-    VHDCI[1][1] = (SFP[1][1] & 0x4000) | ((SFP[1][3] & 0x80) << 24);
+      VHDCI[1][0] = (SFP[0][1] & 0x4000) | ((SFP[0][3] & 0x80) << 24);
+      VHDCI[1][1] = (SFP[1][1] & 0x4000) | ((SFP[1][3] & 0x80) << 24);
 
-    for (int i = 0; i < 7; i++) {
-      VHDCI[1][0] = VHDCI[1][0] | (((SFP[0][2] >> i) & 0x1) << (2 * i)) |
-                    (((SFP[0][2] >> (i + 8)) & 0x1) << ((2 * i) + 1)) |
-                    (((sfp_reverse[0][3] >> (i + 1)) & 0x1) << ((2 * i) + 17)) |
-                    (((sfp_reverse[0][3] >> (i + 9)) & 0x1) << ((2 * i) + 18));
-      VHDCI[1][1] = VHDCI[1][1] | (((SFP[1][2] >> i) & 0x1) << (2 * i)) |
-                    (((SFP[1][2] >> (i + 8)) & 0x1) << ((2 * i) + 1)) |
-                    (((sfp_reverse[1][3] >> (i + 1)) & 0x1) << ((2 * i) + 17)) |
-                    (((sfp_reverse[1][3] >> (i + 9)) & 0x1) << ((2 * i) + 18));
-    }
-    break;
-  case 2:
-    VHDCI[0][0] = (SFP[0][0] & 0xfff) | ((SFP[0][1] & 0x7) << 12) |
-                  ((sfp_reverse[0][1] & 0xe) << 16) |
-                  ((sfp_reverse[0][0] & 0xe) << 19) |
-                  ((sfp_reverse[0][1] & 0x1ff0) << 19);
-    VHDCI[0][1] = (SFP[1][0] & 0xfff) | ((SFP[1][1] & 0x7) << 12) |
-                  ((sfp_reverse[1][1] & 0xe) << 16) |
-                  ((sfp_reverse[1][0] & 0xe) << 19) |
-                  ((sfp_reverse[1][1] & 0x1ff0) << 19);
-    VHDCI[1][0] = 0;
-    VHDCI[1][1] = 0;
-    break;
-  case 3:
-    VHDCI[0][0] = ((SFP[0][0] >> 12) & 0x7) | ((SFP[0][1] >> 9) & 0x38) |
-                  ((SFP[0][0] & 0x1ff) << 6) |
-                  ((sfp_reverse[0][1] & 0xfff0) << 13) |
-                  ((sfp_reverse[0][0] & 0x70) << 25);
-    VHDCI[0][1] = ((SFP[1][0] >> 12) & 0x7) | ((SFP[1][1] >> 9) & 0x38) |
-                  ((SFP[1][0] & 0x1ff) << 6) |
-                  ((sfp_reverse[1][1] & 0xfff0) << 13) |
-                  ((sfp_reverse[1][0] & 0x70) << 25);
+      for (int i = 0; i < 7; i++) {
+        VHDCI[1][0] = VHDCI[1][0] | (((SFP[0][2] >> i) & 0x1) << (2 * i)) |
+                      (((SFP[0][2] >> (i + 8)) & 0x1) << ((2 * i) + 1)) |
+                      (((sfp_reverse[0][3] >> (i + 1)) & 0x1) << ((2 * i) + 17)) |
+                      (((sfp_reverse[0][3] >> (i + 9)) & 0x1) << ((2 * i) + 18));
+        VHDCI[1][1] = VHDCI[1][1] | (((SFP[1][2] >> i) & 0x1) << (2 * i)) |
+                      (((SFP[1][2] >> (i + 8)) & 0x1) << ((2 * i) + 1)) |
+                      (((sfp_reverse[1][3] >> (i + 1)) & 0x1) << ((2 * i) + 17)) |
+                      (((sfp_reverse[1][3] >> (i + 9)) & 0x1) << ((2 * i) + 18));
+      }
+      break;
+    case 2:
+      VHDCI[0][0] = (SFP[0][0] & 0xfff) | ((SFP[0][1] & 0x7) << 12) | ((sfp_reverse[0][1] & 0xe) << 16) |
+                    ((sfp_reverse[0][0] & 0xe) << 19) | ((sfp_reverse[0][1] & 0x1ff0) << 19);
+      VHDCI[0][1] = (SFP[1][0] & 0xfff) | ((SFP[1][1] & 0x7) << 12) | ((sfp_reverse[1][1] & 0xe) << 16) |
+                    ((sfp_reverse[1][0] & 0xe) << 19) | ((sfp_reverse[1][1] & 0x1ff0) << 19);
+      VHDCI[1][0] = 0;
+      VHDCI[1][1] = 0;
+      break;
+    case 3:
+      VHDCI[0][0] = ((SFP[0][0] >> 12) & 0x7) | ((SFP[0][1] >> 9) & 0x38) | ((SFP[0][0] & 0x1ff) << 6) |
+                    ((sfp_reverse[0][1] & 0xfff0) << 13) | ((sfp_reverse[0][0] & 0x70) << 25);
+      VHDCI[0][1] = ((SFP[1][0] >> 12) & 0x7) | ((SFP[1][1] >> 9) & 0x38) | ((SFP[1][0] & 0x1ff) << 6) |
+                    ((sfp_reverse[1][1] & 0xfff0) << 13) | ((sfp_reverse[1][0] & 0x70) << 25);
 
-    VHDCI[1][0] = ((SFP[0][2] >> 12) & 0x7) | ((SFP[0][3] >> 9) & 0x38) |
-                  ((SFP[0][2] & 0x1ff) << 6) |
-                  ((sfp_reverse[0][3] & 0xfff0) << 13) |
-                  ((sfp_reverse[0][2] & 0x70) << 25);
-    VHDCI[1][1] = ((SFP[1][2] >> 12) & 0x7) | ((SFP[1][3] >> 9) & 0x38) |
-                  ((SFP[1][2] & 0x1ff) << 6) |
-                  ((sfp_reverse[1][3] & 0xfff0) << 13) |
-                  ((sfp_reverse[1][2] & 0x70) << 25);
-    break;
-  default:
-    VHDCI[0][0] = 0;
-    VHDCI[0][1] = 0;
-    VHDCI[1][0] = 0;
-    VHDCI[1][1] = 0;
+      VHDCI[1][0] = ((SFP[0][2] >> 12) & 0x7) | ((SFP[0][3] >> 9) & 0x38) | ((SFP[0][2] & 0x1ff) << 6) |
+                    ((sfp_reverse[0][3] & 0xfff0) << 13) | ((sfp_reverse[0][2] & 0x70) << 25);
+      VHDCI[1][1] = ((SFP[1][2] >> 12) & 0x7) | ((SFP[1][3] >> 9) & 0x38) | ((SFP[1][2] & 0x1ff) << 6) |
+                    ((sfp_reverse[1][3] & 0xfff0) << 13) | ((sfp_reverse[1][2] & 0x70) << 25);
+      break;
+    default:
+      VHDCI[0][0] = 0;
+      VHDCI[0][1] = 0;
+      VHDCI[1][0] = 0;
+      VHDCI[1][1] = 0;
   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // VHDCI arrays are VHDCI[VHDCI<2][cycle<2]
 // SFP arrays are SFP[cycle<2][sfp number<4]
-void SourceCardRouting::VHDCItoSFP(int RoutingMode, unsigned short (&SFP)[2][4],
-                                   unsigned long (&VHDCI)[2][2]) const {
-
+void SourceCardRouting::VHDCItoSFP(int RoutingMode, unsigned short (&SFP)[2][4], unsigned long (&VHDCI)[2][2]) const {
   unsigned short VHDCI_reverse[2][4] = {{0}};
 
   for (int i = 0; i < 2; i++) {
     for (int j = 0; j < 2; j++) {
       for (int k = 0; k < 32; k++) {
-        VHDCI_reverse[i][j] =
-            VHDCI_reverse[i][j] | (((VHDCI[i][j] >> k) & 0x01) << (31 - k));
+        VHDCI_reverse[i][j] = VHDCI_reverse[i][j] | (((VHDCI[i][j] >> k) & 0x01) << (31 - k));
       }
     }
   }
 
   switch (RoutingMode) {
-  case 0:
-    SFP[0][0] = ((VHDCI[0][0] >> 22) & 0xff) | ((VHDCI[1][0] >> 14) & 0x3f00);
-    SFP[1][0] =
-        0x8000 | ((VHDCI[0][1] >> 22) & 0xff) | ((VHDCI[1][1] >> 14) & 0x3f00);
-    SFP[0][1] = (VHDCI[0][0] & 0x3ff) | ((VHDCI[0][0] >> 1) & 0x1c00);
-    SFP[1][1] = 0x8000 | (VHDCI[0][1] & 0x3ff) | ((VHDCI[0][1] >> 1) & 0x1c00);
-    SFP[0][2] = (VHDCI[1][0] & 0x3ff) | ((VHDCI[0][0] >> 4) & 0x3c00);
-    SFP[1][2] = 0x8000 | (VHDCI[1][1] & 0x3ff) | ((VHDCI[0][1] >> 4) & 0x3c00);
-    SFP[0][3] = ((VHDCI[1][0] >> 11) & 0x3ff) | ((VHDCI[0][0] >> 8) & 0x1c00);
-    SFP[1][3] =
-        0x8000 | ((VHDCI[1][1] >> 11) & 0x3ff) | ((VHDCI[0][1] >> 8) & 0x1c00);
-    break;
-  case 1:
-    SFP[0][0] = (VHDCI[0][0] & 0xfff) | ((VHDCI_reverse[0][0] & 0x600) << 3) |
-                ((VHDCI_reverse[0][0] & 0x2000) << 1);
-    SFP[1][0] = 0x8000 | (VHDCI[0][1] & 0xfff) |
-                ((VHDCI_reverse[0][1] & 0x600) << 3) |
-                ((VHDCI_reverse[0][1] & 0x2000) << 1);
-    SFP[0][1] = ((VHDCI[0][0] & 0x7000) >> 12) |
-                ((VHDCI_reverse[0][0] & 0x1ff) << 3) |
-                ((VHDCI_reverse[0][0] & 0x1800) << 1) | (VHDCI[1][0] & 0x4000);
-    SFP[1][1] = 0x8000 | ((VHDCI[0][1] & 0x7000) >> 12) |
-                ((VHDCI_reverse[0][1] & 0x1ff) << 3) |
-                ((VHDCI_reverse[0][1] & 0x1800) << 1) | (VHDCI[1][1] & 0x4000);
+    case 0:
+      SFP[0][0] = ((VHDCI[0][0] >> 22) & 0xff) | ((VHDCI[1][0] >> 14) & 0x3f00);
+      SFP[1][0] = 0x8000 | ((VHDCI[0][1] >> 22) & 0xff) | ((VHDCI[1][1] >> 14) & 0x3f00);
+      SFP[0][1] = (VHDCI[0][0] & 0x3ff) | ((VHDCI[0][0] >> 1) & 0x1c00);
+      SFP[1][1] = 0x8000 | (VHDCI[0][1] & 0x3ff) | ((VHDCI[0][1] >> 1) & 0x1c00);
+      SFP[0][2] = (VHDCI[1][0] & 0x3ff) | ((VHDCI[0][0] >> 4) & 0x3c00);
+      SFP[1][2] = 0x8000 | (VHDCI[1][1] & 0x3ff) | ((VHDCI[0][1] >> 4) & 0x3c00);
+      SFP[0][3] = ((VHDCI[1][0] >> 11) & 0x3ff) | ((VHDCI[0][0] >> 8) & 0x1c00);
+      SFP[1][3] = 0x8000 | ((VHDCI[1][1] >> 11) & 0x3ff) | ((VHDCI[0][1] >> 8) & 0x1c00);
+      break;
+    case 1:
+      SFP[0][0] = (VHDCI[0][0] & 0xfff) | ((VHDCI_reverse[0][0] & 0x600) << 3) | ((VHDCI_reverse[0][0] & 0x2000) << 1);
+      SFP[1][0] =
+          0x8000 | (VHDCI[0][1] & 0xfff) | ((VHDCI_reverse[0][1] & 0x600) << 3) | ((VHDCI_reverse[0][1] & 0x2000) << 1);
+      SFP[0][1] = ((VHDCI[0][0] & 0x7000) >> 12) | ((VHDCI_reverse[0][0] & 0x1ff) << 3) |
+                  ((VHDCI_reverse[0][0] & 0x1800) << 1) | (VHDCI[1][0] & 0x4000);
+      SFP[1][1] = 0x8000 | ((VHDCI[0][1] & 0x7000) >> 12) | ((VHDCI_reverse[0][1] & 0x1ff) << 3) |
+                  ((VHDCI_reverse[0][1] & 0x1800) << 1) | (VHDCI[1][1] & 0x4000);
 
-    SFP[0][2] = ((VHDCI[0][0] & 0x20000) >> 10);
-    SFP[1][2] = 0x8000 | ((VHDCI[0][1] & 0x20000) >> 10);
-    SFP[0][3] = ((VHDCI[1][0] & 0x20000) >> 3);
-    SFP[1][3] = 0x8000 | ((VHDCI[1][1] & 0x20000) >> 3);
-    for (int i = 0; i < 7; i++) {
-      SFP[0][2] = SFP[0][2] | (((VHDCI[1][0] >> (2 * i)) & 0x1) << i) |
-                  (((VHDCI[1][0] >> ((2 * i) + 1)) & 0x1) << (i + 8));
-      SFP[1][2] = SFP[1][2] | (((VHDCI[1][1] >> (2 * i)) & 0x1) << i) |
-                  (((VHDCI[1][1] >> ((2 * i) + 1)) & 0x1) << (i + 8));
-      SFP[0][3] = SFP[0][3] |
-                  (((VHDCI_reverse[1][0] >> ((2 * i) + 1)) & 0x1) << i) |
-                  (((VHDCI_reverse[1][0] >> (2 * i)) & 0x1) << (i + 7));
-      SFP[1][3] = SFP[1][3] |
-                  (((VHDCI_reverse[1][1] >> ((2 * i) + 1)) & 0x1) << i) |
-                  (((VHDCI_reverse[1][1] >> (2 * i)) & 0x1) << (i + 7));
-    }
-    break;
-  case 2:
-    SFP[0][0] = (VHDCI[0][0] & 0xfff) | ((VHDCI_reverse[0][0] & 0xe00) << 3);
-    SFP[1][0] =
-        0x8000 | (VHDCI[0][1] & 0xfff) | ((VHDCI_reverse[0][1] & 0xe00) << 3);
-    SFP[0][1] = ((VHDCI[0][0] & 0x7000) >> 12) |
-                ((VHDCI_reverse[0][0] & 0x1ff) << 3) |
-                (VHDCI_reverse[0][0] & 0x7000);
-    SFP[1][1] = 0x8000 | ((VHDCI[0][1] & 0x7000) >> 12) |
-                ((VHDCI_reverse[0][1] & 0x1ff) << 3) |
-                (VHDCI_reverse[0][1] & 0x7000);
-    SFP[0][2] = (VHDCI[0][0] & 0xfff);
-    SFP[1][2] = 0x8000 | (VHDCI[0][1] & 0xfff);
-    SFP[0][3] =
-        ((VHDCI[0][0] & 0x7000) >> 12) | ((VHDCI_reverse[0][0] & 0x1ff) << 3);
-    SFP[1][3] = 0x8000 | ((VHDCI[0][1] & 0x7000) >> 12) |
-                ((VHDCI_reverse[0][1] & 0x1ff) << 3);
-    break;
-  case 3:
-    SFP[0][0] = ((VHDCI[0][0] & 0x7fc0) >> 6) |
-                ((VHDCI_reverse[0][0] & 0x7) << 9) |
-                ((VHDCI[0][0] & 0x7) << 12);
-    SFP[1][0] = 0x8000 | ((VHDCI[0][1] & 0x7fc0) >> 6) |
-                ((VHDCI_reverse[0][1] & 0x7) << 9) |
-                ((VHDCI[0][1] & 0x7) << 12);
-    SFP[0][1] =
-        ((VHDCI_reverse[0][0] & 0x7ff8) >> 3) | ((VHDCI[0][0] & 0x38) << 9);
-    SFP[1][1] = 0x8000 | ((VHDCI_reverse[0][1] & 0x7ff8) >> 3) |
-                ((VHDCI[0][1] & 0x38) << 9);
-    SFP[0][2] = ((VHDCI[1][0] & 0x7fc0) >> 6) |
-                ((VHDCI_reverse[1][0] & 0x7) << 9) |
-                ((VHDCI[1][0] & 0x7) << 12);
-    SFP[1][2] = 0x8000 | ((VHDCI[1][1] & 0x7fc0) >> 6) |
-                ((VHDCI_reverse[1][1] & 0x7) << 9) |
-                ((VHDCI[1][1] & 0x7) << 12);
-    SFP[0][3] =
-        ((VHDCI_reverse[1][0] & 0x7ff8) >> 3) | ((VHDCI[1][0] & 0x38) << 9);
-    SFP[1][3] = 0x8000 | ((VHDCI_reverse[1][1] & 0x7ff8) >> 3) |
-                ((VHDCI[1][1] & 0x38) << 9);
-    break;
-  default:
-    SFP[0][0] = 0;
-    SFP[1][0] = 0x8000;
-    SFP[0][1] = 0;
-    SFP[1][1] = 0x8000;
-    SFP[0][2] = 0;
-    SFP[1][2] = 0x8000;
-    SFP[0][3] = 0;
-    SFP[1][3] = 0x8000;
+      SFP[0][2] = ((VHDCI[0][0] & 0x20000) >> 10);
+      SFP[1][2] = 0x8000 | ((VHDCI[0][1] & 0x20000) >> 10);
+      SFP[0][3] = ((VHDCI[1][0] & 0x20000) >> 3);
+      SFP[1][3] = 0x8000 | ((VHDCI[1][1] & 0x20000) >> 3);
+      for (int i = 0; i < 7; i++) {
+        SFP[0][2] =
+            SFP[0][2] | (((VHDCI[1][0] >> (2 * i)) & 0x1) << i) | (((VHDCI[1][0] >> ((2 * i) + 1)) & 0x1) << (i + 8));
+        SFP[1][2] =
+            SFP[1][2] | (((VHDCI[1][1] >> (2 * i)) & 0x1) << i) | (((VHDCI[1][1] >> ((2 * i) + 1)) & 0x1) << (i + 8));
+        SFP[0][3] = SFP[0][3] | (((VHDCI_reverse[1][0] >> ((2 * i) + 1)) & 0x1) << i) |
+                    (((VHDCI_reverse[1][0] >> (2 * i)) & 0x1) << (i + 7));
+        SFP[1][3] = SFP[1][3] | (((VHDCI_reverse[1][1] >> ((2 * i) + 1)) & 0x1) << i) |
+                    (((VHDCI_reverse[1][1] >> (2 * i)) & 0x1) << (i + 7));
+      }
+      break;
+    case 2:
+      SFP[0][0] = (VHDCI[0][0] & 0xfff) | ((VHDCI_reverse[0][0] & 0xe00) << 3);
+      SFP[1][0] = 0x8000 | (VHDCI[0][1] & 0xfff) | ((VHDCI_reverse[0][1] & 0xe00) << 3);
+      SFP[0][1] =
+          ((VHDCI[0][0] & 0x7000) >> 12) | ((VHDCI_reverse[0][0] & 0x1ff) << 3) | (VHDCI_reverse[0][0] & 0x7000);
+      SFP[1][1] = 0x8000 | ((VHDCI[0][1] & 0x7000) >> 12) | ((VHDCI_reverse[0][1] & 0x1ff) << 3) |
+                  (VHDCI_reverse[0][1] & 0x7000);
+      SFP[0][2] = (VHDCI[0][0] & 0xfff);
+      SFP[1][2] = 0x8000 | (VHDCI[0][1] & 0xfff);
+      SFP[0][3] = ((VHDCI[0][0] & 0x7000) >> 12) | ((VHDCI_reverse[0][0] & 0x1ff) << 3);
+      SFP[1][3] = 0x8000 | ((VHDCI[0][1] & 0x7000) >> 12) | ((VHDCI_reverse[0][1] & 0x1ff) << 3);
+      break;
+    case 3:
+      SFP[0][0] = ((VHDCI[0][0] & 0x7fc0) >> 6) | ((VHDCI_reverse[0][0] & 0x7) << 9) | ((VHDCI[0][0] & 0x7) << 12);
+      SFP[1][0] =
+          0x8000 | ((VHDCI[0][1] & 0x7fc0) >> 6) | ((VHDCI_reverse[0][1] & 0x7) << 9) | ((VHDCI[0][1] & 0x7) << 12);
+      SFP[0][1] = ((VHDCI_reverse[0][0] & 0x7ff8) >> 3) | ((VHDCI[0][0] & 0x38) << 9);
+      SFP[1][1] = 0x8000 | ((VHDCI_reverse[0][1] & 0x7ff8) >> 3) | ((VHDCI[0][1] & 0x38) << 9);
+      SFP[0][2] = ((VHDCI[1][0] & 0x7fc0) >> 6) | ((VHDCI_reverse[1][0] & 0x7) << 9) | ((VHDCI[1][0] & 0x7) << 12);
+      SFP[1][2] =
+          0x8000 | ((VHDCI[1][1] & 0x7fc0) >> 6) | ((VHDCI_reverse[1][1] & 0x7) << 9) | ((VHDCI[1][1] & 0x7) << 12);
+      SFP[0][3] = ((VHDCI_reverse[1][0] & 0x7ff8) >> 3) | ((VHDCI[1][0] & 0x38) << 9);
+      SFP[1][3] = 0x8000 | ((VHDCI_reverse[1][1] & 0x7ff8) >> 3) | ((VHDCI[1][1] & 0x38) << 9);
+      break;
+    default:
+      SFP[0][0] = 0;
+      SFP[1][0] = 0x8000;
+      SFP[0][1] = 0;
+      SFP[1][1] = 0x8000;
+      SFP[0][2] = 0;
+      SFP[1][2] = 0x8000;
+      SFP[0][3] = 0;
+      SFP[1][3] = 0x8000;
   }
 }
 
@@ -564,16 +484,17 @@ void SourceCardRouting::VHDCItoSFP(int RoutingMode, unsigned short (&SFP)[2][4],
 // electron arrays are eIsoRank[candidate number<4]
 // muon arrays are MIPbits[rec card number<7][region<2]
 
-void SourceCardRouting::EMUtoVHDCI(
-    unsigned short (&eIsoRank)[4], unsigned short (&eIsoCardId)[4],
-    unsigned short (&eIsoRegionId)[4], unsigned short (&eNonIsoRank)[4],
-    unsigned short (&eNonIsoCardId)[4], unsigned short (&eNonIsoRegionId)[4],
-    unsigned short (&MIPbits)[7][2], unsigned short (&Qbits)[7][2],
-    unsigned long (&VHDCI)[2][2]) const {
-
+void SourceCardRouting::EMUtoVHDCI(unsigned short (&eIsoRank)[4],
+                                   unsigned short (&eIsoCardId)[4],
+                                   unsigned short (&eIsoRegionId)[4],
+                                   unsigned short (&eNonIsoRank)[4],
+                                   unsigned short (&eNonIsoCardId)[4],
+                                   unsigned short (&eNonIsoRegionId)[4],
+                                   unsigned short (&MIPbits)[7][2],
+                                   unsigned short (&Qbits)[7][2],
+                                   unsigned long (&VHDCI)[2][2]) const {
   unsigned short SFP[2][4] = {{0}};
-  EMUtoSFP(eIsoRank, eIsoCardId, eIsoRegionId, eNonIsoRank, eNonIsoCardId,
-           eNonIsoRegionId, MIPbits, Qbits, SFP);
+  EMUtoSFP(eIsoRank, eIsoCardId, eIsoRegionId, eNonIsoRank, eNonIsoCardId, eNonIsoRegionId, MIPbits, Qbits, SFP);
   SFPtoVHDCI(0, SFP, VHDCI);
 }
 
@@ -582,17 +503,18 @@ void SourceCardRouting::EMUtoVHDCI(
 // electron arrays are eIsoRank[candidate number<4]
 // muon arrays are MIPbits[rec card number<7][region<2]
 
-void SourceCardRouting::VHDCItoEMU(
-    unsigned short (&eIsoRank)[4], unsigned short (&eIsoCardId)[4],
-    unsigned short (&eIsoRegionId)[4], unsigned short (&eNonIsoRank)[4],
-    unsigned short (&eNonIsoCardId)[4], unsigned short (&eNonIsoRegionId)[4],
-    unsigned short (&MIPbits)[7][2], unsigned short (&Qbits)[7][2],
-    unsigned long (&VHDCI)[2][2]) const {
-
+void SourceCardRouting::VHDCItoEMU(unsigned short (&eIsoRank)[4],
+                                   unsigned short (&eIsoCardId)[4],
+                                   unsigned short (&eIsoRegionId)[4],
+                                   unsigned short (&eNonIsoRank)[4],
+                                   unsigned short (&eNonIsoCardId)[4],
+                                   unsigned short (&eNonIsoRegionId)[4],
+                                   unsigned short (&MIPbits)[7][2],
+                                   unsigned short (&Qbits)[7][2],
+                                   unsigned long (&VHDCI)[2][2]) const {
   unsigned short SFP[2][4] = {{0}};
   VHDCItoSFP(0, SFP, VHDCI);
-  SFPtoEMU(eIsoRank, eIsoCardId, eIsoRegionId, eNonIsoRank, eNonIsoCardId,
-           eNonIsoRegionId, MIPbits, Qbits, SFP);
+  SFPtoEMU(eIsoRank, eIsoCardId, eIsoRegionId, eNonIsoRank, eNonIsoCardId, eNonIsoRegionId, MIPbits, Qbits, SFP);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -606,7 +528,6 @@ void SourceCardRouting::RC56HFtoVHDCI(unsigned short (&RC)[7][2],
                                       unsigned short (&HF)[4][2],
                                       unsigned short (&HFQ)[4][2],
                                       unsigned long (&VHDCI)[2][2]) const {
-
   unsigned short SFP[2][4] = {{0}};
   RC56HFtoSFP(RC, RCof, RCtau, HF, HFQ, SFP);
   SFPtoVHDCI(1, SFP, VHDCI);
@@ -623,7 +544,6 @@ void SourceCardRouting::VHDCItoRC56HF(unsigned short (&RC)[7][2],
                                       unsigned short (&HF)[4][2],
                                       unsigned short (&HFQ)[4][2],
                                       unsigned long (&VHDCI)[2][2]) const {
-
   unsigned short SFP[2][4] = {{0}};
   VHDCItoSFP(1, SFP, VHDCI);
   SFPtoRC56HF(RC, RCof, RCtau, HF, HFQ, SFP);
@@ -637,7 +557,6 @@ void SourceCardRouting::RC012toVHDCI(unsigned short (&RC)[7][2],
                                      unsigned short (&RCof)[7][2],
                                      unsigned short (&RCtau)[7][2],
                                      unsigned long (&VHDCI)[2][2]) const {
-
   unsigned short SFP[2][4] = {{0}};
   RC012toSFP(RC, RCof, RCtau, SFP);
   SFPtoVHDCI(2, SFP, VHDCI);
@@ -651,7 +570,6 @@ void SourceCardRouting::VHDCItoRC012(unsigned short (&RC)[7][2],
                                      unsigned short (&RCof)[7][2],
                                      unsigned short (&RCtau)[7][2],
                                      unsigned long (&VHDCI)[2][2]) const {
-
   unsigned short SFP[2][4] = {{0}};
   VHDCItoSFP(2, SFP, VHDCI);
   SFPtoRC012(RC, RCof, RCtau, SFP);
@@ -668,7 +586,6 @@ void SourceCardRouting::RC234toVHDCI(unsigned short (&RC)[7][2],
                                      unsigned short (&sisterRCof)[7][2],
                                      unsigned short (&sisterRCtau)[7][2],
                                      unsigned long (&VHDCI)[2][2]) const {
-
   unsigned short SFP[2][4] = {{0}};
   RC234toSFP(RC, RCof, RCtau, sisterRC, sisterRCof, sisterRCtau, SFP);
   SFPtoVHDCI(3, SFP, VHDCI);
@@ -685,7 +602,6 @@ void SourceCardRouting::VHDCItoRC234(unsigned short (&RC)[7][2],
                                      unsigned short (&sisterRCof)[7][2],
                                      unsigned short (&sisterRCtau)[7][2],
                                      unsigned long (&VHDCI)[2][2]) const {
-
   unsigned short SFP[2][4] = {{0}};
   VHDCItoSFP(3, SFP, VHDCI);
   SFPtoRC234(RC, RCof, RCtau, sisterRC, sisterRCof, sisterRCtau, SFP);
@@ -696,17 +612,19 @@ void SourceCardRouting::VHDCItoRC234(unsigned short (&RC)[7][2],
 // electron arrays are eIsoRank[candidate number<4]
 // muon arrays are MIPbits[rec card number<7][region<2]
 
-void SourceCardRouting::EMUtoSTRING(
-    unsigned short &logicalCardID, unsigned short &eventNumber,
-    unsigned short (&eIsoRank)[4], unsigned short (&eIsoCardId)[4],
-    unsigned short (&eIsoRegionId)[4], unsigned short (&eNonIsoRank)[4],
-    unsigned short (&eNonIsoCardId)[4], unsigned short (&eNonIsoRegionId)[4],
-    unsigned short (&MIPbits)[7][2], unsigned short (&Qbits)[7][2],
-    std::string &dataString) const {
-
+void SourceCardRouting::EMUtoSTRING(unsigned short &logicalCardID,
+                                    unsigned short &eventNumber,
+                                    unsigned short (&eIsoRank)[4],
+                                    unsigned short (&eIsoCardId)[4],
+                                    unsigned short (&eIsoRegionId)[4],
+                                    unsigned short (&eNonIsoRank)[4],
+                                    unsigned short (&eNonIsoCardId)[4],
+                                    unsigned short (&eNonIsoRegionId)[4],
+                                    unsigned short (&MIPbits)[7][2],
+                                    unsigned short (&Qbits)[7][2],
+                                    std::string &dataString) const {
   unsigned long VHDCI[2][2] = {{0}};
-  EMUtoVHDCI(eIsoRank, eIsoCardId, eIsoRegionId, eNonIsoRank, eNonIsoCardId,
-             eNonIsoRegionId, MIPbits, Qbits, VHDCI);
+  EMUtoVHDCI(eIsoRank, eIsoCardId, eIsoRegionId, eNonIsoRank, eNonIsoCardId, eNonIsoRegionId, MIPbits, Qbits, VHDCI);
   VHDCItoSTRING(logicalCardID, eventNumber, dataString, VHDCI);
 }
 
@@ -714,12 +632,14 @@ void SourceCardRouting::EMUtoSTRING(
 // RC arrays are RC[receiver card number<7][region<2]
 // HF arrays are HF[eta<4][HF region<2]
 
-void SourceCardRouting::RC56HFtoSTRING(
-    unsigned short &logicalCardID, unsigned short &eventNumber,
-    unsigned short (&RC)[7][2], unsigned short (&RCof)[7][2],
-    unsigned short (&RCtau)[7][2], unsigned short (&HF)[4][2],
-    unsigned short (&HFQ)[4][2], std::string &dataString) const {
-
+void SourceCardRouting::RC56HFtoSTRING(unsigned short &logicalCardID,
+                                       unsigned short &eventNumber,
+                                       unsigned short (&RC)[7][2],
+                                       unsigned short (&RCof)[7][2],
+                                       unsigned short (&RCtau)[7][2],
+                                       unsigned short (&HF)[4][2],
+                                       unsigned short (&HFQ)[4][2],
+                                       std::string &dataString) const {
   unsigned long VHDCI[2][2] = {{0}};
   RC56HFtoVHDCI(RC, RCof, RCtau, HF, HFQ, VHDCI);
   VHDCItoSTRING(logicalCardID, eventNumber, dataString, VHDCI);
@@ -734,7 +654,6 @@ void SourceCardRouting::RC012toSTRING(unsigned short &logicalCardID,
                                       unsigned short (&RCof)[7][2],
                                       unsigned short (&RCtau)[7][2],
                                       std::string &dataString) const {
-
   unsigned long VHDCI[2][2] = {{0}};
   RC012toVHDCI(RC, RCof, RCtau, VHDCI);
   VHDCItoSTRING(logicalCardID, eventNumber, dataString, VHDCI);
@@ -743,13 +662,15 @@ void SourceCardRouting::RC012toSTRING(unsigned short &logicalCardID,
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // RC arrays are RC[receiver card number<7][region<2]
 
-void SourceCardRouting::RC234toSTRING(
-    unsigned short &logicalCardID, unsigned short &eventNumber,
-    unsigned short (&RC)[7][2], unsigned short (&RCof)[7][2],
-    unsigned short (&RCtau)[7][2], unsigned short (&sisterRC)[7][2],
-    unsigned short (&sisterRCof)[7][2], unsigned short (&sisterRCtau)[7][2],
-    std::string &dataString) const {
-
+void SourceCardRouting::RC234toSTRING(unsigned short &logicalCardID,
+                                      unsigned short &eventNumber,
+                                      unsigned short (&RC)[7][2],
+                                      unsigned short (&RCof)[7][2],
+                                      unsigned short (&RCtau)[7][2],
+                                      unsigned short (&sisterRC)[7][2],
+                                      unsigned short (&sisterRCof)[7][2],
+                                      unsigned short (&sisterRCtau)[7][2],
+                                      std::string &dataString) const {
   unsigned long VHDCI[2][2] = {{0}};
   RC234toVHDCI(RC, RCof, RCtau, sisterRC, sisterRCof, sisterRCtau, VHDCI);
   VHDCItoSTRING(logicalCardID, eventNumber, dataString, VHDCI);
@@ -763,7 +684,6 @@ void SourceCardRouting::SFPtoSTRING(unsigned short &logicalCardID,
                                     int RoutingMode,
                                     unsigned short (&SFP)[2][4],
                                     std::string &dataString) const {
-
   unsigned long VHDCI[2][2] = {{0}};
   SFPtoVHDCI(RoutingMode, SFP, VHDCI);
   VHDCItoSTRING(logicalCardID, eventNumber, dataString, VHDCI);
@@ -776,7 +696,6 @@ void SourceCardRouting::STRINGtoVHDCI(unsigned short &logicalCardID,
                                       unsigned short &eventNumber,
                                       std::string &dataString,
                                       unsigned long (&VHDCI)[2][2]) const {
-
   stringstream temp;
 
   if (!dataString.empty()) {
@@ -803,7 +722,6 @@ void SourceCardRouting::VHDCItoSTRING(unsigned short &logicalCardID,
                                       unsigned short &eventNumber,
                                       std::string &dataString,
                                       unsigned long (&VHDCI)[2][2]) const {
-
   stringstream temp;
 
   temp << dec << eventNumber << '\t';
@@ -818,10 +736,9 @@ void SourceCardRouting::VHDCItoSTRING(unsigned short &logicalCardID,
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void SourceCardRouting::LogicalCardIDtoRoutingMode(
-    unsigned short &logicalCardID, int &RoutingMode,
-    int &RCTCrateNumber) const {
-
+void SourceCardRouting::LogicalCardIDtoRoutingMode(unsigned short &logicalCardID,
+                                                   int &RoutingMode,
+                                                   int &RCTCrateNumber) const {
   RCTCrateNumber = (logicalCardID >> 3);
   if ((logicalCardID & 0x4) != 0)
     RCTCrateNumber += 9;
@@ -830,12 +747,10 @@ void SourceCardRouting::LogicalCardIDtoRoutingMode(
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void SourceCardRouting::RoutingModetoLogicalCardID(
-    unsigned short &logicalCardID, int &RoutingMode,
-    int &RCTCrateNumber) const {
-
-  logicalCardID = ((RCTCrateNumber % 9) << 3) |
-                  (RCTCrateNumber > 8 ? 0x4 : 0x0) | (RoutingMode & 0x3);
+void SourceCardRouting::RoutingModetoLogicalCardID(unsigned short &logicalCardID,
+                                                   int &RoutingMode,
+                                                   int &RCTCrateNumber) const {
+  logicalCardID = ((RCTCrateNumber % 9) << 3) | (RCTCrateNumber > 8 ? 0x4 : 0x0) | (RoutingMode & 0x3);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/L1Trigger/TextToDigi/src/SourceCardRouting.h
+++ b/L1Trigger/TextToDigi/src/SourceCardRouting.h
@@ -11,7 +11,6 @@
 #include <string>
 
 class SourceCardRouting {
-
 public:
   SourceCardRouting();
   ~SourceCardRouting();
@@ -29,63 +28,74 @@ public:
     unsigned short mipBits[7][2];
     unsigned short qBits[7][2];
     // Output data.
-    unsigned short sfp[2][4]; // [ cycle ] [ output number ]
+    unsigned short sfp[2][4];  // [ cycle ] [ output number ]
   };
 
   // SFP arrays are SFP[cycle<2][sfp number<4]
   // electron arrays are eIsoRank[candidate number<4]
   // muon arrays are MIPbits[rec card number<7][region<2]
-  void EMUtoSFP(unsigned short (&eIsoRank)[4], unsigned short (&eIsoCardId)[4],
+  void EMUtoSFP(unsigned short (&eIsoRank)[4],
+                unsigned short (&eIsoCardId)[4],
                 unsigned short (&eIsoRegionId)[4],
                 unsigned short (&eNonIsoRank)[4],
                 unsigned short (&eNonIsoCardId)[4],
                 unsigned short (&eNonIsoRegionId)[4],
-                unsigned short (&MIPbits)[7][2], unsigned short (&Qbits)[7][2],
+                unsigned short (&MIPbits)[7][2],
+                unsigned short (&Qbits)[7][2],
                 unsigned short (&SFP)[2][4]) const;
 
   // SFP arrays are SFP[cycle<2][sfp number<4]
   // electron arrays are eIsoRank[candidate number<4]
   // muon arrays are MIPbits[rec card number<7][region<2]
-  void SFPtoEMU(unsigned short (&eIsoRank)[4], unsigned short (&eIsoCardId)[4],
+  void SFPtoEMU(unsigned short (&eIsoRank)[4],
+                unsigned short (&eIsoCardId)[4],
                 unsigned short (&eIsoRegionId)[4],
                 unsigned short (&eNonIsoRank)[4],
                 unsigned short (&eNonIsoCardId)[4],
                 unsigned short (&eNonIsoRegionId)[4],
-                unsigned short (&MIPbits)[7][2], unsigned short (&Qbits)[7][2],
+                unsigned short (&MIPbits)[7][2],
+                unsigned short (&Qbits)[7][2],
                 unsigned short (&SFP)[2][4]) const;
 
   /***********************************************************************************************************************/
   // RC arrays are RC[receiver card number<7][region<2]
   // HF arrays are HF[eta<4][HF region<2]
   // SFP arrays are SFP[cycle<2][sfp number<4]
-  void RC56HFtoSFP(unsigned short (&RC)[7][2], unsigned short (&RCof)[7][2],
-                   unsigned short (&RCtau)[7][2], unsigned short (&HF)[4][2],
+  void RC56HFtoSFP(unsigned short (&RC)[7][2],
+                   unsigned short (&RCof)[7][2],
+                   unsigned short (&RCtau)[7][2],
+                   unsigned short (&HF)[4][2],
                    unsigned short (&HFQ)[4][2],
                    unsigned short (&SFP)[2][4]) const;
 
   // RC arrays are RC[receiver card number<7][region<2]
   // HF arrays are HF[eta<4][HF region<2]
   // SFP arrays are SFP[cycle<2][sfp number<4]
-  void SFPtoRC56HF(unsigned short (&RC)[7][2], unsigned short (&RCof)[7][2],
-                   unsigned short (&RCtau)[7][2], unsigned short (&HF)[4][2],
+  void SFPtoRC56HF(unsigned short (&RC)[7][2],
+                   unsigned short (&RCof)[7][2],
+                   unsigned short (&RCtau)[7][2],
+                   unsigned short (&HF)[4][2],
                    unsigned short (&HFQ)[4][2],
                    unsigned short (&SFP)[2][4]) const;
 
   // RC arrays are RC[receiver card number<7][region<2]
   // SFP arrays are SFP[cycle<2][sfp number<4]
-  void RC012toSFP(unsigned short (&RC)[7][2], unsigned short (&RCof)[7][2],
+  void RC012toSFP(unsigned short (&RC)[7][2],
+                  unsigned short (&RCof)[7][2],
                   unsigned short (&RCtau)[7][2],
                   unsigned short (&SFP)[2][4]) const;
 
   // RC arrays are RC[receiver card number<7][region<2]
   // SFP arrays are SFP[cycle<2][sfp number<4]
-  void SFPtoRC012(unsigned short (&RC)[7][2], unsigned short (&RCof)[7][2],
+  void SFPtoRC012(unsigned short (&RC)[7][2],
+                  unsigned short (&RCof)[7][2],
                   unsigned short (&RCtau)[7][2],
                   unsigned short (&SFP)[2][4]) const;
 
   // RC arrays are RC[receiver card number<7][region<2]
   // SFP arrays are SFP[cycle<2][sfp number<4]
-  void RC234toSFP(unsigned short (&RC)[7][2], unsigned short (&RCof)[7][2],
+  void RC234toSFP(unsigned short (&RC)[7][2],
+                  unsigned short (&RCof)[7][2],
                   unsigned short (&RCtau)[7][2],
                   unsigned short (&sisterRC)[7][2],
                   unsigned short (&sisterRCof)[7][2],
@@ -94,7 +104,8 @@ public:
 
   // RC arrays are RC[receiver card number<7][region<2]
   // SFP arrays are SFP[cycle<2][sfp number<4]
-  void SFPtoRC234(unsigned short (&RC)[7][2], unsigned short (&RCof)[7][2],
+  void SFPtoRC234(unsigned short (&RC)[7][2],
+                  unsigned short (&RCof)[7][2],
                   unsigned short (&RCtau)[7][2],
                   unsigned short (&sisterRC)[7][2],
                   unsigned short (&sisterRCof)[7][2],
@@ -106,70 +117,81 @@ public:
   // VHDCI arrays are VHDCI[VHDCI<2][cycle<2]
   // SFP arrays are SFP[cycle<2][sfp number<4]
 
-  void SFPtoVHDCI(int RoutingMode, unsigned short (&SFP)[2][4],
-                  unsigned long (&VHDCI)[2][2]) const;
+  void SFPtoVHDCI(int RoutingMode, unsigned short (&SFP)[2][4], unsigned long (&VHDCI)[2][2]) const;
 
   // VHDCI arrays are VHDCI[VHDCI<2][cycle<2]
   // SFP arrays are SFP[cycle<2][sfp number<4]
-  void VHDCItoSFP(int RoutingMode, unsigned short (&SFP)[2][4],
+  void VHDCItoSFP(int RoutingMode, unsigned short (&SFP)[2][4], unsigned long (&VHDCI)[2][2]) const;
+
+  /***********************************************************************************************************************/
+
+  // VHDCI arrays are VHDCI[VHDCI<2][cycle<2]
+  // electron arrays are eIsoRank[candidate number<4]
+  // muon arrays are MIPbits[rec card number<7][region<2]
+
+  void EMUtoVHDCI(unsigned short (&eIsoRank)[4],
+                  unsigned short (&eIsoCardId)[4],
+                  unsigned short (&eIsoRegionId)[4],
+                  unsigned short (&eNonIsoRank)[4],
+                  unsigned short (&eNonIsoCardId)[4],
+                  unsigned short (&eNonIsoRegionId)[4],
+                  unsigned short (&MIPbits)[7][2],
+                  unsigned short (&Qbits)[7][2],
+                  unsigned long (&VHDCI)[2][2]) const;
+
+  // VHDCI arrays are VHDCI[VHDCI<2][cycle<2]
+  // electron arrays are eIsoRank[candidate number<4]
+  // muon arrays are MIPbits[rec card number<7][region<2]
+  void VHDCItoEMU(unsigned short (&eIsoRank)[4],
+                  unsigned short (&eIsoCardId)[4],
+                  unsigned short (&eIsoRegionId)[4],
+                  unsigned short (&eNonIsoRank)[4],
+                  unsigned short (&eNonIsoCardId)[4],
+                  unsigned short (&eNonIsoRegionId)[4],
+                  unsigned short (&MIPbits)[7][2],
+                  unsigned short (&Qbits)[7][2],
                   unsigned long (&VHDCI)[2][2]) const;
 
   /***********************************************************************************************************************/
 
-  // VHDCI arrays are VHDCI[VHDCI<2][cycle<2]
-  // electron arrays are eIsoRank[candidate number<4]
-  // muon arrays are MIPbits[rec card number<7][region<2]
-
-  void EMUtoVHDCI(
-      unsigned short (&eIsoRank)[4], unsigned short (&eIsoCardId)[4],
-      unsigned short (&eIsoRegionId)[4], unsigned short (&eNonIsoRank)[4],
-      unsigned short (&eNonIsoCardId)[4], unsigned short (&eNonIsoRegionId)[4],
-      unsigned short (&MIPbits)[7][2], unsigned short (&Qbits)[7][2],
-      unsigned long (&VHDCI)[2][2]) const;
-
-  // VHDCI arrays are VHDCI[VHDCI<2][cycle<2]
-  // electron arrays are eIsoRank[candidate number<4]
-  // muon arrays are MIPbits[rec card number<7][region<2]
-  void VHDCItoEMU(
-      unsigned short (&eIsoRank)[4], unsigned short (&eIsoCardId)[4],
-      unsigned short (&eIsoRegionId)[4], unsigned short (&eNonIsoRank)[4],
-      unsigned short (&eNonIsoCardId)[4], unsigned short (&eNonIsoRegionId)[4],
-      unsigned short (&MIPbits)[7][2], unsigned short (&Qbits)[7][2],
-      unsigned long (&VHDCI)[2][2]) const;
-
-  /***********************************************************************************************************************/
-
   // RC arrays are RC[receiver card number<7][region<2]
   // HF arrays are HF[eta<4][HF region<2]
   // VHDCI arrays are VHDCI[VHDCI<2][cycle<2]
-  void RC56HFtoVHDCI(unsigned short (&RC)[7][2], unsigned short (&RCof)[7][2],
-                     unsigned short (&RCtau)[7][2], unsigned short (&HF)[4][2],
+  void RC56HFtoVHDCI(unsigned short (&RC)[7][2],
+                     unsigned short (&RCof)[7][2],
+                     unsigned short (&RCtau)[7][2],
+                     unsigned short (&HF)[4][2],
                      unsigned short (&HFQ)[4][2],
                      unsigned long (&VHDCI)[2][2]) const;
 
   // RC arrays are RC[receiver card number<7][region<2]
   // HF arrays are HF[eta<4][HF region<2]
   // VHDCI arrays are VHDCI[VHDCI<2][cycle<2]
-  void VHDCItoRC56HF(unsigned short (&RC)[7][2], unsigned short (&RCof)[7][2],
-                     unsigned short (&RCtau)[7][2], unsigned short (&HF)[4][2],
+  void VHDCItoRC56HF(unsigned short (&RC)[7][2],
+                     unsigned short (&RCof)[7][2],
+                     unsigned short (&RCtau)[7][2],
+                     unsigned short (&HF)[4][2],
                      unsigned short (&HFQ)[4][2],
                      unsigned long (&VHDCI)[2][2]) const;
 
   // RC arrays are RC[receiver card number<7][region<2]
   // VHDCI arrays are VHDCI[VHDCI<2][cycle<2]
-  void RC012toVHDCI(unsigned short (&RC)[7][2], unsigned short (&RCof)[7][2],
+  void RC012toVHDCI(unsigned short (&RC)[7][2],
+                    unsigned short (&RCof)[7][2],
                     unsigned short (&RCtau)[7][2],
                     unsigned long (&VHDCI)[2][2]) const;
 
   // RC arrays are RC[receiver card number<7][region<2]
   // VHDCI arrays are VHDCI[VHDCI<2][cycle<2]
-  void VHDCItoRC012(unsigned short (&RC)[7][2], unsigned short (&RCof)[7][2],
+  void VHDCItoRC012(unsigned short (&RC)[7][2],
+                    unsigned short (&RCof)[7][2],
                     unsigned short (&RCtau)[7][2],
                     unsigned long (&VHDCI)[2][2]) const;
 
   // RC arrays are RC[receiver card number<7][region<2]
   // VHDCI arrays are VHDCI[VHDCI<2][cycle<2]
-  void RC234toVHDCI(unsigned short (&RC)[7][2], unsigned short (&RCof)[7][2],
+  void RC234toVHDCI(unsigned short (&RC)[7][2],
+                    unsigned short (&RCof)[7][2],
                     unsigned short (&RCtau)[7][2],
                     unsigned short (&sisterRC)[7][2],
                     unsigned short (&sisterRCof)[7][2],
@@ -178,7 +200,8 @@ public:
 
   // RC arrays are RC[receiver card number<7][region<2]
   // VHDCI arrays are VHDCI[VHDCI<2][cycle<2]
-  void VHDCItoRC234(unsigned short (&RC)[7][2], unsigned short (&RCof)[7][2],
+  void VHDCItoRC234(unsigned short (&RC)[7][2],
+                    unsigned short (&RCof)[7][2],
                     unsigned short (&RCtau)[7][2],
                     unsigned short (&sisterRC)[7][2],
                     unsigned short (&sisterRCof)[7][2],
@@ -190,32 +213,42 @@ public:
   // electron arrays are eIsoRank[candidate number<4]
   // muon arrays are MIPbits[rec card number<7][region<2]
 
-  void EMUtoSTRING(
-      unsigned short &logicalCardID, unsigned short &eventNumber,
-      unsigned short (&eIsoRank)[4], unsigned short (&eIsoCardId)[4],
-      unsigned short (&eIsoRegionId)[4], unsigned short (&eNonIsoRank)[4],
-      unsigned short (&eNonIsoCardId)[4], unsigned short (&eNonIsoRegionId)[4],
-      unsigned short (&MIPbits)[7][2], unsigned short (&Qbits)[7][2],
-      std::string &dataString) const;
+  void EMUtoSTRING(unsigned short &logicalCardID,
+                   unsigned short &eventNumber,
+                   unsigned short (&eIsoRank)[4],
+                   unsigned short (&eIsoCardId)[4],
+                   unsigned short (&eIsoRegionId)[4],
+                   unsigned short (&eNonIsoRank)[4],
+                   unsigned short (&eNonIsoCardId)[4],
+                   unsigned short (&eNonIsoRegionId)[4],
+                   unsigned short (&MIPbits)[7][2],
+                   unsigned short (&Qbits)[7][2],
+                   std::string &dataString) const;
 
   // RC arrays are RC[receiver card number<7][region<2]
   // HF arrays are HF[eta<4][HF region<2]
   void RC56HFtoSTRING(unsigned short &logicalCardID,
-                      unsigned short &eventNumber, unsigned short (&RC)[7][2],
+                      unsigned short &eventNumber,
+                      unsigned short (&RC)[7][2],
                       unsigned short (&RCof)[7][2],
-                      unsigned short (&RCtau)[7][2], unsigned short (&HF)[4][2],
+                      unsigned short (&RCtau)[7][2],
+                      unsigned short (&HF)[4][2],
                       unsigned short (&HFQ)[4][2],
                       std::string &dataString) const;
 
   // RC arrays are RC[receiver card number<7][region<2]
-  void RC012toSTRING(unsigned short &logicalCardID, unsigned short &eventNumber,
-                     unsigned short (&RC)[7][2], unsigned short (&RCof)[7][2],
+  void RC012toSTRING(unsigned short &logicalCardID,
+                     unsigned short &eventNumber,
+                     unsigned short (&RC)[7][2],
+                     unsigned short (&RCof)[7][2],
                      unsigned short (&RCtau)[7][2],
                      std::string &dataString) const;
 
   // RC arrays are RC[receiver card number<7][region<2]
-  void RC234toSTRING(unsigned short &logicalCardID, unsigned short &eventNumber,
-                     unsigned short (&RC)[7][2], unsigned short (&RCof)[7][2],
+  void RC234toSTRING(unsigned short &logicalCardID,
+                     unsigned short &eventNumber,
+                     unsigned short (&RC)[7][2],
+                     unsigned short (&RCof)[7][2],
                      unsigned short (&RCtau)[7][2],
                      unsigned short (&sisterRC)[7][2],
                      unsigned short (&sisterRCof)[7][2],
@@ -225,33 +258,35 @@ public:
   /***********************************************************************************************************************/
 
   // SFP arrays are SFP[cycle<2][sfp number<4]
-  void SFPtoSTRING(unsigned short &logicalCardID, unsigned short &eventNumber,
-                   int RoutingMode, unsigned short (&SFP)[2][4],
+  void SFPtoSTRING(unsigned short &logicalCardID,
+                   unsigned short &eventNumber,
+                   int RoutingMode,
+                   unsigned short (&SFP)[2][4],
                    std::string &dataString) const;
 
   /***********************************************************************************************************************/
 
   // VHDCI arrays are VHDCI[VHDCI<2][cycle<2]
-  void STRINGtoVHDCI(unsigned short &logicalCardID, unsigned short &eventNumber,
+  void STRINGtoVHDCI(unsigned short &logicalCardID,
+                     unsigned short &eventNumber,
                      std::string &dataString,
                      unsigned long (&VHDCI)[2][2]) const;
 
   // VHDCI arrays are VHDCI[VHDCI<2][cycle<2]
-  void VHDCItoSTRING(unsigned short &logicalCardID, unsigned short &eventNumber,
+  void VHDCItoSTRING(unsigned short &logicalCardID,
+                     unsigned short &eventNumber,
                      std::string &dataString,
                      unsigned long (&VHDCI)[2][2]) const;
 
   /***********************************************************************************************************************/
 
-  void LogicalCardIDtoRoutingMode(unsigned short &logicalCardID,
-                                  int &RoutingMode, int &RCTCrateNumber) const;
+  void LogicalCardIDtoRoutingMode(unsigned short &logicalCardID, int &RoutingMode, int &RCTCrateNumber) const;
 
-  void RoutingModetoLogicalCardID(unsigned short &logicalCardID,
-                                  int &RoutingMode, int &RCTCrateNumber) const;
+  void RoutingModetoLogicalCardID(unsigned short &logicalCardID, int &RoutingMode, int &RCTCrateNumber) const;
 
-}; // class SourceCardRouting
+};  // class SourceCardRouting
 
-#endif //~SOURCECARDMANAGER_H
+#endif  //~SOURCECARDMANAGER_H
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // These were going to be implimented but made things a lot more complicated

--- a/L1Trigger/TextToDigi/test/testSourceCardRouting.cpp
+++ b/L1Trigger/TextToDigi/test/testSourceCardRouting.cpp
@@ -5,7 +5,6 @@
 using namespace std;
 
 int main(void) {
-
   unsigned short logicalCardID = 0;
   unsigned short eventNumber = 0;
   std::string tempString;
@@ -29,12 +28,9 @@ int main(void) {
   for (int RCTcrate = 0; RCTcrate < 18; RCTcrate++) {
     for (int RCcard = 0; RCcard < 7; RCcard++) {
       for (int Region = 0; Region < 2; Region++) {
-        RC[RCTcrate][RCcard][Region] =
-            rand() & 0x3ff; // Fill with junk for the time being
-        RCof[RCTcrate][RCcard][Region] =
-            rand() & 0x1; // Fill with junk for the time being
-        RCtau[RCTcrate][RCcard][Region] =
-            rand() & 0x1; // Fill with junk for the time being
+        RC[RCTcrate][RCcard][Region] = rand() & 0x3ff;   // Fill with junk for the time being
+        RCof[RCTcrate][RCcard][Region] = rand() & 0x1;   // Fill with junk for the time being
+        RCtau[RCTcrate][RCcard][Region] = rand() & 0x1;  // Fill with junk for the time being
       }
     }
   }
@@ -42,10 +38,8 @@ int main(void) {
   for (int RCTcrate = 0; RCTcrate < 18; RCTcrate++) {
     for (int HFeta = 0; HFeta < 4; HFeta++) {
       for (int HFRegion = 0; HFRegion < 2; HFRegion++) {
-        HF[RCTcrate][HFeta][HFRegion] =
-            rand() & 0xff; // Fill with junk for the time being
-        HFQ[RCTcrate][HFeta][HFRegion] =
-            rand() & 0x1; // Fill with junk for the time being
+        HF[RCTcrate][HFeta][HFRegion] = rand() & 0xff;  // Fill with junk for the time being
+        HFQ[RCTcrate][HFeta][HFRegion] = rand() & 0x1;  // Fill with junk for the time being
       }
     }
   }
@@ -55,16 +49,20 @@ int main(void) {
   int RoutingMode = 1;
   for (int RCTcrate = 0; RCTcrate < 18; RCTcrate++) {
     temp.RoutingModetoLogicalCardID(logicalCardID, RoutingMode, RCTcrate);
-    temp.RC56HFtoSTRING(logicalCardID, eventNumber, RC[RCTcrate],
-                        RCof[RCTcrate], RCtau[RCTcrate], HF[RCTcrate],
-                        HFQ[RCTcrate], tempString);
+    temp.RC56HFtoSTRING(logicalCardID,
+                        eventNumber,
+                        RC[RCTcrate],
+                        RCof[RCTcrate],
+                        RCtau[RCTcrate],
+                        HF[RCTcrate],
+                        HFQ[RCTcrate],
+                        tempString);
 
     // now check its working ok
     // std::cout<<"MID: "<<tempString<<std::endl;
     temp.STRINGtoVHDCI(logicalCardID, eventNumber, tempString, VHDCI);
-    temp.VHDCItoRC56HF(testRC[RCTcrate], testRCof[RCTcrate],
-                       testRCtau[RCTcrate], testHF[RCTcrate], testHFQ[RCTcrate],
-                       VHDCI);
+    temp.VHDCItoRC56HF(
+        testRC[RCTcrate], testRCof[RCTcrate], testRCtau[RCTcrate], testHF[RCTcrate], testHFQ[RCTcrate], VHDCI);
     /*cout<<"------------------------------------"<<std::endl;
       for(int RCcard=5; RCcard<7; RCcard++){
       for(int Region=0; Region<2; Region++){
@@ -89,14 +87,12 @@ int main(void) {
   RoutingMode = 2;
   for (int RCTcrate = 0; RCTcrate < 18; RCTcrate++) {
     temp.RoutingModetoLogicalCardID(logicalCardID, RoutingMode, RCTcrate);
-    temp.RC012toSTRING(logicalCardID, eventNumber, RC[RCTcrate], RCof[RCTcrate],
-                       RCtau[RCTcrate], tempString);
+    temp.RC012toSTRING(logicalCardID, eventNumber, RC[RCTcrate], RCof[RCTcrate], RCtau[RCTcrate], tempString);
 
     // now check its working ok
     // std::cout<<"MID: "<<tempString<<std::endl;
     temp.STRINGtoVHDCI(logicalCardID, eventNumber, tempString, VHDCI);
-    temp.VHDCItoRC012(testRC[RCTcrate], testRCof[RCTcrate], testRCtau[RCTcrate],
-                      VHDCI);
+    temp.VHDCItoRC012(testRC[RCTcrate], testRCof[RCTcrate], testRCtau[RCTcrate], VHDCI);
     /*cout<<"------------------------------------"<<std::endl;
       for(int RCcard=0; RCcard<7; RCcard++){
       for(int Region=0; Region<2; Region++){
@@ -113,16 +109,26 @@ int main(void) {
   RoutingMode = 3;
   for (int RCTcrate = 0; RCTcrate < 9; RCTcrate++) {
     temp.RoutingModetoLogicalCardID(logicalCardID, RoutingMode, RCTcrate);
-    temp.RC234toSTRING(logicalCardID, eventNumber, RC[RCTcrate], RCof[RCTcrate],
-                       RCtau[RCTcrate], RC[RCTcrate + 9], RCof[RCTcrate + 9],
-                       RCtau[RCTcrate + 9], tempString);
+    temp.RC234toSTRING(logicalCardID,
+                       eventNumber,
+                       RC[RCTcrate],
+                       RCof[RCTcrate],
+                       RCtau[RCTcrate],
+                       RC[RCTcrate + 9],
+                       RCof[RCTcrate + 9],
+                       RCtau[RCTcrate + 9],
+                       tempString);
 
     // now check its working ok
     // std::cout<<"MID: "<<tempString<<std::endl;
     temp.STRINGtoVHDCI(logicalCardID, eventNumber, tempString, VHDCI);
-    temp.VHDCItoRC234(testRC[RCTcrate], testRCof[RCTcrate], testRCtau[RCTcrate],
-                      testRC[RCTcrate + 9], testRCof[RCTcrate + 9],
-                      testRCtau[RCTcrate + 9], VHDCI);
+    temp.VHDCItoRC234(testRC[RCTcrate],
+                      testRCof[RCTcrate],
+                      testRCtau[RCTcrate],
+                      testRC[RCTcrate + 9],
+                      testRCof[RCTcrate + 9],
+                      testRCtau[RCTcrate + 9],
+                      VHDCI);
     /*cout<<"------------------------------------"<<std::endl;
       for(int RCcard=2; RCcard<5; RCcard++){
       for(int Region=0; Region<2; Region++){
@@ -144,35 +150,24 @@ int main(void) {
 
   std::cout << "and now to check..." << std::endl;
   for (int RCTcrate = 0; RCTcrate < 18; RCTcrate++) {
-    std::cout << "------------------ " << RCTcrate << " ------------------"
-              << std::endl;
+    std::cout << "------------------ " << RCTcrate << " ------------------" << std::endl;
     for (int RCcard = 0; RCcard < 7; RCcard++) {
       for (int Region = 0; Region < 2; Region++) {
-        if ((RC[RCTcrate][RCcard][Region] !=
-             testRC[RCTcrate][RCcard][Region]) ||
-            (RCof[RCTcrate][RCcard][Region] !=
-             testRCof[RCTcrate][RCcard][Region]) ||
-            (RCtau[RCTcrate][RCcard][Region] !=
-             testRCtau[RCTcrate][RCcard][Region])) {
-          std::cout << RC[RCTcrate][RCcard][Region] << '\t'
-                    << testRC[RCTcrate][RCcard][Region] << '\t';
-          std::cout << RCof[RCTcrate][RCcard][Region] << '\t'
-                    << testRCof[RCTcrate][RCcard][Region] << '\t';
-          std::cout << RCtau[RCTcrate][RCcard][Region] << '\t'
-                    << testRCtau[RCTcrate][RCcard][Region] << std::endl;
+        if ((RC[RCTcrate][RCcard][Region] != testRC[RCTcrate][RCcard][Region]) ||
+            (RCof[RCTcrate][RCcard][Region] != testRCof[RCTcrate][RCcard][Region]) ||
+            (RCtau[RCTcrate][RCcard][Region] != testRCtau[RCTcrate][RCcard][Region])) {
+          std::cout << RC[RCTcrate][RCcard][Region] << '\t' << testRC[RCTcrate][RCcard][Region] << '\t';
+          std::cout << RCof[RCTcrate][RCcard][Region] << '\t' << testRCof[RCTcrate][RCcard][Region] << '\t';
+          std::cout << RCtau[RCTcrate][RCcard][Region] << '\t' << testRCtau[RCTcrate][RCcard][Region] << std::endl;
         }
       }
     }
     for (int HFeta = 0; HFeta < 4; HFeta++) {
       for (int HFRegion = 0; HFRegion < 2; HFRegion++) {
-        if ((HF[RCTcrate][HFeta][HFRegion] !=
-             testHF[RCTcrate][HFeta][HFRegion]) ||
-            (HFQ[RCTcrate][HFeta][HFRegion] !=
-             testHFQ[RCTcrate][HFeta][HFRegion])) {
-          std::cout << HF[RCTcrate][HFeta][HFRegion] << '\t'
-                    << testHF[RCTcrate][HFeta][HFRegion] << '\t';
-          std::cout << HFQ[RCTcrate][HFeta][HFRegion] << '\t'
-                    << testHFQ[RCTcrate][HFeta][HFRegion] << std::endl;
+        if ((HF[RCTcrate][HFeta][HFRegion] != testHF[RCTcrate][HFeta][HFRegion]) ||
+            (HFQ[RCTcrate][HFeta][HFRegion] != testHFQ[RCTcrate][HFeta][HFRegion])) {
+          std::cout << HF[RCTcrate][HFeta][HFRegion] << '\t' << testHF[RCTcrate][HFeta][HFRegion] << '\t';
+          std::cout << HFQ[RCTcrate][HFeta][HFRegion] << '\t' << testHFQ[RCTcrate][HFeta][HFRegion] << std::endl;
         }
       }
     }

--- a/L1TriggerConfig/DTTPGConfigProducers/plugins/DTTPGParamsWriter.cc
+++ b/L1TriggerConfig/DTTPGConfigProducers/plugins/DTTPGParamsWriter.cc
@@ -25,7 +25,6 @@ using namespace edm;
 
 // Constructor
 DTTPGParamsWriter::DTTPGParamsWriter(const ParameterSet &pset) {
-
   debug_ = pset.getUntrackedParameter<bool>("debug", false);
   inputFileName_ = pset.getUntrackedParameter<string>("inputFile");
   // Create the object to be written to DB
@@ -37,15 +36,12 @@ DTTPGParamsWriter::DTTPGParamsWriter(const ParameterSet &pset) {
 
 // Destructor
 DTTPGParamsWriter::~DTTPGParamsWriter() {
-
   if (debug_)
     cout << "[DTTPGParamsWriter]Destructor called!" << endl;
 }
 
 // Do the job
-void DTTPGParamsWriter::analyze(const Event &event,
-                                const EventSetup &eventSetup) {
-
+void DTTPGParamsWriter::analyze(const Event &event, const EventSetup &eventSetup) {
   if (debug_)
     cout << "[DTTPGParamsWriter]Reading data from file." << endl;
 
@@ -63,41 +59,33 @@ void DTTPGParamsWriter::analyze(const Event &event,
       float fineDB = 0.;
       int coarseDB = 0;
       phaseMap_->get(chId, coarseDB, fineDB, DTTimeUnits::ns);
-      std::cout << "[DTTPGParamsWriter] Read data for chamber " << chId
-                << ". File params -> fine: " << fine << " coarse: " << coarse
-                << ". DB params -> fine: " << fineDB << " coarse: " << coarseDB
-                << std::endl;
+      std::cout << "[DTTPGParamsWriter] Read data for chamber " << chId << ". File params -> fine: " << fine
+                << " coarse: " << coarse << ". DB params -> fine: " << fineDB << " coarse: " << coarseDB << std::endl;
     }
     nLines++;
   }
   if (debug_) {
-    std::cout << "[DTTPGParamsWriter] # of entries written the the DB: "
-              << nLines << std::endl;
+    std::cout << "[DTTPGParamsWriter] # of entries written the the DB: " << nLines << std::endl;
   }
   if (nLines != 250) {
-    std::cout
-        << "[DTTPGParamsWriter] # of DB entries != 250. Check you input file!"
-        << std::endl;
+    std::cout << "[DTTPGParamsWriter] # of DB entries != 250. Check you input file!" << std::endl;
   }
 
   inputFile_.close();
 }
 
-void DTTPGParamsWriter::pharseLine(std::string &line, DTChamberId &chId,
-                                   float &fine, int &coarse) {
-
+void DTTPGParamsWriter::pharseLine(std::string &line, DTChamberId &chId, float &fine, int &coarse) {
   std::vector<std::string> elements;
   boost::algorithm::split(
-      elements, line,
-      boost::algorithm::is_any_of(
-          string(" \t\n"))); // making string conversion explicit (needed to
-                             // cope with -Warray-bounds in slc5_ia32_gcc434
+      elements,
+      line,
+      boost::algorithm::is_any_of(string(" \t\n")));  // making string conversion explicit (needed to
+                                                      // cope with -Warray-bounds in slc5_ia32_gcc434
   if (elements.size() != 5) {
-    std::cout << "[DTTPGParamsWriter] wrong number of entries in line : "
-              << line << " pleas check your input file syntax!" << std::endl;
+    std::cout << "[DTTPGParamsWriter] wrong number of entries in line : " << line
+              << " pleas check your input file syntax!" << std::endl;
   } else {
-    chId = DTChamberId(atoi(elements[0].c_str()), atoi(elements[1].c_str()),
-                       atoi(elements[2].c_str()));
+    chId = DTChamberId(atoi(elements[0].c_str()), atoi(elements[1].c_str()), atoi(elements[2].c_str()));
     fine = atof(elements[3].c_str());
     coarse = atoi(elements[4].c_str());
   }

--- a/L1TriggerConfig/DTTPGConfigProducers/plugins/DTTPGParamsWriter.h
+++ b/L1TriggerConfig/DTTPGConfigProducers/plugins/DTTPGParamsWriter.h
@@ -12,10 +12,10 @@
 #include <string>
 
 namespace edm {
-class ParameterSet;
-class Event;
-class EventSetup;
-} // namespace edm
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
 class DTChamberId;
 
@@ -30,15 +30,13 @@ public:
   // Operations
 
   /// Compute the ttrig by fiting the TB rising edge
-  void analyze(const edm::Event &event,
-               const edm::EventSetup &eventSetup) override;
+  void analyze(const edm::Event &event, const edm::EventSetup &eventSetup) override;
 
   /// Write ttrig in the DB
   void endJob() override;
 
 private:
-  void pharseLine(std::string &line, DTChamberId &chId, float &fine,
-                  int &coarse);
+  void pharseLine(std::string &line, DTChamberId &chId, float &fine, int &coarse);
 
   bool debug_;
   std::string inputFileName_;

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.cc
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.cc
@@ -51,7 +51,7 @@ DTConfigDBProducer::DTConfigDBProducer(const edm::ParameterSet &p) {
   m_debugLUTs = p.getParameter<bool>("debugLUTs");
   m_debugPed = p.getParameter<bool>("debugPed");
 
-  m_UseT0 = p.getParameter<bool>("UseT0"); // CB check for a better way to do it
+  m_UseT0 = p.getParameter<bool>("UseT0");  // CB check for a better way to do it
 }
 
 DTConfigDBProducer::~DTConfigDBProducer() {}
@@ -60,12 +60,10 @@ DTConfigDBProducer::~DTConfigDBProducer() {}
 // member functions
 //
 
-std::unique_ptr<DTConfigManager>
-DTConfigDBProducer::produce(const DTConfigManagerRcd &iRecord) {
+std::unique_ptr<DTConfigManager> DTConfigDBProducer::produce(const DTConfigManagerRcd &iRecord) {
   using namespace edm;
 
-  std::unique_ptr<DTConfigManager> dtConfig =
-      std::unique_ptr<DTConfigManager>(new DTConfigManager());
+  std::unique_ptr<DTConfigManager> dtConfig = std::unique_ptr<DTConfigManager>(new DTConfigManager());
   DTConfigManager &dttpgConfig = *(dtConfig.get());
 
   // DB specific requests
@@ -77,8 +75,7 @@ DTConfigDBProducer::produce(const DTConfigManagerRcd &iRecord) {
   dttpgConfig.setUseAcceptParam(useBtiAcceptParam);
 
   // set debug
-  edm::ParameterSet conf_ps =
-      m_ps.getParameter<edm::ParameterSet>("DTTPGParameters");
+  edm::ParameterSet conf_ps = m_ps.getParameter<edm::ParameterSet>("DTTPGParameters");
   bool dttpgdebug = conf_ps.getUntrackedParameter<bool>("Debug");
   dttpgConfig.setDTTPGDebug(dttpgdebug);
 
@@ -102,19 +99,15 @@ DTConfigDBProducer::produce(const DTConfigManagerRcd &iRecord) {
                          << "configurations has been read from cfg" << endl;
   } else if (code == 0) {
     LogVerbatim("DTTPG") << "DTConfigDBProducer::produce : " << endl
-                         << "Configurations successfully read from OMDS"
-                         << endl;
+                         << "Configurations successfully read from OMDS" << endl;
   } else {
-    LogProblem("DTTPG") << "DTConfigDBProducer::produce : " << endl
-                        << "Wrong configuration return CODE" << endl;
+    LogProblem("DTTPG") << "DTConfigDBProducer::produce : " << endl << "Wrong configuration return CODE" << endl;
   }
 
   return dtConfig;
 }
 
-void DTConfigDBProducer::readDBPedestalsConfig(
-    const DTConfigManagerRcd &iRecord, DTConfigManager &dttpgConfig) {
-
+void DTConfigDBProducer::readDBPedestalsConfig(const DTConfigManagerRcd &iRecord, DTConfigManager &dttpgConfig) {
   edm::ESHandle<DTTPGParameters> dttpgParams;
   iRecord.getRecord<DTTPGParametersRcd>().get(dttpgParams);
 
@@ -122,7 +115,6 @@ void DTConfigDBProducer::readDBPedestalsConfig(
   pedestals.setDebug(m_debugPed);
 
   if (m_UseT0) {
-
     edm::ESHandle<DTT0> t0i;
     iRecord.getRecord<DTT0Rcd>().get(t0i);
 
@@ -131,7 +123,6 @@ void DTConfigDBProducer::readDBPedestalsConfig(
     // cout << "checkDTCCBConfig CODE is " << checkDTCCBConfig() << endl;
 
   } else {
-
     pedestals.setUseT0(false);
     pedestals.setES(dttpgParams.product());
   }
@@ -153,7 +144,6 @@ int DTConfigDBProducer::checkDTCCBConfig(DTConfigManager &dttpgConfig) {
   for (int iwh = -2; iwh <= 2; iwh++) {
     for (int ise = 1; ise <= 12; ise++) {
       for (int ist = 1; ist <= 4; ist++) {
-
         check_cfg_code = 0;
         DTChamberId chid(iwh, ist, ise);
 
@@ -164,42 +154,33 @@ int DTConfigDBProducer::checkDTCCBConfig(DTConfigManager &dttpgConfig) {
         int ntsm = dttpgConfig.getDTConfigTSPhi(chid)->nValidTSM();
 
         // check BTIs
-        if ((ist == 1 && nbti != 168) || (ist == 2 && nbti != 192) ||
-            (ist == 3 && nbti != 224) ||
+        if ((ist == 1 && nbti != 168) || (ist == 2 && nbti != 192) || (ist == 3 && nbti != 224) ||
             (ist == 4 &&
-             (ise == 1 || ise == 2 || ise == 3 || ise == 5 || ise == 6 ||
-              ise == 7 || ise == 8 || ise == 12) &&
+             (ise == 1 || ise == 2 || ise == 3 || ise == 5 || ise == 6 || ise == 7 || ise == 8 || ise == 12) &&
              nbti != 192) ||
-            (ist == 4 && (ise == 9 || ise == 11) && nbti != 96) ||
-            (ist == 4 && ise == 10 && nbti != 128) ||
+            (ist == 4 && (ise == 9 || ise == 11) && nbti != 96) || (ist == 4 && ise == 10 && nbti != 128) ||
             (ist == 4 && ise == 4 && nbti != 160)) {
           check_cfg_code = 1;
           return check_cfg_code;
         }
 
         // check TRACOs
-        if ((ist == 1 && ntraco != 13) || (ist == 2 && ntraco != 16) ||
-            (ist == 3 && ntraco != 20) ||
+        if ((ist == 1 && ntraco != 13) || (ist == 2 && ntraco != 16) || (ist == 3 && ntraco != 20) ||
             (ist == 4 &&
-             (ise == 1 || ise == 2 || ise == 3 || ise == 5 || ise == 6 ||
-              ise == 7 || ise == 8 || ise == 12) &&
+             (ise == 1 || ise == 2 || ise == 3 || ise == 5 || ise == 6 || ise == 7 || ise == 8 || ise == 12) &&
              ntraco != 24) ||
-            (ist == 4 && (ise == 9 || ise == 11) && ntraco != 12) ||
-            (ist == 4 && ise == 10 && ntraco != 16) ||
+            (ist == 4 && (ise == 9 || ise == 11) && ntraco != 12) || (ist == 4 && ise == 10 && ntraco != 16) ||
             (ist == 4 && ise == 4 && ntraco != 20)) {
           check_cfg_code = 2;
           return check_cfg_code;
         }
 
         // check TSS
-        if ((ist == 1 && ntss != 4) || (ist == 2 && ntss != 4) ||
-            (ist == 3 && ntss != 5) ||
+        if ((ist == 1 && ntss != 4) || (ist == 2 && ntss != 4) || (ist == 3 && ntss != 5) ||
             (ist == 4 &&
-             (ise == 1 || ise == 2 || ise == 3 || ise == 5 || ise == 6 ||
-              ise == 7 || ise == 8 || ise == 12) &&
+             (ise == 1 || ise == 2 || ise == 3 || ise == 5 || ise == 6 || ise == 7 || ise == 8 || ise == 12) &&
              ntss != 6) ||
-            (ist == 4 && (ise == 9 || ise == 11) && ntss != 3) ||
-            (ist == 4 && ise == 10 && ntss != 4) ||
+            (ist == 4 && (ise == 9 || ise == 11) && ntss != 3) || (ist == 4 && ise == 10 && ntss != 4) ||
             (ist == 4 && ise == 4 && ntss != 5)) {
           check_cfg_code = 3;
           return check_cfg_code;
@@ -217,12 +198,11 @@ int DTConfigDBProducer::checkDTCCBConfig(DTConfigManager &dttpgConfig) {
         // << ise << " wh " << iwh << " == >check_cfg_code " << check_cfg_code
         // << endl;
         //}
-      } // end st loop
-    }   // end sec loop
+      }  // end st loop
+    }    // end sec loop
 
     // SV MB4 has two more chambers
     for (int ise = 13; ise <= 14; ise++) {
-
       DTChamberId chid(iwh, 4, ise);
 
       int nbti = dttpgConfig.getDTConfigBtiMap(chid).size();
@@ -251,17 +231,16 @@ int DTConfigDBProducer::checkDTCCBConfig(DTConfigManager &dttpgConfig) {
       // " ntsm " << ntsm << endl; cout << "Check: ch " << 4 << " sec " << ise
       // << " wh " << iwh << " == >check_cfg_code " << check_cfg_code << endl;
       //}
-    } // end sec 13 14
+    }  // end sec 13 14
 
-  } // end wh loop
+  }  // end wh loop
 
   // cout << "CheckDTCCB: config OK! check_cfg_code = " << check_cfg_code <<
   // endl;
   return check_cfg_code;
 }
 
-int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord,
-                                        DTConfigManager &dttpgConfig) {
+int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord, DTConfigManager &dttpgConfig) {
   using namespace edm::eventsetup;
 
   // initialize CCB validity flag
@@ -272,22 +251,19 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord,
   iRecord.getRecord<DTCCBConfigRcd>().get(ccb_conf);
   int ndata = std::distance(ccb_conf->begin(), ccb_conf->end());
 
-  const DTKeyedConfigListRcd &keyRecord =
-      iRecord.getRecord<DTKeyedConfigListRcd>();
+  const DTKeyedConfigListRcd &keyRecord = iRecord.getRecord<DTKeyedConfigListRcd>();
 
   if (m_debugDB) {
     cout << ccb_conf->version() << endl;
     cout << ndata << " data in the container" << endl;
   }
 
-  edm::ValidityInterval iov(
-      iRecord.getRecord<DTCCBConfigRcd>().validityInterval());
+  edm::ValidityInterval iov(iRecord.getRecord<DTCCBConfigRcd>().validityInterval());
   unsigned int currValidityStart = iov.first().eventID().run();
   unsigned int currValidityEnd = iov.last().eventID().run();
 
   if (m_debugDB)
-    cout << "valid since run " << currValidityStart << " to run "
-         << currValidityEnd << endl;
+    cout << "valid since run " << currValidityStart << " to run " << currValidityEnd << endl;
 
   // if there are no data in the container, configuration from cfg files...
   if (ndata == 0) {
@@ -295,8 +271,7 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord,
   }
 
   // get DTTPGMap for retrieving bti number and traco number
-  edm::ParameterSet conf_map =
-      m_ps.getUntrackedParameter<edm::ParameterSet>("DTTPGMap");
+  edm::ParameterSet conf_map = m_ps.getUntrackedParameter<edm::ParameterSet>("DTTPGMap");
 
   // loop over chambers
   DTCCBConfig::ccb_config_map configKeys(ccb_conf->configKeyMap());
@@ -304,7 +279,7 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord,
   DTCCBConfig::ccb_config_iterator iend = configKeys.end();
 
   // 110628 SV check that number of CCB is equal to total number of chambers
-  if (ccb_conf->configKeyMap().size() != 250) // check the number of chambers!!!
+  if (ccb_conf->configKeyMap().size() != 250)  // check the number of chambers!!!
     return -1;
 
   // read data from CCBConfig
@@ -320,15 +295,12 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord,
     // get chamber id
     const DTCCBId &ccbId = iter->first;
     if (m_debugDB)
-      cout << " Filling configuration for chamber : wh " << ccbId.wheelId
-           << " st " << ccbId.stationId << " se " << ccbId.sectorId << " -> "
-           << endl;
+      cout << " Filling configuration for chamber : wh " << ccbId.wheelId << " st " << ccbId.stationId << " se "
+           << ccbId.sectorId << " -> " << endl;
 
     // get chamber type and id from ccbId
-    int mbtype =
-        DTPosNegType::getCT(ccbId.wheelId, ccbId.sectorId, ccbId.stationId);
-    int posneg =
-        DTPosNegType::getPN(ccbId.wheelId, ccbId.sectorId, ccbId.stationId);
+    int mbtype = DTPosNegType::getCT(ccbId.wheelId, ccbId.sectorId, ccbId.stationId);
+    int posneg = DTPosNegType::getPN(ccbId.wheelId, ccbId.sectorId, ccbId.stationId);
     if (m_debugDB)
       cout << "Chamber type : " << mbtype << " posneg : " << posneg << endl;
     DTChamberId chambid(ccbId.wheelId, ccbId.stationId, ccbId.sectorId);
@@ -363,7 +335,7 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord,
 
         // copy string in unsigned int buffer
         std::string str = *s_iter++;
-        unsigned short int buffer[100]; // 2 bytes
+        unsigned short int buffer[100];  // 2 bytes
         int c = 0;
         const char *cstr = str.c_str();
         const char *ptr = cstr + 2;
@@ -387,7 +359,7 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord,
             i2 = 10 + c2 - 'A';
           buffer[c] = (i1 * 16) + i2;
           c++;
-        } // end loop over string
+        }  // end loop over string
 
         // BTI configuration string
         if (buffer[2] == 0x54) {
@@ -398,16 +370,16 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord,
           flagDBBti = true;
 
           // compute sl and bti number from board and chip
-          int brd = buffer[3];  // Board Nr.
-          int chip = buffer[4]; // Chip Nr.
+          int brd = buffer[3];   // Board Nr.
+          int chip = buffer[4];  // Chip Nr.
 
           if (brd > 7) {
             cout << "Not existing board ... " << brd << endl;
-            return -1; // Non-existing board
+            return -1;  // Non-existing board
           }
           if (chip > 31) {
             cout << "Not existing chip... " << chip << endl;
-            return -1; // Non existing chip
+            return -1;  // Non existing chip
           }
 
           // Is it Phi or Theta board?
@@ -415,49 +387,49 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord,
           PhiSL = false;
           ThetaSL = false;
           switch (mbtype) {
-          case 1: // mb1
-            if (brd == 6 || brd == 7) {
-              ThetaSL = true;
-              brd -= 6;
-            } else if ((brd < 3 && chip < 32) || (brd == 3 && chip < 8))
-              PhiSL = true;
-            break;
-          case 2: // mb2
-            if (brd == 6 || brd == 7) {
-              ThetaSL = true;
-              brd -= 6;
-            } else if (brd < 4 && chip < 32)
-              PhiSL = true;
-            break;
-          case 3: // mb3
-            if (brd == 6 || brd == 7) {
-              ThetaSL = true;
-              brd -= 6;
-            } else if (brd < 5 && chip < 32)
-              PhiSL = true;
-            break;
-          case 4: // mb4-s, mb4_8
-            if (brd < 6 && chip < 32)
-              PhiSL = true;
-            break;
-          case 5: // mb4-9
-            if (brd < 3 && chip < 32)
-              PhiSL = true;
-            break;
-          case 6: // mb4-4
-            if (brd < 5 && chip < 32)
-              PhiSL = true;
-            break;
-          case 7: // mb4-10
-            if (brd < 4 && chip < 32)
-              PhiSL = true;
-            break;
+            case 1:  // mb1
+              if (brd == 6 || brd == 7) {
+                ThetaSL = true;
+                brd -= 6;
+              } else if ((brd < 3 && chip < 32) || (brd == 3 && chip < 8))
+                PhiSL = true;
+              break;
+            case 2:  // mb2
+              if (brd == 6 || brd == 7) {
+                ThetaSL = true;
+                brd -= 6;
+              } else if (brd < 4 && chip < 32)
+                PhiSL = true;
+              break;
+            case 3:  // mb3
+              if (brd == 6 || brd == 7) {
+                ThetaSL = true;
+                brd -= 6;
+              } else if (brd < 5 && chip < 32)
+                PhiSL = true;
+              break;
+            case 4:  // mb4-s, mb4_8
+              if (brd < 6 && chip < 32)
+                PhiSL = true;
+              break;
+            case 5:  // mb4-9
+              if (brd < 3 && chip < 32)
+                PhiSL = true;
+              break;
+            case 6:  // mb4-4
+              if (brd < 5 && chip < 32)
+                PhiSL = true;
+              break;
+            case 7:  // mb4-10
+              if (brd < 4 && chip < 32)
+                PhiSL = true;
+              break;
           }
           if (!PhiSL && !ThetaSL) {
             cout << "MB type " << mbtype << endl;
             cout << "Board " << brd << " chip " << chip << endl;
             cout << "Not phi SL nor Theta SL" << endl;
-            return -1; // Not PhiSL nor ThetaSL
+            return -1;  // Not PhiSL nor ThetaSL
           }
 
           // compute SL number and bti number
@@ -465,12 +437,12 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord,
           int ibti = 0;
           if (PhiSL) {
             if ((chip % 8) < 4)
-              isl = 1; // Phi1
+              isl = 1;  // Phi1
             else
-              isl = 3; // Phi2
+              isl = 3;  // Phi2
             ibti = brd * 16 + (int)(chip / 8) * 4 + (chip % 4);
           } else if (ThetaSL) {
-            isl = 2; // Theta
+            isl = 2;  // Theta
             if ((chip % 8) < 4)
               ibti = brd * 32 + chip - 4 * (int)(chip / 8);
             else
@@ -483,9 +455,8 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord,
           dttpgConfig.setDTConfigBti(DTBtiId(chambid, isl, ibti + 1), bticonf);
 
           if (m_debugDB)
-            cout << "Filling BTI config for chamber : wh " << chambid.wheel()
-                 << ", st " << chambid.station() << ", se " << chambid.sector()
-                 << "... sl " << isl << ", bti " << ibti + 1 << endl;
+            cout << "Filling BTI config for chamber : wh " << chambid.wheel() << ", st " << chambid.station() << ", se "
+                 << chambid.sector() << "... sl " << isl << ", bti " << ibti + 1 << endl;
         }
 
         // TRACO configuration string
@@ -496,17 +467,16 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord,
           flagDBTraco = true;
 
           // TRACO config constructor from strings
-          int traco_brd = buffer[3];  // Board Nr.;
-          int traco_chip = buffer[4]; // Chip Nr.;
+          int traco_brd = buffer[3];   // Board Nr.;
+          int traco_chip = buffer[4];  // Chip Nr.;
           int itraco = traco_brd * 4 + traco_chip + 1;
           DTConfigTraco tracoconf(m_debugTraco, buffer);
           dttpgConfig.setDTConfigTraco(DTTracoId(chambid, itraco), tracoconf);
 
           if (m_debugDB)
-            cout << "Filling TRACO config for chamber : wh " << chambid.wheel()
-                 << ", st " << chambid.station() << ", se " << chambid.sector()
-                 << ", board " << traco_brd << ", chip " << traco_chip
-                 << ", traco " << itraco << endl;
+            cout << "Filling TRACO config for chamber : wh " << chambid.wheel() << ", st " << chambid.station()
+                 << ", se " << chambid.sector() << ", board " << traco_brd << ", chip " << traco_chip << ", traco "
+                 << itraco << endl;
         }
 
         // TSS configuration string
@@ -546,8 +516,8 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord,
           dttpgConfig.setDTConfigLUTs(chambid, lutconf);
         }
 
-      } // end string iteration
-    }   // end brick iteration
+      }  // end string iteration
+    }    // end brick iteration
 
     // TSS + TSM configurations are set in DTConfigTSPhi constructor
     if (flagDBTSM && flagDBTSS) {
@@ -556,23 +526,18 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord,
     }
 
     // get configuration for TSTheta, SC and TU from .cfg
-    edm::ParameterSet conf_ps =
-        m_ps.getParameter<edm::ParameterSet>("DTTPGParameters");
-    edm::ParameterSet tups =
-        conf_ps.getParameter<edm::ParameterSet>("TUParameters");
+    edm::ParameterSet conf_ps = m_ps.getParameter<edm::ParameterSet>("DTTPGParameters");
+    edm::ParameterSet tups = conf_ps.getParameter<edm::ParameterSet>("TUParameters");
 
     // TSTheta configuration from .cfg
-    DTConfigTSTheta tsthetaconf(
-        tups.getParameter<edm::ParameterSet>("TSThetaParameters"));
+    DTConfigTSTheta tsthetaconf(tups.getParameter<edm::ParameterSet>("TSThetaParameters"));
     tsthetaconf.setDebug(m_debugTST);
     dttpgConfig.setDTConfigTSTheta(chambid, tsthetaconf);
 
     // SC configuration from .cfg
-    DTConfigSectColl sectcollconf(
-        conf_ps.getParameter<edm::ParameterSet>("SectCollParameters"));
+    DTConfigSectColl sectcollconf(conf_ps.getParameter<edm::ParameterSet>("SectCollParameters"));
     sectcollconf.setDebug(m_debugSC);
-    dttpgConfig.setDTConfigSectColl(
-        DTSectCollId(chambid.wheel(), chambid.sector()), sectcollconf);
+    dttpgConfig.setDTConfigSectColl(DTSectCollId(chambid.wheel(), chambid.sector()), sectcollconf);
 
     // TU configuration from .cfg
     DTConfigTrigUnit trigunitconf(tups);
@@ -591,7 +556,7 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord,
     if (!flagDBLUTS && dttpgConfig.lutFromDB() == true) {
       return -1;
     }
-  } // end loop over CCB
+  }  // end loop over CCB
 
   return 0;
 }
@@ -610,27 +575,19 @@ std::string DTConfigDBProducer::mapEntryName(const DTChamberId &chambid) const {
 }
 
 void DTConfigDBProducer::configFromCfg(DTConfigManager &dttpgConfig) {
-
   // ... but still set CCB validity flag to let the emulator run
   dttpgConfig.setCCBConfigValidity(true);
 
   // create config classes&C.
-  edm::ParameterSet conf_ps =
-      m_ps.getParameter<edm::ParameterSet>("DTTPGParameters");
-  edm::ParameterSet conf_map =
-      m_ps.getUntrackedParameter<edm::ParameterSet>("DTTPGMap");
+  edm::ParameterSet conf_ps = m_ps.getParameter<edm::ParameterSet>("DTTPGParameters");
+  edm::ParameterSet conf_map = m_ps.getUntrackedParameter<edm::ParameterSet>("DTTPGMap");
   bool dttpgdebug = conf_ps.getUntrackedParameter<bool>("Debug");
-  DTConfigSectColl sectcollconf(
-      conf_ps.getParameter<edm::ParameterSet>("SectCollParameters"));
-  edm::ParameterSet tups =
-      conf_ps.getParameter<edm::ParameterSet>("TUParameters");
+  DTConfigSectColl sectcollconf(conf_ps.getParameter<edm::ParameterSet>("SectCollParameters"));
+  edm::ParameterSet tups = conf_ps.getParameter<edm::ParameterSet>("TUParameters");
   DTConfigBti bticonf(tups.getParameter<edm::ParameterSet>("BtiParameters"));
-  DTConfigTraco tracoconf(
-      tups.getParameter<edm::ParameterSet>("TracoParameters"));
-  DTConfigTSTheta tsthetaconf(
-      tups.getParameter<edm::ParameterSet>("TSThetaParameters"));
-  DTConfigTSPhi tsphiconf(
-      tups.getParameter<edm::ParameterSet>("TSPhiParameters"));
+  DTConfigTraco tracoconf(tups.getParameter<edm::ParameterSet>("TracoParameters"));
+  DTConfigTSTheta tsthetaconf(tups.getParameter<edm::ParameterSet>("TSThetaParameters"));
+  DTConfigTSPhi tsphiconf(tups.getParameter<edm::ParameterSet>("TSPhiParameters"));
   DTConfigTrigUnit trigunitconf(tups);
   DTConfigLUTs lutconf(tups.getParameter<edm::ParameterSet>("LutParameters"));
 
@@ -638,13 +595,11 @@ void DTConfigDBProducer::configFromCfg(DTConfigManager &dttpgConfig) {
     for (int ist = 1; ist <= 4; ++ist) {
       for (int ise = 1; ise <= 12; ++ise) {
         DTChamberId chambid(iwh, ist, ise);
-        vector<int> nmap = conf_map.getUntrackedParameter<vector<int>>(
-            mapEntryName(chambid).c_str());
+        vector<int> nmap = conf_map.getUntrackedParameter<vector<int>>(mapEntryName(chambid).c_str());
 
         if (dttpgdebug) {
-          cout << " Filling configuration for chamber : wh " << chambid.wheel()
-               << ", st " << chambid.station() << ", se " << chambid.sector()
-               << endl;
+          cout << " Filling configuration for chamber : wh " << chambid.wheel() << ", st " << chambid.station()
+               << ", se " << chambid.sector() << endl;
         }
 
         // fill the bti map
@@ -653,13 +608,10 @@ void DTConfigDBProducer::configFromCfg(DTConfigManager &dttpgConfig) {
             int ncell = nmap[isl - 1];
             //	  cout << ncell <<" , ";
             for (int ibti = 0; ibti < ncell; ibti++) {
-              dttpgConfig.setDTConfigBti(DTBtiId(chambid, isl, ibti + 1),
-                                         bticonf);
+              dttpgConfig.setDTConfigBti(DTBtiId(chambid, isl, ibti + 1), bticonf);
               if (dttpgdebug)
-                cout << "Filling BTI config for chamber : wh "
-                     << chambid.wheel() << ", st " << chambid.station()
-                     << ", se " << chambid.sector() << "... sl " << isl
-                     << ", bti " << ibti + 1 << endl;
+                cout << "Filling BTI config for chamber : wh " << chambid.wheel() << ", st " << chambid.station()
+                     << ", se " << chambid.sector() << "... sl " << isl << ", bti " << ibti + 1 << endl;
             }
           }
         }
@@ -669,12 +621,10 @@ void DTConfigDBProducer::configFromCfg(DTConfigManager &dttpgConfig) {
           int ntraco = nmap[3];
           // cout << ntraco << " }" << endl;
           for (int itraco = 0; itraco < ntraco; itraco++) {
-            dttpgConfig.setDTConfigTraco(DTTracoId(chambid, itraco + 1),
-                                         tracoconf);
+            dttpgConfig.setDTConfigTraco(DTTracoId(chambid, itraco + 1), tracoconf);
             if (dttpgdebug)
-              cout << "Filling TRACO config for chamber : wh "
-                   << chambid.wheel() << ", st " << chambid.station() << ", se "
-                   << chambid.sector() << ", traco " << itraco + 1 << endl;
+              cout << "Filling TRACO config for chamber : wh " << chambid.wheel() << ", st " << chambid.station()
+                   << ", se " << chambid.sector() << ", traco " << itraco + 1 << endl;
           }
         }
 
@@ -692,13 +642,11 @@ void DTConfigDBProducer::configFromCfg(DTConfigManager &dttpgConfig) {
     for (int ise = 13; ise <= 14; ++ise) {
       int ist = 4;
       DTChamberId chambid(iwh, ist, ise);
-      vector<int> nmap = conf_map.getUntrackedParameter<vector<int>>(
-          mapEntryName(chambid).c_str());
+      vector<int> nmap = conf_map.getUntrackedParameter<vector<int>>(mapEntryName(chambid).c_str());
 
       if (dttpgdebug) {
-        cout << " Filling configuration for chamber : wh " << chambid.wheel()
-             << ", st " << chambid.station() << ", se " << chambid.sector()
-             << endl;
+        cout << " Filling configuration for chamber : wh " << chambid.wheel() << ", st " << chambid.station() << ", se "
+             << chambid.sector() << endl;
       }
 
       // fill the bti map
@@ -707,13 +655,10 @@ void DTConfigDBProducer::configFromCfg(DTConfigManager &dttpgConfig) {
           int ncell = nmap[isl - 1];
           // 	cout << ncell <<" , ";
           for (int ibti = 0; ibti < ncell; ibti++) {
-            dttpgConfig.setDTConfigBti(DTBtiId(chambid, isl, ibti + 1),
-                                       bticonf);
+            dttpgConfig.setDTConfigBti(DTBtiId(chambid, isl, ibti + 1), bticonf);
             if (dttpgdebug)
-              cout << "Filling BTI config for chamber : wh " << chambid.wheel()
-                   << ", st " << chambid.station() << ", se "
-                   << chambid.sector() << "... sl " << isl << ", bti "
-                   << ibti + 1 << endl;
+              cout << "Filling BTI config for chamber : wh " << chambid.wheel() << ", st " << chambid.station()
+                   << ", se " << chambid.sector() << "... sl " << isl << ", bti " << ibti + 1 << endl;
           }
         }
       }
@@ -723,12 +668,10 @@ void DTConfigDBProducer::configFromCfg(DTConfigManager &dttpgConfig) {
         int ntraco = nmap[3];
         //       cout << ntraco << " }" << endl;
         for (int itraco = 0; itraco < ntraco; itraco++) {
-          dttpgConfig.setDTConfigTraco(DTTracoId(chambid, itraco + 1),
-                                       tracoconf);
+          dttpgConfig.setDTConfigTraco(DTTracoId(chambid, itraco + 1), tracoconf);
           if (dttpgdebug)
-            cout << "Filling TRACO config for chamber : wh " << chambid.wheel()
-                 << ", st " << chambid.station() << ", se " << chambid.sector()
-                 << ", traco " << itraco + 1 << endl;
+            cout << "Filling TRACO config for chamber : wh " << chambid.wheel() << ", st " << chambid.station()
+                 << ", se " << chambid.sector() << ", traco " << itraco + 1 << endl;
         }
       }
 

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.h
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.h
@@ -44,7 +44,6 @@
 //
 
 class DTConfigDBProducer : public edm::ESProducer {
-
 public:
   //! Constructor
   DTConfigDBProducer(const edm::ParameterSet &);
@@ -57,12 +56,10 @@ public:
 
 private:
   //! Read DTTPG pedestal configuration
-  void readDBPedestalsConfig(const DTConfigManagerRcd &iRecord,
-                             DTConfigManager &dttpgConfig);
+  void readDBPedestalsConfig(const DTConfigManagerRcd &iRecord, DTConfigManager &dttpgConfig);
 
   //! Read CCB string configuration
-  int readDTCCBConfig(const DTConfigManagerRcd &iRecord,
-                      DTConfigManager &dttpgConfig);
+  int readDTCCBConfig(const DTConfigManagerRcd &iRecord, DTConfigManager &dttpgConfig);
 
   //! SV for debugging purpose ONLY
   void configFromCfg(DTConfigManager &dttpgConfig);

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigTester.cc
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigTester.cc
@@ -15,7 +15,6 @@ using std::cout;
 using std::endl;
 
 DTConfigTester::DTConfigTester(const edm::ParameterSet &ps) {
-
   cout << "DTConfigTester::DTConfigTester()" << endl;
 
   my_wh = ps.getUntrackedParameter<int>("wheel");
@@ -27,12 +26,10 @@ DTConfigTester::DTConfigTester(const edm::ParameterSet &ps) {
 }
 
 DTConfigTester::~DTConfigTester() {
-
   // cout << "DTConfigTester::~DTConfigTester()" << endl;
 }
 
 void DTConfigTester::analyze(const edm::Event &e, const edm::EventSetup &es) {
-
   cout << "DTConfigTester::analyze()" << endl;
   cout << "\tRun number :" << e.id().run() << endl;
   cout << "\tEvent number :" << e.id().event() << endl;

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigTester.h
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigTester.h
@@ -28,7 +28,6 @@
 //
 
 class DTConfigTester : public edm::EDAnalyzer {
-
 public:
   //! Constructor
   explicit DTConfigTester(const edm::ParameterSet &);

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigTrivialProducer.cc
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigTrivialProducer.cc
@@ -13,7 +13,6 @@ using std::vector;
 // constructors and destructor
 //
 DTConfigTrivialProducer::DTConfigTrivialProducer(const edm::ParameterSet &ps) {
-
   setWhatProduced(this);
 
   // get and store parameter set
@@ -22,8 +21,7 @@ DTConfigTrivialProducer::DTConfigTrivialProducer(const edm::ParameterSet &ps) {
   m_tpgParams = new DTTPGParameters();
 
   // set debug
-  edm::ParameterSet conf_ps =
-      m_ps.getParameter<edm::ParameterSet>("DTTPGParameters");
+  edm::ParameterSet conf_ps = m_ps.getParameter<edm::ParameterSet>("DTTPGParameters");
   m_debug = conf_ps.getUntrackedParameter<bool>("Debug");
 
   if (m_debug)
@@ -37,12 +35,10 @@ DTConfigTrivialProducer::DTConfigTrivialProducer(const edm::ParameterSet &ps) {
 
   // set specific DB requests
   m_manager->setLutFromDB(tracoLutsFromDB);
-  m_manager->setUseAcceptParam(
-      useBtiAcceptParam); // CB Are these needed here???
+  m_manager->setUseAcceptParam(useBtiAcceptParam);  // CB Are these needed here???
 }
 
 DTConfigTrivialProducer::~DTConfigTrivialProducer() {
-
   if (m_debug)
     cout << "DTConfigTrivialProducer::~DTConfigTrivialProducer()" << endl;
 }
@@ -51,9 +47,7 @@ DTConfigTrivialProducer::~DTConfigTrivialProducer() {
 // member functions
 //
 
-std::unique_ptr<DTConfigManager>
-DTConfigTrivialProducer::produce(const DTConfigManagerRcd &iRecord) {
-
+std::unique_ptr<DTConfigManager> DTConfigTrivialProducer::produce(const DTConfigManagerRcd &iRecord) {
   if (m_debug)
     cout << "DTConfigTrivialProducer::produce()" << endl;
 
@@ -62,46 +56,35 @@ DTConfigTrivialProducer::produce(const DTConfigManagerRcd &iRecord) {
 
   // m_manager->getDTConfigPedestals()->print();
 
-  std::unique_ptr<DTConfigManager> dtConfig =
-      std::unique_ptr<DTConfigManager>(m_manager);
+  std::unique_ptr<DTConfigManager> dtConfig = std::unique_ptr<DTConfigManager>(m_manager);
 
   return dtConfig;
 }
 
 void DTConfigTrivialProducer::buildManager() {
-
   if (m_debug)
     cout << "DTConfigTrivialProducer::buildManager()" << endl;
 
   // create config classes&C.
-  edm::ParameterSet conf_ps =
-      m_ps.getParameter<edm::ParameterSet>("DTTPGParameters");
-  edm::ParameterSet conf_map =
-      m_ps.getUntrackedParameter<edm::ParameterSet>("DTTPGMap");
-  DTConfigSectColl sectcollconf(
-      conf_ps.getParameter<edm::ParameterSet>("SectCollParameters"));
-  edm::ParameterSet tups =
-      conf_ps.getParameter<edm::ParameterSet>("TUParameters");
+  edm::ParameterSet conf_ps = m_ps.getParameter<edm::ParameterSet>("DTTPGParameters");
+  edm::ParameterSet conf_map = m_ps.getUntrackedParameter<edm::ParameterSet>("DTTPGMap");
+  DTConfigSectColl sectcollconf(conf_ps.getParameter<edm::ParameterSet>("SectCollParameters"));
+  edm::ParameterSet tups = conf_ps.getParameter<edm::ParameterSet>("TUParameters");
   DTConfigBti bticonf(tups.getParameter<edm::ParameterSet>("BtiParameters"));
-  DTConfigTraco tracoconf(
-      tups.getParameter<edm::ParameterSet>("TracoParameters"));
+  DTConfigTraco tracoconf(tups.getParameter<edm::ParameterSet>("TracoParameters"));
   DTConfigLUTs lutconf(tups.getParameter<edm::ParameterSet>("LutParameters"));
-  DTConfigTSTheta tsthetaconf(
-      tups.getParameter<edm::ParameterSet>("TSThetaParameters"));
-  DTConfigTSPhi tsphiconf(
-      tups.getParameter<edm::ParameterSet>("TSPhiParameters"));
+  DTConfigTSTheta tsthetaconf(tups.getParameter<edm::ParameterSet>("TSThetaParameters"));
+  DTConfigTSPhi tsphiconf(tups.getParameter<edm::ParameterSet>("TSPhiParameters"));
   DTConfigTrigUnit trigunitconf(tups);
 
   for (int iwh = -2; iwh <= 2; ++iwh) {
     for (int ist = 1; ist <= 4; ++ist) {
       for (int ise = 1; ise <= 12; ++ise) {
         DTChamberId chambid(iwh, ist, ise);
-        vector<int> nmap = conf_map.getUntrackedParameter<vector<int>>(
-            mapEntryName(chambid).c_str());
+        vector<int> nmap = conf_map.getUntrackedParameter<vector<int>>(mapEntryName(chambid).c_str());
 
         if (m_debug) {
-          std::cout << " Filling configuration for chamber : wh "
-                    << chambid.wheel() << ", st " << chambid.station()
+          std::cout << " Filling configuration for chamber : wh " << chambid.wheel() << ", st " << chambid.station()
                     << ", se " << chambid.sector() << endl;
         }
 
@@ -112,10 +95,8 @@ void DTConfigTrivialProducer::buildManager() {
           for (int ibti = 0; ibti < ncell; ibti++) {
             m_manager->setDTConfigBti(DTBtiId(chambid, isl, ibti + 1), bticonf);
             if (m_debug)
-              std::cout << "Filling BTI config for chamber : wh "
-                        << chambid.wheel() << ", st " << chambid.station()
-                        << ", se " << chambid.sector() << "... sl " << isl
-                        << ", bti " << ibti + 1 << endl;
+              std::cout << "Filling BTI config for chamber : wh " << chambid.wheel() << ", st " << chambid.station()
+                        << ", se " << chambid.sector() << "... sl " << isl << ", bti " << ibti + 1 << endl;
           }
         }
 
@@ -123,13 +104,10 @@ void DTConfigTrivialProducer::buildManager() {
         int ntraco = nmap[3];
         // std::cout << ntraco << " }" << std::endl;
         for (int itraco = 0; itraco < ntraco; itraco++) {
-          m_manager->setDTConfigTraco(DTTracoId(chambid, itraco + 1),
-                                      tracoconf);
+          m_manager->setDTConfigTraco(DTTracoId(chambid, itraco + 1), tracoconf);
           if (m_debug)
-            std::cout << "Filling TRACO config for chamber : wh "
-                      << chambid.wheel() << ", st " << chambid.station()
-                      << ", se " << chambid.sector() << ", traco " << itraco + 1
-                      << endl;
+            std::cout << "Filling TRACO config for chamber : wh " << chambid.wheel() << ", st " << chambid.station()
+                      << ", se " << chambid.sector() << ", traco " << itraco + 1 << endl;
         }
 
         // fill TS & TrigUnit
@@ -139,8 +117,7 @@ void DTConfigTrivialProducer::buildManager() {
 
         // fill LUTs
         m_manager->setDTConfigLUTs(chambid, lutconf);
-        m_manager->setLutFromDB(
-            false); // 110204 SV to be sure to compute luts from geometry
+        m_manager->setLutFromDB(false);  // 110204 SV to be sure to compute luts from geometry
       }
     }
   }
@@ -149,13 +126,11 @@ void DTConfigTrivialProducer::buildManager() {
     for (int ise = 13; ise <= 14; ++ise) {
       int ist = 4;
       DTChamberId chambid(iwh, ist, ise);
-      vector<int> nmap = conf_map.getUntrackedParameter<vector<int>>(
-          mapEntryName(chambid).c_str());
+      vector<int> nmap = conf_map.getUntrackedParameter<vector<int>>(mapEntryName(chambid).c_str());
 
       if (m_debug) {
-        std::cout << " Filling configuration for chamber : wh "
-                  << chambid.wheel() << ", st " << chambid.station() << ", se "
-                  << chambid.sector() << endl;
+        std::cout << " Filling configuration for chamber : wh " << chambid.wheel() << ", st " << chambid.station()
+                  << ", se " << chambid.sector() << endl;
       }
 
       // fill the bti map
@@ -165,10 +140,8 @@ void DTConfigTrivialProducer::buildManager() {
         for (int ibti = 0; ibti < ncell; ibti++) {
           m_manager->setDTConfigBti(DTBtiId(chambid, isl, ibti + 1), bticonf);
           if (m_debug)
-            std::cout << "Filling BTI config for chamber : wh "
-                      << chambid.wheel() << ", st " << chambid.station()
-                      << ", se " << chambid.sector() << "... sl " << isl
-                      << ", bti " << ibti + 1 << endl;
+            std::cout << "Filling BTI config for chamber : wh " << chambid.wheel() << ", st " << chambid.station()
+                      << ", se " << chambid.sector() << "... sl " << isl << ", bti " << ibti + 1 << endl;
         }
       }
 
@@ -178,10 +151,8 @@ void DTConfigTrivialProducer::buildManager() {
       for (int itraco = 0; itraco < ntraco; itraco++) {
         m_manager->setDTConfigTraco(DTTracoId(chambid, itraco + 1), tracoconf);
         if (m_debug)
-          std::cout << "Filling TRACO config for chamber : wh "
-                    << chambid.wheel() << ", st " << chambid.station()
-                    << ", se " << chambid.sector() << ", traco " << itraco + 1
-                    << endl;
+          std::cout << "Filling TRACO config for chamber : wh " << chambid.wheel() << ", st " << chambid.station()
+                    << ", se " << chambid.sector() << ", traco " << itraco + 1 << endl;
       }
 
       // fill TS & TrigUnit
@@ -191,8 +162,7 @@ void DTConfigTrivialProducer::buildManager() {
 
       // fill LUTs
       m_manager->setDTConfigLUTs(chambid, lutconf);
-      m_manager->setLutFromDB(
-          false); // 110204 SV to be sure to compute luts from geometry
+      m_manager->setLutFromDB(false);  // 110204 SV to be sure to compute luts from geometry
     }
   }
 
@@ -206,7 +176,6 @@ void DTConfigTrivialProducer::buildManager() {
 }
 
 DTConfigPedestals DTConfigTrivialProducer::buildTrivialPedestals() {
-
   int counts = m_ps.getParameter<int>("bxOffset");
   float fine = m_ps.getParameter<double>("finePhase");
 
@@ -233,8 +202,7 @@ DTConfigPedestals DTConfigTrivialProducer::buildTrivialPedestals() {
   return tpgPedestals;
 }
 
-std::string
-DTConfigTrivialProducer::mapEntryName(const DTChamberId &chambid) const {
+std::string DTConfigTrivialProducer::mapEntryName(const DTChamberId &chambid) const {
   int iwh = chambid.wheel();
   std::ostringstream os;
   os << "wh";

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTPosNegType.cc
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTPosNegType.cc
@@ -49,7 +49,6 @@ DTPosNegCompare::operator()( const DTCCBId& idl,
 */
 
 void DTPosNegType::dump() {
-
   if (initRequest)
     fillMap();
   std::map<int, int>::const_iterator iter = geomMap.begin();
@@ -86,9 +85,7 @@ int DTPosNegType::getPN(int whe, int sec, int sta) {
   return p_n;
 }
 
-int DTPosNegType::getPN(const DTChamberId &cha) {
-  return getPN(cha.wheel(), cha.sector(), cha.station());
-}
+int DTPosNegType::getPN(const DTChamberId &cha) { return getPN(cha.wheel(), cha.sector(), cha.station()); }
 
 int DTPosNegType::getCT(int whe, int sec, int sta) {
   int p_n;
@@ -97,9 +94,7 @@ int DTPosNegType::getCT(int whe, int sec, int sta) {
   return c_t;
 }
 
-int DTPosNegType::getCT(const DTChamberId &cha) {
-  return getCT(cha.wheel(), cha.sector(), cha.station());
-}
+int DTPosNegType::getCT(const DTChamberId &cha) { return getCT(cha.wheel(), cha.sector(), cha.station()); }
 
 void DTPosNegType::fillMap() {
   // std::cout << "DTPosNeg::fillMap()" << std::endl;
@@ -361,9 +356,7 @@ void DTPosNegType::fillMap() {
   initRequest = false;
 }
 
-int DTPosNegType::idCode(int whe, int sec, int sta) {
-  return ((((whe + 3) * 100) + sec) * 10) + sta;
-}
+int DTPosNegType::idCode(int whe, int sec, int sta) { return ((((whe + 3) * 100) + sec) * 10) + sta; }
 
 int DTPosNegType::pnCode(int p, int t) { return (p * 1000) + t; }
 

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTPosNegType.h
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTPosNegType.h
@@ -36,7 +36,6 @@ class DTPosNegCompare {
 */
 
 class DTPosNegType {
-
 public:
   /** Constructor
    */
@@ -68,4 +67,4 @@ private:
   static int getData(int whe, int sec, int sta);
 };
 
-#endif // DTPosNegType_H
+#endif  // DTPosNegType_H

--- a/L1TriggerConfig/L1GeometryProducers/src/L1CaloGeometryDump.cc
+++ b/L1TriggerConfig/L1GeometryProducers/src/L1CaloGeometryDump.cc
@@ -71,7 +71,6 @@ L1CaloGeometryDump::L1CaloGeometryDump(const edm::ParameterSet &iConfig)
 }
 
 L1CaloGeometryDump::~L1CaloGeometryDump() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -81,8 +80,7 @@ L1CaloGeometryDump::~L1CaloGeometryDump() {
 //
 
 // ------------ method called to for each event  ------------
-void L1CaloGeometryDump::analyze(const edm::Event &iEvent,
-                                 const edm::EventSetup &iSetup) {
+void L1CaloGeometryDump::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
 
   ESHandle<L1CaloGeometry> pGeom;

--- a/L1TriggerConfig/L1GeometryProducers/src/L1CaloGeometryProd.cc
+++ b/L1TriggerConfig/L1GeometryProducers/src/L1CaloGeometryProd.cc
@@ -43,21 +43,19 @@ L1CaloGeometryProd::L1CaloGeometryProd(const edm::ParameterSet &ps) {
 
   // This producer should never make more than one version of L1Geometry,
   // so we can initialize it in the ctor.
-  m_geom = L1CaloGeometry(
-      ps.getParameter<unsigned int>("numberGctEmJetPhiBins"),
-      ps.getParameter<double>("gctEmJetPhiBinOffset"),
-      ps.getParameter<unsigned int>("numberGctEtSumPhiBins"),
-      ps.getParameter<double>("gctEtSumPhiBinOffset"),
-      ps.getParameter<unsigned int>("numberGctHtSumPhiBins"),
-      ps.getParameter<double>("gctHtSumPhiBinOffset"),
-      ps.getParameter<unsigned int>("numberGctCentralEtaBinsPerHalf"),
-      ps.getParameter<unsigned int>("numberGctForwardEtaBinsPerHalf"),
-      ps.getParameter<unsigned int>("etaSignBitOffset"),
-      ps.getParameter<std::vector<double>>("gctEtaBinBoundaries"));
+  m_geom = L1CaloGeometry(ps.getParameter<unsigned int>("numberGctEmJetPhiBins"),
+                          ps.getParameter<double>("gctEmJetPhiBinOffset"),
+                          ps.getParameter<unsigned int>("numberGctEtSumPhiBins"),
+                          ps.getParameter<double>("gctEtSumPhiBinOffset"),
+                          ps.getParameter<unsigned int>("numberGctHtSumPhiBins"),
+                          ps.getParameter<double>("gctHtSumPhiBinOffset"),
+                          ps.getParameter<unsigned int>("numberGctCentralEtaBinsPerHalf"),
+                          ps.getParameter<unsigned int>("numberGctForwardEtaBinsPerHalf"),
+                          ps.getParameter<unsigned int>("etaSignBitOffset"),
+                          ps.getParameter<std::vector<double>>("gctEtaBinBoundaries"));
 }
 
 L1CaloGeometryProd::~L1CaloGeometryProd() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -67,8 +65,7 @@ L1CaloGeometryProd::~L1CaloGeometryProd() {
 //
 
 // ------------ method called to produce the data  ------------
-L1CaloGeometryProd::ReturnType
-L1CaloGeometryProd::produce(const L1CaloGeometryRecord &iRecord) {
+L1CaloGeometryProd::ReturnType L1CaloGeometryProd::produce(const L1CaloGeometryRecord &iRecord) {
   using namespace edm::es;
   std::unique_ptr<L1CaloGeometry> pL1CaloGeometry;
 

--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixAmplitudeFilter.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixAmplitudeFilter.h
@@ -15,7 +15,6 @@ class EcalTPGWeightGroup;
  *
  */
 class EcalFenixAmplitudeFilter {
-
 private:
   int peakFlag_[5];
   int inputsAlreadyIn_;
@@ -32,9 +31,12 @@ private:
 public:
   EcalFenixAmplitudeFilter();
   virtual ~EcalFenixAmplitudeFilter();
-  virtual void process(std::vector<int> &addout, std::vector<int> &output,
-                       std::vector<int> &fgvbIn, std::vector<int> &fgvbOut);
-  void setParameters(uint32_t raw, const EcalTPGWeightIdMap *ecaltpgWeightMap,
+  virtual void process(std::vector<int> &addout,
+                       std::vector<int> &output,
+                       std::vector<int> &fgvbIn,
+                       std::vector<int> &fgvbOut);
+  void setParameters(uint32_t raw,
+                     const EcalTPGWeightIdMap *ecaltpgWeightMap,
                      const EcalTPGWeightGroup *ecaltpgWeightGroup);
 };
 

--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixBypassLin.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixBypassLin.h
@@ -14,7 +14,6 @@
     */
 
 class EcalFenixBypassLin {
-
 public:
   EcalFenixBypassLin();
   virtual ~EcalFenixBypassLin();

--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixEtStrip.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixEtStrip.h
@@ -22,8 +22,7 @@ private:
 public:
   EcalFenixEtStrip();
   virtual ~EcalFenixEtStrip();
-  void process(const std::vector<std::vector<int>> &linout, int nrXtals,
-               std::vector<int> &output);
+  void process(const std::vector<std::vector<int>> &linout, int nrXtals, std::vector<int> &output);
 };
 
 #endif

--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixEtTot.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixEtTot.h
@@ -23,14 +23,12 @@
     *  in case of overflow, result is set to (2**12)-1 or (2**10)-1
     */
 class EcalFenixEtTot {
-
 public:
   EcalFenixEtTot();
   virtual ~EcalFenixEtTot();
   virtual std::vector<int> process(const std::vector<EBDataFrame *> &);
 
-  void process(std::vector<std::vector<int>> &, int nStr, int bitMask,
-               std::vector<int> &out);
+  void process(std::vector<std::vector<int>> &, int nStr, int bitMask, std::vector<int> &out);
 
 private:
 };

--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixFgvbEB.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixFgvbEB.h
@@ -21,7 +21,6 @@ class EcalTPGFineGrainEBIdMap;
    comparison to decide ---> needs to get some values from outside
     */
 class EcalFenixFgvbEB {
-
 private:
   uint32_t ETlow_, EThigh_, Ratlow_, Rathigh_, lut_;
   //    std::vector<int> adder_out_;
@@ -36,8 +35,7 @@ public:
                      const EcalTPGFineGrainEBGroup *ecaltpgFgEBGroup,
                      const EcalTPGFineGrainEBIdMap *ecaltpgFineGrainEB);
 
-  void process(std::vector<int> &add_out, std::vector<int> &maxof2_out,
-               std::vector<int> &output);
+  void process(std::vector<int> &add_out, std::vector<int> &maxof2_out, std::vector<int> &output);
 };
 
 #endif

--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixLinearizer.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixLinearizer.h
@@ -17,7 +17,6 @@
  */
 
 class EcalFenixLinearizer {
-
 private:
   bool famos_;
   int uncorrectedSample_;
@@ -41,16 +40,16 @@ public:
   EcalFenixLinearizer(bool famos);
   virtual ~EcalFenixLinearizer();
 
-  template <class T> void process(const T &, std::vector<int> &);
-  void setParameters(uint32_t raw, const EcalTPGPedestals *ecaltpPed,
+  template <class T>
+  void process(const T &, std::vector<int> &);
+  void setParameters(uint32_t raw,
+                     const EcalTPGPedestals *ecaltpPed,
                      const EcalTPGLinearizationConst *ecaltpLin,
                      const EcalTPGCrystalStatus *ecaltpBadX);
 };
 
 template <class T>
-void EcalFenixLinearizer::process(const T &df,
-                                  std::vector<int> &output_percry) {
-
+void EcalFenixLinearizer::process(const T &df, std::vector<int> &output_percry) {
   // We know a tower numbering is:
   // S1 S2 S3 S4 S5
   //

--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixMaxof2.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixMaxof2.h
@@ -16,12 +16,10 @@
  */
 
 class EcalFenixMaxof2 {
-
 public:
   EcalFenixMaxof2(int maxNrSamples, int nbMaxStrips);
   virtual ~EcalFenixMaxof2();
-  void process(std::vector<std::vector<int>> &, int nStr, int bitMask,
-               std::vector<int> &out);
+  void process(std::vector<std::vector<int>> &, int nStr, int bitMask, std::vector<int> &out);
 
 private:
   int nbMaxStrips_;

--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixPeakFinder.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixPeakFinder.h
@@ -15,7 +15,6 @@
  */
 
 class EcalFenixPeakFinder {
-
 private:
   bool disabled;
   int setInput(int input);
@@ -27,8 +26,7 @@ private:
 public:
   EcalFenixPeakFinder();
   virtual ~EcalFenixPeakFinder();
-  virtual std::vector<int> process(std::vector<int> &filtout,
-                                   std::vector<int> &output);
+  virtual std::vector<int> process(std::vector<int> &filtout, std::vector<int> &output);
   // from CaloVShape
   //  virtual double operator()(double) const {return 0.;}
   //  virtual double derivative(double) const {return 0.;}

--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixStrip.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixStrip.h
@@ -31,8 +31,11 @@ class EcalFenixStrip {
 public:
   // constructor, destructor
   EcalFenixStrip(const edm::EventSetup &setup,
-                 const EcalElectronicsMapping *theMapping, bool debug,
-                 bool famos, int maxNrSamples, int nbMaxXtals);
+                 const EcalElectronicsMapping *theMapping,
+                 bool debug,
+                 bool famos,
+                 int maxNrSamples,
+                 int nbMaxXtals);
   virtual ~EcalFenixStrip();
 
 private:
@@ -100,8 +103,7 @@ public:
   //   the first one is templated, the same except input
   //   the second part is slightly different for barrel/endcap
   template <class T>
-  void process(const edm::EventSetup &, std::vector<const T> &, int nrxtals,
-               std::vector<int> &out);
+  void process(const edm::EventSetup &, std::vector<const T> &, int nrxtals, std::vector<int> &out);
   void process_part2_barrel(uint32_t stripid,
                             const EcalTPGSlidingWindow *ecaltpgSlidW,
                             const EcalTPGFineGrainStripEE *ecaltpgFgStripEE);
@@ -128,89 +130,90 @@ public:
 
   // ========================= implementations
   // ==============================================================
-  void process(const edm::EventSetup &setup, std::vector<EBDataFrame> &samples,
-               int nrXtals, std::vector<int> &out) {
-
+  void process(const edm::EventSetup &setup, std::vector<EBDataFrame> &samples, int nrXtals, std::vector<int> &out) {
     // now call processing
     if (samples.empty()) {
-      std::cout << " Warning: 0 size vector found in EcalFenixStripProcess!!!!!"
-                << std::endl;
+      std::cout << " Warning: 0 size vector found in EcalFenixStripProcess!!!!!" << std::endl;
       return;
     }
-    const EcalTriggerElectronicsId elId =
-        theMapping_->getTriggerElectronicsId(samples[0].id());
-    uint32_t stripid = elId.rawId() & 0xfffffff8; // from Pascal
+    const EcalTriggerElectronicsId elId = theMapping_->getTriggerElectronicsId(samples[0].id());
+    uint32_t stripid = elId.rawId() & 0xfffffff8;  // from Pascal
 
     identif_ = getFGVB()->getMissedStripFlag();
 
-    process_part1(identif_, samples, nrXtals, stripid, ecaltpPed_, ecaltpLin_,
-                  ecaltpgWeightMap_, ecaltpgWeightGroup_,
-                  ecaltpgBadX_); // templated part
+    process_part1(identif_,
+                  samples,
+                  nrXtals,
+                  stripid,
+                  ecaltpPed_,
+                  ecaltpLin_,
+                  ecaltpgWeightMap_,
+                  ecaltpgWeightGroup_,
+                  ecaltpgBadX_);  // templated part
     process_part2_barrel(stripid, ecaltpgSlidW_,
-                         ecaltpgFgStripEE_); // part different for barrel/endcap
+                         ecaltpgFgStripEE_);  // part different for barrel/endcap
     out = format_out_;
   }
 
-  void process(const edm::EventSetup &setup, std::vector<EEDataFrame> &samples,
-               int nrXtals, std::vector<int> &out) {
-
+  void process(const edm::EventSetup &setup, std::vector<EEDataFrame> &samples, int nrXtals, std::vector<int> &out) {
     // now call processing
     if (samples.empty()) {
-      std::cout << " Warning: 0 size vector found in EcalFenixStripProcess!!!!!"
-                << std::endl;
+      std::cout << " Warning: 0 size vector found in EcalFenixStripProcess!!!!!" << std::endl;
       return;
     }
-    const EcalTriggerElectronicsId elId =
-        theMapping_->getTriggerElectronicsId(samples[0].id());
-    uint32_t stripid = elId.rawId() & 0xfffffff8; // from Pascal
+    const EcalTriggerElectronicsId elId = theMapping_->getTriggerElectronicsId(samples[0].id());
+    uint32_t stripid = elId.rawId() & 0xfffffff8;  // from Pascal
 
     identif_ = getFGVB()->getMissedStripFlag();
 
-    process_part1(identif_, samples, nrXtals, stripid, ecaltpPed_, ecaltpLin_,
-                  ecaltpgWeightMap_, ecaltpgWeightGroup_,
-                  ecaltpgBadX_); // templated part
-    process_part2_endcap(stripid, ecaltpgSlidW_, ecaltpgFgStripEE_,
-                         ecaltpgStripStatus_);
-    out = format_out_; // FIXME: timing
+    process_part1(identif_,
+                  samples,
+                  nrXtals,
+                  stripid,
+                  ecaltpPed_,
+                  ecaltpLin_,
+                  ecaltpgWeightMap_,
+                  ecaltpgWeightGroup_,
+                  ecaltpgBadX_);  // templated part
+    process_part2_endcap(stripid, ecaltpgSlidW_, ecaltpgFgStripEE_, ecaltpgStripStatus_);
+    out = format_out_;  // FIXME: timing
     return;
   }
 
   template <class T>
-  void process_part1(int identif, std::vector<T> &df, int nrXtals,
-                     uint32_t stripid, const EcalTPGPedestals *ecaltpPed,
+  void process_part1(int identif,
+                     std::vector<T> &df,
+                     int nrXtals,
+                     uint32_t stripid,
+                     const EcalTPGPedestals *ecaltpPed,
                      const EcalTPGLinearizationConst *ecaltpLin,
                      const EcalTPGWeightIdMap *ecaltpgWeightMap,
                      const EcalTPGWeightGroup *ecaltpgWeightGroup,
                      const EcalTPGCrystalStatus *ecaltpBadX) {
-
     if (debug_)
-      std::cout << "\n\nEcalFenixStrip input is a vector of size: " << nrXtals
-                << std::endl;
+      std::cout << "\n\nEcalFenixStrip input is a vector of size: " << nrXtals << std::endl;
 
     // loop over crystals
     for (int cryst = 0; cryst < nrXtals; cryst++) {
       if (debug_) {
         std::cout << std::endl;
-        std::cout << "cryst= " << cryst
-                  << " EBDataFrame/EEDataFrame is: " << std::endl;
+        std::cout << "cryst= " << cryst << " EBDataFrame/EEDataFrame is: " << std::endl;
         for (int i = 0; i < df[cryst].size(); i++) {
           std::cout << " " << std::dec << df[cryst][i].adc();
         }
         std::cout << std::endl;
       }
       // call linearizer
-      this->getLinearizer(cryst)->setParameters(
-          df[cryst].id().rawId(), ecaltpPed, ecaltpLin, ecaltpBadX);
+      this->getLinearizer(cryst)->setParameters(df[cryst].id().rawId(), ecaltpPed, ecaltpLin, ecaltpBadX);
       this->getLinearizer(cryst)->process(df[cryst], lin_out_[cryst]);
     }
 
     if (debug_) {
-      std::cout << "output of linearizer is a vector of size: " << std::dec
-                << lin_out_.size() << " of which used " << nrXtals << std::endl;
+      std::cout << "output of linearizer is a vector of size: " << std::dec << lin_out_.size() << " of which used "
+                << nrXtals << std::endl;
       for (int ix = 0; ix < nrXtals; ix++) {
         std::cout << "cryst: " << ix << "  value : " << std::dec << std::endl;
-        std::cout << " lin_out[ix].size()= " << std::dec << lin_out_[ix].size()
-                  << std::endl;
+        std::cout << " lin_out[ix].size()= " << std::dec << lin_out_[ix].size() << std::endl;
         for (unsigned int i = 0; i < lin_out_[ix].size(); i++) {
           std::cout << " " << std::dec << (lin_out_[ix])[i];
         }
@@ -225,8 +228,7 @@ public:
     getFGVB()->process(lin_out_, fgvb_out_temp_);
 
     if (debug_) {
-      std::cout << "output of strip fgvb is a vector of size: " << std::dec
-                << fgvb_out_temp_.size() << std::endl;
+      std::cout << "output of strip fgvb is a vector of size: " << std::dec << fgvb_out_temp_.size() << std::endl;
       for (unsigned int i = 0; i < fgvb_out_temp_.size(); i++) {
         std::cout << " " << std::dec << (fgvb_out_temp_[i]);
       }
@@ -234,15 +236,12 @@ public:
     }
 
     // call adder
-    this->getAdder()->process(
-        lin_out_, nrXtals, add_out_); // add_out is of size SIZEMAX=maxNrSamples
+    this->getAdder()->process(lin_out_, nrXtals, add_out_);  // add_out is of size SIZEMAX=maxNrSamples
 
     if (debug_) {
-      std::cout << "output of adder is a vector of size: " << std::dec
-                << add_out_.size() << std::endl;
+      std::cout << "output of adder is a vector of size: " << std::dec << add_out_.size() << std::endl;
       for (unsigned int ix = 0; ix < add_out_.size(); ix++) {
-        std::cout << "cryst: " << ix << "  value : " << std::dec << add_out_[ix]
-                  << std::endl;
+        std::cout << "cryst: " << ix << "  value : " << std::dec << add_out_[ix] << std::endl;
       }
       std::cout << std::endl;
     }
@@ -253,25 +252,19 @@ public:
       return;
     } else {
       // call amplitudefilter
-      this->getFilter()->setParameters(stripid, ecaltpgWeightMap,
-                                       ecaltpgWeightGroup);
-      this->getFilter()->process(add_out_, filt_out_, fgvb_out_temp_,
-                                 fgvb_out_);
+      this->getFilter()->setParameters(stripid, ecaltpgWeightMap, ecaltpgWeightGroup);
+      this->getFilter()->process(add_out_, filt_out_, fgvb_out_temp_, fgvb_out_);
 
       if (debug_) {
-        std::cout << "output of filter is a vector of size: " << std::dec
-                  << filt_out_.size() << std::endl;
+        std::cout << "output of filter is a vector of size: " << std::dec << filt_out_.size() << std::endl;
         for (unsigned int ix = 0; ix < filt_out_.size(); ix++) {
-          std::cout << "cryst: " << ix << "  value : " << std::dec
-                    << filt_out_[ix] << std::endl;
+          std::cout << "cryst: " << ix << "  value : " << std::dec << filt_out_[ix] << std::endl;
         }
         std::cout << std::endl;
 
-        std::cout << "output of sfgvb after filter is a vector of size: "
-                  << std::dec << fgvb_out_.size() << std::endl;
+        std::cout << "output of sfgvb after filter is a vector of size: " << std::dec << fgvb_out_.size() << std::endl;
         for (unsigned int ix = 0; ix < fgvb_out_.size(); ix++) {
-          std::cout << "cryst: " << ix << "  value : " << std::dec
-                    << fgvb_out_[ix] << std::endl;
+          std::cout << "cryst: " << ix << "  value : " << std::dec << fgvb_out_[ix] << std::endl;
         }
         std::cout << std::endl;
       }
@@ -279,11 +272,9 @@ public:
       // call peakfinder
       this->getPeakFinder()->process(filt_out_, peak_out_);
       if (debug_) {
-        std::cout << "output of peakfinder is a vector of size: "
-                  << peak_out_.size() << std::endl;
+        std::cout << "output of peakfinder is a vector of size: " << peak_out_.size() << std::endl;
         for (unsigned int ix = 0; ix < peak_out_.size(); ix++) {
-          std::cout << "cryst: " << ix << "  value : " << peak_out_[ix]
-                    << std::endl;
+          std::cout << "cryst: " << ix << "  value : " << peak_out_[ix] << std::endl;
         }
         std::cout << std::endl;
       }

--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixStripFgvbEE.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixStripFgvbEE.h
@@ -19,7 +19,6 @@ class EEDataFrame;
     *
     */
 class EcalFenixStripFgvbEE {
-
 private:
   int threshold_fg_;
   int lut_fg_;
@@ -30,8 +29,7 @@ public:
   EcalFenixStripFgvbEE();
   virtual ~EcalFenixStripFgvbEE();
   void setParameters(int identif, uint32_t id, const EcalTPGFineGrainStripEE *);
-  void process(std::vector<std::vector<int>> &lin_out,
-               std::vector<int> &output);
+  void process(std::vector<std::vector<int>> &lin_out, std::vector<int> &output);
 
   void setbadStripMissing(bool flag) { flagBadStripMiss_ = flag; }
   bool getMissedStripFlag() const { return flagBadStripMiss_; }

--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixStripFormatEB.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixStripFormatEB.h
@@ -16,7 +16,6 @@ class EcalTPGSlidingWindow;
  */
 
 class EcalFenixStripFormatEB {
-
 private:
   int inputsFGVB_;
   int inputPeak_;
@@ -30,8 +29,7 @@ private:
 public:
   EcalFenixStripFormatEB();
   virtual ~EcalFenixStripFormatEB();
-  virtual void process(std::vector<int> &, std::vector<int> &,
-                       std::vector<int> &, std::vector<int> &);
+  virtual void process(std::vector<int> &, std::vector<int> &, std::vector<int> &, std::vector<int> &);
   void setParameters(uint32_t &, const EcalTPGSlidingWindow *&);
 };
 #endif

--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixStripFormatEE.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixStripFormatEE.h
@@ -31,10 +31,8 @@ public:
   EcalFenixStripFormatEE();
   virtual ~EcalFenixStripFormatEE();
 
-  virtual void process(std::vector<int> &, std::vector<int> &,
-                       std::vector<int> &, std::vector<int> &);
-  void setParameters(uint32_t id, const EcalTPGSlidingWindow *&,
-                     const EcalTPGStripStatus *);
+  virtual void process(std::vector<int> &, std::vector<int> &, std::vector<int> &, std::vector<int> &);
+  void setParameters(uint32_t id, const EcalTPGSlidingWindow *&, const EcalTPGStripStatus *);
 };
 
 #endif

--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixTcp.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixTcp.h
@@ -31,7 +31,6 @@ class EcalTPGTowerStatus;
     \brief class representing the Fenix chip, format strip
 */
 class EcalFenixTcp {
-
 private:
   bool debug_;
 
@@ -72,29 +71,36 @@ public:
   }
   // end temporary, for timing tests
 
-  EcalFenixTcp(const edm::EventSetup &setup, bool tcpFormat, bool debug,
-               bool famos, int binOfMax, int maxNrSamples, int nbMaxStrips);
+  EcalFenixTcp(const edm::EventSetup &setup,
+               bool tcpFormat,
+               bool debug,
+               bool famos,
+               int binOfMax,
+               int maxNrSamples,
+               int nbMaxStrips);
   virtual ~EcalFenixTcp();
 
-  void
-  process(const edm::EventSetup &setup,
-          std::vector<EBDataFrame> &bid, // dummy argument for template call
-          std::vector<std::vector<int>> &tpframetow, int nStr,
-          std::vector<EcalTriggerPrimitiveSample> &tptow,
-          std::vector<EcalTriggerPrimitiveSample> &tptow2, bool isInInnerRings,
-          EcalTrigTowerDetId thisTower);
-  void
-  process(const edm::EventSetup &setup,
-          std::vector<EEDataFrame> &bid, // dummy argument for template call
-          std::vector<std::vector<int>> &tpframetow, int nStr,
-          std::vector<EcalTriggerPrimitiveSample> &tptow,
-          std::vector<EcalTriggerPrimitiveSample> &tptow2, bool isInInnerRings,
-          EcalTrigTowerDetId thisTower);
+  void process(const edm::EventSetup &setup,
+               std::vector<EBDataFrame> &bid,  // dummy argument for template call
+               std::vector<std::vector<int>> &tpframetow,
+               int nStr,
+               std::vector<EcalTriggerPrimitiveSample> &tptow,
+               std::vector<EcalTriggerPrimitiveSample> &tptow2,
+               bool isInInnerRings,
+               EcalTrigTowerDetId thisTower);
+  void process(const edm::EventSetup &setup,
+               std::vector<EEDataFrame> &bid,  // dummy argument for template call
+               std::vector<std::vector<int>> &tpframetow,
+               int nStr,
+               std::vector<EcalTriggerPrimitiveSample> &tptow,
+               std::vector<EcalTriggerPrimitiveSample> &tptow2,
+               bool isInInnerRings,
+               EcalTrigTowerDetId thisTower);
 
-  void process_part1(std::vector<std::vector<int>> &tpframetow, int nStr,
-                     int bitMask);
+  void process_part1(std::vector<std::vector<int>> &tpframetow, int nStr, int bitMask);
 
-  void process_part2_barrel(std::vector<std::vector<int>> &, int nStr,
+  void process_part2_barrel(std::vector<std::vector<int>> &,
+                            int nStr,
                             int bitMask,
                             const EcalTPGFineGrainEBGroup *ecaltpgFgEBGroup,
                             const EcalTPGLutGroup *ecaltpgLutGroup,
@@ -106,15 +112,17 @@ public:
                             std::vector<EcalTriggerPrimitiveSample> &tptow2,
                             EcalTrigTowerDetId towid);
 
-  void
-  process_part2_endcap(std::vector<std::vector<int>> &, int nStr, int bitMask,
-                       const EcalTPGLutGroup *ecaltpgLutGroup,
-                       const EcalTPGLutIdMap *ecaltpgLut,
-                       const EcalTPGFineGrainTowerEE *ecaltpgFineGrainTowerEE,
-                       const EcalTPGTowerStatus *ecaltpgBadTT,
-                       std::vector<EcalTriggerPrimitiveSample> &tptow,
-                       std::vector<EcalTriggerPrimitiveSample> &tptow2,
-                       bool isInInnerRings, EcalTrigTowerDetId towid);
+  void process_part2_endcap(std::vector<std::vector<int>> &,
+                            int nStr,
+                            int bitMask,
+                            const EcalTPGLutGroup *ecaltpgLutGroup,
+                            const EcalTPGLutIdMap *ecaltpgLut,
+                            const EcalTPGFineGrainTowerEE *ecaltpgFineGrainTowerEE,
+                            const EcalTPGTowerStatus *ecaltpgBadTT,
+                            std::vector<EcalTriggerPrimitiveSample> &tptow,
+                            std::vector<EcalTriggerPrimitiveSample> &tptow2,
+                            bool isInInnerRings,
+                            EcalTrigTowerDetId towid);
 
   EcalFenixBypassLin *getBypasslin(int i) const { return bypasslin_[i]; }
   EcalFenixEtTot *getAdder() const { return adder_; }

--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixTcpFgvbEE.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixTcpFgvbEE.h
@@ -22,7 +22,6 @@ class EcalTPGFineGrainTowerEE;
     */
 
 class EcalFenixTcpFgvbEE {
-
 private:
   uint32_t fgee_lut_;
   std::vector<int> indexLut_;
@@ -30,10 +29,8 @@ private:
 public:
   EcalFenixTcpFgvbEE(int maxNrSamples);
   virtual ~EcalFenixTcpFgvbEE();
-  void setParameters(uint32_t towid,
-                     const EcalTPGFineGrainTowerEE *ecaltpgFineGrainTowerEE);
+  void setParameters(uint32_t towid, const EcalTPGFineGrainTowerEE *ecaltpgFineGrainTowerEE);
 
-  void process(std::vector<std::vector<int>> &bypasslin_out, int nStr,
-               int bitMask, std::vector<int> &output);
+  void process(std::vector<std::vector<int>> &bypasslin_out, int nStr, int bitMask, std::vector<int> &output);
 };
 #endif

--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixTcpFormat.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixTcpFormat.h
@@ -20,21 +20,22 @@ class EcalTPGSpike;
     *
     */
 class EcalFenixTcpFormat {
-
 public:
   EcalFenixTcpFormat(bool tccFormat, bool debug, bool famos, int binOfMax);
   virtual ~EcalFenixTcpFormat();
-  virtual std::vector<int> process(const std::vector<int> &,
-                                   const std::vector<int> &) {
+  virtual std::vector<int> process(const std::vector<int> &, const std::vector<int> &) {
     std::vector<int> v;
     return v;
   }
-  void process(std::vector<int> &Et, std::vector<int> &fgvb,
-               std::vector<int> &sfgvb, int eTTotShift,
+  void process(std::vector<int> &Et,
+               std::vector<int> &fgvb,
+               std::vector<int> &sfgvb,
+               int eTTotShift,
                std::vector<EcalTriggerPrimitiveSample> &out,
                std::vector<EcalTriggerPrimitiveSample> &outTcc,
                bool isInInnerRings);
-  void setParameters(uint32_t towid, const EcalTPGLutGroup *ecaltpgLutGroup,
+  void setParameters(uint32_t towid,
+                     const EcalTPGLutGroup *ecaltpgLutGroup,
                      const EcalTPGLutIdMap *ecaltpgLut,
                      const EcalTPGTowerStatus *ecaltpgbadTT,
                      const EcalTPGSpike *ecaltpgSpike);

--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixTcpsFgvbEB.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixTcpsFgvbEB.h
@@ -17,7 +17,6 @@ public:
   EcalFenixTcpsFgvbEB();
   virtual ~EcalFenixTcpsFgvbEB();
 
-  void process(std::vector<std::vector<int>> &bypasslin_out, int nStr,
-               int bitMask, std::vector<int> &output);
+  void process(std::vector<std::vector<int>> &bypasslin_out, int nStr, int bitMask, std::vector<int> &output);
 };
 #endif

--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalTrigPrimFunctionalAlgo.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalTrigPrimFunctionalAlgo.h
@@ -46,27 +46,27 @@ class EcalElectronicsMapping;
 
 class EcalTrigPrimFunctionalAlgo {
 public:
-  explicit EcalTrigPrimFunctionalAlgo(const edm::EventSetup &setup,
-                                      int binofmax, bool tcpFormat,
-                                      bool barrelOnly, bool debug, bool famos);
+  explicit EcalTrigPrimFunctionalAlgo(
+      const edm::EventSetup &setup, int binofmax, bool tcpFormat, bool barrelOnly, bool debug, bool famos);
 
   virtual ~EcalTrigPrimFunctionalAlgo();
 
-  void run(const edm::EventSetup &, const EBDigiCollection *col,
+  void run(const edm::EventSetup &,
+           const EBDigiCollection *col,
            EcalTrigPrimDigiCollection &result,
            EcalTrigPrimDigiCollection &resultTcp);
-  void run(const edm::EventSetup &, const EEDigiCollection *col,
+  void run(const edm::EventSetup &,
+           const EEDigiCollection *col,
            EcalTrigPrimDigiCollection &result,
            EcalTrigPrimDigiCollection &resultTcp);
   void run_part1_EB(EBDigiCollection const *col);
   void run_part1_EE(EEDigiCollection const *col);
   template <class Coll>
-  void run_part2(
-      const edm::EventSetup &, Coll const *col,
-      std::vector<std::vector<std::pair<int, std::vector<typename Coll::Digi>>>>
-          &towerMap,
-      EcalTrigPrimDigiCollection &result,
-      EcalTrigPrimDigiCollection &resultTcp);
+  void run_part2(const edm::EventSetup &,
+                 Coll const *col,
+                 std::vector<std::vector<std::pair<int, std::vector<typename Coll::Digi>>>> &towerMap,
+                 EcalTrigPrimDigiCollection &result,
+                 EcalTrigPrimDigiCollection &resultTcp);
 
   void setPointers(const EcalTPGLinearizationConst *ecaltpLin,
                    const EcalTPGPedestals *ecaltpPed,
@@ -76,9 +76,14 @@ public:
                    const EcalTPGFineGrainStripEE *ecaltpgFgStripEE,
                    const EcalTPGCrystalStatus *ecaltpgBadX,
                    const EcalTPGStripStatus *ecaltpgStripStatus) {
-    estrip_->setPointers(ecaltpPed, ecaltpLin, ecaltpgWeightMap,
-                         ecaltpgWeightGroup, ecaltpgSlidW, ecaltpgFgStripEE,
-                         ecaltpgBadX, ecaltpgStripStatus);
+    estrip_->setPointers(ecaltpPed,
+                         ecaltpLin,
+                         ecaltpgWeightMap,
+                         ecaltpgWeightGroup,
+                         ecaltpgSlidW,
+                         ecaltpgFgStripEE,
+                         ecaltpgBadX,
+                         ecaltpgStripStatus);
   }
   void setPointers2(const EcalTPGFineGrainEBGroup *ecaltpgFgEBGroup,
                     const EcalTPGLutGroup *ecaltpgLutGroup,
@@ -87,32 +92,28 @@ public:
                     const EcalTPGFineGrainTowerEE *ecaltpgFineGrainTowerEE,
                     const EcalTPGTowerStatus *ecaltpgBadTT,
                     const EcalTPGSpike *ecaltpgSpike) {
-
-    etcp_->setPointers(ecaltpgFgEBGroup, ecaltpgLutGroup, ecaltpgLut,
-                       ecaltpgFineGrainEB, ecaltpgFineGrainTowerEE,
-                       ecaltpgBadTT, ecaltpgSpike);
+    etcp_->setPointers(ecaltpgFgEBGroup,
+                       ecaltpgLutGroup,
+                       ecaltpgLut,
+                       ecaltpgFineGrainEB,
+                       ecaltpgFineGrainTowerEE,
+                       ecaltpgBadTT,
+                       ecaltpgSpike);
   }
 
 private:
   void init(const edm::EventSetup &);
   template <class T>
-  void initStructures(
-      std::vector<std::vector<std::pair<int, std::vector<T>>>> &towMap);
+  void initStructures(std::vector<std::vector<std::pair<int, std::vector<T>>>> &towMap);
   template <class T>
-  void
-  clean(std::vector<std::vector<std::pair<int, std::vector<T>>>> &towerMap);
+  void clean(std::vector<std::vector<std::pair<int, std::vector<T>>>> &towerMap);
   template <class Coll>
-  void fillMap(
-      Coll const *col,
-      std::vector<std::vector<std::pair<int, std::vector<typename Coll::Digi>>>>
-          &towerMap);
+  void fillMap(Coll const *col, std::vector<std::vector<std::pair<int, std::vector<typename Coll::Digi>>>> &towerMap);
   int findStripNr(const EBDetId &id);
   int findStripNr(const EEDetId &id);
 
   // FIXME: temporary until hashedIndex works alsom for endcap
-  int getIndex(const EBDigiCollection *, EcalTrigTowerDetId &id) {
-    return id.hashedIndex();
-  }
+  int getIndex(const EBDigiCollection *, EcalTrigTowerDetId &id) { return id.hashedIndex(); }
   // mind that eta is continuous between barrel+endcap
   int getIndex(const EEDigiCollection *, EcalTrigTowerDetId &id) {
     int ind = (id.ietaAbs() - 18) * 72 + id.iphi();
@@ -138,24 +139,19 @@ private:
   bool debug_;
   bool famos_;
 
-  static const unsigned int
-      nrSamples_; // nr samples to write, should not be changed since by
-                  // convention the size means that it is coming from simulation
-  static const unsigned int
-      maxNrSamplesOut_; // to be placed in the intermediate samples
-  static const unsigned int
-      maxNrTowers_; // would be better to get from somewhere..
-  static const unsigned int maxNrTPs_; // would be better to get from
-                                       // somewhere..
+  static const unsigned int nrSamples_;        // nr samples to write, should not be changed since by
+                                               // convention the size means that it is coming from simulation
+  static const unsigned int maxNrSamplesOut_;  // to be placed in the intermediate samples
+  static const unsigned int maxNrTowers_;      // would be better to get from somewhere..
+  static const unsigned int maxNrTPs_;         // would be better to get from
+                                               // somewhere..
 
-  int nrTowers_; // nr of towers found by fillmap method
+  int nrTowers_;  // nr of towers found by fillmap method
 
   // data structures kept during the whole run
   std::vector<std::vector<int>> striptp_;
-  std::vector<std::vector<std::pair<int, std::vector<EBDataFrame>>>>
-      towerMapEB_;
-  std::vector<std::vector<std::pair<int, std::vector<EEDataFrame>>>>
-      towerMapEE_;
+  std::vector<std::vector<std::pair<int, std::vector<EBDataFrame>>>> towerMapEB_;
+  std::vector<std::vector<std::pair<int, std::vector<EEDataFrame>>>> towerMapEE_;
   std::vector<std::pair<int, EcalTrigTowerDetId>> hitTowers_;
   std::vector<EcalTriggerPrimitiveSample> towtp_;
   std::vector<EcalTriggerPrimitiveSample> towtp2_;
@@ -169,10 +165,11 @@ private:
 
 template <class Coll>
 void EcalTrigPrimFunctionalAlgo::run_part2(
-    const edm::EventSetup &setup, Coll const *col,
-    std::vector<std::vector<std::pair<int, std::vector<typename Coll::Digi>>>>
-        &towerMap,
-    EcalTrigPrimDigiCollection &result, EcalTrigPrimDigiCollection &resultTcp) {
+    const edm::EventSetup &setup,
+    Coll const *col,
+    std::vector<std::vector<std::pair<int, std::vector<typename Coll::Digi>>>> &towerMap,
+    EcalTrigPrimDigiCollection &result,
+    EcalTrigPrimDigiCollection &resultTcp) {
   typedef typename Coll::Digi Digi;
 
   // prepare writing of TP-s
@@ -187,29 +184,24 @@ void EcalTrigPrimFunctionalAlgo::run_part2(
   estrip_->getFGVB()->setbadStripMissing(false);
 
   for (int itow = 0; itow < nrTowers_; ++itow) {
-
     int index = hitTowers_[itow].first;
     const EcalTrigTowerDetId &thisTower = hitTowers_[itow].second;
 
     // loop over all strips assigned to this trigger tower
     int nstr = 0;
     for (unsigned int i = 0; i < towerMap[itow].size(); ++i) {
-      std::vector<Digi> &df =
-          (towerMap[index])[i].second; // vector of dataframes for this strip,
-                                       // size; nr of crystals/strip
+      std::vector<Digi> &df = (towerMap[index])[i].second;  // vector of dataframes for this strip,
+                                                            // size; nr of crystals/strip
 
       if ((towerMap[index])[i].first > 0) {
-        estrip_->process(setup, df, (towerMap[index])[i].first,
-                         striptp_[nstr++]);
+        estrip_->process(setup, df, (towerMap[index])[i].first, striptp_[nstr++]);
       }
-    } // loop over strips in one tower
+    }  // loop over strips in one tower
 
     bool isInInnerRings = false;
-    if (thisTower.subDet() == EcalEndcap &&
-        (thisTower.ietaAbs() == 27 || thisTower.ietaAbs() == 28))
+    if (thisTower.subDet() == EcalEndcap && (thisTower.ietaAbs() == 27 || thisTower.ietaAbs() == 28))
       isInInnerRings = true;
-    etcp_->process(setup, dummy, striptp_, nstr, towtp_, towtp2_,
-                   isInInnerRings, thisTower);
+    etcp_->process(setup, dummy, striptp_, nstr, towtp_, towtp2_, isInInnerRings, thisTower);
 
     // prepare TP-s
     // special treatment for 2 inner endcap rings
@@ -217,18 +209,16 @@ void EcalTrigPrimFunctionalAlgo::run_part2(
     if (isInInnerRings) {
       nrTowers = 2;
       int phi = 2 * ((thisTower.iphi() - 1) / 2);
-      tptow[0] = EcalTriggerPrimitiveDigi(EcalTrigTowerDetId(
-          thisTower.zside(), thisTower.subDet(), thisTower.ietaAbs(), phi + 1));
-      tptow[1] = EcalTriggerPrimitiveDigi(EcalTrigTowerDetId(
-          thisTower.zside(), thisTower.subDet(), thisTower.ietaAbs(), phi + 2));
+      tptow[0] = EcalTriggerPrimitiveDigi(
+          EcalTrigTowerDetId(thisTower.zside(), thisTower.subDet(), thisTower.ietaAbs(), phi + 1));
+      tptow[1] = EcalTriggerPrimitiveDigi(
+          EcalTrigTowerDetId(thisTower.zside(), thisTower.subDet(), thisTower.ietaAbs(), phi + 2));
 
       if (tcpFormat_) {
         tptowTcp[0] = EcalTriggerPrimitiveDigi(
-            EcalTrigTowerDetId(thisTower.zside(), thisTower.subDet(),
-                               thisTower.ietaAbs(), phi + 1));
+            EcalTrigTowerDetId(thisTower.zside(), thisTower.subDet(), thisTower.ietaAbs(), phi + 1));
         tptowTcp[1] = EcalTriggerPrimitiveDigi(
-            EcalTrigTowerDetId(thisTower.zside(), thisTower.subDet(),
-                               thisTower.ietaAbs(), phi + 2));
+            EcalTrigTowerDetId(thisTower.zside(), thisTower.subDet(), thisTower.ietaAbs(), phi + 2));
       }
     } else {
       nrTowers = 1;
@@ -240,9 +230,8 @@ void EcalTrigPrimFunctionalAlgo::run_part2(
     // now fill in
     for (int nrt = 0; nrt < nrTowers; nrt++) {
       (tptow[nrt]).setSize(nrSamples_);
-      if (towtp_.size() < nrSamples_) { // FIXME: only once
-        edm::LogWarning("")
-            << "Too few samples produced, nr is " << towtp_.size();
+      if (towtp_.size() < nrSamples_) {  // FIXME: only once
+        edm::LogWarning("") << "Too few samples produced, nr is " << towtp_.size();
         break;
       }
       int isam = 0;
@@ -250,30 +239,26 @@ void EcalTrigPrimFunctionalAlgo::run_part2(
         tptow[nrt].setSample(isam++, EcalTriggerPrimitiveSample(towtp_[i]));
       }
       nrTP++;
-      LogDebug("EcalTPG") << " For tower " << itow << " created TP nr " << nrTP
-                          << " with Et " << tptow[nrt].compressedEt();
+      LogDebug("EcalTPG") << " For tower " << itow << " created TP nr " << nrTP << " with Et "
+                          << tptow[nrt].compressedEt();
       result.push_back(tptow[nrt]);
     }
 
     if (tcpFormat_) {
-
       for (int nrt = 0; nrt < nrTowers; nrt++) {
         tptowTcp[nrt].setSize(nrSamples_);
-        if (towtp2_.size() < nrSamples_) { // FIXME: only once
-          edm::LogWarning("")
-              << "Too few samples produced, nr is " << towtp2_.size();
+        if (towtp2_.size() < nrSamples_) {  // FIXME: only once
+          edm::LogWarning("") << "Too few samples produced, nr is " << towtp2_.size();
           break;
         }
         int isam = 0;
         for (int i = firstSample; i <= lastSample; ++i) {
           if (nrTowers <= 1)
-            tptowTcp[nrt].setSample(isam++,
-                                    EcalTriggerPrimitiveSample(towtp2_[i]));
+            tptowTcp[nrt].setSample(isam++, EcalTriggerPrimitiveSample(towtp2_[i]));
           else {
             int et = towtp2_[i].compressedEt() / 2;
-            tptowTcp[nrt].setSample(
-                isam++, EcalTriggerPrimitiveSample(et, towtp2_[i].fineGrain(),
-                                                   towtp2_[i].ttFlag()));
+            tptowTcp[nrt].setSample(isam++,
+                                    EcalTriggerPrimitiveSample(et, towtp2_[i].fineGrain(), towtp2_[i].ttFlag()));
           }
         }
         resultTcp.push_back(tptowTcp[nrt]);
@@ -285,9 +270,7 @@ void EcalTrigPrimFunctionalAlgo::run_part2(
 
 template <class Coll>
 void EcalTrigPrimFunctionalAlgo::fillMap(
-    Coll const *col,
-    std::vector<std::vector<std::pair<int, std::vector<typename Coll::Digi>>>>
-        &towerMap) {
+    Coll const *col, std::vector<std::vector<std::pair<int, std::vector<typename Coll::Digi>>>> &towerMap) {
   typedef typename Coll::Digi Digi;
 
   // implementation for Barrel and Endcap
@@ -305,16 +288,14 @@ void EcalTrigPrimFunctionalAlgo::fillMap(
       for (unsigned int ij = 0; ij < towerMap[index].size(); ++ij)
         filled += towerMap[index][ij].first;
       if (!filled) {
-        hitTowers_[nrTowers_++] =
-            std::pair<int, EcalTrigTowerDetId>(index, coarser);
+        hitTowers_[nrTowers_++] = std::pair<int, EcalTrigTowerDetId>(index, coarser);
       }
 
       // FIXME: temporary protection
       int ncryst = towerMap[index][stripnr - 1].first;
       if (ncryst >= nbMaxXtals_) {
         edm::LogError("EcalTrigPrimFunctionAlgo")
-            << "! Too many xtals for TT " << coarser << " stripnr " << stripnr
-            << " xtalid " << samples.id();
+            << "! Too many xtals for TT " << coarser << " stripnr " << stripnr << " xtalid " << samples.id();
         continue;
       }
       ((towerMap[index])[stripnr - 1].second)[ncryst] = samples;
@@ -322,16 +303,15 @@ void EcalTrigPrimFunctionalAlgo::fillMap(
     }
 
     LogDebug("EcalTPG") << "fillMap"
-                        << "[EcalTrigPrimFunctionalAlgo] (found " << col->size()
-                        << " frames in " << towerMap.size() << " towers) ";
+                        << "[EcalTrigPrimFunctionalAlgo] (found " << col->size() << " frames in " << towerMap.size()
+                        << " towers) ";
   } else {
     LogDebug("EcalTPG") << "FillMap - FillMap Collection size=0 !!!!";
   }
 }
 
 template <class T>
-void EcalTrigPrimFunctionalAlgo::clean(
-    std::vector<std::vector<std::pair<int, std::vector<T>>>> &towMap) {
+void EcalTrigPrimFunctionalAlgo::clean(std::vector<std::vector<std::pair<int, std::vector<T>>>> &towMap) {
   // clean internal data structures
   for (unsigned int i = 0; i < maxNrTowers_; ++i)
     for (int j = 0; j < nbMaxStrips_; ++j)
@@ -340,8 +320,7 @@ void EcalTrigPrimFunctionalAlgo::clean(
 }
 
 template <class T>
-void EcalTrigPrimFunctionalAlgo::initStructures(
-    std::vector<std::vector<std::pair<int, std::vector<T>>>> &towMap) {
+void EcalTrigPrimFunctionalAlgo::initStructures(std::vector<std::vector<std::pair<int, std::vector<T>>>> &towMap) {
   // initialise internal data structures
 
   std::vector<T> vec0(nbMaxXtals_);

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixAmplitudeFilter.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixAmplitudeFilter.cc
@@ -5,8 +5,7 @@
 #include <SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixAmplitudeFilter.h>
 #include <iostream>
 
-EcalFenixAmplitudeFilter::EcalFenixAmplitudeFilter()
-    : inputsAlreadyIn_(0), shift_(6) {}
+EcalFenixAmplitudeFilter::EcalFenixAmplitudeFilter() : inputsAlreadyIn_(0), shift_(6) {}
 
 EcalFenixAmplitudeFilter::~EcalFenixAmplitudeFilter() {}
 
@@ -37,14 +36,13 @@ void EcalFenixAmplitudeFilter::process(std::vector<int> &addout,
   // test
   inputsAlreadyIn_ = 0;
   for (unsigned int i = 0; i < 5; i++) {
-    buffer_[i] = 0; // FIXME: 5
+    buffer_[i] = 0;  // FIXME: 5
     fgvbBuffer_[i] = 0;
   }
 
   // test end
 
   for (unsigned int i = 0; i < addout.size(); i++) {
-
     setInput(addout[i], fgvbIn[i]);
     process();
     output[i] = processedOutput_;
@@ -85,27 +83,23 @@ void EcalFenixAmplitudeFilter::process() {
   processedFgvbOutput_ = fgvbInt;
 }
 
-void EcalFenixAmplitudeFilter::setParameters(
-    uint32_t raw, const EcalTPGWeightIdMap *ecaltpgWeightMap,
-    const EcalTPGWeightGroup *ecaltpgWeightGroup) {
+void EcalFenixAmplitudeFilter::setParameters(uint32_t raw,
+                                             const EcalTPGWeightIdMap *ecaltpgWeightMap,
+                                             const EcalTPGWeightGroup *ecaltpgWeightGroup) {
   uint32_t params_[5];
-  const EcalTPGGroups::EcalTPGGroupsMap &groupmap =
-      ecaltpgWeightGroup->getMap();
+  const EcalTPGGroups::EcalTPGGroupsMap &groupmap = ecaltpgWeightGroup->getMap();
   EcalTPGGroups::EcalTPGGroupsMapItr it = groupmap.find(raw);
   if (it != groupmap.end()) {
     uint32_t weightid = (*it).second;
-    const EcalTPGWeightIdMap::EcalTPGWeightMap &weightmap =
-        ecaltpgWeightMap->getMap();
+    const EcalTPGWeightIdMap::EcalTPGWeightMap &weightmap = ecaltpgWeightMap->getMap();
     EcalTPGWeightIdMap::EcalTPGWeightMapItr itw = weightmap.find(weightid);
-    (*itw).second.getValues(params_[0], params_[1], params_[2], params_[3],
-                            params_[4]);
+    (*itw).second.getValues(params_[0], params_[1], params_[2], params_[3], params_[4]);
 
     // we have to transform negative coded in 7 bits into negative coded in 32
     // bits maybe this should go into the getValue method??
     // std::cout << "peak flag settings" << std::endl;
     for (int i = 0; i < 5; ++i) {
-      weights_[i] = (params_[i] & 0x40) ? (int)(params_[i] | 0xffffffc0)
-                                        : (int)(params_[i]);
+      weights_[i] = (params_[i] & 0x40) ? (int)(params_[i] | 0xffffffc0) : (int)(params_[i]);
 
       // Construct the peakFlag for sFGVB processing
       // peakFlag_[i] = ((params_[i] & 0x80) > 0x0) ? 1 : 0;
@@ -114,6 +108,5 @@ void EcalFenixAmplitudeFilter::setParameters(
     }
     // std::cout << std::endl;
   } else
-    edm::LogWarning("EcalTPG")
-        << " could not find EcalTPGGroupsMap entry for " << raw;
+    edm::LogWarning("EcalTPG") << " could not find EcalTPGGroupsMap entry for " << raw;
 }

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixBypassLin.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixBypassLin.cc
@@ -7,8 +7,7 @@ class EBDataFrame;
 
 EcalFenixBypassLin::EcalFenixBypassLin() {}
 EcalFenixBypassLin::~EcalFenixBypassLin() {}
-void EcalFenixBypassLin::process(std::vector<int> &stripin,
-                                 std::vector<int> &out) {
+void EcalFenixBypassLin::process(std::vector<int> &stripin, std::vector<int> &out) {
   //    return stripin;
   out = stripin;
   return;

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixEtStrip.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixEtStrip.cc
@@ -3,8 +3,7 @@
 EcalFenixEtStrip::EcalFenixEtStrip() {}
 EcalFenixEtStrip::~EcalFenixEtStrip() {}
 
-void EcalFenixEtStrip::process(const std::vector<std::vector<int>> &linout,
-                               int nrXtals, std::vector<int> &output) {
+void EcalFenixEtStrip::process(const std::vector<std::vector<int>> &linout, int nrXtals, std::vector<int> &output) {
   for (unsigned int i = 0; i < output.size(); i++) {
     output[i] = 0;
   }

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixEtTot.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixEtTot.cc
@@ -5,15 +5,15 @@ EcalFenixEtTot::EcalFenixEtTot() {}
 //----------------------------------------------------------------------------------------
 EcalFenixEtTot::~EcalFenixEtTot() {}
 //----------------------------------------------------------------------------------------
-std::vector<int>
-EcalFenixEtTot::process(const std::vector<EBDataFrame *> &calodatafr) {
+std::vector<int> EcalFenixEtTot::process(const std::vector<EBDataFrame *> &calodatafr) {
   std::vector<int> out;
   return out;
 }
 //----------------------------------------------------------------------------------------
 void EcalFenixEtTot::process(std::vector<std::vector<int>> &bypasslinout,
-                             int nStr, int bitMask, std::vector<int> &output) {
-
+                             int nStr,
+                             int bitMask,
+                             std::vector<int> &output) {
   for (unsigned int i = 0; i < output.size(); i++) {
     output[i] = 0;
   }
@@ -21,9 +21,8 @@ void EcalFenixEtTot::process(std::vector<std::vector<int>> &bypasslinout,
   int mask = (1 << bitMask) - 1;
   for (int istrip = 0; istrip < nStr; istrip++) {
     for (unsigned int i = 0; i < bypasslinout[istrip].size(); i++) {
-      output[i] += (bypasslinout[istrip][i] &
-                    mask); // fix bug inn case of EE: MSB are set for FG, so
-                           // need to apply mask in summation.
+      output[i] += (bypasslinout[istrip][i] & mask);  // fix bug inn case of EE: MSB are set for FG, so
+                                                      // need to apply mask in summation.
       if (output[i] > mask)
         output[i] = mask;
     }

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixFgvbEB.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixFgvbEB.cc
@@ -3,16 +3,11 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixFgvbEB.h>
 
-EcalFenixFgvbEB::EcalFenixFgvbEB(int maxNrSamples) {
-  add_out_8_.resize(maxNrSamples);
-}
+EcalFenixFgvbEB::EcalFenixFgvbEB(int maxNrSamples) { add_out_8_.resize(maxNrSamples); }
 
 EcalFenixFgvbEB::~EcalFenixFgvbEB() {}
 
-void EcalFenixFgvbEB::process(std::vector<int> &add_out,
-                              std::vector<int> &maxof2_out,
-                              std::vector<int> &output) {
-
+void EcalFenixFgvbEB::process(std::vector<int> &add_out, std::vector<int> &maxof2_out, std::vector<int> &output) {
   int Elow, Ehigh, Tlow, Thigh, lut;
   int ERatLow, ERatHigh;
   //    std::vector<int> add_out_8(add_out.size());
@@ -36,7 +31,6 @@ void EcalFenixFgvbEB::process(std::vector<int> &add_out,
     Thigh = Thigh - 128;
 
   for (unsigned int i = 0; i < add_out.size(); i++) {
-
     ERatLow = add_out[i] * Tlow >> 7;
     if (ERatLow > 0xFFF)
       ERatLow = 0xFFF;
@@ -74,10 +68,9 @@ void EcalFenixFgvbEB::process(std::vector<int> &add_out,
   return;
 }
 
-void EcalFenixFgvbEB::setParameters(
-    uint32_t towid, const EcalTPGFineGrainEBGroup *ecaltpgFgEBGroup,
-    const EcalTPGFineGrainEBIdMap *ecaltpgFineGrainEB) {
-
+void EcalFenixFgvbEB::setParameters(uint32_t towid,
+                                    const EcalTPGFineGrainEBGroup *ecaltpgFgEBGroup,
+                                    const EcalTPGFineGrainEBIdMap *ecaltpgFineGrainEB) {
   const EcalTPGGroups::EcalTPGGroupsMap &groupmap = ecaltpgFgEBGroup->getMap();
   EcalTPGGroups::EcalTPGGroupsMapItr it = groupmap.find(towid);
   if (it != groupmap.end()) {
@@ -88,10 +81,8 @@ void EcalFenixFgvbEB::setParameters(
     //     fgmap.find(fgid);
     //     (*itfg).second.getValues( ETlow_,  EThigh_,  Ratlow_,  Rathigh_,
     //     lut_);
-    EcalTPGFineGrainEBIdMap::EcalTPGFineGrainEBMapItr itfg =
-        (ecaltpgFineGrainEB->getMap()).find((*it).second);
+    EcalTPGFineGrainEBIdMap::EcalTPGFineGrainEBMapItr itfg = (ecaltpgFineGrainEB->getMap()).find((*it).second);
     (*itfg).second.getValues(ETlow_, EThigh_, Ratlow_, Rathigh_, lut_);
   } else
-    edm::LogWarning("EcalTPG")
-        << " could not find EcalTPGGroupsMap entry for " << towid;
+    edm::LogWarning("EcalTPG") << " could not find EcalTPGGroupsMap entry for " << towid;
 }

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixLinearizer.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixLinearizer.cc
@@ -6,8 +6,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-EcalFenixLinearizer::EcalFenixLinearizer(bool famos)
-    : famos_(famos), init_(false) {}
+EcalFenixLinearizer::EcalFenixLinearizer(bool famos) : famos_(famos), init_(false) {}
 
 EcalFenixLinearizer::~EcalFenixLinearizer() {
   if (init_) {
@@ -17,25 +16,23 @@ EcalFenixLinearizer::~EcalFenixLinearizer() {
   }
 }
 
-void EcalFenixLinearizer::setParameters(
-    uint32_t raw, const EcalTPGPedestals *ecaltpPed,
-    const EcalTPGLinearizationConst *ecaltpLin,
-    const EcalTPGCrystalStatus *ecaltpBadX) {
+void EcalFenixLinearizer::setParameters(uint32_t raw,
+                                        const EcalTPGPedestals *ecaltpPed,
+                                        const EcalTPGLinearizationConst *ecaltpLin,
+                                        const EcalTPGCrystalStatus *ecaltpBadX) {
   const EcalTPGLinearizationConstMap &linMap = ecaltpLin->getMap();
   EcalTPGLinearizationConstMapIterator it = linMap.find(raw);
   if (it != linMap.end()) {
     linConsts_ = &(*it);
   } else
-    edm::LogWarning("EcalTPG")
-        << " could not find EcalTPGLinearizationConstMap entry for " << raw;
+    edm::LogWarning("EcalTPG") << " could not find EcalTPGLinearizationConstMap entry for " << raw;
 
   const EcalTPGPedestalsMap &pedMap = ecaltpPed->getMap();
   EcalTPGPedestalsMapIterator itped = pedMap.find(raw);
   if (itped != pedMap.end())
     peds_ = &(*itped);
   else
-    edm::LogWarning("EcalTPG")
-        << " could not find EcalTPGPedestalsMap entry for " << raw;
+    edm::LogWarning("EcalTPG") << " could not find EcalTPGPedestalsMap entry for " << raw;
 
   const EcalTPGCrystalStatusMap &badXMap = ecaltpBadX->getMap();
   EcalTPGCrystalStatusMapIterator itbadX = badXMap.find(raw);
@@ -43,8 +40,7 @@ void EcalFenixLinearizer::setParameters(
   if (itbadX != badXMap.end()) {
     badXStatus_ = &(*itbadX);
   } else {
-    edm::LogWarning("EcalTPG")
-        << " could not find EcalTPGCrystalStatusMap entry for " << raw;
+    edm::LogWarning("EcalTPG") << " could not find EcalTPGCrystalStatusMap entry for " << raw;
     badXStatus_ = new EcalTPGCrystalStatusCode();
     vectorbadXStatus_.push_back(&(*badXStatus_));
     init_ = true;
@@ -52,15 +48,15 @@ void EcalFenixLinearizer::setParameters(
 }
 
 int EcalFenixLinearizer::process() {
-  int output = (uncorrectedSample_ - base_); // Substract base
+  int output = (uncorrectedSample_ - base_);  // Substract base
   if (famos_ || output < 0)
     return 0;
 
   if (output < 0)
-    return shift_ << 12;                     // FENIX bug(!)
-  output = (output * mult_) >> (shift_ + 2); // Apply multiplicative factor
+    return shift_ << 12;                      // FENIX bug(!)
+  output = (output * mult_) >> (shift_ + 2);  // Apply multiplicative factor
   if (output > 0X3FFFF)
-    output = 0X3FFFF; // Saturation if too high
+    output = 0X3FFFF;  // Saturation if too high
   return output;
 }
 
@@ -69,19 +65,18 @@ int EcalFenixLinearizer::setInput(const EcalMGPASample &RawSam) {
     LogDebug("EcalTPG") << "ERROR IN INPUT SAMPLE OF FENIX LINEARIZER";
     return -1;
   }
-  uncorrectedSample_ = RawSam.adc(); // uncorrectedSample_ is coded in the 12
-                                     // LSB
-  gainID_ = RawSam.gainId(); // uncorrectedSample_ is coded in the 2 next bits!
+  uncorrectedSample_ = RawSam.adc();  // uncorrectedSample_ is coded in the 12
+                                      // LSB
+  gainID_ = RawSam.gainId();          // uncorrectedSample_ is coded in the 2 next bits!
   // if (gainID_==0)    gainID_=3;
 
   if (gainID_ == 0) {
     base_ = 0;
     shift_ = 0;
     mult_ = 0xFF;
-    if ((linConsts_->mult_x12 == 0) && (linConsts_->mult_x6 == 0) &&
-        (linConsts_->mult_x1 == 0)) {
-      mult_ = 0; // Implemented in CCSSupervisor to
-                 // reject overflow cases in rejected channels
+    if ((linConsts_->mult_x12 == 0) && (linConsts_->mult_x6 == 0) && (linConsts_->mult_x1 == 0)) {
+      mult_ = 0;  // Implemented in CCSSupervisor to
+                  // reject overflow cases in rejected channels
     }
   } else if (gainID_ == 1) {
     base_ = peds_->mean_x12;
@@ -120,7 +115,7 @@ int EcalFenixLinearizer::setInput(const EcalMGPASample &RawSam) {
   }
 
   if (famos_)
-    base_ = 200; // FIXME by preparing a correct TPG.txt for Famos
+    base_ = 200;  // FIXME by preparing a correct TPG.txt for Famos
 
   return 1;
 }

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixMaxof2.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixMaxof2.cc
@@ -2,8 +2,7 @@
 
 // global type definitions for class implementation in source file defined by
 // Tag entries in ArgoUML Result: typedef <typedef_global_source> <tag_value>;
-EcalFenixMaxof2::EcalFenixMaxof2(int maxNrSamples, int nbMaxStrips)
-    : nbMaxStrips_(nbMaxStrips) {
+EcalFenixMaxof2::EcalFenixMaxof2(int maxNrSamples, int nbMaxStrips) : nbMaxStrips_(nbMaxStrips) {
   std::vector<int> vec(maxNrSamples, 0);
   for (int i2strip = 0; i2strip < nbMaxStrips_ - 1; ++i2strip)
     sumby2_.push_back(vec);
@@ -12,7 +11,8 @@ EcalFenixMaxof2::EcalFenixMaxof2(int maxNrSamples, int nbMaxStrips)
 EcalFenixMaxof2::~EcalFenixMaxof2() {}
 
 void EcalFenixMaxof2::process(std::vector<std::vector<int>> &bypasslinout,
-                              int nstrip, int bitMask,
+                              int nstrip,
+                              int bitMask,
                               std::vector<int> &output) {
   int mask = (1 << bitMask) - 1;
   for (int i2strip = 0; i2strip < nstrip - 1; ++i2strip)
@@ -26,8 +26,7 @@ void EcalFenixMaxof2::process(std::vector<std::vector<int>> &bypasslinout,
       output[i] = ((bypasslinout[0][i]) & mask);
     } else {
       for (int i2strip = 0; i2strip < nstrip - 1; ++i2strip) {
-        sumby2_[i2strip][i] = ((bypasslinout[i2strip][i]) & mask) +
-                              ((bypasslinout[i2strip + 1][i]) & mask);
+        sumby2_[i2strip][i] = ((bypasslinout[i2strip][i]) & mask) + ((bypasslinout[i2strip + 1][i]) & mask);
         if (sumby2_[i2strip][i] > output[i]) {
           output[i] = sumby2_[i2strip][i];
         }

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixPeakFinder.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixPeakFinder.cc
@@ -17,7 +17,6 @@ int EcalFenixPeakFinder::setInput(int input) {
 }
 
 int EcalFenixPeakFinder::process() {
-
   if (inputsAlreadyIn_ < 3)
     return 0;
   if (buffer_[1] > buffer_[0] && buffer_[1] > buffer_[2])
@@ -26,9 +25,7 @@ int EcalFenixPeakFinder::process() {
     return 0;
 }
 
-std::vector<int> EcalFenixPeakFinder::process(std::vector<int> &filtout,
-                                              std::vector<int> &output) {
-
+std::vector<int> EcalFenixPeakFinder::process(std::vector<int> &filtout, std::vector<int> &output) {
   // FIXME: 3
   inputsAlreadyIn_ = 0;
   for (unsigned int i = 0; i < 3; i++)
@@ -38,7 +35,6 @@ std::vector<int> EcalFenixPeakFinder::process(std::vector<int> &filtout,
 
   // attention, we have to shift by one, because the peak is found one too late
   for (unsigned int i = 0; i < filtout.size(); i++) {
-
     setInput(filtout[i]);
     if (i > 0) {
       //      int outone = process();

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixStrip.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixStrip.cc
@@ -10,10 +10,11 @@
 //-------------------------------------------------------------------------------------
 EcalFenixStrip::EcalFenixStrip(const edm::EventSetup &setup,
                                const EcalElectronicsMapping *theMapping,
-                               bool debug, bool famos, int maxNrSamples,
+                               bool debug,
+                               bool famos,
+                               int maxNrSamples,
                                int nbMaxXtals)
-    : theMapping_(theMapping), debug_(debug), famos_(famos),
-      nbMaxXtals_(nbMaxXtals) {
+    : theMapping_(theMapping), debug_(debug), famos_(famos), nbMaxXtals_(nbMaxXtals) {
   linearizer_.resize(nbMaxXtals_);
   for (int i = 0; i < nbMaxXtals_; i++)
     linearizer_[i] = new EcalFenixLinearizer(famos_);
@@ -51,10 +52,9 @@ EcalFenixStrip::~EcalFenixStrip() {
 }
 
 //----------------------------------------------------------------------------------
-void EcalFenixStrip::process_part2_barrel(
-    uint32_t stripid, const EcalTPGSlidingWindow *ecaltpgSlidW,
-    const EcalTPGFineGrainStripEE *ecaltpgFgStripEE) {
-
+void EcalFenixStrip::process_part2_barrel(uint32_t stripid,
+                                          const EcalTPGSlidingWindow *ecaltpgSlidW,
+                                          const EcalTPGFineGrainStripEE *ecaltpgFgStripEE) {
   // call  Fgvb
   // this->getFGVB()->setParameters(stripid,ecaltpgFgStripEE);
   // this->getFGVB()->process(lin_out_,fgvb_out_);
@@ -64,8 +64,7 @@ void EcalFenixStrip::process_part2_barrel(
   this->getFormatterEB()->process(fgvb_out_, peak_out_, filt_out_, format_out_);
   // this is a test:
   if (debug_) {
-    std::cout << "output of formatter is a vector of size: "
-              << format_out_.size() << std::endl;
+    std::cout << "output of formatter is a vector of size: " << format_out_.size() << std::endl;
     std::cout << "value : " << std::endl;
     for (unsigned int i = 0; i < format_out_.size(); i++) {
       std::cout << " " << format_out_[i];
@@ -75,25 +74,22 @@ void EcalFenixStrip::process_part2_barrel(
   return;
 }
 //-------------------------------------------------------------------------------------
-void EcalFenixStrip::process_part2_endcap(
-    uint32_t stripid, const EcalTPGSlidingWindow *ecaltpgSlidW,
-    const EcalTPGFineGrainStripEE *ecaltpgFgStripEE,
-    const EcalTPGStripStatus *ecaltpgStripStatus) {
-
+void EcalFenixStrip::process_part2_endcap(uint32_t stripid,
+                                          const EcalTPGSlidingWindow *ecaltpgSlidW,
+                                          const EcalTPGFineGrainStripEE *ecaltpgFgStripEE,
+                                          const EcalTPGStripStatus *ecaltpgStripStatus) {
   // call  Fgvb
   // this->getFGVB()->setParameters(stripid,ecaltpgFgStripEE);
   // this->getFGVB()->process(lin_out_,fgvb_out_);
 
   // call formatter
-  this->getFormatterEE()->setParameters(stripid, ecaltpgSlidW,
-                                        ecaltpgStripStatus);
+  this->getFormatterEE()->setParameters(stripid, ecaltpgSlidW, ecaltpgStripStatus);
 
   this->getFormatterEE()->process(fgvb_out_, peak_out_, filt_out_, format_out_);
 
   // this is a test:
   if (debug_) {
-    std::cout << "output of formatter is a vector of size: "
-              << format_out_.size() << std::endl;
+    std::cout << "output of formatter is a vector of size: " << format_out_.size() << std::endl;
     std::cout << "value : " << std::endl;
     for (unsigned int i = 0; i < format_out_.size(); i++) {
       std::cout << " " << std::dec << format_out_[i];

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixStripFgvbEE.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixStripFgvbEE.cc
@@ -11,8 +11,7 @@ EcalFenixStripFgvbEE::EcalFenixStripFgvbEE() {
 
 EcalFenixStripFgvbEE::~EcalFenixStripFgvbEE() {}
 
-void EcalFenixStripFgvbEE::process(std::vector<std::vector<int>> &linout,
-                                   std::vector<int> &output) {
+void EcalFenixStripFgvbEE::process(std::vector<std::vector<int>> &linout, std::vector<int> &output) {
   std::vector<int> indexLut(output.size());
 
   for (unsigned int i = 0; i < output.size(); i++) {
@@ -20,21 +19,18 @@ void EcalFenixStripFgvbEE::process(std::vector<std::vector<int>> &linout,
     indexLut[i] = 0;
     for (unsigned int ixtal = 0; ixtal < linout.size(); ixtal++) {
       int adc = linout[ixtal][i];
-      int res = (((adc & 0xffff) > threshold_fg_) || ((adc & 0x30000) != 0x0))
-                    ? 1
-                    : 0;
+      int res = (((adc & 0xffff) > threshold_fg_) || ((adc & 0x30000) != 0x0)) ? 1 : 0;
       indexLut[i] = indexLut[i] | (res << ixtal);
     }
     int mask = 1 << (indexLut[i]);
     output[i] = ((lut_fg_ & mask) == 0x0) ? 0 : 1;
     if (i > 0)
-      output[i - 1] = output[i]; // Delay one clock
+      output[i - 1] = output[i];  // Delay one clock
   }
   return;
 }
 
-void EcalFenixStripFgvbEE::setParameters(
-    int identif, uint32_t id, const EcalTPGFineGrainStripEE *ecaltpgFgStripEE) {
+void EcalFenixStripFgvbEE::setParameters(int identif, uint32_t id, const EcalTPGFineGrainStripEE *ecaltpgFgStripEE) {
   const EcalTPGFineGrainStripEEMap &fgmap = ecaltpgFgStripEE->getMap();
   EcalTPGFineGrainStripEEMapIterator it = fgmap.find(id);
   if (it != fgmap.end()) {
@@ -42,9 +38,8 @@ void EcalFenixStripFgvbEE::setParameters(
     lut_fg_ = it->second.lut;
   } else {
     if (identif == false) {
-      edm::LogWarning("EcalTPG")
-          << " could not find EcalTPGFineGrainStripEEMap entry for at least "
-             "one stripId";
+      edm::LogWarning("EcalTPG") << " could not find EcalTPGFineGrainStripEEMap entry for at least "
+                                    "one stripId";
       flagBadStripMiss_ = true;
     }
 

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixStripFormatEB.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixStripFormatEB.cc
@@ -21,7 +21,7 @@ int EcalFenixStripFormatEB::process() {
   //    int output=buffer_;
   int output = input_ >> shift_;
   if (output > 0XFFF)
-    output = 0XFFF; // ok: barrel saturates at 12 bits
+    output = 0XFFF;  // ok: barrel saturates at 12 bits
   // Add stripFGVB
   output |= ((inputsFGVB_ & 0x1) << 12);
 
@@ -33,9 +33,8 @@ void EcalFenixStripFormatEB::process(std::vector<int> &sFGVBout,
                                      std::vector<int> &filtout,
                                      std::vector<int> &output) {
   if (peakout.size() != filtout.size() || sFGVBout.size() != filtout.size()) {
-    edm::LogWarning("EcalTPG")
-        << " problem in EcalFenixStripFormatEB: sfgvb_out, peak_out and "
-           "filt_out don't have the same size";
+    edm::LogWarning("EcalTPG") << " problem in EcalFenixStripFormatEB: sfgvb_out, peak_out and "
+                                  "filt_out don't have the same size";
   }
   for (unsigned int i = 0; i < filtout.size(); i++) {
     setInput(filtout[i], peakout[i], sFGVBout[i]);
@@ -45,14 +44,11 @@ void EcalFenixStripFormatEB::process(std::vector<int> &sFGVBout,
   return;
 }
 
-void EcalFenixStripFormatEB::setParameters(uint32_t &id,
-                                           const EcalTPGSlidingWindow *&slWin) {
-
+void EcalFenixStripFormatEB::setParameters(uint32_t &id, const EcalTPGSlidingWindow *&slWin) {
   const EcalTPGSlidingWindowMap &slwinmap = slWin->getMap();
   EcalTPGSlidingWindowMapIterator it = slwinmap.find(id);
   if (it != slwinmap.end())
     shift_ = (*it).second;
   else
-    edm::LogWarning("EcalTPG")
-        << " could not find EcalTPGSlidingWindowMap entry for " << id;
+    edm::LogWarning("EcalTPG") << " could not find EcalTPGSlidingWindowMap entry for " << id;
 }

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixStripFormatEE.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixStripFormatEE.cc
@@ -36,7 +36,7 @@ int EcalFenixStripFormatEE::process() {
   // Pascal: finally no,endcap has 12 bits as in EB (bug in FENIX!!!!)
   if (output > 0XFFF)
     output = 0XFFF;
-  output = output | ((fgvb_ & 0x1) << 12); // Pascal (was 10)
+  output = output | ((fgvb_ & 0x1) << 12);  // Pascal (was 10)
 
   return output;
 }
@@ -47,12 +47,9 @@ void EcalFenixStripFormatEE::process(std::vector<int> &fgvbout,
                                      std::vector<int> &filtout,
                                      std::vector<int> &output) {
   if (peakout.size() != filtout.size()) {
-    edm::LogWarning("EcalTPG")
-        << " problem in EcalFenixStripFormatEE: peak_out and filt_out don't "
-           "have the same size";
-    std::cout << " Size peak_out" << peakout.size()
-              << ", size filt_out:" << filtout.size() << std::flush
-              << std::endl;
+    edm::LogWarning("EcalTPG") << " problem in EcalFenixStripFormatEE: peak_out and filt_out don't "
+                                  "have the same size";
+    std::cout << " Size peak_out" << peakout.size() << ", size filt_out:" << filtout.size() << std::flush << std::endl;
   }
   for (unsigned int i = 0; i < filtout.size(); i++) {
     setInput(filtout[i], peakout[i], fgvbout[i]);
@@ -62,24 +59,22 @@ void EcalFenixStripFormatEE::process(std::vector<int> &fgvbout,
 }
 //-----------------------------------------------------------------------------------------
 
-void EcalFenixStripFormatEE::setParameters(
-    uint32_t id, const EcalTPGSlidingWindow *&slWin,
-    const EcalTPGStripStatus *stripStatus) {
-
+void EcalFenixStripFormatEE::setParameters(uint32_t id,
+                                           const EcalTPGSlidingWindow *&slWin,
+                                           const EcalTPGStripStatus *stripStatus) {
   const EcalTPGSlidingWindowMap &slwinmap = slWin->getMap();
   EcalTPGSlidingWindowMapIterator it = slwinmap.find(id);
   if (it != slwinmap.end())
     shift_ = (*it).second;
   else
-    edm::LogWarning("EcalTPG")
-        << " could not find EcalTPGSlidingWindowMap entry for " << id;
+    edm::LogWarning("EcalTPG") << " could not find EcalTPGSlidingWindowMap entry for " << id;
 
   const EcalTPGStripStatusMap &statusMap = stripStatus->getMap();
   EcalTPGStripStatusMapIterator sit = statusMap.find(id);
   if (sit != statusMap.end()) {
     stripStatus_ = (*sit).second;
   } else {
-    stripStatus_ = 0; // Assume strip OK
+    stripStatus_ = 0;  // Assume strip OK
   }
 }
 //-----------------------------------------------------------------------------------------

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixTcp.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixTcp.cc
@@ -11,9 +11,13 @@
 
 #include <vector>
 //----------------------------------------------------------------------------------------
-EcalFenixTcp::EcalFenixTcp(const edm::EventSetup &setup, bool tcpFormat,
-                           bool debug, bool famos, int binOfMax,
-                           int maxNrSamples, int nbMaxStrips)
+EcalFenixTcp::EcalFenixTcp(const edm::EventSetup &setup,
+                           bool tcpFormat,
+                           bool debug,
+                           bool famos,
+                           int binOfMax,
+                           int maxNrSamples,
+                           int nbMaxStrips)
     : debug_(debug), nbMaxStrips_(nbMaxStrips) {
   bypasslin_.resize(nbMaxStrips_);
   for (int i = 0; i < nbMaxStrips_; i++)
@@ -47,41 +51,58 @@ EcalFenixTcp::~EcalFenixTcp() {
 }
 //-----------------------------------------------------------------------------------------
 
-void EcalFenixTcp::process(
-    const edm::EventSetup &setup,
-    std::vector<EBDataFrame> &bid, // dummy argument for template call
-    std::vector<std::vector<int>> &tpframetow, int nStr,
-    std::vector<EcalTriggerPrimitiveSample> &tptow,
-    std::vector<EcalTriggerPrimitiveSample> &tptow2, bool isInInnerRing,
-    EcalTrigTowerDetId towid) {
-
+void EcalFenixTcp::process(const edm::EventSetup &setup,
+                           std::vector<EBDataFrame> &bid,  // dummy argument for template call
+                           std::vector<std::vector<int>> &tpframetow,
+                           int nStr,
+                           std::vector<EcalTriggerPrimitiveSample> &tptow,
+                           std::vector<EcalTriggerPrimitiveSample> &tptow2,
+                           bool isInInnerRing,
+                           EcalTrigTowerDetId towid) {
   int bitMask = 12;
   process_part1(tpframetow, nStr, bitMask);
 
-  process_part2_barrel(tpframetow, nStr, bitMask, ecaltpgFgEBGroup_,
-                       ecaltpgLutGroup_, ecaltpgLut_, ecaltpgFineGrainEB_,
-                       ecaltpgBadTT_, ecaltpgSpike_, tptow, tptow2, towid);
+  process_part2_barrel(tpframetow,
+                       nStr,
+                       bitMask,
+                       ecaltpgFgEBGroup_,
+                       ecaltpgLutGroup_,
+                       ecaltpgLut_,
+                       ecaltpgFineGrainEB_,
+                       ecaltpgBadTT_,
+                       ecaltpgSpike_,
+                       tptow,
+                       tptow2,
+                       towid);
 }
 
 //-----------------------------------------------------------------------------------------
-void EcalFenixTcp::process(
-    const edm::EventSetup &setup,
-    std::vector<EEDataFrame> &bid, // dummy argument for template call
-    std::vector<std::vector<int>> &tpframetow, int nStr,
-    std::vector<EcalTriggerPrimitiveSample> &tptow,
-    std::vector<EcalTriggerPrimitiveSample> &tptow2, bool isInInnerRing,
-    EcalTrigTowerDetId towid) {
-  int bitMask = 12; // Pascal: endcap has 12 bits as in EB (bug in FENIX!!!!)
-                    // {was 10 before]
+void EcalFenixTcp::process(const edm::EventSetup &setup,
+                           std::vector<EEDataFrame> &bid,  // dummy argument for template call
+                           std::vector<std::vector<int>> &tpframetow,
+                           int nStr,
+                           std::vector<EcalTriggerPrimitiveSample> &tptow,
+                           std::vector<EcalTriggerPrimitiveSample> &tptow2,
+                           bool isInInnerRing,
+                           EcalTrigTowerDetId towid) {
+  int bitMask = 12;  // Pascal: endcap has 12 bits as in EB (bug in FENIX!!!!)
+                     // {was 10 before]
   process_part1(tpframetow, nStr, bitMask);
 
-  process_part2_endcap(tpframetow, nStr, bitMask, ecaltpgLutGroup_, ecaltpgLut_,
-                       ecaltpgFineGrainTowerEE_, ecaltpgBadTT_, tptow, tptow2,
-                       isInInnerRing, towid);
+  process_part2_endcap(tpframetow,
+                       nStr,
+                       bitMask,
+                       ecaltpgLutGroup_,
+                       ecaltpgLut_,
+                       ecaltpgFineGrainTowerEE_,
+                       ecaltpgBadTT_,
+                       tptow,
+                       tptow2,
+                       isInInnerRing,
+                       towid);
 }
 //-----------------------------------------------------------------------------------------
-void EcalFenixTcp::process_part1(std::vector<std::vector<int>> &tpframetow,
-                                 int nStr, int bitMask) {
+void EcalFenixTcp::process_part1(std::vector<std::vector<int>> &tpframetow, int nStr, int bitMask) {
   //  //call bypasslin
   //     for (int istrip=0;istrip<nStr;istrip ++){
   //       this->getBypasslin(istrip)->process(tpframetow[istrip],bypasslin_out_[istrip]);
@@ -103,8 +124,7 @@ void EcalFenixTcp::process_part1(std::vector<std::vector<int>> &tpframetow,
   this->getAdder()->process(tpframetow, nStr, bitMask, adder_out_);
   // this is a test:
   if (debug_) {
-    std::cout << "output of adder is a vector of size: " << adder_out_.size()
-              << std::endl;
+    std::cout << "output of adder is a vector of size: " << adder_out_.size() << std::endl;
     std::cout << "value : " << std::endl;
     for (unsigned int i = 0; i < adder_out_.size(); i++) {
       std::cout << " " << adder_out_[i];
@@ -115,22 +135,24 @@ void EcalFenixTcp::process_part1(std::vector<std::vector<int>> &tpframetow,
   return;
 }
 //-----------------------------------------------------------------------------------------
-void EcalFenixTcp::process_part2_barrel(
-    std::vector<std::vector<int>> &bypasslinout, int nStr, int bitMask,
-    const EcalTPGFineGrainEBGroup *ecaltpgFgEBGroup,
-    const EcalTPGLutGroup *ecaltpgLutGroup, const EcalTPGLutIdMap *ecaltpgLut,
-    const EcalTPGFineGrainEBIdMap *ecaltpgFineGrainEB,
-    const EcalTPGTowerStatus *ecaltpgBadTT, const EcalTPGSpike *ecaltpgSpike,
-    std::vector<EcalTriggerPrimitiveSample> &tcp_out,
-    std::vector<EcalTriggerPrimitiveSample> &tcp_outTcc,
-    EcalTrigTowerDetId towid) {
+void EcalFenixTcp::process_part2_barrel(std::vector<std::vector<int>> &bypasslinout,
+                                        int nStr,
+                                        int bitMask,
+                                        const EcalTPGFineGrainEBGroup *ecaltpgFgEBGroup,
+                                        const EcalTPGLutGroup *ecaltpgLutGroup,
+                                        const EcalTPGLutIdMap *ecaltpgLut,
+                                        const EcalTPGFineGrainEBIdMap *ecaltpgFineGrainEB,
+                                        const EcalTPGTowerStatus *ecaltpgBadTT,
+                                        const EcalTPGSpike *ecaltpgSpike,
+                                        std::vector<EcalTriggerPrimitiveSample> &tcp_out,
+                                        std::vector<EcalTriggerPrimitiveSample> &tcp_outTcc,
+                                        EcalTrigTowerDetId towid) {
   // call maxof2
   //  this->getMaxOf2()->process(bypasslin_out_,nStr,maxOf2_out_);
   this->getMaxOf2()->process(bypasslinout, nStr, bitMask, maxOf2_out_);
   // this is a test:
   if (debug_) {
-    std::cout << "output of maxof2 is a vector of size: " << maxOf2_out_.size()
-              << std::endl;
+    std::cout << "output of maxof2 is a vector of size: " << maxOf2_out_.size() << std::endl;
     std::cout << "value : " << std::endl;
     for (unsigned int i = 0; i < maxOf2_out_.size(); i++) {
       std::cout << " " << std::dec << maxOf2_out_[i];
@@ -140,8 +162,7 @@ void EcalFenixTcp::process_part2_barrel(
 
   // call fgvb
 
-  this->getFGVBEB()->setParameters(towid.rawId(), ecaltpgFgEBGroup,
-                                   ecaltpgFineGrainEB);
+  this->getFGVBEB()->setParameters(towid.rawId(), ecaltpgFgEBGroup, ecaltpgFineGrainEB);
   this->getFGVBEB()->process(adder_out_, maxOf2_out_, fgvb_out_);
 
   // Call sFGVB
@@ -149,8 +170,7 @@ void EcalFenixTcp::process_part2_barrel(
 
   // this is a test:
   if (debug_) {
-    std::cout << "output of fgvb is a vector of size: " << fgvb_out_.size()
-              << std::endl;
+    std::cout << "output of fgvb is a vector of size: " << fgvb_out_.size() << std::endl;
     std::cout << "value : " << std::endl;
     for (unsigned int i = 0; i < fgvb_out_.size(); i++) {
       std::cout << " " << std::dec << fgvb_out_[i];
@@ -161,14 +181,11 @@ void EcalFenixTcp::process_part2_barrel(
   // call formatter
   int eTTotShift = 2;
 
-  this->getFormatter()->setParameters(towid.rawId(), ecaltpgLutGroup,
-                                      ecaltpgLut, ecaltpgBadTT, ecaltpgSpike);
-  this->getFormatter()->process(adder_out_, fgvb_out_, strip_fgvb_out_,
-                                eTTotShift, tcp_out, tcp_outTcc, false);
+  this->getFormatter()->setParameters(towid.rawId(), ecaltpgLutGroup, ecaltpgLut, ecaltpgBadTT, ecaltpgSpike);
+  this->getFormatter()->process(adder_out_, fgvb_out_, strip_fgvb_out_, eTTotShift, tcp_out, tcp_outTcc, false);
   // this is a test:
   if (debug_) {
-    std::cout << "output of TCP formatter Barrel is a vector of size: "
-              << std::dec << tcp_out.size() << std::endl;
+    std::cout << "output of TCP formatter Barrel is a vector of size: " << std::dec << tcp_out.size() << std::endl;
     std::cout << "value : " << std::endl;
     for (unsigned int i = 0; i < tcp_out.size(); i++) {
       std::cout << " " << i << " " << std::dec << tcp_out[i];
@@ -179,14 +196,17 @@ void EcalFenixTcp::process_part2_barrel(
   return;
 }
 //-----------------------------------------------------------------------------------------
-void EcalFenixTcp::process_part2_endcap(
-    std::vector<std::vector<int>> &bypasslinout, int nStr, int bitMask,
-    const EcalTPGLutGroup *ecaltpgLutGroup, const EcalTPGLutIdMap *ecaltpgLut,
-    const EcalTPGFineGrainTowerEE *ecaltpgFineGrainTowerEE,
-    const EcalTPGTowerStatus *ecaltpgbadTT,
-    std::vector<EcalTriggerPrimitiveSample> &tcp_out,
-    std::vector<EcalTriggerPrimitiveSample> &tcp_outTcc, bool isInInnerRings,
-    EcalTrigTowerDetId towid)
+void EcalFenixTcp::process_part2_endcap(std::vector<std::vector<int>> &bypasslinout,
+                                        int nStr,
+                                        int bitMask,
+                                        const EcalTPGLutGroup *ecaltpgLutGroup,
+                                        const EcalTPGLutIdMap *ecaltpgLut,
+                                        const EcalTPGFineGrainTowerEE *ecaltpgFineGrainTowerEE,
+                                        const EcalTPGTowerStatus *ecaltpgbadTT,
+                                        std::vector<EcalTriggerPrimitiveSample> &tcp_out,
+                                        std::vector<EcalTriggerPrimitiveSample> &tcp_outTcc,
+                                        bool isInInnerRings,
+                                        EcalTrigTowerDetId towid)
 
 {
   // Zero EB strip records
@@ -200,19 +220,16 @@ void EcalFenixTcp::process_part2_endcap(
   fgvbEE_->process(bypasslinout, nStr, bitMask, fgvb_out_);
 
   // call formatter
-  int eTTotShift = 2; // Pascal: endcap has 12 bits as in EB (bug in FENIX!!!!)
-                      // so shift must be applied to just keep [11:2]
+  int eTTotShift = 2;  // Pascal: endcap has 12 bits as in EB (bug in FENIX!!!!)
+                       // so shift must be applied to just keep [11:2]
 
-  this->getFormatter()->setParameters(towid.rawId(), ecaltpgLutGroup,
-                                      ecaltpgLut, ecaltpgbadTT, nullptr);
+  this->getFormatter()->setParameters(towid.rawId(), ecaltpgLutGroup, ecaltpgLut, ecaltpgbadTT, nullptr);
 
-  this->getFormatter()->process(adder_out_, fgvb_out_, strip_fgvb_out_,
-                                eTTotShift, tcp_out, tcp_outTcc,
-                                isInInnerRings);
+  this->getFormatter()->process(
+      adder_out_, fgvb_out_, strip_fgvb_out_, eTTotShift, tcp_out, tcp_outTcc, isInInnerRings);
   // this is a test:
   if (debug_) {
-    std::cout << "output of TCP formatter(endcap) is a vector of size: "
-              << std::dec << tcp_out.size() << std::endl;
+    std::cout << "output of TCP formatter(endcap) is a vector of size: " << std::dec << tcp_out.size() << std::endl;
     std::cout << "value : " << std::endl;
     for (unsigned int i = 0; i < tcp_out.size(); i++) {
       std::cout << " " << i << " " << std::dec << tcp_out[i] << std::endl;

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixTcpFgvbEE.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixTcpFgvbEE.cc
@@ -6,11 +6,12 @@
 //---------------------------------------------------------------
 EcalFenixTcpFgvbEE::EcalFenixTcpFgvbEE(int maxNrSamples) {
   indexLut_.resize(maxNrSamples);
-} //---------------------------------------------------------------
+}  //---------------------------------------------------------------
 EcalFenixTcpFgvbEE::~EcalFenixTcpFgvbEE() {}
 //---------------------------------------------------------------
 void EcalFenixTcpFgvbEE::process(std::vector<std::vector<int>> &bypasslin_out,
-                                 int nStr, int bitMask,
+                                 int nStr,
+                                 int bitMask,
                                  std::vector<int> &output) {
   //  std::vector<int> indexLut(output.size());
 
@@ -22,7 +23,7 @@ void EcalFenixTcpFgvbEE::process(std::vector<std::vector<int>> &bypasslin_out,
   for (unsigned int i = 0; i < output.size(); i++) {
     for (int istrip = 0; istrip < nStr; istrip++) {
       int res = (bypasslin_out[istrip])[i];
-      res = (res >> bitMask) & 1; // res is FGVB at this stage
+      res = (res >> bitMask) & 1;  // res is FGVB at this stage
       indexLut_[i] = indexLut_[i] | (res << istrip);
     }
     indexLut_[i] = indexLut_[i] | (nStr << 5);
@@ -37,16 +38,12 @@ void EcalFenixTcpFgvbEE::process(std::vector<std::vector<int>> &bypasslin_out,
 
 //-------------------------------------------------------------------
 
-void EcalFenixTcpFgvbEE::setParameters(
-    uint32_t towid, const EcalTPGFineGrainTowerEE *ecaltpgFineGrainTowerEE) {
-
-  const EcalTPGFineGrainTowerEEMap &fgee_map =
-      ecaltpgFineGrainTowerEE->getMap();
+void EcalFenixTcpFgvbEE::setParameters(uint32_t towid, const EcalTPGFineGrainTowerEE *ecaltpgFineGrainTowerEE) {
+  const EcalTPGFineGrainTowerEEMap &fgee_map = ecaltpgFineGrainTowerEE->getMap();
 
   EcalTPGFineGrainTowerEEMapIterator it = fgee_map.find(towid);
   if (it != fgee_map.end())
     fgee_lut_ = (*it).second;
   else
-    edm::LogWarning("EcalTPG")
-        << " could not find EcalTPGFineGrainTowerEEMap for " << towid;
+    edm::LogWarning("EcalTPG") << " could not find EcalTPGFineGrainTowerEEMap for " << towid;
 }

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixTcpFormat.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixTcpFormat.cc
@@ -8,8 +8,7 @@
 
 using namespace std;
 
-EcalFenixTcpFormat::EcalFenixTcpFormat(bool tcpFormat, bool debug, bool famos,
-                                       int binOfMax)
+EcalFenixTcpFormat::EcalFenixTcpFormat(bool tcpFormat, bool debug, bool famos, int binOfMax)
     : tcpFormat_(tcpFormat), debug_(debug), famos_(famos), binOfMax_(binOfMax) {
   status_ = 0;
   badTTStatus_ = &status_;
@@ -17,8 +16,10 @@ EcalFenixTcpFormat::EcalFenixTcpFormat(bool tcpFormat, bool debug, bool famos,
 
 EcalFenixTcpFormat::~EcalFenixTcpFormat() {}
 
-void EcalFenixTcpFormat::process(std::vector<int> &Et, std::vector<int> &fgvb,
-                                 std::vector<int> &sfgvb, int eTTotShift,
+void EcalFenixTcpFormat::process(std::vector<int> &Et,
+                                 std::vector<int> &fgvb,
+                                 std::vector<int> &sfgvb,
+                                 int eTTotShift,
                                  std::vector<EcalTriggerPrimitiveSample> &out,
                                  std::vector<EcalTriggerPrimitiveSample> &out2,
                                  bool isInInnerRings) {
@@ -81,8 +82,7 @@ void EcalFenixTcpFormat::process(std::vector<int> &Et, std::vector<int> &fgvb,
 
       int ttFlag = (lut_out & 0x700) >> 8;
       if (tcpFormat_) {
-        out2[i] = EcalTriggerPrimitiveSample(
-            ((ttFlag & 0x7) << 11) | ((myFgvb & 0x1) << 10) | (myEt & 0x3ff));
+        out2[i] = EcalTriggerPrimitiveSample(((ttFlag & 0x7) << 11) | ((myFgvb & 0x1) << 10) | (myEt & 0x3ff));
       }
       myEt = lut_out & 0xff;
       out[i] = EcalTriggerPrimitiveSample(myEt, myFgvb, mysFgvb, ttFlag);
@@ -115,12 +115,10 @@ void EcalFenixTcpFormat::setParameters(uint32_t towid,
     if (itl != lutmap.end()) {
       lut_ = (*itl).second.getLut();
     } else
-      edm::LogWarning("EcalTPG")
-          << " could not find EcalTPGLutMap for " << lutid;
+      edm::LogWarning("EcalTPG") << " could not find EcalTPGLutMap for " << lutid;
 
   } else
-    edm::LogWarning("EcalTPG")
-        << " could not find EcalTPGFineGrainTowerEEMap for " << towid;
+    edm::LogWarning("EcalTPG") << " could not find EcalTPGFineGrainTowerEEMap for " << towid;
 
   const EcalTPGTowerStatusMap &badTTMap = ecaltpgbadTT->getMap();
   EcalTPGTowerStatusMapIterator itbadTT = badTTMap.find(towid);

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixTcpsFgvbEB.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixTcpsFgvbEB.cc
@@ -1,12 +1,12 @@
 #include <SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixTcpsFgvbEB.h>
 
 //---------------------------------------------------------------
-EcalFenixTcpsFgvbEB::EcalFenixTcpsFgvbEB() {
-} //---------------------------------------------------------------
+EcalFenixTcpsFgvbEB::EcalFenixTcpsFgvbEB() {}  //---------------------------------------------------------------
 EcalFenixTcpsFgvbEB::~EcalFenixTcpsFgvbEB() {}
 //---------------------------------------------------------------
 void EcalFenixTcpsFgvbEB::process(std::vector<std::vector<int>> &bypasslin_out,
-                                  int nStr, int bitMask,
+                                  int nStr,
+                                  int bitMask,
                                   std::vector<int> &output) {
   //  std::vector<int> indexLut(output.size());
 
@@ -18,7 +18,7 @@ void EcalFenixTcpsFgvbEB::process(std::vector<std::vector<int>> &bypasslin_out,
     int towRes = 0;
     for (int istrip = 0; istrip < nStr; istrip++) {
       int res = (bypasslin_out[istrip])[i];
-      res = (res >> bitMask) & 1; // res is sFGVB at this stage
+      res = (res >> bitMask) & 1;  // res is sFGVB at this stage
       towRes |= res;
     }
 

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalTrigPrimFunctionalAlgo.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalTrigPrimFunctionalAlgo.cc
@@ -41,22 +41,24 @@
 #include <TMath.h>
 #include <TTree.h>
 
-const unsigned int EcalTrigPrimFunctionalAlgo::nrSamples_ = 5; // to be written
+const unsigned int EcalTrigPrimFunctionalAlgo::nrSamples_ = 5;  // to be written
 const unsigned int EcalTrigPrimFunctionalAlgo::maxNrSamplesOut_ = 10;
 const unsigned int EcalTrigPrimFunctionalAlgo::maxNrTowers_ = 2448;
-const unsigned int EcalTrigPrimFunctionalAlgo::maxNrTPs_ = 2448; // FIXME??
+const unsigned int EcalTrigPrimFunctionalAlgo::maxNrTPs_ = 2448;  // FIXME??
 
 //----------------------------------------------------------------------
 
 EcalTrigPrimFunctionalAlgo::EcalTrigPrimFunctionalAlgo(
-    const edm::EventSetup &setup, int binofmax, bool tcpFormat, bool barrelOnly,
-    bool debug, bool famos)
-    : binOfMaximum_(binofmax), tcpFormat_(tcpFormat), barrelOnly_(barrelOnly),
-      debug_(debug), famos_(famos)
+    const edm::EventSetup &setup, int binofmax, bool tcpFormat, bool barrelOnly, bool debug, bool famos)
+    : binOfMaximum_(binofmax),
+      tcpFormat_(tcpFormat),
+      barrelOnly_(barrelOnly),
+      debug_(debug),
+      famos_(famos)
 
 {
   if (famos_)
-    maxNrSamples_ = 1; // get from input??
+    maxNrSamples_ = 1;  // get from input??
   else
     maxNrSamples_ = 10;
   this->init(setup);
@@ -68,8 +70,7 @@ void EcalTrigPrimFunctionalAlgo::init(const edm::EventSetup &setup) {
     edm::ESHandle<CaloGeometry> theGeometry;
     edm::ESHandle<CaloSubdetectorGeometry> theEndcapGeometry_handle;
     setup.get<CaloGeometryRecord>().get(theGeometry);
-    setup.get<EcalEndcapGeometryRecord>().get("EcalEndcap",
-                                              theEndcapGeometry_handle);
+    setup.get<EcalEndcapGeometryRecord>().get("EcalEndcap", theEndcapGeometry_handle);
     theEndcapGeometry = &(*theEndcapGeometry_handle);
     setup.get<IdealGeometryRecord>().get(eTTmap_);
   }
@@ -79,10 +80,8 @@ void EcalTrigPrimFunctionalAlgo::init(const edm::EventSetup &setup) {
   theMapping_ = ecalmapping.product();
 
   // create main sub algos
-  estrip_ = new EcalFenixStrip(setup, theMapping_, debug_, famos_,
-                               maxNrSamples_, nbMaxXtals_);
-  etcp_ = new EcalFenixTcp(setup, tcpFormat_, debug_, famos_, binOfMaximum_,
-                           maxNrSamples_, nbMaxStrips_);
+  estrip_ = new EcalFenixStrip(setup, theMapping_, debug_, famos_, maxNrSamples_, nbMaxXtals_);
+  etcp_ = new EcalFenixTcp(setup, tcpFormat_, debug_, famos_, binOfMaximum_, maxNrSamples_, nbMaxStrips_);
 
   // initialise data structures
   initStructures(towerMapEB_);
@@ -112,15 +111,13 @@ void EcalTrigPrimFunctionalAlgo::run(const edm::EventSetup &setup,
                                      EEDigiCollection const *col,
                                      EcalTrigPrimDigiCollection &result,
                                      EcalTrigPrimDigiCollection &resultTcp) {
-
   run_part1_EE(col);
   run_part2(setup, col, towerMapEE_, result, resultTcp);
 }
 //----------------------------------------------------------------------
 int EcalTrigPrimFunctionalAlgo::findStripNr(const EBDetId &id) {
   int stripnr;
-  int n = ((id.ic() - 1) % 100) /
-          20; // 20 corresponds to 4 * ecal_barrel_crystals_per_strip FIXME!!
+  int n = ((id.ic() - 1) % 100) / 20;  // 20 corresponds to 4 * ecal_barrel_crystals_per_strip FIXME!!
   if (id.ieta() < 0)
     stripnr = n + 1;
   else
@@ -130,8 +127,7 @@ int EcalTrigPrimFunctionalAlgo::findStripNr(const EBDetId &id) {
 //----------------------------------------------------------------------
 int EcalTrigPrimFunctionalAlgo::findStripNr(const EEDetId &id) {
   int stripnr;
-  const EcalTriggerElectronicsId elId =
-      theMapping_->getTriggerElectronicsId(id);
+  const EcalTriggerElectronicsId elId = theMapping_->getTriggerElectronicsId(id);
   stripnr = elId.pseudoStripId();
   return stripnr;
 }

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTPCondAnalyzer.cc
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTPCondAnalyzer.cc
@@ -55,16 +55,12 @@ EcalTPCondAnalyzer::EcalTPCondAnalyzer(const edm::ParameterSet &iConfig)
 
 {}
 
-void EcalTPCondAnalyzer::beginRun(const edm::Run &run,
-                                  edm::EventSetup const &evtSetup) {
+void EcalTPCondAnalyzer::beginRun(const edm::Run &run, edm::EventSetup const &evtSetup) {
   // get geometry
 
-  edm::ESHandle<CaloSubdetectorGeometry> theEndcapGeometry_handle,
-      theBarrelGeometry_handle;
-  evtSetup.get<EcalEndcapGeometryRecord>().get("EcalEndcap",
-                                               theEndcapGeometry_handle);
-  evtSetup.get<EcalBarrelGeometryRecord>().get("EcalBarrel",
-                                               theBarrelGeometry_handle);
+  edm::ESHandle<CaloSubdetectorGeometry> theEndcapGeometry_handle, theBarrelGeometry_handle;
+  evtSetup.get<EcalEndcapGeometryRecord>().get("EcalEndcap", theEndcapGeometry_handle);
+  evtSetup.get<EcalBarrelGeometryRecord>().get("EcalBarrel", theBarrelGeometry_handle);
   theEndcapGeometry_ = &(*theEndcapGeometry_handle);
   theBarrelGeometry_ = &(*theBarrelGeometry_handle);
 
@@ -75,8 +71,7 @@ void EcalTPCondAnalyzer::beginJob() {}
 
 EcalTPCondAnalyzer::~EcalTPCondAnalyzer() {}
 
-unsigned long long
-EcalTPCondAnalyzer::getRecords(edm::EventSetup const &setup) {
+unsigned long long EcalTPCondAnalyzer::getRecords(edm::EventSetup const &setup) {
   //
   // get Eventsetup records and print them
   //
@@ -84,16 +79,14 @@ EcalTPCondAnalyzer::getRecords(edm::EventSetup const &setup) {
 
   edm::ESHandle<EcalTPGPhysicsConst> theEcalTPGPhysConst_handle;
   setup.get<EcalTPGPhysicsConstRcd>().get(theEcalTPGPhysConst_handle);
-  const EcalTPGPhysicsConst *ecaltpPhysConst =
-      theEcalTPGPhysConst_handle.product();
+  const EcalTPGPhysicsConst *ecaltpPhysConst = theEcalTPGPhysConst_handle.product();
   printEcalTPGPhysicsConst(ecaltpPhysConst);
   // for EcalFenixStrip...
 
   // get parameter records for xtals
   edm::ESHandle<EcalTPGLinearizationConst> theEcalTPGLinearization_handle;
   setup.get<EcalTPGLinearizationConstRcd>().get(theEcalTPGLinearization_handle);
-  const EcalTPGLinearizationConst *ecaltpLin =
-      theEcalTPGLinearization_handle.product();
+  const EcalTPGLinearizationConst *ecaltpLin = theEcalTPGLinearization_handle.product();
 
   edm::ESHandle<EcalTPGPedestals> theEcalTPGPedestals_handle;
   setup.get<EcalTPGPedestalsRcd>().get(theEcalTPGPedestals_handle);
@@ -103,17 +96,14 @@ EcalTPCondAnalyzer::getRecords(edm::EventSetup const &setup) {
   // weight
   edm::ESHandle<EcalTPGWeightIdMap> theEcalTPGWEightIdMap_handle;
   setup.get<EcalTPGWeightIdMapRcd>().get(theEcalTPGWEightIdMap_handle);
-  const EcalTPGWeightIdMap *ecaltpgWeightMap =
-      theEcalTPGWEightIdMap_handle.product();
+  const EcalTPGWeightIdMap *ecaltpgWeightMap = theEcalTPGWEightIdMap_handle.product();
   printWEIGHT(ecaltpgWeightMap);
 
   // .. and for EcalFenixTcp
 
   edm::ESHandle<EcalTPGFineGrainEBIdMap> theEcalTPGFineGrainEBIdMap_handle;
-  setup.get<EcalTPGFineGrainEBIdMapRcd>().get(
-      theEcalTPGFineGrainEBIdMap_handle);
-  const EcalTPGFineGrainEBIdMap *ecaltpgFineGrainEB =
-      theEcalTPGFineGrainEBIdMap_handle.product();
+  setup.get<EcalTPGFineGrainEBIdMapRcd>().get(theEcalTPGFineGrainEBIdMap_handle);
+  const EcalTPGFineGrainEBIdMap *ecaltpgFineGrainEB = theEcalTPGFineGrainEBIdMap_handle.product();
   printEcalTPGFineGrainEBIdMap(ecaltpgFineGrainEB);
 
   edm::ESHandle<EcalTPGLutIdMap> theEcalTPGLutIdMap_handle;
@@ -124,17 +114,13 @@ EcalTPCondAnalyzer::getRecords(edm::EventSetup const &setup) {
   // for strips
   edm::ESHandle<EcalTPGSlidingWindow> theEcalTPGSlidingWindow_handle;
   setup.get<EcalTPGSlidingWindowRcd>().get(theEcalTPGSlidingWindow_handle);
-  const EcalTPGSlidingWindow *ecaltpgSlidW =
-      theEcalTPGSlidingWindow_handle.product();
+  const EcalTPGSlidingWindow *ecaltpgSlidW = theEcalTPGSlidingWindow_handle.product();
   edm::ESHandle<EcalTPGFineGrainStripEE> theEcalTPGFineGrainStripEE_handle;
-  setup.get<EcalTPGFineGrainStripEERcd>().get(
-      theEcalTPGFineGrainStripEE_handle);
-  const EcalTPGFineGrainStripEE *ecaltpgFgStripEE =
-      theEcalTPGFineGrainStripEE_handle.product();
+  setup.get<EcalTPGFineGrainStripEERcd>().get(theEcalTPGFineGrainStripEE_handle);
+  const EcalTPGFineGrainStripEE *ecaltpgFgStripEE = theEcalTPGFineGrainStripEE_handle.product();
   edm::ESHandle<EcalTPGWeightGroup> theEcalTPGWEightGroup_handle;
   setup.get<EcalTPGWeightGroupRcd>().get(theEcalTPGWEightGroup_handle);
-  const EcalTPGWeightGroup *ecaltpgWeightGroup =
-      theEcalTPGWEightGroup_handle.product();
+  const EcalTPGWeightGroup *ecaltpgWeightGroup = theEcalTPGWEightGroup_handle.product();
   printSTRIP(ecaltpgSlidW, ecaltpgWeightGroup, ecaltpgFgStripEE);
 
   // get parameter records for towers
@@ -143,20 +129,16 @@ EcalTPCondAnalyzer::getRecords(edm::EventSetup const &setup) {
   const EcalTPGLutGroup *ecaltpgLutGroup = theEcalTPGLutGroup_handle.product();
 
   edm::ESHandle<EcalTPGFineGrainEBGroup> theEcalTPGFineGrainEBGroup_handle;
-  setup.get<EcalTPGFineGrainEBGroupRcd>().get(
-      theEcalTPGFineGrainEBGroup_handle);
-  const EcalTPGFineGrainEBGroup *ecaltpgFgEBGroup =
-      theEcalTPGFineGrainEBGroup_handle.product();
+  setup.get<EcalTPGFineGrainEBGroupRcd>().get(theEcalTPGFineGrainEBGroup_handle);
+  const EcalTPGFineGrainEBGroup *ecaltpgFgEBGroup = theEcalTPGFineGrainEBGroup_handle.product();
   edm::ESHandle<EcalTPGSpike> theEcalTPGSpike_handle;
   setup.get<EcalTPGSpikeRcd>().get(theEcalTPGSpike_handle);
   const EcalTPGSpike *ecaltpgSpikeTh = theEcalTPGSpike_handle.product();
 
   printTOWEREB(ecaltpgSpikeTh, ecaltpgFgEBGroup, ecaltpgLutGroup);
   edm::ESHandle<EcalTPGFineGrainTowerEE> theEcalTPGFineGrainTowerEE_handle;
-  setup.get<EcalTPGFineGrainTowerEERcd>().get(
-      theEcalTPGFineGrainTowerEE_handle);
-  const EcalTPGFineGrainTowerEE *ecaltpgFineGrainTowerEE =
-      theEcalTPGFineGrainTowerEE_handle.product();
+  setup.get<EcalTPGFineGrainTowerEERcd>().get(theEcalTPGFineGrainTowerEE_handle);
+  const EcalTPGFineGrainTowerEE *ecaltpgFineGrainTowerEE = theEcalTPGFineGrainTowerEE_handle.product();
 
   printTOWEREE(ecaltpgFineGrainTowerEE, ecaltpgLutGroup);
 
@@ -186,13 +168,11 @@ EcalTPCondAnalyzer::getRecords(edm::EventSetup const &setup) {
 }
 
 // ------------ method called to analyze the data  ------------
-void EcalTPCondAnalyzer::analyze(const edm::Event &iEvent,
-                                 const edm::EventSetup &iSetup) {}
+void EcalTPCondAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {}
 
 void EcalTPCondAnalyzer::endJob() {}
 
-void EcalTPCondAnalyzer::printEcalTPGPhysicsConst(
-    const EcalTPGPhysicsConst *ecaltpgPhysConst) const {
+void EcalTPCondAnalyzer::printEcalTPGPhysicsConst(const EcalTPGPhysicsConst *ecaltpgPhysConst) const {
   EcalTPGPhysicsConstMapIterator it;
   const EcalTPGPhysicsConstMap &mymap = ecaltpgPhysConst->getMap();
   for (it = mymap.begin(); it != mymap.end(); ++it) {
@@ -201,19 +181,16 @@ void EcalTPCondAnalyzer::printEcalTPGPhysicsConst(
     } else {
       std::cout << "\nPHYSICS_EE " << (*it).first << std::endl;
     }
-    std::cout << (*it).second.EtSat << " " << (*it).second.ttf_threshold_Low
-              << " " << (*it).second.ttf_threshold_High << std::endl;
-    std::cout << (*it).second.FG_lowThreshold << " "
-              << (*it).second.FG_highThreshold << " "
-              << (*it).second.FG_lowRatio << " " << (*it).second.FG_highRatio
+    std::cout << (*it).second.EtSat << " " << (*it).second.ttf_threshold_Low << " " << (*it).second.ttf_threshold_High
               << std::endl;
+    std::cout << (*it).second.FG_lowThreshold << " " << (*it).second.FG_highThreshold << " " << (*it).second.FG_lowRatio
+              << " " << (*it).second.FG_highRatio << std::endl;
   }
 }
 
-void EcalTPCondAnalyzer::printSTRIP(
-    const EcalTPGSlidingWindow *slWin,
-    const EcalTPGWeightGroup *ecaltpgWeightGroup,
-    const EcalTPGFineGrainStripEE *ecaltpgFgStripEE) const {
+void EcalTPCondAnalyzer::printSTRIP(const EcalTPGSlidingWindow *slWin,
+                                    const EcalTPGWeightGroup *ecaltpgWeightGroup,
+                                    const EcalTPGFineGrainStripEE *ecaltpgFgStripEE) const {
   // print STRIP information
   const EcalTPGSlidingWindowMap &slwinmap = slWin->getMap();
   const EcalTPGFineGrainStripEEMap &fgstripEEmap = ecaltpgFgStripEE->getMap();
@@ -232,34 +209,28 @@ void EcalTPCondAnalyzer::printSTRIP(
         if (subdet == 1) {
           std::cout << "STRIP_EB " << std::dec << (*it).first << std::endl;
           std::cout << std::hex << "0x" << (*it).second << std::endl;
-          std::cout << "" << (*groupId).second << std::endl; // weightgroupid
-          EcalTPGFineGrainStripEEMapIterator it2 =
-              fgstripEEmap.find((*it).first);
+          std::cout << "" << (*groupId).second << std::endl;  // weightgroupid
+          EcalTPGFineGrainStripEEMapIterator it2 = fgstripEEmap.find((*it).first);
           if (it2 == fgstripEEmap.end()) {
-            edm::LogWarning("EcalTPGCondAnalyzer")
-                << " could not find strip Id " << (*it).first
-                << ", given in sliding window, inside the "
-                   "EcalTPGFineGranStripEEMap!!!";
+            edm::LogWarning("EcalTPGCondAnalyzer") << " could not find strip Id " << (*it).first
+                                                   << ", given in sliding window, inside the "
+                                                      "EcalTPGFineGranStripEEMap!!!";
           } else {
             EcalTPGFineGrainStripEE::Item item = (*it2).second;
-            std::cout << std::hex << "0x" << item.threshold << " 0x" << item.lut
-                      << std::endl;
+            std::cout << std::hex << "0x" << item.threshold << " 0x" << item.lut << std::endl;
           }
         } else if (subdet == 2) {
           std::cout << "STRIP_EE " << std::dec << (*it).first << std::endl;
           std::cout << std::hex << "0x" << (*it).second << std::endl;
-          std::cout << " " << (*groupId).second << std::endl; // weightgroupid
-          EcalTPGFineGrainStripEEMapIterator it2 =
-              fgstripEEmap.find((*it).first);
+          std::cout << " " << (*groupId).second << std::endl;  // weightgroupid
+          EcalTPGFineGrainStripEEMapIterator it2 = fgstripEEmap.find((*it).first);
           if (it2 == fgstripEEmap.end()) {
-            edm::LogWarning("EcalTPGCondAnalyzer")
-                << " could not find strip Id " << (*it).first
-                << ", given in sliding window, inside the "
-                   "EcalTPGFineGranStripEEMap!!!";
+            edm::LogWarning("EcalTPGCondAnalyzer") << " could not find strip Id " << (*it).first
+                                                   << ", given in sliding window, inside the "
+                                                      "EcalTPGFineGranStripEEMap!!!";
           } else {
             EcalTPGFineGrainStripEE::Item item = (*it2).second;
-            std::cout << std::hex << "0x" << item.threshold << " 0x" << item.lut
-                      << std::endl;
+            std::cout << std::hex << "0x" << item.threshold << " 0x" << item.lut << std::endl;
           }
         }
       }
@@ -267,44 +238,35 @@ void EcalTPCondAnalyzer::printSTRIP(
   }
 }
 
-void EcalTPCondAnalyzer::printWEIGHT(
-    const EcalTPGWeightIdMap *ecaltpgWeightIdMap) const {
-
+void EcalTPCondAnalyzer::printWEIGHT(const EcalTPGWeightIdMap *ecaltpgWeightIdMap) const {
   std::cout << std::endl;
   EcalTPGWeightIdMap::EcalTPGWeightMapItr it;
   uint32_t w0, w1, w2, w3, w4;
-  const EcalTPGWeightIdMap::EcalTPGWeightMap &map =
-      ecaltpgWeightIdMap->getMap();
+  const EcalTPGWeightIdMap::EcalTPGWeightMap &map = ecaltpgWeightIdMap->getMap();
   for (it = map.begin(); it != map.end(); ++it) {
     std::cout << "WEIGHT " << (*it).first << std::endl;
     (*it).second.getValues(w0, w1, w2, w3, w4);
-    std::cout << std::hex << "0x" << w0 << " 0x" << w1 << " 0x" << w2 << " 0x"
-              << w3 << " 0x" << w4 << " " << std::endl;
+    std::cout << std::hex << "0x" << w0 << " 0x" << w1 << " 0x" << w2 << " 0x" << w3 << " 0x" << w4 << " " << std::endl;
     std::cout << std::endl;
     std::cout << std::endl;
   }
 }
 
-void EcalTPCondAnalyzer::printEcalTPGFineGrainEBIdMap(
-    const EcalTPGFineGrainEBIdMap *ecaltpgFineGrainEB) const {
+void EcalTPCondAnalyzer::printEcalTPGFineGrainEBIdMap(const EcalTPGFineGrainEBIdMap *ecaltpgFineGrainEB) const {
   EcalTPGFineGrainEBIdMap::EcalTPGFineGrainEBMapItr it;
-  const EcalTPGFineGrainEBIdMap::EcalTPGFineGrainEBMap &map =
-      ecaltpgFineGrainEB->getMap();
+  const EcalTPGFineGrainEBIdMap::EcalTPGFineGrainEBMap &map = ecaltpgFineGrainEB->getMap();
   uint32_t ThresholdETLow, ThresholdETHigh, RatioLow, RatioHigh, LUT;
 
   // std::cout<<std::endl;
   for (it = map.begin(); it != map.end(); ++it) {
     std::cout << "FG " << (*it).first << std::endl;
-    (*it).second.getValues(ThresholdETLow, ThresholdETHigh, RatioLow, RatioHigh,
-                           LUT);
-    std::cout << std::hex << "0x" << ThresholdETLow << " 0x" << ThresholdETHigh
-              << " 0x" << RatioLow << " 0x" << RatioHigh << " 0x" << LUT
-              << std::endl;
+    (*it).second.getValues(ThresholdETLow, ThresholdETHigh, RatioLow, RatioHigh, LUT);
+    std::cout << std::hex << "0x" << ThresholdETLow << " 0x" << ThresholdETHigh << " 0x" << RatioLow << " 0x"
+              << RatioHigh << " 0x" << LUT << std::endl;
   }
 }
 
-void EcalTPCondAnalyzer::printEcalTPGLutIdMap(
-    const EcalTPGLutIdMap *ecaltpgLut) const {
+void EcalTPCondAnalyzer::printEcalTPGLutIdMap(const EcalTPGLutIdMap *ecaltpgLut) const {
   EcalTPGLutIdMap::EcalTPGLutMapItr it;
   const EcalTPGLutIdMap::EcalTPGLutMap &map = ecaltpgLut->getMap();
 
@@ -317,47 +279,34 @@ void EcalTPCondAnalyzer::printEcalTPGLutIdMap(
   }
 }
 
-void EcalTPCondAnalyzer::printCRYSTAL(
-    const EcalTPGPedestals *ecaltpPed,
-    const EcalTPGLinearizationConst *ecaltpLin) {
-
+void EcalTPCondAnalyzer::printCRYSTAL(const EcalTPGPedestals *ecaltpPed, const EcalTPGLinearizationConst *ecaltpLin) {
   std::cout << std::endl;
   const EcalTPGPedestalsMap &pedMap = ecaltpPed->getMap();
   const EcalTPGLinearizationConstMap &linMap = ecaltpLin->getMap();
 
-  const std::vector<DetId> &ebCells =
-      theBarrelGeometry_->getValidDetIds(DetId::Ecal, EcalBarrel);
+  const std::vector<DetId> &ebCells = theBarrelGeometry_->getValidDetIds(DetId::Ecal, EcalBarrel);
 
   std::cout << "COMMENT ====== barrel crystals ====== " << std::endl;
-  for (std::vector<DetId>::const_iterator it = ebCells.begin();
-       it != ebCells.end(); ++it) {
+  for (std::vector<DetId>::const_iterator it = ebCells.begin(); it != ebCells.end(); ++it) {
     EBDetId id(*it);
     std::cout << "CRYSTAL " << std::dec << id.rawId() << std::endl;
     const EcalTPGPedestal &ped = pedMap[id.rawId()];
     const EcalTPGLinearizationConstant &lin = linMap[id.rawId()];
-    std::cout << std::hex << " 0x" << ped.mean_x12 << " 0x" << lin.mult_x12
-              << " 0x" << lin.shift_x12 << std::endl;
-    std::cout << std::hex << " 0x" << ped.mean_x6 << " 0x" << lin.mult_x6
-              << " 0x" << lin.shift_x6 << std::endl;
-    std::cout << std::hex << " 0x" << ped.mean_x1 << " 0x" << lin.mult_x1
-              << " 0x" << lin.shift_x1 << std::endl;
+    std::cout << std::hex << " 0x" << ped.mean_x12 << " 0x" << lin.mult_x12 << " 0x" << lin.shift_x12 << std::endl;
+    std::cout << std::hex << " 0x" << ped.mean_x6 << " 0x" << lin.mult_x6 << " 0x" << lin.shift_x6 << std::endl;
+    std::cout << std::hex << " 0x" << ped.mean_x1 << " 0x" << lin.mult_x1 << " 0x" << lin.shift_x1 << std::endl;
   }
 
-  const std::vector<DetId> &eeCells =
-      theEndcapGeometry_->getValidDetIds(DetId::Ecal, EcalEndcap);
+  const std::vector<DetId> &eeCells = theEndcapGeometry_->getValidDetIds(DetId::Ecal, EcalEndcap);
   std::cout << "COMMENT ====== endcap crystals ====== " << std::endl;
-  for (std::vector<DetId>::const_iterator it = eeCells.begin();
-       it != eeCells.end(); ++it) {
+  for (std::vector<DetId>::const_iterator it = eeCells.begin(); it != eeCells.end(); ++it) {
     EEDetId id(*it);
     std::cout << "CRYSTAL " << std::dec << id.rawId() << std::endl;
     const EcalTPGPedestal &ped = pedMap[id.rawId()];
     const EcalTPGLinearizationConstant &lin = linMap[id.rawId()];
-    std::cout << std::hex << " 0x" << ped.mean_x12 << " 0x" << lin.mult_x12
-              << " 0x" << lin.shift_x12 << std::endl;
-    std::cout << std::hex << " 0x" << ped.mean_x6 << " 0x" << lin.mult_x6
-              << " 0x" << lin.shift_x6 << std::endl;
-    std::cout << std::hex << " 0x" << ped.mean_x1 << " 0x" << lin.mult_x1
-              << " 0x" << lin.shift_x1 << std::endl;
+    std::cout << std::hex << " 0x" << ped.mean_x12 << " 0x" << lin.mult_x12 << " 0x" << lin.shift_x12 << std::endl;
+    std::cout << std::hex << " 0x" << ped.mean_x6 << " 0x" << lin.mult_x6 << " 0x" << lin.shift_x6 << std::endl;
+    std::cout << std::hex << " 0x" << ped.mean_x1 << " 0x" << lin.mult_x1 << " 0x" << lin.shift_x1 << std::endl;
   }
 }
 void EcalTPCondAnalyzer::printComment() const {
@@ -459,11 +408,9 @@ void EcalTPCondAnalyzer::printComment() const {
 }
 */
 
-void EcalTPCondAnalyzer::printTOWEREB(
-    const EcalTPGSpike *ecaltpgSpikeTh,
-    const EcalTPGFineGrainEBGroup *ecaltpgFgEBGroup,
-    const EcalTPGLutGroup *ecaltpgLutGroup) const {
-
+void EcalTPCondAnalyzer::printTOWEREB(const EcalTPGSpike *ecaltpgSpikeTh,
+                                      const EcalTPGFineGrainEBGroup *ecaltpgFgEBGroup,
+                                      const EcalTPGLutGroup *ecaltpgLutGroup) const {
   const EcalTPGGroups::EcalTPGGroupsMap &lutMap = ecaltpgLutGroup->getMap();
   EcalTPGGroups::EcalTPGGroupsMapItr lutGroupId;
   const EcalTPGGroups::EcalTPGGroupsMap &fgMap = ecaltpgFgEBGroup->getMap();
@@ -483,10 +430,8 @@ void EcalTPCondAnalyzer::printTOWEREB(
   }
 }
 
-void EcalTPCondAnalyzer::printTOWEREE(
-    const EcalTPGFineGrainTowerEE *ecaltpgFineGrainTowerEE,
-    const EcalTPGLutGroup *ecaltpgLutGroup) const {
-
+void EcalTPCondAnalyzer::printTOWEREE(const EcalTPGFineGrainTowerEE *ecaltpgFineGrainTowerEE,
+                                      const EcalTPGLutGroup *ecaltpgLutGroup) const {
   EcalTPGFineGrainTowerEEMapIterator it;
   const EcalTPGFineGrainTowerEEMap &map = ecaltpgFineGrainTowerEE->getMap();
   const EcalTPGGroups::EcalTPGGroupsMap &lutMap = ecaltpgLutGroup->getMap();

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTPCondAnalyzer.h
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTPCondAnalyzer.h
@@ -70,8 +70,7 @@ private:
 
   void printComment() const;
   void printEcalTPGPhysicsConst(const EcalTPGPhysicsConst *) const;
-  void printCRYSTAL(const EcalTPGPedestals *ecaltpPed,
-                    const EcalTPGLinearizationConst *ecaltpLin);
+  void printCRYSTAL(const EcalTPGPedestals *ecaltpPed, const EcalTPGLinearizationConst *ecaltpLin);
   void printSTRIP(const EcalTPGSlidingWindow *ecaltpgSlidW,
                   const EcalTPGWeightGroup *ecaltpgWeightGroup,
                   const EcalTPGFineGrainStripEE *ecaltpgFgStripEE) const;
@@ -80,8 +79,7 @@ private:
                     const EcalTPGFineGrainEBGroup *ecaltpgFgEBGroup,
                     const EcalTPGLutGroup *ecaltpgLutGroup) const;
   void printEcalTPGLutIdMap(const EcalTPGLutIdMap *ecaltpgLut) const;
-  void printEcalTPGFineGrainEBIdMap(
-      const EcalTPGFineGrainEBIdMap *ecaltpgFineGrainEB) const;
+  void printEcalTPGFineGrainEBIdMap(const EcalTPGFineGrainEBIdMap *ecaltpgFineGrainEB) const;
   void printTOWEREE(const EcalTPGFineGrainTowerEE *ecaltpgFineGrainTowerEE,
                     const EcalTPGLutGroup *ecaltpgLutGroup) const;
   void printBadX(const EcalTPGCrystalStatus *ecaltpgBadX) const;

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTPInputAnalyzer.cc
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTPInputAnalyzer.cc
@@ -57,7 +57,6 @@ EcalTPInputAnalyzer::EcalTPInputAnalyzer(const edm::ParameterSet &iConfig)
 }
 
 EcalTPInputAnalyzer::~EcalTPInputAnalyzer() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 
@@ -70,8 +69,7 @@ EcalTPInputAnalyzer::~EcalTPInputAnalyzer() {
 //
 
 // ------------ method called to analyze the data  ------------
-void EcalTPInputAnalyzer::analyze(const edm::Event &iEvent,
-                                  const edm::EventSetup &iSetup) {
+void EcalTPInputAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
   using namespace std;
 
@@ -80,16 +78,14 @@ void EcalTPInputAnalyzer::analyze(const edm::Event &iEvent,
   edm::Handle<EEDigiCollection> eeDigis;
   if (!iEvent.getByLabel(producer_, ebLabel_, ebDigis)) {
     barrel = false;
-    edm::LogWarning("EcalTPG")
-        << " Couldnt find Barrel dataframes with Producer:" << producer_
-        << " and label: " << ebLabel_;
+    edm::LogWarning("EcalTPG") << " Couldnt find Barrel dataframes with Producer:" << producer_
+                               << " and label: " << ebLabel_;
   }
   bool endcap = true;
   if (!iEvent.getByLabel(producer_, eeLabel_, eeDigis)) {
     endcap = false;
-    edm::LogWarning("EcalTPG")
-        << " Couldnt find Endcap dataframes with Producer:" << producer_
-        << " and label: " << eeLabel_;
+    edm::LogWarning("EcalTPG") << " Couldnt find Endcap dataframes with Producer:" << producer_
+                               << " and label: " << eeLabel_;
   }
   // barrel
   if (barrel) {

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimAnalyzer.cc
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimAnalyzer.cc
@@ -74,8 +74,7 @@ EcalTrigPrimAnalyzer::EcalTrigPrimAnalyzer(const edm::ParameterSet &iConfig)
   recHits_ = iConfig.getParameter<bool>("AnalyzeRecHits");
   label_ = iConfig.getParameter<edm::InputTag>("inputTP");
   if (recHits_) {
-    hTPvsRechit_ =
-        new TH2F("TP_vs_RecHit", "TP vs  rechit", 256, -1, 255, 255, 0, 255);
+    hTPvsRechit_ = new TH2F("TP_vs_RecHit", "TP vs  rechit", 256, -1, 255, 255, 0, 255);
     hTPoverRechit_ = new TH1F("TP_over_RecHit", "TP over rechit", 500, 0, 4);
     rechits_labelEB_ = iConfig.getParameter<edm::InputTag>("inputRecHitsEB");
     rechits_labelEE_ = iConfig.getParameter<edm::InputTag>("inputRecHitsEE");
@@ -83,7 +82,6 @@ EcalTrigPrimAnalyzer::EcalTrigPrimAnalyzer(const edm::ParameterSet &iConfig)
 }
 
 EcalTrigPrimAnalyzer::~EcalTrigPrimAnalyzer() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 
@@ -96,8 +94,7 @@ EcalTrigPrimAnalyzer::~EcalTrigPrimAnalyzer() {
 //
 
 // ------------ method called to analyze the data  ------------
-void EcalTrigPrimAnalyzer::analyze(const edm::Event &iEvent,
-                                   const edm::EventSetup &iSetup) {
+void EcalTrigPrimAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace edm;
   using namespace std;
 
@@ -133,15 +130,11 @@ void EcalTrigPrimAnalyzer::analyze(const edm::Event &iEvent,
   edm::ESHandle<CaloSubdetectorGeometry> theBarrelGeometry_handle;
   edm::ESHandle<CaloSubdetectorGeometry> theEndcapGeometry_handle;
   iSetup.get<CaloGeometryRecord>().get(theGeometry);
-  iSetup.get<EcalEndcapGeometryRecord>().get("EcalEndcap",
-                                             theEndcapGeometry_handle);
-  iSetup.get<EcalBarrelGeometryRecord>().get("EcalBarrel",
-                                             theBarrelGeometry_handle);
+  iSetup.get<EcalEndcapGeometryRecord>().get("EcalEndcap", theEndcapGeometry_handle);
+  iSetup.get<EcalBarrelGeometryRecord>().get("EcalBarrel", theBarrelGeometry_handle);
 
-  const CaloSubdetectorGeometry *theEndcapGeometry =
-      theEndcapGeometry_handle.product();
-  const CaloSubdetectorGeometry *theBarrelGeometry =
-      theBarrelGeometry_handle.product();
+  const CaloSubdetectorGeometry *theEndcapGeometry = theEndcapGeometry_handle.product();
+  const CaloSubdetectorGeometry *theBarrelGeometry = theBarrelGeometry_handle.product();
   edm::ESHandle<EcalTrigTowerConstituentsMap> eTTmap_;
   iSetup.get<IdealGeometryRecord>().get(eTTmap_);
 
@@ -166,8 +159,7 @@ void EcalTrigPrimAnalyzer::analyze(const edm::Event &iEvent,
       const EBDetId &myid2 = (*rechit_EB_col.product())[j].id();
       EcalTrigTowerDetId towid2 = myid2.tower();
       if (towid1 == towid2) {
-        float theta =
-            theBarrelGeometry->getGeometry(myid2)->getPosition().theta();
+        float theta = theBarrelGeometry->getGeometry(myid2)->getPosition().theta();
         Etsum += (*rechit_EB_col.product())[j].energy() * sin(theta);
       }
       j++;
@@ -195,8 +187,7 @@ void EcalTrigPrimAnalyzer::analyze(const edm::Event &iEvent,
       const EEDetId &myid2 = (*rechit_EE_col.product())[j].id();
       EcalTrigTowerDetId towid2 = (*eTTmap_).towerOf(myid2);
       if (towid1 == towid2) {
-        float theta =
-            theEndcapGeometry->getGeometry(myid2)->getPosition().theta();
+        float theta = theEndcapGeometry->getGeometry(myid2)->getPosition().theta();
         Etsum += (*rechit_EE_col.product())[j].energy() * sin(theta);
       }
       //  else loopend=true;

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimESProducer.cc
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimESProducer.cc
@@ -34,12 +34,11 @@ struct GzInputStream {
     }
   }
   ~GzInputStream() { gzclose(gzf); }
-  explicit operator bool() const {
-    return ((eof == true) ? false : !iss.fail());
-  }
+  explicit operator bool() const { return ((eof == true) ? false : !iss.fail()); }
 };
 
-template <typename T> GzInputStream &operator>>(GzInputStream &gis, T &var) {
+template <typename T>
+GzInputStream &operator>>(GzInputStream &gis, T &var) {
   while ((bool)gis && !(gis.iss >> var)) {
     gis.readLine();
   }
@@ -51,8 +50,7 @@ template <typename T> GzInputStream &operator>>(GzInputStream &gis, T &var) {
 //
 
 EcalTrigPrimESProducer::EcalTrigPrimESProducer(const edm::ParameterSet &iConfig)
-    : dbFilename_(
-          iConfig.getUntrackedParameter<std::string>("DatabaseFile", "")),
+    : dbFilename_(iConfig.getUntrackedParameter<std::string>("DatabaseFile", "")),
       flagPrint_(iConfig.getParameter<bool>("WriteInFile")) {
   // the following line is needed to tell the framework what
   // data is being produced
@@ -83,8 +81,7 @@ EcalTrigPrimESProducer::~EcalTrigPrimESProducer() {}
 
 // ------------ method called to produce the data  ------------
 
-std::unique_ptr<EcalTPGPedestals>
-EcalTrigPrimESProducer::producePedestals(const EcalTPGPedestalsRcd &iRecord) {
+std::unique_ptr<EcalTPGPedestals> EcalTrigPrimESProducer::producePedestals(const EcalTPGPedestalsRcd &iRecord) {
   auto prod = std::make_unique<EcalTPGPedestals>();
   parseTextFile();
   std::map<uint32_t, std::vector<uint32_t>>::const_iterator it;
@@ -98,8 +95,7 @@ EcalTrigPrimESProducer::producePedestals(const EcalTPGPedestalsRcd &iRecord) {
   return prod;
 }
 
-std::unique_ptr<EcalTPGLinearizationConst>
-EcalTrigPrimESProducer::produceLinearizationConst(
+std::unique_ptr<EcalTPGLinearizationConst> EcalTrigPrimESProducer::produceLinearizationConst(
     const EcalTPGLinearizationConstRcd &iRecord) {
   auto prod = std::make_unique<EcalTPGLinearizationConst>();
   parseTextFile();
@@ -117,8 +113,7 @@ EcalTrigPrimESProducer::produceLinearizationConst(
   return prod;
 }
 
-std::unique_ptr<EcalTPGSlidingWindow>
-EcalTrigPrimESProducer::produceSlidingWindow(
+std::unique_ptr<EcalTPGSlidingWindow> EcalTrigPrimESProducer::produceSlidingWindow(
     const EcalTPGSlidingWindowRcd &iRecord) {
   auto prod = std::make_unique<EcalTPGSlidingWindow>();
   parseTextFile();
@@ -131,23 +126,20 @@ EcalTrigPrimESProducer::produceSlidingWindow(
   return prod;
 }
 
-std::unique_ptr<EcalTPGFineGrainEBIdMap>
-EcalTrigPrimESProducer::produceFineGrainEB(
+std::unique_ptr<EcalTPGFineGrainEBIdMap> EcalTrigPrimESProducer::produceFineGrainEB(
     const EcalTPGFineGrainEBIdMapRcd &iRecord) {
   auto prod = std::make_unique<EcalTPGFineGrainEBIdMap>();
   parseTextFile();
   EcalTPGFineGrainConstEB fg;
   std::map<uint32_t, std::vector<uint32_t>>::const_iterator it;
   for (it = mapFg_.begin(); it != mapFg_.end(); it++) {
-    fg.setValues((it->second)[0], (it->second)[1], (it->second)[2],
-                 (it->second)[3], (it->second)[4]);
+    fg.setValues((it->second)[0], (it->second)[1], (it->second)[2], (it->second)[3], (it->second)[4]);
     prod->setValue(it->first, fg);
   }
   return prod;
 }
 
-std::unique_ptr<EcalTPGFineGrainStripEE>
-EcalTrigPrimESProducer::produceFineGrainEEstrip(
+std::unique_ptr<EcalTPGFineGrainStripEE> EcalTrigPrimESProducer::produceFineGrainEEstrip(
     const EcalTPGFineGrainStripEERcd &iRecord) {
   auto prod = std::make_unique<EcalTPGFineGrainStripEE>();
   parseTextFile();
@@ -169,8 +161,7 @@ EcalTrigPrimESProducer::produceFineGrainEEstrip(
   return prod;
 }
 
-std::unique_ptr<EcalTPGFineGrainTowerEE>
-EcalTrigPrimESProducer::produceFineGrainEEtower(
+std::unique_ptr<EcalTPGFineGrainTowerEE> EcalTrigPrimESProducer::produceFineGrainEEtower(
     const EcalTPGFineGrainTowerEERcd &iRecord) {
   auto prod = std::make_unique<EcalTPGFineGrainTowerEE>();
   parseTextFile();
@@ -181,8 +172,7 @@ EcalTrigPrimESProducer::produceFineGrainEEtower(
   return prod;
 }
 
-std::unique_ptr<EcalTPGLutIdMap>
-EcalTrigPrimESProducer::produceLUT(const EcalTPGLutIdMapRcd &iRecord) {
+std::unique_ptr<EcalTPGLutIdMap> EcalTrigPrimESProducer::produceLUT(const EcalTPGLutIdMapRcd &iRecord) {
   auto prod = std::make_unique<EcalTPGLutIdMap>();
   parseTextFile();
   EcalTPGLut lut;
@@ -197,22 +187,19 @@ EcalTrigPrimESProducer::produceLUT(const EcalTPGLutIdMapRcd &iRecord) {
   return prod;
 }
 
-std::unique_ptr<EcalTPGWeightIdMap>
-EcalTrigPrimESProducer::produceWeight(const EcalTPGWeightIdMapRcd &iRecord) {
+std::unique_ptr<EcalTPGWeightIdMap> EcalTrigPrimESProducer::produceWeight(const EcalTPGWeightIdMapRcd &iRecord) {
   auto prod = std::make_unique<EcalTPGWeightIdMap>();
   parseTextFile();
   EcalTPGWeights weights;
   std::map<uint32_t, std::vector<uint32_t>>::const_iterator it;
   for (it = mapWeight_.begin(); it != mapWeight_.end(); it++) {
-    weights.setValues((it->second)[0], (it->second)[1], (it->second)[2],
-                      (it->second)[3], (it->second)[4]);
+    weights.setValues((it->second)[0], (it->second)[1], (it->second)[2], (it->second)[3], (it->second)[4]);
     prod->setValue(it->first, weights);
   }
   return prod;
 }
 
-std::unique_ptr<EcalTPGWeightGroup> EcalTrigPrimESProducer::produceWeightGroup(
-    const EcalTPGWeightGroupRcd &iRecord) {
+std::unique_ptr<EcalTPGWeightGroup> EcalTrigPrimESProducer::produceWeightGroup(const EcalTPGWeightGroupRcd &iRecord) {
   auto prod = std::make_unique<EcalTPGWeightGroup>();
   parseTextFile();
   for (int subdet = 0; subdet < 2; subdet++) {
@@ -224,8 +211,7 @@ std::unique_ptr<EcalTPGWeightGroup> EcalTrigPrimESProducer::produceWeightGroup(
   return prod;
 }
 
-std::unique_ptr<EcalTPGLutGroup>
-EcalTrigPrimESProducer::produceLutGroup(const EcalTPGLutGroupRcd &iRecord) {
+std::unique_ptr<EcalTPGLutGroup> EcalTrigPrimESProducer::produceLutGroup(const EcalTPGLutGroupRcd &iRecord) {
   auto prod = std::make_unique<EcalTPGLutGroup>();
   parseTextFile();
   for (int subdet = 0; subdet < 2; subdet++) {
@@ -237,8 +223,7 @@ EcalTrigPrimESProducer::produceLutGroup(const EcalTPGLutGroupRcd &iRecord) {
   return prod;
 }
 
-std::unique_ptr<EcalTPGFineGrainEBGroup>
-EcalTrigPrimESProducer::produceFineGrainEBGroup(
+std::unique_ptr<EcalTPGFineGrainEBGroup> EcalTrigPrimESProducer::produceFineGrainEBGroup(
     const EcalTPGFineGrainEBGroupRcd &iRecord) {
   auto prod = std::make_unique<EcalTPGFineGrainEBGroup>();
   parseTextFile();
@@ -249,9 +234,7 @@ EcalTrigPrimESProducer::produceFineGrainEBGroup(
   return prod;
 }
 
-std::unique_ptr<EcalTPGPhysicsConst>
-EcalTrigPrimESProducer::producePhysicsConst(
-    const EcalTPGPhysicsConstRcd &iRecord) {
+std::unique_ptr<EcalTPGPhysicsConst> EcalTrigPrimESProducer::producePhysicsConst(const EcalTPGPhysicsConstRcd &iRecord) {
   auto prod = std::make_unique<EcalTPGPhysicsConst>();
   parseTextFile();
   std::map<uint32_t, std::vector<float>>::const_iterator it;
@@ -269,13 +252,11 @@ EcalTrigPrimESProducer::producePhysicsConst(
   return prod;
 }
 
-std::unique_ptr<EcalTPGCrystalStatus>
-EcalTrigPrimESProducer::produceBadX(const EcalTPGCrystalStatusRcd &iRecord) {
+std::unique_ptr<EcalTPGCrystalStatus> EcalTrigPrimESProducer::produceBadX(const EcalTPGCrystalStatusRcd &iRecord) {
   auto prod = std::make_unique<EcalTPGCrystalStatus>();
   parseTextFile();
   std::map<uint32_t, std::vector<uint32_t>>::const_iterator it;
   for (it = mapXtal_.begin(); it != mapXtal_.end(); it++) {
-
     EcalTPGCrystalStatusCode badXValue;
     badXValue.setStatusCode(0);
     prod->setValue(it->first, badXValue);
@@ -283,15 +264,13 @@ EcalTrigPrimESProducer::produceBadX(const EcalTPGCrystalStatusRcd &iRecord) {
   return prod;
 }
 
-std::unique_ptr<EcalTPGStripStatus>
-EcalTrigPrimESProducer::produceBadStrip(const EcalTPGStripStatusRcd &iRecord) {
+std::unique_ptr<EcalTPGStripStatus> EcalTrigPrimESProducer::produceBadStrip(const EcalTPGStripStatusRcd &iRecord) {
   auto prod = std::make_unique<EcalTPGStripStatus>();
   // returns an empty map
   return prod;
 }
 
-std::unique_ptr<EcalTPGTowerStatus>
-EcalTrigPrimESProducer::produceBadTT(const EcalTPGTowerStatusRcd &iRecord) {
+std::unique_ptr<EcalTPGTowerStatus> EcalTrigPrimESProducer::produceBadTT(const EcalTPGTowerStatusRcd &iRecord) {
   auto prod = std::make_unique<EcalTPGTowerStatus>();
   parseTextFile();
   std::map<uint32_t, std::vector<uint32_t>>::const_iterator it;
@@ -309,8 +288,7 @@ EcalTrigPrimESProducer::produceBadTT(const EcalTPGTowerStatusRcd &iRecord) {
   return prod;
 }
 
-std::unique_ptr<EcalTPGSpike>
-EcalTrigPrimESProducer::produceSpike(const EcalTPGSpikeRcd &iRecord) {
+std::unique_ptr<EcalTPGSpike> EcalTrigPrimESProducer::produceSpike(const EcalTPGSpikeRcd &iRecord) {
   auto prod = std::make_unique<EcalTPGSpike>();
   parseTextFile();
   // Only need to do barrel
@@ -323,7 +301,7 @@ EcalTrigPrimESProducer::produceSpike(const EcalTPGSpikeRcd &iRecord) {
 
 void EcalTrigPrimESProducer::parseTextFile() {
   if (!mapXtal_.empty())
-    return; // just parse the file once!
+    return;  // just parse the file once!
 
   uint32_t id;
   std::string dataCard;
@@ -338,8 +316,7 @@ void EcalTrigPrimESProducer::parseTextFile() {
   std::string bufString;
   std::string iString;
   std::string fString;
-  std::string filename =
-      "SimCalorimetry/EcalTrigPrimProducers/data/" + dbFilename_;
+  std::string filename = "SimCalorimetry/EcalTrigPrimProducers/data/" + dbFilename_;
   std::string finalFileName;
   size_t slash = dbFilename_.find("/");
   if (slash != 0) {
@@ -355,7 +332,6 @@ void EcalTrigPrimESProducer::parseTextFile() {
 
   GzInputStream gis(finalFileName.c_str());
   while (gis >> dataCard) {
-
     if (dataCard == "PHYSICS_EB" || dataCard == "PHYSICS_EE") {
       gis >> std::dec >> id;
 
@@ -409,7 +385,6 @@ void EcalTrigPrimESProducer::parseTextFile() {
     }
 
     if (dataCard == "CRYSTAL") {
-
       gis >> std::dec >> id;
       // std::cout<<dataCard<<" "<<std::dec<<id;
       std::string st3;
@@ -467,7 +442,7 @@ void EcalTrigPrimESProducer::parseTextFile() {
           }
         }
 
-      } // end for
+      }  // end for
 
       if (flagPrint_) {
         std::cout << " " << st3 << std::endl;
@@ -607,7 +582,6 @@ void EcalTrigPrimESProducer::parseTextFile() {
     }
 
     if (dataCard == "WEIGHT") {
-
       if (flagPrint_)
         std::cout << std::endl;
 
@@ -644,7 +618,6 @@ void EcalTrigPrimESProducer::parseTextFile() {
     }
 
     if (dataCard == "FG") {
-
       if (flagPrint_)
         std::cout << std::endl;
 
@@ -705,36 +678,34 @@ void EcalTrigPrimESProducer::parseTextFile() {
   }
 }
 
-std::vector<int> EcalTrigPrimESProducer::getRange(int subdet, int tccNb,
-                                                  int towerNbInTcc,
-                                                  int stripNbInTower,
-                                                  int xtalNbInStrip) {
+std::vector<int> EcalTrigPrimESProducer::getRange(
+    int subdet, int tccNb, int towerNbInTcc, int stripNbInTower, int xtalNbInStrip) {
   std::vector<int> range;
   if (subdet == 0) {
     // Barrel
-    range.push_back(37); // stccNbMin
-    range.push_back(73); // tccNbMax
-    range.push_back(1);  // towerNbMin
-    range.push_back(69); // towerNbMax
-    range.push_back(1);  // stripNbMin
-    range.push_back(6);  // stripNbMax
-    range.push_back(1);  // xtalNbMin
-    range.push_back(6);  // xtalNbMax
+    range.push_back(37);  // stccNbMin
+    range.push_back(73);  // tccNbMax
+    range.push_back(1);   // towerNbMin
+    range.push_back(69);  // towerNbMax
+    range.push_back(1);   // stripNbMin
+    range.push_back(6);   // stripNbMax
+    range.push_back(1);   // xtalNbMin
+    range.push_back(6);   // xtalNbMax
   } else {
     // Endcap eta >0
     if (subdet > 0) {
-      range.push_back(73);  // tccNbMin
-      range.push_back(109); // tccNbMax
-    } else {                // endcap eta <0
-      range.push_back(1);   // tccNbMin
-      range.push_back(37);  // tccNbMax
+      range.push_back(73);   // tccNbMin
+      range.push_back(109);  // tccNbMax
+    } else {                 // endcap eta <0
+      range.push_back(1);    // tccNbMin
+      range.push_back(37);   // tccNbMax
     }
-    range.push_back(1);  // towerNbMin
-    range.push_back(29); // towerNbMax
-    range.push_back(1);  // stripNbMin
-    range.push_back(6);  // stripNbMax
-    range.push_back(1);  // xtalNbMin
-    range.push_back(6);  // xtalNbMax
+    range.push_back(1);   // towerNbMin
+    range.push_back(29);  // towerNbMax
+    range.push_back(1);   // stripNbMin
+    range.push_back(6);   // stripNbMax
+    range.push_back(1);   // xtalNbMin
+    range.push_back(6);   // xtalNbMax
   }
 
   if (tccNb > 0) {

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimESProducer.h
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimESProducer.h
@@ -52,40 +52,26 @@ public:
   EcalTrigPrimESProducer(const edm::ParameterSet &);
   ~EcalTrigPrimESProducer() override;
 
-  std::unique_ptr<EcalTPGPedestals>
-  producePedestals(const EcalTPGPedestalsRcd &);
-  std::unique_ptr<EcalTPGLinearizationConst>
-  produceLinearizationConst(const EcalTPGLinearizationConstRcd &);
-  std::unique_ptr<EcalTPGSlidingWindow>
-  produceSlidingWindow(const EcalTPGSlidingWindowRcd &);
-  std::unique_ptr<EcalTPGFineGrainEBIdMap>
-  produceFineGrainEB(const EcalTPGFineGrainEBIdMapRcd &);
-  std::unique_ptr<EcalTPGFineGrainStripEE>
-  produceFineGrainEEstrip(const EcalTPGFineGrainStripEERcd &);
-  std::unique_ptr<EcalTPGFineGrainTowerEE>
-  produceFineGrainEEtower(const EcalTPGFineGrainTowerEERcd &);
+  std::unique_ptr<EcalTPGPedestals> producePedestals(const EcalTPGPedestalsRcd &);
+  std::unique_ptr<EcalTPGLinearizationConst> produceLinearizationConst(const EcalTPGLinearizationConstRcd &);
+  std::unique_ptr<EcalTPGSlidingWindow> produceSlidingWindow(const EcalTPGSlidingWindowRcd &);
+  std::unique_ptr<EcalTPGFineGrainEBIdMap> produceFineGrainEB(const EcalTPGFineGrainEBIdMapRcd &);
+  std::unique_ptr<EcalTPGFineGrainStripEE> produceFineGrainEEstrip(const EcalTPGFineGrainStripEERcd &);
+  std::unique_ptr<EcalTPGFineGrainTowerEE> produceFineGrainEEtower(const EcalTPGFineGrainTowerEERcd &);
   std::unique_ptr<EcalTPGLutIdMap> produceLUT(const EcalTPGLutIdMapRcd &);
-  std::unique_ptr<EcalTPGWeightIdMap>
-  produceWeight(const EcalTPGWeightIdMapRcd &);
-  std::unique_ptr<EcalTPGWeightGroup>
-  produceWeightGroup(const EcalTPGWeightGroupRcd &);
+  std::unique_ptr<EcalTPGWeightIdMap> produceWeight(const EcalTPGWeightIdMapRcd &);
+  std::unique_ptr<EcalTPGWeightGroup> produceWeightGroup(const EcalTPGWeightGroupRcd &);
   std::unique_ptr<EcalTPGLutGroup> produceLutGroup(const EcalTPGLutGroupRcd &);
-  std::unique_ptr<EcalTPGFineGrainEBGroup>
-  produceFineGrainEBGroup(const EcalTPGFineGrainEBGroupRcd &);
-  std::unique_ptr<EcalTPGPhysicsConst>
-  producePhysicsConst(const EcalTPGPhysicsConstRcd &);
-  std::unique_ptr<EcalTPGCrystalStatus>
-  produceBadX(const EcalTPGCrystalStatusRcd &);
-  std::unique_ptr<EcalTPGStripStatus>
-  produceBadStrip(const EcalTPGStripStatusRcd &);
-  std::unique_ptr<EcalTPGTowerStatus>
-  produceBadTT(const EcalTPGTowerStatusRcd &);
+  std::unique_ptr<EcalTPGFineGrainEBGroup> produceFineGrainEBGroup(const EcalTPGFineGrainEBGroupRcd &);
+  std::unique_ptr<EcalTPGPhysicsConst> producePhysicsConst(const EcalTPGPhysicsConstRcd &);
+  std::unique_ptr<EcalTPGCrystalStatus> produceBadX(const EcalTPGCrystalStatusRcd &);
+  std::unique_ptr<EcalTPGStripStatus> produceBadStrip(const EcalTPGStripStatusRcd &);
+  std::unique_ptr<EcalTPGTowerStatus> produceBadTT(const EcalTPGTowerStatusRcd &);
   std::unique_ptr<EcalTPGSpike> produceSpike(const EcalTPGSpikeRcd &);
 
 private:
   void parseTextFile();
-  std::vector<int> getRange(int subdet, int smNb, int towerNbInSm,
-                            int stripNbInTower = 0, int xtalNbInStrip = 0);
+  std::vector<int> getRange(int subdet, int smNb, int towerNbInSm, int stripNbInTower = 0, int xtalNbInStrip = 0);
 
   // ----------member data ---------------------------
   std::string dbFilename_;

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimSpikeESProducer.cc
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimSpikeESProducer.cc
@@ -7,10 +7,8 @@
 //
 // constructors and destructor
 //
-EcalTrigPrimSpikeESProducer::EcalTrigPrimSpikeESProducer(
-    const edm::ParameterSet &iConfig)
-    : zeroThresh_(
-          iConfig.getUntrackedParameter<uint32_t>("TCCZeroingThreshold", 0)) {
+EcalTrigPrimSpikeESProducer::EcalTrigPrimSpikeESProducer(const edm::ParameterSet &iConfig)
+    : zeroThresh_(iConfig.getUntrackedParameter<uint32_t>("TCCZeroingThreshold", 0)) {
   // Indicate we produce the spike record
   setWhatProduced(this, &EcalTrigPrimSpikeESProducer::produceSpike);
 
@@ -28,11 +26,9 @@ EcalTrigPrimSpikeESProducer::EcalTrigPrimSpikeESProducer(
 EcalTrigPrimSpikeESProducer::~EcalTrigPrimSpikeESProducer() {}
 
 // ------------ method called to produce the data  ------------
-std::unique_ptr<EcalTPGSpike>
-EcalTrigPrimSpikeESProducer::produceSpike(const EcalTPGSpikeRcd &iRecord) {
+std::unique_ptr<EcalTPGSpike> EcalTrigPrimSpikeESProducer::produceSpike(const EcalTPGSpikeRcd &iRecord) {
   auto prod = std::make_unique<EcalTPGSpike>();
-  for (std::vector<uint32_t>::const_iterator it = towerIDs_.begin();
-       it != towerIDs_.end(); ++it) {
+  for (std::vector<uint32_t>::const_iterator it = towerIDs_.begin(); it != towerIDs_.end(); ++it) {
     prod->setValue(*it, zeroThresh_);
   }
   return prod;

--- a/Validation/EcalTriggerPrimitives/src/TPGCheck.cc
+++ b/Validation/EcalTriggerPrimitives/src/TPGCheck.cc
@@ -93,12 +93,10 @@ TPGCheck::TPGCheck(const edm::ParameterSet &iConfig) {
 
   label_ = iConfig.getParameter<std::string>("Label");
   producer_ = iConfig.getParameter<std::string>("Producer");
-  ecal_tp_token_ =
-      consumes<EcalTrigPrimDigiCollection>(edm::InputTag(label_, producer_));
+  ecal_tp_token_ = consumes<EcalTrigPrimDigiCollection>(edm::InputTag(label_, producer_));
 }
 
 TPGCheck::~TPGCheck() {
-
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 
@@ -111,9 +109,7 @@ TPGCheck::~TPGCheck() {
 //
 
 // ------------ method called to for each event  ------------
-void TPGCheck::analyze(const edm::Event &iEvent,
-                       const edm::EventSetup &iSetup) {
-
+void TPGCheck::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // Get input
   edm::Handle<EcalTrigPrimDigiCollection> tp;
   iEvent.getByToken(ecal_tp_token_, tp);


### PR DESCRIPTION

Applying code-format for CMSSW category l1.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/196//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Fixes the code-formats suggested by #26629 (see #26686)
