### PR TITLE
Running code-format for alca

### DIFF
--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignableData.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignableData.h
@@ -10,29 +10,26 @@
 ///            also surface deformation parameters are foreseen;
 ///  can be used for both absolute and relative positions/rotations
 
-template<class T> class AlignableData 
-{
-
+template <class T>
+class AlignableData {
 public:
-
   /// constructor
   /// deformationParameters can be given if detUnit
   AlignableData(const T& pos,
-		const align::RotationType& rot, 
-		align::ID id, align::StructureType objid,
-		const std::vector<double> &deformationParameters = std::vector<double>()) :
-    thePos(pos), theRot(rot), theObjId(objid), theId(id),
-    theDeformationParameters(deformationParameters) {}
+                const align::RotationType& rot,
+                align::ID id,
+                align::StructureType objid,
+                const std::vector<double>& deformationParameters = std::vector<double>())
+      : thePos(pos), theRot(rot), theObjId(objid), theId(id), theDeformationParameters(deformationParameters) {}
 
   /// accessors
   const T& pos() const { return thePos; }
   const align::RotationType& rot() const { return theRot; }
   align::StructureType objId() const { return theObjId; }
   align::ID id() const { return theId; }
-  const std::vector<double> deformationParameters() const { return theDeformationParameters;}
+  const std::vector<double> deformationParameters() const { return theDeformationParameters; }
 
 private:
-
   // data members
 
   T thePos;
@@ -40,16 +37,14 @@ private:
   align::StructureType theObjId;
   align::ID theId;
   std::vector<double> theDeformationParameters;
-
 };
 
-/// Absolute position/rotation 
-typedef AlignableData<align::GlobalPoint>  AlignableAbsData;
-/// relative position/rotation 
+/// Absolute position/rotation
+typedef AlignableData<align::GlobalPoint> AlignableAbsData;
+/// relative position/rotation
 typedef AlignableData<align::GlobalVector> AlignableRelData;
 
 typedef std::vector<AlignableAbsData> AlignablePositions;
 typedef std::vector<AlignableRelData> AlignableShifts;
 
 #endif
-

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignableDataIO.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignableDataIO.h
@@ -7,80 +7,74 @@
 class Alignable;
 
 /// Abstract base class for IO of alignable positions/shifts.
-/// Derived concrete class must implement raw read/write methods 
+/// Derived concrete class must implement raw read/write methods
 
-class AlignableDataIO
-{
-
-  protected:
-
+class AlignableDataIO {
+protected:
   enum PosType { Abs, Org, Rel };
 
-  /// Constructor 
-  AlignableDataIO(PosType p) : thePosType(p) {}; 
+  /// Constructor
+  AlignableDataIO(PosType p) : thePosType(p){};
 
-  /// Destructor 
+  /// Destructor
   virtual ~AlignableDataIO(){};
 
   /// Open IO handle
-  virtual int open( const char* filename, int iteration, bool writemode ) = 0;
+  virtual int open(const char* filename, int iteration, bool writemode) = 0;
 
   /// Close IO handle
   virtual int close(void) = 0;
 
-  /// Write absolute positions of one Alignable 
+  /// Write absolute positions of one Alignable
   int writeAbsPos(Alignable* ali, bool validCheck);
 
-  /// Write absolute positions of many Alignables 
+  /// Write absolute positions of many Alignables
   int writeAbsPos(const align::Alignables& alivec, bool validCheck);
 
-  /// Read absolute positions of one Alignable 
+  /// Read absolute positions of one Alignable
   AlignableAbsData readAbsPos(Alignable* ali, int& ierr);
 
-  /// Read absolute positions of many Alignables 
+  /// Read absolute positions of many Alignables
   AlignablePositions readAbsPos(const align::Alignables& alivec, int& ierr);
 
-
-  /// Write original positions of one Alignable 
+  /// Write original positions of one Alignable
   int writeOrgPos(Alignable* ali, bool validCheck);
 
-  /// Write original positions of many Alignables 
+  /// Write original positions of many Alignables
   int writeOrgPos(const align::Alignables& alivec, bool validCheck);
 
-  /// Read original positions of one Alignable 
+  /// Read original positions of one Alignable
   AlignableAbsData readOrgPos(Alignable* ali, int& ierr);
 
-  /// Read original positions of many Alignables 
+  /// Read original positions of many Alignables
   AlignablePositions readOrgPos(const align::Alignables& alivec, int& ierr);
 
-
-  /// Write relative positions of one Alignable 
+  /// Write relative positions of one Alignable
   int writeRelPos(Alignable* ali, bool validCheck);
 
-  /// Write relative positions of many Alignables 
+  /// Write relative positions of many Alignables
   int writeRelPos(const align::Alignables& alivec, bool validCheck);
 
-  /// Read relative positions of one Alignable 
+  /// Read relative positions of one Alignable
   AlignableRelData readRelPos(Alignable* ali, int& ierr);
 
-  /// Read relative positions of many Alignables 
+  /// Read relative positions of many Alignables
   AlignableShifts readRelPos(const align::Alignables& alivec, int& ierr);
 
   // 'raw' read/write methods
   // must be provided by concrete derived class
 
-  /// Write absolute positions 
-  virtual int writeAbsRaw(const AlignableAbsData &ad) =0;
-  /// Read absolute positions 
-  virtual AlignableAbsData readAbsRaw(Alignable* ali,int& ierr) =0;
-  /// Write relative positions 
-  virtual int writeRelRaw(const AlignableRelData &ad) =0;
-  /// Read relative positions 
-  virtual AlignableRelData readRelRaw(Alignable* ali,int& ierr) =0;
+  /// Write absolute positions
+  virtual int writeAbsRaw(const AlignableAbsData& ad) = 0;
+  /// Read absolute positions
+  virtual AlignableAbsData readAbsRaw(Alignable* ali, int& ierr) = 0;
+  /// Write relative positions
+  virtual int writeRelRaw(const AlignableRelData& ad) = 0;
+  /// Read relative positions
+  virtual AlignableRelData readRelRaw(Alignable* ali, int& ierr) = 0;
 
   // Data members
-  PosType thePosType; // Defines whether absolute/orig/relative pos. are used
-
+  PosType thePosType;  // Defines whether absolute/orig/relative pos. are used
 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignableDataIORoot.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignableDataIORoot.h
@@ -9,32 +9,32 @@
 
 class Alignable;
 
-/// concrete class for ROOT based IO of Alignable positions 
+/// concrete class for ROOT based IO of Alignable positions
 
-class AlignableDataIORoot : public AlignmentIORootBase, public AlignableDataIO
-{
-
+class AlignableDataIORoot : public AlignmentIORootBase, public AlignableDataIO {
   friend class AlignmentIORoot;
 
-  private:
-  /// constructor 
-  AlignableDataIORoot(PosType p); 
+private:
+  /// constructor
+  AlignableDataIORoot(PosType p);
 
-  /// open IO 
-  int open(const char* filename, int iteration, bool writemode) override
-  { newopen=true; return openRoot(filename,iteration,writemode); }
+  /// open IO
+  int open(const char* filename, int iteration, bool writemode) override {
+    newopen = true;
+    return openRoot(filename, iteration, writemode);
+  }
 
-  /// close IO 
-  int close(void) override{ return closeRoot(); }
+  /// close IO
+  int close(void) override { return closeRoot(); }
 
-  /// write absolute positions 
-  int writeAbsRaw(const AlignableAbsData &ad) override;
-  /// read absolute positions 
-  AlignableAbsData readAbsRaw(Alignable* ali,int& ierr) override;
-  /// write relative positions 
-  int writeRelRaw(const AlignableRelData &ad) override;
-  /// read relative positions 
-  AlignableRelData readRelRaw(Alignable* ali,int& ierr) override;
+  /// write absolute positions
+  int writeAbsRaw(const AlignableAbsData& ad) override;
+  /// read absolute positions
+  AlignableAbsData readAbsRaw(Alignable* ali, int& ierr) override;
+  /// write relative positions
+  int writeRelRaw(const AlignableRelData& ad) override;
+  /// read relative positions
+  AlignableRelData readRelRaw(Alignable* ali, int& ierr) override;
 
   int findEntry(align::ID, align::StructureType);
   void createBranches(void) override;
@@ -42,22 +42,19 @@ class AlignableDataIORoot : public AlignmentIORootBase, public AlignableDataIO
 
   // data members
 
-  /// root tree contents 
+  /// root tree contents
   align::StructureType ObjId;
   //unsigned int Id;
   align::ID Id;
   Double_t Pos[3];
   Double_t Rot[9];
   UInt_t numDeformationValues_;
-  enum {kMaxNumPar = 20}; // slighly above 'two bowed surfaces' limit
+  enum { kMaxNumPar = 20 };  // slighly above 'two bowed surfaces' limit
   Float_t deformationValues_[kMaxNumPar];
 
   bool newopen;
-  typedef std::map< std::pair<align::ID, align::StructureType>, int > treemaptype;
+  typedef std::map<std::pair<align::ID, align::StructureType>, int> treemaptype;
   treemaptype treemap;
-
 };
-
-
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h
@@ -16,8 +16,6 @@
  *            algorithm has to be derived from this class
  */
 
-
-
 #include <vector>
 #include <utility>
 
@@ -39,90 +37,94 @@ class Trajectory;
 #include "DataFormats/Alignment/interface/AliClusterValueMapFwd.h"
 #include "FWCore/Framework/interface/Event.h"
 
-namespace edm { class EventSetup; class ParameterSet; }
-namespace reco { class Track; class BeamSpot; }
+namespace edm {
+  class EventSetup;
+  class ParameterSet;
+}  // namespace edm
+namespace reco {
+  class Track;
+  class BeamSpot;
+}  // namespace reco
 
 /*** Global typedefs part I (see EOF for part II) ***/
-typedef std::pair<const Trajectory*, const reco::Track*> ConstTrajTrackPair;
-typedef std::vector< ConstTrajTrackPair >                ConstTrajTrackPairs;
+typedef std::pair<const Trajectory *, const reco::Track *> ConstTrajTrackPair;
+typedef std::vector<ConstTrajTrackPair> ConstTrajTrackPairs;
 
-typedef std::vector<IntegratedCalibrationBase*> Calibrations;
+typedef std::vector<IntegratedCalibrationBase *> Calibrations;
 
-
-
-class AlignmentAlgorithmBase
-{
-
+class AlignmentAlgorithmBase {
 public:
   // TODO: DEPRECATED: For not breaking the interface, used in serveral files.
   //                   If possible use the global typedefs above.
   // With global typedefs one does not have to typedef again like
   // 'typedef AlignmentAlgorithmBase::ConstTrajTrackPair ConstTrajTrackPair;'
   // in other files.
-  typedef std::pair<const Trajectory*, const reco::Track*> ConstTrajTrackPair; 
-  typedef std::vector< ConstTrajTrackPair >  ConstTrajTrackPairCollection;
+  typedef std::pair<const Trajectory *, const reco::Track *> ConstTrajTrackPair;
+  typedef std::vector<ConstTrajTrackPair> ConstTrajTrackPairCollection;
   using RunNumber = align::RunNumber;
   using RunRange = align::RunRange;
 
   /// define event information passed to algorithms
   class EventInfo {
   public:
-    EventInfo(const edm::EventID &theEventId, 
-	      const ConstTrajTrackPairCollection &theTrajTrackPairs,
-	      const reco::BeamSpot &theBeamSpot,
-	      const AliClusterValueMap *theClusterValueMap) 
-      : eventId_(theEventId), trajTrackPairs_(theTrajTrackPairs), beamSpot_(theBeamSpot), clusterValueMap_(theClusterValueMap) {}
+    EventInfo(const edm::EventID &theEventId,
+              const ConstTrajTrackPairCollection &theTrajTrackPairs,
+              const reco::BeamSpot &theBeamSpot,
+              const AliClusterValueMap *theClusterValueMap)
+        : eventId_(theEventId),
+          trajTrackPairs_(theTrajTrackPairs),
+          beamSpot_(theBeamSpot),
+          clusterValueMap_(theClusterValueMap) {}
 
     const edm::EventID eventId() const { return eventId_; }
-    const ConstTrajTrackPairCollection& trajTrackPairs() const { return trajTrackPairs_; }
-    const reco::BeamSpot& beamSpot() const { return beamSpot_; }
-    const AliClusterValueMap* clusterValueMap() const { return clusterValueMap_; }///might be null!
-    
+    const ConstTrajTrackPairCollection &trajTrackPairs() const { return trajTrackPairs_; }
+    const reco::BeamSpot &beamSpot() const { return beamSpot_; }
+    const AliClusterValueMap *clusterValueMap() const { return clusterValueMap_; }  ///might be null!
 
   private:
-    const edm::EventID                 eventId_;
+    const edm::EventID eventId_;
     const ConstTrajTrackPairCollection &trajTrackPairs_;
-    const reco::BeamSpot               &beamSpot_;
-    const AliClusterValueMap           *clusterValueMap_;///might be null!
+    const reco::BeamSpot &beamSpot_;
+    const AliClusterValueMap *clusterValueMap_;  ///might be null!
   };
-  
+
   /// define run information passed to algorithms (in endRun)
   class EndRunInfo {
   public:
-    EndRunInfo(const edm::RunID &theRunId, const TkFittedLasBeamCollection *theTkLasBeams,
-	       const TsosVectorCollection *theTkLasBeamTsoses)
-      : runId_(theRunId), tkLasBeams_(theTkLasBeams), tkLasBeamTsoses_(theTkLasBeamTsoses) {}
+    EndRunInfo(const edm::RunID &theRunId,
+               const TkFittedLasBeamCollection *theTkLasBeams,
+               const TsosVectorCollection *theTkLasBeamTsoses)
+        : runId_(theRunId), tkLasBeams_(theTkLasBeams), tkLasBeamTsoses_(theTkLasBeamTsoses) {}
 
     const edm::RunID runId() const { return runId_; }
-    const TkFittedLasBeamCollection* tkLasBeams() const { return tkLasBeams_; } /// might be null!
-    const TsosVectorCollection* tkLasBeamTsoses() const { return tkLasBeamTsoses_; } /// might be null!
-
+    const TkFittedLasBeamCollection *tkLasBeams() const { return tkLasBeams_; }       /// might be null!
+    const TsosVectorCollection *tkLasBeamTsoses() const { return tkLasBeamTsoses_; }  /// might be null!
 
   private:
     const edm::RunID runId_;
-    const TkFittedLasBeamCollection *tkLasBeams_; /// might be null!
-    const TsosVectorCollection *tkLasBeamTsoses_; /// might be null!
+    const TkFittedLasBeamCollection *tkLasBeams_;  /// might be null!
+    const TsosVectorCollection *tkLasBeamTsoses_;  /// might be null!
   };
-  
+
   /// Constructor
-  AlignmentAlgorithmBase(const edm::ParameterSet&) {};
-  
+  AlignmentAlgorithmBase(const edm::ParameterSet &){};
+
   /// Destructor
-  virtual ~AlignmentAlgorithmBase() {};
+  virtual ~AlignmentAlgorithmBase(){};
 
   /// Call at beginning of job (must be implemented in derived class)
-  virtual void initialize( const edm::EventSetup& setup, 
-                           AlignableTracker* tracker,
-                           AlignableMuon* muon,
-                           AlignableExtras* extras,
-                           AlignmentParameterStore* store ) = 0;
+  virtual void initialize(const edm::EventSetup &setup,
+                          AlignableTracker *tracker,
+                          AlignableMuon *muon,
+                          AlignableExtras *extras,
+                          AlignmentParameterStore *store) = 0;
 
   /// Returns whether calibrations is supported by algorithm,
   /// default implementation returns false.
   virtual bool supportsCalibrations() { return false; }
   /// Pass integrated calibrations to algorithm, to be called after initialize()
   /// Calibrations' ownership is NOT passed to algorithm
-  virtual bool addCalibrations(const Calibrations&) { return false; }
+  virtual bool addCalibrations(const Calibrations &) { return false; }
 
   /// Returns whether algorithm proccesses events in current configuration
   virtual bool processesEvents() { return true; }
@@ -137,32 +139,32 @@ public:
   virtual void startNewLoop() {}
 
   /// Call at end of each loop (must be implemented in derived class)
-  virtual void terminate(const edm::EventSetup& iSetup) = 0;
+  virtual void terminate(const edm::EventSetup &iSetup) = 0;
   /// Called at end of job (must be implemented in derived class)
   virtual void terminate() {}
 
   /// Run the algorithm (must be implemented in derived class)
-  virtual void run( const edm::EventSetup &setup, const EventInfo &eventInfo) = 0;
+  virtual void run(const edm::EventSetup &setup, const EventInfo &eventInfo) = 0;
 
   /// called at begin of run
-  virtual void beginRun(const edm::Run&, const edm::EventSetup&, bool changed) {};
+  virtual void beginRun(const edm::Run &, const edm::EventSetup &, bool changed){};
 
   /// called at end of run - order of arguments like in EDProducer etc.
-  virtual void endRun(const EndRunInfo &runInfo, const edm::EventSetup &setup) {};
+  virtual void endRun(const EndRunInfo &runInfo, const edm::EventSetup &setup){};
 
   /// called at begin of luminosity block (no lumi block info passed yet)
-  virtual void beginLuminosityBlock(const edm::EventSetup &setup) {};
+  virtual void beginLuminosityBlock(const edm::EventSetup &setup){};
 
   /// called at end of luminosity block (no lumi block info passed yet)
-  virtual void endLuminosityBlock(const edm::EventSetup &setup) {};
+  virtual void endLuminosityBlock(const edm::EventSetup &setup){};
 
   /// called in order to pass parameters to alignables for a specific run
   /// range in case the algorithm supports run range dependent alignment.
-  virtual bool setParametersForRunRange(const RunRange& rr) { return false; };
+  virtual bool setParametersForRunRange(const RunRange &rr) { return false; };
 };
 
 /*** Global typedefs part II ***/
-typedef AlignmentAlgorithmBase::EventInfo  EventInfo;
+typedef AlignmentAlgorithmBase::EventInfo EventInfo;
 typedef AlignmentAlgorithmBase::EndRunInfo EndRunInfo;
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmPluginFactory.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmPluginFactory.h
@@ -10,6 +10,6 @@
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h"
 
-typedef edmplugin::PluginFactory<AlignmentAlgorithmBase* (const edm::ParameterSet&)> AlignmentAlgorithmPluginFactory;
+typedef edmplugin::PluginFactory<AlignmentAlgorithmBase*(const edm::ParameterSet&)> AlignmentAlgorithmPluginFactory;
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentCorrelationsIO.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentCorrelationsIO.h
@@ -3,28 +3,24 @@
 
 #include "Alignment/CommonAlignment/interface/Utilities.h"
 
-/// Abstract base class for IO of Correlations 
+/// Abstract base class for IO of Correlations
 
-class AlignmentCorrelationsIO 
-{
+class AlignmentCorrelationsIO {
+protected:
+  /// destructor
+  virtual ~AlignmentCorrelationsIO() {}
 
-  protected:
-
-  /// destructor 
-  virtual ~AlignmentCorrelationsIO(){}
-
-  /// open IO 
+  /// open IO
   virtual int open(const char* filename, int iteration, bool writemode) = 0;
 
-  /// close IO 
+  /// close IO
   virtual int close(void) = 0;
 
-  /// write correlations 
+  /// write correlations
   virtual int write(const align::Correlations& cor, bool validCheck) = 0;
 
-  /// read correlations 
+  /// read correlations
   virtual align::Correlations read(const align::Alignables& alivec, int& ierr) = 0;
-
 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentCorrelationsIORoot.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentCorrelationsIORoot.h
@@ -5,29 +5,27 @@
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentIORootBase.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentCorrelationsIO.h"
 
-/// Concrete class for ROOT based IO of Correlations 
+/// Concrete class for ROOT based IO of Correlations
 
-class AlignmentCorrelationsIORoot : public AlignmentIORootBase, public AlignmentCorrelationsIO
-{
+class AlignmentCorrelationsIORoot : public AlignmentIORootBase, public AlignmentCorrelationsIO {
   friend class AlignmentIORoot;
 
-  private:
-
-  /// constructor 
+private:
+  /// constructor
   AlignmentCorrelationsIORoot();
 
-  /// open IO 
+  /// open IO
   int open(const char* filename, int iteration, bool writemode) override {
-    return openRoot(filename,iteration,writemode);
+    return openRoot(filename, iteration, writemode);
   };
 
-  /// close IO 
-  int close(void) override{ return closeRoot(); };
+  /// close IO
+  int close(void) override { return closeRoot(); };
 
-  /// write correlations 
+  /// write correlations
   int write(const align::Correlations& cor, bool validCheck) override;
 
-  /// read correlations 
+  /// read correlations
   align::Correlations read(const align::Alignables& alivec, int& ierr) override;
 
   void createBranches(void) override;
@@ -35,12 +33,11 @@ class AlignmentCorrelationsIORoot : public AlignmentIORootBase, public Alignment
 
   // data members
 
-  /// correlation tree 
-  align::ID Ali1Id,Ali2Id;
-  align::StructureType Ali1ObjId,Ali2ObjId;
+  /// correlation tree
+  align::ID Ali1Id, Ali2Id;
+  align::StructureType Ali1ObjId, Ali2ObjId;
   int corSize;
-  double CorMatrix[nParMax*nParMax];
-
+  double CorMatrix[nParMax * nParMax];
 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentCorrelationsStore.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentCorrelationsStore.h
@@ -13,59 +13,57 @@
 
 class Alignable;
 
-class AlignmentCorrelationsStore
-{
-
+class AlignmentCorrelationsStore {
 public:
+  typedef std::map<Alignable*, AlgebraicMatrix> CorrelationsTable;
+  typedef std::map<Alignable*, CorrelationsTable*> Correlations;
 
-  typedef std::map< Alignable*, AlgebraicMatrix > CorrelationsTable;
-  typedef std::map< Alignable*, CorrelationsTable* > Correlations;
+  AlignmentCorrelationsStore(void);
 
-  AlignmentCorrelationsStore( void );
-
-  virtual ~AlignmentCorrelationsStore( void ) {}
+  virtual ~AlignmentCorrelationsStore(void) {}
 
   /// Write correlations directly to the covariance matrix starting at the
   /// given position. Indices are assumed to start from 0.
-  virtual void correlations( Alignable* ap1, Alignable* ap2,
-			     AlgebraicSymMatrix& cov, int row, int col ) const;
+  virtual void correlations(Alignable* ap1, Alignable* ap2, AlgebraicSymMatrix& cov, int row, int col) const;
 
   /// Get correlations directly from the given position of the covariance
   /// matrix and store them. Indices are assumed to start from 0.
-  virtual void setCorrelations( Alignable* ap1, Alignable* ap2,
-				const AlgebraicSymMatrix& cov, int row, int col );
+  virtual void setCorrelations(Alignable* ap1, Alignable* ap2, const AlgebraicSymMatrix& cov, int row, int col);
 
   /// Set correlations.
-  virtual void setCorrelations( Alignable* ap1, Alignable* ap2,	AlgebraicMatrix& mat );
+  virtual void setCorrelations(Alignable* ap1, Alignable* ap2, AlgebraicMatrix& mat);
 
   /// Check whether correlations are stored for a given pair of alignables.
-  virtual bool correlationsAvailable( Alignable* ap1, Alignable* ap2 ) const;
+  virtual bool correlationsAvailable(Alignable* ap1, Alignable* ap2) const;
 
   /// Reset correlations.
-  virtual void resetCorrelations( void );
+  virtual void resetCorrelations(void);
 
   /// Get number of stored correlations.
-  virtual unsigned int size( void ) const;
+  virtual unsigned int size(void) const;
 
 private:
+  void fillCorrelationsTable(Alignable* ap1,
+                             Alignable* ap2,
+                             CorrelationsTable* table,
+                             const AlgebraicSymMatrix& cov,
+                             int row,
+                             int col,
+                             bool transpose);
 
-  void fillCorrelationsTable( Alignable* ap1, Alignable* ap2, CorrelationsTable* table,
-                              const AlgebraicSymMatrix& cov, int row, int col, bool transpose );
+  void fillCovariance(
+      Alignable* ap1, Alignable* ap2, const AlgebraicMatrix& entry, AlgebraicSymMatrix& cov, int row, int col) const;
 
-  void fillCovariance( Alignable* ap1, Alignable* ap2, const AlgebraicMatrix& entry,
-                       AlgebraicSymMatrix& cov, int row, int col ) const;
+  void fillCovarianceT(
+      Alignable* ap1, Alignable* ap2, const AlgebraicMatrix& entry, AlgebraicSymMatrix& cov, int row, int col) const;
 
-  void fillCovarianceT( Alignable* ap1, Alignable* ap2, const AlgebraicMatrix& entry,
-                        AlgebraicSymMatrix& cov, int row, int col ) const;
+  void readFromCovariance(
+      Alignable* ap1, Alignable* ap2, AlgebraicMatrix& entry, const AlgebraicSymMatrix& cov, int row, int col);
 
-  void readFromCovariance( Alignable* ap1, Alignable* ap2, AlgebraicMatrix& entry,
-                           const AlgebraicSymMatrix& cov, int row, int col );
-
-  void readFromCovarianceT( Alignable* ap1, Alignable* ap2, AlgebraicMatrix& entry,
-                            const AlgebraicSymMatrix& cov, int row, int col );
+  void readFromCovarianceT(
+      Alignable* ap1, Alignable* ap2, AlgebraicMatrix& entry, const AlgebraicSymMatrix& cov, int row, int col);
 
   Correlations theCorrelations;
-
 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentExtendedCorrelationsEntry.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentExtendedCorrelationsEntry.h
@@ -4,68 +4,63 @@
 #include <vector>
 #include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
 
-
 /// Data container for a correlations matrix (represented by a vector of floats), with
 /// basic access functions. NOTE: This class is designed specifically for the use within
 /// AlignmentExtendedCorrelationsStore, and is not intended to be used elsewhere.
 
-
-class AlignmentExtendedCorrelationsEntry
-{
-
+class AlignmentExtendedCorrelationsEntry {
 public:
-
   /// Default constructor.
-  AlignmentExtendedCorrelationsEntry( void );
+  AlignmentExtendedCorrelationsEntry(void);
 
   /// Constructor. Leaves the correlations matrix uninitialized.
-  explicit AlignmentExtendedCorrelationsEntry( short unsigned int nRows, short unsigned int nCols );
+  explicit AlignmentExtendedCorrelationsEntry(short unsigned int nRows, short unsigned int nCols);
 
   /// Constructor. Initializes all elements of the correlations matrix to the given value.
-  explicit AlignmentExtendedCorrelationsEntry( short unsigned int nRows, short unsigned int nCols, const float init );
+  explicit AlignmentExtendedCorrelationsEntry(short unsigned int nRows, short unsigned int nCols, const float init);
 
   /// Constructor from CLHEP matrix.
-  explicit AlignmentExtendedCorrelationsEntry( const AlgebraicMatrix& mat );
+  explicit AlignmentExtendedCorrelationsEntry(const AlgebraicMatrix& mat);
 
   /// Destructor.
-  ~AlignmentExtendedCorrelationsEntry( void ) {}
+  ~AlignmentExtendedCorrelationsEntry(void) {}
 
   /// Read or write an element of the correlations matrix. NOTE: Indexing starts from [0,0].
-  inline float& operator()( short unsigned int iRow, short unsigned int jCol ) { return theData[iRow*theNCols+jCol]; }
+  inline float& operator()(short unsigned int iRow, short unsigned int jCol) { return theData[iRow * theNCols + jCol]; }
 
   /// Read or write an element of the correlations matrix. NOTE: Indexing starts from [0,0].
-  inline const float operator()( short unsigned int iRow, short unsigned int jCol ) const { return theData[iRow*theNCols+jCol]; }
+  inline const float operator()(short unsigned int iRow, short unsigned int jCol) const {
+    return theData[iRow * theNCols + jCol];
+  }
 
   /// Get the number of rows of the correlation matrix.
-  inline const short unsigned int numRow( void ) const { return theNRows; }
+  inline const short unsigned int numRow(void) const { return theNRows; }
 
   /// Get the number of columns of the correlation matrix.
-  inline const short unsigned int numCol( void ) const { return theNCols; }
+  inline const short unsigned int numCol(void) const { return theNCols; }
 
   /// Multiply all elements of the correlations matrix with a given number.
-  void operator*=( const float multiply );
+  void operator*=(const float multiply);
 
   /// Retrieve the correlation matrix in a CLHEP matrix representation;
-  AlgebraicMatrix matrix( void ) const;
+  AlgebraicMatrix matrix(void) const;
 
-//   /// Get the counter's value.
-//   inline const int counter( void ) const { return theCounter; }
+  //   /// Get the counter's value.
+  //   inline const int counter( void ) const { return theCounter; }
 
-//   /// Increase the counter's value by 1.
-//   inline void incrementCounter( void ) { ++theCounter; }
+  //   /// Increase the counter's value by 1.
+  //   inline void incrementCounter( void ) { ++theCounter; }
 
-//   /// Decrease the counter's value by 1.
-//   inline void decrementCounter( void ) { --theCounter; }
+  //   /// Decrease the counter's value by 1.
+  //   inline void decrementCounter( void ) { --theCounter; }
 
 private:
-
-//   int theCounter;
+  //   int theCounter;
 
   short unsigned int theNRows;
   short unsigned int theNCols;
 
-  std::vector< float > theData;
-
+  std::vector<float> theData;
 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentExtendedCorrelationsStore.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentExtendedCorrelationsStore.h
@@ -9,78 +9,91 @@
 /// If a correlation exceeds a certain value (especially corrupted correlations with
 /// an absolute value bigger than 1) it is downweighted.
 
-
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentCorrelationsStore.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentExtendedCorrelationsEntry.h"
 
-namespace edm { class ParameterSet; }
+namespace edm {
+  class ParameterSet;
+}
 
-class AlignmentExtendedCorrelationsStore : public AlignmentCorrelationsStore
-{
-
+class AlignmentExtendedCorrelationsStore : public AlignmentCorrelationsStore {
 public:
-
   typedef AlignmentExtendedCorrelationsEntry ExtendedCorrelationsEntry;
-  typedef std::map< Alignable*, ExtendedCorrelationsEntry > ExtendedCorrelationsTable;
-  typedef std::map< Alignable*, ExtendedCorrelationsTable* > ExtendedCorrelations;
+  typedef std::map<Alignable*, ExtendedCorrelationsEntry> ExtendedCorrelationsTable;
+  typedef std::map<Alignable*, ExtendedCorrelationsTable*> ExtendedCorrelations;
 
-  AlignmentExtendedCorrelationsStore( const edm::ParameterSet& config );
+  AlignmentExtendedCorrelationsStore(const edm::ParameterSet& config);
 
-  ~AlignmentExtendedCorrelationsStore( void ) override {}
+  ~AlignmentExtendedCorrelationsStore(void) override {}
 
   /// Write correlations directly to the covariance matrix starting at the
   /// given position. Indices are assumed to start from 0.
-  void correlations( Alignable* ap1, Alignable* ap2,
-			     AlgebraicSymMatrix& cov, int row, int col ) const override;
+  void correlations(Alignable* ap1, Alignable* ap2, AlgebraicSymMatrix& cov, int row, int col) const override;
 
   /// Get correlations directly from the given position of the covariance
   /// matrix and store them. Indices are assumed to start from 0.
-  void setCorrelations( Alignable* ap1, Alignable* ap2,
-				const AlgebraicSymMatrix& cov, int row, int col ) override;
+  void setCorrelations(Alignable* ap1, Alignable* ap2, const AlgebraicSymMatrix& cov, int row, int col) override;
 
   /// Set correlations without checking whether the maximum
   /// number of updates has already been reached.
-  void setCorrelations( Alignable* ap1, Alignable* ap2,	AlgebraicMatrix& mat ) override;
+  void setCorrelations(Alignable* ap1, Alignable* ap2, AlgebraicMatrix& mat) override;
 
   /// Get correlations.
-  virtual void getCorrelations( Alignable* ap1, Alignable* ap2,	AlgebraicMatrix& mat ) const;
+  virtual void getCorrelations(Alignable* ap1, Alignable* ap2, AlgebraicMatrix& mat) const;
 
   /// Check whether correlations are stored for a given pair of alignables.
-  bool correlationsAvailable( Alignable* ap1, Alignable* ap2 ) const override;
+  bool correlationsAvailable(Alignable* ap1, Alignable* ap2) const override;
 
   /// Reset correlations.
-  void resetCorrelations( void ) override;
+  void resetCorrelations(void) override;
 
   /// Get number of stored correlations.
-  unsigned int size( void ) const override;
+  unsigned int size(void) const override;
 
 private:
+  void fillCorrelationsTable(Alignable* ap1,
+                             Alignable* ap2,
+                             ExtendedCorrelationsTable* table,
+                             const AlgebraicSymMatrix& cov,
+                             int row,
+                             int col,
+                             bool transpose);
 
-  void fillCorrelationsTable( Alignable* ap1, Alignable* ap2,
-                              ExtendedCorrelationsTable* table,
-                              const AlgebraicSymMatrix& cov,
-                              int row, int col, bool transpose );
+  void fillCovariance(Alignable* ap1,
+                      Alignable* ap2,
+                      const ExtendedCorrelationsEntry& entry,
+                      AlgebraicSymMatrix& cov,
+                      int row,
+                      int col) const;
 
-  void fillCovariance( Alignable* ap1, Alignable* ap2, const ExtendedCorrelationsEntry& entry,
-                       AlgebraicSymMatrix& cov, int row, int col ) const;
+  void fillCovarianceT(Alignable* ap1,
+                       Alignable* ap2,
+                       const ExtendedCorrelationsEntry& entry,
+                       AlgebraicSymMatrix& cov,
+                       int row,
+                       int col) const;
 
-  void fillCovarianceT( Alignable* ap1, Alignable* ap2, const ExtendedCorrelationsEntry& entry,
-                        AlgebraicSymMatrix& cov, int row, int col ) const;
+  void readFromCovariance(Alignable* ap1,
+                          Alignable* ap2,
+                          ExtendedCorrelationsEntry& entry,
+                          const AlgebraicSymMatrix& cov,
+                          int row,
+                          int col);
 
-  void readFromCovariance( Alignable* ap1, Alignable* ap2, ExtendedCorrelationsEntry& entry,
-                           const AlgebraicSymMatrix& cov, int row, int col );
+  void readFromCovarianceT(Alignable* ap1,
+                           Alignable* ap2,
+                           ExtendedCorrelationsEntry& entry,
+                           const AlgebraicSymMatrix& cov,
+                           int row,
+                           int col);
 
-  void readFromCovarianceT( Alignable* ap1, Alignable* ap2, ExtendedCorrelationsEntry& entry,
-                            const AlgebraicSymMatrix& cov, int row, int col );
-
-  void resizeCorruptCorrelations( ExtendedCorrelationsEntry& entry, double maxCorr );
+  void resizeCorruptCorrelations(ExtendedCorrelationsEntry& entry, double maxCorr);
 
   ExtendedCorrelations theCorrelations;
 
   int theMaxUpdates;
   double theCut;
   double theWeight;
-
 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentIO.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentIO.h
@@ -11,60 +11,65 @@
 ///  $Revision: 1.3 $
 /// (last update by $Author: flucke $)
 
-
 #include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignableData.h"
 
-
-class AlignmentIO
-{
-
-  public:
+class AlignmentIO {
+public:
   virtual ~AlignmentIO() = default;
-  /// write AlignmentParameters 
-  virtual void writeAlignmentParameters (const align::Alignables& alivec, 
-    const char* filename, int iter, bool validCheck, int& ierr) = 0;
+  /// write AlignmentParameters
+  virtual void writeAlignmentParameters(
+      const align::Alignables& alivec, const char* filename, int iter, bool validCheck, int& ierr) = 0;
 
-  /// read AlignmentParameters 
-  virtual align::Parameters readAlignmentParameters (const align::Alignables& alivec, 
-    const char* filename, int iter, int& ierr) = 0;
+  /// read AlignmentParameters
+  virtual align::Parameters readAlignmentParameters(const align::Alignables& alivec,
+                                                    const char* filename,
+                                                    int iter,
+                                                    int& ierr) = 0;
 
   /// write RigidBodyAlignmentParameters as applied on top of original positions
-  virtual void writeOrigRigidBodyAlignmentParameters (const align::Alignables& alivec, 
-    const char* filename, int iter, bool validCheck, int& ierr) = 0;
+  virtual void writeOrigRigidBodyAlignmentParameters(
+      const align::Alignables& alivec, const char* filename, int iter, bool validCheck, int& ierr) = 0;
 
-  /// write Correlations 
-  virtual void writeCorrelations (const align::Correlations& cormap, 
-    const char* filename, int iter, bool validCheck, int& ierr) = 0;
+  /// write Correlations
+  virtual void writeCorrelations(
+      const align::Correlations& cormap, const char* filename, int iter, bool validCheck, int& ierr) = 0;
 
-  /// read Correlations 
-  virtual align::Correlations readCorrelations (const align::Alignables& alivec, 
-    const char* filename, int iter, int& ierr) = 0;
+  /// read Correlations
+  virtual align::Correlations readCorrelations(const align::Alignables& alivec,
+                                               const char* filename,
+                                               int iter,
+                                               int& ierr) = 0;
 
-  /// write Alignable current absolute positions 
-  virtual void writeAlignableAbsolutePositions (const align::Alignables& alivec, 
-    const char* filename, int iter, bool validCheck, int& ierr) = 0;
+  /// write Alignable current absolute positions
+  virtual void writeAlignableAbsolutePositions(
+      const align::Alignables& alivec, const char* filename, int iter, bool validCheck, int& ierr) = 0;
 
-  /// read Alignable current absolute positions 
-  virtual AlignablePositions readAlignableAbsolutePositions (const align::Alignables&
-    alivec, const char* filename, int iter, int& ierr) = 0;
+  /// read Alignable current absolute positions
+  virtual AlignablePositions readAlignableAbsolutePositions(const align::Alignables& alivec,
+                                                            const char* filename,
+                                                            int iter,
+                                                            int& ierr) = 0;
 
-  /// write Alignable original (before misalignment) absolute positions 
-  virtual void writeAlignableOriginalPositions (const align::Alignables& alivec, 
-    const char* filename, int iter, bool validCheck, int& ierr) = 0;
+  /// write Alignable original (before misalignment) absolute positions
+  virtual void writeAlignableOriginalPositions(
+      const align::Alignables& alivec, const char* filename, int iter, bool validCheck, int& ierr) = 0;
 
-  /// read Alignable original (before misalignment) absolute positions 
-  virtual AlignablePositions readAlignableOriginalPositions (const align::Alignables&
-    alivec, const char* filename, int iter, int& ierr) = 0;
+  /// read Alignable original (before misalignment) absolute positions
+  virtual AlignablePositions readAlignableOriginalPositions(const align::Alignables& alivec,
+                                                            const char* filename,
+                                                            int iter,
+                                                            int& ierr) = 0;
 
-  /// write Alignable relative positions (shift,rotation) 
-  virtual  void writeAlignableRelativePositions (const align::Alignables& alivec, 
-    const char* filename, int iter, bool validCheck, int& ierr) = 0;
+  /// write Alignable relative positions (shift,rotation)
+  virtual void writeAlignableRelativePositions(
+      const align::Alignables& alivec, const char* filename, int iter, bool validCheck, int& ierr) = 0;
 
-  /// read Alignable relative positions (shift,rotation) 
-  virtual AlignableShifts readAlignableRelativePositions (const align::Alignables&
-    alivec, const char* filename, int iter, int& ierr) = 0;
-
+  /// read Alignable relative positions (shift,rotation)
+  virtual AlignableShifts readAlignableRelativePositions(const align::Alignables& alivec,
+                                                         const char* filename,
+                                                         int iter,
+                                                         int& ierr) = 0;
 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentIORoot.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentIORoot.h
@@ -3,7 +3,7 @@
 
 /// \class AlignmentIORoot
 ///
-/// concrete class for ROOT-based I/O of Alignment parameters, correlations 
+/// concrete class for ROOT-based I/O of Alignment parameters, correlations
 ///  and Alignable positions. Derived from AlignmentIO
 ///
 ///  $Date: 2006/11/30 09:56:03 $
@@ -12,56 +12,62 @@
 
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentIO.h"
 
-
-class AlignmentIORoot : public AlignmentIO
-{
-
-  public:
+class AlignmentIORoot : public AlignmentIO {
+public:
   ~AlignmentIORoot() override = default;
-  /// write AlignmentParameters 
-  void writeAlignmentParameters (const align::Alignables& alivec, 
-				 const char* filename, int iter, bool validCheck, int& ierr ) override;
+  /// write AlignmentParameters
+  void writeAlignmentParameters(
+      const align::Alignables& alivec, const char* filename, int iter, bool validCheck, int& ierr) override;
 
-  /// read AlignmentParameters 
-  align::Parameters readAlignmentParameters (const align::Alignables& alivec, 
-				      const char* filename, int iter, int& ierr) override;
+  /// read AlignmentParameters
+  align::Parameters readAlignmentParameters(const align::Alignables& alivec,
+                                            const char* filename,
+                                            int iter,
+                                            int& ierr) override;
 
   /// write RigidBodyAlignmentParameters as applied on top of original positions
-  void writeOrigRigidBodyAlignmentParameters (const align::Alignables& alivec, const char* filename,
-					      int iter, bool validCheck, int& ierr) override;
+  void writeOrigRigidBodyAlignmentParameters(
+      const align::Alignables& alivec, const char* filename, int iter, bool validCheck, int& ierr) override;
 
-  /// write Correlations 
-  void writeCorrelations (const align::Correlations& cormap, 
-			  const char* filename, int iter, bool validCheck, int& ierr) override;
+  /// write Correlations
+  void writeCorrelations(
+      const align::Correlations& cormap, const char* filename, int iter, bool validCheck, int& ierr) override;
 
-  /// read Correlations 
-  align::Correlations readCorrelations (const align::Alignables& alivec, 
-				 const char* filename, int iter, int& ierr) override;
-  
-  /// write Alignable current absolute positions 
-  void writeAlignableAbsolutePositions (const align::Alignables& alivec, 
-					const char* filename, int iter, bool validCheck, int& ierr) override;
-  
-  /// read Alignable current absolute positions 
-  AlignablePositions readAlignableAbsolutePositions (const align::Alignables& alivec,
-						     const char* filename, int iter, int& ierr) override;
-  
-  /// write Alignable original (before misalignment) absolute positions 
-  void writeAlignableOriginalPositions (const align::Alignables& alivec, 
-					const char* filename, int iter, bool validCheck, int& ierr) override;
-  
-  /// read Alignable original (before misalignment) absolute positions 
-  AlignablePositions readAlignableOriginalPositions (const align::Alignables& alivec,
-						     const char* filename, int iter, int& ierr) override;
-  
-  /// write Alignable relative positions (shift,rotation) 
-  void writeAlignableRelativePositions (const align::Alignables& alivec, 
-					const char* filename, int iter, bool validCheck, int& ierr) override;
-  
-  /// read Alignable relative positions (shift,rotation) 
-  AlignableShifts readAlignableRelativePositions (const align::Alignables& alivec,
-						  const char* filename, int iter, int& ierr) override;
+  /// read Correlations
+  align::Correlations readCorrelations(const align::Alignables& alivec,
+                                       const char* filename,
+                                       int iter,
+                                       int& ierr) override;
 
+  /// write Alignable current absolute positions
+  void writeAlignableAbsolutePositions(
+      const align::Alignables& alivec, const char* filename, int iter, bool validCheck, int& ierr) override;
+
+  /// read Alignable current absolute positions
+  AlignablePositions readAlignableAbsolutePositions(const align::Alignables& alivec,
+                                                    const char* filename,
+                                                    int iter,
+                                                    int& ierr) override;
+
+  /// write Alignable original (before misalignment) absolute positions
+  void writeAlignableOriginalPositions(
+      const align::Alignables& alivec, const char* filename, int iter, bool validCheck, int& ierr) override;
+
+  /// read Alignable original (before misalignment) absolute positions
+  AlignablePositions readAlignableOriginalPositions(const align::Alignables& alivec,
+                                                    const char* filename,
+                                                    int iter,
+                                                    int& ierr) override;
+
+  /// write Alignable relative positions (shift,rotation)
+  void writeAlignableRelativePositions(
+      const align::Alignables& alivec, const char* filename, int iter, bool validCheck, int& ierr) override;
+
+  /// read Alignable relative positions (shift,rotation)
+  AlignableShifts readAlignableRelativePositions(const align::Alignables& alivec,
+                                                 const char* filename,
+                                                 int iter,
+                                                 int& ierr) override;
 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentIORootBase.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentIORootBase.h
@@ -6,47 +6,45 @@
 class TFile;
 class TTree;
 
-/// Base class for ROOT-based I/O of Alignment parameters etc. 
+/// Base class for ROOT-based I/O of Alignment parameters etc.
 
-class AlignmentIORootBase 
-{
-
-  protected:
+class AlignmentIORootBase {
+protected:
   /// constructor
   AlignmentIORootBase() : tree(nullptr), myFile(nullptr) {}
-  /// destructor 
+  /// destructor
   virtual ~AlignmentIORootBase();
 
-  /// open IO 
+  /// open IO
   int openRoot(const char* filename, int iteration, bool writemode);
 
-  /// close IO 
+  /// close IO
   int closeRoot(void);
 
-  /// create root branches 
+  /// create root branches
   virtual void createBranches(void) = 0;
 
-  /// set root branches 
+  /// set root branches
   virtual void setBranchAddresses(void) = 0;
 
-  /// test if file is existing and if so, what the highest iteration is 
-  int testFile(const char* filename, const TString &tname);
+  /// test if file is existing and if so, what the highest iteration is
+  int testFile(const char* filename, const TString& tname);
 
-  /// compose tree name 
-  TString treeName(int iter, const TString &tname);
+  /// compose tree name
+  TString treeName(int iter, const TString& tname);
 
   // data members
 
-  TTree* tree; // root tree
-  TString treename; // tree identifier name
-  TString treetxt;  // tree text
-  bool bWrite; // if true we are writing, else reading
+  TTree* tree;       // root tree
+  TString treename;  // tree identifier name
+  TString treetxt;   // tree text
+  bool bWrite;       // if true we are writing, else reading
 
-  const static int nParMax = 20;   // maximal number of Parameters
-  const static int itermax = 1000; // max iteration to test for
+  const static int nParMax = 20;    // maximal number of Parameters
+  const static int itermax = 1000;  // max iteration to test for
 
- private:
-  TFile* myFile; // root file
+private:
+  TFile* myFile;  // root file
 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentParameterBuilder.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentParameterBuilder.h
@@ -22,32 +22,31 @@ class AlignableMuon;
 class AlignmentParameters;
 class TrackerTopology;
 
-class AlignmentParameterBuilder 
-{
+class AlignmentParameterBuilder {
 public:
   /// Constructor from tracker only
-  explicit AlignmentParameterBuilder( AlignableTracker *alignableTracker,
-				      AlignableExtras *alignableExtras );
+  explicit AlignmentParameterBuilder(AlignableTracker *alignableTracker, AlignableExtras *alignableExtras);
 
   /// Constructor from tracker and muon
-  AlignmentParameterBuilder( AlignableTracker *alignableTracker, AlignableMuon *alignableMuon,
-			     AlignableExtras *alignableExtras );
+  AlignmentParameterBuilder(AlignableTracker *alignableTracker,
+                            AlignableMuon *alignableMuon,
+                            AlignableExtras *alignableExtras);
 
   /// Constructor adding selections by passing the ParameterSet named 'AlignmentParameterSelector'
   /// (expected in pSet) to addSelections(..)
-  AlignmentParameterBuilder( AlignableTracker *alignableTracker,
-			     AlignableExtras *alignableExtras,
-			     const edm::ParameterSet &pSet );
+  AlignmentParameterBuilder(AlignableTracker *alignableTracker,
+                            AlignableExtras *alignableExtras,
+                            const edm::ParameterSet &pSet);
 
   /// Constructor from tracker and muon, plus selection
-  AlignmentParameterBuilder( AlignableTracker *alignableTracker, AlignableMuon *alignableMuon,
-			     AlignableExtras *alignableExtras,
-                             const edm::ParameterSet &pSet);
+  AlignmentParameterBuilder(AlignableTracker *alignableTracker,
+                            AlignableMuon *alignableMuon,
+                            AlignableExtras *alignableExtras,
+                            const edm::ParameterSet &pSet);
 
-
-  /// destructor 
-  virtual ~AlignmentParameterBuilder() {};
-  /// master initialisation method, PSet must have form as constructor wants it 
+  /// destructor
+  virtual ~AlignmentParameterBuilder(){};
+  /// master initialisation method, PSet must have form as constructor wants it
   void addAllSelections(const edm::ParameterSet &pSet);
 
   /// Add selections of Alignables, using AlignmenParameterSelector::addSelections.
@@ -55,48 +54,46 @@ public:
   /// using the selection of active parameters done in AlignmenParameterSelector,
   /// e.g. for RigidBody a selection string '11100' selects the degrees of freedom in
   /// (x,y,z), but not (alpha,beta,gamma).
-  /// Returns number of added selections 
-  unsigned int addSelections(const edm::ParameterSet &pset,
-			     AlignmentParametersFactory::ParametersType parType);
+  /// Returns number of added selections
+  unsigned int addSelections(const edm::ParameterSet &pset, AlignmentParametersFactory::ParametersType parType);
 
   /// Add arbitrary selection of Alignables, return number of higher level Alignables
   unsigned int add(const align::Alignables &alignables,
-		   AlignmentParametersFactory::ParametersType parType,
-		   const std::vector<bool> &sel);
-  /// Add a single Alignable, true if it is higher level, false if it is an AlignableDet 
-  bool add(Alignable *alignable, AlignmentParametersFactory::ParametersType parType,
-	   const std::vector<bool> &sel);
+                   AlignmentParametersFactory::ParametersType parType,
+                   const std::vector<bool> &sel);
+  /// Add a single Alignable, true if it is higher level, false if it is an AlignableDet
+  bool add(Alignable *alignable, AlignmentParametersFactory::ParametersType parType, const std::vector<bool> &sel);
 
-  /// Get list of alignables for which AlignmentParameters are built 
-  const align::Alignables& alignables() const { return theAlignables; };
+  /// Get list of alignables for which AlignmentParameters are built
+  const align::Alignables &alignables() const { return theAlignables; };
 
-  /// Remove n Alignables from list 
-  void fixAlignables( int n );
+  /// Remove n Alignables from list
+  void fixAlignables(int n);
 
-  /// Alignable tracker   
-  const AlignableTracker* alignableTracker() const;
+  /// Alignable tracker
+  const AlignableTracker *alignableTracker() const;
 
 private:
   /// First remove all spaces (' ') from char selection 'paramSelChar' (coming
   /// from ParameterSelector) and then convert the selection to bool (for AlignmentParameters).
   /// True if (after removal of spaces) anything else than 0 and 1 is found in vector<char>.
   bool decodeParamSel(std::vector<char> &paramSelChar, std::vector<bool> &result) const;
-  /// add SelectionUserVariables corresponding to fullSel 
+  /// add SelectionUserVariables corresponding to fullSel
   bool addFullParamSel(AlignmentParameters *aliPar, const std::vector<char> &fullSel) const;
 
   // data members
 
-  /// Vector of alignables 
+  /// Vector of alignables
   align::Alignables theAlignables;
 
-  /// Alignable tracker   
-  AlignableTracker* theAlignableTracker;
+  /// Alignable tracker
+  AlignableTracker *theAlignableTracker;
 
   /// Alignable muon
-  AlignableMuon* theAlignableMuon;
-  
+  AlignableMuon *theAlignableMuon;
+
   /// extra Alignables
-  AlignableExtras* theAlignableExtras;
+  AlignableExtras *theAlignableExtras;
 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentParameterSelector.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentParameterSelector.h
@@ -24,18 +24,19 @@ namespace edm {
 }
 
 class AlignmentParameterSelector {
- public:
+public:
   /// Constructor from tracker only or from tracker and muon
-  explicit AlignmentParameterSelector(AlignableTracker *aliTracker, AlignableMuon *aliMuon = nullptr,
-				      AlignableExtras *aliExtras = nullptr);
+  explicit AlignmentParameterSelector(AlignableTracker *aliTracker,
+                                      AlignableMuon *aliMuon = nullptr,
+                                      AlignableExtras *aliExtras = nullptr);
 
   /// Destructor
   virtual ~AlignmentParameterSelector() {}
 
   /// vector of alignables selected so far
-  const align::Alignables& selectedAlignables() const { return theSelectedAlignables; }
+  const align::Alignables &selectedAlignables() const { return theSelectedAlignables; }
   /// vector of selection 'strings' for alignables, parallel to selectedAlignables()
-  const std::vector<std::vector<char> >& selectedParameters() const { return theSelectedParameters; }
+  const std::vector<std::vector<char> > &selectedParameters() const { return theSelectedParameters; }
   /// remove all selected Alignables and geometrical restrictions
   void clear();
   /// remove all geometrical restrictions
@@ -58,11 +59,10 @@ class AlignmentParameterSelector {
   /// as defined in setSpecials, returns number of added alignables
   unsigned int addSelection(const std::string &name, const std::vector<char> &paramSel);
   /// as addSelection with one argument, but overwriting geometrical restrictions
-  unsigned int addSelection(const std::string &name, const std::vector<char> &paramSel, 
-			    const edm::ParameterSet &pSet);
+  unsigned int addSelection(const std::string &name, const std::vector<char> &paramSel, const edm::ParameterSet &pSet);
   /// true if layer is deselected via "Layers<N><M>" or "DS/SS"
   bool layerDeselected(const Alignable *alignable) const;
-  /// true if alignable is DetUnit deselected by Unit<Rphi/Stereo> selection 
+  /// true if alignable is DetUnit deselected by Unit<Rphi/Stereo> selection
   bool detUnitDeselected(const Alignable *alignable) const;
   /// true if geometrical restrictions in eta, phi, r, x, y, z not satisfied
   bool outsideGeometricalRanges(const Alignable *alignable) const;
@@ -72,8 +72,8 @@ class AlignmentParameterSelector {
   /// ( => false if ranges.empty() == true), if(isPhi==true) takes into account phi periodicity
   /// for the integer specialized method, true is returned for ranges[i] <= value <= ranges[i+1]
   /// and isPhi is ignored
-  template<typename T> bool insideRanges(T value, const std::vector<T> &ranges,
-					 bool isPhi = false) const;
+  template <typename T>
+  bool insideRanges(T value, const std::vector<T> &ranges, bool isPhi = false) const;
   /// true if value is member of vector of values
   bool isMemberOfVector(int value, const std::vector<int> &values) const;
   /// Decomposing input string 's' into parts separated by 'delimiter'
@@ -81,8 +81,8 @@ class AlignmentParameterSelector {
   /// Converting std::string into std::vector<char>
   std::vector<char> convertParamSel(const std::string &selString) const;
 
- protected:
-  /// adding alignables which fulfil geometrical restrictions and special switches 
+protected:
+  /// adding alignables which fulfil geometrical restrictions and special switches
   unsigned int add(const align::Alignables &alignables, const std::vector<char> &paramSel);
   /// some helper methods
   unsigned int addAllDets(const std::vector<char> &paramSel);
@@ -97,12 +97,12 @@ class AlignmentParameterSelector {
   void setTOBDetIdCuts(const edm::ParameterSet &pSet);
   void setTECDetIdCuts(const edm::ParameterSet &pSet);
 
-  const AlignableTracker* alignableTracker() const;
-  
- private:
-  AlignableTracker* theTracker;
-  AlignableMuon*    theMuon;
-  AlignableExtras*  theExtras;
+  const AlignableTracker *alignableTracker() const;
+
+private:
+  AlignableTracker *theTracker;
+  AlignableMuon *theMuon;
+  AlignableExtras *theExtras;
   align::Alignables theSelectedAlignables;
   std::vector<std::vector<char> > theSelectedParameters;
 
@@ -115,81 +115,92 @@ class AlignmentParameterSelector {
   std::vector<double> theRangesZ;
 
   /// DetId restrictions in eta, phi, r, x, y, z to be applied for next addSelection
-  std::vector<int>    theDetIds;
-  std::vector<int>    theDetIdRanges;
-  std::vector<int>    theExcludedDetIds;
-  std::vector<int>    theExcludedDetIdRanges;
+  std::vector<int> theDetIds;
+  std::vector<int> theDetIdRanges;
+  std::vector<int> theExcludedDetIds;
+  std::vector<int> theExcludedDetIdRanges;
   struct PXBDetIdRanges {
-    std::vector<int>    theLadderRanges;
-    std::vector<int>    theLayerRanges;
-    std::vector<int>    theModuleRanges;
+    std::vector<int> theLadderRanges;
+    std::vector<int> theLayerRanges;
+    std::vector<int> theModuleRanges;
     void clear() {
-      theLadderRanges.clear(); theLayerRanges.clear();
+      theLadderRanges.clear();
+      theLayerRanges.clear();
       theModuleRanges.clear();
     }
-  }                   thePXBDetIdRanges;
+  } thePXBDetIdRanges;
   struct PXFDetIdRanges {
-    std::vector<int>    theBladeRanges;
-    std::vector<int>    theDiskRanges;
-    std::vector<int>    theModuleRanges;
-    std::vector<int>    thePanelRanges;
-    std::vector<int>    theSideRanges;
-    void clear() { 
-      theBladeRanges.clear(); theDiskRanges.clear();
-      theModuleRanges.clear(); thePanelRanges.clear();
+    std::vector<int> theBladeRanges;
+    std::vector<int> theDiskRanges;
+    std::vector<int> theModuleRanges;
+    std::vector<int> thePanelRanges;
+    std::vector<int> theSideRanges;
+    void clear() {
+      theBladeRanges.clear();
+      theDiskRanges.clear();
+      theModuleRanges.clear();
+      thePanelRanges.clear();
       theSideRanges.clear();
     }
-  }                   thePXFDetIdRanges;
+  } thePXFDetIdRanges;
   struct TIBDetIdRanges {
-    std::vector<int>    theLayerRanges;
-    std::vector<int>    theModuleRanges;
-    std::vector<int>    theStringRanges;
-    std::vector<int>    theSideRanges;
-    void clear() { 
-      theLayerRanges.clear(); theModuleRanges.clear();
-      theSideRanges.clear(); theStringRanges.clear();
+    std::vector<int> theLayerRanges;
+    std::vector<int> theModuleRanges;
+    std::vector<int> theStringRanges;
+    std::vector<int> theSideRanges;
+    void clear() {
+      theLayerRanges.clear();
+      theModuleRanges.clear();
+      theSideRanges.clear();
+      theStringRanges.clear();
     }
-  }                   theTIBDetIdRanges;
+  } theTIBDetIdRanges;
   struct TIDDetIdRanges {
-    std::vector<int>    theDiskRanges; 
-    std::vector<int>    theModuleRanges;
-    std::vector<int>    theRingRanges;
-    std::vector<int>    theSideRanges;  
-    void clear() { 
-      theDiskRanges.clear(); theModuleRanges.clear();
-      theRingRanges.clear(); theSideRanges.clear();
-    }
-  }                   theTIDDetIdRanges;
-  struct TOBDetIdRanges {
-    std::vector<int>    theLayerRanges; 
-    std::vector<int>    theModuleRanges;
-    std::vector<int>    theRodRanges;  
-    std::vector<int>    theSideRanges;
-    void clear() { 
-      theLayerRanges.clear(); theModuleRanges.clear();
-      theRodRanges.clear(); theSideRanges.clear();
-    }
-  }                   theTOBDetIdRanges;  
-  struct TECDetIdRanges {
-    std::vector<int>    theWheelRanges; 
-    std::vector<int>    thePetalRanges; 
-    std::vector<int>    theModuleRanges;
-    std::vector<int>    theRingRanges;
-    std::vector<int>    theSideRanges;  
-    void clear() { 
-      theWheelRanges.clear(); thePetalRanges.clear();
-      theModuleRanges.clear(); theRingRanges.clear();
+    std::vector<int> theDiskRanges;
+    std::vector<int> theModuleRanges;
+    std::vector<int> theRingRanges;
+    std::vector<int> theSideRanges;
+    void clear() {
+      theDiskRanges.clear();
+      theModuleRanges.clear();
+      theRingRanges.clear();
       theSideRanges.clear();
     }
-  }                   theTECDetIdRanges;
-    
+  } theTIDDetIdRanges;
+  struct TOBDetIdRanges {
+    std::vector<int> theLayerRanges;
+    std::vector<int> theModuleRanges;
+    std::vector<int> theRodRanges;
+    std::vector<int> theSideRanges;
+    void clear() {
+      theLayerRanges.clear();
+      theModuleRanges.clear();
+      theRodRanges.clear();
+      theSideRanges.clear();
+    }
+  } theTOBDetIdRanges;
+  struct TECDetIdRanges {
+    std::vector<int> theWheelRanges;
+    std::vector<int> thePetalRanges;
+    std::vector<int> theModuleRanges;
+    std::vector<int> theRingRanges;
+    std::vector<int> theSideRanges;
+    void clear() {
+      theWheelRanges.clear();
+      thePetalRanges.clear();
+      theModuleRanges.clear();
+      theRingRanges.clear();
+      theSideRanges.clear();
+    }
+  } theTECDetIdRanges;
+
   // further switches used in add(...)
   bool theOnlyDS;
   bool theOnlySS;
   bool theSelLayers;
-  int  theMinLayer;
-  int  theMaxLayer;
-  enum RphiOrStereoDetUnit { Stereo, Both, Rphi};
+  int theMinLayer;
+  int theMaxLayer;
+  enum RphiOrStereoDetUnit { Stereo, Both, Rphi };
   RphiOrStereoDetUnit theRphiOrStereoDetUnit;
   /// Setting the special switches and returning input string, but after removing the 'special
   /// indicators' from it. Known specials are:
@@ -199,11 +210,9 @@ class AlignmentParameterSelector {
   /// "UnitStereo" and "UnitRphi" anywhere in name:
   ///      for a DetUnit in strip select only if stereo or rphi module (keep 'Unit' in name!)
   std::string setSpecials(const std::string &name);
-
 };
 
-template<> bool
-AlignmentParameterSelector::insideRanges<int>(int value, const std::vector<int> &ranges,
-					      bool isPhi) const;
+template <>
+bool AlignmentParameterSelector::insideRanges<int>(int value, const std::vector<int> &ranges, bool isPhi) const;
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentParameterStore.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentParameterStore.h
@@ -6,80 +6,77 @@
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentCorrelationsStore.h"
 #include "Alignment/CommonAlignmentParametrization/interface/CompositeAlignmentParameters.h"
 
-/// \class AlignmentParameterStore 
+/// \class AlignmentParameterStore
 ///
-/// Basic class for management of alignment parameters and correlations 
+/// Basic class for management of alignment parameters and correlations
 ///
 ///  $Date: 2011/05/23 20:50:31 $
 ///  $Revision: 1.19 $
 /// (last update by $Author: mussgill $)
 
-namespace edm { class ParameterSet; }
+namespace edm {
+  class ParameterSet;
+}
 class AlignmentUserVariables;
 class TrackerTopology;
 
-class AlignmentParameterStore 
-{
-
+class AlignmentParameterStore {
 public:
-
   typedef std::vector<AlignmentParameters*> Parameters;
-  typedef std::map< std::pair<Alignable*,Alignable*>,AlgebraicMatrix > Correlations;
+  typedef std::map<std::pair<Alignable*, Alignable*>, AlgebraicMatrix> Correlations;
   typedef std::vector<unsigned int> DetIds;
 
-  /// constructor 
-  AlignmentParameterStore( const align::Alignables &alis, const edm::ParameterSet& config );
+  /// constructor
+  AlignmentParameterStore(const align::Alignables& alis, const edm::ParameterSet& config);
 
-  /// destructor 
+  /// destructor
   virtual ~AlignmentParameterStore();
 
   /// select parameters
   /// (for backward compatibility, use with vector<AlignableDetOrUnitPtr> as argument instead)
-  CompositeAlignmentParameters
-    selectParameters( const std::vector <AlignableDet*>& alignabledets ) const;
-  /// select parameters 
-  CompositeAlignmentParameters
-    selectParameters( const std::vector <AlignableDetOrUnitPtr>& alignabledets ) const;
-  /// select parameters 
+  CompositeAlignmentParameters selectParameters(const std::vector<AlignableDet*>& alignabledets) const;
+  /// select parameters
+  CompositeAlignmentParameters selectParameters(const std::vector<AlignableDetOrUnitPtr>& alignabledets) const;
+  /// select parameters
   CompositeAlignmentParameters selectParameters(const align::Alignables&) const;
 
-  /// update parameters 
+  /// update parameters
   void updateParameters(const CompositeAlignmentParameters& aap, bool updateCorrelations = true);
 
-  /// get all alignables 
+  /// get all alignables
   const align::Alignables& alignables(void) const { return theAlignables; }
 
-  /// get all alignables with valid parameters 
+  /// get all alignables with valid parameters
   align::Alignables validAlignables(void) const;
 
-  /// returns number of alignables 
+  /// returns number of alignables
   int numObjects(void) const { return theAlignables.size(); }
 
-  /// get full correlation map 
-  AlignmentCorrelationsStore* correlationsStore( void ) const { return theCorrelationsStore; }
+  /// get full correlation map
+  AlignmentCorrelationsStore* correlationsStore(void) const { return theCorrelationsStore; }
 
-  /// get number of correlations between alignables 
-  const unsigned int numCorrelations( void ) const { return theCorrelationsStore->size(); }
+  /// get number of correlations between alignables
+  const unsigned int numCorrelations(void) const { return theCorrelationsStore->size(); }
 
   /// Obsolete: Use AlignableNavigator::alignableDetFromGeomDet and alignableFromAlignableDet
-/*   Alignable* alignableFromGeomDet( const GeomDet* geomDet ) const; */
+  /*   Alignable* alignableFromGeomDet( const GeomDet* geomDet ) const; */
 
   /// get Alignable corresponding to given AlignableDet (non-const ref. argument since might be returned)
-  Alignable* alignableFromAlignableDet( const AlignableDetOrUnitPtr& alignableDet ) const;
+  Alignable* alignableFromAlignableDet(const AlignableDetOrUnitPtr& alignableDet) const;
 
   /// Obsolete: Use AlignableNavigator::alignableDetFromDetId and alignableFromAlignableDet
-/*   Alignable* alignableFromDetId(const unsigned int& detId) const; */
+  /*   Alignable* alignableFromDetId(const unsigned int& detId) const; */
 
-  /// apply all valid parameters to their alignables 
+  /// apply all valid parameters to their alignables
   void applyParameters(void);
 
-  /// apply parameters of a given alignable 
+  /// apply parameters of a given alignable
   void applyParameters(Alignable* alignable);
 
-  /// reset parameters, correlations, user variables 
+  /// reset parameters, correlations, user variables
   void resetParameters(void);
 
-  /// reset parameters of a given alignable 
+  /// reset parameters of a given alignable
   void resetParameters(Alignable* ali);
 
   /// cache the current position, rotation and other parameters
@@ -94,40 +91,38 @@ public:
   /// restore for the given run the previously cached position, rotation and other parameters
   void restoreCachedTransformations(const align::RunNumber&);
 
-  /// acquire shifts/rotations from alignables of the store and copy into 
-  ///  alignment parameters (local frame) 
+  /// acquire shifts/rotations from alignables of the store and copy into
+  ///  alignment parameters (local frame)
   void acquireRelativeParameters(void);
 
-  /// apply absolute positions to alignables 
-  void applyAlignableAbsolutePositions( const align::Alignables& alis, 
-                                        const AlignablePositions& newpos, int& ierr );
+  /// apply absolute positions to alignables
+  void applyAlignableAbsolutePositions(const align::Alignables& alis, const AlignablePositions& newpos, int& ierr);
 
-  /// apply relative shifts to alignables 
-  void applyAlignableRelativePositions( const align::Alignables& alivec, 
-                                        const AlignableShifts& shifts, int& ierr );
+  /// apply relative shifts to alignables
+  void applyAlignableRelativePositions(const align::Alignables& alivec, const AlignableShifts& shifts, int& ierr);
 
-  /// Attach alignment parameters to given alignables 
-  void attachAlignmentParameters( const align::Alignables& alivec, const Parameters& parvec, int& ierr );
+  /// Attach alignment parameters to given alignables
+  void attachAlignmentParameters(const align::Alignables& alivec, const Parameters& parvec, int& ierr);
 
   /// Attach alignment parameters to alignables
   void attachAlignmentParameters(const Parameters& parvec, int& ierr);
 
-  /// Attach correlations to given alignables 
-  void attachCorrelations( const align::Alignables& alivec, const Correlations& cormap, 
-                           bool overwrite, int& ierr );
+  /// Attach correlations to given alignables
+  void attachCorrelations(const align::Alignables& alivec, const Correlations& cormap, bool overwrite, int& ierr);
 
   /// Attach correlations to alignables
-  void attachCorrelations( const Correlations& cormap, bool overwrite, int& ierr );
+  void attachCorrelations(const Correlations& cormap, bool overwrite, int& ierr);
 
-  /// Attach User Variables to given alignables 
-  void attachUserVariables( const align::Alignables& alivec,
-                            const std::vector<AlignmentUserVariables*>& uvarvec, int& ierr);
+  /// Attach User Variables to given alignables
+  void attachUserVariables(const align::Alignables& alivec,
+                           const std::vector<AlignmentUserVariables*>& uvarvec,
+                           int& ierr);
 
-  /// Set Alignment position error 
-  void setAlignmentPositionError( const align::Alignables& alivec, double valshift, double valrot );
+  /// Set Alignment position error
+  void setAlignmentPositionError(const align::Alignables& alivec, double valshift, double valrot);
 
-  /// Obtain type and layer from Alignable 
-  std::pair<int,int> typeAndLayer( const Alignable* ali, const TrackerTopology* tTopo ) const;
+  /// Obtain type and layer from Alignable
+  std::pair<int, int> typeAndLayer(const Alignable* ali, const TrackerTopology* tTopo) const;
 
   /// a single alignable parameter of an Alignable
   typedef std::pair<Alignable*, unsigned int> ParameterId;
@@ -146,13 +141,14 @@ public:
   /// parameter of aliMaster, but in principle these can be empty...
   /// Note that not all combinations of AlignmentParameters classes ar supported.
   /// If not there will be an exception (and false returned...)
-  bool hierarchyConstraints(const Alignable *aliMaster, const align::Alignables &aliComps,
-			    std::vector<std::vector<ParameterId> > &paramIdsVecOut,
-			    std::vector<std::vector<double> > &factorsVecOut,
-			    bool all, double epsilon) const;
+  bool hierarchyConstraints(const Alignable* aliMaster,
+                            const align::Alignables& aliComps,
+                            std::vector<std::vector<ParameterId> >& paramIdsVecOut,
+                            std::vector<std::vector<double> >& factorsVecOut,
+                            bool all,
+                            double epsilon) const;
 
 protected:
-
   // storage for correlations
   AlignmentCorrelationsStore* theCorrelationsStore;
 
@@ -161,11 +157,11 @@ private:
 
   // data members
 
-  /// alignables 
+  /// alignables
   align::Alignables theAlignables;
 
   /// type of constraints
-  TypeOfConstraints theTypeOfConstraints;  
+  TypeOfConstraints theTypeOfConstraints;
 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentParametersIO.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentParametersIO.h
@@ -5,43 +5,39 @@
 
 /// \class AlignmentParametersIO
 ///
-/// abstract base class for I/O of AlignmentParameters 
+/// abstract base class for I/O of AlignmentParameters
 ///
 ///  $Date: 2007/01/23 16:07:08 $
 ///  $Revision: 1.4 $
 /// (last update by $Author: fronga $)
 
-class AlignmentParametersIO 
-{
+class AlignmentParametersIO {
+protected:
+  virtual ~AlignmentParametersIO(){};
 
-  protected:
+  /// open IO
+  virtual int open(const char* filename, int iteration, bool writemode) = 0;
 
-  virtual  ~AlignmentParametersIO(){};
+  /// close IO
+  virtual int close(void) = 0;
 
-  /// open IO 
-  virtual int open(const char* filename, int iteration, bool writemode) =0;
-
-  /// close IO 
-  virtual int close(void) =0;
-
-  /// write AlignmentParameters of one Alignable 
+  /// write AlignmentParameters of one Alignable
   virtual int writeOne(Alignable* ali) = 0;
 
   /// write original RigidBodyAlignmentParameters (i.e. 3 shifts and 3 rotation)
   virtual int writeOneOrigRigidBody(Alignable* ali);
 
-  /// read AlignmentParameters of one Alignable 
+  /// read AlignmentParameters of one Alignable
   virtual AlignmentParameters* readOne(Alignable* ali, int& ierr) = 0;
 
-  /// write AlignmentParameters of many Alignables 
+  /// write AlignmentParameters of many Alignables
   int write(const align::Alignables& alivec, bool validCheck);
 
-  /// write original RigidBodyAlignmentParameters of many Alignables 
+  /// write original RigidBodyAlignmentParameters of many Alignables
   int writeOrigRigidBody(const align::Alignables& alivec, bool validCheck);
 
-  /// read AlignmentParameters of many Alignables 
+  /// read AlignmentParameters of many Alignables
   align::Parameters read(const align::Alignables& alivec, int& ierr);
-
 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentParametersIORoot.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentParametersIORoot.h
@@ -3,7 +3,7 @@
 
 /// \class AlignmentParametersIORoot
 ///
-/// Concrete class for ROOT-based I/O of AlignmentParameters 
+/// Concrete class for ROOT-based I/O of AlignmentParameters
 ///
 ///  $Date: 2008/09/02 15:31:23 $
 ///  $Revision: 1.6 $
@@ -13,26 +13,25 @@
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentIORootBase.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentParametersIO.h"
 
-class AlignmentParametersIORoot : public AlignmentIORootBase, public AlignmentParametersIO
-{
+class AlignmentParametersIORoot : public AlignmentIORootBase, public AlignmentParametersIO {
   friend class AlignmentIORoot;
 
-  private:
+private:
+  /// Constructor
+  AlignmentParametersIORoot();
 
-  /// Constructor 
-  AlignmentParametersIORoot(); 
-
-  /// Write AlignmentParameters of one Alignable 
+  /// Write AlignmentParameters of one Alignable
   int writeOne(Alignable* ali) override;
 
-  /// Read AlignmentParameters of one Alignable 
+  /// Read AlignmentParameters of one Alignable
   AlignmentParameters* readOne(Alignable* ali, int& ierr) override;
 
-  /// Open IO 
-  int open(const char* filename, int iteration, bool writemode) override
-    {return openRoot(filename,iteration,writemode);};
+  /// Open IO
+  int open(const char* filename, int iteration, bool writemode) override {
+    return openRoot(filename, iteration, writemode);
+  };
 
-  /// Close IO 
+  /// Close IO
   int close(void) override;
 
   // helper functions
@@ -47,13 +46,12 @@ class AlignmentParametersIORoot : public AlignmentIORootBase, public AlignmentPa
   /// Set branch adresses
   void setBranchAddresses(void) override;
 
-  // Alignment parameter tree 
+  // Alignment parameter tree
   int theCovRang, theCovarRang, theHieraLevel, theParamType;
   align::ID theId;
   align::StructureType theObjId;
 
-  double thePar[nParMax],theCov[nParMax*(nParMax+1)/2];
-
+  double thePar[nParMax], theCov[nParMax * (nParMax + 1) / 2];
 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentUserVariablesIO.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentUserVariablesIO.h
@@ -14,32 +14,28 @@
 
 class AlignmentUserVariables;
 
-class AlignmentUserVariablesIO 
-{
-
-  protected:
-
+class AlignmentUserVariablesIO {
+protected:
   virtual ~AlignmentUserVariablesIO() {}
 
   /** open IO */
-  virtual int open(const char* filename, int iteration, bool writemode) =0;
+  virtual int open(const char* filename, int iteration, bool writemode) = 0;
 
   /** close IO */
-  virtual int close(void) =0;
+  virtual int close(void) = 0;
 
   /** write AlignmentUserVariables of one Alignable */
-  virtual int writeOne(Alignable* ali) =0;
+  virtual int writeOne(Alignable* ali) = 0;
 
   /** read AlignmentUserVariables of one Alignable,
       object should be created and has to be deleted */
-  virtual AlignmentUserVariables* readOne(Alignable* ali, int& ierr) =0;
+  virtual AlignmentUserVariables* readOne(Alignable* ali, int& ierr) = 0;
 
   /** write AlignmentUserVariables of many Alignables */
   int write(const align::Alignables& alivec, bool validCheck);
 
   /** read AlignmentUserVariables of many Alignables (using readOne, so take care of memory!) */
   std::vector<AlignmentUserVariables*> read(const align::Alignables& alivec, int& ierr);
-
 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationBase.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationBase.h
@@ -19,7 +19,6 @@
  *     EventSetup and AlignmentAlgorithmBase::EventInfo.
  */
 
-
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h"
 
 #include <vector>
@@ -33,21 +32,22 @@ class AlignableExtras;
 class TrajectoryStateOnSurface;
 class TrackingRecHit;
 
-namespace edm { class EventSetup; class ParameterSet; } 
+namespace edm {
+  class EventSetup;
+  class ParameterSet;
+}  // namespace edm
 
-class IntegratedCalibrationBase
-{
+class IntegratedCalibrationBase {
 public:
-
   typedef AlignmentAlgorithmBase::EventInfo EventInfo;
-  typedef std::pair<double,double> Values; /// x- and y-values
-  typedef std::pair<Values, unsigned int> ValuesIndexPair; /// Values and their parameter index
+  typedef std::pair<double, double> Values;                 /// x- and y-values
+  typedef std::pair<Values, unsigned int> ValuesIndexPair;  /// Values and their parameter index
 
   /// Constructor
   explicit IntegratedCalibrationBase(const edm::ParameterSet &cfg);
-  
+
   /// Destructor
-  virtual ~IntegratedCalibrationBase() {};
+  virtual ~IntegratedCalibrationBase(){};
 
   /// How many parameters does this calibration define?
   virtual unsigned int numParameters() const = 0;
@@ -56,19 +56,19 @@ public:
   /// default implementation uses other derivatives(..) method,
   /// but can be overwritten in derived class for efficiency.
   virtual std::vector<Values> derivatives(const TrackingRecHit &hit,
-					  const TrajectoryStateOnSurface &tsos,
-					  const edm::EventSetup &setup,
-					  const EventInfo &eventInfo) const;
+                                          const TrajectoryStateOnSurface &tsos,
+                                          const edm::EventSetup &setup,
+                                          const EventInfo &eventInfo) const;
 
   /// Return non-zero derivatives for x- (ValuesIndexPair.first.first)
   /// and y-measurement (ValuesIndexPair.first.second) with their
   /// indices (ValuesIndexPair.second) by reference.
   /// Return value is their number.
   virtual unsigned int derivatives(std::vector<ValuesIndexPair> &outDerivInds,
-				   const TrackingRecHit &hit,
-				   const TrajectoryStateOnSurface &tsos,
-				   const edm::EventSetup &setup,
-				   const EventInfo &eventInfo) const = 0;
+                                   const TrackingRecHit &hit,
+                                   const TrajectoryStateOnSurface &tsos,
+                                   const edm::EventSetup &setup,
+                                   const EventInfo &eventInfo) const = 0;
 
   /// Setting the determined parameter identified by index,
   /// should return false if out-of-bounds, true otherwise.
@@ -88,23 +88,21 @@ public:
 
   /// Call at beginning of job:
   /// default implementation is dummy, to be overwritten in derived class if useful.
-  virtual void beginOfJob(AlignableTracker *tracker,
-			  AlignableMuon *muon,
-			  AlignableExtras *extras) {};
+  virtual void beginOfJob(AlignableTracker *tracker, AlignableMuon *muon, AlignableExtras *extras){};
 
   /// Call at beginning of run:
   /// default implementation is dummy, to be overwritten in derived class if useful.
-  virtual void beginRun(const edm::Run&, const edm::EventSetup&) {};
+  virtual void beginRun(const edm::Run &, const edm::EventSetup &){};
 
   /// Called at beginning of a loop of the AlignmentProducer,
   /// to be used for iterative algorithms, default does nothing.
   /// FIXME: move call to algorithm?
-  virtual void startNewLoop() {};
+  virtual void startNewLoop(){};
 
   /// Called at end of a loop of the AlignmentProducer,
   /// to be used for iterative algorithms, default does nothing.
   /// FIXME: move call to algorithm?
-  virtual void endOfLoop() {};
+  virtual void endOfLoop(){};
 
   /// Called at end of a the job of the AlignmentProducer.
   /// Do here the necessary stuff with the results that should have been passed
@@ -125,10 +123,10 @@ public:
   /* virtual void endLuminosityBlock(const edm::EventSetup &setup) {}; */
 
   /// name of this calibration
-  const std::string& name() const { return name_;} // non-virtual since refering to private member
+  const std::string &name() const { return name_; }  // non-virtual since refering to private member
 
- private:
-  const std::string name_; /// name of this calibration (i.e. defining plugin)
+private:
+  const std::string name_;  /// name of this calibration (i.e. defining plugin)
 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationPluginFactory.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationPluginFactory.h
@@ -13,7 +13,7 @@
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationBase.h"
 
-typedef edmplugin::PluginFactory<IntegratedCalibrationBase* (const edm::ParameterSet&)>
-		  IntegratedCalibrationPluginFactory;
+typedef edmplugin::PluginFactory<IntegratedCalibrationBase*(const edm::ParameterSet&)>
+    IntegratedCalibrationPluginFactory;
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/SelectionUserVariables.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/SelectionUserVariables.h
@@ -19,17 +19,16 @@
 
 #include <vector>
 
-class SelectionUserVariables : public AlignmentUserVariables 
-{
- public:
-  explicit SelectionUserVariables(const std::vector<char> &sel) : myFullSelection(sel) {}
+class SelectionUserVariables : public AlignmentUserVariables {
+public:
+  explicit SelectionUserVariables(const std::vector<char>& sel) : myFullSelection(sel) {}
   ~SelectionUserVariables() override {}
-  SelectionUserVariables* clone() const override { return new SelectionUserVariables(*this);}
+  SelectionUserVariables* clone() const override { return new SelectionUserVariables(*this); }
 
-  const std::vector<char>& fullSelection() const {return myFullSelection;}
+  const std::vector<char>& fullSelection() const { return myFullSelection; }
 
- private:
-  std::vector<char>  myFullSelection;
+private:
+  std::vector<char> myFullSelection;
 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/interface/TkModuleGroupSelector.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/TkModuleGroupSelector.h
@@ -23,23 +23,24 @@
 #include <map>
 #include <list>
 
-
 class AlignableTracker;
 class AlignableMuon;
 class AlignableExtras;
 
-namespace edm { class EventSetup; class ParameterSet; } 
+namespace edm {
+  class EventSetup;
+  class ParameterSet;
+}  // namespace edm
 
-class TkModuleGroupSelector
-{
+class TkModuleGroupSelector {
 public:
   /// Constructor
   explicit TkModuleGroupSelector(AlignableTracker *aliTracker,
                                  const edm::ParameterSet &cfg,
                                  const std::vector<int> &sdets);
-  
+
   /// Destructor
-  virtual ~TkModuleGroupSelector() {};
+  virtual ~TkModuleGroupSelector(){};
 
   // Returns the number of parameters.
   unsigned int getNumberOfParameters() const;
@@ -53,28 +54,27 @@ public:
   /// Index of parameter for given detId (detId not treated => < 0)
   /// and the given run.
   int getParameterIndexFromDetId(unsigned int detId, edm::RunNumber_t run) const;
-  
- private:
+
+private:
   // Constructs the run-dependent module groups from configuration parameters.
   void createModuleGroups(AlignableTracker *aliTracker,
                           const edm::VParameterSet &granularityConfig,
                           const std::vector<edm::RunNumber_t> &defaultRunRange,
                           edm::RunNumber_t defaultReferenceRun);
-                    
+
   // Method used to test the provided configuration for unknown parameters
   void verifyParameterNames(const edm::ParameterSet &pset, unsigned int psetnr) const;
-  
+
   // Method to test whether the split option has been turned on
   const bool testSplitOption(const edm::ParameterSet &pset) const;
 
   // Add modules to a specific group which is also created in this function.
-  bool createGroup(
-                   unsigned int &Id, //id of the first run
-                   const std::vector<edm::RunNumber_t> &range, //run range
-                   const std::list<Alignable*> &selected_alis, //list of alignables for which a group is created
-                   const edm::RunNumber_t refrun //reference run number
-                   );
-  
+  bool createGroup(unsigned int &Id,                             //id of the first run
+                   const std::vector<edm::RunNumber_t> &range,   //run range
+                   const std::list<Alignable *> &selected_alis,  //list of alignables for which a group is created
+                   const edm::RunNumber_t refrun                 //reference run number
+  );
+
   // Fill the container which is a map between the det id and the id of the group
   // to which the module belongs.
   void fillDetIdMap(const unsigned int detid, const unsigned int groupid);
@@ -100,7 +100,6 @@ public:
 
   // Reference run per module group
   std::vector<edm::RunNumber_t> referenceRun_;
-  
 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/plugins/ApeSettingAlgorithm.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/ApeSettingAlgorithm.cc
@@ -1,4 +1,4 @@
- /**
+/**
  * \file MillePedeAlignmentAlgorithm.cc
  *
  *  \author    : Gero Flucke/Ivan Reid
@@ -33,7 +33,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h" 
+#include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
 #include "DataFormats/GeometrySurface/interface/GloballyPositioned.h"
 #include "CLHEP/Matrix/SymMatrix.h"
 
@@ -57,9 +57,8 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-class ApeSettingAlgorithm : public AlignmentAlgorithmBase
-{
- public:
+class ApeSettingAlgorithm : public AlignmentAlgorithmBase {
+public:
   /// Constructor
   ApeSettingAlgorithm(const edm::ParameterSet &cfg);
 
@@ -67,23 +66,25 @@ class ApeSettingAlgorithm : public AlignmentAlgorithmBase
   ~ApeSettingAlgorithm() override;
 
   /// Call at beginning of job
-  void initialize(const edm::EventSetup &setup, 
-			  AlignableTracker *tracker, AlignableMuon *muon, AlignableExtras *extras,
-			  AlignmentParameterStore *store) override;
+  void initialize(const edm::EventSetup &setup,
+                  AlignableTracker *tracker,
+                  AlignableMuon *muon,
+                  AlignableExtras *extras,
+                  AlignmentParameterStore *store) override;
 
   /// Call at end of job
-  void terminate(const edm::EventSetup& iSetup) override;
+  void terminate(const edm::EventSetup &iSetup) override;
 
   /// Run the algorithm
   void run(const edm::EventSetup &setup, const EventInfo &eventInfo) override;
 
- private:
-  edm::ParameterSet         theConfig;
-  AlignableNavigator       *theAlignableNavigator;
-  AlignableTracker         *theTracker;
-  bool                     saveApeToAscii_,readApeFromAscii_,readFullLocalMatrix_;
-  bool                     readLocalNotGlobal_,saveLocalNotGlobal_;
-  bool                     setComposites_,saveComposites_;
+private:
+  edm::ParameterSet theConfig;
+  AlignableNavigator *theAlignableNavigator;
+  AlignableTracker *theTracker;
+  bool saveApeToAscii_, readApeFromAscii_, readFullLocalMatrix_;
+  bool readLocalNotGlobal_, saveLocalNotGlobal_;
+  bool setComposites_, saveComposites_;
 };
 
 //____________________________________________________
@@ -91,14 +92,12 @@ class ApeSettingAlgorithm : public AlignmentAlgorithmBase
 //____________________________________________________
 //____________________________________________________
 
-
 // Constructor ----------------------------------------------------------------
 //____________________________________________________
-ApeSettingAlgorithm::ApeSettingAlgorithm(const edm::ParameterSet &cfg) :
-  AlignmentAlgorithmBase(cfg), theConfig(cfg),
-  theAlignableNavigator(nullptr)
-{
-  edm::LogInfo("Alignment") << "@SUB=ApeSettingAlgorithm" << "Start.";
+ApeSettingAlgorithm::ApeSettingAlgorithm(const edm::ParameterSet &cfg)
+    : AlignmentAlgorithmBase(cfg), theConfig(cfg), theAlignableNavigator(nullptr) {
+  edm::LogInfo("Alignment") << "@SUB=ApeSettingAlgorithm"
+                            << "Start.";
   saveApeToAscii_ = theConfig.getUntrackedParameter<bool>("saveApeToASCII");
   saveComposites_ = theConfig.getUntrackedParameter<bool>("saveComposites");
   saveLocalNotGlobal_ = theConfig.getUntrackedParameter<bool>("saveLocalNotGlobal");
@@ -106,121 +105,145 @@ ApeSettingAlgorithm::ApeSettingAlgorithm(const edm::ParameterSet &cfg) :
   readLocalNotGlobal_ = theConfig.getParameter<bool>("readLocalNotGlobal");
   readFullLocalMatrix_ = theConfig.getParameter<bool>("readFullLocalMatrix");
   setComposites_ = theConfig.getParameter<bool>("setComposites");
-  
 }
 
 // Destructor ----------------------------------------------------------------
 //____________________________________________________
-ApeSettingAlgorithm::~ApeSettingAlgorithm()
-{
-  delete theAlignableNavigator;
-}
+ApeSettingAlgorithm::~ApeSettingAlgorithm() { delete theAlignableNavigator; }
 
 // Call at beginning of job ---------------------------------------------------
 //____________________________________________________
-void ApeSettingAlgorithm::initialize(const edm::EventSetup &setup, 
-				     AlignableTracker *tracker, AlignableMuon *muon, AlignableExtras *extras,
-				     AlignmentParameterStore *store)
-{
- theAlignableNavigator = new AlignableNavigator(tracker, muon);
- theTracker = tracker;
- 
- if (readApeFromAscii_)
-   { std::ifstream apeReadFile(theConfig.getParameter<edm::FileInPath>("apeASCIIReadFile").fullPath().c_str()); //requires <fstream>
-   if (!apeReadFile.good())
-     { edm::LogInfo("Alignment") << "@SUB=initialize" <<"Problem opening APE file: skipping"
-				 << theConfig.getParameter<edm::FileInPath>("apeASCIIReadFile").fullPath();
-     return;
-     }
-   std::set<int> apeList; //To avoid duplicates
-   while (!apeReadFile.eof())
-     { int apeId=0; double x11,x21,x22,x31,x32,x33,ignore;
-     if (!readLocalNotGlobal_ || readFullLocalMatrix_) 
-       { apeReadFile>>apeId>>x11>>x21>>x22>>x31>>x32>>x33>>ignore>>ignore>>ignore>>ignore>>ignore>>ignore>>ignore>>ignore>>ignore>>ignore>>ignore>>ignore>>ignore>>ignore>>ignore>>std::ws;}
-     else
-       { apeReadFile>>apeId>>x11>>x22>>x33>>std::ws;}
-     //idr What sanity checks do we need to put here?
-     if (apeId != 0) //read appears valid?
-       { if (apeList.find(apeId) == apeList.end()) //Not previously done
-	 {  DetId id(apeId);
-	 AlignableDetOrUnitPtr alidet(theAlignableNavigator->alignableFromDetId(id)); //NULL if none
-	 if (alidet)
-	   { if ((alidet->components().empty()) || setComposites_) //the problem with glued dets...
-	     { GlobalErrorExtended globErr;
-	     if (readLocalNotGlobal_)
-	       { AlgebraicSymMatrix33 as; 
-	       if (readFullLocalMatrix_)
-		 { as[0][0]=x11; as[1][0]=x21; as[1][1]=x22;
-		 as[2][0]=x31; as[2][1]=x32; as[2][2]=x33;
-		 }
-	       else
-	         { as[0][0]=x11*x11; as[1][1]=x22*x22; as[2][2]=x33*x33;} //local cov.
-	       align::RotationType rt=alidet->globalRotation();
-	       AlgebraicMatrix33 am;
-	       am[0][0]=rt.xx(); am[0][1]=rt.xy(); am[0][2]=rt.xz();
-	       am[1][0]=rt.yx(); am[1][1]=rt.yy(); am[1][2]=rt.yz();
-	       am[2][0]=rt.zx(); am[2][1]=rt.zy(); am[2][2]=rt.zz();
-	       globErr = GlobalErrorExtended(ROOT::Math::SimilarityT(am,as));
-	       }
-	     else
-	       {
-                 if (readFullLocalMatrix_)
-		    globErr = GlobalErrorExtended(x11,x21,x31,0,0,0,x22,x32,0,0,0,x33,0,0,0,0,0,0,0,0,0);
-                 else {
-                    globErr = GlobalErrorExtended(x11*x11,0,0,0,0,0,x22*x22,0,0,0,0,x33*x33,0,0,0,0,0,0,0,0,0);
-                  }
-	       }
-	     alidet->setAlignmentPositionError(globErr, false); // do not propagate down!
-	     apeList.insert(apeId); //Flag it's been set
-	     }
-	   else
-	     { edm::LogInfo("Alignment") << "@SUB=initialize" << "Not Setting APE for Composite DetId "<<apeId;
-	     }
-	   }
-	 }
-       else
-	 { edm::LogInfo("Alignment") << "@SUB=initialize" << "Skipping duplicate APE for DetId "<<apeId;
-	 }
-       }
-     }
-   apeReadFile.close();
-   edm::LogInfo("Alignment") << "@SUB=initialize" << "Set "<<apeList.size()<<" APE values.";
-   }
+void ApeSettingAlgorithm::initialize(const edm::EventSetup &setup,
+                                     AlignableTracker *tracker,
+                                     AlignableMuon *muon,
+                                     AlignableExtras *extras,
+                                     AlignmentParameterStore *store) {
+  theAlignableNavigator = new AlignableNavigator(tracker, muon);
+  theTracker = tracker;
+
+  if (readApeFromAscii_) {
+    std::ifstream apeReadFile(
+        theConfig.getParameter<edm::FileInPath>("apeASCIIReadFile").fullPath().c_str());  //requires <fstream>
+    if (!apeReadFile.good()) {
+      edm::LogInfo("Alignment") << "@SUB=initialize"
+                                << "Problem opening APE file: skipping"
+                                << theConfig.getParameter<edm::FileInPath>("apeASCIIReadFile").fullPath();
+      return;
+    }
+    std::set<int> apeList;  //To avoid duplicates
+    while (!apeReadFile.eof()) {
+      int apeId = 0;
+      double x11, x21, x22, x31, x32, x33, ignore;
+      if (!readLocalNotGlobal_ || readFullLocalMatrix_) {
+        apeReadFile >> apeId >> x11 >> x21 >> x22 >> x31 >> x32 >> x33 >> ignore >> ignore >> ignore >> ignore >>
+            ignore >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore >>
+            ignore >> std::ws;
+      } else {
+        apeReadFile >> apeId >> x11 >> x22 >> x33 >> std::ws;
+      }
+      //idr What sanity checks do we need to put here?
+      if (apeId != 0)  //read appears valid?
+      {
+        if (apeList.find(apeId) == apeList.end())  //Not previously done
+        {
+          DetId id(apeId);
+          AlignableDetOrUnitPtr alidet(theAlignableNavigator->alignableFromDetId(id));  //NULL if none
+          if (alidet) {
+            if ((alidet->components().empty()) || setComposites_)  //the problem with glued dets...
+            {
+              GlobalErrorExtended globErr;
+              if (readLocalNotGlobal_) {
+                AlgebraicSymMatrix33 as;
+                if (readFullLocalMatrix_) {
+                  as[0][0] = x11;
+                  as[1][0] = x21;
+                  as[1][1] = x22;
+                  as[2][0] = x31;
+                  as[2][1] = x32;
+                  as[2][2] = x33;
+                } else {
+                  as[0][0] = x11 * x11;
+                  as[1][1] = x22 * x22;
+                  as[2][2] = x33 * x33;
+                }  //local cov.
+                align::RotationType rt = alidet->globalRotation();
+                AlgebraicMatrix33 am;
+                am[0][0] = rt.xx();
+                am[0][1] = rt.xy();
+                am[0][2] = rt.xz();
+                am[1][0] = rt.yx();
+                am[1][1] = rt.yy();
+                am[1][2] = rt.yz();
+                am[2][0] = rt.zx();
+                am[2][1] = rt.zy();
+                am[2][2] = rt.zz();
+                globErr = GlobalErrorExtended(ROOT::Math::SimilarityT(am, as));
+              } else {
+                if (readFullLocalMatrix_)
+                  globErr =
+                      GlobalErrorExtended(x11, x21, x31, 0, 0, 0, x22, x32, 0, 0, 0, x33, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+                else {
+                  globErr = GlobalErrorExtended(
+                      x11 * x11, 0, 0, 0, 0, 0, x22 * x22, 0, 0, 0, 0, x33 * x33, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+                }
+              }
+              alidet->setAlignmentPositionError(globErr, false);  // do not propagate down!
+              apeList.insert(apeId);                              //Flag it's been set
+            } else {
+              edm::LogInfo("Alignment") << "@SUB=initialize"
+                                        << "Not Setting APE for Composite DetId " << apeId;
+            }
+          }
+        } else {
+          edm::LogInfo("Alignment") << "@SUB=initialize"
+                                    << "Skipping duplicate APE for DetId " << apeId;
+        }
+      }
+    }
+    apeReadFile.close();
+    edm::LogInfo("Alignment") << "@SUB=initialize"
+                              << "Set " << apeList.size() << " APE values.";
+  }
 }
- 
 
 // Call at end of job ---------------------------------------------------------
 //____________________________________________________
-void ApeSettingAlgorithm::terminate(const edm::EventSetup& iSetup)
-{
-  if (saveApeToAscii_)
-    { AlignmentErrorsExtended* aliErr=theTracker->alignmentErrors();
-    int theSize=aliErr->m_alignError.size();
-    std::ofstream apeSaveFile(theConfig.getUntrackedParameter<std::string>("apeASCIISaveFile").c_str()); //requires <fstream>
-    for (int i=0; i < theSize; ++i)
-      { int id=	aliErr->m_alignError[i].rawId();
-      AlignableDetOrUnitPtr alidet(theAlignableNavigator->alignableFromDetId(DetId(id))); //NULL if none
-      if (alidet && ((alidet->components().empty()) || saveComposites_))
-	{ apeSaveFile<<id;
-	CLHEP::HepSymMatrix sm = aliErr->m_alignError[i].matrix();
-	if (saveLocalNotGlobal_)
-	  { align::RotationType rt=alidet->globalRotation();
-	  AlgebraicMatrix am(3,3);
-	  am[0][0]=rt.xx(); am[0][1]=rt.xy(); am[0][2]=rt.xz();
-	  am[1][0]=rt.yx(); am[1][1]=rt.yy(); am[1][2]=rt.yz();
-	  am[2][0]=rt.zx(); am[2][1]=rt.zy(); am[2][2]=rt.zz();
-	  sm=sm.similarity(am); //symmetric matrix
-	  } //transform to local
-	for (int j=0; j < sm.num_row(); ++j)
-	  for (int k=0; k <= j; ++k)
-	    apeSaveFile<<"  "<<sm[j][k]; //always write full matrix
-	
-	apeSaveFile<<std::endl;
-	}
+void ApeSettingAlgorithm::terminate(const edm::EventSetup &iSetup) {
+  if (saveApeToAscii_) {
+    AlignmentErrorsExtended *aliErr = theTracker->alignmentErrors();
+    int theSize = aliErr->m_alignError.size();
+    std::ofstream apeSaveFile(
+        theConfig.getUntrackedParameter<std::string>("apeASCIISaveFile").c_str());  //requires <fstream>
+    for (int i = 0; i < theSize; ++i) {
+      int id = aliErr->m_alignError[i].rawId();
+      AlignableDetOrUnitPtr alidet(theAlignableNavigator->alignableFromDetId(DetId(id)));  //NULL if none
+      if (alidet && ((alidet->components().empty()) || saveComposites_)) {
+        apeSaveFile << id;
+        CLHEP::HepSymMatrix sm = aliErr->m_alignError[i].matrix();
+        if (saveLocalNotGlobal_) {
+          align::RotationType rt = alidet->globalRotation();
+          AlgebraicMatrix am(3, 3);
+          am[0][0] = rt.xx();
+          am[0][1] = rt.xy();
+          am[0][2] = rt.xz();
+          am[1][0] = rt.yx();
+          am[1][1] = rt.yy();
+          am[1][2] = rt.yz();
+          am[2][0] = rt.zx();
+          am[2][1] = rt.zy();
+          am[2][2] = rt.zz();
+          sm = sm.similarity(am);  //symmetric matrix
+        }                          //transform to local
+        for (int j = 0; j < sm.num_row(); ++j)
+          for (int k = 0; k <= j; ++k)
+            apeSaveFile << "  " << sm[j][k];  //always write full matrix
+
+        apeSaveFile << std::endl;
       }
+    }
     delete aliErr;
     apeSaveFile.close();
-    }
+  }
   // clean up at end:  // FIXME: should we delete here or in destructor?
   delete theAlignableNavigator;
   theAlignableNavigator = nullptr;
@@ -228,11 +251,9 @@ void ApeSettingAlgorithm::terminate(const edm::EventSetup& iSetup)
 
 // Run the algorithm on trajectories and tracks -------------------------------
 //____________________________________________________
-void ApeSettingAlgorithm::run(const edm::EventSetup &setup, const EventInfo &eventInfo)
-{
+void ApeSettingAlgorithm::run(const edm::EventSetup &setup, const EventInfo &eventInfo) {
   // nothing to do here?
 }
 
 // Plugin definition for the algorithm
-DEFINE_EDM_PLUGIN(AlignmentAlgorithmPluginFactory,
-		   ApeSettingAlgorithm, "ApeSettingAlgorithm");
+DEFINE_EDM_PLUGIN(AlignmentAlgorithmPluginFactory, ApeSettingAlgorithm, "ApeSettingAlgorithm");

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiStripBackplaneCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiStripBackplaneCalibration.cc
@@ -52,12 +52,11 @@
 #include <cstdio>
 #include <functional>
 
-class SiStripBackplaneCalibration : public IntegratedCalibrationBase
-{
+class SiStripBackplaneCalibration : public IntegratedCalibrationBase {
 public:
   /// Constructor
   explicit SiStripBackplaneCalibration(const edm::ParameterSet &cfg);
-  
+
   /// Destructor
   ~SiStripBackplaneCalibration() override;
 
@@ -75,10 +74,10 @@ public:
   /// Return non-zero derivatives for x- and y-measurements with their indices by reference.
   /// Return value is their number.
   unsigned int derivatives(std::vector<ValuesIndexPair> &outDerivInds,
-				   const TransientTrackingRecHit &hit,
-				   const TrajectoryStateOnSurface &tsos,
-				   const edm::EventSetup &setup,
-				   const EventInfo &eventInfo) const override;
+                           const TransientTrackingRecHit &hit,
+                           const TrajectoryStateOnSurface &tsos,
+                           const edm::EventSetup &setup,
+                           const EventInfo &eventInfo) const override;
 
   /// Setting the determined parameter identified by index,
   /// returns false if out-of-bounds, true otherwise.
@@ -97,9 +96,7 @@ public:
   double getParameterError(unsigned int index) const override;
 
   // /// Call at beginning of job:
-  void beginOfJob(AlignableTracker *tracker,
-  			  AlignableMuon *muon,
-  			  AlignableExtras *extras) override;
+  void beginOfJob(AlignableTracker *tracker, AlignableMuon *muon, AlignableExtras *extras) override;
 
   /// Called at end of a the job of the AlignmentProducer.
   /// Write out determined parameters.
@@ -112,15 +109,16 @@ private:
   /// Input BackPlaneCorrection values:
   /// - either from EventSetup of first call to derivatives(..)
   /// - or created from files of passed by configuration (i.e. from parallel processing)
-  const SiStripBackPlaneCorrection* getBackPlaneCorrectionInput();
+  const SiStripBackPlaneCorrection *getBackPlaneCorrectionInput();
 
   /// Determined parameter value for this detId (detId not treated => 0.)
   /// and the given run.
   double getParameterForDetId(unsigned int detId, edm::RunNumber_t run) const;
 
   void writeTree(const SiStripBackPlaneCorrection *backPlaneCorr,
-		 const std::map<unsigned int,TreeStruct> &treeInfo, const char *treeName) const;
-  SiStripBackPlaneCorrection* createFromTree(const char *fileName, const char *treeName) const;
+                 const std::map<unsigned int, TreeStruct> &treeInfo,
+                 const char *treeName) const;
+  SiStripBackPlaneCorrection *createFromTree(const char *fileName, const char *treeName) const;
 
   const std::string readoutModeName_;
   int16_t readoutMode_;
@@ -138,7 +136,6 @@ private:
 
   TkModuleGroupSelector *moduleGroupSelector_;
   const edm::ParameterSet moduleGroupSelCfg_;
-
 };
 
 //======================================================================
@@ -146,17 +143,15 @@ private:
 //======================================================================
 
 SiStripBackplaneCalibration::SiStripBackplaneCalibration(const edm::ParameterSet &cfg)
-  : IntegratedCalibrationBase(cfg),
-    readoutModeName_(cfg.getParameter<std::string>("readoutMode")),
-    saveToDB_(cfg.getParameter<bool>("saveToDB")),
-    recordNameDBwrite_(cfg.getParameter<std::string>("recordNameDBwrite")),
-    outFileName_(cfg.getParameter<std::string>("treeFile")),
-    mergeFileNames_(cfg.getParameter<std::vector<std::string> >("mergeTreeFiles")),
-    siStripBackPlaneCorrInput_(nullptr),
-    moduleGroupSelector_(nullptr),
-    moduleGroupSelCfg_(cfg.getParameter<edm::ParameterSet>("BackplaneModuleGroups"))
-{
-
+    : IntegratedCalibrationBase(cfg),
+      readoutModeName_(cfg.getParameter<std::string>("readoutMode")),
+      saveToDB_(cfg.getParameter<bool>("saveToDB")),
+      recordNameDBwrite_(cfg.getParameter<std::string>("recordNameDBwrite")),
+      outFileName_(cfg.getParameter<std::string>("treeFile")),
+      mergeFileNames_(cfg.getParameter<std::vector<std::string> >("mergeTreeFiles")),
+      siStripBackPlaneCorrInput_(nullptr),
+      moduleGroupSelector_(nullptr),
+      moduleGroupSelCfg_(cfg.getParameter<edm::ParameterSet>("BackplaneModuleGroups")) {
   // SiStripLatency::singleReadOutMode() returns
   // 1: all in peak, 0: all in deco, -1: mixed state
   // (in principle one could treat even mixed state APV by APV...)
@@ -165,101 +160,93 @@ SiStripBackplaneCalibration::SiStripBackplaneCalibration(const edm::ParameterSet
   } else if (readoutModeName_ == "deconvolution") {
     readoutMode_ = kDeconvolutionMode;
   } else {
-    throw cms::Exception("BadConfig")
-	  << "SiStripBackplaneCalibration:\n" << "Unknown mode '" 
-	  << readoutModeName_ << "', should be 'peak' or 'deconvolution' .\n";
+    throw cms::Exception("BadConfig") << "SiStripBackplaneCalibration:\n"
+                                      << "Unknown mode '" << readoutModeName_
+                                      << "', should be 'peak' or 'deconvolution' .\n";
   }
-
 }
-  
+
 //======================================================================
-SiStripBackplaneCalibration::~SiStripBackplaneCalibration()
-{
+SiStripBackplaneCalibration::~SiStripBackplaneCalibration() {
   delete moduleGroupSelector_;
   //  std::cout << "Destroy SiStripBackplaneCalibration named " << this->name() << std::endl;
   delete siStripBackPlaneCorrInput_;
 }
 
 //======================================================================
-unsigned int SiStripBackplaneCalibration::numParameters() const
-{
-  return parameters_.size();
-}
+unsigned int SiStripBackplaneCalibration::numParameters() const { return parameters_.size(); }
 
 //======================================================================
-unsigned int
-SiStripBackplaneCalibration::derivatives(std::vector<ValuesIndexPair> &outDerivInds,
-					 const TransientTrackingRecHit &hit,
-					 const TrajectoryStateOnSurface &tsos,
-					 const edm::EventSetup &setup,
-					 const EventInfo &eventInfo) const
-{
+unsigned int SiStripBackplaneCalibration::derivatives(std::vector<ValuesIndexPair> &outDerivInds,
+                                                      const TransientTrackingRecHit &hit,
+                                                      const TrajectoryStateOnSurface &tsos,
+                                                      const edm::EventSetup &setup,
+                                                      const EventInfo &eventInfo) const {
   // ugly const-cast:
   // But it is either only first initialisation or throwing an exception...
-  const_cast<SiStripBackplaneCalibration*>(this)->checkBackPlaneCorrectionInput(setup, eventInfo);
+  const_cast<SiStripBackplaneCalibration *>(this)->checkBackPlaneCorrectionInput(setup, eventInfo);
 
   outDerivInds.clear();
 
-  edm::ESHandle<SiStripLatency> latency;  
+  edm::ESHandle<SiStripLatency> latency;
   setup.get<SiStripLatencyRcd>().get(latency);
   const int16_t mode = latency->singleReadOutMode();
 
-  if(mode == readoutMode_) {
-    if (hit.det()) { // otherwise 'constraint hit' or whatever
-      
-      const int index = moduleGroupSelector_->getParameterIndexFromDetId(hit.det()->geographicalId(),
-									 eventInfo.eventId().run());
-      if (index >= 0) { // otherwise not treated
+  if (mode == readoutMode_) {
+    if (hit.det()) {  // otherwise 'constraint hit' or whatever
+
+      const int index =
+          moduleGroupSelector_->getParameterIndexFromDetId(hit.det()->geographicalId(), eventInfo.eventId().run());
+      if (index >= 0) {  // otherwise not treated
         edm::ESHandle<MagneticField> magneticField;
         setup.get<IdealMagneticFieldRecord>().get(magneticField);
         const GlobalVector bField(magneticField->inTesla(hit.det()->surface().position()));
         const LocalVector bFieldLocal(hit.det()->surface().toLocal(bField));
         //std::cout << "SiStripBackplaneCalibration derivatives " << readoutModeName_ << std::endl;
-        const double dZ = hit.det()->surface().bounds().thickness(); // it's a float only...
-	const double tanPsi = tsos.localParameters().mixedFormatVector()[1]; //float...
+        const double dZ = hit.det()->surface().bounds().thickness();          // it's a float only...
+        const double tanPsi = tsos.localParameters().mixedFormatVector()[1];  //float...
 
-	edm::ESHandle<SiStripLorentzAngle> lorentzAngleHandle;
-	setup.get<SiStripLorentzAngleRcd>().get(readoutModeName_, lorentzAngleHandle);
-	// Yes, mobility (= LA/By) stored in object called LA...
-	const double mobility = lorentzAngleHandle->getLorentzAngle(hit.det()->geographicalId());
+        edm::ESHandle<SiStripLorentzAngle> lorentzAngleHandle;
+        setup.get<SiStripLorentzAngleRcd>().get(readoutModeName_, lorentzAngleHandle);
+        // Yes, mobility (= LA/By) stored in object called LA...
+        const double mobility = lorentzAngleHandle->getLorentzAngle(hit.det()->geographicalId());
         // shift due to dead back plane has two parts:
-	// 1) Lorentz Angle correction formula gets reduced thickness dz*(1-bp)
-	// 2) 'Direct' effect is shift of effective module position in local z by bp*dz/2
-	//   (see GF's presentation in alignment meeting 25.10.2012,
-	//    https://indico.cern.ch/conferenceDisplay.py?confId=174266#2012-10-25)
+        // 1) Lorentz Angle correction formula gets reduced thickness dz*(1-bp)
+        // 2) 'Direct' effect is shift of effective module position in local z by bp*dz/2
+        //   (see GF's presentation in alignment meeting 25.10.2012,
+        //    https://indico.cern.ch/conferenceDisplay.py?confId=174266#2012-10-25)
         //        const double xDerivative = 0.5 * dZ * (mobility * bFieldLocal.y() - tanPsi);
-        //FIXME: +tanPsi? At least that fits the sign of the dr/dw residual 
+        //FIXME: +tanPsi? At least that fits the sign of the dr/dw residual
         //       in KarimakiDerivatives...
         const double xDerivative = 0.5 * dZ * (mobility * bFieldLocal.y() + tanPsi);
-	// std::cout << "derivative is " << xDerivative << " for index " << index 
-	// 	  << std::endl;
-//         if (index >= 10) {
-//           std::cout << "mobility * y-field " << mobility * bFieldLocal.y()
-//                     << ", \n tanPsi " << tanPsi /*<< ", dZ " << dZ */ << std::endl;
-//           std::cout << "|tanPsi| - |mobility * y-field| "
-//                     << fabs(tanPsi) - fabs(mobility * bFieldLocal.y())
-//                     << std::endl;
-//         }
-	const Values derivs(xDerivative, 0.); // yDerivative = 0.
-	outDerivInds.push_back(ValuesIndexPair(derivs, index));
+        // std::cout << "derivative is " << xDerivative << " for index " << index
+        // 	  << std::endl;
+        //         if (index >= 10) {
+        //           std::cout << "mobility * y-field " << mobility * bFieldLocal.y()
+        //                     << ", \n tanPsi " << tanPsi /*<< ", dZ " << dZ */ << std::endl;
+        //           std::cout << "|tanPsi| - |mobility * y-field| "
+        //                     << fabs(tanPsi) - fabs(mobility * bFieldLocal.y())
+        //                     << std::endl;
+        //         }
+        const Values derivs(xDerivative, 0.);  // yDerivative = 0.
+        outDerivInds.push_back(ValuesIndexPair(derivs, index));
       }
     } else {
       edm::LogWarning("Alignment") << "@SUB=SiStripBackplaneCalibration::derivatives1"
                                    << "Hit without GeomDet, skip!";
     }
   } else if (mode != kDeconvolutionMode && mode != kPeakMode) {
-    // warn only if unknown/mixed mode  
+    // warn only if unknown/mixed mode
     edm::LogWarning("Alignment") << "@SUB=SiStripBackplaneCalibration::derivatives2"
-                                 << "Readout mode is " << mode << ", but looking for "
-                                 << readoutMode_ << " (" << readoutModeName_ << ").";
+                                 << "Readout mode is " << mode << ", but looking for " << readoutMode_ << " ("
+                                 << readoutModeName_ << ").";
   }
-  
+
   return outDerivInds.size();
 }
 
 //======================================================================
-bool SiStripBackplaneCalibration::setParameter(unsigned int index, double value)
-{
+bool SiStripBackplaneCalibration::setParameter(unsigned int index, double value) {
   if (index >= parameters_.size()) {
     return false;
   } else {
@@ -269,8 +256,7 @@ bool SiStripBackplaneCalibration::setParameter(unsigned int index, double value)
 }
 
 //======================================================================
-bool SiStripBackplaneCalibration::setParameterError(unsigned int index, double error)
-{
+bool SiStripBackplaneCalibration::setParameterError(unsigned int index, double error) {
   if (index >= paramUncertainties_.size()) {
     return false;
   } else {
@@ -280,50 +266,44 @@ bool SiStripBackplaneCalibration::setParameterError(unsigned int index, double e
 }
 
 //======================================================================
-double SiStripBackplaneCalibration::getParameter(unsigned int index) const
-{
+double SiStripBackplaneCalibration::getParameter(unsigned int index) const {
   return (index >= parameters_.size() ? 0. : parameters_[index]);
 }
 
 //======================================================================
-double SiStripBackplaneCalibration::getParameterError(unsigned int index) const
-{
+double SiStripBackplaneCalibration::getParameterError(unsigned int index) const {
   return (index >= paramUncertainties_.size() ? 0. : paramUncertainties_[index]);
 }
 
 //======================================================================
 void SiStripBackplaneCalibration::beginOfJob(AlignableTracker *aliTracker,
                                              AlignableMuon * /*aliMuon*/,
-                                             AlignableExtras */*aliExtras*/)
-{
+                                             AlignableExtras * /*aliExtras*/) {
   //specify the sub-detectors for which the back plane correction is determined: all strips
-  const std::vector<int> sdets = boost::assign::list_of(SiStripDetId::TIB)(SiStripDetId::TID)
-    (SiStripDetId::TOB)(SiStripDetId::TEC);
-  
+  const std::vector<int> sdets =
+      boost::assign::list_of(SiStripDetId::TIB)(SiStripDetId::TID)(SiStripDetId::TOB)(SiStripDetId::TEC);
+
   moduleGroupSelector_ = new TkModuleGroupSelector(aliTracker, moduleGroupSelCfg_, sdets);
-  
+
   parameters_.resize(moduleGroupSelector_->getNumberOfParameters(), 0.);
   paramUncertainties_.resize(moduleGroupSelector_->getNumberOfParameters(), 0.);
 
-  edm::LogInfo("Alignment") << "@SUB=SiStripBackplaneCalibration" << "Created with name "
-                            << this->name() << " for readout mode '" << readoutModeName_
-			    << "',\n" << this->numParameters() << " parameters to be determined."
-                            << "\nsaveToDB = " << saveToDB_
-                            << "\n outFileName = " << outFileName_
+  edm::LogInfo("Alignment") << "@SUB=SiStripBackplaneCalibration"
+                            << "Created with name " << this->name() << " for readout mode '" << readoutModeName_
+                            << "',\n"
+                            << this->numParameters() << " parameters to be determined."
+                            << "\nsaveToDB = " << saveToDB_ << "\n outFileName = " << outFileName_
                             << "\n N(merge files) = " << mergeFileNames_.size()
                             << "\n number of IOVs = " << moduleGroupSelector_->numIovs();
-  
+
   if (!mergeFileNames_.empty()) {
     edm::LogInfo("Alignment") << "@SUB=SiStripBackplaneCalibration"
                               << "First file to merge: " << mergeFileNames_[0];
   }
-  
 }
 
-
 //======================================================================
-void SiStripBackplaneCalibration::endOfJob()
-{
+void SiStripBackplaneCalibration::endOfJob() {
   // loginfo output
   std::ostringstream out;
   out << "Parameter results for readout mode '" << readoutModeName_ << "'\n";
@@ -332,33 +312,33 @@ void SiStripBackplaneCalibration::endOfJob()
   }
   edm::LogInfo("Alignment") << "@SUB=SiStripBackplaneCalibration::endOfJob" << out.str();
 
-  std::map<unsigned int, TreeStruct> treeInfo; // map of TreeStruct for each detId
+  std::map<unsigned int, TreeStruct> treeInfo;  // map of TreeStruct for each detId
 
   // now write 'input' tree
-  const SiStripBackPlaneCorrection *input = this->getBackPlaneCorrectionInput(); // never NULL
+  const SiStripBackPlaneCorrection *input = this->getBackPlaneCorrectionInput();  // never NULL
   const std::string treeName(this->name() + '_' + readoutModeName_ + '_');
-  this->writeTree(input, treeInfo, (treeName + "input").c_str()); // empty treeInfo for input...
+  this->writeTree(input, treeInfo, (treeName + "input").c_str());  // empty treeInfo for input...
 
   if (input->getBackPlaneCorrections().empty()) {
     edm::LogError("Alignment") << "@SUB=SiStripBackplaneCalibration::endOfJob"
-			       << "Input back plane correction map is empty ('"
-			       << readoutModeName_ << "' mode), skip writing output!";
+                               << "Input back plane correction map is empty ('" << readoutModeName_
+                               << "' mode), skip writing output!";
     return;
   }
 
-  const unsigned int nonZeroParamsOrErrors =   // Any determined value?
-    count_if (parameters_.begin(), parameters_.end(),[](auto c){return c != 0.;})
-    + count_if(paramUncertainties_.begin(), paramUncertainties_.end(),
-              [](auto c){return c!= 0.;});
+  const unsigned int nonZeroParamsOrErrors =  // Any determined value?
+      count_if(parameters_.begin(), parameters_.end(), [](auto c) { return c != 0.; }) +
+      count_if(paramUncertainties_.begin(), paramUncertainties_.end(), [](auto c) { return c != 0.; });
 
   for (unsigned int iIOV = 0; iIOV < moduleGroupSelector_->numIovs(); ++iIOV) {
     cond::Time_t firstRunOfIOV = moduleGroupSelector_->firstRunOfIOV(iIOV);
     SiStripBackPlaneCorrection *output = new SiStripBackPlaneCorrection;
     // Loop on map of values from input and add (possible) parameter results
     for (auto iterIdValue = input->getBackPlaneCorrections().begin();
-	 iterIdValue != input->getBackPlaneCorrections().end(); ++iterIdValue) {
+         iterIdValue != input->getBackPlaneCorrections().end();
+         ++iterIdValue) {
       // type of (*iterIdValue) is pair<unsigned int, float>
-      const unsigned int detId = iterIdValue->first; // key of map is DetId
+      const unsigned int detId = iterIdValue->first;  // key of map is DetId
       // Some code one could use to miscalibrate wrt input:
       // double param = 0.;
       // const DetId id(detId);
@@ -388,34 +368,33 @@ void SiStripBackplaneCalibration::endOfJob()
       const double param = this->getParameterForDetId(detId, firstRunOfIOV);
       // put result in output, i.e. sum of input and determined parameter:
       output->putBackPlaneCorrection(detId, iterIdValue->second + param);
-      const int paramIndex = moduleGroupSelector_->getParameterIndexFromDetId(detId,firstRunOfIOV);
+      const int paramIndex = moduleGroupSelector_->getParameterIndexFromDetId(detId, firstRunOfIOV);
       treeInfo[detId] = TreeStruct(param, this->getParameterError(paramIndex), paramIndex);
     }
 
-    if (saveToDB_ || nonZeroParamsOrErrors != 0) { // Skip writing mille jobs...
+    if (saveToDB_ || nonZeroParamsOrErrors != 0) {  // Skip writing mille jobs...
       this->writeTree(output, treeInfo, (treeName + Form("result_%lld", firstRunOfIOV)).c_str());
     }
 
-    if (saveToDB_) { // If requested, write out to DB 
+    if (saveToDB_) {  // If requested, write out to DB
       edm::Service<cond::service::PoolDBOutputService> dbService;
       if (dbService.isAvailable()) {
-	dbService->writeOne(output, firstRunOfIOV, recordNameDBwrite_);
-	// no 'delete output;': writeOne(..) took over ownership
+        dbService->writeOne(output, firstRunOfIOV, recordNameDBwrite_);
+        // no 'delete output;': writeOne(..) took over ownership
       } else {
-	delete output;
-	edm::LogError("BadConfig") << "@SUB=SiStripBackplaneCalibration::endOfJob"
-				   << "No PoolDBOutputService available, but saveToDB true!";
+        delete output;
+        edm::LogError("BadConfig") << "@SUB=SiStripBackplaneCalibration::endOfJob"
+                                   << "No PoolDBOutputService available, but saveToDB true!";
       }
     } else {
       delete output;
     }
-  } // end loop on IOVs
+  }  // end loop on IOVs
 }
 
 //======================================================================
 bool SiStripBackplaneCalibration::checkBackPlaneCorrectionInput(const edm::EventSetup &setup,
-								const EventInfo &eventInfo)
-{
+                                                                const EventInfo &eventInfo) {
   edm::ESHandle<SiStripBackPlaneCorrection> backPlaneCorrHandle;
   if (!siStripBackPlaneCorrInput_) {
     setup.get<SiStripBackPlaneCorrectionRcd>().get(readoutModeName_, backPlaneCorrHandle);
@@ -424,69 +403,63 @@ bool SiStripBackplaneCalibration::checkBackPlaneCorrectionInput(const edm::Event
     //        Otherwise could be that next check has to check via following 'else', though
     //        no new IOV has started... (to be checked)
   } else {
-    if (watchBackPlaneCorrRcd_.check(setup)) { // new IOV of input - but how to check peak vs deco?
+    if (watchBackPlaneCorrRcd_.check(setup)) {  // new IOV of input - but how to check peak vs deco?
       setup.get<SiStripBackPlaneCorrectionRcd>().get(readoutModeName_, backPlaneCorrHandle);
-      if (backPlaneCorrHandle->getBackPlaneCorrections() // but only bad if non-identical values
-	  != siStripBackPlaneCorrInput_->getBackPlaneCorrections()) { // (comparing maps)
-	// Maps are containers sorted by key, but comparison problems may arise from
-	// 'floating point comparison' problems (FIXME?)
-	throw cms::Exception("BadInput")
-	  << "SiStripBackplaneCalibration::checkBackPlaneCorrectionInput:\n"
-	  << "Content of SiStripBackPlaneCorrection changed at run " << eventInfo.eventId().run()
-	  << ", but algorithm expects constant input!\n";
-	return false; // not reached...
+      if (backPlaneCorrHandle->getBackPlaneCorrections()               // but only bad if non-identical values
+          != siStripBackPlaneCorrInput_->getBackPlaneCorrections()) {  // (comparing maps)
+        // Maps are containers sorted by key, but comparison problems may arise from
+        // 'floating point comparison' problems (FIXME?)
+        throw cms::Exception("BadInput") << "SiStripBackplaneCalibration::checkBackPlaneCorrectionInput:\n"
+                                         << "Content of SiStripBackPlaneCorrection changed at run "
+                                         << eventInfo.eventId().run() << ", but algorithm expects constant input!\n";
+        return false;  // not reached...
       }
     }
   }
-  
+
   return true;
 }
 
 //======================================================================
-const SiStripBackPlaneCorrection* SiStripBackplaneCalibration::getBackPlaneCorrectionInput()
-{
+const SiStripBackPlaneCorrection *SiStripBackplaneCalibration::getBackPlaneCorrectionInput() {
   // For parallel processing in Millepede II, create SiStripBackPlaneCorrection
   // from info stored in files of parallel jobs and check that they are identical.
   // If this job has run on events, still check that back plane corrections are
   // identical to the ones from mergeFileNames_.
   const std::string treeName(((this->name() + '_') += readoutModeName_) += "_input");
   for (auto iFile = mergeFileNames_.begin(); iFile != mergeFileNames_.end(); ++iFile) {
-    SiStripBackPlaneCorrection* bpCorr = this->createFromTree(iFile->c_str(), treeName.c_str());
+    SiStripBackPlaneCorrection *bpCorr = this->createFromTree(iFile->c_str(), treeName.c_str());
     // siStripBackPlaneCorrInput_ could be non-null from previous file of this loop
     // or from checkBackPlaneCorrectionInput(..) when running on data in this job as well
     if (!siStripBackPlaneCorrInput_ || siStripBackPlaneCorrInput_->getBackPlaneCorrections().empty()) {
-      delete siStripBackPlaneCorrInput_; // NULL or empty
+      delete siStripBackPlaneCorrInput_;  // NULL or empty
       siStripBackPlaneCorrInput_ = bpCorr;
     } else {
       // about comparison of maps see comments in checkBackPlaneCorrectionInput
-      if (bpCorr && !bpCorr->getBackPlaneCorrections().empty() && // single job might not have got events
+      if (bpCorr && !bpCorr->getBackPlaneCorrections().empty() &&  // single job might not have got events
           bpCorr->getBackPlaneCorrections() != siStripBackPlaneCorrInput_->getBackPlaneCorrections()) {
         // Throw exception instead of error?
         edm::LogError("NoInput") << "@SUB=SiStripBackplaneCalibration::getBackPlaneCorrectionInput"
-                                 << "Different input values from tree " << treeName
-                                 << " in file " << *iFile << ".";
-        
+                                 << "Different input values from tree " << treeName << " in file " << *iFile << ".";
       }
       delete bpCorr;
     }
   }
 
-  if (!siStripBackPlaneCorrInput_) { // no files nor ran on events
+  if (!siStripBackPlaneCorrInput_) {  // no files nor ran on events
     siStripBackPlaneCorrInput_ = new SiStripBackPlaneCorrection;
     edm::LogError("NoInput") << "@SUB=SiStripBackplaneCalibration::getBackPlaneCorrectionInput"
-			     << "No input, create an empty one ('" << readoutModeName_ << "' mode)!";
+                             << "No input, create an empty one ('" << readoutModeName_ << "' mode)!";
   } else if (siStripBackPlaneCorrInput_->getBackPlaneCorrections().empty()) {
     edm::LogError("NoInput") << "@SUB=SiStripBackplaneCalibration::getBackPlaneCorrectionInput"
-			     << "Empty result ('" << readoutModeName_ << "' mode)!";
+                             << "Empty result ('" << readoutModeName_ << "' mode)!";
   }
 
   return siStripBackPlaneCorrInput_;
 }
 
 //======================================================================
-double SiStripBackplaneCalibration::getParameterForDetId(unsigned int detId,
-							 edm::RunNumber_t run) const
-{
+double SiStripBackplaneCalibration::getParameterForDetId(unsigned int detId, edm::RunNumber_t run) const {
   const int index = moduleGroupSelector_->getParameterIndexFromDetId(detId, run);
 
   return (index < 0 ? 0. : parameters_[index]);
@@ -495,14 +468,14 @@ double SiStripBackplaneCalibration::getParameterForDetId(unsigned int detId,
 //======================================================================
 void SiStripBackplaneCalibration::writeTree(const SiStripBackPlaneCorrection *backPlaneCorrection,
                                             const std::map<unsigned int, TreeStruct> &treeInfo,
-					    const char *treeName) const
-{
-  if (!backPlaneCorrection) return;
+                                            const char *treeName) const {
+  if (!backPlaneCorrection)
+    return;
 
-  TFile* file = TFile::Open(outFileName_.c_str(), "UPDATE");
+  TFile *file = TFile::Open(outFileName_.c_str(), "UPDATE");
   if (!file) {
     edm::LogError("BadConfig") << "@SUB=SiStripBackplaneCalibration::writeTree"
-			       << "Could not open file '" << outFileName_ << "'.";
+                               << "Could not open file '" << outFileName_ << "'.";
     return;
   }
 
@@ -515,15 +488,16 @@ void SiStripBackplaneCalibration::writeTree(const SiStripBackPlaneCorrection *ba
   tree->Branch("treeStruct", &treeStruct, TreeStruct::LeafList());
 
   for (auto iterIdValue = backPlaneCorrection->getBackPlaneCorrections().begin();
-       iterIdValue != backPlaneCorrection->getBackPlaneCorrections().end(); ++iterIdValue) {
+       iterIdValue != backPlaneCorrection->getBackPlaneCorrections().end();
+       ++iterIdValue) {
     // type of (*iterIdValue) is pair<unsigned int, float>
-    id = iterIdValue->first; // key of map is DetId
+    id = iterIdValue->first;  // key of map is DetId
     value = iterIdValue->second;
     // type of (*treeStructIter) is pair<unsigned int, TreeStruct>
-    auto treeStructIter = treeInfo.find(id); // find info for this id
+    auto treeStructIter = treeInfo.find(id);  // find info for this id
     if (treeStructIter != treeInfo.end()) {
-      treeStruct = treeStructIter->second; // info from input map
-    } else { // if none found, fill at least parameter index (using 1st IOV...)
+      treeStruct = treeStructIter->second;  // info from input map
+    } else {                                // if none found, fill at least parameter index (using 1st IOV...)
       const cond::Time_t run1of1stIov = moduleGroupSelector_->firstRunOfIOV(0);
       const int ind = moduleGroupSelector_->getParameterIndexFromDetId(id, run1of1stIov);
       treeStruct = TreeStruct(ind);
@@ -531,25 +505,24 @@ void SiStripBackplaneCalibration::writeTree(const SiStripBackPlaneCorrection *ba
     tree->Fill();
   }
   tree->Write();
-  delete file; // tree vanishes with the file...
-
+  delete file;  // tree vanishes with the file...
 }
 
 //======================================================================
-SiStripBackPlaneCorrection* 
-SiStripBackplaneCalibration::createFromTree(const char *fileName, const char *treeName) const
-{
+SiStripBackPlaneCorrection *SiStripBackplaneCalibration::createFromTree(const char *fileName,
+                                                                        const char *treeName) const {
   // Check for file existence on your own to work around
   // https://hypernews.cern.ch/HyperNews/CMS/get/swDevelopment/2715.html:
-  TFile* file = nullptr;
-  FILE* testFile = fopen(fileName,"r");
+  TFile *file = nullptr;
+  FILE *testFile = fopen(fileName, "r");
   if (testFile) {
     fclose(testFile);
     file = TFile::Open(fileName, "READ");
-  } // else not existing, see error below
+  }  // else not existing, see error below
 
   TTree *tree = nullptr;
-  if (file) file->GetObject(treeName, tree);
+  if (file)
+    file->GetObject(treeName, tree);
 
   SiStripBackPlaneCorrection *result = nullptr;
   if (tree) {
@@ -564,16 +537,15 @@ SiStripBackplaneCalibration::createFromTree(const char *fileName, const char *tr
       tree->GetEntry(iEntry);
       result->putBackPlaneCorrection(id, value);
     }
-  } else { // Warning only since could be parallel job on no events.
+  } else {  // Warning only since could be parallel job on no events.
     edm::LogWarning("Alignment") << "@SUB=SiStripBackplaneCalibration::createFromTree"
-                                 << "Could not get TTree '" << treeName << "' from file '"
-                                 << fileName << (file ? "'." : "' (file does not exist).");
+                                 << "Could not get TTree '" << treeName << "' from file '" << fileName
+                                 << (file ? "'." : "' (file does not exist).");
   }
 
-  delete file; // tree will vanish with file
+  delete file;  // tree will vanish with file
   return result;
 }
-
 
 //======================================================================
 //======================================================================
@@ -581,5 +553,4 @@ SiStripBackplaneCalibration::createFromTree(const char *fileName, const char *tr
 
 #include "Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationPluginFactory.h"
 
-DEFINE_EDM_PLUGIN(IntegratedCalibrationPluginFactory,
-		   SiStripBackplaneCalibration, "SiStripBackplaneCalibration");
+DEFINE_EDM_PLUGIN(IntegratedCalibrationPluginFactory, SiStripBackplaneCalibration, "SiStripBackplaneCalibration");

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
@@ -50,8 +50,7 @@
 #include <memory>
 #include <functional>
 
-class SiStripLorentzAngleCalibration : public IntegratedCalibrationBase
-{
+class SiStripLorentzAngleCalibration : public IntegratedCalibrationBase {
 public:
   /// Constructor
   explicit SiStripLorentzAngleCalibration(const edm::ParameterSet &cfg);
@@ -87,12 +86,10 @@ public:
   double getParameterError(unsigned int index) const override;
 
   // /// Call at beginning of job:
-  void beginOfJob(AlignableTracker *tracker,
-                  AlignableMuon *muon,
-                  AlignableExtras *extras) override;
+  void beginOfJob(AlignableTracker *tracker, AlignableMuon *muon, AlignableExtras *extras) override;
 
   /// Call at beginning of run:
-  void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void beginRun(const edm::Run &, const edm::EventSetup &) override;
 
   /// Called at end of a the job of the AlignmentProducer.
   /// Write out determined parameters.
@@ -102,7 +99,7 @@ private:
   /// Input LorentzAngle values:
   /// - either from EventSetup of first call to derivatives(..)
   /// - or created from files of passed by configuration (i.e. from parallel processing)
-  const SiStripLorentzAngle* getLorentzAnglesInput(const align::RunNumber& = 0);
+  const SiStripLorentzAngle *getLorentzAnglesInput(const align::RunNumber & = 0);
   /// in non-peak mode the effective thickness is reduced...
   double effectiveThickness(const GeomDet *det, int16_t mode, const edm::EventSetup &setup) const;
 
@@ -111,7 +108,8 @@ private:
   double getParameterForDetId(unsigned int detId, edm::RunNumber_t run) const;
 
   void writeTree(const SiStripLorentzAngle *lorentzAngle,
-                 const std::map<unsigned int,TreeStruct> &treeInfo, const char *treeName) const;
+                 const std::map<unsigned int, TreeStruct> &treeInfo,
+                 const char *treeName) const;
   SiStripLorentzAngle createFromTree(const char *fileName, const char *treeName) const;
 
   const std::string readoutModeName_;
@@ -124,7 +122,7 @@ private:
   edm::ESWatcher<SiStripLorentzAngleRcd> watchLorentzAngleRcd_;
 
   std::map<align::RunNumber, SiStripLorentzAngle> cachedLorentzAngleInputs_;
-  SiStripLorentzAngle* siStripLorentzAngleInput_{nullptr};
+  SiStripLorentzAngle *siStripLorentzAngleInput_{nullptr};
   align::RunNumber currentIOV_{0};
 
   std::vector<double> parameters_;
@@ -139,15 +137,13 @@ private:
 //======================================================================
 
 SiStripLorentzAngleCalibration::SiStripLorentzAngleCalibration(const edm::ParameterSet &cfg)
-  : IntegratedCalibrationBase(cfg),
-    readoutModeName_(cfg.getParameter<std::string>("readoutMode")),
-    saveToDB_(cfg.getParameter<bool>("saveToDB")),
-    recordNameDBwrite_(cfg.getParameter<std::string>("recordNameDBwrite")),
-    outFileName_(cfg.getParameter<std::string>("treeFile")),
-    mergeFileNames_(cfg.getParameter<std::vector<std::string> >("mergeTreeFiles")),
-    moduleGroupSelCfg_(cfg.getParameter<edm::ParameterSet>("LorentzAngleModuleGroups"))
-{
-
+    : IntegratedCalibrationBase(cfg),
+      readoutModeName_(cfg.getParameter<std::string>("readoutMode")),
+      saveToDB_(cfg.getParameter<bool>("saveToDB")),
+      recordNameDBwrite_(cfg.getParameter<std::string>("recordNameDBwrite")),
+      outFileName_(cfg.getParameter<std::string>("treeFile")),
+      mergeFileNames_(cfg.getParameter<std::vector<std::string> >("mergeTreeFiles")),
+      moduleGroupSelCfg_(cfg.getParameter<edm::ParameterSet>("LorentzAngleModuleGroups")) {
   // SiStripLatency::singleReadOutMode() returns
   // 1: all in peak, 0: all in deco, -1: mixed state
   // (in principle one could treat even mixed state APV by APV...)
@@ -156,33 +152,27 @@ SiStripLorentzAngleCalibration::SiStripLorentzAngleCalibration(const edm::Parame
   } else if (readoutModeName_ == "deconvolution") {
     readoutMode_ = kDeconvolutionMode;
   } else {
-    throw cms::Exception("BadConfig")
-      << "SiStripLorentzAngleCalibration:\n" << "Unknown mode '"
-      << readoutModeName_ << "', should be 'peak' or 'deconvolution' .\n";
+    throw cms::Exception("BadConfig") << "SiStripLorentzAngleCalibration:\n"
+                                      << "Unknown mode '" << readoutModeName_
+                                      << "', should be 'peak' or 'deconvolution' .\n";
   }
-
 }
 
 //======================================================================
-unsigned int SiStripLorentzAngleCalibration::numParameters() const
-{
-  return parameters_.size();
-}
+unsigned int SiStripLorentzAngleCalibration::numParameters() const { return parameters_.size(); }
 
 //======================================================================
-void
-SiStripLorentzAngleCalibration::beginRun(const edm::Run& run,
-                                         const edm::EventSetup& setup) {
-
+void SiStripLorentzAngleCalibration::beginRun(const edm::Run &run, const edm::EventSetup &setup) {
   // no action needed if the LA record didn't change
-  if (!(watchLorentzAngleRcd_.check(setup))) return;
+  if (!(watchLorentzAngleRcd_.check(setup)))
+    return;
 
   const auto runNumber = run.run();
   auto firstRun = cond::timeTypeSpecs[cond::runnumber].beginValue;
 
   // avoid infinite loop due to wrap-around of unsigned variable 'i' including
   // arrow from i to zero and a nice smiley ;)
-  for (unsigned int i = moduleGroupSelector_->numIovs(); i-->0 ;) {
+  for (unsigned int i = moduleGroupSelector_->numIovs(); i-- > 0;) {
     const auto firstRunOfIOV = moduleGroupSelector_->firstRunOfIOV(i);
     if (runNumber >= firstRunOfIOV) {
       firstRun = firstRunOfIOV;
@@ -191,24 +181,22 @@ SiStripLorentzAngleCalibration::beginRun(const edm::Run& run,
   }
 
   edm::ESHandle<SiStripLorentzAngle> lorentzAngleHandle;
-  const auto& lorentzAngleRcd = setup.get<SiStripLorentzAngleRcd>();
+  const auto &lorentzAngleRcd = setup.get<SiStripLorentzAngleRcd>();
   lorentzAngleRcd.get(readoutModeName_, lorentzAngleHandle);
   if (cachedLorentzAngleInputs_.find(firstRun) == cachedLorentzAngleInputs_.end()) {
     cachedLorentzAngleInputs_.emplace(firstRun, SiStripLorentzAngle(*lorentzAngleHandle));
   } else {
     if (lorentzAngleRcd.validityInterval().first().eventID().run() > firstRun &&
-        lorentzAngleHandle->getLorentzAngles()  // only bad if non-identical values
-        != cachedLorentzAngleInputs_[firstRun].getLorentzAngles()) { // (comparing maps)
+        lorentzAngleHandle->getLorentzAngles()                            // only bad if non-identical values
+            != cachedLorentzAngleInputs_[firstRun].getLorentzAngles()) {  // (comparing maps)
       // Maps are containers sorted by key, but comparison problems may arise from
       // 'floating point comparison' problems (FIXME?)
-      throw cms::Exception("BadInput")
-        << "Trying to cache SiStripLorentzAngle payload for a run (" << runNumber
-        << ") in an IOV (" << firstRun << ") that was already cached.\n"
-        << "The following record in your input database tag has an IOV "
-        << "boundary that does not match your IOV definition:\n"
-        << " - SiStripLorentzAngleRcd '" << lorentzAngleRcd.key().name()
-        << "' (since "
-        << lorentzAngleRcd.validityInterval().first().eventID().run() << ")\n";
+      throw cms::Exception("BadInput") << "Trying to cache SiStripLorentzAngle payload for a run (" << runNumber
+                                       << ") in an IOV (" << firstRun << ") that was already cached.\n"
+                                       << "The following record in your input database tag has an IOV "
+                                       << "boundary that does not match your IOV definition:\n"
+                                       << " - SiStripLorentzAngleRcd '" << lorentzAngleRcd.key().name() << "' (since "
+                                       << lorentzAngleRcd.validityInterval().first().eventID().run() << ")\n";
     }
   }
 
@@ -217,24 +205,22 @@ SiStripLorentzAngleCalibration::beginRun(const edm::Run& run,
 }
 
 //======================================================================
-unsigned int
-SiStripLorentzAngleCalibration::derivatives(std::vector<ValuesIndexPair> &outDerivInds,
-                                            const TransientTrackingRecHit &hit,
-                                            const TrajectoryStateOnSurface &tsos,
-                                            const edm::EventSetup &setup,
-                                            const EventInfo &eventInfo) const
-{
+unsigned int SiStripLorentzAngleCalibration::derivatives(std::vector<ValuesIndexPair> &outDerivInds,
+                                                         const TransientTrackingRecHit &hit,
+                                                         const TrajectoryStateOnSurface &tsos,
+                                                         const edm::EventSetup &setup,
+                                                         const EventInfo &eventInfo) const {
   outDerivInds.clear();
 
   edm::ESHandle<SiStripLatency> latency;
   setup.get<SiStripLatencyRcd>().get(latency);
   const int16_t mode = latency->singleReadOutMode();
   if (mode == readoutMode_) {
-    if (hit.det()) { // otherwise 'constraint hit' or whatever
+    if (hit.det()) {  // otherwise 'constraint hit' or whatever
 
-      const int index = moduleGroupSelector_->getParameterIndexFromDetId(hit.det()->geographicalId(),
-                                                                         eventInfo.eventId().run());
-      if (index >= 0) { // otherwise not treated
+      const int index =
+          moduleGroupSelector_->getParameterIndexFromDetId(hit.det()->geographicalId(), eventInfo.eventId().run());
+      if (index >= 0) {  // otherwise not treated
         edm::ESHandle<MagneticField> magneticField;
         setup.get<IdealMagneticFieldRecord>().get(magneticField);
         const GlobalVector bField(magneticField->inTesla(hit.det()->surface().position()));
@@ -249,10 +235,10 @@ SiStripLorentzAngleCalibration::derivatives(std::vector<ValuesIndexPair> &outDer
         //      drift.x = -mobility * by * thickness (full drift from backside)
         //      So '-' already comes from that, not from mobility being part of
         //      track model...
-	// GM: sign convention is the same as for pixel LA, i.e. adopt it here, too
-        const double xDerivative = bFieldLocal.y() * dZ * -0.5; // parameter is mobility!
-        const double yDerivative = bFieldLocal.x() * dZ * 0.5; // parameter is mobility!
-        if (xDerivative || yDerivative) { // If field is zero, this is zero: do not return it
+        // GM: sign convention is the same as for pixel LA, i.e. adopt it here, too
+        const double xDerivative = bFieldLocal.y() * dZ * -0.5;  // parameter is mobility!
+        const double yDerivative = bFieldLocal.x() * dZ * 0.5;   // parameter is mobility!
+        if (xDerivative || yDerivative) {                        // If field is zero, this is zero: do not return it
           const Values derivs{xDerivative, yDerivative};
           outDerivInds.push_back(ValuesIndexPair(derivs, index));
         }
@@ -264,16 +250,15 @@ SiStripLorentzAngleCalibration::derivatives(std::vector<ValuesIndexPair> &outDer
   } else if (mode != kDeconvolutionMode && mode != kPeakMode) {
     // warn only if unknown/mixed mode
     edm::LogWarning("Alignment") << "@SUB=SiStripLorentzAngleCalibration::derivatives2"
-                                 << "Readout mode is " << mode << ", but looking for "
-                                 << readoutMode_ << " (" << readoutModeName_ << ").";
+                                 << "Readout mode is " << mode << ", but looking for " << readoutMode_ << " ("
+                                 << readoutModeName_ << ").";
   }
 
   return outDerivInds.size();
 }
 
 //======================================================================
-bool SiStripLorentzAngleCalibration::setParameter(unsigned int index, double value)
-{
+bool SiStripLorentzAngleCalibration::setParameter(unsigned int index, double value) {
   if (index >= parameters_.size()) {
     return false;
   } else {
@@ -283,8 +268,7 @@ bool SiStripLorentzAngleCalibration::setParameter(unsigned int index, double val
 }
 
 //======================================================================
-bool SiStripLorentzAngleCalibration::setParameterError(unsigned int index, double error)
-{
+bool SiStripLorentzAngleCalibration::setParameterError(unsigned int index, double error) {
   if (index >= paramUncertainties_.size()) {
     return false;
   } else {
@@ -294,36 +278,31 @@ bool SiStripLorentzAngleCalibration::setParameterError(unsigned int index, doubl
 }
 
 //======================================================================
-double SiStripLorentzAngleCalibration::getParameter(unsigned int index) const
-{
+double SiStripLorentzAngleCalibration::getParameter(unsigned int index) const {
   return (index >= parameters_.size() ? 0. : parameters_[index]);
 }
 
 //======================================================================
-double SiStripLorentzAngleCalibration::getParameterError(unsigned int index) const
-{
+double SiStripLorentzAngleCalibration::getParameterError(unsigned int index) const {
   return (index >= paramUncertainties_.size() ? 0. : paramUncertainties_[index]);
 }
 
 //======================================================================
 void SiStripLorentzAngleCalibration::beginOfJob(AlignableTracker *aliTracker,
                                                 AlignableMuon * /*aliMuon*/,
-                                                AlignableExtras * /*aliExtras*/)
-{
+                                                AlignableExtras * /*aliExtras*/) {
   //specify the sub-detectors for which the LA is determined
-  const std::vector<int> sdets = {SiStripDetId::TIB, SiStripDetId::TOB,
-                                  SiStripDetId::TID, SiStripDetId::TEC};
-  moduleGroupSelector_ =
-    std::make_unique<TkModuleGroupSelector>(aliTracker, moduleGroupSelCfg_, sdets);
+  const std::vector<int> sdets = {SiStripDetId::TIB, SiStripDetId::TOB, SiStripDetId::TID, SiStripDetId::TEC};
+  moduleGroupSelector_ = std::make_unique<TkModuleGroupSelector>(aliTracker, moduleGroupSelCfg_, sdets);
 
   parameters_.resize(moduleGroupSelector_->getNumberOfParameters(), 0.);
   paramUncertainties_.resize(moduleGroupSelector_->getNumberOfParameters(), 0.);
 
-  edm::LogInfo("Alignment") << "@SUB=SiStripLorentzAngleCalibration" << "Created with name "
-                            << this->name() << " for readout mode '" << readoutModeName_
-                            << "',\n" << this->numParameters() << " parameters to be determined."
-                            << "\nsaveToDB = " << saveToDB_
-                            << "\n outFileName = " << outFileName_
+  edm::LogInfo("Alignment") << "@SUB=SiStripLorentzAngleCalibration"
+                            << "Created with name " << this->name() << " for readout mode '" << readoutModeName_
+                            << "',\n"
+                            << this->numParameters() << " parameters to be determined."
+                            << "\nsaveToDB = " << saveToDB_ << "\n outFileName = " << outFileName_
                             << "\n N(merge files) = " << mergeFileNames_.size()
                             << "\n number of IOVs = " << moduleGroupSelector_->numIovs();
 
@@ -333,10 +312,8 @@ void SiStripLorentzAngleCalibration::beginOfJob(AlignableTracker *aliTracker,
   }
 }
 
-
 //======================================================================
-void SiStripLorentzAngleCalibration::endOfJob()
-{
+void SiStripLorentzAngleCalibration::endOfJob() {
   // loginfo output
   std::ostringstream out;
   out << "Parameter results for readout mode '" << readoutModeName_ << "'\n";
@@ -345,38 +322,38 @@ void SiStripLorentzAngleCalibration::endOfJob()
   }
   edm::LogInfo("Alignment") << "@SUB=SiStripLorentzAngleCalibration::endOfJob" << out.str();
 
-  std::map<unsigned int, TreeStruct> treeInfo; // map of TreeStruct for each detId
+  std::map<unsigned int, TreeStruct> treeInfo;  // map of TreeStruct for each detId
 
   // now write 'input' tree
   const std::string treeName{this->name() + '_' + readoutModeName_ + '_'};
-  std::vector<const SiStripLorentzAngle*> inputs{};
+  std::vector<const SiStripLorentzAngle *> inputs{};
   inputs.reserve(moduleGroupSelector_->numIovs());
   for (unsigned int iIOV = 0; iIOV < moduleGroupSelector_->numIovs(); ++iIOV) {
     const auto firstRunOfIOV = moduleGroupSelector_->firstRunOfIOV(iIOV);
-    inputs.push_back(this->getLorentzAnglesInput(firstRunOfIOV)); // never NULL
-    this->writeTree(inputs.back(), treeInfo,
-                    (treeName + "input_" + std::to_string(firstRunOfIOV)).c_str()); // empty treeInfo for input...
+    inputs.push_back(this->getLorentzAnglesInput(firstRunOfIOV));  // never NULL
+    this->writeTree(inputs.back(),
+                    treeInfo,
+                    (treeName + "input_" + std::to_string(firstRunOfIOV)).c_str());  // empty treeInfo for input...
 
     if (inputs.back()->getLorentzAngles().empty()) {
       edm::LogError("Alignment") << "@SUB=SiStripLorentzAngleCalibration::endOfJob"
-                                 << "Input Lorentz angle map is empty ('"
-                                 << readoutModeName_ << "' mode), skip writing output!";
+                                 << "Input Lorentz angle map is empty ('" << readoutModeName_
+                                 << "' mode), skip writing output!";
       return;
     }
   }
 
-  const unsigned int nonZeroParamsOrErrors =   // Any determined value?
-    count_if (parameters_.begin(), parameters_.end(), [](auto c){return c!=0.;})
-    + count_if(paramUncertainties_.begin(), paramUncertainties_.end(),
-               [](auto c){return c!=0.;});
+  const unsigned int nonZeroParamsOrErrors =  // Any determined value?
+      count_if(parameters_.begin(), parameters_.end(), [](auto c) { return c != 0.; }) +
+      count_if(paramUncertainties_.begin(), paramUncertainties_.end(), [](auto c) { return c != 0.; });
 
   for (unsigned int iIOV = 0; iIOV < moduleGroupSelector_->numIovs(); ++iIOV) {
     auto firstRunOfIOV = static_cast<cond::Time_t>(moduleGroupSelector_->firstRunOfIOV(iIOV));
     SiStripLorentzAngle output{};
     // Loop on map of values from input and add (possible) parameter results
-    for (const auto& iterIdValue: inputs[iIOV]->getLorentzAngles()) {
+    for (const auto &iterIdValue : inputs[iIOV]->getLorentzAngles()) {
       // type of 'iterIdValue' is pair<unsigned int, float>
-      const auto detId = iterIdValue.first; // key of map is DetId
+      const auto detId = iterIdValue.first;  // key of map is DetId
       // Some code one could use to miscalibrate wrt input:
       // double param = 0.;
       // const DetId id(detId);
@@ -389,15 +366,15 @@ void SiStripLorentzAngleCalibration::endOfJob()
       // put result in output, i.e. sum of input and determined parameter:
       auto value = iterIdValue.second + static_cast<float>(param);
       output.putLorentzAngle(detId, value);
-      const int paramIndex = moduleGroupSelector_->getParameterIndexFromDetId(detId,firstRunOfIOV);
+      const int paramIndex = moduleGroupSelector_->getParameterIndexFromDetId(detId, firstRunOfIOV);
       treeInfo[detId] = TreeStruct(param, this->getParameterError(paramIndex), paramIndex);
     }
 
-    if (saveToDB_ || nonZeroParamsOrErrors != 0) { // Skip writing mille jobs...
+    if (saveToDB_ || nonZeroParamsOrErrors != 0) {  // Skip writing mille jobs...
       this->writeTree(&output, treeInfo, (treeName + Form("result_%lld", firstRunOfIOV)).c_str());
     }
 
-    if (saveToDB_) { // If requested, write out to DB
+    if (saveToDB_) {  // If requested, write out to DB
       edm::Service<cond::service::PoolDBOutputService> dbService;
       if (dbService.isAvailable()) {
         dbService->writeOne(&output, firstRunOfIOV, recordNameDBwrite_);
@@ -406,22 +383,22 @@ void SiStripLorentzAngleCalibration::endOfJob()
                                    << "No PoolDBOutputService available, but saveToDB true!";
       }
     }
-  } // end loop on IOVs
+  }  // end loop on IOVs
 }
 
 //======================================================================
 double SiStripLorentzAngleCalibration::effectiveThickness(const GeomDet *det,
                                                           int16_t mode,
-                                                          const edm::EventSetup &setup) const
-{
-  if (!det) return 0.;
-  double dZ = det->surface().bounds().thickness(); // it is a float only...
+                                                          const edm::EventSetup &setup) const {
+  if (!det)
+    return 0.;
+  double dZ = det->surface().bounds().thickness();  // it is a float only...
   const SiStripDetId id(det->geographicalId());
   edm::ESHandle<SiStripBackPlaneCorrection> backPlaneHandle;
   // FIXME: which one? DepRcd->get(handle) or Rcd->get(readoutModeName_, handle)??
   // setup.get<SiStripBackPlaneCorrectionDepRcd>().get(backPlaneHandle); // get correct mode
   setup.get<SiStripBackPlaneCorrectionRcd>().get(readoutModeName_, backPlaneHandle);
-  const double bpCor = backPlaneHandle->getBackPlaneCorrection(id); // it's a float...
+  const double bpCor = backPlaneHandle->getBackPlaneCorrection(id);  // it's a float...
   //  std::cout << "bpCor " << bpCor << " in subdet " << id.subdetId() << std::endl;
   dZ *= (1. - bpCor);
 
@@ -429,17 +406,14 @@ double SiStripLorentzAngleCalibration::effectiveThickness(const GeomDet *det,
 }
 
 //======================================================================
-const SiStripLorentzAngle*
-SiStripLorentzAngleCalibration::getLorentzAnglesInput(const align::RunNumber& run)
-{
-  const auto& resolvedRun = run > 0 ? run : currentIOV_;
+const SiStripLorentzAngle *SiStripLorentzAngleCalibration::getLorentzAnglesInput(const align::RunNumber &run) {
+  const auto &resolvedRun = run > 0 ? run : currentIOV_;
   // For parallel processing in Millepede II, create SiStripLorentzAngle
   // from info stored in files of parallel jobs and check that they are identical.
   // If this job has run on events, still check that LA is identical to the ones
   // from mergeFileNames_.
-  const std::string treeName{this->name()+"_"+readoutModeName_+"_input_"+
-                             std::to_string(resolvedRun)};
-  for (const auto& iFile: mergeFileNames_) {
+  const std::string treeName{this->name() + "_" + readoutModeName_ + "_input_" + std::to_string(resolvedRun)};
+  for (const auto &iFile : mergeFileNames_) {
     auto la = this->createFromTree(iFile.c_str(), treeName.c_str());
     // siStripLorentzAngleInput_ could be non-null from previous file of this loop
     // or from checkLorentzAngleInput(..) when running on data in this job as well
@@ -449,18 +423,16 @@ SiStripLorentzAngleCalibration::getLorentzAnglesInput(const align::RunNumber& ru
       currentIOV_ = resolvedRun;
     } else {
       // FIXME: about comparison of maps see comments in checkLorentzAngleInput
-      if (!la.getLorentzAngles().empty() && // single job might not have got events
+      if (!la.getLorentzAngles().empty() &&  // single job might not have got events
           la.getLorentzAngles() != siStripLorentzAngleInput_->getLorentzAngles()) {
         // Throw exception instead of error?
         edm::LogError("NoInput") << "@SUB=SiStripLorentzAngleCalibration::getLorentzAnglesInput"
-                                 << "Different input values from tree " << treeName
-                                 << " in file " << iFile << ".";
-
+                                 << "Different input values from tree " << treeName << " in file " << iFile << ".";
       }
     }
   }
 
-  if (!siStripLorentzAngleInput_) { // no files nor ran on events
+  if (!siStripLorentzAngleInput_) {  // no files nor ran on events
     // [] operator default-constructs an empty SiStripLorentzAngle object in place:
     siStripLorentzAngleInput_ = &(cachedLorentzAngleInputs_[resolvedRun]);
     currentIOV_ = resolvedRun;
@@ -475,9 +447,7 @@ SiStripLorentzAngleCalibration::getLorentzAnglesInput(const align::RunNumber& ru
 }
 
 //======================================================================
-double SiStripLorentzAngleCalibration::getParameterForDetId(unsigned int detId,
-                                                            edm::RunNumber_t run) const
-{
+double SiStripLorentzAngleCalibration::getParameterForDetId(unsigned int detId, edm::RunNumber_t run) const {
   const int index = moduleGroupSelector_->getParameterIndexFromDetId(detId, run);
 
   return (index < 0 ? 0. : parameters_[index]);
@@ -486,11 +456,11 @@ double SiStripLorentzAngleCalibration::getParameterForDetId(unsigned int detId,
 //======================================================================
 void SiStripLorentzAngleCalibration::writeTree(const SiStripLorentzAngle *lorentzAngle,
                                                const std::map<unsigned int, TreeStruct> &treeInfo,
-                                               const char *treeName) const
-{
-  if (!lorentzAngle) return;
+                                               const char *treeName) const {
+  if (!lorentzAngle)
+    return;
 
-  TFile* file = TFile::Open(outFileName_.c_str(), "UPDATE");
+  TFile *file = TFile::Open(outFileName_.c_str(), "UPDATE");
   if (!file) {
     edm::LogError("BadConfig") << "@SUB=SiStripLorentzAngleCalibration::writeTree"
                                << "Could not open file '" << outFileName_ << "'.";
@@ -506,15 +476,16 @@ void SiStripLorentzAngleCalibration::writeTree(const SiStripLorentzAngle *lorent
   tree->Branch("treeStruct", &treeStruct, TreeStruct::LeafList());
 
   for (auto iterIdValue = lorentzAngle->getLorentzAngles().begin();
-       iterIdValue != lorentzAngle->getLorentzAngles().end(); ++iterIdValue) {
+       iterIdValue != lorentzAngle->getLorentzAngles().end();
+       ++iterIdValue) {
     // type of (*iterIdValue) is pair<unsigned int, float>
-    id = iterIdValue->first; // key of map is DetId
+    id = iterIdValue->first;  // key of map is DetId
     value = iterIdValue->second;
     // type of (*treeStructIter) is pair<unsigned int, TreeStruct>
-    auto treeStructIter = treeInfo.find(id); // find info for this id
+    auto treeStructIter = treeInfo.find(id);  // find info for this id
     if (treeStructIter != treeInfo.end()) {
-      treeStruct = treeStructIter->second; // info from input map
-    } else { // if none found, fill at least parameter index (using 1st IOV...)
+      treeStruct = treeStructIter->second;  // info from input map
+    } else {                                // if none found, fill at least parameter index (using 1st IOV...)
       const cond::Time_t run1of1stIov = moduleGroupSelector_->firstRunOfIOV(0);
       const int ind = moduleGroupSelector_->getParameterIndexFromDetId(id, run1of1stIov);
       treeStruct = TreeStruct(ind);
@@ -522,24 +493,23 @@ void SiStripLorentzAngleCalibration::writeTree(const SiStripLorentzAngle *lorent
     tree->Fill();
   }
   tree->Write();
-  delete file; // tree vanishes with the file...
+  delete file;  // tree vanishes with the file...
 }
 
 //======================================================================
-SiStripLorentzAngle
-SiStripLorentzAngleCalibration::createFromTree(const char *fileName, const char *treeName) const
-{
+SiStripLorentzAngle SiStripLorentzAngleCalibration::createFromTree(const char *fileName, const char *treeName) const {
   // Check for file existence on your own to work around
   // https://hypernews.cern.ch/HyperNews/CMS/get/swDevelopment/2715.html:
-  TFile* file = nullptr;
-  FILE* testFile = fopen(fileName,"r");
+  TFile *file = nullptr;
+  FILE *testFile = fopen(fileName, "r");
   if (testFile) {
     fclose(testFile);
     file = TFile::Open(fileName, "READ");
-  } // else not existing, see error below
+  }  // else not existing, see error below
 
   TTree *tree = nullptr;
-  if (file) file->GetObject(treeName, tree);
+  if (file)
+    file->GetObject(treeName, tree);
 
   SiStripLorentzAngle result{};
   if (tree) {
@@ -553,16 +523,15 @@ SiStripLorentzAngleCalibration::createFromTree(const char *fileName, const char 
       tree->GetEntry(iEntry);
       result.putLorentzAngle(id, value);
     }
-  } else { // Warning only since could be parallel job on no events.
+  } else {  // Warning only since could be parallel job on no events.
     edm::LogWarning("Alignment") << "@SUB=SiStripLorentzAngleCalibration::createFromTree"
-                                 << "Could not get TTree '" << treeName << "' from file '"
-                                 << fileName << (file ? "'." : "' (file does not exist).");
+                                 << "Could not get TTree '" << treeName << "' from file '" << fileName
+                                 << (file ? "'." : "' (file does not exist).");
   }
 
-  delete file; // tree will vanish with file
+  delete file;  // tree will vanish with file
   return result;
 }
-
 
 //======================================================================
 //======================================================================
@@ -570,5 +539,4 @@ SiStripLorentzAngleCalibration::createFromTree(const char *fileName, const char 
 
 #include "Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationPluginFactory.h"
 
-DEFINE_EDM_PLUGIN(IntegratedCalibrationPluginFactory,
-                  SiStripLorentzAngleCalibration, "SiStripLorentzAngleCalibration");
+DEFINE_EDM_PLUGIN(IntegratedCalibrationPluginFactory, SiStripLorentzAngleCalibration, "SiStripLorentzAngleCalibration");

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiStripReadoutModeEnums.h
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiStripReadoutModeEnums.h
@@ -3,6 +3,6 @@
 
 // SiStripLatency::singleReadOutMode() returns
 // 1: all in peak, 0: all in deco, -1: mixed state
-enum {kDeconvolutionMode = 0, kPeakMode = 1};
+enum { kDeconvolutionMode = 0, kPeakMode = 1 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/plugins/TreeStruct.h
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/TreeStruct.h
@@ -3,18 +3,17 @@
 
 /// structure to store algorithm results in a TTree
 
-struct TreeStruct 
-{
+struct TreeStruct {
   TreeStruct() : delta(0.f), error(0.f), paramIndex(0) {}
   TreeStruct(int ind) : delta(0.f), error(0.f), paramIndex(ind) {}
   TreeStruct(float del, float err, int ind) : delta(del), error(err), paramIndex(ind) {}
-  
+
   float delta;     /// parameter from alignment algorithm (change wrt. start)
   float error;     /// error from alignment algorithm
-  int   paramIndex;/// internal param. index (same index => same delta)
+  int paramIndex;  /// internal param. index (same index => same delta)
   /// List of leaves to pass as 3rd argument to TTree::Branch(...) if 2nd argument
   /// is a pointer to TreeStruct - keep in synch with data members above!
-  static const char* LeafList() {return "delta/F:error/F:paramIndex/I";}
+  static const char* LeafList() { return "delta/F:error/F:paramIndex/I"; }
 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/src/AlignableDataIO.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignableDataIO.cc
@@ -7,213 +7,150 @@
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignableDataIO.h"
 
 // ----------------------------------------------------------------------------
-AlignableAbsData AlignableDataIO::readAbsPos(Alignable* ali, int& ierr)
-{ 
-  return readAbsRaw(ali,ierr);
-}
-
+AlignableAbsData AlignableDataIO::readAbsPos(Alignable* ali, int& ierr) { return readAbsRaw(ali, ierr); }
 
 // ----------------------------------------------------------------------------
-AlignableAbsData AlignableDataIO::readOrgPos(Alignable* ali, int& ierr)
-{ 
-  return readAbsRaw(ali,ierr);
-}
-
+AlignableAbsData AlignableDataIO::readOrgPos(Alignable* ali, int& ierr) { return readAbsRaw(ali, ierr); }
 
 // ----------------------------------------------------------------------------
-AlignableRelData AlignableDataIO::readRelPos(Alignable* ali, int& ierr)
-{ 
-  return readRelRaw(ali,ierr);
-}
-
+AlignableRelData AlignableDataIO::readRelPos(Alignable* ali, int& ierr) { return readRelRaw(ali, ierr); }
 
 // ----------------------------------------------------------------------------
-int AlignableDataIO::writeAbsPos(Alignable* ali, bool validCheck)
-{
-  
-  if ( !(validCheck) || ali->alignmentParameters()->isValid() ) 
-    {
-      // position in global frame
-      align::PositionType pos = ali->surface().position();
-      // global rotation
-      align::RotationType rot = ali->surface().rotation();
-      // if a unit: store surface deformation (little kind of hack)...
-      std::vector<double> pars;
-      if (ali->alignableObjectId() == align::AlignableDetUnit) { // only detunits have them
-        std::vector<std::pair<int,SurfaceDeformation*> > result;
-        if (1 == ali->surfaceDeformationIdPairs(result)) { // might not have any...
-          pars = result[0].second->parameters();
-        }
+int AlignableDataIO::writeAbsPos(Alignable* ali, bool validCheck) {
+  if (!(validCheck) || ali->alignmentParameters()->isValid()) {
+    // position in global frame
+    align::PositionType pos = ali->surface().position();
+    // global rotation
+    align::RotationType rot = ali->surface().rotation();
+    // if a unit: store surface deformation (little kind of hack)...
+    std::vector<double> pars;
+    if (ali->alignableObjectId() == align::AlignableDetUnit) {  // only detunits have them
+      std::vector<std::pair<int, SurfaceDeformation*> > result;
+      if (1 == ali->surfaceDeformationIdPairs(result)) {  // might not have any...
+        pars = result[0].second->parameters();
       }
-
-      // write
-      return writeAbsRaw( 
-			 AlignableAbsData( pos,rot,
-					   ali->id(),
-					   ali->alignableObjectId(),
-                                           pars)
-			 );
     }
 
-  return 1;
-}
-
-
-// ----------------------------------------------------------------------------
-int AlignableDataIO::writeRelPos(Alignable* ali, bool validCheck)
-{
-  if ( !(validCheck) || ali->alignmentParameters()->isValid() ) 
-    {
-      // rel. shift in global frame
-      const align::GlobalVector& pos = ali->displacement();
-      // rel. rotation in global frame
-      align::RotationType rot = ali->rotation();
-      // FIXME: should add something to store changes of surface deformations...
-      std::vector<double> pars;
-      // write
-      return writeRelRaw(AlignableRelData(pos,rot,ali->id(),
-					  ali->alignableObjectId(), pars));
-    }
-
-  return 1;
-}
-
-
-// ----------------------------------------------------------------------------
-int AlignableDataIO::writeOrgPos(Alignable* ali, bool validCheck)
-{
-  if ( !(validCheck) || ali->alignmentParameters()->isValid() ) 
-    {
-      // orig position
-      align::PositionType pos = ali->globalPosition() - ali->displacement();
-      // orig rotation
-      align::RotationType rot = ali->globalRotation() * ali->rotation().transposed();
-      // FIXME: should add something to store changes of surface deformations...
-      std::vector<double> pars;
-      // write
-      return writeAbsRaw(AlignableAbsData(pos,rot,ali->id(),
-					  ali->alignableObjectId(), pars));
-    }
-
-  return 1;
-}
-
-
-// ----------------------------------------------------------------------------
-int AlignableDataIO::writeAbsPos(const align::Alignables& alivec, 
-				 bool validCheck)
-{
-
-  int icount=0;
-  for( align::Alignables::const_iterator it=alivec.begin();
-       it!=alivec.end(); ++it ) 
-    {
-      int iret = writeAbsPos(*it,validCheck);
-      if (iret==0) icount++;
-    }
-  LogDebug("WriteAbsPos") << "all,written: " << alivec.size() <<","<< icount;
-
-  return 0;
-
-}
-
-
-// ----------------------------------------------------------------------------
-AlignablePositions 
-AlignableDataIO::readAbsPos(const align::Alignables& alivec, int& ierr) 
-{
- 
-  AlignablePositions retvec;
-  int ierr2=0;
-  ierr=0;
-  for( align::Alignables::const_iterator it=alivec.begin();
-       it!=alivec.end(); ++it ) 
-    {
-      AlignableAbsData ad=readAbsPos(*it, ierr2);
-      if (ierr2==0) retvec.push_back(ad);
-    }
-  
-  LogDebug("ReadAbsPos") << "all,written: " << alivec.size() <<"," << retvec.size();
-
-  return retvec;
-
-}
-
-
-// ----------------------------------------------------------------------------
-int AlignableDataIO::writeOrgPos( const align::Alignables& alivec, 
-				  bool validCheck )
-{
-
-  int icount=0;
-  for( align::Alignables::const_iterator it=alivec.begin();
-       it!=alivec.end(); ++it ) 
-    {
-      int iret=writeOrgPos(*it,validCheck);
-      if (iret==0) icount++;
-    }
-  
-  LogDebug("WriteOrgPos") << "all,written: " << alivec.size() <<"," << icount;
-  return 0;
-
-}
-
-
-// ----------------------------------------------------------------------------
-AlignablePositions 
-AlignableDataIO::readOrgPos(const align::Alignables& alivec, int& ierr) 
-{
-
-  AlignablePositions retvec;
-  int ierr2=0;
-  ierr=0;
-  for( align::Alignables::const_iterator it=alivec.begin();
-       it!=alivec.end(); ++it ) 
-    {
-      AlignableAbsData ad=readOrgPos(*it, ierr2);
-      if (ierr2==0) retvec.push_back(ad);
-    }
-
-  LogDebug("ReadOrgPos") << "all,read: " << alivec.size() <<", "<< retvec.size();
-
-  return retvec;
-
-}
-
-
-// ----------------------------------------------------------------------------
-int AlignableDataIO::writeRelPos(const align::Alignables& alivec, 
-				 bool validCheck )
-{
-
-  int icount=0;
-  for( align::Alignables::const_iterator it=alivec.begin();
-       it!=alivec.end(); ++it ) {
-    int iret=writeRelPos(*it,validCheck);
-    if (iret==0) icount++;
+    // write
+    return writeAbsRaw(AlignableAbsData(pos, rot, ali->id(), ali->alignableObjectId(), pars));
   }
-  LogDebug("WriteRelPos") << "all,written: " << alivec.size() <<", "<< icount;
-  return 0;
 
+  return 1;
 }
 
+// ----------------------------------------------------------------------------
+int AlignableDataIO::writeRelPos(Alignable* ali, bool validCheck) {
+  if (!(validCheck) || ali->alignmentParameters()->isValid()) {
+    // rel. shift in global frame
+    const align::GlobalVector& pos = ali->displacement();
+    // rel. rotation in global frame
+    align::RotationType rot = ali->rotation();
+    // FIXME: should add something to store changes of surface deformations...
+    std::vector<double> pars;
+    // write
+    return writeRelRaw(AlignableRelData(pos, rot, ali->id(), ali->alignableObjectId(), pars));
+  }
+
+  return 1;
+}
 
 // ----------------------------------------------------------------------------
-AlignableShifts 
-AlignableDataIO::readRelPos(const align::Alignables& alivec, int& ierr) 
-{
+int AlignableDataIO::writeOrgPos(Alignable* ali, bool validCheck) {
+  if (!(validCheck) || ali->alignmentParameters()->isValid()) {
+    // orig position
+    align::PositionType pos = ali->globalPosition() - ali->displacement();
+    // orig rotation
+    align::RotationType rot = ali->globalRotation() * ali->rotation().transposed();
+    // FIXME: should add something to store changes of surface deformations...
+    std::vector<double> pars;
+    // write
+    return writeAbsRaw(AlignableAbsData(pos, rot, ali->id(), ali->alignableObjectId(), pars));
+  }
 
-  AlignableShifts retvec;
-  int ierr2=0;
-  ierr=0;
-  for( align::Alignables::const_iterator it=alivec.begin();
-       it!=alivec.end(); ++it ) 
-    {
-      AlignableRelData ad=readRelPos(*it, ierr2);
-      if (ierr2==0) retvec.push_back(ad);
-    }
-  LogDebug("ReadRelPos") << "all,read: " << alivec.size() <<", "<< retvec.size();
+  return 1;
+}
+
+// ----------------------------------------------------------------------------
+int AlignableDataIO::writeAbsPos(const align::Alignables& alivec, bool validCheck) {
+  int icount = 0;
+  for (align::Alignables::const_iterator it = alivec.begin(); it != alivec.end(); ++it) {
+    int iret = writeAbsPos(*it, validCheck);
+    if (iret == 0)
+      icount++;
+  }
+  LogDebug("WriteAbsPos") << "all,written: " << alivec.size() << "," << icount;
+
+  return 0;
+}
+
+// ----------------------------------------------------------------------------
+AlignablePositions AlignableDataIO::readAbsPos(const align::Alignables& alivec, int& ierr) {
+  AlignablePositions retvec;
+  int ierr2 = 0;
+  ierr = 0;
+  for (align::Alignables::const_iterator it = alivec.begin(); it != alivec.end(); ++it) {
+    AlignableAbsData ad = readAbsPos(*it, ierr2);
+    if (ierr2 == 0)
+      retvec.push_back(ad);
+  }
+
+  LogDebug("ReadAbsPos") << "all,written: " << alivec.size() << "," << retvec.size();
 
   return retvec;
+}
 
+// ----------------------------------------------------------------------------
+int AlignableDataIO::writeOrgPos(const align::Alignables& alivec, bool validCheck) {
+  int icount = 0;
+  for (align::Alignables::const_iterator it = alivec.begin(); it != alivec.end(); ++it) {
+    int iret = writeOrgPos(*it, validCheck);
+    if (iret == 0)
+      icount++;
+  }
+
+  LogDebug("WriteOrgPos") << "all,written: " << alivec.size() << "," << icount;
+  return 0;
+}
+
+// ----------------------------------------------------------------------------
+AlignablePositions AlignableDataIO::readOrgPos(const align::Alignables& alivec, int& ierr) {
+  AlignablePositions retvec;
+  int ierr2 = 0;
+  ierr = 0;
+  for (align::Alignables::const_iterator it = alivec.begin(); it != alivec.end(); ++it) {
+    AlignableAbsData ad = readOrgPos(*it, ierr2);
+    if (ierr2 == 0)
+      retvec.push_back(ad);
+  }
+
+  LogDebug("ReadOrgPos") << "all,read: " << alivec.size() << ", " << retvec.size();
+
+  return retvec;
+}
+
+// ----------------------------------------------------------------------------
+int AlignableDataIO::writeRelPos(const align::Alignables& alivec, bool validCheck) {
+  int icount = 0;
+  for (align::Alignables::const_iterator it = alivec.begin(); it != alivec.end(); ++it) {
+    int iret = writeRelPos(*it, validCheck);
+    if (iret == 0)
+      icount++;
+  }
+  LogDebug("WriteRelPos") << "all,written: " << alivec.size() << ", " << icount;
+  return 0;
+}
+
+// ----------------------------------------------------------------------------
+AlignableShifts AlignableDataIO::readRelPos(const align::Alignables& alivec, int& ierr) {
+  AlignableShifts retvec;
+  int ierr2 = 0;
+  ierr = 0;
+  for (align::Alignables::const_iterator it = alivec.begin(); it != alivec.end(); ++it) {
+    AlignableRelData ad = readRelPos(*it, ierr2);
+    if (ierr2 == 0)
+      retvec.push_back(ad);
+  }
+  LogDebug("ReadRelPos") << "all,read: " << alivec.size() << ", " << retvec.size();
+
+  return retvec;
 }

--- a/Alignment/CommonAlignmentAlgorithm/src/AlignableDataIORoot.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignableDataIORoot.cc
@@ -7,18 +7,14 @@
 
 // ----------------------------------------------------------------------------
 // constructor
-AlignableDataIORoot::AlignableDataIORoot(PosType p) : 
-  AlignableDataIO(p)
-{
+AlignableDataIORoot::AlignableDataIORoot(PosType p) : AlignableDataIO(p) {
   if (thePosType == Abs) {
     treename = "AlignablesAbsPos";
     treetxt = "Alignables abs.Pos";
-  }
-  else if (thePosType == Org) {
+  } else if (thePosType == Org) {
     treename = "AlignablesOrgPos";
     treetxt = "Alignables org.Pos";
-  }
-  else if (thePosType == Rel) {
+  } else if (thePosType == Rel) {
     treename = "AlignablesRelPos";
     treetxt = "Alignables rel.Pos";
   }
@@ -27,68 +23,72 @@ AlignableDataIORoot::AlignableDataIORoot(PosType p) :
 // ----------------------------------------------------------------------------
 // create root tree branches (for writing)
 
-void AlignableDataIORoot::createBranches(void) 
-{
-  tree->Branch("Id",    &Id,    "Id/i");
+void AlignableDataIORoot::createBranches(void) {
+  tree->Branch("Id", &Id, "Id/i");
   tree->Branch("ObjId", &ObjId, "ObjId/I");
-  tree->Branch("Pos",   &Pos,   "Pos[3]/D");
-  tree->Branch("Rot",   &Rot,   "Rot[9]/D");
+  tree->Branch("Pos", &Pos, "Pos[3]/D");
+  tree->Branch("Rot", &Rot, "Rot[9]/D");
 
-  tree->Branch("NumDeform",   &numDeformationValues_, "NumDeform/i");
-  tree->Branch("DeformValues", deformationValues_,    "DeformValues[NumDeform]/F");
+  tree->Branch("NumDeform", &numDeformationValues_, "NumDeform/i");
+  tree->Branch("DeformValues", deformationValues_, "DeformValues[NumDeform]/F");
 }
 
 // ----------------------------------------------------------------------------
 // set root tree branch addresses (for reading)
 
-void AlignableDataIORoot::setBranchAddresses(void) 
-{
-  tree->SetBranchAddress("Id",    &Id);
+void AlignableDataIORoot::setBranchAddresses(void) {
+  tree->SetBranchAddress("Id", &Id);
   tree->SetBranchAddress("ObjId", &ObjId);
-  tree->SetBranchAddress("Pos",   &Pos);
-  tree->SetBranchAddress("Rot",   &Rot);
+  tree->SetBranchAddress("Pos", &Pos);
+  tree->SetBranchAddress("Rot", &Rot);
 
-  tree->SetBranchAddress("NumDeform",   &numDeformationValues_);
+  tree->SetBranchAddress("NumDeform", &numDeformationValues_);
   tree->SetBranchAddress("DeformValues", deformationValues_);
 }
 
 // ----------------------------------------------------------------------------
 // find root tree entry based on IDs
 
-int AlignableDataIORoot::findEntry(align::ID id, align::StructureType comp)
-{
-  if (newopen) { // we're here first time
+int AlignableDataIORoot::findEntry(align::ID id, align::StructureType comp) {
+  if (newopen) {  // we're here first time
     edm::LogInfo("Alignment") << "@SUB=AlignableDataIORoot::findEntry"
                               << "Filling map ...";
-    treemap.erase(treemap.begin(),treemap.end());
-    for (int ev = 0;ev<tree->GetEntries();ev++) {
-      tree->GetEntry(ev); 
-      treemap[ std::make_pair(Id,ObjId) ] = ev;
+    treemap.erase(treemap.begin(), treemap.end());
+    for (int ev = 0; ev < tree->GetEntries(); ev++) {
+      tree->GetEntry(ev);
+      treemap[std::make_pair(Id, ObjId)] = ev;
     }
-    newopen=false;
+    newopen = false;
   }
-  
-  // now we have filled the map
-  treemaptype::iterator imap = treemap.find( std::make_pair(id,comp) );
-  int result=-1;
-  if (imap != treemap.end()) result=(*imap).second;
-  return result;
 
+  // now we have filled the map
+  treemaptype::iterator imap = treemap.find(std::make_pair(id, comp));
+  int result = -1;
+  if (imap != treemap.end())
+    result = (*imap).second;
+  return result;
 }
 
 // ----------------------------------------------------------------------------
-int AlignableDataIORoot::writeAbsRaw(const AlignableAbsData &ad)
-{
+int AlignableDataIORoot::writeAbsRaw(const AlignableAbsData& ad) {
   const align::GlobalPoint& pos = ad.pos();
   align::RotationType rot = ad.rot();
   Id = ad.id();
   ObjId = ad.objId();
-  Pos[0]=pos.x(); Pos[1]=pos.y(); Pos[2]=pos.z();
-  Rot[0]=rot.xx(); Rot[1]=rot.xy(); Rot[2]=rot.xz();
-  Rot[3]=rot.yx(); Rot[4]=rot.yy(); Rot[5]=rot.yz();
-  Rot[6]=rot.zx(); Rot[7]=rot.zy(); Rot[8]=rot.zz();
+  Pos[0] = pos.x();
+  Pos[1] = pos.y();
+  Pos[2] = pos.z();
+  Rot[0] = rot.xx();
+  Rot[1] = rot.xy();
+  Rot[2] = rot.xz();
+  Rot[3] = rot.yx();
+  Rot[4] = rot.yy();
+  Rot[5] = rot.yz();
+  Rot[6] = rot.zx();
+  Rot[7] = rot.zy();
+  Rot[8] = rot.zz();
 
-  const std::vector<double> &deformPars = ad.deformationParameters();
+  const std::vector<double>& deformPars = ad.deformationParameters();
   numDeformationValues_ = (deformPars.size() > kMaxNumPar ? kMaxNumPar : deformPars.size());
   for (unsigned int i = 0; i < numDeformationValues_; ++i) {
     deformationValues_[i] = deformPars[i];
@@ -99,18 +99,25 @@ int AlignableDataIORoot::writeAbsRaw(const AlignableAbsData &ad)
 }
 
 // ----------------------------------------------------------------------------
-int AlignableDataIORoot::writeRelRaw(const AlignableRelData &ad)
-{
+int AlignableDataIORoot::writeRelRaw(const AlignableRelData& ad) {
   const align::GlobalVector& pos = ad.pos();
   align::RotationType rot = ad.rot();
   Id = ad.id();
   ObjId = ad.objId();
-  Pos[0]=pos.x(); Pos[1]=pos.y(); Pos[2]=pos.z();
-  Rot[0]=rot.xx(); Rot[1]=rot.xy(); Rot[2]=rot.xz();
-  Rot[3]=rot.yx(); Rot[4]=rot.yy(); Rot[5]=rot.yz();
-  Rot[6]=rot.zx(); Rot[7]=rot.zy(); Rot[8]=rot.zz();
+  Pos[0] = pos.x();
+  Pos[1] = pos.y();
+  Pos[2] = pos.z();
+  Rot[0] = rot.xx();
+  Rot[1] = rot.xy();
+  Rot[2] = rot.xz();
+  Rot[3] = rot.yx();
+  Rot[4] = rot.yy();
+  Rot[5] = rot.yz();
+  Rot[6] = rot.zx();
+  Rot[7] = rot.zy();
+  Rot[8] = rot.zz();
 
-  const std::vector<double> &deformPars = ad.deformationParameters();
+  const std::vector<double>& deformPars = ad.deformationParameters();
   numDeformationValues_ = (deformPars.size() > kMaxNumPar ? kMaxNumPar : deformPars.size());
   for (unsigned int i = 0; i < numDeformationValues_; ++i) {
     deformationValues_[i] = deformPars[i];
@@ -121,62 +128,58 @@ int AlignableDataIORoot::writeRelRaw(const AlignableRelData &ad)
 }
 
 // ----------------------------------------------------------------------------
-AlignableAbsData AlignableDataIORoot::readAbsRaw(Alignable* ali,int& ierr)
-{
+AlignableAbsData AlignableDataIORoot::readAbsRaw(Alignable* ali, int& ierr) {
   align::GlobalPoint pos;
   align::RotationType rot;
 
   align::StructureType typeId = ali->alignableObjectId();
   align::ID id = ali->id();
-  std::vector<double> deformPars; deformPars.reserve(numDeformationValues_);
-  int entry = findEntry(id,typeId);
-  if(entry!=-1) {
+  std::vector<double> deformPars;
+  deformPars.reserve(numDeformationValues_);
+  int entry = findEntry(id, typeId);
+  if (entry != -1) {
     tree->GetEntry(entry);
-    align::GlobalPoint pos2(Pos[0],Pos[1],Pos[2]);
-    align::RotationType rot2(Rot[0],Rot[1],Rot[2],
-			     Rot[3],Rot[4],Rot[5],
-			     Rot[6],Rot[7],Rot[8]);
-    pos=pos2;
-    rot=rot2;
+    align::GlobalPoint pos2(Pos[0], Pos[1], Pos[2]);
+    align::RotationType rot2(Rot[0], Rot[1], Rot[2], Rot[3], Rot[4], Rot[5], Rot[6], Rot[7], Rot[8]);
+    pos = pos2;
+    rot = rot2;
 
     for (unsigned int i = 0; i < numDeformationValues_; ++i) {
       deformPars.push_back((double)deformationValues_[i]);
     }
 
-    ierr=0;
-  }
-  else ierr=-1;
+    ierr = 0;
+  } else
+    ierr = -1;
 
-  return AlignableAbsData(pos,rot,id,typeId,deformPars);
+  return AlignableAbsData(pos, rot, id, typeId, deformPars);
 }
 
 // ----------------------------------------------------------------------------
 
-AlignableRelData AlignableDataIORoot::readRelRaw(Alignable* ali,int& ierr)
-{
+AlignableRelData AlignableDataIORoot::readRelRaw(Alignable* ali, int& ierr) {
   align::GlobalVector pos;
   align::RotationType rot;
 
   align::StructureType typeId = ali->alignableObjectId();
   align::ID id = ali->id();
-  std::vector<double> deformPars; deformPars.reserve(numDeformationValues_);
-  int entry = findEntry(id,typeId);
-  if(entry!=-1) {
+  std::vector<double> deformPars;
+  deformPars.reserve(numDeformationValues_);
+  int entry = findEntry(id, typeId);
+  if (entry != -1) {
     tree->GetEntry(entry);
-    align::GlobalVector pos2(Pos[0],Pos[1],Pos[2]);
-    align::RotationType rot2(Rot[0],Rot[1],Rot[2],
-			     Rot[3],Rot[4],Rot[5],
-			     Rot[6],Rot[7],Rot[8]);
-    pos=pos2;
-    rot=rot2;
+    align::GlobalVector pos2(Pos[0], Pos[1], Pos[2]);
+    align::RotationType rot2(Rot[0], Rot[1], Rot[2], Rot[3], Rot[4], Rot[5], Rot[6], Rot[7], Rot[8]);
+    pos = pos2;
+    rot = rot2;
 
     for (unsigned int i = 0; i < numDeformationValues_; ++i) {
       deformPars.push_back((double)deformationValues_[i]);
     }
 
-    ierr=0;
-  }
-  else ierr=-1;
+    ierr = 0;
+  } else
+    ierr = -1;
 
-  return AlignableRelData(pos,rot,id,typeId,deformPars);
+  return AlignableRelData(pos, rot, id, typeId, deformPars);
 }

--- a/Alignment/CommonAlignmentAlgorithm/src/AlignmentAlgorithmPluginFactory.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignmentAlgorithmPluginFactory.cc
@@ -3,11 +3,7 @@
 ///  \author F. Ronga - CERN
 ///
 
-
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmPluginFactory.h"
 // #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-EDM_REGISTER_PLUGINFACTORY( AlignmentAlgorithmPluginFactory, 
-                            "AlignmentAlgorithmPluginFactory" );
-
-
+EDM_REGISTER_PLUGINFACTORY(AlignmentAlgorithmPluginFactory, "AlignmentAlgorithmPluginFactory");

--- a/Alignment/CommonAlignmentAlgorithm/src/AlignmentCorrelationsIORoot.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignmentCorrelationsIORoot.cc
@@ -10,112 +10,99 @@
 // ----------------------------------------------------------------------------
 // constructor
 
-AlignmentCorrelationsIORoot::AlignmentCorrelationsIORoot()
-{
+AlignmentCorrelationsIORoot::AlignmentCorrelationsIORoot() {
   treename = "AlignmentCorrelations";
   treetxt = "Correlations";
 }
 
 // ----------------------------------------------------------------------------
 
-void AlignmentCorrelationsIORoot::createBranches(void) 
-{
-  tree->Branch("Ali1Id",    &Ali1Id,    "Ali1Id/i");
-  tree->Branch("Ali2Id",    &Ali2Id,    "Ali2Id/i");
+void AlignmentCorrelationsIORoot::createBranches(void) {
+  tree->Branch("Ali1Id", &Ali1Id, "Ali1Id/i");
+  tree->Branch("Ali2Id", &Ali2Id, "Ali2Id/i");
   tree->Branch("Ali1ObjId", &Ali1ObjId, "Ali1ObjId/I");
   tree->Branch("Ali2ObjId", &Ali2ObjId, "Ali2ObjId/I");
-  tree->Branch("corSize",   &corSize,   "corSize/I");
+  tree->Branch("corSize", &corSize, "corSize/I");
   tree->Branch("CorMatrix", &CorMatrix, "CorMatrix[corSize]/D");
 }
 
 // ----------------------------------------------------------------------------
 
-void AlignmentCorrelationsIORoot::setBranchAddresses(void) 
-{
-  tree->SetBranchAddress("corSize",   &corSize);
-  tree->SetBranchAddress("Ali1Id",    &Ali1Id);
-  tree->SetBranchAddress("Ali2Id",    &Ali2Id);
+void AlignmentCorrelationsIORoot::setBranchAddresses(void) {
+  tree->SetBranchAddress("corSize", &corSize);
+  tree->SetBranchAddress("Ali1Id", &Ali1Id);
+  tree->SetBranchAddress("Ali2Id", &Ali2Id);
   tree->SetBranchAddress("Ali1ObjId", &Ali1ObjId);
-  tree->SetBranchAddress("Ali2ObjId", &Ali2ObjId);	 
+  tree->SetBranchAddress("Ali2ObjId", &Ali2ObjId);
   tree->SetBranchAddress("CorMatrix", &CorMatrix);
 }
 
 // ----------------------------------------------------------------------------
 
-int AlignmentCorrelationsIORoot::write(const align::Correlations& cor, bool validCheck)
-{
-  int icount=0;
+int AlignmentCorrelationsIORoot::write(const align::Correlations& cor, bool validCheck) {
+  int icount = 0;
 
-  for(align::Correlations::const_iterator it=cor.begin();
-    it!=cor.end();++it) {
-    AlgebraicMatrix mat=(*it).second;
-	std::pair<Alignable*,Alignable*> Pair = (*it).first;
+  for (align::Correlations::const_iterator it = cor.begin(); it != cor.end(); ++it) {
+    AlgebraicMatrix mat = (*it).second;
+    std::pair<Alignable*, Alignable*> Pair = (*it).first;
     Alignable* ali1 = Pair.first;
     Alignable* ali2 = Pair.second;
-    if( (ali1->alignmentParameters()->isValid()
-	 && ali2->alignmentParameters()->isValid()) || !(validCheck)) {
-      Ali1ObjId = ali1->alignableObjectId(); 
-      Ali2ObjId = ali2->alignableObjectId(); 
+    if ((ali1->alignmentParameters()->isValid() && ali2->alignmentParameters()->isValid()) || !(validCheck)) {
+      Ali1ObjId = ali1->alignableObjectId();
+      Ali2ObjId = ali2->alignableObjectId();
       Ali1Id = ali1->id();
       Ali2Id = ali2->id();
       int maxColumn = mat.num_row();
-      corSize = maxColumn*maxColumn;
-      for(int row = 0;row<maxColumn;row++)	  
-		for(int col = 0;col<maxColumn;col++)
-		  CorMatrix[row+col*maxColumn] =mat[row][col]; 
+      corSize = maxColumn * maxColumn;
+      for (int row = 0; row < maxColumn; row++)
+        for (int col = 0; col < maxColumn; col++)
+          CorMatrix[row + col * maxColumn] = mat[row][col];
       tree->Fill();
       icount++;
     }
   }
-  edm::LogInfo("AlignmentCorrelationsIORoot") << "Writing correlations: all,written: " 
-                                              << cor.size() << "," << icount;
+  edm::LogInfo("AlignmentCorrelationsIORoot") << "Writing correlations: all,written: " << cor.size() << "," << icount;
   return 0;
 }
 
 // ----------------------------------------------------------------------------
 // read correlations for those alignables in vector given as argument
 
-align::Correlations 
-AlignmentCorrelationsIORoot::read(const align::Alignables& alivec, int& ierr)
-{
+align::Correlations AlignmentCorrelationsIORoot::read(const align::Alignables& alivec, int& ierr) {
   align::Correlations theMap;
 
   // create ID map for all Alignables in alivec
   align::Alignables::const_iterator it1;
-  std::map< std::pair<unsigned int,int>, Alignable* > idAlis;
-  for( it1=alivec.begin();it1!=alivec.end();++it1 )
-    idAlis[std::make_pair((*it1)->id(),(*it1)->alignableObjectId())] = (*it1);
+  std::map<std::pair<unsigned int, int>, Alignable*> idAlis;
+  for (it1 = alivec.begin(); it1 != alivec.end(); ++it1)
+    idAlis[std::make_pair((*it1)->id(), (*it1)->alignableObjectId())] = (*it1);
 
-  std::map<std::pair<unsigned int,int>,Alignable*>::const_iterator aliSearch1;  
-  std::map<std::pair<unsigned int,int>,Alignable*>::const_iterator aliSearch2;  
-  int nfound=0;
+  std::map<std::pair<unsigned int, int>, Alignable*>::const_iterator aliSearch1;
+  std::map<std::pair<unsigned int, int>, Alignable*>::const_iterator aliSearch2;
+  int nfound = 0;
   double maxEntry = tree->GetEntries();
-  for( int entry = 0;entry<maxEntry;entry++ ) 
-	{
-	  tree->GetEntry(entry);
-	  aliSearch1 = idAlis.find(std::make_pair(Ali1Id,Ali1ObjId));
-	  aliSearch2 = idAlis.find(std::make_pair(Ali2Id,Ali2ObjId));
-	  if (aliSearch1!=idAlis.end()
-		  && aliSearch2!=idAlis.end()) 
-		{
-		  // Alignables for this pair found
-		  nfound++;
-		  Alignable* myAli1 = (*aliSearch1).second;
-		  Alignable* myAli2 = (*aliSearch2).second;
-		  // FIXME: instead of nParMax in the next few lines one should probably
-		  //        use something like sqrt(corSize) - but take care of rounding!
-		  //        I have no time to test... :-( GF
-		  AlgebraicMatrix  mat(nParMax,nParMax);
-		  for(int row = 0;row<nParMax;row++) 
-			for(int col = 0;col<nParMax;col++) 
-			  mat[row][col] = CorMatrix[row+col*nParMax];
-		  theMap[ std::make_pair(myAli1,myAli2) ] = mat;
-		}
-	}
+  for (int entry = 0; entry < maxEntry; entry++) {
+    tree->GetEntry(entry);
+    aliSearch1 = idAlis.find(std::make_pair(Ali1Id, Ali1ObjId));
+    aliSearch2 = idAlis.find(std::make_pair(Ali2Id, Ali2ObjId));
+    if (aliSearch1 != idAlis.end() && aliSearch2 != idAlis.end()) {
+      // Alignables for this pair found
+      nfound++;
+      Alignable* myAli1 = (*aliSearch1).second;
+      Alignable* myAli2 = (*aliSearch2).second;
+      // FIXME: instead of nParMax in the next few lines one should probably
+      //        use something like sqrt(corSize) - but take care of rounding!
+      //        I have no time to test... :-( GF
+      AlgebraicMatrix mat(nParMax, nParMax);
+      for (int row = 0; row < nParMax; row++)
+        for (int col = 0; col < nParMax; col++)
+          mat[row][col] = CorMatrix[row + col * nParMax];
+      theMap[std::make_pair(myAli1, myAli2)] = mat;
+    }
+  }
 
-  edm::LogInfo("AlignmentCorrelationsIORoot") << "Read correlations: all,read: " 
-                                              << alivec.size() << "," << nfound;
+  edm::LogInfo("AlignmentCorrelationsIORoot") << "Read correlations: all,read: " << alivec.size() << "," << nfound;
 
-  ierr=0;
+  ierr = 0;
   return theMap;
 }

--- a/Alignment/CommonAlignmentAlgorithm/src/AlignmentCorrelationsStore.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignmentCorrelationsStore.cc
@@ -4,50 +4,42 @@
 #include "Alignment/CommonAlignment/interface/AlignmentParameters.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
-AlignmentCorrelationsStore::AlignmentCorrelationsStore( void )
-{
+AlignmentCorrelationsStore::AlignmentCorrelationsStore(void) {
   edm::LogInfo("Alignment") << "@SUB=AlignmentCorrelationsStore::AlignmentCorrelationsStore "
                             << "\nCreated.";
 }
 
-
-void AlignmentCorrelationsStore::correlations( Alignable* ap1, Alignable* ap2,
-					       AlgebraicSymMatrix& cov, int row, int col ) const
-{
+void AlignmentCorrelationsStore::correlations(
+    Alignable* ap1, Alignable* ap2, AlgebraicSymMatrix& cov, int row, int col) const {
   static Alignable* previousAlignable = nullptr;
   static CorrelationsTable* previousCorrelations;
 
   // Needed by 'resetCorrelations()' to reset the static pointer:
-  if ( ap1 == nullptr ) { previousAlignable = nullptr; return; }
-
-  bool transpose = ( ap2 > ap1 );
-  if ( transpose ) std::swap( ap1, ap2 ); 
-
-  if ( ap1 == previousAlignable )
-  {
-    CorrelationsTable::const_iterator itC2 = previousCorrelations->find( ap2 );
-    if ( itC2 != previousCorrelations->end() )
-    {
-      transpose ?
-	fillCovarianceT( ap1, ap2, (*itC2).second, cov, row, col ) :
-	fillCovariance( ap1, ap2, (*itC2).second, cov, row, col );
-    }
+  if (ap1 == nullptr) {
+    previousAlignable = nullptr;
+    return;
   }
-  else
-  {
-    Correlations::const_iterator itC1 = theCorrelations.find( ap1 );
-    if ( itC1 != theCorrelations.end() )
-    {
+
+  bool transpose = (ap2 > ap1);
+  if (transpose)
+    std::swap(ap1, ap2);
+
+  if (ap1 == previousAlignable) {
+    CorrelationsTable::const_iterator itC2 = previousCorrelations->find(ap2);
+    if (itC2 != previousCorrelations->end()) {
+      transpose ? fillCovarianceT(ap1, ap2, (*itC2).second, cov, row, col)
+                : fillCovariance(ap1, ap2, (*itC2).second, cov, row, col);
+    }
+  } else {
+    Correlations::const_iterator itC1 = theCorrelations.find(ap1);
+    if (itC1 != theCorrelations.end()) {
       previousAlignable = ap1;
       previousCorrelations = (*itC1).second;
 
-      CorrelationsTable::const_iterator itC2 = (*itC1).second->find( ap2 );
-      if ( itC2 != (*itC1).second->end() )
-      {
-	transpose ?
-	  fillCovarianceT( ap1, ap2, (*itC2).second, cov, row, col ) :
-	  fillCovariance( ap1, ap2, (*itC2).second, cov, row, col );
+      CorrelationsTable::const_iterator itC2 = (*itC1).second->find(ap2);
+      if (itC2 != (*itC1).second->end()) {
+        transpose ? fillCovarianceT(ap1, ap2, (*itC2).second, cov, row, col)
+                  : fillCovariance(ap1, ap2, (*itC2).second, cov, row, col);
       }
     }
   }
@@ -56,36 +48,32 @@ void AlignmentCorrelationsStore::correlations( Alignable* ap1, Alignable* ap2,
   return;
 }
 
-
-void AlignmentCorrelationsStore::setCorrelations( Alignable* ap1, Alignable* ap2,
-						  const AlgebraicSymMatrix& cov, int row, int col )
-{
+void AlignmentCorrelationsStore::setCorrelations(
+    Alignable* ap1, Alignable* ap2, const AlgebraicSymMatrix& cov, int row, int col) {
   static Alignable* previousAlignable = nullptr;
   static CorrelationsTable* previousCorrelations;
 
   // Needed by 'resetCorrelations()' to reset the static pointer:
-  if ( ap1 == nullptr ) { previousAlignable = nullptr; return; }
-
-  bool transpose = ( ap2 > ap1 );
-  if ( transpose ) std::swap( ap1, ap2 );
-
-  if ( ap1 == previousAlignable )
-  {
-    fillCorrelationsTable( ap1, ap2, previousCorrelations, cov, row, col, transpose );
+  if (ap1 == nullptr) {
+    previousAlignable = nullptr;
+    return;
   }
-  else
-  {
-    Correlations::iterator itC = theCorrelations.find( ap1 );
-    if ( itC != theCorrelations.end() )
-    {
-      fillCorrelationsTable( ap1, ap2, itC->second, cov, row, col, transpose );
+
+  bool transpose = (ap2 > ap1);
+  if (transpose)
+    std::swap(ap1, ap2);
+
+  if (ap1 == previousAlignable) {
+    fillCorrelationsTable(ap1, ap2, previousCorrelations, cov, row, col, transpose);
+  } else {
+    Correlations::iterator itC = theCorrelations.find(ap1);
+    if (itC != theCorrelations.end()) {
+      fillCorrelationsTable(ap1, ap2, itC->second, cov, row, col, transpose);
       previousAlignable = ap1;
       previousCorrelations = itC->second;
-    }
-    else
-    {
+    } else {
       CorrelationsTable* newTable = new CorrelationsTable;
-      fillCorrelationsTable( ap1, ap2, newTable, cov, row, col, transpose );
+      fillCorrelationsTable(ap1, ap2, newTable, cov, row, col, transpose);
 
       theCorrelations[ap1] = newTable;
       previousAlignable = ap1;
@@ -94,139 +82,116 @@ void AlignmentCorrelationsStore::setCorrelations( Alignable* ap1, Alignable* ap2
   }
 }
 
+void AlignmentCorrelationsStore::setCorrelations(Alignable* ap1, Alignable* ap2, AlgebraicMatrix& mat) {
+  bool transpose = (ap2 > ap1);
+  if (transpose)
+    std::swap(ap1, ap2);
 
-void AlignmentCorrelationsStore::setCorrelations( Alignable* ap1, Alignable* ap2, AlgebraicMatrix& mat )
-{
-  bool transpose = ( ap2 > ap1 );
-  if ( transpose ) std::swap( ap1, ap2 );
-
-  Correlations::iterator itC1 = theCorrelations.find( ap1 );
-  if ( itC1 != theCorrelations.end() )
-  {
+  Correlations::iterator itC1 = theCorrelations.find(ap1);
+  if (itC1 != theCorrelations.end()) {
     (*itC1->second)[ap2] = transpose ? mat.T() : mat;
-  }
-  else
-  {
+  } else {
     CorrelationsTable* newTable = new CorrelationsTable;
     (*newTable)[ap2] = transpose ? mat.T() : mat;
     theCorrelations[ap1] = newTable;
   }
 }
 
+bool AlignmentCorrelationsStore::correlationsAvailable(Alignable* ap1, Alignable* ap2) const {
+  bool transpose = (ap2 > ap1);
+  if (transpose)
+    std::swap(ap1, ap2);
 
-bool AlignmentCorrelationsStore::correlationsAvailable( Alignable* ap1, Alignable* ap2 ) const
-{
-  bool transpose = ( ap2 > ap1 );
-  if ( transpose ) std::swap( ap1, ap2 );
-
-  Correlations::const_iterator itC1 = theCorrelations.find( ap1 );
-  if ( itC1 != theCorrelations.end() )
-  {
-    CorrelationsTable::const_iterator itC2 = itC1->second->find( ap2 );
-    if ( itC2 != itC1->second->end() ) return true;
+  Correlations::const_iterator itC1 = theCorrelations.find(ap1);
+  if (itC1 != theCorrelations.end()) {
+    CorrelationsTable::const_iterator itC2 = itC1->second->find(ap2);
+    if (itC2 != itC1->second->end())
+      return true;
   }
   return false;
 }
 
-
-void AlignmentCorrelationsStore::resetCorrelations( void )
-{
+void AlignmentCorrelationsStore::resetCorrelations(void) {
   Correlations::iterator itC;
-  for ( itC = theCorrelations.begin(); itC != theCorrelations.end(); ++itC ) delete (*itC).second;
-  theCorrelations.erase( theCorrelations.begin(), theCorrelations.end() );
+  for (itC = theCorrelations.begin(); itC != theCorrelations.end(); ++itC)
+    delete (*itC).second;
+  theCorrelations.erase(theCorrelations.begin(), theCorrelations.end());
 
   // Reset the static pointers to the 'previous alignables'
   AlgebraicSymMatrix dummy;
-  correlations( nullptr, nullptr, dummy, 0, 0 );
-  setCorrelations( nullptr, nullptr, dummy, 0, 0 );
+  correlations(nullptr, nullptr, dummy, 0, 0);
+  setCorrelations(nullptr, nullptr, dummy, 0, 0);
 }
 
-
-unsigned int AlignmentCorrelationsStore::size( void ) const
-{
+unsigned int AlignmentCorrelationsStore::size(void) const {
   unsigned int size = 0;
   Correlations::const_iterator itC;
-  for ( itC = theCorrelations.begin(); itC != theCorrelations.end(); ++itC )
+  for (itC = theCorrelations.begin(); itC != theCorrelations.end(); ++itC)
     size += itC->second->size();
 
   return size;
 }
 
+void AlignmentCorrelationsStore::fillCorrelationsTable(Alignable* ap1,
+                                                       Alignable* ap2,
+                                                       CorrelationsTable* table,
+                                                       const AlgebraicSymMatrix& cov,
+                                                       int row,
+                                                       int col,
+                                                       bool transpose) {
+  CorrelationsTable::iterator itC = table->find(ap2);
 
-void
-AlignmentCorrelationsStore::fillCorrelationsTable( Alignable* ap1, Alignable* ap2, CorrelationsTable* table,
-						   const AlgebraicSymMatrix& cov, int row, int col, bool transpose )
-{
-  CorrelationsTable::iterator itC = table->find( ap2 );
-
-  if ( itC != table->end() )
-  {
-    transpose ?
-      readFromCovarianceT( ap1, ap2, itC->second, cov, row, col ) :
-      readFromCovariance( ap1, ap2, itC->second, cov, row, col );
-  }
-  else
-  {
+  if (itC != table->end()) {
+    transpose ? readFromCovarianceT(ap1, ap2, itC->second, cov, row, col)
+              : readFromCovariance(ap1, ap2, itC->second, cov, row, col);
+  } else {
     int nRow = ap1->alignmentParameters()->numSelected();
     int nCol = ap2->alignmentParameters()->numSelected();
-    AlgebraicMatrix newEntry( nRow, nCol );
+    AlgebraicMatrix newEntry(nRow, nCol);
 
-    transpose ?
-      readFromCovarianceT( ap1, ap2, newEntry, cov, row, col ) :
-      readFromCovariance( ap1, ap2, newEntry, cov, row, col );
+    transpose ? readFromCovarianceT(ap1, ap2, newEntry, cov, row, col)
+              : readFromCovariance(ap1, ap2, newEntry, cov, row, col);
 
     (*table)[ap2] = newEntry;
   }
 }
 
-
-void
-AlignmentCorrelationsStore::fillCovariance( Alignable* ap1, Alignable* ap2, const AlgebraicMatrix& entry,
-					    AlgebraicSymMatrix& cov, int row, int col ) const
-{
+void AlignmentCorrelationsStore::fillCovariance(
+    Alignable* ap1, Alignable* ap2, const AlgebraicMatrix& entry, AlgebraicSymMatrix& cov, int row, int col) const {
   int nRow = entry.num_row();
   int nCol = entry.num_col();
 
-  for ( int iRow = 0; iRow < nRow; ++iRow )
-    for ( int jCol = 0; jCol < nCol; ++jCol )
-      cov[row+iRow][col+jCol] = entry[iRow][jCol];
+  for (int iRow = 0; iRow < nRow; ++iRow)
+    for (int jCol = 0; jCol < nCol; ++jCol)
+      cov[row + iRow][col + jCol] = entry[iRow][jCol];
 }
 
-
-void
-AlignmentCorrelationsStore::fillCovarianceT( Alignable* ap1, Alignable* ap2, const AlgebraicMatrix& entry,
-					     AlgebraicSymMatrix& cov, int row, int col ) const
-{
+void AlignmentCorrelationsStore::fillCovarianceT(
+    Alignable* ap1, Alignable* ap2, const AlgebraicMatrix& entry, AlgebraicSymMatrix& cov, int row, int col) const {
   int nRow = entry.num_row();
   int nCol = entry.num_col();
 
-  for ( int iRow = 0; iRow < nRow; ++iRow )
-    for ( int jCol = 0; jCol < nCol; ++jCol )
-      cov[row+jCol][col+iRow] = entry[iRow][jCol];
+  for (int iRow = 0; iRow < nRow; ++iRow)
+    for (int jCol = 0; jCol < nCol; ++jCol)
+      cov[row + jCol][col + iRow] = entry[iRow][jCol];
 }
 
-
-void
-AlignmentCorrelationsStore::readFromCovariance( Alignable* ap1, Alignable* ap2, AlgebraicMatrix& entry,
-						const AlgebraicSymMatrix& cov, int row, int col )
-{
+void AlignmentCorrelationsStore::readFromCovariance(
+    Alignable* ap1, Alignable* ap2, AlgebraicMatrix& entry, const AlgebraicSymMatrix& cov, int row, int col) {
   int nRow = entry.num_row();
   int nCol = entry.num_col();
 
-  for ( int iRow = 0; iRow < nRow; ++iRow )
-    for ( int jCol = 0; jCol < nCol; ++jCol )
-      entry[iRow][jCol] = cov[row+iRow][col+jCol];
+  for (int iRow = 0; iRow < nRow; ++iRow)
+    for (int jCol = 0; jCol < nCol; ++jCol)
+      entry[iRow][jCol] = cov[row + iRow][col + jCol];
 }
 
-
-void
-AlignmentCorrelationsStore::readFromCovarianceT( Alignable* ap1, Alignable* ap2, AlgebraicMatrix& entry,
-						 const AlgebraicSymMatrix& cov, int row, int col )
-{
+void AlignmentCorrelationsStore::readFromCovarianceT(
+    Alignable* ap1, Alignable* ap2, AlgebraicMatrix& entry, const AlgebraicSymMatrix& cov, int row, int col) {
   int nRow = entry.num_row();
   int nCol = entry.num_col();
 
-  for ( int iRow = 0; iRow < nRow; ++iRow )
-    for ( int jCol = 0; jCol < nCol; ++jCol )
-      entry[iRow][jCol] = cov[row+jCol][col+iRow];
+  for (int iRow = 0; iRow < nRow; ++iRow)
+    for (int jCol = 0; jCol < nCol; ++jCol)
+      entry[iRow][jCol] = cov[row + jCol][col + iRow];
 }

--- a/Alignment/CommonAlignmentAlgorithm/src/AlignmentExtendedCorrelationsEntry.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignmentExtendedCorrelationsEntry.cc
@@ -1,64 +1,49 @@
 
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentExtendedCorrelationsEntry.h"
 
+AlignmentExtendedCorrelationsEntry::AlignmentExtendedCorrelationsEntry(void)
+    :  //   theCounter( 0 ),
+      theNRows(0),
+      theNCols(0) {}
 
-AlignmentExtendedCorrelationsEntry::AlignmentExtendedCorrelationsEntry( void ) :
-//   theCounter( 0 ),
-  theNRows( 0 ),
-  theNCols( 0 )
-{}
+AlignmentExtendedCorrelationsEntry::AlignmentExtendedCorrelationsEntry(short unsigned int nRows,
+                                                                       short unsigned int nCols)
+    :  //   theCounter( 0 ),
+      theNRows(nRows),
+      theNCols(nCols),
+      theData(nRows * nCols) {}
 
+AlignmentExtendedCorrelationsEntry::AlignmentExtendedCorrelationsEntry(short unsigned int nRows,
+                                                                       short unsigned int nCols,
+                                                                       const float init)
+    :  //   theCounter( 0 ),
+      theNRows(nRows),
+      theNCols(nCols),
+      theData(nRows * nCols, init) {}
 
-AlignmentExtendedCorrelationsEntry::AlignmentExtendedCorrelationsEntry( short unsigned int nRows,
-									short unsigned int nCols ) :
-//   theCounter( 0 ),
-  theNRows( nRows ),
-  theNCols( nCols ),
-  theData( nRows*nCols )
-{}
-
-
-AlignmentExtendedCorrelationsEntry::AlignmentExtendedCorrelationsEntry( short unsigned int nRows,
-						      short unsigned int nCols,
-						      const float init ) :
-//   theCounter( 0 ),
-  theNRows( nRows ),
-  theNCols( nCols ),
-  theData( nRows*nCols, init )
-{}
-
-
-AlignmentExtendedCorrelationsEntry::AlignmentExtendedCorrelationsEntry( const AlgebraicMatrix& mat ) :
-//   theCounter( 0 ),
-  theNRows( mat.num_row() ),
-  theNCols( mat.num_col() ),
-  theData( mat.num_row()*mat.num_col() )
-{
-  for ( int i = 0; i < mat.num_row(); ++i )
-  {
-    for ( int j = 0; j < mat.num_col(); ++j )
-    {
-      theData[i*theNCols+j] = mat[i][j];
+AlignmentExtendedCorrelationsEntry::AlignmentExtendedCorrelationsEntry(const AlgebraicMatrix& mat)
+    :  //   theCounter( 0 ),
+      theNRows(mat.num_row()),
+      theNCols(mat.num_col()),
+      theData(mat.num_row() * mat.num_col()) {
+  for (int i = 0; i < mat.num_row(); ++i) {
+    for (int j = 0; j < mat.num_col(); ++j) {
+      theData[i * theNCols + j] = mat[i][j];
     }
   }
 }
 
-
-void AlignmentExtendedCorrelationsEntry::operator*=( const float multiply )
-{
-  for ( std::vector< float >::iterator it = theData.begin(); it != theData.end(); ++it ) (*it) *= multiply;
+void AlignmentExtendedCorrelationsEntry::operator*=(const float multiply) {
+  for (std::vector<float>::iterator it = theData.begin(); it != theData.end(); ++it)
+    (*it) *= multiply;
 }
 
+AlgebraicMatrix AlignmentExtendedCorrelationsEntry::matrix(void) const {
+  AlgebraicMatrix result(theNRows, theNCols);
 
-AlgebraicMatrix AlignmentExtendedCorrelationsEntry::matrix( void ) const
-{
-  AlgebraicMatrix result( theNRows, theNCols );
-
-  for ( int i = 0; i < theNRows; ++i )
-  {
-    for ( int j = 0; j < theNCols; ++j )
-    {
-      result[i][j] = theData[i*theNCols+j];
+  for (int i = 0; i < theNRows; ++i) {
+    for (int j = 0; j < theNCols; ++j) {
+      result[i][j] = theData[i * theNCols + j];
     }
   }
 

--- a/Alignment/CommonAlignmentAlgorithm/src/AlignmentExtendedCorrelationsStore.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignmentExtendedCorrelationsStore.cc
@@ -8,54 +8,46 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 
-
-AlignmentExtendedCorrelationsStore::AlignmentExtendedCorrelationsStore( const edm::ParameterSet& config )
-{
-  theMaxUpdates = config.getParameter<int>( "MaxUpdates" );
-  theCut = config.getParameter<double>( "CutValue" );
-  theWeight = config.getParameter<double>( "Weight" );
+AlignmentExtendedCorrelationsStore::AlignmentExtendedCorrelationsStore(const edm::ParameterSet& config) {
+  theMaxUpdates = config.getParameter<int>("MaxUpdates");
+  theCut = config.getParameter<double>("CutValue");
+  theWeight = config.getParameter<double>("Weight");
 
   edm::LogInfo("Alignment") << "@SUB=AlignmentExtendedCorrelationsStore::AlignmentExtendedCorrelationsStore"
                             << "Created.";
 }
 
-
-void AlignmentExtendedCorrelationsStore::correlations( Alignable* ap1, Alignable* ap2,
-						       AlgebraicSymMatrix& cov, int row, int col ) const
-{
+void AlignmentExtendedCorrelationsStore::correlations(
+    Alignable* ap1, Alignable* ap2, AlgebraicSymMatrix& cov, int row, int col) const {
   static Alignable* previousAlignable = nullptr;
   static ExtendedCorrelationsTable* previousCorrelations;
 
   // Needed by 'resetCorrelations()' to reset the static pointer:
-  if ( ap1 == nullptr ) { previousAlignable = nullptr; return; }
-
-  bool transpose = ( ap2 > ap1 );
-  if ( transpose ) std::swap( ap1, ap2 ); 
-
-  if ( ap1 == previousAlignable )
-  {
-    ExtendedCorrelationsTable::const_iterator itC2 = previousCorrelations->find( ap2 );
-    if ( itC2 != previousCorrelations->end() )
-    {
-      transpose ?
-	fillCovarianceT( ap1, ap2, (*itC2).second, cov, row, col ) :
-	fillCovariance( ap1, ap2, (*itC2).second, cov, row, col );
-    }
+  if (ap1 == nullptr) {
+    previousAlignable = nullptr;
+    return;
   }
-  else
-  {
-    ExtendedCorrelations::const_iterator itC1 = theCorrelations.find( ap1 );
-    if ( itC1 != theCorrelations.end() )
-    {
+
+  bool transpose = (ap2 > ap1);
+  if (transpose)
+    std::swap(ap1, ap2);
+
+  if (ap1 == previousAlignable) {
+    ExtendedCorrelationsTable::const_iterator itC2 = previousCorrelations->find(ap2);
+    if (itC2 != previousCorrelations->end()) {
+      transpose ? fillCovarianceT(ap1, ap2, (*itC2).second, cov, row, col)
+                : fillCovariance(ap1, ap2, (*itC2).second, cov, row, col);
+    }
+  } else {
+    ExtendedCorrelations::const_iterator itC1 = theCorrelations.find(ap1);
+    if (itC1 != theCorrelations.end()) {
       previousAlignable = ap1;
       previousCorrelations = (*itC1).second;
 
-      ExtendedCorrelationsTable::const_iterator itC2 = (*itC1).second->find( ap2 );
-      if ( itC2 != (*itC1).second->end() )
-      {
-	transpose ?
-	  fillCovarianceT( ap1, ap2, (*itC2).second, cov, row, col ) :
-	  fillCovariance( ap1, ap2, (*itC2).second, cov, row, col );
+      ExtendedCorrelationsTable::const_iterator itC2 = (*itC1).second->find(ap2);
+      if (itC2 != (*itC1).second->end()) {
+        transpose ? fillCovarianceT(ap1, ap2, (*itC2).second, cov, row, col)
+                  : fillCovariance(ap1, ap2, (*itC2).second, cov, row, col);
       }
     }
   }
@@ -64,37 +56,33 @@ void AlignmentExtendedCorrelationsStore::correlations( Alignable* ap1, Alignable
   return;
 }
 
-
-void AlignmentExtendedCorrelationsStore::setCorrelations( Alignable* ap1, Alignable* ap2,
-							  const AlgebraicSymMatrix& cov, int row, int col )
-{
+void AlignmentExtendedCorrelationsStore::setCorrelations(
+    Alignable* ap1, Alignable* ap2, const AlgebraicSymMatrix& cov, int row, int col) {
   static Alignable* previousAlignable = nullptr;
   static ExtendedCorrelationsTable* previousCorrelations;
 
   // Needed by 'resetCorrelations()' to reset the static pointer:
-  if ( ap1 == nullptr ) { previousAlignable = nullptr; return; }
-
-  bool transpose = ( ap2 > ap1 );
-  if ( transpose ) std::swap( ap1, ap2 );
-
-  if ( ap1 == previousAlignable )
-  {
-    fillCorrelationsTable( ap1, ap2, previousCorrelations, cov, row, col, transpose );
+  if (ap1 == nullptr) {
+    previousAlignable = nullptr;
+    return;
   }
-  else
-  {
-    ExtendedCorrelations::iterator itC = theCorrelations.find( ap1 );
-    if ( itC != theCorrelations.end() )
-    {
-      fillCorrelationsTable( ap1, ap2, itC->second, cov, row, col, transpose );
+
+  bool transpose = (ap2 > ap1);
+  if (transpose)
+    std::swap(ap1, ap2);
+
+  if (ap1 == previousAlignable) {
+    fillCorrelationsTable(ap1, ap2, previousCorrelations, cov, row, col, transpose);
+  } else {
+    ExtendedCorrelations::iterator itC = theCorrelations.find(ap1);
+    if (itC != theCorrelations.end()) {
+      fillCorrelationsTable(ap1, ap2, itC->second, cov, row, col, transpose);
       previousAlignable = ap1;
       previousCorrelations = itC->second;
-    }
-    else
-    {
+    } else {
       // make new entry
       ExtendedCorrelationsTable* newTable = new ExtendedCorrelationsTable;
-      fillCorrelationsTable( ap1, ap2, newTable, cov, row, col, transpose );
+      fillCorrelationsTable(ap1, ap2, newTable, cov, row, col, transpose);
 
       theCorrelations[ap1] = newTable;
 
@@ -104,45 +92,35 @@ void AlignmentExtendedCorrelationsStore::setCorrelations( Alignable* ap1, Aligna
   }
 }
 
+void AlignmentExtendedCorrelationsStore::setCorrelations(Alignable* ap1, Alignable* ap2, AlgebraicMatrix& mat) {
+  bool transpose = (ap2 > ap1);
+  if (transpose)
+    std::swap(ap1, ap2);
 
-void AlignmentExtendedCorrelationsStore::setCorrelations( Alignable* ap1, Alignable* ap2, AlgebraicMatrix& mat )
-{
-  bool transpose = ( ap2 > ap1 );
-  if ( transpose ) std::swap( ap1, ap2 );
-
-  ExtendedCorrelations::iterator itC1 = theCorrelations.find( ap1 );
-  if ( itC1 != theCorrelations.end() )
-  { 
-    ExtendedCorrelationsTable::iterator itC2 = itC1->second->find( ap1 );
-    if ( itC2 != itC1->second->end() )
-    {
-      itC2->second = transpose ? ExtendedCorrelationsEntry( mat.T() ) : ExtendedCorrelationsEntry( mat );
+  ExtendedCorrelations::iterator itC1 = theCorrelations.find(ap1);
+  if (itC1 != theCorrelations.end()) {
+    ExtendedCorrelationsTable::iterator itC2 = itC1->second->find(ap1);
+    if (itC2 != itC1->second->end()) {
+      itC2->second = transpose ? ExtendedCorrelationsEntry(mat.T()) : ExtendedCorrelationsEntry(mat);
+    } else {
+      (*itC1->second)[ap2] = transpose ? ExtendedCorrelationsEntry(mat.T()) : ExtendedCorrelationsEntry(mat);
     }
-    else
-    {
-      (*itC1->second)[ap2] = transpose ? ExtendedCorrelationsEntry( mat.T() ) : ExtendedCorrelationsEntry( mat );
-    }
-  }
-  else
-  {
+  } else {
     ExtendedCorrelationsTable* newTable = new ExtendedCorrelationsTable;
-    (*newTable)[ap2] = transpose ? ExtendedCorrelationsEntry( mat.T() ) : ExtendedCorrelationsEntry( mat );
+    (*newTable)[ap2] = transpose ? ExtendedCorrelationsEntry(mat.T()) : ExtendedCorrelationsEntry(mat);
     theCorrelations[ap1] = newTable;
   }
 }
 
+void AlignmentExtendedCorrelationsStore::getCorrelations(Alignable* ap1, Alignable* ap2, AlgebraicMatrix& mat) const {
+  bool transpose = (ap2 > ap1);
+  if (transpose)
+    std::swap(ap1, ap2);
 
-void AlignmentExtendedCorrelationsStore::getCorrelations( Alignable* ap1, Alignable* ap2, AlgebraicMatrix& mat ) const
-{
-  bool transpose = ( ap2 > ap1 );
-  if ( transpose ) std::swap( ap1, ap2 );
-
-  ExtendedCorrelations::const_iterator itC1 = theCorrelations.find( ap1 );
-  if ( itC1 != theCorrelations.end() )
-  {
-    ExtendedCorrelationsTable::const_iterator itC2 = itC1->second->find( ap2 );
-    if ( itC2 != itC1->second->end() )
-    {
+  ExtendedCorrelations::const_iterator itC1 = theCorrelations.find(ap1);
+  if (itC1 != theCorrelations.end()) {
+    ExtendedCorrelationsTable::const_iterator itC2 = itC1->second->find(ap2);
+    if (itC2 != itC1->second->end()) {
       mat = transpose ? itC2->second.matrix().T() : itC2->second.matrix();
       return;
     }
@@ -151,206 +129,181 @@ void AlignmentExtendedCorrelationsStore::getCorrelations( Alignable* ap1, Aligna
   mat = AlgebraicMatrix();
 }
 
+bool AlignmentExtendedCorrelationsStore::correlationsAvailable(Alignable* ap1, Alignable* ap2) const {
+  bool transpose = (ap2 > ap1);
+  if (transpose)
+    std::swap(ap1, ap2);
 
-bool AlignmentExtendedCorrelationsStore::correlationsAvailable( Alignable* ap1, Alignable* ap2 ) const
-{
-  bool transpose = ( ap2 > ap1 );
-  if ( transpose ) std::swap( ap1, ap2 );
-
-  ExtendedCorrelations::const_iterator itC1 = theCorrelations.find( ap1 );
-  if ( itC1 != theCorrelations.end() )
-  {
-    ExtendedCorrelationsTable::const_iterator itC2 = itC1->second->find( ap2 );
-    if ( itC2 != itC1->second->end() ) return true;
+  ExtendedCorrelations::const_iterator itC1 = theCorrelations.find(ap1);
+  if (itC1 != theCorrelations.end()) {
+    ExtendedCorrelationsTable::const_iterator itC2 = itC1->second->find(ap2);
+    if (itC2 != itC1->second->end())
+      return true;
   }
   return false;
 }
 
-
-void AlignmentExtendedCorrelationsStore::resetCorrelations( void )
-{
+void AlignmentExtendedCorrelationsStore::resetCorrelations(void) {
   ExtendedCorrelations::iterator itC;
-  for ( itC = theCorrelations.begin(); itC != theCorrelations.end(); ++itC ) delete (*itC).second;
-  theCorrelations.erase( theCorrelations.begin(), theCorrelations.end() );
+  for (itC = theCorrelations.begin(); itC != theCorrelations.end(); ++itC)
+    delete (*itC).second;
+  theCorrelations.erase(theCorrelations.begin(), theCorrelations.end());
 
   // Reset the static pointers to the 'previous alignables'
   AlgebraicSymMatrix dummy;
-  correlations( nullptr, nullptr, dummy, 0, 0 );
-  setCorrelations( nullptr, nullptr, dummy, 0, 0 );
+  correlations(nullptr, nullptr, dummy, 0, 0);
+  setCorrelations(nullptr, nullptr, dummy, 0, 0);
 }
 
-
-unsigned int AlignmentExtendedCorrelationsStore::size( void ) const
-{
+unsigned int AlignmentExtendedCorrelationsStore::size(void) const {
   unsigned int size = 0;
   ExtendedCorrelations::const_iterator itC;
-  for ( itC = theCorrelations.begin(); itC != theCorrelations.end(); ++itC )
+  for (itC = theCorrelations.begin(); itC != theCorrelations.end(); ++itC)
     size += itC->second->size();
 
   return size;
 }
 
+void AlignmentExtendedCorrelationsStore::fillCorrelationsTable(Alignable* ap1,
+                                                               Alignable* ap2,
+                                                               ExtendedCorrelationsTable* table,
+                                                               const AlgebraicSymMatrix& cov,
+                                                               int row,
+                                                               int col,
+                                                               bool transpose) {
+  ExtendedCorrelationsTable::iterator itC = table->find(ap2);
 
-void
-AlignmentExtendedCorrelationsStore::fillCorrelationsTable( Alignable* ap1, Alignable* ap2,
-							   ExtendedCorrelationsTable* table,
-							   const AlgebraicSymMatrix& cov,
-							   int row, int col, bool transpose )
-{
-  ExtendedCorrelationsTable::iterator itC = table->find( ap2 );
-
-  if ( itC != table->end() )
-  {
+  if (itC != table->end()) {
     //if ( itC->second.counter() > theMaxUpdates ) return;
 
-    transpose ?
-      readFromCovarianceT( ap1, ap2, itC->second, cov, row, col ) :
-      readFromCovariance( ap1, ap2, itC->second, cov, row, col );
+    transpose ? readFromCovarianceT(ap1, ap2, itC->second, cov, row, col)
+              : readFromCovariance(ap1, ap2, itC->second, cov, row, col);
 
     //itC->second.incrementCounter();
-  }
-  else
-  {
+  } else {
     int nRow = ap1->alignmentParameters()->numSelected();
     int nCol = ap2->alignmentParameters()->numSelected();
-    ExtendedCorrelationsEntry newEntry( nRow, nCol );
+    ExtendedCorrelationsEntry newEntry(nRow, nCol);
 
-    transpose ?
-      readFromCovarianceT( ap1, ap2, newEntry, cov, row, col ) :
-      readFromCovariance( ap1, ap2, newEntry, cov, row, col );
+    transpose ? readFromCovarianceT(ap1, ap2, newEntry, cov, row, col)
+              : readFromCovariance(ap1, ap2, newEntry, cov, row, col);
 
     (*table)[ap2] = newEntry;
   }
 }
 
-
-void
-AlignmentExtendedCorrelationsStore::fillCovariance( Alignable* ap1, Alignable* ap2,  const ExtendedCorrelationsEntry& entry,
-						    AlgebraicSymMatrix& cov, int row, int col ) const
-{
+void AlignmentExtendedCorrelationsStore::fillCovariance(Alignable* ap1,
+                                                        Alignable* ap2,
+                                                        const ExtendedCorrelationsEntry& entry,
+                                                        AlgebraicSymMatrix& cov,
+                                                        int row,
+                                                        int col) const {
   int nRow = entry.numRow();
   int nCol = entry.numCol();
 
-  for ( int iRow = 0; iRow < nRow; ++iRow )
-  {
-    double factor = sqrt(cov[row+iRow][row+iRow]);
-    if ( edm::isNotFinite(factor) ) throw cms::Exception("LogicError") << "[AlignmentExtendedCorrelationsStore::fillCovariance] "
-							    << "NaN-factor: sqrt(" << cov[row+iRow][row+iRow] << ")";
+  for (int iRow = 0; iRow < nRow; ++iRow) {
+    double factor = sqrt(cov[row + iRow][row + iRow]);
+    if (edm::isNotFinite(factor))
+      throw cms::Exception("LogicError") << "[AlignmentExtendedCorrelationsStore::fillCovariance] "
+                                         << "NaN-factor: sqrt(" << cov[row + iRow][row + iRow] << ")";
 
-    for ( int jCol = 0; jCol < nCol; ++jCol )
-      cov[row+iRow][col+jCol] = entry( iRow, jCol )*factor;
+    for (int jCol = 0; jCol < nCol; ++jCol)
+      cov[row + iRow][col + jCol] = entry(iRow, jCol) * factor;
   }
 
-  for ( int jCol = 0; jCol < nCol; ++jCol )
-  {
-    double factor = sqrt(cov[col+jCol][col+jCol]);
-    if ( edm::isNotFinite(factor) ) throw cms::Exception("LogicError") << "[AlignmentExtendedCorrelationsStore::fillCovariance] "
-							    << "NaN-factor: sqrt(" << cov[col+jCol][col+jCol] << ")";
+  for (int jCol = 0; jCol < nCol; ++jCol) {
+    double factor = sqrt(cov[col + jCol][col + jCol]);
+    if (edm::isNotFinite(factor))
+      throw cms::Exception("LogicError") << "[AlignmentExtendedCorrelationsStore::fillCovariance] "
+                                         << "NaN-factor: sqrt(" << cov[col + jCol][col + jCol] << ")";
 
-    for ( int iRow = 0; iRow < nRow; ++iRow )
-      cov[row+iRow][col+jCol] *= factor;
+    for (int iRow = 0; iRow < nRow; ++iRow)
+      cov[row + iRow][col + jCol] *= factor;
   }
 }
 
-
-void
-AlignmentExtendedCorrelationsStore::fillCovarianceT( Alignable* ap1, Alignable* ap2, const ExtendedCorrelationsEntry& entry,
-					     AlgebraicSymMatrix& cov, int row, int col ) const
-{
+void AlignmentExtendedCorrelationsStore::fillCovarianceT(Alignable* ap1,
+                                                         Alignable* ap2,
+                                                         const ExtendedCorrelationsEntry& entry,
+                                                         AlgebraicSymMatrix& cov,
+                                                         int row,
+                                                         int col) const {
   int nRow = entry.numRow();
   int nCol = entry.numCol();
 
-  for ( int iRow = 0; iRow < nRow; ++iRow )
-  {
-    double factor = sqrt(cov[col+iRow][col+iRow]);
-    if ( edm::isNotFinite(factor) ) throw cms::Exception("LogicError") << "[AlignmentExtendedCorrelationsStore::fillCovarianceT] "
-							    << "NaN-factor: sqrt(" << cov[col+iRow][col+iRow] << ")";
-    for ( int jCol = 0; jCol < nCol; ++jCol )
-      cov[row+jCol][col+iRow] = entry( iRow, jCol )*factor;
+  for (int iRow = 0; iRow < nRow; ++iRow) {
+    double factor = sqrt(cov[col + iRow][col + iRow]);
+    if (edm::isNotFinite(factor))
+      throw cms::Exception("LogicError") << "[AlignmentExtendedCorrelationsStore::fillCovarianceT] "
+                                         << "NaN-factor: sqrt(" << cov[col + iRow][col + iRow] << ")";
+    for (int jCol = 0; jCol < nCol; ++jCol)
+      cov[row + jCol][col + iRow] = entry(iRow, jCol) * factor;
   }
 
-  for ( int jCol = 0; jCol < nCol; ++jCol )
-  {
-    double factor = sqrt(cov[row+jCol][row+jCol]);
-    if ( edm::isNotFinite(factor) ) throw cms::Exception("LogicError") << "[AlignmentExtendedCorrelationsStore::fillCovarianceT] "
-							    << "NaN-factor: sqrt(" << cov[row+jCol][row+jCol] << ")";
-    for ( int iRow = 0; iRow < nRow; ++iRow )
-      cov[row+jCol][col+iRow] *= factor;
+  for (int jCol = 0; jCol < nCol; ++jCol) {
+    double factor = sqrt(cov[row + jCol][row + jCol]);
+    if (edm::isNotFinite(factor))
+      throw cms::Exception("LogicError") << "[AlignmentExtendedCorrelationsStore::fillCovarianceT] "
+                                         << "NaN-factor: sqrt(" << cov[row + jCol][row + jCol] << ")";
+    for (int iRow = 0; iRow < nRow; ++iRow)
+      cov[row + jCol][col + iRow] *= factor;
   }
-
 }
 
-
-void
-AlignmentExtendedCorrelationsStore::readFromCovariance( Alignable* ap1, Alignable* ap2, ExtendedCorrelationsEntry& entry,
-							const AlgebraicSymMatrix& cov, int row, int col )
-{
+void AlignmentExtendedCorrelationsStore::readFromCovariance(
+    Alignable* ap1, Alignable* ap2, ExtendedCorrelationsEntry& entry, const AlgebraicSymMatrix& cov, int row, int col) {
   int nRow = entry.numRow();
   int nCol = entry.numCol();
 
-  for ( int iRow = 0; iRow < nRow; ++iRow )
-  {
-    double factor = sqrt(cov[row+iRow][row+iRow]);
-    for ( int jCol = 0; jCol < nCol; ++jCol )
-      entry( iRow, jCol ) = cov[row+iRow][col+jCol]/factor;
+  for (int iRow = 0; iRow < nRow; ++iRow) {
+    double factor = sqrt(cov[row + iRow][row + iRow]);
+    for (int jCol = 0; jCol < nCol; ++jCol)
+      entry(iRow, jCol) = cov[row + iRow][col + jCol] / factor;
   }
 
   double maxCorr = 0;
 
-  for ( int jCol = 0; jCol < nCol; ++jCol )
-  {
-    double factor = sqrt(cov[col+jCol][col+jCol]);
-    for ( int iRow = 0; iRow < nRow; ++iRow )
-    {
-      entry( iRow, jCol ) /= factor;
-      if ( fabs( entry( iRow, jCol ) ) > maxCorr ) maxCorr = fabs( entry( iRow, jCol ) );
+  for (int jCol = 0; jCol < nCol; ++jCol) {
+    double factor = sqrt(cov[col + jCol][col + jCol]);
+    for (int iRow = 0; iRow < nRow; ++iRow) {
+      entry(iRow, jCol) /= factor;
+      if (fabs(entry(iRow, jCol)) > maxCorr)
+        maxCorr = fabs(entry(iRow, jCol));
     }
   }
 
-  resizeCorruptCorrelations( entry, maxCorr );
+  resizeCorruptCorrelations(entry, maxCorr);
 }
 
-
-void
-AlignmentExtendedCorrelationsStore::readFromCovarianceT( Alignable* ap1, Alignable* ap2, ExtendedCorrelationsEntry& entry,
-							 const AlgebraicSymMatrix& cov, int row, int col )
-{
+void AlignmentExtendedCorrelationsStore::readFromCovarianceT(
+    Alignable* ap1, Alignable* ap2, ExtendedCorrelationsEntry& entry, const AlgebraicSymMatrix& cov, int row, int col) {
   int nRow = entry.numRow();
   int nCol = entry.numCol();
 
-  for ( int iRow = 0; iRow < nRow; ++iRow )
-  {
-    double factor = sqrt(cov[col+iRow][col+iRow]);
-    for ( int jCol = 0; jCol < nCol; ++jCol )
-      entry( iRow, jCol ) = cov[row+jCol][col+iRow]/factor;
+  for (int iRow = 0; iRow < nRow; ++iRow) {
+    double factor = sqrt(cov[col + iRow][col + iRow]);
+    for (int jCol = 0; jCol < nCol; ++jCol)
+      entry(iRow, jCol) = cov[row + jCol][col + iRow] / factor;
   }
 
   double maxCorr = 0;
 
-  for ( int jCol = 0; jCol < nCol; ++jCol )
-  {
-    double factor = sqrt(cov[row+jCol][row+jCol]);
-    for ( int iRow = 0; iRow < nRow; ++iRow )
-    {
-      entry( iRow, jCol ) /= factor;
-      if ( fabs( entry( iRow, jCol ) ) > maxCorr ) maxCorr = fabs( entry( iRow, jCol ) );
+  for (int jCol = 0; jCol < nCol; ++jCol) {
+    double factor = sqrt(cov[row + jCol][row + jCol]);
+    for (int iRow = 0; iRow < nRow; ++iRow) {
+      entry(iRow, jCol) /= factor;
+      if (fabs(entry(iRow, jCol)) > maxCorr)
+        maxCorr = fabs(entry(iRow, jCol));
     }
   }
 
-  resizeCorruptCorrelations( entry, maxCorr );
+  resizeCorruptCorrelations(entry, maxCorr);
 }
 
-
-void
-AlignmentExtendedCorrelationsStore::resizeCorruptCorrelations( ExtendedCorrelationsEntry& entry,
-							       double maxCorr )
-{
-  if ( maxCorr > 1. )
-  {
-    entry *= theWeight/maxCorr;
-  }
-  else if ( maxCorr > theCut )
-  {
-    entry *= 1. - ( maxCorr - theCut )/( 1. - theCut )*( 1. - theWeight );
+void AlignmentExtendedCorrelationsStore::resizeCorruptCorrelations(ExtendedCorrelationsEntry& entry, double maxCorr) {
+  if (maxCorr > 1.) {
+    entry *= theWeight / maxCorr;
+  } else if (maxCorr > theCut) {
+    entry *= 1. - (maxCorr - theCut) / (1. - theCut) * (1. - theWeight);
   }
 }

--- a/Alignment/CommonAlignmentAlgorithm/src/AlignmentIORoot.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignmentIORoot.cc
@@ -6,139 +6,191 @@
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentIORoot.h"
 
 // ----------------------------------------------------------------------------
-// write alignment parameters 
+// write alignment parameters
 
-void 
-AlignmentIORoot::writeAlignmentParameters(const align::Alignables& alivec, 
-                                          const char* filename, int iter, 
-                                          bool validCheck, int& ierr)
-{
+void AlignmentIORoot::writeAlignmentParameters(
+    const align::Alignables& alivec, const char* filename, int iter, bool validCheck, int& ierr) {
   AlignmentParametersIORoot theIO;
-  ierr=0;
+  ierr = 0;
   int iret;
-  iret = theIO.open(filename,iter,true);
-  if (iret!=0) { ierr=-1; return;}
-  iret = theIO.write(alivec,validCheck);
-  if (iret!=0) { ierr=-2; return;}
+  iret = theIO.open(filename, iter, true);
+  if (iret != 0) {
+    ierr = -1;
+    return;
+  }
+  iret = theIO.write(alivec, validCheck);
+  if (iret != 0) {
+    ierr = -2;
+    return;
+  }
   iret = theIO.close();
-  if (iret!=0) { ierr=-3; return;}
+  if (iret != 0) {
+    ierr = -3;
+    return;
+  }
 }
 
 // ----------------------------------------------------------------------------
-// read alignment parameters 
-align::Parameters 
-AlignmentIORoot::readAlignmentParameters(const align::Alignables& alivec, 
-                                         const char* filename, int iter, int& ierr)
-{
+// read alignment parameters
+align::Parameters AlignmentIORoot::readAlignmentParameters(const align::Alignables& alivec,
+                                                           const char* filename,
+                                                           int iter,
+                                                           int& ierr) {
   align::Parameters result;
 
   AlignmentParametersIORoot theIO;
-  ierr=0;
+  ierr = 0;
   int iret;
-  iret = theIO.open(filename,iter,false);
-  if (iret!=0) { ierr=-1; return result;}
-  result = theIO.read(alivec,iret);
-  if (iret!=0) { ierr=-2; return result;}
+  iret = theIO.open(filename, iter, false);
+  if (iret != 0) {
+    ierr = -1;
+    return result;
+  }
+  result = theIO.read(alivec, iret);
+  if (iret != 0) {
+    ierr = -2;
+    return result;
+  }
   iret = theIO.close();
-  if (iret!=0) { ierr=-3; return result;}
+  if (iret != 0) {
+    ierr = -3;
+    return result;
+  }
 
   return result;
 }
 
 // ----------------------------------------------------------------------------
-// write alignment parameters 
-void
-AlignmentIORoot::writeOrigRigidBodyAlignmentParameters
-(const align::Alignables& alivec, const char* filename, int iter, bool validCheck, int& ierr)
-{
+// write alignment parameters
+void AlignmentIORoot::writeOrigRigidBodyAlignmentParameters(
+    const align::Alignables& alivec, const char* filename, int iter, bool validCheck, int& ierr) {
   AlignmentParametersIORoot theIO;
   ierr = 0;
   int iret = theIO.open(filename, iter, true);
-  if (iret != 0) { ierr = -1; return;}
+  if (iret != 0) {
+    ierr = -1;
+    return;
+  }
   iret = theIO.writeOrigRigidBody(alivec, validCheck);
-  if (iret != 0) { ierr = -2; return;}
+  if (iret != 0) {
+    ierr = -2;
+    return;
+  }
   iret = theIO.close();
-  if (iret != 0) { ierr = -3; return;}
+  if (iret != 0) {
+    ierr = -3;
+    return;
+  }
 }
-
 
 // ----------------------------------------------------------------------------
 // write correlations
 
-void 
-AlignmentIORoot::writeCorrelations (const align::Correlations& cormap, 
-                                    const char* filename, int iter, bool validCheck, int& ierr)
-{
+void AlignmentIORoot::writeCorrelations(
+    const align::Correlations& cormap, const char* filename, int iter, bool validCheck, int& ierr) {
   AlignmentCorrelationsIORoot theIO;
-  ierr=0;
+  ierr = 0;
   int iret;
-  iret = theIO.open(filename,iter,true);
-  if (iret!=0) { ierr=-1; return;}
-  iret = theIO.write(cormap,validCheck);
-  if (iret!=0) { ierr=-2; return;}
+  iret = theIO.open(filename, iter, true);
+  if (iret != 0) {
+    ierr = -1;
+    return;
+  }
+  iret = theIO.write(cormap, validCheck);
+  if (iret != 0) {
+    ierr = -2;
+    return;
+  }
   iret = theIO.close();
-  if (iret!=0) { ierr=-3; return;}
+  if (iret != 0) {
+    ierr = -3;
+    return;
+  }
 }
 
 // ----------------------------------------------------------------------------
 // read correlations
 
-align::Correlations 
-AlignmentIORoot::readCorrelations (const align::Alignables& alivec, const char* filename, 
-                                   int iter, int& ierr)
-{   
+align::Correlations AlignmentIORoot::readCorrelations(const align::Alignables& alivec,
+                                                      const char* filename,
+                                                      int iter,
+                                                      int& ierr) {
   align::Correlations result;
 
   AlignmentCorrelationsIORoot theIO;
-  ierr=0;
+  ierr = 0;
   int iret;
-  iret = theIO.open(filename,iter,false);
-  if (iret!=0) { ierr=-1; return result;}
-  result = theIO.read(alivec,iret);
-  if (iret!=0) { ierr=-2; return result;}
+  iret = theIO.open(filename, iter, false);
+  if (iret != 0) {
+    ierr = -1;
+    return result;
+  }
+  result = theIO.read(alivec, iret);
+  if (iret != 0) {
+    ierr = -2;
+    return result;
+  }
   iret = theIO.close();
-  if (iret!=0) { ierr=-3; return result;}
+  if (iret != 0) {
+    ierr = -3;
+    return result;
+  }
 
   return result;
 }
 
-
 // ----------------------------------------------------------------------------
 // write absolute position of alignable
 
-void AlignmentIORoot::writeAlignableAbsolutePositions ( const align::Alignables& alivec, 
-                                                        const char* filename, int iter, 
-                                                        bool validCheck, int& ierr)
-{
+void AlignmentIORoot::writeAlignableAbsolutePositions(
+    const align::Alignables& alivec, const char* filename, int iter, bool validCheck, int& ierr) {
   AlignableDataIORoot theIO(AlignableDataIORoot::Abs);
-  ierr=0;
+  ierr = 0;
   int iret;
-  iret = theIO.open(filename,iter,true);
-  if (iret!=0) { ierr=-1; return;}
-  iret = theIO.writeAbsPos(alivec,validCheck);
-  if (iret!=0) { ierr=-2; return;}
+  iret = theIO.open(filename, iter, true);
+  if (iret != 0) {
+    ierr = -1;
+    return;
+  }
+  iret = theIO.writeAbsPos(alivec, validCheck);
+  if (iret != 0) {
+    ierr = -2;
+    return;
+  }
   iret = theIO.close();
-  if (iret!=0) { ierr=-3; return;}
+  if (iret != 0) {
+    ierr = -3;
+    return;
+  }
 }
 
 // ----------------------------------------------------------------------------
 // read absolute position of alignable
 
-AlignablePositions 
-AlignmentIORoot::readAlignableAbsolutePositions (const align::Alignables& alivec, 
-                                                 const char* filename, int iter, int& ierr)
-{
+AlignablePositions AlignmentIORoot::readAlignableAbsolutePositions(const align::Alignables& alivec,
+                                                                   const char* filename,
+                                                                   int iter,
+                                                                   int& ierr) {
   AlignablePositions result;
 
   AlignableDataIORoot theIO(AlignableDataIORoot::Abs);
-  ierr=0;
+  ierr = 0;
   int iret;
-  iret = theIO.open(filename,iter,false);
-  if (iret!=0) { ierr=-1; return result;}
-  result = theIO.readAbsPos(alivec,iret);
-  if (iret!=0) { ierr=-2; return result;}
+  iret = theIO.open(filename, iter, false);
+  if (iret != 0) {
+    ierr = -1;
+    return result;
+  }
+  result = theIO.readAbsPos(alivec, iret);
+  if (iret != 0) {
+    ierr = -2;
+    return result;
+  }
   iret = theIO.close();
-  if (iret!=0) { ierr=-3; return result;}
+  if (iret != 0) {
+    ierr = -3;
+    return result;
+  }
 
   return result;
 }
@@ -146,39 +198,55 @@ AlignmentIORoot::readAlignableAbsolutePositions (const align::Alignables& alivec
 // ----------------------------------------------------------------------------
 // write original position of alignable
 
-void AlignmentIORoot::writeAlignableOriginalPositions ( const align::Alignables& alivec, 
-                                                        const char* filename, int iter, 
-                                                        bool validCheck, int& ierr)
-{
+void AlignmentIORoot::writeAlignableOriginalPositions(
+    const align::Alignables& alivec, const char* filename, int iter, bool validCheck, int& ierr) {
   AlignableDataIORoot theIO(AlignableDataIORoot::Org);
-  ierr=0;
+  ierr = 0;
   int iret;
-  iret = theIO.open(filename,iter,true);
-  if (iret!=0) { ierr=-1; return;}
-  iret = theIO.writeOrgPos(alivec,validCheck);
-  if (iret!=0) { ierr=-2; return;}
+  iret = theIO.open(filename, iter, true);
+  if (iret != 0) {
+    ierr = -1;
+    return;
+  }
+  iret = theIO.writeOrgPos(alivec, validCheck);
+  if (iret != 0) {
+    ierr = -2;
+    return;
+  }
   iret = theIO.close();
-  if (iret!=0) { ierr=-3; return;}
+  if (iret != 0) {
+    ierr = -3;
+    return;
+  }
 }
 
 // ----------------------------------------------------------------------------
 // read original position of alignable
 
-AlignablePositions 
-AlignmentIORoot::readAlignableOriginalPositions (const align::Alignables& alivec, 
-                                                 const char* filename, int iter, int& ierr)
-{
+AlignablePositions AlignmentIORoot::readAlignableOriginalPositions(const align::Alignables& alivec,
+                                                                   const char* filename,
+                                                                   int iter,
+                                                                   int& ierr) {
   AlignablePositions result;
 
   AlignableDataIORoot theIO(AlignableDataIORoot::Org);
-  ierr=0;
+  ierr = 0;
   int iret;
-  iret = theIO.open(filename,iter,false);
-  if (iret!=0) { ierr=-1; return result;}
-  result = theIO.readOrgPos(alivec,iret);
-  if (iret!=0) { ierr=-2; return result;}
+  iret = theIO.open(filename, iter, false);
+  if (iret != 0) {
+    ierr = -1;
+    return result;
+  }
+  result = theIO.readOrgPos(alivec, iret);
+  if (iret != 0) {
+    ierr = -2;
+    return result;
+  }
   iret = theIO.close();
-  if (iret!=0) { ierr=-3; return result;}
+  if (iret != 0) {
+    ierr = -3;
+    return result;
+  }
 
   return result;
 }
@@ -186,45 +254,55 @@ AlignmentIORoot::readAlignableOriginalPositions (const align::Alignables& alivec
 // ----------------------------------------------------------------------------
 // write relative position of alignable
 
-void AlignmentIORoot::writeAlignableRelativePositions( const align::Alignables& alivec,
-                                                       const char* filename,
-                                                       int iter, bool validCheck, int& ierr)
-{
+void AlignmentIORoot::writeAlignableRelativePositions(
+    const align::Alignables& alivec, const char* filename, int iter, bool validCheck, int& ierr) {
   AlignableDataIORoot theIO(AlignableDataIORoot::Rel);
-  ierr=0;
+  ierr = 0;
   int iret;
-  iret = theIO.open(filename,iter,true);
-  if (iret!=0) { ierr=-1; return;}
-  iret = theIO.writeRelPos(alivec,validCheck);
-  if (iret!=0) { ierr=-2; return;}
+  iret = theIO.open(filename, iter, true);
+  if (iret != 0) {
+    ierr = -1;
+    return;
+  }
+  iret = theIO.writeRelPos(alivec, validCheck);
+  if (iret != 0) {
+    ierr = -2;
+    return;
+  }
   iret = theIO.close();
-  if (iret!=0) { ierr=-3; return;}
+  if (iret != 0) {
+    ierr = -3;
+    return;
+  }
 }
 
 // ----------------------------------------------------------------------------
 // read relative position of alignable
 
-AlignableShifts 
-AlignmentIORoot::readAlignableRelativePositions (const align::Alignables& alivec, 
-                                                 const char* filename, int iter, int& ierr)
-{
+AlignableShifts AlignmentIORoot::readAlignableRelativePositions(const align::Alignables& alivec,
+                                                                const char* filename,
+                                                                int iter,
+                                                                int& ierr) {
   AlignableShifts result;
 
   AlignableDataIORoot theIO(AlignableDataIORoot::Rel);
-  ierr=0;
+  ierr = 0;
   int iret;
-  iret = theIO.open(filename,iter,false);
-  if (iret!=0) { ierr=-1; return result;}
-  result = theIO.readRelPos(alivec,iret);
-  if (iret!=0) { ierr=-2; return result;}
+  iret = theIO.open(filename, iter, false);
+  if (iret != 0) {
+    ierr = -1;
+    return result;
+  }
+  result = theIO.readRelPos(alivec, iret);
+  if (iret != 0) {
+    ierr = -2;
+    return result;
+  }
   iret = theIO.close();
-  if (iret!=0) { ierr=-3; return result;}
+  if (iret != 0) {
+    ierr = -3;
+    return result;
+  }
 
   return result;
 }
-
-
-
-
-
-

--- a/Alignment/CommonAlignmentAlgorithm/src/AlignmentIORootBase.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignmentIORootBase.cc
@@ -6,85 +6,78 @@
 #include "TFile.h"
 #include "TTree.h"
 
-AlignmentIORootBase::~AlignmentIORootBase()
-{
-  delete myFile; // tree is deleted automatically with file
+AlignmentIORootBase::~AlignmentIORootBase() {
+  delete myFile;  // tree is deleted automatically with file
 }
 
 // ----------------------------------------------------------------------------
 // open file/trees for write
 
-int AlignmentIORootBase::openRoot(const char* filename, int iteration, bool write)
-{
-  bWrite=write;
+int AlignmentIORootBase::openRoot(const char* filename, int iteration, bool write) {
+  bWrite = write;
   int iter;
 
-  edm::LogInfo("AlignmentIORootBase") << "File: " << filename ;
+  edm::LogInfo("AlignmentIORootBase") << "File: " << filename;
 
-  if (bWrite) { // writing
+  if (bWrite) {  // writing
 
-    int iterfile = testFile(filename,treename);
+    int iterfile = testFile(filename, treename);
     if (iterfile == -1) {
-      iter=iteration;
-	  edm::LogInfo("AlignmentIORootBase") << "Write to new file; first iteration: " << iter ;
-	  myFile = TFile::Open(filename,"recreate");
+      iter = iteration;
+      edm::LogInfo("AlignmentIORootBase") << "Write to new file; first iteration: " << iter;
+      myFile = TFile::Open(filename, "recreate");
     } else {
       if (iteration == -1) {
-        iter=iterfile+1;
-		edm::LogInfo("AlignmentIORootBase") 
-		  << "Write to existing file; highest iteration: " << iter;
+        iter = iterfile + 1;
+        edm::LogInfo("AlignmentIORootBase") << "Write to existing file; highest iteration: " << iter;
       } else {
-        if (iteration<=iterfile) {
-          edm::LogError("AlignmentIORootBase") 
-            << "Iteration " << iteration 
-            <<" invalid or already exists for tree " << treename;
-		  return -1;
+        if (iteration <= iterfile) {
+          edm::LogError("AlignmentIORootBase")
+              << "Iteration " << iteration << " invalid or already exists for tree " << treename;
+          return -1;
         }
         iter = iteration;
-        edm::LogInfo("AlignmentIORootBase")  << "Write to new iteration: " << iter;
+        edm::LogInfo("AlignmentIORootBase") << "Write to new iteration: " << iter;
       }
-      myFile = TFile::Open(filename,"update");
-	  
+      myFile = TFile::Open(filename, "update");
     }
 
     // create tree
     myFile->cd();
-    edm::LogInfo("AlignmentIORootBase") << "Tree: " << treeName(iter,treename);
-    tree = new TTree(treeName(iter,treename),treetxt);
+    edm::LogInfo("AlignmentIORootBase") << "Tree: " << treeName(iter, treename);
+    tree = new TTree(treeName(iter, treename), treetxt);
     createBranches();
 
-  } else { // reading
+  } else {  // reading
 
-    int iterfile = testFile(filename,treename);
-    if ( iterfile == -1 ) {
+    int iterfile = testFile(filename, treename);
+    if (iterfile == -1) {
       edm::LogError("AlignmentIORootBase") << "File does not exist!";
       return -1;
-    } else if ( iterfile == -2 ) {
-      edm::LogError("AlignmentIORootBase") << "Tree " << treename 
-                                           << " does not exist in file " << filename;
+    } else if (iterfile == -2) {
+      edm::LogError("AlignmentIORootBase") << "Tree " << treename << " does not exist in file " << filename;
       return -1;
     } else {
       if (iteration == -1) {
-        iter=iterfile;
+        iter = iterfile;
         edm::LogInfo("AlignmentIORootBase") << "Read from highest iteration: " << iter;
       } else {
-        if (iteration>iterfile) {
-        edm::LogError("AlignmentIORootBase")
-          << "Iteration " << iteration << " does not exist for tree " << treename;
-	return -1;
+        if (iteration > iterfile) {
+          edm::LogError("AlignmentIORootBase") << "Iteration " << iteration << " does not exist for tree " << treename;
+          return -1;
         }
         iter = iteration;
-        edm::LogInfo("AlignmentIORootBase")  << "Read from specified iteration: " << iter;
+        edm::LogInfo("AlignmentIORootBase") << "Read from specified iteration: " << iter;
       }
       myFile = TFile::Open(filename, "read");
     }
 
     myFile->cd();
     // set trees
-    edm::LogInfo("AlignmentIORootBase") <<" Tree: " <<treeName(iter,treename);
-    tree = (TTree*)myFile->Get(treeName(iter,treename));
-    if (tree==nullptr) {
-      edm::LogError("AlignmentIORootBase") <<"Tree does not exist in file!";
+    edm::LogInfo("AlignmentIORootBase") << " Tree: " << treeName(iter, treename);
+    tree = (TTree*)myFile->Get(treeName(iter, treename));
+    if (tree == nullptr) {
+      edm::LogError("AlignmentIORootBase") << "Tree does not exist in file!";
       return -1;
     }
     setBranchAddresses();
@@ -96,15 +89,14 @@ int AlignmentIORootBase::openRoot(const char* filename, int iteration, bool writ
 // ----------------------------------------------------------------------------
 // write tree and close file
 
-int AlignmentIORootBase::closeRoot(void)
-{
-  if (bWrite) { //writing
+int AlignmentIORootBase::closeRoot(void) {
+  if (bWrite) {  //writing
     tree->Write();
   }
 
   delete myFile;
   myFile = nullptr;
-  tree = nullptr; // deleted with file
+  tree = nullptr;  // deleted with file
 
   return 0;
 }
@@ -113,19 +105,18 @@ int AlignmentIORootBase::closeRoot(void)
 // returns highest existing iteration in file
 // if file does not exist: return -1
 
-int AlignmentIORootBase::testFile(const char* filename, const TString &tname)
-{
+int AlignmentIORootBase::testFile(const char* filename, const TString& tname) {
   FILE* testFILE;
-  testFILE = fopen(filename,"r");
+  testFILE = fopen(filename, "r");
   if (testFILE == nullptr) {
     return -1;
   } else {
     fclose(testFILE);
-    int ihighest=-2;
-    TFile *aFile = TFile::Open(filename,"read");
-    for (int iter=0; iter<itermax; iter++) {
-      if ((nullptr != (TTree*)aFile->Get(treeName(iter,tname))) 
-	  && (iter>ihighest)) ihighest=iter; 
+    int ihighest = -2;
+    TFile* aFile = TFile::Open(filename, "read");
+    for (int iter = 0; iter < itermax; iter++) {
+      if ((nullptr != (TTree*)aFile->Get(treeName(iter, tname))) && (iter > ihighest))
+        ihighest = iter;
     }
     delete aFile;
     return ihighest;
@@ -135,7 +126,4 @@ int AlignmentIORootBase::testFile(const char* filename, const TString &tname)
 // ----------------------------------------------------------------------------
 // create tree name from stub+iteration
 
-TString AlignmentIORootBase::treeName(int iter, const TString &tname)
-{
-  return TString(tname + Form("_%i",iter));
-}
+TString AlignmentIORootBase::treeName(int iter, const TString& tname) { return TString(tname + Form("_%i", iter)); }

--- a/Alignment/CommonAlignmentAlgorithm/src/AlignmentParameterBuilder.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignmentParameterBuilder.cc
@@ -25,83 +25,69 @@
 using namespace AlignmentParametersFactory;
 
 //__________________________________________________________________________________________________
-AlignmentParameterBuilder::AlignmentParameterBuilder(AlignableTracker* alignableTracker,
-						     AlignableExtras* alignableExtras) :
-  theAlignables(),
-  theAlignableTracker(alignableTracker),
-  theAlignableMuon(nullptr),
-  theAlignableExtras(alignableExtras)
-{
-}
+AlignmentParameterBuilder::AlignmentParameterBuilder(AlignableTracker *alignableTracker,
+                                                     AlignableExtras *alignableExtras)
+    : theAlignables(),
+      theAlignableTracker(alignableTracker),
+      theAlignableMuon(nullptr),
+      theAlignableExtras(alignableExtras) {}
 
 //__________________________________________________________________________________________________
-AlignmentParameterBuilder::AlignmentParameterBuilder(AlignableTracker* alignableTracker, 
-                                                     AlignableMuon* alignableMuon,
-						     AlignableExtras* alignableExtras) :
-  theAlignables(), 
-  theAlignableTracker(alignableTracker),
-  theAlignableMuon(alignableMuon),
-  theAlignableExtras(alignableExtras)
-{
-}
-
+AlignmentParameterBuilder::AlignmentParameterBuilder(AlignableTracker *alignableTracker,
+                                                     AlignableMuon *alignableMuon,
+                                                     AlignableExtras *alignableExtras)
+    : theAlignables(),
+      theAlignableTracker(alignableTracker),
+      theAlignableMuon(alignableMuon),
+      theAlignableExtras(alignableExtras) {}
 
 //__________________________________________________________________________________________________
-AlignmentParameterBuilder::AlignmentParameterBuilder(AlignableTracker* alignableTracker,
-						     AlignableExtras* alignableExtras,
-                                                     const edm::ParameterSet &pSet) :
-  theAlignables(), 
-  theAlignableTracker(alignableTracker),
-  theAlignableMuon(nullptr),
-  theAlignableExtras(alignableExtras)
-{
+AlignmentParameterBuilder::AlignmentParameterBuilder(AlignableTracker *alignableTracker,
+                                                     AlignableExtras *alignableExtras,
+                                                     const edm::ParameterSet &pSet)
+    : theAlignables(),
+      theAlignableTracker(alignableTracker),
+      theAlignableMuon(nullptr),
+      theAlignableExtras(alignableExtras) {
   this->addAllSelections(pSet);
 }
 
 //__________________________________________________________________________________________________
-AlignmentParameterBuilder::AlignmentParameterBuilder(AlignableTracker* alignableTracker,
-                                                     AlignableMuon* alignableMuon,
-						     AlignableExtras* alignableExtras,
-                                                     const edm::ParameterSet &pSet) :
-  theAlignables(), 
-  theAlignableTracker(alignableTracker),
-  theAlignableMuon(alignableMuon),
-  theAlignableExtras(alignableExtras)
-{
+AlignmentParameterBuilder::AlignmentParameterBuilder(AlignableTracker *alignableTracker,
+                                                     AlignableMuon *alignableMuon,
+                                                     AlignableExtras *alignableExtras,
+                                                     const edm::ParameterSet &pSet)
+    : theAlignables(),
+      theAlignableTracker(alignableTracker),
+      theAlignableMuon(alignableMuon),
+      theAlignableExtras(alignableExtras) {
   this->addAllSelections(pSet);
 }
 
-const AlignableTracker* AlignmentParameterBuilder::alignableTracker() const
-{
-  return theAlignableTracker;
-}
+const AlignableTracker *AlignmentParameterBuilder::alignableTracker() const { return theAlignableTracker; }
 
 //__________________________________________________________________________________________________
-void AlignmentParameterBuilder::addAllSelections(const edm::ParameterSet &pSet)
-{
+void AlignmentParameterBuilder::addAllSelections(const edm::ParameterSet &pSet) {
   AlignmentParameterSelector selector(nullptr);
   std::vector<std::string> selsTypes(pSet.getParameter<std::vector<std::string> >("parameterTypes"));
-  
+
   for (unsigned int i = 0; i < selsTypes.size(); ++i) {
     std::vector<std::string> selSetType(selector.decompose(selsTypes[i], ','));
     if (selSetType.size() != 2) {
       throw cms::Exception("BadConfig") << "AlignmentParameterBuilder"
-					<< "parameterTypes should contain 2 comma separated strings"
-					<< ", but found '" << selsTypes[i] << "'.";
+                                        << "parameterTypes should contain 2 comma separated strings"
+                                        << ", but found '" << selsTypes[i] << "'.";
     }
     this->addSelections(pSet.getParameter<edm::ParameterSet>(selSetType[0]),
-			AlignmentParametersFactory::parametersType(selSetType[1]));
+                        AlignmentParametersFactory::parametersType(selSetType[1]));
   }
 }
 
 //__________________________________________________________________________________________________
-unsigned int AlignmentParameterBuilder::addSelections(const edm::ParameterSet &pSet,
-						      ParametersType parType)
-{
-
+unsigned int AlignmentParameterBuilder::addSelections(const edm::ParameterSet &pSet, ParametersType parType) {
   const unsigned int oldAliSize = theAlignables.size();
 
-  AlignmentParameterSelector selector( theAlignableTracker, theAlignableMuon, theAlignableExtras );
+  AlignmentParameterSelector selector(theAlignableTracker, theAlignableMuon, theAlignableExtras);
   const unsigned int addedSets = selector.addSelections(pSet);
 
   const align::Alignables &alignables = selector.selectedAlignables();
@@ -113,10 +99,12 @@ unsigned int AlignmentParameterBuilder::addSelections(const edm::ParameterSet &p
 
   while (iAli != alignables.end() && iParamSel != paramSels.end()) {
     std::vector<bool> boolParSel;
-    std::vector<char> parSel(*iParamSel); // copy, since decodeParamSel may manipulate
+    std::vector<char> parSel(*iParamSel);  // copy, since decodeParamSel may manipulate
     bool charSelIsGeneral = this->decodeParamSel(parSel, boolParSel);
-    if (this->add(*iAli, parType, boolParSel)) ++nHigherLevel;
-    if (charSelIsGeneral) this->addFullParamSel((*iAli)->alignmentParameters(), parSel);
+    if (this->add(*iAli, parType, boolParSel))
+      ++nHigherLevel;
+    if (charSelIsGeneral)
+      this->addFullParamSel((*iAli)->alignmentParameters(), parSel);
 
     ++iAli;
     ++iParamSel;
@@ -126,97 +114,82 @@ unsigned int AlignmentParameterBuilder::addSelections(const edm::ParameterSet &p
                             << " Added " << addedSets << " set(s) of alignables with "
                             << theAlignables.size() - oldAliSize << " alignables in total,"
                             << " of which " << nHigherLevel << " are higher level "
-			    << "(using " << parametersTypeName(parType) << "AlignmentParameters).";
-   
+                            << "(using " << parametersTypeName(parType) << "AlignmentParameters).";
+
   return addedSets;
 }
 
 //__________________________________________________________________________________________________
-bool AlignmentParameterBuilder::add(Alignable *alignable,
-				    ParametersType parType,
-				    const std::vector<bool> &sel)
-{ 
+bool AlignmentParameterBuilder::add(Alignable *alignable, ParametersType parType, const std::vector<bool> &sel) {
   AlignmentParameters *paras = AlignmentParametersFactory::createParameters(alignable, parType, sel);
   alignable->setAlignmentParameters(paras);
   theAlignables.push_back(alignable);
 
   const int aliTypeId = alignable->alignableObjectId();
-  const bool isHigherLevel = (aliTypeId != align::AlignableDet
-			      && aliTypeId != align::AlignableDetUnit);
+  const bool isHigherLevel = (aliTypeId != align::AlignableDet && aliTypeId != align::AlignableDetUnit);
   return isHigherLevel;
 }
 
-
 //__________________________________________________________________________________________________
 unsigned int AlignmentParameterBuilder::add(const align::Alignables &alignables,
-					    ParametersType parType, const std::vector<bool> &sel)
-{
-
+                                            ParametersType parType,
+                                            const std::vector<bool> &sel) {
   unsigned int nHigherLevel = 0;
 
-  for (align::Alignables::const_iterator iAli = alignables.begin();
-       iAli != alignables.end(); ++iAli) {
-    if (this->add(*iAli, parType, sel)) ++nHigherLevel;
+  for (align::Alignables::const_iterator iAli = alignables.begin(); iAli != alignables.end(); ++iAli) {
+    if (this->add(*iAli, parType, sel))
+      ++nHigherLevel;
   }
 
   return nHigherLevel;
 }
 
-
 //__________________________________________________________________________________________________
-void AlignmentParameterBuilder::fixAlignables(int n)
-{
-
-  if (n<1 || n>3) {
+void AlignmentParameterBuilder::fixAlignables(int n) {
+  if (n < 1 || n > 3) {
     edm::LogError("BadArgument") << " n = " << n << " is not in [1,3]";
     return;
   }
 
   align::Alignables theNewAlignables;
-  int i=0;
+  int i = 0;
   int imax = theAlignables.size();
-  for ( align::Alignables::const_iterator ia=theAlignables.begin();
-        ia!=theAlignables.end();  ++ia ) 
-	{
-	  i++;
-	  if ( n==1 && i>1 ) 
-		theNewAlignables.push_back(*ia);
-	  else if ( n==2 && i>1 && i<imax ) 
-		theNewAlignables.push_back(*ia);
-	  else if ( n==3 && i>2 && i<imax) 
-		theNewAlignables.push_back(*ia);
-	}
+  for (align::Alignables::const_iterator ia = theAlignables.begin(); ia != theAlignables.end(); ++ia) {
+    i++;
+    if (n == 1 && i > 1)
+      theNewAlignables.push_back(*ia);
+    else if (n == 2 && i > 1 && i < imax)
+      theNewAlignables.push_back(*ia);
+    else if (n == 3 && i > 2 && i < imax)
+      theNewAlignables.push_back(*ia);
+  }
 
   theAlignables = theNewAlignables;
 
   edm::LogInfo("Alignment") << "@SUB=AlignmentParameterBuilder::fixAlignables"
-                            << "removing " << n << " alignables, so that " 
-                            << theAlignables.size() << " alignables left";
+                            << "removing " << n << " alignables, so that " << theAlignables.size()
+                            << " alignables left";
 }
 
 //__________________________________________________________________________________________________
-bool AlignmentParameterBuilder::decodeParamSel(std::vector<char> &paramSelChar,
-                                               std::vector<bool> &result) const
-{
+bool AlignmentParameterBuilder::decodeParamSel(std::vector<char> &paramSelChar, std::vector<bool> &result) const {
   result.clear();
   // remove all spaces from paramSelChar - useful to group the parameters if they are many
-  paramSelChar.erase(std::remove(paramSelChar.begin(), paramSelChar.end(), ' '),
-		     paramSelChar.end());
+  paramSelChar.erase(std::remove(paramSelChar.begin(), paramSelChar.end(), ' '), paramSelChar.end());
 
   bool anyNon01 = false;
 
   for (unsigned int pos = 0; pos < paramSelChar.size(); ++pos) {
-
     switch (paramSelChar[pos]) {
-    default:
-      anyNon01 = true;
-      // no break;
-    case '1':
-      result.push_back(true);
-      break;
-    case '0':
-      result.push_back(false);
-      break;
+      default:
+        anyNon01 = true;
+        // no break;
+      case '1':
+        result.push_back(true);
+        break;
+      case '0':
+        result.push_back(false);
+        break;
     }
   }
 
@@ -225,9 +198,9 @@ bool AlignmentParameterBuilder::decodeParamSel(std::vector<char> &paramSelChar,
 
 //__________________________________________________________________________________________________
 bool AlignmentParameterBuilder::addFullParamSel(AlignmentParameters *aliParams,
-                                                const std::vector<char> &fullSel) const
-{
-  if (!aliParams) return false;
+                                                const std::vector<char> &fullSel) const {
+  if (!aliParams)
+    return false;
 
   aliParams->setUserVariables(new SelectionUserVariables(fullSel));
 

--- a/Alignment/CommonAlignmentAlgorithm/src/AlignmentParameterSelector.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignmentParameterSelector.cc
@@ -21,25 +21,31 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 //________________________________________________________________________________
-AlignmentParameterSelector::AlignmentParameterSelector(AlignableTracker *aliTracker, AlignableMuon* aliMuon,
-						       AlignableExtras *aliExtras) :
-  theTracker(aliTracker), theMuon(aliMuon), theExtras(aliExtras), theSelectedAlignables(), 
-  theRangesEta(), theRangesPhi(), theRangesR(), theRangesX(), theRangesY(), theRangesZ()
-{
-  this->setSpecials(""); // init theOnlyDS, theOnlySS, theSelLayers, theMinLayer, theMaxLayer, theRphiOrStereoDetUnit
+AlignmentParameterSelector::AlignmentParameterSelector(AlignableTracker *aliTracker,
+                                                       AlignableMuon *aliMuon,
+                                                       AlignableExtras *aliExtras)
+    : theTracker(aliTracker),
+      theMuon(aliMuon),
+      theExtras(aliExtras),
+      theSelectedAlignables(),
+      theRangesEta(),
+      theRangesPhi(),
+      theRangesR(),
+      theRangesX(),
+      theRangesY(),
+      theRangesZ() {
+  this->setSpecials("");  // init theOnlyDS, theOnlySS, theSelLayers, theMinLayer, theMaxLayer, theRphiOrStereoDetUnit
 }
 
 //________________________________________________________________________________
-void AlignmentParameterSelector::clear()
-{
+void AlignmentParameterSelector::clear() {
   theSelectedAlignables.clear();
   theSelectedParameters.clear();
   this->clearGeometryCuts();
 }
 
 //________________________________________________________________________________
-void AlignmentParameterSelector::clearGeometryCuts()
-{
+void AlignmentParameterSelector::clearGeometryCuts() {
   theRangesEta.clear();
   theRangesPhi.clear();
   theRangesR.clear();
@@ -55,27 +61,22 @@ void AlignmentParameterSelector::clearGeometryCuts()
   theTECDetIdRanges.clear();
 }
 
-const AlignableTracker* AlignmentParameterSelector::alignableTracker() const
-{
-  return theTracker;
-}
+const AlignableTracker *AlignmentParameterSelector::alignableTracker() const { return theTracker; }
 
 //__________________________________________________________________________________________________
-unsigned int AlignmentParameterSelector::addSelections(const edm::ParameterSet &pSet)
-{
+unsigned int AlignmentParameterSelector::addSelections(const edm::ParameterSet &pSet) {
+  const std::vector<std::string> selections = pSet.getParameter<std::vector<std::string> >("alignParams");
 
-  const std::vector<std::string> selections
-    = pSet.getParameter<std::vector<std::string> >("alignParams");
-  
   unsigned int addedSets = 0;
 
   for (unsigned int iSel = 0; iSel < selections.size(); ++iSel) {
     std::vector<std::string> decompSel(this->decompose(selections[iSel], ','));
-    if (decompSel.empty()) continue; // edm::LogError or even cms::Exception??
+    if (decompSel.empty())
+      continue;  // edm::LogError or even cms::Exception??
 
     if (decompSel.size() < 2) {
-      throw cms::Exception("BadConfig") << "@SUB=AlignmentParameterSelector::addSelections"
-                                        << selections[iSel]<<" from alignableParamSelector: "
+      throw cms::Exception("BadConfig") << "@SUB=AlignmentParameterSelector::addSelections" << selections[iSel]
+                                        << " from alignableParamSelector: "
                                         << " should have at least 2 ','-separated parts";
     } else if (decompSel.size() > 2) {
       const edm::ParameterSet geoSel(pSet.getParameter<edm::ParameterSet>(decompSel[2].c_str()));
@@ -84,7 +85,7 @@ unsigned int AlignmentParameterSelector::addSelections(const edm::ParameterSet &
       this->clearGeometryCuts();
       this->addSelection(decompSel[0], this->convertParamSel(decompSel[1]));
     }
-    
+
     ++addedSets;
   }
 
@@ -92,16 +93,15 @@ unsigned int AlignmentParameterSelector::addSelections(const edm::ParameterSet &
 }
 
 //________________________________________________________________________________
-void AlignmentParameterSelector::setGeometryCuts(const edm::ParameterSet &pSet)
-{
+void AlignmentParameterSelector::setGeometryCuts(const edm::ParameterSet &pSet) {
   // Allow non-specified arrays to be interpreted as empty (i.e. no selection),
-  // but take care that nothing unknown is configured (to fetch typos!). 
+  // but take care that nothing unknown is configured (to fetch typos!).
 
   this->clearGeometryCuts();
   const std::vector<std::string> parameterNames(pSet.getParameterNames());
-  for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(),
-	 iEnd = parameterNames.end(); iParam != iEnd; ++iParam) {
-
+  for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(), iEnd = parameterNames.end();
+       iParam != iEnd;
+       ++iParam) {
     // Calling swap is more efficient than assignment:
     if (*iParam == "etaRanges") {
       pSet.getParameter<std::vector<double> >(*iParam).swap(theRangesEta);
@@ -124,40 +124,39 @@ void AlignmentParameterSelector::setGeometryCuts(const edm::ParameterSet &pSet)
     } else if (*iParam == "excludedDetIdRanges") {
       pSet.getParameter<std::vector<int> >(*iParam).swap(theExcludedDetIdRanges);
     } else if (*iParam == "pxbDetId") {
-      const edm::ParameterSet & pxbDetIdPSet = pSet.getParameterSet(*iParam);
+      const edm::ParameterSet &pxbDetIdPSet = pSet.getParameterSet(*iParam);
       this->setPXBDetIdCuts(pxbDetIdPSet);
     } else if (*iParam == "pxfDetId") {
-      const edm::ParameterSet & pxfDetIdPSet = pSet.getParameterSet(*iParam);
+      const edm::ParameterSet &pxfDetIdPSet = pSet.getParameterSet(*iParam);
       this->setPXFDetIdCuts(pxfDetIdPSet);
     } else if (*iParam == "tibDetId") {
-      const edm::ParameterSet & tibDetIdPSet = pSet.getParameterSet(*iParam);
+      const edm::ParameterSet &tibDetIdPSet = pSet.getParameterSet(*iParam);
       this->setTIBDetIdCuts(tibDetIdPSet);
     } else if (*iParam == "tidDetId") {
-      const edm::ParameterSet & tidDetIdPSet = pSet.getParameterSet(*iParam);
+      const edm::ParameterSet &tidDetIdPSet = pSet.getParameterSet(*iParam);
       this->setTIDDetIdCuts(tidDetIdPSet);
     } else if (*iParam == "tobDetId") {
-      const edm::ParameterSet & tobDetIdPSet = pSet.getParameterSet(*iParam);
+      const edm::ParameterSet &tobDetIdPSet = pSet.getParameterSet(*iParam);
       this->setTOBDetIdCuts(tobDetIdPSet);
     } else if (*iParam == "tecDetId") {
-      const edm::ParameterSet & tecDetIdPSet = pSet.getParameterSet(*iParam);
+      const edm::ParameterSet &tecDetIdPSet = pSet.getParameterSet(*iParam);
       this->setTECDetIdCuts(tecDetIdPSet);
     } else {
       throw cms::Exception("BadConfig") << "[AlignmentParameterSelector::setGeometryCuts] "
-					<< "Unknown parameter '" << *iParam << "'.\n";
+                                        << "Unknown parameter '" << *iParam << "'.\n";
     }
   }
 }
 
 //________________________________________________________________________________
-void AlignmentParameterSelector::setPXBDetIdCuts(const edm::ParameterSet &pSet)
-{
+void AlignmentParameterSelector::setPXBDetIdCuts(const edm::ParameterSet &pSet) {
   // Allow non-specified arrays to be interpreted as empty (i.e. no selection),
-  // but take care that nothing unknown is configured (to fetch typos!). 
+  // but take care that nothing unknown is configured (to fetch typos!).
 
   const std::vector<std::string> parameterNames(pSet.getParameterNames());
-  for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(),
-	 iEnd = parameterNames.end(); iParam != iEnd; ++iParam) {
-
+  for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(), iEnd = parameterNames.end();
+       iParam != iEnd;
+       ++iParam) {
     // Calling swap is more efficient than assignment:
     if (*iParam == "ladderRanges") {
       pSet.getParameter<std::vector<int> >(*iParam).swap(thePXBDetIdRanges.theLadderRanges);
@@ -167,21 +166,20 @@ void AlignmentParameterSelector::setPXBDetIdCuts(const edm::ParameterSet &pSet)
       pSet.getParameter<std::vector<int> >(*iParam).swap(thePXBDetIdRanges.theModuleRanges);
     } else {
       throw cms::Exception("BadConfig") << "[AlignmentParameterSelector::setPXBDetIdCuts] "
-					<< "Unknown parameter '" << *iParam << "'.\n";
+                                        << "Unknown parameter '" << *iParam << "'.\n";
     }
   }
 }
 
 //________________________________________________________________________________
-void AlignmentParameterSelector::setPXFDetIdCuts(const edm::ParameterSet &pSet)
-{
+void AlignmentParameterSelector::setPXFDetIdCuts(const edm::ParameterSet &pSet) {
   // Allow non-specified arrays to be interpreted as empty (i.e. no selection),
-  // but take care that nothing unknown is configured (to fetch typos!). 
+  // but take care that nothing unknown is configured (to fetch typos!).
 
   const std::vector<std::string> parameterNames(pSet.getParameterNames());
-  for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(),
-	 iEnd = parameterNames.end(); iParam != iEnd; ++iParam) {
-
+  for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(), iEnd = parameterNames.end();
+       iParam != iEnd;
+       ++iParam) {
     // Calling swap is more efficient than assignment:
     if (*iParam == "bladeRanges") {
       pSet.getParameter<std::vector<int> >(*iParam).swap(thePXFDetIdRanges.theBladeRanges);
@@ -195,21 +193,20 @@ void AlignmentParameterSelector::setPXFDetIdCuts(const edm::ParameterSet &pSet)
       pSet.getParameter<std::vector<int> >(*iParam).swap(thePXFDetIdRanges.theSideRanges);
     } else {
       throw cms::Exception("BadConfig") << "[AlignmentParameterSelector::setPXFDetIdCuts] "
-					<< "Unknown parameter '" << *iParam << "'.\n";
+                                        << "Unknown parameter '" << *iParam << "'.\n";
     }
   }
 }
 
 //________________________________________________________________________________
-void AlignmentParameterSelector::setTIBDetIdCuts(const edm::ParameterSet &pSet)
-{
+void AlignmentParameterSelector::setTIBDetIdCuts(const edm::ParameterSet &pSet) {
   // Allow non-specified arrays to be interpreted as empty (i.e. no selection),
-  // but take care that nothing unknown is configured (to fetch typos!). 
+  // but take care that nothing unknown is configured (to fetch typos!).
 
   const std::vector<std::string> parameterNames(pSet.getParameterNames());
-  for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(),
-	 iEnd = parameterNames.end(); iParam != iEnd; ++iParam) {
-
+  for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(), iEnd = parameterNames.end();
+       iParam != iEnd;
+       ++iParam) {
     // Calling swap is more efficient than assignment:
     if (*iParam == "layerRanges") {
       pSet.getParameter<std::vector<int> >(*iParam).swap(theTIBDetIdRanges.theLayerRanges);
@@ -221,21 +218,20 @@ void AlignmentParameterSelector::setTIBDetIdCuts(const edm::ParameterSet &pSet)
       pSet.getParameter<std::vector<int> >(*iParam).swap(theTIBDetIdRanges.theSideRanges);
     } else {
       throw cms::Exception("BadConfig") << "[AlignmentParameterSelector::setTIBDetIdCuts] "
-					<< "Unknown parameter '" << *iParam << "'.\n";
+                                        << "Unknown parameter '" << *iParam << "'.\n";
     }
   }
 }
 
 //________________________________________________________________________________
-void AlignmentParameterSelector::setTIDDetIdCuts(const edm::ParameterSet &pSet)
-{
+void AlignmentParameterSelector::setTIDDetIdCuts(const edm::ParameterSet &pSet) {
   // Allow non-specified arrays to be interpreted as empty (i.e. no selection),
-  // but take care that nothing unknown is configured (to fetch typos!). 
+  // but take care that nothing unknown is configured (to fetch typos!).
 
   const std::vector<std::string> parameterNames(pSet.getParameterNames());
-  for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(),
-	 iEnd = parameterNames.end(); iParam != iEnd; ++iParam) {
-
+  for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(), iEnd = parameterNames.end();
+       iParam != iEnd;
+       ++iParam) {
     // Calling swap is more efficient than assignment:
     if (*iParam == "diskRanges") {
       pSet.getParameter<std::vector<int> >(*iParam).swap(theTIDDetIdRanges.theDiskRanges);
@@ -247,21 +243,20 @@ void AlignmentParameterSelector::setTIDDetIdCuts(const edm::ParameterSet &pSet)
       pSet.getParameter<std::vector<int> >(*iParam).swap(theTIDDetIdRanges.theSideRanges);
     } else {
       throw cms::Exception("BadConfig") << "[AlignmentParameterSelector::setTIDDetIdCuts] "
-					<< "Unknown parameter '" << *iParam << "'.\n";
+                                        << "Unknown parameter '" << *iParam << "'.\n";
     }
   }
 }
 
 //________________________________________________________________________________
-void AlignmentParameterSelector::setTOBDetIdCuts(const edm::ParameterSet &pSet)
-{
+void AlignmentParameterSelector::setTOBDetIdCuts(const edm::ParameterSet &pSet) {
   // Allow non-specified arrays to be interpreted as empty (i.e. no selection),
-  // but take care that nothing unknown is configured (to fetch typos!). 
+  // but take care that nothing unknown is configured (to fetch typos!).
 
   const std::vector<std::string> parameterNames(pSet.getParameterNames());
-  for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(),
-	 iEnd = parameterNames.end(); iParam != iEnd; ++iParam) {
-
+  for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(), iEnd = parameterNames.end();
+       iParam != iEnd;
+       ++iParam) {
     // Calling swap is more efficient than assignment:
     if (*iParam == "layerRanges") {
       pSet.getParameter<std::vector<int> >(*iParam).swap(theTOBDetIdRanges.theLayerRanges);
@@ -273,21 +268,20 @@ void AlignmentParameterSelector::setTOBDetIdCuts(const edm::ParameterSet &pSet)
       pSet.getParameter<std::vector<int> >(*iParam).swap(theTOBDetIdRanges.theRodRanges);
     } else {
       throw cms::Exception("BadConfig") << "[AlignmentParameterSelector::setTOBDetIdCuts] "
-					<< "Unknown parameter '" << *iParam << "'.\n";
+                                        << "Unknown parameter '" << *iParam << "'.\n";
     }
   }
 }
 
 //________________________________________________________________________________
-void AlignmentParameterSelector::setTECDetIdCuts(const edm::ParameterSet &pSet)
-{
+void AlignmentParameterSelector::setTECDetIdCuts(const edm::ParameterSet &pSet) {
   // Allow non-specified arrays to be interpreted as empty (i.e. no selection),
-  // but take care that nothing unknown is configured (to fetch typos!). 
+  // but take care that nothing unknown is configured (to fetch typos!).
 
   const std::vector<std::string> parameterNames(pSet.getParameterNames());
-  for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(),
-	 iEnd = parameterNames.end(); iParam != iEnd; ++iParam) {
-
+  for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(), iEnd = parameterNames.end();
+       iParam != iEnd;
+       ++iParam) {
     // Calling swap is more efficient than assignment:
     if (*iParam == "wheelRanges") {
       pSet.getParameter<std::vector<int> >(*iParam).swap(theTECDetIdRanges.theWheelRanges);
@@ -301,7 +295,7 @@ void AlignmentParameterSelector::setTECDetIdCuts(const edm::ParameterSet &pSet)
       pSet.getParameter<std::vector<int> >(*iParam).swap(theTECDetIdRanges.theSideRanges);
     } else {
       throw cms::Exception("BadConfig") << "[AlignmentParameterSelector::setTECDetIdCuts] "
-					<< "Unknown parameter '" << *iParam << "'.\n";
+                                        << "Unknown parameter '" << *iParam << "'.\n";
     }
   }
 }
@@ -309,54 +303,67 @@ void AlignmentParameterSelector::setTECDetIdCuts(const edm::ParameterSet &pSet)
 //________________________________________________________________________________
 unsigned int AlignmentParameterSelector::addSelection(const std::string &name,
                                                       const std::vector<char> &paramSel,
-                                                      const edm::ParameterSet &pSet)
-{
+                                                      const edm::ParameterSet &pSet) {
   this->setGeometryCuts(pSet);
   return this->addSelection(name, paramSel);
 }
 
 //________________________________________________________________________________
-unsigned int AlignmentParameterSelector::addSelection(const std::string &nameInput, 
-                                                      const std::vector<char> &paramSel)
-{
-  const std::string name(this->setSpecials(nameInput)); // possibly changing name
+unsigned int AlignmentParameterSelector::addSelection(const std::string &nameInput, const std::vector<char> &paramSel) {
+  const std::string name(this->setSpecials(nameInput));  // possibly changing name
 
   unsigned int numAli = 0;
 
   ////////////////////////////////////
   // Generic Tracker Section
   ////////////////////////////////////
-  if (name.find("Tracker") == 0) { // string starts with "Tracker"
+  if (name.find("Tracker") == 0) {  // string starts with "Tracker"
     if (!theTracker) {
       throw cms::Exception("BadConfig") << "[AlignmentParameterSelector::addSelection] "
-					<< "Configuration requires access to AlignableTracker"
-					<< " (for " << name << ") that is not initialized";
+                                        << "Configuration requires access to AlignableTracker"
+                                        << " (for " << name << ") that is not initialized";
     }
-    const std::string substructName(name, 7); // erase "Tracker" at the beginning
+    const std::string substructName(name, 7);  // erase "Tracker" at the beginning
     numAli += this->add(theTracker->subStructures(substructName), paramSel);
   }
   ////////////////////////////////////
   // Old hardcoded, but geometry-independent tracker section (NOTE: no check on theTracker != 0)
   ////////////////////////////////////
-  else if (name == "AllDets")       numAli += this->addAllDets(paramSel);
-  else if (name == "AllRods")       numAli += this->addAllRods(paramSel);
-  else if (name == "AllLayers")     numAli += this->addAllLayers(paramSel);
-  else if (name == "AllComponents") numAli += this->add(theTracker->components(), paramSel);
-  else if (name == "AllAlignables") numAli += this->addAllAlignables(paramSel);
+  else if (name == "AllDets")
+    numAli += this->addAllDets(paramSel);
+  else if (name == "AllRods")
+    numAli += this->addAllRods(paramSel);
+  else if (name == "AllLayers")
+    numAli += this->addAllLayers(paramSel);
+  else if (name == "AllComponents")
+    numAli += this->add(theTracker->components(), paramSel);
+  else if (name == "AllAlignables")
+    numAli += this->addAllAlignables(paramSel);
   //
   // TIB+TOB
   //
-  else if (name == "BarrelRods")   numAli += this->add(theTracker->barrelRods(), paramSel);
-  else if (name == "BarrelDets")   numAli += this->add(theTracker->barrelGeomDets(), paramSel);
-  else if (name == "BarrelLayers") numAli += this->add(theTracker->barrelLayers(), paramSel);
-  else if (name == "TOBDets")      numAli += this->add(theTracker->outerBarrelGeomDets(), paramSel);
-  else if (name == "TOBRods")      numAli += this->add(theTracker->outerBarrelRods(), paramSel);
-  else if (name == "TOBLayers")    numAli += this->add(theTracker->outerBarrelLayers(), paramSel);
-  else if (name == "TOBHalfBarrels") numAli += this->add(theTracker->outerHalfBarrels(), paramSel);
-  else if (name == "TIBDets")      numAli += this->add(theTracker->innerBarrelGeomDets(), paramSel);
-  else if (name == "TIBRods")      numAli += this->add(theTracker->innerBarrelRods(), paramSel);
-  else if (name == "TIBLayers")    numAli += this->add(theTracker->innerBarrelLayers(), paramSel);
-  else if (name == "TIBHalfBarrels") numAli += this->add(theTracker->innerHalfBarrels(), paramSel);
+  else if (name == "BarrelRods")
+    numAli += this->add(theTracker->barrelRods(), paramSel);
+  else if (name == "BarrelDets")
+    numAli += this->add(theTracker->barrelGeomDets(), paramSel);
+  else if (name == "BarrelLayers")
+    numAli += this->add(theTracker->barrelLayers(), paramSel);
+  else if (name == "TOBDets")
+    numAli += this->add(theTracker->outerBarrelGeomDets(), paramSel);
+  else if (name == "TOBRods")
+    numAli += this->add(theTracker->outerBarrelRods(), paramSel);
+  else if (name == "TOBLayers")
+    numAli += this->add(theTracker->outerBarrelLayers(), paramSel);
+  else if (name == "TOBHalfBarrels")
+    numAli += this->add(theTracker->outerHalfBarrels(), paramSel);
+  else if (name == "TIBDets")
+    numAli += this->add(theTracker->innerBarrelGeomDets(), paramSel);
+  else if (name == "TIBRods")
+    numAli += this->add(theTracker->innerBarrelRods(), paramSel);
+  else if (name == "TIBLayers")
+    numAli += this->add(theTracker->innerBarrelLayers(), paramSel);
+  else if (name == "TIBHalfBarrels")
+    numAli += this->add(theTracker->innerHalfBarrels(), paramSel);
   //
   // PXBarrel
   //
@@ -372,11 +379,16 @@ unsigned int AlignmentParameterSelector::addSelection(const std::string &nameInp
   //
   // PXEndcap
   //
-  else if (name == "PXECDets") numAli += this->add(theTracker->pixelEndcapGeomDets(), paramSel);
-  else if (name == "PXECPetals") numAli += this->add(theTracker->pixelEndcapPetals(), paramSel);
-  else if (name == "PXECLayers") numAli += this->add(theTracker->pixelEndcapLayers(), paramSel);
-  else if (name == "PXECHalfCylinders") numAli += this->add(theTracker->pixelEndcapHalfCylinders(), paramSel);
-  else if (name == "PXEndCaps") numAli += this->add(theTracker->pixelEndCaps(), paramSel);
+  else if (name == "PXECDets")
+    numAli += this->add(theTracker->pixelEndcapGeomDets(), paramSel);
+  else if (name == "PXECPetals")
+    numAli += this->add(theTracker->pixelEndcapPetals(), paramSel);
+  else if (name == "PXECLayers")
+    numAli += this->add(theTracker->pixelEndcapLayers(), paramSel);
+  else if (name == "PXECHalfCylinders")
+    numAli += this->add(theTracker->pixelEndcapHalfCylinders(), paramSel);
+  else if (name == "PXEndCaps")
+    numAli += this->add(theTracker->pixelEndCaps(), paramSel);
   //
   // Pixel Barrel+endcap
   //
@@ -393,23 +405,31 @@ unsigned int AlignmentParameterSelector::addSelection(const std::string &nameInp
   //
   // TID
   //
-  else if (name == "TIDs")          numAli += this->add(theTracker->TIDs(), paramSel);
-  else if (name == "TIDLayers")     numAli += this->add(theTracker->TIDLayers(), paramSel);
-  else if (name == "TIDRings")      numAli += this->add(theTracker->TIDRings(), paramSel);
-  else if (name == "TIDDets")       numAli += this->add(theTracker->TIDGeomDets(), paramSel);
+  else if (name == "TIDs")
+    numAli += this->add(theTracker->TIDs(), paramSel);
+  else if (name == "TIDLayers")
+    numAli += this->add(theTracker->TIDLayers(), paramSel);
+  else if (name == "TIDRings")
+    numAli += this->add(theTracker->TIDRings(), paramSel);
+  else if (name == "TIDDets")
+    numAli += this->add(theTracker->TIDGeomDets(), paramSel);
   //
   // TEC
   //
-  else if (name == "TECDets")       numAli += this->add(theTracker->endcapGeomDets(), paramSel);
-  else if (name == "TECPetals")     numAli += this->add(theTracker->endcapPetals(), paramSel);
-  else if (name == "TECLayers")     numAli += this->add(theTracker->endcapLayers(), paramSel);
-  else if (name == "TECs")          numAli += this->add(theTracker->endCaps(), paramSel);
+  else if (name == "TECDets")
+    numAli += this->add(theTracker->endcapGeomDets(), paramSel);
+  else if (name == "TECPetals")
+    numAli += this->add(theTracker->endcapPetals(), paramSel);
+  else if (name == "TECLayers")
+    numAli += this->add(theTracker->endcapLayers(), paramSel);
+  else if (name == "TECs")
+    numAli += this->add(theTracker->endCaps(), paramSel);
   //
   // StripEndcap (TID+TEC)
   //
   else if (name == "EndcapDets") {
     numAli += this->add(theTracker->TIDGeomDets(), paramSel);
-    numAli += this->add(theTracker->endcapGeomDets(), paramSel); 
+    numAli += this->add(theTracker->endcapGeomDets(), paramSel);
   } else if (name == "EndcapPetals") {
     numAli += this->add(theTracker->TIDRings(), paramSel);
     numAli += this->add(theTracker->endcapPetals(), paramSel);
@@ -423,7 +443,7 @@ unsigned int AlignmentParameterSelector::addSelection(const std::string &nameInp
   else if (name == "StripDets") {
     numAli += this->add(theTracker->barrelGeomDets(), paramSel);
     numAli += this->add(theTracker->TIDGeomDets(), paramSel);
-    numAli += this->add(theTracker->endcapGeomDets(), paramSel); 
+    numAli += this->add(theTracker->endcapGeomDets(), paramSel);
   } else if (name == "StripRods") {
     numAli += this->add(theTracker->barrelRods(), paramSel);
     numAli += this->add(theTracker->TIDRings(), paramSel);
@@ -438,70 +458,76 @@ unsigned int AlignmentParameterSelector::addSelection(const std::string &nameInp
   ////////////////////////////////////
   // Check if name contains muon and react if alignable muon not initialized
   else if (name.find("Muon") != std::string::npos) {
-    if  (!theMuon) {
+    if (!theMuon) {
       throw cms::Exception("BadConfig") << "[AlignmentParameterSelector::addSelection] "
-					<< "Configuration requires access to AlignableMuon"
-					<< " which is not initialized";
-    }
-    else if (name == "MuonDTLayers")             add(theMuon->DTLayers(), paramSel);
-    else if (name == "MuonDTSuperLayers")        add(theMuon->DTSuperLayers(), paramSel);
-    else if (name == "MuonDTChambers")  	 add(theMuon->DTChambers(), paramSel);
-    else if (name == "MuonDTStations")  	 add(theMuon->DTStations(), paramSel);
-    else if (name == "MuonDTWheels")    	 add(theMuon->DTWheels(), paramSel);
-    else if (name == "MuonBarrel")      	 add(theMuon->DTBarrel(), paramSel);
-    else if (name == "MuonCSCLayers")   	 add(theMuon->CSCLayers(), paramSel);
-    else if (name == "MuonCSCRings")             add(theMuon->CSCRings(), paramSel);
-    else if (name == "MuonCSCChambers") 	 add(theMuon->CSCChambers(), paramSel);
-    else if (name == "MuonCSCStations") 	 add(theMuon->CSCStations(), paramSel);
-    else if (name == "MuonEndcaps")     	 add(theMuon->CSCEndcaps(), paramSel);
+                                        << "Configuration requires access to AlignableMuon"
+                                        << " which is not initialized";
+    } else if (name == "MuonDTLayers")
+      add(theMuon->DTLayers(), paramSel);
+    else if (name == "MuonDTSuperLayers")
+      add(theMuon->DTSuperLayers(), paramSel);
+    else if (name == "MuonDTChambers")
+      add(theMuon->DTChambers(), paramSel);
+    else if (name == "MuonDTStations")
+      add(theMuon->DTStations(), paramSel);
+    else if (name == "MuonDTWheels")
+      add(theMuon->DTWheels(), paramSel);
+    else if (name == "MuonBarrel")
+      add(theMuon->DTBarrel(), paramSel);
+    else if (name == "MuonCSCLayers")
+      add(theMuon->CSCLayers(), paramSel);
+    else if (name == "MuonCSCRings")
+      add(theMuon->CSCRings(), paramSel);
+    else if (name == "MuonCSCChambers")
+      add(theMuon->CSCChambers(), paramSel);
+    else if (name == "MuonCSCStations")
+      add(theMuon->CSCStations(), paramSel);
+    else if (name == "MuonEndcaps")
+      add(theMuon->CSCEndcaps(), paramSel);
 
     ////////////////////////////////////
     // not found, but Muon
     ////////////////////////////////////
     else {
-      throw cms::Exception("BadConfig") <<"[AlignmentParameterSelector::addSelection]"
-					<< ": Selection '" << name << "' invalid!";
+      throw cms::Exception("BadConfig") << "[AlignmentParameterSelector::addSelection]"
+                                        << ": Selection '" << name << "' invalid!";
     }
   }
 
   ////////////////////////////////////
   // Generic Extra Alignable Section
   ////////////////////////////////////
-  else if (name.find("Extras") == 0) { // string starts with "Extras"
+  else if (name.find("Extras") == 0) {  // string starts with "Extras"
     if (!theExtras) {
       throw cms::Exception("BadConfig") << "[AlignmentParameterSelector::addSelection] "
-					<< "Configuration requires access to AlignableExtras"
-					<< " (for " << name << ") that is not initialized";
+                                        << "Configuration requires access to AlignableExtras"
+                                        << " (for " << name << ") that is not initialized";
     }
-    const std::string substructName(name, 6); // erase "Extras" at the beginning
+    const std::string substructName(name, 6);  // erase "Extras" at the beginning
     numAli += this->add(theExtras->subStructures(substructName), paramSel);
   }
   // end of "name.find("Extras") != std::string::npos"
 
   else {
-    throw cms::Exception("BadConfig") <<"[AlignmentParameterSelector::addSelection]"
-				      << ": Selection '" << name << "' invalid!";
+    throw cms::Exception("BadConfig") << "[AlignmentParameterSelector::addSelection]"
+                                      << ": Selection '" << name << "' invalid!";
   }
-  
-  this->setSpecials(""); // reset
+
+  this->setSpecials("");  // reset
 
   return numAli;
 }
 
 //________________________________________________________________________________
-unsigned int AlignmentParameterSelector::add(const align::Alignables &alignables,
-                                             const std::vector<char> &paramSel)
-{
+unsigned int AlignmentParameterSelector::add(const align::Alignables &alignables, const std::vector<char> &paramSel) {
   unsigned int numAli = 0;
 
   // loop on Alignable objects
-  for (align::Alignables::const_iterator iAli = alignables.begin();
-       iAli != alignables.end(); ++iAli) {
-
-    if (!this->layerDeselected(*iAli)             // check layers
-	&& !this->detUnitDeselected(*iAli)        // check detunit selection
-	&& !this->outsideGeometricalRanges(*iAli) // check geometrical ranges
-	&& !this->outsideDetIdRanges(*iAli)) {    // check DetId ranges
+  for (align::Alignables::const_iterator iAli = alignables.begin(); iAli != alignables.end(); ++iAli) {
+    if (!this->layerDeselected(*iAli)              // check layers
+        && !this->detUnitDeselected(*iAli)         // check detunit selection
+        && !this->outsideGeometricalRanges(*iAli)  // check geometrical ranges
+        && !this->outsideDetIdRanges(*iAli)) {     // check DetId ranges
       // all fine, so add to output arrays
       theSelectedAlignables.push_back(*iAli);
       theSelectedParameters.push_back(paramSel);
@@ -513,248 +539,260 @@ unsigned int AlignmentParameterSelector::add(const align::Alignables &alignables
 }
 
 //_________________________________________________________________________
-bool AlignmentParameterSelector::layerDeselected(const Alignable *ali) const
-{
+bool AlignmentParameterSelector::layerDeselected(const Alignable *ali) const {
   if (theOnlySS || theOnlyDS || theSelLayers) {
     TrackerAlignableId idProvider;
-    std::pair<int,int> typeLayer = idProvider.typeAndLayerFromDetId(ali->id(), alignableTracker()->trackerTopology());
-    int type  = typeLayer.first;
+    std::pair<int, int> typeLayer = idProvider.typeAndLayerFromDetId(ali->id(), alignableTracker()->trackerTopology());
+    int type = typeLayer.first;
     int layer = typeLayer.second;
-    
+
     // select on single/double sided barrel layers in TIB/TOB
-    if (theOnlySS // only single sided
-	&& (std::abs(type) == SiStripDetId::TIB || std::abs(type) == SiStripDetId::TOB)
-	&& layer <= 2) {
+    if (theOnlySS  // only single sided
+        && (std::abs(type) == SiStripDetId::TIB || std::abs(type) == SiStripDetId::TOB) && layer <= 2) {
       return true;
     }
-    if (theOnlyDS // only double sided
-	&& (std::abs(type) == SiStripDetId::TIB || std::abs(type) == SiStripDetId::TOB)
-	&& layer > 2) {
+    if (theOnlyDS  // only double sided
+        && (std::abs(type) == SiStripDetId::TIB || std::abs(type) == SiStripDetId::TOB) && layer > 2) {
       return true;
     }
-    
+
     // reject layers
     if (theSelLayers && (layer < theMinLayer || layer > theMaxLayer)) {
       return true;
     }
   }
-  
-  return false; // do not deselect...
+
+  return false;  // do not deselect...
 }
 
 //_________________________________________________________________________
-bool AlignmentParameterSelector::detUnitDeselected(const Alignable *ali) const
-{
-
+bool AlignmentParameterSelector::detUnitDeselected(const Alignable *ali) const {
   if (theRphiOrStereoDetUnit != Both && ali->alignableObjectId() == align::AlignableDetUnit) {
-    const SiStripDetId detId(ali->geomDetId()); // do not know yet whether right type...
-    if (detId.det() == DetId::Tracker 
-	&& (detId.subdetId() == SiStripDetId::TIB || detId.subdetId() == SiStripDetId::TID ||
-	    detId.subdetId() == SiStripDetId::TOB || detId.subdetId() == SiStripDetId::TEC)) {
+    const SiStripDetId detId(ali->geomDetId());  // do not know yet whether right type...
+    if (detId.det() == DetId::Tracker &&
+        (detId.subdetId() == SiStripDetId::TIB || detId.subdetId() == SiStripDetId::TID ||
+         detId.subdetId() == SiStripDetId::TOB || detId.subdetId() == SiStripDetId::TEC)) {
       // We have a DetUnit in strip, so check for a selection of stereo/rphi (DetUnits in 1D layers are rphi):
-      if ((theRphiOrStereoDetUnit == Stereo && !detId.stereo())
-	  || (theRphiOrStereoDetUnit == Rphi   &&  detId.stereo())) {
-	return true;
+      if ((theRphiOrStereoDetUnit == Stereo && !detId.stereo()) || (theRphiOrStereoDetUnit == Rphi && detId.stereo())) {
+        return true;
       }
     }
   }
 
-  return false; // do not deselect...
+  return false;  // do not deselect...
 }
 
 //_________________________________________________________________________
-bool AlignmentParameterSelector::outsideGeometricalRanges(const Alignable *alignable) const
-{
-  const align::PositionType& position(alignable->globalPosition());
+bool AlignmentParameterSelector::outsideGeometricalRanges(const Alignable *alignable) const {
+  const align::PositionType &position(alignable->globalPosition());
 
-  if (!theRangesEta.empty() && !this->insideRanges<double>((position.eta()),  theRangesEta)) return true;
-  if (!theRangesPhi.empty() && !this->insideRanges<double>((position.phi()),  theRangesPhi, true))return true;
-  if (!theRangesR.empty()   && !this->insideRanges<double>((position.perp()), theRangesR)) return true;
-  if (!theRangesX.empty()   && !this->insideRanges<double>((position.x()),    theRangesX)) return true;
-  if (!theRangesY.empty()   && !this->insideRanges<double>((position.y()),    theRangesY)) return true;
-  if (!theRangesZ.empty()   && !this->insideRanges<double>((position.z()),    theRangesZ)) return true;
-  
+  if (!theRangesEta.empty() && !this->insideRanges<double>((position.eta()), theRangesEta))
+    return true;
+  if (!theRangesPhi.empty() && !this->insideRanges<double>((position.phi()), theRangesPhi, true))
+    return true;
+  if (!theRangesR.empty() && !this->insideRanges<double>((position.perp()), theRangesR))
+    return true;
+  if (!theRangesX.empty() && !this->insideRanges<double>((position.x()), theRangesX))
+    return true;
+  if (!theRangesY.empty() && !this->insideRanges<double>((position.y()), theRangesY))
+    return true;
+  if (!theRangesZ.empty() && !this->insideRanges<double>((position.z()), theRangesZ))
+    return true;
+
   return false;
 }
 
 //_________________________________________________________________________
-bool AlignmentParameterSelector::outsideDetIdRanges(const Alignable *alignable) const
-{
+bool AlignmentParameterSelector::outsideDetIdRanges(const Alignable *alignable) const {
   //const DetId detId(alignable->geomDetId());
   const DetId detId(alignable->id());
   const int subdetId = detId.subdetId();
-  
+
   if (alignableTracker()) {
+    const TrackerTopology *tTopo = alignableTracker()->trackerTopology();
 
-  const TrackerTopology* tTopo = alignableTracker()->trackerTopology();
+    if (!theDetIds.empty() && !this->isMemberOfVector((detId.rawId()), theDetIds))
+      return true;
+    if (!theDetIdRanges.empty() && !this->insideRanges<int>((detId.rawId()), theDetIdRanges))
+      return true;
+    if (!theExcludedDetIds.empty() && this->isMemberOfVector((detId.rawId()), theExcludedDetIds))
+      return true;
+    if (!theExcludedDetIdRanges.empty() && this->insideRanges<int>((detId.rawId()), theExcludedDetIdRanges))
+      return true;
 
-  if (!theDetIds.empty() &&
-      !this->isMemberOfVector((detId.rawId()), theDetIds)) return true;
-  if (!theDetIdRanges.empty() &&
-      !this->insideRanges<int>((detId.rawId()), theDetIdRanges)) return true;
-  if (!theExcludedDetIds.empty() &&
-      this->isMemberOfVector((detId.rawId()), theExcludedDetIds)) return true;
-  if (!theExcludedDetIdRanges.empty() &&
-      this->insideRanges<int>((detId.rawId()), theExcludedDetIdRanges)) return true;
+    if (detId.det() == DetId::Tracker) {
+      if (subdetId == static_cast<int>(PixelSubdetector::PixelBarrel)) {
+        if (!thePXBDetIdRanges.theLadderRanges.empty() &&
+            !this->insideRanges<int>(tTopo->pxbLadder(detId), thePXBDetIdRanges.theLadderRanges))
+          return true;
+        if (!thePXBDetIdRanges.theLayerRanges.empty() &&
+            !this->insideRanges<int>(tTopo->pxbLayer(detId), thePXBDetIdRanges.theLayerRanges))
+          return true;
+        if (!thePXBDetIdRanges.theModuleRanges.empty() &&
+            !this->insideRanges<int>(tTopo->pxbModule(detId), thePXBDetIdRanges.theModuleRanges))
+          return true;
+      }
 
-  if (detId.det()==DetId::Tracker) {
-    
-    if (subdetId==static_cast<int>(PixelSubdetector::PixelBarrel)) {
-      if (!thePXBDetIdRanges.theLadderRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->pxbLadder(detId), thePXBDetIdRanges.theLadderRanges)) return true;
-      if (!thePXBDetIdRanges.theLayerRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->pxbLayer(detId), thePXBDetIdRanges.theLayerRanges)) return true;
-      if (!thePXBDetIdRanges.theModuleRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->pxbModule(detId), thePXBDetIdRanges.theModuleRanges)) return true;
-    }
-    
-    if (subdetId==static_cast<int>(PixelSubdetector::PixelEndcap)) {
-      if (!thePXFDetIdRanges.theBladeRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->pxfBlade(detId), thePXFDetIdRanges.theBladeRanges)) return true;
-      if (!thePXFDetIdRanges.theDiskRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->pxfDisk(detId), thePXFDetIdRanges.theDiskRanges)) return true;
-      if (!thePXFDetIdRanges.theModuleRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->pxfModule(detId), thePXFDetIdRanges.theModuleRanges)) return true;
-      if (!thePXFDetIdRanges.thePanelRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->pxfPanel(detId), thePXFDetIdRanges.thePanelRanges)) return true;
-      if (!thePXFDetIdRanges.theSideRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->pxfSide(detId), thePXFDetIdRanges.theSideRanges)) return true;
-    }
-    
-    if (subdetId==static_cast<int>(SiStripDetId::TIB)) {
-      if (!theTIBDetIdRanges.theLayerRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->tibLayer(detId), theTIBDetIdRanges.theLayerRanges)) return true;
-      if (!theTIBDetIdRanges.theModuleRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->tibModule(detId), theTIBDetIdRanges.theModuleRanges)) return true;
-      if (!theTIBDetIdRanges.theSideRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->tibSide(detId), theTIBDetIdRanges.theSideRanges)) return true;
-      if (!theTIBDetIdRanges.theStringRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->tibString(detId), theTIBDetIdRanges.theStringRanges)) return true;
-    }
-    
-    if (subdetId==static_cast<int>(SiStripDetId::TID)) {
-      if (!theTIDDetIdRanges.theDiskRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->tidWheel(detId), theTIDDetIdRanges.theDiskRanges)) return true;
-      if (!theTIDDetIdRanges.theModuleRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->tidModule(detId), theTIDDetIdRanges.theModuleRanges)) return true;
-      if (!theTIDDetIdRanges.theRingRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->tidRing(detId), theTIDDetIdRanges.theRingRanges)) return true;
-      if (!theTIDDetIdRanges.theSideRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->tidSide(detId), theTIDDetIdRanges.theSideRanges)) return true;
-    }
-    
-    if (subdetId==static_cast<int>(SiStripDetId::TOB)) {
-      if (!theTOBDetIdRanges.theLayerRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->tobLayer(detId), theTOBDetIdRanges.theLayerRanges)) return true;
-      if (!theTOBDetIdRanges.theModuleRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->tobModule(detId), theTOBDetIdRanges.theModuleRanges)) return true;
-      if (!theTOBDetIdRanges.theRodRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->tobRod(detId), theTOBDetIdRanges.theRodRanges)) return true;
-      if (!theTOBDetIdRanges.theSideRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->tobSide(detId), theTOBDetIdRanges.theSideRanges)) return true;
-    }
+      if (subdetId == static_cast<int>(PixelSubdetector::PixelEndcap)) {
+        if (!thePXFDetIdRanges.theBladeRanges.empty() &&
+            !this->insideRanges<int>(tTopo->pxfBlade(detId), thePXFDetIdRanges.theBladeRanges))
+          return true;
+        if (!thePXFDetIdRanges.theDiskRanges.empty() &&
+            !this->insideRanges<int>(tTopo->pxfDisk(detId), thePXFDetIdRanges.theDiskRanges))
+          return true;
+        if (!thePXFDetIdRanges.theModuleRanges.empty() &&
+            !this->insideRanges<int>(tTopo->pxfModule(detId), thePXFDetIdRanges.theModuleRanges))
+          return true;
+        if (!thePXFDetIdRanges.thePanelRanges.empty() &&
+            !this->insideRanges<int>(tTopo->pxfPanel(detId), thePXFDetIdRanges.thePanelRanges))
+          return true;
+        if (!thePXFDetIdRanges.theSideRanges.empty() &&
+            !this->insideRanges<int>(tTopo->pxfSide(detId), thePXFDetIdRanges.theSideRanges))
+          return true;
+      }
 
-    if (subdetId==static_cast<int>(SiStripDetId::TEC)) {
-      if (!theTECDetIdRanges.theWheelRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->tecWheel(detId), theTECDetIdRanges.theWheelRanges)) return true;
-      if (!theTECDetIdRanges.thePetalRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->tecPetalNumber(detId), theTECDetIdRanges.thePetalRanges)) return true;
-      if (!theTECDetIdRanges.theModuleRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->tecModule(detId), theTECDetIdRanges.theModuleRanges)) return true;
-      if (!theTECDetIdRanges.theRingRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->tecRing(detId), theTECDetIdRanges.theRingRanges)) return true;
-      if (!theTECDetIdRanges.theSideRanges.empty() && 
-	  !this->insideRanges<int>(tTopo->tecSide(detId), theTECDetIdRanges.theSideRanges)) return true;
+      if (subdetId == static_cast<int>(SiStripDetId::TIB)) {
+        if (!theTIBDetIdRanges.theLayerRanges.empty() &&
+            !this->insideRanges<int>(tTopo->tibLayer(detId), theTIBDetIdRanges.theLayerRanges))
+          return true;
+        if (!theTIBDetIdRanges.theModuleRanges.empty() &&
+            !this->insideRanges<int>(tTopo->tibModule(detId), theTIBDetIdRanges.theModuleRanges))
+          return true;
+        if (!theTIBDetIdRanges.theSideRanges.empty() &&
+            !this->insideRanges<int>(tTopo->tibSide(detId), theTIBDetIdRanges.theSideRanges))
+          return true;
+        if (!theTIBDetIdRanges.theStringRanges.empty() &&
+            !this->insideRanges<int>(tTopo->tibString(detId), theTIBDetIdRanges.theStringRanges))
+          return true;
+      }
+
+      if (subdetId == static_cast<int>(SiStripDetId::TID)) {
+        if (!theTIDDetIdRanges.theDiskRanges.empty() &&
+            !this->insideRanges<int>(tTopo->tidWheel(detId), theTIDDetIdRanges.theDiskRanges))
+          return true;
+        if (!theTIDDetIdRanges.theModuleRanges.empty() &&
+            !this->insideRanges<int>(tTopo->tidModule(detId), theTIDDetIdRanges.theModuleRanges))
+          return true;
+        if (!theTIDDetIdRanges.theRingRanges.empty() &&
+            !this->insideRanges<int>(tTopo->tidRing(detId), theTIDDetIdRanges.theRingRanges))
+          return true;
+        if (!theTIDDetIdRanges.theSideRanges.empty() &&
+            !this->insideRanges<int>(tTopo->tidSide(detId), theTIDDetIdRanges.theSideRanges))
+          return true;
+      }
+
+      if (subdetId == static_cast<int>(SiStripDetId::TOB)) {
+        if (!theTOBDetIdRanges.theLayerRanges.empty() &&
+            !this->insideRanges<int>(tTopo->tobLayer(detId), theTOBDetIdRanges.theLayerRanges))
+          return true;
+        if (!theTOBDetIdRanges.theModuleRanges.empty() &&
+            !this->insideRanges<int>(tTopo->tobModule(detId), theTOBDetIdRanges.theModuleRanges))
+          return true;
+        if (!theTOBDetIdRanges.theRodRanges.empty() &&
+            !this->insideRanges<int>(tTopo->tobRod(detId), theTOBDetIdRanges.theRodRanges))
+          return true;
+        if (!theTOBDetIdRanges.theSideRanges.empty() &&
+            !this->insideRanges<int>(tTopo->tobSide(detId), theTOBDetIdRanges.theSideRanges))
+          return true;
+      }
+
+      if (subdetId == static_cast<int>(SiStripDetId::TEC)) {
+        if (!theTECDetIdRanges.theWheelRanges.empty() &&
+            !this->insideRanges<int>(tTopo->tecWheel(detId), theTECDetIdRanges.theWheelRanges))
+          return true;
+        if (!theTECDetIdRanges.thePetalRanges.empty() &&
+            !this->insideRanges<int>(tTopo->tecPetalNumber(detId), theTECDetIdRanges.thePetalRanges))
+          return true;
+        if (!theTECDetIdRanges.theModuleRanges.empty() &&
+            !this->insideRanges<int>(tTopo->tecModule(detId), theTECDetIdRanges.theModuleRanges))
+          return true;
+        if (!theTECDetIdRanges.theRingRanges.empty() &&
+            !this->insideRanges<int>(tTopo->tecRing(detId), theTECDetIdRanges.theRingRanges))
+          return true;
+        if (!theTECDetIdRanges.theSideRanges.empty() &&
+            !this->insideRanges<int>(tTopo->tecSide(detId), theTECDetIdRanges.theSideRanges))
+          return true;
+      }
     }
   }
-  }
-  
+
   return false;
 }
 
 //_________________________________________________________________________
-template<typename T> bool AlignmentParameterSelector::insideRanges(T value,
-								   const std::vector<T> &ranges,
-								   bool isPhi) const
-{
+template <typename T>
+bool AlignmentParameterSelector::insideRanges(T value, const std::vector<T> &ranges, bool isPhi) const {
   // might become templated on <double> ?
 
-  if (ranges.size()%2 != 0) {
-    cms::Exception("BadConfig") << "@SUB=AlignmentParameterSelector::insideRanges" 
-                                << " need even number of entries in ranges instead of "
-                                << ranges.size();
+  if (ranges.size() % 2 != 0) {
+    cms::Exception("BadConfig") << "@SUB=AlignmentParameterSelector::insideRanges"
+                                << " need even number of entries in ranges instead of " << ranges.size();
     return false;
   }
 
   for (unsigned int i = 0; i < ranges.size(); i += 2) {
-    if (isPhi) { // mapping into (-pi,+pi] and checking for range including sign flip area
+    if (isPhi) {  // mapping into (-pi,+pi] and checking for range including sign flip area
       Geom::Phi<double> rangePhi1(ranges[i]);
-      Geom::Phi<double> rangePhi2(ranges[i+1]);
+      Geom::Phi<double> rangePhi2(ranges[i + 1]);
       Geom::Phi<double> valuePhi(value);
-      if (rangePhi1 <= valuePhi && valuePhi < rangePhi2) { // 'normal'
+      if (rangePhi1 <= valuePhi && valuePhi < rangePhi2) {  // 'normal'
         return true;
       }
-      if (rangePhi2  < rangePhi1 && (rangePhi1 <= valuePhi || valuePhi < rangePhi2)) {// 'sign flip'
+      if (rangePhi2 < rangePhi1 && (rangePhi1 <= valuePhi || valuePhi < rangePhi2)) {  // 'sign flip'
         return true;
       }
-    } else if (ranges[i] <= value && value < ranges[i+1]) {
+    } else if (ranges[i] <= value && value < ranges[i + 1]) {
       return true;
     }
   }
-  
+
   return false;
 }
 
 //_________________________________________________________________________
-template<> bool AlignmentParameterSelector::insideRanges<int>(int value,
-							      const std::vector<int> &ranges,
-							      bool /*isPhi*/) const
-{
-  if (ranges.size()%2 != 0) {
-    cms::Exception("BadConfig") << "@SUB=AlignmentParameterSelector::insideRanges" 
-                                << " need even number of entries in ranges instead of "
-                                << ranges.size();
+template <>
+bool AlignmentParameterSelector::insideRanges<int>(int value, const std::vector<int> &ranges, bool /*isPhi*/) const {
+  if (ranges.size() % 2 != 0) {
+    cms::Exception("BadConfig") << "@SUB=AlignmentParameterSelector::insideRanges"
+                                << " need even number of entries in ranges instead of " << ranges.size();
     return false;
   }
 
   for (unsigned int i = 0; i < ranges.size(); i += 2) {
-    if (ranges[i] <= value && value <= ranges[i+1]) return true;
+    if (ranges[i] <= value && value <= ranges[i + 1])
+      return true;
   }
-  
+
   return false;
 }
 
-bool AlignmentParameterSelector::isMemberOfVector(int value, const std::vector<int> &values) const
-{
-  if (std::find(values.begin(), values.end(), value)!=values.end()) return true;
+bool AlignmentParameterSelector::isMemberOfVector(int value, const std::vector<int> &values) const {
+  if (std::find(values.begin(), values.end(), value) != values.end())
+    return true;
   return false;
 }
 
 //__________________________________________________________________________________________________
-std::vector<std::string> 
-AlignmentParameterSelector::decompose(const std::string &s, std::string::value_type delimiter) const
-{
-
+std::vector<std::string> AlignmentParameterSelector::decompose(const std::string &s,
+                                                               std::string::value_type delimiter) const {
   std::vector<std::string> result;
 
   std::string::size_type previousPos = 0;
   while (true) {
     const std::string::size_type delimiterPos = s.find(delimiter, previousPos);
     if (delimiterPos == std::string::npos) {
-      result.push_back(s.substr(previousPos)); // until end
+      result.push_back(s.substr(previousPos));  // until end
       break;
     }
     result.push_back(s.substr(previousPos, delimiterPos - previousPos));
-    previousPos = delimiterPos + 1; // +1: skip delimiter
+    previousPos = delimiterPos + 1;  // +1: skip delimiter
   }
 
   return result;
 }
 
 //__________________________________________________________________________________________________
-std::vector<char> AlignmentParameterSelector::convertParamSel(const std::string &selString) const
-{
-
+std::vector<char> AlignmentParameterSelector::convertParamSel(const std::string &selString) const {
   // Convert selString into vector<char> of same length.
   // Note: Old implementation in AlignmentParameterBuilder was rigid in length,
   // expecting RigidBodyAlignmentParameters::N_PARAM.
@@ -769,17 +807,15 @@ std::vector<char> AlignmentParameterSelector::convertParamSel(const std::string 
   return result;
 }
 
-
 //________________________________________________________________________________
-std::string AlignmentParameterSelector::setSpecials(const std::string &name)
-{
+std::string AlignmentParameterSelector::setSpecials(const std::string &name) {
   // Use new string only, although direct erasing of found indicator causes problems for 'DSS',
   // but 'DSS' makes absolutely no sense!
-  std::string newName(name); 
+  std::string newName(name);
 
   const std::string::size_type ss = newName.rfind("SS");
   if (ss != std::string::npos) {
-    newName.erase(ss, 2); // 2: length of 'SS'
+    newName.erase(ss, 2);  // 2: length of 'SS'
     theOnlySS = true;
   } else {
     theOnlySS = false;
@@ -787,19 +823,19 @@ std::string AlignmentParameterSelector::setSpecials(const std::string &name)
 
   const std::string::size_type ds = newName.rfind("DS");
   if (ds != std::string::npos) {
-    newName.erase(ds, 2); // 2: length of 'DS'
+    newName.erase(ds, 2);  // 2: length of 'DS'
     theOnlyDS = true;
   } else {
     theOnlyDS = false;
   }
-  
+
   const std::string::size_type size = newName.size();
   const std::string::size_type layers = newName.rfind("Layers");
-  if (layers != std::string::npos && size - layers - 2 == 6 // 2 digits, 6: length of 'Layers'
-      && isdigit(newName[size-1]) && isdigit(newName[size-2])) {
+  if (layers != std::string::npos && size - layers - 2 == 6  // 2 digits, 6: length of 'Layers'
+      && isdigit(newName[size - 1]) && isdigit(newName[size - 2])) {
     theSelLayers = true;
-    theMinLayer = newName[size-2] - '0';
-    theMaxLayer = newName[size-1] - '0';
+    theMinLayer = newName[size - 2] - '0';
+    theMaxLayer = newName[size - 1] - '0';
     newName.erase(layers);
   } else {
     theSelLayers = false;
@@ -811,72 +847,67 @@ std::string AlignmentParameterSelector::setSpecials(const std::string &name)
   if (newName.rfind("Unit") != std::string::npos) {
     const std::string::size_type uRph = newName.rfind("UnitRphi");
     if (uRph != std::string::npos) {
-      newName.erase(uRph + 4, 4); // keep 'Unit' (4) and erase 'Rphi' (4)
+      newName.erase(uRph + 4, 4);  // keep 'Unit' (4) and erase 'Rphi' (4)
       theRphiOrStereoDetUnit = Rphi;
     }
     const std::string::size_type uSte = newName.rfind("UnitStereo");
     if (uSte != std::string::npos) {
-      newName.erase(uSte + 4, 6); // keep 'Unit' (4) and erase 'Stereo' (6)
+      newName.erase(uSte + 4, 6);  // keep 'Unit' (4) and erase 'Stereo' (6)
       theRphiOrStereoDetUnit = Stereo;
     }
   }
 
   if (newName != name) {
-    LogDebug("Alignment") << "@SUB=AlignmentParameterSelector::setSpecials"
-                          << name << " becomes " << newName << ", makes theOnlySS " << theOnlySS
-                          << ", theOnlyDS " << theOnlyDS << ", theSelLayers " << theSelLayers
-                          << ", theMinLayer " << theMinLayer << ", theMaxLayer " << theMaxLayer
-			  << ", theRphiOrStereoDetUnit " << theRphiOrStereoDetUnit;
+    LogDebug("Alignment") << "@SUB=AlignmentParameterSelector::setSpecials" << name << " becomes " << newName
+                          << ", makes theOnlySS " << theOnlySS << ", theOnlyDS " << theOnlyDS << ", theSelLayers "
+                          << theSelLayers << ", theMinLayer " << theMinLayer << ", theMaxLayer " << theMaxLayer
+                          << ", theRphiOrStereoDetUnit " << theRphiOrStereoDetUnit;
   }
 
   return newName;
 }
 
 //________________________________________________________________________________
-unsigned int AlignmentParameterSelector::addAllDets(const std::vector<char> &paramSel)
-{
+unsigned int AlignmentParameterSelector::addAllDets(const std::vector<char> &paramSel) {
   unsigned int numAli = 0;
 
-  numAli += this->add(theTracker->barrelGeomDets(), paramSel);          // TIB+TOB
-  numAli += this->add(theTracker->endcapGeomDets(), paramSel);          // TEC
-  numAli += this->add(theTracker->TIDGeomDets(), paramSel);             // TID
-  numAli += this->add(theTracker->pixelHalfBarrelGeomDets(), paramSel); // PixelBarrel
-  numAli += this->add(theTracker->pixelEndcapGeomDets(), paramSel);     // PixelEndcap
+  numAli += this->add(theTracker->barrelGeomDets(), paramSel);           // TIB+TOB
+  numAli += this->add(theTracker->endcapGeomDets(), paramSel);           // TEC
+  numAli += this->add(theTracker->TIDGeomDets(), paramSel);              // TID
+  numAli += this->add(theTracker->pixelHalfBarrelGeomDets(), paramSel);  // PixelBarrel
+  numAli += this->add(theTracker->pixelEndcapGeomDets(), paramSel);      // PixelEndcap
 
   return numAli;
 }
 
 //________________________________________________________________________________
-unsigned int AlignmentParameterSelector::addAllRods(const std::vector<char> &paramSel)
-{
+unsigned int AlignmentParameterSelector::addAllRods(const std::vector<char> &paramSel) {
   unsigned int numAli = 0;
 
-  numAli += this->add(theTracker->barrelRods(), paramSel);             // TIB+TOB    
-  numAli += this->add(theTracker->pixelHalfBarrelLadders(), paramSel); // PixelBarrel
-  numAli += this->add(theTracker->endcapPetals(), paramSel);           // TEC        
-  numAli += this->add(theTracker->TIDRings(), paramSel);               // TID        
-  numAli += this->add(theTracker->pixelEndcapPetals(), paramSel);      // PixelEndcap
+  numAli += this->add(theTracker->barrelRods(), paramSel);              // TIB+TOB
+  numAli += this->add(theTracker->pixelHalfBarrelLadders(), paramSel);  // PixelBarrel
+  numAli += this->add(theTracker->endcapPetals(), paramSel);            // TEC
+  numAli += this->add(theTracker->TIDRings(), paramSel);                // TID
+  numAli += this->add(theTracker->pixelEndcapPetals(), paramSel);       // PixelEndcap
 
   return numAli;
 }
 
 //________________________________________________________________________________
-unsigned int AlignmentParameterSelector::addAllLayers(const std::vector<char> &paramSel)
-{
+unsigned int AlignmentParameterSelector::addAllLayers(const std::vector<char> &paramSel) {
   unsigned int numAli = 0;
 
-  numAli += this->add(theTracker->barrelLayers(), paramSel);          // TIB+TOB    
-  numAli += this->add(theTracker->pixelHalfBarrelLayers(), paramSel); // PixelBarrel
-  numAli += this->add(theTracker->endcapLayers(), paramSel);          // TEC
-  numAli += this->add(theTracker->TIDLayers(), paramSel);             // TID
-  numAli += this->add(theTracker->pixelEndcapLayers(), paramSel);     // PixelEndcap
+  numAli += this->add(theTracker->barrelLayers(), paramSel);           // TIB+TOB
+  numAli += this->add(theTracker->pixelHalfBarrelLayers(), paramSel);  // PixelBarrel
+  numAli += this->add(theTracker->endcapLayers(), paramSel);           // TEC
+  numAli += this->add(theTracker->TIDLayers(), paramSel);              // TID
+  numAli += this->add(theTracker->pixelEndcapLayers(), paramSel);      // PixelEndcap
 
   return numAli;
 }
 
 //________________________________________________________________________________
-unsigned int AlignmentParameterSelector::addAllAlignables(const std::vector<char> &paramSel)
-{
+unsigned int AlignmentParameterSelector::addAllAlignables(const std::vector<char> &paramSel) {
   unsigned int numAli = 0;
 
   numAli += this->addAllDets(paramSel);

--- a/Alignment/CommonAlignmentAlgorithm/src/AlignmentParameterStore.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignmentParameterStore.cc
@@ -26,13 +26,11 @@
 #include "Geometry/CommonTopologies/interface/SurfaceDeformationFactory.h"
 
 //__________________________________________________________________________________________________
-AlignmentParameterStore::AlignmentParameterStore( const align::Alignables &alis,
-						  const edm::ParameterSet& config ) :
-  theAlignables(alis)
-{
+AlignmentParameterStore::AlignmentParameterStore(const align::Alignables& alis, const edm::ParameterSet& config)
+    : theAlignables(alis) {
   if (config.getUntrackedParameter<bool>("UseExtendedCorrelations")) {
-    theCorrelationsStore = new AlignmentExtendedCorrelationsStore
-      (config.getParameter<edm::ParameterSet>("ExtendedCorrelationsConfig"));
+    theCorrelationsStore =
+        new AlignmentExtendedCorrelationsStore(config.getParameter<edm::ParameterSet>("ExtendedCorrelationsConfig"));
   } else {
     theCorrelationsStore = new AlignmentCorrelationsStore();
   }
@@ -43,240 +41,210 @@ AlignmentParameterStore::AlignmentParameterStore( const align::Alignables &alis,
   // set hierarchy vs averaging constraints
   theTypeOfConstraints = NONE;
   const std::string cfgStrTypeOfConstraints(config.getParameter<std::string>("TypeOfConstraints"));
-  if( cfgStrTypeOfConstraints == "hierarchy" ) {
+  if (cfgStrTypeOfConstraints == "hierarchy") {
     theTypeOfConstraints = HIERARCHY_CONSTRAINTS;
-  } else if( cfgStrTypeOfConstraints == "approximate_averaging" ) {
+  } else if (cfgStrTypeOfConstraints == "approximate_averaging") {
     theTypeOfConstraints = APPROX_AVERAGING_CONSTRAINTS;
-    edm::LogWarning("Alignment") << "@SUB=AlignmentParameterStore"
-				 << "\n\n\n******* WARNING ******************************************\n"
-				 << "Using approximate implementation of averaging constraints."
-				 << "This is not recommended."
-				 << "Consider to use 'hierarchy' constraints:"
-				 << "  AlignmentProducer.ParameterStore.TypeOfConstraints = cms.string('hierarchy')\n\n\n";
+    edm::LogWarning("Alignment")
+        << "@SUB=AlignmentParameterStore"
+        << "\n\n\n******* WARNING ******************************************\n"
+        << "Using approximate implementation of averaging constraints."
+        << "This is not recommended."
+        << "Consider to use 'hierarchy' constraints:"
+        << "  AlignmentProducer.ParameterStore.TypeOfConstraints = cms.string('hierarchy')\n\n\n";
   } else {
     edm::LogError("BadArgument") << "@SUB=AlignmentParameterStore"
-				 << "Unknown type of hierarchy constraints '" << cfgStrTypeOfConstraints << "'"; 
+                                 << "Unknown type of hierarchy constraints '" << cfgStrTypeOfConstraints << "'";
   }
 }
 
 //__________________________________________________________________________________________________
-AlignmentParameterStore::~AlignmentParameterStore()
-{
-  delete theCorrelationsStore;
-}
+AlignmentParameterStore::~AlignmentParameterStore() { delete theCorrelationsStore; }
 
 //__________________________________________________________________________________________________
-CompositeAlignmentParameters
-AlignmentParameterStore::selectParameters( const std::vector<AlignableDet*>& alignabledets ) const
-{
+CompositeAlignmentParameters AlignmentParameterStore::selectParameters(
+    const std::vector<AlignableDet*>& alignabledets) const {
   std::vector<AlignableDetOrUnitPtr> detOrUnits;
   detOrUnits.reserve(alignabledets.size());
 
   std::vector<AlignableDet*>::const_iterator it, iEnd;
-  for ( it = alignabledets.begin(), iEnd = alignabledets.end(); it != iEnd; ++it)
+  for (it = alignabledets.begin(), iEnd = alignabledets.end(); it != iEnd; ++it)
     detOrUnits.push_back(AlignableDetOrUnitPtr(*it));
 
   return this->selectParameters(detOrUnits);
 }
 
 //__________________________________________________________________________________________________
-CompositeAlignmentParameters
-AlignmentParameterStore::selectParameters( const std::vector<AlignableDetOrUnitPtr>& alignabledets ) const
-{
-
+CompositeAlignmentParameters AlignmentParameterStore::selectParameters(
+    const std::vector<AlignableDetOrUnitPtr>& alignabledets) const {
   align::Alignables alignables;
-  std::map <AlignableDetOrUnitPtr,Alignable*> alidettoalimap;
-  std::map <Alignable*,int> aliposmap;
-  std::map <Alignable*,int> alilenmap;
-  int nparam=0;
+  std::map<AlignableDetOrUnitPtr, Alignable*> alidettoalimap;
+  std::map<Alignable*, int> aliposmap;
+  std::map<Alignable*, int> alilenmap;
+  int nparam = 0;
 
   // iterate over AlignableDet's
-  for( std::vector<AlignableDetOrUnitPtr>::const_iterator iad = alignabledets.begin();
-       iad != alignabledets.end(); ++iad ) 
-  {
-    Alignable* ali = alignableFromAlignableDet( *iad );
-    if ( ali ) 
-    {
-      alidettoalimap[ *iad ] = ali; // Add to map
+  for (std::vector<AlignableDetOrUnitPtr>::const_iterator iad = alignabledets.begin(); iad != alignabledets.end();
+       ++iad) {
+    Alignable* ali = alignableFromAlignableDet(*iad);
+    if (ali) {
+      alidettoalimap[*iad] = ali;  // Add to map
       // Check if Alignable already there, insert into vector if not
-      if ( find(alignables.begin(),alignables.end(),ali) == alignables.end() ) 
-      {
-	alignables.push_back(ali);
-	AlignmentParameters* ap = ali->alignmentParameters();
-	nparam += ap->numSelected();
+      if (find(alignables.begin(), alignables.end(), ali) == alignables.end()) {
+        alignables.push_back(ali);
+        AlignmentParameters* ap = ali->alignmentParameters();
+        nparam += ap->numSelected();
       }
     }
   }
 
-  AlgebraicVector* selpar = new AlgebraicVector( nparam, 0 );
-  AlgebraicSymMatrix* selcov = new AlgebraicSymMatrix( nparam, 0 );
+  AlgebraicVector* selpar = new AlgebraicVector(nparam, 0);
+  AlgebraicSymMatrix* selcov = new AlgebraicSymMatrix(nparam, 0);
 
   // Fill in parameters and corresponding covariance matricess
-  int ipos = 1; // NOTE: .sub indices start from 1
+  int ipos = 1;  // NOTE: .sub indices start from 1
   align::Alignables::const_iterator it1;
-  for( it1 = alignables.begin(); it1 != alignables.end(); ++it1 ) 
-  {
+  for (it1 = alignables.begin(); it1 != alignables.end(); ++it1) {
     AlignmentParameters* ap = (*it1)->alignmentParameters();
-    selpar->sub( ipos, ap->selectedParameters() );
-    selcov->sub( ipos, ap->selectedCovariance() );
+    selpar->sub(ipos, ap->selectedParameters());
+    selcov->sub(ipos, ap->selectedCovariance());
     int npar = ap->numSelected();
-    aliposmap[*it1]=ipos;
-    alilenmap[*it1]=npar;
-    ipos +=npar;
+    aliposmap[*it1] = ipos;
+    alilenmap[*it1] = npar;
+    ipos += npar;
   }
 
   // Fill in the correlations. Has to be an extra loop, because the
   // AlignmentExtendedCorrelationsStore (if used) needs the
   // alignables' covariance matrices already present.
   ipos = 1;
-  for( it1 = alignables.begin(); it1 != alignables.end(); ++it1 ) 
-  {
-    int jpos=1;
+  for (it1 = alignables.begin(); it1 != alignables.end(); ++it1) {
+    int jpos = 1;
 
     // Look for correlations between alignables
     align::Alignables::const_iterator it2;
-    for( it2 = alignables.begin(); it2 != it1; ++it2 ) 
-    {
-      theCorrelationsStore->correlations( *it1, *it2, *selcov, ipos-1, jpos-1 );
+    for (it2 = alignables.begin(); it2 != it1; ++it2) {
+      theCorrelationsStore->correlations(*it1, *it2, *selcov, ipos - 1, jpos - 1);
       jpos += (*it2)->alignmentParameters()->numSelected();
     }
 
     ipos += (*it1)->alignmentParameters()->numSelected();
   }
 
-  AlignmentParametersData::DataContainer data( new AlignmentParametersData( selpar, selcov ) );
-  CompositeAlignmentParameters aap( data, alignables, alidettoalimap, aliposmap, alilenmap );
+  AlignmentParametersData::DataContainer data(new AlignmentParametersData(selpar, selcov));
+  CompositeAlignmentParameters aap(data, alignables, alidettoalimap, aliposmap, alilenmap);
 
   return aap;
 }
 
-
 //__________________________________________________________________________________________________
-CompositeAlignmentParameters
-AlignmentParameterStore::selectParameters( const align::Alignables& alignables ) const
-{
-
+CompositeAlignmentParameters AlignmentParameterStore::selectParameters(const align::Alignables& alignables) const {
   align::Alignables selectedAlignables;
-  std::map <AlignableDetOrUnitPtr,Alignable*> alidettoalimap; // This map won't be filled!!!
-  std::map <Alignable*,int> aliposmap;
-  std::map <Alignable*,int> alilenmap;
-  int nparam=0;
+  std::map<AlignableDetOrUnitPtr, Alignable*> alidettoalimap;  // This map won't be filled!!!
+  std::map<Alignable*, int> aliposmap;
+  std::map<Alignable*, int> alilenmap;
+  int nparam = 0;
 
   // iterate over Alignable's
   align::Alignables::const_iterator ita;
-  for ( ita = alignables.begin(); ita != alignables.end(); ++ita ) 
-  {
+  for (ita = alignables.begin(); ita != alignables.end(); ++ita) {
     // Check if Alignable already there, insert into vector if not
-    if ( find(selectedAlignables.begin(), selectedAlignables.end(), *ita) == selectedAlignables.end() ) 
-    {
-      selectedAlignables.push_back( *ita );
+    if (find(selectedAlignables.begin(), selectedAlignables.end(), *ita) == selectedAlignables.end()) {
+      selectedAlignables.push_back(*ita);
       AlignmentParameters* ap = (*ita)->alignmentParameters();
       nparam += ap->numSelected();
     }
   }
 
-  AlgebraicVector* selpar = new AlgebraicVector( nparam, 0 );
-  AlgebraicSymMatrix* selcov = new AlgebraicSymMatrix( nparam, 0 );
+  AlgebraicVector* selpar = new AlgebraicVector(nparam, 0);
+  AlgebraicSymMatrix* selcov = new AlgebraicSymMatrix(nparam, 0);
 
   // Fill in parameters and corresponding covariance matrices
-  int ipos = 1; // NOTE: .sub indices start from 1
+  int ipos = 1;  // NOTE: .sub indices start from 1
   align::Alignables::const_iterator it1;
-  for( it1 = selectedAlignables.begin(); it1 != selectedAlignables.end(); ++it1 ) 
-  {
+  for (it1 = selectedAlignables.begin(); it1 != selectedAlignables.end(); ++it1) {
     AlignmentParameters* ap = (*it1)->alignmentParameters();
-    selpar->sub( ipos, ap->selectedParameters() );
-    selcov->sub( ipos, ap->selectedCovariance() );
+    selpar->sub(ipos, ap->selectedParameters());
+    selcov->sub(ipos, ap->selectedCovariance());
     int npar = ap->numSelected();
-    aliposmap[*it1]=ipos;
-    alilenmap[*it1]=npar;
-    ipos +=npar;
+    aliposmap[*it1] = ipos;
+    alilenmap[*it1] = npar;
+    ipos += npar;
   }
 
   // Fill in the correlations. Has to be an extra loop, because the
   // AlignmentExtendedCorrelationsStore (if used) needs the
   // alignables' covariance matrices already present.
   ipos = 1;
-  for( it1 = selectedAlignables.begin(); it1 != selectedAlignables.end(); ++it1 ) 
-  {
-    int jpos=1;
+  for (it1 = selectedAlignables.begin(); it1 != selectedAlignables.end(); ++it1) {
+    int jpos = 1;
 
     // Look for correlations between alignables
     align::Alignables::const_iterator it2;
-    for( it2 = selectedAlignables.begin(); it2 != it1; ++it2 ) 
-    {
-      theCorrelationsStore->correlations( *it1, *it2, *selcov, ipos-1, jpos-1 );
+    for (it2 = selectedAlignables.begin(); it2 != it1; ++it2) {
+      theCorrelationsStore->correlations(*it1, *it2, *selcov, ipos - 1, jpos - 1);
       jpos += (*it2)->alignmentParameters()->numSelected();
     }
 
     ipos += (*it1)->alignmentParameters()->numSelected();
   }
 
-  AlignmentParametersData::DataContainer data( new AlignmentParametersData( selpar, selcov ) );
-  CompositeAlignmentParameters aap( data, selectedAlignables, alidettoalimap, aliposmap, alilenmap );
+  AlignmentParametersData::DataContainer data(new AlignmentParametersData(selpar, selcov));
+  CompositeAlignmentParameters aap(data, selectedAlignables, alidettoalimap, aliposmap, alilenmap);
 
   return aap;
 }
 
-
 //__________________________________________________________________________________________________
-void AlignmentParameterStore::updateParameters( const CompositeAlignmentParameters& aap, bool updateCorrelations )
-{
-
+void AlignmentParameterStore::updateParameters(const CompositeAlignmentParameters& aap, bool updateCorrelations) {
   align::Alignables alignables = aap.components();
   const AlgebraicVector& parameters = aap.parameters();
   const AlgebraicSymMatrix& covariance = aap.covariance();
 
-  int ipos = 1; // NOTE: .sub indices start from 1
+  int ipos = 1;  // NOTE: .sub indices start from 1
 
   // Loop over alignables
-  for( align::Alignables::const_iterator it=alignables.begin(); it != alignables.end(); ++it ) 
-  {
-    // Update parameters and local covariance   
+  for (align::Alignables::const_iterator it = alignables.begin(); it != alignables.end(); ++it) {
+    // Update parameters and local covariance
     AlignmentParameters* ap = (*it)->alignmentParameters();
     int nsel = ap->numSelected();
-    AlgebraicVector subvec = parameters.sub( ipos, ipos+nsel-1 );
-    AlgebraicSymMatrix subcov = covariance.sub( ipos, ipos+nsel-1 );
-    AlignmentParameters* apnew = ap->cloneFromSelected( subvec, subcov );
-    (*it)->setAlignmentParameters( apnew );
-	  
+    AlgebraicVector subvec = parameters.sub(ipos, ipos + nsel - 1);
+    AlgebraicSymMatrix subcov = covariance.sub(ipos, ipos + nsel - 1);
+    AlignmentParameters* apnew = ap->cloneFromSelected(subvec, subcov);
+    (*it)->setAlignmentParameters(apnew);
+
     // Now update correlations between detectors
-    if ( updateCorrelations )
-    {
+    if (updateCorrelations) {
       int jpos = 1;
-      for( align::Alignables::const_iterator it2 = alignables.begin(); it2 != it; ++it2 ) 
-      {
-	theCorrelationsStore->setCorrelations( *it, *it2, covariance, ipos-1, jpos-1 );
-	jpos += (*it2)->alignmentParameters()->numSelected();
+      for (align::Alignables::const_iterator it2 = alignables.begin(); it2 != it; ++it2) {
+        theCorrelationsStore->setCorrelations(*it, *it2, covariance, ipos - 1, jpos - 1);
+        jpos += (*it2)->alignmentParameters()->numSelected();
       }
     }
 
-    ipos+=nsel;
+    ipos += nsel;
   }
-
 }
 
-
 //__________________________________________________________________________________________________
-align::Alignables AlignmentParameterStore::validAlignables(void) const
-{ 
+align::Alignables AlignmentParameterStore::validAlignables(void) const {
   align::Alignables result;
-  for (align::Alignables::const_iterator iali = theAlignables.begin();
-       iali != theAlignables.end(); ++iali)
-    if ( (*iali)->alignmentParameters()->isValid() ) result.push_back(*iali);
+  for (align::Alignables::const_iterator iali = theAlignables.begin(); iali != theAlignables.end(); ++iali)
+    if ((*iali)->alignmentParameters()->isValid())
+      result.push_back(*iali);
 
   LogDebug("Alignment") << "@SUB=AlignmentParameterStore::validAlignables"
-                        << "Valid alignables: " << result.size()
-                        << "out of " << theAlignables.size();
+                        << "Valid alignables: " << result.size() << "out of " << theAlignables.size();
   return result;
 }
 
 //__________________________________________________________________________________________________
-Alignable* AlignmentParameterStore::alignableFromAlignableDet( const AlignableDetOrUnitPtr& _alignableDet ) const
-{
+Alignable* AlignmentParameterStore::alignableFromAlignableDet(const AlignableDetOrUnitPtr& _alignableDet) const {
   AlignableDetOrUnitPtr alignableDet = _alignableDet;
-  Alignable *mother = alignableDet;
+  Alignable* mother = alignableDet;
   while (mother) {
-    if (mother->alignmentParameters()) return mother;
+    if (mother->alignmentParameters())
+      return mother;
     mother = mother->mother();
   }
 
@@ -284,157 +252,129 @@ Alignable* AlignmentParameterStore::alignableFromAlignableDet( const AlignableDe
 }
 
 //__________________________________________________________________________________________________
-void AlignmentParameterStore::applyParameters(void)
-{
+void AlignmentParameterStore::applyParameters(void) {
   align::Alignables::const_iterator iali;
-  for ( iali = theAlignables.begin(); iali != theAlignables.end(); ++iali) 
-    applyParameters( *iali );
+  for (iali = theAlignables.begin(); iali != theAlignables.end(); ++iali)
+    applyParameters(*iali);
 }
 
-
 //__________________________________________________________________________________________________
-void AlignmentParameterStore::applyParameters(Alignable* alignable)
-{
-
-  AlignmentParameters *pars = (alignable ? alignable->alignmentParameters() : nullptr);
+void AlignmentParameterStore::applyParameters(Alignable* alignable) {
+  AlignmentParameters* pars = (alignable ? alignable->alignmentParameters() : nullptr);
   if (!pars) {
-    throw cms::Exception("BadAlignable") 
-      << "applyParameters: provided alignable does not have alignment parameters";
+    throw cms::Exception("BadAlignable") << "applyParameters: provided alignable does not have alignment parameters";
   }
   pars->apply();
 }
 
-
 //__________________________________________________________________________________________________
-void AlignmentParameterStore::resetParameters(void)
-{
+void AlignmentParameterStore::resetParameters(void) {
   // Erase contents of correlation map
   theCorrelationsStore->resetCorrelations();
 
   // Iterate over alignables in the store and reset parameters
   align::Alignables::const_iterator iali;
-  for ( iali = theAlignables.begin(); iali != theAlignables.end(); ++iali )
-    resetParameters( *iali );
+  for (iali = theAlignables.begin(); iali != theAlignables.end(); ++iali)
+    resetParameters(*iali);
 }
 
-
 //__________________________________________________________________________________________________
-void AlignmentParameterStore::resetParameters( Alignable* ali )
-{
-  if ( ali ) 
-  {
+void AlignmentParameterStore::resetParameters(Alignable* ali) {
+  if (ali) {
     // Get alignment parameters for this alignable
     AlignmentParameters* ap = ali->alignmentParameters();
-    if ( ap ) 
-    {
-      int npar=ap->numSelected();
-          
-      AlgebraicVector par(npar,0);
-      AlgebraicSymMatrix cov(npar,0);
-      AlignmentParameters* apnew = ap->cloneFromSelected(par,cov);
+    if (ap) {
+      int npar = ap->numSelected();
+
+      AlgebraicVector par(npar, 0);
+      AlgebraicSymMatrix cov(npar, 0);
+      AlignmentParameters* apnew = ap->cloneFromSelected(par, cov);
       ali->setAlignmentParameters(apnew);
       apnew->setValid(false);
-    }
-    else 
+    } else
       edm::LogError("BadArgument") << "@SUB=AlignmentParameterStore::resetParameters"
-				   << "alignable has no alignment parameter";
-  }
-  else
+                                   << "alignable has no alignment parameter";
+  } else
     edm::LogError("BadArgument") << "@SUB=AlignmentParameterStore::resetParameters"
                                  << "argument is NULL";
 }
 
-
 //__________________________________________________________________________________________________
-void AlignmentParameterStore::cacheTransformations(void)
-{
+void AlignmentParameterStore::cacheTransformations(void) {
   align::Alignables::const_iterator iali;
-  for ( iali = theAlignables.begin(); iali != theAlignables.end(); ++iali) 
+  for (iali = theAlignables.begin(); iali != theAlignables.end(); ++iali)
     (*iali)->cacheTransformation();
 }
 
-
 //__________________________________________________________________________________________________
-void AlignmentParameterStore::cacheTransformations(const align::RunNumber& run)
-{
-  for (const auto& iali: theAlignables) iali->cacheTransformation(run);
+void AlignmentParameterStore::cacheTransformations(const align::RunNumber& run) {
+  for (const auto& iali : theAlignables)
+    iali->cacheTransformation(run);
 }
 
-
 //__________________________________________________________________________________________________
-void AlignmentParameterStore::restoreCachedTransformations(void)
-{
+void AlignmentParameterStore::restoreCachedTransformations(void) {
   align::Alignables::const_iterator iali;
-  for ( iali = theAlignables.begin(); iali != theAlignables.end(); ++iali) 
+  for (iali = theAlignables.begin(); iali != theAlignables.end(); ++iali)
     (*iali)->restoreCachedTransformation();
 }
 
-
 //__________________________________________________________________________________________________
-void AlignmentParameterStore::restoreCachedTransformations(const align::RunNumber& run)
-{
-  for (const auto& iali: theAlignables) iali->restoreCachedTransformation(run);
+void AlignmentParameterStore::restoreCachedTransformations(const align::RunNumber& run) {
+  for (const auto& iali : theAlignables)
+    iali->restoreCachedTransformation(run);
 }
 
-
 //__________________________________________________________________________________________________
-void AlignmentParameterStore::acquireRelativeParameters(void)
-{
-
+void AlignmentParameterStore::acquireRelativeParameters(void) {
   unsigned int nAlignables = theAlignables.size();
 
-  for (unsigned int i = 0; i < nAlignables; ++i)
-  {
+  for (unsigned int i = 0; i < nAlignables; ++i) {
     Alignable* ali = theAlignables[i];
 
-    RigidBodyAlignmentParameters* ap = 
-      dynamic_cast<RigidBodyAlignmentParameters*>( ali->alignmentParameters() );
+    RigidBodyAlignmentParameters* ap = dynamic_cast<RigidBodyAlignmentParameters*>(ali->alignmentParameters());
 
-    if ( !ap )
-      throw cms::Exception("BadAlignable") 
-	<< "acquireRelativeParameters: "
-	<< "provided alignable does not have rigid body alignment parameters";
+    if (!ap)
+      throw cms::Exception("BadAlignable") << "acquireRelativeParameters: "
+                                           << "provided alignable does not have rigid body alignment parameters";
 
-    AlgebraicVector par( ap->size(),0 );
-    AlgebraicSymMatrix cov( ap->size(), 0 );
-	  
+    AlgebraicVector par(ap->size(), 0);
+    AlgebraicSymMatrix cov(ap->size(), 0);
+
     // Get displacement and transform global->local
-    align::LocalVector dloc = ali->surface().toLocal( ali->displacement() );
-    par[0]=dloc.x();
-    par[1]=dloc.y();
-    par[2]=dloc.z();
+    align::LocalVector dloc = ali->surface().toLocal(ali->displacement());
+    par[0] = dloc.x();
+    par[1] = dloc.y();
+    par[2] = dloc.z();
 
     // Transform to local euler angles
-    align::EulerAngles euloc = align::toAngles( ali->surface().toLocal( ali->rotation() ) );
-    par[3]=euloc(1);
-    par[4]=euloc(2);
-    par[5]=euloc(3);
-	  
+    align::EulerAngles euloc = align::toAngles(ali->surface().toLocal(ali->rotation()));
+    par[3] = euloc(1);
+    par[4] = euloc(2);
+    par[5] = euloc(3);
+
     // Clone parameters
-    RigidBodyAlignmentParameters* apnew = ap->clone(par,cov);
-	  
+    RigidBodyAlignmentParameters* apnew = ap->clone(par, cov);
+
     ali->setAlignmentParameters(apnew);
   }
 }
-
 
 //__________________________________________________________________________________________________
 // Get type/layer from Alignable
 // type: -6   -5   -4   -3   -2    -1     1     2    3    4    5    6
 //      TEC- TOB- TID- TIB- PxEC- PxBR- PxBr+ PxEC+ TIB+ TID+ TOB+ TEC+
 // Layers start from zero
-std::pair<int,int> AlignmentParameterStore::typeAndLayer(const Alignable* ali, const TrackerTopology* tTopo) const
-{
-  return TrackerAlignableId().typeAndLayerFromDetId( ali->id(), tTopo );
+std::pair<int, int> AlignmentParameterStore::typeAndLayer(const Alignable* ali, const TrackerTopology* tTopo) const {
+  return TrackerAlignableId().typeAndLayerFromDetId(ali->id(), tTopo);
 }
 
-
 //__________________________________________________________________________________________________
-void AlignmentParameterStore::
-applyAlignableAbsolutePositions(const align::Alignables& alivec, const AlignablePositions& newpos, int& ierr)
-{
-  unsigned int nappl=0;
-  ierr=0;
+void AlignmentParameterStore::applyAlignableAbsolutePositions(const align::Alignables& alivec,
+                                                              const AlignablePositions& newpos,
+                                                              int& ierr) {
+  unsigned int nappl = 0;
+  ierr = 0;
 
   // Iterate over list of alignables
   for (align::Alignables::const_iterator iali = alivec.begin(); iali != alivec.end(); ++iali) {
@@ -443,14 +383,12 @@ applyAlignableAbsolutePositions(const align::Alignables& alivec, const Alignable
     align::StructureType typeId = ali->alignableObjectId();
 
     // Find corresponding entry in AlignablePositions
-    bool found=false;
+    bool found = false;
     for (AlignablePositions::const_iterator ipos = newpos.begin(); ipos != newpos.end(); ++ipos) {
       if (id == ipos->id() && typeId == ipos->objId()) {
         if (found) {
-          edm::LogError("DuplicatePosition")
-            << "New positions for alignable found more than once!";
-        }
-        else {
+          edm::LogError("DuplicatePosition") << "New positions for alignable found more than once!";
+        } else {
           // New position/rotation
           const align::PositionType& pnew = ipos->pos();
           const align::RotationType& rnew = ipos->rot();
@@ -460,10 +398,10 @@ applyAlignableAbsolutePositions(const align::Alignables& alivec, const Alignable
           const align::RotationType& rold = ali->globalRotation();
           // Current surf. deformation
           std::vector<std::pair<int, SurfaceDeformation*> > dold_id_pairs;
-          SurfaceDeformation* dold_obj=nullptr;
+          SurfaceDeformation* dold_obj = nullptr;
           SurfaceDeformationFactory::Type dtype = SurfaceDeformationFactory::kNoDeformations;
           std::vector<double> dold;
-          if (1 == ali->surfaceDeformationIdPairs(dold_id_pairs)){ // might not have any...
+          if (1 == ali->surfaceDeformationIdPairs(dold_id_pairs)) {  // might not have any...
             dold_obj = dold_id_pairs[0].second;
             dold = dold_obj->parameters();
             dtype = (SurfaceDeformationFactory::Type)dold_obj->type();
@@ -472,7 +410,7 @@ applyAlignableAbsolutePositions(const align::Alignables& alivec, const Alignable
           // shift needed to move from current to new position
           align::GlobalVector posDiff = pnew - pold;
           align::RotationType rotDiff = rold.multiplyInverse(rnew);
-          align::rectify(rotDiff); // correct for rounding errors 
+          align::rectify(rotDiff);  // correct for rounding errors
           ali->move(posDiff);
           ali->rotateInGlobalFrame(rotDiff);
           LogDebug("NewPosition") << "moving by:" << posDiff;
@@ -480,25 +418,31 @@ applyAlignableAbsolutePositions(const align::Alignables& alivec, const Alignable
 
           // add the surface deformations
           // If an old surface deformation record exists, ensure that the added deformation has the same type and size.
-          if (!dold.empty() && dtype != SurfaceDeformationFactory::kNoDeformations && dnew.size()==dold.size()){
-            std::vector<double> defDiff; defDiff.reserve(dold.size());
-            for (unsigned int i = 0; i < dold.size(); i++) defDiff.push_back(dnew[i] - dold[i]);
+          if (!dold.empty() && dtype != SurfaceDeformationFactory::kNoDeformations && dnew.size() == dold.size()) {
+            std::vector<double> defDiff;
+            defDiff.reserve(dold.size());
+            for (unsigned int i = 0; i < dold.size(); i++)
+              defDiff.push_back(dnew[i] - dold[i]);
             auto deform = SurfaceDeformationFactory::create(dtype, defDiff);
             edm::LogInfo("Alignment") << "@SUB=AlignmentParameterStore::applyAlignableAbsolutePositions"
-              << "Adding surface deformation of type " << SurfaceDeformationFactory::surfaceDeformationTypeName((SurfaceDeformationFactory::Type)deform->type())
-              << ", size " << defDiff.size() << " and first element " << defDiff.at(0)
-              << " to alignable with id / type: " << id << " / " << typeId;
+                                      << "Adding surface deformation of type "
+                                      << SurfaceDeformationFactory::surfaceDeformationTypeName(
+                                             (SurfaceDeformationFactory::Type)deform->type())
+                                      << ", size " << defDiff.size() << " and first element " << defDiff.at(0)
+                                      << " to alignable with id / type: " << id << " / " << typeId;
             ali->addSurfaceDeformation(deform, true);
             delete deform;
           }
           // In case no old surface deformation record exists, only ensure that the new surface deformation record has size>0. Size check is done elsewhere.
-          else if (!dnew.empty()){
+          else if (!dnew.empty()) {
             auto deform = SurfaceDeformationFactory::create(dnew);
             edm::LogInfo("Alignment") << "@SUB=AlignmentParameterStore::applyAlignableAbsolutePositions"
-              << "Setting surface deformation of type " << SurfaceDeformationFactory::surfaceDeformationTypeName((SurfaceDeformationFactory::Type)deform->type())
-              << ", size " << dnew.size() << " and first element " << dnew.at(0)
-              << " to alignable with id / type: " << id << " / " << typeId;
-            ali->addSurfaceDeformation(deform, true); // Equivalent to setSurfaceDeformation in this case
+                                      << "Setting surface deformation of type "
+                                      << SurfaceDeformationFactory::surfaceDeformationTypeName(
+                                             (SurfaceDeformationFactory::Type)deform->type())
+                                      << ", size " << dnew.size() << " and first element " << dnew.at(0)
+                                      << " to alignable with id / type: " << id << " / " << typeId;
+            ali->addSurfaceDeformation(deform, true);  // Equivalent to setSurfaceDeformation in this case
             delete deform;
           }
           // If there is no new surface deformation record, do nothing.
@@ -508,29 +452,26 @@ applyAlignableAbsolutePositions(const align::Alignables& alivec, const Alignable
           // (*iali)->addAlignmentPositionError(ape);
           // (*iali)->addAlignmentPositionErrorFromRotation(rot);
 
-          found=true;
+          found = true;
           ++nappl;
         }
       }
     }
   }
 
-  if (nappl< newpos.size())
+  if (nappl < newpos.size())
     edm::LogError("Mismatch") << "Applied only " << nappl << " new positions"
-    << " out of " << newpos.size();
+                              << " out of " << newpos.size();
 
-  LogDebug("NewPositions") << "Applied new positions for " << nappl
-    << " out of " << alivec.size() <<" alignables.";
-
+  LogDebug("NewPositions") << "Applied new positions for " << nappl << " out of " << alivec.size() << " alignables.";
 }
 
-
 //__________________________________________________________________________________________________
-void AlignmentParameterStore::
-applyAlignableRelativePositions(const align::Alignables& alivec, const AlignableShifts& shifts, int& ierr)
-{
-  ierr=0;
-  unsigned int nappl=0;
+void AlignmentParameterStore::applyAlignableRelativePositions(const align::Alignables& alivec,
+                                                              const AlignableShifts& shifts,
+                                                              int& ierr) {
+  ierr = 0;
+  unsigned int nappl = 0;
   unsigned int nAlignables = alivec.size();
 
   for (unsigned int i = 0; i < nAlignables; ++i) {
@@ -544,16 +485,14 @@ applyAlignableRelativePositions(const align::Alignables& alivec, const Alignable
     for (AlignableShifts::const_iterator ipos = shifts.begin(); ipos != shifts.end(); ++ipos) {
       if (id == ipos->id() && typeId == ipos->objId()) {
         if (found) {
-          edm::LogError("DuplicatePosition")
-            << "New positions for alignable found more than once!";
-        }
-        else {
+          edm::LogError("DuplicatePosition") << "New positions for alignable found more than once!";
+        } else {
           // Current surf. deformation
           std::vector<std::pair<int, SurfaceDeformation*> > dold_id_pairs;
-          SurfaceDeformation* dold_obj=nullptr;
+          SurfaceDeformation* dold_obj = nullptr;
           SurfaceDeformationFactory::Type dtype = SurfaceDeformationFactory::kNoDeformations;
           std::vector<double> dold;
-          if (1 == ali->surfaceDeformationIdPairs(dold_id_pairs)){ // might not have any...
+          if (1 == ali->surfaceDeformationIdPairs(dold_id_pairs)) {  // might not have any...
             dold_obj = dold_id_pairs[0].second;
             dold = dold_obj->parameters();
             dtype = (SurfaceDeformationFactory::Type)dold_obj->type();
@@ -564,23 +503,27 @@ applyAlignableRelativePositions(const align::Alignables& alivec, const Alignable
 
           const std::vector<double>& defDiff = ipos->deformationParameters();
           // If an old surface deformation record exists, ensure that the added deformation has the same type and size.
-          if (!dold.empty() && dtype != SurfaceDeformationFactory::kNoDeformations && defDiff.size()==dold.size()){
+          if (!dold.empty() && dtype != SurfaceDeformationFactory::kNoDeformations && defDiff.size() == dold.size()) {
             auto deform = SurfaceDeformationFactory::create(dtype, defDiff);
             edm::LogInfo("Alignment") << "@SUB=AlignmentParameterStore::applyAlignableRelativePositions"
-              << "Adding surface deformation of type " << SurfaceDeformationFactory::surfaceDeformationTypeName((SurfaceDeformationFactory::Type)deform->type())
-              << ", size " << defDiff.size() << " and first element " << defDiff.at(0)
-              << " to alignable with id / type: " << id << " / " << typeId;
+                                      << "Adding surface deformation of type "
+                                      << SurfaceDeformationFactory::surfaceDeformationTypeName(
+                                             (SurfaceDeformationFactory::Type)deform->type())
+                                      << ", size " << defDiff.size() << " and first element " << defDiff.at(0)
+                                      << " to alignable with id / type: " << id << " / " << typeId;
             ali->addSurfaceDeformation(deform, true);
             delete deform;
           }
           // In case no old surface deformation record exists, only ensure that the new surface deformation record has size>0. Size check is done elsewhere.
-          else if (!defDiff.empty()){
+          else if (!defDiff.empty()) {
             auto deform = SurfaceDeformationFactory::create(defDiff);
             edm::LogInfo("Alignment") << "@SUB=AlignmentParameterStore::applyAlignableRelativePositions"
-              << "Setting surface deformation of type " << SurfaceDeformationFactory::surfaceDeformationTypeName((SurfaceDeformationFactory::Type)deform->type())
-              << ", size " << defDiff.size() << " and first element " << defDiff.at(0)
-              << " to alignable with id / type: " << id << " / " << typeId;
-            ali->addSurfaceDeformation(deform, true); // Equivalent to setSurfaceDeformation in this case
+                                      << "Setting surface deformation of type "
+                                      << SurfaceDeformationFactory::surfaceDeformationTypeName(
+                                             (SurfaceDeformationFactory::Type)deform->type())
+                                      << ", size " << defDiff.size() << " and first element " << defDiff.at(0)
+                                      << " to alignable with id / type: " << id << " / " << typeId;
+            ali->addSurfaceDeformation(deform, true);  // Equivalent to setSurfaceDeformation in this case
             delete deform;
           }
           // If there is no new surface deformation record, do nothing.
@@ -590,7 +533,7 @@ applyAlignableRelativePositions(const align::Alignables& alivec, const Alignable
           //ali->addAlignmentPositionError(ape);
           //ali->addAlignmentPositionErrorFromRotation(rnew);
 
-          found=true;
+          found = true;
           ++nappl;
         }
       }
@@ -599,215 +542,197 @@ applyAlignableRelativePositions(const align::Alignables& alivec, const Alignable
 
   if (nappl < shifts.size())
     edm::LogError("Mismatch") << "Applied only " << nappl << " new positions"
-    << " out of " << shifts.size();
+                              << " out of " << shifts.size();
 
   LogDebug("NewPositions") << "Applied new positions for " << nappl << " alignables.";
 }
 
-
-
 //__________________________________________________________________________________________________
-void AlignmentParameterStore::attachAlignmentParameters( const Parameters& parvec, int& ierr )
-{
-  attachAlignmentParameters( theAlignables, parvec, ierr);
+void AlignmentParameterStore::attachAlignmentParameters(const Parameters& parvec, int& ierr) {
+  attachAlignmentParameters(theAlignables, parvec, ierr);
 }
 
-
-
 //__________________________________________________________________________________________________
-void AlignmentParameterStore::attachAlignmentParameters( const align::Alignables& alivec, 
-                                                         const Parameters& parvec, int& ierr )
-{
+void AlignmentParameterStore::attachAlignmentParameters(const align::Alignables& alivec,
+                                                        const Parameters& parvec,
+                                                        int& ierr) {
   int ipass = 0;
   int ifail = 0;
   ierr = 0;
 
   // Iterate over alignables
-  for ( align::Alignables::const_iterator iali = alivec.begin(); iali != alivec.end(); ++iali ) 
-  {
+  for (align::Alignables::const_iterator iali = alivec.begin(); iali != alivec.end(); ++iali) {
     // Iterate over Parameters
-    bool found=false;
-    for ( Parameters::const_iterator ipar = parvec.begin(); ipar != parvec.end(); ++ipar) 
-    {
+    bool found = false;
+    for (Parameters::const_iterator ipar = parvec.begin(); ipar != parvec.end(); ++ipar) {
       // Get new alignment parameters
-      AlignmentParameters* ap = *ipar; 
+      AlignmentParameters* ap = *ipar;
 
-      // Check if parameters belong to alignable 
-      if ( ap->alignable() == (*iali) )
-      {
-	if (!found) 
-	{
+      // Check if parameters belong to alignable
+      if (ap->alignable() == (*iali)) {
+        if (!found) {
           (*iali)->setAlignmentParameters(ap);
           ++ipass;
-          found=true;
-        } 
-        else edm::LogError("Alignment") << "@SUB=AlignmentParameterStore::attachAlignmentParameters" 
-					<< "More than one parameters for Alignable.";
+          found = true;
+        } else
+          edm::LogError("Alignment") << "@SUB=AlignmentParameterStore::attachAlignmentParameters"
+                                     << "More than one parameters for Alignable.";
       }
     }
-    if (!found) ++ifail;
+    if (!found)
+      ++ifail;
   }
-  if (ifail>0) ierr=-1;
-  
-  LogDebug("attachAlignmentParameters") << " Parameters, Alignables: " << parvec.size() << ","
-                                        << alivec.size() << "\n pass,fail: " << ipass << ","<< ifail;
+  if (ifail > 0)
+    ierr = -1;
+
+  LogDebug("attachAlignmentParameters") << " Parameters, Alignables: " << parvec.size() << "," << alivec.size()
+                                        << "\n pass,fail: " << ipass << "," << ifail;
 }
 
-
 //__________________________________________________________________________________________________
-void AlignmentParameterStore::attachCorrelations( const Correlations& cormap, 
-                                                  bool overwrite, int& ierr )
-{
-  attachCorrelations( theAlignables, cormap, overwrite, ierr );
+void AlignmentParameterStore::attachCorrelations(const Correlations& cormap, bool overwrite, int& ierr) {
+  attachCorrelations(theAlignables, cormap, overwrite, ierr);
 }
 
-
 //__________________________________________________________________________________________________
-void AlignmentParameterStore::attachCorrelations( const align::Alignables& alivec, 
-                                                  const Correlations& cormap, 
-                                                  bool overwrite, int& ierr )
-{
-  ierr=0;
-  int icount=0;
+void AlignmentParameterStore::attachCorrelations(const align::Alignables& alivec,
+                                                 const Correlations& cormap,
+                                                 bool overwrite,
+                                                 int& ierr) {
+  ierr = 0;
+  int icount = 0;
 
   // Iterate over correlations
-  for ( Correlations::const_iterator icor = cormap.begin(); icor!=cormap.end(); ++icor ) 
-  {
-    AlgebraicMatrix mat=(*icor).second;
+  for (Correlations::const_iterator icor = cormap.begin(); icor != cormap.end(); ++icor) {
+    AlgebraicMatrix mat = (*icor).second;
     Alignable* ali1 = (*icor).first.first;
     Alignable* ali2 = (*icor).first.second;
 
     // Check if alignables exist
-    if ( find( alivec.begin(), alivec.end(), ali1 ) != alivec.end() && 
-         find( alivec.begin(), alivec.end(), ali2 ) != alivec.end() )
-    {
+    if (find(alivec.begin(), alivec.end(), ali1) != alivec.end() &&
+        find(alivec.begin(), alivec.end(), ali2) != alivec.end()) {
       // Check if correlations already existing between these alignables
-      if ( !theCorrelationsStore->correlationsAvailable(ali1,ali2) || (overwrite) ) 
-       {
-         theCorrelationsStore->setCorrelations(ali1,ali2,mat);
-         ++icount;
-       }
-      else edm::LogInfo("AlreadyExists") << "Correlation existing and not overwritten";
-    }
-    else edm::LogInfo("IgnoreCorrelation") << "Ignoring correlation with no alignables!";
+      if (!theCorrelationsStore->correlationsAvailable(ali1, ali2) || (overwrite)) {
+        theCorrelationsStore->setCorrelations(ali1, ali2, mat);
+        ++icount;
+      } else
+        edm::LogInfo("AlreadyExists") << "Correlation existing and not overwritten";
+    } else
+      edm::LogInfo("IgnoreCorrelation") << "Ignoring correlation with no alignables!";
   }
 
-  LogDebug( "attachCorrelations" ) << " Alignables,Correlations: " << alivec.size() <<","<< cormap.size() 
-                                   << "\n applied: " << icount ;
-
+  LogDebug("attachCorrelations") << " Alignables,Correlations: " << alivec.size() << "," << cormap.size()
+                                 << "\n applied: " << icount;
 }
 
-
 //__________________________________________________________________________________________________
-void AlignmentParameterStore::
-attachUserVariables( const align::Alignables& alivec,
-                     const std::vector<AlignmentUserVariables*>& uvarvec, int& ierr )
-{
-  ierr=0;
+void AlignmentParameterStore::attachUserVariables(const align::Alignables& alivec,
+                                                  const std::vector<AlignmentUserVariables*>& uvarvec,
+                                                  int& ierr) {
+  ierr = 0;
 
-  LogDebug("DumpArguments") << "size of alivec:   "  << alivec.size()
-                            << "\nsize of uvarvec: " << uvarvec.size();
+  LogDebug("DumpArguments") << "size of alivec:   " << alivec.size() << "\nsize of uvarvec: " << uvarvec.size();
 
-  std::vector<AlignmentUserVariables*>::const_iterator iuvar=uvarvec.begin();
+  std::vector<AlignmentUserVariables*>::const_iterator iuvar = uvarvec.begin();
 
-  for ( align::Alignables::const_iterator iali=alivec.begin(); iali!=alivec.end(); ++iali, ++iuvar ) 
-  {
+  for (align::Alignables::const_iterator iali = alivec.begin(); iali != alivec.end(); ++iali, ++iuvar) {
     AlignmentParameters* ap = (*iali)->alignmentParameters();
     AlignmentUserVariables* uvarnew = (*iuvar);
     ap->setUserVariables(uvarnew);
   }
 }
 
-
 //__________________________________________________________________________________________________
-void AlignmentParameterStore::setAlignmentPositionError( const align::Alignables& alivec, 
-                                                         double valshift, double valrot )
-{
+void AlignmentParameterStore::setAlignmentPositionError(const align::Alignables& alivec,
+                                                        double valshift,
+                                                        double valrot) {
   unsigned int nAlignables = alivec.size();
 
-  for (unsigned int i = 0; i < nAlignables; ++i)
-  {
+  for (unsigned int i = 0; i < nAlignables; ++i) {
     Alignable* ali = alivec[i];
 
-    // First reset APE	 
-    AlignmentPositionError nulApe(0,0,0);	 
+    // First reset APE
+    AlignmentPositionError nulApe(0, 0, 0);
     ali->setAlignmentPositionError(nulApe, true);
 
     // Set APE from displacement
-    AlignmentPositionError ape(valshift,valshift,valshift);
-    if ( valshift > 0. ) ali->addAlignmentPositionError(ape, true);
-    else ali->setAlignmentPositionError(ape, true);
-    // GF: Resetting and setting as above does not really make sense to me, 
-    //     and adding to zero or setting is the same! I'd just do 
+    AlignmentPositionError ape(valshift, valshift, valshift);
+    if (valshift > 0.)
+      ali->addAlignmentPositionError(ape, true);
+    else
+      ali->setAlignmentPositionError(ape, true);
+    // GF: Resetting and setting as above does not really make sense to me,
+    //     and adding to zero or setting is the same! I'd just do
     //ali->setAlignmentPositionError(AlignmentPositionError ape(valshift,valshift,valshift),true);
 
     // Set APE from rotation
     align::EulerAngles r(3);
-    r(1)=valrot; r(2)=valrot; r(3)=valrot;
+    r(1) = valrot;
+    r(2) = valrot;
+    r(3) = valrot;
     ali->addAlignmentPositionErrorFromRotation(align::toMatrix(r), true);
   }
 
-  LogDebug("StoreAPE") << "Store APE from shift: " << valshift
-		       << "\nStore APE from rotation: " << valrot;
+  LogDebug("StoreAPE") << "Store APE from shift: " << valshift << "\nStore APE from rotation: " << valrot;
 }
 
 //__________________________________________________________________________________________________
-bool AlignmentParameterStore
-::hierarchyConstraints(const Alignable *ali, const align::Alignables &aliComps,
-		       std::vector<std::vector<ParameterId> > &paramIdsVecOut,
-		       std::vector<std::vector<double> > &factorsVecOut,
-		       bool all, double epsilon) const
-{
+bool AlignmentParameterStore ::hierarchyConstraints(const Alignable* ali,
+                                                    const align::Alignables& aliComps,
+                                                    std::vector<std::vector<ParameterId> >& paramIdsVecOut,
+                                                    std::vector<std::vector<double> >& factorsVecOut,
+                                                    bool all,
+                                                    double epsilon) const {
   // Weak point if all = false:
   // Ignores constraints between non-subsequent levels in case the parameter is not considered in
   // the intermediate level, e.g. global z for dets and layers is aligned, but not for rods!
-  if (!ali || !ali->alignmentParameters()) return false;
+  if (!ali || !ali->alignmentParameters())
+    return false;
 
-  const std::vector<bool> &aliSel= ali->alignmentParameters()->selector();
+  const std::vector<bool>& aliSel = ali->alignmentParameters()->selector();
   paramIdsVecOut.clear();
   factorsVecOut.clear();
 
   bool firstComp = true;
-  for (align::Alignables::const_iterator iComp = aliComps.begin(), iCompE = aliComps.end();
-       iComp != iCompE; ++iComp) {
-
+  for (align::Alignables::const_iterator iComp = aliComps.begin(), iCompE = aliComps.end(); iComp != iCompE; ++iComp) {
     const ParametersToParametersDerivatives p2pDerivs(**iComp, *ali);
     if (!p2pDerivs.isOK()) {
       // std::cerr << (*iComp)->alignmentParameters()->type() << " "
       // 		<< ali->alignmentParameters()->type() << std::endl;
-      throw cms::Exception("BadConfig")
-	<< "AlignmentParameterStore::hierarchyConstraints"
-	<< " Bad match of types of AlignmentParameters classes.\n";
+      throw cms::Exception("BadConfig") << "AlignmentParameterStore::hierarchyConstraints"
+                                        << " Bad match of types of AlignmentParameters classes.\n";
       return false;
     }
-    const std::vector<bool> &aliCompSel = (*iComp)->alignmentParameters()->selector();
+    const std::vector<bool>& aliCompSel = (*iComp)->alignmentParameters()->selector();
     for (unsigned int iParMast = 0, iParMastUsed = 0; iParMast < aliSel.size(); ++iParMast) {
-      if (!all && !aliSel[iParMast]) continue;// no higher level parameter & constraint deselected
-      if (firstComp) { // fill output with empty arrays 
-	paramIdsVecOut.push_back(std::vector<ParameterId>());
-	factorsVecOut.push_back(std::vector<double>());
+      if (!all && !aliSel[iParMast])
+        continue;       // no higher level parameter & constraint deselected
+      if (firstComp) {  // fill output with empty arrays
+        paramIdsVecOut.push_back(std::vector<ParameterId>());
+        factorsVecOut.push_back(std::vector<double>());
       }
       for (unsigned int iParComp = 0; iParComp < aliCompSel.size(); ++iParComp) {
-	if (aliCompSel[iParComp]) {
-	  double factor = 0.;
-	  if( theTypeOfConstraints == HIERARCHY_CONSTRAINTS ) {
-	    // hierachy constraints
-	    factor = p2pDerivs(iParMast, iParComp);
-	  } else if( theTypeOfConstraints == APPROX_AVERAGING_CONSTRAINTS ) {
-	    // CHK poor mans averaging constraints
-	    factor = p2pDerivs(iParMast, iParComp);
-	    if (iParMast < 3 && (iParComp % 9) >= 3) factor = 0.;
-	  }
-	  if (fabs(factor) > epsilon) {
-	    paramIdsVecOut[iParMastUsed].push_back(ParameterId(*iComp, iParComp));
-	    factorsVecOut[iParMastUsed].push_back(factor);
-	  }
-	}
+        if (aliCompSel[iParComp]) {
+          double factor = 0.;
+          if (theTypeOfConstraints == HIERARCHY_CONSTRAINTS) {
+            // hierachy constraints
+            factor = p2pDerivs(iParMast, iParComp);
+          } else if (theTypeOfConstraints == APPROX_AVERAGING_CONSTRAINTS) {
+            // CHK poor mans averaging constraints
+            factor = p2pDerivs(iParMast, iParComp);
+            if (iParMast < 3 && (iParComp % 9) >= 3)
+              factor = 0.;
+          }
+          if (fabs(factor) > epsilon) {
+            paramIdsVecOut[iParMastUsed].push_back(ParameterId(*iComp, iParComp));
+            factorsVecOut[iParMastUsed].push_back(factor);
+          }
+        }
       }
       ++iParMastUsed;
     }
     firstComp = false;
-  } // end loop on components
+  }  // end loop on components
 
   return true;
 }

--- a/Alignment/CommonAlignmentAlgorithm/src/AlignmentParametersIO.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignmentParametersIO.cc
@@ -8,34 +8,28 @@
 
 //--------------------------------------------------------------------------------------------------
 // write one set of original parameters
-int AlignmentParametersIO::writeOneOrigRigidBody(Alignable *ali)
-{
-
-  AlignmentParameters *par = ali->alignmentParameters();
-  AlignmentParameters *parBack = (par ? par->clone(par->parameters(), par->covariance()) : nullptr);
+int AlignmentParametersIO::writeOneOrigRigidBody(Alignable* ali) {
+  AlignmentParameters* par = ali->alignmentParameters();
+  AlignmentParameters* parBack = (par ? par->clone(par->parameters(), par->covariance()) : nullptr);
 
   ali->setAlignmentParameters(new RigidBodyAlignmentParameters(ali, true));
   int iret = this->writeOne(ali);
 
-  ali->setAlignmentParameters(parBack); // deletes the above created RigidBodyAlignmentParameters
+  ali->setAlignmentParameters(parBack);  // deletes the above created RigidBodyAlignmentParameters
 
   return iret;
 }
 
-
 //-----------------------------------------------------------------------------
 // write many parameters
-int 
-AlignmentParametersIO::write(const align::Alignables& alivec, 
-                             bool validCheck) 
-{
-  int icount=0;
-  for(align::Alignables::const_iterator it=alivec.begin();
-	  it!=alivec.end(); ++it) {
+int AlignmentParametersIO::write(const align::Alignables& alivec, bool validCheck) {
+  int icount = 0;
+  for (align::Alignables::const_iterator it = alivec.begin(); it != alivec.end(); ++it) {
     if ((*it)->alignmentParameters()->isValid() || !(validCheck)) {
       icount++;
-      int iret=writeOne(*it);
-      if (iret!=0) return iret;
+      int iret = writeOne(*it);
+      if (iret != 0)
+        return iret;
     }
   }
   edm::LogInfo("Alignment") << "@SUB=AlignmentParametersIO::write"
@@ -43,39 +37,36 @@ AlignmentParametersIO::write(const align::Alignables& alivec,
   return 0;
 }
 
-
 //-----------------------------------------------------------------------------
 // write many original parameters
-int 
-AlignmentParametersIO::writeOrigRigidBody(const align::Alignables& alivec, bool validCheck)
-{
+int AlignmentParametersIO::writeOrigRigidBody(const align::Alignables& alivec, bool validCheck) {
   int icount = 0;
-  for(align::Alignables::const_iterator it = alivec.begin(); it != alivec.end(); ++it) {
+  for (align::Alignables::const_iterator it = alivec.begin(); it != alivec.end(); ++it) {
     if (!validCheck || (*it)->alignmentParameters()->isValid()) {
       ++icount;
       int iret = this->writeOneOrigRigidBody(*it);
-      if (iret != 0) return iret;
+      if (iret != 0)
+        return iret;
     }
   }
   edm::LogInfo("Alignment") << "@SUB=AlignmentParametersIO::writeOrigRigidBody"
-                            << "Wrote " << icount << " out of " << alivec.size()
-                            << " original parameters.";
+                            << "Wrote " << icount << " out of " << alivec.size() << " original parameters.";
   return 0;
 }
 
 //-----------------------------------------------------------------------------
 // read many parameters
 
-align::Parameters 
-AlignmentParametersIO::read(const align::Alignables& alivec, int& ierr) 
-{
+align::Parameters AlignmentParametersIO::read(const align::Alignables& alivec, int& ierr) {
   align::Parameters retvec;
   int ierr2;
-  int icount=0;
-  for(align::Alignables::const_iterator it=alivec.begin();
-    it!=alivec.end(); ++it) {
-    AlignmentParameters* ad=readOne(*it, ierr2);
-    if (ad!=nullptr && ierr2==0) { retvec.push_back(ad); icount++; }
+  int icount = 0;
+  for (align::Alignables::const_iterator it = alivec.begin(); it != alivec.end(); ++it) {
+    AlignmentParameters* ad = readOne(*it, ierr2);
+    if (ad != nullptr && ierr2 == 0) {
+      retvec.push_back(ad);
+      icount++;
+    }
   }
   edm::LogInfo("Alignment") << "@SUB-AlignmentParametersIO::write"
                             << "Read " << icount << " out of " << alivec.size() << " parameters";

--- a/Alignment/CommonAlignmentAlgorithm/src/AlignmentParametersIORoot.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignmentParametersIORoot.cc
@@ -1,7 +1,7 @@
 // this class's header
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentParametersIORoot.h"
 
-#include "Alignment/CommonAlignment/interface/Alignable.h" 
+#include "Alignment/CommonAlignment/interface/Alignable.h"
 #include "Alignment/CommonAlignment/interface/AlignmentParameters.h"
 #include "Alignment/CommonAlignmentParametrization/interface/AlignmentParametersFactory.h"
 
@@ -9,58 +9,53 @@
 
 #include "TTree.h"
 
-
 // ----------------------------------------------------------------------------
 // constructor
-AlignmentParametersIORoot::AlignmentParametersIORoot()
-{
+AlignmentParametersIORoot::AlignmentParametersIORoot() {
   treename = "AlignmentParameters";
   treetxt = "Alignment Parameters";
 }
 
-
 // ----------------------------------------------------------------------------
-void AlignmentParametersIORoot::createBranches(void) 
-{
-  tree->Branch("parSize",   &theCovRang,   "CovRang/I");
-  tree->Branch("Id",        &theId,        "Id/i");
+void AlignmentParametersIORoot::createBranches(void) {
+  tree->Branch("parSize", &theCovRang, "CovRang/I");
+  tree->Branch("Id", &theId, "Id/i");
   tree->Branch("paramType", &theParamType, "paramType/I");
-  tree->Branch("Par",       &thePar,       "Par[CovRang]/D");
+  tree->Branch("Par", &thePar, "Par[CovRang]/D");
   tree->Branch("covarSize", &theCovarRang, "CovarRang/I");
-  tree->Branch("Cov",       &theCov,       "Cov[CovarRang]/D");
-  tree->Branch("ObjId",     &theObjId,     "ObjId/I");
-  tree->Branch("HieraLevel",&theHieraLevel,"HieraLevel/I");
+  tree->Branch("Cov", &theCov, "Cov[CovarRang]/D");
+  tree->Branch("ObjId", &theObjId, "ObjId/I");
+  tree->Branch("HieraLevel", &theHieraLevel, "HieraLevel/I");
 }
 
-
 // ----------------------------------------------------------------------------
-void AlignmentParametersIORoot::setBranchAddresses(void) 
-{
-  tree->SetBranchAddress("parSize",   &theCovRang);
+void AlignmentParametersIORoot::setBranchAddresses(void) {
+  tree->SetBranchAddress("parSize", &theCovRang);
   tree->SetBranchAddress("covarSize", &theCovarRang);
-  tree->SetBranchAddress("Id",        &theId);
-  tree->SetBranchAddress("Par",       &thePar);
+  tree->SetBranchAddress("Id", &theId);
+  tree->SetBranchAddress("Par", &thePar);
   tree->SetBranchAddress("paramType", &theParamType);
-  tree->SetBranchAddress("Cov",       &theCov);
-  tree->SetBranchAddress("ObjId",     &theObjId);
-  tree->SetBranchAddress("HieraLevel",&theHieraLevel);
+  tree->SetBranchAddress("Cov", &theCov);
+  tree->SetBranchAddress("ObjId", &theObjId);
+  tree->SetBranchAddress("HieraLevel", &theHieraLevel);
 }
 
-
 // ----------------------------------------------------------------------------
-int AlignmentParametersIORoot::writeOne(Alignable* ali)
-{
-  const AlignmentParameters* ap =ali->alignmentParameters();
+int AlignmentParametersIORoot::writeOne(Alignable* ali) {
+  const AlignmentParameters* ap = ali->alignmentParameters();
   const AlgebraicVector& params = ap->parameters();
   const AlgebraicSymMatrix& cov = ap->covariance();
 
-  theCovRang   = params.num_row();
-  theCovarRang = theCovRang*(theCovRang+1)/2;
-  int count=0;
-  for(int row=0;row<theCovRang;row++){
-    thePar[row]=params[row];
-    for(int col=0;col<theCovRang;col++){
-      if(row-1<col) { theCov[count] = cov[row][col]; count++; }
+  theCovRang = params.num_row();
+  theCovarRang = theCovRang * (theCovRang + 1) / 2;
+  int count = 0;
+  for (int row = 0; row < theCovRang; row++) {
+    thePar[row] = params[row];
+    for (int col = 0; col < theCovRang; col++) {
+      if (row - 1 < col) {
+        theCov[count] = cov[row][col];
+        count++;
+      }
     }
   }
 
@@ -73,55 +68,49 @@ int AlignmentParametersIORoot::writeOne(Alignable* ali)
   return 0;
 }
 
-
 // ----------------------------------------------------------------------------
-AlignmentParameters* AlignmentParametersIORoot::readOne( Alignable* ali, int& ierr )
-{
-  
-  if( tree->GetEntryWithIndex( ali->id(), ali->alignableObjectId() ) > 0 ) 
-  {
+AlignmentParameters* AlignmentParametersIORoot::readOne(Alignable* ali, int& ierr) {
+  if (tree->GetEntryWithIndex(ali->id(), ali->alignableObjectId()) > 0) {
     int covsize = theCovRang;
-    int count=0;
+    int count = 0;
     AlgebraicVector par(covsize, 0);
     AlgebraicSymMatrix cov(covsize, 0);
-    for(int row=0;row<covsize;row++) 
-    {
-      par[row]=thePar[row];
-      for(int col=0; col < covsize;col++) {
-	if(row-1<col) {cov[row][col]=theCov[count];count++;}
+    for (int row = 0; row < covsize; row++) {
+      par[row] = thePar[row];
+      for (int col = 0; col < covsize; col++) {
+        if (row - 1 < col) {
+          cov[row][col] = theCov[count];
+          count++;
+        }
       }
     }
 
     using namespace AlignmentParametersFactory;
     ParametersType parType = parametersType(theParamType);
-    AlignmentParameters* alipar1; 
-    if ( ali->alignmentParameters() )
-    {
+    AlignmentParameters* alipar1;
+    if (ali->alignmentParameters()) {
       const std::vector<bool>& sel = ali->alignmentParameters()->selector();
-      alipar1 = createParameters(ali, parType, sel); 
+      alipar1 = createParameters(ali, parType, sel);
     } else {
-      const std::vector<bool> sel( theCovRang, true );
-      alipar1 = createParameters(ali, parType, sel); 
+      const std::vector<bool> sel(theCovRang, true);
+      alipar1 = createParameters(ali, parType, sel);
     }
-    AlignmentParameters* alipar = alipar1->clone(par,cov);
-    alipar->setValid(true); 
-    ierr=0;
+    AlignmentParameters* alipar = alipar1->clone(par, cov);
+    alipar->setValid(true);
+    ierr = 0;
     delete alipar1;
     return alipar;
   }
 
-  ierr=-1;
-  return(nullptr);
+  ierr = -1;
+  return (nullptr);
 }
 
-
-int AlignmentParametersIORoot::close()
-{
-  if ( bWrite )
-  {
-    int nIndices = tree->BuildIndex( "Id", "ObjId" );
-    edm::LogInfo( "Alignment" ) << "@SUB=AlignmentParametersIORoot::setBranchAddresses"
-				<< "number of indexed entries: " << nIndices;
+int AlignmentParametersIORoot::close() {
+  if (bWrite) {
+    int nIndices = tree->BuildIndex("Id", "ObjId");
+    edm::LogInfo("Alignment") << "@SUB=AlignmentParametersIORoot::setBranchAddresses"
+                              << "number of indexed entries: " << nIndices;
   }
 
   return closeRoot();

--- a/Alignment/CommonAlignmentAlgorithm/src/AlignmentUserVariablesIO.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignmentUserVariablesIO.cc
@@ -16,45 +16,40 @@
 //-----------------------------------------------------------------------------
 // write many user variables
 
-int 
-AlignmentUserVariablesIO::write(const align::Alignables& alivec, 
-  bool validCheck) 
-{
-  int icount=0;
-  for(align::Alignables::const_iterator it=alivec.begin();
-    it!=alivec.end(); ++it) {
+int AlignmentUserVariablesIO::write(const align::Alignables& alivec, bool validCheck) {
+  int icount = 0;
+  for (align::Alignables::const_iterator it = alivec.begin(); it != alivec.end(); ++it) {
     if ((*it)->alignmentParameters()->isValid() || !(validCheck)) {
       icount++;
-      int iret=writeOne(*it);
-      if (iret!=0) return iret;
+      int iret = writeOne(*it);
+      if (iret != 0)
+        return iret;
     }
   }
   edm::LogInfo("Alignment") << "@SUB=AlignmentUserVariablesIO::write"
-                            << "Write variables all,written: " << alivec.size() <<","<< icount;
+                            << "Write variables all,written: " << alivec.size() << "," << icount;
   return 0;
 }
 
 //-----------------------------------------------------------------------------
 // read many user variables
 
-std::vector<AlignmentUserVariables*> 
-AlignmentUserVariablesIO::read(const align::Alignables& alivec, int& ierr) 
-{
+std::vector<AlignmentUserVariables*> AlignmentUserVariablesIO::read(const align::Alignables& alivec, int& ierr) {
   std::vector<AlignmentUserVariables*> retvec;
-  ierr=0;
+  ierr = 0;
   int ierr2;
-  int icount=0;
-  int icount2=0;
-  for(align::Alignables::const_iterator it=alivec.begin();
-    it!=alivec.end(); ++it) {
-    AlignmentUserVariables* ad=readOne(*it, ierr2); // should create with new!
-    if (ierr2==0) { 
-      retvec.push_back(ad); icount++; 
-      if (ad!=nullptr) icount2++;
+  int icount = 0;
+  int icount2 = 0;
+  for (align::Alignables::const_iterator it = alivec.begin(); it != alivec.end(); ++it) {
+    AlignmentUserVariables* ad = readOne(*it, ierr2);  // should create with new!
+    if (ierr2 == 0) {
+      retvec.push_back(ad);
+      icount++;
+      if (ad != nullptr)
+        icount2++;
     }
   }
   edm::LogInfo("Alignment") << "@SUB=AlignmentUserVariablesIO::read"
-                            << "Read variables all,read,valid: " << alivec.size() <<","
-                            << icount <<","<< icount2;
+                            << "Read variables all,read,valid: " << alivec.size() << "," << icount << "," << icount2;
   return retvec;
 }

--- a/Alignment/CommonAlignmentAlgorithm/src/IntegratedCalibrationBase.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/IntegratedCalibrationBase.cc
@@ -16,26 +16,21 @@
 //#include <utility>
 
 //============================================================================
-IntegratedCalibrationBase::IntegratedCalibrationBase(const edm::ParameterSet &cfg) 
-  : name_(cfg.getParameter<std::string>("calibrationName"))
-{
-}
-  
+IntegratedCalibrationBase::IntegratedCalibrationBase(const edm::ParameterSet &cfg)
+    : name_(cfg.getParameter<std::string>("calibrationName")) {}
+
 //============================================================================
-std::vector<IntegratedCalibrationBase::Values>
-IntegratedCalibrationBase::derivatives(const TrackingRecHit &hit,
-				       const TrajectoryStateOnSurface &tsos,
-				       const edm::EventSetup &setup,
-				       const EventInfo &eventInfo) const
-{
+std::vector<IntegratedCalibrationBase::Values> IntegratedCalibrationBase::derivatives(
+    const TrackingRecHit &hit,
+    const TrajectoryStateOnSurface &tsos,
+    const edm::EventSetup &setup,
+    const EventInfo &eventInfo) const {
   // Prepare result vector, initialised all with 0.:
-  std::vector<Values> result(this->numParameters(), Values(0.,0.));
+  std::vector<Values> result(this->numParameters(), Values(0., 0.));
 
   // Get non-zero derivatives and their index:
   std::vector<ValuesIndexPair> derivsIndexPairs;
-  const unsigned int numNonZero = this->derivatives(derivsIndexPairs,
-						    hit, tsos, setup,
-						    eventInfo);
+  const unsigned int numNonZero = this->derivatives(derivsIndexPairs, hit, tsos, setup, eventInfo);
 
   // Put non-zero values into result:
   for (unsigned int i = 0; i < numNonZero; ++i) {

--- a/Alignment/CommonAlignmentAlgorithm/src/IntegratedCalibrationPluginFactory.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/IntegratedCalibrationPluginFactory.cc
@@ -7,10 +7,6 @@
 ///  (last update by $Author: mussgill $)
 ///
 
-
 #include "Alignment/CommonAlignmentAlgorithm/interface/IntegratedCalibrationPluginFactory.h"
 
-EDM_REGISTER_PLUGINFACTORY(IntegratedCalibrationPluginFactory,
-			   "IntegratedCalibrationPluginFactory");
-
-
+EDM_REGISTER_PLUGINFACTORY(IntegratedCalibrationPluginFactory, "IntegratedCalibrationPluginFactory");

--- a/Alignment/CommonAlignmentAlgorithm/src/TkModuleGroupSelector.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/TkModuleGroupSelector.cc
@@ -21,229 +21,193 @@
 //============================================================================
 TkModuleGroupSelector::TkModuleGroupSelector(AlignableTracker *aliTracker,
                                              const edm::ParameterSet &cfg,
-                                             const std::vector<int> &sdets
-                                             ) : nparameters_(0),
-                                                 subdetids_(sdets)
-{
+                                             const std::vector<int> &sdets)
+    : nparameters_(0), subdetids_(sdets) {
   //verify that all provided options are known
   std::vector<std::string> parameterNames = cfg.getParameterNames();
-  for ( std::vector<std::string>::const_iterator iParam = parameterNames.begin(); 
-        iParam != parameterNames.end(); ++iParam) {
+  for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(); iParam != parameterNames.end();
+       ++iParam) {
     const std::string name = (*iParam);
-    if(
-       name != "RunRange" && name != "ReferenceRun" && name != "Granularity"
-       ) {
-      throw cms::Exception("BadConfig")
-        << "@SUB=TkModuleGroupSelector::TkModuleGroupSelector:"
-        << " Unknown parameter name '" << name << "' in PSet. Maybe a typo?";
+    if (name != "RunRange" && name != "ReferenceRun" && name != "Granularity") {
+      throw cms::Exception("BadConfig") << "@SUB=TkModuleGroupSelector::TkModuleGroupSelector:"
+                                        << " Unknown parameter name '" << name << "' in PSet. Maybe a typo?";
     }
   }
-  
 
   //extract the reference run range if defined
-  const edm::RunNumber_t defaultReferenceRun
-    = (cfg.exists("ReferenceRun") ? cfg.getParameter<edm::RunNumber_t>("ReferenceRun") : 0);
+  const edm::RunNumber_t defaultReferenceRun =
+      (cfg.exists("ReferenceRun") ? cfg.getParameter<edm::RunNumber_t>("ReferenceRun") : 0);
 
   //extract run range to be used for all module groups (if not locally overwritten)
-  const std::vector<edm::RunNumber_t> defaultRunRange
-    = (cfg.exists("RunRange") ? cfg.getParameter<std::vector<edm::RunNumber_t> >("RunRange")
-       : std::vector<edm::RunNumber_t>());
+  const std::vector<edm::RunNumber_t> defaultRunRange =
+      (cfg.exists("RunRange") ? cfg.getParameter<std::vector<edm::RunNumber_t> >("RunRange")
+                              : std::vector<edm::RunNumber_t>());
 
   // finally create everything from configuration
-  this->createModuleGroups(aliTracker, cfg.getParameter<edm::VParameterSet>("Granularity"),
-                           defaultRunRange, defaultReferenceRun);
+  this->createModuleGroups(
+      aliTracker, cfg.getParameter<edm::VParameterSet>("Granularity"), defaultRunRange, defaultReferenceRun);
 }
 
 //============================================================================
-void TkModuleGroupSelector::fillDetIdMap(const unsigned int detid, const unsigned int groupid)
-{
-  //only add new entries 
-  if(mapDetIdGroupId_.find(detid) == mapDetIdGroupId_.end()) {
+void TkModuleGroupSelector::fillDetIdMap(const unsigned int detid, const unsigned int groupid) {
+  //only add new entries
+  if (mapDetIdGroupId_.find(detid) == mapDetIdGroupId_.end()) {
     mapDetIdGroupId_.insert(std::pair<unsigned int, unsigned int>(detid, groupid));
   } else {
-    throw cms::Exception("BadConfig")
-      << "@SUB=TkModuleGroupSelector:fillDetIdMap:"
-      << " Module with det ID " << detid << " configured in group " << groupid
-      << " but it was already selected"
-      << " in group " << mapDetIdGroupId_[detid] << ".";
+    throw cms::Exception("BadConfig") << "@SUB=TkModuleGroupSelector:fillDetIdMap:"
+                                      << " Module with det ID " << detid << " configured in group " << groupid
+                                      << " but it was already selected"
+                                      << " in group " << mapDetIdGroupId_[detid] << ".";
   }
 }
 
 //============================================================================
-const bool TkModuleGroupSelector::testSplitOption(const edm::ParameterSet &pset) const
-{
+const bool TkModuleGroupSelector::testSplitOption(const edm::ParameterSet &pset) const {
   bool split = false;
-  if(pset.exists("split")) {
+  if (pset.exists("split")) {
     split = pset.getParameter<bool>("split");
   }
   return split;
 }
 
 //============================================================================
-bool TkModuleGroupSelector::createGroup(
-                                        unsigned int &Id, 
-                                        const std::vector<edm::RunNumber_t> &range, 
-                                        const std::list<Alignable*> &selected_alis,
-                                        const edm::RunNumber_t refrun
-                                        )
-{
+bool TkModuleGroupSelector::createGroup(unsigned int &Id,
+                                        const std::vector<edm::RunNumber_t> &range,
+                                        const std::list<Alignable *> &selected_alis,
+                                        const edm::RunNumber_t refrun) {
   bool modules_selected = false;
 
   referenceRun_.push_back(refrun);
   firstId_.push_back(Id);
   runRange_.push_back(range);
-  for(std::list<Alignable*>::const_iterator it = selected_alis.begin();
-      it != selected_alis.end(); ++it) {
-    this->fillDetIdMap((*it)->id(), firstId_.size()-1);
+  for (std::list<Alignable *>::const_iterator it = selected_alis.begin(); it != selected_alis.end(); ++it) {
+    this->fillDetIdMap((*it)->id(), firstId_.size() - 1);
     modules_selected = true;
   }
-  if(refrun > 0 && !range.empty()) { //FIXME: last condition not really needed?
+  if (refrun > 0 && !range.empty()) {  //FIXME: last condition not really needed?
     Id += range.size() - 1;
     nparameters_ += range.size() - 1;
   } else {
     Id += range.size();
-    nparameters_ += range.size();  
+    nparameters_ += range.size();
   }
 
-  if(refrun > 0 && range.front() > refrun) { //range.size() > 0 checked before
-    throw cms::Exception("BadConfig")
-      << "@SUB=TkModuleGroupSelector::createGroup:\n"
-      << "Invalid combination of reference run number and specified run dependence"
-      << "\n in module group " << firstId_.size() << "."
-      << "\n Reference run number (" << refrun << ") is smaller than starting run "
-      << "\n number (" << range.front() << ") of first IOV.";
+  if (refrun > 0 && range.front() > refrun) {  //range.size() > 0 checked before
+    throw cms::Exception("BadConfig") << "@SUB=TkModuleGroupSelector::createGroup:\n"
+                                      << "Invalid combination of reference run number and specified run dependence"
+                                      << "\n in module group " << firstId_.size() << "."
+                                      << "\n Reference run number (" << refrun << ") is smaller than starting run "
+                                      << "\n number (" << range.front() << ") of first IOV.";
   }
   return modules_selected;
 }
 
 //============================================================================
-void TkModuleGroupSelector::verifyParameterNames(const edm::ParameterSet &pset, unsigned int psetnr) const
-{
+void TkModuleGroupSelector::verifyParameterNames(const edm::ParameterSet &pset, unsigned int psetnr) const {
   std::vector<std::string> parameterNames = pset.getParameterNames();
-  for ( std::vector<std::string>::const_iterator iParam = parameterNames.begin(); 
-        iParam != parameterNames.end(); ++iParam) {
+  for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(); iParam != parameterNames.end();
+       ++iParam) {
     const std::string name = (*iParam);
-    if(
-       name != "levels" && name != "RunRange"
-       && name != "split" && name != "ReferenceRun"
-       ) {
-      throw cms::Exception("BadConfig")
-        << "@SUB=TkModuleGroupSelector::verifyParameterNames:"
-        << " Unknown parameter name '" << name << "' in PSet number " << psetnr << ". Maybe a typo?";
+    if (name != "levels" && name != "RunRange" && name != "split" && name != "ReferenceRun") {
+      throw cms::Exception("BadConfig") << "@SUB=TkModuleGroupSelector::verifyParameterNames:"
+                                        << " Unknown parameter name '" << name << "' in PSet number " << psetnr
+                                        << ". Maybe a typo?";
     }
   }
 }
-
 
 //============================================================================
 void TkModuleGroupSelector::createModuleGroups(AlignableTracker *aliTracker,
                                                const edm::VParameterSet &granularityConfig,
                                                const std::vector<edm::RunNumber_t> &defaultRunRange,
-                                               edm::RunNumber_t defaultReferenceRun)
-{
+                                               edm::RunNumber_t defaultReferenceRun) {
   std::set<edm::RunNumber_t> localRunRange;
   nparameters_ = 0;
   unsigned int Id = 0;
   unsigned int psetnr = 0;
   //loop over all LA groups
-  for(edm::VParameterSet::const_iterator pset = granularityConfig.begin();
-      pset != granularityConfig.end();
-      ++pset) {
-
+  for (edm::VParameterSet::const_iterator pset = granularityConfig.begin(); pset != granularityConfig.end(); ++pset) {
     //test for unknown parameters
-    this->verifyParameterNames((*pset),psetnr);
+    this->verifyParameterNames((*pset), psetnr);
     psetnr++;
 
-    bool modules_selected = false; //track whether at all a module has been selected in this group
+    bool modules_selected = false;  //track whether at all a module has been selected in this group
     const std::vector<edm::RunNumber_t> range =
-      ((*pset).exists("RunRange") ? pset->getParameter<std::vector<edm::RunNumber_t> >("RunRange")
-       : defaultRunRange);
-    if(range.empty()) {
-      throw cms::Exception("BadConfig")
-        << "@SUB=TkModuleGroupSelector::createModuleGroups:\n"
-        << "Run range array empty!";
+        ((*pset).exists("RunRange") ? pset->getParameter<std::vector<edm::RunNumber_t> >("RunRange") : defaultRunRange);
+    if (range.empty()) {
+      throw cms::Exception("BadConfig") << "@SUB=TkModuleGroupSelector::createModuleGroups:\n"
+                                        << "Run range array empty!";
     }
     const bool split = this->testSplitOption((*pset));
 
     edm::RunNumber_t refrun = 0;
-    if((*pset).exists("ReferenceRun")) {
+    if ((*pset).exists("ReferenceRun")) {
       refrun = (*pset).getParameter<edm::RunNumber_t>("ReferenceRun");
     } else {
       refrun = defaultReferenceRun;
     }
-    
+
     AlignmentParameterSelector selector(aliTracker);
     selector.clear();
-    selector.addSelections((*pset).getParameter<edm::ParameterSet> ("levels"));
+    selector.addSelections((*pset).getParameter<edm::ParameterSet>("levels"));
 
-    const auto& alis = selector.selectedAlignables();
-    std::list<Alignable*> selected_alis;
-    for(const auto& it: alis) {
-      const auto& aliDaughts = it->deepComponents();
-      for (const auto& iD: aliDaughts) {
-        if(iD->alignableObjectId() == align::AlignableDetUnit || iD->alignableObjectId() == align::AlignableDet) {
-          if(split) {
-            modules_selected = this->createGroup(Id, range, std::list<Alignable*>(1,iD), refrun);
+    const auto &alis = selector.selectedAlignables();
+    std::list<Alignable *> selected_alis;
+    for (const auto &it : alis) {
+      const auto &aliDaughts = it->deepComponents();
+      for (const auto &iD : aliDaughts) {
+        if (iD->alignableObjectId() == align::AlignableDetUnit || iD->alignableObjectId() == align::AlignableDet) {
+          if (split) {
+            modules_selected = this->createGroup(Id, range, std::list<Alignable *>(1, iD), refrun);
           } else {
             selected_alis.push_back(iD);
           }
         }
       }
     }
-    
-    if(!split) {
+
+    if (!split) {
       modules_selected = this->createGroup(Id, range, selected_alis, refrun);
     }
-        
-    edm::RunNumber_t firstRun = 0; 
-    for(std::vector<edm::RunNumber_t>::const_iterator iRun = range.begin(); 
-        iRun != range.end(); ++iRun)  {
+
+    edm::RunNumber_t firstRun = 0;
+    for (std::vector<edm::RunNumber_t>::const_iterator iRun = range.begin(); iRun != range.end(); ++iRun) {
       localRunRange.insert((*iRun));
-      if((*iRun) > firstRun) {
+      if ((*iRun) > firstRun) {
         firstRun = (*iRun);
       } else {
-        throw cms::Exception("BadConfig")
-          << "@SUB=TkModuleGroupSelector::createModuleGroups:"
-          << " Run range not sorted.";
+        throw cms::Exception("BadConfig") << "@SUB=TkModuleGroupSelector::createModuleGroups:"
+                                          << " Run range not sorted.";
       }
     }
 
-    if(!modules_selected) {
-      throw cms::Exception("BadConfig") 
-        << "@SUB=TkModuleGroupSelector:createModuleGroups:"
-        << " No module was selected in the module group selector in group " << (firstId_.size()-1)<< ".";
+    if (!modules_selected) {
+      throw cms::Exception("BadConfig") << "@SUB=TkModuleGroupSelector:createModuleGroups:"
+                                        << " No module was selected in the module group selector in group "
+                                        << (firstId_.size() - 1) << ".";
     }
   }
 
   //copy local set into the global vector of run boundaries
-  for(std::set<edm::RunNumber_t>::const_iterator itRun = localRunRange.begin();
-      itRun != localRunRange.end(); ++itRun) {
+  for (std::set<edm::RunNumber_t>::const_iterator itRun = localRunRange.begin(); itRun != localRunRange.end();
+       ++itRun) {
     globalRunRange_.push_back((*itRun));
   }
 }
 
 //============================================================================
-unsigned int TkModuleGroupSelector::getNumberOfParameters() const
-{
-  return nparameters_;
-}
+unsigned int TkModuleGroupSelector::getNumberOfParameters() const { return nparameters_; }
 
 //============================================================================
-unsigned int TkModuleGroupSelector::numIovs() const
-{
-  return globalRunRange_.size();
-}
+unsigned int TkModuleGroupSelector::numIovs() const { return globalRunRange_.size(); }
 
 //============================================================================
-edm::RunNumber_t TkModuleGroupSelector::firstRunOfIOV(unsigned int iovNum) const
-{
+edm::RunNumber_t TkModuleGroupSelector::firstRunOfIOV(unsigned int iovNum) const {
   return iovNum < this->numIovs() ? globalRunRange_.at(iovNum) : 0;
 }
 
 //======================================================================
-int TkModuleGroupSelector::getParameterIndexFromDetId(unsigned int detId,
-                                                      edm::RunNumber_t run) const
-{
+int TkModuleGroupSelector::getParameterIndexFromDetId(unsigned int detId, edm::RunNumber_t run) const {
   // Return the index of the parameter that is used for this DetId.
   // If this DetId is not treated, return values < 0.
 
@@ -252,48 +216,47 @@ int TkModuleGroupSelector::getParameterIndexFromDetId(unsigned int detId,
   int index = -1;
 
   bool sel = false;
-  for(std::vector<int>::const_iterator itSubDets = subdetids_.begin();
-      itSubDets != subdetids_.end();
-      ++itSubDets) {
+  for (std::vector<int>::const_iterator itSubDets = subdetids_.begin(); itSubDets != subdetids_.end(); ++itSubDets) {
     if (temp_id.det() == DetId::Tracker && temp_id.subdetId() == (*itSubDets)) {
       sel = true;
       break;
     }
   }
 
-  if (temp_id.det() != DetId::Tracker || !sel) return -1;
-  
+  if (temp_id.det() != DetId::Tracker || !sel)
+    return -1;
+
   std::map<unsigned int, unsigned int>::const_iterator it = mapDetIdGroupId_.find(detId);
-  if(it != mapDetIdGroupId_.end()) {
+  if (it != mapDetIdGroupId_.end()) {
     const unsigned int iAlignableGroup = (*it).second;
     const std::vector<edm::RunNumber_t> &runs = runRange_.at(iAlignableGroup);
     const unsigned int id0 = firstId_.at(iAlignableGroup);
     const edm::RunNumber_t refrun = referenceRun_.at(iAlignableGroup);
 
-
     unsigned int iovNum = 0;
-    for ( ; iovNum < runs.size(); ++iovNum) {
-      if (runs[iovNum] > run) break;
+    for (; iovNum < runs.size(); ++iovNum) {
+      if (runs[iovNum] > run)
+        break;
     }
     if (iovNum == 0) {
       throw cms::Exception("BadConfig") << "@SUB=TkModuleGroupSelector::getParameterIndexFromDetId:\n"
-                                        << "Run " << run << " not foreseen for detid '"<< detId <<"'"
-                                        << " in module group " << iAlignableGroup << ".";        
+                                        << "Run " << run << " not foreseen for detid '" << detId << "'"
+                                        << " in module group " << iAlignableGroup << ".";
     } else {
       --iovNum;
     }
 
     //test whether the iov contains the reference run
-    if(refrun > 0) { //if > 0 a reference run number has been provided
-      if(iovNum+1 == runs.size()) {
-        if(refrun >= runs[iovNum])
+    if (refrun > 0) {  //if > 0 a reference run number has been provided
+      if (iovNum + 1 == runs.size()) {
+        if (refrun >= runs[iovNum])
           return -1;
-      } else if( (iovNum+1) < runs.size()) {
-        if(refrun >= runs[iovNum] && refrun < runs[iovNum+1]) {
+      } else if ((iovNum + 1) < runs.size()) {
+        if (refrun >= runs[iovNum] && refrun < runs[iovNum + 1]) {
           return -1;
         }
-      } 
-      if(run > refrun) {
+      }
+      if (run > refrun) {
         //iovNum > 0 due to checks in createGroup(...) and createModuleGroups(...)
         //remove IOV in which the reference run can be found
         iovNum -= 1;

--- a/Alignment/ReferenceTrajectories/interface/BeamSpotGeomDet.h
+++ b/Alignment/ReferenceTrajectories/interface/BeamSpotGeomDet.h
@@ -20,25 +20,18 @@
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 class BeamSpotGeomDet : public GeomDet {
- public:
-
+public:
   typedef GeomDetEnumerators::SubDetector SubDetector;
-  
-  explicit BeamSpotGeomDet(const ReferenceCountingPointer<BoundPlane>& plane)
-    :GeomDet(plane) {
+
+  explicit BeamSpotGeomDet(const ReferenceCountingPointer<BoundPlane>& plane) : GeomDet(plane) {
     setDetId(AlignableBeamSpot::detId());
   }
 
-  ~BeamSpotGeomDet() override { }
+  ~BeamSpotGeomDet() override {}
 
-  SubDetector subDetector() const override {
-    return GeomDetEnumerators::invalidDet;
-  }
+  SubDetector subDetector() const override { return GeomDetEnumerators::invalidDet; }
 
-  std::vector< const GeomDet*> components() const override {
-    return std::vector< const GeomDet*>();
-  }
+  std::vector<const GeomDet*> components() const override { return std::vector<const GeomDet*>(); }
 };
 
 #endif
-

--- a/Alignment/ReferenceTrajectories/interface/BeamSpotTransientTrackingRecHit.h
+++ b/Alignment/ReferenceTrajectories/interface/BeamSpotTransientTrackingRecHit.h
@@ -14,7 +14,7 @@
 
 #include <cmath>
 
-#include "DataFormats/CLHEP/interface/AlgebraicObjects.h" 
+#include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/ErrorFrameTransformer.h"
 
@@ -25,21 +25,18 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TValidTrackingRecHit.h"
 
 class BeamSpotTransientTrackingRecHit final : public TValidTrackingRecHit {
- public:
-
+public:
   typedef TrackingRecHit::Type Type;
-  
-  BeamSpotTransientTrackingRecHit(const reco::BeamSpot &beamSpot,
-				  const BeamSpotGeomDet * geom,
-				  double phi)
-    : TValidTrackingRecHit(*geom) {
 
+  BeamSpotTransientTrackingRecHit(const reco::BeamSpot &beamSpot, const BeamSpotGeomDet *geom, double phi)
+      : TValidTrackingRecHit(*geom) {
     localPosition_ = det()->toLocal(GlobalPoint(beamSpot.x0(), beamSpot.y0(), beamSpot.z0()));
-    localError_ = LocalError(std::pow(beamSpot.BeamWidthX()*cos(phi), 2) +
-		  	     std::pow(beamSpot.BeamWidthY()*sin(phi), 2),
-		             0.0, std::pow(beamSpot.sigmaZ(), 2));
+    localError_ =
+        LocalError(std::pow(beamSpot.BeamWidthX() * cos(phi), 2) + std::pow(beamSpot.BeamWidthY() * sin(phi), 2),
+                   0.0,
+                   std::pow(beamSpot.sigmaZ(), 2));
   }
-    
+
   ~BeamSpotTransientTrackingRecHit() override {}
 
   LocalPoint localPosition() const override { return localPosition_; }
@@ -49,41 +46,27 @@ class BeamSpotTransientTrackingRecHit final : public TValidTrackingRecHit {
   AlgebraicSymMatrix parametersError() const override;
   int dimension() const override { return 1; }
 
-  const TrackingRecHit * hit() const override { return nullptr; }
-  TrackingRecHit * cloneHit() const override { return nullptr;}
+  const TrackingRecHit *hit() const override { return nullptr; }
+  TrackingRecHit *cloneHit() const override { return nullptr; }
 
+  std::vector<const TrackingRecHit *> recHits() const override { return std::vector<const TrackingRecHit *>(); }
+  std::vector<TrackingRecHit *> recHits() override { return std::vector<TrackingRecHit *>(); }
 
-  std::vector<const TrackingRecHit*> recHits() const override {
-    return std::vector<const TrackingRecHit*>();
-  }
-  std::vector<TrackingRecHit*> recHits() override {
-    return std::vector<TrackingRecHit*>();
-  }
+  AlgebraicMatrix projectionMatrix() const override { return theProjectionMatrix; }
 
-  AlgebraicMatrix projectionMatrix() const override {
-    return theProjectionMatrix;
-  }
-
- protected:
-
+protected:
   LocalPoint localPosition_;
   LocalError localError_;
 
- private:
-  
+private:
   // should not have assignment operator (?)
-  BeamSpotTransientTrackingRecHit & operator= (const BeamSpotTransientTrackingRecHit & t) {
-     return *(this);
-  }
+  BeamSpotTransientTrackingRecHit &operator=(const BeamSpotTransientTrackingRecHit &t) { return *(this); }
 
-  // hide the clone method for ReferenceCounted. Warning: this method is still 
+  // hide the clone method for ReferenceCounted. Warning: this method is still
   // accessible via the bas class TrackingRecHit interface!
-   BeamSpotTransientTrackingRecHit * clone() const override {
-     return new BeamSpotTransientTrackingRecHit(*this);
-   }
-   
-   static const AlgebraicMatrix theProjectionMatrix;
+  BeamSpotTransientTrackingRecHit *clone() const override { return new BeamSpotTransientTrackingRecHit(*this); }
+
+  static const AlgebraicMatrix theProjectionMatrix;
 };
 
 #endif
-

--- a/Alignment/ReferenceTrajectories/interface/BzeroReferenceTrajectory.h
+++ b/Alignment/ReferenceTrajectories/interface/BzeroReferenceTrajectory.h
@@ -1,5 +1,5 @@
-#ifndef Alignment_ReferenceTrajectories_BzeroReferenceTrajectory_h 
-#define Alignment_ReferenceTrajectories_BzeroReferenceTrajectory_h 
+#ifndef Alignment_ReferenceTrajectories_BzeroReferenceTrajectory_h
+#define Alignment_ReferenceTrajectories_BzeroReferenceTrajectory_h
 
 /**
  *  Class implementing the reference trajectory of a single particle in
@@ -32,9 +32,7 @@
 
 #include "Alignment/ReferenceTrajectories/interface/ReferenceTrajectory.h"
 
-class BzeroReferenceTrajectory : public ReferenceTrajectory
-{
-
+class BzeroReferenceTrajectory : public ReferenceTrajectory {
 public:
   /**Constructor with Tsos at first hit (in physical order) and list of hits 
      [if (hitsAreReverse) ==> order of hits is in opposite direction compared
@@ -45,17 +43,15 @@ public:
    */
   BzeroReferenceTrajectory(const TrajectoryStateOnSurface& tsos,
                            const TransientTrackingRecHit::ConstRecHitContainer& recHits,
-                           const MagneticField *magField,
+                           const MagneticField* magField,
                            const reco::BeamSpot& beamSpot,
                            const ReferenceTrajectoryBase::Config& config);
 
   ~BzeroReferenceTrajectory() override {}
 
-  BzeroReferenceTrajectory* clone() const override
-    { return new BzeroReferenceTrajectory(*this); }
+  BzeroReferenceTrajectory* clone() const override { return new BzeroReferenceTrajectory(*this); }
 
 private:
-
   double theMomentumEstimate;
 };
 

--- a/Alignment/ReferenceTrajectories/interface/DualBzeroReferenceTrajectory.h
+++ b/Alignment/ReferenceTrajectories/interface/DualBzeroReferenceTrajectory.h
@@ -34,12 +34,8 @@
 
 class BzeroReferenceTrajectory;
 
-
-class DualBzeroReferenceTrajectory : public DualReferenceTrajectory
-{
-
+class DualBzeroReferenceTrajectory : public DualReferenceTrajectory {
 public:
-
   typedef TransientTrackingRecHit::ConstRecHitContainer ConstRecHitContainer;
 
   DualBzeroReferenceTrajectory(const TrajectoryStateOnSurface& tsos,
@@ -56,18 +52,18 @@ public:
 protected:
   using DualReferenceTrajectory::construct;
 
-  virtual ReferenceTrajectory* construct(const TrajectoryStateOnSurface &referenceTsos, 
-					 const ConstRecHitContainer &recHits,
-					 double mass, MaterialEffects materialEffects,
-					 const PropagationDirection propDir,
-					 const MagneticField *magField,
-					 bool useBeamSpot,
-					 const reco::BeamSpot &beamSpot) const;
+  virtual ReferenceTrajectory* construct(const TrajectoryStateOnSurface& referenceTsos,
+                                         const ConstRecHitContainer& recHits,
+                                         double mass,
+                                         MaterialEffects materialEffects,
+                                         const PropagationDirection propDir,
+                                         const MagneticField* magField,
+                                         bool useBeamSpot,
+                                         const reco::BeamSpot& beamSpot) const;
 
-  AlgebraicVector extractParameters(const TrajectoryStateOnSurface &referenceTsos) const override;
+  AlgebraicVector extractParameters(const TrajectoryStateOnSurface& referenceTsos) const override;
 
   double theMomentumEstimate;
-
 };
 
 #endif

--- a/Alignment/ReferenceTrajectories/interface/DualReferenceTrajectory.h
+++ b/Alignment/ReferenceTrajectories/interface/DualReferenceTrajectory.h
@@ -30,49 +30,47 @@
 #include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
 
 class ReferenceTrajectory;
-namespace reco { class BeamSpot;}
+namespace reco {
+  class BeamSpot;
+}
 
-class DualReferenceTrajectory : public ReferenceTrajectoryBase
-{
-
+class DualReferenceTrajectory : public ReferenceTrajectoryBase {
 public:
-
   typedef TransientTrackingRecHit::ConstRecHitContainer ConstRecHitContainer;
 
-  DualReferenceTrajectory(const TrajectoryStateOnSurface& tsos,
-                          const ConstRecHitContainer& forwardRecHits,
-                          const ConstRecHitContainer& backwardRecHits,
-                          const MagneticField* magField,
-                          const reco::BeamSpot& beamSpot,
-                          const ReferenceTrajectoryBase::Config& config);
+  DualReferenceTrajectory(const TrajectoryStateOnSurface &tsos,
+                          const ConstRecHitContainer &forwardRecHits,
+                          const ConstRecHitContainer &backwardRecHits,
+                          const MagneticField *magField,
+                          const reco::BeamSpot &beamSpot,
+                          const ReferenceTrajectoryBase::Config &config);
 
   ~DualReferenceTrajectory() override {}
 
-  DualReferenceTrajectory* clone() const override { return new DualReferenceTrajectory(*this); }
+  DualReferenceTrajectory *clone() const override { return new DualReferenceTrajectory(*this); }
 
 protected:
-
-  DualReferenceTrajectory(unsigned int nPar, unsigned int nHits,
-                          const ReferenceTrajectoryBase::Config& config);
+  DualReferenceTrajectory(unsigned int nPar, unsigned int nHits, const ReferenceTrajectoryBase::Config &config);
 
   /** internal method to calculate members
    */
-  virtual bool construct(const TrajectoryStateOnSurface &referenceTsos, 
-			 const ConstRecHitContainer &forwardRecHits,
-			 const ConstRecHitContainer &backwardRecHits,
-			 const MagneticField *magField,
-			 const reco::BeamSpot &beamSpot);
+  virtual bool construct(const TrajectoryStateOnSurface &referenceTsos,
+                         const ConstRecHitContainer &forwardRecHits,
+                         const ConstRecHitContainer &backwardRecHits,
+                         const MagneticField *magField,
+                         const reco::BeamSpot &beamSpot);
 
-  virtual ReferenceTrajectory* construct(const TrajectoryStateOnSurface &referenceTsos, 
-					 const ConstRecHitContainer &recHits,
-					 const MagneticField *magField,
-					 const reco::BeamSpot &beamSpot,
-					 const bool revertDirection = false) const;
+  virtual ReferenceTrajectory *construct(const TrajectoryStateOnSurface &referenceTsos,
+                                         const ConstRecHitContainer &recHits,
+                                         const MagneticField *magField,
+                                         const reco::BeamSpot &beamSpot,
+                                         const bool revertDirection = false) const;
 
   virtual AlgebraicVector extractParameters(const TrajectoryStateOnSurface &referenceTsos) const;
 
-  inline const PropagationDirection oppositeDirection( const PropagationDirection propDir ) const
-  { return ( propDir == anyDirection ) ? anyDirection : ( ( propDir == alongMomentum ) ? oppositeToMomentum : alongMomentum ); }
+  inline const PropagationDirection oppositeDirection(const PropagationDirection propDir) const {
+    return (propDir == anyDirection) ? anyDirection : ((propDir == alongMomentum) ? oppositeToMomentum : alongMomentum);
+  }
 
 private:
   const double mass_;

--- a/Alignment/ReferenceTrajectories/interface/ReferenceTrajectory.h
+++ b/Alignment/ReferenceTrajectories/interface/ReferenceTrajectory.h
@@ -48,13 +48,12 @@ class MaterialEffectsUpdator;
 class Plane;
 class BeamSpotTransientTrackingRecHit;
 
-namespace reco { class BeamSpot; }
+namespace reco {
+  class BeamSpot;
+}
 
-class ReferenceTrajectory : public ReferenceTrajectoryBase
-{
-
+class ReferenceTrajectory : public ReferenceTrajectoryBase {
 public:
-
   typedef SurfaceSideDefinition::SurfaceSide SurfaceSide;
 
   /**Constructor with Tsos at first hit (in physical order) and list of hits 
@@ -64,130 +63,129 @@ public:
      the material effects to be considered and a particle mass,
      the magnetic field and beamSpot of the event are needed for propagations etc.
    */
-  ReferenceTrajectory(const TrajectoryStateOnSurface& referenceTsos,
-                      const TransientTrackingRecHit::ConstRecHitContainer& recHits,
-                      const MagneticField* magField,
-                      const reco::BeamSpot& beamSpot,
-                      const ReferenceTrajectoryBase::Config& config);
+  ReferenceTrajectory(const TrajectoryStateOnSurface &referenceTsos,
+                      const TransientTrackingRecHit::ConstRecHitContainer &recHits,
+                      const MagneticField *magField,
+                      const reco::BeamSpot &beamSpot,
+                      const ReferenceTrajectoryBase::Config &config);
 
   ~ReferenceTrajectory() override {}
 
-  ReferenceTrajectory* clone() const override { return new ReferenceTrajectory(*this); }
+  ReferenceTrajectory *clone() const override { return new ReferenceTrajectory(*this); }
 
 protected:
-
   // ReferenceTrajectory(unsigned int nPar, unsigned int nHits, MaterialEffects materialEffects);
-  ReferenceTrajectory(unsigned int nPar, unsigned int nHits,
-		      const ReferenceTrajectoryBase::Config& config);
+  ReferenceTrajectory(unsigned int nPar, unsigned int nHits, const ReferenceTrajectoryBase::Config &config);
 
   /** internal method to calculate members
    */
-  virtual bool construct(const TrajectoryStateOnSurface &referenceTsos, 
-			 const TransientTrackingRecHit::ConstRecHitContainer &recHits,
-			 const MagneticField *magField,
-			 const reco::BeamSpot &beamSpot);
+  virtual bool construct(const TrajectoryStateOnSurface &referenceTsos,
+                         const TransientTrackingRecHit::ConstRecHitContainer &recHits,
+                         const MagneticField *magField,
+                         const reco::BeamSpot &beamSpot);
 
   /** internal method to get apropriate updator
    */
-  MaterialEffectsUpdator* createUpdator(MaterialEffects materialEffects, double mass) const;
+  MaterialEffectsUpdator *createUpdator(MaterialEffects materialEffects, double mass) const;
 
   /** internal method to calculate jacobian
    */
-  virtual bool propagate(const Plane &previousSurface, const TrajectoryStateOnSurface &previousTsos,
-			 const Plane &newSurface, TrajectoryStateOnSurface &newTsos, AlgebraicMatrix &newJacobian, 
-			 AlgebraicMatrix &newCurvlinJacobian, double &nextStep,
-			 const MagneticField *magField) const;
-  
+  virtual bool propagate(const Plane &previousSurface,
+                         const TrajectoryStateOnSurface &previousTsos,
+                         const Plane &newSurface,
+                         TrajectoryStateOnSurface &newTsos,
+                         AlgebraicMatrix &newJacobian,
+                         AlgebraicMatrix &newCurvlinJacobian,
+                         double &nextStep,
+                         const MagneticField *magField) const;
+
   /** internal method to fill measurement and error matrix for hit iRow/2
    */
   virtual void fillMeasurementAndError(const TransientTrackingRecHit::ConstRecHitPointer &hitPtr,
-				       unsigned int iRow,
-				       const TrajectoryStateOnSurface &updatedTsos);
+                                       unsigned int iRow,
+                                       const TrajectoryStateOnSurface &updatedTsos);
 
   /** internal method to fill derivatives for hit iRow/2
    */
   virtual void fillDerivatives(const AlgebraicMatrix &projection,
-			       const AlgebraicMatrix &fullJacobian, unsigned int iRow);
+                               const AlgebraicMatrix &fullJacobian,
+                               unsigned int iRow);
 
   /** internal method to fill the trajectory positions for hit iRow/2
    */
-  virtual void fillTrajectoryPositions(const AlgebraicMatrix &projection, 
-				       const AlgebraicVector &mixedLocalParams, 
-				       unsigned int iRow);
+  virtual void fillTrajectoryPositions(const AlgebraicMatrix &projection,
+                                       const AlgebraicVector &mixedLocalParams,
+                                       unsigned int iRow);
 
   /** internal method to add material effects to measurments covariance matrix
    */
-  virtual bool addMaterialEffectsCov(const std::vector<AlgebraicMatrix> &allJacobians, 
-				     const std::vector<AlgebraicMatrix> &allProjections,
-				     const std::vector<AlgebraicSymMatrix> &allCurvChanges,
-				     const std::vector<AlgebraicSymMatrix> &allDeltaParaCovs);
-				     
+  virtual bool addMaterialEffectsCov(const std::vector<AlgebraicMatrix> &allJacobians,
+                                     const std::vector<AlgebraicMatrix> &allProjections,
+                                     const std::vector<AlgebraicSymMatrix> &allCurvChanges,
+                                     const std::vector<AlgebraicSymMatrix> &allDeltaParaCovs);
+
   /** internal method to add material effects using break points
    */
-  virtual bool addMaterialEffectsBp (const std::vector<AlgebraicMatrix> &allJacobians, 
-				     const std::vector<AlgebraicMatrix> &allProjections,
-				     const std::vector<AlgebraicSymMatrix> &allCurvChanges,
-				     const std::vector<AlgebraicSymMatrix> &allDeltaParaCovs,
-				     const std::vector<AlgebraicMatrix> &allLocalToCurv);
-				     
+  virtual bool addMaterialEffectsBp(const std::vector<AlgebraicMatrix> &allJacobians,
+                                    const std::vector<AlgebraicMatrix> &allProjections,
+                                    const std::vector<AlgebraicSymMatrix> &allCurvChanges,
+                                    const std::vector<AlgebraicSymMatrix> &allDeltaParaCovs,
+                                    const std::vector<AlgebraicMatrix> &allLocalToCurv);
+
   /** internal methods to add material effects using broken lines (fine version)
    */
-  virtual bool addMaterialEffectsBrl(const std::vector<AlgebraicMatrix> &allJacobians, 
-				     const std::vector<AlgebraicMatrix> &allProjections,
-				     const std::vector<AlgebraicSymMatrix> &allCurvChanges,
-				     const std::vector<AlgebraicSymMatrix> &allDeltaParaCovs,
-				     const std::vector<AlgebraicMatrix> &allLocalToCurv,
-				     const GlobalTrajectoryParameters &gtp);
+  virtual bool addMaterialEffectsBrl(const std::vector<AlgebraicMatrix> &allJacobians,
+                                     const std::vector<AlgebraicMatrix> &allProjections,
+                                     const std::vector<AlgebraicSymMatrix> &allCurvChanges,
+                                     const std::vector<AlgebraicSymMatrix> &allDeltaParaCovs,
+                                     const std::vector<AlgebraicMatrix> &allLocalToCurv,
+                                     const GlobalTrajectoryParameters &gtp);
   /** internal methods to add material effects using broken lines (coarse version)
    */
   virtual bool addMaterialEffectsBrl(const std::vector<AlgebraicMatrix> &allProjections,
-				     const std::vector<AlgebraicSymMatrix> &allDeltaParaCovs,
-				     const std::vector<AlgebraicMatrix> &allLocalToCurv,
-				     const std::vector<double> &allSteps,
-				     const GlobalTrajectoryParameters &gtp,   
-				     const double minStep = 1.0);
-  
+                                     const std::vector<AlgebraicSymMatrix> &allDeltaParaCovs,
+                                     const std::vector<AlgebraicMatrix> &allLocalToCurv,
+                                     const std::vector<double> &allSteps,
+                                     const GlobalTrajectoryParameters &gtp,
+                                     const double minStep = 1.0);
+
   /** internal methods to add material effects using broken lines (fine version, local system)
    */
   virtual bool addMaterialEffectsLocalGbl(const std::vector<AlgebraicMatrix> &allJacobians,
-                                     const std::vector<AlgebraicMatrix> &allProjections,
-                                     const std::vector<AlgebraicSymMatrix> &allCurvatureChanges,
-                                     const std::vector<AlgebraicSymMatrix> &allDeltaParameterCovs);
+                                          const std::vector<AlgebraicMatrix> &allProjections,
+                                          const std::vector<AlgebraicSymMatrix> &allCurvatureChanges,
+                                          const std::vector<AlgebraicSymMatrix> &allDeltaParameterCovs);
 
   /** internal methods to add material effects using broken lines (fine version, curvilinear system)
    */
   virtual bool addMaterialEffectsCurvlinGbl(const std::vector<AlgebraicMatrix> &allJacobians,
-                                     const std::vector<AlgebraicMatrix> &allProjections,
-                                     const std::vector<AlgebraicSymMatrix> &allCurvChanges,
-                                     const std::vector<AlgebraicSymMatrix> &allDeltaParaCovs,
-                                     const std::vector<AlgebraicMatrix> &allLocalToCurv);
-          
+                                            const std::vector<AlgebraicMatrix> &allProjections,
+                                            const std::vector<AlgebraicSymMatrix> &allCurvChanges,
+                                            const std::vector<AlgebraicSymMatrix> &allDeltaParaCovs,
+                                            const std::vector<AlgebraicMatrix> &allLocalToCurv);
+
   /// Don't care for propagation direction 'anyDirection' - in that case the material effects
   /// are anyway not updated ...
-  inline SurfaceSide surfaceSide(const PropagationDirection dir) const
-  {
-    return ( dir == alongMomentum ) ?
-      SurfaceSideDefinition::beforeSurface :
-      SurfaceSideDefinition::afterSurface;
+  inline SurfaceSide surfaceSide(const PropagationDirection dir) const {
+    return (dir == alongMomentum) ? SurfaceSideDefinition::beforeSurface : SurfaceSideDefinition::afterSurface;
   }
 
   /** first (generic) helper to get the projection matrix
    */
-  AlgebraicMatrix
-    getHitProjectionMatrix(const TransientTrackingRecHit::ConstRecHitPointer &recHit) const;
+  AlgebraicMatrix getHitProjectionMatrix(const TransientTrackingRecHit::ConstRecHitPointer &recHit) const;
 
   /** second helper (templated on the dimension) to get the projection matrix
    */
   template <unsigned int N>
-    AlgebraicMatrix
-    getHitProjectionMatrixT(const TransientTrackingRecHit::ConstRecHitPointer &recHit) const;
+  AlgebraicMatrix getHitProjectionMatrixT(const TransientTrackingRecHit::ConstRecHitPointer &recHit) const;
+
 private:
   template <typename Derived>
-  void clhep2eigen(const AlgebraicVector& in, Eigen::MatrixBase<Derived>& out);
+  void clhep2eigen(const AlgebraicVector &in, Eigen::MatrixBase<Derived> &out);
   template <typename Derived>
-  void clhep2eigen(const AlgebraicMatrix& in, Eigen::MatrixBase<Derived>& out);
+  void clhep2eigen(const AlgebraicMatrix &in, Eigen::MatrixBase<Derived> &out);
   template <typename Derived>
-  void clhep2eigen(const AlgebraicSymMatrix& in, Eigen::MatrixBase<Derived>& out);
+  void clhep2eigen(const AlgebraicSymMatrix &in, Eigen::MatrixBase<Derived> &out);
 
   const double mass_;
   const MaterialEffects materialEffects_;

--- a/Alignment/ReferenceTrajectories/interface/ReferenceTrajectoryBase.h
+++ b/Alignment/ReferenceTrajectories/interface/ReferenceTrajectoryBase.h
@@ -102,26 +102,28 @@
 
 #include "GblTrajectory.h"
 
-
-class ReferenceTrajectoryBase : public ReferenceCounted
-{
-
+class ReferenceTrajectoryBase : public ReferenceCounted {
 public:
-
   typedef ReferenceCountingPointer<ReferenceTrajectoryBase> ReferenceTrajectoryPtr;
 
-  enum MaterialEffects { none, multipleScattering, energyLoss, combined, 
-			 breakPoints, brokenLinesCoarse, brokenLinesFine, localGBL, curvlinGBL };
+  enum MaterialEffects {
+    none,
+    multipleScattering,
+    energyLoss,
+    combined,
+    breakPoints,
+    brokenLinesCoarse,
+    brokenLinesFine,
+    localGBL,
+    curvlinGBL
+  };
 
   struct Config {
-    Config(MaterialEffects matEff, PropagationDirection direction,
-	   double m = -std::numeric_limits<double>::infinity(),
-	   double est = -std::numeric_limits<double>::infinity()) :
-      materialEffects(matEff),
-      propDir(direction),
-      mass(m),
-      momentumEstimate(est)
-    {}
+    Config(MaterialEffects matEff,
+           PropagationDirection direction,
+           double m = -std::numeric_limits<double>::infinity(),
+           double est = -std::numeric_limits<double>::infinity())
+        : materialEffects(matEff), propDir(direction), mass(m), momentumEstimate(est) {}
 
     MaterialEffects materialEffects;
     PropagationDirection propDir;
@@ -146,7 +148,7 @@ public:
   /** Returns the full covariance matrix of the measurements. ORCA-equivalent: covariance()
    */
   const AlgebraicSymMatrix& measurementErrors() const { return theMeasurementsCov; }
-  
+
   /** Returns the local coordinates of the reference trajectory.
       ORCA-equivalent: referenceTrack()
    */
@@ -166,8 +168,8 @@ public:
   const AlgebraicMatrix& trajectoryToCurv() const { return theInnerTrajectoryToCurvilinear; }
   /** Returns the transformation of local to tracjectory parameters
    */
-  const AlgebraicMatrix& localToTrajectory() const { return theInnerLocalToTrajectory; }  
-  
+  const AlgebraicMatrix& localToTrajectory() const { return theInnerLocalToTrajectory; }
+
   /** Returns the GBL input
    */
   std::vector<std::pair<std::vector<gbl::GblPoint>, Eigen::MatrixXd> >& gblInput() { return theGblInput; }
@@ -183,10 +185,9 @@ public:
   /** Returns the GBL external derivatives.
    */
   const Eigen::VectorXd& gblExtPrecisions() const { return theGblExtPrecisions; }
-  
 
   /** Returns the set of 'track'-parameters.
-   */  
+   */
   const AlgebraicVector& parameters() const { return theParameters; }
 
   /** Returns true if the covariance matrix of the 'track'-parameters is set.
@@ -195,8 +196,11 @@ public:
 
   /** Set the covariance matrix of the 'track'-parameters.
    */
-  inline void setParameterErrors( const AlgebraicSymMatrix& error ) { theParameterCov = error; theParamCovFlag = true; }
-  
+  inline void setParameterErrors(const AlgebraicSymMatrix& error) {
+    theParameterCov = error;
+    theParamCovFlag = true;
+  }
+
   /** Returns the covariance matrix of the 'track'-parameters.
    */
   inline const AlgebraicSymMatrix& parameterErrors() const { return theParameterCov; }
@@ -212,57 +216,57 @@ public:
 
   inline unsigned int numberOfHits() const { return theNumberOfHits; }
   inline unsigned int numberOfPar() const { return theNumberOfPars; }
-  inline unsigned int numberOfVirtualMeas() const { return theNumberOfVirtualMeas; }  
-  inline unsigned int numberOfVirtualPar() const { return theNumberOfVirtualPars; }  
-  inline unsigned int numberOfHitMeas() const { return theNumberOfHits * nMeasPerHit; } 
+  inline unsigned int numberOfVirtualMeas() const { return theNumberOfVirtualMeas; }
+  inline unsigned int numberOfVirtualPar() const { return theNumberOfVirtualPars; }
+  inline unsigned int numberOfHitMeas() const { return theNumberOfHits * nMeasPerHit; }
   inline int nominalField() const { return theNomField; }
-       
+
   virtual ReferenceTrajectoryBase* clone() const = 0;
 
 protected:
+  explicit ReferenceTrajectoryBase(unsigned int nPar,
+                                   unsigned int nHits,
+                                   unsigned int nVirtualPar,
+                                   unsigned int nVirtualMeas);
 
-  explicit ReferenceTrajectoryBase(unsigned int nPar, unsigned int nHits,
-				   unsigned int nVirtualPar, unsigned int nVirtualMeas);
-
-  unsigned int numberOfUsedRecHits(const TransientTrackingRecHit::ConstRecHitContainer &recHits) const;
+  unsigned int numberOfUsedRecHits(const TransientTrackingRecHit::ConstRecHitContainer& recHits) const;
   bool useRecHit(const TransientTrackingRecHit::ConstRecHitPointer& hitPtr) const;
 
   bool theValidityFlag;
   bool theParamCovFlag;
 
-  unsigned int theNumberOfHits;   // number of (measurements from) hits
-  unsigned int theNumberOfPars;   // number of (track) parameters
-  unsigned int theNumberOfVirtualMeas; // number of virtual measurements
-  unsigned int theNumberOfVirtualPars; // number of parameters for virtual measurements
-      
+  unsigned int theNumberOfHits;         // number of (measurements from) hits
+  unsigned int theNumberOfPars;         // number of (track) parameters
+  unsigned int theNumberOfVirtualMeas;  // number of virtual measurements
+  unsigned int theNumberOfVirtualPars;  // number of parameters for virtual measurements
+
   std::vector<TrajectoryStateOnSurface> theTsosVec;
   TransientTrackingRecHit::ConstRecHitContainer theRecHits;
 
-  AlgebraicVector     theMeasurements;
-  AlgebraicSymMatrix  theMeasurementsCov;
+  AlgebraicVector theMeasurements;
+  AlgebraicSymMatrix theMeasurementsCov;
 
-  AlgebraicVector     theTrajectoryPositions;
-  AlgebraicSymMatrix  theTrajectoryPositionCov;
+  AlgebraicVector theTrajectoryPositions;
+  AlgebraicSymMatrix theTrajectoryPositionCov;
 
-  AlgebraicVector     theParameters;
-  AlgebraicSymMatrix  theParameterCov;
+  AlgebraicVector theParameters;
+  AlgebraicSymMatrix theParameterCov;
 
-  AlgebraicMatrix     theDerivatives;
+  AlgebraicMatrix theDerivatives;
 
-// CHK for beamspot   transformation trajectory parameter to curvilinear at refTSos
-  AlgebraicMatrix     theInnerTrajectoryToCurvilinear;  
-// CHK for TwoBodyD.  transformation local to trajectory parameter at refTsos
-  AlgebraicMatrix     theInnerLocalToTrajectory;
-// CHK GBL input:     list of (list of points on trajectory and transformation at inner (first) point)
+  // CHK for beamspot   transformation trajectory parameter to curvilinear at refTSos
+  AlgebraicMatrix theInnerTrajectoryToCurvilinear;
+  // CHK for TwoBodyD.  transformation local to trajectory parameter at refTsos
+  AlgebraicMatrix theInnerLocalToTrajectory;
+  // CHK GBL input:     list of (list of points on trajectory and transformation at inner (first) point)
   std::vector<std::pair<std::vector<gbl::GblPoint>, Eigen::MatrixXd> > theGblInput;
-  int                           theNomField;
-// CHK GBL TBD:       virtual (mass) measurement
-  Eigen::MatrixXd     theGblExtDerivatives;
-  Eigen::VectorXd     theGblExtMeasurements;
-  Eigen::VectorXd     theGblExtPrecisions;
-    
+  int theNomField;
+  // CHK GBL TBD:       virtual (mass) measurement
+  Eigen::MatrixXd theGblExtDerivatives;
+  Eigen::VectorXd theGblExtMeasurements;
+  Eigen::VectorXd theGblExtPrecisions;
+
   static constexpr unsigned int nMeasPerHit{2};
 };
 
-#endif // REFERENCE_TRAJECTORY_BASE_H
-
+#endif  // REFERENCE_TRAJECTORY_BASE_H

--- a/Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h
+++ b/Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h
@@ -13,56 +13,51 @@
 /// Base class for factories producing reference trajectories, i.e. instances of classes deriving from
 /// ReferenceTrajectoryBase, from a TrajTrackPairCollection.
 
+namespace reco {
+  class BeamSpot;
+}
 
-namespace reco { class BeamSpot;}
-
-class TrajectoryFactoryBase
-{
-
+class TrajectoryFactoryBase {
 public:
-
   typedef ReferenceTrajectoryBase::ReferenceTrajectoryPtr ReferenceTrajectoryPtr;
   typedef ReferenceTrajectoryBase::MaterialEffects MaterialEffects;
   typedef AlignmentAlgorithmBase::ConstTrajTrackPair ConstTrajTrackPair;
   typedef AlignmentAlgorithmBase::ConstTrajTrackPairCollection ConstTrajTrackPairCollection;
-  typedef std::vector< ReferenceTrajectoryPtr > ReferenceTrajectoryCollection;
-  typedef std::pair< TrajectoryStateOnSurface, TransientTrackingRecHit::ConstRecHitContainer > TrajectoryInput;
-  typedef std::vector< TrajectoryStateOnSurface > ExternalPredictionCollection;
+  typedef std::vector<ReferenceTrajectoryPtr> ReferenceTrajectoryCollection;
+  typedef std::pair<TrajectoryStateOnSurface, TransientTrackingRecHit::ConstRecHitContainer> TrajectoryInput;
+  typedef std::vector<TrajectoryStateOnSurface> ExternalPredictionCollection;
 
   TrajectoryFactoryBase(const edm::ParameterSet& config);
-  TrajectoryFactoryBase(const edm::ParameterSet& config,
-                        unsigned int tracksPerTrajectory);
-  virtual ~TrajectoryFactoryBase( void );
+  TrajectoryFactoryBase(const edm::ParameterSet& config, unsigned int tracksPerTrajectory);
+  virtual ~TrajectoryFactoryBase(void);
 
-  virtual const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
-							   const ConstTrajTrackPairCollection &tracks,
-							   const reco::BeamSpot &beamSpot) const = 0;
+  virtual const ReferenceTrajectoryCollection trajectories(const edm::EventSetup& setup,
+                                                           const ConstTrajTrackPairCollection& tracks,
+                                                           const reco::BeamSpot& beamSpot) const = 0;
 
-  virtual const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
-							   const ConstTrajTrackPairCollection &tracks,
-							   const ExternalPredictionCollection &external,
-							   const reco::BeamSpot &beamSpot) const = 0;
+  virtual const ReferenceTrajectoryCollection trajectories(const edm::EventSetup& setup,
+                                                           const ConstTrajTrackPairCollection& tracks,
+                                                           const ExternalPredictionCollection& external,
+                                                           const reco::BeamSpot& beamSpot) const = 0;
 
-  virtual TrajectoryFactoryBase* clone( void ) const = 0;
+  virtual TrajectoryFactoryBase* clone(void) const = 0;
 
-  inline MaterialEffects materialEffects( void ) const { return materialEffects_; }
-  inline PropagationDirection propagationDirection( void ) const { return propDir_; }
+  inline MaterialEffects materialEffects(void) const { return materialEffects_; }
+  inline PropagationDirection propagationDirection(void) const { return propDir_; }
   inline const edm::ParameterSet& configuration() const { return cfg_; }
   inline unsigned int tracksPerTrajectory() const { return tracksPerTrajectory_; }
 
 protected:
-
-  virtual const TrajectoryInput innermostStateAndRecHits( const ConstTrajTrackPair & track ) const;
-  virtual const Trajectory::DataContainer orderedTrajectoryMeasurements( const Trajectory & trajectory ) const;
-  bool sameSurface( const Surface& s1, const Surface& s2 ) const;
-  bool useRecHit( const TransientTrackingRecHit::ConstRecHitPointer& hitPtr ) const;
+  virtual const TrajectoryInput innermostStateAndRecHits(const ConstTrajTrackPair& track) const;
+  virtual const Trajectory::DataContainer orderedTrajectoryMeasurements(const Trajectory& trajectory) const;
+  bool sameSurface(const Surface& s1, const Surface& s2) const;
+  bool useRecHit(const TransientTrackingRecHit::ConstRecHitPointer& hitPtr) const;
 
 private:
+  MaterialEffects materialEffects(const std::string& strME) const;
+  PropagationDirection propagationDirection(const std::string& strPD) const;
 
-  MaterialEffects materialEffects( const std::string & strME ) const;
-  PropagationDirection propagationDirection( const std::string & strPD ) const;
-
-  const edm::ParameterSet cfg_; // need to keep for possible re-use after constructor... :-(
+  const edm::ParameterSet cfg_;  // need to keep for possible re-use after constructor... :-(
   const unsigned int tracksPerTrajectory_;
   const MaterialEffects materialEffects_;
   const PropagationDirection propDir_;
@@ -70,13 +65,11 @@ private:
   const bool useWithoutDet_;
   const bool useInvalidHits_;
   const bool useProjectedHits_;
-  
-protected:
 
+protected:
   const bool useBeamSpot_;
   const bool includeAPEs_;
   const bool allowZeroMaterial_;
 };
-
 
 #endif

--- a/Alignment/ReferenceTrajectories/interface/TrajectoryFactoryPlugin.h
+++ b/Alignment/ReferenceTrajectories/interface/TrajectoryFactoryPlugin.h
@@ -8,8 +8,6 @@
 
 /// A PluginFactory that produces factories that inherit from TrajectoryFactoryBase.
 
-
-typedef edmplugin::PluginFactory< TrajectoryFactoryBase *( const edm::ParameterSet & ) >
-                   TrajectoryFactoryPlugin;
+typedef edmplugin::PluginFactory<TrajectoryFactoryBase *(const edm::ParameterSet &)> TrajectoryFactoryPlugin;
 
 #endif

--- a/Alignment/ReferenceTrajectories/interface/TwoBodyDecayTrajectory.h
+++ b/Alignment/ReferenceTrajectories/interface/TwoBodyDecayTrajectory.h
@@ -4,20 +4,18 @@
 #include "Alignment/ReferenceTrajectories/interface/ReferenceTrajectory.h"
 #include "Alignment/ReferenceTrajectories/interface/TwoBodyDecayTrajectoryState.h"
 
-
 /**
    by Edmund Widl, see CMS NOTE-2007/032.
  */
 
-namespace reco { class BeamSpot; }
+namespace reco {
+  class BeamSpot;
+}
 
-class TwoBodyDecayTrajectory : public ReferenceTrajectoryBase
-{
-
+class TwoBodyDecayTrajectory : public ReferenceTrajectoryBase {
 public:
-
   typedef TransientTrackingRecHit::ConstRecHitContainer ConstRecHitContainer;
-  typedef std::pair< ConstRecHitContainer, ConstRecHitContainer > ConstRecHitCollection;
+  typedef std::pair<ConstRecHitContainer, ConstRecHitContainer> ConstRecHitCollection;
 
   TwoBodyDecayTrajectory(const TwoBodyDecayTrajectoryState& tsos,
                          const ConstRecHitCollection& recHits,
@@ -25,38 +23,34 @@ public:
                          const reco::BeamSpot& beamSpot,
                          const ReferenceTrajectoryBase::Config& config);
 
-  TwoBodyDecayTrajectory( void );
+  TwoBodyDecayTrajectory(void);
 
-  ~TwoBodyDecayTrajectory( void ) override {}
+  ~TwoBodyDecayTrajectory(void) override {}
 
-  TwoBodyDecayTrajectory* clone( void ) const override
-    { return new TwoBodyDecayTrajectory( *this ); }
+  TwoBodyDecayTrajectory* clone(void) const override { return new TwoBodyDecayTrajectory(*this); }
 
   /**Number of RecHits belonging to the first and second track.
    */
-  inline const std::pair< int, int > numberOfRecHits( void ) { return theNumberOfRecHits; }
+  inline const std::pair<int, int> numberOfRecHits(void) { return theNumberOfRecHits; }
 
 private:
-
   bool construct(const TwoBodyDecayTrajectoryState& state,
                  const ConstRecHitCollection& recHits,
                  const MagneticField* field,
                  const reco::BeamSpot& beamSpot);
 
-  void constructTsosVecWithErrors( const ReferenceTrajectory& traj1,
-				   const ReferenceTrajectory& traj2,
-				   const MagneticField* field );
+  void constructTsosVecWithErrors(const ReferenceTrajectory& traj1,
+                                  const ReferenceTrajectory& traj2,
+                                  const MagneticField* field);
 
-  void constructSingleTsosWithErrors( const TrajectoryStateOnSurface & tsos,
-				      int iTsos,
-				      const MagneticField* field );
+  void constructSingleTsosWithErrors(const TrajectoryStateOnSurface& tsos, int iTsos, const MagneticField* field);
 
   const MaterialEffects materialEffects_;
   const PropagationDirection propDir_;
   const bool useRefittedState_;
   const bool constructTsosWithErrors_;
 
-  std::pair< int, int > theNumberOfRecHits;
+  std::pair<int, int> theNumberOfRecHits;
 };
 
 #endif

--- a/Alignment/ReferenceTrajectories/interface/TwoBodyDecayTrajectoryState.h
+++ b/Alignment/ReferenceTrajectories/interface/TwoBodyDecayTrajectoryState.h
@@ -9,54 +9,48 @@
 
 class GlobalTrajectoryParameters;
 
-
-class TwoBodyDecayTrajectoryState
-{
-
+class TwoBodyDecayTrajectoryState {
 public:
-
-  typedef std::pair< TrajectoryStateOnSurface, TrajectoryStateOnSurface > TsosContainer;
-  typedef std::pair< AlgebraicMatrix, AlgebraicMatrix > Derivatives;
+  typedef std::pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface> TsosContainer;
+  typedef std::pair<AlgebraicMatrix, AlgebraicMatrix> Derivatives;
 
   /** The constructor takes the two trajectory states that are to be updated (typically the
    *  innermost trajectory states of two tracks) and the decay parameters.
    */
-  TwoBodyDecayTrajectoryState( const TsosContainer & tsos,
-			       const TwoBodyDecay & tbd,
-			       double particleMass,
-			       const MagneticField* magField,
-			       bool propagateErrors = false );
+  TwoBodyDecayTrajectoryState(const TsosContainer& tsos,
+                              const TwoBodyDecay& tbd,
+                              double particleMass,
+                              const MagneticField* magField,
+                              bool propagateErrors = false);
 
-  ~TwoBodyDecayTrajectoryState( void ) {}
+  ~TwoBodyDecayTrajectoryState(void) {}
 
-  inline bool isValid( void ) const { return theValidityFlag; }
+  inline bool isValid(void) const { return theValidityFlag; }
 
-  inline double particleMass( void ) const { return theParticleMass; }
-  inline const TwoBodyDecayParameters & decayParameters( void ) const { return theParameters; }
-  inline const TsosContainer& trajectoryStates( bool useRefittedState = true ) const { return useRefittedState ? theRefittedTsos : theOriginalTsos; }
-  inline const Derivatives& derivatives( void ) const { return theDerivatives; }
+  inline double particleMass(void) const { return theParticleMass; }
+  inline const TwoBodyDecayParameters& decayParameters(void) const { return theParameters; }
+  inline const TsosContainer& trajectoryStates(bool useRefittedState = true) const {
+    return useRefittedState ? theRefittedTsos : theOriginalTsos;
+  }
+  inline const Derivatives& derivatives(void) const { return theDerivatives; }
 
-  void rescaleError( double scale );
+  void rescaleError(double scale);
 
-  inline double primaryMass( void ) const { return thePrimaryMass; }
-  inline double primaryWidth( void ) const { return thePrimaryWidth; }
+  inline double primaryMass(void) const { return thePrimaryMass; }
+  inline double primaryWidth(void) const { return thePrimaryWidth; }
 
 private:
+  void construct(const MagneticField* magField, bool propagateErrors);
 
-  void construct( const MagneticField* magField,
-		  bool propagateErrors );
+  bool propagateSingleState(const FreeTrajectoryState& fts,
+                            const GlobalTrajectoryParameters& gtp,
+                            const AlgebraicMatrix& startDeriv,
+                            const Surface& surface,
+                            const MagneticField* magField,
+                            TrajectoryStateOnSurface& tsos,
+                            AlgebraicMatrix& endDeriv) const;
 
-  bool propagateSingleState( const FreeTrajectoryState & fts,
-			     const GlobalTrajectoryParameters & gtp,
-			     const AlgebraicMatrix & startDeriv,
-			     const Surface & surface,
-			     const MagneticField* magField,
-			     TrajectoryStateOnSurface & tsos,
-			     AlgebraicMatrix & endDeriv ) const;
-
-
-  void setError( FreeTrajectoryState& fts,
-		 AlgebraicMatrix& derivative ) const;
+  void setError(FreeTrajectoryState& fts, AlgebraicMatrix& derivative) const;
 
   bool theValidityFlag;
 
@@ -73,6 +67,5 @@ private:
   static const unsigned int nLocalParam = 5;
   static const unsigned int nDecayParam = TwoBodyDecayParameters::dimension;
 };
-
 
 #endif

--- a/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.h
+++ b/Alignment/ReferenceTrajectories/plugins/BzeroReferenceTrajectoryFactory.h
@@ -3,7 +3,7 @@
 namespace edm {
   class ParameterSet;
   class EventSetup;
-}
+}  // namespace edm
 namespace reco {
   class BeamSpot;
 }
@@ -11,27 +11,24 @@ namespace reco {
 /// A factory that produces instances of class BzeroReferenceTrajectory from a
 /// given TrajTrackPairCollection.
 
-class BzeroReferenceTrajectoryFactory : public TrajectoryFactoryBase
-{
+class BzeroReferenceTrajectoryFactory : public TrajectoryFactoryBase {
 public:
   BzeroReferenceTrajectoryFactory(const edm::ParameterSet &config);
   ~BzeroReferenceTrajectoryFactory() override;
 
   /// Produce the reference trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
-							   const ConstTrajTrackPairCollection &tracks,
-							   const reco::BeamSpot &beamSpot) const override;
+                                                   const ConstTrajTrackPairCollection &tracks,
+                                                   const reco::BeamSpot &beamSpot) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
-							   const ConstTrajTrackPairCollection &tracks,
-							   const ExternalPredictionCollection &external,
-							   const reco::BeamSpot &beamSpot) const override;
+                                                   const ConstTrajTrackPairCollection &tracks,
+                                                   const ExternalPredictionCollection &external,
+                                                   const reco::BeamSpot &beamSpot) const override;
 
-  BzeroReferenceTrajectoryFactory* clone() const override { return new BzeroReferenceTrajectoryFactory( *this ); }
+  BzeroReferenceTrajectoryFactory *clone() const override { return new BzeroReferenceTrajectoryFactory(*this); }
 
 private:
-
   double theMass;
   double theMomentumEstimate;
 };
-

--- a/Alignment/ReferenceTrajectories/plugins/CombinedTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/CombinedTrajectoryFactory.cc
@@ -10,41 +10,36 @@
 
 /// A factory that can combine the functionality of several 'trajectory factories'. At construction
 /// time, it is given an ordered list of what kinds factories it should use. When called, all the
-/// factories are called one after each other, 
+/// factories are called one after each other,
 ///  - either until one of them gives a result
 ///  - or until all factories are really called.
 /// This is determined by the useAllFactories flag.
 ///
-/// Example: 
-/// Combine TwoBodyDecayTrajectoryFactory and ReferenceTrajectoryFactory 
+/// Example:
+/// Combine TwoBodyDecayTrajectoryFactory and ReferenceTrajectoryFactory
 /// with useAllFactories = false. In case the former
 /// can't produce a trajectory from two given tracks, the tracks can still be used for 'ordinary'
 /// reference trajectories (see also TrajectoryFactories.cff).
 
-
-class CombinedTrajectoryFactory : public TrajectoryFactoryBase
-{
-
+class CombinedTrajectoryFactory : public TrajectoryFactoryBase {
 public:
-
   CombinedTrajectoryFactory(const edm::ParameterSet &config);
   ~CombinedTrajectoryFactory() override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
-							   const ConstTrajTrackPairCollection &tracks,
-							   const reco::BeamSpot &beamSpot) const override;
+                                                   const ConstTrajTrackPairCollection &tracks,
+                                                   const reco::BeamSpot &beamSpot) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
-							   const ConstTrajTrackPairCollection &tracks,
-							   const ExternalPredictionCollection &external,
-							   const reco::BeamSpot &beamSpot) const override;
+                                                   const ConstTrajTrackPairCollection &tracks,
+                                                   const ExternalPredictionCollection &external,
+                                                   const reco::BeamSpot &beamSpot) const override;
 
-  CombinedTrajectoryFactory* clone() const override { return new CombinedTrajectoryFactory(*this); }
+  CombinedTrajectoryFactory *clone() const override { return new CombinedTrajectoryFactory(*this); }
 
 private:
-
-  std::vector<TrajectoryFactoryBase*> theFactories;
-  bool                                theUseAllFactories; /// use not only the first 'successful'?
+  std::vector<TrajectoryFactoryBase *> theFactories;
+  bool theUseAllFactories;  /// use not only the first 'successful'?
 };
 
 //////////////////////////////////////////////////////////////////////////////////////
@@ -53,13 +48,11 @@ private:
 
 using namespace std;
 
-CombinedTrajectoryFactory::CombinedTrajectoryFactory( const edm::ParameterSet & config ) :
-  TrajectoryFactoryBase( config ), theUseAllFactories(config.getParameter<bool>("useAllFactories"))
-{
-  vector<string> factoryNames = config.getParameter< vector<string> >( "TrajectoryFactoryNames" );
+CombinedTrajectoryFactory::CombinedTrajectoryFactory(const edm::ParameterSet &config)
+    : TrajectoryFactoryBase(config), theUseAllFactories(config.getParameter<bool>("useAllFactories")) {
+  vector<string> factoryNames = config.getParameter<vector<string> >("TrajectoryFactoryNames");
   vector<string>::iterator itFactoryName;
-  for ( itFactoryName = factoryNames.begin(); itFactoryName != factoryNames.end(); ++itFactoryName )
-  {
+  for (itFactoryName = factoryNames.begin(); itFactoryName != factoryNames.end(); ++itFactoryName) {
     // auto_ptr to avoid missing a delete due to throw...
     std::unique_ptr<TObjArray> namePset(TString((*itFactoryName).c_str()).Tokenize(","));
     if (namePset->GetEntriesFast() != 2) {
@@ -67,57 +60,48 @@ CombinedTrajectoryFactory::CombinedTrajectoryFactory( const edm::ParameterSet & 
                                         << "TrajectoryFactoryNames must contain 2 comma "
                                         << "separated strings, but is '" << *itFactoryName << "'";
     }
-    const edm::ParameterSet factoryCfg 
-      = config.getParameter<edm::ParameterSet>(namePset->At(1)->GetName());
-    theFactories.push_back(TrajectoryFactoryPlugin::get()->create(namePset->At(0)->GetName(),
-								  factoryCfg));
+    const edm::ParameterSet factoryCfg = config.getParameter<edm::ParameterSet>(namePset->At(1)->GetName());
+    theFactories.push_back(TrajectoryFactoryPlugin::get()->create(namePset->At(0)->GetName(), factoryCfg));
   }
 }
 
- 
-CombinedTrajectoryFactory::~CombinedTrajectoryFactory( void ) {}
+CombinedTrajectoryFactory::~CombinedTrajectoryFactory(void) {}
 
-
-const CombinedTrajectoryFactory::ReferenceTrajectoryCollection
-CombinedTrajectoryFactory::trajectories(const edm::EventSetup &setup,
-					const ConstTrajTrackPairCollection &tracks,
-					const reco::BeamSpot &beamSpot) const
-{
+const CombinedTrajectoryFactory::ReferenceTrajectoryCollection CombinedTrajectoryFactory::trajectories(
+    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
-  ReferenceTrajectoryCollection tmpTrajectories; // outside loop for efficiency
+  ReferenceTrajectoryCollection tmpTrajectories;  // outside loop for efficiency
 
-  vector< TrajectoryFactoryBase* >::const_iterator itFactory;
-  for ( itFactory = theFactories.begin(); itFactory != theFactories.end(); ++itFactory )
-  {
-    tmpTrajectories = ( *itFactory )->trajectories(setup, tracks, beamSpot);
+  vector<TrajectoryFactoryBase *>::const_iterator itFactory;
+  for (itFactory = theFactories.begin(); itFactory != theFactories.end(); ++itFactory) {
+    tmpTrajectories = (*itFactory)->trajectories(setup, tracks, beamSpot);
     trajectories.insert(trajectories.end(), tmpTrajectories.begin(), tmpTrajectories.end());
 
-    if (!theUseAllFactories && !trajectories.empty()) break;
+    if (!theUseAllFactories && !trajectories.empty())
+      break;
   }
 
   return trajectories;
 }
 
-const CombinedTrajectoryFactory::ReferenceTrajectoryCollection
-CombinedTrajectoryFactory::trajectories(const edm::EventSetup &setup,
-					const ConstTrajTrackPairCollection &tracks,
-					const ExternalPredictionCollection &external,
-					const reco::BeamSpot &beamSpot) const
-{
+const CombinedTrajectoryFactory::ReferenceTrajectoryCollection CombinedTrajectoryFactory::trajectories(
+    const edm::EventSetup &setup,
+    const ConstTrajTrackPairCollection &tracks,
+    const ExternalPredictionCollection &external,
+    const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
-  ReferenceTrajectoryCollection tmpTrajectories; // outside loop for efficiency
+  ReferenceTrajectoryCollection tmpTrajectories;  // outside loop for efficiency
 
-  vector< TrajectoryFactoryBase* >::const_iterator itFactory;
-  for ( itFactory = theFactories.begin(); itFactory != theFactories.end(); ++itFactory )
-  {
-    tmpTrajectories = ( *itFactory )->trajectories(setup, tracks, external, beamSpot);
+  vector<TrajectoryFactoryBase *>::const_iterator itFactory;
+  for (itFactory = theFactories.begin(); itFactory != theFactories.end(); ++itFactory) {
+    tmpTrajectories = (*itFactory)->trajectories(setup, tracks, external, beamSpot);
     trajectories.insert(trajectories.end(), tmpTrajectories.begin(), tmpTrajectories.end());
 
-    if (!theUseAllFactories && !trajectories.empty()) break;
+    if (!theUseAllFactories && !trajectories.empty())
+      break;
   }
 
   return trajectories;
 }
 
-
-DEFINE_EDM_PLUGIN( TrajectoryFactoryPlugin, CombinedTrajectoryFactory, "CombinedTrajectoryFactory" );
+DEFINE_EDM_PLUGIN(TrajectoryFactoryPlugin, CombinedTrajectoryFactory, "CombinedTrajectoryFactory");

--- a/Alignment/ReferenceTrajectories/plugins/DualBzeroTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/DualBzeroTrajectoryFactory.cc
@@ -2,40 +2,37 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h" 
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "Alignment/ReferenceTrajectories/interface/TrajectoryFactoryPlugin.h"
 #include "TrackingTools/GeomPropagators/interface/AnalyticalPropagator.h"
 
 #include <algorithm>
 
-#include "Alignment/ReferenceTrajectories/interface/DualBzeroReferenceTrajectory.h" 
+#include "Alignment/ReferenceTrajectories/interface/DualBzeroReferenceTrajectory.h"
 
 #include "Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h"
 
 /// A factory that produces instances of class ReferenceTrajectory from a given TrajTrackPairCollection.
 
-
-class DualBzeroTrajectoryFactory : public TrajectoryFactoryBase
-{
+class DualBzeroTrajectoryFactory : public TrajectoryFactoryBase {
 public:
   DualBzeroTrajectoryFactory(const edm::ParameterSet &config);
   ~DualBzeroTrajectoryFactory() override;
 
   /// Produce the reference trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
-							   const ConstTrajTrackPairCollection &tracks,
-							    const reco::BeamSpot &beamSpot) const override;
+                                                   const ConstTrajTrackPairCollection &tracks,
+                                                   const reco::BeamSpot &beamSpot) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
-							   const ConstTrajTrackPairCollection &tracks,
-							   const ExternalPredictionCollection &external,
-							   const reco::BeamSpot &beamSpot) const override;
+                                                   const ConstTrajTrackPairCollection &tracks,
+                                                   const ExternalPredictionCollection &external,
+                                                   const reco::BeamSpot &beamSpot) const override;
 
-  DualBzeroTrajectoryFactory* clone() const override { return new DualBzeroTrajectoryFactory(*this); }
+  DualBzeroTrajectoryFactory *clone() const override { return new DualBzeroTrajectoryFactory(*this); }
 
 protected:
-  struct DualBzeroTrajectoryInput
-  {
+  struct DualBzeroTrajectoryInput {
     TrajectoryStateOnSurface refTsos;
     TransientTrackingRecHit::ConstRecHitContainer fwdRecHits;
     TransientTrackingRecHit::ConstRecHitContainer bwdRecHits;
@@ -44,59 +41,45 @@ protected:
   const DualBzeroTrajectoryInput referenceStateAndRecHits(const ConstTrajTrackPair &track) const;
 
   const TrajectoryStateOnSurface propagateExternal(const TrajectoryStateOnSurface &external,
-						   const Surface &surface,
-						   const MagneticField *magField) const;
+                                                   const Surface &surface,
+                                                   const MagneticField *magField) const;
 
   double theMass;
   double theMomentumEstimate;
-  
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-DualBzeroTrajectoryFactory::DualBzeroTrajectoryFactory( const edm::ParameterSet & config ) :
-  TrajectoryFactoryBase( config )
-{
-  theMass = config.getParameter< double >( "ParticleMass" );
-  theMomentumEstimate = config.getParameter< double >( "MomentumEstimate" );
+DualBzeroTrajectoryFactory::DualBzeroTrajectoryFactory(const edm::ParameterSet &config)
+    : TrajectoryFactoryBase(config) {
+  theMass = config.getParameter<double>("ParticleMass");
+  theMomentumEstimate = config.getParameter<double>("MomentumEstimate");
 }
 
- 
-DualBzeroTrajectoryFactory::~DualBzeroTrajectoryFactory( void ) {}
+DualBzeroTrajectoryFactory::~DualBzeroTrajectoryFactory(void) {}
 
-
-const DualBzeroTrajectoryFactory::ReferenceTrajectoryCollection
-DualBzeroTrajectoryFactory::trajectories(const edm::EventSetup  &setup,
-					 const ConstTrajTrackPairCollection &tracks,
-					 const reco::BeamSpot &beamSpot) const
-{
+const DualBzeroTrajectoryFactory::ReferenceTrajectoryCollection DualBzeroTrajectoryFactory::trajectories(
+    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
-  edm::ESHandle< MagneticField > magneticField;
-  setup.get< IdealMagneticFieldRecord >().get( magneticField );
+  edm::ESHandle<MagneticField> magneticField;
+  setup.get<IdealMagneticFieldRecord>().get(magneticField);
 
   ConstTrajTrackPairCollection::const_iterator itTracks = tracks.begin();
 
-  while ( itTracks != tracks.end() )
-  { 
-    const DualBzeroTrajectoryInput input = this->referenceStateAndRecHits( *itTracks );
+  while (itTracks != tracks.end()) {
+    const DualBzeroTrajectoryInput input = this->referenceStateAndRecHits(*itTracks);
     // Check input: If all hits were rejected, the TSOS is initialized as invalid.
-    if ( input.refTsos.isValid() )
-    {
-      ReferenceTrajectoryBase::Config config(materialEffects(), propagationDirection(),
-                                             theMass, theMomentumEstimate);
+    if (input.refTsos.isValid()) {
+      ReferenceTrajectoryBase::Config config(materialEffects(), propagationDirection(), theMass, theMomentumEstimate);
       config.useBeamSpot = useBeamSpot_;
       config.includeAPEs = includeAPEs_;
       config.allowZeroMaterial = allowZeroMaterial_;
-      ReferenceTrajectoryPtr ptr(new DualBzeroReferenceTrajectory(input.refTsos,
-                                                                  input.fwdRecHits,
-                                                                  input.bwdRecHits,
-                                                                  magneticField.product(),
-                                                                  beamSpot,
-                                                                  config));
-      trajectories.push_back( ptr );
+      ReferenceTrajectoryPtr ptr(new DualBzeroReferenceTrajectory(
+          input.refTsos, input.fwdRecHits, input.bwdRecHits, magneticField.product(), beamSpot, config));
+      trajectories.push_back(ptr);
     }
 
     ++itTracks;
@@ -105,73 +88,57 @@ DualBzeroTrajectoryFactory::trajectories(const edm::EventSetup  &setup,
   return trajectories;
 }
 
-const DualBzeroTrajectoryFactory::ReferenceTrajectoryCollection
-DualBzeroTrajectoryFactory::trajectories(const edm::EventSetup &setup,
-					 const ConstTrajTrackPairCollection &tracks,
-					 const ExternalPredictionCollection &external,
-					 const reco::BeamSpot &beamSpot) const
-{
+const DualBzeroTrajectoryFactory::ReferenceTrajectoryCollection DualBzeroTrajectoryFactory::trajectories(
+    const edm::EventSetup &setup,
+    const ConstTrajTrackPairCollection &tracks,
+    const ExternalPredictionCollection &external,
+    const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
-  if ( tracks.size() != external.size() )
-  {
-    edm::LogInfo("ReferenceTrajectories") << "@SUB=DualBzeroTrajectoryFactory::trajectories"
-					  << "Inconsistent input:\n"
-					  << "\tnumber of tracks = " << tracks.size()
-					  << "\tnumber of external predictions = " << external.size();
+  if (tracks.size() != external.size()) {
+    edm::LogInfo("ReferenceTrajectories")
+        << "@SUB=DualBzeroTrajectoryFactory::trajectories"
+        << "Inconsistent input:\n"
+        << "\tnumber of tracks = " << tracks.size() << "\tnumber of external predictions = " << external.size();
     return trajectories;
   }
 
-  edm::ESHandle< MagneticField > magneticField;
-  setup.get< IdealMagneticFieldRecord >().get( magneticField );
+  edm::ESHandle<MagneticField> magneticField;
+  setup.get<IdealMagneticFieldRecord>().get(magneticField);
 
   ConstTrajTrackPairCollection::const_iterator itTracks = tracks.begin();
   ExternalPredictionCollection::const_iterator itExternal = external.begin();
 
-  while ( itTracks != tracks.end() )
-  {
-    const DualBzeroTrajectoryInput input = referenceStateAndRecHits( *itTracks );
+  while (itTracks != tracks.end()) {
+    const DualBzeroTrajectoryInput input = referenceStateAndRecHits(*itTracks);
     // Check input: If all hits were rejected, the TSOS is initialized as invalid.
-    if ( input.refTsos.isValid() )
-    {
-      if ( (*itExternal).isValid() )
-      {
-	TrajectoryStateOnSurface propExternal =
-	  propagateExternal( *itExternal, input.refTsos.surface(), magneticField.product() );
+    if (input.refTsos.isValid()) {
+      if ((*itExternal).isValid()) {
+        TrajectoryStateOnSurface propExternal =
+            propagateExternal(*itExternal, input.refTsos.surface(), magneticField.product());
 
-	if ( !propExternal.isValid() ) continue;
+        if (!propExternal.isValid())
+          continue;
 
-        ReferenceTrajectoryBase::Config config(materialEffects(), propagationDirection(),
-                                               theMass, theMomentumEstimate);
+        ReferenceTrajectoryBase::Config config(materialEffects(), propagationDirection(), theMass, theMomentumEstimate);
         config.useBeamSpot = useBeamSpot_;
         config.includeAPEs = includeAPEs_;
         config.allowZeroMaterial = allowZeroMaterial_;
-        ReferenceTrajectoryPtr ptr(new DualBzeroReferenceTrajectory(propExternal,
-                                                                    input.fwdRecHits,
-                                                                    input.bwdRecHits,
-                                                                    magneticField.product(),
-                                                                    beamSpot,
-                                                                    config));
+        ReferenceTrajectoryPtr ptr(new DualBzeroReferenceTrajectory(
+            propExternal, input.fwdRecHits, input.bwdRecHits, magneticField.product(), beamSpot, config));
 
-	AlgebraicSymMatrix externalParamErrors( asHepMatrix<5>( propExternal.localError().matrix() ) );
-	ptr->setParameterErrors( externalParamErrors.sub( 2, 5 ) );
-	trajectories.push_back( ptr );
-      }
-      else
-      {
-        ReferenceTrajectoryBase::Config config(materialEffects(), propagationDirection(),
-                                               theMass, theMomentumEstimate);
+        AlgebraicSymMatrix externalParamErrors(asHepMatrix<5>(propExternal.localError().matrix()));
+        ptr->setParameterErrors(externalParamErrors.sub(2, 5));
+        trajectories.push_back(ptr);
+      } else {
+        ReferenceTrajectoryBase::Config config(materialEffects(), propagationDirection(), theMass, theMomentumEstimate);
         config.useBeamSpot = useBeamSpot_;
         config.includeAPEs = includeAPEs_;
         config.allowZeroMaterial = allowZeroMaterial_;
-        ReferenceTrajectoryPtr ptr(new DualBzeroReferenceTrajectory(input.refTsos,
-                                                                    input.fwdRecHits,
-                                                                    input.bwdRecHits,
-                                                                    magneticField.product(),
-                                                                    beamSpot,
-                                                                    config));
+        ReferenceTrajectoryPtr ptr(new DualBzeroReferenceTrajectory(
+            input.refTsos, input.fwdRecHits, input.bwdRecHits, magneticField.product(), beamSpot, config));
 
-	trajectories.push_back( ptr );
+        trajectories.push_back(ptr);
       }
     }
 
@@ -182,64 +149,56 @@ DualBzeroTrajectoryFactory::trajectories(const edm::EventSetup &setup,
   return trajectories;
 }
 
-
-const DualBzeroTrajectoryFactory::DualBzeroTrajectoryInput
-DualBzeroTrajectoryFactory::referenceStateAndRecHits( const ConstTrajTrackPair& track ) const
-{
+const DualBzeroTrajectoryFactory::DualBzeroTrajectoryInput DualBzeroTrajectoryFactory::referenceStateAndRecHits(
+    const ConstTrajTrackPair &track) const {
   DualBzeroTrajectoryInput input;
- 
+
   // get the trajectory measurements in the correct order, i.e. reverse if needed
-  Trajectory::DataContainer allTrajMeas = this->orderedTrajectoryMeasurements( *track.first );
+  Trajectory::DataContainer allTrajMeas = this->orderedTrajectoryMeasurements(*track.first);
   Trajectory::DataContainer usedTrajMeas;
   Trajectory::DataContainer::iterator itM;
   // get all relevant trajectory measurements
-  for ( itM = allTrajMeas.begin(); itM != allTrajMeas.end(); itM++ )
-  {
-    if ( useRecHit( ( *itM ).recHit() ) ) usedTrajMeas.push_back( *itM );
+  for (itM = allTrajMeas.begin(); itM != allTrajMeas.end(); itM++) {
+    if (useRecHit((*itM).recHit()))
+      usedTrajMeas.push_back(*itM);
   }
 
   unsigned int iMeas = 0;
   unsigned int nMeas = usedTrajMeas.size();
-  unsigned int nRefStateMeas = nMeas/2;
+  unsigned int nRefStateMeas = nMeas / 2;
   // get the valid RecHits
-  for ( itM = usedTrajMeas.begin(); itM != usedTrajMeas.end(); itM++, iMeas++ )
-  {
-    TransientTrackingRecHit::ConstRecHitPointer aRecHit = ( *itM ).recHit();
+  for (itM = usedTrajMeas.begin(); itM != usedTrajMeas.end(); itM++, iMeas++) {
+    TransientTrackingRecHit::ConstRecHitPointer aRecHit = (*itM).recHit();
 
-    if ( iMeas < nRefStateMeas ) {
-      input.bwdRecHits.push_back( aRecHit );
-    } else if ( iMeas > nRefStateMeas ) {
-      input.fwdRecHits.push_back( aRecHit );
-    } else { // iMeas == nRefStateMeas
-      if ( ( *itM ).updatedState().isValid() )
-      {
-	input.refTsos = ( *itM ).updatedState();
-	input.bwdRecHits.push_back( aRecHit );
-	input.fwdRecHits.push_back( aRecHit );
+    if (iMeas < nRefStateMeas) {
+      input.bwdRecHits.push_back(aRecHit);
+    } else if (iMeas > nRefStateMeas) {
+      input.fwdRecHits.push_back(aRecHit);
+    } else {  // iMeas == nRefStateMeas
+      if ((*itM).updatedState().isValid()) {
+        input.refTsos = (*itM).updatedState();
+        input.bwdRecHits.push_back(aRecHit);
+        input.fwdRecHits.push_back(aRecHit);
       } else {
-	// if the tsos of the middle hit is not valid, try the next one ...
-	nRefStateMeas++;
-	input.bwdRecHits.push_back( aRecHit );
+        // if the tsos of the middle hit is not valid, try the next one ...
+        nRefStateMeas++;
+        input.bwdRecHits.push_back(aRecHit);
       }
     }
   }
 
   // bring input.fwdRecHits into correct order
-  std::reverse( input.bwdRecHits.begin(), input.bwdRecHits.end() );
+  std::reverse(input.bwdRecHits.begin(), input.bwdRecHits.end());
 
   return input;
 }
 
-const TrajectoryStateOnSurface
-DualBzeroTrajectoryFactory::propagateExternal( const TrajectoryStateOnSurface& external,
-					  const Surface& surface,
-					  const MagneticField* magField ) const
-{
-  AnalyticalPropagator propagator( magField, anyDirection );
-  const std::pair< TrajectoryStateOnSurface, double > tsosWithPath =
-    propagator.propagateWithPath( external, surface );
+const TrajectoryStateOnSurface DualBzeroTrajectoryFactory::propagateExternal(const TrajectoryStateOnSurface &external,
+                                                                             const Surface &surface,
+                                                                             const MagneticField *magField) const {
+  AnalyticalPropagator propagator(magField, anyDirection);
+  const std::pair<TrajectoryStateOnSurface, double> tsosWithPath = propagator.propagateWithPath(external, surface);
   return tsosWithPath.first;
 }
 
-
-DEFINE_EDM_PLUGIN( TrajectoryFactoryPlugin, DualBzeroTrajectoryFactory, "DualBzeroTrajectoryFactory" );
+DEFINE_EDM_PLUGIN(TrajectoryFactoryPlugin, DualBzeroTrajectoryFactory, "DualBzeroTrajectoryFactory");

--- a/Alignment/ReferenceTrajectories/plugins/DualTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/DualTrajectoryFactory.cc
@@ -2,40 +2,37 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h" 
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "Alignment/ReferenceTrajectories/interface/TrajectoryFactoryPlugin.h"
 #include "TrackingTools/GeomPropagators/interface/AnalyticalPropagator.h"
 
 #include <algorithm>
 
-#include "Alignment/ReferenceTrajectories/interface/DualReferenceTrajectory.h" 
+#include "Alignment/ReferenceTrajectories/interface/DualReferenceTrajectory.h"
 #include "Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h"
 
 /// A factory that produces instances of class ReferenceTrajectory from a given TrajTrackPairCollection.
 
-
-class DualTrajectoryFactory : public TrajectoryFactoryBase
-{
+class DualTrajectoryFactory : public TrajectoryFactoryBase {
 public:
   DualTrajectoryFactory(const edm::ParameterSet &config);
   ~DualTrajectoryFactory() override;
 
   /// Produce the reference trajectories.
-  const ReferenceTrajectoryCollection trajectories(const edm::EventSetup  &setup,
-							   const ConstTrajTrackPairCollection &tracks,
-							   const reco::BeamSpot &beamSpot) const override;
+  const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
+                                                   const ConstTrajTrackPairCollection &tracks,
+                                                   const reco::BeamSpot &beamSpot) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
-							   const ConstTrajTrackPairCollection &tracks,
-							   const ExternalPredictionCollection &external,
-							   const reco::BeamSpot &beamSpot) const override;
+                                                   const ConstTrajTrackPairCollection &tracks,
+                                                   const ExternalPredictionCollection &external,
+                                                   const reco::BeamSpot &beamSpot) const override;
 
-  DualTrajectoryFactory* clone() const override { return new DualTrajectoryFactory(*this); }
+  DualTrajectoryFactory *clone() const override { return new DualTrajectoryFactory(*this); }
 
 protected:
-  struct DualTrajectoryInput
-  {
+  struct DualTrajectoryInput {
     TrajectoryStateOnSurface refTsos;
     TransientTrackingRecHit::ConstRecHitContainer fwdRecHits;
     TransientTrackingRecHit::ConstRecHitContainer bwdRecHits;
@@ -44,8 +41,8 @@ protected:
   const DualTrajectoryInput referenceStateAndRecHits(const ConstTrajTrackPair &track) const;
 
   const TrajectoryStateOnSurface propagateExternal(const TrajectoryStateOnSurface &external,
-						   const Surface &surface,
-						   const MagneticField *magField) const;
+                                                   const Surface &surface,
+                                                   const MagneticField *magField) const;
 
   double theMass;
 };
@@ -54,53 +51,40 @@ protected:
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-DualTrajectoryFactory::DualTrajectoryFactory( const edm::ParameterSet & config ) :
-  TrajectoryFactoryBase( config ),
-  theMass(config.getParameter<double>("ParticleMass"))
-{
+DualTrajectoryFactory::DualTrajectoryFactory(const edm::ParameterSet &config)
+    : TrajectoryFactoryBase(config), theMass(config.getParameter<double>("ParticleMass")) {
   edm::LogInfo("Alignment") << "@SUB=DualTrajectoryFactory"
                             << "mass: " << theMass;
 }
 
- 
-DualTrajectoryFactory::~DualTrajectoryFactory( void ) {}
+DualTrajectoryFactory::~DualTrajectoryFactory(void) {}
 
-
-const DualTrajectoryFactory::ReferenceTrajectoryCollection
-DualTrajectoryFactory::trajectories(const edm::EventSetup &setup,
-				    const ConstTrajTrackPairCollection &tracks,
-				    const reco::BeamSpot &beamSpot) const
-{
+const DualTrajectoryFactory::ReferenceTrajectoryCollection DualTrajectoryFactory::trajectories(
+    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
-  edm::ESHandle< MagneticField > magneticField;
-  setup.get< IdealMagneticFieldRecord >().get( magneticField );
-  if (magneticField->inTesla(GlobalPoint(0.,0.,0.)).mag2() < 1.e-6) {
+  edm::ESHandle<MagneticField> magneticField;
+  setup.get<IdealMagneticFieldRecord>().get(magneticField);
+  if (magneticField->inTesla(GlobalPoint(0., 0., 0.)).mag2() < 1.e-6) {
     edm::LogWarning("Alignment") << "@SUB=DualTrajectoryFactory::trajectories"
-                                 << "B-field in z is " << magneticField->inTesla(GlobalPoint(0.,0.,0.)).z()
-                                 << ": You should probably use the DualBzeroTrajectoryFactory\n" 
+                                 << "B-field in z is " << magneticField->inTesla(GlobalPoint(0., 0., 0.)).z()
+                                 << ": You should probably use the DualBzeroTrajectoryFactory\n"
                                  << "or fix this code to switch automatically as the ReferenceTrajectoryFactory does.";
   }
 
   ConstTrajTrackPairCollection::const_iterator itTracks = tracks.begin();
 
-  while ( itTracks != tracks.end() )
-  { 
-    const DualTrajectoryInput input = this->referenceStateAndRecHits( *itTracks );
+  while (itTracks != tracks.end()) {
+    const DualTrajectoryInput input = this->referenceStateAndRecHits(*itTracks);
     // Check input: If all hits were rejected, the TSOS is initialized as invalid.
-    if ( input.refTsos.isValid() )
-    {
+    if (input.refTsos.isValid()) {
       ReferenceTrajectoryBase::Config config(materialEffects(), propagationDirection(), theMass);
       config.useBeamSpot = useBeamSpot_;
       config.includeAPEs = includeAPEs_;
       config.allowZeroMaterial = allowZeroMaterial_;
-      ReferenceTrajectoryPtr ptr(new DualReferenceTrajectory(input.refTsos,
-                                                             input.fwdRecHits,
-                                                             input.bwdRecHits,
-                                                             magneticField.product(),
-                                                             beamSpot,
-                                                             config));
-      trajectories.push_back( ptr );
+      ReferenceTrajectoryPtr ptr(new DualReferenceTrajectory(
+          input.refTsos, input.fwdRecHits, input.bwdRecHits, magneticField.product(), beamSpot, config));
+      trajectories.push_back(ptr);
     }
 
     ++itTracks;
@@ -109,76 +93,62 @@ DualTrajectoryFactory::trajectories(const edm::EventSetup &setup,
   return trajectories;
 }
 
-const DualTrajectoryFactory::ReferenceTrajectoryCollection
-DualTrajectoryFactory::trajectories(const edm::EventSetup &setup,
-				    const ConstTrajTrackPairCollection &tracks,
-				    const ExternalPredictionCollection &external,
-				    const reco::BeamSpot &beamSpot) const
-{
+const DualTrajectoryFactory::ReferenceTrajectoryCollection DualTrajectoryFactory::trajectories(
+    const edm::EventSetup &setup,
+    const ConstTrajTrackPairCollection &tracks,
+    const ExternalPredictionCollection &external,
+    const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
-  if ( tracks.size() != external.size() )
-  {
-    edm::LogInfo("ReferenceTrajectories") << "@SUB=DualTrajectoryFactory::trajectories"
-					  << "Inconsistent input:\n"
-					  << "\tnumber of tracks = " << tracks.size()
-					  << "\tnumber of external predictions = " << external.size();
+  if (tracks.size() != external.size()) {
+    edm::LogInfo("ReferenceTrajectories")
+        << "@SUB=DualTrajectoryFactory::trajectories"
+        << "Inconsistent input:\n"
+        << "\tnumber of tracks = " << tracks.size() << "\tnumber of external predictions = " << external.size();
     return trajectories;
   }
 
-  edm::ESHandle< MagneticField > magneticField;
-  setup.get< IdealMagneticFieldRecord >().get( magneticField );
-  if (magneticField->inTesla(GlobalPoint(0.,0.,0.)).mag2() < 1.e-6) {
+  edm::ESHandle<MagneticField> magneticField;
+  setup.get<IdealMagneticFieldRecord>().get(magneticField);
+  if (magneticField->inTesla(GlobalPoint(0., 0., 0.)).mag2() < 1.e-6) {
     edm::LogWarning("Alignment") << "@SUB=DualTrajectoryFactory::trajectories"
-                                 << "B-field in z is " << magneticField->inTesla(GlobalPoint(0.,0.,0.)).z()
-                                 << ": You should probably use the DualBzeroTrajectoryFactory\n" 
+                                 << "B-field in z is " << magneticField->inTesla(GlobalPoint(0., 0., 0.)).z()
+                                 << ": You should probably use the DualBzeroTrajectoryFactory\n"
                                  << "or fix this code to switch automatically as the ReferenceTrajectoryFactory does.";
   }
 
   ConstTrajTrackPairCollection::const_iterator itTracks = tracks.begin();
   ExternalPredictionCollection::const_iterator itExternal = external.begin();
 
-  while ( itTracks != tracks.end() )
-  {
-    const DualTrajectoryInput input = referenceStateAndRecHits( *itTracks );
+  while (itTracks != tracks.end()) {
+    const DualTrajectoryInput input = referenceStateAndRecHits(*itTracks);
     // Check input: If all hits were rejected, the TSOS is initialized as invalid.
-    if ( input.refTsos.isValid() )
-    {
-      if ( (*itExternal).isValid() )
-      {
-	TrajectoryStateOnSurface propExternal =
-	  propagateExternal( *itExternal, input.refTsos.surface(), magneticField.product() );
+    if (input.refTsos.isValid()) {
+      if ((*itExternal).isValid()) {
+        TrajectoryStateOnSurface propExternal =
+            propagateExternal(*itExternal, input.refTsos.surface(), magneticField.product());
 
-	if ( !propExternal.isValid() ) continue;
+        if (!propExternal.isValid())
+          continue;
 
         ReferenceTrajectoryBase::Config config(materialEffects(), propagationDirection(), theMass);
         config.useBeamSpot = useBeamSpot_;
         config.includeAPEs = includeAPEs_;
         config.allowZeroMaterial = allowZeroMaterial_;
-        ReferenceTrajectoryPtr ptr(new DualReferenceTrajectory(propExternal,
-                                                               input.fwdRecHits,
-                                                               input.bwdRecHits,
-                                                               magneticField.product(),
-                                                               beamSpot,
-                                                               config));
+        ReferenceTrajectoryPtr ptr(new DualReferenceTrajectory(
+            propExternal, input.fwdRecHits, input.bwdRecHits, magneticField.product(), beamSpot, config));
 
-	AlgebraicSymMatrix externalParamErrors( asHepMatrix<5>( propExternal.localError().matrix() ) );
-	ptr->setParameterErrors( externalParamErrors );
-	trajectories.push_back( ptr );
-      }
-      else
-      {
+        AlgebraicSymMatrix externalParamErrors(asHepMatrix<5>(propExternal.localError().matrix()));
+        ptr->setParameterErrors(externalParamErrors);
+        trajectories.push_back(ptr);
+      } else {
         ReferenceTrajectoryBase::Config config(materialEffects(), propagationDirection(), theMass);
         config.useBeamSpot = useBeamSpot_;
         config.includeAPEs = includeAPEs_;
         config.allowZeroMaterial = allowZeroMaterial_;
-        ReferenceTrajectoryPtr ptr(new DualReferenceTrajectory(input.refTsos,
-                                                               input.fwdRecHits,
-                                                               input.bwdRecHits,
-                                                               magneticField.product(),
-                                                               beamSpot,
-                                                               config));
-	trajectories.push_back( ptr );
+        ReferenceTrajectoryPtr ptr(new DualReferenceTrajectory(
+            input.refTsos, input.fwdRecHits, input.bwdRecHits, magneticField.product(), beamSpot, config));
+        trajectories.push_back(ptr);
       }
     }
 
@@ -189,64 +159,56 @@ DualTrajectoryFactory::trajectories(const edm::EventSetup &setup,
   return trajectories;
 }
 
-
-const DualTrajectoryFactory::DualTrajectoryInput
-DualTrajectoryFactory::referenceStateAndRecHits( const ConstTrajTrackPair& track ) const
-{
+const DualTrajectoryFactory::DualTrajectoryInput DualTrajectoryFactory::referenceStateAndRecHits(
+    const ConstTrajTrackPair &track) const {
   DualTrajectoryInput input;
- 
+
   // get the trajectory measurements in the correct order, i.e. reverse if needed
-  Trajectory::DataContainer allTrajMeas = this->orderedTrajectoryMeasurements( *track.first );
+  Trajectory::DataContainer allTrajMeas = this->orderedTrajectoryMeasurements(*track.first);
   Trajectory::DataContainer usedTrajMeas;
   Trajectory::DataContainer::iterator itM;
   // get all relevant trajectory measurements
-  for ( itM = allTrajMeas.begin(); itM != allTrajMeas.end(); itM++ )
-  {
-    if ( useRecHit( ( *itM ).recHit() ) ) usedTrajMeas.push_back( *itM );
+  for (itM = allTrajMeas.begin(); itM != allTrajMeas.end(); itM++) {
+    if (useRecHit((*itM).recHit()))
+      usedTrajMeas.push_back(*itM);
   }
 
   unsigned int iMeas = 0;
   unsigned int nMeas = usedTrajMeas.size();
-  unsigned int nRefStateMeas = nMeas/2;
+  unsigned int nRefStateMeas = nMeas / 2;
   // get the valid RecHits
-  for ( itM = usedTrajMeas.begin(); itM != usedTrajMeas.end(); itM++, iMeas++ )
-  {
-    TransientTrackingRecHit::ConstRecHitPointer aRecHit = ( *itM ).recHit();
+  for (itM = usedTrajMeas.begin(); itM != usedTrajMeas.end(); itM++, iMeas++) {
+    TransientTrackingRecHit::ConstRecHitPointer aRecHit = (*itM).recHit();
 
-    if ( iMeas < nRefStateMeas ) {
-      input.bwdRecHits.push_back( aRecHit );
-    } else if ( iMeas > nRefStateMeas ) {
-      input.fwdRecHits.push_back( aRecHit );
-    } else { // iMeas == nRefStateMeas
-      if ( ( *itM ).updatedState().isValid() )
-      {
-	input.refTsos = ( *itM ).updatedState();
-	input.bwdRecHits.push_back( aRecHit );
-	input.fwdRecHits.push_back( aRecHit );
+    if (iMeas < nRefStateMeas) {
+      input.bwdRecHits.push_back(aRecHit);
+    } else if (iMeas > nRefStateMeas) {
+      input.fwdRecHits.push_back(aRecHit);
+    } else {  // iMeas == nRefStateMeas
+      if ((*itM).updatedState().isValid()) {
+        input.refTsos = (*itM).updatedState();
+        input.bwdRecHits.push_back(aRecHit);
+        input.fwdRecHits.push_back(aRecHit);
       } else {
-	// if the tsos of the middle hit is not valid, try the next one ...
-	nRefStateMeas++;
-	input.bwdRecHits.push_back( aRecHit );
+        // if the tsos of the middle hit is not valid, try the next one ...
+        nRefStateMeas++;
+        input.bwdRecHits.push_back(aRecHit);
       }
     }
   }
 
   // bring input.fwdRecHits into correct order
-  std::reverse( input.bwdRecHits.begin(), input.bwdRecHits.end() );
+  std::reverse(input.bwdRecHits.begin(), input.bwdRecHits.end());
 
   return input;
 }
 
-const TrajectoryStateOnSurface
-DualTrajectoryFactory::propagateExternal( const TrajectoryStateOnSurface& external,
-					  const Surface& surface,
-					  const MagneticField* magField ) const
-{
-  AnalyticalPropagator propagator( magField, anyDirection );
-  const std::pair< TrajectoryStateOnSurface, double > tsosWithPath =
-    propagator.propagateWithPath( external, surface );
+const TrajectoryStateOnSurface DualTrajectoryFactory::propagateExternal(const TrajectoryStateOnSurface &external,
+                                                                        const Surface &surface,
+                                                                        const MagneticField *magField) const {
+  AnalyticalPropagator propagator(magField, anyDirection);
+  const std::pair<TrajectoryStateOnSurface, double> tsosWithPath = propagator.propagateWithPath(external, surface);
   return tsosWithPath.first;
 }
 
-
-DEFINE_EDM_PLUGIN( TrajectoryFactoryPlugin, DualTrajectoryFactory, "DualTrajectoryFactory" );
+DEFINE_EDM_PLUGIN(TrajectoryFactoryPlugin, DualTrajectoryFactory, "DualTrajectoryFactory");

--- a/Alignment/ReferenceTrajectories/plugins/ReferenceTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/ReferenceTrajectoryFactory.cc
@@ -4,10 +4,10 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h" 
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "Alignment/ReferenceTrajectories/interface/TrajectoryFactoryPlugin.h"
-#include "Alignment/ReferenceTrajectories/interface/ReferenceTrajectory.h" 
+#include "Alignment/ReferenceTrajectories/interface/ReferenceTrajectory.h"
 
 #include "Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h"
 
@@ -17,30 +17,29 @@
 /// If |B| = 0 T and configuration parameter UseBzeroIfFieldOff is True,
 /// hand-over to the BzeroReferenceTrajectoryFactory.
 
-class ReferenceTrajectoryFactory : public TrajectoryFactoryBase
-{
+class ReferenceTrajectoryFactory : public TrajectoryFactoryBase {
 public:
   ReferenceTrajectoryFactory(const edm::ParameterSet &config);
   ~ReferenceTrajectoryFactory() override;
 
   /// Produce the reference trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
-							   const ConstTrajTrackPairCollection &tracks,
-							   const reco::BeamSpot &beamSpot) const override;
+                                                   const ConstTrajTrackPairCollection &tracks,
+                                                   const reco::BeamSpot &beamSpot) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
-							   const ConstTrajTrackPairCollection &tracks,
-							   const ExternalPredictionCollection &external,
-							   const reco::BeamSpot &beamSpot) const override;
+                                                   const ConstTrajTrackPairCollection &tracks,
+                                                   const ExternalPredictionCollection &external,
+                                                   const reco::BeamSpot &beamSpot) const override;
 
-  ReferenceTrajectoryFactory* clone() const override { return new ReferenceTrajectoryFactory(*this); }
+  ReferenceTrajectoryFactory *clone() const override { return new ReferenceTrajectoryFactory(*this); }
 
 protected:
   ReferenceTrajectoryFactory(const ReferenceTrajectoryFactory &other);
   const TrajectoryFactoryBase *bzeroFactory() const;
 
   double theMass;
-  bool   theUseBzeroIfFieldOff;
+  bool theUseBzeroIfFieldOff;
   mutable const TrajectoryFactoryBase *theBzeroFactory;
 };
 
@@ -48,63 +47,50 @@ protected:
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-ReferenceTrajectoryFactory::ReferenceTrajectoryFactory( const edm::ParameterSet & config ) :
-  TrajectoryFactoryBase( config ),
-  theMass(config.getParameter<double>("ParticleMass")),
-  theUseBzeroIfFieldOff(config.getParameter<bool>("UseBzeroIfFieldOff")),
-  theBzeroFactory(nullptr)
-{
+ReferenceTrajectoryFactory::ReferenceTrajectoryFactory(const edm::ParameterSet &config)
+    : TrajectoryFactoryBase(config),
+      theMass(config.getParameter<double>("ParticleMass")),
+      theUseBzeroIfFieldOff(config.getParameter<bool>("UseBzeroIfFieldOff")),
+      theBzeroFactory(nullptr) {
   edm::LogInfo("Alignment") << "@SUB=ReferenceTrajectoryFactory"
                             << "mass: " << theMass
-                            << "\nusing Bzero if |B| = 0: " 
-                            << (theUseBzeroIfFieldOff ? "yes" : "no");
+                            << "\nusing Bzero if |B| = 0: " << (theUseBzeroIfFieldOff ? "yes" : "no");
 }
 
-ReferenceTrajectoryFactory::ReferenceTrajectoryFactory(const ReferenceTrajectoryFactory &other) :
-  TrajectoryFactoryBase(other),
-  theMass(other.theMass),
-  theUseBzeroIfFieldOff(other.theUseBzeroIfFieldOff),
-  theBzeroFactory(nullptr) // copy data members, but no double pointing to same Bzero factory...
-{
-}
- 
-ReferenceTrajectoryFactory::~ReferenceTrajectoryFactory( void )
-{
-  delete theBzeroFactory;
-}
+ReferenceTrajectoryFactory::ReferenceTrajectoryFactory(const ReferenceTrajectoryFactory &other)
+    : TrajectoryFactoryBase(other),
+      theMass(other.theMass),
+      theUseBzeroIfFieldOff(other.theUseBzeroIfFieldOff),
+      theBzeroFactory(nullptr)  // copy data members, but no double pointing to same Bzero factory...
+{}
 
+ReferenceTrajectoryFactory::~ReferenceTrajectoryFactory(void) { delete theBzeroFactory; }
 
-const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection
-ReferenceTrajectoryFactory::trajectories(const edm::EventSetup &setup,
-					 const ConstTrajTrackPairCollection &tracks,
-					 const reco::BeamSpot &beamSpot) const
-{
-  edm::ESHandle< MagneticField > magneticField;
-  setup.get< IdealMagneticFieldRecord >().get( magneticField );
-  if (theUseBzeroIfFieldOff && magneticField->inTesla(GlobalPoint(0.,0.,0.)).mag2() < 1.e-6) {
+const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTrajectoryFactory::trajectories(
+    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
+  edm::ESHandle<MagneticField> magneticField;
+  setup.get<IdealMagneticFieldRecord>().get(magneticField);
+  if (theUseBzeroIfFieldOff && magneticField->inTesla(GlobalPoint(0., 0., 0.)).mag2() < 1.e-6) {
     return this->bzeroFactory()->trajectories(setup, tracks, beamSpot);
   }
 
   ReferenceTrajectoryCollection trajectories;
 
   ConstTrajTrackPairCollection::const_iterator itTracks = tracks.begin();
-  
-  while ( itTracks != tracks.end() )
-  { 
-    TrajectoryInput input = this->innermostStateAndRecHits( *itTracks );
-    
+
+  while (itTracks != tracks.end()) {
+    TrajectoryInput input = this->innermostStateAndRecHits(*itTracks);
+
     // Check input: If all hits were rejected, the TSOS is initialized as invalid.
-    if ( input.first.isValid() )
-    {
+    if (input.first.isValid()) {
       ReferenceTrajectoryBase::Config config(materialEffects(), propagationDirection(), theMass);
       config.useBeamSpot = useBeamSpot_;
       config.includeAPEs = includeAPEs_;
       config.allowZeroMaterial = allowZeroMaterial_;
       // set the flag for reversing the RecHits to false, since they are already in the correct order.
       config.hitsAreReverse = false;
-      trajectories.push_back(ReferenceTrajectoryPtr(new ReferenceTrajectory(input.first, input.second,
-                                                                            magneticField.product(),
-                                                                            beamSpot, config)));
+      trajectories.push_back(ReferenceTrajectoryPtr(
+          new ReferenceTrajectory(input.first, input.second, magneticField.product(), beamSpot, config)));
     }
 
     ++itTracks;
@@ -113,82 +99,71 @@ ReferenceTrajectoryFactory::trajectories(const edm::EventSetup &setup,
   return trajectories;
 }
 
-
-const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection
-ReferenceTrajectoryFactory::trajectories( const edm::EventSetup & setup,
-					  const ConstTrajTrackPairCollection& tracks,
-					  const ExternalPredictionCollection& external,
-					  const reco::BeamSpot &beamSpot) const
-{
+const ReferenceTrajectoryFactory::ReferenceTrajectoryCollection ReferenceTrajectoryFactory::trajectories(
+    const edm::EventSetup &setup,
+    const ConstTrajTrackPairCollection &tracks,
+    const ExternalPredictionCollection &external,
+    const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
-  if ( tracks.size() != external.size() )
-  {
-    edm::LogInfo("ReferenceTrajectories") << "@SUB=ReferenceTrajectoryFactory::trajectories"
-					  << "Inconsistent input:\n"
-					  << "\tnumber of tracks = " << tracks.size()
-					  << "\tnumber of external predictions = " << external.size();
+  if (tracks.size() != external.size()) {
+    edm::LogInfo("ReferenceTrajectories")
+        << "@SUB=ReferenceTrajectoryFactory::trajectories"
+        << "Inconsistent input:\n"
+        << "\tnumber of tracks = " << tracks.size() << "\tnumber of external predictions = " << external.size();
     return trajectories;
   }
 
-  edm::ESHandle< MagneticField > magneticField;
-  setup.get< IdealMagneticFieldRecord >().get( magneticField );
-  if (theUseBzeroIfFieldOff && magneticField->inTesla(GlobalPoint(0.,0.,0.)).mag2() < 1.e-6) {
+  edm::ESHandle<MagneticField> magneticField;
+  setup.get<IdealMagneticFieldRecord>().get(magneticField);
+  if (theUseBzeroIfFieldOff && magneticField->inTesla(GlobalPoint(0., 0., 0.)).mag2() < 1.e-6) {
     return this->bzeroFactory()->trajectories(setup, tracks, external, beamSpot);
   }
 
   ConstTrajTrackPairCollection::const_iterator itTracks = tracks.begin();
   ExternalPredictionCollection::const_iterator itExternal = external.begin();
 
-  while ( itTracks != tracks.end() )
-  {
-    TrajectoryInput input = innermostStateAndRecHits( *itTracks );
+  while (itTracks != tracks.end()) {
+    TrajectoryInput input = innermostStateAndRecHits(*itTracks);
     // Check input: If all hits were rejected, the TSOS is initialized as invalid.
-    if ( input.first.isValid() )
-    {
-      if ( (*itExternal).isValid() && sameSurface( (*itExternal).surface(), input.first.surface() ) )
-      {
+    if (input.first.isValid()) {
+      if ((*itExternal).isValid() && sameSurface((*itExternal).surface(), input.first.surface())) {
         ReferenceTrajectoryBase::Config config(materialEffects(), propagationDirection(), theMass);
         config.useBeamSpot = useBeamSpot_;
         config.includeAPEs = includeAPEs_;
         config.allowZeroMaterial = allowZeroMaterial_;
         // set the flag for reversing the RecHits to false, since they are already in the correct order.
         config.hitsAreReverse = false;
-        ReferenceTrajectoryPtr refTraj(new ReferenceTrajectory(*itExternal, input.second,
-                                                               magneticField.product(),
-                                                               beamSpot, config));
+        ReferenceTrajectoryPtr refTraj(
+            new ReferenceTrajectory(*itExternal, input.second, magneticField.product(), beamSpot, config));
 
-        AlgebraicSymMatrix externalParamErrors( asHepMatrix<5>( (*itExternal).localError().matrix() ) );
-        refTraj->setParameterErrors( externalParamErrors );
-	trajectories.push_back( refTraj );
-      }
-      else
-      {
+        AlgebraicSymMatrix externalParamErrors(asHepMatrix<5>((*itExternal).localError().matrix()));
+        refTraj->setParameterErrors(externalParamErrors);
+        trajectories.push_back(refTraj);
+      } else {
         ReferenceTrajectoryBase::Config config(materialEffects(), propagationDirection(), theMass);
         config.useBeamSpot = useBeamSpot_;
         config.includeAPEs = includeAPEs_;
         config.allowZeroMaterial = allowZeroMaterial_;
         config.hitsAreReverse = false;
-        trajectories.push_back(ReferenceTrajectoryPtr(new ReferenceTrajectory(input.first, input.second,
-                                                                              magneticField.product(),
-                                                                              beamSpot, config)));
+        trajectories.push_back(ReferenceTrajectoryPtr(
+            new ReferenceTrajectory(input.first, input.second, magneticField.product(), beamSpot, config)));
       }
     }
-    
+
     ++itTracks;
     ++itExternal;
   }
-  
+
   return trajectories;
 }
 
-const TrajectoryFactoryBase *ReferenceTrajectoryFactory::bzeroFactory() const
-{
+const TrajectoryFactoryBase *ReferenceTrajectoryFactory::bzeroFactory() const {
   if (!theBzeroFactory) {
     const edm::ParameterSet &myPset = this->configuration();
     edm::LogInfo("Alignment") << "@SUB=ReferenceTrajectoryFactory::bzeroFactory"
-			      << "Using BzeroReferenceTrajectoryFactory for some (all?) events.";
-    // We take the config of this factory, copy it, replace its name and add 
+                              << "Using BzeroReferenceTrajectoryFactory for some (all?) events.";
+    // We take the config of this factory, copy it, replace its name and add
     // the momentum parameter as expected by BzeroReferenceTrajectoryFactory and create it:
     edm::ParameterSet pset;
     pset.copyForModify(myPset);
@@ -201,4 +176,4 @@ const TrajectoryFactoryBase *ReferenceTrajectoryFactory::bzeroFactory() const
   return theBzeroFactory;
 }
 
-DEFINE_EDM_PLUGIN( TrajectoryFactoryPlugin, ReferenceTrajectoryFactory, "ReferenceTrajectoryFactory" );
+DEFINE_EDM_PLUGIN(TrajectoryFactoryPlugin, ReferenceTrajectoryFactory, "ReferenceTrajectoryFactory");

--- a/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/TwoBodyDecayTrajectoryFactory.cc
@@ -1,20 +1,19 @@
-#include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h" 
-#include "DataFormats/GeometrySurface/interface/Surface.h" 
-#include "DataFormats/CLHEP/interface/AlgebraicObjects.h" 
-#include "DataFormats/Math/interface/Vector.h" 
-#include "DataFormats/Math/interface/Error.h" 
-#include "RecoVertex/VertexTools/interface/PerigeeLinearizedTrackState.h" 
+#include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
+#include "DataFormats/GeometrySurface/interface/Surface.h"
+#include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
+#include "DataFormats/Math/interface/Vector.h"
+#include "DataFormats/Math/interface/Error.h"
+#include "RecoVertex/VertexTools/interface/PerigeeLinearizedTrackState.h"
 #include "Alignment/ReferenceTrajectories/interface/TrajectoryFactoryPlugin.h"
 
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 
 #include "Geometry/CommonDetUnit/interface/TrackerGeomDet.h"
 
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h" 
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
 
 #include "Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h"
 #include "Alignment/ReferenceTrajectories/interface/TwoBodyDecayTrajectory.h"
@@ -26,10 +25,8 @@
    extension for BreakPoints or BrokenLines by Claus Kleinwort
  */
 
-class TwoBodyDecayTrajectoryFactory : public TrajectoryFactoryBase
-{
+class TwoBodyDecayTrajectoryFactory : public TrajectoryFactoryBase {
 public:
-
   typedef TwoBodyDecayVirtualMeasurement VirtualMeasurement;
   typedef TwoBodyDecayTrajectoryState::TsosContainer TsosContainer;
   typedef TwoBodyDecayTrajectory::ConstRecHitCollection ConstRecHitCollection;
@@ -39,26 +36,25 @@ public:
 
   /// Produce the trajectories.
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
-							   const ConstTrajTrackPairCollection &tracks,
-							   const reco::BeamSpot &beamSpot) const override;
+                                                   const ConstTrajTrackPairCollection &tracks,
+                                                   const reco::BeamSpot &beamSpot) const override;
 
   const ReferenceTrajectoryCollection trajectories(const edm::EventSetup &setup,
-							   const ConstTrajTrackPairCollection &tracks,
-							   const ExternalPredictionCollection &external,
-							   const reco::BeamSpot &beamSpot) const override;
+                                                   const ConstTrajTrackPairCollection &tracks,
+                                                   const ExternalPredictionCollection &external,
+                                                   const reco::BeamSpot &beamSpot) const override;
 
-  TwoBodyDecayTrajectoryFactory* clone() const override { return new TwoBodyDecayTrajectoryFactory(*this); }
+  TwoBodyDecayTrajectoryFactory *clone() const override { return new TwoBodyDecayTrajectoryFactory(*this); }
 
 protected:
   const ReferenceTrajectoryCollection constructTrajectories(const ConstTrajTrackPairCollection &tracks,
-							    const TwoBodyDecay &tbd,
-							    const MagneticField *magField,
-							    const reco::BeamSpot &beamSpot,
-							    bool setParameterErrors) const;
+                                                            const TwoBodyDecay &tbd,
+                                                            const MagneticField *magField,
+                                                            const reco::BeamSpot &beamSpot,
+                                                            bool setParameterErrors) const;
 
-  bool match(const TrajectoryStateOnSurface &state,
-	     const TransientTrackingRecHit::ConstRecHitPointer &recHit) const;
-    
+  bool match(const TrajectoryStateOnSurface &state, const TransientTrackingRecHit::ConstRecHitPointer &recHit) const;
+
   TwoBodyDecayFitter theFitter;
 
   double thePrimaryMass;
@@ -69,152 +65,130 @@ protected:
   double theChi2CutValue;
   bool theUseRefittedStateFlag;
   bool theConstructTsosWithErrorsFlag;
-
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-TwoBodyDecayTrajectoryFactory::TwoBodyDecayTrajectoryFactory( const edm::ParameterSet& config )
-  : TrajectoryFactoryBase(config, 2),
-    theFitter(config)
-{
-  const edm::ParameterSet ppc = config.getParameter< edm::ParameterSet >( "ParticleProperties" );
-  thePrimaryMass = ppc.getParameter< double >( "PrimaryMass" );
-  thePrimaryWidth = ppc.getParameter< double >( "PrimaryWidth" );
-  theSecondaryMass = ppc.getParameter< double >( "SecondaryMass" );
+TwoBodyDecayTrajectoryFactory::TwoBodyDecayTrajectoryFactory(const edm::ParameterSet &config)
+    : TrajectoryFactoryBase(config, 2), theFitter(config) {
+  const edm::ParameterSet ppc = config.getParameter<edm::ParameterSet>("ParticleProperties");
+  thePrimaryMass = ppc.getParameter<double>("PrimaryMass");
+  thePrimaryWidth = ppc.getParameter<double>("PrimaryWidth");
+  theSecondaryMass = ppc.getParameter<double>("SecondaryMass");
 
-  theNSigmaCutValue = config.getParameter< double >( "NSigmaCut" );
-  theChi2CutValue = config.getParameter< double >( "Chi2Cut" );
-  theUseRefittedStateFlag = config.getParameter< bool >( "UseRefittedState" );
-  theConstructTsosWithErrorsFlag = config.getParameter< bool >( "ConstructTsosWithErrors" );
+  theNSigmaCutValue = config.getParameter<double>("NSigmaCut");
+  theChi2CutValue = config.getParameter<double>("Chi2Cut");
+  theUseRefittedStateFlag = config.getParameter<bool>("UseRefittedState");
+  theConstructTsosWithErrorsFlag = config.getParameter<bool>("ConstructTsosWithErrors");
 }
 
-TwoBodyDecayTrajectoryFactory::~TwoBodyDecayTrajectoryFactory()
-{
-}
+TwoBodyDecayTrajectoryFactory::~TwoBodyDecayTrajectoryFactory() {}
 
-const TrajectoryFactoryBase::ReferenceTrajectoryCollection
-TwoBodyDecayTrajectoryFactory::trajectories(const edm::EventSetup &setup,
-					    const ConstTrajTrackPairCollection &tracks,
-					    const reco::BeamSpot &beamSpot) const
-{
+const TrajectoryFactoryBase::ReferenceTrajectoryCollection TwoBodyDecayTrajectoryFactory::trajectories(
+    const edm::EventSetup &setup, const ConstTrajTrackPairCollection &tracks, const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
-  edm::ESHandle< MagneticField > magneticField;
-  setup.get< IdealMagneticFieldRecord >().get( magneticField );
+  edm::ESHandle<MagneticField> magneticField;
+  setup.get<IdealMagneticFieldRecord>().get(magneticField);
 
-  if ( tracks.size() == 2 )
-  {
+  if (tracks.size() == 2) {
     // produce transient tracks from persistent tracks
-    std::vector< reco::TransientTrack > transientTracks( 2 );
+    std::vector<reco::TransientTrack> transientTracks(2);
 
-    transientTracks[0] = reco::TransientTrack( *tracks[0].second, magneticField.product() );
-    transientTracks[0].setES( setup );
+    transientTracks[0] = reco::TransientTrack(*tracks[0].second, magneticField.product());
+    transientTracks[0].setES(setup);
 
-    transientTracks[1] = reco::TransientTrack( *tracks[1].second, magneticField.product() );
-    transientTracks[1].setES( setup );
+    transientTracks[1] = reco::TransientTrack(*tracks[1].second, magneticField.product());
+    transientTracks[1].setES(setup);
 
     // estimate the decay parameters
-    VirtualMeasurement vm( thePrimaryMass, thePrimaryWidth, theSecondaryMass, beamSpot );
-    TwoBodyDecay tbd = theFitter.estimate( transientTracks, vm );
+    VirtualMeasurement vm(thePrimaryMass, thePrimaryWidth, theSecondaryMass, beamSpot);
+    TwoBodyDecay tbd = theFitter.estimate(transientTracks, vm);
 
-    if ( !tbd.isValid() || ( tbd.chi2() > theChi2CutValue ) )
-    {
-      trajectories.push_back( ReferenceTrajectoryPtr( new TwoBodyDecayTrajectory() ) );
+    if (!tbd.isValid() || (tbd.chi2() > theChi2CutValue)) {
+      trajectories.push_back(ReferenceTrajectoryPtr(new TwoBodyDecayTrajectory()));
       return trajectories;
     }
 
-    return constructTrajectories( tracks, tbd, magneticField.product(), beamSpot, false );
-  }
-  else
-  {
-    edm::LogInfo( "ReferenceTrajectories" ) << "@SUB=TwoBodyDecayTrajectoryFactory::trajectories"
-					    << "Need 2 tracks, got " << tracks.size() << ".\n";
+    return constructTrajectories(tracks, tbd, magneticField.product(), beamSpot, false);
+  } else {
+    edm::LogInfo("ReferenceTrajectories") << "@SUB=TwoBodyDecayTrajectoryFactory::trajectories"
+                                          << "Need 2 tracks, got " << tracks.size() << ".\n";
   }
 
   return trajectories;
 }
 
-
-const TrajectoryFactoryBase::ReferenceTrajectoryCollection
-TwoBodyDecayTrajectoryFactory::trajectories(const edm::EventSetup &setup,
-					    const ConstTrajTrackPairCollection &tracks,
-					    const ExternalPredictionCollection &external,
-					    const reco::BeamSpot &beamSpot) const
-{
+const TrajectoryFactoryBase::ReferenceTrajectoryCollection TwoBodyDecayTrajectoryFactory::trajectories(
+    const edm::EventSetup &setup,
+    const ConstTrajTrackPairCollection &tracks,
+    const ExternalPredictionCollection &external,
+    const reco::BeamSpot &beamSpot) const {
   ReferenceTrajectoryCollection trajectories;
 
-  edm::ESHandle< MagneticField > magneticField;
-  setup.get< IdealMagneticFieldRecord >().get( magneticField );
+  edm::ESHandle<MagneticField> magneticField;
+  setup.get<IdealMagneticFieldRecord>().get(magneticField);
 
-  if ( tracks.size() == 2 && external.size() == 2 )
-  {
-    if ( external[0].isValid() && external[1].isValid() ) // Include external estimates
+  if (tracks.size() == 2 && external.size() == 2) {
+    if (external[0].isValid() && external[1].isValid())  // Include external estimates
     {
       // produce transient tracks from persistent tracks
-      std::vector< reco::TransientTrack > transientTracks( 2 );
+      std::vector<reco::TransientTrack> transientTracks(2);
 
-      transientTracks[0] = reco::TransientTrack( *tracks[0].second, magneticField.product() );
-      transientTracks[0].setES( setup );
+      transientTracks[0] = reco::TransientTrack(*tracks[0].second, magneticField.product());
+      transientTracks[0].setES(setup);
 
-      transientTracks[1] = reco::TransientTrack( *tracks[1].second, magneticField.product() );
-      transientTracks[1].setES( setup );
+      transientTracks[1] = reco::TransientTrack(*tracks[1].second, magneticField.product());
+      transientTracks[1].setES(setup);
 
       // estimate the decay parameters. the transient tracks are not really associated to the
       // the external tsos, but this is o.k., because the only information retrieved from them
       // is the magnetic field.
-      VirtualMeasurement vm( thePrimaryMass, thePrimaryWidth, theSecondaryMass, beamSpot );
+      VirtualMeasurement vm(thePrimaryMass, thePrimaryWidth, theSecondaryMass, beamSpot);
       TwoBodyDecay tbd = theFitter.estimate(transientTracks, external, vm);
 
-      if ( !tbd.isValid()  || ( tbd.chi2() > theChi2CutValue ) )
-      {
-	trajectories.push_back( ReferenceTrajectoryPtr( new TwoBodyDecayTrajectory() ) );
-	return trajectories;
+      if (!tbd.isValid() || (tbd.chi2() > theChi2CutValue)) {
+        trajectories.push_back(ReferenceTrajectoryPtr(new TwoBodyDecayTrajectory()));
+        return trajectories;
       }
 
-      return constructTrajectories( tracks, tbd, magneticField.product(), beamSpot, true );
-    }
-    else
-    {
+      return constructTrajectories(tracks, tbd, magneticField.product(), beamSpot, true);
+    } else {
       // Return without external estimate
       trajectories = this->trajectories(setup, tracks, beamSpot);
     }
-  }
-  else
-  {
-    edm::LogInfo( "ReferenceTrajectories" ) << "@SUB=TwoBodyDecayTrajectoryFactory::trajectories"
-					    << "Need 2 tracks, got " << tracks.size() << ".\n";
+  } else {
+    edm::LogInfo("ReferenceTrajectories") << "@SUB=TwoBodyDecayTrajectoryFactory::trajectories"
+                                          << "Need 2 tracks, got " << tracks.size() << ".\n";
   }
 
   return trajectories;
 }
 
-
-const TwoBodyDecayTrajectoryFactory::ReferenceTrajectoryCollection
-TwoBodyDecayTrajectoryFactory::constructTrajectories( const ConstTrajTrackPairCollection& tracks,
-						      const TwoBodyDecay& tbd,
-						      const MagneticField* magField,
-						      const reco::BeamSpot &beamSpot,
-						      bool setParameterErrors ) const
-{
+const TwoBodyDecayTrajectoryFactory::ReferenceTrajectoryCollection TwoBodyDecayTrajectoryFactory::constructTrajectories(
+    const ConstTrajTrackPairCollection &tracks,
+    const TwoBodyDecay &tbd,
+    const MagneticField *magField,
+    const reco::BeamSpot &beamSpot,
+    bool setParameterErrors) const {
   ReferenceTrajectoryCollection trajectories;
 
   // get innermost valid trajectory state and hits from the tracks
-  TrajectoryInput input1 = this->innermostStateAndRecHits( tracks[0] );
-  TrajectoryInput input2 = this->innermostStateAndRecHits( tracks[1] );
+  TrajectoryInput input1 = this->innermostStateAndRecHits(tracks[0]);
+  TrajectoryInput input2 = this->innermostStateAndRecHits(tracks[1]);
 
-  if ( !( input1.first.isValid() && input2.first.isValid() ) ) return trajectories;
+  if (!(input1.first.isValid() && input2.first.isValid()))
+    return trajectories;
 
   // produce TwoBodyDecayTrajectoryState (input for TwoBodyDecayTrajectory)
-  TsosContainer tsos( input1.first, input2.first );
-  ConstRecHitCollection recHits( input1.second, input2.second );
-  TwoBodyDecayTrajectoryState trajectoryState( tsos, tbd, theSecondaryMass, magField );
+  TsosContainer tsos(input1.first, input2.first);
+  ConstRecHitCollection recHits(input1.second, input2.second);
+  TwoBodyDecayTrajectoryState trajectoryState(tsos, tbd, theSecondaryMass, magField);
 
-  if ( !trajectoryState.isValid() )
-  {
-    trajectories.push_back( ReferenceTrajectoryPtr( new TwoBodyDecayTrajectory() ) );
+  if (!trajectoryState.isValid()) {
+    trajectories.push_back(ReferenceTrajectoryPtr(new TwoBodyDecayTrajectory()));
     return trajectories;
   }
 
@@ -223,19 +197,15 @@ TwoBodyDecayTrajectoryFactory::constructTrajectories( const ConstTrajTrackPairCo
   //TrackingRecHit::ConstRecHitPointer updatedRecHit1( recHits.first.front()->clone( tsos.first ) );
   // TrackingRecHit::ConstRecHitPointer updatedRecHit2( recHits.second.front()->clone( tsos.second ) );
 
-  TrackingRecHit::ConstRecHitPointer updatedRecHit1( recHits.first.front() );
-  TrackingRecHit::ConstRecHitPointer updatedRecHit2( recHits.second.front() );
+  TrackingRecHit::ConstRecHitPointer updatedRecHit1(recHits.first.front());
+  TrackingRecHit::ConstRecHitPointer updatedRecHit2(recHits.second.front());
 
+  bool valid1 = match(trajectoryState.trajectoryStates(true).first, updatedRecHit1);
 
-  bool valid1 = match( trajectoryState.trajectoryStates( true ).first,
-		       updatedRecHit1 );
+  bool valid2 = match(trajectoryState.trajectoryStates(true).second, updatedRecHit2);
 
-  bool valid2 = match( trajectoryState.trajectoryStates( true ).second,
-		       updatedRecHit2 );
-
-  if ( !valid1 || !valid2 )
-  {
-    trajectories.push_back( ReferenceTrajectoryPtr( new TwoBodyDecayTrajectory() ) );
+  if (!valid1 || !valid2) {
+    trajectories.push_back(ReferenceTrajectoryPtr(new TwoBodyDecayTrajectory()));
     return trajectories;
   }
 
@@ -247,20 +217,15 @@ TwoBodyDecayTrajectoryFactory::constructTrajectories( const ConstTrajTrackPairCo
   config.constructTsosWithErrors = theConstructTsosWithErrorsFlag;
   // set the flag for reversing the RecHits to false, since they are already in the correct order.
   config.hitsAreReverse = false;
-  TwoBodyDecayTrajectory* result = new TwoBodyDecayTrajectory(trajectoryState,
-                                                              recHits,
-                                                              magField,
-                                                              beamSpot,
-                                                              config);
-  if ( setParameterErrors && tbd.hasError() ) result->setParameterErrors( tbd.covariance() );
-  trajectories.push_back( ReferenceTrajectoryPtr( result ) );
+  TwoBodyDecayTrajectory *result = new TwoBodyDecayTrajectory(trajectoryState, recHits, magField, beamSpot, config);
+  if (setParameterErrors && tbd.hasError())
+    result->setParameterErrors(tbd.covariance());
+  trajectories.push_back(ReferenceTrajectoryPtr(result));
   return trajectories;
 }
 
-
-bool TwoBodyDecayTrajectoryFactory::match( const TrajectoryStateOnSurface& state,
-					   const TransientTrackingRecHit::ConstRecHitPointer& recHit ) const
-{
+bool TwoBodyDecayTrajectoryFactory::match(const TrajectoryStateOnSurface &state,
+                                          const TransientTrackingRecHit::ConstRecHitPointer &recHit) const {
   LocalPoint lp1 = state.localPosition();
   LocalPoint lp2 = recHit->localPosition();
 
@@ -272,8 +237,7 @@ bool TwoBodyDecayTrajectoryFactory::match( const TrajectoryStateOnSurface& state
   double varX = le.xx();
   double varY = le.yy();
 
-  return ( ( fabs(deltaX)/sqrt(varX) < theNSigmaCutValue ) && ( fabs(deltaY)/sqrt(varY) < theNSigmaCutValue ) );
+  return ((fabs(deltaX) / sqrt(varX) < theNSigmaCutValue) && (fabs(deltaY) / sqrt(varY) < theNSigmaCutValue));
 }
 
-
-DEFINE_EDM_PLUGIN( TrajectoryFactoryPlugin, TwoBodyDecayTrajectoryFactory, "TwoBodyDecayTrajectoryFactory" );
+DEFINE_EDM_PLUGIN(TrajectoryFactoryPlugin, TwoBodyDecayTrajectoryFactory, "TwoBodyDecayTrajectoryFactory");

--- a/Alignment/ReferenceTrajectories/src/BeamSpotTransientTrackingRecHit.cc
+++ b/Alignment/ReferenceTrajectories/src/BeamSpotTransientTrackingRecHit.cc
@@ -8,27 +8,23 @@
 
 #include "Alignment/ReferenceTrajectories/interface/BeamSpotTransientTrackingRecHit.h"
 
-AlgebraicVector BeamSpotTransientTrackingRecHit::parameters() const
-{
+AlgebraicVector BeamSpotTransientTrackingRecHit::parameters() const {
   AlgebraicVector result(1);
   result[0] = localPosition().x();
   return result;
 }
 
-AlgebraicSymMatrix BeamSpotTransientTrackingRecHit::parametersError() const
-{
+AlgebraicSymMatrix BeamSpotTransientTrackingRecHit::parametersError() const {
   LocalError le = localPositionError();
   AlgebraicSymMatrix m(1);
   m[0][0] = le.xx();
   return m;
 }
 
-
-static AlgebraicMatrix initialize()
-{
-  AlgebraicMatrix ret( 1, 5, 0);
+static AlgebraicMatrix initialize() {
+  AlgebraicMatrix ret(1, 5, 0);
   ret[0][3] = 1;
   return ret;
 }
 
-const AlgebraicMatrix BeamSpotTransientTrackingRecHit::theProjectionMatrix=initialize();
+const AlgebraicMatrix BeamSpotTransientTrackingRecHit::theProjectionMatrix = initialize();

--- a/Alignment/ReferenceTrajectories/src/BzeroReferenceTrajectory.cc
+++ b/Alignment/ReferenceTrajectories/src/BzeroReferenceTrajectory.cc
@@ -1,41 +1,38 @@
 
 #include "Alignment/ReferenceTrajectories/interface/BzeroReferenceTrajectory.h"
 
-#include "DataFormats/CLHEP/interface/AlgebraicObjects.h" 
+#include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
 #include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 
-
 BzeroReferenceTrajectory::BzeroReferenceTrajectory(const TrajectoryStateOnSurface& tsos,
                                                    const TransientTrackingRecHit::ConstRecHitContainer& recHits,
-                                                   const MagneticField *magField,
+                                                   const MagneticField* magField,
                                                    const reco::BeamSpot& beamSpot,
-                                                   const ReferenceTrajectoryBase::Config& config) :
-  ReferenceTrajectory(tsos.localParameters().mixedFormatVector().kSize, recHits.size(), config),
-  theMomentumEstimate(config.momentumEstimate)
-{
+                                                   const ReferenceTrajectoryBase::Config& config)
+    : ReferenceTrajectory(tsos.localParameters().mixedFormatVector().kSize, recHits.size(), config),
+      theMomentumEstimate(config.momentumEstimate) {
   // no check against magField == 0
 
   // No estimate for momentum of cosmics available -> set to default value.
   theParameters = asHepVector(tsos.localParameters().mixedFormatVector());
-  theParameters[0] = 1./theMomentumEstimate;
+  theParameters[0] = 1. / theMomentumEstimate;
 
-  LocalTrajectoryParameters locParamWithFixedMomentum( asSVector<5>(theParameters),
-						       tsos.localParameters().pzSign(),
-						       tsos.localParameters().charge() );
+  LocalTrajectoryParameters locParamWithFixedMomentum(
+      asSVector<5>(theParameters), tsos.localParameters().pzSign(), tsos.localParameters().charge());
 
-  const TrajectoryStateOnSurface refTsosWithFixedMomentum(locParamWithFixedMomentum, tsos.localError(),
-							  tsos.surface(), magField,
-							  surfaceSide(config.propDir));
+  const TrajectoryStateOnSurface refTsosWithFixedMomentum(
+      locParamWithFixedMomentum, tsos.localError(), tsos.surface(), magField, surfaceSide(config.propDir));
 
-  if (config.hitsAreReverse)
-  {
+  if (config.hitsAreReverse) {
     TransientTrackingRecHit::ConstRecHitContainer fwdRecHits;
     fwdRecHits.reserve(recHits.size());
 
-    for (TransientTrackingRecHit::ConstRecHitContainer::const_reverse_iterator it=recHits.rbegin(); it != recHits.rend(); ++it)
+    for (TransientTrackingRecHit::ConstRecHitContainer::const_reverse_iterator it = recHits.rbegin();
+         it != recHits.rend();
+         ++it)
       fwdRecHits.push_back(*it);
 
     theValidityFlag = this->construct(refTsosWithFixedMomentum, fwdRecHits, magField, beamSpot);
@@ -44,6 +41,6 @@ BzeroReferenceTrajectory::BzeroReferenceTrajectory(const TrajectoryStateOnSurfac
   }
 
   // Exclude momentum from the parameters and also the derivatives of the measurements w.r.t. the momentum.
-  theParameters = theParameters.sub( 2, 5 );
-  theDerivatives = theDerivatives.sub( 1, theDerivatives.num_row(), 2, theDerivatives.num_col() );
+  theParameters = theParameters.sub(2, 5);
+  theDerivatives = theDerivatives.sub(1, theDerivatives.num_row(), 2, theDerivatives.num_col());
 }

--- a/Alignment/ReferenceTrajectories/src/DualBzeroReferenceTrajectory.cc
+++ b/Alignment/ReferenceTrajectories/src/DualBzeroReferenceTrajectory.cc
@@ -4,50 +4,43 @@
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
-#include "DataFormats/CLHEP/interface/AlgebraicObjects.h" 
+#include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
 #include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
 
 #include "Alignment/ReferenceTrajectories/interface/BzeroReferenceTrajectory.h"
-
-
 
 DualBzeroReferenceTrajectory::DualBzeroReferenceTrajectory(const TrajectoryStateOnSurface& tsos,
                                                            const ConstRecHitContainer& forwardRecHits,
                                                            const ConstRecHitContainer& backwardRecHits,
                                                            const MagneticField* magField,
                                                            const reco::BeamSpot& beamSpot,
-                                                           const ReferenceTrajectoryBase::Config& config) :
-  DualReferenceTrajectory(tsos.localParameters().mixedFormatVector().kSize - 1,
-                          numberOfUsedRecHits(forwardRecHits) + numberOfUsedRecHits(backwardRecHits) - 1,
-                          config),
-    theMomentumEstimate(config.momentumEstimate)
-{
+                                                           const ReferenceTrajectoryBase::Config& config)
+    : DualReferenceTrajectory(tsos.localParameters().mixedFormatVector().kSize - 1,
+                              numberOfUsedRecHits(forwardRecHits) + numberOfUsedRecHits(backwardRecHits) - 1,
+                              config),
+      theMomentumEstimate(config.momentumEstimate) {
   theValidityFlag = construct(tsos, forwardRecHits, backwardRecHits, magField, beamSpot);
 }
 
+ReferenceTrajectory* DualBzeroReferenceTrajectory::construct(const TrajectoryStateOnSurface& referenceTsos,
+                                                             const ConstRecHitContainer& recHits,
+                                                             double mass,
+                                                             MaterialEffects materialEffects,
+                                                             const PropagationDirection propDir,
+                                                             const MagneticField* magField,
+                                                             bool useBeamSpot,
+                                                             const reco::BeamSpot& beamSpot) const {
+  if (materialEffects >= breakPoints)
+    throw cms::Exception("BadConfig") << "[DualBzeroReferenceTrajectory::construct] Wrong MaterialEffects: "
+                                      << materialEffects;
 
-ReferenceTrajectory*
-DualBzeroReferenceTrajectory::construct(const TrajectoryStateOnSurface &referenceTsos, 
-					const ConstRecHitContainer &recHits,
-					double mass, MaterialEffects materialEffects,
-					const PropagationDirection propDir,
-					const MagneticField *magField,
-					bool useBeamSpot,
-					const reco::BeamSpot &beamSpot) const
-{
-  if (materialEffects >= breakPoints)  throw cms::Exception("BadConfig")
-    << "[DualBzeroReferenceTrajectory::construct] Wrong MaterialEffects: " << materialEffects;
-  
   ReferenceTrajectoryBase::Config config(materialEffects, propDir, mass, theMomentumEstimate);
   config.useBeamSpot = useBeamSpot;
   config.hitsAreReverse = false;
   return new BzeroReferenceTrajectory(referenceTsos, recHits, magField, beamSpot, config);
 }
 
-
-AlgebraicVector
-DualBzeroReferenceTrajectory::extractParameters(const TrajectoryStateOnSurface &referenceTsos) const
-{
-  AlgebraicVector param = asHepVector<5>( referenceTsos.localParameters().mixedFormatVector() );
-  return param.sub( 2, 5 );
+AlgebraicVector DualBzeroReferenceTrajectory::extractParameters(const TrajectoryStateOnSurface& referenceTsos) const {
+  AlgebraicVector param = asHepVector<5>(referenceTsos.localParameters().mixedFormatVector());
+  return param.sub(2, 5);
 }

--- a/Alignment/ReferenceTrajectories/src/DualReferenceTrajectory.cc
+++ b/Alignment/ReferenceTrajectories/src/DualReferenceTrajectory.cc
@@ -3,7 +3,7 @@
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
-#include "DataFormats/CLHEP/interface/AlgebraicObjects.h" 
+#include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
 #include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
 
 #include "Alignment/ReferenceTrajectories/interface/ReferenceTrajectory.h"
@@ -13,46 +13,42 @@ DualReferenceTrajectory::DualReferenceTrajectory(const TrajectoryStateOnSurface&
                                                  const ConstRecHitContainer& backwardRecHits,
                                                  const MagneticField* magField,
                                                  const reco::BeamSpot& beamSpot,
-                                                 const ReferenceTrajectoryBase::Config& config) :
-  ReferenceTrajectoryBase(tsos.localParameters().mixedFormatVector().kSize,
-                          numberOfUsedRecHits(forwardRecHits) + numberOfUsedRecHits(backwardRecHits) - 1,
-                          0, 0),
-  mass_(config.mass),
-  materialEffects_(config.materialEffects),
-  propDir_(config.propDir),
-  useBeamSpot_(config.useBeamSpot)
-{
+                                                 const ReferenceTrajectoryBase::Config& config)
+    : ReferenceTrajectoryBase(tsos.localParameters().mixedFormatVector().kSize,
+                              numberOfUsedRecHits(forwardRecHits) + numberOfUsedRecHits(backwardRecHits) - 1,
+                              0,
+                              0),
+      mass_(config.mass),
+      materialEffects_(config.materialEffects),
+      propDir_(config.propDir),
+      useBeamSpot_(config.useBeamSpot) {
   theValidityFlag = this->construct(tsos, forwardRecHits, backwardRecHits, magField, beamSpot);
 }
 
+DualReferenceTrajectory::DualReferenceTrajectory(unsigned int nPar,
+                                                 unsigned int nHits,
+                                                 const ReferenceTrajectoryBase::Config& config)
+    : ReferenceTrajectoryBase(nPar, nHits, 0, 0),
+      mass_(config.mass),
+      materialEffects_(config.materialEffects),
+      propDir_(config.propDir),
+      useBeamSpot_(config.useBeamSpot) {}
 
+bool DualReferenceTrajectory::construct(const TrajectoryStateOnSurface& refTsos,
+                                        const ConstRecHitContainer& forwardRecHits,
+                                        const ConstRecHitContainer& backwardRecHits,
+                                        const MagneticField* magField,
+                                        const reco::BeamSpot& beamSpot) {
+  if (materialEffects_ >= breakPoints)
+    throw cms::Exception("BadConfig") << "[DualReferenceTrajectory::construct] Wrong MaterialEffects: "
+                                      << materialEffects_;
 
-DualReferenceTrajectory::DualReferenceTrajectory(unsigned int nPar, unsigned int nHits,
-						 const ReferenceTrajectoryBase::Config& config)
-  : ReferenceTrajectoryBase(nPar, nHits, 0, 0),
-  mass_(config.mass),
-  materialEffects_(config.materialEffects),
-  propDir_(config.propDir),
-  useBeamSpot_(config.useBeamSpot)
-{}
-
-
-bool DualReferenceTrajectory::construct(const TrajectoryStateOnSurface &refTsos,
-                                        const ConstRecHitContainer &forwardRecHits,
-                                        const ConstRecHitContainer &backwardRecHits,
-                                        const MagneticField *magField,
-                                        const reco::BeamSpot &beamSpot)
-{
-  if (materialEffects_ >= breakPoints)  throw cms::Exception("BadConfig")
-    << "[DualReferenceTrajectory::construct] Wrong MaterialEffects: " << materialEffects_;
-    
   ReferenceTrajectoryBase* fwdTraj = construct(refTsos, forwardRecHits, magField, beamSpot);
 
   // set flag for opposite direction to true
   ReferenceTrajectoryBase* bwdTraj = construct(refTsos, backwardRecHits, magField, beamSpot, true);
 
-  if ( !( fwdTraj->isValid() && bwdTraj->isValid() ) )
-  {
+  if (!(fwdTraj->isValid() && bwdTraj->isValid())) {
     delete fwdTraj;
     delete bwdTraj;
     return false;
@@ -64,83 +60,81 @@ bool DualReferenceTrajectory::construct(const TrajectoryStateOnSurface &refTsos,
 
   const std::vector<TrajectoryStateOnSurface>& fwdTsosVec = fwdTraj->trajectoryStates();
   const std::vector<TrajectoryStateOnSurface>& bwdTsosVec = bwdTraj->trajectoryStates();
-  theTsosVec.insert( theTsosVec.end(), fwdTsosVec.begin(), fwdTsosVec.end() );
-  theTsosVec.insert( theTsosVec.end(), ++bwdTsosVec.begin(), bwdTsosVec.end() );
+  theTsosVec.insert(theTsosVec.end(), fwdTsosVec.begin(), fwdTsosVec.end());
+  theTsosVec.insert(theTsosVec.end(), ++bwdTsosVec.begin(), bwdTsosVec.end());
 
-  const ConstRecHitContainer &fwdRecHits = fwdTraj->recHits();
-  const ConstRecHitContainer &bwdRecHits = bwdTraj->recHits();
-  theRecHits.insert( theRecHits.end(), fwdRecHits.begin(), fwdRecHits.end() );
-  theRecHits.insert( theRecHits.end(), ++bwdRecHits.begin(), bwdRecHits.end() );
+  const ConstRecHitContainer& fwdRecHits = fwdTraj->recHits();
+  const ConstRecHitContainer& bwdRecHits = bwdTraj->recHits();
+  theRecHits.insert(theRecHits.end(), fwdRecHits.begin(), fwdRecHits.end());
+  theRecHits.insert(theRecHits.end(), ++bwdRecHits.begin(), bwdRecHits.end());
 
-  theParameters = extractParameters( refTsos );
-  
-  unsigned int nParam   = theNumberOfPars;
+  theParameters = extractParameters(refTsos);
+
+  unsigned int nParam = theNumberOfPars;
   unsigned int nFwdMeas = fwdTraj->numberOfHitMeas();
   unsigned int nBwdMeas = bwdTraj->numberOfHitMeas();
-  unsigned int nFwdBP   = fwdTraj->numberOfVirtualMeas();
-  unsigned int nBwdBP   = bwdTraj->numberOfVirtualMeas();
-  unsigned int nMeas    = nFwdMeas+nBwdMeas-nMeasPerHit; 
-       
-  theMeasurements.sub( 1, fwdTraj->measurements().sub( 1, nFwdMeas ) );
-  theMeasurements.sub( nFwdMeas+1, bwdTraj->measurements().sub( nMeasPerHit+1, nBwdMeas ) );
-    
-  theMeasurementsCov.sub( 1, fwdTraj->measurementErrors().sub( 1, nFwdMeas ) );
-  theMeasurementsCov.sub( nFwdMeas+1, bwdTraj->measurementErrors().sub( nMeasPerHit+1, nBwdMeas ) );
-  
-  theTrajectoryPositions.sub( 1, fwdTraj->trajectoryPositions() );
-  theTrajectoryPositions.sub( nFwdMeas+1, bwdTraj->trajectoryPositions().sub( nMeasPerHit+1, nBwdMeas ) );
+  unsigned int nFwdBP = fwdTraj->numberOfVirtualMeas();
+  unsigned int nBwdBP = bwdTraj->numberOfVirtualMeas();
+  unsigned int nMeas = nFwdMeas + nBwdMeas - nMeasPerHit;
 
-  theTrajectoryPositionCov.sub( 1, fwdTraj->trajectoryPositionErrors() );
-  theTrajectoryPositionCov.sub( nFwdMeas+1, bwdTraj->trajectoryPositionErrors().sub( nMeasPerHit+1, nBwdMeas ) );
+  theMeasurements.sub(1, fwdTraj->measurements().sub(1, nFwdMeas));
+  theMeasurements.sub(nFwdMeas + 1, bwdTraj->measurements().sub(nMeasPerHit + 1, nBwdMeas));
 
-  theDerivatives.sub( 1, 1, fwdTraj->derivatives().sub( 1, nFwdMeas, 1, nParam ) );
-  theDerivatives.sub( nFwdMeas+1, 1, bwdTraj->derivatives().sub( nMeasPerHit+1, nBwdMeas, 1, nParam ) );
-  
-// for the break points 
-// DUAL with break points makes no sense: (MS) correlations between the two parts are lost ! 
-  if (nFwdBP>0 )
-  {
-    theMeasurements.sub( nMeas+1, fwdTraj->measurements().sub( nFwdMeas+1, nFwdMeas+nFwdBP ) );
-    theMeasurementsCov.sub( nMeas+1, fwdTraj->measurementErrors().sub( nFwdMeas+1, nFwdMeas+nFwdBP ) );  
-    theDerivatives.sub( 1, nParam+1, fwdTraj->derivatives().sub( 1, nFwdMeas, nParam+1, nParam+nFwdBP ) );
-    theDerivatives.sub( nMeas+1, nParam+1, fwdTraj->derivatives().sub( nFwdMeas+1, nFwdMeas+nFwdBP, nParam+1, nParam+nFwdBP ) );
-  }  
-  if (nBwdBP>0 )
-  {
-    theMeasurements.sub( nMeas+nFwdBP+1, bwdTraj->measurements().sub( nBwdMeas+1, nBwdMeas+nBwdBP ) );  
-    theMeasurementsCov.sub( nMeas+nFwdBP+1, bwdTraj->measurementErrors().sub( nBwdMeas+1, nBwdMeas+nBwdBP ) );  
-    theDerivatives.sub( nFwdMeas+1, nParam+nFwdBP+1, bwdTraj->derivatives().sub( nMeasPerHit+1, nBwdMeas, nParam+1, nParam+nBwdBP ) );
-    theDerivatives.sub( nMeas+nFwdBP+1, nParam+nFwdBP+1, bwdTraj->derivatives().sub( nBwdMeas+1, nBwdMeas+nBwdBP, nParam+1, nParam+nBwdBP ) );
+  theMeasurementsCov.sub(1, fwdTraj->measurementErrors().sub(1, nFwdMeas));
+  theMeasurementsCov.sub(nFwdMeas + 1, bwdTraj->measurementErrors().sub(nMeasPerHit + 1, nBwdMeas));
+
+  theTrajectoryPositions.sub(1, fwdTraj->trajectoryPositions());
+  theTrajectoryPositions.sub(nFwdMeas + 1, bwdTraj->trajectoryPositions().sub(nMeasPerHit + 1, nBwdMeas));
+
+  theTrajectoryPositionCov.sub(1, fwdTraj->trajectoryPositionErrors());
+  theTrajectoryPositionCov.sub(nFwdMeas + 1, bwdTraj->trajectoryPositionErrors().sub(nMeasPerHit + 1, nBwdMeas));
+
+  theDerivatives.sub(1, 1, fwdTraj->derivatives().sub(1, nFwdMeas, 1, nParam));
+  theDerivatives.sub(nFwdMeas + 1, 1, bwdTraj->derivatives().sub(nMeasPerHit + 1, nBwdMeas, 1, nParam));
+
+  // for the break points
+  // DUAL with break points makes no sense: (MS) correlations between the two parts are lost !
+  if (nFwdBP > 0) {
+    theMeasurements.sub(nMeas + 1, fwdTraj->measurements().sub(nFwdMeas + 1, nFwdMeas + nFwdBP));
+    theMeasurementsCov.sub(nMeas + 1, fwdTraj->measurementErrors().sub(nFwdMeas + 1, nFwdMeas + nFwdBP));
+    theDerivatives.sub(1, nParam + 1, fwdTraj->derivatives().sub(1, nFwdMeas, nParam + 1, nParam + nFwdBP));
+    theDerivatives.sub(nMeas + 1,
+                       nParam + 1,
+                       fwdTraj->derivatives().sub(nFwdMeas + 1, nFwdMeas + nFwdBP, nParam + 1, nParam + nFwdBP));
   }
-    
+  if (nBwdBP > 0) {
+    theMeasurements.sub(nMeas + nFwdBP + 1, bwdTraj->measurements().sub(nBwdMeas + 1, nBwdMeas + nBwdBP));
+    theMeasurementsCov.sub(nMeas + nFwdBP + 1, bwdTraj->measurementErrors().sub(nBwdMeas + 1, nBwdMeas + nBwdBP));
+    theDerivatives.sub(nFwdMeas + 1,
+                       nParam + nFwdBP + 1,
+                       bwdTraj->derivatives().sub(nMeasPerHit + 1, nBwdMeas, nParam + 1, nParam + nBwdBP));
+    theDerivatives.sub(nMeas + nFwdBP + 1,
+                       nParam + nFwdBP + 1,
+                       bwdTraj->derivatives().sub(nBwdMeas + 1, nBwdMeas + nBwdBP, nParam + 1, nParam + nBwdBP));
+  }
+
   delete fwdTraj;
   delete bwdTraj;
 
-  return true; 
+  return true;
 }
 
+ReferenceTrajectory* DualReferenceTrajectory::construct(const TrajectoryStateOnSurface& referenceTsos,
+                                                        const ConstRecHitContainer& recHits,
+                                                        const MagneticField* magField,
+                                                        const reco::BeamSpot& beamSpot,
+                                                        const bool revertDirection) const {
+  if (materialEffects_ >= breakPoints)
+    throw cms::Exception("BadConfig") << "[DualReferenceTrajectory::construct] Wrong MaterialEffects: "
+                                      << materialEffects_;
 
-ReferenceTrajectory*
-DualReferenceTrajectory::construct(const TrajectoryStateOnSurface &referenceTsos, 
-				   const ConstRecHitContainer &recHits,
-				   const MagneticField *magField,
-				   const reco::BeamSpot &beamSpot,
-				   const bool revertDirection) const
-{
-  if (materialEffects_ >= breakPoints)  throw cms::Exception("BadConfig")
-    << "[DualReferenceTrajectory::construct] Wrong MaterialEffects: " << materialEffects_;
-  
-  ReferenceTrajectoryBase::Config config(materialEffects_,
-                                         (revertDirection ? oppositeDirection(propDir_): propDir_),
-                                         mass_);
+  ReferenceTrajectoryBase::Config config(
+      materialEffects_, (revertDirection ? oppositeDirection(propDir_) : propDir_), mass_);
   config.useBeamSpot = useBeamSpot_;
   config.hitsAreReverse = false;
   return new ReferenceTrajectory(referenceTsos, recHits, magField, beamSpot, config);
 }
 
-
-AlgebraicVector
-DualReferenceTrajectory::extractParameters(const TrajectoryStateOnSurface &referenceTsos) const
-{
-  return asHepVector<5>( referenceTsos.localParameters().mixedFormatVector() );
+AlgebraicVector DualReferenceTrajectory::extractParameters(const TrajectoryStateOnSurface& referenceTsos) const {
+  return asHepVector<5>(referenceTsos.localParameters().mixedFormatVector());
 }

--- a/Alignment/ReferenceTrajectories/src/ReferenceTrajectory.cc
+++ b/Alignment/ReferenceTrajectories/src/ReferenceTrajectory.cc
@@ -10,12 +10,12 @@
 
 #include "Alignment/ReferenceTrajectories/interface/ReferenceTrajectory.h"
 
-#include "DataFormats/GeometrySurface/interface/Surface.h" 
+#include "DataFormats/GeometrySurface/interface/Surface.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "DataFormats/CLHEP/interface/AlgebraicObjects.h" 
+#include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
 #include "DataFormats/GeometrySurface/interface/LocalError.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "Geometry/CommonDetUnit/interface/TrackerGeomDet.h"
@@ -49,36 +49,39 @@
 //__________________________________________________________________________________
 using namespace gbl;
 
+ReferenceTrajectory::ReferenceTrajectory(const TrajectoryStateOnSurface &refTsos,
+                                         const TransientTrackingRecHit::ConstRecHitContainer &recHits,
+                                         const MagneticField *magField,
+                                         const reco::BeamSpot &beamSpot,
+                                         const ReferenceTrajectoryBase::Config &config)
+    : ReferenceTrajectoryBase(
+          (config.materialEffects >= brokenLinesCoarse) ? 1 : refTsos.localParameters().mixedFormatVector().kSize,
+          (config.useBeamSpot) ? recHits.size() + 1 : recHits.size(),
+          (config.materialEffects >= brokenLinesCoarse)
+              ? 2 * ((config.useBeamSpot) ? recHits.size() + 1 : recHits.size())
+              : ((config.materialEffects == breakPoints)
+                     ? 2 * ((config.useBeamSpot) ? recHits.size() + 1 : recHits.size()) - 2
+                     : 0),
+          (config.materialEffects >= brokenLinesCoarse)
+              ? 2 * ((config.useBeamSpot) ? recHits.size() + 1 : recHits.size()) - 4
+              : ((config.materialEffects == breakPoints)
+                     ? 2 * ((config.useBeamSpot) ? recHits.size() + 1 : recHits.size()) - 2
+                     : 0)),
+      mass_(config.mass),
+      materialEffects_(config.materialEffects),
+      propDir_(config.propDir),
+      useBeamSpot_(config.useBeamSpot),
+      includeAPEs_(config.includeAPEs),
+      allowZeroMaterial_(config.allowZeroMaterial) {
+  // no check against magField == 0
+  theParameters = asHepVector<5>(refTsos.localParameters().mixedFormatVector());
 
-ReferenceTrajectory::ReferenceTrajectory(const TrajectoryStateOnSurface& refTsos,
-                                         const TransientTrackingRecHit::ConstRecHitContainer& recHits,
-                                         const MagneticField* magField,
-                                         const reco::BeamSpot& beamSpot,
-                                         const ReferenceTrajectoryBase::Config& config) :
-  ReferenceTrajectoryBase(
-   (config.materialEffects >= brokenLinesCoarse) ? 1 : refTsos.localParameters().mixedFormatVector().kSize,
-   (config.useBeamSpot) ? recHits.size()+1 : recHits.size(),
-   (config.materialEffects >= brokenLinesCoarse) ?
-       2*((config.useBeamSpot) ? recHits.size()+1 : recHits.size())   :
-   ( (config.materialEffects == breakPoints) ? 2*((config.useBeamSpot) ? recHits.size()+1 : recHits.size())-2 : 0) ,
-   (config.materialEffects >= brokenLinesCoarse) ?
-       2*((config.useBeamSpot) ? recHits.size()+1 : recHits.size())-4 :
-   ( (config.materialEffects == breakPoints) ? 2*((config.useBeamSpot) ? recHits.size()+1 : recHits.size())-2 : 0) ),
-  mass_(config.mass),
-  materialEffects_(config.materialEffects),
-  propDir_(config.propDir),
-  useBeamSpot_(config.useBeamSpot),
-  includeAPEs_(config.includeAPEs),
-  allowZeroMaterial_(config.allowZeroMaterial)
-{
-  // no check against magField == 0  
-  theParameters = asHepVector<5>( refTsos.localParameters().mixedFormatVector() );
-  
   if (config.hitsAreReverse) {
     TransientTrackingRecHit::ConstRecHitContainer fwdRecHits;
     fwdRecHits.reserve(recHits.size());
-    for (TransientTrackingRecHit::ConstRecHitContainer::const_reverse_iterator it=recHits.rbegin();
-	 it != recHits.rend(); ++it) {
+    for (TransientTrackingRecHit::ConstRecHitContainer::const_reverse_iterator it = recHits.rbegin();
+         it != recHits.rend();
+         ++it) {
       fwdRecHits.push_back(*it);
     }
     theValidityFlag = this->construct(refTsos, fwdRecHits, magField, beamSpot);
@@ -87,50 +90,50 @@ ReferenceTrajectory::ReferenceTrajectory(const TrajectoryStateOnSurface& refTsos
   }
 }
 
+//__________________________________________________________________________________
+
+ReferenceTrajectory::ReferenceTrajectory(unsigned int nPar,
+                                         unsigned int nHits,
+                                         const ReferenceTrajectoryBase::Config &config)
+    : ReferenceTrajectoryBase((config.materialEffects >= brokenLinesCoarse) ? 1 : nPar,
+                              nHits,
+                              (config.materialEffects >= brokenLinesCoarse)
+                                  ? 2 * nHits
+                                  : ((config.materialEffects == breakPoints) ? 2 * nHits - 2 : 0),
+                              (config.materialEffects >= brokenLinesCoarse)
+                                  ? 2 * nHits - 4
+                                  : ((config.materialEffects == breakPoints) ? 2 * nHits - 2 : 0)),
+      mass_(config.mass),
+      materialEffects_(config.materialEffects),
+      propDir_(config.propDir),
+      useBeamSpot_(config.useBeamSpot),
+      includeAPEs_(config.includeAPEs),
+      allowZeroMaterial_(config.allowZeroMaterial) {}
 
 //__________________________________________________________________________________
 
-ReferenceTrajectory::ReferenceTrajectory(unsigned int nPar, unsigned int nHits,
-					 const ReferenceTrajectoryBase::Config& config)
- : ReferenceTrajectoryBase( 
-   (config.materialEffects >= brokenLinesCoarse) ? 1 : nPar,
-   nHits, 
-   (config.materialEffects >= brokenLinesCoarse) ? 2*nHits   : ( (config.materialEffects == breakPoints) ? 2*nHits-2 : 0 ),
-   (config.materialEffects >= brokenLinesCoarse) ? 2*nHits-4 : ( (config.materialEffects == breakPoints) ? 2*nHits-2 : 0 ) ),
-   mass_(config.mass),
-   materialEffects_(config.materialEffects),
-   propDir_(config.propDir),
-   useBeamSpot_(config.useBeamSpot),
-   includeAPEs_(config.includeAPEs),
-   allowZeroMaterial_(config.allowZeroMaterial)
-{}
-
-
-//__________________________________________________________________________________
-
-bool ReferenceTrajectory::construct(const TrajectoryStateOnSurface &refTsos, 
-				    const TransientTrackingRecHit::ConstRecHitContainer &recHits,
-				    const MagneticField *magField,
-				    const reco::BeamSpot &beamSpot)
-{   
+bool ReferenceTrajectory::construct(const TrajectoryStateOnSurface &refTsos,
+                                    const TransientTrackingRecHit::ConstRecHitContainer &recHits,
+                                    const MagneticField *magField,
+                                    const reco::BeamSpot &beamSpot) {
   TrajectoryStateOnSurface theRefTsos = refTsos;
 
   const SurfaceSide surfaceSide = this->surfaceSide(propDir_);
   // auto_ptr to avoid memory leaks in case of not reaching delete at end of method:
-  std::unique_ptr<MaterialEffectsUpdator> aMaterialEffectsUpdator
-    (this->createUpdator(materialEffects_, mass_));
-  if (!aMaterialEffectsUpdator.get()) return false; // empty auto_ptr
+  std::unique_ptr<MaterialEffectsUpdator> aMaterialEffectsUpdator(this->createUpdator(materialEffects_, mass_));
+  if (!aMaterialEffectsUpdator.get())
+    return false;  // empty auto_ptr
 
-  AlgebraicMatrix                 fullJacobian(theParameters.num_row(), theParameters.num_row());
-  std::vector<AlgebraicMatrix>    allJacobians; 
+  AlgebraicMatrix fullJacobian(theParameters.num_row(), theParameters.num_row());
+  std::vector<AlgebraicMatrix> allJacobians;
   allJacobians.reserve(theNumberOfHits);
 
-  TransientTrackingRecHit::ConstRecHitPointer  previousHitPtr;
-  TrajectoryStateOnSurface                     previousTsos;
-  AlgebraicSymMatrix              previousChangeInCurvature(theParameters.num_row(), 1);
-  std::vector<AlgebraicSymMatrix> allCurvatureChanges; 
+  TransientTrackingRecHit::ConstRecHitPointer previousHitPtr;
+  TrajectoryStateOnSurface previousTsos;
+  AlgebraicSymMatrix previousChangeInCurvature(theParameters.num_row(), 1);
+  std::vector<AlgebraicSymMatrix> allCurvatureChanges;
   allCurvatureChanges.reserve(theNumberOfHits);
-  
+
   const LocalTrajectoryError zeroErrors(0., 0., 0., 0., 0.);
 
   std::vector<AlgebraicMatrix> allProjections;
@@ -140,197 +143,199 @@ bool ReferenceTrajectory::construct(const TrajectoryStateOnSurface &refTsos,
 
   // CHK
   std::vector<AlgebraicMatrix> allLocalToCurv;
-  allLocalToCurv.reserve(theNumberOfHits); 
+  allLocalToCurv.reserve(theNumberOfHits);
   std::vector<double> allSteps;
-  allSteps.reserve(theNumberOfHits); 
-  std::vector<AlgebraicMatrix>    allCurvlinJacobians; 
+  allSteps.reserve(theNumberOfHits);
+  std::vector<AlgebraicMatrix> allCurvlinJacobians;
   allCurvlinJacobians.reserve(theNumberOfHits);
-  
+
   AlgebraicMatrix firstCurvlinJacobian(5, 5, 1);
-  
+
   unsigned int iRow = 0;
 
-  theNomField = magField->nominalValue(); // nominal magnetic field in kGauss
+  theNomField = magField->nominalValue();  // nominal magnetic field in kGauss
   // local storage vector of all rechits (including rechit for beam spot in case it is used)
   TransientTrackingRecHit::ConstRecHitContainer allRecHits;
 
-  if (useBeamSpot_ && propDir_==alongMomentum) {
-    
+  if (useBeamSpot_ && propDir_ == alongMomentum) {
     GlobalPoint bs(beamSpot.x0(), beamSpot.y0(), beamSpot.z0());
-    
+
     TrajectoryStateClosestToBeamLine tsctbl(TSCBLBuilderNoMaterial()(*(refTsos.freeState()), beamSpot));
     if (!tsctbl.isValid()) {
-      edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::construct" 
-				 << "TrajectoryStateClostestToBeamLine invalid. Skip track.";
+      edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::construct"
+                                 << "TrajectoryStateClostestToBeamLine invalid. Skip track.";
       return false;
     }
 
     FreeTrajectoryState pcaFts = tsctbl.trackStateAtPCA();
     GlobalVector bd(beamSpot.dxdz(), beamSpot.dydz(), 1.0);
-    
+
     //propagation FIXME: Should use same propagator everywhere...
     AnalyticalPropagator propagator(magField);
-    std::pair< TrajectoryStateOnSurface, double > tsosWithPath =
-      propagator.propagateWithPath(pcaFts, refTsos.surface());
-    
-    if (!tsosWithPath.first.isValid()) return false;
-    
+    std::pair<TrajectoryStateOnSurface, double> tsosWithPath = propagator.propagateWithPath(pcaFts, refTsos.surface());
+
+    if (!tsosWithPath.first.isValid())
+      return false;
+
     GlobalVector momDir(pcaFts.momentum());
     GlobalVector perpDir(bd.cross(momDir));
     Plane::RotationType rotation(perpDir, bd);
-    
-    BeamSpotGeomDet * bsGeom = new BeamSpotGeomDet(Plane::build(bs, rotation));
+
+    BeamSpotGeomDet *bsGeom = new BeamSpotGeomDet(Plane::build(bs, rotation));
 
     // There is also a constructor taking the magentic field. Use this one instead?
     theRefTsos = TrajectoryStateOnSurface(pcaFts, bsGeom->surface());
-    
-    TransientTrackingRecHit::ConstRecHitPointer bsRecHit(new BeamSpotTransientTrackingRecHit(beamSpot,
-					  bsGeom,
-					  theRefTsos.freeState()->momentum().phi()));
-    allRecHits.push_back(bsRecHit);
 
+    TransientTrackingRecHit::ConstRecHitPointer bsRecHit(
+        new BeamSpotTransientTrackingRecHit(beamSpot, bsGeom, theRefTsos.freeState()->momentum().phi()));
+    allRecHits.push_back(bsRecHit);
   }
-  
+
   // copy all rechits to the local storage vector
   TransientTrackingRecHit::ConstRecHitContainer::const_iterator itRecHit;
-  for ( itRecHit = recHits.begin(); itRecHit != recHits.end(); ++itRecHit ) { 
+  for (itRecHit = recHits.begin(); itRecHit != recHits.end(); ++itRecHit) {
     const TransientTrackingRecHit::ConstRecHitPointer &hitPtr = *itRecHit;
     allRecHits.push_back(hitPtr);
   }
 
-  for ( itRecHit = allRecHits.begin(); itRecHit != allRecHits.end(); ++itRecHit ) { 
-    
+  for (itRecHit = allRecHits.begin(); itRecHit != allRecHits.end(); ++itRecHit) {
     const TransientTrackingRecHit::ConstRecHitPointer &hitPtr = *itRecHit;
     theRecHits.push_back(hitPtr);
 
     if (0 == iRow) {
-
       // compute the derivatives of the reference-track's parameters w.r.t. the initial ones
-      // derivative of the initial reference-track parameters w.r.t. themselves is of course the identity 
+      // derivative of the initial reference-track parameters w.r.t. themselves is of course the identity
       fullJacobian = AlgebraicMatrix(theParameters.num_row(), theParameters.num_row(), 1);
       allJacobians.push_back(fullJacobian);
       theTsosVec.push_back(theRefTsos);
       const JacobianLocalToCurvilinear startTrafo(hitPtr->det()->surface(), theRefTsos.localParameters(), *magField);
-      const AlgebraicMatrix localToCurvilinear =  asHepMatrix<5>(startTrafo.jacobian());
+      const AlgebraicMatrix localToCurvilinear = asHepMatrix<5>(startTrafo.jacobian());
       if (materialEffects_ <= breakPoints) {
-         theInnerTrajectoryToCurvilinear = asHepMatrix<5>(startTrafo.jacobian());
-	 theInnerLocalToTrajectory = AlgebraicMatrix(5, 5, 1);
-      }	 
+        theInnerTrajectoryToCurvilinear = asHepMatrix<5>(startTrafo.jacobian());
+        theInnerLocalToTrajectory = AlgebraicMatrix(5, 5, 1);
+      }
       allLocalToCurv.push_back(localToCurvilinear);
       allSteps.push_back(0.);
       allCurvlinJacobians.push_back(firstCurvlinJacobian);
 
     } else {
-
       AlgebraicMatrix nextJacobian;
       AlgebraicMatrix nextCurvlinJacobian;
       double nextStep = 0.;
       TrajectoryStateOnSurface nextTsos;
 
-      if (!this->propagate(previousHitPtr->det()->surface(), previousTsos,
-			   hitPtr->det()->surface(), nextTsos,
-			   nextJacobian, nextCurvlinJacobian, nextStep, magField)) {
-	return false; // stop if problem...// no delete aMaterialEffectsUpdator needed
+      if (!this->propagate(previousHitPtr->det()->surface(),
+                           previousTsos,
+                           hitPtr->det()->surface(),
+                           nextTsos,
+                           nextJacobian,
+                           nextCurvlinJacobian,
+                           nextStep,
+                           magField)) {
+        return false;  // stop if problem...// no delete aMaterialEffectsUpdator needed
       }
-      
+
       allJacobians.push_back(nextJacobian);
       fullJacobian = nextJacobian * previousChangeInCurvature * fullJacobian;
       theTsosVec.push_back(nextTsos);
-      
+
       const JacobianLocalToCurvilinear startTrafo(hitPtr->det()->surface(), nextTsos.localParameters(), *magField);
-      const AlgebraicMatrix localToCurvilinear =  asHepMatrix<5>(startTrafo.jacobian());
+      const AlgebraicMatrix localToCurvilinear = asHepMatrix<5>(startTrafo.jacobian());
       allLocalToCurv.push_back(localToCurvilinear);
-      if (nextStep == 0.) { 
-	edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::construct"
-				   << "step 0. from id " << previousHitPtr->geographicalId()
-				   << " to " << hitPtr->det()->geographicalId() << ".";
-	// brokenLinesFine will not work, brokenLinesCoarse combines close by layers
-	if (materialEffects_ == brokenLinesFine) {
-	  edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::construct" << "Skip track.";
-	  return false;
-	}
+      if (nextStep == 0.) {
+        edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::construct"
+                                   << "step 0. from id " << previousHitPtr->geographicalId() << " to "
+                                   << hitPtr->det()->geographicalId() << ".";
+        // brokenLinesFine will not work, brokenLinesCoarse combines close by layers
+        if (materialEffects_ == brokenLinesFine) {
+          edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::construct"
+                                     << "Skip track.";
+          return false;
+        }
       }
       allSteps.push_back(nextStep);
       allCurvlinJacobians.push_back(nextCurvlinJacobian);
-
     }
 
     // take material effects into account. since trajectory-state is constructed with errors equal zero,
     // the updated state contains only the uncertainties due to interactions in the current layer.
-    const TrajectoryStateOnSurface tmpTsos(theTsosVec.back().localParameters(), zeroErrors,
-					   theTsosVec.back().surface(), magField, surfaceSide);
+    const TrajectoryStateOnSurface tmpTsos(
+        theTsosVec.back().localParameters(), zeroErrors, theTsosVec.back().surface(), magField, surfaceSide);
     const TrajectoryStateOnSurface updatedTsos = aMaterialEffectsUpdator->updateState(tmpTsos, propDir_);
 
-    if ( !updatedTsos.isValid() ) return false;// no delete aMaterialEffectsUpdator needed
-    
-    if ( theTsosVec.back().localParameters().charge() )
-    {
-      previousChangeInCurvature[0][0] = updatedTsos.localParameters().signedInverseMomentum() 
-	/ theTsosVec.back().localParameters().signedInverseMomentum();
+    if (!updatedTsos.isValid())
+      return false;  // no delete aMaterialEffectsUpdator needed
+
+    if (theTsosVec.back().localParameters().charge()) {
+      previousChangeInCurvature[0][0] = updatedTsos.localParameters().signedInverseMomentum() /
+                                        theTsosVec.back().localParameters().signedInverseMomentum();
     }
-    
+
     // get multiple-scattering covariance-matrix
-    allDeltaParameterCovs.push_back( asHepMatrix<5>(updatedTsos.localError().matrix()) );
+    allDeltaParameterCovs.push_back(asHepMatrix<5>(updatedTsos.localError().matrix()));
     allCurvatureChanges.push_back(previousChangeInCurvature);
-    
+
     // projection-matrix tsos-parameters -> measurement-coordinates
     allProjections.push_back(this->getHitProjectionMatrix(hitPtr));
     // set start-parameters for next propagation. trajectory-state without error
     //  - no error propagation needed here.
     previousHitPtr = hitPtr;
-    previousTsos   = TrajectoryStateOnSurface(updatedTsos.globalParameters(),
-                                              updatedTsos.surface(), surfaceSide);
-    
+    previousTsos = TrajectoryStateOnSurface(updatedTsos.globalParameters(), updatedTsos.surface(), surfaceSide);
+
     if (materialEffects_ < brokenLinesCoarse) {
       this->fillDerivatives(allProjections.back(), fullJacobian, iRow);
     }
 
     AlgebraicVector mixedLocalParams = asHepVector<5>(theTsosVec.back().localParameters().mixedFormatVector());
     this->fillTrajectoryPositions(allProjections.back(), mixedLocalParams, iRow);
-    if ( useRecHit( hitPtr ) ) this->fillMeasurementAndError(hitPtr, iRow, updatedTsos);
+    if (useRecHit(hitPtr))
+      this->fillMeasurementAndError(hitPtr, iRow, updatedTsos);
 
     iRow += nMeasPerHit;
-  } // end of loop on hits
+  }  // end of loop on hits
 
   bool msOK = true;
   switch (materialEffects_) {
-  case none:
-    break;
-  case multipleScattering:
-  case energyLoss:
-  case combined:
-    msOK = this->addMaterialEffectsCov(allJacobians, allProjections, allCurvatureChanges,
-                                       allDeltaParameterCovs);
-    break;
-  case breakPoints:
-    msOK = this->addMaterialEffectsBp(allJacobians, allProjections, allCurvatureChanges,
-                                      allDeltaParameterCovs, allLocalToCurv);
-    break;
-  case brokenLinesCoarse:
-    msOK = this->addMaterialEffectsBrl(allProjections, allDeltaParameterCovs, allLocalToCurv,
-                                       allSteps, refTsos.globalParameters());
-    break;
-  case brokenLinesFine:
-    msOK = this->addMaterialEffectsBrl(allCurvlinJacobians, allProjections, allCurvatureChanges,
-                                       allDeltaParameterCovs, allLocalToCurv, refTsos.globalParameters());
-    break;
-  case localGBL:
-    msOK = this->addMaterialEffectsLocalGbl(allJacobians, allProjections, allCurvatureChanges,
-                                       allDeltaParameterCovs);
-    break;
-  case curvlinGBL:
-    msOK = this->addMaterialEffectsCurvlinGbl(allCurvlinJacobians, allProjections, allCurvatureChanges,
-                                       allDeltaParameterCovs, allLocalToCurv);
+    case none:
+      break;
+    case multipleScattering:
+    case energyLoss:
+    case combined:
+      msOK = this->addMaterialEffectsCov(allJacobians, allProjections, allCurvatureChanges, allDeltaParameterCovs);
+      break;
+    case breakPoints:
+      msOK = this->addMaterialEffectsBp(
+          allJacobians, allProjections, allCurvatureChanges, allDeltaParameterCovs, allLocalToCurv);
+      break;
+    case brokenLinesCoarse:
+      msOK = this->addMaterialEffectsBrl(
+          allProjections, allDeltaParameterCovs, allLocalToCurv, allSteps, refTsos.globalParameters());
+      break;
+    case brokenLinesFine:
+      msOK = this->addMaterialEffectsBrl(allCurvlinJacobians,
+                                         allProjections,
+                                         allCurvatureChanges,
+                                         allDeltaParameterCovs,
+                                         allLocalToCurv,
+                                         refTsos.globalParameters());
+      break;
+    case localGBL:
+      msOK = this->addMaterialEffectsLocalGbl(allJacobians, allProjections, allCurvatureChanges, allDeltaParameterCovs);
+      break;
+    case curvlinGBL:
+      msOK = this->addMaterialEffectsCurvlinGbl(
+          allCurvlinJacobians, allProjections, allCurvatureChanges, allDeltaParameterCovs, allLocalToCurv);
   }
-  if (!msOK) return false;
- 
+  if (!msOK)
+    return false;
+
   if (refTsos.hasError()) {
     AlgebraicSymMatrix parameterCov = asHepMatrix<5>(refTsos.localError().matrix());
-    AlgebraicMatrix  parDeriv;
-    if (theNumberOfVirtualPars>0) { 
-      parDeriv = theDerivatives.sub( 1, nMeasPerHit*allJacobians.size(), 1, theParameters.num_row() ); 
+    AlgebraicMatrix parDeriv;
+    if (theNumberOfVirtualPars > 0) {
+      parDeriv = theDerivatives.sub(1, nMeasPerHit * allJacobians.size(), 1, theParameters.num_row());
     } else {
-      parDeriv = theDerivatives; 
+      parDeriv = theDerivatives;
     }
     theTrajectoryPositionCov = parameterCov.similarity(parDeriv);
   } else {
@@ -342,38 +347,39 @@ bool ReferenceTrajectory::construct(const TrajectoryStateOnSurface &refTsos,
 
 //__________________________________________________________________________________
 
-MaterialEffectsUpdator*
-ReferenceTrajectory::createUpdator(MaterialEffects materialEffects, double mass) const
-{
+MaterialEffectsUpdator *ReferenceTrajectory::createUpdator(MaterialEffects materialEffects, double mass) const {
   switch (materialEffects) {
-    // MultipleScatteringUpdator doesn't change the trajectory-state
-    // during update and can therefore be used if material effects should be ignored:
-  case none:
-  case multipleScattering: 
-    return new MultipleScatteringUpdator(mass);
-  case energyLoss:
-    return new EnergyLossUpdator(mass);
-  case combined:
-    return new CombinedMaterialEffectsUpdator(mass);
-  case breakPoints:
-    return new CombinedMaterialEffectsUpdator(mass);
-  case brokenLinesCoarse:
-  case brokenLinesFine:
-  case localGBL:
-  case curvlinGBL:
-    return new CombinedMaterialEffectsUpdator(mass);
-}
+      // MultipleScatteringUpdator doesn't change the trajectory-state
+      // during update and can therefore be used if material effects should be ignored:
+    case none:
+    case multipleScattering:
+      return new MultipleScatteringUpdator(mass);
+    case energyLoss:
+      return new EnergyLossUpdator(mass);
+    case combined:
+      return new CombinedMaterialEffectsUpdator(mass);
+    case breakPoints:
+      return new CombinedMaterialEffectsUpdator(mass);
+    case brokenLinesCoarse:
+    case brokenLinesFine:
+    case localGBL:
+    case curvlinGBL:
+      return new CombinedMaterialEffectsUpdator(mass);
+  }
 
   return nullptr;
 }
 
 //__________________________________________________________________________________
 
-bool ReferenceTrajectory::propagate(const Plane &previousSurface, const TrajectoryStateOnSurface &previousTsos,
-				    const Plane &newSurface, TrajectoryStateOnSurface &newTsos, AlgebraicMatrix &newJacobian, 
-				    AlgebraicMatrix &newCurvlinJacobian, double &nextStep,
-				    const MagneticField *magField) const
-{
+bool ReferenceTrajectory::propagate(const Plane &previousSurface,
+                                    const TrajectoryStateOnSurface &previousTsos,
+                                    const Plane &newSurface,
+                                    TrajectoryStateOnSurface &newTsos,
+                                    AlgebraicMatrix &newJacobian,
+                                    AlgebraicMatrix &newCurvlinJacobian,
+                                    double &nextStep,
+                                    const MagneticField *magField) const {
   // propagate to next layer
   /** From TrackingTools/ GeomPropagators/ interface/ AnalyticalPropagator.h
    * NB: this propagator assumes constant, non-zero magnetic field parallel to the z-axis!
@@ -382,36 +388,37 @@ bool ReferenceTrajectory::propagate(const Plane &previousSurface, const Trajecto
   // Hard coded RungeKutta instead Analytical (avoid bias in TEC), but
   // work around TrackPropagation/RungeKutta/interface/RKTestPropagator.h and
   // http://www.parashift.com/c++-faq-lite/strange-inheritance.html#faq-23.9
-  defaultRKPropagator::Product  rkprod(magField, propDir_); //double tolerance = 5.e-5)
+  defaultRKPropagator::Product rkprod(magField, propDir_);  //double tolerance = 5.e-5)
   Propagator &aPropagator = rkprod.propagator;
   const std::pair<TrajectoryStateOnSurface, double> tsosWithPath =
-    aPropagator.propagateWithPath(previousTsos, newSurface);
+      aPropagator.propagateWithPath(previousTsos, newSurface);
 
   // stop if propagation wasn't successful
-  if (!tsosWithPath.first.isValid()) return false;
-  
+  if (!tsosWithPath.first.isValid())
+    return false;
+
   nextStep = tsosWithPath.second;
   // calculate derivative of reference-track parameters on the actual layer w.r.t. the ones
   // on the previous layer (both in global coordinates)
-  const AnalyticalCurvilinearJacobian aJacobian(previousTsos.globalParameters(), 
-						tsosWithPath.first.globalPosition(),
-						tsosWithPath.first.globalMomentum(),
-						tsosWithPath.second);
-  const AlgebraicMatrix curvilinearJacobian = asHepMatrix<5,5>(aJacobian.jacobian());
+  const AnalyticalCurvilinearJacobian aJacobian(previousTsos.globalParameters(),
+                                                tsosWithPath.first.globalPosition(),
+                                                tsosWithPath.first.globalMomentum(),
+                                                tsosWithPath.second);
+  const AlgebraicMatrix curvilinearJacobian = asHepMatrix<5, 5>(aJacobian.jacobian());
 
   // jacobian of the track parameters on the previous layer for local->global transformation
   const JacobianLocalToCurvilinear startTrafo(previousSurface, previousTsos.localParameters(), *magField);
   const AlgebraicMatrix localToCurvilinear = asHepMatrix<5>(startTrafo.jacobian());
-    
+
   // jacobian of the track parameters on the actual layer for global->local transformation
   const JacobianCurvilinearToLocal endTrafo(newSurface, tsosWithPath.first.localParameters(), *magField);
   const AlgebraicMatrix curvilinearToLocal = asHepMatrix<5>(endTrafo.jacobian());
-  
+
   // compute derivative of reference-track parameters on the actual layer w.r.t. the ones on
   // the previous layer (both in their local representation)
   newCurvlinJacobian = curvilinearJacobian;
   newJacobian = curvilinearToLocal * curvilinearJacobian * localToCurvilinear;
-  newTsos     = tsosWithPath.first;
+  newTsos = tsosWithPath.first;
 
   return true;
 }
@@ -419,38 +426,37 @@ bool ReferenceTrajectory::propagate(const Plane &previousSurface, const Trajecto
 //__________________________________________________________________________________
 
 void ReferenceTrajectory::fillMeasurementAndError(const TransientTrackingRecHit::ConstRecHitPointer &hitPtr,
-						  unsigned int iRow,
-						  const TrajectoryStateOnSurface &updatedTsos)
-{
+                                                  unsigned int iRow,
+                                                  const TrajectoryStateOnSurface &updatedTsos) {
   // get the measurements and their errors, use information updated with tsos if improving
   // (GF: Also for measurements or only for errors or do the former not change?)
   // GF 10/2008: I doubt that it makes sense to update the hit with the tsos here:
-  //             That is an analytical extrapolation and not the best guess of the real 
+  //             That is an analytical extrapolation and not the best guess of the real
   //             track state on the module, but the latter should be better to get the best
   //             hit uncertainty estimate!
 
-   // FIXME FIXME  CLONE
-  const auto& newHitPtr =  hitPtr;
-//  TransientTrackingRecHit::ConstRecHitPointer newHitPtr(hitPtr->canImproveWithTrack() ?
-//							hitPtr->clone(updatedTsos) : hitPtr);
+  // FIXME FIXME  CLONE
+  const auto &newHitPtr = hitPtr;
+  //  TransientTrackingRecHit::ConstRecHitPointer newHitPtr(hitPtr->canImproveWithTrack() ?
+  //							hitPtr->clone(updatedTsos) : hitPtr);
 
-  const LocalPoint localMeasurement    = newHitPtr->localPosition();
-  const LocalError localMeasurementCov = newHitPtr->localPositionError(); // CPE+APE
-  
-  theMeasurements[iRow]   = localMeasurement.x();
-  theMeasurements[iRow+1] = localMeasurement.y();
-  theMeasurementsCov[iRow][iRow]     = localMeasurementCov.xx();
-  theMeasurementsCov[iRow][iRow+1]   = localMeasurementCov.xy();
-  theMeasurementsCov[iRow+1][iRow+1] = localMeasurementCov.yy();
+  const LocalPoint localMeasurement = newHitPtr->localPosition();
+  const LocalError localMeasurementCov = newHitPtr->localPositionError();  // CPE+APE
+
+  theMeasurements[iRow] = localMeasurement.x();
+  theMeasurements[iRow + 1] = localMeasurement.y();
+  theMeasurementsCov[iRow][iRow] = localMeasurementCov.xx();
+  theMeasurementsCov[iRow][iRow + 1] = localMeasurementCov.xy();
+  theMeasurementsCov[iRow + 1][iRow + 1] = localMeasurementCov.yy();
 
   if (!includeAPEs_) {
     // subtract APEs (if existing) from covariance matrix
-    auto det = static_cast<const TrackerGeomDet*>(newHitPtr->det());
+    auto det = static_cast<const TrackerGeomDet *>(newHitPtr->det());
     const auto localAPE = det->localAlignmentError();
     if (localAPE.valid()) {
-      theMeasurementsCov[iRow][iRow]     -= localAPE.xx();
-      theMeasurementsCov[iRow][iRow+1]   -= localAPE.xy();
-      theMeasurementsCov[iRow+1][iRow+1] -= localAPE.yy();
+      theMeasurementsCov[iRow][iRow] -= localAPE.xx();
+      theMeasurementsCov[iRow][iRow + 1] -= localAPE.xy();
+      theMeasurementsCov[iRow + 1][iRow + 1] -= localAPE.yy();
     }
   }
 }
@@ -458,38 +464,35 @@ void ReferenceTrajectory::fillMeasurementAndError(const TransientTrackingRecHit:
 //__________________________________________________________________________________
 
 void ReferenceTrajectory::fillDerivatives(const AlgebraicMatrix &projection,
-					  const AlgebraicMatrix &fullJacobian,
-					  unsigned int iRow)
-{
+                                          const AlgebraicMatrix &fullJacobian,
+                                          unsigned int iRow) {
   // derivatives of the local coordinates of the reference track w.r.t. to the inital track-parameters
   const AlgebraicMatrix projectedJacobian(projection * fullJacobian);
   for (int i = 0; i < parameters().num_row(); ++i) {
     for (int j = 0; j < projectedJacobian.num_row(); ++j) {
-      theDerivatives[iRow+j][i] = projectedJacobian[j][i];
+      theDerivatives[iRow + j][i] = projectedJacobian[j][i];
     }
   }
 }
 
 //__________________________________________________________________________________
 
-void ReferenceTrajectory::fillTrajectoryPositions(const AlgebraicMatrix &projection, 
-						  const AlgebraicVector &mixedLocalParams, 
-						  unsigned int iRow)
-{
+void ReferenceTrajectory::fillTrajectoryPositions(const AlgebraicMatrix &projection,
+                                                  const AlgebraicVector &mixedLocalParams,
+                                                  unsigned int iRow) {
   // get the local coordinates of the reference trajectory
   const AlgebraicVector localPosition(projection * mixedLocalParams);
   for (int i = 0; i < localPosition.num_row(); ++i) {
-    theTrajectoryPositions[iRow+i] = localPosition[i];
+    theTrajectoryPositions[iRow + i] = localPosition[i];
   }
 }
 
 //__________________________________________________________________________________
 
-bool ReferenceTrajectory::addMaterialEffectsCov(const std::vector<AlgebraicMatrix> &allJacobians, 
-						const std::vector<AlgebraicMatrix> &allProjections,
-						const std::vector<AlgebraicSymMatrix> &allCurvatureChanges,
-						const std::vector<AlgebraicSymMatrix> &allDeltaParameterCovs)
-{
+bool ReferenceTrajectory::addMaterialEffectsCov(const std::vector<AlgebraicMatrix> &allJacobians,
+                                                const std::vector<AlgebraicMatrix> &allProjections,
+                                                const std::vector<AlgebraicSymMatrix> &allCurvatureChanges,
+                                                const std::vector<AlgebraicSymMatrix> &allDeltaParameterCovs) {
   // the uncertainty due to multiple scattering is 'transferred' to the error matrix of the hits
 
   // GF: Needs update once hit dimension is not hardcoded as nMeasPerHit!
@@ -500,7 +503,7 @@ bool ReferenceTrajectory::addMaterialEffectsCov(const std::vector<AlgebraicMatri
   AlgebraicSymMatrix deltaMaterialEffectsCov;
 
   // additional covariance-matrix of the parameters due to material-effects
-  AlgebraicSymMatrix paramMaterialEffectsCov(allDeltaParameterCovs[0]); //initialization
+  AlgebraicSymMatrix paramMaterialEffectsCov(allDeltaParameterCovs[0]);  //initialization
   // error-propagation to state after energy loss
   //GFback  paramMaterialEffectsCov = paramMaterialEffectsCov.similarity(allCurvatureChanges[0]);
 
@@ -513,10 +516,10 @@ bool ReferenceTrajectory::addMaterialEffectsCov(const std::vector<AlgebraicMatri
 
     // get dependences for the measurements
     deltaMaterialEffectsCov = paramMaterialEffectsCov.similarity(allProjections[k]);
-    materialEffectsCov[nMeasPerHit*k  ][nMeasPerHit*k  ] = deltaMaterialEffectsCov[0][0];
-    materialEffectsCov[nMeasPerHit*k  ][nMeasPerHit*k+1] = deltaMaterialEffectsCov[0][1];
-    materialEffectsCov[nMeasPerHit*k+1][nMeasPerHit*k  ] = deltaMaterialEffectsCov[1][0];
-    materialEffectsCov[nMeasPerHit*k+1][nMeasPerHit*k+1] = deltaMaterialEffectsCov[1][1];
+    materialEffectsCov[nMeasPerHit * k][nMeasPerHit * k] = deltaMaterialEffectsCov[0][0];
+    materialEffectsCov[nMeasPerHit * k][nMeasPerHit * k + 1] = deltaMaterialEffectsCov[0][1];
+    materialEffectsCov[nMeasPerHit * k + 1][nMeasPerHit * k] = deltaMaterialEffectsCov[1][0];
+    materialEffectsCov[nMeasPerHit * k + 1][nMeasPerHit * k + 1] = deltaMaterialEffectsCov[1][1];
 
     // GFback add uncertainties for the following layers due to scattering at this layer
     paramMaterialEffectsCov += allDeltaParameterCovs[k];
@@ -524,93 +527,89 @@ bool ReferenceTrajectory::addMaterialEffectsCov(const std::vector<AlgebraicMatri
     tempParameterCov = paramMaterialEffectsCov;
 
     // compute "inter-layer-dependencies"
-    for (unsigned int l = k+1; l < allJacobians.size(); ++l) {
-      tempParameterCov   = allJacobians[l]   * allCurvatureChanges[l] * tempParameterCov;
-      tempMeasurementCov = allProjections[l] * tempParameterCov       * allProjections[k].T();
+    for (unsigned int l = k + 1; l < allJacobians.size(); ++l) {
+      tempParameterCov = allJacobians[l] * allCurvatureChanges[l] * tempParameterCov;
+      tempMeasurementCov = allProjections[l] * tempParameterCov * allProjections[k].T();
 
-      materialEffectsCov[nMeasPerHit*l][nMeasPerHit*k] = tempMeasurementCov[0][0];
-      materialEffectsCov[nMeasPerHit*k][nMeasPerHit*l] = tempMeasurementCov[0][0];
+      materialEffectsCov[nMeasPerHit * l][nMeasPerHit * k] = tempMeasurementCov[0][0];
+      materialEffectsCov[nMeasPerHit * k][nMeasPerHit * l] = tempMeasurementCov[0][0];
 
-      materialEffectsCov[nMeasPerHit*l][nMeasPerHit*k+1] = tempMeasurementCov[0][1];
-      materialEffectsCov[nMeasPerHit*k+1][nMeasPerHit*l] = tempMeasurementCov[0][1];
+      materialEffectsCov[nMeasPerHit * l][nMeasPerHit * k + 1] = tempMeasurementCov[0][1];
+      materialEffectsCov[nMeasPerHit * k + 1][nMeasPerHit * l] = tempMeasurementCov[0][1];
 
-      materialEffectsCov[nMeasPerHit*l+1][nMeasPerHit*k] = tempMeasurementCov[1][0];
-      materialEffectsCov[nMeasPerHit*k][nMeasPerHit*l+1] = tempMeasurementCov[1][0];
+      materialEffectsCov[nMeasPerHit * l + 1][nMeasPerHit * k] = tempMeasurementCov[1][0];
+      materialEffectsCov[nMeasPerHit * k][nMeasPerHit * l + 1] = tempMeasurementCov[1][0];
 
-      materialEffectsCov[nMeasPerHit*l+1][nMeasPerHit*k+1] = tempMeasurementCov[1][1];
-      materialEffectsCov[nMeasPerHit*k+1][nMeasPerHit*l+1] = tempMeasurementCov[1][1];
-    } 
+      materialEffectsCov[nMeasPerHit * l + 1][nMeasPerHit * k + 1] = tempMeasurementCov[1][1];
+      materialEffectsCov[nMeasPerHit * k + 1][nMeasPerHit * l + 1] = tempMeasurementCov[1][1];
+    }
     // add uncertainties for the following layers due to scattering at this layer
-    // GFback paramMaterialEffectsCov += allDeltaParameterCovs[k];    
+    // GFback paramMaterialEffectsCov += allDeltaParameterCovs[k];
     // error-propagation to state after energy loss
     paramMaterialEffectsCov = paramMaterialEffectsCov.similarity(allCurvatureChanges[k]);
-     
   }
   theMeasurementsCov += materialEffectsCov;
 
-  return true; // cannot fail
+  return true;  // cannot fail
 }
 
 //__________________________________________________________________________________
 
-bool ReferenceTrajectory::addMaterialEffectsBp(const std::vector<AlgebraicMatrix> &allJacobians, 
+bool ReferenceTrajectory::addMaterialEffectsBp(const std::vector<AlgebraicMatrix> &allJacobians,
                                                const std::vector<AlgebraicMatrix> &allProjections,
                                                const std::vector<AlgebraicSymMatrix> &allCurvatureChanges,
                                                const std::vector<AlgebraicSymMatrix> &allDeltaParameterCovs,
-                                               const std::vector<AlgebraicMatrix> &allLocalToCurv)
-{
-//CHK: add material effects using break points
-  int offsetPar = theNumberOfPars; 
+                                               const std::vector<AlgebraicMatrix> &allLocalToCurv) {
+  //CHK: add material effects using break points
+  int offsetPar = theNumberOfPars;
   int offsetMeas = nMeasPerHit * allJacobians.size();
-  int ierr = 0; 
+  int ierr = 0;
 
   AlgebraicMatrix tempJacobian;
-  AlgebraicMatrix MSprojection(2,5);
+  AlgebraicMatrix MSprojection(2, 5);
   MSprojection[0][1] = 1;
   MSprojection[1][2] = 1;
-  AlgebraicSymMatrix tempMSCov; 
+  AlgebraicSymMatrix tempMSCov;
   AlgebraicSymMatrix tempMSCovProj;
-  AlgebraicMatrix tempMSJacProj;   
+  AlgebraicMatrix tempMSJacProj;
 
   for (unsigned int k = 1; k < allJacobians.size(); ++k) {
-// CHK 
-    int kbp = k-1;
+    // CHK
+    int kbp = k - 1;
     tempJacobian = allJacobians[k] * allCurvatureChanges[k];
-    tempMSCov = allDeltaParameterCovs[k-1].similarity(allLocalToCurv[k-1]);
+    tempMSCov = allDeltaParameterCovs[k - 1].similarity(allLocalToCurv[k - 1]);
     tempMSCovProj = tempMSCov.similarity(MSprojection);
-    theMeasurementsCov[offsetMeas+nMeasPerHit*kbp  ][offsetMeas+nMeasPerHit*kbp  ] = tempMSCovProj[0][0];
-    theMeasurementsCov[offsetMeas+nMeasPerHit*kbp+1][offsetMeas+nMeasPerHit*kbp+1]=  tempMSCovProj[1][1];
-    theDerivatives[offsetMeas+nMeasPerHit*kbp  ][offsetPar+2*kbp  ] = 1.0;
-    theDerivatives[offsetMeas+nMeasPerHit*kbp+1][offsetPar+2*kbp+1] = 1.0 ; 
+    theMeasurementsCov[offsetMeas + nMeasPerHit * kbp][offsetMeas + nMeasPerHit * kbp] = tempMSCovProj[0][0];
+    theMeasurementsCov[offsetMeas + nMeasPerHit * kbp + 1][offsetMeas + nMeasPerHit * kbp + 1] = tempMSCovProj[1][1];
+    theDerivatives[offsetMeas + nMeasPerHit * kbp][offsetPar + 2 * kbp] = 1.0;
+    theDerivatives[offsetMeas + nMeasPerHit * kbp + 1][offsetPar + 2 * kbp + 1] = 1.0;
 
-    tempMSJacProj = (allProjections[k] * ( tempJacobian * allLocalToCurv[k-1].inverse(ierr) )) * MSprojection.T();
+    tempMSJacProj = (allProjections[k] * (tempJacobian * allLocalToCurv[k - 1].inverse(ierr))) * MSprojection.T();
     if (ierr) {
       edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::addMaterialEffectsBp"
-	                         << "Inversion 1 for break points failed: " << ierr;
+                                 << "Inversion 1 for break points failed: " << ierr;
       return false;
     }
-    theDerivatives[nMeasPerHit*k  ][offsetPar+2*kbp  ] =  tempMSJacProj[0][0];  
-    theDerivatives[nMeasPerHit*k  ][offsetPar+2*kbp+1] =  tempMSJacProj[0][1]; 
-    theDerivatives[nMeasPerHit*k+1][offsetPar+2*kbp  ] =  tempMSJacProj[1][0];  
-    theDerivatives[nMeasPerHit*k+1][offsetPar+2*kbp+1] =  tempMSJacProj[1][1];
-              
-    for (unsigned int l = k+1; l < allJacobians.size(); ++l) {
-// CHK    
-      int kbp = k-1;
-      tempJacobian = allJacobians[l] * allCurvatureChanges[l] * tempJacobian; 
-      tempMSJacProj = (allProjections[l] * ( tempJacobian * allLocalToCurv[k-1].inverse(ierr) )) * MSprojection.T();
+    theDerivatives[nMeasPerHit * k][offsetPar + 2 * kbp] = tempMSJacProj[0][0];
+    theDerivatives[nMeasPerHit * k][offsetPar + 2 * kbp + 1] = tempMSJacProj[0][1];
+    theDerivatives[nMeasPerHit * k + 1][offsetPar + 2 * kbp] = tempMSJacProj[1][0];
+    theDerivatives[nMeasPerHit * k + 1][offsetPar + 2 * kbp + 1] = tempMSJacProj[1][1];
+
+    for (unsigned int l = k + 1; l < allJacobians.size(); ++l) {
+      // CHK
+      int kbp = k - 1;
+      tempJacobian = allJacobians[l] * allCurvatureChanges[l] * tempJacobian;
+      tempMSJacProj = (allProjections[l] * (tempJacobian * allLocalToCurv[k - 1].inverse(ierr))) * MSprojection.T();
       if (ierr) {
-	edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::addMaterialEffectsBp"
-				   << "Inversion 2 for break points failed: " << ierr;
+        edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::addMaterialEffectsBp"
+                                   << "Inversion 2 for break points failed: " << ierr;
         return false;
       }
-      theDerivatives[nMeasPerHit*l  ][offsetPar+2*kbp  ] =  tempMSJacProj[0][0];  
-      theDerivatives[nMeasPerHit*l  ][offsetPar+2*kbp+1] =  tempMSJacProj[0][1]; 
-      theDerivatives[nMeasPerHit*l+1][offsetPar+2*kbp  ] =  tempMSJacProj[1][0];  
-      theDerivatives[nMeasPerHit*l+1][offsetPar+2*kbp+1] =  tempMSJacProj[1][1]; 
-
+      theDerivatives[nMeasPerHit * l][offsetPar + 2 * kbp] = tempMSJacProj[0][0];
+      theDerivatives[nMeasPerHit * l][offsetPar + 2 * kbp + 1] = tempMSJacProj[0][1];
+      theDerivatives[nMeasPerHit * l + 1][offsetPar + 2 * kbp] = tempMSJacProj[1][0];
+      theDerivatives[nMeasPerHit * l + 1][offsetPar + 2 * kbp + 1] = tempMSJacProj[1][1];
     }
-
   }
 
   return true;
@@ -618,51 +617,50 @@ bool ReferenceTrajectory::addMaterialEffectsBp(const std::vector<AlgebraicMatrix
 
 //__________________________________________________________________________________
 
-bool ReferenceTrajectory::addMaterialEffectsBrl(const std::vector<AlgebraicMatrix> &allCurvlinJacobians, 
-						const std::vector<AlgebraicMatrix> &allProjections,
-						const std::vector<AlgebraicSymMatrix> &allCurvatureChanges,
-						const std::vector<AlgebraicSymMatrix> &allDeltaParameterCovs,
-						const std::vector<AlgebraicMatrix> &allLocalToCurv,
-						const GlobalTrajectoryParameters &gtp)
-{
-//CHK: add material effects using broken lines
-//fine: use exact Jacobians, all detectors  
-//broken lines: pair of offsets (u1,u2) = (xt,yt) (in curvilinear frame (q/p,lambda,phi,xt,yt)) at each layer
-//              scattering angles (alpha1,alpha2) = (cosLambda*dPhi, dLambda) (cosLambda cancels in Chi2)
-//              DU' = (dU'/dU)*DU + (dU'/dAlpha)*DAlpha + (dU'/dQbyp)*DQbyp (propagation of U)
-//                  = J*DU + S*DAlpha + d*DQbyp
-//           => DAlpha = S^-1 (DU' - J*DU - d*DQbyp)
+bool ReferenceTrajectory::addMaterialEffectsBrl(const std::vector<AlgebraicMatrix> &allCurvlinJacobians,
+                                                const std::vector<AlgebraicMatrix> &allProjections,
+                                                const std::vector<AlgebraicSymMatrix> &allCurvatureChanges,
+                                                const std::vector<AlgebraicSymMatrix> &allDeltaParameterCovs,
+                                                const std::vector<AlgebraicMatrix> &allLocalToCurv,
+                                                const GlobalTrajectoryParameters &gtp) {
+  //CHK: add material effects using broken lines
+  //fine: use exact Jacobians, all detectors
+  //broken lines: pair of offsets (u1,u2) = (xt,yt) (in curvilinear frame (q/p,lambda,phi,xt,yt)) at each layer
+  //              scattering angles (alpha1,alpha2) = (cosLambda*dPhi, dLambda) (cosLambda cancels in Chi2)
+  //              DU' = (dU'/dU)*DU + (dU'/dAlpha)*DAlpha + (dU'/dQbyp)*DQbyp (propagation of U)
+  //                  = J*DU + S*DAlpha + d*DQbyp
+  //           => DAlpha = S^-1 (DU' - J*DU - d*DQbyp)
 
   int offsetPar = theNumberOfPars;
-  int offsetMeas = nMeasPerHit*allCurvlinJacobians.size();
+  int offsetMeas = nMeasPerHit * allCurvlinJacobians.size();
   int ierr = 0;
 
   GlobalVector p = gtp.momentum();
-  double cosLambda = sqrt((p.x()*p.x()+p.y()*p.y())/(p.x()*p.x()+p.y()*p.y()+p.z()*p.z()));
+  double cosLambda = sqrt((p.x() * p.x() + p.y() * p.y()) / (p.x() * p.x() + p.y() * p.y() + p.z() * p.z()));
 
-// transformations Curvilinear <-> BrokenLines
-  AlgebraicMatrix QbypToCurv(5,1);   // dCurv/dQbyp
-  QbypToCurv[0][0] = 1.;             // dQbyp/dQbyp
-  AlgebraicMatrix AngleToCurv(5,2);  // dCurv/dAlpha
-  AngleToCurv[1][1] = 1.;            // dlambda/dalpha2
-  AngleToCurv[2][0] = 1./cosLambda;  // dphi/dalpha1
-  AlgebraicMatrix CurvToAngle(2,5);  // dAlpha/dCurv
-  CurvToAngle[1][1] = 1.;            // dalpha2/dlambda
-  CurvToAngle[0][2] = cosLambda;     // dalpha1/dphi
-  AlgebraicMatrix OffsetToCurv(5,2); // dCurv/dU
-  OffsetToCurv[3][0] = 1.;           // dxt/du1
-  OffsetToCurv[4][1] = 1.;           // dyt/du2
-  AlgebraicMatrix CurvToOffset(2,5); // dU/dCurv
-  CurvToOffset[0][3] = 1.;           // du1/dxt
-  CurvToOffset[1][4] = 1.;           // du2/dyt
+  // transformations Curvilinear <-> BrokenLines
+  AlgebraicMatrix QbypToCurv(5, 1);    // dCurv/dQbyp
+  QbypToCurv[0][0] = 1.;               // dQbyp/dQbyp
+  AlgebraicMatrix AngleToCurv(5, 2);   // dCurv/dAlpha
+  AngleToCurv[1][1] = 1.;              // dlambda/dalpha2
+  AngleToCurv[2][0] = 1. / cosLambda;  // dphi/dalpha1
+  AlgebraicMatrix CurvToAngle(2, 5);   // dAlpha/dCurv
+  CurvToAngle[1][1] = 1.;              // dalpha2/dlambda
+  CurvToAngle[0][2] = cosLambda;       // dalpha1/dphi
+  AlgebraicMatrix OffsetToCurv(5, 2);  // dCurv/dU
+  OffsetToCurv[3][0] = 1.;             // dxt/du1
+  OffsetToCurv[4][1] = 1.;             // dyt/du2
+  AlgebraicMatrix CurvToOffset(2, 5);  // dU/dCurv
+  CurvToOffset[0][3] = 1.;             // du1/dxt
+  CurvToOffset[1][4] = 1.;             // du2/dyt
 
-// transformations  trajectory to components (Qbyp, U1, U2)
-  AlgebraicMatrix TrajToQbyp(1,5);
+  // transformations  trajectory to components (Qbyp, U1, U2)
+  AlgebraicMatrix TrajToQbyp(1, 5);
   TrajToQbyp[0][0] = 1.;
-  AlgebraicMatrix TrajToOff1(2,5);
+  AlgebraicMatrix TrajToOff1(2, 5);
   TrajToOff1[0][1] = 1.;
   TrajToOff1[1][2] = 1.;
-  AlgebraicMatrix TrajToOff2(2,5);
+  AlgebraicMatrix TrajToOff2(2, 5);
   TrajToOff2[0][3] = 1.;
   TrajToOff2[1][4] = 1.;
 
@@ -670,22 +668,24 @@ bool ReferenceTrajectory::addMaterialEffectsBrl(const std::vector<AlgebraicMatri
   AlgebraicMatrix JacCurvToOffsetL, JacOffsetToOffsetL, JacAngleToOffsetL, JacQbypToOffsetL, JacOffsetToAngleL;
   AlgebraicMatrix JacCurvToOffsetN, JacOffsetToOffsetN, JacAngleToOffsetN, JacQbypToOffsetN, JacOffsetToAngleN;
 
-// transformation from trajectory to curvilinear parameters
+  // transformation from trajectory to curvilinear parameters
 
-  JacCurvToOffsetN = CurvToOffset * allCurvlinJacobians[1]; // (dU'/dCurv') * (dCurv'/dCurv) @ 2nd point
-  JacOffsetToOffsetN = JacCurvToOffsetN * OffsetToCurv; // J: (dU'/dU)     = (dU'/dCurv') * (dCurv'/dCurv) * (dCurv/dU)
-  JacAngleToOffsetN  = JacCurvToOffsetN * AngleToCurv;  // S: (dU'/dAlpha) = (dU'/dCurv') * (dCurv'/dCurv) * (dCurv/dAlpha)
-  JacQbypToOffsetN   = JacCurvToOffsetN * QbypToCurv;   // d: (dU'/dQbyp)  = (dU'/dCurv') * (dCurv'/dCurv) * (dCurv/dQbyp)
-  JacOffsetToAngleN  = JacAngleToOffsetN.inverse(ierr); // W
+  JacCurvToOffsetN = CurvToOffset * allCurvlinJacobians[1];  // (dU'/dCurv') * (dCurv'/dCurv) @ 2nd point
+  JacOffsetToOffsetN = JacCurvToOffsetN * OffsetToCurv;  // J: (dU'/dU)     = (dU'/dCurv') * (dCurv'/dCurv) * (dCurv/dU)
+  JacAngleToOffsetN =
+      JacCurvToOffsetN * AngleToCurv;                // S: (dU'/dAlpha) = (dU'/dCurv') * (dCurv'/dCurv) * (dCurv/dAlpha)
+  JacQbypToOffsetN = JacCurvToOffsetN * QbypToCurv;  // d: (dU'/dQbyp)  = (dU'/dCurv') * (dCurv'/dCurv) * (dCurv/dQbyp)
+  JacOffsetToAngleN = JacAngleToOffsetN.inverse(ierr);  // W
   if (ierr) {
-     edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::addMaterialEffectsBrl"
-                                << "Inversion 1 for fine broken lines failed: " << ierr;
-     return false;
+    edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::addMaterialEffectsBrl"
+                               << "Inversion 1 for fine broken lines failed: " << ierr;
+    return false;
   }
-  JacOffsetToAngleC = -(JacOffsetToAngleN * JacOffsetToOffsetN); // (dAlpha/dU)
-  JacQbypToAngleC   = -(JacOffsetToAngleN * JacQbypToOffsetN);   // (dAlpha/dQbyp)
+  JacOffsetToAngleC = -(JacOffsetToAngleN * JacOffsetToOffsetN);  // (dAlpha/dU)
+  JacQbypToAngleC = -(JacOffsetToAngleN * JacQbypToOffsetN);      // (dAlpha/dQbyp)
   // (dAlpha/dTraj) = (dAlpha/dQbyp) * (dQbyp/dTraj) + (dAlpha/dU1) * (dU1/dTraj) + (dAlpha/dU2) * (dU2/dTraj)
-  AlgebraicMatrix JacTrajToAngle = JacQbypToAngleC * TrajToQbyp + JacOffsetToAngleC * TrajToOff1 + JacOffsetToAngleN * TrajToOff2;
+  AlgebraicMatrix JacTrajToAngle =
+      JacQbypToAngleC * TrajToQbyp + JacOffsetToAngleC * TrajToOff1 + JacOffsetToAngleN * TrajToOff2;
   // (dCurv/dTraj) = (dCurv/dQbyp) * (dQbyp/dTraj) + (dCurv/dAlpha) * (dAlpha/dTraj) + (dCurv/dU) * (dU/dTraj)
   theInnerTrajectoryToCurvilinear = QbypToCurv * TrajToQbyp + AngleToCurv * JacTrajToAngle + OffsetToCurv * TrajToOff1;
   theInnerLocalToTrajectory = theInnerTrajectoryToCurvilinear.inverse(ierr) * allLocalToCurv[0];
@@ -701,87 +701,93 @@ bool ReferenceTrajectory::addMaterialEffectsBrl(const std::vector<AlgebraicMatri
   AlgebraicMatrix tempJacL, tempJacN;
   AlgebraicMatrix JacOffsetToMeas;
 
-// measurements from hits  
+  // measurements from hits
   for (unsigned int k = 0; k < allCurvlinJacobians.size(); ++k) {
-//  (dMeas/dU) = (dMeas/dLoc) * (dLoc/dCurv) * (dCurv/dU)
-    JacOffsetToMeas = (allProjections[k] * allLocalToCurv[k].inverse(ierr) ) * OffsetToCurv;
+    //  (dMeas/dU) = (dMeas/dLoc) * (dLoc/dCurv) * (dCurv/dU)
+    JacOffsetToMeas = (allProjections[k] * allLocalToCurv[k].inverse(ierr)) * OffsetToCurv;
     if (ierr) {
-       edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::addMaterialEffectsBrl"
-				   << "Inversion 3 for fine broken lines failed: " << ierr;
-       return false;
+      edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::addMaterialEffectsBrl"
+                                 << "Inversion 3 for fine broken lines failed: " << ierr;
+      return false;
     }
-    theDerivatives[nMeasPerHit*k  ][offsetPar+2*k  ] =  JacOffsetToMeas[0][0];
-    theDerivatives[nMeasPerHit*k  ][offsetPar+2*k+1] =  JacOffsetToMeas[0][1];
-    theDerivatives[nMeasPerHit*k+1][offsetPar+2*k  ] =  JacOffsetToMeas[1][0];
-    theDerivatives[nMeasPerHit*k+1][offsetPar+2*k+1] =  JacOffsetToMeas[1][1];
+    theDerivatives[nMeasPerHit * k][offsetPar + 2 * k] = JacOffsetToMeas[0][0];
+    theDerivatives[nMeasPerHit * k][offsetPar + 2 * k + 1] = JacOffsetToMeas[0][1];
+    theDerivatives[nMeasPerHit * k + 1][offsetPar + 2 * k] = JacOffsetToMeas[1][0];
+    theDerivatives[nMeasPerHit * k + 1][offsetPar + 2 * k + 1] = JacOffsetToMeas[1][1];
   }
 
-// measurement of MS kink  
-  for (unsigned int k = 1; k < allCurvlinJacobians.size()-1; ++k) {
-// CHK 
-    int iMsMeas = k-1; 
-    int l    = k-1; // last hit
-    int n    = k+1; // next hit
+  // measurement of MS kink
+  for (unsigned int k = 1; k < allCurvlinJacobians.size() - 1; ++k) {
+    // CHK
+    int iMsMeas = k - 1;
+    int l = k - 1;  // last hit
+    int n = k + 1;  // next hit
 
-// amount of multiple scattering in layer k  (angular error perp to direction)  
+    // amount of multiple scattering in layer k  (angular error perp to direction)
     tempMSCov = allDeltaParameterCovs[k].similarity(allLocalToCurv[k]);
     tempMSCovProj = tempMSCov.similarity(CurvToAngle);
-    theMeasurementsCov[offsetMeas+nMeasPerHit*iMsMeas  ][offsetMeas+nMeasPerHit*iMsMeas  ] = tempMSCovProj[1][1];
-    theMeasurementsCov[offsetMeas+nMeasPerHit*iMsMeas+1][offsetMeas+nMeasPerHit*iMsMeas+1] = tempMSCovProj[0][0];
+    theMeasurementsCov[offsetMeas + nMeasPerHit * iMsMeas][offsetMeas + nMeasPerHit * iMsMeas] = tempMSCovProj[1][1];
+    theMeasurementsCov[offsetMeas + nMeasPerHit * iMsMeas + 1][offsetMeas + nMeasPerHit * iMsMeas + 1] =
+        tempMSCovProj[0][0];
 
-// transformation matices for offsets ( l <- k -> n )
+    // transformation matices for offsets ( l <- k -> n )
     tempJacL = allCurvlinJacobians[k] * tempJacobian;
-    JacCurvToOffsetL = CurvToOffset * tempJacL.inverse(ierr); // (dU'/dCurv') * (dCurv'/dCurv) @ last point
+    JacCurvToOffsetL = CurvToOffset * tempJacL.inverse(ierr);  // (dU'/dCurv') * (dCurv'/dCurv) @ last point
 
     if (ierr) {
-       edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::addMaterialEffectsBrl"
-				   << "Inversion 4 for fine broken lines failed: " << ierr;
-       return false;
+      edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::addMaterialEffectsBrl"
+                                 << "Inversion 4 for fine broken lines failed: " << ierr;
+      return false;
     }
-    JacOffsetToOffsetL = JacCurvToOffsetL * OffsetToCurv; // J-: (dU'/dU)     = (dU'/dCurv') * (dCurv'/dCurv) * (dCurv/dU)
-    JacAngleToOffsetL  = JacCurvToOffsetL * AngleToCurv;  // S-: (dU'/dAlpha) = (dU'/dCurv') * (dCurv'/dCurv) * (dCurv/dAlpha)
-    JacQbypToOffsetL   = JacCurvToOffsetL * QbypToCurv;   // d-: (dU'/dQbyp)  = (dU'/dCurv') * (dCurv'/dCurv) * (dCurv/dQbyp)
-    JacOffsetToAngleL  =-JacAngleToOffsetL.inverse(ierr); // W-
+    JacOffsetToOffsetL =
+        JacCurvToOffsetL * OffsetToCurv;  // J-: (dU'/dU)     = (dU'/dCurv') * (dCurv'/dCurv) * (dCurv/dU)
+    JacAngleToOffsetL =
+        JacCurvToOffsetL * AngleToCurv;  // S-: (dU'/dAlpha) = (dU'/dCurv') * (dCurv'/dCurv) * (dCurv/dAlpha)
+    JacQbypToOffsetL =
+        JacCurvToOffsetL * QbypToCurv;  // d-: (dU'/dQbyp)  = (dU'/dCurv') * (dCurv'/dCurv) * (dCurv/dQbyp)
+    JacOffsetToAngleL = -JacAngleToOffsetL.inverse(ierr);  // W-
     if (ierr) {
-       edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::addMaterialEffectsBrl"
-				   << "Inversion 5 for fine broken lines failed: " << ierr;
-       return false;
+      edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::addMaterialEffectsBrl"
+                                 << "Inversion 5 for fine broken lines failed: " << ierr;
+      return false;
     }
     tempJacobian = tempJacobian * allCurvatureChanges[k];
     tempJacN = allCurvlinJacobians[n] * tempJacobian;
-    JacCurvToOffsetN = CurvToOffset * tempJacN; // (dU'/dCurv') * (dCurv'/dCurv) @ next point
-    JacOffsetToOffsetN = JacCurvToOffsetN * OffsetToCurv; // J+: (dU'/dU)     = (dU'/dCurv') * (dCurv'/dCurv) * (dCurv/dU)
-    JacAngleToOffsetN  = JacCurvToOffsetN * AngleToCurv;  // S+: (dU'/dAlpha) = (dU'/dCurv') * (dCurv'/dCurv) * (dCurv/dAlpha)
-    JacQbypToOffsetN   = JacCurvToOffsetN * QbypToCurv;   // d+: (dU'/dQbyp)  = (dU'/dCurv') * (dCurv'/dCurv) * (dCurv/dQbyp)
-    JacOffsetToAngleN  = JacAngleToOffsetN.inverse(ierr); // W+
+    JacCurvToOffsetN = CurvToOffset * tempJacN;  // (dU'/dCurv') * (dCurv'/dCurv) @ next point
+    JacOffsetToOffsetN =
+        JacCurvToOffsetN * OffsetToCurv;  // J+: (dU'/dU)     = (dU'/dCurv') * (dCurv'/dCurv) * (dCurv/dU)
+    JacAngleToOffsetN =
+        JacCurvToOffsetN * AngleToCurv;  // S+: (dU'/dAlpha) = (dU'/dCurv') * (dCurv'/dCurv) * (dCurv/dAlpha)
+    JacQbypToOffsetN =
+        JacCurvToOffsetN * QbypToCurv;  // d+: (dU'/dQbyp)  = (dU'/dCurv') * (dCurv'/dCurv) * (dCurv/dQbyp)
+    JacOffsetToAngleN = JacAngleToOffsetN.inverse(ierr);  // W+
     if (ierr) {
-       edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::addMaterialEffectsBrl"
-				   << "Inversion 6 for fine broken lines failed: " << ierr;
-       return false;
+      edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::addMaterialEffectsBrl"
+                                 << "Inversion 6 for fine broken lines failed: " << ierr;
+      return false;
     }
     JacOffsetToAngleC = -(JacOffsetToAngleL * JacOffsetToOffsetL + JacOffsetToAngleN * JacOffsetToOffsetN);
-    JacQbypToAngleC   = -(JacOffsetToAngleL * JacQbypToOffsetL   + JacOffsetToAngleN * JacQbypToOffsetN);
+    JacQbypToAngleC = -(JacOffsetToAngleL * JacQbypToOffsetL + JacOffsetToAngleN * JacQbypToOffsetN);
 
-    // bending    
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas  ][              0] = JacQbypToAngleC[0][0];
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas+1][              0] = JacQbypToAngleC[1][0];
+    // bending
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas][0] = JacQbypToAngleC[0][0];
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas + 1][0] = JacQbypToAngleC[1][0];
     // last layer
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas  ][offsetPar+2*l  ] = JacOffsetToAngleL[0][0];
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas  ][offsetPar+2*l+1] = JacOffsetToAngleL[0][1];
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas+1][offsetPar+2*l  ] = JacOffsetToAngleL[1][0];
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas+1][offsetPar+2*l+1] = JacOffsetToAngleL[1][1];
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas][offsetPar + 2 * l] = JacOffsetToAngleL[0][0];
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas][offsetPar + 2 * l + 1] = JacOffsetToAngleL[0][1];
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas + 1][offsetPar + 2 * l] = JacOffsetToAngleL[1][0];
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas + 1][offsetPar + 2 * l + 1] = JacOffsetToAngleL[1][1];
     // current layer
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas  ][offsetPar+2*k  ] = JacOffsetToAngleC[0][0];
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas  ][offsetPar+2*k+1] = JacOffsetToAngleC[0][1];
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas+1][offsetPar+2*k  ] = JacOffsetToAngleC[1][0];
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas+1][offsetPar+2*k+1] = JacOffsetToAngleC[1][1];
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas][offsetPar + 2 * k] = JacOffsetToAngleC[0][0];
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas][offsetPar + 2 * k + 1] = JacOffsetToAngleC[0][1];
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas + 1][offsetPar + 2 * k] = JacOffsetToAngleC[1][0];
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas + 1][offsetPar + 2 * k + 1] = JacOffsetToAngleC[1][1];
 
     // next layer
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas  ][offsetPar+2*n  ] = JacOffsetToAngleN[0][0];
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas  ][offsetPar+2*n+1] = JacOffsetToAngleN[0][1];
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas+1][offsetPar+2*n  ] = JacOffsetToAngleN[1][0];
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas+1][offsetPar+2*n+1] = JacOffsetToAngleN[1][1];
-
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas][offsetPar + 2 * n] = JacOffsetToAngleN[0][0];
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas][offsetPar + 2 * n + 1] = JacOffsetToAngleN[0][1];
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas + 1][offsetPar + 2 * n] = JacOffsetToAngleN[1][0];
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas + 1][offsetPar + 2 * n + 1] = JacOffsetToAngleN[1][1];
   }
 
   return true;
@@ -790,33 +796,32 @@ bool ReferenceTrajectory::addMaterialEffectsBrl(const std::vector<AlgebraicMatri
 //__________________________________________________________________________________
 
 bool ReferenceTrajectory::addMaterialEffectsBrl(const std::vector<AlgebraicMatrix> &allProjections,
-						const std::vector<AlgebraicSymMatrix> &allDeltaParameterCovs,
-						const std::vector<AlgebraicMatrix> &allLocalToCurv,
-						const std::vector<double> &allSteps,
-						const GlobalTrajectoryParameters &gtp,
-						const double minStep)
-{
-//CHK: add material effects using broken lines
-//BrokenLinesCoarse: combine close by detectors, 
-//                   use approximate Jacobians from Steps (limit Qbyp -> 0),
-//                   bending only in RPhi (B=(0,0,Bz)), no energy loss correction
+                                                const std::vector<AlgebraicSymMatrix> &allDeltaParameterCovs,
+                                                const std::vector<AlgebraicMatrix> &allLocalToCurv,
+                                                const std::vector<double> &allSteps,
+                                                const GlobalTrajectoryParameters &gtp,
+                                                const double minStep) {
+  //CHK: add material effects using broken lines
+  //BrokenLinesCoarse: combine close by detectors,
+  //                   use approximate Jacobians from Steps (limit Qbyp -> 0),
+  //                   bending only in RPhi (B=(0,0,Bz)), no energy loss correction
 
-  int offsetPar = theNumberOfPars; 
-  int offsetMeas = nMeasPerHit*allSteps.size();
+  int offsetPar = theNumberOfPars;
+  int offsetMeas = nMeasPerHit * allSteps.size();
   int ierr = 0;
 
   GlobalVector p = gtp.momentum();
-  double cosLambda = sqrt((p.x()*p.x()+p.y()*p.y())/(p.x()*p.x()+p.y()*p.y()+p.z()*p.z()));
+  double cosLambda = sqrt((p.x() * p.x() + p.y() * p.y()) / (p.x() * p.x() + p.y() * p.y() + p.z() * p.z()));
   double bFac = -gtp.magneticFieldInInverseGeV(gtp.position()).mag();
 
   // transformation from trajectory to curvilinear parameters at refTsos
-  double delta (1.0/allSteps[1]);    
+  double delta(1.0 / allSteps[1]);
   theInnerTrajectoryToCurvilinear[0][0] = 1;
-  theInnerTrajectoryToCurvilinear[1][2] = -delta;  
-  theInnerTrajectoryToCurvilinear[1][4] =  delta;    
-  theInnerTrajectoryToCurvilinear[2][0] = -0.5*bFac/delta;
-  theInnerTrajectoryToCurvilinear[2][1] = -delta/cosLambda;
-  theInnerTrajectoryToCurvilinear[2][3] =  delta/cosLambda;
+  theInnerTrajectoryToCurvilinear[1][2] = -delta;
+  theInnerTrajectoryToCurvilinear[1][4] = delta;
+  theInnerTrajectoryToCurvilinear[2][0] = -0.5 * bFac / delta;
+  theInnerTrajectoryToCurvilinear[2][1] = -delta / cosLambda;
+  theInnerTrajectoryToCurvilinear[2][3] = delta / cosLambda;
   theInnerTrajectoryToCurvilinear[3][1] = 1;
   theInnerTrajectoryToCurvilinear[4][2] = 1;
   theInnerLocalToTrajectory = theInnerTrajectoryToCurvilinear.inverse(ierr) * allLocalToCurv[0];
@@ -826,12 +831,12 @@ bool ReferenceTrajectory::addMaterialEffectsBrl(const std::vector<AlgebraicMatri
     return false;
   }
 
-  AlgebraicMatrix CurvToAngle(2,5);  // dAlpha/dCurv
-  CurvToAngle[1][1] = 1.;            // dalpha2/dlambda
-  CurvToAngle[0][2] = cosLambda;     // dalpha1/dphi
-  AlgebraicMatrix OffsetToCurv(5,2); // dCurv/dU
-  OffsetToCurv[3][0] = 1.;           // dxt/du1
-  OffsetToCurv[4][1] = 1.;           // dyt/du2
+  AlgebraicMatrix CurvToAngle(2, 5);   // dAlpha/dCurv
+  CurvToAngle[1][1] = 1.;              // dalpha2/dlambda
+  CurvToAngle[0][2] = cosLambda;       // dalpha1/dphi
+  AlgebraicMatrix OffsetToCurv(5, 2);  // dCurv/dU
+  OffsetToCurv[3][0] = 1.;             // dxt/du1
+  OffsetToCurv[4][1] = 1.;             // dyt/du2
 
   AlgebraicSymMatrix tempMSCov;
   AlgebraicSymMatrix tempMSCovProj;
@@ -839,7 +844,7 @@ bool ReferenceTrajectory::addMaterialEffectsBrl(const std::vector<AlgebraicMatri
 
   // combine closeby detectors into single plane
   std::vector<unsigned int> first(allSteps.size());
-  std::vector<unsigned int> last (allSteps.size());
+  std::vector<unsigned int> last(allSteps.size());
   std::vector<unsigned int> plane(allSteps.size());
   std::vector<double> sPlane(allSteps.size());
   unsigned int nPlane = 0;
@@ -847,23 +852,29 @@ bool ReferenceTrajectory::addMaterialEffectsBrl(const std::vector<AlgebraicMatri
 
   for (unsigned int k = 1; k < allSteps.size(); ++k) {
     sTot += allSteps[k];
-    if (fabs(allSteps[k])>minStep) { nPlane += 1; first[nPlane] = k; }
+    if (fabs(allSteps[k]) > minStep) {
+      nPlane += 1;
+      first[nPlane] = k;
+    }
     last[nPlane] = k;
     plane[k] = nPlane;
     sPlane[nPlane] += sTot;
   }
-  if (nPlane < 2) return false; // pathological cases: need at least 2 planes
+  if (nPlane < 2)
+    return false;  // pathological cases: need at least 2 planes
 
-  theNumberOfVirtualPars = 2*(nPlane+1);
-  theNumberOfVirtualMeas = 2*(nPlane-1);// unsigned underflow for nPlane == 0...
-  for (unsigned int k = 0; k <= nPlane; ++k) { sPlane[k] /= (double) (last[k]-first[k]+1); }
+  theNumberOfVirtualPars = 2 * (nPlane + 1);
+  theNumberOfVirtualMeas = 2 * (nPlane - 1);  // unsigned underflow for nPlane == 0...
+  for (unsigned int k = 0; k <= nPlane; ++k) {
+    sPlane[k] /= (double)(last[k] - first[k] + 1);
+  }
 
   // measurements from hits
-  sTot = 0; 
+  sTot = 0;
   for (unsigned int k = 0; k < allSteps.size(); ++k) {
     sTot += allSteps[k];
-//  (dMeas/dU) = (dMeas/dLoc) * (dLoc/dCurv) * (dCurv/dU)
-    JacOffsetToMeas = (allProjections[k] * allLocalToCurv[k].inverse(ierr) ) * OffsetToCurv;
+    //  (dMeas/dU) = (dMeas/dLoc) * (dLoc/dCurv) * (dCurv/dU)
+    JacOffsetToMeas = (allProjections[k] * allLocalToCurv[k].inverse(ierr)) * OffsetToCurv;
     if (ierr) {
       edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::addMaterialEffectsBrl"
                                  << "Inversion 2 for coarse broken lines failed: " << ierr;
@@ -871,64 +882,66 @@ bool ReferenceTrajectory::addMaterialEffectsBrl(const std::vector<AlgebraicMatri
     }
 
     unsigned int iPlane = plane[k];
-    if (last[iPlane] == first[iPlane])
-    { // single plane
-      theDerivatives[nMeasPerHit*k  ][offsetPar+2*iPlane  ] =  JacOffsetToMeas[0][0];
-      theDerivatives[nMeasPerHit*k  ][offsetPar+2*iPlane+1] =  JacOffsetToMeas[0][1];
-      theDerivatives[nMeasPerHit*k+1][offsetPar+2*iPlane  ] =  JacOffsetToMeas[1][0];
-      theDerivatives[nMeasPerHit*k+1][offsetPar+2*iPlane+1] =  JacOffsetToMeas[1][1];
-    } else
-    { // combined plane: (linear) interpolation
-      unsigned int jPlane; // neighbor plane for interpolation
-      if (fabs(sTot) < fabs(sPlane[iPlane])) { jPlane = (iPlane>0) ? iPlane - 1 : 1; }
-      else  { jPlane = (iPlane<nPlane) ? iPlane + 1 : nPlane -1 ;}
+    if (last[iPlane] == first[iPlane]) {  // single plane
+      theDerivatives[nMeasPerHit * k][offsetPar + 2 * iPlane] = JacOffsetToMeas[0][0];
+      theDerivatives[nMeasPerHit * k][offsetPar + 2 * iPlane + 1] = JacOffsetToMeas[0][1];
+      theDerivatives[nMeasPerHit * k + 1][offsetPar + 2 * iPlane] = JacOffsetToMeas[1][0];
+      theDerivatives[nMeasPerHit * k + 1][offsetPar + 2 * iPlane + 1] = JacOffsetToMeas[1][1];
+    } else {                // combined plane: (linear) interpolation
+      unsigned int jPlane;  // neighbor plane for interpolation
+      if (fabs(sTot) < fabs(sPlane[iPlane])) {
+        jPlane = (iPlane > 0) ? iPlane - 1 : 1;
+      } else {
+        jPlane = (iPlane < nPlane) ? iPlane + 1 : nPlane - 1;
+      }
       // interpolation weights
       double sDiff = sPlane[iPlane] - sPlane[jPlane];
       double iFrac = (sTot - sPlane[jPlane]) / sDiff;
       double jFrac = 1.0 - iFrac;
-      theDerivatives[nMeasPerHit*k  ][offsetPar+2*iPlane  ] =  JacOffsetToMeas[0][0]*iFrac;
-      theDerivatives[nMeasPerHit*k  ][offsetPar+2*iPlane+1] =  JacOffsetToMeas[0][1]*iFrac;
-      theDerivatives[nMeasPerHit*k+1][offsetPar+2*iPlane  ] =  JacOffsetToMeas[1][0]*iFrac;
-      theDerivatives[nMeasPerHit*k+1][offsetPar+2*iPlane+1] =  JacOffsetToMeas[1][1]*iFrac;
-      theDerivatives[nMeasPerHit*k  ][offsetPar+2*jPlane  ] =  JacOffsetToMeas[0][0]*jFrac;
-      theDerivatives[nMeasPerHit*k  ][offsetPar+2*jPlane+1] =  JacOffsetToMeas[0][1]*jFrac;
-      theDerivatives[nMeasPerHit*k+1][offsetPar+2*jPlane  ] =  JacOffsetToMeas[1][0]*jFrac;
-      theDerivatives[nMeasPerHit*k+1][offsetPar+2*jPlane+1] =  JacOffsetToMeas[1][1]*jFrac;
+      theDerivatives[nMeasPerHit * k][offsetPar + 2 * iPlane] = JacOffsetToMeas[0][0] * iFrac;
+      theDerivatives[nMeasPerHit * k][offsetPar + 2 * iPlane + 1] = JacOffsetToMeas[0][1] * iFrac;
+      theDerivatives[nMeasPerHit * k + 1][offsetPar + 2 * iPlane] = JacOffsetToMeas[1][0] * iFrac;
+      theDerivatives[nMeasPerHit * k + 1][offsetPar + 2 * iPlane + 1] = JacOffsetToMeas[1][1] * iFrac;
+      theDerivatives[nMeasPerHit * k][offsetPar + 2 * jPlane] = JacOffsetToMeas[0][0] * jFrac;
+      theDerivatives[nMeasPerHit * k][offsetPar + 2 * jPlane + 1] = JacOffsetToMeas[0][1] * jFrac;
+      theDerivatives[nMeasPerHit * k + 1][offsetPar + 2 * jPlane] = JacOffsetToMeas[1][0] * jFrac;
+      theDerivatives[nMeasPerHit * k + 1][offsetPar + 2 * jPlane + 1] = JacOffsetToMeas[1][1] * jFrac;
       // 2nd order neglected
       // theDerivatives[nMeasPerHit*k  ][                   0] = -0.5*bFac*sDiff*iFrac*sDiff*jFrac*cosLambda;
     }
   }
 
-// measurement of MS kink
+  // measurement of MS kink
   for (unsigned int i = 1; i < nPlane; ++i) {
-// CHK 
-    int iMsMeas = i-1;
-    int l    = i-1; // last hit
-    int n    = i+1; // next hit
+    // CHK
+    int iMsMeas = i - 1;
+    int l = i - 1;  // last hit
+    int n = i + 1;  // next hit
 
-// amount of multiple scattering in plane k
+    // amount of multiple scattering in plane k
     for (unsigned int k = first[i]; k <= last[i]; ++k) {
       tempMSCov = allDeltaParameterCovs[k].similarity(allLocalToCurv[k]);
       tempMSCovProj = tempMSCov.similarity(CurvToAngle);
-      theMeasurementsCov[offsetMeas+nMeasPerHit*iMsMeas  ][offsetMeas+nMeasPerHit*iMsMeas  ] += tempMSCovProj[0][0];
-      theMeasurementsCov[offsetMeas+nMeasPerHit*iMsMeas+1][offsetMeas+nMeasPerHit*iMsMeas+1] += tempMSCovProj[1][1];
+      theMeasurementsCov[offsetMeas + nMeasPerHit * iMsMeas][offsetMeas + nMeasPerHit * iMsMeas] += tempMSCovProj[0][0];
+      theMeasurementsCov[offsetMeas + nMeasPerHit * iMsMeas + 1][offsetMeas + nMeasPerHit * iMsMeas + 1] +=
+          tempMSCovProj[1][1];
     }
-// broken line measurements for layer k, correlations between both planes neglected
+    // broken line measurements for layer k, correlations between both planes neglected
     double stepK = sPlane[i] - sPlane[l];
     double stepN = sPlane[n] - sPlane[i];
-    double deltaK (1.0/stepK);
-    double deltaN (1.0/stepN);
+    double deltaK(1.0 / stepK);
+    double deltaN(1.0 / stepN);
     // bending (only in RPhi)
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas  ][              0] = -0.5*bFac*(stepK+stepN)*cosLambda;
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas][0] = -0.5 * bFac * (stepK + stepN) * cosLambda;
     // last layer
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas  ][offsetPar+2*l  ] = deltaK;
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas+1][offsetPar+2*l+1] = deltaK;
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas][offsetPar + 2 * l] = deltaK;
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas + 1][offsetPar + 2 * l + 1] = deltaK;
     // current layer
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas  ][offsetPar+2*i  ] = -(deltaK + deltaN);
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas+1][offsetPar+2*i+1] = -(deltaK + deltaN);
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas][offsetPar + 2 * i] = -(deltaK + deltaN);
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas + 1][offsetPar + 2 * i + 1] = -(deltaK + deltaN);
     // next layer
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas  ][offsetPar+2*n  ] = deltaN;
-    theDerivatives[offsetMeas+nMeasPerHit*iMsMeas+1][offsetPar+2*n+1] = deltaN;
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas][offsetPar + 2 * n] = deltaN;
+    theDerivatives[offsetMeas + nMeasPerHit * iMsMeas + 1][offsetPar + 2 * n + 1] = deltaN;
   }
 
   return true;
@@ -937,19 +950,18 @@ bool ReferenceTrajectory::addMaterialEffectsBrl(const std::vector<AlgebraicMatri
 //__________________________________________________________________________________
 
 bool ReferenceTrajectory::addMaterialEffectsLocalGbl(const std::vector<AlgebraicMatrix> &allJacobians,
-                                                const std::vector<AlgebraicMatrix> &allProjections,
-                                                const std::vector<AlgebraicSymMatrix> &allCurvatureChanges,
-                                                const std::vector<AlgebraicSymMatrix> &allDeltaParameterCovs)
-{
-//CHK: add material effects using general broken lines, no initial kinks
-// local track parameters are defined in the TSO system
+                                                     const std::vector<AlgebraicMatrix> &allProjections,
+                                                     const std::vector<AlgebraicSymMatrix> &allCurvatureChanges,
+                                                     const std::vector<AlgebraicSymMatrix> &allDeltaParameterCovs) {
+  //CHK: add material effects using general broken lines, no initial kinks
+  // local track parameters are defined in the TSO system
 
-  const double minPrec = 1.0; // minimum precision to use measurement (reject measurements in strip direction)
+  const double minPrec = 1.0;  // minimum precision to use measurement (reject measurements in strip direction)
 
-  AlgebraicMatrix OffsetToLocal(5,2); // dLocal/dU
+  AlgebraicMatrix OffsetToLocal(5, 2);  // dLocal/dU
   OffsetToLocal[3][0] = 1.;
   OffsetToLocal[4][1] = 1.;
-  AlgebraicMatrix SlopeToLocal(5,2); // dLocal/dU'
+  AlgebraicMatrix SlopeToLocal(5, 2);  // dLocal/dU'
   SlopeToLocal[1][0] = 1.;
   SlopeToLocal[2][1] = 1.;
 
@@ -962,36 +974,35 @@ bool ReferenceTrajectory::addMaterialEffectsLocalGbl(const std::vector<Algebraic
 
   //bool initialKinks = (allCurvlinKinks.size()>0);
 
-// measurements and scatterers from hits
+  // measurements and scatterers from hits
   unsigned int numHits = allJacobians.size();
   std::vector<GblPoint> GblPointList;
   GblPointList.reserve(numHits);
   for (unsigned int k = 0; k < numHits; ++k) {
-
     // GBL point to point jacobian
     clhep2eigen(allJacobians[k] * allCurvatureChanges[k], jacPointToPoint);
 
     // GBL point
-    GblPoint aGblPoint( jacPointToPoint );
+    GblPoint aGblPoint(jacPointToPoint);
 
     // GBL projection from local to measurement system
     clhep2eigen(allProjections[k] * OffsetToLocal, proLocalToMeas);
 
     // GBL measurement (residuum to initial trajectory)
-    clhep2eigen(theMeasurements.sub(2*k+1,2*k+2) - theTrajectoryPositions.sub(2*k+1,2*k+2), measurement);
+    clhep2eigen(theMeasurements.sub(2 * k + 1, 2 * k + 2) - theTrajectoryPositions.sub(2 * k + 1, 2 * k + 2),
+                measurement);
 
     // GBL measurement covariance matrix
-    clhep2eigen(theMeasurementsCov.sub(2*k+1,2*k+2), covariance);
+    clhep2eigen(theMeasurementsCov.sub(2 * k + 1, 2 * k + 2), covariance);
 
     // GBL add measurement to point
-    if (std::abs(covariance(0,1)) < std::numeric_limits<double>::epsilon()) {
+    if (std::abs(covariance(0, 1)) < std::numeric_limits<double>::epsilon()) {
       // covariance matrix is diagonal, independent measurements
       for (unsigned int row = 0; row < 2; ++row) {
-        measPrecDiag(row) = ( 0. < covariance(row,row) ? 1.0/covariance(row,row) : 0. );
+        measPrecDiag(row) = (0. < covariance(row, row) ? 1.0 / covariance(row, row) : 0.);
       }
       aGblPoint.addMeasurement(proLocalToMeas, measurement, measPrecDiag, minPrec);
-    } else
-    {
+    } else {
       // covariance matrix needs diagonalization
       aGblPoint.addMeasurement(proLocalToMeas, measurement, covariance.inverse(), minPrec);
     }
@@ -1000,17 +1011,16 @@ bool ReferenceTrajectory::addMaterialEffectsLocalGbl(const std::vector<Algebraic
     clhep2eigen(allDeltaParameterCovs[k].similarityT(SlopeToLocal), scatPrecision);
     if (!(scatPrecision.colPivHouseholderQr().isInvertible())) {
       if (!allowZeroMaterial_) {
-        throw cms::Exception("Alignment")
-          << "@SUB=ReferenceTrajectory::addMaterialEffectsLocalGbl"
-          << "\nEncountered singular scatter covariance-matrix without allowing "
-          << "for zero material.";
+        throw cms::Exception("Alignment") << "@SUB=ReferenceTrajectory::addMaterialEffectsLocalGbl"
+                                          << "\nEncountered singular scatter covariance-matrix without allowing "
+                                          << "for zero material.";
       }
     } else {
       // GBL add scatterer to point
       aGblPoint.addScatterer(scatterer, scatPrecision.inverse());
     }
     // add point to list
-    GblPointList.push_back( aGblPoint );
+    GblPointList.push_back(aGblPoint);
   }
   // add list of points and transformation local to fit (=local) system at first hit
   theGblInput.push_back(std::make_pair(GblPointList, identity));
@@ -1021,20 +1031,19 @@ bool ReferenceTrajectory::addMaterialEffectsLocalGbl(const std::vector<Algebraic
 //__________________________________________________________________________________
 
 bool ReferenceTrajectory::addMaterialEffectsCurvlinGbl(const std::vector<AlgebraicMatrix> &allCurvlinJacobians,
-                                                const std::vector<AlgebraicMatrix> &allProjections,
-                                                const std::vector<AlgebraicSymMatrix> &allCurvatureChanges,
-                                                const std::vector<AlgebraicSymMatrix> &allDeltaParameterCovs,
-                                                const std::vector<AlgebraicMatrix> &allLocalToCurv)
-{
-//CHK: add material effects using general broken lines
-// local track parameters are defined in the curvilinear system
+                                                       const std::vector<AlgebraicMatrix> &allProjections,
+                                                       const std::vector<AlgebraicSymMatrix> &allCurvatureChanges,
+                                                       const std::vector<AlgebraicSymMatrix> &allDeltaParameterCovs,
+                                                       const std::vector<AlgebraicMatrix> &allLocalToCurv) {
+  //CHK: add material effects using general broken lines
+  // local track parameters are defined in the curvilinear system
 
-  const double minPrec = 1.0; // minimum precision to use measurement (reject measurements in strip direction)
+  const double minPrec = 1.0;  // minimum precision to use measurement (reject measurements in strip direction)
   int ierr = 0;
 
-  AlgebraicMatrix OffsetToCurv(5,2); // dCurv/dU
-  OffsetToCurv[3][0] = 1.;           // dxt/du1
-  OffsetToCurv[4][1] = 1.;           // dyt/du2
+  AlgebraicMatrix OffsetToCurv(5, 2);  // dCurv/dU
+  OffsetToCurv[3][0] = 1.;             // dxt/du1
+  OffsetToCurv[4][1] = 1.;             // dyt/du2
 
   AlgebraicMatrix JacOffsetToMeas, tempMSCov;
 
@@ -1044,43 +1053,43 @@ bool ReferenceTrajectory::addMaterialEffectsCurvlinGbl(const std::vector<Algebra
   Eigen::Vector2d measurement, measPrecDiag, scatPrecDiag;
   auto scatterer = Eigen::Vector2d::Zero();
 
-// measurements and scatterers from hits
+  // measurements and scatterers from hits
   unsigned int numHits = allCurvlinJacobians.size();
   std::vector<GblPoint> GblPointList;
   GblPointList.reserve(numHits);
   for (unsigned int k = 0; k < numHits; ++k) {
-//  (dMeas/dU) = (dMeas/dLoc) * (dLoc/dCurv) * (dCurv/dU)
-    JacOffsetToMeas = (allProjections[k] * allLocalToCurv[k].inverse(ierr) ) * OffsetToCurv;
+    //  (dMeas/dU) = (dMeas/dLoc) * (dLoc/dCurv) * (dCurv/dU)
+    JacOffsetToMeas = (allProjections[k] * allLocalToCurv[k].inverse(ierr)) * OffsetToCurv;
     if (ierr) {
-       edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::addMaterialEffectsGbl"
-                                   << "Inversion 1 for general broken lines failed: " << ierr;
-       return false;
+      edm::LogError("Alignment") << "@SUB=ReferenceTrajectory::addMaterialEffectsGbl"
+                                 << "Inversion 1 for general broken lines failed: " << ierr;
+      return false;
     }
 
     // GBL point to point jacobian
     clhep2eigen(allCurvlinJacobians[k] * allCurvatureChanges[k], jacPointToPoint);
 
     // GBL point
-    GblPoint aGblPoint( jacPointToPoint );
+    GblPoint aGblPoint(jacPointToPoint);
 
     // GBL projection from local to measurement system
     clhep2eigen(JacOffsetToMeas, proLocalToMeas);
 
     // GBL measurement (residuum to initial trajectory)
-    clhep2eigen(theMeasurements.sub(2*k+1,2*k+2) - theTrajectoryPositions.sub(2*k+1,2*k+2), measurement);
+    clhep2eigen(theMeasurements.sub(2 * k + 1, 2 * k + 2) - theTrajectoryPositions.sub(2 * k + 1, 2 * k + 2),
+                measurement);
 
     // GBL measurement covariance matrix
-    clhep2eigen(theMeasurementsCov.sub(2*k+1,2*k+2), covariance);
+    clhep2eigen(theMeasurementsCov.sub(2 * k + 1, 2 * k + 2), covariance);
 
     // GBL add measurement to point
-    if (std::abs(covariance(0,1)) < std::numeric_limits<double>::epsilon()) {
+    if (std::abs(covariance(0, 1)) < std::numeric_limits<double>::epsilon()) {
       // covariance matrix is diagonal, independent measurements
       for (unsigned int row = 0; row < 2; ++row) {
-        measPrecDiag(row) = ( 0. < covariance(row,row) ? 1.0/covariance(row,row) : 0. );
+        measPrecDiag(row) = (0. < covariance(row, row) ? 1.0 / covariance(row, row) : 0.);
       }
       aGblPoint.addMeasurement(proLocalToMeas, measurement, measPrecDiag, minPrec);
-    } else
-    {
+    } else {
       // covariance matrix needs diagonalization
       aGblPoint.addMeasurement(proLocalToMeas, measurement, covariance.inverse(), minPrec);
     }
@@ -1088,29 +1097,28 @@ bool ReferenceTrajectory::addMaterialEffectsCurvlinGbl(const std::vector<Algebra
     // GBL multiple scattering (diagonal matrix in curvilinear system)
     tempMSCov = allDeltaParameterCovs[k].similarity(allLocalToCurv[k]);
     for (unsigned int row = 0; row < 2; ++row) {
-      scatPrecDiag(row) = 1.0/tempMSCov[row+1][row+1];
+      scatPrecDiag(row) = 1.0 / tempMSCov[row + 1][row + 1];
     }
 
     // check for singularity
     bool singularCovariance{false};
     for (int row = 0; row < scatPrecDiag.rows(); ++row) {
       if (!(scatPrecDiag[row] < std::numeric_limits<double>::infinity())) {
-	singularCovariance = true;
-	break;
+        singularCovariance = true;
+        break;
       }
     }
     if (singularCovariance && !allowZeroMaterial_) {
-      throw cms::Exception("Alignment")
-	<< "@SUB=ReferenceTrajectory::addMaterialEffectsCurvlinGbl"
-	<< "\nEncountered singular scatter covariance-matrix without allowing "
-	<< "for zero material.";
+      throw cms::Exception("Alignment") << "@SUB=ReferenceTrajectory::addMaterialEffectsCurvlinGbl"
+                                        << "\nEncountered singular scatter covariance-matrix without allowing "
+                                        << "for zero material.";
     }
 
     // GBL add scatterer to point
     aGblPoint.addScatterer(scatterer, scatPrecDiag);
 
     // add point to list
-    GblPointList.push_back( aGblPoint );
+    GblPointList.push_back(aGblPoint);
   }
   // add list of points and transformation local to fit (=curvilinear) system at first hit
   clhep2eigen(allLocalToCurv[0], firstLocalToCurv);
@@ -1121,18 +1129,15 @@ bool ReferenceTrajectory::addMaterialEffectsCurvlinGbl(const std::vector<Algebra
 
 //__________________________________________________________________________________
 template <typename Derived>
-void ReferenceTrajectory::clhep2eigen(const AlgebraicVector& in,
-                                      Eigen::MatrixBase<Derived>& out) {
-  static_assert(Derived::ColsAtCompileTime == 1,
-                "clhep2eigen: 'out' must be of vector type");
+void ReferenceTrajectory::clhep2eigen(const AlgebraicVector &in, Eigen::MatrixBase<Derived> &out) {
+  static_assert(Derived::ColsAtCompileTime == 1, "clhep2eigen: 'out' must be of vector type");
   for (int row = 0; row < in.num_row(); ++row) {
     out(row) = in[row];
   }
 }
 
 template <typename Derived>
-void ReferenceTrajectory::clhep2eigen(const AlgebraicMatrix& in,
-                                      Eigen::MatrixBase<Derived>& out) {
+void ReferenceTrajectory::clhep2eigen(const AlgebraicMatrix &in, Eigen::MatrixBase<Derived> &out) {
   for (int row = 0; row < in.num_row(); ++row) {
     for (int col = 0; col < in.num_col(); ++col) {
       out(row, col) = in[row][col];
@@ -1141,8 +1146,7 @@ void ReferenceTrajectory::clhep2eigen(const AlgebraicMatrix& in,
 }
 
 template <typename Derived>
-void ReferenceTrajectory::clhep2eigen(const AlgebraicSymMatrix& in,
-                                      Eigen::MatrixBase<Derived>& out) {
+void ReferenceTrajectory::clhep2eigen(const AlgebraicSymMatrix &in, Eigen::MatrixBase<Derived> &out) {
   for (int row = 0; row < in.num_row(); ++row) {
     for (int col = 0; col < in.num_col(); ++col) {
       out(row, col) = in[row][col];
@@ -1152,45 +1156,41 @@ void ReferenceTrajectory::clhep2eigen(const AlgebraicSymMatrix& in,
 
 //__________________________________________________________________________________
 
-AlgebraicMatrix
-ReferenceTrajectory::getHitProjectionMatrix
-(const TransientTrackingRecHit::ConstRecHitPointer &hitPtr) const
-{
+AlgebraicMatrix ReferenceTrajectory::getHitProjectionMatrix(
+    const TransientTrackingRecHit::ConstRecHitPointer &hitPtr) const {
   if (this->useRecHit(hitPtr)) {
     // check which templated non-member function to call:
     switch (hitPtr->dimension()) {
-    case 1:
-      return getHitProjectionMatrixT<1>(hitPtr);
-    case 2:
-      return getHitProjectionMatrixT<2>(hitPtr);
-    case 3:
-      return getHitProjectionMatrixT<3>(hitPtr);
-    case 4:
-      return getHitProjectionMatrixT<4>(hitPtr);
-    case 5:
-      return getHitProjectionMatrixT<5>(hitPtr);
-    default:
-      throw cms::Exception("ReferenceTrajectory::getHitProjectionMatrix")
-        << "Unexpected hit dimension: " << hitPtr->dimension() << "\n";
+      case 1:
+        return getHitProjectionMatrixT<1>(hitPtr);
+      case 2:
+        return getHitProjectionMatrixT<2>(hitPtr);
+      case 3:
+        return getHitProjectionMatrixT<3>(hitPtr);
+      case 4:
+        return getHitProjectionMatrixT<4>(hitPtr);
+      case 5:
+        return getHitProjectionMatrixT<5>(hitPtr);
+      default:
+        throw cms::Exception("ReferenceTrajectory::getHitProjectionMatrix")
+            << "Unexpected hit dimension: " << hitPtr->dimension() << "\n";
     }
   }
   // invalid or (to please compiler) unknown dimension
-  return AlgebraicMatrix(2, 5, 0); // get size from ???
+  return AlgebraicMatrix(2, 5, 0);  // get size from ???
 }
 
 //__________________________________________________________________________________
 
-template<unsigned int N>
-AlgebraicMatrix 
-ReferenceTrajectory::getHitProjectionMatrixT
-(const TransientTrackingRecHit::ConstRecHitPointer &hitPtr) const
-{
+template <unsigned int N>
+AlgebraicMatrix ReferenceTrajectory::getHitProjectionMatrixT(
+    const TransientTrackingRecHit::ConstRecHitPointer &hitPtr) const {
   // define variables that will be used to setup the KfComponentsHolder
   // (their allocated memory is needed by 'hitPtr->getKfComponents(..)'
 
-  ProjectMatrix<double,5,N>  pf; 
-  typename AlgebraicROOTObject<N>::Vector r, rMeas; 
-  typename AlgebraicROOTObject<N,N>::SymMatrix V, VMeas;
+  ProjectMatrix<double, 5, N> pf;
+  typename AlgebraicROOTObject<N>::Vector r, rMeas;
+  typename AlgebraicROOTObject<N, N>::SymMatrix V, VMeas;
   // input for the holder - but dummy is OK here to just get the projection matrix:
   const AlgebraicVector5 dummyPars;
   const AlgebraicSymMatrix55 dummyErr;
@@ -1200,6 +1200,5 @@ ReferenceTrajectory::getHitProjectionMatrixT
   holder.setup<N>(&r, &V, &pf, &rMeas, &VMeas, dummyPars, dummyErr);
   hitPtr->getKfComponents(holder);
 
-  return asHepMatrix<N,5>(holder.projection<N>());
+  return asHepMatrix<N, 5>(holder.projection<N>());
 }
-

--- a/Alignment/ReferenceTrajectories/src/ReferenceTrajectoryBase.cc
+++ b/Alignment/ReferenceTrajectories/src/ReferenceTrajectoryBase.cc
@@ -1,38 +1,40 @@
 #include "Alignment/ReferenceTrajectories/interface/ReferenceTrajectoryBase.h"
 
-ReferenceTrajectoryBase::ReferenceTrajectoryBase(unsigned int nPar, unsigned int nHits, 
-						 unsigned int nVirtualPar, unsigned int nVirtualMeas)
-  : theValidityFlag(false), theParamCovFlag(false),
-    theNumberOfHits( nHits ), theNumberOfPars( nPar ), 
-    theNumberOfVirtualMeas( nVirtualMeas ), theNumberOfVirtualPars( nVirtualPar ),
-    theTsosVec(), theRecHits(),
-    theMeasurements(nMeasPerHit * nHits + nVirtualMeas), 
-    theMeasurementsCov(nMeasPerHit * nHits + nVirtualMeas, 0),
-    theTrajectoryPositions(nMeasPerHit * nHits), 
-    theTrajectoryPositionCov(nMeasPerHit * nHits, 0),
-    theParameters(nPar), 
-    theParameterCov(nPar, 0),
-    theDerivatives(nMeasPerHit * nHits + nVirtualMeas, nPar + nVirtualPar, 0),
-    theInnerTrajectoryToCurvilinear( 5, 5, 0 ),
-    theInnerLocalToTrajectory( 5, 5, 0 )    
-{
+ReferenceTrajectoryBase::ReferenceTrajectoryBase(unsigned int nPar,
+                                                 unsigned int nHits,
+                                                 unsigned int nVirtualPar,
+                                                 unsigned int nVirtualMeas)
+    : theValidityFlag(false),
+      theParamCovFlag(false),
+      theNumberOfHits(nHits),
+      theNumberOfPars(nPar),
+      theNumberOfVirtualMeas(nVirtualMeas),
+      theNumberOfVirtualPars(nVirtualPar),
+      theTsosVec(),
+      theRecHits(),
+      theMeasurements(nMeasPerHit * nHits + nVirtualMeas),
+      theMeasurementsCov(nMeasPerHit * nHits + nVirtualMeas, 0),
+      theTrajectoryPositions(nMeasPerHit * nHits),
+      theTrajectoryPositionCov(nMeasPerHit * nHits, 0),
+      theParameters(nPar),
+      theParameterCov(nPar, 0),
+      theDerivatives(nMeasPerHit * nHits + nVirtualMeas, nPar + nVirtualPar, 0),
+      theInnerTrajectoryToCurvilinear(5, 5, 0),
+      theInnerLocalToTrajectory(5, 5, 0) {
   theTsosVec.reserve(nHits);
   theRecHits.reserve(nHits);
 }
 
-
-unsigned int
-ReferenceTrajectoryBase::numberOfUsedRecHits( const TransientTrackingRecHit::ConstRecHitContainer &recHits ) const
-{
+unsigned int ReferenceTrajectoryBase::numberOfUsedRecHits(
+    const TransientTrackingRecHit::ConstRecHitContainer& recHits) const {
   unsigned int nUsedHits = 0;
   TransientTrackingRecHit::ConstRecHitContainer::const_iterator itHit;
-  for ( itHit = recHits.begin(); itHit != recHits.end(); ++itHit ) if ( useRecHit( *itHit ) ) ++nUsedHits;
+  for (itHit = recHits.begin(); itHit != recHits.end(); ++itHit)
+    if (useRecHit(*itHit))
+      ++nUsedHits;
   return nUsedHits;
 }
 
-
-bool
-ReferenceTrajectoryBase::useRecHit( const TransientTrackingRecHit::ConstRecHitPointer& hitPtr ) const
-{
+bool ReferenceTrajectoryBase::useRecHit(const TransientTrackingRecHit::ConstRecHitPointer& hitPtr) const {
   return hitPtr->isValid();
 }

--- a/Alignment/ReferenceTrajectories/src/TrajectoryFactoryBase.cc
+++ b/Alignment/ReferenceTrajectories/src/TrajectoryFactoryBase.cc
@@ -6,92 +6,78 @@
 
 #include "Alignment/ReferenceTrajectories/interface/TrajectoryFactoryBase.h"
 
+TrajectoryFactoryBase::TrajectoryFactoryBase(const edm::ParameterSet& config) : TrajectoryFactoryBase(config, 1) {}
 
-TrajectoryFactoryBase::TrajectoryFactoryBase(const edm::ParameterSet& config) :
-  TrajectoryFactoryBase(config, 1)
-{
+TrajectoryFactoryBase::TrajectoryFactoryBase(const edm::ParameterSet& config, unsigned int tracksPerTrajectory)
+    : cfg_(config),
+      tracksPerTrajectory_(tracksPerTrajectory),
+      materialEffects_(materialEffects(config.getParameter<std::string>("MaterialEffects"))),
+      propDir_(propagationDirection(config.getParameter<std::string>("PropagationDirection"))),
+      useWithoutDet_(config.getParameter<bool>("UseHitWithoutDet")),
+      useInvalidHits_(config.getParameter<bool>("UseInvalidHits")),
+      useProjectedHits_(config.getParameter<bool>("UseProjectedHits")),
+      useBeamSpot_(config.getParameter<bool>("UseBeamSpot")),
+      includeAPEs_(config.getParameter<bool>("IncludeAPEs")),
+      allowZeroMaterial_(config.getParameter<bool>("AllowZeroMaterial")) {
+  edm::LogInfo("Alignment") << "@SUB=TrajectoryFactoryBase"
+                            << "TrajectoryFactory '" << cfg_.getParameter<std::string>("TrajectoryFactoryName")
+                            << "' with following settings:"
+                            << "\nmaterial effects: " << cfg_.getParameter<std::string>("MaterialEffects")
+                            << "\npropagation: " << cfg_.getParameter<std::string>("PropagationDirection")
+                            << "\nuse hits without det: " << (useWithoutDet_ ? "yes" : "no")
+                            << "\nuse invalid hits: " << (useInvalidHits_ ? "yes" : "no")
+                            << "\nuse projected hits: " << (useProjectedHits_ ? "yes" : "no")
+                            << "\nuse beamspot: " << (useBeamSpot_ ? "yes" : "no")
+                            << "\ninclude APEs: " << (includeAPEs_ ? "yes" : "no")
+                            << "\nallow zero material: " << (allowZeroMaterial_ ? "yes" : "no");
 }
 
-TrajectoryFactoryBase::TrajectoryFactoryBase(const edm::ParameterSet& config,
-                                             unsigned int tracksPerTrajectory) :
-  cfg_(config),
-  tracksPerTrajectory_(tracksPerTrajectory),
-  materialEffects_(materialEffects(config.getParameter<std::string>("MaterialEffects"))),
-  propDir_(propagationDirection(config.getParameter<std::string>("PropagationDirection"))),
-  useWithoutDet_(config.getParameter<bool>("UseHitWithoutDet")),
-  useInvalidHits_(config.getParameter<bool>("UseInvalidHits")),
-  useProjectedHits_(config.getParameter<bool>("UseProjectedHits")),
-  useBeamSpot_(config.getParameter<bool>("UseBeamSpot")),
-  includeAPEs_(config.getParameter<bool>("IncludeAPEs")),
-  allowZeroMaterial_(config.getParameter<bool>("AllowZeroMaterial"))
-{
-  edm::LogInfo("Alignment")
-    << "@SUB=TrajectoryFactoryBase"
-    << "TrajectoryFactory '" << cfg_.getParameter<std::string>("TrajectoryFactoryName")
-    << "' with following settings:"
-    << "\nmaterial effects: " << cfg_.getParameter<std::string>("MaterialEffects")
-    << "\npropagation: " << cfg_.getParameter<std::string>("PropagationDirection")
-    << "\nuse hits without det: " << (useWithoutDet_ ? "yes" : "no")
-    << "\nuse invalid hits: " << (useInvalidHits_ ? "yes" : "no")
-    << "\nuse projected hits: " << (useProjectedHits_ ? "yes" : "no")
-    << "\nuse beamspot: " << (useBeamSpot_ ? "yes" : "no")
-    << "\ninclude APEs: " << (includeAPEs_ ? "yes" : "no")
-    << "\nallow zero material: " << (allowZeroMaterial_ ? "yes" : "no");
-}
+TrajectoryFactoryBase::~TrajectoryFactoryBase(void) {}
 
-
-TrajectoryFactoryBase::~TrajectoryFactoryBase( void ) {}
-
-
-const TrajectoryFactoryBase::TrajectoryInput
-TrajectoryFactoryBase::innermostStateAndRecHits( const ConstTrajTrackPair & track ) const
-{
+const TrajectoryFactoryBase::TrajectoryInput TrajectoryFactoryBase::innermostStateAndRecHits(
+    const ConstTrajTrackPair& track) const {
   TrajectoryInput result;
 
   // get the trajectory measurements in the correct order, i.e. reverse if needed
-  Trajectory::DataContainer trajectoryMeasurements 
-    = this->orderedTrajectoryMeasurements( *track.first );
+  Trajectory::DataContainer trajectoryMeasurements = this->orderedTrajectoryMeasurements(*track.first);
   Trajectory::DataContainer::iterator itM = trajectoryMeasurements.begin();
 
   // get the innermost valid trajectory state - the corresponding hit must be o.k. as well
-  while ( itM != trajectoryMeasurements.end() )
-  {
-    if ( ( *itM ).updatedState().isValid() && useRecHit( ( *itM ).recHit() ) ) break;
+  while (itM != trajectoryMeasurements.end()) {
+    if ((*itM).updatedState().isValid() && useRecHit((*itM).recHit()))
+      break;
     ++itM;
   }
-  if ( itM != trajectoryMeasurements.end() ) result.first = ( *itM ).updatedState();
+  if (itM != trajectoryMeasurements.end())
+    result.first = (*itM).updatedState();
 
   // get the valid RecHits
-  while ( itM != trajectoryMeasurements.end() )
-  {
-    TransientTrackingRecHit::ConstRecHitPointer aRecHit = ( *itM ).recHit();
-    if ( useRecHit( aRecHit ) ) result.second.push_back( aRecHit );
+  while (itM != trajectoryMeasurements.end()) {
+    TransientTrackingRecHit::ConstRecHitPointer aRecHit = (*itM).recHit();
+    if (useRecHit(aRecHit))
+      result.second.push_back(aRecHit);
     ++itM;
   }
 
   return result;
 }
 
-
-const Trajectory::DataContainer
-TrajectoryFactoryBase::orderedTrajectoryMeasurements( const Trajectory & trajectory ) const
-{
+const Trajectory::DataContainer TrajectoryFactoryBase::orderedTrajectoryMeasurements(
+    const Trajectory& trajectory) const {
   const PropagationDirection dir = trajectory.direction();
-  const bool hitsAreReverse = ( ( dir == propDir_ || propDir_ == anyDirection ) ? false : true );
+  const bool hitsAreReverse = ((dir == propDir_ || propDir_ == anyDirection) ? false : true);
 
-  const Trajectory::DataContainer & original = trajectory.measurements();
+  const Trajectory::DataContainer& original = trajectory.measurements();
 
-  if ( hitsAreReverse )
-  {
+  if (hitsAreReverse) {
     // Simply use this line instead of the copying by hand?
     // const Trajectory::DataContainer reordered(original.rbegin(), original.rend());
     Trajectory::DataContainer reordered;
-    reordered.reserve( original.size() );
+    reordered.reserve(original.size());
 
     Trajectory::DataContainer::const_reverse_iterator itM;
-    for ( itM = original.rbegin(); itM != original.rend(); ++itM )
-    {
-      reordered.push_back( *itM );
+    for (itM = original.rbegin(); itM != original.rend(); ++itM) {
+      reordered.push_back(*itM);
     }
     return reordered;
   }
@@ -99,58 +85,60 @@ TrajectoryFactoryBase::orderedTrajectoryMeasurements( const Trajectory & traject
   return original;
 }
 
-
-bool TrajectoryFactoryBase::sameSurface( const Surface& s1, const Surface& s2 ) const
-{
+bool TrajectoryFactoryBase::sameSurface(const Surface& s1, const Surface& s2) const {
   // - Should use perp2() instead of perp()
   // - Should not rely on floating point equality, but make a minimal range, e.g. 1.e-6 ?
-  return ( s1.eta() == s2.eta() ) && ( s1.phi() == s2.phi() ) && ( s1.position().perp() == s2.position().perp() );
+  return (s1.eta() == s2.eta()) && (s1.phi() == s2.phi()) && (s1.position().perp() == s2.position().perp());
 }
 
-
-bool
-TrajectoryFactoryBase::useRecHit( const TransientTrackingRecHit::ConstRecHitPointer& hitPtr ) const
-{
+bool TrajectoryFactoryBase::useRecHit(const TransientTrackingRecHit::ConstRecHitPointer& hitPtr) const {
   const GeomDet* det = hitPtr->det();
-  if ( !det && !useWithoutDet_ ) return false;
-  
-  if ( !( useInvalidHits_ || hitPtr->isValid() ) ) return false;
+  if (!det && !useWithoutDet_)
+    return false;
 
-  if ( !useProjectedHits_ )
-  {
-    if(trackerHitRTTI::isProjected(*hitPtr)) return false;
+  if (!(useInvalidHits_ || hitPtr->isValid()))
+    return false;
+
+  if (!useProjectedHits_) {
+    if (trackerHitRTTI::isProjected(*hitPtr))
+      return false;
   }
 
   return true;
 }
 
+TrajectoryFactoryBase::MaterialEffects TrajectoryFactoryBase::materialEffects(const std::string& strME) const {
+  if (strME == "MultipleScattering")
+    return ReferenceTrajectoryBase::multipleScattering;
+  if (strME == "EnergyLoss")
+    return ReferenceTrajectoryBase::energyLoss;
+  if (strME == "Combined")
+    return ReferenceTrajectoryBase::combined;
+  if (strME == "None")
+    return ReferenceTrajectoryBase::none;
+  if (strME == "BreakPoints")
+    return ReferenceTrajectoryBase::breakPoints;
+  if (strME == "BrokenLines")
+    return ReferenceTrajectoryBase::brokenLinesCoarse;
+  if (strME == "BrokenLinesCoarse")
+    return ReferenceTrajectoryBase::brokenLinesCoarse;
+  if (strME == "BrokenLinesFine")
+    return ReferenceTrajectoryBase::brokenLinesFine;
+  if (strME == "LocalGBL")
+    return ReferenceTrajectoryBase::localGBL;
+  if (strME == "CurvlinGBL")
+    return ReferenceTrajectoryBase::curvlinGBL;
 
-TrajectoryFactoryBase::MaterialEffects
-TrajectoryFactoryBase::materialEffects( const std::string & strME ) const
-{
-  if ( strME == "MultipleScattering" ) return ReferenceTrajectoryBase::multipleScattering;
-  if ( strME == "EnergyLoss" ) return ReferenceTrajectoryBase::energyLoss;
-  if ( strME == "Combined" ) return ReferenceTrajectoryBase::combined;
-  if ( strME == "None" ) return ReferenceTrajectoryBase::none;
-  if ( strME == "BreakPoints" ) return ReferenceTrajectoryBase::breakPoints;
-  if ( strME == "BrokenLines" ) return ReferenceTrajectoryBase::brokenLinesCoarse;
-  if ( strME == "BrokenLinesCoarse" ) return ReferenceTrajectoryBase::brokenLinesCoarse;
-  if ( strME == "BrokenLinesFine" ) return ReferenceTrajectoryBase::brokenLinesFine;
-  if ( strME == "LocalGBL" ) return ReferenceTrajectoryBase::localGBL;
-  if ( strME == "CurvlinGBL" ) return ReferenceTrajectoryBase::curvlinGBL;
-            
-  throw cms::Exception("BadConfig")
-    << "[TrajectoryFactoryBase::materialEffects] Unknown parameter: " << strME;
+  throw cms::Exception("BadConfig") << "[TrajectoryFactoryBase::materialEffects] Unknown parameter: " << strME;
 }
 
+PropagationDirection TrajectoryFactoryBase::propagationDirection(const std::string& strPD) const {
+  if (strPD == "oppositeToMomentum")
+    return oppositeToMomentum;
+  if (strPD == "alongMomentum")
+    return alongMomentum;
+  if (strPD == "anyDirection")
+    return anyDirection;
 
-PropagationDirection
-TrajectoryFactoryBase::propagationDirection( const std::string & strPD ) const
-{
-  if ( strPD == "oppositeToMomentum" ) return oppositeToMomentum;
-  if ( strPD == "alongMomentum" ) return alongMomentum;
-  if ( strPD == "anyDirection" ) return anyDirection;
-
-  throw cms::Exception("BadConfig")
-    << "[TrajectoryFactoryBase::propagationDirection] Unknown parameter: " << strPD;
+  throw cms::Exception("BadConfig") << "[TrajectoryFactoryBase::propagationDirection] Unknown parameter: " << strPD;
 }

--- a/Alignment/ReferenceTrajectories/src/TrajectoryFactoryPlugin.cc
+++ b/Alignment/ReferenceTrajectories/src/TrajectoryFactoryPlugin.cc
@@ -1,5 +1,4 @@
 
 #include "Alignment/ReferenceTrajectories/interface/TrajectoryFactoryPlugin.h"
 
-EDM_REGISTER_PLUGINFACTORY( TrajectoryFactoryPlugin, 
-                            "TrajectoryFactoryPlugin" );
+EDM_REGISTER_PLUGINFACTORY(TrajectoryFactoryPlugin, "TrajectoryFactoryPlugin");

--- a/Alignment/ReferenceTrajectories/src/TwoBodyDecayTrajectory.cc
+++ b/Alignment/ReferenceTrajectories/src/TwoBodyDecayTrajectory.cc
@@ -1,14 +1,13 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h" 
-#include "DataFormats/GeometrySurface/interface/Surface.h" 
+#include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
+#include "DataFormats/GeometrySurface/interface/Surface.h"
 #include "Alignment/ReferenceTrajectories/interface/TwoBodyDecayTrajectory.h"
-#include "DataFormats/CLHEP/interface/AlgebraicObjects.h" 
-#include "DataFormats/Math/interface/Error.h" 
+#include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
+#include "DataFormats/Math/interface/Error.h"
 #include "Alignment/TwoBodyDecay/interface/TwoBodyDecayParameters.h"
 
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
@@ -16,57 +15,49 @@ TwoBodyDecayTrajectory::TwoBodyDecayTrajectory(const TwoBodyDecayTrajectoryState
                                                const ConstRecHitCollection& recHits,
                                                const MagneticField* magField,
                                                const reco::BeamSpot& beamSpot,
-                                               const ReferenceTrajectoryBase::Config& config) :
-  ReferenceTrajectoryBase(
-     TwoBodyDecayParameters::dimension, recHits.first.size() + recHits.second.size(),
-     (config.materialEffects >= breakPoints) ? 2*(recHits.first.size() + recHits.second.size())-4 : 0,
-     (config.materialEffects >= breakPoints) ? 2*(recHits.first.size() + recHits.second.size())-3 : 1 ),
-  materialEffects_(config.materialEffects),
-  propDir_(config.propDir),
-  useRefittedState_(config.useRefittedState),
-  constructTsosWithErrors_(config.constructTsosWithErrors)
+                                               const ReferenceTrajectoryBase::Config& config)
+    : ReferenceTrajectoryBase(
+          TwoBodyDecayParameters::dimension,
+          recHits.first.size() + recHits.second.size(),
+          (config.materialEffects >= breakPoints) ? 2 * (recHits.first.size() + recHits.second.size()) - 4 : 0,
+          (config.materialEffects >= breakPoints) ? 2 * (recHits.first.size() + recHits.second.size()) - 3 : 1),
+      materialEffects_(config.materialEffects),
+      propDir_(config.propDir),
+      useRefittedState_(config.useRefittedState),
+      constructTsosWithErrors_(config.constructTsosWithErrors)
 
 {
-  if ( config.hitsAreReverse )
-  {
+  if (config.hitsAreReverse) {
     TransientTrackingRecHit::ConstRecHitContainer::const_reverse_iterator itRecHits;
     ConstRecHitCollection fwdRecHits;
 
-    fwdRecHits.first.reserve( recHits.first.size() );
-    for ( itRecHits = recHits.first.rbegin(); itRecHits != recHits.first.rend(); ++itRecHits )
-    {
-      fwdRecHits.first.push_back( *itRecHits );
+    fwdRecHits.first.reserve(recHits.first.size());
+    for (itRecHits = recHits.first.rbegin(); itRecHits != recHits.first.rend(); ++itRecHits) {
+      fwdRecHits.first.push_back(*itRecHits);
     }
 
-    fwdRecHits.second.reserve( recHits.second.size() );
-    for ( itRecHits = recHits.second.rbegin(); itRecHits != recHits.second.rend(); ++itRecHits )
-    {
-      fwdRecHits.second.push_back( *itRecHits );
+    fwdRecHits.second.reserve(recHits.second.size());
+    for (itRecHits = recHits.second.rbegin(); itRecHits != recHits.second.rend(); ++itRecHits) {
+      fwdRecHits.second.push_back(*itRecHits);
     }
 
     theValidityFlag = this->construct(tsos, fwdRecHits, magField, beamSpot);
-  }
-  else
-  {
+  } else {
     theValidityFlag = this->construct(tsos, recHits, magField, beamSpot);
   }
 }
 
-
-TwoBodyDecayTrajectory::TwoBodyDecayTrajectory( void )
-  : ReferenceTrajectoryBase( 0, 0, 0, 0),
-  materialEffects_(none),
-  propDir_(anyDirection),
-  useRefittedState_(false),
-  constructTsosWithErrors_(false)
-{}
-
+TwoBodyDecayTrajectory::TwoBodyDecayTrajectory(void)
+    : ReferenceTrajectoryBase(0, 0, 0, 0),
+      materialEffects_(none),
+      propDir_(anyDirection),
+      useRefittedState_(false),
+      constructTsosWithErrors_(false) {}
 
 bool TwoBodyDecayTrajectory::construct(const TwoBodyDecayTrajectoryState& state,
                                        const ConstRecHitCollection& recHits,
                                        const MagneticField* field,
-                                       const reco::BeamSpot& beamSpot)
-{  
+                                       const reco::BeamSpot& beamSpot) {
   const TwoBodyDecayTrajectoryState::TsosContainer& tsos = state.trajectoryStates(useRefittedState_);
   const TwoBodyDecayTrajectoryState::Derivatives& deriv = state.derivatives();
   double mass = state.particleMass();
@@ -83,7 +74,8 @@ bool TwoBodyDecayTrajectory::construct(const TwoBodyDecayTrajectoryState& state,
   ReferenceTrajectory trajectory1(tsos.first, recHits.first, field, beamSpot, config);
 
   // check if construction of trajectory was successful
-  if ( !trajectory1.isValid() ) return false;
+  if (!trajectory1.isValid())
+    return false;
 
   //
   // second track
@@ -91,13 +83,14 @@ bool TwoBodyDecayTrajectory::construct(const TwoBodyDecayTrajectoryState& state,
 
   ReferenceTrajectory trajectory2(tsos.second, recHits.second, field, beamSpot, config);
 
-  if ( !trajectory2.isValid() ) return false;
-  
+  if (!trajectory2.isValid())
+    return false;
+
   //
   // combine both tracks
   //
   unsigned int nLocal = deriv.first.num_row();
-  unsigned int nTbd   = deriv.first.num_col();
+  unsigned int nTbd = deriv.first.num_col();
 
   if (materialEffects_ >= localGBL) {
     // GBL trajectory inputs
@@ -105,26 +98,26 @@ bool TwoBodyDecayTrajectory::construct(const TwoBodyDecayTrajectoryState& state,
     Eigen::MatrixXd tbdToLocal1{nLocal, nTbd};
     for (unsigned int row = 0; row < nLocal; ++row) {
       for (unsigned int col = 0; col < nTbd; ++col) {
-        tbdToLocal1(row,col) = deriv.first[row][col];
+        tbdToLocal1(row, col) = deriv.first[row][col];
       }
     }
     // add first body
-    theGblInput.push_back(std::make_pair(trajectory1.gblInput().front().first, 
-                                         trajectory1.gblInput().front().second*tbdToLocal1));
+    theGblInput.push_back(
+        std::make_pair(trajectory1.gblInput().front().first, trajectory1.gblInput().front().second * tbdToLocal1));
     // convert to Eigen::MatrixXd
     Eigen::MatrixXd tbdToLocal2{nLocal, nTbd};
     for (unsigned int row = 0; row < nLocal; ++row) {
       for (unsigned int col = 0; col < nTbd; ++col) {
-        tbdToLocal2(row,col) = deriv.second[row][col];
+        tbdToLocal2(row, col) = deriv.second[row][col];
       }
     }
     // add second body
-    theGblInput.push_back(std::make_pair(trajectory2.gblInput().front().first, 
-                                         trajectory2.gblInput().front().second*tbdToLocal2));
+    theGblInput.push_back(
+        std::make_pair(trajectory2.gblInput().front().first, trajectory2.gblInput().front().second * tbdToLocal2));
     // add virtual mass measurement
-    theGblExtDerivatives.resize(1,nTbd);
+    theGblExtDerivatives.resize(1, nTbd);
     theGblExtDerivatives.setZero();
-    theGblExtDerivatives(0,TwoBodyDecayParameters::mass) = 1.0;
+    theGblExtDerivatives(0, TwoBodyDecayParameters::mass) = 1.0;
     theGblExtMeasurements.resize(1);
     theGblExtMeasurements(0) = state.primaryMass() - state.decayParameters()[TwoBodyDecayParameters::mass];
     theGblExtPrecisions.resize(1);
@@ -132,127 +125,129 @@ bool TwoBodyDecayTrajectory::construct(const TwoBodyDecayTrajectoryState& state,
     // nominal field
     theNomField = trajectory1.nominalField();
   } else {
-    unsigned int nHitMeas1     = trajectory1.numberOfHitMeas();
-    unsigned int nVirtualMeas1 = trajectory1.numberOfVirtualMeas(); 
-    unsigned int nPar1         = trajectory1.numberOfPar();
-    unsigned int nVirtualPar1  = trajectory1.numberOfVirtualPar(); 
-     
+    unsigned int nHitMeas1 = trajectory1.numberOfHitMeas();
+    unsigned int nVirtualMeas1 = trajectory1.numberOfVirtualMeas();
+    unsigned int nPar1 = trajectory1.numberOfPar();
+    unsigned int nVirtualPar1 = trajectory1.numberOfVirtualPar();
+
     // derivatives of the trajectory w.r.t. to the decay parameters
-    AlgebraicMatrix fullDeriv1 = trajectory1.derivatives().sub(1,nHitMeas1+nVirtualMeas1,1,nLocal) * trajectory1.localToTrajectory() * deriv.first;
+    AlgebraicMatrix fullDeriv1 = trajectory1.derivatives().sub(1, nHitMeas1 + nVirtualMeas1, 1, nLocal) *
+                                 trajectory1.localToTrajectory() * deriv.first;
 
-    unsigned int nHitMeas2     = trajectory2.numberOfHitMeas();
-    unsigned int nVirtualMeas2 = trajectory2.numberOfVirtualMeas();  
-    unsigned int nPar2         = trajectory2.numberOfPar();
-    unsigned int nVirtualPar2  = trajectory2.numberOfVirtualPar();
+    unsigned int nHitMeas2 = trajectory2.numberOfHitMeas();
+    unsigned int nVirtualMeas2 = trajectory2.numberOfVirtualMeas();
+    unsigned int nPar2 = trajectory2.numberOfPar();
+    unsigned int nVirtualPar2 = trajectory2.numberOfVirtualPar();
 
-    AlgebraicMatrix fullDeriv2 = trajectory2.derivatives().sub(1,nHitMeas2+nVirtualMeas2,1,nLocal) * trajectory2.localToTrajectory() * deriv.second;
+    AlgebraicMatrix fullDeriv2 = trajectory2.derivatives().sub(1, nHitMeas2 + nVirtualMeas2, 1, nLocal) *
+                                 trajectory2.localToTrajectory() * deriv.second;
 
     theNumberOfRecHits.first = recHits.first.size();
     theNumberOfRecHits.second = recHits.second.size();
 
-    theNumberOfHits = trajectory1.numberOfHits() + trajectory2.numberOfHits(); 
+    theNumberOfHits = trajectory1.numberOfHits() + trajectory2.numberOfHits();
     theNumberOfPars = nPar1 + nPar2;
     theNumberOfVirtualPars = nVirtualPar1 + nVirtualPar2;
-    theNumberOfVirtualMeas = nVirtualMeas1 + nVirtualMeas2 + 1; // add virtual mass measurement
-  
+    theNumberOfVirtualMeas = nVirtualMeas1 + nVirtualMeas2 + 1;  // add virtual mass measurement
+
     // hit measurements from trajectory 1
     int rowOffset = 1;
-    int colOffset = 1; 
-    theDerivatives.sub( rowOffset, colOffset,                fullDeriv1.sub(            1, nHitMeas1,                     1, nTbd ) );
+    int colOffset = 1;
+    theDerivatives.sub(rowOffset, colOffset, fullDeriv1.sub(1, nHitMeas1, 1, nTbd));
     colOffset += nTbd;
-    theDerivatives.sub( rowOffset, colOffset, trajectory1.derivatives().sub(            1, nHitMeas1,            nLocal + 1, nPar1 + nVirtualPar1 ) );
+    theDerivatives.sub(
+        rowOffset, colOffset, trajectory1.derivatives().sub(1, nHitMeas1, nLocal + 1, nPar1 + nVirtualPar1));
     // hit measurements from trajectory 2
     rowOffset += nHitMeas1;
-    colOffset = 1; 
-    theDerivatives.sub( rowOffset, colOffset,                fullDeriv2.sub(            1, nHitMeas2,                     1, nTbd ) );
+    colOffset = 1;
+    theDerivatives.sub(rowOffset, colOffset, fullDeriv2.sub(1, nHitMeas2, 1, nTbd));
     colOffset += (nPar1 + nVirtualPar1 + nTbd - nLocal);
-    theDerivatives.sub( rowOffset, colOffset, trajectory2.derivatives().sub(            1, nHitMeas2,            nLocal + 1, nPar2 + nVirtualPar2 ) );  
+    theDerivatives.sub(
+        rowOffset, colOffset, trajectory2.derivatives().sub(1, nHitMeas2, nLocal + 1, nPar2 + nVirtualPar2));
     // MS measurements from trajectory 1
-    rowOffset += nHitMeas2;  
-    colOffset = 1; 
-    theDerivatives.sub( rowOffset, colOffset,                fullDeriv1.sub(nHitMeas1 + 1, nHitMeas1 + nVirtualMeas1,          1, nTbd ) );  
+    rowOffset += nHitMeas2;
+    colOffset = 1;
+    theDerivatives.sub(rowOffset, colOffset, fullDeriv1.sub(nHitMeas1 + 1, nHitMeas1 + nVirtualMeas1, 1, nTbd));
     colOffset += nTbd;
-    theDerivatives.sub( rowOffset, colOffset, trajectory1.derivatives().sub(nHitMeas1 + 1, nHitMeas1 + nVirtualMeas1, nLocal + 1, nPar1 + nVirtualPar1 ) ); 
+    theDerivatives.sub(
+        rowOffset,
+        colOffset,
+        trajectory1.derivatives().sub(nHitMeas1 + 1, nHitMeas1 + nVirtualMeas1, nLocal + 1, nPar1 + nVirtualPar1));
     // MS measurements from trajectory 2
-    rowOffset += nVirtualMeas1;  
-    colOffset = 1; 
-    theDerivatives.sub( rowOffset, colOffset,                fullDeriv2.sub(nHitMeas2 + 1, nHitMeas2 + nVirtualMeas2,          1, nTbd ) );
-    colOffset += (nPar1 + nVirtualPar1 + nTbd - nLocal);  
-    theDerivatives.sub( rowOffset, colOffset, trajectory2.derivatives().sub(nHitMeas2 + 1, nHitMeas2 + nVirtualMeas2, nLocal + 1, nPar2 + nVirtualPar2 ) ); 
-        
-    theMeasurements.sub(                                         1, trajectory1.measurements().sub(            1, nHitMeas1 ) );
-    theMeasurements.sub( nHitMeas1                             + 1, trajectory2.measurements().sub(            1, nHitMeas2 ) );
-    theMeasurements.sub( nHitMeas1 + nHitMeas2                 + 1, trajectory1.measurements().sub(nHitMeas1 + 1, nHitMeas1 + nVirtualMeas1 ) );
-    theMeasurements.sub( nHitMeas1 + nHitMeas2 + nVirtualMeas1 + 1, trajectory2.measurements().sub(nHitMeas2 + 1, nHitMeas2 + nVirtualMeas2 ) );
+    rowOffset += nVirtualMeas1;
+    colOffset = 1;
+    theDerivatives.sub(rowOffset, colOffset, fullDeriv2.sub(nHitMeas2 + 1, nHitMeas2 + nVirtualMeas2, 1, nTbd));
+    colOffset += (nPar1 + nVirtualPar1 + nTbd - nLocal);
+    theDerivatives.sub(
+        rowOffset,
+        colOffset,
+        trajectory2.derivatives().sub(nHitMeas2 + 1, nHitMeas2 + nVirtualMeas2, nLocal + 1, nPar2 + nVirtualPar2));
 
-    theMeasurementsCov.sub(                                         1, trajectory1.measurementErrors().sub(            1, nHitMeas1 ) );
-    theMeasurementsCov.sub( nHitMeas1                             + 1, trajectory2.measurementErrors().sub(            1, nHitMeas2 ) );
-    theMeasurementsCov.sub( nHitMeas1 + nHitMeas2                 + 1, trajectory1.measurementErrors().sub(nHitMeas1 + 1, nHitMeas1 + nVirtualMeas1 ) );
-    theMeasurementsCov.sub( nHitMeas1 + nHitMeas2 + nVirtualMeas1 + 1, trajectory2.measurementErrors().sub(nHitMeas2 + 1, nHitMeas2 + nVirtualMeas2 ) );
+    theMeasurements.sub(1, trajectory1.measurements().sub(1, nHitMeas1));
+    theMeasurements.sub(nHitMeas1 + 1, trajectory2.measurements().sub(1, nHitMeas2));
+    theMeasurements.sub(nHitMeas1 + nHitMeas2 + 1,
+                        trajectory1.measurements().sub(nHitMeas1 + 1, nHitMeas1 + nVirtualMeas1));
+    theMeasurements.sub(nHitMeas1 + nHitMeas2 + nVirtualMeas1 + 1,
+                        trajectory2.measurements().sub(nHitMeas2 + 1, nHitMeas2 + nVirtualMeas2));
 
-    theTrajectoryPositions.sub(             1, trajectory1.trajectoryPositions() );
-    theTrajectoryPositions.sub( nHitMeas1 + 1, trajectory2.trajectoryPositions() );
+    theMeasurementsCov.sub(1, trajectory1.measurementErrors().sub(1, nHitMeas1));
+    theMeasurementsCov.sub(nHitMeas1 + 1, trajectory2.measurementErrors().sub(1, nHitMeas2));
+    theMeasurementsCov.sub(nHitMeas1 + nHitMeas2 + 1,
+                           trajectory1.measurementErrors().sub(nHitMeas1 + 1, nHitMeas1 + nVirtualMeas1));
+    theMeasurementsCov.sub(nHitMeas1 + nHitMeas2 + nVirtualMeas1 + 1,
+                           trajectory2.measurementErrors().sub(nHitMeas2 + 1, nHitMeas2 + nVirtualMeas2));
 
-    theTrajectoryPositionCov = state.decayParameters().covariance().similarity( theDerivatives.sub(1, nHitMeas1 + nHitMeas2, 1, 9) );
+    theTrajectoryPositions.sub(1, trajectory1.trajectoryPositions());
+    theTrajectoryPositions.sub(nHitMeas1 + 1, trajectory2.trajectoryPositions());
+
+    theTrajectoryPositionCov =
+        state.decayParameters().covariance().similarity(theDerivatives.sub(1, nHitMeas1 + nHitMeas2, 1, 9));
 
     theParameters = state.decayParameters().parameters();
 
     // add virtual mass measurement
     rowOffset += nVirtualMeas2;
-    int indMass = rowOffset-1;
+    int indMass = rowOffset - 1;
     theMeasurements[indMass] = state.primaryMass() - state.decayParameters()[TwoBodyDecayParameters::mass];
     theMeasurementsCov[indMass][indMass] = state.primaryWidth() * state.primaryWidth();
     theDerivatives[indMass][TwoBodyDecayParameters::mass] = 1.0;
   }
 
-  theRecHits.insert( theRecHits.end(), recHits.first.begin(), recHits.first.end() );
-  theRecHits.insert( theRecHits.end(), recHits.second.begin(), recHits.second.end() );
+  theRecHits.insert(theRecHits.end(), recHits.first.begin(), recHits.first.end());
+  theRecHits.insert(theRecHits.end(), recHits.second.begin(), recHits.second.end());
 
-  if (constructTsosWithErrors_)
-  {
-    constructTsosVecWithErrors( trajectory1, trajectory2, field );
-  }
-  else
-  {
-    theTsosVec.insert( theTsosVec.end(),
-		       trajectory1.trajectoryStates().begin(),
-		       trajectory1.trajectoryStates().end() );
+  if (constructTsosWithErrors_) {
+    constructTsosVecWithErrors(trajectory1, trajectory2, field);
+  } else {
+    theTsosVec.insert(theTsosVec.end(), trajectory1.trajectoryStates().begin(), trajectory1.trajectoryStates().end());
 
-    theTsosVec.insert( theTsosVec.end(),
-		       trajectory2.trajectoryStates().begin(),
-		       trajectory2.trajectoryStates().end() );
+    theTsosVec.insert(theTsosVec.end(), trajectory2.trajectoryStates().begin(), trajectory2.trajectoryStates().end());
   }
 
   return true;
 }
 
-
-void TwoBodyDecayTrajectory::constructTsosVecWithErrors( const ReferenceTrajectory& traj1,
-							 const ReferenceTrajectory& traj2,
-							 const MagneticField* field )
-{
+void TwoBodyDecayTrajectory::constructTsosVecWithErrors(const ReferenceTrajectory& traj1,
+                                                        const ReferenceTrajectory& traj2,
+                                                        const MagneticField* field) {
   int iTsos = 0;
 
-  std::vector< TrajectoryStateOnSurface >::const_iterator itTsos;
+  std::vector<TrajectoryStateOnSurface>::const_iterator itTsos;
 
-  for ( itTsos = traj1.trajectoryStates().begin(); itTsos != traj1.trajectoryStates().end(); itTsos++ )
-  {
-    constructSingleTsosWithErrors( *itTsos, iTsos, field );
+  for (itTsos = traj1.trajectoryStates().begin(); itTsos != traj1.trajectoryStates().end(); itTsos++) {
+    constructSingleTsosWithErrors(*itTsos, iTsos, field);
     iTsos++;
   }
 
-  for ( itTsos = traj2.trajectoryStates().begin(); itTsos != traj2.trajectoryStates().end(); itTsos++ )
-  {
-    constructSingleTsosWithErrors( *itTsos, iTsos, field );
+  for (itTsos = traj2.trajectoryStates().begin(); itTsos != traj2.trajectoryStates().end(); itTsos++) {
+    constructSingleTsosWithErrors(*itTsos, iTsos, field);
     iTsos++;
   }
 }
 
-
-void TwoBodyDecayTrajectory::constructSingleTsosWithErrors( const TrajectoryStateOnSurface& tsos,
-							    int iTsos,
-							    const MagneticField* field )
-{
+void TwoBodyDecayTrajectory::constructSingleTsosWithErrors(const TrajectoryStateOnSurface& tsos,
+                                                           int iTsos,
+                                                           const MagneticField* field) {
   AlgebraicSymMatrix55 localErrors;
   const double coeff = 1e-2;
 
@@ -261,22 +256,19 @@ void TwoBodyDecayTrajectory::constructSingleTsosWithErrors( const TrajectoryStat
 
   // rough estimate for the errors of q/p, dx/dz and dy/dz, assuming that
   // sigma(px) = sigma(py) = sigma(pz) = coeff*p.
-  float dpinv = coeff*( fabs(p.x()) + fabs(p.y()) + fabs(p.z()) )*invP*invP;
-  float dxdir = coeff*( fabs(p.x()) + fabs(p.z()) )/p.z()/p.z();
-  float dydir = coeff*( fabs(p.y()) + fabs(p.z()) )/p.z()/p.z();
-  localErrors[0][0] = dpinv*dpinv;
-  localErrors[1][1] = dxdir*dxdir;
-  localErrors[2][2] = dydir*dydir;
+  float dpinv = coeff * (fabs(p.x()) + fabs(p.y()) + fabs(p.z())) * invP * invP;
+  float dxdir = coeff * (fabs(p.x()) + fabs(p.z())) / p.z() / p.z();
+  float dydir = coeff * (fabs(p.y()) + fabs(p.z())) / p.z() / p.z();
+  localErrors[0][0] = dpinv * dpinv;
+  localErrors[1][1] = dxdir * dxdir;
+  localErrors[2][2] = dydir * dydir;
 
   // exact values for the errors on local x and y
-  localErrors[3][3] = theTrajectoryPositionCov[nMeasPerHit*iTsos][nMeasPerHit*iTsos];
-  localErrors[3][4] = theTrajectoryPositionCov[nMeasPerHit*iTsos][nMeasPerHit*iTsos+1];
-  localErrors[4][4] = theTrajectoryPositionCov[nMeasPerHit*iTsos+1][nMeasPerHit*iTsos+1];
+  localErrors[3][3] = theTrajectoryPositionCov[nMeasPerHit * iTsos][nMeasPerHit * iTsos];
+  localErrors[3][4] = theTrajectoryPositionCov[nMeasPerHit * iTsos][nMeasPerHit * iTsos + 1];
+  localErrors[4][4] = theTrajectoryPositionCov[nMeasPerHit * iTsos + 1][nMeasPerHit * iTsos + 1];
 
   // construct tsos with local errors
-  theTsosVec[iTsos] =  TrajectoryStateOnSurface( tsos.localParameters(),
-						 LocalTrajectoryError( localErrors ),
-						 tsos.surface(),
-						 field,
-						 tsos.surfaceSide() );
+  theTsosVec[iTsos] = TrajectoryStateOnSurface(
+      tsos.localParameters(), LocalTrajectoryError(localErrors), tsos.surface(), field, tsos.surfaceSide());
 }

--- a/Alignment/ReferenceTrajectories/src/TwoBodyDecayTrajectoryState.cc
+++ b/Alignment/ReferenceTrajectories/src/TwoBodyDecayTrajectoryState.cc
@@ -1,6 +1,6 @@
 
 #include "Alignment/ReferenceTrajectories/interface/TwoBodyDecayTrajectoryState.h"
-#include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h" 
+#include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 
 #include "Alignment/TwoBodyDecay/interface/TwoBodyDecayModel.h"
 #include "Alignment/TwoBodyDecay/interface/TwoBodyDecayDerivatives.h"
@@ -17,137 +17,120 @@
 
 using namespace std;
 
-
-TwoBodyDecayTrajectoryState::TwoBodyDecayTrajectoryState( const TsosContainer & tsos,
-							  const TwoBodyDecay & tbd,
-							  double particleMass,
-							  const MagneticField* magField,
-							  bool propagateErrors )
-  : theValidityFlag( false ),
-    theParticleMass( particleMass ),
-    theParameters( tbd.decayParameters() ),
-    theDerivatives( AlgebraicMatrix( nLocalParam, nDecayParam ), AlgebraicMatrix( nLocalParam, nDecayParam ) ),
-    theOriginalTsos( tsos ),
-    thePrimaryMass( tbd.primaryMass() ),
-    thePrimaryWidth( tbd.primaryWidth() )
-{
-  construct( magField, propagateErrors );
+TwoBodyDecayTrajectoryState::TwoBodyDecayTrajectoryState(const TsosContainer& tsos,
+                                                         const TwoBodyDecay& tbd,
+                                                         double particleMass,
+                                                         const MagneticField* magField,
+                                                         bool propagateErrors)
+    : theValidityFlag(false),
+      theParticleMass(particleMass),
+      theParameters(tbd.decayParameters()),
+      theDerivatives(AlgebraicMatrix(nLocalParam, nDecayParam), AlgebraicMatrix(nLocalParam, nDecayParam)),
+      theOriginalTsos(tsos),
+      thePrimaryMass(tbd.primaryMass()),
+      thePrimaryWidth(tbd.primaryWidth()) {
+  construct(magField, propagateErrors);
 }
 
-
-void TwoBodyDecayTrajectoryState::rescaleError( double scale )
-{
-  theOriginalTsos.first.rescaleError( scale );
-  theOriginalTsos.second.rescaleError( scale );
-  theRefittedTsos.first.rescaleError( scale );
-  theRefittedTsos.second.rescaleError( scale );
+void TwoBodyDecayTrajectoryState::rescaleError(double scale) {
+  theOriginalTsos.first.rescaleError(scale);
+  theOriginalTsos.second.rescaleError(scale);
+  theRefittedTsos.first.rescaleError(scale);
+  theRefittedTsos.second.rescaleError(scale);
 }
 
-
-void TwoBodyDecayTrajectoryState::construct( const MagneticField* magField,
-					     bool propagateErrors )
-{
+void TwoBodyDecayTrajectoryState::construct(const MagneticField* magField, bool propagateErrors) {
   // construct global trajectory parameters at the starting point
-  TwoBodyDecayModel tbdDecayModel( theParameters[TwoBodyDecayParameters::mass], theParticleMass );
-  pair< AlgebraicVector, AlgebraicVector > secondaryMomenta = tbdDecayModel.cartesianSecondaryMomenta( theParameters );
+  TwoBodyDecayModel tbdDecayModel(theParameters[TwoBodyDecayParameters::mass], theParticleMass);
+  pair<AlgebraicVector, AlgebraicVector> secondaryMomenta = tbdDecayModel.cartesianSecondaryMomenta(theParameters);
 
-  GlobalPoint vtx( theParameters[TwoBodyDecayParameters::x],
-		   theParameters[TwoBodyDecayParameters::y],
-		   theParameters[TwoBodyDecayParameters::z] );
+  GlobalPoint vtx(theParameters[TwoBodyDecayParameters::x],
+                  theParameters[TwoBodyDecayParameters::y],
+                  theParameters[TwoBodyDecayParameters::z]);
 
-  GlobalVector p1( secondaryMomenta.first[0],
-		   secondaryMomenta.first[1],
-		   secondaryMomenta.first[2] );
+  GlobalVector p1(secondaryMomenta.first[0], secondaryMomenta.first[1], secondaryMomenta.first[2]);
 
-  GlobalVector p2( secondaryMomenta.second[0],
-		   secondaryMomenta.second[1],
-		   secondaryMomenta.second[2] );
+  GlobalVector p2(secondaryMomenta.second[0], secondaryMomenta.second[1], secondaryMomenta.second[2]);
 
-  GlobalTrajectoryParameters gtp1( vtx, p1, theOriginalTsos.first.charge(), magField );
-  FreeTrajectoryState fts1( gtp1 );
+  GlobalTrajectoryParameters gtp1(vtx, p1, theOriginalTsos.first.charge(), magField);
+  FreeTrajectoryState fts1(gtp1);
 
-  GlobalTrajectoryParameters gtp2( vtx, p2, theOriginalTsos.second.charge(), magField );
-  FreeTrajectoryState fts2( gtp2 );
+  GlobalTrajectoryParameters gtp2(vtx, p2, theOriginalTsos.second.charge(), magField);
+  FreeTrajectoryState fts2(gtp2);
 
   // contruct derivatives at the starting point
-  TwoBodyDecayDerivatives tbdDerivatives( theParameters[TwoBodyDecayParameters::mass], theParticleMass );
-  pair< AlgebraicMatrix, AlgebraicMatrix > derivatives = tbdDerivatives.derivatives( theParameters );
+  TwoBodyDecayDerivatives tbdDerivatives(theParameters[TwoBodyDecayParameters::mass], theParticleMass);
+  pair<AlgebraicMatrix, AlgebraicMatrix> derivatives = tbdDerivatives.derivatives(theParameters);
 
-  AlgebraicMatrix deriv1( 6, 9, 0 );
-  deriv1.sub( 1, 1, AlgebraicMatrix( 3, 3, 1 ) );
-  deriv1.sub( 4, 4, derivatives.first );
+  AlgebraicMatrix deriv1(6, 9, 0);
+  deriv1.sub(1, 1, AlgebraicMatrix(3, 3, 1));
+  deriv1.sub(4, 4, derivatives.first);
 
-  AlgebraicMatrix deriv2( 6, 9, 0 );
-  deriv2.sub( 1, 1, AlgebraicMatrix( 3, 3, 1 ) );
-  deriv2.sub( 4, 4, derivatives.second );
+  AlgebraicMatrix deriv2(6, 9, 0);
+  deriv2.sub(1, 1, AlgebraicMatrix(3, 3, 1));
+  deriv2.sub(4, 4, derivatives.second);
 
   // compute errors of initial states
-  if ( propagateErrors ) {
-    setError( fts1, deriv1 );
-    setError( fts2, deriv2 );
+  if (propagateErrors) {
+    setError(fts1, deriv1);
+    setError(fts2, deriv2);
   }
 
-
   // propgate states and derivatives from the starting points to the end points
-  bool valid1 = propagateSingleState( fts1, gtp1, deriv1, theOriginalTsos.first.surface(),
-				      magField, theRefittedTsos.first, theDerivatives.first );
+  bool valid1 = propagateSingleState(
+      fts1, gtp1, deriv1, theOriginalTsos.first.surface(), magField, theRefittedTsos.first, theDerivatives.first);
 
-  bool valid2 = propagateSingleState( fts2, gtp2, deriv2, theOriginalTsos.second.surface(),
-				      magField, theRefittedTsos.second, theDerivatives.second );
+  bool valid2 = propagateSingleState(
+      fts2, gtp2, deriv2, theOriginalTsos.second.surface(), magField, theRefittedTsos.second, theDerivatives.second);
 
   theValidityFlag = valid1 && valid2;
 
   return;
 }
 
-
-bool TwoBodyDecayTrajectoryState::propagateSingleState( const FreeTrajectoryState & fts,
-							const GlobalTrajectoryParameters & gtp,
-							const AlgebraicMatrix & startDeriv,
-							const Surface & surface,
-							const MagneticField* magField,
-							TrajectoryStateOnSurface & tsos,
-							AlgebraicMatrix & endDeriv ) const
-{
-  AnalyticalPropagator propagator( magField );
+bool TwoBodyDecayTrajectoryState::propagateSingleState(const FreeTrajectoryState& fts,
+                                                       const GlobalTrajectoryParameters& gtp,
+                                                       const AlgebraicMatrix& startDeriv,
+                                                       const Surface& surface,
+                                                       const MagneticField* magField,
+                                                       TrajectoryStateOnSurface& tsos,
+                                                       AlgebraicMatrix& endDeriv) const {
+  AnalyticalPropagator propagator(magField);
 
   // propagate state
-  pair< TrajectoryStateOnSurface, double > tsosWithPath = propagator.propagateWithPath( fts, surface );
+  pair<TrajectoryStateOnSurface, double> tsosWithPath = propagator.propagateWithPath(fts, surface);
 
   // check if propagation was successful
-  if ( !tsosWithPath.first.isValid() ) return false;
+  if (!tsosWithPath.first.isValid())
+    return false;
 
   // jacobian for transformation from cartesian to curvilinear frame at the starting point
-  JacobianCartesianToCurvilinear cartToCurv( gtp );
+  JacobianCartesianToCurvilinear cartToCurv(gtp);
   const AlgebraicMatrix56& matCartToCurv = cartToCurv.jacobian();
 
   // jacobian in curvilinear frame for propagation from the starting point to the end point
-  AnalyticalCurvilinearJacobian curvJac( gtp, tsosWithPath.first.globalPosition(),
-					 tsosWithPath.first.globalMomentum(),
-					 tsosWithPath.second );
+  AnalyticalCurvilinearJacobian curvJac(
+      gtp, tsosWithPath.first.globalPosition(), tsosWithPath.first.globalMomentum(), tsosWithPath.second);
   const AlgebraicMatrix55& matCurvJac = curvJac.jacobian();
 
   // jacobian for transformation from curvilinear to local frame at the end point
-  JacobianCurvilinearToLocal curvToLoc( surface, tsosWithPath.first.localParameters(), *magField );
+  JacobianCurvilinearToLocal curvToLoc(surface, tsosWithPath.first.localParameters(), *magField);
   const AlgebraicMatrix55& matCurvToLoc = curvToLoc.jacobian();
 
-  AlgebraicMatrix56 tmpDeriv = matCurvToLoc*matCurvJac*matCartToCurv;
-  AlgebraicMatrix hepMatDeriv( asHepMatrix( tmpDeriv ) );
+  AlgebraicMatrix56 tmpDeriv = matCurvToLoc * matCurvJac * matCartToCurv;
+  AlgebraicMatrix hepMatDeriv(asHepMatrix(tmpDeriv));
   //AlgebraicMatrix hepMatDeriv = asHepMatrix< 5, 6 >( tmpDeriv );
 
   // replace original state with new state
   tsos = tsosWithPath.first;
 
   // propagate derivative matrix
-  endDeriv = hepMatDeriv*startDeriv;
+  endDeriv = hepMatDeriv * startDeriv;
 
   return true;
 }
 
-
-void TwoBodyDecayTrajectoryState::setError( FreeTrajectoryState& fts,
-					    AlgebraicMatrix& derivative ) const
-{
-  AlgebraicSymMatrix ftsCartesianError( theParameters.covariance().similarity( derivative ) );
-  fts.setCartesianError( asSMatrix<6>( ftsCartesianError ) );
+void TwoBodyDecayTrajectoryState::setError(FreeTrajectoryState& fts, AlgebraicMatrix& derivative) const {
+  AlgebraicSymMatrix ftsCartesianError(theParameters.covariance().similarity(derivative));
+  fts.setCartesianError(asSMatrix<6>(ftsCartesianError));
 }

--- a/CalibCalorimetry/EcalLaserSorting/interface/LaserSorter.h
+++ b/CalibCalorimetry/EcalLaserSorting/interface/LaserSorter.h
@@ -44,43 +44,41 @@
 class LaserSorter : public edm::EDAnalyzer {
   //inner classes
 private:
-  struct IndexRecord{
+  struct IndexRecord {
     uint32_t orbit;
     uint32_t filePos;
     bool operator<(const IndexRecord& i) const { return orbit < i.orbit; }
   };
-  
-  class OutStreamRecord{
+
+  class OutStreamRecord {
   public:
     //default ctor
     OutStreamRecord(int fedId__,
-		    edm::LuminosityBlockNumber_t startingLumiBlock__,
-		    std::ofstream* out__,
-		    std::string& tmpFileName__,
-		    std::string& finalFileName__):
-      fedId_(fedId__),
-      startingLumiBlock_(startingLumiBlock__),
-      out_(out__),
-      tmpFileName_(tmpFileName__), finalFileName_(finalFileName__),
-      indexError_(false){
+                    edm::LuminosityBlockNumber_t startingLumiBlock__,
+                    std::ofstream* out__,
+                    std::string& tmpFileName__,
+                    std::string& finalFileName__)
+        : fedId_(fedId__),
+          startingLumiBlock_(startingLumiBlock__),
+          out_(out__),
+          tmpFileName_(tmpFileName__),
+          finalFileName_(finalFileName__),
+          indexError_(false) {
       indices_.reserve(indexReserve_);
     }
-    
+
     int fedId() const { return fedId_; }
-    edm::LuminosityBlockNumber_t startingLumiBlock() const{
-      return startingLumiBlock_; 
-    } 
+    edm::LuminosityBlockNumber_t startingLumiBlock() const { return startingLumiBlock_; }
     std::ofstream* out() const { return out_.get(); }
     std::string finalFileName() const { return finalFileName_; }
     std::string tmpFileName() const { return tmpFileName_; }
-    std::vector<IndexRecord> * indices() { return &indices_; }
- 
-    
+    std::vector<IndexRecord>* indices() { return &indices_; }
+
     /** Gets the list of orbits to skip. Used to update an existing file:
      * orbits of events already present in the file are excluded.
      * @return the list of orbits to skip.
      */
-    std::set<uint32_t>&  excludedOrbit() { return excludedOrbit_; }   
+    std::set<uint32_t>& excludedOrbit() { return excludedOrbit_; }
 
   private:
     int fedId_;
@@ -99,8 +97,8 @@ private:
     /** List of orbits to skip. Used to update an existing file: orbits
      * of events already present in the file are excluded. 
      */
-    std::set<uint32_t> excludedOrbit_; 
-    
+    std::set<uint32_t> excludedOrbit_;
+
     /** Used to invalidate index table in case a problem preventing
      * indexing is encountered: in principle non unicity of the orbit id.
      */
@@ -109,18 +107,16 @@ private:
     /** Initial memory allocation for index table (see vector::reserve()).
      */
     static const size_t indexReserve_;
-
   };
 
   //typedefs:
 private:
   typedef boost::ptr_list<OutStreamRecord> OutStreamList;
-  
+
   //ctors/dtors
 public:
   LaserSorter(const edm::ParameterSet&);
   ~LaserSorter() override;
-
 
   //methods
 public:
@@ -148,8 +144,7 @@ private:
    * blocks, -1 is returned otherwise. If event does not contain any ECAL data
    * -2 is returned.
    */
-  int getDetailedTriggerType(const edm::Handle<FEDRawDataCollection>& rawdata,
-                             double* proba = nullptr);
+  int getDetailedTriggerType(const edm::Handle<FEDRawDataCollection>& rawdata, double* proba = nullptr);
 
   /** Closes output stream 2 lumi block older than the input 'lumiBlock' ID.
    * @param lumiBlock ID of the reference luminosity block.
@@ -160,15 +155,13 @@ private:
    */
   void closeAllStreams();
 
-  
   /** Gets and eventually creates the output stream for writing the events 
    * of a given FED and luminosity block.
    * @param fedId ID of the FED the event is issued from
    * @param lumiBlock luminositu block of the event
    * @return pointer of the output stream record or null if not found.
    */
-  OutStreamRecord* getStream(int fedId,
-			     edm::LuminosityBlockNumber_t lumiBlock);
+  OutStreamRecord* getStream(int fedId, edm::LuminosityBlockNumber_t lumiBlock);
 
   /** Writes a monitoring events to an output stream.
    * @param out stream to write the event out
@@ -179,17 +172,17 @@ private:
    * @return true on success, false on failure
    * @see getStream(int, edm::LuminosityBlockNumber_t)
    */
-  bool writeEvent(OutStreamRecord& out, const edm::Event& event,
-		  int detailedTriggerType,
-		  const FEDRawDataCollection& data);
-  
+  bool writeEvent(OutStreamRecord& out,
+                  const edm::Event& event,
+                  int detailedTriggerType,
+                  const FEDRawDataCollection& data);
+
   /** Writes out data of a FED
    * @param out stream to write the event out
    * @param data FED data
    * @return true on success, false on failure
    */
-  bool writeFedBlock(std::ofstream& out,
-                     const FEDRawData& data);
+  bool writeFedBlock(std::ofstream& out, const FEDRawData& data);
 
   /** Closes an output stream and removed it from opened stream records.
    * Beware: this methode modifies outStreamList_.
@@ -206,8 +199,7 @@ private:
    * @return iterator to the new stream record. outStreamList_.end() in case
    * of failure.
    */
-  OutStreamList::iterator createOutStream(int fedId, 
-					  edm::LuminosityBlockNumber_t lumiBlock);
+  OutStreamList::iterator createOutStream(int fedId, edm::LuminosityBlockNumber_t lumiBlock);
 
   /** Writing file header for an LMF binary file
    * @param out stream of the output file
@@ -219,12 +211,8 @@ private:
    * @param evt event
    * @return false in case of write failure
    */
-  bool writeEventHeader(std::ofstream& out,
-                        const edm::Event& evt,
-                        int fedId,
-                        unsigned nFeds);
+  bool writeEventHeader(std::ofstream& out, const edm::Event& evt, int fedId, unsigned nFeds);
 
-  
   /** Builds the file names for the group of event corresponding
    * to a FED and a starting lumi block.
    * @param fedId FED ID of the event set
@@ -232,9 +220,7 @@ private:
    * @param [out] tmpName name of the file to use when filling it.
    * @param [out] finalName name of the file once completed.
    */
-  void streamFileName(int fedId, edm::LuminosityBlockNumber_t lumiBlock, 
-                      std::string& tmpName, std::string& finalName);
-
+  void streamFileName(int fedId, edm::LuminosityBlockNumber_t lumiBlock, std::string& tmpName, std::string& finalName);
 
   /** Checks if an ECAL DCC event is empty. It is considered as
    * empty if it does not contains FE data ("tower" block). So
@@ -245,16 +231,13 @@ private:
    * @nTowerBlocks if not null, filled with number of tower blocks
    * @return true if event is empty, false otherwise
    */
-  bool isDccEventEmpty(const FEDRawData& data, size_t* dccLen = nullptr,
-		       int* nTowerBlocks = nullptr) const;
-  
+  bool isDccEventEmpty(const FEDRawData& data, size_t* dccLen = nullptr, int* nTowerBlocks = nullptr) const;
+
   /** Computes the list of FEDs which data must be written out.
    * @param data CMS raw event
    * @param fedIds [out] list of FEDs to keep
    */
-  void getOutputFedList(const edm::Event& event,
-                        const FEDRawDataCollection& data,
-                        std::vector<unsigned>& fedIds) const;
+  void getOutputFedList(const edm::Event& event, const FEDRawDataCollection& data, std::vector<unsigned>& fedIds) const;
 
   /** Read index table of an LMF file.
    * @param in LMF file whose index table must be read.
@@ -264,28 +247,23 @@ private:
    * @param err if not nul, in case of failure filled with the error message.
    * @return true in case of success, false otherwise
    */
-  bool readIndexTable(std::ifstream& in, std::string& inName,
-                      OutStreamRecord& outRcd, std::string* err);
+  bool readIndexTable(std::ifstream& in, std::string& inName, OutStreamRecord& outRcd, std::string* err);
 
   /** Writes index table in LMF output file. stream must be positionned
    * to the place for the index table (end of file).
    * @param out stream of output file.
    * @param indices index table
    */
-  bool writeIndexTable(std::ofstream& out,
-		       std::vector<IndexRecord>& indices);
+  bool writeIndexTable(std::ofstream& out, std::vector<IndexRecord>& indices);
 
-  bool renameAsBackup(const std::string& fileName,
-                      std::string& newFileName);
-  
+  bool renameAsBackup(const std::string& fileName, std::string& newFileName);
 
   /** Gets format version of an LMF file. Position of file is preserved.
    * @param in stream to read the file
    * @param fileName name of the file. Used in error message.
    * @return version or -1 in case of error.
    */
-  int readFormatVersion(std::ifstream& in,
-                        const std::string& fileName);
+  int readFormatVersion(std::ifstream& in, const std::string& fileName);
 
   /** Help function to format a date
    */
@@ -304,7 +282,7 @@ private:
    * @return FED ids.
    */
   std::vector<int> getFullyReadoutDccs(const FEDRawDataCollection& data) const;
-  
+
   //fields
 private:
   /** Lower bound of ECAL DCC FED ID
@@ -383,7 +361,7 @@ private:
   /** Debugging message verbosity level
    */
   int verbosity_;
-  
+
   /** stream where list of output file is listed to
    */
   std::ofstream outputList_;
@@ -411,11 +389,9 @@ private:
    */
   int iNoFullReadoutDccError_;
 
-
   /** Maximum number of "No fully readout DCC error" message in a run
    */
-  int maxFullReadoutDccError_;  
-
+  int maxFullReadoutDccError_;
 
   /** number of "ECAL DCC data" message in a run
    */
@@ -452,7 +428,7 @@ private:
   /** Limit of number of events to prevent exhausting memory
    * with indexTable_ in case of file corruption.
    */
-  static const unsigned maxEvents_ = 1<<20;
+  static const unsigned maxEvents_ = 1 << 20;
 
   /** Statistics on event processing
    */
@@ -474,8 +450,7 @@ private:
 
   /** Switch to recompute and overwrite the lumi block ID
    */
-  bool overWriteLumiBlockId_; 
-
+  bool overWriteLumiBlockId_;
 
   /** Length of a lumi block in number of orbits used when
    * overWriteLumiBlockId is set to true;
@@ -493,7 +468,6 @@ private:
    * Calibration event time = orbitZeroTime_ + orbit_ * (89.1 microsec).
    */
   struct timeval orbitZeroTime_;
-
 };
-  
-#endif //EVENT_SELECT_H not defined
+
+#endif  //EVENT_SELECT_H not defined

--- a/CalibCalorimetry/EcalLaserSorting/interface/LmfSource.h
+++ b/CalibCalorimetry/EcalLaserSorting/interface/LmfSource.h
@@ -11,32 +11,33 @@
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
 
-class LmfSource: public edm::ProducerSourceBase{
+class LmfSource : public edm::ProducerSourceBase {
 private:
-  struct IndexRecord{
+  struct IndexRecord {
     uint32_t orbit;
     uint32_t filePos;
     //    bool operator<(const IndexRecord& i) const { return orbit < i.orbit; }
   };
-  
+
 public:
-  LmfSource(const edm::ParameterSet& pset,
-	       const edm::InputSourceDescription& isd);
-  ~LmfSource() override{}
-  
+  LmfSource(const edm::ParameterSet& pset, const edm::InputSourceDescription& isd);
+  ~LmfSource() override {}
+
 private:
   /** Called by the framework after setRunAndEventInfo()
    */
-  void produce(edm::Event &e) override;
+  void produce(edm::Event& e) override;
 
   /** Callback funtion to set run and event information
    * (lumi block, run number, event number, timestamp)
    * Called by the framework before produce()
    */
-  bool setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& time, edm::EventAuxiliary::ExperimentType& eType) override;
+  bool setRunAndEventInfo(edm::EventID& id,
+                          edm::TimeValue_t& time,
+                          edm::EventAuxiliary::ExperimentType& eType) override;
 
   bool openFile(int iFile);
-  
+
   bool readFileHeader();
 
   /** Read event from current opened file. Called by readEvent, which
@@ -46,14 +47,13 @@ private:
    * @return true iff succeeded
    */
   bool readEventWithinFile(bool doSkip);
-  
+
   /** timeval to string conversion
    * @param t timestamp
    * @return human readable character string
    */
   std::string toString(edm::TimeValue_t& t) const;
 
-  
 private:
   /** List of names of the input files
    */
@@ -66,7 +66,7 @@ private:
   /** Buffer for FED block collection
    */
   FEDRawDataCollection fedColl_;
-  
+
   /** empty fed block
    */
   FEDRawData emptyFedBlock_;
@@ -81,16 +81,15 @@ private:
   std::vector<uint32_t> header_;
 
   static const unsigned fileHeaderSize;
-  
+
   /** Buffer for file header readout
    */
   std::vector<uint32_t> fileHeader_;
 
-
   /** Minimal LMF data format version supported.
    */
   static const unsigned char minDataFormatVersion_;
-  
+
   /** Maximal LMF data format version supported.
    */
   static const unsigned char maxDataFormatVersion_;
@@ -111,7 +110,7 @@ private:
    * @return false in case of failure (end of file)
    */
   bool nextEventWithinFile();
-  
+
   /** Checks paths specified in fileNames_ and remove eventual
    * file: prefix.
    * @throw cms::Exception in case of a non valid path
@@ -122,14 +121,14 @@ private:
    * must be called beforehand.
    */
   void readIndexTable();
-  
+
   uint64_t timeStamp_;
   uint32_t lumiBlock_;
   uint32_t runNum_;
   uint32_t bx_;
   uint32_t eventNum_;
   uint32_t orbitNum_;
-  
+
   unsigned char dataFormatVers_;
 
   std::ifstream in_;
@@ -151,7 +150,7 @@ private:
   uint32_t indexTablePos_;
 
   int calibTrig_;
-  
+
   int nFeds_;
 
   /** Table with file position of each event order by event time
@@ -162,13 +161,13 @@ private:
   /** Limit of number of events to prevent exhausting memory
    * with indexTable_ in case of file corruption.
    */
-  static const unsigned maxEvents_ = 1<<20;
+  static const unsigned maxEvents_ = 1 << 20;
 
   /** Limit on event size to prevent exhausting memory
    * in case of error in the event size read from file.
    */
-  static const unsigned maxEventSize_ = 1<<20; //1MB. (full DCC event is 49kB)
-  
+  static const unsigned maxEventSize_ = 1 << 20;  //1MB. (full DCC event is 49kB)
+
   /** Switch for enabling reading event in ordered using
    * event index table
    */
@@ -201,5 +200,4 @@ private:
    */
   int verbosity_;
 };
-#endif //SourceModule_H not defined
-
+#endif  //SourceModule_H not defined

--- a/CalibCalorimetry/EcalLaserSorting/interface/WatcherSource.h
+++ b/CalibCalorimetry/EcalLaserSorting/interface/WatcherSource.h
@@ -6,6 +6,4 @@
 
 typedef edm::StreamerInputModule<WatcherStreamFileReader> WatcherSource;
 
-
-#endif //WatcherSourceModule_H not defined
-
+#endif  //WatcherSourceModule_H not defined

--- a/CalibCalorimetry/EcalLaserSorting/interface/WatcherStreamFileReader.h
+++ b/CalibCalorimetry/EcalLaserSorting/interface/WatcherStreamFileReader.h
@@ -19,36 +19,35 @@
  * This protection is obviously not full proof, especially to transfer lag.
  */
 
-namespace edm{
+namespace edm {
   class StreamerInputFile;
 }
 
-class WatcherStreamFileReader{
+class WatcherStreamFileReader {
 public:
   WatcherStreamFileReader(edm::ParameterSet const& pset);
   ~WatcherStreamFileReader();
 
-  const InitMsgView* getHeader(); 
+  const InitMsgView* getHeader();
   const EventMsgView* getNextEvent();
-  const bool newHeader(); 
+  const bool newHeader();
 
   edm::StreamerInputFile* getInputFile();
 
   void closeFile();
-  
+
 private:
   /** Directory to look for streamer files
    */
   std::string inputDir_;
-  
+
   /** Streamer file name pattern list
    */
-  std::vector<std::string> filePatterns_; 
+  std::vector<std::string> filePatterns_;
 
   /** Directory where file are moved during processing
    */
   std::string inprocessDir_;
-
 
   /** Directory where file must be moved once processed
    */
@@ -57,7 +56,7 @@ private:
   /** Directory where file must be moved if file is unreadble (e.g empty size)
    */
   std::string corruptedDir_;
-  
+
   /** Cached input file stream
    */
   std::unique_ptr<edm::StreamerInputFile> streamerInputFile_;
@@ -67,18 +66,16 @@ private:
   std::string tokenFile_;
 
   int timeOut_;
-  
+
   std::deque<std::string> filesInQueue_;
 
   bool end_;
-  
+
   int verbosity_;
 
   std::string fileListCmd_;
 
   std::string curDir_;
-
 };
 
 #endif
-

--- a/CalibCalorimetry/EcalLaserSorting/src/LaserSorter.cc
+++ b/CalibCalorimetry/EcalLaserSorting/src/LaserSorter.cc
@@ -6,7 +6,6 @@
  *        completion of partial output file        * 
  ***************************************************/
 
-
 #include "CalibCalorimetry/EcalLaserSorting/interface/LaserSorter.h"
 #include "CalibCalorimetry/EcalLaserSorting/src/Majority.h"
 
@@ -43,156 +42,136 @@ const size_t LaserSorter::OutStreamRecord::indexReserve_ = 2000;
 static const struct timeval nullTime = {0, 0};
 
 static const char* const detailedTrigNames[] = {
-  "Inv0",//000
-  "Inv1",//001
-  "Inv2",//010
-  "Inv3",//011
-  "Las", //100
-  "Led", //101
-  "TP",  //110
-  "Ped"  //111
+    "Inv0",  //000
+    "Inv1",  //001
+    "Inv2",  //010
+    "Inv3",  //011
+    "Las",   //100
+    "Led",   //101
+    "TP",    //110
+    "Ped"    //111
 };
 
-static const char* const colorNames[] = {
-  "Blue",
-  "Green",
-  "Red",
-  "IR"
-};
+static const char* const colorNames[] = {"Blue", "Green", "Red", "IR"};
 
 const LaserSorter::stats_t LaserSorter::stats_init = {0, 0, 0, 0, 0};
 const int LaserSorter::indexOffset32_ = 1;
 
-static std::string now(){
+static std::string now() {
   struct timeval t;
   gettimeofday(&t, nullptr);
- 
+
   char buf[256];
   strftime(buf, sizeof(buf), "%F %R %S s", localtime(&t.tv_sec));
-  buf[sizeof(buf)-1] = 0;
+  buf[sizeof(buf) - 1] = 0;
 
   stringstream buf2;
-  buf2 << buf << " " << ((t.tv_usec+500)/1000)  << " ms";
+  buf2 << buf << " " << ((t.tv_usec + 500) / 1000) << " ms";
 
   return buf2.str();
 }
 
 LaserSorter::LaserSorter(const edm::ParameterSet& pset)
-  : lumiBlock_(0),
-    lumiBlockPrev_(0),
-    formatVersion_(5),
-    outputDir_(pset.getParameter<std::string>("outputDir")),
-    fedSubDirs_(pset.getParameter<std::vector<std::string> >("fedSubDirs")),
-    timeLogFile_(pset.getUntrackedParameter<std::string>("timeLogFile", "")),
-    disableOutput_(pset.getUntrackedParameter<bool>("disableOutput", false)),
-    runNumber_(0),
-    outputListFile_(pset.getUntrackedParameter<string>("outputListFile", "")),
-    doOutputList_(false),
-    verbosity_(pset.getUntrackedParameter<int>("verbosity", 0)),
-    iNoFullReadoutDccError_(0),
-    maxFullReadoutDccError_(pset.getParameter<int>("maxFullReadoutDccError")),
-    iNoEcalDataMess_(0),
-    maxNoEcalDataMess_(pset.getParameter<int>("maxNoEcalDataMess")),
-    lumiBlockSpan_(pset.getParameter<int>("lumiBlockSpan")),
-    fedRawDataCollectionTag_(pset.getParameter<edm::InputTag>("fedRawDataCollectionTag")),
-    stats_(stats_init),
-    overWriteLumiBlockId_(pset.getParameter<bool>("overWriteLumiBlockId")),
-    orbitCountInALumiBlock_(pset.getParameter<int>("orbitCountInALumiBlock")),
-    orbit_(-1),
-    orbitZeroTime_(nullTime)
-{
-
+    : lumiBlock_(0),
+      lumiBlockPrev_(0),
+      formatVersion_(5),
+      outputDir_(pset.getParameter<std::string>("outputDir")),
+      fedSubDirs_(pset.getParameter<std::vector<std::string> >("fedSubDirs")),
+      timeLogFile_(pset.getUntrackedParameter<std::string>("timeLogFile", "")),
+      disableOutput_(pset.getUntrackedParameter<bool>("disableOutput", false)),
+      runNumber_(0),
+      outputListFile_(pset.getUntrackedParameter<string>("outputListFile", "")),
+      doOutputList_(false),
+      verbosity_(pset.getUntrackedParameter<int>("verbosity", 0)),
+      iNoFullReadoutDccError_(0),
+      maxFullReadoutDccError_(pset.getParameter<int>("maxFullReadoutDccError")),
+      iNoEcalDataMess_(0),
+      maxNoEcalDataMess_(pset.getParameter<int>("maxNoEcalDataMess")),
+      lumiBlockSpan_(pset.getParameter<int>("lumiBlockSpan")),
+      fedRawDataCollectionTag_(pset.getParameter<edm::InputTag>("fedRawDataCollectionTag")),
+      stats_(stats_init),
+      overWriteLumiBlockId_(pset.getParameter<bool>("overWriteLumiBlockId")),
+      orbitCountInALumiBlock_(pset.getParameter<int>("orbitCountInALumiBlock")),
+      orbit_(-1),
+      orbitZeroTime_(nullTime) {
   gettimeofday(&timer_, nullptr);
-  logFile_.open("eventSelect.log", ios::app | ios::out); 
-  
-  const unsigned nEcalFeds= 54;
-  if(fedSubDirs_.size()!= nEcalFeds+1){
-    throw cms::Exception("LaserSorter") 
-      << "Configuration error: "
-      << "fedSubDirs parameter must be a vector "
-      << " of " << nEcalFeds << " strings"
-      << " (subdirectory for unknown triggered FED followed by "
-      "subdirectories for FED ID 601 "
-      "to FED ID 654 in increasing FED ID order)";
+  logFile_.open("eventSelect.log", ios::app | ios::out);
+
+  const unsigned nEcalFeds = 54;
+  if (fedSubDirs_.size() != nEcalFeds + 1) {
+    throw cms::Exception("LaserSorter") << "Configuration error: "
+                                        << "fedSubDirs parameter must be a vector "
+                                        << " of " << nEcalFeds << " strings"
+                                        << " (subdirectory for unknown triggered FED followed by "
+                                           "subdirectories for FED ID 601 "
+                                           "to FED ID 654 in increasing FED ID order)";
   }
 
   fedRawDataCollectionToken_ = consumes<FEDRawDataCollection>(fedRawDataCollectionTag_);
-  
-  if(!outputListFile_.empty()){
+
+  if (!outputListFile_.empty()) {
     outputList_.open(outputListFile_.c_str(), ios::app);
-    if(outputList_.bad()){
-      throw cms::Exception("FileOpen")
-	<< "Failed to open file '" << outputListFile_
-	<< "' for logging of output file path list.";
+    if (outputList_.bad()) {
+      throw cms::Exception("FileOpen") << "Failed to open file '" << outputListFile_
+                                       << "' for logging of output file path list.";
     }
     doOutputList_ = true;
   }
-  
-  if(!timeLogFile_.empty()){
+
+  if (!timeLogFile_.empty()) {
     timeLog_.open(timeLogFile_.c_str());
-    if(timeLog_.fail()){
+    if (timeLog_.fail()) {
       cout << "[LaserSorter " << now() << "] "
            << "Failed to open file " << timeLogFile_ << " to log timing.\n";
       timing_ = false;
-    } else{
+    } else {
       timing_ = true;
     }
   }
 
   struct stat fileStat;
-  if(0==stat(outputDir_.c_str(), &fileStat)){
-    if(!S_ISDIR(fileStat.st_mode)){
-      throw cms::Exception("[LaserSorter]")
-        << "File " << outputDir_ << " exists but is not a directory "
-        << " as expected.";
+  if (0 == stat(outputDir_.c_str(), &fileStat)) {
+    if (!S_ISDIR(fileStat.st_mode)) {
+      throw cms::Exception("[LaserSorter]") << "File " << outputDir_ << " exists but is not a directory "
+                                            << " as expected.";
     }
-  } else {//directory does not exists, let's try to create it
-    if(0!=mkdir(outputDir_.c_str(), 0755)){
-      throw cms::Exception("[LaserSorter]")
-        << "Failed to create directory " << outputDir_
-        << " for writing data.";
+  } else {  //directory does not exists, let's try to create it
+    if (0 != mkdir(outputDir_.c_str(), 0755)) {
+      throw cms::Exception("[LaserSorter]") << "Failed to create directory " << outputDir_ << " for writing data.";
     }
   }
 
   logFile_ << "# "
-    "run\t"
-    "LB\t" 
-    "event\t" 
-    "trigType\t"
-    "FED\t"
-    "side\t"
-    "LB out\t"
-    "Written\t"
-    "ECAL data\n";
+              "run\t"
+              "LB\t"
+              "event\t"
+              "trigType\t"
+              "FED\t"
+              "side\t"
+              "LB out\t"
+              "Written\t"
+              "ECAL data\n";
 }
 
-LaserSorter::~LaserSorter(){
-  logFile_ << "Summary. Event count: "
-           << stats_.nRead << " processed, "
-           << stats_.nWritten << " written, "
-           << stats_.nInvalidDccStrict << " with errors in DCC ID values, "
-           << stats_.nInvalidDccWeak << " with unusable DCC ID values, "
-           << stats_.nRestoredDcc << " restored DCC ID based on DCC block size\n";
+LaserSorter::~LaserSorter() {
+  logFile_ << "Summary. Event count: " << stats_.nRead << " processed, " << stats_.nWritten << " written, "
+           << stats_.nInvalidDccStrict << " with errors in DCC ID values, " << stats_.nInvalidDccWeak
+           << " with unusable DCC ID values, " << stats_.nRestoredDcc << " restored DCC ID based on DCC block size\n";
 }
-
 
 // ------------ method called to analyze the data  ------------
-void
-LaserSorter::analyze(const edm::Event& event, const edm::EventSetup& es){
-  if(timing_){
+void LaserSorter::analyze(const edm::Event& event, const edm::EventSetup& es) {
+  if (timing_) {
     timeval t;
     gettimeofday(&t, nullptr);
-    timeLog_ << t.tv_sec << "."
-             << setfill('0') << setw(3) << (t.tv_usec+500)/1000 << setfill(' ')
-             << "\t"
-             << (t.tv_usec - timer_.tv_usec)*1. 
-      + (t.tv_sec - timer_.tv_sec)*1.e6 << "\t";
+    timeLog_ << t.tv_sec << "." << setfill('0') << setw(3) << (t.tv_usec + 500) / 1000 << setfill(' ') << "\t"
+             << (t.tv_usec - timer_.tv_usec) * 1. + (t.tv_sec - timer_.tv_sec) * 1.e6 << "\t";
     timer_ = t;
-  } 
+  }
 
   ++stats_.nRead;
-  
-  if(event.id().run()!=runNumber_){//run changed or first event
+
+  if (event.id().run() != runNumber_) {  //run changed or first event
     //for a new run, starts with a new output stream set.
     closeAllStreams();
     runNumber_ = event.id().run();
@@ -201,9 +180,9 @@ LaserSorter::analyze(const edm::Event& event, const edm::EventSetup& es){
     lumiBlockPrev_ = 0;
     lumiBlock_ = 0;
   }
-  
+
   edm::Handle<FEDRawDataCollection> rawdata;
-  event.getByToken(fedRawDataCollectionToken_, rawdata);  
+  event.getByToken(fedRawDataCollectionToken_, rawdata);
 
   //orbit number
   //FIXME: orbit from edm Event is currently wrong. Forcing to use of CMS orbit until
@@ -216,361 +195,353 @@ LaserSorter::analyze(const edm::Event& event, const edm::EventSetup& es){
 
   //  std::cerr << "Orbit ID CMS, ECAL: " << orbit_ << "\t" << getOrbitFromDcc(rawdata) << "\n";
 
-  if(orbit_ < 0){ //For local run CMSSW failed to find the orbit number
+  if (orbit_ < 0) {  //For local run CMSSW failed to find the orbit number
     //    cout << "Look for orbit from DCC headers....\n";
     orbit_ = getOrbitFromDcc(rawdata);
   }
 
-  
   //The "detailed trigger type DCC field content:
   double dttProba = 0;
   int dtt = getDetailedTriggerType(rawdata, &dttProba);
 
-  if(overWriteLumiBlockId_){
+  if (overWriteLumiBlockId_) {
     edm::LuminosityBlockNumber_t lb = lumiBlock_;
     lumiBlock_ = orbit_ / orbitCountInALumiBlock_;
-    if(lb!=lumiBlock_){
-      std::cout << "[LaserSorter " << now() << "] Overwrite LB mode. LB number changed from: " << lb << " to " <<lumiBlock_<< "\n";
+    if (lb != lumiBlock_) {
+      std::cout << "[LaserSorter " << now() << "] Overwrite LB mode. LB number changed from: " << lb << " to "
+                << lumiBlock_ << "\n";
     }
-  } else{
+  } else {
     edm::LuminosityBlockNumber_t lb = lumiBlock_;
     lumiBlock_ = event.luminosityBlock();
-    if(lb!=lumiBlock_){
-      std::cout << "[LaserSorter " << now() << "] Standard LB mode. LB number changed from: " << lb << " to " <<lumiBlock_<< "\n";
-     }
+    if (lb != lumiBlock_) {
+      std::cout << "[LaserSorter " << now() << "] Standard LB mode. LB number changed from: " << lb << " to "
+                << lumiBlock_ << "\n";
+    }
   }
 
   detailedTrigType_ = dtt;
-  const int trigType =   (detailedTrigType_ >>8 ) & 0x7;
-  const int color    =   (detailedTrigType_ >>6 ) & 0x3;
-  const int dccId    =   (detailedTrigType_ >>0 ) & 0x3F;
-  int triggeredFedId =   (detailedTrigType_ == -2) ? -1 : (600 + dccId);
-  const int side     =   (detailedTrigType_ >>11) & 0x1;
+  const int trigType = (detailedTrigType_ >> 8) & 0x7;
+  const int color = (detailedTrigType_ >> 6) & 0x3;
+  const int dccId = (detailedTrigType_ >> 0) & 0x3F;
+  int triggeredFedId = (detailedTrigType_ == -2) ? -1 : (600 + dccId);
+  const int side = (detailedTrigType_ >> 11) & 0x1;
   //monitoring region extended id:
   //  const int lme = dcc2Lme(dccId, side);
 
-  if(detailedTrigType_ > -2){
-    if(dttProba < 1. || triggeredFedId < ecalDccFedIdMin_
-       || triggeredFedId > ecalDccFedIdMax_){
+  if (detailedTrigType_ > -2) {
+    if (dttProba < 1. || triggeredFedId < ecalDccFedIdMin_ || triggeredFedId > ecalDccFedIdMax_) {
       ++stats_.nInvalidDccStrict;
     }
 
-    if(triggeredFedId<ecalDccFedIdMin_ || triggeredFedId > ecalDccFedIdMax_){
-      if(verbosity_) cout <<  "[LaserSorter " << now() << "] " << "DCC ID (" << dccId
-                          << ") found in trigger type is out of range.";
+    if (triggeredFedId < ecalDccFedIdMin_ || triggeredFedId > ecalDccFedIdMax_) {
+      if (verbosity_)
+        cout << "[LaserSorter " << now() << "] "
+             << "DCC ID (" << dccId << ") found in trigger type is out of range.";
       ++stats_.nInvalidDccWeak;
       vector<int> ids = getFullyReadoutDccs(*rawdata);
-      if(ids.empty()){
-        if(verbosity_ && iNoFullReadoutDccError_ < maxFullReadoutDccError_){
+      if (ids.empty()) {
+        if (verbosity_ && iNoFullReadoutDccError_ < maxFullReadoutDccError_) {
           cout << " No fully read-out DCC found\n";
           ++iNoFullReadoutDccError_;
         }
-      } else if(ids.size()==1){
+      } else if (ids.size() == 1) {
         triggeredFedId = ids[0];
-        if(verbosity_) cout << " ID guessed from DCC payloads\n";
+        if (verbosity_)
+          cout << " ID guessed from DCC payloads\n";
         ++stats_.nRestoredDcc;
-      } else{ //ids.size()>1
-        if(verbosity_){
+      } else {  //ids.size()>1
+        if (verbosity_) {
           cout << " Several fully read-out Dccs:";
-          for(unsigned i=0; i < ids.size(); ++i) cout << " " << ids[i];
+          for (unsigned i = 0; i < ids.size(); ++i)
+            cout << " " << ids[i];
           cout << "\n";
         }
       }
     }
-  
-    if(verbosity_>1) cout << "\n----------------------------------------------------------------------\n"
-                          << "Event id: " 
-                          << " " << event.id() << "\n"
-                          << "Lumin block: " << lumiBlock_ << "\n"
-                          << "TrigType: " << detailedTrigNames[trigType&0x7]
-                          << " Color: " << colorNames[color&0x3]
-                          <<  " FED: " << triggeredFedId
-                          << " side:" << side << "\n"
-                          << "\n----------------------------------------------------------------------\n";
-    
-  } else{ //NO ECAL DATA
-    if(verbosity_>1) cout << "\n----------------------------------------------------------------------\n"
-                          << "Event id: " 
-                          << " " << event.id() << "\n"
-                          << "Lumin block: " << lumiBlock_ << "\n"
-                          << "No ECAL data\n"
-                          << "\n----------------------------------------------------------------------\n";
+
+    if (verbosity_ > 1)
+      cout << "\n----------------------------------------------------------------------\n"
+           << "Event id: "
+           << " " << event.id() << "\n"
+           << "Lumin block: " << lumiBlock_ << "\n"
+           << "TrigType: " << detailedTrigNames[trigType & 0x7] << " Color: " << colorNames[color & 0x3]
+           << " FED: " << triggeredFedId << " side:" << side << "\n"
+           << "\n----------------------------------------------------------------------\n";
+
+  } else {  //NO ECAL DATA
+    if (verbosity_ > 1)
+      cout << "\n----------------------------------------------------------------------\n"
+           << "Event id: "
+           << " " << event.id() << "\n"
+           << "Lumin block: " << lumiBlock_ << "\n"
+           << "No ECAL data\n"
+           << "\n----------------------------------------------------------------------\n";
   }
-  
-  logFile_ << event.id().run() << "\t"
-           << lumiBlock_ << "\t" 
-           << event.id().event() << "\t" 
-           << trigType << "\t"
-           << triggeredFedId << "\t"
-           << side;
-    
+
+  logFile_ << event.id().run() << "\t" << lumiBlock_ << "\t" << event.id().event() << "\t" << trigType << "\t"
+           << triggeredFedId << "\t" << side;
+
   bool written = false;
   int assignedLB = -1;
-  
-  if(lumiBlock_!=lumiBlockPrev_){
+
+  if (lumiBlock_ != lumiBlockPrev_) {
     //lumi block change => need for stream garbage collection
     const int lb = lumiBlock_;
     closeOldStreams(lb);
     int minLumi = lumiBlock_ - lumiBlockSpan_;
     int maxLumi = lumiBlock_ + lumiBlockSpan_;
-    for(int lb1 = minLumi; lb1 <= maxLumi; ++lb1){
+    for (int lb1 = minLumi; lb1 <= maxLumi; ++lb1) {
       restoreStreamsOfLumiBlock(lb1);
     }
   }
-    
-//     if(lumiBlock_ < lumiBlockPrev_){
-//       throw cms::Exception("LaserSorter") 
-//         << "Process event has a lumi block (" << lumiBlock_ << ")"
-//         << "older than previous one (" << lumiBlockPrev_ << "). "
-//         << "This can be due by wrong input file ordering or bad luminosity "
-//         << "block indication is the event header. "
-//         << "Event cannot be processed";
-//     }
 
-    if(disableOutput_){
-      /* NO OP*/
-    } else{
-      OutStreamRecord* out = getStream(triggeredFedId, lumiBlock_);
+  //     if(lumiBlock_ < lumiBlockPrev_){
+  //       throw cms::Exception("LaserSorter")
+  //         << "Process event has a lumi block (" << lumiBlock_ << ")"
+  //         << "older than previous one (" << lumiBlockPrev_ << "). "
+  //         << "This can be due by wrong input file ordering or bad luminosity "
+  //         << "block indication is the event header. "
+  //         << "Event cannot be processed";
+  //     }
 
-      if(out!=nullptr){
-        assignedLB = out->startingLumiBlock();
-        if(out->excludedOrbit().find(orbit_)
-           ==out->excludedOrbit().end()){
-          if(verbosity_ > 1) cout << "[LaserSorter " << now() << "] "
-                              << "Writing out event from FED " << triggeredFedId 
-                              << " LB " << lumiBlock_
-                              << " orbit " << orbit_ << "\n";
-          int dtt = (detailedTrigType_ >=0) ? detailedTrigType_ : -1; //shall we use -1 or 0 for undefined value?
-          written = written
-            || writeEvent(*out, event, dtt, *rawdata);
-          ++stats_.nWritten;
-        } else{
-          if(verbosity_) cout << "[LaserSorter " << now() << "] "
-                              << "File " << out->finalFileName() << " "
-                              << "already contains calibration event from FED "
-                              << triggeredFedId << ", LB = "
-                              << lumiBlock_
-                              << " with orbit ID "
-                              << orbit_ << ". Event skipped.\n";
-        }
+  if (disableOutput_) {
+    /* NO OP*/
+  } else {
+    OutStreamRecord* out = getStream(triggeredFedId, lumiBlock_);
+
+    if (out != nullptr) {
+      assignedLB = out->startingLumiBlock();
+      if (out->excludedOrbit().find(orbit_) == out->excludedOrbit().end()) {
+        if (verbosity_ > 1)
+          cout << "[LaserSorter " << now() << "] "
+               << "Writing out event from FED " << triggeredFedId << " LB " << lumiBlock_ << " orbit " << orbit_
+               << "\n";
+        int dtt = (detailedTrigType_ >= 0) ? detailedTrigType_ : -1;  //shall we use -1 or 0 for undefined value?
+        written = written || writeEvent(*out, event, dtt, *rawdata);
+        ++stats_.nWritten;
+      } else {
+        if (verbosity_)
+          cout << "[LaserSorter " << now() << "] "
+               << "File " << out->finalFileName() << " "
+               << "already contains calibration event from FED " << triggeredFedId << ", LB = " << lumiBlock_
+               << " with orbit ID " << orbit_ << ". Event skipped.\n";
       }
     }
-    lumiBlockPrev_ = lumiBlock_;
-    
-    logFile_ << "\t";
-    if(assignedLB>=0) logFile_ << assignedLB; else logFile_ << "-";
-    logFile_ << "\t" << (written?"Y":"N") << "\n"; 
-    logFile_  << "\t" << (detailedTrigType_==-2?"N":"Y") << "\n";
-    
-    if(timing_){
-      timeval t;
-      gettimeofday(&t, nullptr);
-      timeLog_ << (t.tv_usec - timer_.tv_usec)*1. 
-        + (t.tv_sec - timer_.tv_sec)*1.e6 << "\n";
-      timer_ = t;
-    }
+  }
+  lumiBlockPrev_ = lumiBlock_;
+
+  logFile_ << "\t";
+  if (assignedLB >= 0)
+    logFile_ << assignedLB;
+  else
+    logFile_ << "-";
+  logFile_ << "\t" << (written ? "Y" : "N") << "\n";
+  logFile_ << "\t" << (detailedTrigType_ == -2 ? "N" : "Y") << "\n";
+
+  if (timing_) {
+    timeval t;
+    gettimeofday(&t, nullptr);
+    timeLog_ << (t.tv_usec - timer_.tv_usec) * 1. + (t.tv_sec - timer_.tv_sec) * 1.e6 << "\n";
+    timer_ = t;
+  }
 }
 
-int LaserSorter::dcc2Lme(int dcc, int side){
-  int fedid = (dcc%600) + 600; //to handle both FED and DCC id.
+int LaserSorter::dcc2Lme(int dcc, int side) {
+  int fedid = (dcc % 600) + 600;  //to handle both FED and DCC id.
   vector<int> lmes;
   // EE -
-  if( fedid <= 609 ) {
-    if ( fedid <= 607 ) {
-      lmes.push_back(fedid-601+83);
-    } else if ( fedid == 608 ) {
+  if (fedid <= 609) {
+    if (fedid <= 607) {
+      lmes.push_back(fedid - 601 + 83);
+    } else if (fedid == 608) {
       lmes.push_back(90);
       lmes.push_back(91);
-    } else if ( fedid == 609 ) {
+    } else if (fedid == 609) {
       lmes.push_back(92);
     }
-  } //EB
-  else if ( fedid >= 610  && fedid <= 645 ) {
-    lmes.push_back(2*(fedid-610)+1);
-    lmes.push_back(lmes[0]+1);
-  } // EE+ 
-  else if ( fedid >= 646 ) {
-    if ( fedid <= 652 ) {
-      lmes.push_back(fedid-646+73);
-    } else if ( fedid == 653 ) {
+  }  //EB
+  else if (fedid >= 610 && fedid <= 645) {
+    lmes.push_back(2 * (fedid - 610) + 1);
+    lmes.push_back(lmes[0] + 1);
+  }  // EE+
+  else if (fedid >= 646) {
+    if (fedid <= 652) {
+      lmes.push_back(fedid - 646 + 73);
+    } else if (fedid == 653) {
       lmes.push_back(80);
       lmes.push_back(81);
-    } else if ( fedid == 654 ) {
+    } else if (fedid == 654) {
       lmes.push_back(82);
     }
   }
-  return lmes.empty()?-1:lmes[min(lmes.size(), (size_t)side)];
+  return lmes.empty() ? -1 : lmes[min(lmes.size(), (size_t)side)];
 }
 
-int LaserSorter::getOrbitFromDcc(const edm::Handle<FEDRawDataCollection>& rawdata) const{
+int LaserSorter::getOrbitFromDcc(const edm::Handle<FEDRawDataCollection>& rawdata) const {
   const int orbit32 = 6;
-  for(int id=ecalDccFedIdMin_; id<=ecalDccFedIdMax_; ++id){
-    if(!FEDNumbering::inRange(id)) continue;
+  for (int id = ecalDccFedIdMin_; id <= ecalDccFedIdMax_; ++id) {
+    if (!FEDNumbering::inRange(id))
+      continue;
     const FEDRawData& data = rawdata->FEDData(id);
-    if(data.size() >= 4*(orbit32+1)){
-      const uint32_t* pData32 = (const uint32_t*) data.data();
-//      cout << "Found a DCC header: "
-//           << pData32[0] << " "
-//           << pData32[1] << " "
-//           << pData32[2] << " "
-//           << pData32[3] << " "
-//           << pData32[4] << " "
-//           << pData32[5] << " "
-//           << pData32[6] << " "
-//           << "\n";
+    if (data.size() >= 4 * (orbit32 + 1)) {
+      const uint32_t* pData32 = (const uint32_t*)data.data();
+      //      cout << "Found a DCC header: "
+      //           << pData32[0] << " "
+      //           << pData32[1] << " "
+      //           << pData32[2] << " "
+      //           << pData32[3] << " "
+      //           << pData32[4] << " "
+      //           << pData32[5] << " "
+      //           << pData32[6] << " "
+      //           << "\n";
       return pData32[orbit32];
     }
   }
   return -1;
 }
 
-int LaserSorter::getDetailedTriggerType(const edm::Handle<FEDRawDataCollection>& rawdata,
-                                        double* proba){  
+int LaserSorter::getDetailedTriggerType(const edm::Handle<FEDRawDataCollection>& rawdata, double* proba) {
   Majority<int> stat;
   bool ecalData = false;
-  for(int id=ecalDccFedIdMin_; id<=ecalDccFedIdMax_; ++id){
-    if(!FEDNumbering::inRange(id)) continue;
+  for (int id = ecalDccFedIdMin_; id <= ecalDccFedIdMax_; ++id) {
+    if (!FEDNumbering::inRange(id))
+      continue;
     const FEDRawData& data = rawdata->FEDData(id);
     const int detailedTrigger32 = 5;
-    if(verbosity_>3) cout << "[LaserSorter " << now() << "] " 
-                          << "FED " << id << " data size: "  
-                          << data.size() << "\n"; 
-    if(data.size()>=4*(detailedTrigger32+1)){
+    if (verbosity_ > 3)
+      cout << "[LaserSorter " << now() << "] "
+           << "FED " << id << " data size: " << data.size() << "\n";
+    if (data.size() >= 4 * (detailedTrigger32 + 1)) {
       ecalData = true;
-      const uint32_t* pData32 = (const uint32_t*) data.data();
+      const uint32_t* pData32 = (const uint32_t*)data.data();
       int tType = pData32[detailedTrigger32] & 0xFFF;
-      if(verbosity_>3) cout << "[LaserSorter " << now() << "] "
-                            << "Trigger type " << tType << "\n";
+      if (verbosity_ > 3)
+        cout << "[LaserSorter " << now() << "] "
+             << "Trigger type " << tType << "\n";
       stat.add(tType);
     }
   }
-  if(!ecalData) return -2;
+  if (!ecalData)
+    return -2;
   double p;
   int tType = stat.result(&p);
-  if(p<0){
+  if (p < 0) {
     //throw cms::Exception("NotFound") << "No ECAL DCC data found\n";
-    if(iNoEcalDataMess_ < maxNoEcalDataMess_){
-      edm::LogWarning("NotFound")  << "No ECAL DCC data found. "
-        "(This warning will be disabled for the current run after "
-                                   << maxNoEcalDataMess_ << " occurences.)";
+    if (iNoEcalDataMess_ < maxNoEcalDataMess_) {
+      edm::LogWarning("NotFound") << "No ECAL DCC data found. "
+                                     "(This warning will be disabled for the current run after "
+                                  << maxNoEcalDataMess_ << " occurences.)";
       ++iNoEcalDataMess_;
     }
     tType = -1;
-  } else if(p<.8){
+  } else if (p < .8) {
     //throw cms::Exception("EventCorruption") << "Inconsitency in detailed trigger type indicated in ECAL DCC data headers\n";
     edm::LogWarning("EventCorruption") << "Inconsitency in detailed trigger type indicated in ECAL DCC data headers\n";
     tType = -1;
   }
-  if(proba) *proba = p;
+  if (proba)
+    *proba = p;
   return tType;
 }
 
-void LaserSorter::closeAllStreams(){
-  for(OutStreamList::iterator it = outStreamList_.begin();
-      it != outStreamList_.end();/*NOOP*/){
+void LaserSorter::closeAllStreams() {
+  for (OutStreamList::iterator it = outStreamList_.begin(); it != outStreamList_.end(); /*NOOP*/) {
     it = closeOutStream(it);
   }
 }
 
-void LaserSorter::closeOldStreams(edm::LuminosityBlockNumber_t lumiBlock){
+void LaserSorter::closeOldStreams(edm::LuminosityBlockNumber_t lumiBlock) {
   const edm::LuminosityBlockNumber_t minLumiBlock = lumiBlock - lumiBlockSpan_;
   const edm::LuminosityBlockNumber_t maxLumiBlock = lumiBlock + lumiBlockSpan_;
   //If container type is ever changed, beware that
   //closeOutStream call in the loop removes it from outStreamList
-  for(boost::ptr_list<OutStreamRecord>::iterator it = outStreamList_.begin();
-      it != outStreamList_.end();
-      /*NOOP*/){
-    if(it->startingLumiBlock() < minLumiBlock
-       || it->startingLumiBlock() > maxLumiBlock){
+  for (boost::ptr_list<OutStreamRecord>::iterator it = outStreamList_.begin(); it != outStreamList_.end();
+       /*NOOP*/) {
+    if (it->startingLumiBlock() < minLumiBlock || it->startingLumiBlock() > maxLumiBlock) {
       //event older than 2 lumi block => stream can be closed
-      if(verbosity_) cout << "[LaserSorter " << now() << "] "
-                       << "Closing file for "
-                       << "FED " 
-                       << it->fedId()
-                       << " LB " << it->startingLumiBlock()
-                       << "\n";
+      if (verbosity_)
+        cout << "[LaserSorter " << now() << "] "
+             << "Closing file for "
+             << "FED " << it->fedId() << " LB " << it->startingLumiBlock() << "\n";
       it = closeOutStream(it);
-    } else{
+    } else {
       ++it;
     }
   }
 }
 
-LaserSorter::OutStreamRecord*
-LaserSorter::getStream(int fedId, 
-                       edm::LuminosityBlockNumber_t lumiBlock){
+LaserSorter::OutStreamRecord* LaserSorter::getStream(int fedId, edm::LuminosityBlockNumber_t lumiBlock) {
+  if ((fedId != -1) && (fedId < ecalDccFedIdMin_ || fedId > ecalDccFedIdMax_))
+    fedId = -1;
 
-  if((fedId != -1) &&
-     (fedId < ecalDccFedIdMin_ || fedId > ecalDccFedIdMax_)) fedId = -1;
-  
-  if(verbosity_>1) cout << "[LaserSorter " << now() << "] "
-       << "Looking for an opened output file for FED " 
-       << fedId << " LB " << lumiBlock
-       << "\n";
+  if (verbosity_ > 1)
+    cout << "[LaserSorter " << now() << "] "
+         << "Looking for an opened output file for FED " << fedId << " LB " << lumiBlock << "\n";
 
   //first look if stream is already open:
-  for(OutStreamList::iterator it = outStreamList_.begin();
-      it != outStreamList_.end();
-      ++it){
-    if(it->fedId()==fedId && 
-       (abs((int)it->startingLumiBlock()-(int)lumiBlock)<=lumiBlockSpan_)){
+  for (OutStreamList::iterator it = outStreamList_.begin(); it != outStreamList_.end(); ++it) {
+    if (it->fedId() == fedId && (abs((int)it->startingLumiBlock() - (int)lumiBlock) <= lumiBlockSpan_)) {
       //stream found!
       return &(*it);
     }
   }
   //stream was not found. Let's create one
 
-  if(verbosity_) cout << "[LaserSorter " << now() << "] "
-                      << "File not yet opened. Opening it.\n";
+  if (verbosity_)
+    cout << "[LaserSorter " << now() << "] "
+         << "File not yet opened. Opening it.\n";
 
   OutStreamList::iterator streamRecord = createOutStream(fedId, lumiBlock);
-  return streamRecord!=outStreamList_.end()?&(*streamRecord):nullptr;
+  return streamRecord != outStreamList_.end() ? &(*streamRecord) : nullptr;
 }
 
-bool LaserSorter::writeEvent(OutStreamRecord& outRcd, const edm::Event& event,
+bool LaserSorter::writeEvent(OutStreamRecord& outRcd,
+                             const edm::Event& event,
                              int dtt,
-                             const FEDRawDataCollection& data){
-
+                             const FEDRawDataCollection& data) {
   ofstream& out = *outRcd.out();
   bool rc = true;
   vector<unsigned> fedIds;
   getOutputFedList(event, data, fedIds);
-  
+
   out.clear();
   uint32_t evtStart = out.tellp();
-  if(out.bad()) evtStart = 0;
+  if (out.bad())
+    evtStart = 0;
   rc &= writeEventHeader(out, event, dtt, fedIds.size());
-  
-  if(orbitZeroTime_.tv_sec==0 && data.FEDData(matacqFedId_).size()!=0){
+
+  if (orbitZeroTime_.tv_sec == 0 && data.FEDData(matacqFedId_).size() != 0) {
     struct timeval ts = {0, 0};
     MatacqRawEvent mre(data.FEDData(matacqFedId_).data(), data.FEDData(matacqFedId_).size());
     mre.getTimeStamp(ts);
     uint32_t orb = mre.getOrbitId();
-      if(ts.tv_sec!=0){
-        div_t dt = div(orb * 89.1, 1000*1000); //an orbit lasts 89.1 microseconds
-        orbitZeroTime_.tv_sec = ts.tv_sec - dt.quot;
-        orbitZeroTime_.tv_usec = ts.tv_usec - dt.rem;
-        if(orbitZeroTime_.tv_usec < 0){
-          orbitZeroTime_.tv_usec += 1000*1000;
-          orbitZeroTime_.tv_sec -= 1;
-        }
+    if (ts.tv_sec != 0) {
+      div_t dt = div(orb * 89.1, 1000 * 1000);  //an orbit lasts 89.1 microseconds
+      orbitZeroTime_.tv_sec = ts.tv_sec - dt.quot;
+      orbitZeroTime_.tv_usec = ts.tv_usec - dt.rem;
+      if (orbitZeroTime_.tv_usec < 0) {
+        orbitZeroTime_.tv_usec += 1000 * 1000;
+        orbitZeroTime_.tv_sec -= 1;
       }
+    }
   }
 
-  for(unsigned iFed = 0; iFed < fedIds.size() && rc; ++iFed){
-    if(verbosity_>3) cout << "[LaserSorter " << now() << "] " 
-                          << "Writing data block of FED " << fedIds[iFed] << ". Data size: "  
-                          <<  data.FEDData(fedIds[iFed]).size() << "\n"; 
-    rc  &= writeFedBlock(out, data.FEDData(fedIds[iFed]));
+  for (unsigned iFed = 0; iFed < fedIds.size() && rc; ++iFed) {
+    if (verbosity_ > 3)
+      cout << "[LaserSorter " << now() << "] "
+           << "Writing data block of FED " << fedIds[iFed] << ". Data size: " << data.FEDData(fedIds[iFed]).size()
+           << "\n";
+    rc &= writeFedBlock(out, data.FEDData(fedIds[iFed]));
   }
 
-  if(rc){
+  if (rc) {
     //update index table for this file:
     vector<IndexRecord>& indices = *outRcd.indices();
-    if(verbosity_ > 2){
-      std::cout << "Event " << " written successfully. "
-                << "Orbit: " << orbit_
-                << "\tFile index: " << evtStart << "\n";
+    if (verbosity_ > 2) {
+      std::cout << "Event "
+                << " written successfully. "
+                << "Orbit: " << orbit_ << "\tFile index: " << evtStart << "\n";
     }
     IndexRecord indexRcd = {(uint32_t)orbit_, evtStart};
     indices.push_back(indexRcd);
@@ -578,69 +549,67 @@ bool LaserSorter::writeEvent(OutStreamRecord& outRcd, const edm::Event& event,
   return rc;
 }
 
-bool LaserSorter::writeFedBlock(std::ofstream& out,
-                                const FEDRawData& data){
+bool LaserSorter::writeFedBlock(std::ofstream& out, const FEDRawData& data) {
   bool rc = false;
-  if (data.size()>4){
-    const uint32_t * pData
-      = reinterpret_cast<const uint32_t*>(data.data());
-    
-    uint32_t dccLen64 = pData[2] & 0x00FFFFFF; //in 32-byte unit
+  if (data.size() > 4) {
+    const uint32_t* pData = reinterpret_cast<const uint32_t*>(data.data());
 
-    if(data.size() != dccLen64*sizeof(uint64_t)){
-//       throw cms::Exception("Bug") << "Bug found in "
-//                                   << __FILE__ << ":" << __LINE__ << ".";
-      throw cms::Exception("LaserSorter")
-        << "Mismatch between FED fragment size indicated in header "
-        << "(" << dccLen64 << "*8 Byte) "
-        << "and actual size (" <<  data.size() << " Byte) "
-        << "for FED ID " <<  ((pData[0] >>8) & 0xFFF) << "!\n";
+    uint32_t dccLen64 = pData[2] & 0x00FFFFFF;  //in 32-byte unit
+
+    if (data.size() != dccLen64 * sizeof(uint64_t)) {
+      //       throw cms::Exception("Bug") << "Bug found in "
+      //                                   << __FILE__ << ":" << __LINE__ << ".";
+      throw cms::Exception("LaserSorter") << "Mismatch between FED fragment size indicated in header "
+                                          << "(" << dccLen64 << "*8 Byte) "
+                                          << "and actual size (" << data.size() << " Byte) "
+                                          << "for FED ID " << ((pData[0] >> 8) & 0xFFF) << "!\n";
     }
-    
-    if(verbosity_>3) cout << "[LaserSorter " << now() << "] " << "Event fragment size: "
-                          << data.size() << " Byte"
-                          << "\t From Dcc header: " << dccLen64*8 << " Byte\n";
-    
+
+    if (verbosity_ > 3)
+      cout << "[LaserSorter " << now() << "] "
+           << "Event fragment size: " << data.size() << " Byte"
+           << "\t From Dcc header: " << dccLen64 * 8 << " Byte\n";
+
     const size_t nBytes = data.size();
-    //       cout << "[LaserSorter " << now() << "] " 
-    //            << "Writing " << nBytes << " byte from adress " 
+    //       cout << "[LaserSorter " << now() << "] "
+    //            << "Writing " << nBytes << " byte from adress "
     //            << (void*) data.data() << " to file.\n";
-    if(out.fail()) cout << "[LaserSorter " << now() << "] " << "Problem with stream!\n";
+    if (out.fail())
+      cout << "[LaserSorter " << now() << "] "
+           << "Problem with stream!\n";
     out.write((char*)data.data(), nBytes);
     rc = true;
-  } else{
-    throw cms::Exception("Bug") << "Bug found in "
-                                << __FILE__ << ":" << __LINE__ << ".\n";
+  } else {
+    throw cms::Exception("Bug") << "Bug found in " << __FILE__ << ":" << __LINE__ << ".\n";
   }
   return rc;
 }
 
-bool LaserSorter::renameAsBackup(const std::string& fileName,
-                                 std::string& newFileName){
+bool LaserSorter::renameAsBackup(const std::string& fileName, std::string& newFileName) {
   int i = 0;
   int err;
   //  static int maxTries = 100;
   int maxTries = 20;
   stringstream newFileName_;
-  do{
+  do {
     newFileName_.str("");
     newFileName_ << fileName << "~";
-    if(i>0) newFileName_ << i;
+    if (i > 0)
+      newFileName_ << i;
     err = link(fileName.c_str(), newFileName_.str().c_str());
-    if(err==0){
+    if (err == 0) {
       newFileName = newFileName_.str();
       err = unlink(fileName.c_str());
     }
     ++i;
-  } while((err!=0) && (errno == EEXIST) && (i < maxTries));
-  return err==0;
+  } while ((err != 0) && (errno == EEXIST) && (i < maxTries));
+  return err == 0;
 }
 
-LaserSorter::OutStreamList::iterator 
-LaserSorter::createOutStream(int fedId, 
-                             edm::LuminosityBlockNumber_t lumiBlock){
-  if(verbosity_) cout << "[LaserSorter " << now() << "] " << "Creating a stream for FED " << fedId
-                      << " lumi block " << lumiBlock << ".\n";
+LaserSorter::OutStreamList::iterator LaserSorter::createOutStream(int fedId, edm::LuminosityBlockNumber_t lumiBlock) {
+  if (verbosity_)
+    cout << "[LaserSorter " << now() << "] "
+         << "Creating a stream for FED " << fedId << " lumi block " << lumiBlock << ".\n";
   std::string tmpName;
   std::string finalName;
 
@@ -649,99 +618,88 @@ LaserSorter::createOutStream(int fedId,
   errno = 0;
 
   //checks if a file with tmpName name already exists:
-  ofstream* out = new ofstream(tmpName.c_str(), ios::out | ios::in);  
-  if(out->is_open()){//temporary file already exists. Making a backup:
+  ofstream* out = new ofstream(tmpName.c_str(), ios::out | ios::in);
+  if (out->is_open()) {  //temporary file already exists. Making a backup:
     string newName;
-    if(!renameAsBackup(tmpName, newName)){
-      throw cms::Exception("LaserSorter")
-        << "Failed to rename file " << tmpName
-        << "  to " << newName << "\n";
+    if (!renameAsBackup(tmpName, newName)) {
+      throw cms::Exception("LaserSorter") << "Failed to rename file " << tmpName << "  to " << newName << "\n";
     }
-    if(verbosity_) cout << "[LaserSorter " << now() << "] "
-                        << "Already existing File " << tmpName
-                        << " renamed to "
-                        << newName << "\n";
+    if (verbosity_)
+      cout << "[LaserSorter " << now() << "] "
+           << "Already existing File " << tmpName << " renamed to " << newName << "\n";
     out->close();
   }
 
   out->clear();
   out->open(tmpName.c_str(), ios::out | ios::trunc);
-  
-  if(out->fail()){//failed to create file
+
+  if (out->fail()) {  //failed to create file
     delete out;
-    throw cms::Exception("LaserSorter")
-      << "Failed to create file " 
-      << tmpName << " for writing event from FED " << fedId
-      << " lumi block " << lumiBlock
-      << ": "  << strerror(errno) << "\n.";
+    throw cms::Exception("LaserSorter") << "Failed to create file " << tmpName << " for writing event from FED "
+                                        << fedId << " lumi block " << lumiBlock << ": " << strerror(errno) << "\n.";
   }
-  
+
   ifstream in(finalName.c_str());
   bool newFile = true;
-  if(in.good()){//file already exists with final name.
-    if(verbosity_) cout << "[LaserSorter " << now() << "] " << "File "
-                        << finalName
-                        << " already exists. It will be updated if needed.\n";
+  if (in.good()) {  //file already exists with final name.
+    if (verbosity_)
+      cout << "[LaserSorter " << now() << "] "
+           << "File " << finalName << " already exists. It will be updated if needed.\n";
     //Copying its contents:
     char buffer[256];
     streamsize nread = -1;
     int vers = readFormatVersion(in, finalName);
-    if(vers==-1){
-      edm::LogWarning("LaserSorter") << "File " << tmpName.c_str()
-                                     << " is not an LMF file despite its extension or "
+    if (vers == -1) {
+      edm::LogWarning("LaserSorter") << "File " << tmpName.c_str() << " is not an LMF file despite its extension or "
                                      << "it is corrupted.\n";
-    } else if(vers!=formatVersion_){
-      edm::LogWarning("LaserSorter") << "Cannot include events already in file "
-                                     << tmpName.c_str()
+    } else if (vers != formatVersion_) {
+      edm::LogWarning("LaserSorter") << "Cannot include events already in file " << tmpName.c_str()
                                      << " because of version "
-                                     << "mismatch (found version "
-                                     << (int)vers << " while "
-                                     << "only version "
-                                     << (int)formatVersion_
-                                     << " is supported).\n";
-    } else{
+                                     << "mismatch (found version " << (int)vers << " while "
+                                     << "only version " << (int)formatVersion_ << " is supported).\n";
+    } else {
       newFile = false;
       //read index table offset value:
-      const int indexTableOffsetPos8 = 1*sizeof(uint32_t);
+      const int indexTableOffsetPos8 = 1 * sizeof(uint32_t);
       uint32_t indexTableOffsetValue = 0;
       in.clear();
       in.seekg(indexTableOffsetPos8, ios::beg);
-      in.read((char*) &indexTableOffsetValue,
-              sizeof(indexTableOffsetValue));
-      if(in.fail()){
-        cout << "[LaserSorter " << now() << "] " << "Failed to read offset of index table "
-          " in the existing file " << finalName << "\n";
-      } else{
-        if(verbosity_>2) cout << "[LaserSorter " << now() << "] " << "Index table offset of "
-                           "original file " << finalName << ": 0x"
-                              << hex << setfill('0')
-                              << setw(8) << indexTableOffsetValue
-                              << dec << setfill(' ') << "\n";
+      in.read((char*)&indexTableOffsetValue, sizeof(indexTableOffsetValue));
+      if (in.fail()) {
+        cout << "[LaserSorter " << now() << "] "
+             << "Failed to read offset of index table "
+                " in the existing file "
+             << finalName << "\n";
+      } else {
+        if (verbosity_ > 2)
+          cout << "[LaserSorter " << now() << "] "
+               << "Index table offset of "
+                  "original file "
+               << finalName << ": 0x" << hex << setfill('0') << setw(8) << indexTableOffsetValue << dec << setfill(' ')
+               << "\n";
       }
       in.clear();
       in.seekg(0, ios::beg);
 
       //copy legacy file contents except the index table
       uint32_t toRead = indexTableOffsetValue;
-      cout << "[LaserSorter " << now() << "] " << "Copying " << finalName << " to " << tmpName << endl;
-      while(!in.eof()
-            && (toRead > 0)
-            && (nread=in.readsome(buffer, min(toRead, (uint32_t)sizeof(buffer))))!=0){
+      cout << "[LaserSorter " << now() << "] "
+           << "Copying " << finalName << " to " << tmpName << endl;
+      while (!in.eof() && (toRead > 0) && (nread = in.readsome(buffer, min(toRead, (uint32_t)sizeof(buffer)))) != 0) {
         //         cout << "Writing " << nread << " bytes to file "
         //              << tmpName.c_str() << "\n";
         toRead -= nread;
         // out->seekp(0, ios::end);
         out->write(buffer, nread);
-        if(out->bad()){
-          throw cms::Exception("LaserSorter") << "Error while writing to file "
-                                              << tmpName
-                                              << ". Check if there is enough "
-                                              << "space on the device.\n";
+        if (out->bad()) {
+          throw cms::Exception("LaserSorter")
+              << "Error while writing to file " << tmpName << ". Check if there is enough "
+              << "space on the device.\n";
         }
       }
 
       //resets index table offset field:
-      indexTableOffsetValue = 0 ;
+      indexTableOffsetValue = 0;
       out->clear();
       out->seekp(indexTableOffsetPos8, ios::beg);
       out->write((char*)&indexTableOffsetValue, sizeof(uint32_t));
@@ -756,16 +714,14 @@ LaserSorter::createOutStream(int fedId,
   char c;
   cin >> c;
 #endif
-  
-  OutStreamRecord* outRcd = new OutStreamRecord(fedId, lumiBlock,
-                                                out,
-                                                tmpName, finalName);
-  
-  if(newFile){
+
+  OutStreamRecord* outRcd = new OutStreamRecord(fedId, lumiBlock, out, tmpName, finalName);
+
+  if (newFile) {
     writeFileHeader(*out);
-  } else{
+  } else {
     std::string errMsg;
-    if(!readIndexTable(in, finalName, *outRcd, &errMsg)){
+    if (!readIndexTable(in, finalName, *outRcd, &errMsg)) {
       throw cms::Exception("LaserSorter") << errMsg << "\n";
     }
   }
@@ -773,10 +729,10 @@ LaserSorter::createOutStream(int fedId,
   return outStreamList_.insert(outStreamList_.end(), outRcd);
 }
 
-void LaserSorter::writeFileHeader(std::ofstream& out){
+void LaserSorter::writeFileHeader(std::ofstream& out) {
   out.clear();
-  
-  uint32_t id = 'L' | ('M' <<8) | ('F' <<16) | (formatVersion_<<24);
+
+  uint32_t id = 'L' | ('M' << 8) | ('F' << 16) | (formatVersion_ << 24);
 
   out.write((char*)&id, sizeof(uint32_t));
 
@@ -784,149 +740,135 @@ void LaserSorter::writeFileHeader(std::ofstream& out){
   uint32_t zero = 0;
   out.write((char*)&zero, sizeof(uint32_t));
 
-  if(out.fail()){
-    throw cms::Exception("LaserSorter")
-      << "Failed to write file header.\n";
+  if (out.fail()) {
+    throw cms::Exception("LaserSorter") << "Failed to write file header.\n";
   }
 }
 
-bool LaserSorter::writeEventHeader(std::ofstream& out,
-                                   const edm::Event& evt,
-                                   int dtt,
-                                   unsigned nFeds){
+bool LaserSorter::writeEventHeader(std::ofstream& out, const edm::Event& evt, int dtt, unsigned nFeds) {
   uint32_t data[10];
   timeval tt = {0, 0};
-  if((evt.time().value() >>32)){
+  if ((evt.time().value() >> 32)) {
     tt.tv_usec = evt.time().value() & 0xFFFFFFFF;
-    tt.tv_sec = evt.time().value() >>32;
-  } else if(orbitZeroTime_.tv_sec){
-    div_t dt = div(orbit_*89.1, 1000*1000); //one orbit lasts 89.1 microseconds
+    tt.tv_sec = evt.time().value() >> 32;
+  } else if (orbitZeroTime_.tv_sec) {
+    div_t dt = div(orbit_ * 89.1, 1000 * 1000);  //one orbit lasts 89.1 microseconds
     tt.tv_sec = orbitZeroTime_.tv_sec + dt.quot;
     tt.tv_usec = orbitZeroTime_.tv_usec + dt.rem;
-    if(tt.tv_usec > 1000*1000){
-      tt.tv_usec -= 1000*1000;
+    if (tt.tv_usec > 1000 * 1000) {
+      tt.tv_usec -= 1000 * 1000;
       tt.tv_sec += 1;
     }
   }
-    
+
   data[0] = tt.tv_usec;
   data[1] = tt.tv_sec;
   data[2] = evt.luminosityBlock();
-  data[3] = evt.run();     
+  data[3] = evt.run();
   data[4] = orbit_;
   data[5] = evt.bunchCrossing();
   data[6] = evt.id().event();
   data[7] = dtt;
   data[8] = nFeds;
-  data[9] = 0; //reserved (to be aligned on 64-bits)
+  data[9] = 0;  //reserved (to be aligned on 64-bits)
 
-  if(verbosity_>1){
-    cout << "[LaserSorter " << now() << "] " << "Write header of event: "
-         << "Time: " << toString(evt.time().value())
-         << ", LB: " << evt.luminosityBlock()
-         << ", Run: " << evt.run()
-         << ", Bx: " << evt.bunchCrossing()
-         << ", Event ID: " << evt.id().event()
-         << ", Detailed trigger type: 0x" << hex << dtt << dec
-         << " (" << detailedTrigNames[(dtt>>8)&0x7]  << ", "
-         << colorNames[(dtt>>6)&0x3] << ", DCC " << (dtt&0x3f)
-         << ", side " << ((dtt>>10) &0x1) << ")"
+  if (verbosity_ > 1) {
+    cout << "[LaserSorter " << now() << "] "
+         << "Write header of event: "
+         << "Time: " << toString(evt.time().value()) << ", LB: " << evt.luminosityBlock() << ", Run: " << evt.run()
+         << ", Bx: " << evt.bunchCrossing() << ", Event ID: " << evt.id().event() << ", Detailed trigger type: 0x"
+         << hex << dtt << dec << " (" << detailedTrigNames[(dtt >> 8) & 0x7] << ", " << colorNames[(dtt >> 6) & 0x3]
+         << ", DCC " << (dtt & 0x3f) << ", side " << ((dtt >> 10) & 0x1) << ")"
          << ", number of FEDs: "
          << "\n";
   }
-    
+
   out.clear();
   out.write((char*)data, sizeof(data));
   return !out.bad();
 }
 
-void LaserSorter::streamFileName(int fedId, 
-                                 edm::LuminosityBlockNumber_t lumiBlock, 
-                                 std::string& tmpName, std::string& finalName){
+void LaserSorter::streamFileName(int fedId,
+                                 edm::LuminosityBlockNumber_t lumiBlock,
+                                 std::string& tmpName,
+                                 std::string& finalName) {
   int iFed;
-  if(fedId >= ecalDccFedIdMin_ && fedId <= ecalDccFedIdMax_){
+  if (fedId >= ecalDccFedIdMin_ && fedId <= ecalDccFedIdMax_) {
     iFed = fedId - ecalDccFedIdMin_ + 1;
-  } else if(fedId < 0){
-    iFed = -1; //event w/o ECAL data
+  } else if (fedId < 0) {
+    iFed = -1;  //event w/o ECAL data
   } else {
     iFed = 0;
   }
-  if(iFed < -1 || iFed >= (int)fedSubDirs_.size()){
-    throw cms::Exception("LaserSorter")
-      << "Bug found at " << __FILE__ << ":" << __LINE__ 
-      << ". FED ID is out of index!";
+  if (iFed < -1 || iFed >= (int)fedSubDirs_.size()) {
+    throw cms::Exception("LaserSorter") << "Bug found at " << __FILE__ << ":" << __LINE__
+                                        << ". FED ID is out of index!";
   }
 
-  
   struct stat fileStat;
 
   stringstream buf;
-  buf << outputDir_ << "/"
-      << (iFed<0 ? "Empty" : fedSubDirs_[iFed]);
+  buf << outputDir_ << "/" << (iFed < 0 ? "Empty" : fedSubDirs_[iFed]);
 
   string dir = buf.str();
-  if(0==stat(dir.c_str(), &fileStat)){
-    if(!S_ISDIR(fileStat.st_mode)){
-      throw cms::Exception("[LaserSorter]")
-        << "File " << dir << " exists but is not a directory "
-        << " as expected.";
+  if (0 == stat(dir.c_str(), &fileStat)) {
+    if (!S_ISDIR(fileStat.st_mode)) {
+      throw cms::Exception("[LaserSorter]") << "File " << dir << " exists but is not a directory "
+                                            << " as expected.";
     }
-  } else {//directory does not exists, let's try to create it
-    if(0!=mkdir(dir.c_str(), 0755)){
-      throw cms::Exception("[LaserSorter]")
-        << "Failed to create directory " << dir
-        << " for writing data.";
+  } else {  //directory does not exists, let's try to create it
+    if (0 != mkdir(dir.c_str(), 0755)) {
+      throw cms::Exception("[LaserSorter]") << "Failed to create directory " << dir << " for writing data.";
     }
   }
 
   buf.str("");
-  buf << "Run" << runNumber_
-      << "_LB" << setfill('0') << setw(4) << lumiBlock
-      << ".lmf";
+  buf << "Run" << runNumber_ << "_LB" << setfill('0') << setw(4) << lumiBlock << ".lmf";
   string fileName = buf.str();
   string tmpFileName = fileName + ".part";
 
   finalName = dir + "/" + fileName;
   tmpName = dir + "/" + tmpFileName;
 
-  if(verbosity_>3) cout << "[LaserSorter " << now() << "] " << "File path: "
-                        << finalName << "\n";
+  if (verbosity_ > 3)
+    cout << "[LaserSorter " << now() << "] "
+         << "File path: " << finalName << "\n";
 }
 
-LaserSorter::OutStreamList::iterator
-LaserSorter::closeOutStream(LaserSorter::OutStreamList::iterator
-                            streamRecord){
-  if(streamRecord==outStreamList_.end()) return outStreamList_.end();
-  
-  if(verbosity_) cout << "[LaserSorter " << now() << "] " << "Writing Index table of file "
-                      << streamRecord->finalFileName() << "\n";
+LaserSorter::OutStreamList::iterator LaserSorter::closeOutStream(LaserSorter::OutStreamList::iterator streamRecord) {
+  if (streamRecord == outStreamList_.end())
+    return outStreamList_.end();
+
+  if (verbosity_)
+    cout << "[LaserSorter " << now() << "] "
+         << "Writing Index table of file " << streamRecord->finalFileName() << "\n";
   ofstream& out = *streamRecord->out();
   out.clear();
-  if(!writeIndexTable(out, *streamRecord->indices())){
-    cout << "Error while writing index table for file "
-         << streamRecord->finalFileName() << ". "
+  if (!writeIndexTable(out, *streamRecord->indices())) {
+    cout << "Error while writing index table for file " << streamRecord->finalFileName() << ". "
          << "Resulting file might be corrupted. "
          << "The error can be due to a lack of disk space.";
   }
-  
-  if(verbosity_) cout << "[LaserSorter " << now() << "] " << "Closing file " 
-                      << streamRecord->finalFileName() << ".\n";
+
+  if (verbosity_)
+    cout << "[LaserSorter " << now() << "] "
+         << "Closing file " << streamRecord->finalFileName() << ".\n";
   out.close();
-  
+
   const std::string& tmpFileName = streamRecord->tmpFileName();
   const std::string& finalFileName = streamRecord->finalFileName();
 
-  if(verbosity_) cout << "[LaserSorter " << now() << "] " << "Renaming " << tmpFileName
-                      << " to "    << finalFileName << ".\n";
-
-  if(0!=rename(tmpFileName.c_str(), finalFileName.c_str())){
+  if (verbosity_)
     cout << "[LaserSorter " << now() << "] "
-         << " Failed to rename output file from "
-         << tmpFileName << " to "    << finalFileName
-         << ". " << strerror(errno) << "\n";
+         << "Renaming " << tmpFileName << " to " << finalFileName << ".\n";
+
+  if (0 != rename(tmpFileName.c_str(), finalFileName.c_str())) {
+    cout << "[LaserSorter " << now() << "] "
+         << " Failed to rename output file from " << tmpFileName << " to " << finalFileName << ". " << strerror(errno)
+         << "\n";
   }
 
-  if(doOutputList_){
+  if (doOutputList_) {
     char buf[256];
     time_t t = time(nullptr);
     strftime(buf, sizeof(buf), "%F %R:%S", localtime(&t));
@@ -934,52 +876,52 @@ LaserSorter::closeOutStream(LaserSorter::OutStreamList::iterator
     ifstream f(".watcherfile");
     string inputFile;
     f >> inputFile;
-    outputList_ << finalFileName << "\t" << buf
-                << "\t" << inputFile
-                << endl;
+    outputList_ << finalFileName << "\t" << buf << "\t" << inputFile << endl;
   }
-  
+
   return outStreamList_.erase(streamRecord);
 }
 
-void LaserSorter::endJob(){
+void LaserSorter::endJob() {
   //TODO: better treatement of last files:
   //they might be imcomplete...
   closeAllStreams();
 }
 
-void LaserSorter::beginJob(){
-}
+void LaserSorter::beginJob() {}
 
-bool LaserSorter::isDccEventEmpty(const FEDRawData& data, size_t* dccLen,
-                                  int* nTowerBlocks) const{
-  if(nTowerBlocks) *nTowerBlocks = 0;
+bool LaserSorter::isDccEventEmpty(const FEDRawData& data, size_t* dccLen, int* nTowerBlocks) const {
+  if (nTowerBlocks)
+    *nTowerBlocks = 0;
   //DCC event is considered empty if it does not contains any Tower block
   //( = FE data)
   bool rc = true;
-  if(dccLen) *dccLen = 0;
-  const unsigned nWord32 = data.size()/sizeof(uint32_t);
-  if(nWord32==0){
+  if (dccLen)
+    *dccLen = 0;
+  const unsigned nWord32 = data.size() / sizeof(uint32_t);
+  if (nWord32 == 0) {
     //cout << "[LaserSorter " << now() << "] " << "FED block completly empty\n";
     return true;
   }
-  for(unsigned iWord32 = 0; iWord32 < nWord32; iWord32 += 2){
+  for (unsigned iWord32 = 0; iWord32 < nWord32; iWord32 += 2) {
     const uint32_t* data32 = ((const uint32_t*)(data.data())) + iWord32;
-    int dataType = (data32[1] >>28) & 0xF;
+    int dataType = (data32[1] >> 28) & 0xF;
     //     cout << hex << "0x" << setfill('0')
     //          << setw(8) << data32[1] << "'" << setw(8) << data32[0]
-    //          << " dataType: 0x" << dataType 
+    //          << " dataType: 0x" << dataType
     //          << dec << setfill(' ') << "\n";
-    if(0==(dataType>>2)){//in DCC header
-      const int dccHeaderId = (data32[1] >>24) & 0x3F;
-      if(dccHeaderId==1){
-        if(dccLen) *dccLen=((data32[0] >>0 ) & 0xFFFFFF);
+    if (0 == (dataType >> 2)) {  //in DCC header
+      const int dccHeaderId = (data32[1] >> 24) & 0x3F;
+      if (dccHeaderId == 1) {
+        if (dccLen)
+          *dccLen = ((data32[0] >> 0) & 0xFFFFFF);
       }
-    } if((dataType>>2)==3){//Tower block
+    }
+    if ((dataType >> 2) == 3) {  //Tower block
       rc = false;
-      if(nTowerBlocks){//number of tower block must be counted
+      if (nTowerBlocks) {  //number of tower block must be counted
         ++(*nTowerBlocks);
-      } else{
+      } else {
         break;
       }
     }
@@ -996,77 +938,76 @@ bool LaserSorter::isDccEventEmpty(const FEDRawData& data, size_t* dccLen,
 
 void LaserSorter::getOutputFedList(const edm::Event& event,
                                    const FEDRawDataCollection& data,
-                                   std::vector<unsigned>& fedIds) const{
+                                   std::vector<unsigned>& fedIds) const {
   fedIds.erase(fedIds.begin(), fedIds.end());
-  for(int id = ecalDccFedIdMin_; id <= ecalDccFedIdMax_; ++id){
+  for (int id = ecalDccFedIdMin_; id <= ecalDccFedIdMax_; ++id) {
     size_t dccLen;
     const FEDRawData& dccEvent = data.FEDData(id);
-    if(!isDccEventEmpty(dccEvent, &dccLen)){
+    if (!isDccEventEmpty(dccEvent, &dccLen)) {
       fedIds.push_back(id);
     }
-    if(dccLen*sizeof(uint64_t)!=dccEvent.size()){
-      edm::LogWarning("LaserSorter")
-        << "Length error in data of FED " << id
-        << " in event " << event.id() 
-        << ", Data of this FED dropped.";
+    if (dccLen * sizeof(uint64_t) != dccEvent.size()) {
+      edm::LogWarning("LaserSorter") << "Length error in data of FED " << id << " in event " << event.id()
+                                     << ", Data of this FED dropped.";
     }
   }
   //   cout << __FILE__ << ":" << __LINE__ << ": "
   //        <<  "data.FEDData(" << matacqFedId_ << ").size() = "
   //        <<  data.FEDData(matacqFedId_).size() << "\n";
-  if(data.FEDData(matacqFedId_).size()>4){//matacq block present
+  if (data.FEDData(matacqFedId_).size() > 4) {  //matacq block present
     //    cout << __FILE__ << ":" << __LINE__ << ": "
     //     <<  "Adding matacq to list of FEDs\n";
     fedIds.push_back(matacqFedId_);
   }
 }
 
-std::vector<int>
-LaserSorter::getFullyReadoutDccs(const FEDRawDataCollection& data) const{
+std::vector<int> LaserSorter::getFullyReadoutDccs(const FEDRawDataCollection& data) const {
   int nTowers;
   vector<int> result;
-  for(int fed = ecalDccFedIdMin_; fed <= ecalDccFedIdMax_; ++fed){
+  for (int fed = ecalDccFedIdMin_; fed <= ecalDccFedIdMax_; ++fed) {
     const FEDRawData& fedData = data.FEDData(fed);
     isDccEventEmpty(fedData, nullptr, &nTowers);
-    if(nTowers>=68) result.push_back(fed);
+    if (nTowers >= 68)
+      result.push_back(fed);
   }
   return result;
 }
 
-
-bool LaserSorter::writeIndexTable(std::ofstream& out,
-                                  std::vector<IndexRecord>& indices){
+bool LaserSorter::writeIndexTable(std::ofstream& out, std::vector<IndexRecord>& indices) {
   uint32_t indexTablePos = out.tellp();
   uint32_t nevts = indices.size();
-  
+
   out.clear();
   out.write((char*)&nevts, sizeof(nevts));
   const uint32_t reserved = 0;
   out.write((const char*)&reserved, sizeof(reserved));
-  
-  if(out.bad()) return false;
+
+  if (out.bad())
+    return false;
 
   sort(indices.begin(), indices.end());
 
-  for(unsigned i = 0; i < indices.size(); ++i){
+  for (unsigned i = 0; i < indices.size(); ++i) {
     uint32_t data[2];
     data[0] = indices[i].orbit;
     data[1] = indices[i].filePos;
     out.write((char*)data, sizeof(data));
   }
 
-  if(out.bad()) return false; //intial 0 valur for index table position
+  if (out.bad())
+    return false;  //intial 0 valur for index table position
   //                            is left to indicate corrupted table.
-  
+
   //writes index table position:x
   out.clear();
-  out.seekp(indexOffset32_*sizeof(uint32_t));
+  out.seekp(indexOffset32_ * sizeof(uint32_t));
   //   cout << "[LaserSorter] Index table position: 0x" << hex << indexTablePos
-  //        << dec << "\n"; 
-  if(!out.bad()) out.write((char*)&indexTablePos, sizeof(uint32_t));
+  //        << dec << "\n";
+  if (!out.bad())
+    out.write((char*)&indexTablePos, sizeof(uint32_t));
 
   bool rc = !out.bad();
-  
+
   //reposition pointer to eof:
   out.seekp(0, ios::end);
 
@@ -1074,146 +1015,144 @@ bool LaserSorter::writeIndexTable(std::ofstream& out,
 }
 
 //beware this method change the pointer position in the ifstream in
-bool LaserSorter::readIndexTable(std::ifstream& in,
-                                 std::string& inName,
-                                 OutStreamRecord& outRcd,
-                                 std::string* err){
+bool LaserSorter::readIndexTable(std::ifstream& in, std::string& inName, OutStreamRecord& outRcd, std::string* err) {
   stringstream errMsg;
 
   ifstream* s = &in;
-  
+
   //streampos pos = s->tellg();
   s->clear();
   s->seekg(0);
-  
+
   uint32_t fileHeader[2];
   s->read((char*)&fileHeader[0], sizeof(fileHeader));
-  uint32_t indexTablePos = fileHeader[1]; 
-  
-  if(s->eof()){
+  uint32_t indexTablePos = fileHeader[1];
+
+  if (s->eof()) {
     s->clear();
     s->seekg(0);
-    errMsg << "Failed to read header of file " << inName
-           << ".";
-    if(err) *err = errMsg.str();
+    errMsg << "Failed to read header of file " << inName << ".";
+    if (err)
+      *err = errMsg.str();
     return false;
   }
-  
+
   s->seekg(indexTablePos);
 
   uint32_t nevts = 0;
   s->read((char*)&nevts, sizeof(nevts));
-  s->ignore(4);  
-  if(s->bad()){
-    errMsg << "Failed to read index table from file "
-           << inName << ".";
-    if(err) *err = errMsg.str();
+  s->ignore(4);
+  if (s->bad()) {
+    errMsg << "Failed to read index table from file " << inName << ".";
+    if (err)
+      *err = errMsg.str();
     return false;
   }
-  if(nevts>maxEvents_){
-    errMsg << "Number of events indicated in event index of file "
-           << inName << " (" << nevts << ") "
+  if (nevts > maxEvents_) {
+    errMsg << "Number of events indicated in event index of file " << inName << " (" << nevts << ") "
            << "is unexpectively large.";
-    if(err) *err = errMsg.str();
+    if (err)
+      *err = errMsg.str();
     return false;
   }
   outRcd.indices()->resize(nevts);
-  s->read((char*)&(*outRcd.indices())[0], nevts*sizeof(IndexRecord));
-  if(s->bad()){
+  s->read((char*)&(*outRcd.indices())[0], nevts * sizeof(IndexRecord));
+  if (s->bad()) {
     outRcd.indices()->clear();
-    errMsg << "Failed to read index table from file "
-           << inName << ".";
-    if(err) *err = errMsg.str();
+    errMsg << "Failed to read index table from file " << inName << ".";
+    if (err)
+      *err = errMsg.str();
     return false;
   }
-  if(nevts>maxEvents_){
-    errMsg << "Number of events indicated in event index of file "
-           << inName << " is unexpectively large.";
-    if(err) *err = errMsg.str();
+  if (nevts > maxEvents_) {
+    errMsg << "Number of events indicated in event index of file " << inName << " is unexpectively large.";
+    if (err)
+      *err = errMsg.str();
     outRcd.indices()->clear();
     return false;
   }
 
-  if(verbosity_ > 1) cout << "[LaserSorter " << now() << "] " << "Orbit IDs of events "
-                          << "already contained in the file "
-                          << inName << ":";
-  for(unsigned i = 0; i < outRcd.indices()->size(); ++i){
-    if(verbosity_>1){
-      cout << " "  << setw(9) << (*outRcd.indices())[i].orbit;
+  if (verbosity_ > 1)
+    cout << "[LaserSorter " << now() << "] "
+         << "Orbit IDs of events "
+         << "already contained in the file " << inName << ":";
+  for (unsigned i = 0; i < outRcd.indices()->size(); ++i) {
+    if (verbosity_ > 1) {
+      cout << " " << setw(9) << (*outRcd.indices())[i].orbit;
     }
     outRcd.excludedOrbit().insert((*outRcd.indices())[i].orbit);
   }
-  if(verbosity_>1) cout << "\n";
+  if (verbosity_ > 1)
+    cout << "\n";
 
   return true;
 }
 
-int LaserSorter::readFormatVersion(std::ifstream& in,
-                                   const std::string& fileName){
+int LaserSorter::readFormatVersion(std::ifstream& in, const std::string& fileName) {
   int vers = -1;
   streampos p = in.tellg();
 
   uint32_t data;
 
   in.read((char*)&data, sizeof(data));
-  
+
   char magic[4];
-  
+
   magic[0] = data & 0xFF;
-  magic[1] = (data >>8) & 0xFF;
-  magic[2] = (data >>16) & 0xFF;
+  magic[1] = (data >> 8) & 0xFF;
+  magic[2] = (data >> 16) & 0xFF;
   magic[3] = 0;
 
-
   const string lmf = string("LMF");
-  
-  if(in.good() && lmf==magic){
-    vers = (data >>24) & 0xFF;
+
+  if (in.good() && lmf == magic) {
+    vers = (data >> 24) & 0xFF;
   }
 
-  if(lmf!=magic){
-    edm::LogWarning("LaserSorter") << "File " << fileName
-                                   << "is not an LMF file.\n";
+  if (lmf != magic) {
+    edm::LogWarning("LaserSorter") << "File " << fileName << "is not an LMF file.\n";
   }
-  
+
   in.clear();
   in.seekg(p);
   return vers;
 }
- 
-std::string LaserSorter::toString(uint64_t t){
+
+std::string LaserSorter::toString(uint64_t t) {
   char buf[256];
-  
-  time_t tsec = t>>32;
-  
+
+  time_t tsec = t >> 32;
+
   uint32_t tusec = t & 0xFFFFFFFF;
   strftime(buf, sizeof(buf), "%F %R %S s", localtime(&tsec));
-  buf[sizeof(buf)-1] = 0;
-  
+  buf[sizeof(buf) - 1] = 0;
+
   stringstream buf2;
-  buf2 << (tusec+500)/1000;
+  buf2 << (tusec + 500) / 1000;
 
   return string(buf) + " " + buf2.str() + " ms";
 }
- 
-void LaserSorter::restoreStreamsOfLumiBlock(int lumiBlock){
+
+void LaserSorter::restoreStreamsOfLumiBlock(int lumiBlock) {
   string dummy;
   string fileName;
-  
-  for(int fedId = ecalDccFedIdMin_-2; fedId <= ecalDccFedIdMax_; ++fedId){
+
+  for (int fedId = ecalDccFedIdMin_ - 2; fedId <= ecalDccFedIdMax_; ++fedId) {
     int fedId_;
-    if(fedId == ecalDccFedIdMin_-2) fedId_ = -1; //stream for event w/o ECAL data
-    else fedId_ = fedId;
+    if (fedId == ecalDccFedIdMin_ - 2)
+      fedId_ = -1;  //stream for event w/o ECAL data
+    else
+      fedId_ = fedId;
     streamFileName(fedId_, lumiBlock, dummy, fileName);
     struct stat s;
     //TODO: could be optimized by adding an option to get stream
     //to open only existing file: would avoid double call to streamFileName.
-    if(stat(fileName.c_str(), &s)==0){//file exists
+    if (stat(fileName.c_str(), &s) == 0) {  //file exists
       getStream(fedId_, lumiBlock);
     }
   }
 }
 
-void LaserSorter::beginRun(edm::Run const& run, edm::EventSetup const& es){
+void LaserSorter::beginRun(edm::Run const& run, edm::EventSetup const& es) {
   //  cout << "Run starts at :" << run.runAuxiliary().beginTime().value() << "\n";
 }

--- a/CalibCalorimetry/EcalLaserSorting/src/LmfSource.cc
+++ b/CalibCalorimetry/EcalLaserSorting/src/LmfSource.cc
@@ -20,101 +20,97 @@ const unsigned char LmfSource::minDataFormatVersion_ = 4;
 const unsigned char LmfSource::maxDataFormatVersion_ = 5;
 const unsigned LmfSource::fileHeaderSize = 2;
 
-
-LmfSource::LmfSource(const ParameterSet& pset,
-		     const InputSourceDescription& desc) :
-  ProducerSourceBase(pset, desc, true),
-  fileNames_(pset.getParameter<vector<string> >("fileNames")),
-  iFile_ (-1),
-  fedId_(-1),
-  fileHeader_(fileHeaderSize),
-  dataFormatVers_(5),
-  rcRead_(false),
-  preScale_(pset.getParameter<unsigned>("preScale")),
-  iEvent_(0),
-  iEventInFile_(0),
-  indexTablePos_(0),
-  orderedRead_(pset.getParameter<bool>("orderedRead")),
-  watchFileList_(pset.getParameter<bool>("watchFileList")),
-  fileListName_(pset.getParameter<std::string>("fileListName")),
-  inputDir_(pset.getParameter<std::string>("inputDir")),
-  nSecondsToSleep_(pset.getParameter<int>("nSecondsToSleep")),
-  verbosity_(pset.getUntrackedParameter<int>("verbosity"))
-{
-  if(preScale_==0) preScale_ = 1;
+LmfSource::LmfSource(const ParameterSet& pset, const InputSourceDescription& desc)
+    : ProducerSourceBase(pset, desc, true),
+      fileNames_(pset.getParameter<vector<string> >("fileNames")),
+      iFile_(-1),
+      fedId_(-1),
+      fileHeader_(fileHeaderSize),
+      dataFormatVers_(5),
+      rcRead_(false),
+      preScale_(pset.getParameter<unsigned>("preScale")),
+      iEvent_(0),
+      iEventInFile_(0),
+      indexTablePos_(0),
+      orderedRead_(pset.getParameter<bool>("orderedRead")),
+      watchFileList_(pset.getParameter<bool>("watchFileList")),
+      fileListName_(pset.getParameter<std::string>("fileListName")),
+      inputDir_(pset.getParameter<std::string>("inputDir")),
+      nSecondsToSleep_(pset.getParameter<int>("nSecondsToSleep")),
+      verbosity_(pset.getUntrackedParameter<int>("verbosity")) {
+  if (preScale_ == 0)
+    preScale_ = 1;
   produces<FEDRawDataCollection>();
   // open fileListName
   if (watchFileList_) {
-    fileList_.open( fileListName_.c_str() );
+    fileList_.open(fileListName_.c_str());
     if (fileList_.fail()) {
-      throw cms::Exception("FileListOpenError")
-        << "Failed to open input file " << fileListName_ << "\n";
+      throw cms::Exception("FileListOpenError") << "Failed to open input file " << fileListName_ << "\n";
     }
   } else {
-  //throws a cms exception if error in fileNames parameter
-  checkFileNames();
+    //throws a cms exception if error in fileNames parameter
+    checkFileNames();
   }
 }
 
-bool LmfSource::readFileHeader(){
-  if(iFile_==-1) return false; //no file open
+bool LmfSource::readFileHeader() {
+  if (iFile_ == -1)
+    return false;  //no file open
 
-  if(verbosity_) cout << "[LmfSource]"
-                   << "Opening file #" << (iFile_+1) << " '"
-                   << currentFileName_ << "'\n";
-  
-  in_.read((char*)&fileHeader_[0], fileHeaderSize*sizeof(uint32_t));
+  if (verbosity_)
+    cout << "[LmfSource]"
+         << "Opening file #" << (iFile_ + 1) << " '" << currentFileName_ << "'\n";
 
-  if(in_.eof()) return false;
-  
-  if(verbosity_){
+  in_.read((char*)&fileHeader_[0], fileHeaderSize * sizeof(uint32_t));
+
+  if (in_.eof())
+    return false;
+
+  if (verbosity_) {
     cout << "[LmfSource]"
          << "File header (in hex):" << hex;
-    for(unsigned i=0; i < fileHeaderSize; ++i){ 
-      if(i%8==0) cout << "\n";
+    for (unsigned i = 0; i < fileHeaderSize; ++i) {
+      if (i % 8 == 0)
+        cout << "\n";
       cout << setw(8) << fileHeader_[i] << " ";
     }
     cout << dec << "\n";
   }
 
-
   char id[4];
 
   id[0] = fileHeader_[0] & 0xFF;
-  id[1] = (fileHeader_[0] >>8) & 0xFF;
-  id[2] = (fileHeader_[0] >>16) & 0xFF;
-  id[3] = (fileHeader_[0] >>24) & 0xFF;
-  
-  if(!(id[0]=='L' && id[1] == 'M'
-       && id[2] == 'F')){
-    throw cms::Exception("FileReadError")
-      << currentFileName_ << " is not a file in LMF format!";
+  id[1] = (fileHeader_[0] >> 8) & 0xFF;
+  id[2] = (fileHeader_[0] >> 16) & 0xFF;
+  id[3] = (fileHeader_[0] >> 24) & 0xFF;
+
+  if (!(id[0] == 'L' && id[1] == 'M' && id[2] == 'F')) {
+    throw cms::Exception("FileReadError") << currentFileName_ << " is not a file in LMF format!";
   }
   dataFormatVers_ = id[3];
-  if(verbosity_) cout << "[LmfSource]"
-                   << "LMF format: " << (int)dataFormatVers_ << "\n";
-  
-  if(dataFormatVers_ > maxDataFormatVersion_
-     || dataFormatVers_ < minDataFormatVersion_){
-    throw cms::Exception("FileReadError")
-      << currentFileName_ << ": LMF format version " << (int) dataFormatVers_
-      << " is not supported by this release of LmfSource module";
+  if (verbosity_)
+    cout << "[LmfSource]"
+         << "LMF format: " << (int)dataFormatVers_ << "\n";
+
+  if (dataFormatVers_ > maxDataFormatVersion_ || dataFormatVers_ < minDataFormatVersion_) {
+    throw cms::Exception("FileReadError") << currentFileName_ << ": LMF format version " << (int)dataFormatVers_
+                                          << " is not supported by this release of LmfSource module";
   }
 
   indexTablePos_ = fileHeader_[1];
 
-  if(verbosity_) cout << "[LmfSource] File position of index table: 0x"
-                   << setfill('0') << hex << setw(8) << indexTablePos_
-                   << setfill(' ') << dec << "\n";
-  
-  if(dataFormatVers_ < 5){
+  if (verbosity_)
+    cout << "[LmfSource] File position of index table: 0x" << setfill('0') << hex << setw(8) << indexTablePos_
+         << setfill(' ') << dec << "\n";
+
+  if (dataFormatVers_ < 5) {
     in_.ignore(4);
   }
-    
+
   return true;
 }
 
-void LmfSource::produce(edm::Event& evt){
+void LmfSource::produce(edm::Event& evt) {
   //   bool rc;
   //   while(!((rc = readFileHeader()) & readEventPayload())){
   //     if(openFile(++iFile_)==false){//no more files
@@ -125,14 +121,15 @@ void LmfSource::produce(edm::Event& evt){
   //   }
   auto coll = std::make_unique<FEDRawDataCollection>();
   coll->swap(fedColl_);
-  if(verbosity_) cout << "[LmfSource] Putting FEDRawDataCollection in event\n";
+  if (verbosity_)
+    cout << "[LmfSource] Putting FEDRawDataCollection in event\n";
   evt.put(std::move(coll));
 }
 
-bool LmfSource::openFile(int iFile){
+bool LmfSource::openFile(int iFile) {
   iEventInFile_ = 0;
-  if(watchFileList_) {
-    for ( ;; ) {
+  if (watchFileList_) {
+    for (;;) {
       // read the first field of the line, which must be the filename
       fileList_ >> currentFileName_;
       currentFileName_ = inputDir_ + "/" + currentFileName_;
@@ -140,344 +137,335 @@ bool LmfSource::openFile(int iFile){
         // skip the rest of the line
         std::string tmp_buffer;
         std::getline(fileList_, tmp_buffer);
-        if(verbosity_) cout << "[LmfSource]"
-          << "Opening file " << currentFileName_ << "\n";
+        if (verbosity_)
+          cout << "[LmfSource]"
+               << "Opening file " << currentFileName_ << "\n";
         in_.open(currentFileName_.c_str());
         if (!in_.fail()) {
           // file was successfully open
           return true;
         } else {
           // skip file
-          edm::LogError("FileOpenError")
-            << "Failed to open input file " << currentFileName_ << ". Skipping file\n";
+          edm::LogError("FileOpenError") << "Failed to open input file " << currentFileName_ << ". Skipping file\n";
           in_.close();
           in_.clear();
         }
       }
       // if here, no new file is available: sleep and retry later
-      if (verbosity_) std::cout << "[LmfSource]"
-        << " going to sleep 5 seconds\n";
+      if (verbosity_)
+        std::cout << "[LmfSource]"
+                  << " going to sleep 5 seconds\n";
       sleep(nSecondsToSleep_);
       fileList_.clear();
     }
   } else {
-    if(iFile > (int)fileNames_.size()-1) return false;
+    if (iFile > (int)fileNames_.size() - 1)
+      return false;
     currentFileName_ = fileNames_[iFile];
-    if(verbosity_) cout << "[LmfSource]"
-      << "Opening file " << currentFileName_ << "\n";
+    if (verbosity_)
+      cout << "[LmfSource]"
+           << "Opening file " << currentFileName_ << "\n";
     in_.open(currentFileName_.c_str());
-    if(in_.fail()){
-      throw cms::Exception("FileOpenError")
-        << "Failed to open input file " << currentFileName_ << "\n";
+    if (in_.fail()) {
+      throw cms::Exception("FileOpenError") << "Failed to open input file " << currentFileName_ << "\n";
     }
   }
   return true;
 }
 
-bool LmfSource::nextEventWithinFile(){
-  if(iFile_<0) return false; //no file opened.
-  if(orderedRead_){
-    if(iEventInFile_>=indexTable_.size()) return false;
-    if(verbosity_){
-      cout << "[LmfSource] move to event with orbit Id "
-           << indexTable_[iEventInFile_].orbit
-           << " at file position 0x"
-           << hex << setfill('0')
-           << setw(8) << indexTable_[iEventInFile_].filePos
-           << setfill(' ') << dec << "\n";
+bool LmfSource::nextEventWithinFile() {
+  if (iFile_ < 0)
+    return false;  //no file opened.
+  if (orderedRead_) {
+    if (iEventInFile_ >= indexTable_.size())
+      return false;
+    if (verbosity_) {
+      cout << "[LmfSource] move to event with orbit Id " << indexTable_[iEventInFile_].orbit << " at file position 0x"
+           << hex << setfill('0') << setw(8) << indexTable_[iEventInFile_].filePos << setfill(' ') << dec << "\n";
     }
     const streampos pos = indexTable_[iEventInFile_].filePos;
     in_.clear();
     in_.seekg(pos);
-    if(in_.bad()){
-      cout << "[LmfSource] Problem while reading file "
-           << currentFileName_ << ". Problem with event index table?\n";
+    if (in_.bad()) {
+      cout << "[LmfSource] Problem while reading file " << currentFileName_ << ". Problem with event index table?\n";
       return false;
     }
     ++iEventInFile_;
     return true;
-  } else{
+  } else {
     return true;
   }
 }
-               
-bool LmfSource::readEvent(bool doSkip){
-  while(!(nextEventWithinFile() && readEventWithinFile(doSkip))){
+
+bool LmfSource::readEvent(bool doSkip) {
+  while (!(nextEventWithinFile() && readEventWithinFile(doSkip))) {
     //failed to read event. Let's look for next file:
     in_.close();
     in_.clear();
     bool rcOpen = openFile(++iFile_);
-    if(rcOpen==false){//no more files
-      if(verbosity_) cout << "[LmfSource]"
-		       << "No more input file";
+    if (rcOpen == false) {  //no more files
+      if (verbosity_)
+        cout << "[LmfSource]"
+             << "No more input file";
       rcRead_ = false;
       return rcRead_;
     }
     rcRead_ = readFileHeader();
-    if(verbosity_) cout << "File header readout "
-		     << (rcRead_?"succeeded":"failed") << "\n";
-    if(rcRead_ && orderedRead_) readIndexTable();
+    if (verbosity_)
+      cout << "File header readout " << (rcRead_ ? "succeeded" : "failed") << "\n";
+    if (rcRead_ && orderedRead_)
+      readIndexTable();
   }
   return rcRead_;
 }
- 
-bool LmfSource::setRunAndEventInfo(EventID& id, TimeValue_t& time, edm::EventAuxiliary::ExperimentType& eType){
+
+bool LmfSource::setRunAndEventInfo(EventID& id, TimeValue_t& time, edm::EventAuxiliary::ExperimentType& eType) {
   //empties collection:
-  if(fedId_>0){
+  if (fedId_ > 0) {
     fedColl_.FEDData(fedId_).resize(0);
   }
-  if(verbosity_) cout << "[LmfSource]"
-		   << "About to read event...\n";
+  if (verbosity_)
+    cout << "[LmfSource]"
+         << "About to read event...\n";
 
   bool rc;
-  for(;;){
-    if(filter()){//event to read
+  for (;;) {
+    if (filter()) {  //event to read
       rc = readEvent();
-      break;    //either event is read or no more event
-    } else { //event to skip
+      break;  //either event is read or no more event
+    } else {  //event to skip
       rc = readEvent(true);
-      if(rc==false){//no more events
-	break;
+      if (rc == false) {  //no more events
+        break;
       }
     }
   }
 
-  if(!rc) return false; //event readout failed
-    
-  if(verbosity_) cout << "[LmfSource]"
-		   << "Setting event time to "
-		   << /*toString(*/timeStamp_/*)*/ << ", "
-		   << "Run number to " << runNum_ << ","
-		   << "Event number to " << eventNum_ << "\n";
+  if (!rc)
+    return false;  //event readout failed
+
+  if (verbosity_)
+    cout << "[LmfSource]"
+         << "Setting event time to " << /*toString(*/ timeStamp_ /*)*/ << ", "
+         << "Run number to " << runNum_ << ","
+         << "Event number to " << eventNum_ << "\n";
 
   time = timeStamp_;
   id = EventID(runNum_, lumiBlock_, eventNum_);
-  return true; 
+  return true;
 }
 
-bool LmfSource::readEventWithinFile(bool doSkip){
-  if(iFile_==-1 || !rcRead_) return false; //no file open
+bool LmfSource::readEventWithinFile(bool doSkip) {
+  if (iFile_ == -1 || !rcRead_)
+    return false;  //no file open
   //                                         or header reading failed
   //number of 32-bit word to read first to get the event size
   //field
-  const int timeStamp32[]      = {0, 0}; //timestamp is 64-bit long
-  const int lumiBlock32[]      = {2, 2};
-  const int runNum32[]         = {3, 3};
-  const int orbitNum32[]       = {4, 4};
-  const int bx32[]             = {5, 5};
-  const int eventNum32[]       = {6, 6};
-  const int activeFedId32[]    = {7,-1};
-  const int calibTrig32[]      = {-1,7};
-  const int nFeds32[]          = {-1,8};
+  const int timeStamp32[] = {0, 0};  //timestamp is 64-bit long
+  const int lumiBlock32[] = {2, 2};
+  const int runNum32[] = {3, 3};
+  const int orbitNum32[] = {4, 4};
+  const int bx32[] = {5, 5};
+  const int eventNum32[] = {6, 6};
+  const int activeFedId32[] = {7, -1};
+  const int calibTrig32[] = {-1, 7};
+  const int nFeds32[] = {-1, 8};
   // const int reserved32[]       = {-1,9};
-  const int evtHeadSize32[]    = {8,10};
-  
-  const unsigned char iv = dataFormatVers_-minDataFormatVersion_;
-  assert(iv<=sizeof(timeStamp32)/sizeof(timeStamp32[0]));
-  
-  if((int)header_.size() < evtHeadSize32[iv]) header_.resize(evtHeadSize32[iv]);
+  const int evtHeadSize32[] = {8, 10};
 
+  const unsigned char iv = dataFormatVers_ - minDataFormatVersion_;
+  assert(iv <= sizeof(timeStamp32) / sizeof(timeStamp32[0]));
 
-  if(verbosity_) cout << "[LmfSource]"
-		   << "Reading event header\n";
+  if ((int)header_.size() < evtHeadSize32[iv])
+    header_.resize(evtHeadSize32[iv]);
 
-  in_.read((char*)&header_[0], evtHeadSize32[iv]*4);
-  if(in_.bad()){//reading error other than eof
-    throw cms::Exception("FileReadError")
-      << "Error while reading from file " << currentFileName_;
-  }
-  if(in_.eof()) return false;
-
-  if(verbosity_){
+  if (verbosity_)
     cout << "[LmfSource]"
-	 << "Event header (in hex):" << hex << setfill('0');
-    for(int i=0; i < evtHeadSize32[iv]; ++i){ 
-      if(i%8==0) cout << "\n";
+         << "Reading event header\n";
+
+  in_.read((char*)&header_[0], evtHeadSize32[iv] * 4);
+  if (in_.bad()) {  //reading error other than eof
+    throw cms::Exception("FileReadError") << "Error while reading from file " << currentFileName_;
+  }
+  if (in_.eof())
+    return false;
+
+  if (verbosity_) {
+    cout << "[LmfSource]"
+         << "Event header (in hex):" << hex << setfill('0');
+    for (int i = 0; i < evtHeadSize32[iv]; ++i) {
+      if (i % 8 == 0)
+        cout << "\n";
       cout << setw(8) << header_[i] << " ";
     }
     cout << dec << setfill(' ') << "\n";
   }
-  
-  timeStamp_   = *(uint64_t*)&header_[timeStamp32[iv]];
-  lumiBlock_   = header_[lumiBlock32[iv]];
-  runNum_      = header_[runNum32[iv]];
-  orbitNum_    = header_[orbitNum32[iv]];
-  eventNum_    = header_[eventNum32[iv]];
-  bx_          = header_[bx32[iv]];
-  calibTrig_   = calibTrig32[iv]>=0?header_[calibTrig32[iv]]:0;
-  int activeFedId = activeFedId32[iv]>=0?
-    header_[activeFedId32[iv]]:
-    ((calibTrig_ & 0x3F) + 600);
-  nFeds_       = nFeds32[iv] < 0 ? 1 : header_[nFeds32[iv]];
-  
-  if(verbosity_){
-    time_t t = time_t(timeStamp_ >>32);
+
+  timeStamp_ = *(uint64_t*)&header_[timeStamp32[iv]];
+  lumiBlock_ = header_[lumiBlock32[iv]];
+  runNum_ = header_[runNum32[iv]];
+  orbitNum_ = header_[orbitNum32[iv]];
+  eventNum_ = header_[eventNum32[iv]];
+  bx_ = header_[bx32[iv]];
+  calibTrig_ = calibTrig32[iv] >= 0 ? header_[calibTrig32[iv]] : 0;
+  int activeFedId = activeFedId32[iv] >= 0 ? header_[activeFedId32[iv]] : ((calibTrig_ & 0x3F) + 600);
+  nFeds_ = nFeds32[iv] < 0 ? 1 : header_[nFeds32[iv]];
+
+  if (verbosity_) {
+    time_t t = time_t(timeStamp_ >> 32);
     div_t t_ms_us = div(timeStamp_ & 0xFFFFFFFF, 1000);
     char tbuf[256];
     strftime(tbuf, sizeof(tbuf), "%F %T", localtime(&t));
-    tbuf[sizeof(tbuf)-1] = 0;
+    tbuf[sizeof(tbuf) - 1] = 0;
     cout << "[LmfSource] "
-	 << "timeStamp:          " << /*toString(timeStamp_)*/ timeStamp_ 
-	 << " (" << tbuf << " " << t_ms_us.quot << " ms " << t_ms_us.rem   << " us)\n"
-	 << "lumiBlock:          " << lumiBlock_ << "\n"
-	 << "runNum:             " << runNum_ << "\n"
-	 << "orbitNum:           " << orbitNum_ << "\n"
-	 << "eventNum:           " << eventNum_ << "\n"
-	 << "bx:                 " << bx_ << "\n"
-	 << "activeFedId:        " << activeFedId << "\n"
-         << "Calib trigger type: " << ((calibTrig_ >>8) & 0x3) << "\n"
-         << "Color:              " << ((calibTrig_ >>6) & 0x3) << "\n"
-	 << "Side:               " << ((calibTrig_ >>11) & 0x1) << "\n"
+         << "timeStamp:          " << /*toString(timeStamp_)*/ timeStamp_ << " (" << tbuf << " " << t_ms_us.quot
+         << " ms " << t_ms_us.rem << " us)\n"
+         << "lumiBlock:          " << lumiBlock_ << "\n"
+         << "runNum:             " << runNum_ << "\n"
+         << "orbitNum:           " << orbitNum_ << "\n"
+         << "eventNum:           " << eventNum_ << "\n"
+         << "bx:                 " << bx_ << "\n"
+         << "activeFedId:        " << activeFedId << "\n"
+         << "Calib trigger type: " << ((calibTrig_ >> 8) & 0x3) << "\n"
+         << "Color:              " << ((calibTrig_ >> 6) & 0x3) << "\n"
+         << "Side:               " << ((calibTrig_ >> 11) & 0x1) << "\n"
          << "nFeds:              " << nFeds_ << "\n";
   }
 
   const int dccLenOffset32 = 2;
-  const int fedIdOffset32  = 0; 
-  const int nPreRead32     = 3;
+  const int fedIdOffset32 = 0;
+  const int nPreRead32 = 3;
   vector<int32_t> buf(nPreRead32);
-  for(int iFed = 0; iFed < nFeds_; ++iFed){  
-    in_.read((char*) &buf[0], nPreRead32*sizeof(uint32_t));
+  for (int iFed = 0; iFed < nFeds_; ++iFed) {
+    in_.read((char*)&buf[0], nPreRead32 * sizeof(uint32_t));
 
-    if(verbosity_){
+    if (verbosity_) {
       cout << "[LmfSource] " << nPreRead32 << " first 32-bit words of "
            << "FED block: " << hex << setfill('0');
-      for(unsigned i = 0; i< buf.size(); ++i){
+      for (unsigned i = 0; i < buf.size(); ++i) {
         cout << "0x" << setw(8) << buf[i] << " ";
       }
       cout << dec << setfill(' ');
     }
-        
-    
-    if(in_.bad()) return false;
-    
-    const unsigned eventSize64 = buf[dccLenOffset32] &  0x00FFFFFF;
-    const unsigned eventSize32 = eventSize64*2;
-    const unsigned eventSize8  = eventSize64*8;
-    const unsigned fedId_      = (buf[fedIdOffset32] >>8) & 0xFFF;
 
-    if(eventSize8 > maxEventSize_){
+    if (in_.bad())
+      return false;
+
+    const unsigned eventSize64 = buf[dccLenOffset32] & 0x00FFFFFF;
+    const unsigned eventSize32 = eventSize64 * 2;
+    const unsigned eventSize8 = eventSize64 * 8;
+    const unsigned fedId_ = (buf[fedIdOffset32] >> 8) & 0xFFF;
+
+    if (eventSize8 > maxEventSize_) {
       throw cms::Exception("FileReadError")
-        << "Size of event fragment (FED block) read from "
-        << " data of file " << currentFileName_
-        << "is unexpctively large (" << (eventSize8 >>10)
-        << " kByte). "
-        << "This must be an error (corrupted file?)\n";
-    }
-    
-    if(!FEDNumbering::inRange(fedId_)){
-      throw cms::Exception("FileReadError")
-        << "Invalid FED number read from data file.";
+          << "Size of event fragment (FED block) read from "
+          << " data of file " << currentFileName_ << "is unexpctively large (" << (eventSize8 >> 10) << " kByte). "
+          << "This must be an error (corrupted file?)\n";
     }
 
-    int32_t toRead8 = (eventSize32-nPreRead32)*sizeof(int32_t);
-
-    if(toRead8<0){
-      throw cms::Exception("FileReadError")
-        << "Event size error while reading an event from file "
-        << currentFileName_ << "\n";
+    if (!FEDNumbering::inRange(fedId_)) {
+      throw cms::Exception("FileReadError") << "Invalid FED number read from data file.";
     }
-    
-    if(doSkip){//event to skip
-      if(verbosity_) cout << "[LmfSource] "
-                       << "Skipping on event. Move file pointer "
-                       << toRead8 << " ahead.\n";
+
+    int32_t toRead8 = (eventSize32 - nPreRead32) * sizeof(int32_t);
+
+    if (toRead8 < 0) {
+      throw cms::Exception("FileReadError")
+          << "Event size error while reading an event from file " << currentFileName_ << "\n";
+    }
+
+    if (doSkip) {  //event to skip
+      if (verbosity_)
+        cout << "[LmfSource] "
+             << "Skipping on event. Move file pointer " << toRead8 << " ahead.\n";
       in_.seekg(toRead8, ios::cur);
-      if(in_.bad()){//reading error other than eof
-        throw cms::Exception("FileReadError")
-          << "Error while reading from file " << currentFileName_;
+      if (in_.bad()) {  //reading error other than eof
+        throw cms::Exception("FileReadError") << "Error while reading from file " << currentFileName_;
       }
-    } else{
+    } else {
       //reads FED data:
       FEDRawData& data_ = fedColl_.FEDData(fedId_);
       data_.resize(eventSize8);
-      
+
       //copy already read data:
       copy(buf.begin(), buf.end(), (int32_t*)data_.data());
-      
-      in_.read((char*)(data_.data()) + nPreRead32*4,
-               toRead8);
-      
-      if(in_.bad()){//reading error other than eof
-        throw cms::Exception("FileReadError")
-          << "Error while reading from file " << currentFileName_;
+
+      in_.read((char*)(data_.data()) + nPreRead32 * 4, toRead8);
+
+      if (in_.bad()) {  //reading error other than eof
+        throw cms::Exception("FileReadError") << "Error while reading from file " << currentFileName_;
       }
-    
-      if(verbosity_ && data_.size()>16){
+
+      if (verbosity_ && data_.size() > 16) {
         cout << "[LmfSource]"
              << "Head of DCC data (in hex):" << hex;
-        for(int i=0; i < 16; ++i){ 
-          if(i%8==0) cout << "\n";
+        for (int i = 0; i < 16; ++i) {
+          if (i % 8 == 0)
+            cout << "\n";
           cout << setw(8) << ((uint32_t*)data_.data())[i] << " ";
         }
         cout << dec << "\n";
       }
 
-      if(dataFormatVers_<=4){//calib trigger in not in event header.
+      if (dataFormatVers_ <= 4) {  //calib trigger in not in event header.
         //                    gets it from DCC block
-        calibTrig_ = (((uint32_t*)data_.data())[5] & 0xFC0)
-          | ((activeFedId-600) &  0x3F);
-        if(verbosity_){
+        calibTrig_ = (((uint32_t*)data_.data())[5] & 0xFC0) | ((activeFedId - 600) & 0x3F);
+        if (verbosity_) {
           cout << "[LmfSource] Old data format. "
-            "Uses information read from FED block to retrieve calibration "
-            "trigger type. Value is: 0x"
-               << hex << setfill('0') << setw(3) << calibTrig_
-               << setfill(' ') << dec << "\n";
+                  "Uses information read from FED block to retrieve calibration "
+                  "trigger type. Value is: 0x"
+               << hex << setfill('0') << setw(3) << calibTrig_ << setfill(' ') << dec << "\n";
         }
       }
     }
-    if(in_.eof()) return false;
+    if (in_.eof())
+      return false;
   }
   ++iEvent_;
   return true;
 }
 
-bool LmfSource::filter() const{
-  return (iEvent_%preScale_==0);
-}
-	    
-std::string LmfSource::toString(TimeValue_t& t) const{
+bool LmfSource::filter() const { return (iEvent_ % preScale_ == 0); }
+
+std::string LmfSource::toString(TimeValue_t& t) const {
   char buf[256];
-  const int secTousec = 1000*1000;
-  time_t tsec = t/secTousec;
-  uint32_t tusec = (uint32_t)(t-tsec);
+  const int secTousec = 1000 * 1000;
+  time_t tsec = t / secTousec;
+  uint32_t tusec = (uint32_t)(t - tsec);
   strftime(buf, sizeof(buf), "%F %R %S s", localtime(&tsec));
-  buf[sizeof(buf)-1] = 0;
+  buf[sizeof(buf) - 1] = 0;
   stringstream buf2;
-  buf2 << (tusec+500)/1000;
+  buf2 << (tusec + 500) / 1000;
   return string(buf) + " " + buf2.str() + " ms";
 }
 
-void LmfSource::checkFileNames(){
-  for(unsigned i = 0; i < fileNames_.size(); ++i){
+void LmfSource::checkFileNames() {
+  for (unsigned i = 0; i < fileNames_.size(); ++i) {
     std::string& fileName = fileNames_[i];
     const char s[] = "file:";
-    if(fileName.compare(0, sizeof(s)-1, s)==0){ //file: prefix => to strip
-      fileName.erase(fileName.begin(),
-		     fileName.begin() + sizeof(s)-1);
+    if (fileName.compare(0, sizeof(s) - 1, s) == 0) {  //file: prefix => to strip
+      fileName.erase(fileName.begin(), fileName.begin() + sizeof(s) - 1);
     }
-    if(fileName.find_first_of(":")!=string::npos){
-      throw cms::Exception("LmfSource")
-	<< "Character ':' is not allowed in paths specified fileNames "
-	<< "parameter. Please note only local file (or NFS, AFS)"
-	<< " is supported (no rfio, no /store)";
+    if (fileName.find_first_of(":") != string::npos) {
+      throw cms::Exception("LmfSource") << "Character ':' is not allowed in paths specified fileNames "
+                                        << "parameter. Please note only local file (or NFS, AFS)"
+                                        << " is supported (no rfio, no /store)";
     }
     const char s1[] = "/store";
-    if(fileName.compare(0, sizeof(s1)-1, s1)==0){
-      throw cms::Exception("LmfSource")
-	<< "CMSSW /store not supported by LmfSource. Only local file "
-	<< "(or NFS/AFS) allowed. Path starting with /store not permitted";
+    if (fileName.compare(0, sizeof(s1) - 1, s1) == 0) {
+      throw cms::Exception("LmfSource") << "CMSSW /store not supported by LmfSource. Only local file "
+                                        << "(or NFS/AFS) allowed. Path starting with /store not permitted";
     }
   }
 }
 
-void LmfSource::readIndexTable(){
-
+void LmfSource::readIndexTable() {
   stringstream errMsg;
-  errMsg << "Error while reading event index table of file "
-         << currentFileName_ << ". Try to read it with "
+  errMsg << "Error while reading event index table of file " << currentFileName_ << ". Try to read it with "
          << "option orderedRead disabled.\n";
 
-  if(indexTablePos_==0) throw cms::Exception("LmfSource") << errMsg.str();
+  if (indexTablePos_ == 0)
+    throw cms::Exception("LmfSource") << errMsg.str();
 
   in_.clear();
   in_.seekg(indexTablePos_);
@@ -485,15 +473,15 @@ void LmfSource::readIndexTable(){
   uint32_t nevts = 0;
   in_.read((char*)&nevts, sizeof(nevts));
   in_.ignore(4);
-  if(nevts>maxEvents_){
-    throw cms::Exception("LmfSource")
-      << "Number of events indicated in event index of file "
-      << currentFileName_ << " is unexpectively large. File cannot be "
-      << "read in time-ordered event mode. See orderedRead parmater of "
-      << "LmfSource module.\n";
+  if (nevts > maxEvents_) {
+    throw cms::Exception("LmfSource") << "Number of events indicated in event index of file " << currentFileName_
+                                      << " is unexpectively large. File cannot be "
+                                      << "read in time-ordered event mode. See orderedRead parmater of "
+                                      << "LmfSource module.\n";
   }
   //if(in_.bad()) throw cms::Exception("LmfSource") << errMsg.str();
-  if(in_.bad()) throw cms::Exception("LmfSource") << errMsg.str();
+  if (in_.bad())
+    throw cms::Exception("LmfSource") << errMsg.str();
   indexTable_.resize(nevts);
-  in_.read((char*)&indexTable_[0], nevts*sizeof(IndexRecord));
+  in_.read((char*)&indexTable_[0], nevts * sizeof(IndexRecord));
 }

--- a/CalibCalorimetry/EcalLaserSorting/src/Majority.h
+++ b/CalibCalorimetry/EcalLaserSorting/src/Majority.h
@@ -5,44 +5,41 @@
 #define MAJORITY_H
 
 #include <map>
-  
+
 /**
  */
-template<class T>
+template <class T>
 class Majority {
   //constructor(s) and destructor(s)
 public:
   /** Constructs a Majority
    */
-  Majority(): n_(0){}
+  Majority() : n_(0) {}
 
   /**Destructor
    */
-  virtual ~Majority(){}
-  
-  void
-  add(const T& value){
+  virtual ~Majority() {}
+
+  void add(const T& value) {
     votes_[value] += 1.;
     n_ += 1.;
   }
-  
-  T result(double* proba) const{
+
+  T result(double* proba) const {
     std::pair<T, double> m(T(), -1.);
-    for(typename std::map<T, double>::const_iterator it = votes_.begin();
-	it != votes_.end();
-	++it){
-      if(it->second > m.second){
-	m = *it;
+    for (typename std::map<T, double>::const_iterator it = votes_.begin(); it != votes_.end(); ++it) {
+      if (it->second > m.second) {
+        m = *it;
       }
     }
-    if(proba) *proba = n_>0?m.second/n_:-1;
+    if (proba)
+      *proba = n_ > 0 ? m.second / n_ : -1;
     return m.first;
   }
 
   //method(s)
 public:
 private:
-
   //attribute(s)
 protected:
 private:
@@ -50,4 +47,4 @@ private:
   double n_;
 };
 
-#endif //MAJORITY_H not defined
+#endif  //MAJORITY_H not defined

--- a/CalibCalorimetry/EcalLaserSorting/src/SealModules.cc
+++ b/CalibCalorimetry/EcalLaserSorting/src/SealModules.cc
@@ -5,7 +5,6 @@
 #include "CalibCalorimetry/EcalLaserSorting/interface/LaserSorter.h"
 #include "CalibCalorimetry/EcalLaserSorting/interface/LmfSource.h"
 
-
 DEFINE_FWK_INPUT_SOURCE(WatcherSource);
 DEFINE_FWK_MODULE(LaserSorter);
 DEFINE_FWK_INPUT_SOURCE(LmfSource);

--- a/CalibCalorimetry/EcalLaserSorting/src/WatcherStreamFileReader.cc
+++ b/CalibCalorimetry/EcalLaserSorting/src/WatcherStreamFileReader.cc
@@ -21,123 +21,111 @@ using namespace std;
 
 //std::string WatcherStreamFileReader::fileName_;
 
-
 #if !defined(__linux__) && !(defined(__APPLE__) && __DARWIN_C_LEVEL >= 200809L)
 /* getline implementation is copied from glibc. */
 
 #ifndef SIZE_MAX
-# define SIZE_MAX ((size_t) -1)
+#define SIZE_MAX ((size_t)-1)
 #endif
 #ifndef SSIZE_MAX
-# define SSIZE_MAX ((ssize_t) (SIZE_MAX / 2))
+#define SSIZE_MAX ((ssize_t)(SIZE_MAX / 2))
 #endif
 namespace {
-ssize_t getline (char **lineptr, size_t *n, FILE *fp)
-{
+  ssize_t getline(char** lineptr, size_t* n, FILE* fp) {
     ssize_t result = -1;
     size_t cur_len = 0;
 
-    if (lineptr == NULL || n == NULL || fp == NULL)
-    {
-        errno = EINVAL;
-        return -1;
-   }
-
-    if (*lineptr == NULL || *n == 0)
-    {
-        *n = 120;
-        *lineptr = (char *) malloc (*n);
-        if (*lineptr == NULL)
-        {
-            result = -1;
-            goto end;
-        }
+    if (lineptr == NULL || n == NULL || fp == NULL) {
+      errno = EINVAL;
+      return -1;
     }
 
-    for (;;)
-    {
-        int i;
+    if (*lineptr == NULL || *n == 0) {
+      *n = 120;
+      *lineptr = (char*)malloc(*n);
+      if (*lineptr == NULL) {
+        result = -1;
+        goto end;
+      }
+    }
 
-        i = getc (fp);
-        if (i == EOF)
-        {
-            result = -1;
-            break;
+    for (;;) {
+      int i;
+
+      i = getc(fp);
+      if (i == EOF) {
+        result = -1;
+        break;
+      }
+
+      /* Make enough space for len+1 (for final NUL) bytes.  */
+      if (cur_len + 1 >= *n) {
+        size_t needed_max = SSIZE_MAX < SIZE_MAX ? (size_t)SSIZE_MAX + 1 : SIZE_MAX;
+        size_t needed = 2 * *n + 1; /* Be generous. */
+        char* new_lineptr;
+
+        if (needed_max < needed)
+          needed = needed_max;
+        if (cur_len + 1 >= needed) {
+          result = -1;
+          goto end;
         }
 
-        /* Make enough space for len+1 (for final NUL) bytes.  */
-        if (cur_len + 1 >= *n)
-        {
-            size_t needed_max =
-                SSIZE_MAX < SIZE_MAX ? (size_t) SSIZE_MAX + 1 : SIZE_MAX;
-            size_t needed = 2 * *n + 1;   /* Be generous. */
-            char *new_lineptr;
-
-            if (needed_max < needed)
-                needed = needed_max;
-            if (cur_len + 1 >= needed)
-            {
-                result = -1;
-                goto end;
-            }
-
-            new_lineptr = (char *) realloc (*lineptr, needed);
-            if (new_lineptr == NULL)
-            {
-                result = -1;
-                goto end;
-            }
-
-            *lineptr = new_lineptr;
-            *n = needed;
+        new_lineptr = (char*)realloc(*lineptr, needed);
+        if (new_lineptr == NULL) {
+          result = -1;
+          goto end;
         }
 
-        (*lineptr)[cur_len] = i;
-        cur_len++;
+        *lineptr = new_lineptr;
+        *n = needed;
+      }
 
-        if (i == '\n')
-            break;
+      (*lineptr)[cur_len] = i;
+      cur_len++;
+
+      if (i == '\n')
+        break;
     }
     (*lineptr)[cur_len] = '\0';
-    result = cur_len ? (ssize_t) cur_len : result;
+    result = cur_len ? (ssize_t)cur_len : result;
 
-end:
+  end:
     return result;
-}
-}
+  }
+}  // namespace
 #endif
 
-static std::string now(){
+static std::string now() {
   struct timeval t;
   gettimeofday(&t, nullptr);
- 
+
   char buf[256];
   strftime(buf, sizeof(buf), "%F %R %S s", localtime(&t.tv_sec));
-  buf[sizeof(buf)-1] = 0;
+  buf[sizeof(buf) - 1] = 0;
 
   stringstream buf2;
-  buf2 << buf << " " << ((t.tv_usec+500)/1000)  << " ms";
+  buf2 << buf << " " << ((t.tv_usec + 500) / 1000) << " ms";
 
   return buf2.str();
 }
 
-WatcherStreamFileReader::WatcherStreamFileReader(edm::ParameterSet const& pset):
-  inputDir_(pset.getParameter<std::string>("inputDir")),
-  filePatterns_(pset.getParameter<std::vector<std::string> >("filePatterns")),
-  inprocessDir_(pset.getParameter<std::string>("inprocessDir")),
-  processedDir_(pset.getParameter<std::string>("processedDir")),
-  corruptedDir_(pset.getParameter<std::string>("corruptedDir")),
-  tokenFile_(pset.getUntrackedParameter<std::string>("tokenFile",
-						     "watcherSourceToken")),
-  timeOut_(pset.getParameter<int>("timeOutInSec")),
-  end_(false),
-  verbosity_(pset.getUntrackedParameter<int>("verbosity", 0)){
+WatcherStreamFileReader::WatcherStreamFileReader(edm::ParameterSet const& pset)
+    : inputDir_(pset.getParameter<std::string>("inputDir")),
+      filePatterns_(pset.getParameter<std::vector<std::string> >("filePatterns")),
+      inprocessDir_(pset.getParameter<std::string>("inprocessDir")),
+      processedDir_(pset.getParameter<std::string>("processedDir")),
+      corruptedDir_(pset.getParameter<std::string>("corruptedDir")),
+      tokenFile_(pset.getUntrackedParameter<std::string>("tokenFile", "watcherSourceToken")),
+      timeOut_(pset.getParameter<int>("timeOutInSec")),
+      end_(false),
+      verbosity_(pset.getUntrackedParameter<int>("verbosity", 0)) {
   struct stat buf;
-  if(stat(tokenFile_.c_str(), &buf)){
+  if (stat(tokenFile_.c_str(), &buf)) {
     FILE* f = fopen(tokenFile_.c_str(), "w");
-    if(f){
+    if (f) {
       fclose(f);
-    } else{
+    } else {
       throw cms::Exception("WatcherSource") << "Failed to create token file.";
     }
   }
@@ -145,282 +133,277 @@ WatcherStreamFileReader::WatcherStreamFileReader(edm::ParameterSet const& pset):
   dirs.push_back(inprocessDir_);
   dirs.push_back(processedDir_);
   dirs.push_back(corruptedDir_);
-  
-  for(unsigned i = 0; i < dirs.size(); ++i){
+
+  for (unsigned i = 0; i < dirs.size(); ++i) {
     const string& dir = dirs[i];
     struct stat fileStat;
-    if(0==stat(dir.c_str(), &fileStat)){
-      if(!S_ISDIR(fileStat.st_mode)){
-	throw cms::Exception("[WatcherSource]")
-	  << "File " << dir << " exists but is not a directory "
-	  << " as expected.";
+    if (0 == stat(dir.c_str(), &fileStat)) {
+      if (!S_ISDIR(fileStat.st_mode)) {
+        throw cms::Exception("[WatcherSource]") << "File " << dir << " exists but is not a directory "
+                                                << " as expected.";
       }
-    } else {//directory does not exists, let's try to create it
-      if(0!=mkdir(dir.c_str(), 0755)){
-	throw cms::Exception("[WatcherSource]")
-	  << "Failed to create directory " << dir
-	  << " for writing data.";
+    } else {  //directory does not exists, let's try to create it
+      if (0 != mkdir(dir.c_str(), 0755)) {
+        throw cms::Exception("[WatcherSource]") << "Failed to create directory " << dir << " for writing data.";
       }
     }
   }
 
-    std::stringstream fileListCmdBuf;
-    fileListCmdBuf.str("");
-    //    fileListCmdBuf << "/bin/ls -rt " << inputDir_ << " | egrep '(";
-    //by default ls will sort the file alphabetically which will results
-    //in ordering the files in increasing LB number, which is the desired
-    //order.
-    //    fileListCmdBuf << "/bin/ls " << inputDir_ << " | egrep '(";
-    fileListCmdBuf << "/bin/find " << inputDir_ << " -maxdepth 2 -print | egrep '(";
-    //TODO: validate patternDir (see ;, &&, ||) and escape special character
-    if(filePatterns_.empty()) throw cms::Exception("WacherSource", "filePatterns parameter is empty");
-    char curDir[PATH_MAX>0?PATH_MAX:4096];
-    if(getcwd(curDir, sizeof(curDir))==nullptr){
-      throw cms::Exception("WatcherSource")
-	<< "Failed to retreived working directory path: "
-	<< strerror(errno);
-    }
-    curDir_ = curDir;
-    
-    for(unsigned i = 0 ; i < filePatterns_.size(); ++i){
-      if(i>0) fileListCmdBuf << "|";
-      //     if(filePatterns_[i].size()>0 && filePatterns_[0] != "/"){//relative path
-      //       fileListCmdBuf << curDir << "/";
-      //     }
-      fileListCmdBuf << filePatterns_[i];
-    }
-    fileListCmdBuf << ")' | sort";
+  std::stringstream fileListCmdBuf;
+  fileListCmdBuf.str("");
+  //    fileListCmdBuf << "/bin/ls -rt " << inputDir_ << " | egrep '(";
+  //by default ls will sort the file alphabetically which will results
+  //in ordering the files in increasing LB number, which is the desired
+  //order.
+  //    fileListCmdBuf << "/bin/ls " << inputDir_ << " | egrep '(";
+  fileListCmdBuf << "/bin/find " << inputDir_ << " -maxdepth 2 -print | egrep '(";
+  //TODO: validate patternDir (see ;, &&, ||) and escape special character
+  if (filePatterns_.empty())
+    throw cms::Exception("WacherSource", "filePatterns parameter is empty");
+  char curDir[PATH_MAX > 0 ? PATH_MAX : 4096];
+  if (getcwd(curDir, sizeof(curDir)) == nullptr) {
+    throw cms::Exception("WatcherSource") << "Failed to retreived working directory path: " << strerror(errno);
+  }
+  curDir_ = curDir;
 
-    fileListCmd_ = fileListCmdBuf.str();
-    
-    cout << "[WatcherSource " << now() << "]" 
-	 << " Command to retrieve input files: "
-	 << fileListCmd_ << "\n";
+  for (unsigned i = 0; i < filePatterns_.size(); ++i) {
+    if (i > 0)
+      fileListCmdBuf << "|";
+    //     if(filePatterns_[i].size()>0 && filePatterns_[0] != "/"){//relative path
+    //       fileListCmdBuf << curDir << "/";
+    //     }
+    fileListCmdBuf << filePatterns_[i];
+  }
+  fileListCmdBuf << ")' | sort";
 
+  fileListCmd_ = fileListCmdBuf.str();
+
+  cout << "[WatcherSource " << now() << "]"
+       << " Command to retrieve input files: " << fileListCmd_ << "\n";
 }
 
-WatcherStreamFileReader::~WatcherStreamFileReader(){
-}
+WatcherStreamFileReader::~WatcherStreamFileReader() {}
 
 const bool WatcherStreamFileReader::newHeader() {
   edm::StreamerInputFile* inputFile = getInputFile();
-  return inputFile?inputFile->newHeader():false;
+  return inputFile ? inputFile->newHeader() : false;
 }
 
-const InitMsgView* WatcherStreamFileReader::getHeader(){
-
+const InitMsgView* WatcherStreamFileReader::getHeader() {
   edm::StreamerInputFile* inputFile = getInputFile();
 
   //TODO: shall better send an exception...
-  if(inputFile==nullptr){
+  if (inputFile == nullptr) {
     throw cms::Exception("WatcherSource") << "No input file found.";
   }
-  
+
   const InitMsgView* header = inputFile->startMessage();
-  
-  if(header->code() != Header::INIT) //INIT Msg
-    throw cms::Exception("readHeader","WatcherStreamFileReader")
-      << "received wrong message type: expected INIT, got "
-      << header->code() << "\n";
-    
+
+  if (header->code() != Header::INIT)  //INIT Msg
+    throw cms::Exception("readHeader", "WatcherStreamFileReader")
+        << "received wrong message type: expected INIT, got " << header->code() << "\n";
+
   return header;
 }
-  
-const EventMsgView* WatcherStreamFileReader::getNextEvent(){
-  if(end_){ closeFile(); return nullptr;}
-  
+
+const EventMsgView* WatcherStreamFileReader::getNextEvent() {
+  if (end_) {
+    closeFile();
+    return nullptr;
+  }
+
   edm::StreamerInputFile* inputFile;
 
   //go to next input file, till no new event is found
-  while((inputFile=getInputFile())!=nullptr
-	&& inputFile->next()==0){
+  while ((inputFile = getInputFile()) != nullptr && inputFile->next() == 0) {
     closeFile();
   }
 
-  return inputFile==nullptr?nullptr:inputFile->currentRecord();
+  return inputFile == nullptr ? nullptr : inputFile->currentRecord();
 }
 
-edm::StreamerInputFile* WatcherStreamFileReader::getInputFile(){
+edm::StreamerInputFile* WatcherStreamFileReader::getInputFile() {
   char* lineptr = nullptr;
   size_t n = 0;
 
   struct stat buf;
-  
-  if(stat(tokenFile_.c_str(), &buf)!=0){ 
-    end_ = true; 
+
+  if (stat(tokenFile_.c_str(), &buf) != 0) {
+    end_ = true;
   }
-  
+
   bool waiting = false;
   static bool firstWait = true;
   timeval waitStart;
   //if no cached input file, look for new files until one is found:
-  if(!end_ && streamerInputFile_.get()==nullptr){
+  if (!end_ && streamerInputFile_.get() == nullptr) {
     fileName_.assign("");
-    
+
     //check if we have file in the queue, if not look for new files:
-    while(filesInQueue_.empty()){
-      if(stat(tokenFile_.c_str(), &buf)!=0){ 
-	end_ = true; 
-	break;
+    while (filesInQueue_.empty()) {
+      if (stat(tokenFile_.c_str(), &buf) != 0) {
+        end_ = true;
+        break;
       }
       FILE* s = popen(fileListCmd_.c_str(), "r");
-      if(s==nullptr){
-	throw cms::Exception("WatcherSource")
-	  << "Failed to retrieve list of input file: " << strerror(errno);
+      if (s == nullptr) {
+        throw cms::Exception("WatcherSource") << "Failed to retrieve list of input file: " << strerror(errno);
       }
-      
+
       ssize_t len;
-      while(!feof(s)){
-	if((len=getline(&lineptr, &n, s))>0){
-	  //remove end-of-line character:
-	  lineptr[len-1] = 0;
-	  string fileName;
-	  if(lineptr[0] != '/'){
-	    if(!inputDir_.empty() && inputDir_[0] != '/'){//relative path
-	      fileName.assign(curDir_);
-	      fileName.append("/");
-	      fileName.append(inputDir_);
-	    } else{
-	      fileName.assign(inputDir_);
-	    }
-	    fileName.append("/");
-	  }
-	  fileName.append(lineptr);
-	  filesInQueue_.push_back(fileName);
-	  if(verbosity_) cout << "[WatcherSource " << now() << "]" 
-			      << " File to process: '"
-			      << fileName << "'\n";
-	}
+      while (!feof(s)) {
+        if ((len = getline(&lineptr, &n, s)) > 0) {
+          //remove end-of-line character:
+          lineptr[len - 1] = 0;
+          string fileName;
+          if (lineptr[0] != '/') {
+            if (!inputDir_.empty() && inputDir_[0] != '/') {  //relative path
+              fileName.assign(curDir_);
+              fileName.append("/");
+              fileName.append(inputDir_);
+            } else {
+              fileName.assign(inputDir_);
+            }
+            fileName.append("/");
+          }
+          fileName.append(lineptr);
+          filesInQueue_.push_back(fileName);
+          if (verbosity_)
+            cout << "[WatcherSource " << now() << "]"
+                 << " File to process: '" << fileName << "'\n";
+        }
       }
-      while(!feof(s)) fgetc(s);
+      while (!feof(s))
+        fgetc(s);
       pclose(s);
-      if(filesInQueue_.empty()){
-	if(!waiting){
-	  cout << "[WatcherSource " << now() << "]" 
-	       << " No file found. Waiting for new file...\n";
-	  cout << flush;
-	  waiting = true;
-	  gettimeofday(&waitStart, nullptr);
-	} else if(!firstWait){
-	  timeval t;
-	  gettimeofday(&t, nullptr);
-	  float dt = (t.tv_sec-waitStart.tv_sec) * 1.
-	    + (t.tv_usec-waitStart.tv_usec) * 1.e-6;
-	  if((timeOut_ >= 0) && (dt > timeOut_)){
-	    cout << "[WatcherSource " << now() << "]"
-		 << " Having waited for new file for " << (int)dt << " sec. "
-		 << "Timeout exceeded. Exits.\n";
-	    //remove(tokenFile_.c_str()); //we do not delete the token, otherwise sorting process on the monitoring farm will not be restarted by the runloop.sh script.
-	    end_ = true;
-	    break;
-	  }
-	}
+      if (filesInQueue_.empty()) {
+        if (!waiting) {
+          cout << "[WatcherSource " << now() << "]"
+               << " No file found. Waiting for new file...\n";
+          cout << flush;
+          waiting = true;
+          gettimeofday(&waitStart, nullptr);
+        } else if (!firstWait) {
+          timeval t;
+          gettimeofday(&t, nullptr);
+          float dt = (t.tv_sec - waitStart.tv_sec) * 1. + (t.tv_usec - waitStart.tv_usec) * 1.e-6;
+          if ((timeOut_ >= 0) && (dt > timeOut_)) {
+            cout << "[WatcherSource " << now() << "]"
+                 << " Having waited for new file for " << (int)dt << " sec. "
+                 << "Timeout exceeded. Exits.\n";
+            //remove(tokenFile_.c_str()); //we do not delete the token, otherwise sorting process on the monitoring farm will not be restarted by the runloop.sh script.
+            end_ = true;
+            break;
+          }
+        }
       }
       sleep(1);
-    } //end of file queue update
+    }  //end of file queue update
     firstWait = false;
-    free(lineptr); lineptr=nullptr;
-    
-    while(streamerInputFile_.get()==nullptr && !filesInQueue_.empty()){
+    free(lineptr);
+    lineptr = nullptr;
 
+    while (streamerInputFile_.get() == nullptr && !filesInQueue_.empty()) {
       fileName_ = filesInQueue_.front();
       filesInQueue_.pop_front();
       int fd = open(fileName_.c_str(), 0);
-      if(fd!=0){
-	struct stat buf;
-	off_t size = -1;
-	//check that file transfer is finished, by monitoring its size:
-	time_t t = time(nullptr);
-	for(;;){
-	  fstat(fd, &buf);
-	  if(verbosity_) cout << "file size: " << buf.st_size << ", prev size: "  << size << "\n";
-	  if(buf.st_size==size) break; else size = buf.st_size;
-	  if(difftime(t,buf.st_mtime)>60) break; //file older then 1 min=> tansfer must be finished
-	  sleep(1);
-	}
+      if (fd != 0) {
+        struct stat buf;
+        off_t size = -1;
+        //check that file transfer is finished, by monitoring its size:
+        time_t t = time(nullptr);
+        for (;;) {
+          fstat(fd, &buf);
+          if (verbosity_)
+            cout << "file size: " << buf.st_size << ", prev size: " << size << "\n";
+          if (buf.st_size == size)
+            break;
+          else
+            size = buf.st_size;
+          if (difftime(t, buf.st_mtime) > 60)
+            break;  //file older then 1 min=> tansfer must be finished
+          sleep(1);
+        }
 
-	if(fd!=0 && buf.st_size == 0){//file is empty. streamer reader 
-	  //                   does not like empty file=> skip it
-	  stringstream c;
-	  c << "/bin/mv -f \"" << fileName_ << "\" \"" << corruptedDir_
-	    << "/.\"";
-	  if(verbosity_) cout << "[WatcherSource " << now() << "]" 
-			      << " Excuting "
-			      << c.str() << "\n"; 
-	  int i = system(c.str().c_str());
-	  if(i!=0){
-	    //throw cms::Exception("WatcherSource")
-	    cout << "[WatcherSource " << now() << "] "
-		 << "Failed to move empty file '" << fileName_ << "'"
-		 << " to corrupted directory '" << corruptedDir_ << "'\n";
-	  }
-	  continue;
-	}
-	
-	close(fd);
+        if (fd != 0 && buf.st_size == 0) {  //file is empty. streamer reader
+          //                   does not like empty file=> skip it
+          stringstream c;
+          c << "/bin/mv -f \"" << fileName_ << "\" \"" << corruptedDir_ << "/.\"";
+          if (verbosity_)
+            cout << "[WatcherSource " << now() << "]"
+                 << " Excuting " << c.str() << "\n";
+          int i = system(c.str().c_str());
+          if (i != 0) {
+            //throw cms::Exception("WatcherSource")
+            cout << "[WatcherSource " << now() << "] "
+                 << "Failed to move empty file '" << fileName_ << "'"
+                 << " to corrupted directory '" << corruptedDir_ << "'\n";
+          }
+          continue;
+        }
 
-	vector<char> buf1(fileName_.size()+1);
-	copy(fileName_.begin(), fileName_.end(), buf1.begin());
-	buf1[buf1.size()-1] = 0;
-	
-	vector<char> buf2(fileName_.size()+1);
-	copy(fileName_.begin(), fileName_.end(), buf2.begin());
-	buf2[buf1.size()-1] = 0;
-	
-	string dirnam(dirname(&buf1[0]));
-	string filenam(basename(&buf2[0]));
-	
-	string dest  = inprocessDir_ + "/" + filenam;
-	
-	if(verbosity_) cout << "[WatcherSource " << now() << "]" 
-			    << " Moving file "
-			    << fileName_ << " to " << dest << "\n";
-	
-	stringstream c;
-	c << "/bin/mv -f \"" << fileName_ << "\" \"" << dest
-	  << "/.\"";
-	
+        close(fd);
 
-	if(0!=rename(fileName_.c_str(), dest.c_str())){
-	  //if(0!=system(c.str().c_str())){
-	  throw cms::Exception("WatcherSource")
-	    << "Failed to move file '" << fileName_ << "' "
-	    << "to processing directory " << inprocessDir_
-	    << ": " << strerror(errno);
-	}
-	
-	fileName_ = dest;
+        vector<char> buf1(fileName_.size() + 1);
+        copy(fileName_.begin(), fileName_.end(), buf1.begin());
+        buf1[buf1.size() - 1] = 0;
 
-	cout << "[WatcherSource " << now() << "]" 
-	     << " Opening file " << fileName_ << "\n" << flush;
-	streamerInputFile_
-	  = unique_ptr<edm::StreamerInputFile>(new edm::StreamerInputFile(fileName_));
+        vector<char> buf2(fileName_.size() + 1);
+        copy(fileName_.begin(), fileName_.end(), buf2.begin());
+        buf2[buf1.size() - 1] = 0;
 
-	ofstream f(".watcherfile");
-	f << fileName_;	
-      } else{
-	cout << "[WatcherSource " << now() << "]" 
-	     << " Failed to open file " << fileName_ << endl;
+        string dirnam(dirname(&buf1[0]));
+        string filenam(basename(&buf2[0]));
+
+        string dest = inprocessDir_ + "/" + filenam;
+
+        if (verbosity_)
+          cout << "[WatcherSource " << now() << "]"
+               << " Moving file " << fileName_ << " to " << dest << "\n";
+
+        stringstream c;
+        c << "/bin/mv -f \"" << fileName_ << "\" \"" << dest << "/.\"";
+
+        if (0 != rename(fileName_.c_str(), dest.c_str())) {
+          //if(0!=system(c.str().c_str())){
+          throw cms::Exception("WatcherSource")
+              << "Failed to move file '" << fileName_ << "' "
+              << "to processing directory " << inprocessDir_ << ": " << strerror(errno);
+        }
+
+        fileName_ = dest;
+
+        cout << "[WatcherSource " << now() << "]"
+             << " Opening file " << fileName_ << "\n"
+             << flush;
+        streamerInputFile_ = unique_ptr<edm::StreamerInputFile>(new edm::StreamerInputFile(fileName_));
+
+        ofstream f(".watcherfile");
+        f << fileName_;
+      } else {
+        cout << "[WatcherSource " << now() << "]"
+             << " Failed to open file " << fileName_ << endl;
       }
-    } //loop on file queue to find one file which opening succeeded
+    }  //loop on file queue to find one file which opening succeeded
   }
   return streamerInputFile_.get();
 }
 
-void WatcherStreamFileReader::closeFile(){
-  if(streamerInputFile_.get()==nullptr) return;
+void WatcherStreamFileReader::closeFile() {
+  if (streamerInputFile_.get() == nullptr)
+    return;
   //delete the streamer input file:
   streamerInputFile_.reset();
   stringstream cmd;
   //TODO: validation of processDir
   cmd << "/bin/mv -f \"" << fileName_ << "\" \"" << processedDir_ << "/.\"";
-  if(verbosity_) cout << "[WatcherSource " << now() << "]" 
-		      << " Excuting " << cmd.str() << "\n"; 
+  if (verbosity_)
+    cout << "[WatcherSource " << now() << "]"
+         << " Excuting " << cmd.str() << "\n";
   int i = system(cmd.str().c_str());
-  if(i!=0){
-    throw cms::Exception("WatcherSource")
-      << "Failed to move processed file '" << fileName_ << "'"
-      << " to processed directory '" << processedDir_ << "'\n";
+  if (i != 0) {
+    throw cms::Exception("WatcherSource") << "Failed to move processed file '" << fileName_ << "'"
+                                          << " to processed directory '" << processedDir_ << "'\n";
     //Stop further processing to prevent endless loop:
     end_ = true;
   }

--- a/CalibCalorimetry/EcalSRTools/interface/EcalDccWeightBuilder.h
+++ b/CalibCalorimetry/EcalSRTools/interface/EcalDccWeightBuilder.h
@@ -4,7 +4,6 @@
 #ifndef ECALDCCWEIGHTBUILDER_CC
 #define ECALDCCWEIGHTBUILDER_CC
 
-
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EBShape.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EEShape.h"
@@ -24,24 +23,23 @@ class EcalElectronicsMapping;
 
 /**
  */
-class EcalDccWeightBuilder: public edm::EDAnalyzer {
+class EcalDccWeightBuilder : public edm::EDAnalyzer {
 private:
-  enum mode_t { WEIGHTS_FROM_CONFIG, COMPUTE_WEIGHTS};
-  
+  enum mode_t { WEIGHTS_FROM_CONFIG, COMPUTE_WEIGHTS };
+
   //constructor(s) and destructor(s)
 public:
   /** Constructs an EcalDccWeightBuilder
    * @param ps CMSSW mondule configuration
    */
   EcalDccWeightBuilder(edm::ParameterSet const& ps);
-  
+
   /**Destructor
    */
   ~EcalDccWeightBuilder() override{};
 
   //method(s)
 public:
-
   /** Analyze method called by the event loop.
    * @param event CMSSW event
    * @param es event setup
@@ -49,7 +47,6 @@ public:
   void analyze(const edm::Event& event, const edm::EventSetup& es) override;
 
 private:
-
   /** Weight computation
    * @param shape signal shape to use for weight computation
    * @param binOfMax time bin which shall contain the pulse peak
@@ -63,34 +60,34 @@ private:
    * @param result [out] vector filled with computed weights. The vector is
    * resized to the number of weights
    */
-  void
-  computeWeights(const EcalShapeBase& shape,
-		 int binOfMax, double timePhase, 
-		 int iFirst0, int nWeights, int iSkip0,
-                 std::vector<double>& result);
+  void computeWeights(const EcalShapeBase& shape,
+                      int binOfMax,
+                      double timePhase,
+                      int iFirst0,
+                      int nWeights,
+                      int iSkip0,
+                      std::vector<double>& result);
 
   void computeAllWeights(bool withIntercalib, const edm::EventSetup& es);
-  
+
   int encodeWeight(double w);
 
   double decodeWeight(int W);
 
-  void unbiasWeights(std::vector<double>& weights,
-                     std::vector<int32_t>* encodedWeigths);
+  void unbiasWeights(std::vector<double>& weights, std::vector<int32_t>* encodedWeigths);
 
   /** Retrieve intercalibration coefficent for channel detId.
    * @param detId ID of the channel the intercalibration coef. must be
    * retrieved for.
    */
   double intercalib(const DetId& detId);
-  
+
   void writeWeightToAsciiFile();
-  void writeWeightToRootFile();   
+  void writeWeightToRootFile();
   void writeWeightToDB();
 
   //converts DetId to IDs used by DB:
-  void dbId(const DetId& detId, int& fedId, int& smId, int& ruId,
-           int& xtalId) const;
+  void dbId(const DetId& detId, int& fedId, int& smId, int& ruId, int& xtalId) const;
 
   /** Vector index sorting.
    * @param vector of values
@@ -98,12 +95,9 @@ private:
    * @param decreasingOrder switch to use decreasing order instead of
    * default increasing order
    */
-  template<class T>
-  void sort(const std::vector<T>& a,
-	    std::vector<int>& s,
-	    bool decreasingOrder = false);
+  template <class T>
+  void sort(const std::vector<T>& a, std::vector<int>& s, bool decreasingOrder = false);
 
-  
   //attribute(s)
 protected:
 private:
@@ -127,9 +121,9 @@ private:
   std::string dbTag_;
   int dbVersion_;
   bool sqlMode_;
-  
+
   edm::ESHandle<CaloGeometry> geom_;
-  
+
   EcalIntercalibConstantMap& calibMap_;
   EcalIntercalibConstantMap emptyCalibMap_;
   std::map<DetId, std::vector<int> > encodedWeights_;
@@ -139,7 +133,7 @@ private:
 
   static const int ecalDccFedIdMin = 601;
   static const int ecalDccFedIdMax = 654;
-  static const int nDccs = ecalDccFedIdMax-ecalDccFedIdMin+1;
+  static const int nDccs = ecalDccFedIdMax - ecalDccFedIdMin + 1;
 };
 
-#endif //ECALDCCWEIGHTBUILDER_CC not defined
+#endif  //ECALDCCWEIGHTBUILDER_CC not defined

--- a/CalibCalorimetry/EcalSRTools/src/EcalDccWeightBuilder.cc
+++ b/CalibCalorimetry/EcalSRTools/src/EcalDccWeightBuilder.cc
@@ -28,9 +28,9 @@
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 
 #ifdef DB_WRITE_SUPPORT
-#  include "OnlineDB/EcalCondDB/interface/EcalCondDBInterface.h"
-#  include "OnlineDB/EcalCondDB/interface/ODWeightsDat.h"
-#endif //DB_WRITE_SUPPORT defined
+#include "OnlineDB/EcalCondDB/interface/EcalCondDBInterface.h"
+#include "OnlineDB/EcalCondDB/interface/ODWeightsDat.h"
+#endif  //DB_WRITE_SUPPORT defined
 
 #include "CalibCalorimetry/EcalSRTools/src/PasswordReader.h"
 
@@ -39,59 +39,51 @@ using namespace edm;
 
 const double EcalDccWeightBuilder::weightScale_ = 1024.;
 
-
 //TODO: handling case of weight encoding saturation: weights shall be downscaled to prevent saturation
 
-EcalDccWeightBuilder::EcalDccWeightBuilder(edm::ParameterSet const& ps):
-  dcc1stSample_(ps.getParameter<int>("dcc1stSample")),
-  sampleToSkip_(ps.getParameter<int>("sampleToSkip")),
-  nDccWeights_(ps.getParameter<int>("nDccWeights")),
-  inputWeights_(ps.getParameter<vector<double> >("inputWeights")),
-  mode_(ps.getParameter<string>("mode")),
-  dccWeightsWithIntercalib_(ps.getParameter<bool>("dccWeightsWithIntercalib")),
-  writeToDB_(ps.getParameter<bool>("writeToDB")),
-  writeToAsciiFile_(ps.getParameter<bool>("writeToAsciiFile")),
-  writeToRootFile_(ps.getParameter<bool>("writeToRootFile")),
-  asciiOutputFileName_(ps.getParameter<string>("asciiOutputFileName")),
-  rootOutputFileName_(ps.getParameter<string>("rootOutputFileName")),
-  dbSid_(ps.getParameter<string>("dbSid")),
-  dbUser_(ps.getParameter<string>("dbUser")),
-  dbPassword_(ps.getUntrackedParameter<string>("dbPassword","")),
-  dbTag_(ps.getParameter<string>("dbTag")),
-  dbVersion_(ps.getParameter<int>("dbVersion")),
-  sqlMode_(ps.getParameter<bool>("sqlMode")),
-  calibMap_(emptyCalibMap_)
-{
-  if(mode_=="weightsFromConfig"){
+EcalDccWeightBuilder::EcalDccWeightBuilder(edm::ParameterSet const& ps)
+    : dcc1stSample_(ps.getParameter<int>("dcc1stSample")),
+      sampleToSkip_(ps.getParameter<int>("sampleToSkip")),
+      nDccWeights_(ps.getParameter<int>("nDccWeights")),
+      inputWeights_(ps.getParameter<vector<double> >("inputWeights")),
+      mode_(ps.getParameter<string>("mode")),
+      dccWeightsWithIntercalib_(ps.getParameter<bool>("dccWeightsWithIntercalib")),
+      writeToDB_(ps.getParameter<bool>("writeToDB")),
+      writeToAsciiFile_(ps.getParameter<bool>("writeToAsciiFile")),
+      writeToRootFile_(ps.getParameter<bool>("writeToRootFile")),
+      asciiOutputFileName_(ps.getParameter<string>("asciiOutputFileName")),
+      rootOutputFileName_(ps.getParameter<string>("rootOutputFileName")),
+      dbSid_(ps.getParameter<string>("dbSid")),
+      dbUser_(ps.getParameter<string>("dbUser")),
+      dbPassword_(ps.getUntrackedParameter<string>("dbPassword", "")),
+      dbTag_(ps.getParameter<string>("dbTag")),
+      dbVersion_(ps.getParameter<int>("dbVersion")),
+      sqlMode_(ps.getParameter<bool>("sqlMode")),
+      calibMap_(emptyCalibMap_) {
+  if (mode_ == "weightsFromConfig") {
     imode_ = WEIGHTS_FROM_CONFIG;
-    if(inputWeights_.size()!=(unsigned)nDccWeights_){
-      throw cms::Exception("Config")
-        << "Inconsistent configuration. 'nDccWeights' parameters indicated "
-        << nDccWeights_ << " weights while parameter 'inputWeights_' contains "
-        << inputWeights_.size() << " weight values!\n";
+    if (inputWeights_.size() != (unsigned)nDccWeights_) {
+      throw cms::Exception("Config") << "Inconsistent configuration. 'nDccWeights' parameters indicated "
+                                     << nDccWeights_ << " weights while parameter 'inputWeights_' contains "
+                                     << inputWeights_.size() << " weight values!\n";
     }
-  } else if(mode_=="computeWeights"){
+  } else if (mode_ == "computeWeights") {
     imode_ = COMPUTE_WEIGHTS;
-  } else{
-    throw cms::Exception("Config")
-      << "Invalid value ('" << mode_ << "') for parameter mode. "
-      << "Valid values are: 'weightsFromConfig' and 'computeWeights'\n";
+  } else {
+    throw cms::Exception("Config") << "Invalid value ('" << mode_ << "') for parameter mode. "
+                                   << "Valid values are: 'weightsFromConfig' and 'computeWeights'\n";
   }
 }
 
-
-void
-EcalDccWeightBuilder::analyze(const edm::Event& event,
-                              const edm::EventSetup& es){
-
+void EcalDccWeightBuilder::analyze(const edm::Event& event, const edm::EventSetup& es) {
   edm::ESHandle<EcalElectronicsMapping> handle;
   es.get<EcalMappingRcd>().get(handle);
   ecalElectronicsMap_ = handle.product();
-  
+
   // Retrieval of intercalib constants
-  if(dccWeightsWithIntercalib_){
-    ESHandle<EcalIntercalibConstants> hIntercalib ;
-    es.get<EcalIntercalibConstantsRcd>().get(hIntercalib) ;
+  if (dccWeightsWithIntercalib_) {
+    ESHandle<EcalIntercalibConstants> hIntercalib;
+    es.get<EcalIntercalibConstantsRcd>().get(hIntercalib);
     const EcalIntercalibConstants* intercalib = hIntercalib.product();
     calibMap_ = intercalib->getMap();
   }
@@ -99,55 +91,51 @@ EcalDccWeightBuilder::analyze(const edm::Event& event,
   //gets geometry
   es.get<CaloGeometryRecord>().get(geom_);
 
-  
   //computes the weights:
   computeAllWeights(dccWeightsWithIntercalib_, es);
 
   //Writing out weights.
-  if(writeToAsciiFile_) writeWeightToAsciiFile();
-  if(writeToRootFile_)  writeWeightToRootFile();
-  if(writeToDB_)        writeWeightToDB();
+  if (writeToAsciiFile_)
+    writeWeightToAsciiFile();
+  if (writeToRootFile_)
+    writeWeightToRootFile();
+  if (writeToDB_)
+    writeWeightToDB();
 }
 
-void EcalDccWeightBuilder::computeAllWeights(bool withIntercalib, const edm::EventSetup& es){
+void EcalDccWeightBuilder::computeAllWeights(bool withIntercalib, const edm::EventSetup& es) {
   const int nw = nDccWeights_;
-  int iSkip0_ = sampleToSkip_>=0?(sampleToSkip_-dcc1stSample_):-1;
+  int iSkip0_ = sampleToSkip_ >= 0 ? (sampleToSkip_ - dcc1stSample_) : -1;
 
   EcalSimParameterMap parameterMap;
-  const vector<DetId>& ebDetIds
-    = geom_->getValidDetIds(DetId::Ecal, EcalBarrel);
+  const vector<DetId>& ebDetIds = geom_->getValidDetIds(DetId::Ecal, EcalBarrel);
 
   //   cout << __FILE__ << ":" << __LINE__ << ": "
   //        <<  "Number of EB det IDs: " << ebDetIds.size() << "\n";
-  
-  const vector<DetId>& eeDetIds
-    = geom_->getValidDetIds(DetId::Ecal, EcalEndcap);
+
+  const vector<DetId>& eeDetIds = geom_->getValidDetIds(DetId::Ecal, EcalEndcap);
 
   //  cout << __FILE__ << ":" << __LINE__ << ": "
   //        <<  "Number of EE det IDs: " << eeDetIds.size() << "\n";
-  
-  
-  vector<DetId> detIds(ebDetIds.size()+eeDetIds.size());
+
+  vector<DetId> detIds(ebDetIds.size() + eeDetIds.size());
   copy(ebDetIds.begin(), ebDetIds.end(), detIds.begin());
-  copy(eeDetIds.begin(), eeDetIds.end(), detIds.begin()+ebDetIds.size());
-  
-  vector<double> baseWeights(nw); //weight obtained from signal shape
-  vector<double> w(nw); //weight*intercalib
-  vector<int> W(nw);    //weight in hw encoding (integrer)
+  copy(eeDetIds.begin(), eeDetIds.end(), detIds.begin() + ebDetIds.size());
+
+  vector<double> baseWeights(nw);  //weight obtained from signal shape
+  vector<double> w(nw);            //weight*intercalib
+  vector<int> W(nw);               //weight in hw encoding (integrer)
   double prevPhase = numeric_limits<double>::min();
 
-
-  if(imode_==WEIGHTS_FROM_CONFIG){
-    assert(inputWeights_.size()==baseWeights.size());
+  if (imode_ == WEIGHTS_FROM_CONFIG) {
+    assert(inputWeights_.size() == baseWeights.size());
     copy(inputWeights_.begin(), inputWeights_.end(), baseWeights.begin());
   }
-  
-  for(vector<DetId>::const_iterator it = detIds.begin();
-      it != detIds.end(); ++it){
-    
+
+  for (vector<DetId>::const_iterator it = detIds.begin(); it != detIds.end(); ++it) {
     double phase = parameterMap.simParameters(*it).timePhase();
     int binOfMax = parameterMap.simParameters(*it).binOfMaximum();
-    
+
 #if 0
     //for debugging...
     cout << __FILE__ << ":" << __LINE__ << ": ";
@@ -167,132 +155,123 @@ void EcalDccWeightBuilder::computeAllWeights(bool withIntercalib, const edm::Eve
     cout << " -> phase: "  << phase << "\n";
     cout << " -> binOfMax: " << binOfMax << "\n";
 #endif
-    
-    try{
-      bool useDBShape = true;
-      EBShape ebShape(useDBShape);  
-      EEShape eeShape(useDBShape); 
-      EcalShapeBase* pShape;      
 
-      if(it->subdetId()==EcalBarrel){
-	pShape = &ebShape;
-      } else if(it->subdetId()==EcalEndcap){
-	pShape = &eeShape;
-      } else{
-	throw cms::Exception("EcalDccWeightBuilder")
-	  << "Bug found in " << __FILE__ << ":" << __LINE__ << ": "
-	  << "Got a detId which is neither tagged as ECAL Barrel "
-	  << "not ECAL endcap while looping on ECAL cell detIds\n";
+    try {
+      bool useDBShape = true;
+      EBShape ebShape(useDBShape);
+      EEShape eeShape(useDBShape);
+      EcalShapeBase* pShape;
+
+      if (it->subdetId() == EcalBarrel) {
+        pShape = &ebShape;
+      } else if (it->subdetId() == EcalEndcap) {
+        pShape = &eeShape;
+      } else {
+        throw cms::Exception("EcalDccWeightBuilder") << "Bug found in " << __FILE__ << ":" << __LINE__ << ": "
+                                                     << "Got a detId which is neither tagged as ECAL Barrel "
+                                                     << "not ECAL endcap while looping on ECAL cell detIds\n";
       }
-      
-      if(phase!=prevPhase){
-        if(imode_==COMPUTE_WEIGHTS){
-	  if(it->subdetId()==EcalBarrel){
-	    computeWeights(*pShape, binOfMax, phase, 
-			   dcc1stSample_-1, nDccWeights_, iSkip0_,
-			   baseWeights);
-	  } 
-	  prevPhase = phase;
-	}
+
+      if (phase != prevPhase) {
+        if (imode_ == COMPUTE_WEIGHTS) {
+          if (it->subdetId() == EcalBarrel) {
+            computeWeights(*pShape, binOfMax, phase, dcc1stSample_ - 1, nDccWeights_, iSkip0_, baseWeights);
+          }
+          prevPhase = phase;
+        }
       }
-      for(int i = 0; i < nw; ++i){
-	w[i] = baseWeights[i];
-	if(withIntercalib) w[i]*= intercalib(*it);
+      for (int i = 0; i < nw; ++i) {
+        w[i] = baseWeights[i];
+        if (withIntercalib)
+          w[i] *= intercalib(*it);
       }
       unbiasWeights(w, &W);
       encodedWeights_[*it] = W;
-    } catch(std::exception& e){
+    } catch (std::exception& e) {
       cout << __FILE__ << ":" << __LINE__ << ": ";
-      if(it->subdetId()==EcalBarrel){
-	cout << "ieta = " << setw(4) << ((EBDetId)(*it)).ieta()
-	     << " iphi = " << setw(4) << ((EBDetId)(*it)).iphi() << " ";
-      } else if(it->subdetId()==EcalEndcap){
-	cout << "ix = " << setw(3) << ((EEDetId)(*it)).ix()
-	     << " iy = " << setw(3) << ((EEDetId)(*it)).iy()
-	     << " iz = " << setw(1) << ((EEDetId)(*it)).iy() << " ";
-      } else{
-	cout << "DetId " << (uint32_t) (*it);
+      if (it->subdetId() == EcalBarrel) {
+        cout << "ieta = " << setw(4) << ((EBDetId)(*it)).ieta() << " iphi = " << setw(4) << ((EBDetId)(*it)).iphi()
+             << " ";
+      } else if (it->subdetId() == EcalEndcap) {
+        cout << "ix = " << setw(3) << ((EEDetId)(*it)).ix() << " iy = " << setw(3) << ((EEDetId)(*it)).iy()
+             << " iz = " << setw(1) << ((EEDetId)(*it)).iy() << " ";
+      } else {
+        cout << "DetId " << (uint32_t)(*it);
       }
-      cout <<  "phase: "  << phase << "\n";
+      cout << "phase: " << phase << "\n";
       throw;
     }
   }
 }
 
-void
-EcalDccWeightBuilder::computeWeights(const EcalShapeBase& shape,
-				     int binOfMax,
-				     double timePhase,
-				     int iFirst,
-				     int nWeights, int iSkip,
-				     vector<double>& result){
+void EcalDccWeightBuilder::computeWeights(const EcalShapeBase& shape,
+                                          int binOfMax,
+                                          double timePhase,
+                                          int iFirst,
+                                          int nWeights,
+                                          int iSkip,
+                                          vector<double>& result) {
   double sum2 = 0.;
   double sum = 0;
   result.resize(nWeights);
 
   int nActualWeights = 0;
 
-  const double tzero = -(binOfMax-1)*25+timePhase + shape.timeToRise();//ns
+  const double tzero = -(binOfMax - 1) * 25 + timePhase + shape.timeToRise();  //ns
 
-  for(int i=0; i<nWeights; ++i){
-    double t_ns = tzero+(iFirst+i)*25;
+  for (int i = 0; i < nWeights; ++i) {
+    double t_ns = tzero + (iFirst + i) * 25;
     double s = shape(t_ns);
-    if(i==iSkip){
+    if (i == iSkip) {
       continue;
     }
     result[i] = s;
     sum += s;
-    sum2 += s*s;
+    sum2 += s * s;
     ++nActualWeights;
   }
-  for(int i=0; i<nWeights; ++i){
-    if(i==iSkip){
+  for (int i = 0; i < nWeights; ++i) {
+    if (i == iSkip) {
       result[i] = 0;
-    } else{
-      result[i] = (result[i]-sum/nActualWeights)/(sum2-sum*sum/nActualWeights);
+    } else {
+      result[i] = (result[i] - sum / nActualWeights) / (sum2 - sum * sum / nActualWeights);
     }
   }
 }
 
-int EcalDccWeightBuilder::encodeWeight(double w){
-  return lround(w * weightScale_);
-}
+int EcalDccWeightBuilder::encodeWeight(double w) { return lround(w * weightScale_); }
 
-double EcalDccWeightBuilder::decodeWeight(int W){
-  return ((double) W) / weightScale_;
-}
+double EcalDccWeightBuilder::decodeWeight(int W) { return ((double)W) / weightScale_; }
 
-
-template<class T>
-void EcalDccWeightBuilder::sort(const std::vector<T>& a,
-				std::vector<int>& s,
-				bool decreasingOrder){
+template <class T>
+void EcalDccWeightBuilder::sort(const std::vector<T>& a, std::vector<int>& s, bool decreasingOrder) {
   //   cout << __FILE__ << ":" << __LINE__ << ": "
   //        << "sort input array:" ;
   //   for(unsigned i=0; i<a.size(); ++i){
   //     cout << "\t" << a[i];
   //   }
   //   cout << "\n";
-  
+
   //performs a bubble sort: adjacent elements are successively swapped 2 by 2
   //until the list is finally sorted.
   bool changed = false;
   s.resize(a.size());
-  for(unsigned i=0; i<a.size(); ++i) s[i] = i;
-  if(a.empty()) return;
+  for (unsigned i = 0; i < a.size(); ++i)
+    s[i] = i;
+  if (a.empty())
+    return;
   do {
     changed = false;
-    for(unsigned i = 0; i < a.size()-1; ++i){
+    for (unsigned i = 0; i < a.size() - 1; ++i) {
       const int j = s[i];
-      const int nextj = s[i+1];
-      if((decreasingOrder && (a[j] < a[nextj]))
-	 || (!decreasingOrder && (a[j] > a[nextj]))){
-	std::swap(s[i], s[i+1]);
-	changed = true;
+      const int nextj = s[i + 1];
+      if ((decreasingOrder && (a[j] < a[nextj])) || (!decreasingOrder && (a[j] > a[nextj]))) {
+        std::swap(s[i], s[i + 1]);
+        changed = true;
       }
     }
-  } while(changed);
-  
+  } while (changed);
+
   //   cout << __FILE__ << ":" << __LINE__ << ": "
   //        << "sorted list of indices:" ;
   //   for(unsigned i=0; i < s.size(); ++i){
@@ -300,29 +279,28 @@ void EcalDccWeightBuilder::sort(const std::vector<T>& a,
   //   }
   //   cout << "\n";
 }
-  
-void EcalDccWeightBuilder::unbiasWeights(std::vector<double>& weights,
-					 std::vector<int>* encodedWeights){
+
+void EcalDccWeightBuilder::unbiasWeights(std::vector<double>& weights, std::vector<int>* encodedWeights) {
   const unsigned nw = weights.size();
-  
+
   //computes integer weights, weights residuals and weight sum residual:
-  vector<double> dw(nw); //weight residuals due to interger encoding
-  vector<int> W(nw); //integer weights
+  vector<double> dw(nw);  //weight residuals due to interger encoding
+  vector<int> W(nw);      //integer weights
   int wsum = 0;
-  for(unsigned i = 0; i < nw; ++i){
+  for (unsigned i = 0; i < nw; ++i) {
     W[i] = encodeWeight(weights[i]);
     dw[i] = decodeWeight(W[i]) - weights[i];
     wsum += W[i];
   }
 
-//   cout << __FILE__ << ":" << __LINE__ << ": "
-//        <<  "weights before bias correction: ";
-//   for(unsigned i=0; i<weights.size(); ++i){
-//     const double w = weights[i];
-//     cout << "\t" << encodeWeight(w) << "(" << w << ", dw = " << dw[i] << ")";
-//   }
-//   cout << "\t sum: " << wsum << "\n";
-  
+  //   cout << __FILE__ << ":" << __LINE__ << ": "
+  //        <<  "weights before bias correction: ";
+  //   for(unsigned i=0; i<weights.size(); ++i){
+  //     const double w = weights[i];
+  //     cout << "\t" << encodeWeight(w) << "(" << w << ", dw = " << dw[i] << ")";
+  //   }
+  //   cout << "\t sum: " << wsum << "\n";
+
   //sorts weight residuals in decreasing order:
   vector<int> iw(nw);
   sort(dw, iw, true);
@@ -333,50 +311,52 @@ void EcalDccWeightBuilder::unbiasWeights(std::vector<double>& weights,
   // is positive (wsum<0)
   // 2) the weight with the maximal signed residual if the correction
   // is negative (wsum>0)
-  int wsumSign = wsum>0?1:-1;
-  int i = wsum>0?0:(nw-1);
-  while(wsum!=0){
+  int wsumSign = wsum > 0 ? 1 : -1;
+  int i = wsum > 0 ? 0 : (nw - 1);
+  while (wsum != 0) {
     W[iw[i]] -= wsumSign;
     wsum -= wsumSign;
     i += wsumSign;
-    if(i<0 || i>=(int)nw){ //recompute the residuals if a second iteration is
-      // needed (in principle, it is not expected with usual input weights), : 
-      for(unsigned i = 0; i < nw; ++i){
-	dw[i] = decodeWeight(W[i]) - weights[i];
-	sort(dw, iw, true);
+    if (i < 0 || i >= (int)nw) {  //recompute the residuals if a second iteration is
+      // needed (in principle, it is not expected with usual input weights), :
+      for (unsigned i = 0; i < nw; ++i) {
+        dw[i] = decodeWeight(W[i]) - weights[i];
+        sort(dw, iw, true);
       }
     }
-    if(i<0) i = nw-1;
-    if(i>=(int)nw) i = 0;
+    if (i < 0)
+      i = nw - 1;
+    if (i >= (int)nw)
+      i = 0;
   }
 
-//   cout << __FILE__ << ":" << __LINE__ << ": "
-//        <<  "weights after bias correction: ";
-//   for(unsigned i=0; i<weights.size(); ++i){
-//     cout << "\t" << W[i] << "(" << decodeWeight(W[i]) << ", dw = "
-// 	 << (decodeWeight(W[i])-weights[i]) << ")";
-//   }
-//   cout << "\n";
-  
+  //   cout << __FILE__ << ":" << __LINE__ << ": "
+  //        <<  "weights after bias correction: ";
+  //   for(unsigned i=0; i<weights.size(); ++i){
+  //     cout << "\t" << W[i] << "(" << decodeWeight(W[i]) << ", dw = "
+  // 	 << (decodeWeight(W[i])-weights[i]) << ")";
+  //   }
+  //   cout << "\n";
+
   //copy result
-  if(encodedWeights!=nullptr) encodedWeights->resize(nw);
-  for(unsigned i = 0; i < nw; ++i){
+  if (encodedWeights != nullptr)
+    encodedWeights->resize(nw);
+  for (unsigned i = 0; i < nw; ++i) {
     weights[i] = decodeWeight(W[i]);
-    if(encodedWeights) (*encodedWeights)[i] = W[i];
+    if (encodedWeights)
+      (*encodedWeights)[i] = W[i];
   }
 }
 
-double EcalDccWeightBuilder::intercalib(const DetId& detId){
+double EcalDccWeightBuilder::intercalib(const DetId& detId) {
   // get current intercalibration coeff
   double coef;
-  EcalIntercalibConstantMap::const_iterator itCalib
-    = calibMap_.find(detId.rawId());
-  if(itCalib != calibMap_.end()){
+  EcalIntercalibConstantMap::const_iterator itCalib = calibMap_.find(detId.rawId());
+  if (itCalib != calibMap_.end()) {
     coef = (*itCalib);
-  } else{
+  } else {
     coef = 1.;
-    std::cout << (uint32_t) detId
-	      << " not found in EcalIntercalibConstantMap"<<std::endl ;
+    std::cout << (uint32_t)detId << " not found in EcalIntercalibConstantMap" << std::endl;
   }
 #if 0
   cout << __FILE__ << ":" << __LINE__ << ": ";
@@ -393,104 +373,98 @@ double EcalDccWeightBuilder::intercalib(const DetId& detId){
   return coef;
 }
 
-void EcalDccWeightBuilder::writeWeightToAsciiFile(){
-  string fName = !asciiOutputFileName_.empty()?
-    asciiOutputFileName_.c_str()
-    :"dccWeights.txt";
+void EcalDccWeightBuilder::writeWeightToAsciiFile() {
+  string fName = !asciiOutputFileName_.empty() ? asciiOutputFileName_.c_str() : "dccWeights.txt";
   ofstream file(fName.c_str());
-  if(!file.good()){
-    throw cms::Exception("Output")
-      << "Failed to open file '"
-      << fName
-      << "'for writing DCC weights\n";
+  if (!file.good()) {
+    throw cms::Exception("Output") << "Failed to open file '" << fName << "'for writing DCC weights\n";
   }
 
-  const char* comment = sqlMode_?"-- ":"# ";
-  
+  const char* comment = sqlMode_ ? "-- " : "# ";
+
   file << comment << "List of weights for amplitude estimation to be used in DCC for\n"
        << comment << "zero suppresssion.\n\n";
-  if(!sqlMode_){
+  if (!sqlMode_) {
     file << comment << "Note: RU: trigger tower in EB, supercrystal in EE\n"
-	 << comment << "      xtl: crystal electronic channel id in RU, from 1 to 25\n\n"
-	 << comment << " DetId    SM  FED RU xtl weights[0..5]...\n";
+         << comment << "      xtl: crystal electronic channel id in RU, from 1 to 25\n\n"
+         << comment << " DetId    SM  FED RU xtl weights[0..5]...\n";
   }
-  
-  if(sqlMode_){
+
+  if (sqlMode_) {
     file << "variable recid number;\n"
-      "exec select COND2CONF_INFO_SQ.NextVal into :recid from DUAL;\n"
-      "insert into weights_info (rec_id,tag,version) values (:recid,'"
-	 << dbTag_ << "'," << dbVersion_ << ");\n";
-    file << "\n" << comment
-	 << "index of first sample used in the weighting sum\n"
-      "begin\n"
-      "  for fedid in " << ecalDccFedIdMin << ".." << ecalDccFedIdMax
-	 << " loop\n"
-      "    insert into dcc_weightsample_dat (rec_id, logic_id, sample_id, \n"
-      "    weight_number)\n"
-      "    values(:recid,fedid," << dcc1stSample_ << ",1);\n"
-      "  end loop;\n"
-      "end;\n"
-      "/\n";
-  } else{
+            "exec select COND2CONF_INFO_SQ.NextVal into :recid from DUAL;\n"
+            "insert into weights_info (rec_id,tag,version) values (:recid,'"
+         << dbTag_ << "'," << dbVersion_ << ");\n";
+    file << "\n"
+         << comment
+         << "index of first sample used in the weighting sum\n"
+            "begin\n"
+            "  for fedid in "
+         << ecalDccFedIdMin << ".." << ecalDccFedIdMax
+         << " loop\n"
+            "    insert into dcc_weightsample_dat (rec_id, logic_id, sample_id, \n"
+            "    weight_number)\n"
+            "    values(:recid,fedid,"
+         << dcc1stSample_
+         << ",1);\n"
+            "  end loop;\n"
+            "end;\n"
+            "/\n";
+  } else {
     file << "1st DCC sample: " << dcc1stSample_ << "\n";
   }
 
   file << "\n" << comment << "list of weights per crystal channel\n";
-  
-  for(map<DetId, std::vector<int32_t> >::const_iterator it
-	= encodedWeights_.begin();
-      it !=  encodedWeights_.end();
-      ++it){
+
+  for (map<DetId, std::vector<int32_t> >::const_iterator it = encodedWeights_.begin(); it != encodedWeights_.end();
+       ++it) {
     const DetId& detId = it->first;
-    
+
     int fedId;
     int smId;
     int ruId;
     int xtalId;
-    
+
     //detId ->  fedId, smId, ruId, xtalId
     dbId(detId, fedId, smId, ruId, xtalId);
 
-    char delim = sqlMode_?',':' ';
+    char delim = sqlMode_ ? ',' : ' ';
 
-    if(sqlMode_) file << "-- detId " << detId.rawId() << "\n"
-		      << "insert into dcc_weights_dat(rec_id,sm_id,fed_id,"
-		   "tt_id, cry_id,\n"
-		   "weight_0,weight_1,weight_2,weight_3,weight_4,weight_5) \n"
-		   "values ("
-		   ":recid";
-    
+    if (sqlMode_)
+      file << "-- detId " << detId.rawId() << "\n"
+           << "insert into dcc_weights_dat(rec_id,sm_id,fed_id,"
+              "tt_id, cry_id,\n"
+              "weight_0,weight_1,weight_2,weight_3,weight_4,weight_5) \n"
+              "values ("
+              ":recid";
+
     const vector<int>& weights = it->second;
-    if(!sqlMode_) file << setw(10) << detId.rawId();
+    if (!sqlMode_)
+      file << setw(10) << detId.rawId();
     file << delim << setw(2) << smId;
     file << delim << setw(3) << fedId;
     file << delim << setw(2) << ruId;
     file << delim << setw(2) << xtalId;
-      
-    for(unsigned i=0; i<weights.size(); ++i){
+
+    for (unsigned i = 0; i < weights.size(); ++i) {
       file << delim << setw(5) << weights[i];
     }
-    if(sqlMode_) file << ");";
+    if (sqlMode_)
+      file << ");";
     file << "\n";
   }
-  if(!file.good()){
-    throw cms::Exception("Output") << "Error while writing DCC weights to '"
-				   << fName << "' file.";
+  if (!file.good()) {
+    throw cms::Exception("Output") << "Error while writing DCC weights to '" << fName << "' file.";
   }
 }
-void EcalDccWeightBuilder::writeWeightToRootFile(){
-  string fName = !rootOutputFileName_.empty()?
-    rootOutputFileName_.c_str()
-    :"dccWeights.root";
+void EcalDccWeightBuilder::writeWeightToRootFile() {
+  string fName = !rootOutputFileName_.empty() ? rootOutputFileName_.c_str() : "dccWeights.root";
   TFile file(fName.c_str(), "RECREATE");
-  if(file.IsZombie()){
-    throw cms::Exception("Output")
-      << "Failed to open file '"
-      << fName
-      << "'for writing DCC weights\n";
+  if (file.IsZombie()) {
+    throw cms::Exception("Output") << "Failed to open file '" << fName << "'for writing DCC weights\n";
   }
   TTree t("dccWeights", "Weights for DCC ZS filter");
-  const int nWeightMax = 20; //normally n_weights = 6. A different might be used
+  const int nWeightMax = 20;  //normally n_weights = 6. A different might be used
   //                           used for test purposes.
   struct {
     Int_t detId;
@@ -501,30 +475,26 @@ void EcalDccWeightBuilder::writeWeightToRootFile(){
     Int_t n_weights;
     Int_t weights[nWeightMax];
   } buf;
-  t.Branch("weights", &buf,
-	   "rawDetId/I:"
-	   "feId/I:"
-	   "smSlotId/I:"
-	   "ruId/I:"
-	   "xtalInRuId/I:"
-	   "n_weights/I:"
-	   "weights[n_weights]/I");
-  for(map<DetId, std::vector<int32_t> >::const_iterator it
-	= encodedWeights_.begin();
-      it !=  encodedWeights_.end();
-      ++it){
+  t.Branch("weights",
+           &buf,
+           "rawDetId/I:"
+           "feId/I:"
+           "smSlotId/I:"
+           "ruId/I:"
+           "xtalInRuId/I:"
+           "n_weights/I:"
+           "weights[n_weights]/I");
+  for (map<DetId, std::vector<int32_t> >::const_iterator it = encodedWeights_.begin(); it != encodedWeights_.end();
+       ++it) {
     buf.detId = it->first.rawId();
     buf.n_weights = it->second.size();
 
     //detId ->  fedId, smId, ruId, xtalId
     dbId(buf.detId, buf.fedId, buf.smId, buf.ruId, buf.xtalId);
 
-    if(buf.n_weights>nWeightMax){
-      throw cms::Exception("EcalDccWeight")
-	<< "Number of weights (" << buf.n_weights
-	<< ") for DetId " << buf.detId
-	<< " exceeded maximum limit (" << nWeightMax
-	<< ") of root output format. ";
+    if (buf.n_weights > nWeightMax) {
+      throw cms::Exception("EcalDccWeight") << "Number of weights (" << buf.n_weights << ") for DetId " << buf.detId
+                                            << " exceeded maximum limit (" << nWeightMax << ") of root output format. ";
     }
     copy(it->second.begin(), it->second.end(), buf.weights);
     t.Fill();
@@ -534,21 +504,21 @@ void EcalDccWeightBuilder::writeWeightToRootFile(){
 }
 
 #ifndef DB_WRITE_SUPPORT
-void EcalDccWeightBuilder::writeWeightToDB(){
-  throw cms::Exception("DccWeight")
-    << "Code was compiled without support for writing dcc weights directly "
-    " into configuration DB. Configurable writeToDB must be set to False. "
-    "sqlMode can be used to produce an SQL*PLUS script to fill the DB\n";
+void EcalDccWeightBuilder::writeWeightToDB() {
+  throw cms::Exception("DccWeight") << "Code was compiled without support for writing dcc weights directly "
+                                       " into configuration DB. Configurable writeToDB must be set to False. "
+                                       "sqlMode can be used to produce an SQL*PLUS script to fill the DB\n";
 }
-#else //DB_WRITE_SUPPORT defined
-void EcalDccWeightBuilder::writeWeightToDB(){
-  cout << "going to write to the online DB "<<dbSid_<<" user "<<dbUser_<<endl;;
+#else   //DB_WRITE_SUPPORT defined
+void EcalDccWeightBuilder::writeWeightToDB() {
+  cout << "going to write to the online DB " << dbSid_ << " user " << dbUser_ << endl;
+  ;
   EcalCondDBInterface* econn;
 
   try {
     cout << "Making connection..." << flush;
     const string& filePrefix = string("file:");
-    if(dbPassword_.find(filePrefix)==0){ //password must be read for a file
+    if (dbPassword_.find(filePrefix) == 0) {  //password must be read for a file
       string fileName = dbPassword_.substr(filePrefix.size());
       //substitute dbPassword_ value by the password read from the file
       PasswordReader pr;
@@ -558,48 +528,46 @@ void EcalDccWeightBuilder::writeWeightToDB(){
     //     cout << __FILE__ << ":" << __LINE__ << ": "
     //           <<  "Password: " << dbPassword_ << "\n";
 
-    econn = new EcalCondDBInterface( dbSid_, dbUser_, dbPassword_ );
+    econn = new EcalCondDBInterface(dbSid_, dbUser_, dbPassword_);
     cout << "Done." << endl;
-  } catch (runtime_error &e) {
+  } catch (runtime_error& e) {
     cerr << e.what() << endl;
     exit(-1);
   }
-  
+
   ODFEWeightsInfo weight_info;
   weight_info.setConfigTag(dbTag_);
   weight_info.setVersion(dbVersion_);
   cout << "Inserting in DB..." << endl;
 
   econn->insertConfigSet(&weight_info);
-  
-  int weight_id=weight_info.getId();
-  cout << "WeightInfo inserted with ID "<< weight_id<< endl;
+
+  int weight_id = weight_info.getId();
+  cout << "WeightInfo inserted with ID " << weight_id << endl;
 
   vector<ODWeightsDat> datadel;
   datadel.reserve(encodedWeights_.size());
 
   vector<ODWeightsSamplesDat> dcc1stSampleConfig(nDccs);
-  for(int i = ecalDccFedIdMin; i <= ecalDccFedIdMax; ++i){
+  for (int i = ecalDccFedIdMin; i <= ecalDccFedIdMax; ++i) {
     dcc1stSampleConfig[i].setId(weight_id);
-    dcc1stSampleConfig[i].setFedId(601+i);
+    dcc1stSampleConfig[i].setFedId(601 + i);
     dcc1stSampleConfig[i].setSampleId(dcc1stSample_);
-    dcc1stSampleConfig[i].setWeightNumber(-1); //not used.
+    dcc1stSampleConfig[i].setWeightNumber(-1);  //not used.
   }
   econn->insertConfigDataArraySet(dcc1stSampleConfig, &weight_info);
-  
-  for(map<DetId, std::vector<int32_t> >::const_iterator it
-	= encodedWeights_.begin();
-      it !=  encodedWeights_.end();
-      ++it){
+
+  for (map<DetId, std::vector<int32_t> >::const_iterator it = encodedWeights_.begin(); it != encodedWeights_.end();
+       ++it) {
     const DetId& detId = it->first;
     const unsigned nWeights = 6;
     vector<int> weights(nWeights);
 
-    for(unsigned i=0; i<weights.size(); ++i){
+    for (unsigned i = 0; i < weights.size(); ++i) {
       //completing the weight vector with zeros in case it has
       //less than 6 elements:
       const vector<int>& w = it->second;
-      weights[i] = i<w.size()?w[i]:0;
+      weights[i] = i < w.size() ? w[i] : 0;
     }
 
     ODWeightsDat one_dat;
@@ -609,49 +577,45 @@ void EcalDccWeightBuilder::writeWeightToDB(){
     int smId;
     int ruId;
     int xtalId;
-    
+
     //detId ->  fedId, smId, ruId, xtalId
     dbId(detId, fedId, smId, ruId, xtalId);
-      
+
     one_dat.setSMId(smId);
     one_dat.setFedId(fedId);
     one_dat.setTTId(ruId);
     one_dat.setCrystalId(xtalId);
-    
+
     one_dat.setWeight0(weights[0]);
     one_dat.setWeight1(weights[1]);
     one_dat.setWeight2(weights[2]);
     one_dat.setWeight3(weights[3]);
     one_dat.setWeight4(weights[4]);
     one_dat.setWeight5(weights[5]);
-    
+
     datadel.push_back(one_dat);
   }
-  econn->insertConfigDataArraySet(datadel,&weight_info);
-  std::cout<< " .. done insertion in DB "<< endl;
+  econn->insertConfigDataArraySet(datadel, &weight_info);
+  std::cout << " .. done insertion in DB " << endl;
   delete econn;
-  cout<< "closed DB connection ... done"  << endl;
+  cout << "closed DB connection ... done" << endl;
 }
-#endif //DB_WRITE_SUPPORT not defined
+#endif  //DB_WRITE_SUPPORT not defined
 
+void EcalDccWeightBuilder::dbId(const DetId& detId, int& fedId, int& smId, int& ruId, int& xtalId) const {
+  const EcalElectronicsId& elecId = ecalElectronicsMap_->getElectronicsId(detId);
 
-void EcalDccWeightBuilder::dbId(const DetId& detId, int& fedId, int& smId,
-				int& ruId,
-				int& xtalId) const{
-  const EcalElectronicsId& elecId
-    = ecalElectronicsMap_->getElectronicsId(detId);
-  
   fedId = 600 + elecId.dccId();
-  ruId =  ecalElectronicsMap_->getElectronicsId(detId).towerId();
-  
-  if(detId.subdetId()==EcalBarrel) {
-    smId=((EBDetId)detId).ism();
-  } else{
-    smId = 10000-fedId; //no SM in EE. Use some unique value to satisfy
+  ruId = ecalElectronicsMap_->getElectronicsId(detId).towerId();
+
+  if (detId.subdetId() == EcalBarrel) {
+    smId = ((EBDetId)detId).ism();
+  } else {
+    smId = 10000 - fedId;  //no SM in EE. Use some unique value to satisfy
     //              current DB PK constraints.
   }
-  const int stripLength = 5; //1 strip = 5 crystals in a row
-  xtalId = (elecId.stripId()-1)*stripLength  + elecId.xtalId();
+  const int stripLength = 5;  //1 strip = 5 crystals in a row
+  xtalId = (elecId.stripId() - 1) * stripLength + elecId.xtalId();
 
 #if 0
   cout << __FILE__ << ":" << __LINE__ << ": FED ID "

--- a/CalibCalorimetry/EcalSRTools/src/PasswordReader.cc
+++ b/CalibCalorimetry/EcalSRTools/src/PasswordReader.cc
@@ -8,74 +8,69 @@
 
 using namespace std;
 
-void PasswordReader::readPassword(const std::string& fileName,
-                                  const std::string& user,
-                                  std::string& password){
+void PasswordReader::readPassword(const std::string& fileName, const std::string& user, std::string& password) {
   ifstream f(fileName.c_str());
-  if(!f.good()){
-    throw cms::Exception("File")
-      << "Failed to open file " << fileName << " for reading condition "
-      "database password\n";
+  if (!f.good()) {
+    throw cms::Exception("File") << "Failed to open file " << fileName
+                                 << " for reading condition "
+                                    "database password\n";
   }
   string line;
   bool found = false;
-  int nstatements = 0; //number of lines other than empty and comment lines
-  while(f.good() && !found){
+  int nstatements = 0;  //number of lines other than empty and comment lines
+  while (f.good() && !found) {
     size_t pos = 0;
     getline(f, line);
     trim(line, " \t");
-    if(line[0]=='#' || line.empty()){//comment line
+    if (line[0] == '#' || line.empty()) {  //comment line
       continue;
     }
     ++nstatements;
     string u = tokenize(line, ":/ \t", pos);
-    if(u == user){//user found
+    if (u == user) {  //user found
       password = tokenize(line, ":/ \t", pos);
       found = true;
     }
   }
-  if(!found && nstatements==1){//login not found in the file
+  if (!found && nstatements == 1) {  //login not found in the file
     //let's check if file does not contain a single password, w/o login
     f.clear();
     f.seekg(0, ios::beg);
-    getline(f,line);
+    getline(f, line);
     trim(line, " \t");
-    if(line.find_first_of(": \t")==string::npos){//no login/password delimiter
+    if (line.find_first_of(": \t") == string::npos) {  //no login/password delimiter
       //looks like a single password file
       password = line;
       found = true;
     }
   }
-  if(!found){
-    throw cms::Exception("Database")
-      << " Password for condition database user '" << user << "' not found in"
-      << " password file " << fileName << "\n";
+  if (!found) {
+    throw cms::Exception("Database") << " Password for condition database user '" << user << "' not found in"
+                                     << " password file " << fileName << "\n";
   }
 }
 
-std::string PasswordReader::tokenize(const string& s,
-                                     const string& delim,
-                                     size_t& pos) const{
+std::string PasswordReader::tokenize(const string& s, const string& delim, size_t& pos) const {
   size_t pos0 = pos;
   size_t len = s.size();
   //eats delimeters at beginning of the string
-  while(pos0<s.size() && find(delim.begin(), delim.end(), s[pos0])!=delim.end()){
+  while (pos0 < s.size() && find(delim.begin(), delim.end(), s[pos0]) != delim.end()) {
     ++pos0;
   }
-  if(pos0>=len || pos0==string::npos) return "";
+  if (pos0 >= len || pos0 == string::npos)
+    return "";
   pos = s.find_first_of(delim, pos0);
-  return s.substr(pos0, (pos>0?pos:s.size())-pos0);
+  return s.substr(pos0, (pos > 0 ? pos : s.size()) - pos0);
 }
 
-std::string PasswordReader::trim(const std::string& s,
-                                 const std::string& chars) const{
+std::string PasswordReader::trim(const std::string& s, const std::string& chars) const {
   std::string::size_type pos0 = s.find_first_not_of(chars);
-  if(pos0==std::string::npos){
-    pos0=0;
+  if (pos0 == std::string::npos) {
+    pos0 = 0;
   }
-  string::size_type pos1 = s.find_last_not_of(chars)+1;
-  if(pos1==std::string::npos){
+  string::size_type pos1 = s.find_last_not_of(chars) + 1;
+  if (pos1 == std::string::npos) {
     pos1 = pos0;
   }
-  return s.substr(pos0, pos1-pos0);
+  return s.substr(pos0, pos1 - pos0);
 }

--- a/CalibCalorimetry/EcalSRTools/src/PasswordReader.h
+++ b/CalibCalorimetry/EcalSRTools/src/PasswordReader.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-class PasswordReader{
+class PasswordReader {
 public:
   /** Read data password from a local file. File can contain password for
    * several user. The format is one record by line. Line must start with the
@@ -15,10 +15,7 @@ public:
    * @throw cms::Exception if file cannot be read or if the password was not
    * found
    */
-  void readPassword(const std::string& fileName,
-                    const std::string& user,
-                    std::string& password);
-
+  void readPassword(const std::string& fileName, const std::string& user, std::string& password);
 
   /** Function to split a string into tokens. Usage:
    * <pre>
@@ -34,9 +31,7 @@ public:
    * @param list of delimiters
    * @param [in,out] pos current scan position in the string
    */
-  std::string tokenize(const std::string& s,
-                       const std::string& delim,
-                       size_t& pos) const;
+  std::string tokenize(const std::string& s, const std::string& delim, size_t& pos) const;
 
   /** Trims unwanted characters (e.g. spaces) at start and end of a string.
    * @param s [in,out] input string
@@ -44,5 +39,5 @@ public:
    */
   std::string trim(const std::string& s, const std::string& chars) const;
 };
-  
-#endif //PASSWORDREADER_H not defined
+
+#endif  //PASSWORDREADER_H not defined

--- a/CalibCalorimetry/EcalSRTools/src/SealModules.cc
+++ b/CalibCalorimetry/EcalSRTools/src/SealModules.cc
@@ -1,6 +1,5 @@
- #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 
- #include "CalibCalorimetry/EcalSRTools/interface/EcalDccWeightBuilder.h"
+#include "CalibCalorimetry/EcalSRTools/interface/EcalDccWeightBuilder.h"
 
- 
- DEFINE_FWK_MODULE(EcalDccWeightBuilder);
+DEFINE_FWK_MODULE(EcalDccWeightBuilder);

--- a/CalibFormats/CastorObjects/interface/CastorCalibrationWidths.h
+++ b/CalibFormats/CastorObjects/interface/CastorCalibrationWidths.h
@@ -7,16 +7,17 @@
 
 */
 class CastorCalibrationWidths {
- public:
-  CastorCalibrationWidths () : mGain{}, mPedestal{} {};
-  CastorCalibrationWidths (const float fGain [4], const float fPedestal [4]);
+public:
+  CastorCalibrationWidths() : mGain{}, mPedestal{} {};
+  CastorCalibrationWidths(const float fGain[4], const float fPedestal[4]);
   /// get gain width for capid=0..3
-  double gain (int fCapId) const {return mGain [fCapId];}
+  double gain(int fCapId) const { return mGain[fCapId]; }
   /// get pedestal width for capid=0..3
-  double pedestal (int fCapId) const {return mPedestal [fCapId];}
- private:
-  double mGain [4];
-  double mPedestal [4];
+  double pedestal(int fCapId) const { return mPedestal[fCapId]; }
+
+private:
+  double mGain[4];
+  double mPedestal[4];
 };
 
 #endif

--- a/CalibFormats/CastorObjects/interface/CastorCalibrationWidthsSet.h
+++ b/CalibFormats/CastorObjects/interface/CastorCalibrationWidthsSet.h
@@ -17,9 +17,10 @@ public:
   void setCalibrationWidths(const DetId id, const CastorCalibrationWidths& ca);
   void sort();
   void clear();
+
 private:
   struct CalibWidthSetObject {
-    CalibWidthSetObject(const DetId& aid) : id(aid) { }
+    CalibWidthSetObject(const DetId& aid) : id(aid) {}
     DetId id;
     CastorCalibrationWidths calib;
     bool operator<(const CalibWidthSetObject& cso) const { return id < cso.id; }

--- a/CalibFormats/CastorObjects/interface/CastorCalibrations.h
+++ b/CalibFormats/CastorObjects/interface/CastorCalibrations.h
@@ -7,16 +7,17 @@
 
 */
 class CastorCalibrations {
- public:
-  CastorCalibrations () : mGain{}, mPedestal{} {};
-  CastorCalibrations (const float fGain [4], const float fPedestal [4]);
+public:
+  CastorCalibrations() : mGain{}, mPedestal{} {};
+  CastorCalibrations(const float fGain[4], const float fPedestal[4]);
   /// get gain for capid=0..3
-  double gain (int fCapId) const {return mGain [fCapId];}
+  double gain(int fCapId) const { return mGain[fCapId]; }
   /// get pedestal for capid=0..3
-  double pedestal (int fCapId) const {return mPedestal [fCapId];}
- private:
-  double mGain [4];
-  double mPedestal [4];
+  double pedestal(int fCapId) const { return mPedestal[fCapId]; }
+
+private:
+  double mGain[4];
+  double mPedestal[4];
 };
 
 #endif

--- a/CalibFormats/CastorObjects/interface/CastorCalibrationsSet.h
+++ b/CalibFormats/CastorObjects/interface/CastorCalibrationsSet.h
@@ -12,9 +12,10 @@ public:
   void setCalibrations(const DetId id, const CastorCalibrations& ca);
   void sort();
   void clear();
+
 private:
   struct CalibSetObject {
-    CalibSetObject(const DetId& aid) : id(aid) { }
+    CalibSetObject(const DetId& aid) : id(aid) {}
     DetId id;
     CastorCalibrations calib;
     bool operator<(const CalibSetObject& cso) const { return id < cso.id; }

--- a/CalibFormats/CastorObjects/interface/CastorChannelCoder.h
+++ b/CalibFormats/CastorObjects/interface/CastorChannelCoder.h
@@ -11,19 +11,20 @@ namespace reco {
   namespace castor {
     class QieShape;
   }
-}
+}  // namespace reco
 
 class CastorChannelCoder {
- public:
-  CastorChannelCoder (const float fOffset [16], const float fSlope [16]); // [CapId][Range]
+public:
+  CastorChannelCoder(const float fOffset[16], const float fSlope[16]);  // [CapId][Range]
   /// ADC[0..127]+capid[0..3]->fC conversion
-  double charge (const reco::castor::QieShape& fShape, int fAdc, int fCapId) const;
+  double charge(const reco::castor::QieShape& fShape, int fAdc, int fCapId) const;
   /// fC + capid[0..3] -> ADC conversion
-  int adc (const reco::castor::QieShape& fShape, double fCharge, int fCapId) const;
-  int index (int fCapId, int Range) {return fCapId*4+Range;}
- private:
-  double mOffset [4][4];
-  double mSlope [4][4];
+  int adc(const reco::castor::QieShape& fShape, double fCharge, int fCapId) const;
+  int index(int fCapId, int Range) { return fCapId * 4 + Range; }
+
+private:
+  double mOffset[4][4];
+  double mSlope[4][4];
 };
 
 #endif

--- a/CalibFormats/CastorObjects/interface/CastorCoderDb.h
+++ b/CalibFormats/CastorObjects/interface/CastorCoderDb.h
@@ -15,15 +15,17 @@ class CastorQIEShape;
 
 class CastorCoderDb : public CastorCoder {
 public:
-  CastorCoderDb (const CastorQIECoder& fCoder, const CastorQIEShape& fShape);
+  CastorCoderDb(const CastorQIECoder& fCoder, const CastorQIEShape& fShape);
 
   void adc2fC(const CastorDataFrame& df, CaloSamples& lf) const override;
- 
+
   void fC2adc(const CaloSamples& clf, CastorDataFrame& df, int fCapIdOffset) const override;
- 
- private:
-  template <class Digi> void adc2fC_ (const Digi& df, CaloSamples& clf) const;
-  template <class Digi> void fC2adc_ (const CaloSamples& clf, Digi& df, int fCapIdOffset) const;
+
+private:
+  template <class Digi>
+  void adc2fC_(const Digi& df, CaloSamples& clf) const;
+  template <class Digi>
+  void fC2adc_(const CaloSamples& clf, Digi& df, int fCapIdOffset) const;
 
   const CastorQIECoder* mCoder;
   const CastorQIEShape* mShape;

--- a/CalibFormats/CastorObjects/interface/CastorDbRecord.h
+++ b/CalibFormats/CastorObjects/interface/CastorDbRecord.h
@@ -4,7 +4,7 @@
 //
 // Package:     CastorDbProducer
 // Class  :     CastorDbRecord
-// 
+//
 /**\class CastorDbRecord CastorDbRecord.h CalibFormats/CastorDbProducer/interface/CastorDbRecord.h
 
  Description: based on the HCAL Db record class
@@ -18,16 +18,22 @@
 // #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 
 #include "CondFormats/DataRecord/interface/CastorChannelQualityRcd.h"
-#include "CondFormats/DataRecord/interface/CastorElectronicsMapRcd.h"  
-#include "CondFormats/DataRecord/interface/CastorElectronicsMapRcd.h"      
+#include "CondFormats/DataRecord/interface/CastorElectronicsMapRcd.h"
+#include "CondFormats/DataRecord/interface/CastorElectronicsMapRcd.h"
 #include "CondFormats/DataRecord/interface/CastorGainWidthsRcd.h"
 #include "CondFormats/DataRecord/interface/CastorGainsRcd.h"
 #include "CondFormats/DataRecord/interface/CastorPedestalWidthsRcd.h"
-#include "CondFormats/DataRecord/interface/CastorPedestalsRcd.h" 
+#include "CondFormats/DataRecord/interface/CastorPedestalsRcd.h"
 #include "CondFormats/DataRecord/interface/CastorQIEDataRcd.h"
 
-class CastorDbRecord : public edm::eventsetup::DependentRecordImplementation <CastorDbRecord,  
-  boost::mpl::vector<CastorPedestalsRcd, CastorPedestalWidthsRcd, CastorGainsRcd, CastorGainWidthsRcd, CastorQIEDataRcd, CastorChannelQualityRcd, CastorElectronicsMapRcd > > {}; 
+class CastorDbRecord
+    : public edm::eventsetup::DependentRecordImplementation<CastorDbRecord,
+                                                            boost::mpl::vector<CastorPedestalsRcd,
+                                                                               CastorPedestalWidthsRcd,
+                                                                               CastorGainsRcd,
+                                                                               CastorGainWidthsRcd,
+                                                                               CastorQIEDataRcd,
+                                                                               CastorChannelQualityRcd,
+                                                                               CastorElectronicsMapRcd> > {};
 
 #endif /* CASTORDBPRODUCER_CASTORDBRECORD_H */
-

--- a/CalibFormats/CastorObjects/interface/CastorDbService.h
+++ b/CalibFormats/CastorObjects/interface/CastorDbService.h
@@ -26,39 +26,41 @@ class CastorCalibrations;
 class CastorCalibrationWidths;
 
 class CastorDbService {
- public:
-  CastorDbService ();
+public:
+  CastorDbService();
 
-  const CastorCalibrations& getCastorCalibrations(const HcalGenericDetId& fId) const 
-  { return mCalibSet.getCalibrations(fId); }
-  const CastorCalibrationWidths& getCastorCalibrationWidths(const HcalGenericDetId& fId) const 
-  { return mCalibWidthSet.getCalibrationWidths(fId); }
+  const CastorCalibrations& getCastorCalibrations(const HcalGenericDetId& fId) const {
+    return mCalibSet.getCalibrations(fId);
+  }
+  const CastorCalibrationWidths& getCastorCalibrationWidths(const HcalGenericDetId& fId) const {
+    return mCalibWidthSet.getCalibrationWidths(fId);
+  }
 
-  const CastorPedestal* getPedestal (const HcalGenericDetId& fId) const;
-  const CastorPedestalWidth* getPedestalWidth (const HcalGenericDetId& fId) const;
-  const CastorGain* getGain (const HcalGenericDetId& fId) const;
-  const CastorGainWidth* getGainWidth (const HcalGenericDetId& fId) const;
-  const CastorQIECoder* getCastorCoder (const HcalGenericDetId& fId) const;
-  const CastorQIEShape* getCastorShape () const;
-  const CastorElectronicsMap* getCastorMapping () const;
-  const CastorChannelStatus* getCastorChannelStatus (const HcalGenericDetId& fId) const;
+  const CastorPedestal* getPedestal(const HcalGenericDetId& fId) const;
+  const CastorPedestalWidth* getPedestalWidth(const HcalGenericDetId& fId) const;
+  const CastorGain* getGain(const HcalGenericDetId& fId) const;
+  const CastorGainWidth* getGainWidth(const HcalGenericDetId& fId) const;
+  const CastorQIECoder* getCastorCoder(const HcalGenericDetId& fId) const;
+  const CastorQIEShape* getCastorShape() const;
+  const CastorElectronicsMap* getCastorMapping() const;
+  const CastorChannelStatus* getCastorChannelStatus(const HcalGenericDetId& fId) const;
 
-  void setData (const CastorPedestals* fItem) { mPedestals = fItem; }
-  void setData (const CastorPedestalWidths* fItem) { mPedestalWidths = fItem; }
-  void setData (const CastorGains* fItem) { mGains = fItem; }
-  void setData (const CastorGainWidths* fItem) {mGainWidths = fItem; }
-  void setData (const CastorQIEData* fItem) {mQIEData = fItem; }
-  void setData (const CastorChannelQuality* fItem) {mChannelQuality = fItem;}
-  void setData (const CastorElectronicsMap* fItem) {mElectronicsMap = fItem;}
+  void setData(const CastorPedestals* fItem) { mPedestals = fItem; }
+  void setData(const CastorPedestalWidths* fItem) { mPedestalWidths = fItem; }
+  void setData(const CastorGains* fItem) { mGains = fItem; }
+  void setData(const CastorGainWidths* fItem) { mGainWidths = fItem; }
+  void setData(const CastorQIEData* fItem) { mQIEData = fItem; }
+  void setData(const CastorChannelQuality* fItem) { mChannelQuality = fItem; }
+  void setData(const CastorElectronicsMap* fItem) { mElectronicsMap = fItem; }
 
   void buildCalibrations();
   void buildCalibWidths();
 
- private:
-  bool makeCastorCalibration (const HcalGenericDetId& fId, CastorCalibrations* fObject, 
-			    bool pedestalInADC) const;
-  bool makeCastorCalibrationWidth (const HcalGenericDetId& fId, CastorCalibrationWidths* fObject, 
-				 bool pedestalInADC) const;
+private:
+  bool makeCastorCalibration(const HcalGenericDetId& fId, CastorCalibrations* fObject, bool pedestalInADC) const;
+  bool makeCastorCalibrationWidth(const HcalGenericDetId& fId,
+                                  CastorCalibrationWidths* fObject,
+                                  bool pedestalInADC) const;
   const CastorPedestals* mPedestals;
   const CastorPedestalWidths* mPedestalWidths;
   const CastorGains* mGains;

--- a/CalibFormats/CastorObjects/interface/CastorNominalCoder.h
+++ b/CalibFormats/CastorObjects/interface/CastorNominalCoder.h
@@ -12,7 +12,7 @@ class CastorNominalCoder : public CastorCoder {
 public:
   void adc2fC(const CastorDataFrame& df, CaloSamples& lf) const override;
 
-  void fC2adc(const CaloSamples& clf, CastorDataFrame& df, int fCapIdOffset) const override; 
+  void fC2adc(const CaloSamples& clf, CastorDataFrame& df, int fCapIdOffset) const override;
 };
 
 #endif

--- a/CalibFormats/CastorObjects/interface/CastorTPGCoder.h
+++ b/CalibFormats/CastorObjects/interface/CastorTPGCoder.h
@@ -7,7 +7,7 @@
 
 // forward declaration of EventSetup is all that is needed here
 namespace edm {
-  class EventSetup; 
+  class EventSetup;
 }
 
 /** \class CastorTPGCoder
@@ -25,8 +25,10 @@ public:
   virtual ~CastorTPGCoder() = default;
   //  virtual void adc2Linear(const CastorDataFrame& df, IntegerCaloSamples& ics) const = 0;
 
-  virtual unsigned short adc2Linear(HcalQIESample sample,HcalDetId id) const = 0;
-  unsigned short adc2Linear(unsigned char adc, HcalDetId id) const { return adc2Linear(HcalQIESample(adc,0,0,0),id); }
+  virtual unsigned short adc2Linear(HcalQIESample sample, HcalDetId id) const = 0;
+  unsigned short adc2Linear(unsigned char adc, HcalDetId id) const {
+    return adc2Linear(HcalQIESample(adc, 0, 0, 0), id);
+  }
   virtual float getLUTPedestal(HcalDetId id) const = 0;
   virtual float getLUTGain(HcalDetId id) const = 0;
   /** \brief Get the full linearization LUT (128 elements).

--- a/CalibFormats/CastorObjects/interface/CastorTPGRecord.h
+++ b/CalibFormats/CastorObjects/interface/CastorTPGRecord.h
@@ -13,6 +13,7 @@
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "CalibFormats/CastorObjects/interface/CastorDbRecord.h"
 
-class CastorTPGRecord : public edm::eventsetup::DependentRecordImplementation<CastorTPGRecord, boost::mpl::vector<CastorDbRecord> >{};
+class CastorTPGRecord
+    : public edm::eventsetup::DependentRecordImplementation<CastorTPGRecord, boost::mpl::vector<CastorDbRecord> > {};
 
 #endif

--- a/CalibFormats/CastorObjects/interface/CastorText2DetIdConverter.h
+++ b/CalibFormats/CastorObjects/interface/CastorText2DetIdConverter.h
@@ -10,29 +10,32 @@
 #include "DataFormats/DetId/interface/DetId.h"
 
 class CastorText2DetIdConverter {
- public:
+public:
+  CastorText2DetIdConverter(const std::string& fFlavor = "NA",
+                            const std::string& fField1 = "0",
+                            const std::string& fField2 = "0",
+                            const std::string& fField3 = "0");
 
-  CastorText2DetIdConverter (const std::string& fFlavor = "NA", const std::string& fField1 = "0",
-			  const std::string& fField2 = "0", const std::string& fField3 = "0");
-  
-  CastorText2DetIdConverter (DetId fId);
+  CastorText2DetIdConverter(DetId fId);
 
   //  bool isHcalDetId () const;
-  bool isHcalCastorDetId () const;
+  bool isHcalCastorDetId() const;
 
-  const std::string& getFlavor () const {return flavorName;}
-  const std::string& getField1 () const {return field1;}
-  const std::string& getField2 () const {return field2;}
-  const std::string& getField3 () const {return field3;}
-  DetId getId () const {return mId;}
-  int getField (int i) const;
-  std::string toString () const;
-  
- private:
-  bool init (const std::string& fFlavor, const std::string& fField1,
-	     const std::string& fField2, const std::string& fField3);
-  bool init (DetId fId);
-  void setField (int i, int fValue);
+  const std::string& getFlavor() const { return flavorName; }
+  const std::string& getField1() const { return field1; }
+  const std::string& getField2() const { return field2; }
+  const std::string& getField3() const { return field3; }
+  DetId getId() const { return mId; }
+  int getField(int i) const;
+  std::string toString() const;
+
+private:
+  bool init(const std::string& fFlavor,
+            const std::string& fField1,
+            const std::string& fField2,
+            const std::string& fField3);
+  bool init(DetId fId);
+  void setField(int i, int fValue);
   std::string flavorName;
   std::string field1;
   std::string field2;

--- a/CalibFormats/CastorObjects/interface/QieShape.h
+++ b/CalibFormats/CastorObjects/interface/QieShape.h
@@ -8,21 +8,22 @@
 */
 
 namespace reco {
-namespace castor {
+  namespace castor {
 
-class QieShape {
- public:
-  QieShape (const double fAdcShape [32], const double fAdcBin [32]);
-  // center of the nominal linearized QIE bin
-  double linearization (int fAdc) const {return mLinearization [fAdc];}
-  // width of the nominal linearized bin
-  double binSize (int fAdc) const {return mBinSize [fAdc];}
- private:
-  double mLinearization [128];
-  double mBinSize [128];
-};
+    class QieShape {
+    public:
+      QieShape(const double fAdcShape[32], const double fAdcBin[32]);
+      // center of the nominal linearized QIE bin
+      double linearization(int fAdc) const { return mLinearization[fAdc]; }
+      // width of the nominal linearized bin
+      double binSize(int fAdc) const { return mBinSize[fAdc]; }
 
-}
-}
+    private:
+      double mLinearization[128];
+      double mBinSize[128];
+    };
+
+  }  // namespace castor
+}  // namespace reco
 
 #endif

--- a/CalibFormats/CastorObjects/src/CastorCalibrationWidths.cc
+++ b/CalibFormats/CastorObjects/src/CastorCalibrationWidths.cc
@@ -7,10 +7,9 @@
    $Author: katsas
 */
 
-CastorCalibrationWidths::CastorCalibrationWidths (const float fGain [4], const float fPedestal [4]) {
-  for (size_t iCap = 0; iCap < 4; ++iCap)
-  {
-    mGain [iCap] = fGain [iCap];
-    mPedestal [iCap] = fPedestal [iCap];
+CastorCalibrationWidths::CastorCalibrationWidths(const float fGain[4], const float fPedestal[4]) {
+  for (size_t iCap = 0; iCap < 4; ++iCap) {
+    mGain[iCap] = fGain[iCap];
+    mPedestal[iCap] = fPedestal[iCap];
   }
 }

--- a/CalibFormats/CastorObjects/src/CastorCalibrationWidthsSet.cc
+++ b/CalibFormats/CastorObjects/src/CastorCalibrationWidthsSet.cc
@@ -4,41 +4,36 @@
 #include <algorithm>
 #include <iostream>
 
-
-CastorCalibrationWidthsSet::CastorCalibrationWidthsSet() 
-  : sorted_ (false) {}
+CastorCalibrationWidthsSet::CastorCalibrationWidthsSet() : sorted_(false) {}
 
 const CastorCalibrationWidths& CastorCalibrationWidthsSet::getCalibrationWidths(const DetId fId) const {
   Item target(fId);
   std::vector<Item>::const_iterator cell;
   if (sorted_) {
-    cell = std::lower_bound (mItems.begin(), mItems.end(), target);
+    cell = std::lower_bound(mItems.begin(), mItems.end(), target);
+  } else {
+    cell = std::find(mItems.begin(), mItems.end(), target);
   }
-  else {
-    cell = std::find(mItems.begin(),mItems.end(), target);
-  }
-  if (cell == mItems.end() || cell->id != fId) 
-    throw cms::Exception ("Conditions not found") << "Unavailable CastorCalibrationWidths for cell " << HcalGenericDetId(fId);
+  if (cell == mItems.end() || cell->id != fId)
+    throw cms::Exception("Conditions not found")
+        << "Unavailable CastorCalibrationWidths for cell " << HcalGenericDetId(fId);
   return cell->calib;
 }
 
 void CastorCalibrationWidthsSet::setCalibrationWidths(DetId fId, const CastorCalibrationWidths& ca) {
-  sorted_=false;
-  std::vector<Item>::iterator cell=std::find(mItems.begin(),mItems.end(),Item(fId)); //slow, but guaranteed
-  if (cell==mItems.end()) 
-    {
-      mItems.push_back(Item(fId));
-      mItems.at(mItems.size()-1).calib=ca;
-      return;
-    }
-  cell->calib=ca;
+  sorted_ = false;
+  std::vector<Item>::iterator cell = std::find(mItems.begin(), mItems.end(), Item(fId));  //slow, but guaranteed
+  if (cell == mItems.end()) {
+    mItems.push_back(Item(fId));
+    mItems.at(mItems.size() - 1).calib = ca;
+    return;
+  }
+  cell->calib = ca;
 }
-void CastorCalibrationWidthsSet::sort () {
+void CastorCalibrationWidthsSet::sort() {
   if (!sorted_) {
-    std::sort (mItems.begin(), mItems.end());
+    std::sort(mItems.begin(), mItems.end());
     sorted_ = true;
   }
 }
-void CastorCalibrationWidthsSet::clear() {
-  mItems.clear();
-}
+void CastorCalibrationWidthsSet::clear() { mItems.clear(); }

--- a/CalibFormats/CastorObjects/src/CastorCalibrations.cc
+++ b/CalibFormats/CastorObjects/src/CastorCalibrations.cc
@@ -7,10 +7,9 @@
    $Author: katsas
 */
 
-CastorCalibrations::CastorCalibrations (const float fGain [4], const float fPedestal [4]) {
-  for (size_t iCap = 0; iCap < 4; ++iCap)
-  {
-    mGain [iCap] = fGain [iCap];
-    mPedestal [iCap] = fPedestal [iCap];
+CastorCalibrations::CastorCalibrations(const float fGain[4], const float fPedestal[4]) {
+  for (size_t iCap = 0; iCap < 4; ++iCap) {
+    mGain[iCap] = fGain[iCap];
+    mPedestal[iCap] = fPedestal[iCap];
   }
 }

--- a/CalibFormats/CastorObjects/src/CastorCalibrationsSet.cc
+++ b/CalibFormats/CastorObjects/src/CastorCalibrationsSet.cc
@@ -3,42 +3,36 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include <algorithm>
 
-
-CastorCalibrationsSet::CastorCalibrationsSet() 
-  : sorted_ (false) {}
+CastorCalibrationsSet::CastorCalibrationsSet() : sorted_(false) {}
 
 const CastorCalibrations& CastorCalibrationsSet::getCalibrations(const DetId fId) const {
   Item target(fId);
   std::vector<Item>::const_iterator cell;
   if (sorted_) {
-    cell = std::lower_bound (mItems.begin(), mItems.end(), target);
+    cell = std::lower_bound(mItems.begin(), mItems.end(), target);
+  } else {
+    cell = std::find(mItems.begin(), mItems.end(), target);
   }
-  else {
-    cell = std::find(mItems.begin(),mItems.end(), target);
-  }
-  if (cell == mItems.end() || cell->id != fId) 
-    throw cms::Exception ("Conditions not found") << "Unavailable CastorCalibrations for cell " << HcalGenericDetId(fId);
+  if (cell == mItems.end() || cell->id != fId)
+    throw cms::Exception("Conditions not found") << "Unavailable CastorCalibrations for cell " << HcalGenericDetId(fId);
   return cell->calib;
 }
 
 void CastorCalibrationsSet::setCalibrations(DetId fId, const CastorCalibrations& ca) {
-  sorted_=false;
-  std::vector<Item>::iterator cell=std::find(mItems.begin(),mItems.end(),Item(fId)); //slow, but guaranteed
- if (cell==mItems.end())
-    {
-      mItems.push_back(Item(fId));
-      mItems.at(mItems.size()-1).calib=ca;
-      return;
-    }
+  sorted_ = false;
+  std::vector<Item>::iterator cell = std::find(mItems.begin(), mItems.end(), Item(fId));  //slow, but guaranteed
+  if (cell == mItems.end()) {
+    mItems.push_back(Item(fId));
+    mItems.at(mItems.size() - 1).calib = ca;
+    return;
+  }
 
-  cell->calib=ca;
+  cell->calib = ca;
 }
-void CastorCalibrationsSet::sort () {
+void CastorCalibrationsSet::sort() {
   if (!sorted_) {
-    std::sort (mItems.begin(), mItems.end());
+    std::sort(mItems.begin(), mItems.end());
     sorted_ = true;
   }
 }
-void CastorCalibrationsSet::clear() {
-  mItems.clear();
-}
+void CastorCalibrationsSet::clear() { mItems.clear(); }

--- a/CalibFormats/CastorObjects/src/CastorChannelCoder.cc
+++ b/CalibFormats/CastorObjects/src/CastorChannelCoder.cc
@@ -9,44 +9,46 @@
 #include "CalibFormats/CastorObjects/interface/CastorChannelCoder.h"
 #include "CalibFormats/CastorObjects/interface/QieShape.h"
 
-CastorChannelCoder::CastorChannelCoder (const float fOffset [16], const float fSlope [16]) { // [CapId][Range]
+CastorChannelCoder::CastorChannelCoder(const float fOffset[16], const float fSlope[16]) {  // [CapId][Range]
   for (int range = 0; range < 4; range++) {
     for (int capId = 0; capId < 4; capId++) {
-      mOffset [capId][range] = fOffset [index (capId, range)];
-      mSlope [capId][range] = fSlope [index (capId, range)];
+      mOffset[capId][range] = fOffset[index(capId, range)];
+      mSlope[capId][range] = fSlope[index(capId, range)];
     }
   }
 }
 
-double CastorChannelCoder::charge (const reco::castor::QieShape& fShape, int fAdc, int fCapId) const {
+double CastorChannelCoder::charge(const reco::castor::QieShape& fShape, int fAdc, int fCapId) const {
   int range = (fAdc >> 6) & 0x3;
-  double charge = fShape.linearization (fAdc) / mSlope [fCapId][range] + mOffset [fCapId][range];
-//   std::cout << "CastorChannelCoder::charge-> " << fAdc << '/' << fCapId 
-// 	    << " result: " << charge << std::endl;
+  double charge = fShape.linearization(fAdc) / mSlope[fCapId][range] + mOffset[fCapId][range];
+  //   std::cout << "CastorChannelCoder::charge-> " << fAdc << '/' << fCapId
+  // 	    << " result: " << charge << std::endl;
   return charge;
 }
 
-int CastorChannelCoder::adc (const reco::castor::QieShape& fShape, double fCharge, int fCapId) const {
-
-  int adc = -1; //nothing found yet
+int CastorChannelCoder::adc(const reco::castor::QieShape& fShape, double fCharge, int fCapId) const {
+  int adc = -1;  //nothing found yet
   // search for the range
   for (int range = 0; range < 4; range++) {
-    double qieCharge = (fCharge - mOffset [fCapId][range]) * mSlope [fCapId][range];
-    double qieChargeMax = fShape.linearization (32*range+31) + 0.5 * fShape.binSize (32*range+31);
-    if (range == 3 && qieCharge > qieChargeMax) adc = 127; // overflow
-    if (qieCharge > qieChargeMax) continue; // next range
-    for (int bin = 32*range; bin < 32*(range+1); bin++) {
-      if (qieCharge < fShape.linearization (bin) + 0.5 * fShape.binSize (bin)) {
+    double qieCharge = (fCharge - mOffset[fCapId][range]) * mSlope[fCapId][range];
+    double qieChargeMax = fShape.linearization(32 * range + 31) + 0.5 * fShape.binSize(32 * range + 31);
+    if (range == 3 && qieCharge > qieChargeMax)
+      adc = 127;  // overflow
+    if (qieCharge > qieChargeMax)
+      continue;  // next range
+    for (int bin = 32 * range; bin < 32 * (range + 1); bin++) {
+      if (qieCharge < fShape.linearization(bin) + 0.5 * fShape.binSize(bin)) {
         adc = bin;
         break;
       }
     }
-    if (adc >= 0) break; // found
+    if (adc >= 0)
+      break;  // found
   }
-  if (adc < 0) adc = 0; // underflow
+  if (adc < 0)
+    adc = 0;  // underflow
 
-  //   std::cout << "CastorChannelCoder::adc-> " << fCharge << '/' << fCapId 
+  //   std::cout << "CastorChannelCoder::adc-> " << fCharge << '/' << fCapId
   //	    << " result: " << adc << std::endl;
   return adc;
 }
-

--- a/CalibFormats/CastorObjects/src/CastorCoderDB.cc
+++ b/CalibFormats/CastorObjects/src/CastorCoderDB.cc
@@ -8,30 +8,31 @@
 
 #include "CalibFormats/CastorObjects/interface/CastorCoderDb.h"
 
-CastorCoderDb::CastorCoderDb (const CastorQIECoder& fCoder, const CastorQIEShape& fShape)
-  : mCoder (&fCoder),
-    mShape (&fShape)
-{}
+CastorCoderDb::CastorCoderDb(const CastorQIECoder& fCoder, const CastorQIEShape& fShape)
+    : mCoder(&fCoder), mShape(&fShape) {}
 
-template <class Digi> void CastorCoderDb::adc2fC_ (const Digi& df, CaloSamples& clf) const {
-  clf=CaloSamples(df.id(),df.size());
-  for (int i=0; i<df.size(); i++) {
-    clf[i]=mCoder->charge (*mShape, df[i].adc (), df[i].capid ());
+template <class Digi>
+void CastorCoderDb::adc2fC_(const Digi& df, CaloSamples& clf) const {
+  clf = CaloSamples(df.id(), df.size());
+  for (int i = 0; i < df.size(); i++) {
+    clf[i] = mCoder->charge(*mShape, df[i].adc(), df[i].capid());
   }
   clf.setPresamples(df.presamples());
 }
 
-template <class Digi> void CastorCoderDb::fC2adc_ (const CaloSamples& clf, Digi& df, int fCapIdOffset) const {
-  df = Digi (clf.id ());
-  df.setSize (clf.size ());
-  df.setPresamples (clf.presamples ());
-  for (int i=0; i<clf.size(); i++) {
+template <class Digi>
+void CastorCoderDb::fC2adc_(const CaloSamples& clf, Digi& df, int fCapIdOffset) const {
+  df = Digi(clf.id());
+  df.setSize(clf.size());
+  df.setPresamples(clf.presamples());
+  for (int i = 0; i < clf.size(); i++) {
     int capId = (fCapIdOffset + i) % 4;
     df.setSample(i, HcalQIESample(mCoder->adc(*mShape, clf[i], capId), capId, 0, 0));
   }
 }
 
-void CastorCoderDb::adc2fC(const CastorDataFrame& df, CaloSamples& lf) const {adc2fC_ (df, lf);}
+void CastorCoderDb::adc2fC(const CastorDataFrame& df, CaloSamples& lf) const { adc2fC_(df, lf); }
 
-void CastorCoderDb::fC2adc(const CaloSamples& clf, CastorDataFrame& df, int fCapIdOffset) const {fC2adc_ (clf, df, fCapIdOffset);}
-
+void CastorCoderDb::fC2adc(const CaloSamples& clf, CastorDataFrame& df, int fCapIdOffset) const {
+  fC2adc_(clf, df, fCapIdOffset);
+}

--- a/CalibFormats/CastorObjects/src/CastorDbRecord.cc
+++ b/CalibFormats/CastorObjects/src/CastorDbRecord.cc
@@ -2,7 +2,7 @@
 //
 // Package:     CastorDbProducer
 // Class  :     CastorDbRecord
-// 
+//
 // Implementation:
 //     first version copy from HcalDbRecord
 //

--- a/CalibFormats/CastorObjects/src/CastorDbService.cc
+++ b/CalibFormats/CastorObjects/src/CastorDbService.cc
@@ -13,43 +13,43 @@
 
 #include <cmath>
 
-CastorDbService::CastorDbService ()
-  : 
-  mPedestals (nullptr),
-  mPedestalWidths (nullptr),
-  mGains (nullptr),
-  mGainWidths (nullptr),
-  mQIEData(nullptr),
-  mChannelQuality(nullptr),
-  mElectronicsMap(nullptr)
- {}
+CastorDbService::CastorDbService()
+    : mPedestals(nullptr),
+      mPedestalWidths(nullptr),
+      mGains(nullptr),
+      mGainWidths(nullptr),
+      mQIEData(nullptr),
+      mChannelQuality(nullptr),
+      mElectronicsMap(nullptr) {}
 
-bool CastorDbService::makeCastorCalibration (const HcalGenericDetId& fId, CastorCalibrations* fObject, bool pedestalInADC) const {
+bool CastorDbService::makeCastorCalibration(const HcalGenericDetId& fId,
+                                            CastorCalibrations* fObject,
+                                            bool pedestalInADC) const {
   if (fObject) {
-    const CastorPedestal* pedestal = getPedestal (fId);
-    const CastorGain* gain = getGain (fId);
+    const CastorPedestal* pedestal = getPedestal(fId);
+    const CastorGain* gain = getGain(fId);
 
     if (pedestalInADC) {
-      const CastorQIEShape* shape=getCastorShape();
-      const CastorQIECoder* coder=getCastorCoder(fId);
-      if (pedestal && gain && shape && coder ) {
-	float pedTrue[4];
-	for (int i=0; i<4; i++) {
-	  float x=pedestal->getValues()[i];
-	  int x1=(int)std::floor(x);
-	  int x2=(int)std::floor(x+1);
-	  // y = (y2-y1)/(x2-x1) * (x - x1) + y1  [note: x2-x1=1]
-	  float y2=coder->charge(*shape,x2,i);
-	  float y1=coder->charge(*shape,x1,i);
-	  pedTrue[i]=(y2-y1)*(x-x1)+y1;
-	}
-	*fObject = CastorCalibrations (gain->getValues (), pedTrue );
-	return true; 
+      const CastorQIEShape* shape = getCastorShape();
+      const CastorQIECoder* coder = getCastorCoder(fId);
+      if (pedestal && gain && shape && coder) {
+        float pedTrue[4];
+        for (int i = 0; i < 4; i++) {
+          float x = pedestal->getValues()[i];
+          int x1 = (int)std::floor(x);
+          int x2 = (int)std::floor(x + 1);
+          // y = (y2-y1)/(x2-x1) * (x - x1) + y1  [note: x2-x1=1]
+          float y2 = coder->charge(*shape, x2, i);
+          float y1 = coder->charge(*shape, x1, i);
+          pedTrue[i] = (y2 - y1) * (x - x1) + y1;
+        }
+        *fObject = CastorCalibrations(gain->getValues(), pedTrue);
+        return true;
       }
     } else {
-      if (pedestal && gain ) {
-	*fObject = CastorCalibrations (gain->getValues (), pedestal->getValues () );
-	return true;
+      if (pedestal && gain) {
+        *fObject = CastorCalibrations(gain->getValues(), pedestal->getValues());
+        return true;
       }
     }
   }
@@ -58,8 +58,9 @@ bool CastorDbService::makeCastorCalibration (const HcalGenericDetId& fId, Castor
 
 void CastorDbService::buildCalibrations() {
   // we use the set of ids for pedestals as the master list
-  if ((!mPedestals) || (!mGains) || (!mQIEData) ) return;
-  std::vector<DetId> ids=mPedestals->getAllChannels();
+  if ((!mPedestals) || (!mGains) || (!mQIEData))
+    return;
+  std::vector<DetId> ids = mPedestals->getAllChannels();
   bool pedsInADC = mPedestals->isADC();
   // clear the calibrations set
   mCalibSet.clear();
@@ -67,11 +68,12 @@ void CastorDbService::buildCalibrations() {
   CastorCalibrations tool;
 
   //  std::cout << " length of id-vector: " << ids.size() << std::endl;
-  for (std::vector<DetId>::const_iterator id=ids.begin(); id!=ids.end(); ++id) {
+  for (std::vector<DetId>::const_iterator id = ids.begin(); id != ids.end(); ++id) {
     // make
-    bool ok=makeCastorCalibration(*id,&tool,pedsInADC);
+    bool ok = makeCastorCalibration(*id, &tool, pedsInADC);
     // store
-    if (ok) mCalibSet.setCalibrations(*id,tool);
+    if (ok)
+      mCalibSet.setCalibrations(*id, tool);
     //    std::cout << "Castor calibrations built... detid no. " << HcalGenericDetId(*id) << std::endl;
   }
   mCalibSet.sort();
@@ -79,9 +81,10 @@ void CastorDbService::buildCalibrations() {
 
 void CastorDbService::buildCalibWidths() {
   // we use the set of ids for pedestal widths as the master list
-  if ((!mPedestalWidths) || (!mGainWidths) || (!mQIEData) ) return;
+  if ((!mPedestalWidths) || (!mGainWidths) || (!mQIEData))
+    return;
 
-  std::vector<DetId> ids=mPedestalWidths->getAllChannels();
+  std::vector<DetId> ids = mPedestalWidths->getAllChannels();
   bool pedsInADC = mPedestalWidths->isADC();
   // clear the calibrations set
   mCalibWidthSet.clear();
@@ -89,99 +92,98 @@ void CastorDbService::buildCalibWidths() {
   CastorCalibrationWidths tool;
 
   //  std::cout << " length of id-vector: " << ids.size() << std::endl;
-  for (std::vector<DetId>::const_iterator id=ids.begin(); id!=ids.end(); ++id) {
+  for (std::vector<DetId>::const_iterator id = ids.begin(); id != ids.end(); ++id) {
     // make
-    bool ok=makeCastorCalibrationWidth(*id,&tool,pedsInADC);
+    bool ok = makeCastorCalibrationWidth(*id, &tool, pedsInADC);
     // store
-    if (ok) mCalibWidthSet.setCalibrationWidths(*id,tool);
+    if (ok)
+      mCalibWidthSet.setCalibrationWidths(*id, tool);
     //    std::cout << "Castor calibrations built... detid no. " << HcalGenericDetId(*id) << std::endl;
   }
   mCalibWidthSet.sort();
 }
 
-bool CastorDbService::makeCastorCalibrationWidth (const HcalGenericDetId& fId, 
-					      CastorCalibrationWidths* fObject, bool pedestalInADC) const {
+bool CastorDbService::makeCastorCalibrationWidth(const HcalGenericDetId& fId,
+                                                 CastorCalibrationWidths* fObject,
+                                                 bool pedestalInADC) const {
   if (fObject) {
-    const CastorPedestalWidth* pedestalwidth = getPedestalWidth (fId);
-    const CastorGainWidth* gainwidth = getGainWidth (fId);
+    const CastorPedestalWidth* pedestalwidth = getPedestalWidth(fId);
+    const CastorGainWidth* gainwidth = getGainWidth(fId);
     if (pedestalInADC) {
-      const CastorQIEShape* shape=getCastorShape();
-      const CastorQIECoder* coder=getCastorCoder(fId);
+      const CastorQIEShape* shape = getCastorShape();
+      const CastorQIECoder* coder = getCastorCoder(fId);
       if (pedestalwidth && gainwidth && shape && coder) {
-	float pedTrueWidth[4];
-	for (int i=0; i<4; i++) {
-	  float x=pedestalwidth->getWidth(i);
-	  // assume QIE is linear in low range and use x1=0 and x2=1
-	  // y = (y2-y1) * (x) [do not add any constant, only scale!]
-	  float y2=coder->charge(*shape,1,i);
-	  float y1=coder->charge(*shape,0,i);
-	  pedTrueWidth[i]=(y2-y1)*x;
-	}
-	*fObject = CastorCalibrationWidths (gainwidth->getValues (), pedTrueWidth);
-	return true; 
-      } 
+        float pedTrueWidth[4];
+        for (int i = 0; i < 4; i++) {
+          float x = pedestalwidth->getWidth(i);
+          // assume QIE is linear in low range and use x1=0 and x2=1
+          // y = (y2-y1) * (x) [do not add any constant, only scale!]
+          float y2 = coder->charge(*shape, 1, i);
+          float y1 = coder->charge(*shape, 0, i);
+          pedTrueWidth[i] = (y2 - y1) * x;
+        }
+        *fObject = CastorCalibrationWidths(gainwidth->getValues(), pedTrueWidth);
+        return true;
+      }
     } else {
       if (pedestalwidth && gainwidth) {
-	float pedestalWidth [4];
-	for (int i = 0; i < 4; i++) pedestalWidth [i] = pedestalwidth->getWidth (i);
-	*fObject = CastorCalibrationWidths (gainwidth->getValues (), pedestalWidth);
-	return true;
-      }      
+        float pedestalWidth[4];
+        for (int i = 0; i < 4; i++)
+          pedestalWidth[i] = pedestalwidth->getWidth(i);
+        *fObject = CastorCalibrationWidths(gainwidth->getValues(), pedestalWidth);
+        return true;
+      }
     }
   }
   return false;
-}  
+}
 
-
-const CastorPedestal* CastorDbService::getPedestal (const HcalGenericDetId& fId) const {
+const CastorPedestal* CastorDbService::getPedestal(const HcalGenericDetId& fId) const {
   if (mPedestals) {
-    return mPedestals->getValues (fId);
+    return mPedestals->getValues(fId);
   }
   return nullptr;
 }
 
-  const CastorPedestalWidth* CastorDbService::getPedestalWidth (const HcalGenericDetId& fId) const {
+const CastorPedestalWidth* CastorDbService::getPedestalWidth(const HcalGenericDetId& fId) const {
   if (mPedestalWidths) {
-    return mPedestalWidths->getValues (fId);
+    return mPedestalWidths->getValues(fId);
   }
   return nullptr;
 }
 
-const CastorGain* CastorDbService::getGain (const HcalGenericDetId& fId) const {
+const CastorGain* CastorDbService::getGain(const HcalGenericDetId& fId) const {
   if (mGains) {
     return mGains->getValues(fId);
   }
   return nullptr;
 }
 
-  const CastorGainWidth* CastorDbService::getGainWidth (const HcalGenericDetId& fId) const {
+const CastorGainWidth* CastorDbService::getGainWidth(const HcalGenericDetId& fId) const {
   if (mGainWidths) {
-    return mGainWidths->getValues (fId);
+    return mGainWidths->getValues(fId);
   }
   return nullptr;
 }
 
-const CastorQIECoder* CastorDbService::getCastorCoder (const HcalGenericDetId& fId) const {
+const CastorQIECoder* CastorDbService::getCastorCoder(const HcalGenericDetId& fId) const {
   if (mQIEData) {
-    return mQIEData->getCoder (fId);
+    return mQIEData->getCoder(fId);
   }
   return nullptr;
 }
 
-const CastorQIEShape* CastorDbService::getCastorShape () const {
+const CastorQIEShape* CastorDbService::getCastorShape() const {
   if (mQIEData) {
-    return &mQIEData->getShape ();
+    return &mQIEData->getShape();
   }
   return nullptr;
 }
 
-const CastorElectronicsMap* CastorDbService::getCastorMapping () const {
-  return mElectronicsMap;
-}
+const CastorElectronicsMap* CastorDbService::getCastorMapping() const { return mElectronicsMap; }
 
-const CastorChannelStatus* CastorDbService::getCastorChannelStatus (const HcalGenericDetId& fId) const
-{
-  return mChannelQuality->getValues (fId);
+const CastorChannelStatus* CastorDbService::getCastorChannelStatus(const HcalGenericDetId& fId) const {
+  return mChannelQuality->getValues(fId);
 }
 
 TYPELOOKUP_DATA_REG(CastorDbService);

--- a/CalibFormats/CastorObjects/src/CastorNominalCoder.cc
+++ b/CalibFormats/CastorObjects/src/CastorNominalCoder.cc
@@ -1,32 +1,31 @@
 #include "CalibFormats/CastorObjects/interface/CastorNominalCoder.h"
 
 void CastorNominalCoder::adc2fC(const CastorDataFrame& df, CaloSamples& lf) const {
-  lf=CaloSamples(df.id(),df.size());
-  for (int i=0; i<df.size(); i++) lf[i]=df[i].nominal_fC();
+  lf = CaloSamples(df.id(), df.size());
+  for (int i = 0; i < df.size(); i++)
+    lf[i] = df[i].nominal_fC();
   lf.setPresamples(df.presamples());
 }
-
 
 namespace CastorNominalCoderTemplate {
   template <class Digi>
   void process(const CaloSamples& clf, Digi& df, int fCapIdOffset) {
-    df=Digi(clf.id());
+    df = Digi(clf.id());
     df.setSize(clf.size());
     df.setPresamples(clf.presamples());
-    for (int i=0; i<clf.size(); i++) {
+    for (int i = 0; i < clf.size(); i++) {
       int capId = (fCapIdOffset + i) % 4;
-      for (int q=1; q<128; q++) {
-	df.setSample(i,HcalQIESample(q,capId,0,0));
-	if (df[i].nominal_fC()>clf[i]) {
-	  df.setSample(i,HcalQIESample(q-1,capId,0,0));
-	  break;
-	}
+      for (int q = 1; q < 128; q++) {
+        df.setSample(i, HcalQIESample(q, capId, 0, 0));
+        if (df[i].nominal_fC() > clf[i]) {
+          df.setSample(i, HcalQIESample(q - 1, capId, 0, 0));
+          break;
+        }
       }
     }
   }
-}
+}  // namespace CastorNominalCoderTemplate
 
 void CastorNominalCoder::fC2adc(const CaloSamples& clf, CastorDataFrame& df, int fCapIdOffset) const {
-  CastorNominalCoderTemplate::process(clf,df, fCapIdOffset);
+  CastorNominalCoderTemplate::process(clf, df, fCapIdOffset);
 }
-

--- a/CalibFormats/CastorObjects/src/CastorTPGCoder.cc
+++ b/CalibFormats/CastorObjects/src/CastorTPGCoder.cc
@@ -2,6 +2,7 @@
 
 std::vector<unsigned short> CastorTPGCoder::getLinearizationLUT(HcalDetId id) const {
   std::vector<unsigned short> lut(128);
-  for (unsigned char i=0; i<128; ++i) lut[i]=adc2Linear(i,id);
+  for (unsigned char i = 0; i < 128; ++i)
+    lut[i] = adc2Linear(i, id);
   return lut;
 }

--- a/CalibFormats/CastorObjects/src/CastorTPGRecord.cc
+++ b/CalibFormats/CastorObjects/src/CastorTPGRecord.cc
@@ -2,12 +2,11 @@
 //
 // Package:     CastorObjects
 // Class  :     CastorTPGRecord
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
-// Author: katsas     
-
+// Author: katsas
 
 #include "CalibFormats/CastorObjects/interface/CastorTPGRecord.h"
 #include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"

--- a/CalibFormats/CastorObjects/src/CastorText2DetIdConverter.cc
+++ b/CalibFormats/CastorObjects/src/CastorText2DetIdConverter.cc
@@ -14,74 +14,81 @@
 #include "CalibFormats/CastorObjects/interface/CastorText2DetIdConverter.h"
 
 namespace {
-  std::string strip (const std::string& fString) {
-    if (fString.empty ()) return fString;
+  std::string strip(const std::string& fString) {
+    if (fString.empty())
+      return fString;
     int startIndex = fString.find_first_not_of(" \t\n");
     int endIndex = fString.find_last_not_of(" \t\n");
-    return fString.substr(startIndex, (endIndex-startIndex)+1);
+    return fString.substr(startIndex, (endIndex - startIndex) + 1);
+  }
+}  // namespace
+
+CastorText2DetIdConverter::CastorText2DetIdConverter(const std::string& fFlavor,
+                                                     const std::string& fField1,
+                                                     const std::string& fField2,
+                                                     const std::string& fField3) {
+  if (!init(fFlavor, fField1, fField2, fField3)) {
+    std::cerr << "CastorText2DetIdConverter::CastorText2DetIdConverter-> Can not initiate detId from items: " << fFlavor
+              << '/' << fField1 << '/' << fField2 << '/' << fField3 << std::endl;
+    throw cms::Exception("HcalGenDetId initialization error")
+        << " Can not initiate detId from items: " << fFlavor << '/' << fField1 << '/' << fField2 << '/' << fField3
+        << std::endl;
   }
 }
 
-CastorText2DetIdConverter::CastorText2DetIdConverter (const std::string& fFlavor, const std::string& fField1,
-						  const std::string& fField2, const std::string& fField3) {
-  if (!init (fFlavor, fField1, fField2, fField3)) {
-    std::cerr << "CastorText2DetIdConverter::CastorText2DetIdConverter-> Can not initiate detId from items: "
-	      << fFlavor << '/' << fField1 << '/' << fField2 << '/' << fField3 << std::endl;
-    throw cms::Exception("HcalGenDetId initialization error") 
-      << " Can not initiate detId from items: "
-      << fFlavor << '/' << fField1 << '/' << fField2 << '/' << fField3 << std::endl;
-  }
-}
+CastorText2DetIdConverter::CastorText2DetIdConverter(DetId fId) { init(fId); }
 
-CastorText2DetIdConverter::CastorText2DetIdConverter (DetId fId) {
-  init (fId);
-}
+bool CastorText2DetIdConverter::isHcalCastorDetId() const { return HcalGenericDetId(mId).isHcalCastorDetId(); }
 
-bool CastorText2DetIdConverter::isHcalCastorDetId () const {
-  return HcalGenericDetId (mId).isHcalCastorDetId ();
-}
-
-bool CastorText2DetIdConverter::init (DetId fId) {
+bool CastorText2DetIdConverter::init(DetId fId) {
   bool result = true;
   flavorName = "UNKNOWN";
   mId = fId;
-  HcalGenericDetId genId (mId);
+  HcalGenericDetId genId(mId);
   if (fId == HcalDetId::Undefined) {
     flavorName = "NA";
   }
 
-  else if (genId.isHcalCastorDetId ()) {
-    HcalCastorDetId castorId (mId);
+  else if (genId.isHcalCastorDetId()) {
+    HcalCastorDetId castorId(mId);
     switch (castorId.section()) {
-    case HcalCastorDetId::EM: flavorName = "CASTOR_EM"; break;
-    case HcalCastorDetId::HAD: flavorName = "CASTOR_HAD"; break;
-    default: result = false;
+      case HcalCastorDetId::EM:
+        flavorName = "CASTOR_EM";
+        break;
+      case HcalCastorDetId::HAD:
+        flavorName = "CASTOR_HAD";
+        break;
+      default:
+        result = false;
     }
-    setField (1, castorId.zside());
-    setField (2, castorId.sector());
-    setField (3, castorId.module());
+    setField(1, castorId.zside());
+    setField(2, castorId.sector());
+    setField(3, castorId.module());
   }
 
   else {
     flavorName = "UNKNOWN_FLAVOR";
-    std::cerr << "CastorText2DetIdConverter::init-> Unknown detId: " << std::hex << std::showbase << mId.rawId() << std::endl;
+    std::cerr << "CastorText2DetIdConverter::init-> Unknown detId: " << std::hex << std::showbase << mId.rawId()
+              << std::endl;
     result = false;
   }
   return result;
 }
 
-
-bool CastorText2DetIdConverter::init (const std::string& fFlavor, const std::string& fField1,
-				   const std::string& fField2, const std::string& fField3) {
+bool CastorText2DetIdConverter::init(const std::string& fFlavor,
+                                     const std::string& fField1,
+                                     const std::string& fField2,
+                                     const std::string& fField3) {
   bool result = true;
-  flavorName = strip (fFlavor);
-  field1 = strip (fField1);
-  field2 = strip (fField2);
-  field3 = strip (fField3);
-  if (flavorName.find ("CASTOR_") == 0) {
-    HcalCastorDetId::Section section = flavorName == "CASTOR_EM" ? HcalCastorDetId::EM :
-      flavorName == "CASTOR_HAD" ? HcalCastorDetId::HAD : HcalCastorDetId::Unknown;
-    mId = HcalCastorDetId (section, getField (1)>0, getField (2), getField(3));
+  flavorName = strip(fFlavor);
+  field1 = strip(fField1);
+  field2 = strip(fField2);
+  field3 = strip(fField3);
+  if (flavorName.find("CASTOR_") == 0) {
+    HcalCastorDetId::Section section =
+        flavorName == "CASTOR_EM" ? HcalCastorDetId::EM
+                                  : flavorName == "CASTOR_HAD" ? HcalCastorDetId::HAD : HcalCastorDetId::Unknown;
+    mId = HcalCastorDetId(section, getField(1) > 0, getField(2), getField(3));
   }
 
   else {
@@ -91,29 +98,31 @@ bool CastorText2DetIdConverter::init (const std::string& fFlavor, const std::str
   return result;
 }
 
-
-int CastorText2DetIdConverter::getField (int i) const{
+int CastorText2DetIdConverter::getField(int i) const {
   char* endptr;
-  const char* nptr = i == 1 ? field1.c_str() :
-    i == 2 ? field2.c_str() : field3.c_str();
-  long result = strtol (nptr, &endptr, 0);
-    if (*nptr != '\0' && *endptr == '\0') {
-      return result;
-    }
-    if (*nptr != '\0') {
-      std::cerr << "CastorText2DetIdConverter::getField-> Can not convert string "<< nptr << " to int. Bad symbol: " << *endptr << std::endl;
-    }
-    return 0;
+  const char* nptr = i == 1 ? field1.c_str() : i == 2 ? field2.c_str() : field3.c_str();
+  long result = strtol(nptr, &endptr, 0);
+  if (*nptr != '\0' && *endptr == '\0') {
+    return result;
+  }
+  if (*nptr != '\0') {
+    std::cerr << "CastorText2DetIdConverter::getField-> Can not convert string " << nptr
+              << " to int. Bad symbol: " << *endptr << std::endl;
+  }
+  return 0;
 }
 
-void CastorText2DetIdConverter::setField (int i, int fValue) {
-  char buffer [128];
-  sprintf (buffer, "%d", fValue);
-  if (i == 1) field1 = buffer;
-  else if (i == 2) field2 = buffer;
-  else  field3 = buffer;
+void CastorText2DetIdConverter::setField(int i, int fValue) {
+  char buffer[128];
+  sprintf(buffer, "%d", fValue);
+  if (i == 1)
+    field1 = buffer;
+  else if (i == 2)
+    field2 = buffer;
+  else
+    field3 = buffer;
 }
 
-std::string CastorText2DetIdConverter::toString () const {
+std::string CastorText2DetIdConverter::toString() const {
   return flavorName + " " + field1 + " " + field2 + " " + field3;
 }

--- a/CalibFormats/CastorObjects/src/QieShape.cc
+++ b/CalibFormats/CastorObjects/src/QieShape.cc
@@ -9,26 +9,27 @@
 #include "CalibFormats/CastorObjects/interface/QieShape.h"
 
 namespace reco {
-namespace castor {
+  namespace castor {
 
-QieShape::QieShape (const double fAdcShape [32], const double fAdcBin [32]) {
-  for (int i = 0; i < 32; i++) {  // initial settings
-    mLinearization [i] = fAdcShape [i];
-    mBinSize [i] = fAdcBin [i];
-    //    std::cout << "QieShape::QieShape-> #/adc/bin: " << i << '/' << fAdcShape [i] << '/' << fAdcBin [i] << std::endl;
-  }
-  double factor = 1;
-  for (int range = 1; range < 4; range++) {
-    factor = factor * 5;
-    int offset = 32 * range;
-    mLinearization [offset] = mLinearization[offset-2]; // initial overlap
-    for (int bin = 1; bin < 32; bin++) {
-      mLinearization [offset+bin] = mLinearization [offset+bin-1] +
-        factor * (mLinearization [bin] - mLinearization [bin-1]); // scale initial curve
-      mBinSize [offset+bin] = factor * mBinSize [bin];
+    QieShape::QieShape(const double fAdcShape[32], const double fAdcBin[32]) {
+      for (int i = 0; i < 32; i++) {  // initial settings
+        mLinearization[i] = fAdcShape[i];
+        mBinSize[i] = fAdcBin[i];
+        //    std::cout << "QieShape::QieShape-> #/adc/bin: " << i << '/' << fAdcShape [i] << '/' << fAdcBin [i] << std::endl;
+      }
+      double factor = 1;
+      for (int range = 1; range < 4; range++) {
+        factor = factor * 5;
+        int offset = 32 * range;
+        mLinearization[offset] = mLinearization[offset - 2];  // initial overlap
+        for (int bin = 1; bin < 32; bin++) {
+          mLinearization[offset + bin] =
+              mLinearization[offset + bin - 1] +
+              factor * (mLinearization[bin] - mLinearization[bin - 1]);  // scale initial curve
+          mBinSize[offset + bin] = factor * mBinSize[bin];
+        }
+      }
     }
-  }
-}
 
-}
-}
+  }  // namespace castor
+}  // namespace reco

--- a/CalibTracker/SiPixelConnectivity/interface/PixelBarrelLinkMaker.h
+++ b/CalibTracker/SiPixelConnectivity/interface/PixelBarrelLinkMaker.h
@@ -5,7 +5,6 @@
  * Assign barrel pixel modules (defined by name and unit) to links
  */
 
-
 #include <boost/cstdint.hpp>
 #include <vector>
 
@@ -18,43 +17,48 @@ class PixelBarrelName;
 
 class PixelBarrelLinkMaker {
 public:
-  typedef sipixelobjects::PixelFEDCabling  PixelFEDCabling;
+  typedef sipixelobjects::PixelFEDCabling PixelFEDCabling;
   typedef sipixelobjects::PixelFEDLink PixelFEDLink;
   typedef sipixelobjects::PixelROC PixelROC;
 
-  typedef std::vector<PixelModuleName* > Names;
+  typedef std::vector<PixelModuleName*> Names;
   typedef std::vector<uint32_t> DetUnits;
   typedef PixelFEDCabling::Links Links;
   typedef TRange<int> Range;
 
   /// ctor from owner
-  PixelBarrelLinkMaker(const PixelFEDCabling * o) : theOwner(o) { }
+  PixelBarrelLinkMaker(const PixelFEDCabling* o) : theOwner(o) {}
 
   /// construct links
-  /// Each barrel module triggers one or two link Items. 
-  /// They are sorted according to Order(). 
+  /// Each barrel module triggers one or two link Items.
+  /// They are sorted according to Order().
   /// The ROCs corresponding to items are created. The link is
   /// form from link items and ROCS.
-  Links links( const Names & n, const DetUnits & u) const;
+  Links links(const Names& n, const DetUnits& u) const;
 
 private:
-  const PixelFEDCabling * theOwner;
+  const PixelFEDCabling* theOwner;
 
-  /// link item. 
-  /// defined by DetUnit with name (representing Pixel Detector module) 
-  /// and Ids of associated ROCs. The Id is the ROC number in module according 
+  /// link item.
+  /// defined by DetUnit with name (representing Pixel Detector module)
+  /// and Ids of associated ROCs. The Id is the ROC number in module according
   /// to PixelDatabase.
-  struct Item { const PixelBarrelName * name; uint32_t unit; Range rocIds; };
+  struct Item {
+    const PixelBarrelName* name;
+    uint32_t unit;
+    Range rocIds;
+  };
 
-  /// define order of items in a link. 
+  /// define order of items in a link.
   /// Highest priority to layer id.
   /// Second priority for ladder id (phi).
   /// Third priority by abs(module) (ie. along |z|)
   /// If all equal id of ROC matters
-  struct Order { bool operator() (const Item&, const Item&) const; } ;
+  struct Order {
+    bool operator()(const Item&, const Item&) const;
+  };
 
 private:
-  
 };
 
 #endif

--- a/CalibTracker/SiPixelConnectivity/interface/PixelEndcapLinkMaker.h
+++ b/CalibTracker/SiPixelConnectivity/interface/PixelEndcapLinkMaker.h
@@ -13,28 +13,27 @@ class PixelEndcapName;
 
 class PixelEndcapLinkMaker {
 public:
-
-  typedef sipixelobjects::PixelFEDCabling  PixelFEDCabling;
+  typedef sipixelobjects::PixelFEDCabling PixelFEDCabling;
   typedef sipixelobjects::PixelFEDLink PixelFEDLink;
   typedef sipixelobjects::PixelROC PixelROC;
 
-  typedef std::vector<PixelModuleName* > Names;
+  typedef std::vector<PixelModuleName*> Names;
   typedef std::vector<uint32_t> DetUnits;
-  typedef PixelFEDCabling::Links  Links;
+  typedef PixelFEDCabling::Links Links;
   typedef TRange<int> Range;
 
   /// ctor from owner
-  PixelEndcapLinkMaker(const PixelFEDCabling * o) : theOwner(o) { }
+  PixelEndcapLinkMaker(const PixelFEDCabling* o) : theOwner(o) {}
 
   /// construct links
   /// Each Endcap module triggers one or two link Items.
   /// They are sorted according to Order().
   /// The ROCs corresponding to items are created. The link is
   /// form from link items and ROCS.
-  Links links( const Names & n, const DetUnits & u) const;
+  Links links(const Names& n, const DetUnits& u) const;
 
 private:
-  const PixelFEDCabling * theOwner;
+  const PixelFEDCabling* theOwner;
 
   /// link item.
   /// defined by DetUnit with name (representing Pixel Detector module)
@@ -42,9 +41,11 @@ private:
   /// to PixelDatabase.
   /// The Item represents one module (DetUnit+name) with the Plaquette type
   /// and associated ROCs Ids given explicitly (Id is the ROC number in module)
-  struct Item { const PixelEndcapName * name;
-                uint32_t unit;
-                Range rocIds; };
+  struct Item {
+    const PixelEndcapName* name;
+    uint32_t unit;
+    Range rocIds;
+  };
 
   /// define order of link components.
   /// Highest priority to Endcap id (forward or backward endcpa)
@@ -53,12 +54,11 @@ private:
   /// Next panned
   /// To compare order of modules in one pannel plaquette id is used.
   /// The order of plaquettes define order of ROCs in link
-  struct Order { bool operator() (const Item&, const Item&) const; } ;
+  struct Order {
+    bool operator()(const Item&, const Item&) const;
+  };
 
 private:
-
 };
 
 #endif
-
-

--- a/CalibTracker/SiPixelConnectivity/interface/PixelToFEDAssociate.h
+++ b/CalibTracker/SiPixelConnectivity/interface/PixelToFEDAssociate.h
@@ -10,12 +10,17 @@
 
 #include "DataFormats/SiPixelDetId/interface/PixelModuleName.h"
 
-
 class PixelToFEDAssociate {
 public:
-
-  struct CablingRocId { int fedId; int linkId; int rocLinkId; }; 
-  struct DetectorRocId { const PixelModuleName * module; int rocDetId; };
+  struct CablingRocId {
+    int fedId;
+    int linkId;
+    int rocLinkId;
+  };
+  struct DetectorRocId {
+    const PixelModuleName *module;
+    int rocDetId;
+  };
 
   virtual ~PixelToFEDAssociate() {}
 
@@ -23,13 +28,9 @@ public:
   virtual std::string version() const = 0;
 
   /// FED id for module
-  virtual int operator()(const PixelModuleName &) const {
-    return 0;
-  } 
+  virtual int operator()(const PixelModuleName &) const { return 0; }
 
   /// LNK id for module
-  virtual const CablingRocId * operator()(const DetectorRocId & roc) const {
-    return nullptr;
-  }
+  virtual const CablingRocId *operator()(const DetectorRocId &roc) const { return nullptr; }
 };
-#endif 
+#endif

--- a/CalibTracker/SiPixelConnectivity/interface/PixelToFEDAssociateFromAscii.h
+++ b/CalibTracker/SiPixelConnectivity/interface/PixelToFEDAssociateFromAscii.h
@@ -16,12 +16,9 @@ class PixelBarrelName;
 class PixelEndcapName;
 class PixelModuleName;
 
-
-
 class PixelToFEDAssociateFromAscii : public PixelToFEDAssociate {
 public:
-
-  PixelToFEDAssociateFromAscii(const std::string & fileName);
+  PixelToFEDAssociateFromAscii(const std::string &fileName);
 
   /// FED id for module
   int operator()(const PixelModuleName &) const override;
@@ -29,42 +26,46 @@ public:
   /// version
   std::string version() const override;
 
-
-  /// FED id to which barrel modul (identified by name) should be assigned 
+  /// FED id to which barrel modul (identified by name) should be assigned
   int operator()(const PixelBarrelName &) const;
 
-  /// FED id to which endcape modul (identified by name) should be assigned 
+  /// FED id to which endcape modul (identified by name) should be assigned
   int operator()(const PixelEndcapName &) const;
 
 private:
   /// initialisatin (read file)
-  void init( const std::string & fileName);
+  void init(const std::string &fileName);
 
-
-  typedef TRange<int> Range; 
+  typedef TRange<int> Range;
 
   /// define allowed (layer,module,ladder) ranges for barrel units,
   /// check if module represented by name falls in allowed ranges
-  struct Bdu { int b; Range l,z,f; bool operator()(const PixelBarrelName&) const;};
+  struct Bdu {
+    int b;
+    Range l, z, f;
+    bool operator()(const PixelBarrelName &) const;
+  };
 
   /// define allowed (endcap,disk,blade) ranges for endcap units,
   /// check if module represented by name falls in allowed ranges
-  struct Edu { int e; Range d,b; bool operator()(const PixelEndcapName&) const;};
+  struct Edu {
+    int e;
+    Range d, b;
+    bool operator()(const PixelEndcapName &) const;
+  };
 
-  typedef std::vector< std::pair< int, std::vector<Bdu> > > BarrelConnections;
-  typedef std::vector< std::pair< int, std::vector<Edu> > > EndcapConnections;
+  typedef std::vector<std::pair<int, std::vector<Bdu> > > BarrelConnections;
+  typedef std::vector<std::pair<int, std::vector<Edu> > > EndcapConnections;
   BarrelConnections theBarrel;
   EndcapConnections theEndcap;
 
 private:
-
   std::string theVersion;
 
   /// initialisation (read input file)
-  void send (std::pair< int, std::vector<Bdu> > & , 
-      std::pair< int, std::vector<Edu> > & ) ;
-  Bdu getBdu( std::string ) const;
-  Edu getEdu( std::string ) const;
-  Range readRange( const std::string &) const;
+  void send(std::pair<int, std::vector<Bdu> > &, std::pair<int, std::vector<Edu> > &);
+  Bdu getBdu(std::string) const;
+  Edu getEdu(std::string) const;
+  Range readRange(const std::string &) const;
 };
-#endif 
+#endif

--- a/CalibTracker/SiPixelConnectivity/interface/PixelToLNKAssociateFromAscii.h
+++ b/CalibTracker/SiPixelConnectivity/interface/PixelToLNKAssociateFromAscii.h
@@ -19,27 +19,25 @@ class PixelModuleName;
 
 class PixelToLNKAssociateFromAscii : public PixelToFEDAssociate {
 public:
-
   typedef PixelToFEDAssociate::CablingRocId CablingRocId;
   typedef PixelToFEDAssociate::DetectorRocId DetectorRocId;
 
-  PixelToLNKAssociateFromAscii(const std::string & fileName, const bool phase1=false);
+  PixelToLNKAssociateFromAscii(const std::string& fileName, const bool phase1 = false);
 
-  const CablingRocId * operator()(const DetectorRocId& roc) const override;
+  const CablingRocId* operator()(const DetectorRocId& roc) const override;
 
   /// version
   std::string version() const override;
 
 private:
-  typedef TRange<int> Range; 
+  typedef TRange<int> Range;
 
   /// initialisatin (read file)
-  void init( const std::string & fileName);
-  void addConnections( int fedId, int linkId, std::string module, Range rocDetIds);
+  void init(const std::string& fileName);
+  void addConnections(int fedId, int linkId, std::string module, Range rocDetIds);
   std::string theVersion;
-  std::vector< std::pair<DetectorRocId,CablingRocId> > theConnection;
-  Range readRange( const std::string &) const;
-  bool phase1_; // signals phase1 detector
-    
+  std::vector<std::pair<DetectorRocId, CablingRocId> > theConnection;
+  Range readRange(const std::string&) const;
+  bool phase1_;  // signals phase1 detector
 };
-#endif 
+#endif

--- a/CalibTracker/SiPixelConnectivity/interface/SiPixelFedCablingMapBuilder.h
+++ b/CalibTracker/SiPixelConnectivity/interface/SiPixelFedCablingMapBuilder.h
@@ -11,22 +11,21 @@
 class PixelModuleName;
 class PixelGeomDetUnit;
 
-class SiPixelFedCablingMapBuilder{
+class SiPixelFedCablingMapBuilder {
 public:
   //SiPixelFedCablingMapBuilder(const std::string & associatorName);
-  SiPixelFedCablingMapBuilder(const std::string fileName, const bool phase1=false);
-  SiPixelFedCablingTree* produce(const edm::EventSetup& setup);  
+  SiPixelFedCablingMapBuilder(const std::string fileName, const bool phase1 = false);
+  SiPixelFedCablingTree* produce(const edm::EventSetup& setup);
 
 private:
-
   struct FedSpec {
-      int fedId;                             // fed ID
-      std::vector<PixelModuleName* > names;  // names of modules
-      std::vector<uint32_t> rawids;          // modules corresponding to names
+    int fedId;                            // fed ID
+    std::vector<PixelModuleName*> names;  // names of modules
+    std::vector<uint32_t> rawids;         // modules corresponding to names
   };
   //std::string theAssociatorName;
   std::string fileName_;
-  std::string myprint(const PixelGeomDetUnit * pxUnit);  
+  std::string myprint(const PixelGeomDetUnit* pxUnit);
   bool phase1_;
 };
 

--- a/CalibTracker/SiPixelConnectivity/interface/TRange.h
+++ b/CalibTracker/SiPixelConnectivity/interface/TRange.h
@@ -7,36 +7,35 @@
 #include <utility>
 #include <algorithm>
 
-
-template<class T> class TRange : public std::pair<T,T> {
+template <class T>
+class TRange : public std::pair<T, T> {
 public:
+  TRange() {}
 
-  TRange() { }
+  TRange(const T& aMin, const T& aMax) : std::pair<T, T>(aMin, aMax) {}
 
-  TRange(const T & aMin, const T & aMax) 
-      : std::pair<T,T> (aMin,aMax) { }
+  TRange(const std::pair<T, T>& apair) : std::pair<T, T>(apair) {}
 
-  TRange(const std::pair<T,T> & apair ) 
-      : std::pair<T,T> (apair) { }  
-
-  /// lower edge of range 
-  const T & min() const { return this->first; }
+  /// lower edge of range
+  const T& min() const { return this->first; }
 
   /// upper edge of range
-  const T & max() const { return this->second; }
+  const T& max() const { return this->second; }
 
-  T mean() const { return (this->first+this->second)/2.; }
+  T mean() const { return (this->first + this->second) / 2.; }
 
   /// true for empty region. note that region [x,x] is not empty
   bool empty() const { return (this->second < this->first); }
 
   /// check if object is inside region
-  bool inside(const T & value) const {
-    if (value < this->first || this->second < value)  return false; 
-    else  return true;
+  bool inside(const T& value) const {
+    if (value < this->first || this->second < value)
+      return false;
+    else
+      return true;
   }
 
-/*
+  /*
   /// check if ranges overlap
   bool hasIntersection( const TRange<T> & r) const {
     return rangesIntersect(*this,r); 
@@ -50,19 +49,23 @@ public:
 */
 
   /// sum of overlaping regions. the overlapping should be checked before.
-  TRange<T> sum(const TRange<T> & r) const {
-   if( this->empty()) return r;
-   else if( r.empty()) return *this;
-   else return TRange( (min() < r.min()) ? min() : r.min(), 
-      (max() < r.max()) ? r.max() : max()); 
+  TRange<T> sum(const TRange<T>& r) const {
+    if (this->empty())
+      return r;
+    else if (r.empty())
+      return *this;
+    else
+      return TRange((min() < r.min()) ? min() : r.min(), (max() < r.max()) ? r.max() : max());
   }
 
-  void sort() { if (empty() ) std::swap(this->first,this->second); }
+  void sort() {
+    if (empty())
+      std::swap(this->first, this->second);
+  }
 };
 
-template <class T> std::ostream & operator<<( 
-    std::ostream& out, const TRange<T>& r) 
-{
-  return out << "("<<r.min()<<","<<r.max()<<")";
+template <class T>
+std::ostream& operator<<(std::ostream& out, const TRange<T>& r) {
+  return out << "(" << r.min() << "," << r.max() << ")";
 }
 #endif

--- a/CalibTracker/SiPixelConnectivity/plugins/PixelToFEDAssociateFromAsciiESProducer.cc
+++ b/CalibTracker/SiPixelConnectivity/plugins/PixelToFEDAssociateFromAsciiESProducer.cc
@@ -4,21 +4,15 @@
 
 using namespace edm;
 
-PixelToFEDAssociateFromAsciiESProducer::
-    PixelToFEDAssociateFromAsciiESProducer(const edm::ParameterSet & p)
-    : theConfig(p)
-{
+PixelToFEDAssociateFromAsciiESProducer::PixelToFEDAssociateFromAsciiESProducer(const edm::ParameterSet& p)
+    : theConfig(p) {
   std::string myname = "PixelToFEDAssociateFromAscii";
-  setWhatProduced(this,myname);
+  setWhatProduced(this, myname);
 }
 
-PixelToFEDAssociateFromAsciiESProducer::
-    ~PixelToFEDAssociateFromAsciiESProducer()
-{ }
+PixelToFEDAssociateFromAsciiESProducer::~PixelToFEDAssociateFromAsciiESProducer() {}
 
-std::unique_ptr<PixelToFEDAssociate> PixelToFEDAssociateFromAsciiESProducer::
-    produce(const TrackerDigiGeometryRecord & r)
-{
+std::unique_ptr<PixelToFEDAssociate> PixelToFEDAssociateFromAsciiESProducer::produce(
+    const TrackerDigiGeometryRecord& r) {
   return std::make_unique<PixelToFEDAssociateFromAscii>(theConfig.getParameter<std::string>("fileName"));
 }
-

--- a/CalibTracker/SiPixelConnectivity/plugins/PixelToFEDAssociateFromAsciiESProducer.h
+++ b/CalibTracker/SiPixelConnectivity/plugins/PixelToFEDAssociateFromAsciiESProducer.h
@@ -1,7 +1,7 @@
 #ifndef PixelToFEDAssociateFromAsciiESProducer_H
 #define PixelToFEDAssociateFromAsciiESProducer_H
 
-#include  "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <memory>
 
@@ -10,12 +10,12 @@
 
 class PixelToFEDAssociateFromAsciiESProducer : public edm::ESProducer {
 public:
-  PixelToFEDAssociateFromAsciiESProducer(const edm::ParameterSet & p);
+  PixelToFEDAssociateFromAsciiESProducer(const edm::ParameterSet& p);
   ~PixelToFEDAssociateFromAsciiESProducer() override;
   std::unique_ptr<PixelToFEDAssociate> produce(const TrackerDigiGeometryRecord&);
+
 private:
   edm::ParameterSet theConfig;
 };
 
 #endif
-

--- a/CalibTracker/SiPixelConnectivity/plugins/PixelToLNKAssociateFromAsciiESProducer.cc
+++ b/CalibTracker/SiPixelConnectivity/plugins/PixelToLNKAssociateFromAsciiESProducer.cc
@@ -4,21 +4,15 @@
 
 using namespace edm;
 
-PixelToLNKAssociateFromAsciiESProducer::
-    PixelToLNKAssociateFromAsciiESProducer(const edm::ParameterSet & p)
-    : theConfig(p)
-{
+PixelToLNKAssociateFromAsciiESProducer::PixelToLNKAssociateFromAsciiESProducer(const edm::ParameterSet& p)
+    : theConfig(p) {
   std::string myname = "PixelToLNKAssociateFromAscii";
-  setWhatProduced(this,myname);
+  setWhatProduced(this, myname);
 }
 
-PixelToLNKAssociateFromAsciiESProducer::
-    ~PixelToLNKAssociateFromAsciiESProducer()
-{ }
+PixelToLNKAssociateFromAsciiESProducer::~PixelToLNKAssociateFromAsciiESProducer() {}
 
-std::unique_ptr<PixelToFEDAssociate> PixelToLNKAssociateFromAsciiESProducer::
-    produce(const TrackerDigiGeometryRecord & r)
-{
+std::unique_ptr<PixelToFEDAssociate> PixelToLNKAssociateFromAsciiESProducer::produce(
+    const TrackerDigiGeometryRecord& r) {
   return std::make_unique<PixelToLNKAssociateFromAscii>(theConfig.getParameter<std::string>("fileName"));
 }
-

--- a/CalibTracker/SiPixelConnectivity/plugins/PixelToLNKAssociateFromAsciiESProducer.h
+++ b/CalibTracker/SiPixelConnectivity/plugins/PixelToLNKAssociateFromAsciiESProducer.h
@@ -1,7 +1,7 @@
 #ifndef PixelToLNKAssociateFromAsciiESProducer_H
 #define PixelToLNKAssociateFromAsciiESProducer_H
 
-#include  "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <memory>
 
@@ -10,12 +10,12 @@
 
 class PixelToLNKAssociateFromAsciiESProducer : public edm::ESProducer {
 public:
-  PixelToLNKAssociateFromAsciiESProducer(const edm::ParameterSet & p);
+  PixelToLNKAssociateFromAsciiESProducer(const edm::ParameterSet& p);
   ~PixelToLNKAssociateFromAsciiESProducer() override;
   std::unique_ptr<PixelToFEDAssociate> produce(const TrackerDigiGeometryRecord&);
+
 private:
   edm::ParameterSet theConfig;
 };
 
 #endif
-

--- a/CalibTracker/SiPixelConnectivity/src/PixelBarrelLinkMaker.cc
+++ b/CalibTracker/SiPixelConnectivity/src/PixelBarrelLinkMaker.cc
@@ -9,80 +9,80 @@
 using namespace std;
 using namespace sipixelobjects;
 
-bool PixelBarrelLinkMaker::Order::operator() 
-    (const Item &u1, const Item& u2) const
-{
-  const PixelBarrelName & n1 = *u1.name;
-  const PixelBarrelName & n2 = *u2.name;
+bool PixelBarrelLinkMaker::Order::operator()(const Item& u1, const Item& u2) const {
+  const PixelBarrelName& n1 = *u1.name;
+  const PixelBarrelName& n2 = *u2.name;
 
   bool res = false;
 
-       if ( n1.layerName() < n2.layerName() ) res = true;
-  else if ( n1.layerName() > n2.layerName() ) res = false;
-  else if ( n1.ladderName() < n2.ladderName() ) res = true;
-  else if ( n1.ladderName() > n2.ladderName() ) res = false;
-  else if ( abs(n1.moduleName()) < abs(n2.moduleName()) ) res =  true;
-  else if ( abs(n1.moduleName()) > abs(n2.moduleName()) ) res =  false;
-  else if ( u1.rocIds.min() < u2.rocIds.min() ) res = true;
-  else if ( u1.rocIds.min() > u2.rocIds.min() ) res = false;
+  if (n1.layerName() < n2.layerName())
+    res = true;
+  else if (n1.layerName() > n2.layerName())
+    res = false;
+  else if (n1.ladderName() < n2.ladderName())
+    res = true;
+  else if (n1.ladderName() > n2.ladderName())
+    res = false;
+  else if (abs(n1.moduleName()) < abs(n2.moduleName()))
+    res = true;
+  else if (abs(n1.moduleName()) > abs(n2.moduleName()))
+    res = false;
+  else if (u1.rocIds.min() < u2.rocIds.min())
+    res = true;
+  else if (u1.rocIds.min() > u2.rocIds.min())
+    res = false;
 
   return res;
 }
 
-PixelBarrelLinkMaker::Links PixelBarrelLinkMaker::links( 
-    const Names & n, const DetUnits & u) const
-{
-
+PixelBarrelLinkMaker::Links PixelBarrelLinkMaker::links(const Names& n, const DetUnits& u) const {
   Links result;
   typedef Names::const_iterator CIN;
 
   //
-  // construct link items from names. 
+  // construct link items from names.
   // the item is equivalent to name for layer=3.
   // for layer=1,2 each module has 2 links
   //
   vector<Item> linkItems;
   typedef vector<Item>::const_iterator CIU;
 
-  for(unsigned int idx = 0; idx < n.size(); idx++) {
+  for (unsigned int idx = 0; idx < n.size(); idx++) {
     Item item;
-    PixelBarrelName * b = dynamic_cast<PixelBarrelName * >(n[idx]);
+    PixelBarrelName* b = dynamic_cast<PixelBarrelName*>(n[idx]);
     uint32_t d = u[idx];
     item.name = b;
     item.unit = d;
 
-    if ( b->isHalfModule()) {
-      item.rocIds = Range(0,7);      // half modules 
+    if (b->isHalfModule()) {
+      item.rocIds = Range(0, 7);  // half modules
       linkItems.push_back(item);
-    } else if(b->layerName() <= 2) {
-      item.rocIds = Range(0,7);      // first link for modules in Layer=1,2
+    } else if (b->layerName() <= 2) {
+      item.rocIds = Range(0, 7);  // first link for modules in Layer=1,2
       linkItems.push_back(item);
-      item.rocIds = Range(8,15);     // second link for modules in Layer=1,2
+      item.rocIds = Range(8, 15);  // second link for modules in Layer=1,2
       linkItems.push_back(item);
     } else {
-      item.rocIds = Range(0,15);    // one module per link 
-      linkItems.push_back(item);     
+      item.rocIds = Range(0, 15);  // one module per link
+      linkItems.push_back(item);
     }
   }
-
-
 
   //
   // sort link items to get the order as in links
   //
-  
+
   Order myLess;
-  sort( linkItems.begin(), linkItems.end(), myLess );
+  sort(linkItems.begin(), linkItems.end(), myLess);
 
   //
   // DEBUG
   //
   ostringstream str;
   for (CIU it = linkItems.begin(); it != linkItems.end(); it++) {
-    str << (*it).name->name() <<" r="<< (*it).rocIds << endl;
+    str << (*it).name->name() << " r=" << (*it).rocIds << endl;
   }
   LogDebug(" sorted BARREL links: ") << str.str();
-
 
   //
   // create corresponding PixelROC and link
@@ -90,15 +90,15 @@ PixelBarrelLinkMaker::Links PixelBarrelLinkMaker::links(
   int idLink = 0;
   result.reserve(linkItems.size());
   for (CIU it = linkItems.begin(); it != linkItems.end(); it++) {
-    PixelFEDLink::ROCs rocs; 
+    PixelFEDLink::ROCs rocs;
     PixelFEDLink link(++idLink);
     int idRoc = 0;
     for (int id = (*it).rocIds.min(); id <= (*it).rocIds.max(); id++) {
       idRoc++;
-      rocs.push_back( PixelROC( it->unit, id, idRoc) ); 
+      rocs.push_back(PixelROC(it->unit, id, idRoc));
     }
     link.add(rocs);
-    result.push_back(link); 
+    result.push_back(link);
   }
 
   return result;

--- a/CalibTracker/SiPixelConnectivity/src/PixelEndcapLinkMaker.cc
+++ b/CalibTracker/SiPixelConnectivity/src/PixelEndcapLinkMaker.cc
@@ -8,32 +8,37 @@
 using namespace std;
 using namespace sipixelobjects;
 
-bool PixelEndcapLinkMaker::Order::operator()
-    (const Item &u1, const Item& u2) const
-{
+bool PixelEndcapLinkMaker::Order::operator()(const Item& u1, const Item& u2) const {
   bool res = true;
-  const PixelEndcapName & n1 = *u1.name;
-  const PixelEndcapName & n2 = *u2.name;
+  const PixelEndcapName& n1 = *u1.name;
+  const PixelEndcapName& n2 = *u2.name;
 
-  if (n1.halfCylinder() < n2.halfCylinder() ) res = true;
-  else if(n1.halfCylinder() > n2.halfCylinder() ) res = false;
-  else if (n1.diskName() < n2.diskName() ) res =  true;
-  else if (n1.diskName() > n2.diskName() ) res =  false;
-  else if (n1.bladeName() < n2.bladeName() ) res =  true;
-  else if (n1.bladeName() > n2.bladeName() ) res =  false;
-  else if (n1.pannelName() < n2.pannelName() ) res =  true;
-  else if (n1.pannelName() > n2.pannelName() ) res =  false;
-  else if (n1.plaquetteName() < n2.plaquetteName() ) res =  true;
-  else if (n1.plaquetteName() > n2.plaquetteName() ) res =  false;
+  if (n1.halfCylinder() < n2.halfCylinder())
+    res = true;
+  else if (n1.halfCylinder() > n2.halfCylinder())
+    res = false;
+  else if (n1.diskName() < n2.diskName())
+    res = true;
+  else if (n1.diskName() > n2.diskName())
+    res = false;
+  else if (n1.bladeName() < n2.bladeName())
+    res = true;
+  else if (n1.bladeName() > n2.bladeName())
+    res = false;
+  else if (n1.pannelName() < n2.pannelName())
+    res = true;
+  else if (n1.pannelName() > n2.pannelName())
+    res = false;
+  else if (n1.plaquetteName() < n2.plaquetteName())
+    res = true;
+  else if (n1.plaquetteName() > n2.plaquetteName())
+    res = false;
 
   return res;
 }
 
-PixelEndcapLinkMaker::Links PixelEndcapLinkMaker::links(
-    const Names & n, const DetUnits & u) const
-{
-    
-  Links result; 
+PixelEndcapLinkMaker::Links PixelEndcapLinkMaker::links(const Names& n, const DetUnits& u) const {
+  Links result;
   typedef Names::const_iterator CIN;
 
   //
@@ -42,23 +47,37 @@ PixelEndcapLinkMaker::Links PixelEndcapLinkMaker::links(
   vector<Item> linkItems;
   typedef vector<Item>::const_iterator CIU;
 
-
-  for(unsigned int idx = 0; idx < n.size(); idx++) {
+  for (unsigned int idx = 0; idx < n.size(); idx++) {
     Item item;
-    PixelEndcapName * e = dynamic_cast<PixelEndcapName * >(n[idx]);
+    PixelEndcapName* e = dynamic_cast<PixelEndcapName*>(n[idx]);
     uint32_t d = u[idx];
     item.name = e;
     item.unit = d;
-    Range rocIds(-1,-1);
-    PixelModuleName::ModuleType type = e->moduleType(); 
+    Range rocIds(-1, -1);
+    PixelModuleName::ModuleType type = e->moduleType();
     switch (type) {
-      case(PixelModuleName::v1x2) : { rocIds = Range(0,1); break; }
-      case(PixelModuleName::v1x5) : { rocIds = Range(0,4); break; }
-      case(PixelModuleName::v2x3) : { rocIds = Range(0,5); break; }
-      case(PixelModuleName::v2x4) : { rocIds = Range(0,7); break; }
-      case(PixelModuleName::v2x5) : { rocIds = Range(0,9); break; }
+      case (PixelModuleName::v1x2): {
+        rocIds = Range(0, 1);
+        break;
+      }
+      case (PixelModuleName::v1x5): {
+        rocIds = Range(0, 4);
+        break;
+      }
+      case (PixelModuleName::v2x3): {
+        rocIds = Range(0, 5);
+        break;
+      }
+      case (PixelModuleName::v2x4): {
+        rocIds = Range(0, 7);
+        break;
+      }
+      case (PixelModuleName::v2x5): {
+        rocIds = Range(0, 9);
+        break;
+      }
       default:
-        edm::LogError("PixelEndcapLinkMaker")<< " *** UNEXPECTED roc: " << e->name() ;
+        edm::LogError("PixelEndcapLinkMaker") << " *** UNEXPECTED roc: " << e->name();
     };
     item.rocIds = rocIds;
     linkItems.push_back(item);
@@ -67,14 +86,14 @@ PixelEndcapLinkMaker::Links PixelEndcapLinkMaker::links(
   // sort names to get the order as in links
   //
 
-  sort( linkItems.begin(), linkItems.end(), Order() );
+  sort(linkItems.begin(), linkItems.end(), Order());
 
   //
   // DEBUG
   //
   ostringstream str;
   for (CIU it = linkItems.begin(); it != linkItems.end(); it++) {
-    str << (*it).name->name() <<" r="<< (*it).rocIds << endl;
+    str << (*it).name->name() << " r=" << (*it).rocIds << endl;
   }
   LogDebug(" sorted ENDCAP links: ") << str.str();
 
@@ -82,30 +101,29 @@ PixelEndcapLinkMaker::Links PixelEndcapLinkMaker::links(
   int lastPannelId = -1;
   int idLink = 0;
   int idRoc = 0;
-  PixelFEDLink link(idLink); // dummy object, id=0
+  PixelFEDLink link(idLink);  // dummy object, id=0
 
   for (CIU it = linkItems.begin(); it != linkItems.end(); it++) {
     PixelFEDLink::ROCs rocs;
     int pannelId = it->name->pannelName();
 
-    if ( pannelId != lastPannelId ) {
+    if (pannelId != lastPannelId) {
       lastPannelId = pannelId;
-      if (idLink > 0) result.push_back(link);
+      if (idLink > 0)
+        result.push_back(link);
       idRoc = 0;
-      link = PixelFEDLink(++idLink); // real link, to be filled
+      link = PixelFEDLink(++idLink);  // real link, to be filled
     }
 
-    for (int id = (*it).rocIds.min(); id <= (*it).rocIds.max(); id++) { 
-     ++idRoc;
-     rocs.push_back( PixelROC( it->unit, id, idRoc ) );
+    for (int id = (*it).rocIds.min(); id <= (*it).rocIds.max(); id++) {
+      ++idRoc;
+      rocs.push_back(PixelROC(it->unit, id, idRoc));
     }
 
-    link.add( rocs);
+    link.add(rocs);
   }
 
-  if (idLink > 0) result.push_back(link);
+  if (idLink > 0)
+    result.push_back(link);
   return result;
 }
-
-
-

--- a/CalibTracker/SiPixelConnectivity/src/PixelToFEDAssociateFromAscii.cc
+++ b/CalibTracker/SiPixelConnectivity/src/PixelToFEDAssociateFromAscii.cc
@@ -10,129 +10,108 @@
 
 using namespace std;
 
+PixelToFEDAssociateFromAscii::PixelToFEDAssociateFromAscii(const string& fn) { init(fn); }
+std::string PixelToFEDAssociateFromAscii::version() const { return theVersion; }
 
-PixelToFEDAssociateFromAscii::PixelToFEDAssociateFromAscii(const string & fn) {
-  init(fn);
-}
-std::string PixelToFEDAssociateFromAscii::version() const
-{
-  return theVersion; 
-}
-
-int PixelToFEDAssociateFromAscii::operator()(const PixelModuleName & id) const 
-{
-  return id.isBarrel() ?
-    operator()(dynamic_cast<const PixelBarrelName & >(id)) :
-    operator()(dynamic_cast<const PixelEndcapName & >(id)) ;
+int PixelToFEDAssociateFromAscii::operator()(const PixelModuleName& id) const {
+  return id.isBarrel() ? operator()(dynamic_cast<const PixelBarrelName&>(id)) :
+                       operator()(dynamic_cast<const PixelEndcapName&>(id));
 }
 
-int PixelToFEDAssociateFromAscii::operator()(const PixelBarrelName & id) const
-{
-  for (BarrelConnections::const_iterator
-      ibc = theBarrel.begin(); ibc != theBarrel.end(); ibc++) {
-    for (vector<Bdu>::const_iterator
-        ibd = (*ibc).second.begin(); ibd != (*ibc).second.end(); ibd++) {
-      if (    ibd->b == id.shell() 
-           && ibd->l.inside( id.layerName() )
-           && ibd->z.inside( id.moduleName() )
-           && ibd->f.inside( id.ladderName() ) ) return (*ibc).first; 
+int PixelToFEDAssociateFromAscii::operator()(const PixelBarrelName& id) const {
+  for (BarrelConnections::const_iterator ibc = theBarrel.begin(); ibc != theBarrel.end(); ibc++) {
+    for (vector<Bdu>::const_iterator ibd = (*ibc).second.begin(); ibd != (*ibc).second.end(); ibd++) {
+      if (ibd->b == id.shell() && ibd->l.inside(id.layerName()) && ibd->z.inside(id.moduleName()) &&
+          ibd->f.inside(id.ladderName()))
+        return (*ibc).first;
     }
   }
-  edm::LogError("** PixelToFEDAssociateFromAscii WARNING, name: ")
-       << id.name()<<" not associated to FED";
+  edm::LogError("** PixelToFEDAssociateFromAscii WARNING, name: ") << id.name() << " not associated to FED";
   return -1;
 }
 
-int PixelToFEDAssociateFromAscii::operator()(const PixelEndcapName & id) const 
-{
-  for (EndcapConnections::const_iterator
-      iec = theEndcap.begin(); iec != theEndcap.end(); iec++) {
-    for (vector<Edu>::const_iterator
-        ied = (*iec).second.begin(); ied != (*iec).second.end(); ied++) {
-      if (    ied->e == id.halfCylinder() 
-           && ied->d.inside( id.diskName() )
-           && ied->b.inside( id.bladeName() ) ) return iec->first; 
+int PixelToFEDAssociateFromAscii::operator()(const PixelEndcapName& id) const {
+  for (EndcapConnections::const_iterator iec = theEndcap.begin(); iec != theEndcap.end(); iec++) {
+    for (vector<Edu>::const_iterator ied = (*iec).second.begin(); ied != (*iec).second.end(); ied++) {
+      if (ied->e == id.halfCylinder() && ied->d.inside(id.diskName()) && ied->b.inside(id.bladeName()))
+        return iec->first;
     }
   }
-  edm::LogError("** PixelToFEDAssociateFromAscii WARNING, name: ")
-       << id.name()<<" not associated to FED";
+  edm::LogError("** PixelToFEDAssociateFromAscii WARNING, name: ") << id.name() << " not associated to FED";
   return -1;
 }
 
-
-void PixelToFEDAssociateFromAscii::init(const string & cfg_name)
-{
+void PixelToFEDAssociateFromAscii::init(const string& cfg_name) {
   LogDebug("init, input file:") << cfg_name.c_str();
 
-  std::ifstream file( cfg_name.c_str() );
-  if ( !file ) {
-    edm::LogError(" ** PixelToFEDAssociateFromAscii,init ** ")
-         << " cant open data file: " << cfg_name;
+  std::ifstream file(cfg_name.c_str());
+  if (!file) {
+    edm::LogError(" ** PixelToFEDAssociateFromAscii,init ** ") << " cant open data file: " << cfg_name;
     return;
   } else {
-    edm::LogInfo("PixelToFEDAssociateFromAscii, read data from: ") <<cfg_name ;
+    edm::LogInfo("PixelToFEDAssociateFromAscii, read data from: ") << cfg_name;
   }
 
   string line;
-  pair< int, vector<Bdu> > barCon;
-  pair< int, vector<Edu> > endCon;
+  pair<int, vector<Bdu> > barCon;
+  pair<int, vector<Edu> > endCon;
 
   try {
-  while (getline(file,line)) {
-    //
-    // treat # lines
-    //
-    string::size_type pos = line.find("#");
-    if (pos != string::npos) line = line.erase(pos);
+    while (getline(file, line)) {
+      //
+      // treat # lines
+      //
+      string::size_type pos = line.find("#");
+      if (pos != string::npos)
+        line = line.erase(pos);
 
-    string::size_type posF = line.find("FED:");
-    string::size_type posB = line.find("S:");
-    string::size_type posE = line.find("E:");
+      string::size_type posF = line.find("FED:");
+      string::size_type posB = line.find("S:");
+      string::size_type posE = line.find("E:");
 
-    LogDebug ( "line read" ) << line;
+      LogDebug("line read") << line;
 
-    //
-    // treat version lines, reset date
-    //
-    if (     line.compare(0,3,"VER") == 0 ) { 
-      edm::LogInfo("version: ")<<line;
-      theVersion = line;
-      send(barCon,endCon);
-      theBarrel.clear();
-      theEndcap.clear();
+      //
+      // treat version lines, reset date
+      //
+      if (line.compare(0, 3, "VER") == 0) {
+        edm::LogInfo("version: ") << line;
+        theVersion = line;
+        send(barCon, endCon);
+        theBarrel.clear();
+        theEndcap.clear();
+      }
+
+      //
+      // fed id line
+      //
+      else if (posF != string::npos) {
+        line = line.substr(posF + 4);
+        int id = atoi(line.c_str());
+        send(barCon, endCon);
+        barCon.first = id;
+        endCon.first = id;
+      }
+
+      //
+      // barrel connections
+      //
+      else if (posB != string::npos) {
+        line = line.substr(posB + 2);
+        barCon.second.push_back(getBdu(line));
+      }
+
+      //
+      // endcap connections
+      //
+      else if (posE != string::npos) {
+        line = line.substr(posE + 2);
+        endCon.second.push_back(getEdu(line));
+      }
     }
-
-    //
-    // fed id line
-    //
-    else if ( posF != string::npos) { 
-      line = line.substr(posF+4);
-      int id = atoi(line.c_str());
-      send(barCon,endCon); 
-      barCon.first = id;
-      endCon.first = id;
-    }
-
-    //
-    // barrel connections
-    //
-    else if ( posB != string::npos) {
-      line = line.substr(posB+2);
-      barCon.second.push_back( getBdu(line) );
-    }
-
-    //
-    // endcap connections
-    //
-    else if ( posE != string::npos) {
-      line = line.substr(posE+2);
-      endCon.second.push_back( getEdu(line) );
-    }
-  }
-  send(barCon,endCon);
-  } 
-  catch(exception& err) {
-    edm::LogError("**PixelToFEDAssociateFromAscii**  exception")<<err.what();
+    send(barCon, endCon);
+  } catch (exception& err) {
+    edm::LogError("**PixelToFEDAssociateFromAscii**  exception") << err.what();
     theBarrel.clear();
     theEndcap.clear();
   }
@@ -141,101 +120,104 @@ void PixelToFEDAssociateFromAscii::init(const string & cfg_name)
   // for debug
   //
   std::ostringstream str;
-  str <<" **PixelToFEDAssociateFromAscii ** BARREL FED CONNECTIONS: "<< endl;
-  for (BarrelConnections::const_iterator
-      ibc = theBarrel.begin(); ibc != theBarrel.end(); ibc++) {
+  str << " **PixelToFEDAssociateFromAscii ** BARREL FED CONNECTIONS: " << endl;
+  for (BarrelConnections::const_iterator ibc = theBarrel.begin(); ibc != theBarrel.end(); ibc++) {
     str << "FED: " << ibc->first << endl;
-    for (vector<Bdu>::const_iterator
-        ibd = (*ibc).second.begin(); ibd != (*ibc).second.end(); ibd++) {
-      str << "b: "<<ibd->b<<" l: "<<ibd->l<<" z: "<<ibd->z<<" f: "<<ibd->f<<endl;
+    for (vector<Bdu>::const_iterator ibd = (*ibc).second.begin(); ibd != (*ibc).second.end(); ibd++) {
+      str << "b: " << ibd->b << " l: " << ibd->l << " z: " << ibd->z << " f: " << ibd->f << endl;
     }
   }
-  str <<" **PixelToFEDAssociateFromAscii ** ENDCAP FED CONNECTIONS: " << endl;
-  for (EndcapConnections::const_iterator
-    iec = theEndcap.begin(); iec != theEndcap.end(); iec++) {
+  str << " **PixelToFEDAssociateFromAscii ** ENDCAP FED CONNECTIONS: " << endl;
+  for (EndcapConnections::const_iterator iec = theEndcap.begin(); iec != theEndcap.end(); iec++) {
     str << "FED: " << iec->first << endl;
-    for (vector<Edu>::const_iterator
-        ied = (*iec).second.begin(); ied != (*iec).second.end(); ied++) {
-      str << " e: "<<ied->e<<" d: "<<ied->d<<" b: "<<ied->b<<endl;
+    for (vector<Edu>::const_iterator ied = (*iec).second.begin(); ied != (*iec).second.end(); ied++) {
+      str << " e: " << ied->e << " d: " << ied->d << " b: " << ied->b << endl;
     }
   }
-  edm::LogInfo("PixelToFEDAssociateFromAscii")<<str.str();
+  edm::LogInfo("PixelToFEDAssociateFromAscii") << str.str();
 }
 
-void PixelToFEDAssociateFromAscii::send(
-    pair<int,vector<Bdu> > & b, pair<int,vector<Edu> > & e)
-{
-  if (!b.second.empty()) theBarrel.push_back(b);
-  if (!e.second.empty()) theEndcap.push_back(e);
+void PixelToFEDAssociateFromAscii::send(pair<int, vector<Bdu> >& b, pair<int, vector<Edu> >& e) {
+  if (!b.second.empty())
+    theBarrel.push_back(b);
+  if (!e.second.empty())
+    theEndcap.push_back(e);
   b.second.clear();
   e.second.clear();
 }
 
-PixelToFEDAssociateFromAscii::Bdu PixelToFEDAssociateFromAscii::getBdu( string line) const
-{
+PixelToFEDAssociateFromAscii::Bdu PixelToFEDAssociateFromAscii::getBdu(string line) const {
   Bdu result;
   string::size_type pos;
 
-  result.b =  readRange(line).first;
+  result.b = readRange(line).first;
 
   pos = line.find("L:");
-  if (pos != string::npos) line = line.substr(pos+2);
+  if (pos != string::npos)
+    line = line.substr(pos + 2);
   result.l = readRange(line);
 
   pos = line.find("Z:");
-  if (pos != string::npos) line = line.substr(pos+2);
+  if (pos != string::npos)
+    line = line.substr(pos + 2);
   result.z = readRange(line);
 
   pos = line.find("F:");
-  if (pos != string::npos) line = line.substr(pos+2);
+  if (pos != string::npos)
+    line = line.substr(pos + 2);
   result.f = readRange(line);
 
   return result;
 }
 
-PixelToFEDAssociateFromAscii::Edu PixelToFEDAssociateFromAscii::getEdu( string line) const
-{
+PixelToFEDAssociateFromAscii::Edu PixelToFEDAssociateFromAscii::getEdu(string line) const {
   Edu result;
   string::size_type pos;
 
   result.e = readRange(line).first;
 
   pos = line.find("D:");
-  if (pos != string::npos) line = line.substr(pos+2);
+  if (pos != string::npos)
+    line = line.substr(pos + 2);
   result.d = readRange(line);
 
   pos = line.find("B:");
-  if (pos != string::npos) line = line.substr(pos+2);
+  if (pos != string::npos)
+    line = line.substr(pos + 2);
   result.b = readRange(line);
-  
+
   return result;
 }
 
-PixelToFEDAssociateFromAscii::Range 
-    PixelToFEDAssociateFromAscii::readRange( const string & l) const
-{
+PixelToFEDAssociateFromAscii::Range PixelToFEDAssociateFromAscii::readRange(const string& l) const {
   bool first = true;
   int num1 = -1;
   int num2 = -1;
-  const char * line = l.c_str();
+  const char* line = l.c_str();
   while (line) {
-    char * evp = nullptr;
+    char* evp = nullptr;
     int num = strtol(line, &evp, 10);
-    { stringstream s; s<<"raad from line: "; s<<num; LogDebug(s.str()); }
+    {
+      stringstream s;
+      s << "raad from line: ";
+      s << num;
+      LogDebug(s.str());
+    }
     if (evp != line) {
-      line = evp +1;
-      if (first) { num1 = num; first = false; }
+      line = evp + 1;
+      if (first) {
+        num1 = num;
+        first = false;
+      }
       num2 = num;
-    } else line = nullptr;
+    } else
+      line = nullptr;
   }
   if (first) {
-    string s = "** PixelToFEDAssociateFromAscii, read data, cant intrpret: " ;
-    edm::LogInfo(s) << endl 
-              << l << endl 
-              <<"=====> send exception " << endl;
+    string s = "** PixelToFEDAssociateFromAscii, read data, cant intrpret: ";
+    edm::LogInfo(s) << endl << l << endl << "=====> send exception " << endl;
     s += l;
     throw cms::Exception(s);
   }
-  return Range(num1,num2);
+  return Range(num1, num2);
 }
-

--- a/CalibTracker/SiPixelConnectivity/src/PixelToLNKAssociateFromAscii.cc
+++ b/CalibTracker/SiPixelConnectivity/src/PixelToLNKAssociateFromAscii.cc
@@ -11,155 +11,147 @@
 
 using namespace std;
 
-PixelToLNKAssociateFromAscii::PixelToLNKAssociateFromAscii(const string & fn, const bool phase) {
+PixelToLNKAssociateFromAscii::PixelToLNKAssociateFromAscii(const string& fn, const bool phase) {
   phase1_ = phase;
   init(fn);
-
 }
-std::string PixelToLNKAssociateFromAscii::version() const {
-  return theVersion; 
-}
+std::string PixelToLNKAssociateFromAscii::version() const { return theVersion; }
 
-const PixelToLNKAssociateFromAscii::CablingRocId * PixelToLNKAssociateFromAscii::operator()( 
+const PixelToLNKAssociateFromAscii::CablingRocId* PixelToLNKAssociateFromAscii::operator()(
     const PixelToLNKAssociateFromAscii::DetectorRocId& roc) const {
-
-  typedef std::vector< std::pair<DetectorRocId,CablingRocId> >::const_iterator IM;
+  typedef std::vector<std::pair<DetectorRocId, CablingRocId> >::const_iterator IM;
   for (IM im = theConnection.begin(); im != theConnection.end(); im++) {
-    if( ( *(im->first.module) == *roc.module ) && (im->first.rocDetId == roc.rocDetId)) {
-      return &(im->second);  
+    if ((*(im->first.module) == *roc.module) && (im->first.rocDetId == roc.rocDetId)) {
+      return &(im->second);
     }
   }
   return nullptr;
 }
 
 // This is where the reading and interpretation of the ascci cabling input file is
-void PixelToLNKAssociateFromAscii::init(const string & cfg_name) {
-
+void PixelToLNKAssociateFromAscii::init(const string& cfg_name) {
   edm::LogInfo(" init, input file: ") << cfg_name;
 
-  std::ifstream file( cfg_name.c_str() );
-  if ( !file ) {
-    edm::LogError(" ** PixelToLNKAssociateFromAscii,init ** ")
-         << " cant open data file: " << cfg_name;
+  std::ifstream file(cfg_name.c_str());
+  if (!file) {
+    edm::LogError(" ** PixelToLNKAssociateFromAscii,init ** ") << " cant open data file: " << cfg_name;
     return;
   } else {
-    edm::LogInfo("PixelToLNKAssociateFromAscii, read data from: ") <<cfg_name;
+    edm::LogInfo("PixelToLNKAssociateFromAscii, read data from: ") << cfg_name;
   }
 
   string line;
-  int fedId=-1;
-  int linkId=-1;
+  int fedId = -1;
+  int linkId = -1;
 
   try {
-  while (getline(file,line)) {
-    //
-    // treat # lines
-    //
-    string::size_type pos = line.find("#");
-    if (pos != string::npos) line = line.erase(pos);
+    while (getline(file, line)) {
+      //
+      // treat # lines
+      //
+      string::size_type pos = line.find("#");
+      if (pos != string::npos)
+        line = line.erase(pos);
 
-    string::size_type posF = line.find("FED:");
-    string::size_type posL = line.find("LNK:");
-    string::size_type posM = line.find("MOD:");
-    string::size_type posR = line.find("ROC:");
+      string::size_type posF = line.find("FED:");
+      string::size_type posL = line.find("LNK:");
+      string::size_type posM = line.find("MOD:");
+      string::size_type posR = line.find("ROC:");
 
-    edm::LogInfo("") <<" read line: "<< line;
-    
+      edm::LogInfo("") << " read line: " << line;
 
-    //
-    // treat version lines, reset date
-    //
-    if (     line.compare(0,3,"VER") == 0 ) { 
-      edm::LogInfo("version: ")<<line;
-      theVersion = line;
-    }
+      //
+      // treat version lines, reset date
+      //
+      if (line.compare(0, 3, "VER") == 0) {
+        edm::LogInfo("version: ") << line;
+        theVersion = line;
+      }
 
-    //
-    // fed id line
-    //
-    else if ( posF != string::npos) { 
-      line = line.substr(posF+4);
-      fedId = atoi(line.c_str());
-    }
+      //
+      // fed id line
+      //
+      else if (posF != string::npos) {
+        line = line.substr(posF + 4);
+        fedId = atoi(line.c_str());
+      }
 
-    //
-    // link id linke
-    //
-    else if ( posL != string::npos) {
-      string srtL = line.substr(posL+4);
-      linkId = atoi(srtL.c_str());
-    }
+      //
+      // link id linke
+      //
+      else if (posL != string::npos) {
+        string srtL = line.substr(posL + 4);
+        linkId = atoi(srtL.c_str());
+      }
 
-    //
-    // module description
-    //
-    if ( posM != string::npos) {
-      if (posR != string::npos) {
-        string strM = line.substr(posM+4, posR-posM-5);
-        string::size_type pos = strM.find(" "); 
-        if(pos != string::npos) strM = strM.substr(pos+1);
-        string strR = line.substr(posR+4);
-        Range range = readRange(strR);
-	//cout<<" range find "<<strR<<" "<<strR.size()<<" "<<range.min()<<" "<<range.max()<<endl;
-        addConnections( fedId, linkId, strM, range);
-      } else { 
-        string strM= line.substr(posM+4);
-        string::size_type pos = strM.find(" "); 
-        if(pos != string::npos) strM = strM.substr(pos+1);
-        addConnections( fedId, linkId, strM, Range(0,0));
+      //
+      // module description
+      //
+      if (posM != string::npos) {
+        if (posR != string::npos) {
+          string strM = line.substr(posM + 4, posR - posM - 5);
+          string::size_type pos = strM.find(" ");
+          if (pos != string::npos)
+            strM = strM.substr(pos + 1);
+          string strR = line.substr(posR + 4);
+          Range range = readRange(strR);
+          //cout<<" range find "<<strR<<" "<<strR.size()<<" "<<range.min()<<" "<<range.max()<<endl;
+          addConnections(fedId, linkId, strM, range);
+        } else {
+          string strM = line.substr(posM + 4);
+          string::size_type pos = strM.find(" ");
+          if (pos != string::npos)
+            strM = strM.substr(pos + 1);
+          addConnections(fedId, linkId, strM, Range(0, 0));
+        }
       }
     }
-  }
-  } 
-  catch(exception& err) {
-    edm::LogError("**PixelToLNKAssociateFromAscii**  exception")<<err.what();
+  } catch (exception& err) {
+    edm::LogError("**PixelToLNKAssociateFromAscii**  exception") << err.what();
   }
 
   //
   // for debug
   //
   std::ostringstream str;
-  str <<" **PixelToLNKAssociateFromAscii ** CONNECTIONS: "<< endl;
-  typedef vector< pair<DetectorRocId,CablingRocId> >::const_iterator ICON;
+  str << " **PixelToLNKAssociateFromAscii ** CONNECTIONS: " << endl;
+  typedef vector<pair<DetectorRocId, CablingRocId> >::const_iterator ICON;
   for (ICON ic = theConnection.begin(); ic != theConnection.end(); ic++) {
-    str<< (*ic).first.module->name()
-       <<", rocDetId="<<(*ic).first.rocDetId
-       <<", fedId="<<ic->second.fedId
-       <<", linkId="<<ic->second.linkId
-       <<", rocLinkId="<<ic->second.rocLinkId
-       <<endl;
+    str << (*ic).first.module->name() << ", rocDetId=" << (*ic).first.rocDetId << ", fedId=" << ic->second.fedId
+        << ", linkId=" << ic->second.linkId << ", rocLinkId=" << ic->second.rocLinkId << endl;
   }
-  edm::LogInfo("PixelToLNKAssociateFromAscii")<<str.str();
+  edm::LogInfo("PixelToLNKAssociateFromAscii") << str.str();
 }
 
-void PixelToLNKAssociateFromAscii::addConnections(
-    int fedId, int linkId,  std::string module, Range rocDetIds) {
-
+void PixelToLNKAssociateFromAscii::addConnections(int fedId, int linkId, std::string module, Range rocDetIds) {
   string::size_type pos;
-
 
   // check for Barrel modules
   pos = module.find("BPix");
-  if (pos != string::npos) { 
-    
-    string module0=module;
-    // strip the trailing spaces 
+  if (pos != string::npos) {
+    string module0 = module;
+    // strip the trailing spaces
     string::size_type p = module0.find(" ");
     //string::size_type p1 = module0.find_first_of(" ");
     //string::size_type p2 = module0.find_last_not_of(" ");
     //cout<<p<<" "<<p1<<" "<<p2<<endl;
-    if(p != string::npos) module0 = module0.substr(0,p);
-    PixelBarrelName * name = new PixelBarrelName(module0,phase1_);
+    if (p != string::npos)
+      module0 = module0.substr(0, p);
+    PixelBarrelName* name = new PixelBarrelName(module0, phase1_);
 
     // shell
-    string strP = module.substr(pos+6,2);
+    string strP = module.substr(pos + 6, 2);
     PixelBarrelName::Shell part;
-    if (strP=="mO")     part = PixelBarrelName::mO; 
-    else if(strP=="mI") part = PixelBarrelName::mI;
-    else if(strP=="pO") part = PixelBarrelName::pO;
-    else                part = PixelBarrelName::pI;
+    if (strP == "mO")
+      part = PixelBarrelName::mO;
+    else if (strP == "mI")
+      part = PixelBarrelName::mI;
+    else if (strP == "pO")
+      part = PixelBarrelName::pO;
+    else
+      part = PixelBarrelName::pI;
 
-    // // all this can be skipped ----------------------------------- 
+    // // all this can be skipped -----------------------------------
     // module = module.substr(pos+9);
     // // sector
     // pos = module.find("_");
@@ -177,7 +169,7 @@ void PixelToLNKAssociateFromAscii::addConnections(
     // int ladder = atoi( module.substr(3,pos-3).c_str());
     // module = module.substr(pos+1);
     // // z-module
-    // int zmodule = atoi( module.substr(3,pos-3).c_str());    
+    // int zmodule = atoi( module.substr(3,pos-3).c_str());
     // // place modules in connections
     // PixelBarrelName * name0 = new PixelBarrelName(part, layer, zmodule, ladder, phase1_);
     // if(name->name() != module0) cout<<" wrong name "<<fedId<<" "<<linkId<<" "
@@ -186,276 +178,346 @@ void PixelToLNKAssociateFromAscii::addConnections(
     // 				     <<module0<<" "<<name->name()<<" "<<name0->name()<<endl;
     // //edm::LogInfo(" module ")<<fedId<<" "<<linkId<<" "<<module0<<" "
     // //			     <<name0->name()<<" "<<rocDetIds.max()<<endl;
-    // // until here 
-    
-    
-     int rocLnkId = 0; 
-     bool loopExecuted = false;
-     for (int rocDetId=rocDetIds.min(); rocDetId <= rocDetIds.max(); rocDetId++) {
-       loopExecuted = true;
-       rocLnkId++;
-       DetectorRocId  detectorRocId;
-       //detectorRocId.module = name0;
-       detectorRocId.module = name;
-       detectorRocId.rocDetId = rocDetId;
+    // // until here
 
-       CablingRocId   cablingRocId;
-       cablingRocId.fedId = fedId;
-       cablingRocId.linkId = linkId;
-       cablingRocId.rocLinkId = rocLnkId;
-       // fix for type-B modules in barrel
-       edm::LogInfo(" roc ")<<rocDetId<<" "<<rocLnkId<<" "<<name->isHalfModule()<<endl;
-       if (name->isHalfModule() && (rocDetIds.min()>7)  
-           && (part==PixelBarrelName::mO || part==PixelBarrelName::mI) ) {
-	 //cablingRocId.rocLinkId = 9-rocLnkId;
-	 // rocDetId=8,...,15
-	 edm::LogInfo(" special for half modules ");
-         cablingRocId.rocLinkId = rocLnkId;   // 1...8    19/11/08 d.k.
-         detectorRocId.rocDetId = rocDetId-8; // 0...7
-       }
-       theConnection.push_back( make_pair(detectorRocId,cablingRocId));
-     } 
-     if (!loopExecuted) delete name;
+    int rocLnkId = 0;
+    bool loopExecuted = false;
+    for (int rocDetId = rocDetIds.min(); rocDetId <= rocDetIds.max(); rocDetId++) {
+      loopExecuted = true;
+      rocLnkId++;
+      DetectorRocId detectorRocId;
+      //detectorRocId.module = name0;
+      detectorRocId.module = name;
+      detectorRocId.rocDetId = rocDetId;
+
+      CablingRocId cablingRocId;
+      cablingRocId.fedId = fedId;
+      cablingRocId.linkId = linkId;
+      cablingRocId.rocLinkId = rocLnkId;
+      // fix for type-B modules in barrel
+      edm::LogInfo(" roc ") << rocDetId << " " << rocLnkId << " " << name->isHalfModule() << endl;
+      if (name->isHalfModule() && (rocDetIds.min() > 7) &&
+          (part == PixelBarrelName::mO || part == PixelBarrelName::mI)) {
+        //cablingRocId.rocLinkId = 9-rocLnkId;
+        // rocDetId=8,...,15
+        edm::LogInfo(" special for half modules ");
+        cablingRocId.rocLinkId = rocLnkId;      // 1...8    19/11/08 d.k.
+        detectorRocId.rocDetId = rocDetId - 8;  // 0...7
+      }
+      theConnection.push_back(make_pair(detectorRocId, cablingRocId));
+    }
+    if (!loopExecuted)
+      delete name;
   }
-
 
   // check for endcap modules
   pos = module.find("FPix");
   if (pos != string::npos) {
+    string strH = module.substr(pos + 6, 2);
+    PixelEndcapName::HalfCylinder part;
+    if (strH == "mO")
+      part = PixelEndcapName::mO;
+    else if (strH == "mI")
+      part = PixelEndcapName::mI;
+    else if (strH == "pO")
+      part = PixelEndcapName::pO;
+    else
+      part = PixelEndcapName::pI;
+    module = module.substr(pos + 9);
 
-     string strH = module.substr(pos+6,2);
-     PixelEndcapName::HalfCylinder part;
-         if (strH=="mO") part = PixelEndcapName::mO;
-     else if(strH=="mI") part = PixelEndcapName::mI;
-     else if(strH=="pO") part = PixelEndcapName::pO;
-     else                part = PixelEndcapName::pI;
-     module = module.substr(pos+9);
+    // disk
+    pos = module.find("_");
+    if (pos == string::npos)
+      throw cms::Exception("problem with disk formatting");
+    int disk = atoi(module.substr(1, pos - 1).c_str());
+    module = module.substr(pos + 1);
 
-     // disk
-     pos = module.find("_");
-     if (pos ==  string::npos) throw cms::Exception("problem with disk formatting");
-     int disk = atoi( module.substr(1,pos-1).c_str());
-     module = module.substr(pos+1);
+    // blade
+    pos = module.find("_");
+    if (pos == string::npos)
+      throw cms::Exception("problem with blade formatting");
+    int blade = atoi(module.substr(3, pos - 3).c_str());
+    module = module.substr(pos + 1);
 
-     // blade
-     pos = module.find("_");
-     if (pos ==  string::npos) throw cms::Exception("problem with blade formatting");
-     int blade = atoi( module.substr(3,pos-3).c_str());
-     module = module.substr(pos+1);
+    //pannel
+    pos = module.find("_");
+    if (pos == string::npos)
+      throw cms::Exception("problem with pannel formatting");
+    int pannel = atoi(module.substr(3, pos - 3).c_str());
+    module = module.substr(pos + 1);
 
-     //pannel
-     pos = module.find("_");
-     if (pos ==  string::npos) throw cms::Exception("problem with pannel formatting");
-     int pannel = atoi( module.substr(3,pos-3).c_str());
-     module = module.substr(pos+1);
-     
-     // plaquete
-//     pos = module.find("_");
-//     if (pos ==  string::npos) throw cms::Exception("problem with plaquette formatting");
-//     int plaq = atoi( module.substr(3,pos-3).c_str());
+    // plaquete
+    //     pos = module.find("_");
+    //     if (pos ==  string::npos) throw cms::Exception("problem with plaquette formatting");
+    //     int plaq = atoi( module.substr(3,pos-3).c_str());
 
-     int ring=1; // preset to 1 so it is ok for pilot blades
-     // pannel type
-     PixelPannelType::PannelType pannelType; 
-     if(phase1_) {
-       pannelType=PixelPannelType::p2x8; // only 1 type for phase1
-       
-       // this is not really needed, just for testing 
-       // ring 
-       pos = module.find("RNG");
-       if (pos ==  string::npos) throw cms::Exception("problem with ring  formatting");
-       ring  = atoi( module.substr(pos+3,1).c_str()); //
-       //cout<<" ring "<<ring<<" "<<module<<endl;
+    int ring = 1;  // preset to 1 so it is ok for pilot blades
+    // pannel type
+    PixelPannelType::PannelType pannelType;
+    if (phase1_) {
+      pannelType = PixelPannelType::p2x8;  // only 1 type for phase1
 
-     } else { // phase0
-       pos = module.find("TYP:");
-       if (pos ==  string::npos) throw cms::Exception("problem with pannel type formatting");
-       string strT = module.substr(pos+5,3);
-       string strT4 = module.substr(pos+5,4);
-       ring=1;
-       if (strT=="P3R") pannelType=PixelPannelType::p3R;
-       else if (strT=="P3L") pannelType=PixelPannelType::p3L;
-       else if (strT=="P4R") pannelType=PixelPannelType::p4R;
-       else if (strT=="P4L") pannelType=PixelPannelType::p4L;
-       else if (strT4=="P2X8") pannelType=PixelPannelType::p2x8;  // for pilot blades
-       else throw cms::Exception("problem with pannel type formatting (unrecoginzed word)");      
-     }
-     
+      // this is not really needed, just for testing
+      // ring
+      pos = module.find("RNG");
+      if (pos == string::npos)
+        throw cms::Exception("problem with ring  formatting");
+      ring = atoi(module.substr(pos + 3, 1).c_str());  //
+      //cout<<" ring "<<ring<<" "<<module<<endl;
 
-     // Cabling accoring to the panle type
-     if ( pannelType==PixelPannelType::p4L) {
-//     cout <<"----------- p4L"<<endl;
-       int rocLnkId =0;
-       for (int plaq = 1; plaq <= 4; plaq++) {
-         Range rocs; int firstRoc=0; int step=0;
-         if (plaq==1) { rocs = Range(0,1); firstRoc=1; step=-1; }
-         if (plaq==2) { rocs = Range(0,5); firstRoc=0; step=+1; }
-         if (plaq==3) { rocs = Range(0,7); firstRoc=0; step=+1; }
-         if (plaq==4) { rocs = Range(0,4); firstRoc=0; step=+1; }
-         PixelEndcapName * name  = new PixelEndcapName(part,disk,blade,pannel,plaq);
-         for (int iroc =rocs.min(); iroc<=rocs.max(); iroc++) {
-           rocLnkId++;
-           int rocDetId = firstRoc + step*iroc; 
+    } else {  // phase0
+      pos = module.find("TYP:");
+      if (pos == string::npos)
+        throw cms::Exception("problem with pannel type formatting");
+      string strT = module.substr(pos + 5, 3);
+      string strT4 = module.substr(pos + 5, 4);
+      ring = 1;
+      if (strT == "P3R")
+        pannelType = PixelPannelType::p3R;
+      else if (strT == "P3L")
+        pannelType = PixelPannelType::p3L;
+      else if (strT == "P4R")
+        pannelType = PixelPannelType::p4R;
+      else if (strT == "P4L")
+        pannelType = PixelPannelType::p4L;
+      else if (strT4 == "P2X8")
+        pannelType = PixelPannelType::p2x8;  // for pilot blades
+      else
+        throw cms::Exception("problem with pannel type formatting (unrecoginzed word)");
+    }
 
-           DetectorRocId  detectorRocId;
-           //detectorRocId.module = new PixelEndcapName(part,disk,blade,pannel,plaq);
-           detectorRocId.module = name;
-           detectorRocId.rocDetId = rocDetId;
+    // Cabling accoring to the panle type
+    if (pannelType == PixelPannelType::p4L) {
+      //     cout <<"----------- p4L"<<endl;
+      int rocLnkId = 0;
+      for (int plaq = 1; plaq <= 4; plaq++) {
+        Range rocs;
+        int firstRoc = 0;
+        int step = 0;
+        if (plaq == 1) {
+          rocs = Range(0, 1);
+          firstRoc = 1;
+          step = -1;
+        }
+        if (plaq == 2) {
+          rocs = Range(0, 5);
+          firstRoc = 0;
+          step = +1;
+        }
+        if (plaq == 3) {
+          rocs = Range(0, 7);
+          firstRoc = 0;
+          step = +1;
+        }
+        if (plaq == 4) {
+          rocs = Range(0, 4);
+          firstRoc = 0;
+          step = +1;
+        }
+        PixelEndcapName* name = new PixelEndcapName(part, disk, blade, pannel, plaq);
+        for (int iroc = rocs.min(); iroc <= rocs.max(); iroc++) {
+          rocLnkId++;
+          int rocDetId = firstRoc + step * iroc;
 
-           CablingRocId   cablingRocId;
-           cablingRocId.fedId = fedId;
-           cablingRocId.linkId = linkId;
-           cablingRocId.rocLinkId = rocLnkId;
+          DetectorRocId detectorRocId;
+          //detectorRocId.module = new PixelEndcapName(part,disk,blade,pannel,plaq);
+          detectorRocId.module = name;
+          detectorRocId.rocDetId = rocDetId;
 
-           theConnection.push_back( make_pair(detectorRocId,cablingRocId));
-//         cout <<"PLAQ:"<<plaq<<" rocDetId: "<<rocDetId<<" rocLnkId:"<<rocLnkId<<endl;
-         }
-       } 
-     } 
-     else if ( pannelType==PixelPannelType::p4R) {
-//     cout <<"----------- p4R"<<endl;
-       int rocLnkId =0;
-       for (int plaq = 4; plaq >= 1; plaq--) {
-         Range rocs; int firstRoc=0; int step=0;
-         if (plaq==1) { rocs = Range(0,1); firstRoc=1; step=-1; }
-         if (plaq==2) { rocs = Range(0,5); firstRoc=3; step=+1; }
-         if (plaq==3) { rocs = Range(0,7); firstRoc=4; step=+1; }
-         if (plaq==4) { rocs = Range(0,4); firstRoc=0; step=+1; }
-         PixelEndcapName * name  = new PixelEndcapName(part,disk,blade,pannel,plaq);
-         for (int iroc =rocs.min(); iroc-rocs.max() <= 0; iroc++) {
-           rocLnkId++;
-           int rocDetId = firstRoc + step*iroc;
-           if (rocDetId > rocs.max()) rocDetId = (rocDetId-1)%rocs.max();
+          CablingRocId cablingRocId;
+          cablingRocId.fedId = fedId;
+          cablingRocId.linkId = linkId;
+          cablingRocId.rocLinkId = rocLnkId;
 
-           DetectorRocId  detectorRocId;
-           //detectorRocId.module = new PixelEndcapName(part,disk,blade,pannel,plaq);
-           detectorRocId.module = name;
-           detectorRocId.rocDetId = rocDetId;
-           CablingRocId   cablingRocId;
-           cablingRocId.fedId = fedId;
-           cablingRocId.linkId = linkId;
-           cablingRocId.rocLinkId = rocLnkId;
+          theConnection.push_back(make_pair(detectorRocId, cablingRocId));
+          //         cout <<"PLAQ:"<<plaq<<" rocDetId: "<<rocDetId<<" rocLnkId:"<<rocLnkId<<endl;
+        }
+      }
+    } else if (pannelType == PixelPannelType::p4R) {
+      //     cout <<"----------- p4R"<<endl;
+      int rocLnkId = 0;
+      for (int plaq = 4; plaq >= 1; plaq--) {
+        Range rocs;
+        int firstRoc = 0;
+        int step = 0;
+        if (plaq == 1) {
+          rocs = Range(0, 1);
+          firstRoc = 1;
+          step = -1;
+        }
+        if (plaq == 2) {
+          rocs = Range(0, 5);
+          firstRoc = 3;
+          step = +1;
+        }
+        if (plaq == 3) {
+          rocs = Range(0, 7);
+          firstRoc = 4;
+          step = +1;
+        }
+        if (plaq == 4) {
+          rocs = Range(0, 4);
+          firstRoc = 0;
+          step = +1;
+        }
+        PixelEndcapName* name = new PixelEndcapName(part, disk, blade, pannel, plaq);
+        for (int iroc = rocs.min(); iroc - rocs.max() <= 0; iroc++) {
+          rocLnkId++;
+          int rocDetId = firstRoc + step * iroc;
+          if (rocDetId > rocs.max())
+            rocDetId = (rocDetId - 1) % rocs.max();
 
-           theConnection.push_back( make_pair(detectorRocId,cablingRocId));
-//         cout <<"PLAQ:"<<plaq<<" rocDetId: "<<rocDetId<<" rocLnkId:"<<rocLnkId<<endl;
-         }
-       }
-     }
-     else if ( pannelType==PixelPannelType::p3L) {
-//     cout <<"----------- p3L"<<endl;
-       int rocLnkId =0;
-       for (int plaq = 1; plaq <= 3; plaq++) {
-         Range rocs; int firstRoc=0; int step=0;
-         if (plaq==1) { rocs = Range(0,5); firstRoc=0; step=1; }
-         if (plaq==2) { rocs = Range(0,7); firstRoc=0; step=1; }
-         if (plaq==3) { rocs = Range(0,9); firstRoc=0; step=1; }
-         PixelEndcapName * name  = new PixelEndcapName(part,disk,blade,pannel,plaq);
-         for (int iroc =rocs.min(); iroc<=rocs.max(); iroc++) {
-           rocLnkId++;
-           int rocDetId = firstRoc + step*iroc; 
+          DetectorRocId detectorRocId;
+          //detectorRocId.module = new PixelEndcapName(part,disk,blade,pannel,plaq);
+          detectorRocId.module = name;
+          detectorRocId.rocDetId = rocDetId;
+          CablingRocId cablingRocId;
+          cablingRocId.fedId = fedId;
+          cablingRocId.linkId = linkId;
+          cablingRocId.rocLinkId = rocLnkId;
 
-           DetectorRocId  detectorRocId;
-           detectorRocId.module = name;
-           detectorRocId.rocDetId = rocDetId;
+          theConnection.push_back(make_pair(detectorRocId, cablingRocId));
+          //         cout <<"PLAQ:"<<plaq<<" rocDetId: "<<rocDetId<<" rocLnkId:"<<rocLnkId<<endl;
+        }
+      }
+    } else if (pannelType == PixelPannelType::p3L) {
+      //     cout <<"----------- p3L"<<endl;
+      int rocLnkId = 0;
+      for (int plaq = 1; plaq <= 3; plaq++) {
+        Range rocs;
+        int firstRoc = 0;
+        int step = 0;
+        if (plaq == 1) {
+          rocs = Range(0, 5);
+          firstRoc = 0;
+          step = 1;
+        }
+        if (plaq == 2) {
+          rocs = Range(0, 7);
+          firstRoc = 0;
+          step = 1;
+        }
+        if (plaq == 3) {
+          rocs = Range(0, 9);
+          firstRoc = 0;
+          step = 1;
+        }
+        PixelEndcapName* name = new PixelEndcapName(part, disk, blade, pannel, plaq);
+        for (int iroc = rocs.min(); iroc <= rocs.max(); iroc++) {
+          rocLnkId++;
+          int rocDetId = firstRoc + step * iroc;
 
-           CablingRocId   cablingRocId;
-           cablingRocId.fedId = fedId;
-           cablingRocId.linkId = linkId;
-           cablingRocId.rocLinkId = rocLnkId;
+          DetectorRocId detectorRocId;
+          detectorRocId.module = name;
+          detectorRocId.rocDetId = rocDetId;
 
-           theConnection.push_back( make_pair(detectorRocId,cablingRocId));
-//         cout <<"PLAQ:"<<plaq<<" rocDetId: "<<rocDetId<<" rocLnkId:"<<rocLnkId<<endl;
-         }
-       } 
-     } 
-     else if ( pannelType==PixelPannelType::p3R) {
-//     cout <<"----------- p3R"<<endl;
-       int rocLnkId =0;
-       for (int plaq = 3; plaq >= 1; plaq--) {
-         Range rocs; int firstRoc=0; int step=0;
-         if (plaq==1) { rocs = Range(0,5); firstRoc=3; step=1; }
-         if (plaq==2) { rocs = Range(0,7); firstRoc=4; step=1; }
-         if (plaq==3) { rocs = Range(0,9); firstRoc=5; step=1; }
-         PixelEndcapName * name  = new PixelEndcapName(part,disk,blade,pannel,plaq);
-         for (int iroc =rocs.min(); iroc<=rocs.max(); iroc++) {
-           rocLnkId++;
-           int rocDetId = firstRoc + step*iroc;
-           if (rocDetId > rocs.max()) rocDetId = (rocDetId-1)%rocs.max();
+          CablingRocId cablingRocId;
+          cablingRocId.fedId = fedId;
+          cablingRocId.linkId = linkId;
+          cablingRocId.rocLinkId = rocLnkId;
 
-           DetectorRocId  detectorRocId;
-           detectorRocId.module = name;
-           detectorRocId.rocDetId = rocDetId;
+          theConnection.push_back(make_pair(detectorRocId, cablingRocId));
+          //         cout <<"PLAQ:"<<plaq<<" rocDetId: "<<rocDetId<<" rocLnkId:"<<rocLnkId<<endl;
+        }
+      }
+    } else if (pannelType == PixelPannelType::p3R) {
+      //     cout <<"----------- p3R"<<endl;
+      int rocLnkId = 0;
+      for (int plaq = 3; plaq >= 1; plaq--) {
+        Range rocs;
+        int firstRoc = 0;
+        int step = 0;
+        if (plaq == 1) {
+          rocs = Range(0, 5);
+          firstRoc = 3;
+          step = 1;
+        }
+        if (plaq == 2) {
+          rocs = Range(0, 7);
+          firstRoc = 4;
+          step = 1;
+        }
+        if (plaq == 3) {
+          rocs = Range(0, 9);
+          firstRoc = 5;
+          step = 1;
+        }
+        PixelEndcapName* name = new PixelEndcapName(part, disk, blade, pannel, plaq);
+        for (int iroc = rocs.min(); iroc <= rocs.max(); iroc++) {
+          rocLnkId++;
+          int rocDetId = firstRoc + step * iroc;
+          if (rocDetId > rocs.max())
+            rocDetId = (rocDetId - 1) % rocs.max();
 
-           CablingRocId   cablingRocId;
-           cablingRocId.fedId = fedId;
-           cablingRocId.linkId = linkId;
-           cablingRocId.rocLinkId = rocLnkId;
+          DetectorRocId detectorRocId;
+          detectorRocId.module = name;
+          detectorRocId.rocDetId = rocDetId;
 
-           theConnection.push_back( make_pair(detectorRocId,cablingRocId));
-//         cout <<"PLAQ:"<<plaq<<" rocDetId: "<<rocDetId<<" rocLnkId:"<<rocLnkId<<endl;
-         } // for
-       } // for
+          CablingRocId cablingRocId;
+          cablingRocId.fedId = fedId;
+          cablingRocId.linkId = linkId;
+          cablingRocId.rocLinkId = rocLnkId;
 
-     } else if ( pannelType==PixelPannelType::p2x8) { // phase-1 blades
-       //       cout <<"----------- p2x8"<<endl;
-       int rocLnkId = 0; 
-       //       Range rocs = Range(0, 15); 
-       //       for (int rocDetId=rocs.min(); rocDetId <= rocs.max(); rocDetId++) {
-       PixelEndcapName * name = new PixelEndcapName(part, disk, blade, pannel, ring, phase1_); 
-       bool loopExecuted = false;
-       for (int rocDetId=rocDetIds.min(); rocDetId <= rocDetIds.max(); rocDetId++) {
-           loopExecuted = true;
-	 rocLnkId++;
-	 DetectorRocId  detectorRocId;
-	 detectorRocId.module = name;
-	 detectorRocId.rocDetId = rocDetId;
-	 CablingRocId   cablingRocId;
-	 cablingRocId.fedId = fedId;
-	 cablingRocId.linkId = linkId;
-	 cablingRocId.rocLinkId = rocLnkId;
-	 theConnection.push_back( make_pair(detectorRocId,cablingRocId));
-	 edm::LogInfo("PixelToLNKAssociateFromAscii FPix ")
-	   << " rocDetId: " << rocDetId 
-	   << " rocLnkId:" << rocLnkId 
-	   << " fedId = " << fedId 
-	   << " linkId = " << linkId
-	   << " name = " << name->name();
-	 // cout << " rocDetId: " << rocDetId 
-	 //      << " rocLnkId:" << rocLnkId 
-	 //      << " fedId = " << fedId 
-	 //      << " linkId = " << linkId
-	 //      << " name = " << name0->name()
-	 //      << endl;
-       } // end for 
-       if (!loopExecuted) {
-           delete name;
-       }
-       
-     } // end of type
+          theConnection.push_back(make_pair(detectorRocId, cablingRocId));
+          //         cout <<"PLAQ:"<<plaq<<" rocDetId: "<<rocDetId<<" rocLnkId:"<<rocLnkId<<endl;
+        }  // for
+      }    // for
 
+    } else if (pannelType == PixelPannelType::p2x8) {  // phase-1 blades
+      //       cout <<"----------- p2x8"<<endl;
+      int rocLnkId = 0;
+      //       Range rocs = Range(0, 15);
+      //       for (int rocDetId=rocs.min(); rocDetId <= rocs.max(); rocDetId++) {
+      PixelEndcapName* name = new PixelEndcapName(part, disk, blade, pannel, ring, phase1_);
+      bool loopExecuted = false;
+      for (int rocDetId = rocDetIds.min(); rocDetId <= rocDetIds.max(); rocDetId++) {
+        loopExecuted = true;
+        rocLnkId++;
+        DetectorRocId detectorRocId;
+        detectorRocId.module = name;
+        detectorRocId.rocDetId = rocDetId;
+        CablingRocId cablingRocId;
+        cablingRocId.fedId = fedId;
+        cablingRocId.linkId = linkId;
+        cablingRocId.rocLinkId = rocLnkId;
+        theConnection.push_back(make_pair(detectorRocId, cablingRocId));
+        edm::LogInfo("PixelToLNKAssociateFromAscii FPix ")
+            << " rocDetId: " << rocDetId << " rocLnkId:" << rocLnkId << " fedId = " << fedId << " linkId = " << linkId
+            << " name = " << name->name();
+        // cout << " rocDetId: " << rocDetId
+        //      << " rocLnkId:" << rocLnkId
+        //      << " fedId = " << fedId
+        //      << " linkId = " << linkId
+        //      << " name = " << name0->name()
+        //      << endl;
+      }  // end for
+      if (!loopExecuted) {
+        delete name;
+      }
+
+    }  // end of type
   }
 }
 
-PixelToLNKAssociateFromAscii::Range 
-    PixelToLNKAssociateFromAscii::readRange( const string & l) const {
+PixelToLNKAssociateFromAscii::Range PixelToLNKAssociateFromAscii::readRange(const string& l) const {
   //cout<<l<<" in range "<<l.size()<<endl;
-  string l1,l2;
-  int i1=-1, i2=-1;
+  string l1, l2;
+  int i1 = -1, i2 = -1;
   int len = l.size();
   //for(int i=0; i<len;i++) {
   // cout<<i<<" "<<l[i]<<endl;
   //}
   string::size_type p = l.find(",");
-  if(p != string::npos) {
+  if (p != string::npos) {
     //cout<<p<<" "<<len<<endl;
-    l1 = l.substr(0,p-1+1);
-    l2 = l.substr(p+1,len-1-p);
+    l1 = l.substr(0, p - 1 + 1);
+    l2 = l.substr(p + 1, len - 1 - p);
     i1 = stoi(l1);
     i2 = stoi(l2);
     //cout<<l1<<" "<<l2<<" "<<i1<<" "<<i2<<endl;
   }
 
-  return Range(i1,i2);
+  return Range(i1, i2);
 
   // this method is very stupid it relies on a space being present after the last number!
   // exchange with string opertaions (above)
@@ -480,8 +542,8 @@ PixelToLNKAssociateFromAscii::Range
   // }
   // if (first) {
   //   string s = "** PixelToLNKAssociateFromAscii, read data, cant intrpret: " ;
-  //   edm::LogInfo(s) << endl 
-  // 		    << l << endl 
+  //   edm::LogInfo(s) << endl
+  // 		    << l << endl
   //             <<"=====> send exception " << endl;
   //   s += l;
   //   throw cms::Exception(s);
@@ -490,6 +552,4 @@ PixelToLNKAssociateFromAscii::Range
   //if(!phase1_ && (i2!=num2)) cout<<" something wrong with max range "<<i2<<" "<<num2<<endl;
   //cout<<" min max "<<num1<<" "<<num2<<endl;
   //return Range(num1,num2);
-
 }
-

--- a/CalibTracker/SiPixelConnectivity/src/SiPixelFedCablingMapBuilder.cc
+++ b/CalibTracker/SiPixelConnectivity/src/SiPixelFedCablingMapBuilder.cc
@@ -30,19 +30,17 @@
 using namespace std;
 using namespace sipixelobjects;
 
-SiPixelFedCablingMapBuilder::SiPixelFedCablingMapBuilder(const string fileName, 
-							 const bool phase1) : 
-  fileName_(fileName)  //, phase1_(phase1) not used anymore
-{ }
+SiPixelFedCablingMapBuilder::SiPixelFedCablingMapBuilder(const string fileName,
+                                                         const bool phase1)
+    : fileName_(fileName)  //, phase1_(phase1) not used anymore
+{}
 
-
-SiPixelFedCablingTree * SiPixelFedCablingMapBuilder::produce( const edm::EventSetup& setup) {
-
+SiPixelFedCablingTree* SiPixelFedCablingMapBuilder::produce(const edm::EventSetup& setup) {
   // Access geometry
   edm::LogInfo("read tracker geometry...");
   edm::ESHandle<TrackerGeometry> pDD;
-  setup.get<TrackerDigiGeometryRecord>().get( pDD );
-  edm::LogInfo("tracker geometry read")<<"There are: "<<  pDD->dets().size() <<" detectors";
+  setup.get<TrackerDigiGeometryRecord>().get(pDD);
+  edm::LogInfo("tracker geometry read") << "There are: " << pDD->dets().size() << " detectors";
 
   // Test new TrackerGeometry features
   //cout << "Test of TrackerGeometry::isThere";
@@ -52,41 +50,40 @@ SiPixelFedCablingTree * SiPixelFedCablingMapBuilder::produce( const edm::EventSe
   //cout  << " is there P1PXEC: " << pDD->isThere(GeomDetEnumerators::P1PXEC);
   //cout  << endl;
 
-  // switch on the phase1 
-  if( (pDD->isThere(GeomDetEnumerators::P1PXB)) || 
-      (pDD->isThere(GeomDetEnumerators::P1PXEC)) ) {
+  // switch on the phase1
+  if ((pDD->isThere(GeomDetEnumerators::P1PXB)) || (pDD->isThere(GeomDetEnumerators::P1PXEC))) {
     phase1_ = true;
     //cout<<" this is phase1 "<<endl;
-    edm::LogInfo("SiPixelFedCablingMapBuilder")<<" pixel phase1 setup ";
+    edm::LogInfo("SiPixelFedCablingMapBuilder") << " pixel phase1 setup ";
   } else {
     phase1_ = false;
     //cout<<" this is phase0 "<<endl;
-    edm::LogInfo("SiPixelFedCablingMapBuilder")<<" pixel phase0 setup ";
+    edm::LogInfo("SiPixelFedCablingMapBuilder") << " pixel phase0 setup ";
   }
 
   int MINFEDID = FEDNumbering::MINSiPixelFEDID;
   int MAXFEDID = FEDNumbering::MAXSiPixelFEDID;
-  if(phase1_) {
+  if (phase1_) {
     // bpix 1200-1239, fpix 1240-1255
     MINFEDID = FEDNumbering::MINSiPixeluTCAFEDID;
-    MAXFEDID = FEDNumbering::MAXSiPixeluTCAFEDID; // is actually 1349, might work
+    MAXFEDID = FEDNumbering::MAXSiPixeluTCAFEDID;  // is actually 1349, might work
   }
-  TRange<int> fedIds(MINFEDID,MAXFEDID);
-  edm::LogInfo("SiPixelFedCablingMapBuilder")<<"pixel fedid range: "<<fedIds;
+  TRange<int> fedIds(MINFEDID, MAXFEDID);
+  edm::LogInfo("SiPixelFedCablingMapBuilder") << "pixel fedid range: " << fedIds;
 
-  // in the constrcuctor init() is called which reads the ascii file and makes 
-  // the map roc<->link 
+  // in the constrcuctor init() is called which reads the ascii file and makes
+  // the map roc<->link
   // what is this junk? Replace by fixed associator.
   //edm::ESHandle<PixelToFEDAssociate> associator;
   //setup.get<TrackerDigiGeometryRecord>().get(theAssociatorName,associator);
   //PixelToFEDAssociate * associator = new PixelToLNKAssociateFromAscii("pixelToLNK.ascii",phase1_);
-  PixelToFEDAssociate * associator = new PixelToLNKAssociateFromAscii(fileName_,phase1_);
-  
-  const PixelToFEDAssociate & name2fed = *associator; 
-  
+  PixelToFEDAssociate* associator = new PixelToLNKAssociateFromAscii(fileName_, phase1_);
+
+  const PixelToFEDAssociate& name2fed = *associator;
+
   string version = name2fed.version();
-  SiPixelFedCablingTree * result = new SiPixelFedCablingTree(version);
-  edm::LogInfo(" version ")<<version<<endl;
+  SiPixelFedCablingTree* result = new SiPixelFedCablingTree(version);
+  edm::LogInfo(" version ") << version << endl;
 
   // Access topology
   edm::ESHandle<TrackerTopology> tTopo;
@@ -96,30 +93,31 @@ SiPixelFedCablingTree * SiPixelFedCablingMapBuilder::produce( const edm::EventSe
   typedef TrackerGeometry::DetContainer::const_iterator ITG;
   int npxdets = 0;
 
-  typedef  std::vector<pair<PixelModuleName* , uint32_t> > UNITS;
+  typedef std::vector<pair<PixelModuleName*, uint32_t> > UNITS;
   UNITS units;
 
   for (ITG it = pDD->dets().begin(); it != pDD->dets().end(); it++) {
-    const PixelGeomDetUnit * pxUnit = dynamic_cast<const PixelGeomDetUnit*>(*it);
-    if (pxUnit  ==nullptr ) continue;
+    const PixelGeomDetUnit* pxUnit = dynamic_cast<const PixelGeomDetUnit*>(*it);
+    if (pxUnit == nullptr)
+      continue;
     npxdets++;
     DetId geomid = pxUnit->geographicalId();
-    PixelModuleName * name =  nullptr;
-    if (1 == geomid.subdetId()) {  // bpix 
-      name = new PixelBarrelName(geomid,tt,phase1_);
-    } else {                      // fpix 
-      name = new PixelEndcapName(geomid,tt,phase1_);
-    } 
-    edm::LogInfo(" NAME: ")<<name->name();
+    PixelModuleName* name = nullptr;
+    if (1 == geomid.subdetId()) {  // bpix
+      name = new PixelBarrelName(geomid, tt, phase1_);
+    } else {  // fpix
+      name = new PixelEndcapName(geomid, tt, phase1_);
+    }
+    edm::LogInfo(" NAME: ") << name->name();
     //cout << " NAME: "<<name->name()<<" "<<geomid.rawId()<<
     //" "<<myprint(pxUnit)<<endl;
-    units.push_back( std::make_pair( name, geomid.rawId() ) );
+    units.push_back(std::make_pair(name, geomid.rawId()));
   }
 
-  // This produces  a simple, unrealistic map, NOT USED ANYMORE 
+  // This produces  a simple, unrealistic map, NOT USED ANYMORE
   // if (theAssociatorName=="PixelToFEDAssociateFromAscii") {
   //   cout <<" HERE PixelToFEDAssociateFromAscii"<<endl;
-  //   vector<FedSpec> fedSpecs(fedIds.max()-fedIds.min()+1); 
+  //   vector<FedSpec> fedSpecs(fedIds.max()-fedIds.min()+1);
   //   for (int id=fedIds.first; id<=fedIds.second; id++) {
   //     FedSpec fs={ id, vector<PixelModuleName* >(), vector<uint32_t>()};
   //     int idx = id - fedIds.min();
@@ -147,7 +145,7 @@ SiPixelFedCablingTree * SiPixelFedCablingMapBuilder::produce( const edm::EventSe
   //     PixelFEDCabling fed(fedId);
   //     bool barrel = it->names.front()->isBarrel();
   //     if (barrel) {
-  // 	PixelFEDCabling::Links links = 
+  // 	PixelFEDCabling::Links links =
   //         PixelBarrelLinkMaker(&fed).links(names,units);
   // 	fed.setLinks(links);
   // 	result->addFed(fed);
@@ -158,55 +156,62 @@ SiPixelFedCablingTree * SiPixelFedCablingMapBuilder::produce( const edm::EventSe
   // 	result->addFed(fed);
   //     }
   //   }
-  // } else {     // This is what is really used 
+  // } else {     // This is what is really used
 
-    PixelToFEDAssociate::DetectorRocId detectorRocId;
-    edm::LogInfo(" HERE PixelToLNKAssociateFromAscii");
-    for (UNITS::iterator iu=units.begin(); iu != units.end(); iu++) {
-      PixelModuleName * name =  (*iu).first; 
-      detectorRocId.module = name;
-      //for (int rocDetId=0; rocDetId<=16; rocDetId++) {
-      for (int rocDetId=0; rocDetId<16; rocDetId++) {
-        detectorRocId.rocDetId = rocDetId;
-        const PixelToFEDAssociate::CablingRocId * cablingRocId =  name2fed(detectorRocId);
-        if (cablingRocId) {
-          sipixelobjects::PixelROC roc( iu->second, rocDetId, cablingRocId->rocLinkId ); 
-          result->addItem(cablingRocId->fedId, cablingRocId->linkId, roc);
-	  edm::LogInfo(" ok ")<<name->name()<<" "<<rocDetId<<" "<<cablingRocId->fedId<<" "
-	      <<cablingRocId->linkId;
-        } else {  // did it fail?
-	  edm::LogInfo(" failed ")<<name->name()<<" "<<rocDetId;
-	  //cout<<" failed "<<name->name()<<" "<<rocDetId<<endl;
-	}
+  PixelToFEDAssociate::DetectorRocId detectorRocId;
+  edm::LogInfo(" HERE PixelToLNKAssociateFromAscii");
+  for (UNITS::iterator iu = units.begin(); iu != units.end(); iu++) {
+    PixelModuleName* name = (*iu).first;
+    detectorRocId.module = name;
+    //for (int rocDetId=0; rocDetId<=16; rocDetId++) {
+    for (int rocDetId = 0; rocDetId < 16; rocDetId++) {
+      detectorRocId.rocDetId = rocDetId;
+      const PixelToFEDAssociate::CablingRocId* cablingRocId = name2fed(detectorRocId);
+      if (cablingRocId) {
+        sipixelobjects::PixelROC roc(iu->second, rocDetId, cablingRocId->rocLinkId);
+        result->addItem(cablingRocId->fedId, cablingRocId->linkId, roc);
+        edm::LogInfo(" ok ") << name->name() << " " << rocDetId << " " << cablingRocId->fedId << " "
+                             << cablingRocId->linkId;
+      } else {  // did it fail?
+        edm::LogInfo(" failed ") << name->name() << " " << rocDetId;
+        //cout<<" failed "<<name->name()<<" "<<rocDetId<<endl;
       }
     }
-    //}
+  }
+  //}
 
   //clear names:
-  for (UNITS::iterator iu=units.begin(); iu != units.end(); iu++) delete iu->first;
+  for (UNITS::iterator iu = units.begin(); iu != units.end(); iu++)
+    delete iu->first;
 
   return result;
- 
 }
-std::string SiPixelFedCablingMapBuilder::myprint(const PixelGeomDetUnit * pxUnit)
-{
+std::string SiPixelFedCablingMapBuilder::myprint(const PixelGeomDetUnit* pxUnit) {
   std::ostringstream str;
-  const PixelTopology & tpl = pxUnit->specificTopology();
+  const PixelTopology& tpl = pxUnit->specificTopology();
   LocalPoint local;
   GlobalPoint global;
 
-  local = LocalPoint(0,0,0); global = (*pxUnit).toGlobal(local);
+  local = LocalPoint(0, 0, 0);
+  global = (*pxUnit).toGlobal(local);
   // phi measured from Y axis
-  float phi = 180*atan2(global.x(),global.y())/M_PI;  if (phi > 180.) phi = phi-360;
+  float phi = 180 * atan2(global.x(), global.y()) / M_PI;
+  if (phi > 180.)
+    phi = phi - 360;
   float r = global.perp();
   float z = global.z();
-  str <<"    POSITION: "<<" r="<<r<<" phi="<<phi<<" z="<<z;
-  str <<"   (rows,coll:"<<tpl.nrows()<<","<<tpl.ncolumns()<<")";
-  str <<endl; 
-  local = LocalPoint(0,0,0); str <<local<<"global: "<<(*pxUnit).toGlobal(local) <<endl;
-  local = LocalPoint(1,0,0); str <<local<<"global: "<<(*pxUnit).toGlobal(local) <<endl;
-  local = LocalPoint(0,1,0); str <<local<<"global: "<<(*pxUnit).toGlobal(local) <<endl;
-  local = LocalPoint(0,0,1); str <<local<<"global: "<<(*pxUnit).toGlobal(local) <<endl;
-      
+  str << "    POSITION: "
+      << " r=" << r << " phi=" << phi << " z=" << z;
+  str << "   (rows,coll:" << tpl.nrows() << "," << tpl.ncolumns() << ")";
+  str << endl;
+  local = LocalPoint(0, 0, 0);
+  str << local << "global: " << (*pxUnit).toGlobal(local) << endl;
+  local = LocalPoint(1, 0, 0);
+  str << local << "global: " << (*pxUnit).toGlobal(local) << endl;
+  local = LocalPoint(0, 1, 0);
+  str << local << "global: " << (*pxUnit).toGlobal(local) << endl;
+  local = LocalPoint(0, 0, 1);
+  str << local << "global: " << (*pxUnit).toGlobal(local) << endl;
+
   return str.str();
 }

--- a/CalibTracker/SiPixelConnectivity/test/SiPixelFedCablingMapWriter.cc
+++ b/CalibTracker/SiPixelConnectivity/test/SiPixelFedCablingMapWriter.cc
@@ -20,50 +20,44 @@ using namespace edm;
 using namespace sipixelobjects;
 
 class SiPixelFedCablingMapWriter : public edm::EDAnalyzer {
- public:
-  explicit SiPixelFedCablingMapWriter( const edm::ParameterSet& cfg);
+public:
+  explicit SiPixelFedCablingMapWriter(const edm::ParameterSet& cfg);
   ~SiPixelFedCablingMapWriter();
   virtual void beginJob();
-  virtual void endJob( );
-  virtual void analyze(const edm::Event& , const edm::EventSetup&);
- private:
-  SiPixelFedCablingTree * cabling;
+  virtual void endJob();
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
+private:
+  SiPixelFedCablingTree* cabling;
   string record_;
   //string pixelToFedAssociator_;
   string fileName_;
   //bool phase1_;
 };
 
-SiPixelFedCablingMapWriter::SiPixelFedCablingMapWriter( 
-    const edm::ParameterSet& cfg ) 
-  : 
-    record_(cfg.getParameter<std::string>("record")), 
-    //pixelToFedAssociator_(cfg.getUntrackedParameter<std::string>("associator","PixelToFEDAssociateFromAscii")), 
-    //phase1_(cfg.getUntrackedParameter<bool>("phase1",false)), 
-    fileName_(cfg.getUntrackedParameter<std::string>("fileName","pixelToLNK.ascii")) 
-{
-  
+SiPixelFedCablingMapWriter::SiPixelFedCablingMapWriter(const edm::ParameterSet& cfg)
+    : record_(cfg.getParameter<std::string>("record")),
+      //pixelToFedAssociator_(cfg.getUntrackedParameter<std::string>("associator","PixelToFEDAssociateFromAscii")),
+      //phase1_(cfg.getUntrackedParameter<bool>("phase1",false)),
+      fileName_(cfg.getUntrackedParameter<std::string>("fileName", "pixelToLNK.ascii")) {
   stringstream out;
   out << " record:          " << record_ << endl;
-  out << " input file name "  << fileName_ << endl;
+  out << " input file name " << fileName_ << endl;
   //out << " phase " << phase1_ << endl;
-  LogInfo("initialisation: ")<<out.str();
-
+  LogInfo("initialisation: ") << out.str();
 
   //::putenv(const_cast<char*>(std::string("CORAL_AUTH_USER=me").c_str()));
-  //::putenv(const_cast<char*>(std::string("CORAL_AUTH_PASSWORD=none").c_str())); 
+  //::putenv(const_cast<char*>(std::string("CORAL_AUTH_PASSWORD=none").c_str()));
 }
 
-
-SiPixelFedCablingMapWriter::~SiPixelFedCablingMapWriter(){
-//  delete cabling;
+SiPixelFedCablingMapWriter::~SiPixelFedCablingMapWriter() {
+  //  delete cabling;
 }
 
-
-void SiPixelFedCablingMapWriter::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
-  static int first(1); 
+void SiPixelFedCablingMapWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  static int first(1);
   if (1 == first) {
-    first = 0; 
+    first = 0;
     //std::cout << "-------HERE-----------" << endl;
     //cabling = SiPixelFedCablingMapBuilder(pixelToFedAssociator_).produce(iSetup);
     //cabling = SiPixelFedCablingMapBuilder(fileName_,phase1_).produce(iSetup);
@@ -73,37 +67,33 @@ void SiPixelFedCablingMapWriter::analyze(const edm::Event &iEvent, const edm::Ev
   }
 }
 
-void SiPixelFedCablingMapWriter::beginJob() {
-}
+void SiPixelFedCablingMapWriter::beginJob() {}
 
-void SiPixelFedCablingMapWriter::endJob( ) {
-  SiPixelFedCablingMap * result = new SiPixelFedCablingMap(cabling);
+void SiPixelFedCablingMapWriter::endJob() {
+  SiPixelFedCablingMap* result = new SiPixelFedCablingMap(cabling);
   LogInfo("Now NEW writing to DB");
   edm::Service<cond::service::PoolDBOutputService> mydbservice;
-  if( !mydbservice.isAvailable() ){
+  if (!mydbservice.isAvailable()) {
     edm::LogInfo("db service unavailable");
     //std::cout<<"db service unavailable"<<std::endl;
     return;
-  } else { 
-    //std::cout<<"OK"<<std::endl; 
+  } else {
+    //std::cout<<"OK"<<std::endl;
     edm::LogInfo("Writing finished ");
   }
 
   try {
-    if( mydbservice->isNewTagRequest(record_) ){
-      mydbservice->createNewIOV<SiPixelFedCablingMap>( result, 
-						       mydbservice->beginOfTime(),
-						       mydbservice->endOfTime(), 
-						       record_);
-    }else{
-      mydbservice->appendSinceTime<SiPixelFedCablingMap>( 
-          result, 
-	  mydbservice->currentTime(), 
-	  record_);
+    if (mydbservice->isNewTagRequest(record_)) {
+      mydbservice->createNewIOV<SiPixelFedCablingMap>(
+          result, mydbservice->beginOfTime(), mydbservice->endOfTime(), record_);
+    } else {
+      mydbservice->appendSinceTime<SiPixelFedCablingMap>(result, mydbservice->currentTime(), record_);
     }
-  } 
-  catch (std::exception &e) { LogError("std::exception:  ") << e.what(); }
-  catch (...) { LogError("Unknown error caught "); }
+  } catch (std::exception& e) {
+    LogError("std::exception:  ") << e.what();
+  } catch (...) {
+    LogError("Unknown error caught ");
+  }
   LogInfo("... all done, end");
 }
 

--- a/CalibTracker/SiPixelGainCalibration/plugins/SiPixelCalibDigiProducer.cc
+++ b/CalibTracker/SiPixelGainCalibration/plugins/SiPixelCalibDigiProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    SiPixelCalibDigiProducer
 // Class:      SiPixelCalibDigiProducer
-// 
+//
 /**\class SiPixelCalibDigiProducer SiPixelCalibDigiProducer.cc CalibTracker/SiPixelCalibDigiProducer/src/SiPixelCalibDigiProducer.cc
 
  Description: <one line class summary>
@@ -16,18 +16,12 @@
 //
 //
 
-
 // system include files
 
 // user include files
 #include "FWCore/Framework/interface/EventSetup.h"
 
-
-
-
-
-
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h" 
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 #include "DataFormats/SiPixelDigi/interface/SiPixelCalibDigiError.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
@@ -43,7 +37,6 @@
 // constants, enums and typedefs
 //
 
-
 //
 // static data member definitions
 //
@@ -51,35 +44,29 @@
 //
 // constructors and destructor
 //
-SiPixelCalibDigiProducer::SiPixelCalibDigiProducer(const edm::ParameterSet& iConfig):
-  src_(iConfig.getParameter<edm::InputTag>("src")),
-  iEventCounter_(0),
-  ignore_non_pattern_(iConfig.getParameter<bool>("ignoreNonPattern")),
-  control_pattern_size_(iConfig.getParameter<bool>("checkPatternEachEvent")),
-  includeErrors_(iConfig.getUntrackedParameter<bool>("includeErrors",false)),
-  errorType(iConfig.getUntrackedParameter<int>("errorTypeNumber",1)),
-  conf_(iConfig),
-  number_of_pixels_per_pattern_(0),
-  use_realeventnumber_(iConfig.getParameter<bool>("useRealEventNumber"))
+SiPixelCalibDigiProducer::SiPixelCalibDigiProducer(const edm::ParameterSet& iConfig)
+    : src_(iConfig.getParameter<edm::InputTag>("src")),
+      iEventCounter_(0),
+      ignore_non_pattern_(iConfig.getParameter<bool>("ignoreNonPattern")),
+      control_pattern_size_(iConfig.getParameter<bool>("checkPatternEachEvent")),
+      includeErrors_(iConfig.getUntrackedParameter<bool>("includeErrors", false)),
+      errorType(iConfig.getUntrackedParameter<int>("errorTypeNumber", 1)),
+      conf_(iConfig),
+      number_of_pixels_per_pattern_(0),
+      use_realeventnumber_(iConfig.getParameter<bool>("useRealEventNumber"))
 
 {
-  tPixelDigi = consumes<edm::DetSetVector<PixelDigi>> (src_);
-   //register your products
-  produces< edm::DetSetVector<SiPixelCalibDigi> >();
-  if(includeErrors_)
-    produces< edm::DetSetVector<SiPixelCalibDigiError> > ();
-
+  tPixelDigi = consumes<edm::DetSetVector<PixelDigi>>(src_);
+  //register your products
+  produces<edm::DetSetVector<SiPixelCalibDigi>>();
+  if (includeErrors_)
+    produces<edm::DetSetVector<SiPixelCalibDigiError>>();
 }
 
-
-SiPixelCalibDigiProducer::~SiPixelCalibDigiProducer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+SiPixelCalibDigiProducer::~SiPixelCalibDigiProducer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
@@ -87,16 +74,13 @@ SiPixelCalibDigiProducer::~SiPixelCalibDigiProducer()
 
 /////////////////////////////////////////////
 // function description:
-// this function checks where/when the pattern changes so that one can fill the data from the temporary container into the event 
-bool 
-SiPixelCalibDigiProducer::store()
-{
+// this function checks where/when the pattern changes so that one can fill the data from the temporary container into the event
+bool SiPixelCalibDigiProducer::store() {
   //  std::cout << "in store() " << std::endl;
-  if(iEventCounter_%pattern_repeat_==0){
+  if (iEventCounter_ % pattern_repeat_ == 0) {
     //    std::cout << "now at event " << iEventCounter_ <<" where we save the calibration information into the CMSSW digi";
     return true;
-  }
-  else if(iEventCounter_==calib_->expectedTotalEvents())
+  } else if (iEventCounter_ == calib_->expectedTotalEvents())
     return true;
   else
     return false;
@@ -105,43 +89,42 @@ SiPixelCalibDigiProducer::store()
 ////////////////////////////////////////////////////////////////////
 // function description:
 // fill function, uses maps to keep track of which pixel is where in the local storage container. Called every event to fill and compress the digi data into calibdig format
-void
-SiPixelCalibDigiProducer::fill(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-
+void SiPixelCalibDigiProducer::fill(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // figure out which calibration point we're on now..
   short icalibpoint = calib_->vcalIndexForEvent(iEventCounter_);
-  edm::Handle< edm::DetSetVector<PixelDigi> > pixelDigis;
-  iEvent.getByToken( tPixelDigi, pixelDigis );
-  
-  edm::LogInfo("SiPixelCalibProducer") << "in fill(), calibpoint " << icalibpoint <<" ndigis " << pixelDigis->size() <<  std::endl;
-    // loop over the data and store things
-  edm::DetSetVector<PixelDigi>::const_iterator digiIter;
-  for(digiIter=pixelDigis->begin(); digiIter!=pixelDigis->end(); ++digiIter){// ITERATOR OVER DET IDs
-    uint32_t detid = digiIter->id;
-    edm::DetSet<PixelDigi>::const_iterator ipix; // ITERATOR OVER DIGI DATA  
+  edm::Handle<edm::DetSetVector<PixelDigi>> pixelDigis;
+  iEvent.getByToken(tPixelDigi, pixelDigis);
 
-    for(ipix = digiIter->data.begin(); ipix!=digiIter->end(); ++ipix){
+  edm::LogInfo("SiPixelCalibProducer") << "in fill(), calibpoint " << icalibpoint << " ndigis " << pixelDigis->size()
+                                       << std::endl;
+  // loop over the data and store things
+  edm::DetSetVector<PixelDigi>::const_iterator digiIter;
+  for (digiIter = pixelDigis->begin(); digiIter != pixelDigis->end(); ++digiIter) {  // ITERATOR OVER DET IDs
+    uint32_t detid = digiIter->id;
+    edm::DetSet<PixelDigi>::const_iterator ipix;  // ITERATOR OVER DIGI DATA
+
+    for (ipix = digiIter->data.begin(); ipix != digiIter->end(); ++ipix) {
       // fill in the appropriate location of the temporary data container
-      fillPixel(detid,ipix->row(),ipix->column(),icalibpoint,ipix->adc());
+      fillPixel(detid, ipix->row(), ipix->column(), icalibpoint, ipix->adc());
     }
   }
 }
 ////////////////////////////////////////////////////
 // function description:
-// this is the function where we check the cabling map and see if we can assign a fed id to the det ID. 
+// this is the function where we check the cabling map and see if we can assign a fed id to the det ID.
 // returns false if no fed <-> detid association was found
-bool SiPixelCalibDigiProducer::checkFED(uint32_t detid){
+bool SiPixelCalibDigiProducer::checkFED(uint32_t detid) {
   //  edm::LogInfo("SiPixelCalibProducer") << "in checkFED" << std::endl;
 
-  if(detid_to_fedid_[detid])
+  if (detid_to_fedid_[detid])
     return true;
-  for(int fedid=0; fedid<=40; ++fedid){
+  for (int fedid = 0; fedid <= 40; ++fedid) {
     //    edm::LogInfo("SiPixelCalibProducer") << " looking at fedid " << fedid << std::endl;
-    SiPixelFrameConverter converter(theCablingMap_.product(),fedid);
-    if(converter.hasDetUnit(detid)){
-      detid_to_fedid_[detid]=fedid;
-      edm::LogInfo("SiPixelCalibDigiProducer") << "matched detid " << detid << " to fed " << detid_to_fedid_[detid] << std::endl;
+    SiPixelFrameConverter converter(theCablingMap_.product(), fedid);
+    if (converter.hasDetUnit(detid)) {
+      detid_to_fedid_[detid] = fedid;
+      edm::LogInfo("SiPixelCalibDigiProducer")
+          << "matched detid " << detid << " to fed " << detid_to_fedid_[detid] << std::endl;
       return true;
     }
   }
@@ -151,55 +134,54 @@ bool SiPixelCalibDigiProducer::checkFED(uint32_t detid){
 ////////////////////////////////////////////////////
 // function description:
 // this is the function where we look in the maps to find the correct calibration digi container, after which the data is filled.
-void SiPixelCalibDigiProducer::fillPixel(uint32_t detid, short row, short col, short ipoint, short adc){
+void SiPixelCalibDigiProducer::fillPixel(uint32_t detid, short row, short col, short ipoint, short adc) {
   //  edm::LogInfo("SiPixelCalibProducer") << " in fillpixel()" << std::endl;
- 
+
   //  edm::LogInfo("SiPixelCalibProducer") << "in fillPixel " << detid << " " << row << " " << col << " " << ipoint << " " << adc << std::endl;
-  if(!checkFED(detid)){
+  if (!checkFED(detid)) {
     edm::LogError("SiPixelCalibDigiProducer") << " was unable to match detid " << detid << " to a FED!" << std::endl;
     return;
   }
-  if(!checkPixel(detid,row,col)){
+  if (!checkPixel(detid, row, col)) {
     return;
   }
   // now the check if the pixel exists and fill
   //
   pixelstruct temppixelworker;
-  temppixelworker.first=detid;
-  temppixelworker.second.first=row;
-  temppixelworker.second.second=col;  
-  std::map<pixelstruct,SiPixelCalibDigi>::const_iterator ipix = intermediate_data_.find(temppixelworker);
-  
-  if(ipix == intermediate_data_.end()){
+  temppixelworker.first = detid;
+  temppixelworker.second.first = row;
+  temppixelworker.second.second = col;
+  std::map<pixelstruct, SiPixelCalibDigi>::const_iterator ipix = intermediate_data_.find(temppixelworker);
+
+  if (ipix == intermediate_data_.end()) {
     SiPixelCalibDigi tempdigi(calib_->nVCal());
-    tempdigi.setrowcol(row,col);
-    intermediate_data_[temppixelworker]=tempdigi;
+    tempdigi.setrowcol(row, col);
+    intermediate_data_[temppixelworker] = tempdigi;
   }
 
-  intermediate_data_[temppixelworker].fill(ipoint,adc);
+  intermediate_data_[temppixelworker].fill(ipoint, adc);
   return;
-
 }
 //////////////////////////////////////////////////////////////
 // function description:
-// this function cleans up after everything in the pattern is filled. This involves setting the content of the intermediate_data_ containers to zero and completely emptying the map 
-void
-SiPixelCalibDigiProducer::clear(){
+// this function cleans up after everything in the pattern is filled. This involves setting the content of the intermediate_data_ containers to zero and completely emptying the map
+void SiPixelCalibDigiProducer::clear() {
   //  edm::LogInfo("SiPixelCalibProducer") << "in clear() " << std::endl;
   // this is where we empty the containers so they can be re-filled
-  // the idea: the detPixelMap_ container shrinks/expands as a function 
-  // of the number of pixels looked at at one particular time... 
-  // unlike the intermediate_data_ container which only expands when 
+  // the idea: the detPixelMap_ container shrinks/expands as a function
+  // of the number of pixels looked at at one particular time...
+  // unlike the intermediate_data_ container which only expands when
   // detPixelMap_ becomes bigger than intermedate_data_
-  
+
   // shrink the detPixelMap_
   uint32_t tempsize = intermediate_data_.size();
-  if(tempsize>number_of_pixels_per_pattern_){
-    edm::LogError("SiPixelCalibDigiProducer") << "Number of pixels in pattern is now: " << tempsize<< ", size is was " << number_of_pixels_per_pattern_ << std::endl;
-    number_of_pixels_per_pattern_=tempsize;
+  if (tempsize > number_of_pixels_per_pattern_) {
+    edm::LogError("SiPixelCalibDigiProducer") << "Number of pixels in pattern is now: " << tempsize << ", size is was "
+                                              << number_of_pixels_per_pattern_ << std::endl;
+    number_of_pixels_per_pattern_ = tempsize;
   }
 
-  intermediate_data_.erase(intermediate_data_.begin(),intermediate_data_.end());
+  intermediate_data_.erase(intermediate_data_.begin(), intermediate_data_.end());
   intermediate_data_.clear();
 
   // and erase the error bits
@@ -209,57 +191,54 @@ SiPixelCalibDigiProducer::clear(){
 
 ////////////////////////////////////////////////////
 // function description:
-// This method gets the pattern from the calib_ (SiPixelCalibConfiguration) object and fills a vector of pairs that is easier to check 
-void 
-SiPixelCalibDigiProducer::setPattern(){
+// This method gets the pattern from the calib_ (SiPixelCalibConfiguration) object and fills a vector of pairs that is easier to check
+void SiPixelCalibDigiProducer::setPattern() {
   //  edm::LogInfo("SiPixelCalibProducer") << "in setPattern()" << std::endl;
-  uint32_t patternnumber = (iEventCounter_-1)/pattern_repeat_;
-  uint32_t rowpatternnumber = patternnumber/calib_->nColumnPatterns();
-  uint32_t colpatternnumber = patternnumber%calib_->nColumnPatterns();
-  edm::LogInfo("SiPixelCalibDigiProducer") << " rowpatternnumbers = " << rowpatternnumber << " " << colpatternnumber << " " << patternnumber << std::endl;
+  uint32_t patternnumber = (iEventCounter_ - 1) / pattern_repeat_;
+  uint32_t rowpatternnumber = patternnumber / calib_->nColumnPatterns();
+  uint32_t colpatternnumber = patternnumber % calib_->nColumnPatterns();
+  edm::LogInfo("SiPixelCalibDigiProducer")
+      << " rowpatternnumbers = " << rowpatternnumber << " " << colpatternnumber << " " << patternnumber << std::endl;
   // update currentpattern_
   std::vector<short> calibcols = calib_->getColumnPattern();
   std::vector<short> calibrows = calib_->getRowPattern();
   std::vector<short> temprowvals(0);
   std::vector<short> tempcolvals(0);
-  uint32_t nminuscol=0;
-  uint32_t nminusrow=0;
-  uint32_t npatterns=0;
-  for(uint32_t icol=0; icol<calibcols.size(); icol++){
-    if(calibcols[icol]==-1){
+  uint32_t nminuscol = 0;
+  uint32_t nminusrow = 0;
+  uint32_t npatterns = 0;
+  for (uint32_t icol = 0; icol < calibcols.size(); icol++) {
+    if (calibcols[icol] == -1) {
       nminuscol++;
-    }
-    else if(nminuscol==colpatternnumber){
+    } else if (nminuscol == colpatternnumber) {
       //edm::LogInfo("SiPixelCalibProducer") << "col " << calibcols[icol] << std::endl;
-      short val=calibcols[icol];
+      short val = calibcols[icol];
       tempcolvals.push_back(val);
-    }
-    else if (nminuscol> colpatternnumber)
+    } else if (nminuscol > colpatternnumber)
       break;
   }
-  for(uint32_t irow=0; irow<calibrows.size(); irow++){
+  for (uint32_t irow = 0; irow < calibrows.size(); irow++) {
     // edm::LogInfo("SiPixelCalibProducer") << "row " << irow <<" "<< nminusrow<<" "  << calibrows[irow] << std::endl;
-    if(calibrows[irow]==-1)
+    if (calibrows[irow] == -1)
       nminusrow++;
-    else if(nminusrow==rowpatternnumber){
-      short val=calibrows[irow];
+    else if (nminusrow == rowpatternnumber) {
+      short val = calibrows[irow];
       temprowvals.push_back(val);
-    }
-    else if(nminusrow>rowpatternnumber)
+    } else if (nminusrow > rowpatternnumber)
       break;
   }
   //now clean up the currentpattern_;
-  while(currentpattern_.size()>temprowvals.size()*tempcolvals.size()){
+  while (currentpattern_.size() > temprowvals.size() * tempcolvals.size()) {
     currentpattern_.erase(currentpattern_.end());
   }
-  for(uint32_t irow=0; irow<temprowvals.size(); irow++){
-    for(uint32_t icol=0; icol<tempcolvals.size(); icol++){
-      std::pair<short,short> pattern(temprowvals[irow],tempcolvals[icol]);
+  for (uint32_t irow = 0; irow < temprowvals.size(); irow++) {
+    for (uint32_t icol = 0; icol < tempcolvals.size(); icol++) {
+      std::pair<short, short> pattern(temprowvals[irow], tempcolvals[icol]);
       npatterns++;
-      if(npatterns>currentpattern_.size())
-	currentpattern_.push_back(pattern);
+      if (npatterns > currentpattern_.size())
+        currentpattern_.push_back(pattern);
       else
-	currentpattern_[npatterns-1]=pattern;
+        currentpattern_[npatterns - 1] = pattern;
     }
   }
 }
@@ -267,81 +246,80 @@ SiPixelCalibDigiProducer::setPattern(){
 ////////////////////////////////////////////
 // function description:
 // produce method. This is the main loop method
-void
-SiPixelCalibDigiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void SiPixelCalibDigiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //  edm::LogInfo("SiPixelCalibDigiProducer") <<"in produce() " << std::endl;
   using namespace edm;
   iSetup.get<SiPixelCalibConfigurationRcd>().get(calib_);
-  iSetup.get<TrackerDigiGeometryRecord>().get( theGeometry_ );
+  iSetup.get<TrackerDigiGeometryRecord>().get(theGeometry_);
   iSetup.get<SiPixelFedCablingMapRcd>().get(theCablingMap_);
-  pattern_repeat_=calib_->getNTriggers()*calib_->nVCal();
-  if(use_realeventnumber_){
-    iEventCounter_= iEvent.id().event()-1;
-  }
-  else
+  pattern_repeat_ = calib_->getNTriggers() * calib_->nVCal();
+  if (use_realeventnumber_) {
+    iEventCounter_ = iEvent.id().event() - 1;
+  } else
     iEventCounter_++;
-  if(iEventCounter_%pattern_repeat_==1)
+  if (iEventCounter_ % pattern_repeat_ == 1)
     setPattern();
-  
+
   //  edm::LogInfo("SiPixelCalibDigiProducer") << "now starting fill..." << std::endl;
-  fill(iEvent,iSetup); // fill method where the actual looping over the digis is done.
+  fill(iEvent, iSetup);  // fill method where the actual looping over the digis is done.
   //  edm::LogInfo("SiPixelCalibDigiProducer") << "done filling..." << std::endl;
   auto pOut = std::make_unique<edm::DetSetVector<SiPixelCalibDigi>>();
   auto pErr = std::make_unique<edm::DetSetVector<SiPixelCalibDigiError>>();
-  
+
   // copy things over into pOut if necessary (this is only once per pattern)
-  if(store()){
+  if (store()) {
     //    edm::LogInfo("SiPixelCalibDigiProducer") << "in loop" << std::endl;
-    for(std::map<pixelstruct,SiPixelCalibDigi>::const_iterator idet=intermediate_data_.begin(); idet!=intermediate_data_.end();++idet){
-      uint32_t detid=idet->first.first;
-      if(!control_pattern_size_){
-	if(! checkPixel(idet->first.first,idet->first.second.first,idet->first.second.second))
-	  continue;
+    for (std::map<pixelstruct, SiPixelCalibDigi>::const_iterator idet = intermediate_data_.begin();
+         idet != intermediate_data_.end();
+         ++idet) {
+      uint32_t detid = idet->first.first;
+      if (!control_pattern_size_) {
+        if (!checkPixel(idet->first.first, idet->first.second.first, idet->first.second.second))
+          continue;
       }
 
-      
-      SiPixelCalibDigi tempdigi=idet->second;
-      edm::DetSet<SiPixelCalibDigi> & detSet = pOut->find_or_insert(detid);
+      SiPixelCalibDigi tempdigi = idet->second;
+      edm::DetSet<SiPixelCalibDigi>& detSet = pOut->find_or_insert(detid);
       detSet.data.push_back(tempdigi);
     }
-    if(includeErrors_){
-      for(std::map<pixelstruct,SiPixelCalibDigiError>::const_iterator ierr=error_data_.begin(); ierr!=error_data_.end();++ierr){
-	uint32_t detid=ierr->first.first;
-	SiPixelCalibDigiError temperror = ierr->second;
-	edm::DetSet<SiPixelCalibDigiError> & errSet = pErr->find_or_insert(detid);
-	errSet.data.push_back(temperror);
+    if (includeErrors_) {
+      for (std::map<pixelstruct, SiPixelCalibDigiError>::const_iterator ierr = error_data_.begin();
+           ierr != error_data_.end();
+           ++ierr) {
+        uint32_t detid = ierr->first.first;
+        SiPixelCalibDigiError temperror = ierr->second;
+        edm::DetSet<SiPixelCalibDigiError>& errSet = pErr->find_or_insert(detid);
+        errSet.data.push_back(temperror);
       }
     }
-    edm::LogInfo("INFO") << "now filling event " << iEventCounter_ << " as pixel pattern changes every " <<  pattern_repeat_ << " events..." << std::endl;
+    edm::LogInfo("INFO") << "now filling event " << iEventCounter_ << " as pixel pattern changes every "
+                         << pattern_repeat_ << " events..." << std::endl;
     clear();
   }
   iEvent.put(std::move(pOut));
-  if(includeErrors_)
+  if (includeErrors_)
     iEvent.put(std::move(pErr));
 }
 //-----------------------------------------------
 //  method to check that the pixels are actually valid...
-bool SiPixelCalibDigiProducer::checkPixel(uint32_t detid, short row, short col){
+bool SiPixelCalibDigiProducer::checkPixel(uint32_t detid, short row, short col) {
+  if (!control_pattern_size_ && !store())
+    return true;
 
-  if(!control_pattern_size_ && !store())
+  if (!ignore_non_pattern_)
     return true;
-  
-  if( !ignore_non_pattern_ )
-    return true;
-  
-  
+
   edm::LogInfo("SiPixelCalibDigiProducer") << "Event" << iEventCounter_ << ",now in checkpixel() " << std::endl;
-  if(currentpattern_.empty())
+  if (currentpattern_.empty())
     setPattern();
   //  uint32_t iroc;
   uint32_t fedid = detid_to_fedid_[detid];
 
-  SiPixelFrameConverter formatter(theCablingMap_.product(),fedid);
-  sipixelobjects::DetectorIndex detector ={detid, row, col};
+  SiPixelFrameConverter formatter(theCablingMap_.product(), fedid);
+  sipixelobjects::DetectorIndex detector = {detid, row, col};
   sipixelobjects::ElectronicIndex cabling;
-  
-  formatter.toCabling(cabling,detector);
+
+  formatter.toCabling(cabling, detector);
   // cabling should now contain cabling.roc and cabling.dcol  and cabling.pxid
 
   // however, the coordinates now need to be converted from dcl, pxid to the row,col coordinates used in the calibration info
@@ -352,37 +330,39 @@ bool SiPixelCalibDigiProducer::checkPixel(uint32_t detid, short row, short col){
   currentpair_.first = locpixel.rocRow();
   currentpair_.second = locpixel.rocCol();
 
-  for(uint32_t i=0; i<currentpattern_.size(); ++i){
+  for (uint32_t i = 0; i < currentpattern_.size(); ++i) {
     //    edm::LogInfo("SiPixelCalibDigiProducer") << "found pair " << currentpair_.first << "," << currentpair_.second << " calib " << currentpattern_[i].first << ","<< currentpattern_[i].second << " input " << row << "," << col << std::endl;
-    if(currentpair_==currentpattern_[i]){
+    if (currentpair_ == currentpattern_[i]) {
       return true;
     }
   }
   std::ostringstream errorlog;
-  errorlog <<  "DETID "<<detid<<", row, col (offline)="<<row<<","<<col<<" row, col (ROC) ="<<currentpair_.first<<","<< currentpair_.second<< " found no match in list of patterns: " ;
-  for(uint32_t i=0; i<currentpattern_.size(); ++i){
-    if(i!=0 && i!=currentpattern_.size()-1)
-      errorlog<<" ";
-    errorlog<<"(";
-    errorlog<<currentpattern_[i].first;
-    errorlog<<",";
-    errorlog<<currentpattern_[i].second;
-    errorlog<<")";
+  errorlog << "DETID " << detid << ", row, col (offline)=" << row << "," << col
+           << " row, col (ROC) =" << currentpair_.first << "," << currentpair_.second
+           << " found no match in list of patterns: ";
+  for (uint32_t i = 0; i < currentpattern_.size(); ++i) {
+    if (i != 0 && i != currentpattern_.size() - 1)
+      errorlog << " ";
+    errorlog << "(";
+    errorlog << currentpattern_[i].first;
+    errorlog << ",";
+    errorlog << currentpattern_[i].second;
+    errorlog << ")";
   }
   edm::LogError("ERROR") << errorlog.str() << std::endl;
-  if(includeErrors_){// book the error
-    
+  if (includeErrors_) {  // book the error
+
     pixelstruct temppixelworker;
-    temppixelworker.first=detid;
-    temppixelworker.second.first=row;
-    temppixelworker.second.second=col;
-    std::map<pixelstruct,SiPixelCalibDigiError>::const_iterator ierr = error_data_.find(temppixelworker);
-    if(ierr== error_data_.end()){
-      SiPixelCalibDigiError temperr(row,col,1);
-      error_data_[temppixelworker]=temperr;
+    temppixelworker.first = detid;
+    temppixelworker.second.first = row;
+    temppixelworker.second.second = col;
+    std::map<pixelstruct, SiPixelCalibDigiError>::const_iterator ierr = error_data_.find(temppixelworker);
+    if (ierr == error_data_.end()) {
+      SiPixelCalibDigiError temperr(row, col, 1);
+      error_data_[temppixelworker] = temperr;
     }
   }
-    
+
   return false;
 }
 

--- a/CalibTracker/SiPixelGainCalibration/plugins/SiPixelCalibDigiProducer.h
+++ b/CalibTracker/SiPixelGainCalibration/plugins/SiPixelCalibDigiProducer.h
@@ -4,7 +4,7 @@
 //
 // Package:    SiPixelCalibDigiProducer
 // Class:      SiPixelCalibDigiProducer
-// 
+//
 /**\class SiPixelCalibDigiProducer SiPixelCalibDigiProducer.cc CalibTracker/SiPixelGainCalibration/src/SiPixelCalibDigiProducer.cc
 
  Description: <one line class summary>
@@ -54,51 +54,50 @@
 //
 
 class SiPixelCalibDigiProducer : public edm::EDProducer {
-   public:
-      explicit SiPixelCalibDigiProducer(const edm::ParameterSet& iConfig);
-      ~SiPixelCalibDigiProducer() override;
+public:
+  explicit SiPixelCalibDigiProducer(const edm::ParameterSet& iConfig);
+  ~SiPixelCalibDigiProducer() override;
 
-   private:
+private:
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  virtual bool store();
+  virtual void setPattern();
+  virtual void fill(edm::Event& iEvent, const edm::EventSetup& iSetup);
+  virtual void fillPixel(uint32_t detid, short row, short col, short ipoint, short adc);
+  virtual bool checkPixel(uint32_t detid, short row, short col);
+  virtual bool checkFED(uint32_t detid);
+  virtual void clear();
+  typedef std::pair<uint32_t, std::pair<short, short>> pixelstruct;
+  // ----------member data ---------------------------
+  edm::InputTag src_;
+  edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> tPixelDigi;
+  uint32_t iEventCounter_;
 
-      void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
-      virtual bool store();
-      virtual void setPattern();
-      virtual void fill(edm::Event &iEvent, const edm::EventSetup& iSetup);
-      virtual void fillPixel(uint32_t detid, short row, short col,short ipoint, short adc);
-      virtual bool checkPixel(uint32_t detid, short row, short col);
-      virtual bool checkFED(uint32_t detid);
-      virtual void clear();
-      typedef std::pair<uint32_t,std::pair<short,short> >  pixelstruct;
-      // ----------member data ---------------------------
-      edm::InputTag src_;
-      edm::EDGetTokenT <edm::DetSetVector<PixelDigi>>  tPixelDigi;
-      uint32_t iEventCounter_;
-      
-      bool ignore_non_pattern_;
-      bool control_pattern_size_;
-      bool includeErrors_;
-      int errorType;
-      edm::ParameterSet conf_;
-      std::string label_;
-      std::string instance_;
-      uint32_t number_of_pixels_per_pattern_;
-      bool use_realeventnumber_;
-      
-      edm::ESHandle<SiPixelCalibConfiguration> calib_; // keeps track of the calibration constants
-      edm::ESHandle<TrackerGeometry> theGeometry_; // the tracker geometry
-      edm::ESHandle<SiPixelFedCablingMap> theCablingMap_;
+  bool ignore_non_pattern_;
+  bool control_pattern_size_;
+  bool includeErrors_;
+  int errorType;
+  edm::ParameterSet conf_;
+  std::string label_;
+  std::string instance_;
+  uint32_t number_of_pixels_per_pattern_;
+  bool use_realeventnumber_;
 
-      // worker variables
-      std::map<pixelstruct,SiPixelCalibDigi> intermediate_data_; // data container, copied over into the event every pattern_repeat_ events
-      std::map<pixelstruct,SiPixelCalibDigiError> error_data_;
-      //      std::vector<SiPixelCalibDigi> intermediate_data_; // data container, copied over into the event every pattern_repeat_ events
-      std::vector<pixelstruct> detPixelMap_;// map to keep track of which pixels are filled where in intermediate_data_
-      uint32_t pattern_repeat_; // keeps track of when the pattern should change
-      std::map<uint32_t,uint32_t> detid_to_fedid_; // keeps track in which fed each detid is present.
+  edm::ESHandle<SiPixelCalibConfiguration> calib_;  // keeps track of the calibration constants
+  edm::ESHandle<TrackerGeometry> theGeometry_;      // the tracker geometry
+  edm::ESHandle<SiPixelFedCablingMap> theCablingMap_;
 
-      std::vector<std::pair<short,short> > currentpattern_;// keeps track of which pattern we are at
-      std::pair<short,short> currentpair_;//worker class to keep track of pairs
+  // worker variables
+  std::map<pixelstruct, SiPixelCalibDigi>
+      intermediate_data_;  // data container, copied over into the event every pattern_repeat_ events
+  std::map<pixelstruct, SiPixelCalibDigiError> error_data_;
+  //      std::vector<SiPixelCalibDigi> intermediate_data_; // data container, copied over into the event every pattern_repeat_ events
+  std::vector<pixelstruct> detPixelMap_;  // map to keep track of which pixels are filled where in intermediate_data_
+  uint32_t pattern_repeat_;               // keeps track of when the pattern should change
+  std::map<uint32_t, uint32_t> detid_to_fedid_;  // keeps track in which fed each detid is present.
+
+  std::vector<std::pair<short, short>> currentpattern_;  // keeps track of which pattern we are at
+  std::pair<short, short> currentpair_;                  //worker class to keep track of pairs
 };
-
 
 #endif

--- a/CalibTracker/SiPixelGainCalibration/plugins/SiPixelGainCalibrationAnalysis.cc
+++ b/CalibTracker/SiPixelGainCalibration/plugins/SiPixelGainCalibrationAnalysis.cc
@@ -2,7 +2,7 @@
 //
 // Package:    SiPixelGainCalibrationAnalysis
 // Class:      SiPixelGainCalibrationAnalysis
-// 
+//
 /**\class SiPixelGainCalibrationAnalysis SiPixelGainCalibrationAnalysis.cc CalibTracker/SiPixelGainCalibrationAnalysis/src/SiPixelGainCalibrationAnalysis.cc
 
 Description: <one line class summary>
@@ -31,170 +31,164 @@ using std::endl;
 //
 // constructors and destructor
 //
-SiPixelGainCalibrationAnalysis::SiPixelGainCalibrationAnalysis(const edm::ParameterSet& iConfig):
-  SiPixelOfflineCalibAnalysisBase(iConfig),
-  conf_(iConfig),
-  bookkeeper_(),
-  bookkeeper_pixels_(),
-  nfitparameters_(iConfig.getUntrackedParameter<int>("numberOfFitParameters",2)),
-  fitfunction_(iConfig.getUntrackedParameter<std::string>("fitFunctionRootFormula","pol1")),
-   listofdetids_(conf_.getUntrackedParameter<std::vector<uint32_t> >("listOfDetIDs")),
-  ignoreMode_(conf_.getUntrackedParameter<bool>("ignoreMode",false)),
-  reject_plateaupoints_(iConfig.getUntrackedParameter<bool>("suppressPlateauInFit",true)),
-  reject_single_entries_(iConfig.getUntrackedParameter<bool>("suppressPointsWithOneEntryOrLess",true)),
-  plateau_max_slope_(iConfig.getUntrackedParameter<double>("plateauSlopeMax",1.0)),
-  reject_first_point_(iConfig.getUntrackedParameter<bool>("rejectVCalZero",true)),
-  reject_badpoints_frac_(iConfig.getUntrackedParameter<double>("suppressZeroAndPlateausInFitFrac",0)),
-  bookBIGCalibPayload_(iConfig.getUntrackedParameter<bool>("saveFullPayloads",false)),
-  savePixelHists_(iConfig.getUntrackedParameter<bool>("savePixelLevelHists",false)),
-  chi2Threshold_(iConfig.getUntrackedParameter<double>("minChi2NDFforHistSave",10)),
-  chi2ProbThreshold_(iConfig.getUntrackedParameter<double>("minChi2ProbforHistSave",0.05)),
-  maxGainInHist_(iConfig.getUntrackedParameter<double>("maxGainInHist",10)),
-  maxChi2InHist_(iConfig.getUntrackedParameter<double>("maxChi2InHist",25)),
-  saveALLHistograms_(iConfig.getUntrackedParameter<bool>("saveAllHistograms",false)),
- 
+SiPixelGainCalibrationAnalysis::SiPixelGainCalibrationAnalysis(const edm::ParameterSet &iConfig)
+    : SiPixelOfflineCalibAnalysisBase(iConfig),
+      conf_(iConfig),
+      bookkeeper_(),
+      bookkeeper_pixels_(),
+      nfitparameters_(iConfig.getUntrackedParameter<int>("numberOfFitParameters", 2)),
+      fitfunction_(iConfig.getUntrackedParameter<std::string>("fitFunctionRootFormula", "pol1")),
+      listofdetids_(conf_.getUntrackedParameter<std::vector<uint32_t> >("listOfDetIDs")),
+      ignoreMode_(conf_.getUntrackedParameter<bool>("ignoreMode", false)),
+      reject_plateaupoints_(iConfig.getUntrackedParameter<bool>("suppressPlateauInFit", true)),
+      reject_single_entries_(iConfig.getUntrackedParameter<bool>("suppressPointsWithOneEntryOrLess", true)),
+      plateau_max_slope_(iConfig.getUntrackedParameter<double>("plateauSlopeMax", 1.0)),
+      reject_first_point_(iConfig.getUntrackedParameter<bool>("rejectVCalZero", true)),
+      reject_badpoints_frac_(iConfig.getUntrackedParameter<double>("suppressZeroAndPlateausInFitFrac", 0)),
+      bookBIGCalibPayload_(iConfig.getUntrackedParameter<bool>("saveFullPayloads", false)),
+      savePixelHists_(iConfig.getUntrackedParameter<bool>("savePixelLevelHists", false)),
+      chi2Threshold_(iConfig.getUntrackedParameter<double>("minChi2NDFforHistSave", 10)),
+      chi2ProbThreshold_(iConfig.getUntrackedParameter<double>("minChi2ProbforHistSave", 0.05)),
+      maxGainInHist_(iConfig.getUntrackedParameter<double>("maxGainInHist", 10)),
+      maxChi2InHist_(iConfig.getUntrackedParameter<double>("maxChi2InHist", 25)),
+      saveALLHistograms_(iConfig.getUntrackedParameter<bool>("saveAllHistograms", false)),
 
-  filldb_(iConfig.getUntrackedParameter<bool>("writeDatabase",false)),
-  writeSummary_(iConfig.getUntrackedParameter<bool>("writeSummary",true)),
-  recordName_(conf_.getParameter<std::string>("record")),
+      filldb_(iConfig.getUntrackedParameter<bool>("writeDatabase", false)),
+      writeSummary_(iConfig.getUntrackedParameter<bool>("writeSummary", true)),
+      recordName_(conf_.getParameter<std::string>("record")),
 
-  appendMode_(conf_.getUntrackedParameter<bool>("appendMode",true)),
-  /*theGainCalibrationDbInput_(0),
+      appendMode_(conf_.getUntrackedParameter<bool>("appendMode", true)),
+      /*theGainCalibrationDbInput_(0),
   theGainCalibrationDbInputOffline_(0),
   theGainCalibrationDbInputHLT_(0),
   theGainCalibrationDbInputService_(iConfig),*/
-  gainlow_(10.),gainhi_(0.),pedlow_(255.),pedhi_(0.),
-  useVcalHigh_(conf_.getParameter<bool>("useVCALHIGH")),
-  scalarVcalHigh_VcalLow_(conf_.getParameter<double>("vcalHighToLowConversionFac"))
-{
-  if(reject_single_entries_)
-    min_nentries_=1;
+      gainlow_(10.),
+      gainhi_(0.),
+      pedlow_(255.),
+      pedhi_(0.),
+      useVcalHigh_(conf_.getParameter<bool>("useVCALHIGH")),
+      scalarVcalHigh_VcalLow_(conf_.getParameter<double>("vcalHighToLowConversionFac")) {
+  if (reject_single_entries_)
+    min_nentries_ = 1;
   else
-    min_nentries_=0;
-  ::putenv((char*)"CORAL_AUTH_USER=me");
-  ::putenv((char*)"CORAL_AUTH_PASSWORD=test");   
-  edm::LogInfo("SiPixelGainCalibrationAnalysis") << "now using fit function " << fitfunction_ << ", which has " << nfitparameters_ << " free parameters. " << std::endl;
-  func_= new TF1("func",fitfunction_.c_str(),0,256*scalarVcalHigh_VcalLow_);
+    min_nentries_ = 0;
+  ::putenv((char *)"CORAL_AUTH_USER=me");
+  ::putenv((char *)"CORAL_AUTH_PASSWORD=test");
+  edm::LogInfo("SiPixelGainCalibrationAnalysis") << "now using fit function " << fitfunction_ << ", which has "
+                                                 << nfitparameters_ << " free parameters. " << std::endl;
+  func_ = new TF1("func", fitfunction_.c_str(), 0, 256 * scalarVcalHigh_VcalLow_);
   graph_ = new TGraphErrors();
-  currentDetID_=0;
+  currentDetID_ = 0;
   summary_.open("SummaryPerDetID.txt");
   statusNumbers_ = new int[10];
-  for(int ii=0;ii<10;ii++)
-    statusNumbers_[ii]=0;
+  for (int ii = 0; ii < 10; ii++)
+    statusNumbers_[ii] = 0;
 }
 
-SiPixelGainCalibrationAnalysis::~SiPixelGainCalibrationAnalysis()
-{
-}
+SiPixelGainCalibrationAnalysis::~SiPixelGainCalibrationAnalysis() {}
 // member functions
 //
 // ------------ method called once each job just before starting event loop  ------------
 
-std::vector<float> SiPixelGainCalibrationAnalysis::CalculateAveragePerColumn(uint32_t detid, std::string label){
+std::vector<float> SiPixelGainCalibrationAnalysis::CalculateAveragePerColumn(uint32_t detid, std::string label) {
   std::vector<float> result;
-  int ncols= bookkeeper_[detid][label]->getNbinsX();
-  int nrows= bookkeeper_[detid][label]->getNbinsY();
-  for(int icol=1; icol<=ncols; ++icol){
-    float val=0;
-    float ntimes =0;
-    for(int irow=1; irow<=nrows; ++irow){
-      val+= bookkeeper_[detid][label]->getBinContent(icol,irow);
+  int ncols = bookkeeper_[detid][label]->getNbinsX();
+  int nrows = bookkeeper_[detid][label]->getNbinsY();
+  for (int icol = 1; icol <= ncols; ++icol) {
+    float val = 0;
+    float ntimes = 0;
+    for (int irow = 1; irow <= nrows; ++irow) {
+      val += bookkeeper_[detid][label]->getBinContent(icol, irow);
       ntimes++;
     }
-    val/= ntimes;
+    val /= ntimes;
     result.push_back(val);
   }
   return result;
 }
 
-bool
-SiPixelGainCalibrationAnalysis::checkCorrectCalibrationType()
-{
-  if(calibrationMode_=="GainCalibration")
+bool SiPixelGainCalibrationAnalysis::checkCorrectCalibrationType() {
+  if (calibrationMode_ == "GainCalibration")
     return true;
-  else if(ignoreMode_==true)
+  else if (ignoreMode_ == true)
     return true;
-  else if(calibrationMode_=="unknown"){
-    edm::LogInfo("SiPixelGainCalibrationAnalysis") <<  "calibration mode is: " << calibrationMode_ << ", continuing anyway..." ;
+  else if (calibrationMode_ == "unknown") {
+    edm::LogInfo("SiPixelGainCalibrationAnalysis")
+        << "calibration mode is: " << calibrationMode_ << ", continuing anyway...";
     return true;
-  }
-  else{
+  } else {
     //    edm::LogError("SiPixelGainCalibrationAnalysis") << "unknown calibration mode for Gain calibration, should be \"Gain\" and is \"" << calibrationMode_ << "\"";
   }
   return false;
 }
 
-void SiPixelGainCalibrationAnalysis::calibrationSetup(const edm::EventSetup&)
-{
-}
+void SiPixelGainCalibrationAnalysis::calibrationSetup(const edm::EventSetup &) {}
 //------- summary printing method. Very verbose.
-void
-SiPixelGainCalibrationAnalysis::printSummary(){
-
-  uint32_t detid=0;
-  for(std::map<uint32_t,std::map<std::string,MonitorElement *> >::const_iterator idet = bookkeeper_.begin(); idet != bookkeeper_.end(); ++idet){
-    if(detid==idet->first)
-      continue;// only do things once per detid
-    detid=idet->first;
-    std::vector<float> gainvec=CalculateAveragePerColumn(detid,"gain_2d");
-    std::vector<float> pedvec =CalculateAveragePerColumn(detid,"ped_2d");
-    std::vector<float> chi2vec = CalculateAveragePerColumn(detid,"chi2_2d");
+void SiPixelGainCalibrationAnalysis::printSummary() {
+  uint32_t detid = 0;
+  for (std::map<uint32_t, std::map<std::string, MonitorElement *> >::const_iterator idet = bookkeeper_.begin();
+       idet != bookkeeper_.end();
+       ++idet) {
+    if (detid == idet->first)
+      continue;  // only do things once per detid
+    detid = idet->first;
+    std::vector<float> gainvec = CalculateAveragePerColumn(detid, "gain_2d");
+    std::vector<float> pedvec = CalculateAveragePerColumn(detid, "ped_2d");
+    std::vector<float> chi2vec = CalculateAveragePerColumn(detid, "chi2_2d");
     std::ostringstream summarytext;
 
     summarytext << "Summary for det ID " << detid << "(" << translateDetIdToString(detid) << ")\n";
     summarytext << "\t Following: values per column: column #, gain, pedestal, chi2\n";
-    for(uint32_t i=0; i<gainvec.size(); i++)
+    for (uint32_t i = 0; i < gainvec.size(); i++)
       summarytext << "\t " << i << " \t" << gainvec[i] << " \t" << pedvec[i] << " \t" << chi2vec[i] << "\n";
     summarytext << "\t list of pixels with high chi2 (chi2> " << chi2Threshold_ << "): \n";
 
-    
-    for(std::map<std::string, MonitorElement *>::const_iterator ipix = bookkeeper_pixels_[detid].begin(); ipix!=bookkeeper_pixels_[detid].end(); ++ipix)
+    for (std::map<std::string, MonitorElement *>::const_iterator ipix = bookkeeper_pixels_[detid].begin();
+         ipix != bookkeeper_pixels_[detid].end();
+         ++ipix)
       summarytext << "\t " << ipix->first << "\n";
     edm::LogInfo("SiPixelGainCalibrationAnalysis") << summarytext.str() << std::endl;
-
   }
-  if(summary_.is_open()){
+  if (summary_.is_open()) {
     summary_.close();
     summary_.open("Summary.txt");
-    summary_<<"Total Number of Pixel computed :"<<statusNumbers_[9]<<endl;
-    summary_<<"Number of pixel tagged with status :"<<endl;
-    for(int ii=0;ii<9;ii++)
-      summary_<<ii<<" -> "<<statusNumbers_[ii]<<" ~ "<<double(statusNumbers_[ii])/double(statusNumbers_[9])*100.<<" %"<<endl;
-    
-    summary_.close();
-  
-  }
+    summary_ << "Total Number of Pixel computed :" << statusNumbers_[9] << endl;
+    summary_ << "Number of pixel tagged with status :" << endl;
+    for (int ii = 0; ii < 9; ii++)
+      summary_ << ii << " -> " << statusNumbers_[ii] << " ~ "
+               << double(statusNumbers_[ii]) / double(statusNumbers_[9]) * 100. << " %" << endl;
 
+    summary_.close();
+  }
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
 
-void 
-SiPixelGainCalibrationAnalysis::calibrationEnd() {
+void SiPixelGainCalibrationAnalysis::calibrationEnd() {
+  if (writeSummary_)
+    printSummary();
 
-  if(writeSummary_) printSummary();
-  
   // this is where we loop over all histograms and save the database objects
-  if(filldb_)
+  if (filldb_)
     fillDatabase();
 }
 //-----------method to fill the database
-void SiPixelGainCalibrationAnalysis::fillDatabase(){
- // only create when necessary.
+void SiPixelGainCalibrationAnalysis::fillDatabase() {
+  // only create when necessary.
   // process the minimum and maximum gain & ped values...
-  edm::LogError("SiPixelGainCalibration::fillDatabase()") << "PLEASE do not fill the database directly from the gain calibration analyzer. This function is currently disabled and no DB payloads will be produced!" << std::endl;
-
+  edm::LogError("SiPixelGainCalibration::fillDatabase()")
+      << "PLEASE do not fill the database directly from the gain calibration analyzer. This function is currently "
+         "disabled and no DB payloads will be produced!"
+      << std::endl;
 }
 // ------------ method called to do fits to all objects available  ------------
-bool
-SiPixelGainCalibrationAnalysis::doFits(uint32_t detid, std::vector<SiPixelCalibDigi>::const_iterator ipix)
-{
-  float lowmeanval=255;
-  float highmeanval=0;
+bool SiPixelGainCalibrationAnalysis::doFits(uint32_t detid, std::vector<SiPixelCalibDigi>::const_iterator ipix) {
+  float lowmeanval = 255;
+  float highmeanval = 0;
   bool makehistopersistent = saveALLHistograms_;
-  std::vector<uint32_t>::const_iterator detidfinder=find(listofdetids_.begin(),listofdetids_.end(),detid);
-  if(detidfinder!=listofdetids_.end())
-    makehistopersistent=true;
+  std::vector<uint32_t>::const_iterator detidfinder = find(listofdetids_.begin(), listofdetids_.end(), detid);
+  if (detidfinder != listofdetids_.end())
+    makehistopersistent = true;
   // first, fill the input arrays to the TLinearFitter.
   double xvals[257];
   double yvals[256];
@@ -202,296 +196,313 @@ SiPixelGainCalibrationAnalysis::doFits(uint32_t detid, std::vector<SiPixelCalibD
   double xvalsall[257];
   double yvalsall[256];
   double yerrvalsall[256];
-  int npoints=0;
-  int nallpoints=0;
-  bool use_point=true;
-  int status=0;
+  int npoints = 0;
+  int nallpoints = 0;
+  bool use_point = true;
+  int status = 0;
   statusNumbers_[9]++;
-  
-  bookkeeper_[detid]["status_2d"]->setBinContent(ipix->col()+1,ipix->row()+1,0);
-  if(writeSummary_ && detid!=currentDetID_){
+
+  bookkeeper_[detid]["status_2d"]->setBinContent(ipix->col() + 1, ipix->row() + 1, 0);
+  if (writeSummary_ && detid != currentDetID_) {
     currentDetID_ = detid;
-    summary_<<endl<<"DetId_"<<currentDetID_<<endl;
+    summary_ << endl << "DetId_" << currentDetID_ << endl;
   }
-  
-  for(uint32_t ii=0; ii< ipix->getnpoints() && ii<200; ii++){
+
+  for (uint32_t ii = 0; ii < ipix->getnpoints() && ii < 200; ii++) {
     //    std::cout << ipix->getsum(ii) << " " << ipix->getnentries(ii) << " " << ipix->getsumsquares(ii) << std::endl;
     nallpoints++;
-    use_point=true;
-    if(useVcalHigh_){
-      xvalsall[ii]=vCalValues_[ii]*scalarVcalHigh_VcalLow_;
-    }
-    else
-      xvalsall[ii]=vCalValues_[ii];
-    yerrvalsall[ii]=yvalsall[ii]=0; 
-  
-    if(ipix->getnentries(ii)>min_nentries_){
-      yvalsall[ii]=ipix->getsum(ii)/(float)ipix->getnentries(ii);
-      yerrvalsall[ii]=ipix->getsumsquares(ii)/(float)(ipix->getnentries(ii));
-      yerrvalsall[ii]-=pow(yvalsall[ii],2);
-      yerrvalsall[ii]=sqrt(yerrvalsall[ii])/sqrt(ipix->getnentries(ii));
-      
-      if(yvalsall[ii]<lowmeanval)
-	lowmeanval=yvalsall[ii];
-      if(yvalsall[ii]>highmeanval)
-	highmeanval=yvalsall[ii];
+    use_point = true;
+    if (useVcalHigh_) {
+      xvalsall[ii] = vCalValues_[ii] * scalarVcalHigh_VcalLow_;
+    } else
+      xvalsall[ii] = vCalValues_[ii];
+    yerrvalsall[ii] = yvalsall[ii] = 0;
+
+    if (ipix->getnentries(ii) > min_nentries_) {
+      yvalsall[ii] = ipix->getsum(ii) / (float)ipix->getnentries(ii);
+      yerrvalsall[ii] = ipix->getsumsquares(ii) / (float)(ipix->getnentries(ii));
+      yerrvalsall[ii] -= pow(yvalsall[ii], 2);
+      yerrvalsall[ii] = sqrt(yerrvalsall[ii]) / sqrt(ipix->getnentries(ii));
+
+      if (yvalsall[ii] < lowmeanval)
+        lowmeanval = yvalsall[ii];
+      if (yvalsall[ii] > highmeanval)
+        highmeanval = yvalsall[ii];
     }
   }
-  
+
   // calculate plateau value from last 4 entries
-  double plateauval=0;
-  bool noPlateau=false;
-  if(nallpoints>=4){
-    for(int ii=nallpoints-1; ii>nallpoints-5; --ii) plateauval+=yvalsall[ii];
-    plateauval/=4;
-    for(int ii=nallpoints-1; ii>nallpoints-5; --ii){
-      if(fabs(yvalsall[ii]-plateauval)>5){
-        plateauval=255;
-	noPlateau=true;
+  double plateauval = 0;
+  bool noPlateau = false;
+  if (nallpoints >= 4) {
+    for (int ii = nallpoints - 1; ii > nallpoints - 5; --ii)
+      plateauval += yvalsall[ii];
+    plateauval /= 4;
+    for (int ii = nallpoints - 1; ii > nallpoints - 5; --ii) {
+      if (fabs(yvalsall[ii] - plateauval) > 5) {
+        plateauval = 255;
+        noPlateau = true;
         continue;
       }
     }
-    
-    int NbofPointsInPlateau=0;
-    for(int ii=0; ii<nallpoints; ++ii)
-      if(fabs(yvalsall[ii]-plateauval)<10 || yvalsall[ii]==0) NbofPointsInPlateau++;
+
+    int NbofPointsInPlateau = 0;
+    for (int ii = 0; ii < nallpoints; ++ii)
+      if (fabs(yvalsall[ii] - plateauval) < 10 || yvalsall[ii] == 0)
+        NbofPointsInPlateau++;
     //summary_<<"row_"<<ipix->row()<<" col_"<<ipix->col()<<"   "<<plateauval<<"  "<<NbofPointsInPlateau<<"  "<<nallpoints<<endl;
-    if(NbofPointsInPlateau>=(nallpoints-2)){
-      status=-2;
-      bookkeeper_[detid]["status_2d"]->setBinContent(ipix->col()+1,ipix->row()+1,status);
-      if(writeSummary_){
-        summary_<<"row_"<<ipix->row()<<" col_"<<ipix->col()<<" status_"<<status<<endl;
-	statusNumbers_[abs(status)]++;
+    if (NbofPointsInPlateau >= (nallpoints - 2)) {
+      status = -2;
+      bookkeeper_[detid]["status_2d"]->setBinContent(ipix->col() + 1, ipix->row() + 1, status);
+      if (writeSummary_) {
+        summary_ << "row_" << ipix->row() << " col_" << ipix->col() << " status_" << status << endl;
+        statusNumbers_[abs(status)]++;
       }
       return false;
     }
-  }
-  else plateauval=255;
-    
-  double maxgoodvalinfit=plateauval*(1.-reject_badpoints_frac_);
-  npoints=0;
-  for(int ii=0; ii<nallpoints; ++ii){
-   
+  } else
+    plateauval = 255;
+
+  double maxgoodvalinfit = plateauval * (1. - reject_badpoints_frac_);
+  npoints = 0;
+  for (int ii = 0; ii < nallpoints; ++ii) {
     // now selecting the appropriate points for the fit.
-    use_point=true;
-    if(reject_first_point_ && xvalsall[ii]<0.1)
-      use_point=false;
-    if(ipix->getnentries(ii)<=min_nentries_ && reject_single_entries_)
-      use_point=false;
-    if(ipix->getnentries(ii)==0 && reject_badpoints_)
-      use_point=false;
-    if(yvalsall[ii]>maxgoodvalinfit && !noPlateau)
-      use_point=false;
-    if(ii>1 && fabs(yvalsall[ii]-yvalsall[ii-1])<5. && yvalsall[ii]>0.8*maxgoodvalinfit && reject_plateaupoints_){
-      use_point=false;
+    use_point = true;
+    if (reject_first_point_ && xvalsall[ii] < 0.1)
+      use_point = false;
+    if (ipix->getnentries(ii) <= min_nentries_ && reject_single_entries_)
+      use_point = false;
+    if (ipix->getnentries(ii) == 0 && reject_badpoints_)
+      use_point = false;
+    if (yvalsall[ii] > maxgoodvalinfit && !noPlateau)
+      use_point = false;
+    if (ii > 1 && fabs(yvalsall[ii] - yvalsall[ii - 1]) < 5. && yvalsall[ii] > 0.8 * maxgoodvalinfit &&
+        reject_plateaupoints_) {
+      use_point = false;
       break;
     }
-    
-    if(use_point){
-      xvals[npoints]=xvalsall[ii];
-      yvals[npoints]=yvalsall[ii];
-      yerrvals[npoints]=yerrvalsall[ii];
+
+    if (use_point) {
+      xvals[npoints] = xvalsall[ii];
+      yvals[npoints] = yvalsall[ii];
+      yerrvals[npoints] = yerrvalsall[ii];
       npoints++;
     }
   }
-  
-  float chi2,slope,intercept,prob,slopeerror,intercepterror;
-  prob=chi2=-1;
-  slope=intercept=slopeerror=intercepterror=0;
-  
+
+  float chi2, slope, intercept, prob, slopeerror, intercepterror;
+  prob = chi2 = -1;
+  slope = intercept = slopeerror = intercepterror = 0;
 
   // now check on number of points. If bad just start taking the first 4:
 
-  if(npoints<4){
-    npoints=0;
-    for(int ii=0; ii<nallpoints && npoints<4 && yvalsall[ii]<plateauval*0.97; ++ii){
-      if(yvalsall[ii]>0){
-	if(ii>0 && yvalsall[ii]-yvalsall[ii-1]<0.1)
-	  continue;
-	xvals[npoints]=xvalsall[ii];
-	yvals[npoints]=yvalsall[ii];
-	yerrvals[npoints]=yerrvalsall[ii];
-	npoints++;
+  if (npoints < 4) {
+    npoints = 0;
+    for (int ii = 0; ii < nallpoints && npoints < 4 && yvalsall[ii] < plateauval * 0.97; ++ii) {
+      if (yvalsall[ii] > 0) {
+        if (ii > 0 && yvalsall[ii] - yvalsall[ii - 1] < 0.1)
+          continue;
+        xvals[npoints] = xvalsall[ii];
+        yvals[npoints] = yvalsall[ii];
+        yerrvals[npoints] = yerrvalsall[ii];
+        npoints++;
       }
     }
   }
-  if(npoints<2){
+  if (npoints < 2) {
     status = -7;
-    bookkeeper_[detid]["status_2d"]->setBinContent(ipix->col()+1,ipix->row()+1,status);
-    if(writeSummary_){
-      summary_<<"row_"<<ipix->row()<<" col_"<<ipix->col()<<" status_"<<status<<endl;
+    bookkeeper_[detid]["status_2d"]->setBinContent(ipix->col() + 1, ipix->row() + 1, status);
+    if (writeSummary_) {
+      summary_ << "row_" << ipix->row() << " col_" << ipix->col() << " status_" << status << endl;
       statusNumbers_[abs(status)]++;
     }
     std::ostringstream pixelinfo;
     pixelinfo << "GainCurve_row_" << ipix->row() << "_col_" << ipix->col();
-    std::string tempname=translateDetIdToString(detid);
-    tempname+="_";
-    tempname+=pixelinfo.str();
+    std::string tempname = translateDetIdToString(detid);
+    tempname += "_";
+    tempname += pixelinfo.str();
     setDQMDirectory(detid);
-    bookkeeper_pixels_[detid][pixelinfo.str()] = bookDQMHistogram1D(detid,pixelinfo.str(),tempname,105*nallpoints,xvalsall[0],xvalsall[nallpoints-1]*1.05);
-    for(int ii=0; ii<nallpoints; ++ii)
-      bookkeeper_pixels_[detid][pixelinfo.str()]->Fill(xvalsall[ii],yvalsall[ii]);
+    bookkeeper_pixels_[detid][pixelinfo.str()] = bookDQMHistogram1D(
+        detid, pixelinfo.str(), tempname, 105 * nallpoints, xvalsall[0], xvalsall[nallpoints - 1] * 1.05);
+    for (int ii = 0; ii < nallpoints; ++ii)
+      bookkeeper_pixels_[detid][pixelinfo.str()]->Fill(xvalsall[ii], yvalsall[ii]);
     return false;
   }
-    
+
   //  std::cout << "starting fit!" << std::endl;
   graph_->Set(npoints);
-  
-  func_->SetParameter(0,50.);
-  func_->SetParameter(1,0.25);
-  for(int ipointtemp=0; ipointtemp<npoints; ++ipointtemp){
-    graph_->SetPoint(ipointtemp,xvals[ipointtemp],yvals[ipointtemp]);
-    graph_->SetPointError(ipointtemp,0,yerrvals[ipointtemp]);
+
+  func_->SetParameter(0, 50.);
+  func_->SetParameter(1, 0.25);
+  for (int ipointtemp = 0; ipointtemp < npoints; ++ipointtemp) {
+    graph_->SetPoint(ipointtemp, xvals[ipointtemp], yvals[ipointtemp]);
+    graph_->SetPointError(ipointtemp, 0, yerrvals[ipointtemp]);
   }
-  Int_t tempresult = graph_->Fit(func_,"FQ0N");
-  slope=func_->GetParameter(1);
-  slopeerror=func_->GetParError(1);
-  intercept=func_->GetParameter(0);
-  intercepterror=func_->GetParError(0);
-  chi2=func_->GetChisquare()/((float)npoints-func_->GetNpar());
-  prob= TMath::Prob(func_->GetChisquare(),npoints-func_->GetNpar());
-  size_t ntimes=0;
-  while((isnan(slope) || isnan(intercept) )&& ntimes<10){
+  Int_t tempresult = graph_->Fit(func_, "FQ0N");
+  slope = func_->GetParameter(1);
+  slopeerror = func_->GetParError(1);
+  intercept = func_->GetParameter(0);
+  intercepterror = func_->GetParError(0);
+  chi2 = func_->GetChisquare() / ((float)npoints - func_->GetNpar());
+  prob = TMath::Prob(func_->GetChisquare(), npoints - func_->GetNpar());
+  size_t ntimes = 0;
+  while ((isnan(slope) || isnan(intercept)) && ntimes < 10) {
     ntimes++;
-    makehistopersistent=true;
+    makehistopersistent = true;
     //    std::cout << slope << " " << intercept << " " << prob << std::endl;
-    edm::LogWarning("SiPixelGainCalibrationAnalysis") << "impossible to fit values, try " << ntimes << ": " ;
-    for(int ii=0; ii<npoints; ++ii){
-      edm::LogWarning("SiPixelGainCalibrationAnalysis")<< "vcal " << xvals[ii] << " response: " << yvals[ii] << "+/-" << yerrvals[ii] << std::endl; 
-    } 
-    tempresult = graph_->Fit(func_,"FQ0NW");
-    slope=func_->GetParameter(1);
-    slopeerror=func_->GetParError(1);
+    edm::LogWarning("SiPixelGainCalibrationAnalysis") << "impossible to fit values, try " << ntimes << ": ";
+    for (int ii = 0; ii < npoints; ++ii) {
+      edm::LogWarning("SiPixelGainCalibrationAnalysis")
+          << "vcal " << xvals[ii] << " response: " << yvals[ii] << "+/-" << yerrvals[ii] << std::endl;
+    }
+    tempresult = graph_->Fit(func_, "FQ0NW");
+    slope = func_->GetParameter(1);
+    slopeerror = func_->GetParError(1);
     intercept = func_->GetParameter(0);
-    intercepterror=func_->GetParError(0);
-    chi2=func_->GetChisquare()/((float)npoints-func_->GetNpar());
-    prob= TMath::Prob(func_->GetChisquare(),npoints-func_->GetNpar());
+    intercepterror = func_->GetParError(0);
+    chi2 = func_->GetChisquare() / ((float)npoints - func_->GetNpar());
+    prob = TMath::Prob(func_->GetChisquare(), npoints - func_->GetNpar());
   }
-  
-  if(tempresult==0)
-    status=1;
+
+  if (tempresult == 0)
+    status = 1;
   else
-    status=0;
-  if(slope!=0)
-    slope = 1./slope;
-  if(isnan(slope) || isnan(intercept)){
-    status=-6;
-    bookkeeper_[detid]["status_2d"]->setBinContent(ipix->col()+1,ipix->row()+1,status);
-    if(writeSummary_){
-      summary_<<"row_"<<ipix->row()<<" col_"<<ipix->col()<<" status_"<<status<<endl;
+    status = 0;
+  if (slope != 0)
+    slope = 1. / slope;
+  if (isnan(slope) || isnan(intercept)) {
+    status = -6;
+    bookkeeper_[detid]["status_2d"]->setBinContent(ipix->col() + 1, ipix->row() + 1, status);
+    if (writeSummary_) {
+      summary_ << "row_" << ipix->row() << " col_" << ipix->col() << " status_" << status << endl;
       statusNumbers_[abs(status)]++;
     }
     //return false;
   }
-  if(chi2>chi2Threshold_ && chi2Threshold_>=0)
-    status=5;
-  if(prob<chi2ProbThreshold_)
-    status=5;
-  if(noPlateau)
-    status=3;
-  if(nallpoints<4)
-    status=-7;
-  if(TMath::Abs(slope>maxGainInHist_) || slope < 0)
-    status=-8;
-  if(status!=1)
-    makehistopersistent=true;
+  if (chi2 > chi2Threshold_ && chi2Threshold_ >= 0)
+    status = 5;
+  if (prob < chi2ProbThreshold_)
+    status = 5;
+  if (noPlateau)
+    status = 3;
+  if (nallpoints < 4)
+    status = -7;
+  if (TMath::Abs(slope > maxGainInHist_) || slope < 0)
+    status = -8;
+  if (status != 1)
+    makehistopersistent = true;
   statusNumbers_[abs(status)]++;
 
-
-  if(slope<gainlow_)
-    gainlow_=slope;
-  if(slope>gainhi_)
-    gainhi_=slope;
-  if(intercept>pedhi_)
-    pedhi_=intercept;
-  if(intercept<pedlow_)
-    pedlow_=intercept;
+  if (slope < gainlow_)
+    gainlow_ = slope;
+  if (slope > gainhi_)
+    gainhi_ = slope;
+  if (intercept > pedhi_)
+    pedhi_ = intercept;
+  if (intercept < pedlow_)
+    pedlow_ = intercept;
   bookkeeper_[detid]["gain_1d"]->Fill(slope);
-  if(slope>maxGainInHist_){
-    makehistopersistent=true;
-    edm::LogWarning("SiPixelGainCalibration") << "For DETID " << detid << "pixel row,col " << ipix->row() << "," << ipix->col() << " Gain was measured to be " << slope << " which is outside the range of the summary plot (" <<maxGainInHist_ << ") !!!! " << std::endl;
+  if (slope > maxGainInHist_) {
+    makehistopersistent = true;
+    edm::LogWarning("SiPixelGainCalibration")
+        << "For DETID " << detid << "pixel row,col " << ipix->row() << "," << ipix->col() << " Gain was measured to be "
+        << slope << " which is outside the range of the summary plot (" << maxGainInHist_ << ") !!!! " << std::endl;
   }
-  bookkeeper_[detid]["dynamicrange_2d"]->setBinContent(ipix->col()+1,ipix->row()+1,highmeanval-lowmeanval);
-  bookkeeper_[detid]["plateau_2d"]->setBinContent(ipix->col()+1,ipix->row()+1,highmeanval);
-  bookkeeper_[detid]["gain_2d"]->setBinContent(ipix->col()+1,ipix->row()+1,slope);
-  bookkeeper_[detid]["errorgain_2d"]->setBinContent(ipix->col()+1,ipix->row()+1,slopeerror);
+  bookkeeper_[detid]["dynamicrange_2d"]->setBinContent(ipix->col() + 1, ipix->row() + 1, highmeanval - lowmeanval);
+  bookkeeper_[detid]["plateau_2d"]->setBinContent(ipix->col() + 1, ipix->row() + 1, highmeanval);
+  bookkeeper_[detid]["gain_2d"]->setBinContent(ipix->col() + 1, ipix->row() + 1, slope);
+  bookkeeper_[detid]["errorgain_2d"]->setBinContent(ipix->col() + 1, ipix->row() + 1, slopeerror);
   bookkeeper_[detid]["ped_1d"]->Fill(intercept);
-  bookkeeper_[detid]["ped_2d"]->setBinContent(ipix->col()+1,ipix->row()+1,intercept);
-  bookkeeper_[detid]["errorped_2d"]->setBinContent(ipix->col()+1,ipix->row()+1,intercepterror);
+  bookkeeper_[detid]["ped_2d"]->setBinContent(ipix->col() + 1, ipix->row() + 1, intercept);
+  bookkeeper_[detid]["errorped_2d"]->setBinContent(ipix->col() + 1, ipix->row() + 1, intercepterror);
   bookkeeper_[detid]["chi2_1d"]->Fill(chi2);
-  bookkeeper_[detid]["chi2_2d"]->setBinContent(ipix->col()+1,ipix->row()+1,chi2);
+  bookkeeper_[detid]["chi2_2d"]->setBinContent(ipix->col() + 1, ipix->row() + 1, chi2);
   bookkeeper_[detid]["prob_1d"]->Fill(prob);
-  bookkeeper_[detid]["prob_2d"]->setBinContent(ipix->col()+1,ipix->row()+1,prob);
+  bookkeeper_[detid]["prob_2d"]->setBinContent(ipix->col() + 1, ipix->row() + 1, prob);
   bookkeeper_[detid]["lowpoint_1d"]->Fill(xvals[0]);
-  bookkeeper_[detid]["lowpoint_2d"]->setBinContent(ipix->col()+1,ipix->row()+1,xvals[0]);
-  bookkeeper_[detid]["highpoint_1d"]->Fill(xvals[npoints-1]);
-  bookkeeper_[detid]["highpoint_2d"]->setBinContent(ipix->col()+1,ipix->row()+1,xvals[npoints-1]);
+  bookkeeper_[detid]["lowpoint_2d"]->setBinContent(ipix->col() + 1, ipix->row() + 1, xvals[0]);
+  bookkeeper_[detid]["highpoint_1d"]->Fill(xvals[npoints - 1]);
+  bookkeeper_[detid]["highpoint_2d"]->setBinContent(ipix->col() + 1, ipix->row() + 1, xvals[npoints - 1]);
   bookkeeper_[detid]["nfitpoints_1d"]->Fill(npoints);
-  bookkeeper_[detid]["endpoint_1d"]->Fill((255 - intercept)*slope);
-  bookkeeper_[detid]["status_2d"]->setBinContent(ipix->col()+1,ipix->row()+1,status);
+  bookkeeper_[detid]["endpoint_1d"]->Fill((255 - intercept) * slope);
+  bookkeeper_[detid]["status_2d"]->setBinContent(ipix->col() + 1, ipix->row() + 1, status);
 
-    if(!savePixelHists_)
+  if (!savePixelHists_)
     return true;
-  if(detidfinder==listofdetids_.end() && !listofdetids_.empty())
+  if (detidfinder == listofdetids_.end() && !listofdetids_.empty())
     return true;
-  if(makehistopersistent){
+  if (makehistopersistent) {
     std::ostringstream pixelinfo;
     pixelinfo << "GainCurve_row_" << ipix->row() << "_col_" << ipix->col();
-    std::string tempname=translateDetIdToString(detid);
-    tempname+="_";
-    tempname+=pixelinfo.str();
-    
+    std::string tempname = translateDetIdToString(detid);
+    tempname += "_";
+    tempname += pixelinfo.str();
+
     // and book the histo
-    // fill the last value of the vcal array...   
+    // fill the last value of the vcal array...
 
     setDQMDirectory(detid);
-    bookkeeper_pixels_[detid][pixelinfo.str()] =  bookDQMHistogram1D(detid,pixelinfo.str(),tempname,105*nallpoints,xvalsall[0],xvalsall[nallpoints-1]*1.05);
-    
-    edm::LogInfo("SiPixelGainCalibrationAnalysis") << "now saving histogram for pixel " << tempname << ", gain = " << slope << ", pedestal = " << intercept << ", chi2/NDF=" << chi2 << "(prob:" << prob << "), fit status " << status;
-    for(int ii=0; ii<nallpoints; ++ii){
+    bookkeeper_pixels_[detid][pixelinfo.str()] = bookDQMHistogram1D(
+        detid, pixelinfo.str(), tempname, 105 * nallpoints, xvalsall[0], xvalsall[nallpoints - 1] * 1.05);
+
+    edm::LogInfo("SiPixelGainCalibrationAnalysis")
+        << "now saving histogram for pixel " << tempname << ", gain = " << slope << ", pedestal = " << intercept
+        << ", chi2/NDF=" << chi2 << "(prob:" << prob << "), fit status " << status;
+    for (int ii = 0; ii < nallpoints; ++ii) {
       //      std::cout << xvalsall[ii]<<","<<yvalsall[ii]<< " " << tempfloats[ii] << std::endl;
-      bookkeeper_pixels_[detid][pixelinfo.str()]->Fill(xvalsall[ii],yvalsall[ii]);
+      bookkeeper_pixels_[detid][pixelinfo.str()]->Fill(xvalsall[ii], yvalsall[ii]);
     }
-    
+
     //    addTF1ToDQMMonitoringElement(bookkeeper_pixels_[detid][pixelinfo.str()],func_);
-    
-    
-    if(writeSummary_){
-      summary_<<"row_"<<ipix->row()<<" col_"<<ipix->col();
-      summary_<<" status_"<<status;
-      summary_<<endl;
-      
+
+    if (writeSummary_) {
+      summary_ << "row_" << ipix->row() << " col_" << ipix->col();
+      summary_ << " status_" << status;
+      summary_ << endl;
+
       //std::cout<<detid<<"  "<<"row " <<ipix->row()<<" col "<<ipix->col()<<"  "<<status<<"  "<<chi2<<"  "<<prob<<"  "<<npoints<<"  "<<xvals[0]<<"  "<<xvals[npoints-1]<<"  "<<plateauval<<std::endl;
     }
-  } 
+  }
   return true;
 }
 // ------------ method called to do fill new detids  ------------
-void 
-SiPixelGainCalibrationAnalysis::newDetID(uint32_t detid)
-{
+void SiPixelGainCalibrationAnalysis::newDetID(uint32_t detid) {
   setDQMDirectory(detid);
-  std::string tempname=translateDetIdToString(detid);
-  bookkeeper_[detid]["gain_1d"] = bookDQMHistogram1D(detid,"Gain1d","gain for "+tempname,100,0.,maxGainInHist_);
-  bookkeeper_[detid]["gain_2d"] = bookDQMHistoPlaquetteSummary2D(detid, "Gain2d","gain for "+tempname);
-  bookkeeper_[detid]["errorgain_2d"] = bookDQMHistoPlaquetteSummary2D(detid, "ErrorGain2d","error on gain for "+tempname);
-  bookkeeper_[detid]["ped_1d"] = bookDQMHistogram1D(detid,"Pedestal1d","pedestal for "+tempname,256,0.,256.0);
-  bookkeeper_[detid]["ped_2d"] = bookDQMHistoPlaquetteSummary2D(detid,"Pedestal2d","pedestal for "+tempname);
-  bookkeeper_[detid]["errorped_2d"] = bookDQMHistoPlaquetteSummary2D(detid,"ErrorPedestal2d","error on pedestal for "+tempname);
-  bookkeeper_[detid]["chi2_1d"] = bookDQMHistogram1D(detid,"GainChi2NDF1d","#chi^{2}/NDOF for "+tempname,100,0.,maxChi2InHist_);
-  bookkeeper_[detid]["chi2_2d"] = bookDQMHistoPlaquetteSummary2D(detid,"GainChi2NDF2d","#chi^{2}/NDOF for "+tempname);
-  bookkeeper_[detid]["prob_1d"] = bookDQMHistogram1D(detid,"GainChi2Prob1d","P(#chi^{2},NDOF) for "+tempname,100,0.,1.0);
-  bookkeeper_[detid]["prob_2d"] = bookDQMHistoPlaquetteSummary2D(detid,"GainChi2Prob2d","P(#chi^{2},NDOF) for "+tempname);
-  bookkeeper_[detid]["status_2d"] = bookDQMHistoPlaquetteSummary2D(detid,"GainFitResult2d","Fit result for "+tempname);
-  bookkeeper_[detid]["endpoint_1d"]= bookDQMHistogram1D(detid,"GainEndPoint1d","point where fit meets ADC=255 for "+tempname,256,0.,256.*scalarVcalHigh_VcalLow_);
-  bookkeeper_[detid]["lowpoint_1d"]= bookDQMHistogram1D(detid,"GainLowPoint1d","lowest fit point for "+tempname,256,0.,256.*scalarVcalHigh_VcalLow_);
-  bookkeeper_[detid]["highpoint_1d"]= bookDQMHistogram1D(detid,"GainHighPoint1d","highest fit point for "+tempname,256,0.,256.*scalarVcalHigh_VcalLow_);
-  bookkeeper_[detid]["nfitpoints_1d"]= bookDQMHistogram1D(detid,"GainNPoints1d","number of fit point for "+tempname,20,0.,20);
-  bookkeeper_[detid]["dynamicrange_2d"]=bookDQMHistoPlaquetteSummary2D(detid,"GainDynamicRange2d","Difference lowest and highest points on gain curve for "+tempname); 
-  bookkeeper_[detid]["lowpoint_2d"]=bookDQMHistoPlaquetteSummary2D(detid,"GainLowPoint2d","lowest fit point for "+tempname);
-  bookkeeper_[detid]["highpoint_2d"]=bookDQMHistoPlaquetteSummary2D(detid,"GainHighPoint2d","highest fit point for "+tempname);
-  bookkeeper_[detid]["plateau_2d"]=bookDQMHistoPlaquetteSummary2D(detid,"GainSaturate2d","Highest points on gain curve for "+tempname);
-
+  std::string tempname = translateDetIdToString(detid);
+  bookkeeper_[detid]["gain_1d"] = bookDQMHistogram1D(detid, "Gain1d", "gain for " + tempname, 100, 0., maxGainInHist_);
+  bookkeeper_[detid]["gain_2d"] = bookDQMHistoPlaquetteSummary2D(detid, "Gain2d", "gain for " + tempname);
+  bookkeeper_[detid]["errorgain_2d"] =
+      bookDQMHistoPlaquetteSummary2D(detid, "ErrorGain2d", "error on gain for " + tempname);
+  bookkeeper_[detid]["ped_1d"] = bookDQMHistogram1D(detid, "Pedestal1d", "pedestal for " + tempname, 256, 0., 256.0);
+  bookkeeper_[detid]["ped_2d"] = bookDQMHistoPlaquetteSummary2D(detid, "Pedestal2d", "pedestal for " + tempname);
+  bookkeeper_[detid]["errorped_2d"] =
+      bookDQMHistoPlaquetteSummary2D(detid, "ErrorPedestal2d", "error on pedestal for " + tempname);
+  bookkeeper_[detid]["chi2_1d"] =
+      bookDQMHistogram1D(detid, "GainChi2NDF1d", "#chi^{2}/NDOF for " + tempname, 100, 0., maxChi2InHist_);
+  bookkeeper_[detid]["chi2_2d"] =
+      bookDQMHistoPlaquetteSummary2D(detid, "GainChi2NDF2d", "#chi^{2}/NDOF for " + tempname);
+  bookkeeper_[detid]["prob_1d"] =
+      bookDQMHistogram1D(detid, "GainChi2Prob1d", "P(#chi^{2},NDOF) for " + tempname, 100, 0., 1.0);
+  bookkeeper_[detid]["prob_2d"] =
+      bookDQMHistoPlaquetteSummary2D(detid, "GainChi2Prob2d", "P(#chi^{2},NDOF) for " + tempname);
+  bookkeeper_[detid]["status_2d"] =
+      bookDQMHistoPlaquetteSummary2D(detid, "GainFitResult2d", "Fit result for " + tempname);
+  bookkeeper_[detid]["endpoint_1d"] = bookDQMHistogram1D(
+      detid, "GainEndPoint1d", "point where fit meets ADC=255 for " + tempname, 256, 0., 256. * scalarVcalHigh_VcalLow_);
+  bookkeeper_[detid]["lowpoint_1d"] = bookDQMHistogram1D(
+      detid, "GainLowPoint1d", "lowest fit point for " + tempname, 256, 0., 256. * scalarVcalHigh_VcalLow_);
+  bookkeeper_[detid]["highpoint_1d"] = bookDQMHistogram1D(
+      detid, "GainHighPoint1d", "highest fit point for " + tempname, 256, 0., 256. * scalarVcalHigh_VcalLow_);
+  bookkeeper_[detid]["nfitpoints_1d"] =
+      bookDQMHistogram1D(detid, "GainNPoints1d", "number of fit point for " + tempname, 20, 0., 20);
+  bookkeeper_[detid]["dynamicrange_2d"] = bookDQMHistoPlaquetteSummary2D(
+      detid, "GainDynamicRange2d", "Difference lowest and highest points on gain curve for " + tempname);
+  bookkeeper_[detid]["lowpoint_2d"] =
+      bookDQMHistoPlaquetteSummary2D(detid, "GainLowPoint2d", "lowest fit point for " + tempname);
+  bookkeeper_[detid]["highpoint_2d"] =
+      bookDQMHistoPlaquetteSummary2D(detid, "GainHighPoint2d", "highest fit point for " + tempname);
+  bookkeeper_[detid]["plateau_2d"] =
+      bookDQMHistoPlaquetteSummary2D(detid, "GainSaturate2d", "Highest points on gain curve for " + tempname);
 }
 //define this as a plug-in
 DEFINE_FWK_MODULE(SiPixelGainCalibrationAnalysis);

--- a/CalibTracker/SiPixelGainCalibration/plugins/SiPixelGainCalibrationAnalysis.h
+++ b/CalibTracker/SiPixelGainCalibration/plugins/SiPixelGainCalibrationAnalysis.h
@@ -2,7 +2,7 @@
 //
 // Package:    SiPixelGainCalibrationAnalysis
 // Class:      SiPixelGainCalibrationAnalysis
-// 
+//
 /**\class SiPixelGainCalibrationAnalysis SiPixelGainCalibrationAnalysis.h CalibTracker/SiPixelGainCalibrationAnalysis/interface/SiPixelGainCalibrationAnalysis.h
 
 Description: <one line class summary>
@@ -15,7 +15,6 @@ Implementation:
 //         Created:  Wed Nov 14 15:02:06 CET 2007
 //
 //
-
 
 // system include files
 #include <memory>
@@ -47,28 +46,27 @@ Implementation:
 
 class SiPixelGainCalibrationAnalysis : public SiPixelOfflineCalibAnalysisBase {
 public:
-  explicit SiPixelGainCalibrationAnalysis(const edm::ParameterSet& iConfig);
+  explicit SiPixelGainCalibrationAnalysis(const edm::ParameterSet &iConfig);
   ~SiPixelGainCalibrationAnalysis() override;
 
-  void doSetup(const edm::ParameterSet&);
+  void doSetup(const edm::ParameterSet &);
   bool doFits(uint32_t detid, std::vector<SiPixelCalibDigi>::const_iterator ipix) override;
 
   bool checkCorrectCalibrationType() override;
 
 private:
-      
-  void calibrationSetup(const edm::EventSetup& iSetup) override;
-      
+  void calibrationSetup(const edm::EventSetup &iSetup) override;
+
   void calibrationEnd() override;
   void newDetID(uint32_t detid) override;
   void fillDatabase();
   void printSummary();
   std::vector<float> CalculateAveragePerColumn(uint32_t detid, std::string label);
-  // ----------member data --------------------------- 
+  // ----------member data ---------------------------
   edm::ParameterSet conf_;
   // more class members used to keep track of the histograms
-  std::map<uint32_t,std::map<std::string, MonitorElement *> > bookkeeper_;
-  std::map<uint32_t,std::map<std::string, MonitorElement *> > bookkeeper_pixels_;
+  std::map<uint32_t, std::map<std::string, MonitorElement *> > bookkeeper_;
+  std::map<uint32_t, std::map<std::string, MonitorElement *> > bookkeeper_pixels_;
 
   // fitter
   int nfitparameters_;
@@ -97,9 +95,9 @@ private:
   bool sum_gain_cols_;
   bool filldb_;
   bool writeSummary_;
-  
-  // parameters for database output  
-  std::string  recordName_;
+
+  // parameters for database output
+  std::string recordName_;
   bool appendMode_;
   /*SiPixelGainCalibration *theGainCalibrationDbInput_;
   SiPixelGainCalibrationOffline *theGainCalibrationDbInputOffline_;
@@ -114,10 +112,9 @@ private:
   uint16_t min_nentries_;
   bool useVcalHigh_;
   double scalarVcalHigh_VcalLow_;
-  
+
   //Summary
   std::ofstream summary_;
   uint32_t currentDetID_;
-  int* statusNumbers_;
-  
+  int *statusNumbers_;
 };

--- a/CalibTracker/SiPixelGainCalibration/test/SealModules.cc
+++ b/CalibTracker/SiPixelGainCalibration/test/SealModules.cc
@@ -3,6 +3,4 @@
 
 #include "CalibTracker/SiPixelGainCalibration/test/SimpleTestPrintOutPixelCalibAnalyzer.h"
 
-
-
 DEFINE_FWK_MODULE(SimpleTestPrintOutPixelCalibAnalyzer);

--- a/CalibTracker/SiPixelGainCalibration/test/SimpleTestPrintOutPixelCalibAnalyzer.cc
+++ b/CalibTracker/SiPixelGainCalibration/test/SimpleTestPrintOutPixelCalibAnalyzer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    SimpleTestPrintOutPixelCalibAnalyzer
 // Class:      SimpleTestPrintOutPixelCalibAnalyzer
-// 
+//
 /**\class SimpleTestPrintOutPixelCalibAnalyzer CalibTracker/SiPixelGainCalibration/test/SimpleTestPrintOutPixelCalibAnalyzer.cc
 
  Description: <one line class summary>
@@ -15,7 +15,6 @@
 //         Created:  Mon Nov  5 16:56:35 CET 2007
 //
 //
-
 
 // system include files
 #include <memory>
@@ -45,62 +44,45 @@
 SimpleTestPrintOutPixelCalibAnalyzer::SimpleTestPrintOutPixelCalibAnalyzer(const edm::ParameterSet& iConfig)
 
 {
-  tPixelCalibDigi = consumes <edm::DetSetVector<SiPixelCalibDigi> > (edm::InputTag("siPixelCalibDigis"));
-
+  tPixelCalibDigi = consumes<edm::DetSetVector<SiPixelCalibDigi> >(edm::InputTag("siPixelCalibDigis"));
 }
 
-
-SimpleTestPrintOutPixelCalibAnalyzer::~SimpleTestPrintOutPixelCalibAnalyzer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+SimpleTestPrintOutPixelCalibAnalyzer::~SimpleTestPrintOutPixelCalibAnalyzer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
-void
-SimpleTestPrintOutPixelCalibAnalyzer::printInfo(const edm::Event& iEvent, const edm::EventSetup& iSetup){
-
+void SimpleTestPrintOutPixelCalibAnalyzer::printInfo(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
-  
+
   Handle<DetSetVector<SiPixelCalibDigi> > pIn;
-  iEvent.getByToken(tPixelCalibDigi,pIn);
+  iEvent.getByToken(tPixelCalibDigi, pIn);
 
   DetSetVector<SiPixelCalibDigi>::const_iterator digiIter;
-  for(digiIter=pIn->begin(); digiIter!=pIn->end(); ++digiIter){
+  for (digiIter = pIn->begin(); digiIter != pIn->end(); ++digiIter) {
     uint32_t detid = digiIter->id;
     DetSet<SiPixelCalibDigi>::const_iterator ipix;
-    for(ipix= digiIter->data.begin(); ipix!=digiIter->end(); ++ipix){
-      std::cout  << std::endl;
-      for(uint32_t ipoint=0; ipoint<ipix->getnpoints(); ++ipoint)
-	std::cout << "\t Det ID " << detid << " row:" << ipix->row() << " col:" << ipix->col() << " point " << ipoint << " has " << ipix->getnentries(ipoint) << " entries, adc: " << ipix->getsum(ipoint) << ", adcsq: " << ipix->getsumsquares(ipoint) << std::endl;
+    for (ipix = digiIter->data.begin(); ipix != digiIter->end(); ++ipix) {
+      std::cout << std::endl;
+      for (uint32_t ipoint = 0; ipoint < ipix->getnpoints(); ++ipoint)
+        std::cout << "\t Det ID " << detid << " row:" << ipix->row() << " col:" << ipix->col() << " point " << ipoint
+                  << " has " << ipix->getnentries(ipoint) << " entries, adc: " << ipix->getsum(ipoint)
+                  << ", adcsq: " << ipix->getsumsquares(ipoint) << std::endl;
     }
   }
-
 }
 // ------------ method called to for each event  ------------
-void
-SimpleTestPrintOutPixelCalibAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
+void SimpleTestPrintOutPixelCalibAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-   printInfo(iEvent,iSetup);
-
+  printInfo(iEvent, iSetup);
 }
-
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-SimpleTestPrintOutPixelCalibAnalyzer::beginJob()
-{
-}
+void SimpleTestPrintOutPixelCalibAnalyzer::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-SimpleTestPrintOutPixelCalibAnalyzer::endJob() {
-}
-
+void SimpleTestPrintOutPixelCalibAnalyzer::endJob() {}

--- a/CalibTracker/SiPixelGainCalibration/test/SimpleTestPrintOutPixelCalibAnalyzer.h
+++ b/CalibTracker/SiPixelGainCalibration/test/SimpleTestPrintOutPixelCalibAnalyzer.h
@@ -2,7 +2,7 @@
 //
 // Package:    SimpleTestPrintOutPixelCalibAnalyzer
 // Class:      SimpleTestPrintOutPixelCalibAnalyzer
-// 
+//
 /**\class SimpleTestPrintOutPixelCalibAnalyzer CalibTracker/SiPixelGainCalibration/test/SimpleTestPrintOutPixelCalibAnalyzer.cc
 
  Description: <one line class summary>
@@ -15,7 +15,6 @@
 //         Created:  Mon Nov  5 16:56:35 CET 2007
 //
 //
-
 
 // system include files
 #include <memory>
@@ -37,16 +36,14 @@ class SimpleTestPrintOutPixelCalibAnalyzer : public edm::EDAnalyzer {
 public:
   explicit SimpleTestPrintOutPixelCalibAnalyzer(const edm::ParameterSet&);
   ~SimpleTestPrintOutPixelCalibAnalyzer();
-  
-  
+
 private:
-  virtual void beginJob() ;
+  virtual void beginJob();
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void printInfo(const edm::Event&, const edm::EventSetup&); // print method added by Freya, this way the analyzer stays clean
-  virtual void endJob() ;
+  virtual void printInfo(const edm::Event&,
+                         const edm::EventSetup&);  // print method added by Freya, this way the analyzer stays clean
+  virtual void endJob();
 
-      // ----------member data ---------------------------
+  // ----------member data ---------------------------
   edm::EDGetTokenT<edm::DetSetVector<SiPixelCalibDigi> > tPixelCalibDigi;
-
 };
-

--- a/CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h
+++ b/CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h
@@ -21,6 +21,6 @@ namespace StandaloneTrackerTopology {
    * edm::EventSetup (e.g. ROOT macros).
    */
   TrackerTopology fromTrackerParametersXMLString(const std::string& xmlContent);
-};
+};  // namespace StandaloneTrackerTopology
 
-#endif // TRACKER_TOPOLOGY_STANDALONE_H
+#endif  // TRACKER_TOPOLOGY_STANDALONE_H

--- a/CalibTracker/StandaloneTrackerTopology/src/StandaloneTrackerTopology.cc
+++ b/CalibTracker/StandaloneTrackerTopology/src/StandaloneTrackerTopology.cc
@@ -5,11 +5,10 @@
 
 namespace {
   // split into tokens and convert them to uint32_t
-  inline std::vector<uint32_t> split_string_to_uints(const std::string& str)
-  {
+  inline std::vector<uint32_t> split_string_to_uints(const std::string& str) {
     std::vector<uint32_t> out{};
     std::size_t iStart{str.find_first_not_of(" ,\n")}, iEnd{};
-    while ( std::string::npos != iStart ) {
+    while (std::string::npos != iStart) {
       iEnd = str.find_first_of(" ,\n", iStart);
       out.push_back(std::stoul(str.substr(iStart, iEnd), nullptr, 0));
       iStart = str.find_first_not_of(" ,\n", iEnd);
@@ -17,176 +16,175 @@ namespace {
     return out;
   }
 
-  class TrackerTopologyExtractor : public tinyxml2::XMLVisitor
-  {
-    public:
-    bool VisitEnter(const tinyxml2::XMLElement& elem, const tinyxml2::XMLAttribute*) override
-      {
-        if ( std::strcmp(elem.Value(), "Vector") == 0 ) {
-          const std::string att_type{elem.Attribute("type")};
-          if ( att_type == "numeric" ) {
-            const std::string att_name{elem.Attribute("name")};
-            if ( 0 == att_name.compare(0, SubdetName.size(), SubdetName) ) { // starts with
-              const std::string att_nEntries{elem.Attribute("nEntries")};
-              const std::size_t nEntries = att_nEntries.empty() ? 0 : std::stoul(att_nEntries);
-              const auto vals = split_string_to_uints(elem.GetText());
+  class TrackerTopologyExtractor : public tinyxml2::XMLVisitor {
+  public:
+    bool VisitEnter(const tinyxml2::XMLElement& elem, const tinyxml2::XMLAttribute*) override {
+      if (std::strcmp(elem.Value(), "Vector") == 0) {
+        const std::string att_type{elem.Attribute("type")};
+        if (att_type == "numeric") {
+          const std::string att_name{elem.Attribute("name")};
+          if (0 == att_name.compare(0, SubdetName.size(), SubdetName)) {  // starts with
+            const std::string att_nEntries{elem.Attribute("nEntries")};
+            const std::size_t nEntries = att_nEntries.empty() ? 0 : std::stoul(att_nEntries);
+            const auto vals = split_string_to_uints(elem.GetText());
 
-              if ( nEntries != vals.size() ) {
-                throw cms::Exception("StandaloneTrackerTopology",
-                    ("Problem parsing element with name '"+att_name+"': "+
-                     "'nEntries' attribute claims "+std::to_string(nEntries)+" elements, but parsed "+std::to_string(vals.size())));
-              }
-              const auto subDet = std::stoi(att_name.substr(SubdetName.size()));
-              switch (subDet) {
-                case PixelSubdetector::PixelBarrel: // layer, ladder module
-                  pxbVals_.layerStartBit_        = vals[0];
-                  pxbVals_.ladderStartBit_       = vals[1];
-                  pxbVals_.moduleStartBit_       = vals[2];
+            if (nEntries != vals.size()) {
+              throw cms::Exception(
+                  "StandaloneTrackerTopology",
+                  ("Problem parsing element with name '" + att_name + "': " + "'nEntries' attribute claims " +
+                   std::to_string(nEntries) + " elements, but parsed " + std::to_string(vals.size())));
+            }
+            const auto subDet = std::stoi(att_name.substr(SubdetName.size()));
+            switch (subDet) {
+              case PixelSubdetector::PixelBarrel:  // layer, ladder module
+                pxbVals_.layerStartBit_ = vals[0];
+                pxbVals_.ladderStartBit_ = vals[1];
+                pxbVals_.moduleStartBit_ = vals[2];
 
-                  pxbVals_.layerMask_            = vals[3];
-                  pxbVals_.ladderMask_           = vals[4];
-                  pxbVals_.moduleMask_           = vals[5];
+                pxbVals_.layerMask_ = vals[3];
+                pxbVals_.ladderMask_ = vals[4];
+                pxbVals_.moduleMask_ = vals[5];
 
-                  foundPXB = true;
-                  break;
+                foundPXB = true;
+                break;
 
-                case PixelSubdetector::PixelEndcap: // side, disk, blade, panel, module
-                  pxfVals_.sideStartBit_         = vals[0];
-                  pxfVals_.diskStartBit_         = vals[1];
-                  pxfVals_.bladeStartBit_        = vals[2];
-                  pxfVals_.panelStartBit_        = vals[3];
-                  pxfVals_.moduleStartBit_       = vals[4];
+              case PixelSubdetector::PixelEndcap:  // side, disk, blade, panel, module
+                pxfVals_.sideStartBit_ = vals[0];
+                pxfVals_.diskStartBit_ = vals[1];
+                pxfVals_.bladeStartBit_ = vals[2];
+                pxfVals_.panelStartBit_ = vals[3];
+                pxfVals_.moduleStartBit_ = vals[4];
 
-                  pxfVals_.sideMask_             = vals[5];
-                  pxfVals_.diskMask_             = vals[6];
-                  pxfVals_.bladeMask_            = vals[7];
-                  pxfVals_.panelMask_            = vals[8];
-                  pxfVals_.moduleMask_           = vals[9];
+                pxfVals_.sideMask_ = vals[5];
+                pxfVals_.diskMask_ = vals[6];
+                pxfVals_.bladeMask_ = vals[7];
+                pxfVals_.panelMask_ = vals[8];
+                pxfVals_.moduleMask_ = vals[9];
 
-                  foundPXF = true;
-                  break;
+                foundPXF = true;
+                break;
 
-                case StripSubdetector::TIB: // layer, str_fw_bw, str_int_ext, str, module, ster
-                  tibVals_.layerStartBit_        = vals[ 0];
-                  tibVals_.str_fw_bwStartBit_    = vals[ 1];
-                  tibVals_.str_int_extStartBit_  = vals[ 2];
-                  tibVals_.strStartBit_          = vals[ 3];
-                  tibVals_.moduleStartBit_       = vals[ 4];
-                  tibVals_.sterStartBit_         = vals[ 5];
+              case StripSubdetector::TIB:  // layer, str_fw_bw, str_int_ext, str, module, ster
+                tibVals_.layerStartBit_ = vals[0];
+                tibVals_.str_fw_bwStartBit_ = vals[1];
+                tibVals_.str_int_extStartBit_ = vals[2];
+                tibVals_.strStartBit_ = vals[3];
+                tibVals_.moduleStartBit_ = vals[4];
+                tibVals_.sterStartBit_ = vals[5];
 
-                  tibVals_.layerMask_            = vals[ 6];
-                  tibVals_.str_fw_bwMask_        = vals[ 7];
-                  tibVals_.str_int_extMask_      = vals[ 8];
-                  tibVals_.strMask_              = vals[ 9];
-                  tibVals_.moduleMask_           = vals[10];
-                  tibVals_.sterMask_             = vals[11];
+                tibVals_.layerMask_ = vals[6];
+                tibVals_.str_fw_bwMask_ = vals[7];
+                tibVals_.str_int_extMask_ = vals[8];
+                tibVals_.strMask_ = vals[9];
+                tibVals_.moduleMask_ = vals[10];
+                tibVals_.sterMask_ = vals[11];
 
-                  foundTIB = true;
-                  break;
+                foundTIB = true;
+                break;
 
-                case StripSubdetector::TID: // side, wheel, ring, module_fw_bw, module, ster
-                  tidVals_.sideStartBit_         = vals[ 0];
-                  tidVals_.wheelStartBit_        = vals[ 1];
-                  tidVals_.ringStartBit_         = vals[ 2];
-                  tidVals_.module_fw_bwStartBit_ = vals[ 3];
-                  tidVals_.moduleStartBit_       = vals[ 4];
-                  tidVals_.sterStartBit_         = vals[ 5];
+              case StripSubdetector::TID:  // side, wheel, ring, module_fw_bw, module, ster
+                tidVals_.sideStartBit_ = vals[0];
+                tidVals_.wheelStartBit_ = vals[1];
+                tidVals_.ringStartBit_ = vals[2];
+                tidVals_.module_fw_bwStartBit_ = vals[3];
+                tidVals_.moduleStartBit_ = vals[4];
+                tidVals_.sterStartBit_ = vals[5];
 
-                  tidVals_.sideMask_             = vals[ 6];
-                  tidVals_.wheelMask_            = vals[ 7];
-                  tidVals_.ringMask_             = vals[ 8];
-                  tidVals_.module_fw_bwMask_     = vals[ 9];
-                  tidVals_.moduleMask_           = vals[10];
-                  tidVals_.sterMask_             = vals[11];
+                tidVals_.sideMask_ = vals[6];
+                tidVals_.wheelMask_ = vals[7];
+                tidVals_.ringMask_ = vals[8];
+                tidVals_.module_fw_bwMask_ = vals[9];
+                tidVals_.moduleMask_ = vals[10];
+                tidVals_.sterMask_ = vals[11];
 
-                  foundTID = true;
-                  break;
+                foundTID = true;
+                break;
 
-                case StripSubdetector::TOB: // layer, rod_fw_bw, rod, module, ster
-                  tobVals_.layerStartBit_        = vals[0];
-                  tobVals_.rod_fw_bwStartBit_    = vals[1];
-                  tobVals_.rodStartBit_          = vals[2];
-                  tobVals_.moduleStartBit_       = vals[3];
-                  tobVals_.sterStartBit_         = vals[4];
+              case StripSubdetector::TOB:  // layer, rod_fw_bw, rod, module, ster
+                tobVals_.layerStartBit_ = vals[0];
+                tobVals_.rod_fw_bwStartBit_ = vals[1];
+                tobVals_.rodStartBit_ = vals[2];
+                tobVals_.moduleStartBit_ = vals[3];
+                tobVals_.sterStartBit_ = vals[4];
 
-                  tobVals_.layerMask_            = vals[5];
-                  tobVals_.rod_fw_bwMask_        = vals[6];
-                  tobVals_.rodMask_              = vals[7];
-                  tobVals_.moduleMask_           = vals[8];
-                  tobVals_.sterMask_             = vals[9];
+                tobVals_.layerMask_ = vals[5];
+                tobVals_.rod_fw_bwMask_ = vals[6];
+                tobVals_.rodMask_ = vals[7];
+                tobVals_.moduleMask_ = vals[8];
+                tobVals_.sterMask_ = vals[9];
 
-                  foundTOB = true;
-                  break;
+                foundTOB = true;
+                break;
 
-                case StripSubdetector::TEC: // side, wheel, petal_fw_bw, petal, ring, module, ster
-                  tecVals_.sideStartBit_        = vals[ 0];
-                  tecVals_.wheelStartBit_       = vals[ 1];
-                  tecVals_.petal_fw_bwStartBit_ = vals[ 2];
-                  tecVals_.petalStartBit_       = vals[ 3];
-                  tecVals_.ringStartBit_        = vals[ 4];
-                  tecVals_.moduleStartBit_      = vals[ 5];
-                  tecVals_.sterStartBit_        = vals[ 6];
+              case StripSubdetector::TEC:  // side, wheel, petal_fw_bw, petal, ring, module, ster
+                tecVals_.sideStartBit_ = vals[0];
+                tecVals_.wheelStartBit_ = vals[1];
+                tecVals_.petal_fw_bwStartBit_ = vals[2];
+                tecVals_.petalStartBit_ = vals[3];
+                tecVals_.ringStartBit_ = vals[4];
+                tecVals_.moduleStartBit_ = vals[5];
+                tecVals_.sterStartBit_ = vals[6];
 
-                  tecVals_.sideMask_            = vals[ 7];
-                  tecVals_.wheelMask_           = vals[ 8];
-                  tecVals_.petal_fw_bwMask_     = vals[ 9];
-                  tecVals_.petalMask_           = vals[10];
-                  tecVals_.ringMask_            = vals[11];
-                  tecVals_.moduleMask_          = vals[12];
-                  tecVals_.sterMask_            = vals[13];
+                tecVals_.sideMask_ = vals[7];
+                tecVals_.wheelMask_ = vals[8];
+                tecVals_.petal_fw_bwMask_ = vals[9];
+                tecVals_.petalMask_ = vals[10];
+                tecVals_.ringMask_ = vals[11];
+                tecVals_.moduleMask_ = vals[12];
+                tecVals_.sterMask_ = vals[13];
 
-                  foundTEC = true;
-                  break;
-              }
+                foundTEC = true;
+                break;
             }
           }
         }
-        return true;
       }
+      return true;
+    }
 
-      TrackerTopology getTrackerTopology() const
-      {
-        if ( ! ( foundPXB && foundPXF && foundTIB && foundTID && foundTOB && foundTEC ) ) {
-          throw cms::Exception("StandaloneTrackerTopology", "Could not find parameters for all tracker subdetectors");
-        }
-        return TrackerTopology(pxbVals_, pxfVals_, tecVals_, tibVals_, tidVals_, tobVals_);
+    TrackerTopology getTrackerTopology() const {
+      if (!(foundPXB && foundPXF && foundTIB && foundTID && foundTOB && foundTEC)) {
+        throw cms::Exception("StandaloneTrackerTopology", "Could not find parameters for all tracker subdetectors");
       }
+      return TrackerTopology(pxbVals_, pxfVals_, tecVals_, tibVals_, tidVals_, tobVals_);
+    }
 
-    private:
-      TrackerTopology::PixelBarrelValues pxbVals_;
-      TrackerTopology::PixelEndcapValues pxfVals_;
-      TrackerTopology::TIBValues tibVals_;
-      TrackerTopology::TIDValues tidVals_;
-      TrackerTopology::TOBValues tobVals_;
-      TrackerTopology::TECValues tecVals_;
+  private:
+    TrackerTopology::PixelBarrelValues pxbVals_;
+    TrackerTopology::PixelEndcapValues pxfVals_;
+    TrackerTopology::TIBValues tibVals_;
+    TrackerTopology::TIDValues tidVals_;
+    TrackerTopology::TOBValues tobVals_;
+    TrackerTopology::TECValues tecVals_;
 
-      bool foundPXB = false, foundPXF = false, foundTIB = false, foundTID = false, foundTOB = false, foundTEC = false;
+    bool foundPXB = false, foundPXF = false, foundTIB = false, foundTID = false, foundTOB = false, foundTEC = false;
 
-      const std::string SubdetName = "Subdetector";
+    const std::string SubdetName = "Subdetector";
   };
-}
+}  // namespace
 
 namespace StandaloneTrackerTopology {
-TrackerTopology fromTrackerParametersXMLFile( const std::string& xmlFileName ) {
-  tinyxml2::XMLDocument xmlDoc;
-  xmlDoc.LoadFile(xmlFileName.c_str());
-  if ( ! xmlDoc.Error() ) {
-    TrackerTopologyExtractor extr{};
-    xmlDoc.Accept(&extr);
-    return extr.getTrackerTopology();
-  } else {
-    throw cms::Exception("StandaloneTrackerTopology", std::string{"Failed to parse file "}+xmlFileName+": "+xmlDoc.ErrorStr());
+  TrackerTopology fromTrackerParametersXMLFile(const std::string& xmlFileName) {
+    tinyxml2::XMLDocument xmlDoc;
+    xmlDoc.LoadFile(xmlFileName.c_str());
+    if (!xmlDoc.Error()) {
+      TrackerTopologyExtractor extr{};
+      xmlDoc.Accept(&extr);
+      return extr.getTrackerTopology();
+    } else {
+      throw cms::Exception("StandaloneTrackerTopology",
+                           std::string{"Failed to parse file "} + xmlFileName + ": " + xmlDoc.ErrorStr());
+    }
   }
-}
-TrackerTopology fromTrackerParametersXMLString( const std::string& xmlContent ) {
-  tinyxml2::XMLDocument xmlDoc;
-  xmlDoc.Parse(xmlContent.c_str());
-  if ( ! xmlDoc.Error() ) {
-    TrackerTopologyExtractor extr{};
-    xmlDoc.Accept(&extr);
-    return extr.getTrackerTopology();
-  } else {
-    throw cms::Exception("StandaloneTrackerTopology", std::string{"Error while parsing XML: "}+xmlDoc.ErrorStr());
+  TrackerTopology fromTrackerParametersXMLString(const std::string& xmlContent) {
+    tinyxml2::XMLDocument xmlDoc;
+    xmlDoc.Parse(xmlContent.c_str());
+    if (!xmlDoc.Error()) {
+      TrackerTopologyExtractor extr{};
+      xmlDoc.Accept(&extr);
+      return extr.getTrackerTopology();
+    } else {
+      throw cms::Exception("StandaloneTrackerTopology", std::string{"Error while parsing XML: "} + xmlDoc.ErrorStr());
+    }
   }
-}
-}
+}  // namespace StandaloneTrackerTopology

--- a/Calibration/HcalIsolatedTrackReco/interface/ECALRegFEDSelector.h
+++ b/Calibration/HcalIsolatedTrackReco/interface/ECALRegFEDSelector.h
@@ -28,23 +28,21 @@
 #include "DataFormats/EcalRawData/interface/EcalListOfFEDS.h"
 
 class ECALRegFEDSelector : public edm::EDProducer {
- public:
+public:
   ECALRegFEDSelector(const edm::ParameterSet&);
   ~ECALRegFEDSelector() override;
   std::unique_ptr<const EcalElectronicsMapping> ec_mapping;
 
   double delta_;
   bool fedSaved[1200];
-  
+
   edm::EDGetTokenT<FEDRawDataCollection> tok_raw_;
   edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tok_seed_;
-  
- private:
-  void beginJob() override ;
+
+private:
+  void beginJob() override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override ;
-  
+  void endJob() override;
 };
 
 #endif
-

--- a/Calibration/HcalIsolatedTrackReco/interface/EcalIsolatedParticleCandidateProducer.h
+++ b/Calibration/HcalIsolatedTrackReco/interface/EcalIsolatedParticleCandidateProducer.h
@@ -35,7 +35,7 @@ private:
   edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tok_hlt_;
   edm::EDGetTokenT<EcalRecHitCollection> tok_EB_;
   edm::EDGetTokenT<EcalRecHitCollection> tok_EE_;
-      
+
   // ----------member data ---------------------------
 };
 

--- a/Calibration/HcalIsolatedTrackReco/interface/IPTCorrector.h
+++ b/Calibration/HcalIsolatedTrackReco/interface/IPTCorrector.h
@@ -17,10 +17,9 @@
 #include "DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidate.h"
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
 
-class IPTCorrector : public edm::global::EDProducer<>
-{
+class IPTCorrector : public edm::global::EDProducer<> {
 public:
-  IPTCorrector (const edm::ParameterSet& ps);
+  IPTCorrector(const edm::ParameterSet& ps);
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -31,6 +30,5 @@ private:
   const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tok_uncor_;
   const double assocCone_;
 };
-
 
 #endif

--- a/Calibration/HcalIsolatedTrackReco/interface/IsolatedEcalPixelTrackCandidateProducer.h
+++ b/Calibration/HcalIsolatedTrackReco/interface/IsolatedEcalPixelTrackCandidateProducer.h
@@ -18,7 +18,6 @@
 //
 
 class IsolatedEcalPixelTrackCandidateProducer : public edm::global::EDProducer<> {
-
 public:
   explicit IsolatedEcalPixelTrackCandidateProducer(const edm::ParameterSet&);
   ~IsolatedEcalPixelTrackCandidateProducer() override;

--- a/Calibration/HcalIsolatedTrackReco/interface/IsolatedPixelTrackCandidateL1TProducer.h
+++ b/Calibration/HcalIsolatedTrackReco/interface/IsolatedPixelTrackCandidateL1TProducer.h
@@ -43,26 +43,24 @@
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMap.h"
 
 class IsolatedPixelTrackCandidateL1TProducer : public edm::stream::EDProducer<> {
-
 public:
-
-  IsolatedPixelTrackCandidateL1TProducer (const edm::ParameterSet& ps);
+  IsolatedPixelTrackCandidateL1TProducer(const edm::ParameterSet& ps);
   ~IsolatedPixelTrackCandidateL1TProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
   void produce(edm::Event& evt, const edm::EventSetup& es) override;
-  
+
   double getDistInCM(double eta1, double phi1, double eta2, double phi2);
   std::pair<double, double> GetEtaPhiAtEcal(double etaIP, double phiIP, double pT, int charge, double vtxZ);
 
 private:
   struct seedAtEC {
-    seedAtEC(unsigned int i, bool f, double et, double fi) : index(i), ok(f), eta(et), phi(fi) { }
+    seedAtEC(unsigned int i, bool f, double et, double fi) : index(i), ok(f), eta(et), phi(fi) {}
     unsigned int index;
-    bool         ok;
-    double       eta, phi;
+    bool ok;
+    double eta, phi;
   };
 
   const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tok_hlt_;
@@ -86,6 +84,5 @@ private:
   double zEE_;
   double bfVal_;
 };
-
 
 #endif

--- a/Calibration/HcalIsolatedTrackReco/interface/IsolatedPixelTrackCandidateProducer.h
+++ b/Calibration/HcalIsolatedTrackReco/interface/IsolatedPixelTrackCandidateProducer.h
@@ -40,26 +40,24 @@
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMap.h"
 
 class IsolatedPixelTrackCandidateProducer : public edm::stream::EDProducer<> {
-
 public:
-
-  IsolatedPixelTrackCandidateProducer (const edm::ParameterSet& ps);
+  IsolatedPixelTrackCandidateProducer(const edm::ParameterSet& ps);
   ~IsolatedPixelTrackCandidateProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
   void produce(edm::Event& evt, const edm::EventSetup& es) override;
-  
+
   double getDistInCM(double eta1, double phi1, double eta2, double phi2);
   std::pair<double, double> GetEtaPhiAtEcal(double etaIP, double phiIP, double pT, int charge, double vtxZ);
 
 private:
   struct seedAtEC {
-    seedAtEC(unsigned int i, bool f, double et, double fi) : index(i), ok(f), eta(et), phi(fi) { }
+    seedAtEC(unsigned int i, bool f, double et, double fi) : index(i), ok(f), eta(et), phi(fi) {}
     unsigned int index;
-    bool         ok;
-    double       eta, phi;
+    bool ok;
+    double eta, phi;
   };
 
   const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tok_hlt_;
@@ -83,6 +81,5 @@ private:
   double zEE_;
   double bfVal_;
 };
-
 
 #endif

--- a/Calibration/HcalIsolatedTrackReco/interface/SiStripRegFEDSelector.h
+++ b/Calibration/HcalIsolatedTrackReco/interface/SiStripRegFEDSelector.h
@@ -29,15 +29,14 @@ public:
   edm::ESHandle<SiStripRegionCabling> strip_cabling;
 
   double delta_;
-  
+
   edm::EDGetTokenT<FEDRawDataCollection> tok_raw_;
   edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tok_seed_;
 
 private:
-  void beginJob() override ;
+  void beginJob() override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override ;
-
+  void endJob() override;
 };
 
 #endif

--- a/Calibration/HcalIsolatedTrackReco/interface/SubdetFEDSelector.h
+++ b/Calibration/HcalIsolatedTrackReco/interface/SubdetFEDSelector.h
@@ -32,11 +32,11 @@ public:
   edm::EDGetTokenT<FEDRawDataCollection> tok_raw_;
 
 private:
-  void beginJob() override ;
+  void beginJob() override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override ;
+  void endJob() override;
 
-      // ----------member data ---------------------------
+  // ----------member data ---------------------------
 };
 
 #endif

--- a/Calibration/HcalIsolatedTrackReco/src/ECALRegFEDSelector.cc
+++ b/Calibration/HcalIsolatedTrackReco/src/ECALRegFEDSelector.cc
@@ -5,11 +5,10 @@
 #include "DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidate.h"
 #include "DataFormats/Math/interface/RectangularEtaPhiRegion.h"
 
-ECALRegFEDSelector::ECALRegFEDSelector(const edm::ParameterSet& iConfig)
-{
+ECALRegFEDSelector::ECALRegFEDSelector(const edm::ParameterSet& iConfig) {
   tok_seed_ = consumes<trigger::TriggerFilterObjectWithRefs>(iConfig.getParameter<edm::InputTag>("regSeedLabel"));
-  delta_=iConfig.getParameter<double>("delta");
-  
+  delta_ = iConfig.getParameter<double>("delta");
+
   tok_raw_ = consumes<FEDRawDataCollection>(iConfig.getParameter<edm::InputTag>("rawInputLabel"));
 
   ec_mapping = std::make_unique<EcalElectronicsMapping>();
@@ -17,106 +16,85 @@ ECALRegFEDSelector::ECALRegFEDSelector(const edm::ParameterSet& iConfig)
   produces<FEDRawDataCollection>();
   produces<EcalListOfFEDS>();
 
-  for (int p=0; p<1200; p++)
-    {
-      fedSaved[p]=false;
-    }
+  for (int p = 0; p < 1200; p++) {
+    fedSaved[p] = false;
+  }
 }
 
+ECALRegFEDSelector::~ECALRegFEDSelector() {}
 
-ECALRegFEDSelector::~ECALRegFEDSelector()
-{
-}
-
-
-void ECALRegFEDSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-  for (int p=0; p<1200; p++)
-    {
-      fedSaved[p]=false;
-    }
+void ECALRegFEDSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  for (int p = 0; p < 1200; p++) {
+    fedSaved[p] = false;
+  }
 
   auto producedData = std::make_unique<FEDRawDataCollection>();
 
   auto fedList = std::make_unique<EcalListOfFEDS>();
 
   edm::Handle<trigger::TriggerFilterObjectWithRefs> trigSeedTrks;
-  iEvent.getByToken(tok_seed_,trigSeedTrks);
+  iEvent.getByToken(tok_seed_, trigSeedTrks);
 
-  std::vector< edm::Ref<reco::IsolatedPixelTrackCandidateCollection> > isoPixTrackRefs;
+  std::vector<edm::Ref<reco::IsolatedPixelTrackCandidateCollection> > isoPixTrackRefs;
   trigSeedTrks->getObjects(trigger::TriggerTrack, isoPixTrackRefs);
 
   edm::Handle<FEDRawDataCollection> rawIn;
-  iEvent.getByToken(tok_raw_,rawIn);
+  iEvent.getByToken(tok_raw_, rawIn);
 
   //  std::vector<int> EC_FED_IDs;
-  
-  for (uint32_t p=0; p<isoPixTrackRefs.size(); p++)
-    {
-      double etaObj_=isoPixTrackRefs[p]->track()->eta();
-      double phiObj_=isoPixTrackRefs[p]->track()->phi();
 
-      RectangularEtaPhiRegion ecEtaPhi(etaObj_-delta_,etaObj_+delta_,phiObj_-delta_,phiObj_+delta_);
-      
-      const std::vector<int> EC_FED_IDs=ec_mapping->GetListofFEDs(ecEtaPhi);
-      
-      const FEDRawDataCollection *rdc=rawIn.product();
-      
-      for ( int j=0; j< FEDNumbering::MAXFEDID; j++ ) 
-	{
-	  bool rightFED=false;
-	  for (uint32_t k=0; k<EC_FED_IDs.size(); k++)
-	    {
-	      if (j==EcalRegionCabling::fedIndex(EC_FED_IDs[k])) 
-		{
-		  if (!fedSaved[j]) 
-		    {
-		      fedList->AddFED(j);
-		      rightFED=true;
-		      fedSaved[j]=true;
-		    }
-		}
-	    }
-	  if (j>=FEDNumbering::MINPreShowerFEDID&&j<=FEDNumbering::MAXPreShowerFEDID) 
-	    {
-	      fedSaved[j]=true;
-	      rightFED=true;
-	    }
-	  if (!rightFED) continue;
-	  const FEDRawData & fedData = rdc->FEDData(j);
-	  size_t size=fedData.size();
-	  
-	  if ( size > 0 ) 
-	    {
-	      // this fed has data -- lets copy it
-	      FEDRawData & fedDataProd = producedData->FEDData(j);
-	      if ( fedDataProd.size() != 0 ) 
-		{
-//		  std::cout << " More than one FEDRawDataCollection with data in FED ";
-//		  std::cout << j << " Skipping the 2nd\n";
-		  continue;
-		}
-	      fedDataProd.resize(size);
-	      unsigned char *dataProd=fedDataProd.data();
-	      const unsigned char *data=fedData.data();
-	      for ( unsigned int k=0; k<size; ++k ) 
-		{
-		  dataProd[k]=data[k];
-		}
-	    }
-	  
-	}
+  for (uint32_t p = 0; p < isoPixTrackRefs.size(); p++) {
+    double etaObj_ = isoPixTrackRefs[p]->track()->eta();
+    double phiObj_ = isoPixTrackRefs[p]->track()->phi();
+
+    RectangularEtaPhiRegion ecEtaPhi(etaObj_ - delta_, etaObj_ + delta_, phiObj_ - delta_, phiObj_ + delta_);
+
+    const std::vector<int> EC_FED_IDs = ec_mapping->GetListofFEDs(ecEtaPhi);
+
+    const FEDRawDataCollection* rdc = rawIn.product();
+
+    for (int j = 0; j < FEDNumbering::MAXFEDID; j++) {
+      bool rightFED = false;
+      for (uint32_t k = 0; k < EC_FED_IDs.size(); k++) {
+        if (j == EcalRegionCabling::fedIndex(EC_FED_IDs[k])) {
+          if (!fedSaved[j]) {
+            fedList->AddFED(j);
+            rightFED = true;
+            fedSaved[j] = true;
+          }
+        }
+      }
+      if (j >= FEDNumbering::MINPreShowerFEDID && j <= FEDNumbering::MAXPreShowerFEDID) {
+        fedSaved[j] = true;
+        rightFED = true;
+      }
+      if (!rightFED)
+        continue;
+      const FEDRawData& fedData = rdc->FEDData(j);
+      size_t size = fedData.size();
+
+      if (size > 0) {
+        // this fed has data -- lets copy it
+        FEDRawData& fedDataProd = producedData->FEDData(j);
+        if (fedDataProd.size() != 0) {
+          //		  std::cout << " More than one FEDRawDataCollection with data in FED ";
+          //		  std::cout << j << " Skipping the 2nd\n";
+          continue;
+        }
+        fedDataProd.resize(size);
+        unsigned char* dataProd = fedDataProd.data();
+        const unsigned char* data = fedData.data();
+        for (unsigned int k = 0; k < size; ++k) {
+          dataProd[k] = data[k];
+        }
+      }
     }
+  }
 
   iEvent.put(std::move(producedData));
   iEvent.put(std::move(fedList));
-  
 }
 
+void ECALRegFEDSelector::beginJob() {}
 
-void ECALRegFEDSelector::beginJob() {
-}
-
-
-void ECALRegFEDSelector::endJob() {
-}
+void ECALRegFEDSelector::endJob() {}

--- a/Calibration/HcalIsolatedTrackReco/src/EcalIsolatedParticleCandidateProducer.cc
+++ b/Calibration/HcalIsolatedTrackReco/src/EcalIsolatedParticleCandidateProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    EcalIsolatedParticleCandidateProducer
 // Class:      EcalIsolatedParticleCandidateProducer
-// 
+//
 /**\class EcalIsolatedParticleCandidateProducer EcalIsolatedParticleCandidateProducer.cc Calibration/EcalIsolatedParticleCandidateProducer/src/EcalIsolatedParticleCandidateProducer.cc
 
  Description: <one line class summary>
@@ -16,7 +16,6 @@
 //
 //
 
-
 // system include files
 #include <cmath>
 #include <memory>
@@ -24,7 +23,6 @@
 // user include files
 
 #include "FWCore/Framework/interface/EventSetup.h"
-
 
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/DetId/interface/DetId.h"
@@ -34,173 +32,161 @@
 
 #include "Calibration/HcalIsolatedTrackReco/interface/EcalIsolatedParticleCandidateProducer.h"
 
-EcalIsolatedParticleCandidateProducer::EcalIsolatedParticleCandidateProducer(const edm::ParameterSet& conf)
-{
+EcalIsolatedParticleCandidateProducer::EcalIsolatedParticleCandidateProducer(const edm::ParameterSet& conf) {
   InConeSize_ = conf.getParameter<double>("EcalInnerConeSize");
-  OutConeSize_= conf.getParameter<double>("EcalOuterConeSize");
-  hitCountEthr_= conf.getParameter<double>("ECHitCountEnergyThreshold");
-  hitEthr_=conf.getParameter<double>("ECHitEnergyThreshold");
+  OutConeSize_ = conf.getParameter<double>("EcalOuterConeSize");
+  hitCountEthr_ = conf.getParameter<double>("ECHitCountEnergyThreshold");
+  hitEthr_ = conf.getParameter<double>("ECHitEnergyThreshold");
   tok_l1tau_ = consumes<l1extra::L1JetParticleCollection>(conf.getParameter<edm::InputTag>("L1eTauJetsSource"));
   tok_hlt_ = consumes<trigger::TriggerFilterObjectWithRefs>(conf.getParameter<edm::InputTag>("L1GTSeedLabel"));
   tok_EB_ = consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("EBrecHitCollectionLabel"));
   tok_EE_ = consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("EErecHitCollectionLabel"));
 
-   //register your products
-  produces< reco::IsolatedPixelTrackCandidateCollection >();
-
+  //register your products
+  produces<reco::IsolatedPixelTrackCandidateCollection>();
 }
 
-
-EcalIsolatedParticleCandidateProducer::~EcalIsolatedParticleCandidateProducer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+EcalIsolatedParticleCandidateProducer::~EcalIsolatedParticleCandidateProducer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void 
-EcalIsolatedParticleCandidateProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
-
-//  std::cout<<"get tau"<<std::endl;
+void EcalIsolatedParticleCandidateProducer::produce(edm::StreamID,
+                                                    edm::Event& iEvent,
+                                                    const edm::EventSetup& iSetup) const {
+  //  std::cout<<"get tau"<<std::endl;
 
   edm::Handle<l1extra::L1JetParticleCollection> l1Taus;
-  iEvent.getByToken(tok_l1tau_,l1Taus);
-  
-//  std::cout<<"get geom"<<std::endl;
+  iEvent.getByToken(tok_l1tau_, l1Taus);
+
+  //  std::cout<<"get geom"<<std::endl;
 
   edm::ESHandle<CaloGeometry> pG;
   iSetup.get<CaloGeometryRecord>().get(pG);
   const CaloGeometry* geo = pG.product();
 
-//  std::cout<<" get ec rechit"<<std::endl;
+  //  std::cout<<" get ec rechit"<<std::endl;
 
   edm::Handle<EcalRecHitCollection> ecalEB;
-  iEvent.getByToken(tok_EB_,ecalEB);
+  iEvent.getByToken(tok_EB_, ecalEB);
 
   edm::Handle<EcalRecHitCollection> ecalEE;
-  iEvent.getByToken(tok_EE_,ecalEE);
+  iEvent.getByToken(tok_EE_, ecalEE);
 
-//  std::cout<<"get l1 trig obj"<<std::endl;
+  //  std::cout<<"get l1 trig obj"<<std::endl;
 
   edm::Handle<trigger::TriggerFilterObjectWithRefs> l1trigobj;
   iEvent.getByToken(tok_hlt_, l1trigobj);
 
-  std::vector< edm::Ref<l1t::TauBxCollection> > l1tauobjref;
-  std::vector< edm::Ref<l1t::JetBxCollection> > l1jetobjref;
-  
+  std::vector<edm::Ref<l1t::TauBxCollection> > l1tauobjref;
+  std::vector<edm::Ref<l1t::JetBxCollection> > l1jetobjref;
+
   l1trigobj->getObjects(trigger::TriggerL1Tau, l1tauobjref);
   l1trigobj->getObjects(trigger::TriggerL1Jet, l1jetobjref);
-   
-  double ptTriggered=-10;
-  double etaTriggered=-100;
-  double phiTriggered=-100;
 
-//  std::cout<<"find highest pT triggered obj"<<std::endl;
+  double ptTriggered = -10;
+  double etaTriggered = -100;
+  double phiTriggered = -100;
 
-  for (unsigned int p=0; p<l1tauobjref.size(); p++) {
-    if (l1tauobjref[p]->pt()>ptTriggered) {
-      ptTriggered=l1tauobjref[p]->pt();
-      phiTriggered=l1tauobjref[p]->phi();
-      etaTriggered=l1tauobjref[p]->eta();
+  //  std::cout<<"find highest pT triggered obj"<<std::endl;
+
+  for (unsigned int p = 0; p < l1tauobjref.size(); p++) {
+    if (l1tauobjref[p]->pt() > ptTriggered) {
+      ptTriggered = l1tauobjref[p]->pt();
+      phiTriggered = l1tauobjref[p]->phi();
+      etaTriggered = l1tauobjref[p]->eta();
     }
   }
-  for (unsigned int p=0; p<l1jetobjref.size(); p++) {
-    if (l1jetobjref[p]->pt()>ptTriggered) {
-      ptTriggered=l1jetobjref[p]->pt();
-      phiTriggered=l1jetobjref[p]->phi();
-      etaTriggered=l1jetobjref[p]->eta();
+  for (unsigned int p = 0; p < l1jetobjref.size(); p++) {
+    if (l1jetobjref[p]->pt() > ptTriggered) {
+      ptTriggered = l1jetobjref[p]->pt();
+      phiTriggered = l1jetobjref[p]->phi();
+      etaTriggered = l1jetobjref[p]->eta();
     }
   }
 
   auto iptcCollection = std::make_unique<reco::IsolatedPixelTrackCandidateCollection>();
 
-//  std::cout<<"loop over l1taus"<<std::endl;
+  //  std::cout<<"loop over l1taus"<<std::endl;
 
-  for (l1extra::L1JetParticleCollection::const_iterator tit=l1Taus->begin(); tit!=l1Taus->end(); tit++) {
-    double dphi=fabs(tit->phi()-phiTriggered);
-    if (dphi>M_PI) dphi=2*M_PI-dphi;
-    double Rseed=sqrt(pow(etaTriggered-tit->eta(),2)+dphi*dphi);
-    if (Rseed<1.2) continue;
-    int nhitOut=0;
-    int nhitIn=0;
-    double OutEnergy=0;
-    double InEnergy=0;
-//	std::cout<<" loops over rechits"<<std::endl;
-    for (EcalRecHitCollection::const_iterator eItr=ecalEB->begin(); eItr!=ecalEB->end(); eItr++) {
+  for (l1extra::L1JetParticleCollection::const_iterator tit = l1Taus->begin(); tit != l1Taus->end(); tit++) {
+    double dphi = fabs(tit->phi() - phiTriggered);
+    if (dphi > M_PI)
+      dphi = 2 * M_PI - dphi;
+    double Rseed = sqrt(pow(etaTriggered - tit->eta(), 2) + dphi * dphi);
+    if (Rseed < 1.2)
+      continue;
+    int nhitOut = 0;
+    int nhitIn = 0;
+    double OutEnergy = 0;
+    double InEnergy = 0;
+    //	std::cout<<" loops over rechits"<<std::endl;
+    for (EcalRecHitCollection::const_iterator eItr = ecalEB->begin(); eItr != ecalEB->end(); eItr++) {
       double phiD, R;
       const GlobalPoint& pos = geo->getPosition(eItr->detid());
       double phihit = pos.phi();
       double etahit = pos.eta();
-      phiD=fabs(phihit-tit->phi());
-      if (phiD>M_PI) phiD=2*M_PI-phiD;
-      R=sqrt(pow(etahit-tit->eta(),2)+phiD*phiD);
-                
-      if (R<OutConeSize_&&R>InConeSize_&&eItr->energy()>hitCountEthr_) {
-	nhitOut++;
+      phiD = fabs(phihit - tit->phi());
+      if (phiD > M_PI)
+        phiD = 2 * M_PI - phiD;
+      R = sqrt(pow(etahit - tit->eta(), 2) + phiD * phiD);
+
+      if (R < OutConeSize_ && R > InConeSize_ && eItr->energy() > hitCountEthr_) {
+        nhitOut++;
       }
-      if (R<InConeSize_&&eItr->energy()>hitCountEthr_)                 {
-	nhitIn++;
+      if (R < InConeSize_ && eItr->energy() > hitCountEthr_) {
+        nhitIn++;
       }
 
-      if (R<OutConeSize_&&R>InConeSize_&&eItr->energy()>hitEthr_)      {
-	OutEnergy+=eItr->energy();
+      if (R < OutConeSize_ && R > InConeSize_ && eItr->energy() > hitEthr_) {
+        OutEnergy += eItr->energy();
       }
-      if (R<InConeSize_&&eItr->energy()>hitEthr_)                      {
-	InEnergy+=eItr->energy();
+      if (R < InConeSize_ && eItr->energy() > hitEthr_) {
+        InEnergy += eItr->energy();
       }
-
     }
-    
-    for (EcalRecHitCollection::const_iterator eItr=ecalEE->begin(); eItr!=ecalEE->end(); eItr++)  {
+
+    for (EcalRecHitCollection::const_iterator eItr = ecalEE->begin(); eItr != ecalEE->end(); eItr++) {
       double phiD, R;
       const GlobalPoint& pos = geo->getPosition(eItr->detid());
       double phihit = pos.phi();
       double etahit = pos.eta();
-      phiD=fabs(phihit-tit->phi());
-      if (phiD>M_PI) phiD=2*M_PI-phiD;
-      R=sqrt(pow(etahit-tit->eta(),2)+phiD*phiD);
-      if (R<OutConeSize_&&R>InConeSize_&&eItr->energy()>hitCountEthr_)  {
-	nhitOut++;
+      phiD = fabs(phihit - tit->phi());
+      if (phiD > M_PI)
+        phiD = 2 * M_PI - phiD;
+      R = sqrt(pow(etahit - tit->eta(), 2) + phiD * phiD);
+      if (R < OutConeSize_ && R > InConeSize_ && eItr->energy() > hitCountEthr_) {
+        nhitOut++;
       }
-      if (R<InConeSize_&&eItr->energy()>hitCountEthr_)                  {
-	nhitIn++;
+      if (R < InConeSize_ && eItr->energy() > hitCountEthr_) {
+        nhitIn++;
       }
-      if (R<OutConeSize_&&R>InConeSize_&&eItr->energy()>hitEthr_)       {
-	OutEnergy+=eItr->energy();
+      if (R < OutConeSize_ && R > InConeSize_ && eItr->energy() > hitEthr_) {
+        OutEnergy += eItr->energy();
       }
-      if (R<InConeSize_&&eItr->energy()>hitEthr_)                       {
-	InEnergy+=eItr->energy();
+      if (R < InConeSize_ && eItr->energy() > hitEthr_) {
+        InEnergy += eItr->energy();
       }
-
     }
-//	std::cout<<"create and push_back candidate"<<std::endl;
-    reco::IsolatedPixelTrackCandidate newca(l1extra::L1JetParticleRef(l1Taus,tit-l1Taus->begin()), InEnergy, OutEnergy, nhitIn, nhitOut);
-    iptcCollection->push_back(newca);	
+    //	std::cout<<"create and push_back candidate"<<std::endl;
+    reco::IsolatedPixelTrackCandidate newca(
+        l1extra::L1JetParticleRef(l1Taus, tit - l1Taus->begin()), InEnergy, OutEnergy, nhitIn, nhitOut);
+    iptcCollection->push_back(newca);
   }
 
-
-  
-  //Use the ExampleData to create an ExampleData2 which 
+  //Use the ExampleData to create an ExampleData2 which
   // is put into the Event
-  
-//  std::cout<<"put cand into event"<<std::endl;
-  iEvent.put(std::move(iptcCollection));
 
+  //  std::cout<<"put cand into event"<<std::endl;
+  iEvent.put(std::move(iptcCollection));
 }
 // ------------ method called once each job just before starting event loop  ------------
-void 
-EcalIsolatedParticleCandidateProducer::beginJob() {
-}
+void EcalIsolatedParticleCandidateProducer::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-EcalIsolatedParticleCandidateProducer::endJob() {
-}
-
+void EcalIsolatedParticleCandidateProducer::endJob() {}

--- a/Calibration/HcalIsolatedTrackReco/src/HITRegionalPixelSeedGenerator.h
+++ b/Calibration/HcalIsolatedTrackReco/src/HITRegionalPixelSeedGenerator.h
@@ -4,7 +4,6 @@
 //
 // Class:           HITRegionalPixelSeedGenerator
 
-
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -34,20 +33,17 @@
 #include "DataFormats/JetReco/interface/Jet.h"
 
 class HITRegionalPixelSeedGenerator : public TrackingRegionProducer {
- public:
-  
-  explicit HITRegionalPixelSeedGenerator(const edm::ParameterSet& conf_,
-	edm::ConsumesCollector && iC)
-  {
-    edm::LogInfo ("HITRegionalPixelSeedGenerator")<<"Enter the HITRegionalPixelSeedGenerator";
-    
+public:
+  explicit HITRegionalPixelSeedGenerator(const edm::ParameterSet& conf_, edm::ConsumesCollector&& iC) {
+    edm::LogInfo("HITRegionalPixelSeedGenerator") << "Enter the HITRegionalPixelSeedGenerator";
+
     edm::ParameterSet regionPSet = conf_.getParameter<edm::ParameterSet>("RegionPSet");
-    
-    ptmin=regionPSet.getParameter<double>("ptMin");
-    originradius=regionPSet.getParameter<double>("originRadius");
-    halflength=regionPSet.getParameter<double>("originHalfLength");
-    etaCenter_=regionPSet.getParameter<double>("etaCenter");
-    phiCenter_=regionPSet.getParameter<double>("phiCenter");
+
+    ptmin = regionPSet.getParameter<double>("ptMin");
+    originradius = regionPSet.getParameter<double>("originRadius");
+    halflength = regionPSet.getParameter<double>("originHalfLength");
+    etaCenter_ = regionPSet.getParameter<double>("etaCenter");
+    phiCenter_ = regionPSet.getParameter<double>("phiCenter");
     deltaTrackEta = regionPSet.getParameter<double>("deltaEtaTrackRegion");
     deltaTrackPhi = regionPSet.getParameter<double>("deltaPhiTrackRegion");
     deltaL1JetEta = regionPSet.getParameter<double>("deltaEtaL1JetRegion");
@@ -57,175 +53,140 @@ class HITRegionalPixelSeedGenerator : public TrackingRegionProducer {
     useIsoTracks_ = regionPSet.getParameter<bool>("useIsoTracks");
     fixedReg_ = regionPSet.getParameter<bool>("fixedReg");
 
-    if (usetracks_) token_trks = iC.consumes<reco::TrackCollection>(regionPSet.getParameter<edm::InputTag>("trackSrc"));
-    if (usetracks_ || useIsoTracks_ || fixedReg_ || usejets_) 
+    if (usetracks_)
+      token_trks = iC.consumes<reco::TrackCollection>(regionPSet.getParameter<edm::InputTag>("trackSrc"));
+    if (usetracks_ || useIsoTracks_ || fixedReg_ || usejets_)
       token_vertex = iC.consumes<reco::VertexCollection>(regionPSet.getParameter<edm::InputTag>("vertexSrc"));
-    if (useIsoTracks_) token_isoTrack = iC.consumes<trigger::TriggerFilterObjectWithRefs>(regionPSet.getParameter<edm::InputTag>("isoTrackSrc"));
-    if (usejets_) token_l1jet = iC.consumes<l1extra::L1JetParticleCollection>(regionPSet.getParameter<edm::InputTag>("l1tjetSrc"));
+    if (useIsoTracks_)
+      token_isoTrack =
+          iC.consumes<trigger::TriggerFilterObjectWithRefs>(regionPSet.getParameter<edm::InputTag>("isoTrackSrc"));
+    if (usejets_)
+      token_l1jet = iC.consumes<l1extra::L1JetParticleCollection>(regionPSet.getParameter<edm::InputTag>("l1tjetSrc"));
   }
 
   ~HITRegionalPixelSeedGenerator() override {}
-  
-  
-  std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event& e, const edm::EventSetup& es) const override
-    {
-      std::vector<std::unique_ptr<TrackingRegion> > result;
-      float originz =0.;
-      
-      double deltaZVertex =  halflength;
-      
-      
-      
-      if (usetracks_)
-	{
-	  edm::Handle<reco::TrackCollection> tracks;
-	  e.getByToken(token_trks, tracks);
-	  
-	  edm::Handle<reco::VertexCollection> vertices;
-	  e.getByToken(token_vertex,vertices);
-	  const reco::VertexCollection vertCollection = *(vertices.product());
-	  reco::VertexCollection::const_iterator ci = vertCollection.begin();
-	  
-	  if(!vertCollection.empty()) 
-	    {
-	      originz = ci->z();
-	    }
-	  else
-	    {
-	      deltaZVertex = 15.;
-	    }
-      
-	  GlobalVector globalVector(0,0,1);
-	  if(tracks->empty()) return result;
-	  
-	  reco::TrackCollection::const_iterator itr = tracks->begin();
-	  for(;itr != tracks->end();itr++)
-	    {
-	      
-	      GlobalVector ptrVec((itr)->px(),(itr)->py(),(itr)->pz());
-	      globalVector = ptrVec;
-	      
-	      
-	      result.push_back(std::make_unique<RectangularEtaPhiTrackingRegion>(globalVector,
-                                                                                 GlobalPoint(0,0,originz),
-                                                                                 ptmin,
-                                                                                 originradius,
-                                                                                 deltaZVertex,
-                                                                                 deltaTrackEta,
-                                                                                 deltaTrackPhi));
-	    }
-	}
-      
-      if (useIsoTracks_)
-        {
-          edm::Handle<trigger::TriggerFilterObjectWithRefs> isotracks;
-          e.getByToken(token_isoTrack, isotracks);
 
-	  std::vector< edm::Ref<reco::IsolatedPixelTrackCandidateCollection> > isoPixTrackRefs;
-	
-	  isotracks->getObjects(trigger::TriggerTrack, isoPixTrackRefs);
-	  
-          edm::Handle<reco::VertexCollection> vertices;
-          e.getByToken(token_vertex,vertices);
-          const reco::VertexCollection vertCollection = *(vertices.product());
-          reco::VertexCollection::const_iterator ci = vertCollection.begin();
+  std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event& e, const edm::EventSetup& es) const override {
+    std::vector<std::unique_ptr<TrackingRegion> > result;
+    float originz = 0.;
 
-          if(!vertCollection.empty()) 
-	    {
-	      originz = ci->z();
-	    }
-	  else
-	    {
-	      deltaZVertex = 15.;
-	    }
-	  
-          GlobalVector globalVector(0,0,1);
-          if(isoPixTrackRefs.empty()) return result;
-	  
-          for(uint32_t p=0; p<isoPixTrackRefs.size(); p++)
-            {
-              GlobalVector ptrVec((isoPixTrackRefs[p]->track())->px(),(isoPixTrackRefs[p]->track())->py(),(isoPixTrackRefs[p]->track())->pz());
-              globalVector = ptrVec;
-	      
-              result.push_back(std::make_unique<RectangularEtaPhiTrackingRegion>(globalVector,
-                                                                                 GlobalPoint(0,0,originz),
-                                                                                 ptmin,
-                                                                                 originradius,
-                                                                                 deltaZVertex,
-                                                                                 deltaTrackEta,
-                                                                                 deltaTrackPhi));
-	    }
-	}
-      
-      if (usejets_)
-	{
-	  edm::Handle<l1extra::L1JetParticleCollection> jets;
-	  e.getByToken(token_l1jet, jets);
+    double deltaZVertex = halflength;
 
-          edm::Handle<reco::VertexCollection> vertices;
-          e.getByToken(token_vertex, vertices);
-          const reco::VertexCollection vertCollection = *(vertices.product());
-          reco::VertexCollection::const_iterator ci = vertCollection.begin();
-          if(!vertCollection.empty()) 
-	    {
-	      originz = ci->z();
-	    }
-	  else
-	    {
-	      deltaZVertex = 15.;
-	    }
+    if (usetracks_) {
+      edm::Handle<reco::TrackCollection> tracks;
+      e.getByToken(token_trks, tracks);
 
-	  GlobalVector globalVector(0,0,1);
-	  if(jets->empty()) return result;
-	  
-	  for (l1extra::L1JetParticleCollection::const_iterator iJet = jets->begin(); iJet != jets->end(); iJet++) 
-	    {
-	      GlobalVector jetVector(iJet->p4().x(), iJet->p4().y(), iJet->p4().z());
-	      GlobalPoint  vertex(0, 0, originz);
-	      
-	      result.push_back(std::make_unique<RectangularEtaPhiTrackingRegion>( jetVector,
-                                                                                  vertex,
-                                                                                  ptmin,
-                                                                                  originradius,
-                                                                                  deltaZVertex,
-                                                                                  deltaL1JetEta,
-                                                                                  deltaL1JetPhi ));
-	    }
-	}
-      if (fixedReg_)
-	{
-	  GlobalVector fixedVector(cos(phiCenter_)*sin(2*atan(exp(-etaCenter_))), sin(phiCenter_)*sin(2*atan(exp(-etaCenter_))), cos(2*atan(exp(-etaCenter_))));
-	  GlobalPoint  vertex(0, 0, originz);
-	  
-	  edm::Handle<reco::VertexCollection> vertices;
-	  e.getByToken(token_vertex,vertices);
-	  const reco::VertexCollection vertCollection = *(vertices.product());
-	  reco::VertexCollection::const_iterator ci = vertCollection.begin();
-	  if(!vertCollection.empty()) 
-	    {
-	      originz = ci->z();
-	    }
-	  else
-	    {
-	      deltaZVertex = 15.;
-	    }
-	  
-	  result.push_back(std::make_unique<RectangularEtaPhiTrackingRegion>( fixedVector,
-                                                                              vertex,
-                                                                              ptmin,
-                                                                              originradius,
-                                                                              deltaZVertex,
-                                                                              deltaL1JetEta,
-                                                                              deltaL1JetPhi ));
-	}
-      
-      return result;
+      edm::Handle<reco::VertexCollection> vertices;
+      e.getByToken(token_vertex, vertices);
+      const reco::VertexCollection vertCollection = *(vertices.product());
+      reco::VertexCollection::const_iterator ci = vertCollection.begin();
+
+      if (!vertCollection.empty()) {
+        originz = ci->z();
+      } else {
+        deltaZVertex = 15.;
+      }
+
+      GlobalVector globalVector(0, 0, 1);
+      if (tracks->empty())
+        return result;
+
+      reco::TrackCollection::const_iterator itr = tracks->begin();
+      for (; itr != tracks->end(); itr++) {
+        GlobalVector ptrVec((itr)->px(), (itr)->py(), (itr)->pz());
+        globalVector = ptrVec;
+
+        result.push_back(std::make_unique<RectangularEtaPhiTrackingRegion>(
+            globalVector, GlobalPoint(0, 0, originz), ptmin, originradius, deltaZVertex, deltaTrackEta, deltaTrackPhi));
+      }
     }
-  
-  
- private:
+
+    if (useIsoTracks_) {
+      edm::Handle<trigger::TriggerFilterObjectWithRefs> isotracks;
+      e.getByToken(token_isoTrack, isotracks);
+
+      std::vector<edm::Ref<reco::IsolatedPixelTrackCandidateCollection> > isoPixTrackRefs;
+
+      isotracks->getObjects(trigger::TriggerTrack, isoPixTrackRefs);
+
+      edm::Handle<reco::VertexCollection> vertices;
+      e.getByToken(token_vertex, vertices);
+      const reco::VertexCollection vertCollection = *(vertices.product());
+      reco::VertexCollection::const_iterator ci = vertCollection.begin();
+
+      if (!vertCollection.empty()) {
+        originz = ci->z();
+      } else {
+        deltaZVertex = 15.;
+      }
+
+      GlobalVector globalVector(0, 0, 1);
+      if (isoPixTrackRefs.empty())
+        return result;
+
+      for (uint32_t p = 0; p < isoPixTrackRefs.size(); p++) {
+        GlobalVector ptrVec((isoPixTrackRefs[p]->track())->px(),
+                            (isoPixTrackRefs[p]->track())->py(),
+                            (isoPixTrackRefs[p]->track())->pz());
+        globalVector = ptrVec;
+
+        result.push_back(std::make_unique<RectangularEtaPhiTrackingRegion>(
+            globalVector, GlobalPoint(0, 0, originz), ptmin, originradius, deltaZVertex, deltaTrackEta, deltaTrackPhi));
+      }
+    }
+
+    if (usejets_) {
+      edm::Handle<l1extra::L1JetParticleCollection> jets;
+      e.getByToken(token_l1jet, jets);
+
+      edm::Handle<reco::VertexCollection> vertices;
+      e.getByToken(token_vertex, vertices);
+      const reco::VertexCollection vertCollection = *(vertices.product());
+      reco::VertexCollection::const_iterator ci = vertCollection.begin();
+      if (!vertCollection.empty()) {
+        originz = ci->z();
+      } else {
+        deltaZVertex = 15.;
+      }
+
+      GlobalVector globalVector(0, 0, 1);
+      if (jets->empty())
+        return result;
+
+      for (l1extra::L1JetParticleCollection::const_iterator iJet = jets->begin(); iJet != jets->end(); iJet++) {
+        GlobalVector jetVector(iJet->p4().x(), iJet->p4().y(), iJet->p4().z());
+        GlobalPoint vertex(0, 0, originz);
+
+        result.push_back(std::make_unique<RectangularEtaPhiTrackingRegion>(
+            jetVector, vertex, ptmin, originradius, deltaZVertex, deltaL1JetEta, deltaL1JetPhi));
+      }
+    }
+    if (fixedReg_) {
+      GlobalVector fixedVector(cos(phiCenter_) * sin(2 * atan(exp(-etaCenter_))),
+                               sin(phiCenter_) * sin(2 * atan(exp(-etaCenter_))),
+                               cos(2 * atan(exp(-etaCenter_))));
+      GlobalPoint vertex(0, 0, originz);
+
+      edm::Handle<reco::VertexCollection> vertices;
+      e.getByToken(token_vertex, vertices);
+      const reco::VertexCollection vertCollection = *(vertices.product());
+      reco::VertexCollection::const_iterator ci = vertCollection.begin();
+      if (!vertCollection.empty()) {
+        originz = ci->z();
+      } else {
+        deltaZVertex = 15.;
+      }
+
+      result.push_back(std::make_unique<RectangularEtaPhiTrackingRegion>(
+          fixedVector, vertex, ptmin, originradius, deltaZVertex, deltaL1JetEta, deltaL1JetPhi));
+    }
+
+    return result;
+  }
+
+private:
   edm::ParameterSet conf_;
-  
+
   float ptmin;
   float originradius;
   float halflength;
@@ -239,14 +200,10 @@ class HITRegionalPixelSeedGenerator : public TrackingRegionProducer {
   bool usetracks_;
   bool fixedReg_;
   bool useIsoTracks_;
-  edm::EDGetTokenT<reco::TrackCollection> token_trks; 
-  edm::EDGetTokenT<reco::VertexCollection> token_vertex; 
-  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> token_isoTrack; 
-  edm::EDGetTokenT<l1extra::L1JetParticleCollection> token_l1jet; 
-
+  edm::EDGetTokenT<reco::TrackCollection> token_trks;
+  edm::EDGetTokenT<reco::VertexCollection> token_vertex;
+  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> token_isoTrack;
+  edm::EDGetTokenT<l1extra::L1JetParticleCollection> token_l1jet;
 };
 
 #endif
-
-
-

--- a/Calibration/HcalIsolatedTrackReco/src/IPTCorrector.cc
+++ b/Calibration/HcalIsolatedTrackReco/src/IPTCorrector.cc
@@ -19,74 +19,73 @@
 #include "Math/GenVector/PxPyPzE4D.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
-IPTCorrector::IPTCorrector(const edm::ParameterSet& config) :
-  tok_cor_(   consumes<reco::TrackCollection>(config.getParameter<edm::InputTag>("corTracksLabel")) ),
-  tok_uncor_( consumes<trigger::TriggerFilterObjectWithRefs>(config.getParameter<edm::InputTag>("filterLabel")) ),
-  assocCone_( config.getParameter<double>("associationCone") )
-{  
+IPTCorrector::IPTCorrector(const edm::ParameterSet& config)
+    : tok_cor_(consumes<reco::TrackCollection>(config.getParameter<edm::InputTag>("corTracksLabel"))),
+      tok_uncor_(consumes<trigger::TriggerFilterObjectWithRefs>(config.getParameter<edm::InputTag>("filterLabel"))),
+      assocCone_(config.getParameter<double>("associationCone")) {
   // register the product
-  produces< reco::IsolatedPixelTrackCandidateCollection >();
+  produces<reco::IsolatedPixelTrackCandidateCollection>();
 }
 
 void IPTCorrector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("corTracksLabel",edm::InputTag("hltIter0PFlowCtfWithMaterialTracks"));
-  desc.add<edm::InputTag>("filterLabel",edm::InputTag("hltIsolPixelTrackL2Filter"));
-  desc.add<double>("associationCone",0.2);
-  descriptions.add("iptCorrector",desc);
+  desc.add<edm::InputTag>("corTracksLabel", edm::InputTag("hltIter0PFlowCtfWithMaterialTracks"));
+  desc.add<edm::InputTag>("filterLabel", edm::InputTag("hltIsolPixelTrackL2Filter"));
+  desc.add<double>("associationCone", 0.2);
+  descriptions.add("iptCorrector", desc);
 }
 
 void IPTCorrector::produce(edm::StreamID, edm::Event& theEvent, edm::EventSetup const&) const {
-
   auto trackCollection = std::make_unique<reco::IsolatedPixelTrackCandidateCollection>();
 
   edm::Handle<reco::TrackCollection> corTracks;
-  theEvent.getByToken(tok_cor_,corTracks);
+  theEvent.getByToken(tok_cor_, corTracks);
 
   edm::Handle<trigger::TriggerFilterObjectWithRefs> fiCand;
-  theEvent.getByToken(tok_uncor_,fiCand);
+  theEvent.getByToken(tok_uncor_, fiCand);
 
-  std::vector< edm::Ref<reco::IsolatedPixelTrackCandidateCollection> > isoPixTrackRefs;
+  std::vector<edm::Ref<reco::IsolatedPixelTrackCandidateCollection> > isoPixTrackRefs;
 
   fiCand->getObjects(trigger::TriggerTrack, isoPixTrackRefs);
 
-  int nCand=isoPixTrackRefs.size();
+  int nCand = isoPixTrackRefs.size();
 
   //loop over input ipt
 
-  for (int p=0; p<nCand; p++) {
-    double iptEta=isoPixTrackRefs[p]->track()->eta();
-    double iptPhi=isoPixTrackRefs[p]->track()->phi();
-  
-    int ntrk=0;
-    double minDR=100;
+  for (int p = 0; p < nCand; p++) {
+    double iptEta = isoPixTrackRefs[p]->track()->eta();
+    double iptPhi = isoPixTrackRefs[p]->track()->phi();
+
+    int ntrk = 0;
+    double minDR = 100;
     reco::TrackCollection::const_iterator citSel;
 
-    for (reco::TrackCollection::const_iterator cit=corTracks->begin(); cit!=corTracks->end(); cit++) {
-      double dR=deltaR(cit->eta(), cit->phi(), iptEta, iptPhi);
-      if (dR<minDR&&dR<assocCone_) {
-	minDR=dR;
-	ntrk++;
-	citSel=cit;
+    for (reco::TrackCollection::const_iterator cit = corTracks->begin(); cit != corTracks->end(); cit++) {
+      double dR = deltaR(cit->eta(), cit->phi(), iptEta, iptPhi);
+      if (dR < minDR && dR < assocCone_) {
+        minDR = dR;
+        ntrk++;
+        citSel = cit;
       }
     }
 
-    if (ntrk>0) {
-      reco::IsolatedPixelTrackCandidate newCandidate(reco::TrackRef(corTracks,citSel-corTracks->begin()), isoPixTrackRefs[p]->l1tau(),isoPixTrackRefs[p]->maxPtPxl(), isoPixTrackRefs[p]->sumPtPxl());
+    if (ntrk > 0) {
+      reco::IsolatedPixelTrackCandidate newCandidate(reco::TrackRef(corTracks, citSel - corTracks->begin()),
+                                                     isoPixTrackRefs[p]->l1tau(),
+                                                     isoPixTrackRefs[p]->maxPtPxl(),
+                                                     isoPixTrackRefs[p]->sumPtPxl());
       newCandidate.setEnergyIn(isoPixTrackRefs[p]->energyIn());
       newCandidate.setEnergyOut(isoPixTrackRefs[p]->energyOut());
       newCandidate.setNHitIn(isoPixTrackRefs[p]->nHitIn());
       newCandidate.setNHitOut(isoPixTrackRefs[p]->nHitOut());
       if (isoPixTrackRefs[p]->etaPhiEcalValid()) {
-	std::pair<double,double> etaphi = (isoPixTrackRefs[p]->etaPhiEcal());
-	newCandidate.setEtaPhiEcal(etaphi.first,etaphi.second);
+        std::pair<double, double> etaphi = (isoPixTrackRefs[p]->etaPhiEcal());
+        newCandidate.setEtaPhiEcal(etaphi.first, etaphi.second);
       }
       trackCollection->push_back(newCandidate);
     }
   }
-  
+
   // put the product in the event
   theEvent.put(std::move(trackCollection));
-
-
 }

--- a/Calibration/HcalIsolatedTrackReco/src/IsolatedEcalPixelTrackCandidateProducer.cc
+++ b/Calibration/HcalIsolatedTrackReco/src/IsolatedEcalPixelTrackCandidateProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    IsolatedEcalPixelTrackCandidateProducer
 // Class:      IsolatedEcalPixelTrackCandidateProducer
-// 
+//
 /**\class IsolatedEcalPixelTrackCandidateProducer IsolatedEcalPixelTrackCandidateProducer.cc Calibration/HcalIsolatedTrackReco/src/IsolatedEcalPixelTrackCandidateProducer.cc
 
  Description: <one line class summary>
@@ -34,45 +34,46 @@
 
 #include "Calibration/HcalIsolatedTrackReco/interface/IsolatedEcalPixelTrackCandidateProducer.h"
 
-IsolatedEcalPixelTrackCandidateProducer::IsolatedEcalPixelTrackCandidateProducer(const edm::ParameterSet& conf) :
-  tok_ee(        consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("EERecHitSource")) ),
-  tok_eb(        consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("EBRecHitSource")) ),
-  tok_trigcand(  consumes<trigger::TriggerFilterObjectWithRefs>(conf.getParameter<edm::InputTag>("filterLabel")) ),
-  coneSizeEta0_( conf.getParameter<double>("EcalConeSizeEta0") ),
-  coneSizeEta1_( conf.getParameter<double>("EcalConeSizeEta1") ),
-  hitCountEthrEB_( conf.getParameter<double>("EBHitCountEnergyThreshold") ),
-  hitEthrEB_(      conf.getParameter<double>("EBHitEnergyThreshold") ),
-  fachitCountEE_(  conf.getParameter<double>("EEFacHitCountEnergyThreshold") ),
-  hitEthrEE0_(     conf.getParameter<double>("EEHitEnergyThreshold0") ),
-  hitEthrEE1_(     conf.getParameter<double>("EEHitEnergyThreshold1") ),
-  hitEthrEE2_(     conf.getParameter<double>("EEHitEnergyThreshold2") ),
-  hitEthrEE3_(     conf.getParameter<double>("EEHitEnergyThreshold3") )
-{
+IsolatedEcalPixelTrackCandidateProducer::IsolatedEcalPixelTrackCandidateProducer(const edm::ParameterSet& conf)
+    : tok_ee(consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("EERecHitSource"))),
+      tok_eb(consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("EBRecHitSource"))),
+      tok_trigcand(consumes<trigger::TriggerFilterObjectWithRefs>(conf.getParameter<edm::InputTag>("filterLabel"))),
+      coneSizeEta0_(conf.getParameter<double>("EcalConeSizeEta0")),
+      coneSizeEta1_(conf.getParameter<double>("EcalConeSizeEta1")),
+      hitCountEthrEB_(conf.getParameter<double>("EBHitCountEnergyThreshold")),
+      hitEthrEB_(conf.getParameter<double>("EBHitEnergyThreshold")),
+      fachitCountEE_(conf.getParameter<double>("EEFacHitCountEnergyThreshold")),
+      hitEthrEE0_(conf.getParameter<double>("EEHitEnergyThreshold0")),
+      hitEthrEE1_(conf.getParameter<double>("EEHitEnergyThreshold1")),
+      hitEthrEE2_(conf.getParameter<double>("EEHitEnergyThreshold2")),
+      hitEthrEE3_(conf.getParameter<double>("EEHitEnergyThreshold3")) {
   // register the products
-  produces< reco::IsolatedPixelTrackCandidateCollection >();
+  produces<reco::IsolatedPixelTrackCandidateCollection>();
 }
 
-IsolatedEcalPixelTrackCandidateProducer::~IsolatedEcalPixelTrackCandidateProducer() { }
+IsolatedEcalPixelTrackCandidateProducer::~IsolatedEcalPixelTrackCandidateProducer() {}
 
 void IsolatedEcalPixelTrackCandidateProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("filterLabel",edm::InputTag("hltIsolPixelTrackL2Filter"));
-  desc.add<edm::InputTag>("EBRecHitSource",edm::InputTag("hltEcalRecHit", "EcalRecHitsEB"));
-  desc.add<edm::InputTag>("EERecHitSource",edm::InputTag("hltEcalRecHit", "EcalRecHitsEE"));
-  desc.add<double>("EBHitEnergyThreshold",0.10);
-  desc.add<double>("EBHitCountEnergyThreshold",0.5);
-  desc.add<double>("EEHitEnergyThreshold0",-41.0664);
-  desc.add<double>("EEHitEnergyThreshold1",68.7950);
-  desc.add<double>("EEHitEnergyThreshold2",-38.1483);
-  desc.add<double>("EEHitEnergyThreshold3",7.04303);
-  desc.add<double>("EEFacHitCountEnergyThreshold",10.0);
-  desc.add<double>("EcalConeSizeEta0",0.09);
-  desc.add<double>("EcalConeSizeEta1",0.14);
-  descriptions.add("isolEcalPixelTrackProd",desc);
+  desc.add<edm::InputTag>("filterLabel", edm::InputTag("hltIsolPixelTrackL2Filter"));
+  desc.add<edm::InputTag>("EBRecHitSource", edm::InputTag("hltEcalRecHit", "EcalRecHitsEB"));
+  desc.add<edm::InputTag>("EERecHitSource", edm::InputTag("hltEcalRecHit", "EcalRecHitsEE"));
+  desc.add<double>("EBHitEnergyThreshold", 0.10);
+  desc.add<double>("EBHitCountEnergyThreshold", 0.5);
+  desc.add<double>("EEHitEnergyThreshold0", -41.0664);
+  desc.add<double>("EEHitEnergyThreshold1", 68.7950);
+  desc.add<double>("EEHitEnergyThreshold2", -38.1483);
+  desc.add<double>("EEHitEnergyThreshold3", 7.04303);
+  desc.add<double>("EEFacHitCountEnergyThreshold", 10.0);
+  desc.add<double>("EcalConeSizeEta0", 0.09);
+  desc.add<double>("EcalConeSizeEta1", 0.14);
+  descriptions.add("isolEcalPixelTrackProd", desc);
 }
 
 // ------------ method called to produce the data  ------------
-void IsolatedEcalPixelTrackCandidateProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+void IsolatedEcalPixelTrackCandidateProducer::produce(edm::StreamID,
+                                                      edm::Event& iEvent,
+                                                      const edm::EventSetup& iSetup) const {
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("HcalIsoTrack") << "==============Inside IsolatedEcalPixelTrackCandidateProducer";
 #endif
@@ -81,113 +82,103 @@ void IsolatedEcalPixelTrackCandidateProducer::produce(edm::StreamID, edm::Event&
   const CaloGeometry* geo = pG.product();
 
   edm::Handle<EcalRecHitCollection> ecalEB;
-  iEvent.getByToken(tok_eb,ecalEB);
+  iEvent.getByToken(tok_eb, ecalEB);
 
   edm::Handle<EcalRecHitCollection> ecalEE;
-  iEvent.getByToken(tok_ee,ecalEE);
+  iEvent.getByToken(tok_ee, ecalEE);
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo("HcalIsoTrack") << "ecal Collections isValid: " 
-			       << ecalEB.isValid() << "/" << ecalEE.isValid();
+  edm::LogInfo("HcalIsoTrack") << "ecal Collections isValid: " << ecalEB.isValid() << "/" << ecalEE.isValid();
 #endif
 
   edm::Handle<trigger::TriggerFilterObjectWithRefs> trigCand;
-  iEvent.getByToken(tok_trigcand,trigCand);
+  iEvent.getByToken(tok_trigcand, trigCand);
 
-  std::vector< edm::Ref<reco::IsolatedPixelTrackCandidateCollection> > isoPixTrackRefs;
+  std::vector<edm::Ref<reco::IsolatedPixelTrackCandidateCollection> > isoPixTrackRefs;
   trigCand->getObjects(trigger::TriggerTrack, isoPixTrackRefs);
-  int nCand=isoPixTrackRefs.size();  
+  int nCand = isoPixTrackRefs.size();
 
   auto iptcCollection = std::make_unique<reco::IsolatedPixelTrackCandidateCollection>();
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo("HcalIsoTrack") << "coneSize_ " << coneSizeEta0_ << "/"
-			       << coneSizeEta1_ << " hitCountEthrEB_ " 
-			       << hitCountEthrEB_ << " hitEthrEB_ " 
-			       << hitEthrEB_ << " fachitCountEE_ "
-			       << fachitCountEE_ << " hitEthrEE "
-			       << hitEthrEE0_ << ":" << hitEthrEE1_ << ":"
-			       << hitEthrEE2_ << ":" << hitEthrEE3_;
+  edm::LogInfo("HcalIsoTrack") << "coneSize_ " << coneSizeEta0_ << "/" << coneSizeEta1_ << " hitCountEthrEB_ "
+                               << hitCountEthrEB_ << " hitEthrEB_ " << hitEthrEB_ << " fachitCountEE_ "
+                               << fachitCountEE_ << " hitEthrEE " << hitEthrEE0_ << ":" << hitEthrEE1_ << ":"
+                               << hitEthrEE2_ << ":" << hitEthrEE3_;
 #endif
-  for (int p=0; p<nCand; p++) {
-    int    nhitIn(0), nhitOut(0);
+  for (int p = 0; p < nCand; p++) {
+    int nhitIn(0), nhitOut(0);
     double inEnergy(0), outEnergy(0);
-    std::pair<double,double> etaPhi(isoPixTrackRefs[p]->track()->eta(), isoPixTrackRefs[p]->track()->phi());
-    if (isoPixTrackRefs[p]->etaPhiEcalValid()) etaPhi = isoPixTrackRefs[p]->etaPhiEcal();
+    std::pair<double, double> etaPhi(isoPixTrackRefs[p]->track()->eta(), isoPixTrackRefs[p]->track()->phi());
+    if (isoPixTrackRefs[p]->etaPhiEcalValid())
+      etaPhi = isoPixTrackRefs[p]->etaPhiEcal();
     double etaAbs = std::abs(etaPhi.first);
-    double coneSize_ = (etaAbs > 1.5) ? coneSizeEta1_ : (coneSizeEta0_*(1.5-etaAbs)+coneSizeEta1_*etaAbs)/1.5;
+    double coneSize_ = (etaAbs > 1.5) ? coneSizeEta1_ : (coneSizeEta0_ * (1.5 - etaAbs) + coneSizeEta1_ * etaAbs) / 1.5;
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalIsoTrack") << "Track: eta/phi " << etaPhi.first << "/" 
-				 << etaPhi.second << " pt:" 
-				 << isoPixTrackRefs[p]->track()->pt() 
-				 << " cone " << coneSize_ << "\n" 
-				 << "rechit size EB/EE : " << ecalEB->size() 
-				 << "/" << ecalEE->size() << " coneSize_: " 
-				 << coneSize_;
+    edm::LogInfo("HcalIsoTrack") << "Track: eta/phi " << etaPhi.first << "/" << etaPhi.second
+                                 << " pt:" << isoPixTrackRefs[p]->track()->pt() << " cone " << coneSize_ << "\n"
+                                 << "rechit size EB/EE : " << ecalEB->size() << "/" << ecalEE->size()
+                                 << " coneSize_: " << coneSize_;
 #endif
-    if (etaAbs<1.7) {
+    if (etaAbs < 1.7) {
       int nin(0), nout(0);
       for (auto eItr : *(ecalEB.product())) {
-	const GlobalPoint& pos = geo->getPosition(eItr.detid());
-	double      R   = reco::deltaR(pos.eta(),pos.phi(),etaPhi.first,etaPhi.second);
-	if (R < coneSize_) {
-	  nhitIn++;
-	  inEnergy += (eItr.energy());
-	  ++nin;
-	  if (eItr.energy() > hitCountEthrEB_) nhitOut++;
-	  if (eItr.energy() > hitEthrEB_) {
-	    outEnergy += (eItr.energy());
-	    ++nout;
-	  }
+        const GlobalPoint& pos = geo->getPosition(eItr.detid());
+        double R = reco::deltaR(pos.eta(), pos.phi(), etaPhi.first, etaPhi.second);
+        if (R < coneSize_) {
+          nhitIn++;
+          inEnergy += (eItr.energy());
+          ++nin;
+          if (eItr.energy() > hitCountEthrEB_)
+            nhitOut++;
+          if (eItr.energy() > hitEthrEB_) {
+            outEnergy += (eItr.energy());
+            ++nout;
+          }
 #ifdef EDM_ML_DEBUG
-	  edm::LogInfo("HcalIsoTrack") << "EBRechit close to the track has E " 
-				       << eItr.energy() << " eta/phi: " 
-				       << pos.eta() << "/" << pos.phi() 
-				       << " deltaR: " << R;
+          edm::LogInfo("HcalIsoTrack") << "EBRechit close to the track has E " << eItr.energy()
+                                       << " eta/phi: " << pos.eta() << "/" << pos.phi() << " deltaR: " << R;
 #endif
-	}
+        }
       }
     }
-    if (etaAbs>1.25) {
+    if (etaAbs > 1.25) {
       int nin(0), nout(0);
       for (auto eItr : *(ecalEE.product())) {
-	const GlobalPoint& pos = geo->getPosition(eItr.detid());
-	double      R   = reco::deltaR(pos.eta(),pos.phi(),etaPhi.first,etaPhi.second);
-	if (R < coneSize_) {
-	  double eta = std::abs(pos.eta());
-	  double hitEthr = (((eta*hitEthrEE3_+hitEthrEE2_)*eta+hitEthrEE1_)*eta+
-			    hitEthrEE0_);
-	  if (hitEthr < hitEthrEB_) hitEthr = hitEthrEB_;
-	  nhitIn++;
-	  inEnergy += (eItr.energy());
-	  ++nin;
-	  if (eItr.energy() > fachitCountEE_*hitEthr) nhitOut++;
-	  if (eItr.energy() > hitEthr) {
-	    outEnergy += (eItr.energy());
-	    ++nout;
-	  }
+        const GlobalPoint& pos = geo->getPosition(eItr.detid());
+        double R = reco::deltaR(pos.eta(), pos.phi(), etaPhi.first, etaPhi.second);
+        if (R < coneSize_) {
+          double eta = std::abs(pos.eta());
+          double hitEthr = (((eta * hitEthrEE3_ + hitEthrEE2_) * eta + hitEthrEE1_) * eta + hitEthrEE0_);
+          if (hitEthr < hitEthrEB_)
+            hitEthr = hitEthrEB_;
+          nhitIn++;
+          inEnergy += (eItr.energy());
+          ++nin;
+          if (eItr.energy() > fachitCountEE_ * hitEthr)
+            nhitOut++;
+          if (eItr.energy() > hitEthr) {
+            outEnergy += (eItr.energy());
+            ++nout;
+          }
 #ifdef EDM_ML_DEBUG
-	  edm::LogInfo("HcalIsoTrack") << "EERechit close to the track has E "
-				       << eItr.energy() << " eta/phi: " 
-				       << pos.eta() << "/" << pos.phi() 
-				       << " deltaR: " << R;
+          edm::LogInfo("HcalIsoTrack") << "EERechit close to the track has E " << eItr.energy()
+                                       << " eta/phi: " << pos.eta() << "/" << pos.phi() << " deltaR: " << R;
 #endif
-	}
+        }
       }
     }
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("HcalIsoTrack") << "nhitIn:" << nhitIn << " inEnergy:" 
-				 << inEnergy << " nhitOut:" << nhitOut 
-				 << " outEnergy:" << outEnergy;
+    edm::LogInfo("HcalIsoTrack") << "nhitIn:" << nhitIn << " inEnergy:" << inEnergy << " nhitOut:" << nhitOut
+                                 << " outEnergy:" << outEnergy;
 #endif
     reco::IsolatedPixelTrackCandidate newca(*isoPixTrackRefs[p]);
     newca.setEnergyIn(inEnergy);
     newca.setEnergyOut(outEnergy);
     newca.setNHitIn(nhitIn);
     newca.setNHitOut(nhitOut);
-    iptcCollection->push_back(newca);	
+    iptcCollection->push_back(newca);
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo("HcalIsoTrack") << "ncand:" << nCand << " outcollction size:" 
-			       << iptcCollection->size();
+  edm::LogInfo("HcalIsoTrack") << "ncand:" << nCand << " outcollction size:" << iptcCollection->size();
 #endif
   iEvent.put(std::move(iptcCollection));
 }

--- a/Calibration/HcalIsolatedTrackReco/src/IsolatedPixelTrackCandidateL1TProducer.cc
+++ b/Calibration/HcalIsolatedTrackReco/src/IsolatedPixelTrackCandidateL1TProducer.cc
@@ -16,7 +16,6 @@
 #include "FWCore/Utilities/interface/transform.h"
 //
 
-
 // Math
 #include "Math/GenVector/VectorUtil.h"
 #include "Math/GenVector/PxPyPzE4D.h"
@@ -38,61 +37,60 @@
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 
-
-IsolatedPixelTrackCandidateL1TProducer::IsolatedPixelTrackCandidateL1TProducer(const edm::ParameterSet& config) :
-  tok_hlt_(                     consumes<trigger::TriggerFilterObjectWithRefs>(config.getParameter<edm::InputTag>("L1GTSeedLabel")) ),
-  tok_l1_(                      consumes<l1t::TauBxCollection>(config.getParameter<edm::InputTag>("L1eTauJetsSource")) ),
-  tok_vert_(                    consumes<reco::VertexCollection>(config.getParameter<edm::InputTag>("VertexLabel")) ),
-  toks_pix_(                    edm::vector_transform(
-                                  config.getParameter<std::vector<edm::InputTag> >("PixelTracksSources"),
-                                  [this](edm::InputTag const & tag){return consumes<reco::TrackCollection>(tag);}) ),
-  bfield_(                      config.getParameter<std::string>("MagFieldRecordName") ),
-  prelimCone_(                  config.getParameter<double>("ExtrapolationConeSize") ),
-  pixelIsolationConeSizeAtEC_(  config.getParameter<double>("PixelIsolationConeSizeAtEC") ),
-  vtxCutSeed_(                  config.getParameter<double>("MaxVtxDXYSeed") ),
-  vtxCutIsol_(                  config.getParameter<double>("MaxVtxDXYIsol") ),
-  tauAssocCone_(                config.getParameter<double>("tauAssociationCone") ), 
-  tauUnbiasCone_(               config.getParameter<double>("tauUnbiasCone") ),
-  minPTrackValue_(              config.getParameter<double>("minPTrack") ),
-  maxPForIsolationValue_(       config.getParameter<double>("maxPTrackForIsolation") ),
-  ebEtaBoundary_(               config.getParameter<double>("EBEtaBoundary") ),
-  rEB_( -1 ), 
-  zEE_( -1 ),
-  bfVal_( 0 )
-{
+IsolatedPixelTrackCandidateL1TProducer::IsolatedPixelTrackCandidateL1TProducer(const edm::ParameterSet& config)
+    : tok_hlt_(consumes<trigger::TriggerFilterObjectWithRefs>(config.getParameter<edm::InputTag>("L1GTSeedLabel"))),
+      tok_l1_(consumes<l1t::TauBxCollection>(config.getParameter<edm::InputTag>("L1eTauJetsSource"))),
+      tok_vert_(consumes<reco::VertexCollection>(config.getParameter<edm::InputTag>("VertexLabel"))),
+      toks_pix_(
+          edm::vector_transform(config.getParameter<std::vector<edm::InputTag> >("PixelTracksSources"),
+                                [this](edm::InputTag const& tag) { return consumes<reco::TrackCollection>(tag); })),
+      bfield_(config.getParameter<std::string>("MagFieldRecordName")),
+      prelimCone_(config.getParameter<double>("ExtrapolationConeSize")),
+      pixelIsolationConeSizeAtEC_(config.getParameter<double>("PixelIsolationConeSizeAtEC")),
+      vtxCutSeed_(config.getParameter<double>("MaxVtxDXYSeed")),
+      vtxCutIsol_(config.getParameter<double>("MaxVtxDXYIsol")),
+      tauAssocCone_(config.getParameter<double>("tauAssociationCone")),
+      tauUnbiasCone_(config.getParameter<double>("tauUnbiasCone")),
+      minPTrackValue_(config.getParameter<double>("minPTrack")),
+      maxPForIsolationValue_(config.getParameter<double>("maxPTrackForIsolation")),
+      ebEtaBoundary_(config.getParameter<double>("EBEtaBoundary")),
+      rEB_(-1),
+      zEE_(-1),
+      bfVal_(0) {
   // Register the product
-  produces< reco::IsolatedPixelTrackCandidateCollection >();
+  produces<reco::IsolatedPixelTrackCandidateCollection>();
 }
 
-IsolatedPixelTrackCandidateL1TProducer::~IsolatedPixelTrackCandidateL1TProducer() { }
+IsolatedPixelTrackCandidateL1TProducer::~IsolatedPixelTrackCandidateL1TProducer() {}
 
 void IsolatedPixelTrackCandidateL1TProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   std::vector<edm::InputTag> tracksrc = {edm::InputTag("hltPixelTracks")};
-  desc.add<edm::InputTag>("L1eTauJetsSource",edm::InputTag("hltGtStage2Digis","Tau"));
-  desc.add<double>("tauAssociationCone",        0.0 );
-  desc.add<double>("tauUnbiasCone",             1.2 );
-  desc.add<std::vector<edm::InputTag> >("PixelTracksSources",tracksrc);
-  desc.add<double>("ExtrapolationConeSize",     1.0);
-  desc.add<double>("PixelIsolationConeSizeAtEC",40);
-  desc.add<edm::InputTag>("L1GTSeedLabel",edm::InputTag("hltL1sV0SingleJet60"));
-  desc.add<double>("MaxVtxDXYSeed",             101.0);
-  desc.add<double>("MaxVtxDXYIsol",             101.0);
-  desc.add<edm::InputTag>("VertexLabel",edm::InputTag("hltTrimmedPixelVertices"));
-  desc.add<std::string>("MagFieldRecordName","VolumeBasedMagneticField");
-  desc.add<double>("minPTrack",                 5.0);
-  desc.add<double>("maxPTrackForIsolation",     3.0);
-  desc.add<double>("EBEtaBoundary",             1.479);
-  descriptions.add("isolPixelTrackProdL1T",desc);
+  desc.add<edm::InputTag>("L1eTauJetsSource", edm::InputTag("hltGtStage2Digis", "Tau"));
+  desc.add<double>("tauAssociationCone", 0.0);
+  desc.add<double>("tauUnbiasCone", 1.2);
+  desc.add<std::vector<edm::InputTag> >("PixelTracksSources", tracksrc);
+  desc.add<double>("ExtrapolationConeSize", 1.0);
+  desc.add<double>("PixelIsolationConeSizeAtEC", 40);
+  desc.add<edm::InputTag>("L1GTSeedLabel", edm::InputTag("hltL1sV0SingleJet60"));
+  desc.add<double>("MaxVtxDXYSeed", 101.0);
+  desc.add<double>("MaxVtxDXYIsol", 101.0);
+  desc.add<edm::InputTag>("VertexLabel", edm::InputTag("hltTrimmedPixelVertices"));
+  desc.add<std::string>("MagFieldRecordName", "VolumeBasedMagneticField");
+  desc.add<double>("minPTrack", 5.0);
+  desc.add<double>("maxPTrackForIsolation", 3.0);
+  desc.add<double>("EBEtaBoundary", 1.479);
+  descriptions.add("isolPixelTrackProdL1T", desc);
 }
 
-void IsolatedPixelTrackCandidateL1TProducer::beginRun(const edm::Run &run, const edm::EventSetup &theEventSetup) {
-
+void IsolatedPixelTrackCandidateL1TProducer::beginRun(const edm::Run& run, const edm::EventSetup& theEventSetup) {
   edm::ESHandle<CaloGeometry> pG;
-  theEventSetup.get<CaloGeometryRecord>().get(pG);   
-  
-  const double rad (dynamic_cast<const EcalBarrelGeometry*>( pG->getSubdetectorGeometry(DetId::Ecal, EcalBarrel ))->avgRadiusXYFrontFaceCenter() ) ;
-  const double zz  (dynamic_cast<const EcalEndcapGeometry*>( pG->getSubdetectorGeometry(DetId::Ecal, EcalEndcap ))->avgAbsZFrontFaceCenter() ) ;
+  theEventSetup.get<CaloGeometryRecord>().get(pG);
+
+  const double rad(dynamic_cast<const EcalBarrelGeometry*>(pG->getSubdetectorGeometry(DetId::Ecal, EcalBarrel))
+                       ->avgRadiusXYFrontFaceCenter());
+  const double zz(dynamic_cast<const EcalEndcapGeometry*>(pG->getSubdetectorGeometry(DetId::Ecal, EcalEndcap))
+                      ->avgAbsZFrontFaceCenter());
 
   rEB_ = rad;
   zEE_ = zz;
@@ -100,238 +98,271 @@ void IsolatedPixelTrackCandidateL1TProducer::beginRun(const edm::Run &run, const
   edm::ESHandle<MagneticField> vbfField;
   theEventSetup.get<IdealMagneticFieldRecord>().get(vbfField);
   const VolumeBasedMagneticField* vbfCPtr = dynamic_cast<const VolumeBasedMagneticField*>(&(*vbfField));
-  GlobalVector BField = vbfCPtr->inTesla(GlobalPoint(0,0,0));
-  bfVal_=BField.mag();
-  edm::LogVerbatim("IsoTrack") << "rEB " << rEB_ << " zEE " << zEE_ << " B "
-			       << bfVal_ << std::endl;
+  GlobalVector BField = vbfCPtr->inTesla(GlobalPoint(0, 0, 0));
+  bfVal_ = BField.mag();
+  edm::LogVerbatim("IsoTrack") << "rEB " << rEB_ << " zEE " << zEE_ << " B " << bfVal_ << std::endl;
 }
 
 void IsolatedPixelTrackCandidateL1TProducer::produce(edm::Event& theEvent, const edm::EventSetup& theEventSetup) {
-
   auto trackCollection = std::make_unique<reco::IsolatedPixelTrackCandidateCollection>();
 
   //create vector of refs from input collections
   std::vector<reco::TrackRef> pixelTrackRefs;
 
-  for (unsigned int iPix=0; iPix<toks_pix_.size(); iPix++) {
+  for (unsigned int iPix = 0; iPix < toks_pix_.size(); iPix++) {
     edm::Handle<reco::TrackCollection> iPixCol;
-    theEvent.getByToken(toks_pix_[iPix],iPixCol);
-    for (reco::TrackCollection::const_iterator pit=iPixCol->begin(); pit!=iPixCol->end(); pit++) {
-      pixelTrackRefs.push_back(reco::TrackRef(iPixCol,pit-iPixCol->begin()));
+    theEvent.getByToken(toks_pix_[iPix], iPixCol);
+    for (reco::TrackCollection::const_iterator pit = iPixCol->begin(); pit != iPixCol->end(); pit++) {
+      pixelTrackRefs.push_back(reco::TrackRef(iPixCol, pit - iPixCol->begin()));
     }
   }
 
   edm::Handle<l1t::TauBxCollection> l1eTauJets;
-  theEvent.getByToken(tok_l1_,l1eTauJets);
+  theEvent.getByToken(tok_l1_, l1eTauJets);
 
   edm::Handle<reco::VertexCollection> pVert;
-  theEvent.getByToken(tok_vert_,pVert);
+  theEvent.getByToken(tok_vert_, pVert);
 
-  double ptTriggered  = -10;
+  double ptTriggered = -10;
   double etaTriggered = -100;
   double phiTriggered = -100;
-  
+
   edm::Handle<trigger::TriggerFilterObjectWithRefs> l1trigobj;
   theEvent.getByToken(tok_hlt_, l1trigobj);
-  
-  std::vector< edm::Ref<l1t::TauBxCollection> > l1tauobjref;
-  std::vector< edm::Ref<l1t::JetBxCollection> > l1jetobjref;
-  
+
+  std::vector<edm::Ref<l1t::TauBxCollection> > l1tauobjref;
+  std::vector<edm::Ref<l1t::JetBxCollection> > l1jetobjref;
+
   //  l1trigobj->getObjects(trigger::TriggerTau, l1tauobjref);
   l1trigobj->getObjects(trigger::TriggerL1Tau, l1tauobjref);
   //  l1trigobj->getObjects(trigger::TriggerJet, l1jetobjref);
   l1trigobj->getObjects(trigger::TriggerL1Jet, l1jetobjref);
-  
+
   for (auto p : l1tauobjref) {
-    if (p->pt()>ptTriggered) {
-      ptTriggered  = p->pt(); 
+    if (p->pt() > ptTriggered) {
+      ptTriggered = p->pt();
       phiTriggered = p->phi();
       etaTriggered = p->eta();
     }
   }
   for (auto p : l1jetobjref) {
-    if (p->pt()>ptTriggered) {
-      ptTriggered  = p->pt();
+    if (p->pt() > ptTriggered) {
+      ptTriggered = p->pt();
       phiTriggered = p->phi();
       etaTriggered = p->eta();
     }
   }
-  edm::LogVerbatim("IsoTrack") << "Sizes " << l1tauobjref.size() << ":" 
-			       << l1jetobjref.size() << " Trig " << ptTriggered
-			       << ":" << etaTriggered << ":" << phiTriggered 
-			       << std::endl;
+  edm::LogVerbatim("IsoTrack") << "Sizes " << l1tauobjref.size() << ":" << l1jetobjref.size() << " Trig " << ptTriggered
+                               << ":" << etaTriggered << ":" << phiTriggered << std::endl;
 
   double drMaxL1Track_ = tauAssocCone_;
   int ntr = 0;
-  std::vector<seedAtEC>  VecSeedsatEC;
+  std::vector<seedAtEC> VecSeedsatEC;
   //loop to select isolated tracks
-  for (unsigned iS=0; iS<pixelTrackRefs.size(); iS++) {
+  for (unsigned iS = 0; iS < pixelTrackRefs.size(); iS++) {
     bool vtxMatch = false;
-    //associate to vertex (in Z) 
+    //associate to vertex (in Z)
     reco::VertexCollection::const_iterator vitSel;
     double minDZ = 1000;
-    bool   found(false);
-    for (reco::VertexCollection::const_iterator vit=pVert->begin(); vit!=pVert->end(); vit++) {
-      if (std::abs(pixelTrackRefs[iS]->dz(vit->position()))<minDZ) {
-	minDZ  = std::abs(pixelTrackRefs[iS]->dz(vit->position()));
-	vitSel = vit;
-	found  = true;
+    bool found(false);
+    for (reco::VertexCollection::const_iterator vit = pVert->begin(); vit != pVert->end(); vit++) {
+      if (std::abs(pixelTrackRefs[iS]->dz(vit->position())) < minDZ) {
+        minDZ = std::abs(pixelTrackRefs[iS]->dz(vit->position()));
+        vitSel = vit;
+        found = true;
       }
     }
     //cut on dYX:
     if (found) {
-      if(std::abs(pixelTrackRefs[iS]->dxy(vitSel->position()))<vtxCutSeed_) vtxMatch=true;
+      if (std::abs(pixelTrackRefs[iS]->dxy(vitSel->position())) < vtxCutSeed_)
+        vtxMatch = true;
     } else {
-      vtxMatch=true;
+      vtxMatch = true;
     }
-    edm::LogVerbatim("IsoTrack") << "minZD " << minDZ << " Found " << found 
-				 << ":" << vtxMatch << std::endl;
+    edm::LogVerbatim("IsoTrack") << "minZD " << minDZ << " Found " << found << ":" << vtxMatch << std::endl;
 
     //select tracks not matched to triggered L1 jet
-    double R=reco::deltaR(etaTriggered, phiTriggered, 
-			  pixelTrackRefs[iS]->eta(), pixelTrackRefs[iS]->phi());
-    edm::LogVerbatim("IsoTrack") << "Distance to L1 " << R << ":" 
-				 << tauUnbiasCone_ << " Result "
-				 << (R<tauUnbiasCone_) << std::endl;
-    if (R<tauUnbiasCone_) continue;
+    double R = reco::deltaR(etaTriggered, phiTriggered, pixelTrackRefs[iS]->eta(), pixelTrackRefs[iS]->phi());
+    edm::LogVerbatim("IsoTrack") << "Distance to L1 " << R << ":" << tauUnbiasCone_ << " Result "
+                                 << (R < tauUnbiasCone_) << std::endl;
+    if (R < tauUnbiasCone_)
+      continue;
 
     //check taujet matching
-    bool tmatch=false;
+    bool tmatch = false;
     l1t::TauBxCollection::const_iterator selj;
-    for (l1t::TauBxCollection::const_iterator tj=l1eTauJets->begin(); tj!=l1eTauJets->end(); tj++) {
-      if (reco::deltaR(pixelTrackRefs[iS]->momentum().eta(), pixelTrackRefs[iS]->momentum().phi(), tj->momentum().eta(), tj->momentum().phi()) > drMaxL1Track_) continue;
-      selj   = tj;
+    for (l1t::TauBxCollection::const_iterator tj = l1eTauJets->begin(); tj != l1eTauJets->end(); tj++) {
+      if (reco::deltaR(pixelTrackRefs[iS]->momentum().eta(),
+                       pixelTrackRefs[iS]->momentum().phi(),
+                       tj->momentum().eta(),
+                       tj->momentum().phi()) > drMaxL1Track_)
+        continue;
+      selj = tj;
       tmatch = true;
-    } //loop over L1 tau
+    }  //loop over L1 tau
     edm::LogVerbatim("IsoTrack") << "tMatch " << tmatch << std::endl;
-    
+
     //propagate seed track to ECAL surface:
-    std::pair<double,double> seedCooAtEC;
+    std::pair<double, double> seedCooAtEC;
     // in case vertex is found:
-    if (found) seedCooAtEC=GetEtaPhiAtEcal(pixelTrackRefs[iS]->eta(), pixelTrackRefs[iS]->phi(), pixelTrackRefs[iS]->pt(), pixelTrackRefs[iS]->charge(), vitSel->z());
+    if (found)
+      seedCooAtEC = GetEtaPhiAtEcal(pixelTrackRefs[iS]->eta(),
+                                    pixelTrackRefs[iS]->phi(),
+                                    pixelTrackRefs[iS]->pt(),
+                                    pixelTrackRefs[iS]->charge(),
+                                    vitSel->z());
     //in case vertex is not found:
-    else       seedCooAtEC=GetEtaPhiAtEcal(pixelTrackRefs[iS]->eta(), pixelTrackRefs[iS]->phi(), pixelTrackRefs[iS]->pt(), pixelTrackRefs[iS]->charge(), 0);
-    seedAtEC seed(iS,(tmatch||vtxMatch),seedCooAtEC.first,seedCooAtEC.second);
+    else
+      seedCooAtEC = GetEtaPhiAtEcal(pixelTrackRefs[iS]->eta(),
+                                    pixelTrackRefs[iS]->phi(),
+                                    pixelTrackRefs[iS]->pt(),
+                                    pixelTrackRefs[iS]->charge(),
+                                    0);
+    seedAtEC seed(iS, (tmatch || vtxMatch), seedCooAtEC.first, seedCooAtEC.second);
     VecSeedsatEC.push_back(seed);
-    edm::LogVerbatim("IsoTrack") << "Seed " << seedCooAtEC.first 
-				 << seedCooAtEC.second << std::endl;
+    edm::LogVerbatim("IsoTrack") << "Seed " << seedCooAtEC.first << seedCooAtEC.second << std::endl;
   }
-  for (unsigned int i=0; i<VecSeedsatEC.size(); i++) {
+  for (unsigned int i = 0; i < VecSeedsatEC.size(); i++) {
     unsigned int iSeed = VecSeedsatEC[i].index;
-    if (!VecSeedsatEC[i].ok) continue;
-    if(pixelTrackRefs[iSeed]->p()<minPTrackValue_) continue; 
+    if (!VecSeedsatEC[i].ok)
+      continue;
+    if (pixelTrackRefs[iSeed]->p() < minPTrackValue_)
+      continue;
     l1t::TauBxCollection::const_iterator selj;
-    for (l1t::TauBxCollection::const_iterator tj=l1eTauJets->begin(); tj!=l1eTauJets->end(); tj++)  {
-      if (reco::deltaR(pixelTrackRefs[iSeed]->momentum().eta(),pixelTrackRefs[iSeed]->momentum().phi(),tj->momentum().eta(),tj->momentum().phi()) > drMaxL1Track_) continue;
-      selj   = tj;
-    } //loop over L1 tau
+    for (l1t::TauBxCollection::const_iterator tj = l1eTauJets->begin(); tj != l1eTauJets->end(); tj++) {
+      if (reco::deltaR(pixelTrackRefs[iSeed]->momentum().eta(),
+                       pixelTrackRefs[iSeed]->momentum().phi(),
+                       tj->momentum().eta(),
+                       tj->momentum().phi()) > drMaxL1Track_)
+        continue;
+      selj = tj;
+    }  //loop over L1 tau
     double maxP = 0;
     double sumP = 0;
-    for(unsigned int j=0; j<VecSeedsatEC.size(); j++) {
-      if (i==j) continue;
+    for (unsigned int j = 0; j < VecSeedsatEC.size(); j++) {
+      if (i == j)
+        continue;
       unsigned int iSurr = VecSeedsatEC[j].index;
       //define preliminary cone around seed track impact point from which tracks will be extrapolated:
-      if (reco::deltaR(pixelTrackRefs[iSeed]->eta(), pixelTrackRefs[iSeed]->phi(), pixelTrackRefs[iSurr]->eta(), pixelTrackRefs[iSurr]->phi())>prelimCone_) continue;
+      if (reco::deltaR(pixelTrackRefs[iSeed]->eta(),
+                       pixelTrackRefs[iSeed]->phi(),
+                       pixelTrackRefs[iSurr]->eta(),
+                       pixelTrackRefs[iSurr]->phi()) > prelimCone_)
+        continue;
       double minDZ2(1000);
-      bool   found(false);
+      bool found(false);
       reco::VertexCollection::const_iterator vitSel2;
-      for (reco::VertexCollection::const_iterator vit=pVert->begin(); vit!=pVert->end(); vit++) {
-	if (std::abs(pixelTrackRefs[iSurr]->dz(vit->position()))<minDZ2) {
-	  minDZ2  = std::abs(pixelTrackRefs[iSurr]->dz(vit->position()));
-	  vitSel2 = vit;
-	  found   = true;
-	}
+      for (reco::VertexCollection::const_iterator vit = pVert->begin(); vit != pVert->end(); vit++) {
+        if (std::abs(pixelTrackRefs[iSurr]->dz(vit->position())) < minDZ2) {
+          minDZ2 = std::abs(pixelTrackRefs[iSurr]->dz(vit->position()));
+          vitSel2 = vit;
+          found = true;
+        }
       }
       //cut ot dXY:
-      if (found&&std::abs(pixelTrackRefs[iSurr]->dxy(vitSel2->position()))>vtxCutIsol_) continue;
-      //calculate distance at ECAL surface and update isolation: 
-      if (getDistInCM(VecSeedsatEC[i].eta, VecSeedsatEC[i].phi, VecSeedsatEC[j].eta, VecSeedsatEC[j].phi)<pixelIsolationConeSizeAtEC_) {
-	sumP+=pixelTrackRefs[iSurr]->p();
-	if(pixelTrackRefs[iSurr]->p()>maxP) maxP=pixelTrackRefs[iSurr]->p();
-      }      
+      if (found && std::abs(pixelTrackRefs[iSurr]->dxy(vitSel2->position())) > vtxCutIsol_)
+        continue;
+      //calculate distance at ECAL surface and update isolation:
+      if (getDistInCM(VecSeedsatEC[i].eta, VecSeedsatEC[i].phi, VecSeedsatEC[j].eta, VecSeedsatEC[j].phi) <
+          pixelIsolationConeSizeAtEC_) {
+        sumP += pixelTrackRefs[iSurr]->p();
+        if (pixelTrackRefs[iSurr]->p() > maxP)
+          maxP = pixelTrackRefs[iSurr]->p();
+      }
     }
-    if (maxP<maxPForIsolationValue_) {
-      reco::IsolatedPixelTrackCandidate newCandidate(pixelTrackRefs[iSeed], l1t::TauRef(l1eTauJets,selj-l1eTauJets->begin()), maxP, sumP);
+    if (maxP < maxPForIsolationValue_) {
+      reco::IsolatedPixelTrackCandidate newCandidate(
+          pixelTrackRefs[iSeed], l1t::TauRef(l1eTauJets, selj - l1eTauJets->begin()), maxP, sumP);
       newCandidate.setEtaPhiEcal(VecSeedsatEC[i].eta, VecSeedsatEC[i].phi);
       trackCollection->push_back(newCandidate);
       ntr++;
-    }    
+    }
   }
   edm::LogVerbatim("IsoTrack") << "Number of Isolated Track " << ntr << "\n";
   // put the product in the event
   theEvent.put(std::move(trackCollection));
 }
 
-
 double IsolatedPixelTrackCandidateL1TProducer::getDistInCM(double eta1, double phi1, double eta2, double phi2) {
   double Rec;
-  double theta1=2*atan(exp(-eta1));
-  double theta2=2*atan(exp(-eta2));
-  if (std::abs(eta1)<1.479) Rec=rEB_; //radius of ECAL barrel
-  else if (std::abs(eta1)>1.479&&std::abs(eta1)<7.0) Rec=tan(theta1)*zEE_; //distance from IP to ECAL endcap
-  else return 1000;
+  double theta1 = 2 * atan(exp(-eta1));
+  double theta2 = 2 * atan(exp(-eta2));
+  if (std::abs(eta1) < 1.479)
+    Rec = rEB_;  //radius of ECAL barrel
+  else if (std::abs(eta1) > 1.479 && std::abs(eta1) < 7.0)
+    Rec = tan(theta1) * zEE_;  //distance from IP to ECAL endcap
+  else
+    return 1000;
 
   //|vect| times tg of acos(scalar product)
-  double angle=acos((sin(theta1)*sin(theta2)*(sin(phi1)*sin(phi2)+cos(phi1)*cos(phi2))+cos(theta1)*cos(theta2)));
-  if (angle<M_PI_2) return std::abs((Rec/sin(theta1))*tan(angle));
-  else return 1000;
+  double angle =
+      acos((sin(theta1) * sin(theta2) * (sin(phi1) * sin(phi2) + cos(phi1) * cos(phi2)) + cos(theta1) * cos(theta2)));
+  if (angle < M_PI_2)
+    return std::abs((Rec / sin(theta1)) * tan(angle));
+  else
+    return 1000;
 }
 
-
-std::pair<double,double> IsolatedPixelTrackCandidateL1TProducer::GetEtaPhiAtEcal(double etaIP, double phiIP, double pT, int charge, double vtxZ) {
-
-  double deltaPhi=0;
+std::pair<double, double> IsolatedPixelTrackCandidateL1TProducer::GetEtaPhiAtEcal(
+    double etaIP, double phiIP, double pT, int charge, double vtxZ) {
+  double deltaPhi = 0;
   double etaEC = 100;
   double phiEC = 100;
 
   double Rcurv = 9999999;
-  if (bfVal_!=0) Rcurv=pT*33.3*100/(bfVal_*10); //r(m)=pT(GeV)*33.3/B(kG)
+  if (bfVal_ != 0)
+    Rcurv = pT * 33.3 * 100 / (bfVal_ * 10);  //r(m)=pT(GeV)*33.3/B(kG)
 
   double ecDist = zEE_;  //distance to ECAL andcap from IP (cm), 317 - ecal (not preshower), preshower -300
-  double ecRad  = rEB_;  //radius of ECAL barrel (cm)
-  double theta  = 2*atan(exp(-etaIP));
-  double zNew   = 0;
-  if (theta>M_PI_2) theta=M_PI-theta;
-  if (std::abs(etaIP)<ebEtaBoundary_) {
-    if ((0.5*ecRad/Rcurv)>1) {
-      etaEC         = 10000;
-      deltaPhi      = 0;
+  double ecRad = rEB_;   //radius of ECAL barrel (cm)
+  double theta = 2 * atan(exp(-etaIP));
+  double zNew = 0;
+  if (theta > M_PI_2)
+    theta = M_PI - theta;
+  if (std::abs(etaIP) < ebEtaBoundary_) {
+    if ((0.5 * ecRad / Rcurv) > 1) {
+      etaEC = 10000;
+      deltaPhi = 0;
     } else {
-      deltaPhi      =-charge*asin(0.5*ecRad/Rcurv);
-      double alpha1 = 2*asin(0.5*ecRad/Rcurv);
-      double z      = ecRad/tan(theta);
-      if (etaIP>0) zNew = z*(Rcurv*alpha1)/ecRad+vtxZ; //new z-coordinate of track
-      else         zNew =-z*(Rcurv*alpha1)/ecRad+vtxZ; //new z-coordinate of track
-      double zAbs=std::abs(zNew);
-      if (zAbs<ecDist) {
-	etaEC    = -log(tan(0.5*atan(ecRad/zAbs)));
-	deltaPhi = -charge*asin(0.5*ecRad/Rcurv);
+      deltaPhi = -charge * asin(0.5 * ecRad / Rcurv);
+      double alpha1 = 2 * asin(0.5 * ecRad / Rcurv);
+      double z = ecRad / tan(theta);
+      if (etaIP > 0)
+        zNew = z * (Rcurv * alpha1) / ecRad + vtxZ;  //new z-coordinate of track
+      else
+        zNew = -z * (Rcurv * alpha1) / ecRad + vtxZ;  //new z-coordinate of track
+      double zAbs = std::abs(zNew);
+      if (zAbs < ecDist) {
+        etaEC = -log(tan(0.5 * atan(ecRad / zAbs)));
+        deltaPhi = -charge * asin(0.5 * ecRad / Rcurv);
       }
-      if (zAbs>ecDist) {
-	zAbs           = (std::abs(etaIP)/etaIP)*ecDist;
-	double Zflight = std::abs(zAbs-vtxZ);
-	double alpha   = (Zflight*ecRad)/(z*Rcurv);
-	double Rec     = 2*Rcurv*sin(alpha/2);
-	deltaPhi       =-charge*alpha/2;
-	etaEC          =-log(tan(0.5*atan(Rec/ecDist)));
+      if (zAbs > ecDist) {
+        zAbs = (std::abs(etaIP) / etaIP) * ecDist;
+        double Zflight = std::abs(zAbs - vtxZ);
+        double alpha = (Zflight * ecRad) / (z * Rcurv);
+        double Rec = 2 * Rcurv * sin(alpha / 2);
+        deltaPhi = -charge * alpha / 2;
+        etaEC = -log(tan(0.5 * atan(Rec / ecDist)));
       }
     }
   } else {
-    zNew           = (std::abs(etaIP)/etaIP)*ecDist;
-    double Zflight = std::abs(zNew-vtxZ);
-    double Rvirt   = std::abs(Zflight*tan(theta));
-    double Rec     = 2*Rcurv*sin(Rvirt/(2*Rcurv));
-    deltaPhi       =-(charge)*(Rvirt/(2*Rcurv));
-    etaEC          =-log(tan(0.5*atan(Rec/ecDist)));
+    zNew = (std::abs(etaIP) / etaIP) * ecDist;
+    double Zflight = std::abs(zNew - vtxZ);
+    double Rvirt = std::abs(Zflight * tan(theta));
+    double Rec = 2 * Rcurv * sin(Rvirt / (2 * Rcurv));
+    deltaPhi = -(charge) * (Rvirt / (2 * Rcurv));
+    etaEC = -log(tan(0.5 * atan(Rec / ecDist)));
   }
 
-  if (zNew<0) etaEC=-etaEC;
-  phiEC            = phiIP+deltaPhi;
+  if (zNew < 0)
+    etaEC = -etaEC;
+  phiEC = phiIP + deltaPhi;
 
-  if (phiEC<-M_PI) phiEC += M_2_PI;
-  if (phiEC>M_PI)  phiEC -= M_2_PI;
+  if (phiEC < -M_PI)
+    phiEC += M_2_PI;
+  if (phiEC > M_PI)
+    phiEC -= M_2_PI;
 
-  std::pair<double,double> retVal(etaEC,phiEC);
+  std::pair<double, double> retVal(etaEC, phiEC);
   return retVal;
 }
-

--- a/Calibration/HcalIsolatedTrackReco/src/IsolatedPixelTrackCandidateProducer.cc
+++ b/Calibration/HcalIsolatedTrackReco/src/IsolatedPixelTrackCandidateProducer.cc
@@ -16,7 +16,6 @@
 #include "FWCore/Utilities/interface/transform.h"
 //
 
-
 // Math
 #include "Math/GenVector/VectorUtil.h"
 #include "Math/GenVector/PxPyPzE4D.h"
@@ -40,60 +39,60 @@
 
 //#define DebugLog
 
-IsolatedPixelTrackCandidateProducer::IsolatedPixelTrackCandidateProducer(const edm::ParameterSet& config) :
-  tok_hlt_(                     consumes<trigger::TriggerFilterObjectWithRefs>(config.getParameter<edm::InputTag>("L1GTSeedLabel")) ),
-  tok_l1_(                      consumes<l1extra::L1JetParticleCollection>(config.getParameter<edm::InputTag>("L1eTauJetsSource")) ),
-  tok_vert_(                    consumes<reco::VertexCollection>(config.getParameter<edm::InputTag>("VertexLabel")) ),
-  toks_pix_(                    edm::vector_transform(
-                                  config.getParameter<std::vector<edm::InputTag> >("PixelTracksSources"),
-                                  [this](edm::InputTag const & tag){return consumes<reco::TrackCollection>(tag);}) ),
-  bfield_(                      config.getParameter<std::string>("MagFieldRecordName") ),
-  prelimCone_(                  config.getParameter<double>("ExtrapolationConeSize") ),
-  pixelIsolationConeSizeAtEC_(  config.getParameter<double>("PixelIsolationConeSizeAtEC") ),
-  vtxCutSeed_(                  config.getParameter<double>("MaxVtxDXYSeed") ),
-  vtxCutIsol_(                  config.getParameter<double>("MaxVtxDXYIsol") ),
-  tauAssocCone_(                config.getParameter<double>("tauAssociationCone") ), 
-  tauUnbiasCone_(               config.getParameter<double>("tauUnbiasCone") ),
-  minPTrackValue_(              config.getParameter<double>("minPTrack") ),
-  maxPForIsolationValue_(       config.getParameter<double>("maxPTrackForIsolation") ),
-  ebEtaBoundary_(               config.getParameter<double>("EBEtaBoundary") ),
-  rEB_( -1 ), 
-  zEE_( -1 ),
-  bfVal_( 0 )
-{
+IsolatedPixelTrackCandidateProducer::IsolatedPixelTrackCandidateProducer(const edm::ParameterSet& config)
+    : tok_hlt_(consumes<trigger::TriggerFilterObjectWithRefs>(config.getParameter<edm::InputTag>("L1GTSeedLabel"))),
+      tok_l1_(consumes<l1extra::L1JetParticleCollection>(config.getParameter<edm::InputTag>("L1eTauJetsSource"))),
+      tok_vert_(consumes<reco::VertexCollection>(config.getParameter<edm::InputTag>("VertexLabel"))),
+      toks_pix_(
+          edm::vector_transform(config.getParameter<std::vector<edm::InputTag> >("PixelTracksSources"),
+                                [this](edm::InputTag const& tag) { return consumes<reco::TrackCollection>(tag); })),
+      bfield_(config.getParameter<std::string>("MagFieldRecordName")),
+      prelimCone_(config.getParameter<double>("ExtrapolationConeSize")),
+      pixelIsolationConeSizeAtEC_(config.getParameter<double>("PixelIsolationConeSizeAtEC")),
+      vtxCutSeed_(config.getParameter<double>("MaxVtxDXYSeed")),
+      vtxCutIsol_(config.getParameter<double>("MaxVtxDXYIsol")),
+      tauAssocCone_(config.getParameter<double>("tauAssociationCone")),
+      tauUnbiasCone_(config.getParameter<double>("tauUnbiasCone")),
+      minPTrackValue_(config.getParameter<double>("minPTrack")),
+      maxPForIsolationValue_(config.getParameter<double>("maxPTrackForIsolation")),
+      ebEtaBoundary_(config.getParameter<double>("EBEtaBoundary")),
+      rEB_(-1),
+      zEE_(-1),
+      bfVal_(0) {
   // Register the product
-  produces< reco::IsolatedPixelTrackCandidateCollection >();
+  produces<reco::IsolatedPixelTrackCandidateCollection>();
 }
 
-IsolatedPixelTrackCandidateProducer::~IsolatedPixelTrackCandidateProducer() { }
+IsolatedPixelTrackCandidateProducer::~IsolatedPixelTrackCandidateProducer() {}
 
 void IsolatedPixelTrackCandidateProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   std::vector<edm::InputTag> tracksrc = {edm::InputTag("hltPixelTracks")};
-  desc.add<edm::InputTag>("L1eTauJetsSource",edm::InputTag("hltCaloStage2Digis","Tau"));
-  desc.add<double>("tauAssociationCone",        0.0 );
-  desc.add<double>("tauUnbiasCone",             1.2 );
-  desc.add<std::vector<edm::InputTag> >("PixelTracksSources",tracksrc);
-  desc.add<double>("ExtrapolationConeSize",     1.0);
-  desc.add<double>("PixelIsolationConeSizeAtEC",40);
-  desc.add<edm::InputTag>("L1GTSeedLabel",edm::InputTag("hltL1sIsoTrack"));
-  desc.add<double>("MaxVtxDXYSeed",             101.0);
-  desc.add<double>("MaxVtxDXYIsol",             101.0);
-  desc.add<edm::InputTag>("VertexLabel",edm::InputTag("hltTrimmedPixelVertices"));
-  desc.add<std::string>("MagFieldRecordName","VolumeBasedMagneticField");
-  desc.add<double>("minPTrack",                 5.0);
-  desc.add<double>("maxPTrackForIsolation",     3.0);
-  desc.add<double>("EBEtaBoundary",             1.479);
-  descriptions.add("isolPixelTrackProd",desc);
+  desc.add<edm::InputTag>("L1eTauJetsSource", edm::InputTag("hltCaloStage2Digis", "Tau"));
+  desc.add<double>("tauAssociationCone", 0.0);
+  desc.add<double>("tauUnbiasCone", 1.2);
+  desc.add<std::vector<edm::InputTag> >("PixelTracksSources", tracksrc);
+  desc.add<double>("ExtrapolationConeSize", 1.0);
+  desc.add<double>("PixelIsolationConeSizeAtEC", 40);
+  desc.add<edm::InputTag>("L1GTSeedLabel", edm::InputTag("hltL1sIsoTrack"));
+  desc.add<double>("MaxVtxDXYSeed", 101.0);
+  desc.add<double>("MaxVtxDXYIsol", 101.0);
+  desc.add<edm::InputTag>("VertexLabel", edm::InputTag("hltTrimmedPixelVertices"));
+  desc.add<std::string>("MagFieldRecordName", "VolumeBasedMagneticField");
+  desc.add<double>("minPTrack", 5.0);
+  desc.add<double>("maxPTrackForIsolation", 3.0);
+  desc.add<double>("EBEtaBoundary", 1.479);
+  descriptions.add("isolPixelTrackProd", desc);
 }
 
-void IsolatedPixelTrackCandidateProducer::beginRun(const edm::Run &run, const edm::EventSetup &theEventSetup) {
-
+void IsolatedPixelTrackCandidateProducer::beginRun(const edm::Run& run, const edm::EventSetup& theEventSetup) {
   edm::ESHandle<CaloGeometry> pG;
-  theEventSetup.get<CaloGeometryRecord>().get(pG);   
-  
-  const double rad (dynamic_cast<const EcalBarrelGeometry*>( pG->getSubdetectorGeometry(DetId::Ecal, EcalBarrel ))->avgRadiusXYFrontFaceCenter() ) ;
-  const double zz  (dynamic_cast<const EcalEndcapGeometry*>( pG->getSubdetectorGeometry(DetId::Ecal, EcalEndcap ))->avgAbsZFrontFaceCenter() ) ;
+  theEventSetup.get<CaloGeometryRecord>().get(pG);
+
+  const double rad(dynamic_cast<const EcalBarrelGeometry*>(pG->getSubdetectorGeometry(DetId::Ecal, EcalBarrel))
+                       ->avgRadiusXYFrontFaceCenter());
+  const double zz(dynamic_cast<const EcalEndcapGeometry*>(pG->getSubdetectorGeometry(DetId::Ecal, EcalEndcap))
+                      ->avgAbsZFrontFaceCenter());
 
   rEB_ = rad;
   zEE_ = zz;
@@ -101,120 +100,150 @@ void IsolatedPixelTrackCandidateProducer::beginRun(const edm::Run &run, const ed
   edm::ESHandle<MagneticField> vbfField;
   theEventSetup.get<IdealMagneticFieldRecord>().get(vbfField);
   const VolumeBasedMagneticField* vbfCPtr = dynamic_cast<const VolumeBasedMagneticField*>(&(*vbfField));
-  GlobalVector BField = vbfCPtr->inTesla(GlobalPoint(0,0,0));
-  bfVal_=BField.mag();
+  GlobalVector BField = vbfCPtr->inTesla(GlobalPoint(0, 0, 0));
+  bfVal_ = BField.mag();
 }
 
 void IsolatedPixelTrackCandidateProducer::produce(edm::Event& theEvent, const edm::EventSetup& theEventSetup) {
-
   auto trackCollection = std::make_unique<reco::IsolatedPixelTrackCandidateCollection>();
 
   //create vector of refs from input collections
   std::vector<reco::TrackRef> pixelTrackRefs;
 #ifdef DebugLog
-  edm::LogInfo("HcalIsoTrack") << "IsolatedPixelTrakCandidate: with" << toks_pix_.size() << " candidates to start with\n";
+  edm::LogInfo("HcalIsoTrack") << "IsolatedPixelTrakCandidate: with" << toks_pix_.size()
+                               << " candidates to start with\n";
 #endif
-  for (unsigned int iPix=0; iPix<toks_pix_.size(); iPix++) {
+  for (unsigned int iPix = 0; iPix < toks_pix_.size(); iPix++) {
     edm::Handle<reco::TrackCollection> iPixCol;
-    theEvent.getByToken(toks_pix_[iPix],iPixCol);
-    for (reco::TrackCollection::const_iterator pit=iPixCol->begin(); pit!=iPixCol->end(); pit++) {
-      pixelTrackRefs.push_back(reco::TrackRef(iPixCol,pit-iPixCol->begin()));
+    theEvent.getByToken(toks_pix_[iPix], iPixCol);
+    for (reco::TrackCollection::const_iterator pit = iPixCol->begin(); pit != iPixCol->end(); pit++) {
+      pixelTrackRefs.push_back(reco::TrackRef(iPixCol, pit - iPixCol->begin()));
     }
   }
 
   edm::Handle<l1extra::L1JetParticleCollection> l1eTauJets;
-  theEvent.getByToken(tok_l1_,l1eTauJets);
+  theEvent.getByToken(tok_l1_, l1eTauJets);
 
   edm::Handle<reco::VertexCollection> pVert;
-  theEvent.getByToken(tok_vert_,pVert);
+  theEvent.getByToken(tok_vert_, pVert);
 
   double drMaxL1Track_ = tauAssocCone_;
-  
+
   int ntr = 0;
-  std::vector<seedAtEC>  VecSeedsatEC;
+  std::vector<seedAtEC> VecSeedsatEC;
   //loop to select isolated tracks
-  for (unsigned iS=0; iS<pixelTrackRefs.size(); iS++) {
+  for (unsigned iS = 0; iS < pixelTrackRefs.size(); iS++) {
     bool vtxMatch = false;
-    //associate to vertex (in Z) 
+    //associate to vertex (in Z)
     reco::VertexCollection::const_iterator vitSel;
     double minDZ = 1000;
-    bool   found(false);
-    for (reco::VertexCollection::const_iterator vit=pVert->begin(); vit!=pVert->end(); vit++) {
-      if (std::abs(pixelTrackRefs[iS]->dz(vit->position()))<minDZ) {
-	minDZ  = std::abs(pixelTrackRefs[iS]->dz(vit->position()));
-	vitSel = vit;
-	found  = true;
+    bool found(false);
+    for (reco::VertexCollection::const_iterator vit = pVert->begin(); vit != pVert->end(); vit++) {
+      if (std::abs(pixelTrackRefs[iS]->dz(vit->position())) < minDZ) {
+        minDZ = std::abs(pixelTrackRefs[iS]->dz(vit->position()));
+        vitSel = vit;
+        found = true;
       }
     }
     //cut on dYX:
     if (found) {
-      if(std::abs(pixelTrackRefs[iS]->dxy(vitSel->position()))<vtxCutSeed_) vtxMatch=true;
+      if (std::abs(pixelTrackRefs[iS]->dxy(vitSel->position())) < vtxCutSeed_)
+        vtxMatch = true;
     } else {
-      vtxMatch=true;
+      vtxMatch = true;
     }
 
     //check taujet matching
-    bool tmatch=false;
+    bool tmatch = false;
     l1extra::L1JetParticleCollection::const_iterator selj;
-    for (l1extra::L1JetParticleCollection::const_iterator tj=l1eTauJets->begin(); tj!=l1eTauJets->end(); tj++) {
-      if (reco::deltaR(pixelTrackRefs[iS]->momentum().eta(), pixelTrackRefs[iS]->momentum().phi(), tj->momentum().eta(), tj->momentum().phi()) > drMaxL1Track_) continue;
-      selj   = tj;
+    for (l1extra::L1JetParticleCollection::const_iterator tj = l1eTauJets->begin(); tj != l1eTauJets->end(); tj++) {
+      if (reco::deltaR(pixelTrackRefs[iS]->momentum().eta(),
+                       pixelTrackRefs[iS]->momentum().phi(),
+                       tj->momentum().eta(),
+                       tj->momentum().phi()) > drMaxL1Track_)
+        continue;
+      selj = tj;
       tmatch = true;
-    } //loop over L1 tau
+    }  //loop over L1 tau
 
     //propagate seed track to ECAL surface:
-    std::pair<double,double> seedCooAtEC;
+    std::pair<double, double> seedCooAtEC;
     // in case vertex is found:
-    if (found) seedCooAtEC=GetEtaPhiAtEcal(pixelTrackRefs[iS]->eta(), pixelTrackRefs[iS]->phi(), pixelTrackRefs[iS]->pt(), pixelTrackRefs[iS]->charge(), vitSel->z());
+    if (found)
+      seedCooAtEC = GetEtaPhiAtEcal(pixelTrackRefs[iS]->eta(),
+                                    pixelTrackRefs[iS]->phi(),
+                                    pixelTrackRefs[iS]->pt(),
+                                    pixelTrackRefs[iS]->charge(),
+                                    vitSel->z());
     //in case vertex is not found:
-    else       seedCooAtEC=GetEtaPhiAtEcal(pixelTrackRefs[iS]->eta(), pixelTrackRefs[iS]->phi(), pixelTrackRefs[iS]->pt(), pixelTrackRefs[iS]->charge(), 0);
-    seedAtEC seed(iS,(tmatch||vtxMatch),seedCooAtEC.first,seedCooAtEC.second);
+    else
+      seedCooAtEC = GetEtaPhiAtEcal(pixelTrackRefs[iS]->eta(),
+                                    pixelTrackRefs[iS]->phi(),
+                                    pixelTrackRefs[iS]->pt(),
+                                    pixelTrackRefs[iS]->charge(),
+                                    0);
+    seedAtEC seed(iS, (tmatch || vtxMatch), seedCooAtEC.first, seedCooAtEC.second);
     VecSeedsatEC.push_back(seed);
   }
 #ifdef DebugLog
   edm::LogInfo("HcalIsoTrack") << "IsolatedPixelTrakCandidate: " << VecSeedsatEC.size() << " seeds after propagation\n";
 #endif
 
-  for (unsigned int i=0; i<VecSeedsatEC.size(); i++) {
+  for (unsigned int i = 0; i < VecSeedsatEC.size(); i++) {
     unsigned int iSeed = VecSeedsatEC[i].index;
-    if (!VecSeedsatEC[i].ok) continue;
-    if(pixelTrackRefs[iSeed]->p()<minPTrackValue_) continue; 
+    if (!VecSeedsatEC[i].ok)
+      continue;
+    if (pixelTrackRefs[iSeed]->p() < minPTrackValue_)
+      continue;
     l1extra::L1JetParticleCollection::const_iterator selj;
-    for (l1extra::L1JetParticleCollection::const_iterator tj=l1eTauJets->begin(); tj!=l1eTauJets->end(); tj++)  {
-      if (reco::deltaR(pixelTrackRefs[iSeed]->momentum().eta(),pixelTrackRefs[iSeed]->momentum().phi(),tj->momentum().eta(),tj->momentum().phi()) > drMaxL1Track_) continue;
-      selj   = tj;
-    } //loop over L1 tau
+    for (l1extra::L1JetParticleCollection::const_iterator tj = l1eTauJets->begin(); tj != l1eTauJets->end(); tj++) {
+      if (reco::deltaR(pixelTrackRefs[iSeed]->momentum().eta(),
+                       pixelTrackRefs[iSeed]->momentum().phi(),
+                       tj->momentum().eta(),
+                       tj->momentum().phi()) > drMaxL1Track_)
+        continue;
+      selj = tj;
+    }  //loop over L1 tau
     double maxP = 0;
     double sumP = 0;
-    for(unsigned int j=0; j<VecSeedsatEC.size(); j++) {
-      if (i==j) continue;
+    for (unsigned int j = 0; j < VecSeedsatEC.size(); j++) {
+      if (i == j)
+        continue;
       unsigned int iSurr = VecSeedsatEC[j].index;
       //define preliminary cone around seed track impact point from which tracks will be extrapolated:
-      if (reco::deltaR(pixelTrackRefs[iSeed]->eta(), pixelTrackRefs[iSeed]->phi(), pixelTrackRefs[iSurr]->eta(), pixelTrackRefs[iSurr]->phi())>prelimCone_) continue;
+      if (reco::deltaR(pixelTrackRefs[iSeed]->eta(),
+                       pixelTrackRefs[iSeed]->phi(),
+                       pixelTrackRefs[iSurr]->eta(),
+                       pixelTrackRefs[iSurr]->phi()) > prelimCone_)
+        continue;
       double minDZ2(1000);
-      bool   found(false);
+      bool found(false);
       reco::VertexCollection::const_iterator vitSel2;
-      for (reco::VertexCollection::const_iterator vit=pVert->begin(); vit!=pVert->end(); vit++) {
-	if (std::abs(pixelTrackRefs[iSurr]->dz(vit->position()))<minDZ2) {
-	  minDZ2  = std::abs(pixelTrackRefs[iSurr]->dz(vit->position()));
-	  vitSel2 = vit;
-	  found   = true;
-	}
+      for (reco::VertexCollection::const_iterator vit = pVert->begin(); vit != pVert->end(); vit++) {
+        if (std::abs(pixelTrackRefs[iSurr]->dz(vit->position())) < minDZ2) {
+          minDZ2 = std::abs(pixelTrackRefs[iSurr]->dz(vit->position()));
+          vitSel2 = vit;
+          found = true;
+        }
       }
       //cut ot dXY:
-      if (found&&std::abs(pixelTrackRefs[iSurr]->dxy(vitSel2->position()))>vtxCutIsol_) continue;
-      //calculate distance at ECAL surface and update isolation: 
-      if (getDistInCM(VecSeedsatEC[i].eta, VecSeedsatEC[i].phi, VecSeedsatEC[j].eta, VecSeedsatEC[j].phi)<pixelIsolationConeSizeAtEC_) {
-	sumP+=pixelTrackRefs[iSurr]->p();
-	if(pixelTrackRefs[iSurr]->p()>maxP) maxP=pixelTrackRefs[iSurr]->p();
-      }      
+      if (found && std::abs(pixelTrackRefs[iSurr]->dxy(vitSel2->position())) > vtxCutIsol_)
+        continue;
+      //calculate distance at ECAL surface and update isolation:
+      if (getDistInCM(VecSeedsatEC[i].eta, VecSeedsatEC[i].phi, VecSeedsatEC[j].eta, VecSeedsatEC[j].phi) <
+          pixelIsolationConeSizeAtEC_) {
+        sumP += pixelTrackRefs[iSurr]->p();
+        if (pixelTrackRefs[iSurr]->p() > maxP)
+          maxP = pixelTrackRefs[iSurr]->p();
+      }
     }
-    if (maxP<maxPForIsolationValue_) {
-      reco::IsolatedPixelTrackCandidate newCandidate(pixelTrackRefs[iSeed], l1extra::L1JetParticleRef(l1eTauJets,selj-l1eTauJets->begin()), maxP, sumP);
+    if (maxP < maxPForIsolationValue_) {
+      reco::IsolatedPixelTrackCandidate newCandidate(
+          pixelTrackRefs[iSeed], l1extra::L1JetParticleRef(l1eTauJets, selj - l1eTauJets->begin()), maxP, sumP);
       newCandidate.setEtaPhiEcal(VecSeedsatEC[i].eta, VecSeedsatEC[i].phi);
       trackCollection->push_back(newCandidate);
       ntr++;
-    }    
+    }
   }
   // put the product in the event
   theEvent.put(std::move(trackCollection));
@@ -223,77 +252,86 @@ void IsolatedPixelTrackCandidateProducer::produce(edm::Event& theEvent, const ed
 #endif
 }
 
-
 double IsolatedPixelTrackCandidateProducer::getDistInCM(double eta1, double phi1, double eta2, double phi2) {
   double Rec;
-  double theta1=2*atan(exp(-eta1));
-  double theta2=2*atan(exp(-eta2));
-  if (std::abs(eta1)<1.479) Rec=rEB_; //radius of ECAL barrel
-  else if (std::abs(eta1)>1.479&&std::abs(eta1)<7.0) Rec=tan(theta1)*zEE_; //distance from IP to ECAL endcap
-  else return 1000;
+  double theta1 = 2 * atan(exp(-eta1));
+  double theta2 = 2 * atan(exp(-eta2));
+  if (std::abs(eta1) < 1.479)
+    Rec = rEB_;  //radius of ECAL barrel
+  else if (std::abs(eta1) > 1.479 && std::abs(eta1) < 7.0)
+    Rec = tan(theta1) * zEE_;  //distance from IP to ECAL endcap
+  else
+    return 1000;
 
   //|vect| times tg of acos(scalar product)
-  double angle=acos((sin(theta1)*sin(theta2)*(sin(phi1)*sin(phi2)+cos(phi1)*cos(phi2))+cos(theta1)*cos(theta2)));
-  if (angle<M_PI_2) return std::abs((Rec/sin(theta1))*tan(angle));
-  else return 1000;
+  double angle =
+      acos((sin(theta1) * sin(theta2) * (sin(phi1) * sin(phi2) + cos(phi1) * cos(phi2)) + cos(theta1) * cos(theta2)));
+  if (angle < M_PI_2)
+    return std::abs((Rec / sin(theta1)) * tan(angle));
+  else
+    return 1000;
 }
 
-
-std::pair<double,double> IsolatedPixelTrackCandidateProducer::GetEtaPhiAtEcal(double etaIP, double phiIP, double pT, int charge, double vtxZ) {
-
-  double deltaPhi=0;
+std::pair<double, double> IsolatedPixelTrackCandidateProducer::GetEtaPhiAtEcal(
+    double etaIP, double phiIP, double pT, int charge, double vtxZ) {
+  double deltaPhi = 0;
   double etaEC = 100;
   double phiEC = 100;
 
   double Rcurv = 9999999;
-  if (bfVal_!=0) Rcurv=pT*33.3*100/(bfVal_*10); //r(m)=pT(GeV)*33.3/B(kG)
+  if (bfVal_ != 0)
+    Rcurv = pT * 33.3 * 100 / (bfVal_ * 10);  //r(m)=pT(GeV)*33.3/B(kG)
 
   double ecDist = zEE_;  //distance to ECAL andcap from IP (cm), 317 - ecal (not preshower), preshower -300
-  double ecRad  = rEB_;  //radius of ECAL barrel (cm)
-  double theta  = 2*atan(exp(-etaIP));
-  double zNew   = 0;
-  if (theta>M_PI_2) theta=M_PI-theta;
-  if (std::abs(etaIP)<ebEtaBoundary_) {
-    if ((0.5*ecRad/Rcurv)>1) {
-      etaEC         = 10000;
-      deltaPhi      = 0;
+  double ecRad = rEB_;   //radius of ECAL barrel (cm)
+  double theta = 2 * atan(exp(-etaIP));
+  double zNew = 0;
+  if (theta > M_PI_2)
+    theta = M_PI - theta;
+  if (std::abs(etaIP) < ebEtaBoundary_) {
+    if ((0.5 * ecRad / Rcurv) > 1) {
+      etaEC = 10000;
+      deltaPhi = 0;
     } else {
-      deltaPhi      =-charge*asin(0.5*ecRad/Rcurv);
-      double alpha1 = 2*asin(0.5*ecRad/Rcurv);
-      double z      = ecRad/tan(theta);
-      if (etaIP>0) zNew = z*(Rcurv*alpha1)/ecRad+vtxZ; //new z-coordinate of track
-      else         zNew =-z*(Rcurv*alpha1)/ecRad+vtxZ; //new z-coordinate of track
-      double zAbs=std::abs(zNew);
-      if (zAbs<ecDist) {
-	etaEC    = -log(tan(0.5*atan(ecRad/zAbs)));
-	deltaPhi = -charge*asin(0.5*ecRad/Rcurv);
+      deltaPhi = -charge * asin(0.5 * ecRad / Rcurv);
+      double alpha1 = 2 * asin(0.5 * ecRad / Rcurv);
+      double z = ecRad / tan(theta);
+      if (etaIP > 0)
+        zNew = z * (Rcurv * alpha1) / ecRad + vtxZ;  //new z-coordinate of track
+      else
+        zNew = -z * (Rcurv * alpha1) / ecRad + vtxZ;  //new z-coordinate of track
+      double zAbs = std::abs(zNew);
+      if (zAbs < ecDist) {
+        etaEC = -log(tan(0.5 * atan(ecRad / zAbs)));
+        deltaPhi = -charge * asin(0.5 * ecRad / Rcurv);
       }
-      if (zAbs>ecDist) {
-	zAbs           = (std::abs(etaIP)/etaIP)*ecDist;
-	double Zflight = std::abs(zAbs-vtxZ);
-	double alpha   = (Zflight*ecRad)/(z*Rcurv);
-	double Rec     = 2*Rcurv*sin(alpha/2);
-	deltaPhi       =-charge*alpha/2;
-	etaEC          =-log(tan(0.5*atan(Rec/ecDist)));
+      if (zAbs > ecDist) {
+        zAbs = (std::abs(etaIP) / etaIP) * ecDist;
+        double Zflight = std::abs(zAbs - vtxZ);
+        double alpha = (Zflight * ecRad) / (z * Rcurv);
+        double Rec = 2 * Rcurv * sin(alpha / 2);
+        deltaPhi = -charge * alpha / 2;
+        etaEC = -log(tan(0.5 * atan(Rec / ecDist)));
       }
     }
   } else {
-    zNew           = (std::abs(etaIP)/etaIP)*ecDist;
-    double Zflight = std::abs(zNew-vtxZ);
-    double Rvirt   = std::abs(Zflight*tan(theta));
-    double Rec     = 2*Rcurv*sin(Rvirt/(2*Rcurv));
-    deltaPhi       =-(charge)*(Rvirt/(2*Rcurv));
-    etaEC          =-log(tan(0.5*atan(Rec/ecDist)));
+    zNew = (std::abs(etaIP) / etaIP) * ecDist;
+    double Zflight = std::abs(zNew - vtxZ);
+    double Rvirt = std::abs(Zflight * tan(theta));
+    double Rec = 2 * Rcurv * sin(Rvirt / (2 * Rcurv));
+    deltaPhi = -(charge) * (Rvirt / (2 * Rcurv));
+    etaEC = -log(tan(0.5 * atan(Rec / ecDist)));
   }
 
-  if (zNew<0) etaEC=-etaEC;
-  phiEC            = phiIP+deltaPhi;
+  if (zNew < 0)
+    etaEC = -etaEC;
+  phiEC = phiIP + deltaPhi;
 
-  if (phiEC<-M_PI) phiEC += M_2_PI;
-  if (phiEC>M_PI)  phiEC -= M_2_PI;
+  if (phiEC < -M_PI)
+    phiEC += M_2_PI;
+  if (phiEC > M_PI)
+    phiEC -= M_2_PI;
 
-  std::pair<double,double> retVal(etaEC,phiEC);
+  std::pair<double, double> retVal(etaEC, phiEC);
   return retVal;
 }
-
-

--- a/Calibration/HcalIsolatedTrackReco/src/SealModule.cc
+++ b/Calibration/HcalIsolatedTrackReco/src/SealModule.cc
@@ -4,15 +4,15 @@
 #include "Calibration/HcalIsolatedTrackReco/interface/IsolatedPixelTrackCandidateL1TProducer.h"
 #include "Calibration/HcalIsolatedTrackReco/interface/IsolatedEcalPixelTrackCandidateProducer.h"
 #include "Calibration/HcalIsolatedTrackReco/interface/EcalIsolatedParticleCandidateProducer.h"
-#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducerFactory.h" 	 
-#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h" 	 
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducerFactory.h"
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h"
 #include "Calibration/HcalIsolatedTrackReco/interface/SiStripRegFEDSelector.h"
 #include "Calibration/HcalIsolatedTrackReco/interface/ECALRegFEDSelector.h"
 #include "Calibration/HcalIsolatedTrackReco/interface/SubdetFEDSelector.h"
 #include "HITRegionalPixelSeedGenerator.h"
 #include "Calibration/HcalIsolatedTrackReco/interface/IPTCorrector.h"
 
-DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, HITRegionalPixelSeedGenerator, "HITRegionalPixelSeedGenerator"); 
+DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, HITRegionalPixelSeedGenerator, "HITRegionalPixelSeedGenerator");
 //
 DEFINE_FWK_MODULE(IsolatedPixelTrackCandidateProducer);
 DEFINE_FWK_MODULE(IsolatedPixelTrackCandidateL1TProducer);

--- a/Calibration/HcalIsolatedTrackReco/src/SiStripRegFEDSelector.cc
+++ b/Calibration/HcalIsolatedTrackReco/src/SiStripRegFEDSelector.cc
@@ -5,146 +5,123 @@
 #include "DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidate.h"
 #include "DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidateFwd.h"
 
-SiStripRegFEDSelector::SiStripRegFEDSelector(const edm::ParameterSet& iConfig)
-{
+SiStripRegFEDSelector::SiStripRegFEDSelector(const edm::ParameterSet& iConfig) {
   tok_seed_ = consumes<trigger::TriggerFilterObjectWithRefs>(iConfig.getParameter<edm::InputTag>("regSeedLabel"));
-  delta_=iConfig.getParameter<double>("delta");
-  
+  delta_ = iConfig.getParameter<double>("delta");
+
   tok_raw_ = consumes<FEDRawDataCollection>(iConfig.getParameter<edm::InputTag>("rawInputLabel"));
 
   produces<FEDRawDataCollection>();
 }
 
+SiStripRegFEDSelector::~SiStripRegFEDSelector() {}
 
-SiStripRegFEDSelector::~SiStripRegFEDSelector()
-{
- 
-}
-
-void
-SiStripRegFEDSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void SiStripRegFEDSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   auto producedData = std::make_unique<FEDRawDataCollection>();
 
   edm::Handle<trigger::TriggerFilterObjectWithRefs> trigSeedTrks;
-  iEvent.getByToken(tok_seed_,trigSeedTrks);
-  
-  std::vector< edm::Ref<reco::IsolatedPixelTrackCandidateCollection> > isoPixTrackRefs;
+  iEvent.getByToken(tok_seed_, trigSeedTrks);
+
+  std::vector<edm::Ref<reco::IsolatedPixelTrackCandidateCollection> > isoPixTrackRefs;
   trigSeedTrks->getObjects(trigger::TriggerTrack, isoPixTrackRefs);
- 
+
   edm::Handle<FEDRawDataCollection> rawIn;
-  iEvent.getByToken(tok_raw_,rawIn);
-  
+  iEvent.getByToken(tok_raw_, rawIn);
+
   iSetup.get<SiStripRegionCablingRcd>().get(strip_cabling);
-  
-  std::vector<int> stripFEDVec; 
-  
+
+  std::vector<int> stripFEDVec;
+
   //get vector of regions
-  const SiStripRegionCabling::Cabling ccab=strip_cabling->getRegionCabling();
-  
+  const SiStripRegionCabling::Cabling ccab = strip_cabling->getRegionCabling();
+
   //size of region (eta,phi)
-  const std::pair<double,double> regDim=strip_cabling->regionDimensions();
-  
+  const std::pair<double, double> regDim = strip_cabling->regionDimensions();
+
   const SiStripRegionCabling::ElementCabling elcabling;
-  
+
   bool fedSaved[1000];
-  for (int i=0; i<1000; i++) fedSaved[i]=false;
-  
+  for (int i = 0; i < 1000; i++)
+    fedSaved[i] = false;
+
   //cycle on seeds
-  for (uint32_t p=0; p<isoPixTrackRefs.size(); p++)
-    {
-      double etaObj_=isoPixTrackRefs[p]->track()->eta();
-      double phiObj_=isoPixTrackRefs[p]->track()->phi();
-      
-      //cycle on regions
-      for (uint32_t i=0; i<ccab.size(); i++)
-	{
-	  SiStripRegionCabling::Position pos=strip_cabling->position(i);
-	  double dphi=fabs(pos.second-phiObj_);
-	  if (dphi>acos(-1)) dphi=2*acos(-1)-dphi;
-	  double R=sqrt(pow(pos.first-etaObj_,2)+dphi*dphi);
-	  if (R-sqrt(pow(regDim.first/2,2)+pow(regDim.second/2,2))>delta_) continue;
-	  //get vector of subdets within region
-	  const SiStripRegionCabling::RegionCabling regSubdets= ccab[i];
-	  //cycle on subdets
-	  for (uint32_t idet=0; idet<SiStripRegionCabling::ALLSUBDETS; idet++)
-	    {
-	      //get vector of layers within subdet of region
-	      const SiStripRegionCabling::WedgeCabling regSubdetLayers=regSubdets[idet];	
-	      for (uint32_t ilayer=0; ilayer<SiStripRegionCabling::ALLLAYERS; ilayer++)
-		{
-		  //get map of vectors of feds withing the layer of subdet of region
-		  const SiStripRegionCabling::ElementCabling fedVectorMap=regSubdetLayers[ilayer];
-		  SiStripRegionCabling::ElementCabling::const_iterator it=fedVectorMap.begin();
-		  for( ; it!=fedVectorMap.end(); it++)
-		    {
-		      for (uint32_t op=0; op<(it->second).size(); op++)
-			{
-			  //get fed id 
-			  int fediid=(it->second)[op].fedId(); 
-			  if (!fedSaved[fediid]) 
-			    {
-			      stripFEDVec.push_back(fediid);
-			    }
-			  fedSaved[fediid]=true;
-			  
-			}
-		    }	
-		  
-		}
-	      
-	    }
-	}
+  for (uint32_t p = 0; p < isoPixTrackRefs.size(); p++) {
+    double etaObj_ = isoPixTrackRefs[p]->track()->eta();
+    double phiObj_ = isoPixTrackRefs[p]->track()->phi();
+
+    //cycle on regions
+    for (uint32_t i = 0; i < ccab.size(); i++) {
+      SiStripRegionCabling::Position pos = strip_cabling->position(i);
+      double dphi = fabs(pos.second - phiObj_);
+      if (dphi > acos(-1))
+        dphi = 2 * acos(-1) - dphi;
+      double R = sqrt(pow(pos.first - etaObj_, 2) + dphi * dphi);
+      if (R - sqrt(pow(regDim.first / 2, 2) + pow(regDim.second / 2, 2)) > delta_)
+        continue;
+      //get vector of subdets within region
+      const SiStripRegionCabling::RegionCabling regSubdets = ccab[i];
+      //cycle on subdets
+      for (uint32_t idet = 0; idet < SiStripRegionCabling::ALLSUBDETS; idet++) {
+        //get vector of layers within subdet of region
+        const SiStripRegionCabling::WedgeCabling regSubdetLayers = regSubdets[idet];
+        for (uint32_t ilayer = 0; ilayer < SiStripRegionCabling::ALLLAYERS; ilayer++) {
+          //get map of vectors of feds withing the layer of subdet of region
+          const SiStripRegionCabling::ElementCabling fedVectorMap = regSubdetLayers[ilayer];
+          SiStripRegionCabling::ElementCabling::const_iterator it = fedVectorMap.begin();
+          for (; it != fedVectorMap.end(); it++) {
+            for (uint32_t op = 0; op < (it->second).size(); op++) {
+              //get fed id
+              int fediid = (it->second)[op].fedId();
+              if (!fedSaved[fediid]) {
+                stripFEDVec.push_back(fediid);
+              }
+              fedSaved[fediid] = true;
+            }
+          }
+        }
+      }
     }
-  
-  
+  }
+
   /////////////// Copying FEDs:
-  
-  const FEDRawDataCollection *rdc=rawIn.product();
-  
+
+  const FEDRawDataCollection* rdc = rawIn.product();
+
   //   if ( ( rawData[i].provenance()->processName() != e.processHistory().rbegin()->processName() ) )
   //       continue ; // skip all raw collections not produced by the current process
-  
-  for ( int j=0; j< FEDNumbering::MAXFEDID; ++j ) 
-    {
-      bool rightFED=false;
-      for (uint32_t k=0; k<stripFEDVec.size(); k++) 
-	{
-	  if (j==stripFEDVec[k])
-	    {
-	      rightFED=true;
-	    }
-	}
-      if (!rightFED) continue;
-      const FEDRawData & fedData = rdc->FEDData(j);
-      size_t size=fedData.size();
-      
-      if ( size > 0 ) 
-	{
-	  // this fed has data -- lets copy it
-	  FEDRawData & fedDataProd = producedData->FEDData(j);
-	  if ( fedDataProd.size() != 0 ) {
-//	    std::cout << " More than one FEDRawDataCollection with data in FED ";
-//	    std::cout << j << " Skipping the 2nd\n";
-	    continue;
-	  }
-	  fedDataProd.resize(size);
-	  unsigned char *dataProd=fedDataProd.data();
-	  const unsigned char *data=fedData.data();
-	  for ( unsigned int k=0; k<size; ++k ) {
-	    dataProd[k]=data[k];
-	  }
-	}
+
+  for (int j = 0; j < FEDNumbering::MAXFEDID; ++j) {
+    bool rightFED = false;
+    for (uint32_t k = 0; k < stripFEDVec.size(); k++) {
+      if (j == stripFEDVec[k]) {
+        rightFED = true;
+      }
     }
-  
+    if (!rightFED)
+      continue;
+    const FEDRawData& fedData = rdc->FEDData(j);
+    size_t size = fedData.size();
+
+    if (size > 0) {
+      // this fed has data -- lets copy it
+      FEDRawData& fedDataProd = producedData->FEDData(j);
+      if (fedDataProd.size() != 0) {
+        //	    std::cout << " More than one FEDRawDataCollection with data in FED ";
+        //	    std::cout << j << " Skipping the 2nd\n";
+        continue;
+      }
+      fedDataProd.resize(size);
+      unsigned char* dataProd = fedDataProd.data();
+      const unsigned char* data = fedData.data();
+      for (unsigned int k = 0; k < size; ++k) {
+        dataProd[k] = data[k];
+      }
+    }
+  }
+
   iEvent.put(std::move(producedData));
-  
 }
 
-void 
-SiStripRegFEDSelector::beginJob() {
-}
+void SiStripRegFEDSelector::beginJob() {}
 
-void 
-SiStripRegFEDSelector::endJob() {
-}
+void SiStripRegFEDSelector::endJob() {}

--- a/Calibration/HcalIsolatedTrackReco/src/SubdetFEDSelector.cc
+++ b/Calibration/HcalIsolatedTrackReco/src/SubdetFEDSelector.cc
@@ -1,231 +1,178 @@
 
 #include "Calibration/HcalIsolatedTrackReco/interface/SubdetFEDSelector.h"
 
-SubdetFEDSelector::SubdetFEDSelector(const edm::ParameterSet& iConfig)
-{
-  getEcal_=iConfig.getParameter<bool>("getECAL");
-  getStrip_=iConfig.getParameter<bool>("getSiStrip");
-  getPixel_=iConfig.getParameter<bool>("getSiPixel");
-  getHcal_=iConfig.getParameter<bool>("getHCAL");
-  getMuon_=iConfig.getParameter<bool>("getMuon");
-  getTrigger_=iConfig.getParameter<bool>("getTrigger");
-  
+SubdetFEDSelector::SubdetFEDSelector(const edm::ParameterSet& iConfig) {
+  getEcal_ = iConfig.getParameter<bool>("getECAL");
+  getStrip_ = iConfig.getParameter<bool>("getSiStrip");
+  getPixel_ = iConfig.getParameter<bool>("getSiPixel");
+  getHcal_ = iConfig.getParameter<bool>("getHCAL");
+  getMuon_ = iConfig.getParameter<bool>("getMuon");
+  getTrigger_ = iConfig.getParameter<bool>("getTrigger");
+
   tok_raw_ = consumes<FEDRawDataCollection>(iConfig.getParameter<edm::InputTag>("rawInputLabel"));
 
   produces<FEDRawDataCollection>();
-  
 }
 
-SubdetFEDSelector::~SubdetFEDSelector()
-{
-}
+SubdetFEDSelector::~SubdetFEDSelector() {}
 
-void
-SubdetFEDSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-
+void SubdetFEDSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   auto producedData = std::make_unique<FEDRawDataCollection>();
 
   edm::Handle<FEDRawDataCollection> rawIn;
-  iEvent.getByToken(tok_raw_,rawIn);
- 
+  iEvent.getByToken(tok_raw_, rawIn);
+
   std::vector<int> selFEDs;
 
-  if (getEcal_)
-    {
-      for (int i=FEDNumbering::MINECALFEDID; i<=FEDNumbering::MAXECALFEDID; i++)
-	{
-	  selFEDs.push_back(i);
-	}
-      for (int i=FEDNumbering::MINPreShowerFEDID; i<=FEDNumbering::MAXPreShowerFEDID; i++)
-	{
-	  selFEDs.push_back(i);
-	}
-    }
-
-  if (getMuon_)
-    {
-      for (int i=FEDNumbering::MINCSCFEDID; i<=FEDNumbering::MAXCSCFEDID; i++)
-	{
-	  selFEDs.push_back(i);
-	}
-  for (int i=FEDNumbering::MINCSCTFFEDID; i<=FEDNumbering::MAXCSCTFFEDID; i++)
-        {
-	  selFEDs.push_back(i);
-        }
-  for (int i=FEDNumbering::MINDTFEDID; i<=FEDNumbering::MAXDTFEDID; i++)
-        {
-	  selFEDs.push_back(i);
-        }
-  for (int i=FEDNumbering::MINDTTFFEDID; i<=FEDNumbering::MAXDTTFFEDID; i++)
-        {
-	  selFEDs.push_back(i);
-        }
-  for (int i=FEDNumbering::MINRPCFEDID; i<=FEDNumbering::MAXRPCFEDID; i++)
-        {
-	  selFEDs.push_back(i);
-        }
-  for (int i=FEDNumbering::MINCSCDDUFEDID; i<=FEDNumbering::MAXCSCDDUFEDID; i++)
-        {
-	  selFEDs.push_back(i);
-        }
-  for (int i=FEDNumbering::MINCSCContingencyFEDID; i<=FEDNumbering::MAXCSCContingencyFEDID; i++)
-        {
-	  selFEDs.push_back(i);
-        }
-  for (int i=FEDNumbering::MINCSCTFSPFEDID; i<=FEDNumbering::MAXCSCTFSPFEDID; i++)
-        {
-	  selFEDs.push_back(i);
-        }
-    }
-
-
-  if (getHcal_)
-    {
-      for (int i=FEDNumbering::MINHCALFEDID; i<=FEDNumbering::MAXHCALFEDID; i++)
-	{
-	  selFEDs.push_back(i);
-	}
-    }
-
-  
-  if (getStrip_)
-    {
-      for (int i=FEDNumbering::MINSiStripFEDID;  i<=FEDNumbering::MAXSiStripFEDID; i++)
-	{
-	  selFEDs.push_back(i);
-	}
-    }
-
-  
-  if (getPixel_)
-    {
-      for (int i=FEDNumbering::MINSiPixelFEDID;  i<=FEDNumbering::MAXSiPixelFEDID; i++)
-	{
-	  selFEDs.push_back(i);
-	}
-    }
-  
-  if (getTrigger_)
-    {
-      for (int i=FEDNumbering::MINTriggerEGTPFEDID;  i<=FEDNumbering::MAXTriggerEGTPFEDID; i++)
-	{
-	  selFEDs.push_back(i);
-	}
-      for (int i=FEDNumbering::MINTriggerGTPFEDID;  i<=FEDNumbering::MAXTriggerGTPFEDID; i++)
-	{
-	  selFEDs.push_back(i);
-	}
-      for (int i=FEDNumbering::MINTriggerLTCFEDID;  i<=FEDNumbering::MAXTriggerLTCFEDID; i++)
-	{
-	  selFEDs.push_back(i);
-	}
-      for (int i=FEDNumbering::MINTriggerLTCmtccFEDID;  i<=FEDNumbering::MAXTriggerLTCmtccFEDID; i++)
-	{
-	  selFEDs.push_back(i);
-	}
-      for (int i=FEDNumbering::MINTriggerGCTFEDID;  i<=FEDNumbering::MAXTriggerGCTFEDID; i++)
-        {
-          selFEDs.push_back(i);
-        }
-
-      for (int i=FEDNumbering::MINTriggerLTCTriggerFEDID;  i<=FEDNumbering::MAXTriggerLTCTriggerFEDID; i++)
-        {
-          selFEDs.push_back(i);
-        }
-
-      for (int i=FEDNumbering::MINTriggerLTCHCALFEDID;  i<=FEDNumbering::MAXTriggerLTCHCALFEDID; i++)
-        {
-          selFEDs.push_back(i);
-        }
-
-      for (int i=FEDNumbering::MINTriggerLTCSiStripFEDID;  i<=FEDNumbering::MAXTriggerLTCSiStripFEDID; i++)
-        {
-          selFEDs.push_back(i);
-        }
-
-      for (int i=FEDNumbering::MINTriggerLTCECALFEDID;  i<=FEDNumbering::MAXTriggerLTCECALFEDID; i++)
-        {
-          selFEDs.push_back(i);
-        }
-
-      for (int i=FEDNumbering::MINTriggerLTCTotemCastorFEDID;  i<=FEDNumbering::MAXTriggerLTCTotemCastorFEDID; i++)
-        {
-          selFEDs.push_back(i);
-        }
-      for (int i=FEDNumbering::MINTriggerLTCRPCFEDID;  i<=FEDNumbering::MAXTriggerLTCRPCFEDID; i++)
-        {
-          selFEDs.push_back(i);
-        }
-      
-      for (int i=FEDNumbering::MINTriggerLTCCSCFEDID;  i<=FEDNumbering::MAXTriggerLTCCSCFEDID; i++)
-        {
-          selFEDs.push_back(i);
-        }
-      for (int i=FEDNumbering::MINTriggerLTCDTFEDID;  i<=FEDNumbering::MAXTriggerLTCDTFEDID; i++)
-        {
-          selFEDs.push_back(i);
-        }
-      for (int i=FEDNumbering::MINTriggerLTCSiPixelFEDID;  i<=FEDNumbering::MAXTriggerLTCSiPixelFEDID; i++)
-        {
-          selFEDs.push_back(i);
-        }
-
-    }
-  
-  for (int i=FEDNumbering::MINDAQeFEDFEDID;  i<=FEDNumbering::MAXDAQeFEDFEDID; i++)
-    {
+  if (getEcal_) {
+    for (int i = FEDNumbering::MINECALFEDID; i <= FEDNumbering::MAXECALFEDID; i++) {
       selFEDs.push_back(i);
     }
-  
+    for (int i = FEDNumbering::MINPreShowerFEDID; i <= FEDNumbering::MAXPreShowerFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+  }
+
+  if (getMuon_) {
+    for (int i = FEDNumbering::MINCSCFEDID; i <= FEDNumbering::MAXCSCFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+    for (int i = FEDNumbering::MINCSCTFFEDID; i <= FEDNumbering::MAXCSCTFFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+    for (int i = FEDNumbering::MINDTFEDID; i <= FEDNumbering::MAXDTFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+    for (int i = FEDNumbering::MINDTTFFEDID; i <= FEDNumbering::MAXDTTFFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+    for (int i = FEDNumbering::MINRPCFEDID; i <= FEDNumbering::MAXRPCFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+    for (int i = FEDNumbering::MINCSCDDUFEDID; i <= FEDNumbering::MAXCSCDDUFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+    for (int i = FEDNumbering::MINCSCContingencyFEDID; i <= FEDNumbering::MAXCSCContingencyFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+    for (int i = FEDNumbering::MINCSCTFSPFEDID; i <= FEDNumbering::MAXCSCTFSPFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+  }
+
+  if (getHcal_) {
+    for (int i = FEDNumbering::MINHCALFEDID; i <= FEDNumbering::MAXHCALFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+  }
+
+  if (getStrip_) {
+    for (int i = FEDNumbering::MINSiStripFEDID; i <= FEDNumbering::MAXSiStripFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+  }
+
+  if (getPixel_) {
+    for (int i = FEDNumbering::MINSiPixelFEDID; i <= FEDNumbering::MAXSiPixelFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+  }
+
+  if (getTrigger_) {
+    for (int i = FEDNumbering::MINTriggerEGTPFEDID; i <= FEDNumbering::MAXTriggerEGTPFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+    for (int i = FEDNumbering::MINTriggerGTPFEDID; i <= FEDNumbering::MAXTriggerGTPFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+    for (int i = FEDNumbering::MINTriggerLTCFEDID; i <= FEDNumbering::MAXTriggerLTCFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+    for (int i = FEDNumbering::MINTriggerLTCmtccFEDID; i <= FEDNumbering::MAXTriggerLTCmtccFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+    for (int i = FEDNumbering::MINTriggerGCTFEDID; i <= FEDNumbering::MAXTriggerGCTFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+
+    for (int i = FEDNumbering::MINTriggerLTCTriggerFEDID; i <= FEDNumbering::MAXTriggerLTCTriggerFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+
+    for (int i = FEDNumbering::MINTriggerLTCHCALFEDID; i <= FEDNumbering::MAXTriggerLTCHCALFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+
+    for (int i = FEDNumbering::MINTriggerLTCSiStripFEDID; i <= FEDNumbering::MAXTriggerLTCSiStripFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+
+    for (int i = FEDNumbering::MINTriggerLTCECALFEDID; i <= FEDNumbering::MAXTriggerLTCECALFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+
+    for (int i = FEDNumbering::MINTriggerLTCTotemCastorFEDID; i <= FEDNumbering::MAXTriggerLTCTotemCastorFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+    for (int i = FEDNumbering::MINTriggerLTCRPCFEDID; i <= FEDNumbering::MAXTriggerLTCRPCFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+
+    for (int i = FEDNumbering::MINTriggerLTCCSCFEDID; i <= FEDNumbering::MAXTriggerLTCCSCFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+    for (int i = FEDNumbering::MINTriggerLTCDTFEDID; i <= FEDNumbering::MAXTriggerLTCDTFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+    for (int i = FEDNumbering::MINTriggerLTCSiPixelFEDID; i <= FEDNumbering::MAXTriggerLTCSiPixelFEDID; i++) {
+      selFEDs.push_back(i);
+    }
+  }
+
+  for (int i = FEDNumbering::MINDAQeFEDFEDID; i <= FEDNumbering::MAXDAQeFEDFEDID; i++) {
+    selFEDs.push_back(i);
+  }
 
   // Copying:
-  const FEDRawDataCollection *rdc=rawIn.product();
-  
+  const FEDRawDataCollection* rdc = rawIn.product();
+
   //   if ( ( rawData[i].provenance()->processName() != e.processHistory().rbegin()->processName() ) )
   //       continue ; // skip all raw collections not produced by the current process
-  
-  for ( int j=0; j< FEDNumbering::MAXFEDID; ++j ) 
-    {
-      bool rightFED=false;
-      for (uint32_t k=0; k<selFEDs.size(); k++)
-	{
-	  if (j==selFEDs[k])
-	   {
-	     rightFED=true;
-	   }
-       }
-     if (!rightFED) continue;
-     const FEDRawData & fedData = rdc->FEDData(j);
-     size_t size=fedData.size();
-     
-     if ( size > 0 ) 
-       {
-       // this fed has data -- lets copy it
-	 FEDRawData & fedDataProd = producedData->FEDData(j);
-	 if ( fedDataProd.size() != 0 ) {
-//	   std::cout << " More than one FEDRawDataCollection with data in FED ";
-//	   std::cout << j << " Skipping the 2nd\n";
-	   continue;
-	 }
-	 fedDataProd.resize(size);
-	 unsigned char *dataProd=fedDataProd.data();
-	 const unsigned char *data=fedData.data();
-	 for ( unsigned int k=0; k<size; ++k ) {
-	   dataProd[k]=data[k];
-	 }
-       }
-   }
 
- iEvent.put(std::move(producedData));
+  for (int j = 0; j < FEDNumbering::MAXFEDID; ++j) {
+    bool rightFED = false;
+    for (uint32_t k = 0; k < selFEDs.size(); k++) {
+      if (j == selFEDs[k]) {
+        rightFED = true;
+      }
+    }
+    if (!rightFED)
+      continue;
+    const FEDRawData& fedData = rdc->FEDData(j);
+    size_t size = fedData.size();
 
+    if (size > 0) {
+      // this fed has data -- lets copy it
+      FEDRawData& fedDataProd = producedData->FEDData(j);
+      if (fedDataProd.size() != 0) {
+        //	   std::cout << " More than one FEDRawDataCollection with data in FED ";
+        //	   std::cout << j << " Skipping the 2nd\n";
+        continue;
+      }
+      fedDataProd.resize(size);
+      unsigned char* dataProd = fedDataProd.data();
+      const unsigned char* data = fedData.data();
+      for (unsigned int k = 0; k < size; ++k) {
+        dataProd[k] = data[k];
+      }
+    }
+  }
+
+  iEvent.put(std::move(producedData));
 }
-
 
 // ------------ method called once each job just before starting event loop  ------------
-void SubdetFEDSelector::beginJob() {
-}
+void SubdetFEDSelector::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void SubdetFEDSelector::endJob() {
-}
+void SubdetFEDSelector::endJob() {}

--- a/CaloOnlineTools/EcalTools/interface/EcalFedMap.h
+++ b/CaloOnlineTools/EcalTools/interface/EcalFedMap.h
@@ -4,22 +4,20 @@
 #include <map>
 #include <string>
 
-class EcalFedMap{
-
- public: 
-
+class EcalFedMap {
+public:
   EcalFedMap();
   ~EcalFedMap();
   int getFedFromSlice(std::string);
   std::string getSliceFromFed(int);
 
- private:
+private:
   // use:
   // #include <boost/bimap.hpp>
-  // bimap< int, std::string > bm; 
+  // bimap< int, std::string > bm;
   // when available
 
-  std::map<int,  std::string> fedToSliceMap_;
-  std::map<std::string, int>  sliceToFedMap_;
+  std::map<int, std::string> fedToSliceMap_;
+  std::map<std::string, int> sliceToFedMap_;
 };
 #endif

--- a/CaloOnlineTools/EcalTools/plugins/EcalBxOrbitNumberGrapher.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalBxOrbitNumberGrapher.cc
@@ -1,8 +1,8 @@
 // -*- C++ -*-
 //
-// Package:   EcalBxOrbitNumberGrapher 
-// Class:     EcalBxOrbitNumberGrapher 
-// 
+// Package:   EcalBxOrbitNumberGrapher
+// Class:     EcalBxOrbitNumberGrapher
+//
 /**\class EcalBxOrbitNumberGrapher EcalBxOrbitNumberGrapher.cc
 
  Description: <one line class summary>
@@ -35,126 +35,93 @@ using namespace std;
 //
 // constructors and destructor
 //
-EcalBxOrbitNumberGrapher::EcalBxOrbitNumberGrapher(const edm::ParameterSet& iConfig) :
-  digiProducer_(iConfig.getParameter<std::string>("RawDigis")),
-  runNum_(-1),
-  fileName_ (iConfig.getUntrackedParameter<std::string>("fileName", std::string("ecalURechHitHists")))
-{
-  
-  
-}
+EcalBxOrbitNumberGrapher::EcalBxOrbitNumberGrapher(const edm::ParameterSet& iConfig)
+    : digiProducer_(iConfig.getParameter<std::string>("RawDigis")),
+      runNum_(-1),
+      fileName_(iConfig.getUntrackedParameter<std::string>("fileName", std::string("ecalURechHitHists"))) {}
 
-
-EcalBxOrbitNumberGrapher::~EcalBxOrbitNumberGrapher()
-{
-}
-
+EcalBxOrbitNumberGrapher::~EcalBxOrbitNumberGrapher() {}
 
 //
 // member functions
 //
 
 // ------------ method called to for each event  ------------
-void
-EcalBxOrbitNumberGrapher::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void EcalBxOrbitNumberGrapher::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
-   using namespace cms;
+  using namespace cms;
   //int ievt = iEvent.id().event();
   int orbit = -100;
   int bx = -100;
   int numorbiterrors = 0;
   bool orbiterror = false;
 
-  
   edm::Handle<EcalRawDataCollection> DCCHeaders;
   iEvent.getByLabel(digiProducer_, DCCHeaders);
   if (!DCCHeaders.isValid()) {
-	edm::LogError("BxOrbitNumber") << "can't get the product for EcalRawDataCollection";
+    edm::LogError("BxOrbitNumber") << "can't get the product for EcalRawDataCollection";
   }
 
   //-----------------BX STuff here
-   for ( EcalRawDataCollection::const_iterator headerItr= DCCHeaders->begin();headerItr != DCCHeaders->end(); 
-	  ++headerItr ) {
+  for (EcalRawDataCollection::const_iterator headerItr = DCCHeaders->begin(); headerItr != DCCHeaders->end();
+       ++headerItr) {
     headerItr->getEventSettings();
     int myorbit = headerItr->getOrbit();
     int mybx = headerItr->getBX();
-    
-    if ( orbit == -100 )
-    {
+
+    if (orbit == -100) {
       orbit = myorbit;
+    } else if (orbit != myorbit) {
+      std::cout << " NOOOO This header has a conflicting orbit OTHER " << orbit << " new " << myorbit << std::endl;
+      orbiterror = true;
+      numorbiterrors++;
+      orbitErrorBxDiffPlot_->Fill(myorbit - orbit);
     }
-    else if (orbit != myorbit)
-    {
-       std::cout << " NOOOO This header has a conflicting orbit OTHER " << orbit << " new " << myorbit  << std::endl;
-       orbiterror = true; 
-       numorbiterrors++;
-       orbitErrorBxDiffPlot_->Fill(myorbit - orbit);
-    }
-    
-    if ( bx == -100 )
-    {
+
+    if (bx == -100) {
       bx = mybx;
-    }
-    else if (bx != mybx)
-    {
-       std::cout << " NOOOO This header has a conflicting bx OTHER " << bx << " new " << mybx  << std::endl; 
+    } else if (bx != mybx) {
+      std::cout << " NOOOO This header has a conflicting bx OTHER " << bx << " new " << mybx << std::endl;
     }
     //LogDebug("EcalTimingCosmic") << " Lambda " << lambda; //hmm... this isn't good, I should keep a record of the wavelength in the headers as an inactive SM might have a different wavelength for this field and make this not go through.
   }
-  
-  if ( (bx != -100) & ( orbit != -100) )
-  {
-     std::cout << " Interesting event Orbit " << orbit << " BX " << bx << std::endl;
-     bxnumberPlot_->Fill(bx);
-     if (orbiterror) 
-     {
-        orbitErrorPlot_->Fill(bx);	
-     }
+
+  if ((bx != -100) & (orbit != -100)) {
+    std::cout << " Interesting event Orbit " << orbit << " BX " << bx << std::endl;
+    bxnumberPlot_->Fill(bx);
+    if (orbiterror) {
+      orbitErrorPlot_->Fill(bx);
+    }
   }
   numberofOrbitDiffPlot_->Fill(numorbiterrors);
-  
-  
-  if(runNum_==-1)
-  {
+
+  if (runNum_ == -1) {
     runNum_ = iEvent.id().run();
   }
 }
 
-
 // insert the hist map into the map keyed by FED number
-void EcalBxOrbitNumberGrapher::initHists(int FED)
-{
- 
-  
-}
+void EcalBxOrbitNumberGrapher::initHists(int FED) {}
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-EcalBxOrbitNumberGrapher::beginJob()
-{
-  bxnumberPlot_ = new TH1F("bxnumber", "BX number of interexting events",3600, 0., 3600.);
-  orbitErrorPlot_ = new TH1F("bxOfOrbitDiffs", "BX number of interexting events with orbit changes",3600, 0., 3600.);
-  orbitErrorBxDiffPlot_ = new TH1F("orbitErrorDiffPlot","Orbit Difference of those HEADERS that have a difference",20,-10.,10.);
-  numberofOrbitDiffPlot_ = new TH1F("numberOfOrbitDiffsPlot","Number of Orbit Differences",54,0., 54.);
+void EcalBxOrbitNumberGrapher::beginJob() {
+  bxnumberPlot_ = new TH1F("bxnumber", "BX number of interexting events", 3600, 0., 3600.);
+  orbitErrorPlot_ = new TH1F("bxOfOrbitDiffs", "BX number of interexting events with orbit changes", 3600, 0., 3600.);
+  orbitErrorBxDiffPlot_ =
+      new TH1F("orbitErrorDiffPlot", "Orbit Difference of those HEADERS that have a difference", 20, -10., 10.);
+  numberofOrbitDiffPlot_ = new TH1F("numberOfOrbitDiffsPlot", "Number of Orbit Differences", 54, 0., 54.);
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-EcalBxOrbitNumberGrapher::endJob()
-{
+void EcalBxOrbitNumberGrapher::endJob() {
   using namespace std;
   fileName_ += ".bx.root";
 
-  TFile root_file_(fileName_.c_str() , "RECREATE");
+  TFile root_file_(fileName_.c_str(), "RECREATE");
 
   bxnumberPlot_->Write();
   orbitErrorPlot_->Write();
   numberofOrbitDiffPlot_->Write();
   orbitErrorBxDiffPlot_->Write();
   root_file_.Close();
-
 }
-
-
-

--- a/CaloOnlineTools/EcalTools/plugins/EcalBxOrbitNumberGrapher.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalBxOrbitNumberGrapher.h
@@ -1,9 +1,9 @@
 
 // -*- C++ -*-
 //
-// Package:   EcalBxOrbitNumberGrapher 
-// Class:     EcalBxOrbitNumberGrapher 
-// 
+// Package:   EcalBxOrbitNumberGrapher
+// Class:     EcalBxOrbitNumberGrapher
+//
 /**\class EcalBxOrbitNumberGrapher EcalBxOrbitNumberGrapher.cc
 
  Description: <one line class summary>
@@ -16,7 +16,6 @@
 //         Created:  Th Nov 22 5:46:22 CEST 2007
 //
 //
-
 
 // system include files
 #include <memory>
@@ -37,31 +36,26 @@
 
 #include "DataFormats/EcalRawData/interface/EcalRawDataCollections.h"
 
-
-
 #include "TFile.h"
 #include "TH1F.h"
-
 
 //
 // class declaration
 //
 
 class EcalBxOrbitNumberGrapher : public edm::EDAnalyzer {
-   public:
-      explicit EcalBxOrbitNumberGrapher(const edm::ParameterSet&);
-      ~EcalBxOrbitNumberGrapher() override;
+public:
+  explicit EcalBxOrbitNumberGrapher(const edm::ParameterSet&);
+  ~EcalBxOrbitNumberGrapher() override;
 
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+  void initHists(int);
 
-   private:
-      void beginJob() override;
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob() override ;
-      void initHists(int);
+  // ----------member data ---------------------------
 
-    // ----------member data ---------------------------
-
- 
   std::string digiProducer_;
   int runNum_;
   std::string fileName_;
@@ -72,5 +66,4 @@ class EcalBxOrbitNumberGrapher : public edm::EDAnalyzer {
   TH1F* numberofOrbitDiffPlot_;
 
   TFile* file;
-  
 };

--- a/CaloOnlineTools/EcalTools/plugins/EcalCosmicsHists.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalCosmicsHists.cc
@@ -1,8 +1,8 @@
 // -*- C++ -*-
 //
-// Package:   EcalCosmicsHists 
-// Class:     EcalCosmicsHists  
-// 
+// Package:   EcalCosmicsHists
+// Class:     EcalCosmicsHists
+//
 /**\class EcalCosmicsHists EcalCosmicsHists.cc
 
  Description: <one line class summary>
@@ -11,7 +11,6 @@
      <Notes on implementation>
 */
 
- 
 #include "CaloOnlineTools/EcalTools/plugins/EcalCosmicsHists.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
@@ -36,11 +35,9 @@
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
 #include "CondFormats/DataRecord/interface/EcalADCToGeVConstantRcd.h"
 
-
 #include <vector>
 #include "TLine.h"
 
- 
 using namespace cms;
 using namespace edm;
 using namespace std;
@@ -56,28 +53,27 @@ using namespace std;
 //
 // constructors and destructor
 //
-EcalCosmicsHists::EcalCosmicsHists(const edm::ParameterSet& iConfig) :
-  ecalRawDataColl_(iConfig.getParameter<edm::InputTag>("ecalRawDataColl")),
-  ecalRecHitCollectionEB_ (iConfig.getParameter<edm::InputTag>("ecalRecHitCollectionEB")),
-  ecalRecHitCollectionEE_ (iConfig.getParameter<edm::InputTag>("ecalRecHitCollectionEE")),
-  barrelClusterCollection_ (iConfig.getParameter<edm::InputTag>("barrelClusterCollection")),
-  endcapClusterCollection_ (iConfig.getParameter<edm::InputTag>("endcapClusterCollection")),
-  l1GTReadoutRecTag_ (iConfig.getUntrackedParameter<std::string>("L1GlobalReadoutRecord","gtDigis")),
-  l1GMTReadoutRecTag_ (iConfig.getUntrackedParameter<std::string>("L1GlobalMuonReadoutRecord","gtDigis")),
-  runNum_(-1),
-  histRangeMax_ (iConfig.getUntrackedParameter<double>("histogramMaxRange",1.8)),
-  histRangeMin_ (iConfig.getUntrackedParameter<double>("histogramMinRange",0.0)),
-  minTimingAmpEB_ (iConfig.getUntrackedParameter<double>("MinTimingAmpEB",0.100)),
-  minTimingAmpEE_ (iConfig.getUntrackedParameter<double>("MinTimingAmpEE",0.100)),
-  minRecHitAmpEB_(iConfig.getUntrackedParameter<double>("MinRecHitAmpEB",0.027)),
-  minRecHitAmpEE_(iConfig.getUntrackedParameter<double>("MinRecHitAmpEE",0.18)),
-  minHighEnergy_(iConfig.getUntrackedParameter<double>("MinHighEnergy",2.0)),
-  fileName_ (iConfig.getUntrackedParameter<std::string>("fileName", std::string("ecalCosmicHists"))),
-  runInFileName_(iConfig.getUntrackedParameter<bool>("runInFileName",true)),
-  startTime_ (iConfig.getUntrackedParameter<double>("TimeStampStart",1215107133.)),
-  runTimeLength_ (iConfig.getUntrackedParameter<double>("TimeStampLength",3.)),
-  numTimingBins_(iConfig.getUntrackedParameter<int>("TimeStampBins",1800))
-{
+EcalCosmicsHists::EcalCosmicsHists(const edm::ParameterSet& iConfig)
+    : ecalRawDataColl_(iConfig.getParameter<edm::InputTag>("ecalRawDataColl")),
+      ecalRecHitCollectionEB_(iConfig.getParameter<edm::InputTag>("ecalRecHitCollectionEB")),
+      ecalRecHitCollectionEE_(iConfig.getParameter<edm::InputTag>("ecalRecHitCollectionEE")),
+      barrelClusterCollection_(iConfig.getParameter<edm::InputTag>("barrelClusterCollection")),
+      endcapClusterCollection_(iConfig.getParameter<edm::InputTag>("endcapClusterCollection")),
+      l1GTReadoutRecTag_(iConfig.getUntrackedParameter<std::string>("L1GlobalReadoutRecord", "gtDigis")),
+      l1GMTReadoutRecTag_(iConfig.getUntrackedParameter<std::string>("L1GlobalMuonReadoutRecord", "gtDigis")),
+      runNum_(-1),
+      histRangeMax_(iConfig.getUntrackedParameter<double>("histogramMaxRange", 1.8)),
+      histRangeMin_(iConfig.getUntrackedParameter<double>("histogramMinRange", 0.0)),
+      minTimingAmpEB_(iConfig.getUntrackedParameter<double>("MinTimingAmpEB", 0.100)),
+      minTimingAmpEE_(iConfig.getUntrackedParameter<double>("MinTimingAmpEE", 0.100)),
+      minRecHitAmpEB_(iConfig.getUntrackedParameter<double>("MinRecHitAmpEB", 0.027)),
+      minRecHitAmpEE_(iConfig.getUntrackedParameter<double>("MinRecHitAmpEE", 0.18)),
+      minHighEnergy_(iConfig.getUntrackedParameter<double>("MinHighEnergy", 2.0)),
+      fileName_(iConfig.getUntrackedParameter<std::string>("fileName", std::string("ecalCosmicHists"))),
+      runInFileName_(iConfig.getUntrackedParameter<bool>("runInFileName", true)),
+      startTime_(iConfig.getUntrackedParameter<double>("TimeStampStart", 1215107133.)),
+      runTimeLength_(iConfig.getUntrackedParameter<double>("TimeStampLength", 3.)),
+      numTimingBins_(iConfig.getUntrackedParameter<int>("TimeStampBins", 1800)) {
   naiveEvtNum_ = 0;
   cosmicCounter_ = 0;
   cosmicCounterEB_ = 0;
@@ -88,100 +84,88 @@ EcalCosmicsHists::EcalCosmicsHists(const edm::ParameterSet& iConfig) :
   // TrackAssociator parameters
   edm::ParameterSet trkParameters = iConfig.getParameter<edm::ParameterSet>("TrackAssociatorParameters");
   edm::ConsumesCollector iC = consumesCollector();
-  trackParameters_.loadParameters( trkParameters, iC );
+  trackParameters_.loadParameters(trkParameters, iC);
   trackAssociator_.useDefaultPropagator();
-  
+
   string title1 = "Seed Energy for All Feds; Seed Energy (GeV)";
   string name1 = "SeedEnergyAllFEDs";
-  int numBins = 200;//(int)round(histRangeMax_-histRangeMin_)+1;
-  allFedsHist_ = new TH1F(name1.c_str(),title1.c_str(),numBins,histRangeMin_,histRangeMax_);
-  
+  int numBins = 200;  //(int)round(histRangeMax_-histRangeMin_)+1;
+  allFedsHist_ = new TH1F(name1.c_str(), title1.c_str(), numBins, histRangeMin_, histRangeMax_);
+
   fedMap_ = new EcalFedMap();
 }
 
-
-EcalCosmicsHists::~EcalCosmicsHists()
-{
-}
-
+EcalCosmicsHists::~EcalCosmicsHists() {}
 
 //
 // member functions
 //
 
 // ------------ method called to for each event  ------------
-void
-EcalCosmicsHists::analyze(edm::Event const & iEvent, edm::EventSetup const & iSetup)
-{
+void EcalCosmicsHists::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
   bool hasEndcapClusters = true;
   int ievt = iEvent.id().event();
-  
-  edm::Handle<reco::SuperClusterCollection> bscHandle;  
-  edm::Handle<reco::SuperClusterCollection> escHandle;  
-  
+
+  edm::Handle<reco::SuperClusterCollection> bscHandle;
+  edm::Handle<reco::SuperClusterCollection> escHandle;
+
   naiveEvtNum_++;
-  
+
   //LogDebug("EcalCosmicsHists")<< "  My Event: " << naiveEvtNum_ << " " << iEvent.id().run() << " " << iEvent.id().event() << " " << iEvent.time().value();
   //LogDebug("EcalCosmicsHists")<< "Timestamp: " << iEvent.id().run() << " " << iEvent.id().event() << " " << iEvent.time().value();
-  
 
   // check DB payload
   edm::ESHandle<EcalADCToGeVConstant> pAgc;
   iSetup.get<EcalADCToGeVConstantRcd>().get(pAgc);
   const EcalADCToGeVConstant* agc = pAgc.product();
-  if (naiveEvtNum_<=1) {
-    LogWarning("EcalCosmicsHists") << "Global EB ADC->GeV scale: " << agc->getEBValue() << " GeV/ADC count" ;
-    LogWarning("EcalCosmicsHists") << "Global EE ADC->GeV scale: " << agc->getEEValue() << " GeV/ADC count" ;
+  if (naiveEvtNum_ <= 1) {
+    LogWarning("EcalCosmicsHists") << "Global EB ADC->GeV scale: " << agc->getEBValue() << " GeV/ADC count";
+    LogWarning("EcalCosmicsHists") << "Global EE ADC->GeV scale: " << agc->getEEValue() << " GeV/ADC count";
   }
-    //float adcEBconst = agc->getEBValue();
-    //float adcEEconst = agc->getEEValue();
-
+  //float adcEBconst = agc->getEBValue();
+  //float adcEEconst = agc->getEEValue();
 
   //
 
   //===================TIMESTAMP INFORMTION=================================
   // Code added to get the time in seconds
-  unsigned int  timeStampLow = ( 0xFFFFFFFF & iEvent.time().value() );
-  unsigned int  timeStampHigh = ( iEvent.time().value() >> 32 );
-  double rawEventTime = ( double)(timeStampHigh)+((double )(timeStampLow)/1000000.);
-  double eventTime = rawEventTime - startTime_; //Notice the subtraction of the "starttime"
-  //std::cout << "Event Time " << eventTime << " High " <<timeStampHigh<< " low"<<timeStampLow <<" value " <<iEvent.time().value() << std::endl;  
+  unsigned int timeStampLow = (0xFFFFFFFF & iEvent.time().value());
+  unsigned int timeStampHigh = (iEvent.time().value() >> 32);
+  double rawEventTime = (double)(timeStampHigh) + ((double)(timeStampLow) / 1000000.);
+  double eventTime = rawEventTime - startTime_;  //Notice the subtraction of the "starttime"
+  //std::cout << "Event Time " << eventTime << " High " <<timeStampHigh<< " low"<<timeStampLow <<" value " <<iEvent.time().value() << std::endl;
   //========================================================================
 
   iEvent.getByLabel(barrelClusterCollection_, bscHandle);
-  if (!(bscHandle.isValid())) 
-    {
-      LogWarning("EcalCosmicsHists") << barrelClusterCollection_ << " not available";
-      return;
-    }
+  if (!(bscHandle.isValid())) {
+    LogWarning("EcalCosmicsHists") << barrelClusterCollection_ << " not available";
+    return;
+  }
   LogDebug("EcalCosmicsHists") << "event " << ievt;
-  
+
   iEvent.getByLabel(endcapClusterCollection_, escHandle);
-  if (!(escHandle.isValid())) 
-    {
-      LogWarning("EcalCosmicsHists") << endcapClusterCollection_ << " not available";
-      hasEndcapClusters = false;
-      //return;
-    }
-  
+  if (!(escHandle.isValid())) {
+    LogWarning("EcalCosmicsHists") << endcapClusterCollection_ << " not available";
+    hasEndcapClusters = false;
+    //return;
+  }
+
   Handle<EcalRecHitCollection> hits;
   iEvent.getByLabel(ecalRecHitCollectionEB_, hits);
-  if (!(hits.isValid())) 
-    {
-      LogWarning("EcalCosmicsHists") << ecalRecHitCollectionEB_ << " not available";
-      return;
-    }
+  if (!(hits.isValid())) {
+    LogWarning("EcalCosmicsHists") << ecalRecHitCollectionEB_ << " not available";
+    return;
+  }
   Handle<EcalRecHitCollection> hitsEE;
   iEvent.getByLabel(ecalRecHitCollectionEE_, hitsEE);
-  if (!(hitsEE.isValid())) 
-    {
-      LogWarning("EcalCosmicsHists") << ecalRecHitCollectionEE_ << " not available";
-      return;
-    }
-  
+  if (!(hitsEE.isValid())) {
+    LogWarning("EcalCosmicsHists") << ecalRecHitCollectionEE_ << " not available";
+    return;
+  }
+
   Handle<EcalRawDataCollection> DCCHeaders;
   iEvent.getByLabel(ecalRawDataColl_, DCCHeaders);
-  if(!DCCHeaders.isValid())
+  if (!DCCHeaders.isValid())
     LogWarning("EcalCosmicsHists") << "DCC headers not available";
 
   //make the bx histos right here
@@ -190,399 +174,406 @@ EcalCosmicsHists::analyze(edm::Event const & iEvent, edm::EventSetup const & iSe
   int bx = -100;
   int runType = -100;
 
-  for(EcalRawDataCollection::const_iterator headerItr= DCCHeaders->begin();headerItr != DCCHeaders->end(); 
-      ++headerItr) {
+  for (EcalRawDataCollection::const_iterator headerItr = DCCHeaders->begin(); headerItr != DCCHeaders->end();
+       ++headerItr) {
     headerItr->getEventSettings();
     int myorbit = headerItr->getOrbit();
     int mybx = headerItr->getBX();
     int myRunType = headerItr->getRunType();
     int FEDid = headerItr->fedId();
     TH2F* dccRuntypeHist = FEDsAndDCCRuntypeVsBxHists_[FEDid];
-    if(dccRuntypeHist==nullptr)
-    {
+    if (dccRuntypeHist == nullptr) {
       initHists(FEDid);
       dccRuntypeHist = FEDsAndDCCRuntypeVsBxHists_[FEDid];
     }
-    dccRuntypeHist->Fill(mybx,myRunType);
-    
-    if (bx == -100)
-    {
+    dccRuntypeHist->Fill(mybx, myRunType);
+
+    if (bx == -100) {
       bx = mybx;
-    }
-    else if (bx != mybx)
-    {
+    } else if (bx != mybx) {
       LogWarning("EcalCosmicsHists") << "This header has a conflicting bx OTHERS were " << bx << " here " << mybx;
       dccBXErrorByFEDHist_->Fill(headerItr->fedId());
-      if(bx != -100)
-      {
-        dccErrorVsBxHist_->Fill(bx,0);
+      if (bx != -100) {
+        dccErrorVsBxHist_->Fill(bx, 0);
       }
     }
 
-    if (runType == -100)
-    {
+    if (runType == -100) {
       runType = myRunType;
-    }
-    else if (runType != myRunType)
-    {
+    } else if (runType != myRunType) {
       LogWarning("EcalCosmicsHists") << "This header has a conflicting runType OTHERS were " << bx << " here " << mybx;
       dccRuntypeErrorByFEDHist_->Fill(headerItr->fedId());
-      if(bx != -100)
-        dccErrorVsBxHist_->Fill(bx,2);
+      if (bx != -100)
+        dccErrorVsBxHist_->Fill(bx, 2);
     }
-    
-    
-    if (orbit == -100)
-    {
+
+    if (orbit == -100) {
       orbit = myorbit;
-    }
-    else if (orbit != myorbit)
-    {
-      LogWarning("EcalCosmicsHists") << "This header has a conflicting orbit; OTHERS were " << orbit << " here " << myorbit;
+    } else if (orbit != myorbit) {
+      LogWarning("EcalCosmicsHists") << "This header has a conflicting orbit; OTHERS were " << orbit << " here "
+                                     << myorbit;
       dccOrbitErrorByFEDHist_->Fill(headerItr->fedId());
-      if(bx != -100)
-        dccErrorVsBxHist_->Fill(bx,1);
+      if (bx != -100)
+        dccErrorVsBxHist_->Fill(bx, 1);
     }
   }
-  dccEventVsBxHist_->Fill(bx,runType);
+  dccEventVsBxHist_->Fill(bx, runType);
   dccRuntypeHist_->Fill(runType);
 
-
-  
-  std::vector<bool> l1Triggers = determineTriggers(iEvent, iSetup);      
+  std::vector<bool> l1Triggers = determineTriggers(iEvent, iSetup);
   bool isEcalL1 = l1Triggers[4];
   bool isHCALL1 = l1Triggers[3];
   bool isRPCL1 = l1Triggers[2];
   bool isCSCL1 = l1Triggers[1];
   bool isDTL1 = l1Triggers[0];
-  
-  if(runNum_==-1)
-    {
-      runNum_ = iEvent.id().run();
-    }      
-  
-  int  numberOfCosmics = 0;
-  int  numberOfCosmicsEB = 0;
-  int  numberOfCosmicsEEP = 0;
-  int  numberOfCosmicsEEM = 0;
-  int  numberOfCosmicsTop = 0;
-  int  numberOfCosmicsBottom = 0;
-  int  numberOfHighEClusters = 0;
+
+  if (runNum_ == -1) {
+    runNum_ = iEvent.id().run();
+  }
+
+  int numberOfCosmics = 0;
+  int numberOfCosmicsEB = 0;
+  int numberOfCosmicsEEP = 0;
+  int numberOfCosmicsEEM = 0;
+  int numberOfCosmicsTop = 0;
+  int numberOfCosmicsBottom = 0;
+  int numberOfHighEClusters = 0;
   //int eventnum = iEvent.id().event();
   std::vector<EBDetId> seeds;
-  
+
   //++++++++++++++++++BEGIN LOOP OVER EB SUPERCLUSTERS+++++++++++++++++++++++++//
 
-  const reco::SuperClusterCollection *clusterCollection_p = bscHandle.product();
-  for (reco::SuperClusterCollection::const_iterator clus = clusterCollection_p->begin(); clus != clusterCollection_p->end(); ++clus) 
-   {
-     double energy = clus->energy();
-     double phi    = clus->phi();
-     double eta    = clus->eta();
-     double time = -1000.0;
-     double ampli = 0.;
-     double secondMin = 0.;
-     double secondTime = -1000.;
-     int numXtalsinCluster = 0;
-     
-     EBDetId maxDet;
-     EBDetId secDet;
-     
-     numberofBCinSC_->Fill(clus->clustersSize());
-     numberofBCinSCphi_->Fill(phi,clus->clustersSize());     
-     
-     for (reco::CaloCluster_iterator bclus = (clus->clustersBegin()); bclus != (clus->clustersEnd()); ++bclus) 
-       {
-	 double cphi = (*bclus)->phi();
-	 double ceta = (*bclus)->eta();     
-	 TrueBCOccupancy_->Fill(cphi,ceta);
-	 TrueBCOccupancyCoarse_->Fill(cphi,ceta);
-       }
-     
-     std::vector< std::pair<DetId, float> > clusterDetIds = clus->hitsAndFractions();//get these from the cluster
-     for(std::vector<std::pair<DetId, float> >::const_iterator detitr = clusterDetIds.begin(); detitr != clusterDetIds.end(); ++detitr) 
-       {
-	 //Here I use the "find" on a digi collection... I have been warned...
-	 if ((*detitr).first.det() != DetId::Ecal) { std::cout << " det is " <<(*detitr).first.det() << std::endl;continue;}
-	 if ((*detitr).first.subdetId() != EcalBarrel) {std::cout << " subdet is " <<(*detitr).first.subdetId() << std::endl; continue; }
-	 EcalRecHitCollection::const_iterator thishit = hits->find((*detitr).first);
-	 if (thishit == hits->end()) continue;
-	 //The checking above should no longer be needed...... as only those in the cluster would already have rechits..
-	 
-	 EcalRecHit myhit = (*thishit);
-	 
-	 double thisamp = myhit.energy();
-	 if (thisamp > minRecHitAmpEB_) {numXtalsinCluster++; }
-	 if (thisamp > secondMin) {secondMin = thisamp; secondTime = myhit.time(); secDet = (EBDetId)(*detitr).first;}
-	 if (secondMin > ampli) {std::swap(ampli,secondMin); std::swap(time,secondTime); std::swap(maxDet,secDet);}
-       }
-     
-     double fullnumXtalsinCluster = clusterDetIds.size();     
-     
-     float E2 = ampli + secondMin;
-     EcalElectronicsId elecId = ecalElectronicsMap_->getElectronicsId((EBDetId) maxDet);
-     int FEDid = 600+elecId.dccId();
-     
-     numberOfCosmics++;
-     numberOfCosmicsEB++;
-     
-     //Set some more values
-     seeds.push_back(maxDet);
-     int ieta = maxDet.ieta();
-     int iphi = maxDet.iphi();
-     int ietaSM = maxDet.ietaSM();
-     int iphiSM = maxDet.iphiSM();
-     
-     int LM = ecalElectronicsMap_->getLMNumber(maxDet) ;//FIX ME
-     
-     // top and bottom clusters
-     if (iphi>0&&iphi<180) { 
-       numberOfCosmicsTop++;
-     } else {
-       numberOfCosmicsBottom++;
-     }      
-     
-     // fill the proper hist
-     TH1F* uRecHist = FEDsAndHists_[FEDid];
-     TH1F* E2uRecHist = FEDsAndE2Hists_[FEDid];
-     TH1F* energyuRecHist = FEDsAndenergyHists_[FEDid];
-     TH1F* timingHist = FEDsAndTimingHists_[FEDid];
-     TH1F* freqHist = FEDsAndFrequencyHists_[FEDid];
-     TH1F* iphiProfileHist = FEDsAndiPhiProfileHists_[FEDid];
-     TH1F* ietaProfileHist = FEDsAndiEtaProfileHists_[FEDid];
-     TH2F* timingHistVsFreq = FEDsAndTimingVsFreqHists_[FEDid];
-     TH2F* timingHistVsAmp = FEDsAndTimingVsAmpHists_[FEDid];
-     TH2F* E2vsE1uRecHist = FEDsAndE2vsE1Hists_[FEDid];
-     TH2F* energyvsE1uRecHist = FEDsAndenergyvsE1Hists_[FEDid];
-     TH2F* occupHist = FEDsAndOccupancyHists_[FEDid];
-     TH2F* timingHistVsPhi = FEDsAndTimingVsPhiHists_[FEDid];
-     TH2F* timingHistVsModule = FEDsAndTimingVsModuleHists_[FEDid];
-     
-     if(uRecHist==nullptr)
-       {
-	 initHists(FEDid);
-	 uRecHist = FEDsAndHists_[FEDid];
-	 E2uRecHist = FEDsAndE2Hists_[FEDid];
-	 energyuRecHist = FEDsAndenergyHists_[FEDid];
-	 timingHist = FEDsAndTimingHists_[FEDid];
-	 freqHist = FEDsAndFrequencyHists_[FEDid];
-	 timingHistVsFreq = FEDsAndTimingVsFreqHists_[FEDid];
-	 timingHistVsAmp = FEDsAndTimingVsAmpHists_[FEDid];
-	 iphiProfileHist = FEDsAndiPhiProfileHists_[FEDid];
-	 ietaProfileHist = FEDsAndiEtaProfileHists_[FEDid];
-	 E2vsE1uRecHist = FEDsAndE2vsE1Hists_[FEDid];
-	 energyvsE1uRecHist = FEDsAndenergyvsE1Hists_[FEDid];
-	 occupHist = FEDsAndOccupancyHists_[FEDid];
-	 timingHistVsPhi = FEDsAndTimingVsPhiHists_[FEDid];
-	 timingHistVsModule = FEDsAndTimingVsModuleHists_[FEDid];
-       }
-     
-     uRecHist->Fill(ampli);
-     E2uRecHist->Fill(E2);
-     E2vsE1uRecHist->Fill(ampli,E2);
-     energyuRecHist->Fill(energy);
-     energyvsE1uRecHist->Fill(ampli,energy);
-     allFedsHist_->Fill(ampli);
-     allFedsE2Hist_->Fill(E2); 
-     allFedsenergyHist_->Fill(energy);
-     allFedsenergyHighHist_->Fill(energy);
-     allFedsE2vsE1Hist_->Fill(ampli,E2);
-     allFedsenergyvsE1Hist_->Fill(ampli,energy);
-     freqHist->Fill(naiveEvtNum_);
-     iphiProfileHist->Fill(iphi);
-     ietaProfileHist->Fill(ieta);
-     
-     allFedsFrequencyHist_->Fill(naiveEvtNum_);
-     allFedsiPhiProfileHist_->Fill(iphi);
-     allFedsiEtaProfileHist_->Fill(ieta);
-     allOccupancy_->Fill(iphi, ieta);
-     TrueOccupancy_->Fill(phi, eta);
-     allOccupancyCoarse_->Fill(iphi, ieta);
-     TrueOccupancyCoarse_->Fill(phi, eta);
-     allFedsNumXtalsInClusterHist_->Fill(numXtalsinCluster);
-     NumXtalsInClusterHist_->Fill(fullnumXtalsinCluster);
-     numxtalsVsEnergy_->Fill(energy,numXtalsinCluster);
-     numxtalsVsHighEnergy_->Fill(energy,numXtalsinCluster);
-     
-     //Fill the hists for the time stamp information
-     allFedsFreqTimeVsPhiHist_->Fill(iphi,eventTime);
-     allFedsFreqTimeVsPhiTTHist_->Fill(iphi,eventTime);
-     allFedsFreqTimeVsEtaHist_->Fill(eventTime,ieta);
-     allFedsFreqTimeVsEtaTTHist_->Fill(eventTime,ieta);
-     //end time stamp hists
-     
-     occupHist->Fill(ietaSM,iphiSM);
-     if (fullnumXtalsinCluster==1) {
-       allOccupancySingleXtal_->Fill(iphi, ieta);
-       energySingleXtalHist_->Fill(energy);
-     }
-     
-     // Exclusive trigger plots
-     
-     if(isEcalL1&&!isDTL1&&!isRPCL1&&!isCSCL1&&!isHCALL1) {
-       allOccupancyExclusiveECAL_->Fill(iphi, ieta);
-       allOccupancyCoarseExclusiveECAL_->Fill(iphi, ieta);
-       if (ampli > minTimingAmpEB_) {
-	 allFedsTimingHistECAL_->Fill(time);
-	 allFedsTimingPhiEtaHistECAL_->Fill(iphi,ieta,time);
-	 allFedsTimingTTHistECAL_->Fill(iphi,ieta,time);
-	 allFedsTimingLMHistECAL_->Fill(LM,time);
-       }      
-       triggerExclusiveHist_->Fill(0);
-     } 
-     
-     if(!isEcalL1&&!isDTL1&&!isRPCL1&&!isCSCL1&&isHCALL1) {   
-       allOccupancyExclusiveHCAL_->Fill(iphi, ieta);
-       allOccupancyCoarseExclusiveHCAL_->Fill(iphi, ieta);
-       if (ampli > minTimingAmpEB_) {
-	 allFedsTimingHistHCAL_->Fill(time);
-	 allFedsTimingPhiEtaHistHCAL_->Fill(iphi,ieta,time);
-	 allFedsTimingTTHistHCAL_->Fill(iphi,ieta,time);
-	 allFedsTimingLMHistHCAL_->Fill(LM,time);
-       }      
-       triggerExclusiveHist_->Fill(1);
-     }
-     
-     if(!isEcalL1&&isDTL1&&!isRPCL1&&!isCSCL1&&!isHCALL1) {
-       allOccupancyExclusiveDT_->Fill(iphi, ieta);
-       allOccupancyCoarseExclusiveDT_->Fill(iphi, ieta);
-       if (ampli > minTimingAmpEB_) {
-	 allFedsTimingHistDT_->Fill(time);
-	 allFedsTimingPhiEtaHistDT_->Fill(iphi,ieta,time);
-	 allFedsTimingTTHistDT_->Fill(iphi,ieta,time);
-	 allFedsTimingLMHistDT_->Fill(LM,time);
-       }      
-       triggerExclusiveHist_->Fill(2);
-     }
-     
-     if(!isEcalL1&&!isDTL1&&isRPCL1&&!isCSCL1&&!isHCALL1) {
-       allOccupancyExclusiveRPC_->Fill(iphi, ieta);
-       allOccupancyCoarseExclusiveRPC_->Fill(iphi, ieta);
-       if (ampli > minTimingAmpEB_) {
-	 allFedsTimingHistRPC_->Fill(time);
-	 allFedsTimingPhiEtaHistRPC_->Fill(iphi,ieta,time);
-	 allFedsTimingTTHistRPC_->Fill(iphi,ieta,time);
-	 allFedsTimingLMHistRPC_->Fill(LM,time);
-       }      
-       triggerExclusiveHist_->Fill(3);
-     }
-     
-     if(!isEcalL1&&!isDTL1&&!isRPCL1&&isCSCL1&&!isHCALL1) {   
-       allOccupancyExclusiveCSC_->Fill(iphi, ieta);
-       allOccupancyCoarseExclusiveCSC_->Fill(iphi, ieta);
-       if (ampli > minTimingAmpEB_) {
-	 allFedsTimingHistCSC_->Fill(time);
-	 allFedsTimingPhiEtaHistCSC_->Fill(iphi,ieta,time);
-	 allFedsTimingTTHistCSC_->Fill(iphi,ieta,time);
-	 allFedsTimingLMHistCSC_->Fill(LM,time);
-       }      
-       triggerExclusiveHist_->Fill(4);
-     }
-     
-     // Inclusive trigger plots
-     
-     if (isEcalL1) { 
-       triggerHist_->Fill(0);
-       allOccupancyECAL_->Fill(iphi, ieta);
-       allOccupancyCoarseECAL_->Fill(iphi, ieta);
-     }
-     if (isHCALL1) {
-       triggerHist_->Fill(1);
-       allOccupancyHCAL_->Fill(iphi, ieta);
-       allOccupancyCoarseHCAL_->Fill(iphi, ieta);
-     }
-     if (isDTL1)   {
-       triggerHist_->Fill(2);
-       allOccupancyDT_->Fill(iphi, ieta);
-       allOccupancyCoarseDT_->Fill(iphi, ieta);
-     }
-     if (isRPCL1)  {
-       triggerHist_->Fill(3);
-       allOccupancyRPC_->Fill(iphi, ieta);
-       allOccupancyCoarseRPC_->Fill(iphi, ieta);
-     }
-     if (isCSCL1)  {
-       triggerHist_->Fill(4);
-       allOccupancyCSC_->Fill(iphi, ieta);
-       allOccupancyCoarseCSC_->Fill(iphi, ieta);
-     }
-     
-     // Fill histo for Ecal+muon coincidence
-     if(isEcalL1&&(isCSCL1||isRPCL1||isDTL1)&&!isHCALL1)
-       allFedsTimingHistEcalMuon_->Fill(time);
-     
-     if (ampli > minTimingAmpEB_) {
-       timingHist->Fill(time);
-       timingHistVsFreq->Fill(time, naiveEvtNum_);
-       timingHistVsAmp->Fill(time, ampli);
-       allFedsTimingHist_->Fill(time);
-       allFedsTimingVsAmpHist_->Fill(time, ampli);
-       allFedsTimingVsFreqHist_->Fill(time, naiveEvtNum_);
-       timingHistVsPhi->Fill(time, iphiSM);
-       timingHistVsModule->Fill(time, ietaSM);
-       allFedsTimingPhiHist_->Fill(iphi,time);
-       allFedsTimingPhiEtaHist_->Fill(iphi,ieta,time);
-       allFedsTimingTTHist_->Fill(iphi,ieta,time);
-       allFedsTimingLMHist_->Fill(LM,time);
-       if (FEDid>=610&&FEDid<=627)  allFedsTimingPhiEbmHist_->Fill(iphi,time);
-       if (FEDid>=628&&FEDid<=645)  allFedsTimingPhiEbpHist_->Fill(iphi,time);
-       
-       if (FEDid>=610&&FEDid<=627)  allFedsTimingEbmHist_->Fill(time);
-       if (FEDid>=628&&FEDid<=645)  allFedsTimingEbpHist_->Fill(time);
-       if (FEDid>=613&&FEDid<=616)  allFedsTimingEbmTopHist_->Fill(time);
-       if (FEDid>=631&&FEDid<=634)  allFedsTimingEbpTopHist_->Fill(time);
-       if (FEDid>=622&&FEDid<=625)  allFedsTimingEbmBottomHist_->Fill(time);
-       if (FEDid>=640&&FEDid<=643)  allFedsTimingEbpBottomHist_->Fill(time);
-     }         
-     
-     // *** High Energy Clusters Analysis ** //
-     
-     if (energy>minHighEnergy_) {
-       
-       LogInfo("EcalCosmicsHists") << "High energy event " << iEvent.id().run() << " : " 
-				   << iEvent.id().event() << " " << naiveEvtNum_  
-				   << " : " << energy << " " << numXtalsinCluster
-				   << " : " << iphi << " " << ieta 
-				   << " : " << isEcalL1 << isHCALL1 << isDTL1 << isRPCL1 << isCSCL1 ;
-       
-       numberOfHighEClusters++;
-       allOccupancyHighEnergy_->Fill(iphi, ieta);
-       allOccupancyHighEnergyCoarse_->Fill(iphi, ieta);    
-       allFedsOccupancyHighEnergyHist_->Fill(iphi,ieta,energy);
-       allFedsenergyOnlyHighHist_->Fill(energy);
-       
-       HighEnergy_2GeV_occuCoarse->Fill(iphi,ieta);    
-       HighEnergy_2GeV_occu3D->Fill(iphi,ieta,energy);
-       
-       HighEnergy_NumXtal->Fill(fullnumXtalsinCluster);
-       HighEnergy_NumXtalFedId->Fill(FEDid,fullnumXtalsinCluster);
-       HighEnergy_NumXtaliphi->Fill(iphi,fullnumXtalsinCluster);
-       HighEnergy_energy3D->Fill(iphi,ieta,energy);
-       HighEnergy_energyNumXtal->Fill(fullnumXtalsinCluster,energy);
-       
-       if (energy>100.0) {
-	 LogInfo("EcalCosmicsHists") << "Very high energy event " << iEvent.id().run() << " : " 
-				     << iEvent.id().event() << " " << naiveEvtNum_  
-				     << " : " << energy << " " << numXtalsinCluster 
-				     << " : " << iphi << " " << ieta 
-				     << " : " << isEcalL1 << isHCALL1 << isDTL1 << isRPCL1 << isCSCL1 ;
-	 
-	 HighEnergy_100GeV_occuCoarse->Fill(iphi,ieta);    
-	 HighEnergy_100GeV_occu3D->Fill(iphi,ieta,energy);
-	 
-       }
-       
-     }  
-     
-     // *** end of High Energy Clusters analysis *** //
-     
-   }//++++++++++++++++++END LOOP OVER EB SUPERCLUSTERS+++++++++++++++++++++++//
-  
+  const reco::SuperClusterCollection* clusterCollection_p = bscHandle.product();
+  for (reco::SuperClusterCollection::const_iterator clus = clusterCollection_p->begin();
+       clus != clusterCollection_p->end();
+       ++clus) {
+    double energy = clus->energy();
+    double phi = clus->phi();
+    double eta = clus->eta();
+    double time = -1000.0;
+    double ampli = 0.;
+    double secondMin = 0.;
+    double secondTime = -1000.;
+    int numXtalsinCluster = 0;
+
+    EBDetId maxDet;
+    EBDetId secDet;
+
+    numberofBCinSC_->Fill(clus->clustersSize());
+    numberofBCinSCphi_->Fill(phi, clus->clustersSize());
+
+    for (reco::CaloCluster_iterator bclus = (clus->clustersBegin()); bclus != (clus->clustersEnd()); ++bclus) {
+      double cphi = (*bclus)->phi();
+      double ceta = (*bclus)->eta();
+      TrueBCOccupancy_->Fill(cphi, ceta);
+      TrueBCOccupancyCoarse_->Fill(cphi, ceta);
+    }
+
+    std::vector<std::pair<DetId, float> > clusterDetIds = clus->hitsAndFractions();  //get these from the cluster
+    for (std::vector<std::pair<DetId, float> >::const_iterator detitr = clusterDetIds.begin();
+         detitr != clusterDetIds.end();
+         ++detitr) {
+      //Here I use the "find" on a digi collection... I have been warned...
+      if ((*detitr).first.det() != DetId::Ecal) {
+        std::cout << " det is " << (*detitr).first.det() << std::endl;
+        continue;
+      }
+      if ((*detitr).first.subdetId() != EcalBarrel) {
+        std::cout << " subdet is " << (*detitr).first.subdetId() << std::endl;
+        continue;
+      }
+      EcalRecHitCollection::const_iterator thishit = hits->find((*detitr).first);
+      if (thishit == hits->end())
+        continue;
+      //The checking above should no longer be needed...... as only those in the cluster would already have rechits..
+
+      EcalRecHit myhit = (*thishit);
+
+      double thisamp = myhit.energy();
+      if (thisamp > minRecHitAmpEB_) {
+        numXtalsinCluster++;
+      }
+      if (thisamp > secondMin) {
+        secondMin = thisamp;
+        secondTime = myhit.time();
+        secDet = (EBDetId)(*detitr).first;
+      }
+      if (secondMin > ampli) {
+        std::swap(ampli, secondMin);
+        std::swap(time, secondTime);
+        std::swap(maxDet, secDet);
+      }
+    }
+
+    double fullnumXtalsinCluster = clusterDetIds.size();
+
+    float E2 = ampli + secondMin;
+    EcalElectronicsId elecId = ecalElectronicsMap_->getElectronicsId((EBDetId)maxDet);
+    int FEDid = 600 + elecId.dccId();
+
+    numberOfCosmics++;
+    numberOfCosmicsEB++;
+
+    //Set some more values
+    seeds.push_back(maxDet);
+    int ieta = maxDet.ieta();
+    int iphi = maxDet.iphi();
+    int ietaSM = maxDet.ietaSM();
+    int iphiSM = maxDet.iphiSM();
+
+    int LM = ecalElectronicsMap_->getLMNumber(maxDet);  //FIX ME
+
+    // top and bottom clusters
+    if (iphi > 0 && iphi < 180) {
+      numberOfCosmicsTop++;
+    } else {
+      numberOfCosmicsBottom++;
+    }
+
+    // fill the proper hist
+    TH1F* uRecHist = FEDsAndHists_[FEDid];
+    TH1F* E2uRecHist = FEDsAndE2Hists_[FEDid];
+    TH1F* energyuRecHist = FEDsAndenergyHists_[FEDid];
+    TH1F* timingHist = FEDsAndTimingHists_[FEDid];
+    TH1F* freqHist = FEDsAndFrequencyHists_[FEDid];
+    TH1F* iphiProfileHist = FEDsAndiPhiProfileHists_[FEDid];
+    TH1F* ietaProfileHist = FEDsAndiEtaProfileHists_[FEDid];
+    TH2F* timingHistVsFreq = FEDsAndTimingVsFreqHists_[FEDid];
+    TH2F* timingHistVsAmp = FEDsAndTimingVsAmpHists_[FEDid];
+    TH2F* E2vsE1uRecHist = FEDsAndE2vsE1Hists_[FEDid];
+    TH2F* energyvsE1uRecHist = FEDsAndenergyvsE1Hists_[FEDid];
+    TH2F* occupHist = FEDsAndOccupancyHists_[FEDid];
+    TH2F* timingHistVsPhi = FEDsAndTimingVsPhiHists_[FEDid];
+    TH2F* timingHistVsModule = FEDsAndTimingVsModuleHists_[FEDid];
+
+    if (uRecHist == nullptr) {
+      initHists(FEDid);
+      uRecHist = FEDsAndHists_[FEDid];
+      E2uRecHist = FEDsAndE2Hists_[FEDid];
+      energyuRecHist = FEDsAndenergyHists_[FEDid];
+      timingHist = FEDsAndTimingHists_[FEDid];
+      freqHist = FEDsAndFrequencyHists_[FEDid];
+      timingHistVsFreq = FEDsAndTimingVsFreqHists_[FEDid];
+      timingHistVsAmp = FEDsAndTimingVsAmpHists_[FEDid];
+      iphiProfileHist = FEDsAndiPhiProfileHists_[FEDid];
+      ietaProfileHist = FEDsAndiEtaProfileHists_[FEDid];
+      E2vsE1uRecHist = FEDsAndE2vsE1Hists_[FEDid];
+      energyvsE1uRecHist = FEDsAndenergyvsE1Hists_[FEDid];
+      occupHist = FEDsAndOccupancyHists_[FEDid];
+      timingHistVsPhi = FEDsAndTimingVsPhiHists_[FEDid];
+      timingHistVsModule = FEDsAndTimingVsModuleHists_[FEDid];
+    }
+
+    uRecHist->Fill(ampli);
+    E2uRecHist->Fill(E2);
+    E2vsE1uRecHist->Fill(ampli, E2);
+    energyuRecHist->Fill(energy);
+    energyvsE1uRecHist->Fill(ampli, energy);
+    allFedsHist_->Fill(ampli);
+    allFedsE2Hist_->Fill(E2);
+    allFedsenergyHist_->Fill(energy);
+    allFedsenergyHighHist_->Fill(energy);
+    allFedsE2vsE1Hist_->Fill(ampli, E2);
+    allFedsenergyvsE1Hist_->Fill(ampli, energy);
+    freqHist->Fill(naiveEvtNum_);
+    iphiProfileHist->Fill(iphi);
+    ietaProfileHist->Fill(ieta);
+
+    allFedsFrequencyHist_->Fill(naiveEvtNum_);
+    allFedsiPhiProfileHist_->Fill(iphi);
+    allFedsiEtaProfileHist_->Fill(ieta);
+    allOccupancy_->Fill(iphi, ieta);
+    TrueOccupancy_->Fill(phi, eta);
+    allOccupancyCoarse_->Fill(iphi, ieta);
+    TrueOccupancyCoarse_->Fill(phi, eta);
+    allFedsNumXtalsInClusterHist_->Fill(numXtalsinCluster);
+    NumXtalsInClusterHist_->Fill(fullnumXtalsinCluster);
+    numxtalsVsEnergy_->Fill(energy, numXtalsinCluster);
+    numxtalsVsHighEnergy_->Fill(energy, numXtalsinCluster);
+
+    //Fill the hists for the time stamp information
+    allFedsFreqTimeVsPhiHist_->Fill(iphi, eventTime);
+    allFedsFreqTimeVsPhiTTHist_->Fill(iphi, eventTime);
+    allFedsFreqTimeVsEtaHist_->Fill(eventTime, ieta);
+    allFedsFreqTimeVsEtaTTHist_->Fill(eventTime, ieta);
+    //end time stamp hists
+
+    occupHist->Fill(ietaSM, iphiSM);
+    if (fullnumXtalsinCluster == 1) {
+      allOccupancySingleXtal_->Fill(iphi, ieta);
+      energySingleXtalHist_->Fill(energy);
+    }
+
+    // Exclusive trigger plots
+
+    if (isEcalL1 && !isDTL1 && !isRPCL1 && !isCSCL1 && !isHCALL1) {
+      allOccupancyExclusiveECAL_->Fill(iphi, ieta);
+      allOccupancyCoarseExclusiveECAL_->Fill(iphi, ieta);
+      if (ampli > minTimingAmpEB_) {
+        allFedsTimingHistECAL_->Fill(time);
+        allFedsTimingPhiEtaHistECAL_->Fill(iphi, ieta, time);
+        allFedsTimingTTHistECAL_->Fill(iphi, ieta, time);
+        allFedsTimingLMHistECAL_->Fill(LM, time);
+      }
+      triggerExclusiveHist_->Fill(0);
+    }
+
+    if (!isEcalL1 && !isDTL1 && !isRPCL1 && !isCSCL1 && isHCALL1) {
+      allOccupancyExclusiveHCAL_->Fill(iphi, ieta);
+      allOccupancyCoarseExclusiveHCAL_->Fill(iphi, ieta);
+      if (ampli > minTimingAmpEB_) {
+        allFedsTimingHistHCAL_->Fill(time);
+        allFedsTimingPhiEtaHistHCAL_->Fill(iphi, ieta, time);
+        allFedsTimingTTHistHCAL_->Fill(iphi, ieta, time);
+        allFedsTimingLMHistHCAL_->Fill(LM, time);
+      }
+      triggerExclusiveHist_->Fill(1);
+    }
+
+    if (!isEcalL1 && isDTL1 && !isRPCL1 && !isCSCL1 && !isHCALL1) {
+      allOccupancyExclusiveDT_->Fill(iphi, ieta);
+      allOccupancyCoarseExclusiveDT_->Fill(iphi, ieta);
+      if (ampli > minTimingAmpEB_) {
+        allFedsTimingHistDT_->Fill(time);
+        allFedsTimingPhiEtaHistDT_->Fill(iphi, ieta, time);
+        allFedsTimingTTHistDT_->Fill(iphi, ieta, time);
+        allFedsTimingLMHistDT_->Fill(LM, time);
+      }
+      triggerExclusiveHist_->Fill(2);
+    }
+
+    if (!isEcalL1 && !isDTL1 && isRPCL1 && !isCSCL1 && !isHCALL1) {
+      allOccupancyExclusiveRPC_->Fill(iphi, ieta);
+      allOccupancyCoarseExclusiveRPC_->Fill(iphi, ieta);
+      if (ampli > minTimingAmpEB_) {
+        allFedsTimingHistRPC_->Fill(time);
+        allFedsTimingPhiEtaHistRPC_->Fill(iphi, ieta, time);
+        allFedsTimingTTHistRPC_->Fill(iphi, ieta, time);
+        allFedsTimingLMHistRPC_->Fill(LM, time);
+      }
+      triggerExclusiveHist_->Fill(3);
+    }
+
+    if (!isEcalL1 && !isDTL1 && !isRPCL1 && isCSCL1 && !isHCALL1) {
+      allOccupancyExclusiveCSC_->Fill(iphi, ieta);
+      allOccupancyCoarseExclusiveCSC_->Fill(iphi, ieta);
+      if (ampli > minTimingAmpEB_) {
+        allFedsTimingHistCSC_->Fill(time);
+        allFedsTimingPhiEtaHistCSC_->Fill(iphi, ieta, time);
+        allFedsTimingTTHistCSC_->Fill(iphi, ieta, time);
+        allFedsTimingLMHistCSC_->Fill(LM, time);
+      }
+      triggerExclusiveHist_->Fill(4);
+    }
+
+    // Inclusive trigger plots
+
+    if (isEcalL1) {
+      triggerHist_->Fill(0);
+      allOccupancyECAL_->Fill(iphi, ieta);
+      allOccupancyCoarseECAL_->Fill(iphi, ieta);
+    }
+    if (isHCALL1) {
+      triggerHist_->Fill(1);
+      allOccupancyHCAL_->Fill(iphi, ieta);
+      allOccupancyCoarseHCAL_->Fill(iphi, ieta);
+    }
+    if (isDTL1) {
+      triggerHist_->Fill(2);
+      allOccupancyDT_->Fill(iphi, ieta);
+      allOccupancyCoarseDT_->Fill(iphi, ieta);
+    }
+    if (isRPCL1) {
+      triggerHist_->Fill(3);
+      allOccupancyRPC_->Fill(iphi, ieta);
+      allOccupancyCoarseRPC_->Fill(iphi, ieta);
+    }
+    if (isCSCL1) {
+      triggerHist_->Fill(4);
+      allOccupancyCSC_->Fill(iphi, ieta);
+      allOccupancyCoarseCSC_->Fill(iphi, ieta);
+    }
+
+    // Fill histo for Ecal+muon coincidence
+    if (isEcalL1 && (isCSCL1 || isRPCL1 || isDTL1) && !isHCALL1)
+      allFedsTimingHistEcalMuon_->Fill(time);
+
+    if (ampli > minTimingAmpEB_) {
+      timingHist->Fill(time);
+      timingHistVsFreq->Fill(time, naiveEvtNum_);
+      timingHistVsAmp->Fill(time, ampli);
+      allFedsTimingHist_->Fill(time);
+      allFedsTimingVsAmpHist_->Fill(time, ampli);
+      allFedsTimingVsFreqHist_->Fill(time, naiveEvtNum_);
+      timingHistVsPhi->Fill(time, iphiSM);
+      timingHistVsModule->Fill(time, ietaSM);
+      allFedsTimingPhiHist_->Fill(iphi, time);
+      allFedsTimingPhiEtaHist_->Fill(iphi, ieta, time);
+      allFedsTimingTTHist_->Fill(iphi, ieta, time);
+      allFedsTimingLMHist_->Fill(LM, time);
+      if (FEDid >= 610 && FEDid <= 627)
+        allFedsTimingPhiEbmHist_->Fill(iphi, time);
+      if (FEDid >= 628 && FEDid <= 645)
+        allFedsTimingPhiEbpHist_->Fill(iphi, time);
+
+      if (FEDid >= 610 && FEDid <= 627)
+        allFedsTimingEbmHist_->Fill(time);
+      if (FEDid >= 628 && FEDid <= 645)
+        allFedsTimingEbpHist_->Fill(time);
+      if (FEDid >= 613 && FEDid <= 616)
+        allFedsTimingEbmTopHist_->Fill(time);
+      if (FEDid >= 631 && FEDid <= 634)
+        allFedsTimingEbpTopHist_->Fill(time);
+      if (FEDid >= 622 && FEDid <= 625)
+        allFedsTimingEbmBottomHist_->Fill(time);
+      if (FEDid >= 640 && FEDid <= 643)
+        allFedsTimingEbpBottomHist_->Fill(time);
+    }
+
+    // *** High Energy Clusters Analysis ** //
+
+    if (energy > minHighEnergy_) {
+      LogInfo("EcalCosmicsHists") << "High energy event " << iEvent.id().run() << " : " << iEvent.id().event() << " "
+                                  << naiveEvtNum_ << " : " << energy << " " << numXtalsinCluster << " : " << iphi << " "
+                                  << ieta << " : " << isEcalL1 << isHCALL1 << isDTL1 << isRPCL1 << isCSCL1;
+
+      numberOfHighEClusters++;
+      allOccupancyHighEnergy_->Fill(iphi, ieta);
+      allOccupancyHighEnergyCoarse_->Fill(iphi, ieta);
+      allFedsOccupancyHighEnergyHist_->Fill(iphi, ieta, energy);
+      allFedsenergyOnlyHighHist_->Fill(energy);
+
+      HighEnergy_2GeV_occuCoarse->Fill(iphi, ieta);
+      HighEnergy_2GeV_occu3D->Fill(iphi, ieta, energy);
+
+      HighEnergy_NumXtal->Fill(fullnumXtalsinCluster);
+      HighEnergy_NumXtalFedId->Fill(FEDid, fullnumXtalsinCluster);
+      HighEnergy_NumXtaliphi->Fill(iphi, fullnumXtalsinCluster);
+      HighEnergy_energy3D->Fill(iphi, ieta, energy);
+      HighEnergy_energyNumXtal->Fill(fullnumXtalsinCluster, energy);
+
+      if (energy > 100.0) {
+        LogInfo("EcalCosmicsHists") << "Very high energy event " << iEvent.id().run() << " : " << iEvent.id().event()
+                                    << " " << naiveEvtNum_ << " : " << energy << " " << numXtalsinCluster << " : "
+                                    << iphi << " " << ieta << " : " << isEcalL1 << isHCALL1 << isDTL1 << isRPCL1
+                                    << isCSCL1;
+
+        HighEnergy_100GeV_occuCoarse->Fill(iphi, ieta);
+        HighEnergy_100GeV_occu3D->Fill(iphi, ieta, energy);
+      }
+    }
+
+    // *** end of High Energy Clusters analysis *** //
+
+  }  //++++++++++++++++++END LOOP OVER EB SUPERCLUSTERS+++++++++++++++++++++++//
+
   //+++++++++++++++++++LOOP OVER ENDCAP EE CLUSTERS++++++++++++++++++++//
-  
-  if(hasEndcapClusters) {
+
+  if (hasEndcapClusters) {
     clusterCollection_p = escHandle.product();
-    for (reco::SuperClusterCollection::const_iterator clus = clusterCollection_p->begin(); clus != clusterCollection_p->end(); ++clus) {
+    for (reco::SuperClusterCollection::const_iterator clus = clusterCollection_p->begin();
+         clus != clusterCollection_p->end();
+         ++clus) {
       double energy = clus->energy();
       //double phi    = clus->phi();
       //double eta    = clus->eta();
@@ -592,83 +583,98 @@ EcalCosmicsHists::analyze(edm::Event const & iEvent, edm::EventSetup const & iSe
       double secondTime = -1000.;
       int clusSize = clus->clustersSize();
       int numXtalsinCluster = 0;
-      
+
       EEDetId maxDet;
       EEDetId secDet;
       //LogInfo("EcalCosmicsHists") << "Here is what we initialized the maxDet to: " << maxDet;
-      
- //      for (reco::basicCluster_iterator bclus = (clus->clustersBegin()); bclus != (clus->clustersEnd()); ++bclus) {
-// 	//double cphi = (*bclus)->phi();
-// 	//double ceta = (*bclus)->eta();	
-//         //TODO: extend histos to EE
-//         //TrueBCOccupancy_->Fill(cphi,ceta);
-//         //TrueBCOccupancyCoarse_->Fill(cphi,ceta);
-//       }
-      
-      std::vector<std::pair<DetId, float> > clusterDetIds = clus->hitsAndFractions();//get these from the cluster
-      for(std::vector<std::pair<DetId, float> >::const_iterator detitr = clusterDetIds.begin(); detitr != clusterDetIds.end(); ++detitr) {
-	
-	//LogInfo("EcalCosmicsHists") << " Here is the DetId inside the cluster: " << (EEDetId)(*detitr);
-	//Here I use the "find" on a digi collection... I have been warned...
-	
-	if ((*detitr).first.det() != DetId::Ecal) {
-	  LogError("EcalCosmicsHists") << " det is " <<(*detitr).first.det(); continue;
-	}
+
+      //      for (reco::basicCluster_iterator bclus = (clus->clustersBegin()); bclus != (clus->clustersEnd()); ++bclus) {
+      // 	//double cphi = (*bclus)->phi();
+      // 	//double ceta = (*bclus)->eta();
+      //         //TODO: extend histos to EE
+      //         //TrueBCOccupancy_->Fill(cphi,ceta);
+      //         //TrueBCOccupancyCoarse_->Fill(cphi,ceta);
+      //       }
+
+      std::vector<std::pair<DetId, float> > clusterDetIds = clus->hitsAndFractions();  //get these from the cluster
+      for (std::vector<std::pair<DetId, float> >::const_iterator detitr = clusterDetIds.begin();
+           detitr != clusterDetIds.end();
+           ++detitr) {
+        //LogInfo("EcalCosmicsHists") << " Here is the DetId inside the cluster: " << (EEDetId)(*detitr);
+        //Here I use the "find" on a digi collection... I have been warned...
+
+        if ((*detitr).first.det() != DetId::Ecal) {
+          LogError("EcalCosmicsHists") << " det is " << (*detitr).first.det();
+          continue;
+        }
         if ((*detitr).first.subdetId() != EcalEndcap) {
-	  LogError("EcalCosmicsHists") << " subdet is " <<(*detitr).first.subdetId(); continue; 
-	}
+          LogError("EcalCosmicsHists") << " subdet is " << (*detitr).first.subdetId();
+          continue;
+        }
 
         EcalRecHitCollection::const_iterator thishit = hitsEE->find((*detitr).first);
-	
+
         if (thishit == hitsEE->end()) {
           LogInfo("EcalCosmicsHists") << " WARNING: EEDetId not found in the RecHit collection!";
           continue;
         }
-        // The checking above should no longer be needed...... 
-	// as only those in the cluster would already have rechits..
-	
+        // The checking above should no longer be needed......
+        // as only those in the cluster would already have rechits..
+
         EcalRecHit myhit = (*thishit);
-	
+
         //LogInfo("EcalCosmicsHists") << " Found hit for DetId: " << (EEDetId)(*detitr);
         double thisamp = myhit.energy();
-        if (thisamp > minRecHitAmpEE_) {numXtalsinCluster++; }
-        if (thisamp > secondMin) {secondMin = thisamp; secondTime = myhit.time(); secDet = (EEDetId)(*detitr).first;}
-        if (secondMin > ampli) {std::swap(ampli,secondMin); std::swap(time,secondTime); std::swap(maxDet,secDet);}
-	
+        if (thisamp > minRecHitAmpEE_) {
+          numXtalsinCluster++;
+        }
+        if (thisamp > secondMin) {
+          secondMin = thisamp;
+          secondTime = myhit.time();
+          secDet = (EEDetId)(*detitr).first;
+        }
+        if (secondMin > ampli) {
+          std::swap(ampli, secondMin);
+          std::swap(time, secondTime);
+          std::swap(maxDet, secDet);
+        }
+
         //LogInfo("EcalCosmicsHists") << "maxDetId is now: " << (EEDetId)(maxDet);
       }
-      
-      double fullnumXtalsinCluster = clusterDetIds.size();     
-      
+
+      double fullnumXtalsinCluster = clusterDetIds.size();
+
       float E2 = ampli + secondMin;
-      
-      ecalElectronicsMap_->getElectronicsId((EEDetId) maxDet);      
-      //int FEDid = 600+elecId.dccId();           
+
+      ecalElectronicsMap_->getElectronicsId((EEDetId)maxDet);
+      //int FEDid = 600+elecId.dccId();
 
       //Set some more values
       //TODO: need to fix the seeds vector to be DetId or have another one for EE
       //seeds.push_back(maxDet);
-      
+
       int ix = maxDet.ix();
       int iy = maxDet.iy();
       int iz = maxDet.zside();
-     
-      //      LogWarning("EcalCosmicsHists") << "EE cluster (x,y,z) : ( " 
-      //				     << ix << " , " << iy << " , " << iz 
+
+      //      LogWarning("EcalCosmicsHists") << "EE cluster (x,y,z) : ( "
+      //				     << ix << " , " << iy << " , " << iz
       //				     << " ) " << std::endl;
 
-      if (!EEDetId::validDetId(ix,iy,iz)) {
-	LogWarning("EcalCosmicsHists") << "INVALID EE DetId !!!" << endl;
-	return;
+      if (!EEDetId::validDetId(ix, iy, iz)) {
+        LogWarning("EcalCosmicsHists") << "INVALID EE DetId !!!" << endl;
+        return;
       }
 
-
       numberOfCosmics++;
-      if (iz<0) { numberOfCosmicsEEM++; }
-      else { numberOfCosmicsEEP++; }
+      if (iz < 0) {
+        numberOfCosmicsEEM++;
+      } else {
+        numberOfCosmicsEEP++;
+      }
 
       //int LM = ecalElectronicsMap_->getLMNumber(maxDet) ;//FIX ME
-      
+
       //TODO: extend histos to EE
       //TH1F* uRecHist = FEDsAndHists_[FEDid];
       //TH1F* E2uRecHist = FEDsAndE2Hists_[FEDid];
@@ -681,7 +687,7 @@ EcalCosmicsHists::analyze(edm::Event const & iEvent, edm::EventSetup const & iSe
       //TH2F* timingHistVsAmp = FEDsAndTimingVsAmpHists_[FEDid];
       //TH2F* E2vsE1uRecHist = FEDsAndE2vsE1Hists_[FEDid];
       //TH2F* energyvsE1uRecHist = FEDsAndenergyvsE1Hists_[FEDid];
-      //TH1F* numXtalInClusterHist = FEDsAndNumXtalsInClusterHists_[FEDid];    
+      //TH1F* numXtalInClusterHist = FEDsAndNumXtalsInClusterHists_[FEDid];
       //TH2F* occupHist = FEDsAndOccupancyHists_[FEDid];
       //TH2F* timingHistVsPhi = FEDsAndTimingVsPhiHists_[FEDid];
       //TH2F* timingHistVsModule = FEDsAndTimingVsModuleHists_[FEDid];
@@ -711,280 +717,272 @@ EcalCosmicsHists::analyze(edm::Event const & iEvent, edm::EventSetup const & iSe
       //energyvsE1uRecHist->Fill(ampli,energy);
       //allFedsHist_->Fill(ampli);
 
-      if (iz<0) {
-	EEM_FedsSeedEnergyHist_->Fill(ampli);
-	EEM_FedsenergyHist_->Fill(energy);
-	EEM_FedsenergyHighHist_->Fill(energy);
-	EEM_FedsE2Hist_->Fill(E2); 
-	EEM_FedsE2vsE1Hist_->Fill(ampli,E2);
-	EEM_FedsenergyvsE1Hist_->Fill(ampli,energy);
-	EEM_AllOccupancyCoarse_->Fill(ix-0.5,iy-0.5);
-	EEM_AllOccupancy_->Fill(ix-0.5,iy-0.5);
+      if (iz < 0) {
+        EEM_FedsSeedEnergyHist_->Fill(ampli);
+        EEM_FedsenergyHist_->Fill(energy);
+        EEM_FedsenergyHighHist_->Fill(energy);
+        EEM_FedsE2Hist_->Fill(E2);
+        EEM_FedsE2vsE1Hist_->Fill(ampli, E2);
+        EEM_FedsenergyvsE1Hist_->Fill(ampli, energy);
+        EEM_AllOccupancyCoarse_->Fill(ix - 0.5, iy - 0.5);
+        EEM_AllOccupancy_->Fill(ix - 0.5, iy - 0.5);
 
-	EEM_FedsNumXtalsInClusterHist_->Fill(numXtalsinCluster);
-	EEM_NumXtalsInClusterHist_->Fill(fullnumXtalsinCluster);
-	EEM_numxtalsVsEnergy_->Fill(energy,numXtalsinCluster);
-	EEM_numxtalsVsHighEnergy_->Fill(energy,numXtalsinCluster);
-	EEM_numberofBCinSC_->Fill(clusSize);
+        EEM_FedsNumXtalsInClusterHist_->Fill(numXtalsinCluster);
+        EEM_NumXtalsInClusterHist_->Fill(fullnumXtalsinCluster);
+        EEM_numxtalsVsEnergy_->Fill(energy, numXtalsinCluster);
+        EEM_numxtalsVsHighEnergy_->Fill(energy, numXtalsinCluster);
+        EEM_numberofBCinSC_->Fill(clusSize);
 
-	if (fullnumXtalsinCluster==1) {
-	  EEM_OccupancySingleXtal_->Fill(ix-0.5,iy-0.5);
-	  EEM_energySingleXtalHist_->Fill(energy);
-	}
+        if (fullnumXtalsinCluster == 1) {
+          EEM_OccupancySingleXtal_->Fill(ix - 0.5, iy - 0.5);
+          EEM_energySingleXtalHist_->Fill(energy);
+        }
 
-	if (ampli > minTimingAmpEE_) {
-	  EEM_FedsTimingHist_->Fill(time);
-	  EEM_FedsTimingVsAmpHist_->Fill(time, ampli);
-	  EEM_FedsTimingTTHist_->Fill(ix-0.5,iy-0.5,time);
-	}
+        if (ampli > minTimingAmpEE_) {
+          EEM_FedsTimingHist_->Fill(time);
+          EEM_FedsTimingVsAmpHist_->Fill(time, ampli);
+          EEM_FedsTimingTTHist_->Fill(ix - 0.5, iy - 0.5, time);
+        }
 
-	// Exclusive trigger plots
-	
-	if(isEcalL1&&!isDTL1&&!isRPCL1&&!isCSCL1&&!isHCALL1) {
-	  EEM_OccupancyExclusiveECAL_->Fill(ix-0.5,iy-0.5);
-	  EEM_OccupancyCoarseExclusiveECAL_->Fill(ix-0.5,iy-0.5);
-	  if (ampli > minTimingAmpEE_) {
-	    EEM_FedsTimingHistECAL_->Fill(time);
-	    EEM_FedsTimingTTHistECAL_->Fill(ix-0.5,iy-0.5,time);
-	  }      
-	  EEM_triggerExclusiveHist_->Fill(0);
-	} 
-	
-	if(!isEcalL1&&!isDTL1&&!isRPCL1&&!isCSCL1&&isHCALL1) {   
-	  EEM_OccupancyExclusiveHCAL_->Fill(ix-0.5,iy-0.5);
-	  EEM_OccupancyCoarseExclusiveHCAL_->Fill(ix-0.5,iy-0.5);
-	  if (ampli > minTimingAmpEE_) {
-	    EEM_FedsTimingHistHCAL_->Fill(time);
-	    EEM_FedsTimingTTHistHCAL_->Fill(ix-0.5,iy-0.5,time);
-	  }      
-	  EEM_triggerExclusiveHist_->Fill(1);
-	}
-	
-	if(!isEcalL1&&isDTL1&&!isRPCL1&&!isCSCL1&&!isHCALL1) {
-	  EEM_OccupancyExclusiveDT_->Fill(ix-0.5,iy-0.5);
-	  EEM_OccupancyCoarseExclusiveDT_->Fill(ix-0.5,iy-0.5);
-	  if (ampli > minTimingAmpEE_) {
-	    EEM_FedsTimingHistDT_->Fill(time);
-	    EEM_FedsTimingTTHistDT_->Fill(ix-0.5,iy-0.5,time);
-	  }      
-	  EEM_triggerExclusiveHist_->Fill(2);
-	}
-	
-	if(!isEcalL1&&!isDTL1&&isRPCL1&&!isCSCL1&&!isHCALL1) {
-	  EEM_OccupancyExclusiveRPC_->Fill(ix-0.5,iy-0.5);
-	  EEM_OccupancyCoarseExclusiveRPC_->Fill(ix-0.5,iy-0.5);
-	  if (ampli > minTimingAmpEE_) {
-	    EEM_FedsTimingHistRPC_->Fill(time);
-	    EEM_FedsTimingTTHistRPC_->Fill(ix-0.5,iy-0.5,time);
-	  }      
-	  EEM_triggerExclusiveHist_->Fill(3);
-	}
-	
-	if(!isEcalL1&&!isDTL1&&!isRPCL1&&isCSCL1&&!isHCALL1) {   
-	  EEM_OccupancyExclusiveCSC_->Fill(ix-0.5,iy-0.5);
-	  EEM_OccupancyCoarseExclusiveCSC_->Fill(ix-0.5,iy-0.5);
-	  if (ampli > minTimingAmpEE_) {
-	    EEM_FedsTimingHistCSC_->Fill(time);
-	    EEM_FedsTimingTTHistCSC_->Fill(ix-0.5,iy-0.5,time);
-	  }      
-	  EEM_triggerExclusiveHist_->Fill(4);
-	}
-	
-	// Inclusive trigger plots
-	
-	if (isEcalL1) { 
-	  EEM_triggerHist_->Fill(0);
-	  EEM_OccupancyECAL_->Fill(ix-0.5,iy-0.5);
-	  EEM_OccupancyCoarseECAL_->Fill(ix-0.5,iy-0.5);
-	}
-	if (isHCALL1) {
-	  EEM_triggerHist_->Fill(1);
-	  EEM_OccupancyHCAL_->Fill(ix-0.5,iy-0.5);
-	  EEM_OccupancyCoarseHCAL_->Fill(ix-0.5,iy-0.5);
-	}
-	if (isDTL1)   {
-	  EEM_triggerHist_->Fill(2);
-	  EEM_OccupancyDT_->Fill(ix-0.5,iy-0.5);
-	  EEM_OccupancyCoarseDT_->Fill(ix-0.5,iy-0.5);
-	}
-	if (isRPCL1)  {
-	  EEM_triggerHist_->Fill(3);
-	  EEM_OccupancyRPC_->Fill(ix-0.5,iy-0.5);
-	  EEM_OccupancyCoarseRPC_->Fill(ix-0.5,iy-0.5);
-	}
-	if (isCSCL1)  {
-	  EEM_triggerHist_->Fill(4);
-	  EEM_OccupancyCSC_->Fill(ix-0.5,iy-0.5);
-	  EEM_OccupancyCoarseCSC_->Fill(ix-0.5,iy-0.5);
-	}		
+        // Exclusive trigger plots
+
+        if (isEcalL1 && !isDTL1 && !isRPCL1 && !isCSCL1 && !isHCALL1) {
+          EEM_OccupancyExclusiveECAL_->Fill(ix - 0.5, iy - 0.5);
+          EEM_OccupancyCoarseExclusiveECAL_->Fill(ix - 0.5, iy - 0.5);
+          if (ampli > minTimingAmpEE_) {
+            EEM_FedsTimingHistECAL_->Fill(time);
+            EEM_FedsTimingTTHistECAL_->Fill(ix - 0.5, iy - 0.5, time);
+          }
+          EEM_triggerExclusiveHist_->Fill(0);
+        }
+
+        if (!isEcalL1 && !isDTL1 && !isRPCL1 && !isCSCL1 && isHCALL1) {
+          EEM_OccupancyExclusiveHCAL_->Fill(ix - 0.5, iy - 0.5);
+          EEM_OccupancyCoarseExclusiveHCAL_->Fill(ix - 0.5, iy - 0.5);
+          if (ampli > minTimingAmpEE_) {
+            EEM_FedsTimingHistHCAL_->Fill(time);
+            EEM_FedsTimingTTHistHCAL_->Fill(ix - 0.5, iy - 0.5, time);
+          }
+          EEM_triggerExclusiveHist_->Fill(1);
+        }
+
+        if (!isEcalL1 && isDTL1 && !isRPCL1 && !isCSCL1 && !isHCALL1) {
+          EEM_OccupancyExclusiveDT_->Fill(ix - 0.5, iy - 0.5);
+          EEM_OccupancyCoarseExclusiveDT_->Fill(ix - 0.5, iy - 0.5);
+          if (ampli > minTimingAmpEE_) {
+            EEM_FedsTimingHistDT_->Fill(time);
+            EEM_FedsTimingTTHistDT_->Fill(ix - 0.5, iy - 0.5, time);
+          }
+          EEM_triggerExclusiveHist_->Fill(2);
+        }
+
+        if (!isEcalL1 && !isDTL1 && isRPCL1 && !isCSCL1 && !isHCALL1) {
+          EEM_OccupancyExclusiveRPC_->Fill(ix - 0.5, iy - 0.5);
+          EEM_OccupancyCoarseExclusiveRPC_->Fill(ix - 0.5, iy - 0.5);
+          if (ampli > minTimingAmpEE_) {
+            EEM_FedsTimingHistRPC_->Fill(time);
+            EEM_FedsTimingTTHistRPC_->Fill(ix - 0.5, iy - 0.5, time);
+          }
+          EEM_triggerExclusiveHist_->Fill(3);
+        }
+
+        if (!isEcalL1 && !isDTL1 && !isRPCL1 && isCSCL1 && !isHCALL1) {
+          EEM_OccupancyExclusiveCSC_->Fill(ix - 0.5, iy - 0.5);
+          EEM_OccupancyCoarseExclusiveCSC_->Fill(ix - 0.5, iy - 0.5);
+          if (ampli > minTimingAmpEE_) {
+            EEM_FedsTimingHistCSC_->Fill(time);
+            EEM_FedsTimingTTHistCSC_->Fill(ix - 0.5, iy - 0.5, time);
+          }
+          EEM_triggerExclusiveHist_->Fill(4);
+        }
+
+        // Inclusive trigger plots
+
+        if (isEcalL1) {
+          EEM_triggerHist_->Fill(0);
+          EEM_OccupancyECAL_->Fill(ix - 0.5, iy - 0.5);
+          EEM_OccupancyCoarseECAL_->Fill(ix - 0.5, iy - 0.5);
+        }
+        if (isHCALL1) {
+          EEM_triggerHist_->Fill(1);
+          EEM_OccupancyHCAL_->Fill(ix - 0.5, iy - 0.5);
+          EEM_OccupancyCoarseHCAL_->Fill(ix - 0.5, iy - 0.5);
+        }
+        if (isDTL1) {
+          EEM_triggerHist_->Fill(2);
+          EEM_OccupancyDT_->Fill(ix - 0.5, iy - 0.5);
+          EEM_OccupancyCoarseDT_->Fill(ix - 0.5, iy - 0.5);
+        }
+        if (isRPCL1) {
+          EEM_triggerHist_->Fill(3);
+          EEM_OccupancyRPC_->Fill(ix - 0.5, iy - 0.5);
+          EEM_OccupancyCoarseRPC_->Fill(ix - 0.5, iy - 0.5);
+        }
+        if (isCSCL1) {
+          EEM_triggerHist_->Fill(4);
+          EEM_OccupancyCSC_->Fill(ix - 0.5, iy - 0.5);
+          EEM_OccupancyCoarseCSC_->Fill(ix - 0.5, iy - 0.5);
+        }
 
       } else {
+        EEP_FedsSeedEnergyHist_->Fill(ampli);
+        EEP_FedsenergyHist_->Fill(energy);
+        EEP_FedsenergyHighHist_->Fill(energy);
+        EEP_FedsE2Hist_->Fill(E2);
+        EEP_FedsE2vsE1Hist_->Fill(ampli, E2);
+        EEP_FedsenergyvsE1Hist_->Fill(ampli, energy);
+        EEP_AllOccupancyCoarse_->Fill(ix - 0.5, iy - 0.5);
+        EEP_AllOccupancy_->Fill(ix - 0.5, iy - 0.5);
 
-	EEP_FedsSeedEnergyHist_->Fill(ampli);
-	EEP_FedsenergyHist_->Fill(energy);
-	EEP_FedsenergyHighHist_->Fill(energy);
-	EEP_FedsE2Hist_->Fill(E2); 
-	EEP_FedsE2vsE1Hist_->Fill(ampli,E2);
-	EEP_FedsenergyvsE1Hist_->Fill(ampli,energy);
-	EEP_AllOccupancyCoarse_->Fill(ix-0.5,iy-0.5);
-	EEP_AllOccupancy_->Fill(ix-0.5,iy-0.5);
+        EEP_FedsNumXtalsInClusterHist_->Fill(numXtalsinCluster);
+        EEP_NumXtalsInClusterHist_->Fill(fullnumXtalsinCluster);
+        EEP_numxtalsVsEnergy_->Fill(energy, numXtalsinCluster);
+        EEP_numxtalsVsHighEnergy_->Fill(energy, numXtalsinCluster);
+        EEP_numberofBCinSC_->Fill(clusSize);
 
-	EEP_FedsNumXtalsInClusterHist_->Fill(numXtalsinCluster);
-	EEP_NumXtalsInClusterHist_->Fill(fullnumXtalsinCluster);
-	EEP_numxtalsVsEnergy_->Fill(energy,numXtalsinCluster);
-	EEP_numxtalsVsHighEnergy_->Fill(energy,numXtalsinCluster);
-	EEP_numberofBCinSC_->Fill(clusSize);
+        if (fullnumXtalsinCluster == 1) {
+          EEP_OccupancySingleXtal_->Fill(ix - 0.5, iy - 0.5);
+          EEP_energySingleXtalHist_->Fill(energy);
+        }
 
-	if (fullnumXtalsinCluster==1) {
-	  EEP_OccupancySingleXtal_->Fill(ix-0.5,iy-0.5);
-	  EEP_energySingleXtalHist_->Fill(energy);
-	}
+        if (ampli > minTimingAmpEE_) {
+          EEP_FedsTimingHist_->Fill(time);
+          EEP_FedsTimingVsAmpHist_->Fill(time, ampli);
+          EEP_FedsTimingTTHist_->Fill(ix - 0.5, iy - 0.5, time);
+        }
 
-	if (ampli > minTimingAmpEE_) {
-	  EEP_FedsTimingHist_->Fill(time);
-	  EEP_FedsTimingVsAmpHist_->Fill(time, ampli);
-	  EEP_FedsTimingTTHist_->Fill(ix-0.5,iy-0.5,time);
-	}
+        // Exclusive trigger plots
 
-	// Exclusive trigger plots
-	
-	if(isEcalL1&&!isDTL1&&!isRPCL1&&!isCSCL1&&!isHCALL1) {
-	  EEP_OccupancyExclusiveECAL_->Fill(ix-0.5,iy-0.5);
-	  EEP_OccupancyCoarseExclusiveECAL_->Fill(ix-0.5,iy-0.5);
-	  if (ampli > minTimingAmpEE_) {
-	    EEP_FedsTimingHistECAL_->Fill(time);
-	    EEP_FedsTimingTTHistECAL_->Fill(ix-0.5,iy-0.5,time);
-	  }      
-	  EEP_triggerExclusiveHist_->Fill(0);
-	} 
-	
-	if(!isEcalL1&&!isDTL1&&!isRPCL1&&!isCSCL1&&isHCALL1) {   
-	  EEP_OccupancyExclusiveHCAL_->Fill(ix-0.5,iy-0.5);
-	  EEP_OccupancyCoarseExclusiveHCAL_->Fill(ix-0.5,iy-0.5);
-	  if (ampli > minTimingAmpEE_) {
-	    EEP_FedsTimingHistHCAL_->Fill(time);
-	    EEP_FedsTimingTTHistHCAL_->Fill(ix-0.5,iy-0.5,time);
-	  }      
-	  EEP_triggerExclusiveHist_->Fill(1);
-	}
-	
-	if(!isEcalL1&&isDTL1&&!isRPCL1&&!isCSCL1&&!isHCALL1) {
-	  EEP_OccupancyExclusiveDT_->Fill(ix-0.5,iy-0.5);
-	  EEP_OccupancyCoarseExclusiveDT_->Fill(ix-0.5,iy-0.5);
-	  if (ampli > minTimingAmpEE_) {
-	    EEP_FedsTimingHistDT_->Fill(time);
-	    EEP_FedsTimingTTHistDT_->Fill(ix-0.5,iy-0.5,time);
-	  }      
-	  EEP_triggerExclusiveHist_->Fill(2);
-	}
-	
-	if(!isEcalL1&&!isDTL1&&isRPCL1&&!isCSCL1&&!isHCALL1) {
-	  EEP_OccupancyExclusiveRPC_->Fill(ix-0.5,iy-0.5);
-	  EEP_OccupancyCoarseExclusiveRPC_->Fill(ix-0.5,iy-0.5);
-	  if (ampli > minTimingAmpEE_) {
-	    EEP_FedsTimingHistRPC_->Fill(time);
-	    EEP_FedsTimingTTHistRPC_->Fill(ix-0.5,iy-0.5,time);
-	  }      
-	  EEP_triggerExclusiveHist_->Fill(3);
-	}
-	
-	if(!isEcalL1&&!isDTL1&&!isRPCL1&&isCSCL1&&!isHCALL1) {   
-	  EEP_OccupancyExclusiveCSC_->Fill(ix-0.5,iy-0.5);
-	  EEP_OccupancyCoarseExclusiveCSC_->Fill(ix-0.5,iy-0.5);
-	  if (ampli > minTimingAmpEE_) {
-	    EEP_FedsTimingHistCSC_->Fill(time);
-	    EEP_FedsTimingTTHistCSC_->Fill(ix-0.5,iy-0.5,time);
-	  }      
-	  EEP_triggerExclusiveHist_->Fill(4);
-	}
-	
-	// Inclusive trigger plots
-	
-	if (isEcalL1) { 
-	  EEP_triggerHist_->Fill(0);
-	  EEP_OccupancyECAL_->Fill(ix-0.5,iy-0.5);
-	  EEP_OccupancyCoarseECAL_->Fill(ix-0.5,iy-0.5);
-	}
-	if (isHCALL1) {
-	  EEP_triggerHist_->Fill(1);
-	  EEP_OccupancyHCAL_->Fill(ix-0.5,iy-0.5);
-	  EEP_OccupancyCoarseHCAL_->Fill(ix-0.5,iy-0.5);
-	}
-	if (isDTL1)   {
-	  EEP_triggerHist_->Fill(2);
-	  EEP_OccupancyDT_->Fill(ix-0.5,iy-0.5);
-	  EEP_OccupancyCoarseDT_->Fill(ix-0.5,iy-0.5);
-	}
-	if (isRPCL1)  {
-	  EEP_triggerHist_->Fill(3);
-	  EEP_OccupancyRPC_->Fill(ix-0.5,iy-0.5);
-	  EEP_OccupancyCoarseRPC_->Fill(ix-0.5,iy-0.5);
-	}
-	if (isCSCL1)  {
-	  EEP_triggerHist_->Fill(4);
-	  EEP_OccupancyCSC_->Fill(ix-0.5,iy-0.5);
-	  EEP_OccupancyCoarseCSC_->Fill(ix-0.5,iy-0.5);
-	}	
+        if (isEcalL1 && !isDTL1 && !isRPCL1 && !isCSCL1 && !isHCALL1) {
+          EEP_OccupancyExclusiveECAL_->Fill(ix - 0.5, iy - 0.5);
+          EEP_OccupancyCoarseExclusiveECAL_->Fill(ix - 0.5, iy - 0.5);
+          if (ampli > minTimingAmpEE_) {
+            EEP_FedsTimingHistECAL_->Fill(time);
+            EEP_FedsTimingTTHistECAL_->Fill(ix - 0.5, iy - 0.5, time);
+          }
+          EEP_triggerExclusiveHist_->Fill(0);
+        }
 
+        if (!isEcalL1 && !isDTL1 && !isRPCL1 && !isCSCL1 && isHCALL1) {
+          EEP_OccupancyExclusiveHCAL_->Fill(ix - 0.5, iy - 0.5);
+          EEP_OccupancyCoarseExclusiveHCAL_->Fill(ix - 0.5, iy - 0.5);
+          if (ampli > minTimingAmpEE_) {
+            EEP_FedsTimingHistHCAL_->Fill(time);
+            EEP_FedsTimingTTHistHCAL_->Fill(ix - 0.5, iy - 0.5, time);
+          }
+          EEP_triggerExclusiveHist_->Fill(1);
+        }
+
+        if (!isEcalL1 && isDTL1 && !isRPCL1 && !isCSCL1 && !isHCALL1) {
+          EEP_OccupancyExclusiveDT_->Fill(ix - 0.5, iy - 0.5);
+          EEP_OccupancyCoarseExclusiveDT_->Fill(ix - 0.5, iy - 0.5);
+          if (ampli > minTimingAmpEE_) {
+            EEP_FedsTimingHistDT_->Fill(time);
+            EEP_FedsTimingTTHistDT_->Fill(ix - 0.5, iy - 0.5, time);
+          }
+          EEP_triggerExclusiveHist_->Fill(2);
+        }
+
+        if (!isEcalL1 && !isDTL1 && isRPCL1 && !isCSCL1 && !isHCALL1) {
+          EEP_OccupancyExclusiveRPC_->Fill(ix - 0.5, iy - 0.5);
+          EEP_OccupancyCoarseExclusiveRPC_->Fill(ix - 0.5, iy - 0.5);
+          if (ampli > minTimingAmpEE_) {
+            EEP_FedsTimingHistRPC_->Fill(time);
+            EEP_FedsTimingTTHistRPC_->Fill(ix - 0.5, iy - 0.5, time);
+          }
+          EEP_triggerExclusiveHist_->Fill(3);
+        }
+
+        if (!isEcalL1 && !isDTL1 && !isRPCL1 && isCSCL1 && !isHCALL1) {
+          EEP_OccupancyExclusiveCSC_->Fill(ix - 0.5, iy - 0.5);
+          EEP_OccupancyCoarseExclusiveCSC_->Fill(ix - 0.5, iy - 0.5);
+          if (ampli > minTimingAmpEE_) {
+            EEP_FedsTimingHistCSC_->Fill(time);
+            EEP_FedsTimingTTHistCSC_->Fill(ix - 0.5, iy - 0.5, time);
+          }
+          EEP_triggerExclusiveHist_->Fill(4);
+        }
+
+        // Inclusive trigger plots
+
+        if (isEcalL1) {
+          EEP_triggerHist_->Fill(0);
+          EEP_OccupancyECAL_->Fill(ix - 0.5, iy - 0.5);
+          EEP_OccupancyCoarseECAL_->Fill(ix - 0.5, iy - 0.5);
+        }
+        if (isHCALL1) {
+          EEP_triggerHist_->Fill(1);
+          EEP_OccupancyHCAL_->Fill(ix - 0.5, iy - 0.5);
+          EEP_OccupancyCoarseHCAL_->Fill(ix - 0.5, iy - 0.5);
+        }
+        if (isDTL1) {
+          EEP_triggerHist_->Fill(2);
+          EEP_OccupancyDT_->Fill(ix - 0.5, iy - 0.5);
+          EEP_OccupancyCoarseDT_->Fill(ix - 0.5, iy - 0.5);
+        }
+        if (isRPCL1) {
+          EEP_triggerHist_->Fill(3);
+          EEP_OccupancyRPC_->Fill(ix - 0.5, iy - 0.5);
+          EEP_OccupancyCoarseRPC_->Fill(ix - 0.5, iy - 0.5);
+        }
+        if (isCSCL1) {
+          EEP_triggerHist_->Fill(4);
+          EEP_OccupancyCSC_->Fill(ix - 0.5, iy - 0.5);
+          EEP_OccupancyCoarseCSC_->Fill(ix - 0.5, iy - 0.5);
+        }
       }
-      
 
       // *** High Energy Clusters Analysis ** //
-      
-      if (energy>minHighEnergy_) {
-	
-        LogInfo("EcalCosmicsHists") << "High energy event in EE " << iEvent.id().run() << " : " 
-				    << iEvent.id().event() << " " << naiveEvtNum_  
-				    << " : " << energy << " " << numXtalsinCluster
-				    << " : " << ix << " " << iy 
-				    << " : " << isEcalL1 << isHCALL1 << isDTL1 << isRPCL1 << isCSCL1 ;
-	
-	//  numberOfHighEClusters++;
-	//  allOccupancyHighEnergy_->Fill(iphi, ieta);
-	//  allOccupancyHighEnergyCoarse_->Fill(iphi, ieta);    
-	//  allFedsOccupancyHighEnergyHist_->Fill(iphi,ieta,energy);
-	if (iz<0) {
-	  EEM_FedsenergyOnlyHighHist_->Fill(energy);
-	  EEM_OccupancyHighEnergy_->Fill(ix-0.5,iy-0.5);
-	  EEM_OccupancyHighEnergyCoarse_->Fill(ix-0.5,iy-0.5);    
-	} else {
-	  EEP_FedsenergyOnlyHighHist_->Fill(energy);
-	}
-	//  HighEnergy_2GeV_occuCoarse->Fill(iphi,ieta);    
-	//  HighEnergy_2GeV_occu3D->Fill(iphi,ieta,energy);
-	
-	//  HighEnergy_NumXtal->Fill(fullnumXtalsinCluster);
-	//  HighEnergy_NumXtalFedId->Fill(FEDid,fullnumXtalsinCluster);
-	//  HighEnergy_NumXtaliphi->Fill(iphi,fullnumXtalsinCluster);
-	//  HighEnergy_energy3D->Fill(iphi,ieta,energy);
-	//  HighEnergy_energyNumXtal->Fill(fullnumXtalsinCluster,energy);
-	
-	if (energy>100.0) {
-	  LogInfo("EcalCosmicsHists") << "Very high energy event in EE " << iEvent.id().run() << " : " 
-				      << iEvent.id().event() << " " << naiveEvtNum_  
-				      << " : " << energy << " " << numXtalsinCluster
-				      << " : " << ix << " " << iy 
-				      << " : " << isEcalL1 << isHCALL1 << isDTL1 << isRPCL1 << isCSCL1 ;
-	  //    HighEnergy_100GeV_occuCoarse->Fill(iphi,ieta);    
-	  //    HighEnergy_100GeV_occu3D->Fill(iphi,ieta,energy);
-	}
-	
-      }  
-      
+
+      if (energy > minHighEnergy_) {
+        LogInfo("EcalCosmicsHists") << "High energy event in EE " << iEvent.id().run() << " : " << iEvent.id().event()
+                                    << " " << naiveEvtNum_ << " : " << energy << " " << numXtalsinCluster << " : " << ix
+                                    << " " << iy << " : " << isEcalL1 << isHCALL1 << isDTL1 << isRPCL1 << isCSCL1;
+
+        //  numberOfHighEClusters++;
+        //  allOccupancyHighEnergy_->Fill(iphi, ieta);
+        //  allOccupancyHighEnergyCoarse_->Fill(iphi, ieta);
+        //  allFedsOccupancyHighEnergyHist_->Fill(iphi,ieta,energy);
+        if (iz < 0) {
+          EEM_FedsenergyOnlyHighHist_->Fill(energy);
+          EEM_OccupancyHighEnergy_->Fill(ix - 0.5, iy - 0.5);
+          EEM_OccupancyHighEnergyCoarse_->Fill(ix - 0.5, iy - 0.5);
+        } else {
+          EEP_FedsenergyOnlyHighHist_->Fill(energy);
+        }
+        //  HighEnergy_2GeV_occuCoarse->Fill(iphi,ieta);
+        //  HighEnergy_2GeV_occu3D->Fill(iphi,ieta,energy);
+
+        //  HighEnergy_NumXtal->Fill(fullnumXtalsinCluster);
+        //  HighEnergy_NumXtalFedId->Fill(FEDid,fullnumXtalsinCluster);
+        //  HighEnergy_NumXtaliphi->Fill(iphi,fullnumXtalsinCluster);
+        //  HighEnergy_energy3D->Fill(iphi,ieta,energy);
+        //  HighEnergy_energyNumXtal->Fill(fullnumXtalsinCluster,energy);
+
+        if (energy > 100.0) {
+          LogInfo("EcalCosmicsHists") << "Very high energy event in EE " << iEvent.id().run() << " : "
+                                      << iEvent.id().event() << " " << naiveEvtNum_ << " : " << energy << " "
+                                      << numXtalsinCluster << " : " << ix << " " << iy << " : " << isEcalL1 << isHCALL1
+                                      << isDTL1 << isRPCL1 << isCSCL1;
+          //    HighEnergy_100GeV_occuCoarse->Fill(iphi,ieta);
+          //    HighEnergy_100GeV_occu3D->Fill(iphi,ieta,energy);
+        }
+      }
+
       // *** end of High Energy Clusters analysis *** //
-      
-    }//++++++++++++++++++END LOOP OVER EE SUPERCLUSTERS+++++++++++++++++++++++++++++++++++
+
+    }  //++++++++++++++++++END LOOP OVER EE SUPERCLUSTERS+++++++++++++++++++++++++++++++++++
   }
-  
+
   HighEnergy_numClusHighEn->Fill(numberOfHighEClusters);
-  HighEnergy_ratioClusters->Fill((double(numberOfHighEClusters))/(double(numberOfCosmics)));
-  
+  HighEnergy_ratioClusters->Fill((double(numberOfHighEClusters)) / (double(numberOfCosmics)));
+
   numberofCosmicsHist_->Fill(numberOfCosmics);
   EEP_numberofCosmicsHist_->Fill(numberOfCosmicsEEP);
   EEM_numberofCosmicsHist_->Fill(numberOfCosmicsEEM);
   numberofCosmicsHistEB_->Fill(numberOfCosmicsEB);
-  
-  if ( numberOfCosmics > 0 ) {
+
+  if (numberOfCosmics > 0) {
     cosmicCounter_++;
     numberofGoodEvtFreq_->Fill(naiveEvtNum_);
     allFedsFreqTimeHist_->Fill(eventTime);
@@ -993,36 +991,39 @@ EcalCosmicsHists::analyze(edm::Event const & iEvent, edm::EventSetup const & iSe
     //std::cout << " BX " << iEvent.experimentType() << std::endl;
   }
 
-  if ( numberOfCosmicsEB > 0 ) cosmicCounterEB_++;
-  if ( numberOfCosmicsEEP > 0 ) cosmicCounterEEP_++;
-  if ( numberOfCosmicsEEM > 0 ) cosmicCounterEEM_++;
+  if (numberOfCosmicsEB > 0)
+    cosmicCounterEB_++;
+  if (numberOfCosmicsEEP > 0)
+    cosmicCounterEEP_++;
+  if (numberOfCosmicsEEM > 0)
+    cosmicCounterEEM_++;
 
-  if (numberOfCosmicsTop&&numberOfCosmicsBottom) {
+  if (numberOfCosmicsTop && numberOfCosmicsBottom) {
     cosmicCounterTopBottom_++;
-    numberofCosmicsTopBottomHist_->Fill(numberOfCosmicsTop+numberOfCosmicsBottom);
+    numberofCosmicsTopBottomHist_->Fill(numberOfCosmicsTop + numberOfCosmicsBottom);
   }
-  
+
   // *** TrackAssociator *** //
-  
-  // get reco tracks 
+
+  // get reco tracks
   edm::Handle<reco::TrackCollection> recoTracks;
-  iEvent.getByLabel("cosmicMuons", recoTracks);  
-  
-  if ( recoTracks.isValid() ) {
+  iEvent.getByLabel("cosmicMuons", recoTracks);
+
+  if (recoTracks.isValid()) {
     //    LogWarning("EcalCosmicsHists") << "... Valid TrackAssociator recoTracks !!! " << recoTracks.product()->size();
-    std::map<int,std::vector<DetId> > trackDetIdMap;
+    std::map<int, std::vector<DetId> > trackDetIdMap;
     int tracks = 0;
-    for(reco::TrackCollection::const_iterator recoTrack = recoTracks->begin(); recoTrack != recoTracks->end(); ++recoTrack){
-      
-      if(fabs(recoTrack->d0())>70 || fabs(recoTrack->dz())>70)
+    for (reco::TrackCollection::const_iterator recoTrack = recoTracks->begin(); recoTrack != recoTracks->end();
+         ++recoTrack) {
+      if (fabs(recoTrack->d0()) > 70 || fabs(recoTrack->dz()) > 70)
         continue;
-      if(recoTrack->numberOfValidHits()<20)
+      if (recoTrack->numberOfValidHits() < 20)
         continue;
-      
-      //if (recoTrack->pt() < 2) continue; // skip low Pt tracks       
-      
-      TrackDetMatchInfo info = trackAssociator_.associate(iEvent, iSetup, *recoTrack, trackParameters_);      
-      
+
+      //if (recoTrack->pt() < 2) continue; // skip low Pt tracks
+
+      TrackDetMatchInfo info = trackAssociator_.associate(iEvent, iSetup, *recoTrack, trackParameters_);
+
       //       edm::LogVerbatim("TrackAssociator") << "\n-------------------------------------------------------\n Track (pt,eta,phi): " <<
       //    recoTrack->pt() << " , " << recoTrack->eta() << " , " << recoTrack->phi() ;
       //       edm::LogVerbatim("TrackAssociator") << "Ecal energy in crossed crystals based on RecHits: " <<
@@ -1034,7 +1035,7 @@ EcalCosmicsHists::analyze(edm::Event const & iEvent, edm::EventSetup const & iSe
       //       edm::LogVerbatim("TrackAssociator") << "Hcal energy in 3x3 towers based on RecHits: " <<
       //    info.nXnEnergy(TrackDetMatchInfo::HcalRecHits, 1);
       //       edm::LogVerbatim("TrackAssociator") << "Number of muon segment matches: " << info.numberOfSegments();
-      
+
       //       std::cout << "\n-------------------------------------------------------\n Track (pt,eta,phi): " <<
       //    recoTrack->pt() << " , " << recoTrack->eta() << " , " << recoTrack->phi() << std::endl;
       //       std::cout << "Ecal energy in crossed crystals based on RecHits: " <<
@@ -1045,41 +1046,41 @@ EcalCosmicsHists::analyze(edm::Event const & iEvent, edm::EventSetup const & iSe
       //    info.crossedEnergy(TrackDetMatchInfo::HcalRecHits) << std::endl;
       //       std::cout << "Hcal energy in 3x3 towers based on RecHits: " <<
       //    info.nXnEnergy(TrackDetMatchInfo::HcalRecHits, 1) << std::endl;
-      
-      for (unsigned int i=0; i<info.crossedEcalIds.size(); i++) {	 
-	// only checks for barrel
-	if (info.crossedEcalIds[i].det() == DetId::Ecal && info.crossedEcalIds[i].subdetId() == 1) {	     
-	  EBDetId ebDetId (info.crossedEcalIds[i]);	   
-	  trackAssoc_muonsEcal_->Fill(ebDetId.iphi(), ebDetId.ieta());
-	  //std::cout << "Crossed iphi: " << ebDetId.iphi() 
-	  //    << " ieta: " << ebDetId.ieta() << " : nCross " << info.crossedEcalIds.size() << std::endl;
 
-	  EcalRecHitCollection::const_iterator thishit = hits->find(ebDetId);
-	  if (thishit == hits->end()) continue;
-	  
-	  //EcalRecHit myhit = (*thishit);	 
-	  //double thisamp = myhit.energy();
-	  //std::cout << " Crossed energy: " << thisamp << " : nCross " << info.crossedEcalIds.size() << std::endl;	  
-	}
+      for (unsigned int i = 0; i < info.crossedEcalIds.size(); i++) {
+        // only checks for barrel
+        if (info.crossedEcalIds[i].det() == DetId::Ecal && info.crossedEcalIds[i].subdetId() == 1) {
+          EBDetId ebDetId(info.crossedEcalIds[i]);
+          trackAssoc_muonsEcal_->Fill(ebDetId.iphi(), ebDetId.ieta());
+          //std::cout << "Crossed iphi: " << ebDetId.iphi()
+          //    << " ieta: " << ebDetId.ieta() << " : nCross " << info.crossedEcalIds.size() << std::endl;
+
+          EcalRecHitCollection::const_iterator thishit = hits->find(ebDetId);
+          if (thishit == hits->end())
+            continue;
+
+          //EcalRecHit myhit = (*thishit);
+          //double thisamp = myhit.energy();
+          //std::cout << " Crossed energy: " << thisamp << " : nCross " << info.crossedEcalIds.size() << std::endl;
+        }
       }
-      
+
       //edm::LogVerbatim("TrackAssociator") << " crossedEcalIds size: " << info.crossedEcalIds.size()
       //				  << " crossedEcalRecHits size: " << info.crossedEcalRecHits.size();
       numberofCrossedEcalIdsHist_->Fill(info.crossedEcalIds.size());
       tracks++;
-      if(!info.crossedEcalIds.empty())
-        trackDetIdMap.insert(std::pair<int,std::vector<DetId> > (tracks,info.crossedEcalIds));
-    }      
-    
+      if (!info.crossedEcalIds.empty())
+        trackDetIdMap.insert(std::pair<int, std::vector<DetId> >(tracks, info.crossedEcalIds));
+    }
+
     // Now to match recoTracks with cosmic clusters
-    
+
     int numAssocTracks = 0;
     int numAssocClusters = 0;
     edm::LogVerbatim("TrackAssociator") << "Matching cosmic clusters to tracks...";
     int numSeeds = seeds.size();
     int numTracks = trackDetIdMap.size();
-    while(!seeds.empty() && !trackDetIdMap.empty())
-    {
+    while (!seeds.empty() && !trackDetIdMap.empty()) {
       double bestDr = 1000;
       double bestDPhi = 1000;
       double bestDEta = 1000;
@@ -1090,28 +1091,28 @@ EcalCosmicsHists::analyze(edm::Event const & iEvent, edm::EventSetup const & iSe
       EBDetId bestTrackDet;
       EBDetId bestSeed;
       int bestTrack = -1;
-      std::map<EBDetId,EBDetId> trackDetIdToSeedMap;
+      std::map<EBDetId, EBDetId> trackDetIdToSeedMap;
 
       //edm::LogVerbatim("TrackAssociator") << "NumTracks:" << trackDetIdMap.size() << " numClusters:" << seeds.size();
 
-      for(std::vector<EBDetId>::const_iterator seedItr = seeds.begin(); seedItr != seeds.end(); ++seedItr) {
-        for(std::map<int,std::vector<DetId> >::const_iterator mapItr = trackDetIdMap.begin();
-            mapItr != trackDetIdMap.end(); ++mapItr) {
-          for(unsigned int i=0; i<mapItr->second.size(); i++) {
+      for (std::vector<EBDetId>::const_iterator seedItr = seeds.begin(); seedItr != seeds.end(); ++seedItr) {
+        for (std::map<int, std::vector<DetId> >::const_iterator mapItr = trackDetIdMap.begin();
+             mapItr != trackDetIdMap.end();
+             ++mapItr) {
+          for (unsigned int i = 0; i < mapItr->second.size(); i++) {
             // only checks for barrel
-            if(mapItr->second[i].det() == DetId::Ecal && mapItr->second[i].subdetId() == 1) {
+            if (mapItr->second[i].det() == DetId::Ecal && mapItr->second[i].subdetId() == 1) {
               EBDetId ebDet = (mapItr->second[i]);
               double seedEta = seedItr->ieta();
-              double deta = ebDet.ieta()-seedEta;
-              if(seedEta * ebDet.ieta() < 0 )
-                deta > 0 ? (deta=deta-1.) : (deta=deta+1.); 
+              double deta = ebDet.ieta() - seedEta;
+              if (seedEta * ebDet.ieta() < 0)
+                deta > 0 ? (deta = deta - 1.) : (deta = deta + 1.);
               double dR;
-              double dphi = ebDet.iphi()-seedItr->iphi();
+              double dphi = ebDet.iphi() - seedItr->iphi();
               if (abs(dphi) > 180)
-                dphi > 0 ?  (dphi=360-dphi) : (dphi=-360-dphi);
-              dR = sqrt(deta*deta + dphi*dphi);
-              if(dR < bestDr)
-              {
+                dphi > 0 ? (dphi = 360 - dphi) : (dphi = -360 - dphi);
+              dR = sqrt(deta * deta + dphi * dphi);
+              if (dR < bestDr) {
                 bestDr = dR;
                 bestDPhi = dphi;
                 bestDEta = deta;
@@ -1127,133 +1128,149 @@ EcalCosmicsHists::analyze(edm::Event const & iEvent, edm::EventSetup const & iSe
           }
         }
       }
-      if(bestDr < 1000) {
+      if (bestDr < 1000) {
         //edm::LogVerbatim("TrackAssociator") << "Best deltaR from matched DetId's to cluster:" << bestDr;
         deltaRHist_->Fill(bestDr);
         deltaPhiHist_->Fill(bestDPhi);
         deltaEtaHist_->Fill(bestDEta);
-        deltaEtaDeltaPhiHist_->Fill(bestDEta,bestDPhi);
-        seedTrackEtaHist_->Fill(bestEtaSeed,bestEtaTrack);
-        seedTrackPhiHist_->Fill(bestPhiSeed,bestPhiTrack);
-        seeds.erase(find(seeds.begin(),seeds.end(), bestSeed));
+        deltaEtaDeltaPhiHist_->Fill(bestDEta, bestDPhi);
+        seedTrackEtaHist_->Fill(bestEtaSeed, bestEtaTrack);
+        seedTrackPhiHist_->Fill(bestPhiSeed, bestPhiTrack);
+        seeds.erase(find(seeds.begin(), seeds.end(), bestSeed));
         trackDetIdMap.erase(trackDetIdMap.find(bestTrack));
         trackDetIdToSeedMap[bestTrackDet] = bestSeed;
         numAssocTracks++;
         numAssocClusters++;
 
-	// for high energy analysis
-	if(bestDPhi < 1.5 && bestDEta < 1.8 ) {
-	  //edm::LogVerbatim("TrackAssociator") << "Best seed ieta and iphi: (" 
-	  //					<< bestSeed.ieta() << ", " << bestSeed.iphi() << ") ";
-	  //check if the bestSeed is a High Energy one
-	  EcalRecHitCollection::const_iterator Ecalhit = hits->find(bestSeed);
-	  if (Ecalhit == hits->end()) {
-	    continue;
-	  }
-	  double EcalhitEnergy = Ecalhit->energy();
-	  //edm::LogVerbatim("TrackAssociator") << "Best seed energy: " << EcalhitEnergy ;
-	  HighEnergy_bestSeed->Fill(EcalhitEnergy);
-	  HighEnergy_bestSeedOccupancy->Fill(bestSeed.iphi(), bestSeed.ieta());
-	}
-      }
-      else {
-	edm::LogVerbatim("TrackAssociator") << "could not match cluster seed to track." << bestDr;
-	break; // no match found
+        // for high energy analysis
+        if (bestDPhi < 1.5 && bestDEta < 1.8) {
+          //edm::LogVerbatim("TrackAssociator") << "Best seed ieta and iphi: ("
+          //					<< bestSeed.ieta() << ", " << bestSeed.iphi() << ") ";
+          //check if the bestSeed is a High Energy one
+          EcalRecHitCollection::const_iterator Ecalhit = hits->find(bestSeed);
+          if (Ecalhit == hits->end()) {
+            continue;
+          }
+          double EcalhitEnergy = Ecalhit->energy();
+          //edm::LogVerbatim("TrackAssociator") << "Best seed energy: " << EcalhitEnergy ;
+          HighEnergy_bestSeed->Fill(EcalhitEnergy);
+          HighEnergy_bestSeedOccupancy->Fill(bestSeed.iphi(), bestSeed.ieta());
+        }
+      } else {
+        edm::LogVerbatim("TrackAssociator") << "could not match cluster seed to track." << bestDr;
+        break;  // no match found
       }
     }
-    if(numSeeds>0 && numTracks>0) {
-      ratioAssocClustersHist_->AddBinContent(1,numAssocClusters);
-      ratioAssocClustersHist_->AddBinContent(2,numSeeds);
+    if (numSeeds > 0 && numTracks > 0) {
+      ratioAssocClustersHist_->AddBinContent(1, numAssocClusters);
+      ratioAssocClustersHist_->AddBinContent(2, numSeeds);
     }
-    if(numTracks>0) {
-      ratioAssocTracksHist_->AddBinContent(1,numAssocTracks);
-      ratioAssocTracksHist_->AddBinContent(2,numTracks);
+    if (numTracks > 0) {
+      ratioAssocTracksHist_->AddBinContent(1, numAssocTracks);
+      ratioAssocTracksHist_->AddBinContent(2, numTracks);
       numberofCosmicsWTrackHist_->Fill(numSeeds);
     }
   } else {
-    //    LogWarning("EcalCosmicsHists") << "!!! No TrackAssociator recoTracks !!!";    
+    //    LogWarning("EcalCosmicsHists") << "!!! No TrackAssociator recoTracks !!!";
   }
-  
-  
+
   // Study on Tracks for High Energy events
   edm::Handle<reco::TrackCollection> recoTracksBarrel;
   iEvent.getByLabel("cosmicMuonsBarrelOnly", recoTracksBarrel);
-  if ( !recoTracksBarrel.isValid() ) {
+  if (!recoTracksBarrel.isValid()) {
     //edm::LogWarning("EcalCosmicsHists") << "RecoTracksBarrel not valid!! " ;
-  }
-  else {
+  } else {
     //edm::LogWarning("EcalCosmicsHists") << "Number of barrel reco tracks found in the event: " << recoTracksBarrel->size() ;
     HighEnergy_numRecoTrackBarrel->Fill(recoTracksBarrel->size());
-    for(reco::TrackCollection::const_iterator recoTrack = recoTracksBarrel->begin(); recoTrack != recoTracksBarrel->end(); ++recoTrack) {
+    for (reco::TrackCollection::const_iterator recoTrack = recoTracksBarrel->begin();
+         recoTrack != recoTracksBarrel->end();
+         ++recoTrack) {
       //edm::LogWarning("EcalCosmicsHists") << "Track (pt,eta,phi): " << recoTrack->pt() << " , " << recoTrack->eta() << " , " << recoTrack->phi() ;
       //edm::LogWarning("EcalCosmicsHists") << "Track innermost hit: " << recoTrack->innerPosition().phi() ;
     }
-    
-    for (reco::SuperClusterCollection::const_iterator clus = clusterCollection_p->begin(); clus != clusterCollection_p->end(); ++clus) {
+
+    for (reco::SuperClusterCollection::const_iterator clus = clusterCollection_p->begin();
+         clus != clusterCollection_p->end();
+         ++clus) {
       double energy = clus->energy();
-      double phi    = clus->phi();
-      double eta    = clus->eta();
-      
-      if (recoTracksBarrel->empty()) HighEnergy_0tracks_occu3D->Fill(phi,eta,energy);
-      if (recoTracksBarrel->size()==1) HighEnergy_1tracks_occu3D->Fill(phi,eta,energy);
-      if (recoTracksBarrel->size()==2) HighEnergy_2tracks_occu3D->Fill(phi,eta,energy);
-      
-      std::vector<std::pair<DetId, float> > clusterDetIds = clus->hitsAndFractions();//get these from the cluster
-      for(std::vector< std::pair<DetId, float> >::const_iterator detitr = clusterDetIds.begin(); detitr != clusterDetIds.end(); ++detitr)
-	{
-	  if ((*detitr).first.det() != DetId::Ecal) {continue;}
-	  if ((*detitr).first.subdetId() != EcalBarrel) {continue; }
-	  EcalRecHitCollection::const_iterator thishit = hits->find((*detitr).first);
-	  if (thishit == hits->end()) {continue;}
-	  
-	  double rechitenergy = thishit->energy();
-	  int ieta = ((EBDetId)(*detitr).first).ieta();
-	  int iphi = ((EBDetId)(*detitr).first).iphi();
-	  if (rechitenergy > minRecHitAmpEB_) {
-	    if (recoTracksBarrel->empty()) HighEnergy_0tracks_occu3DXtal->Fill(iphi,ieta,rechitenergy);
-	    if (recoTracksBarrel->size()==1) HighEnergy_1tracks_occu3DXtal->Fill(iphi,ieta,rechitenergy);
-	    if (recoTracksBarrel->size()==2) HighEnergy_2tracks_occu3DXtal->Fill(iphi,ieta,rechitenergy);
-	    
-	    if (rechitenergy > 10 ) edm::LogWarning("EcalCosmicsHists") << "!!!!! Crystal with energy " << rechitenergy << " at (ieta,iphi) (" << ieta << " ," << iphi << "); Id: " << (*detitr).first.det();
-	  }
-	}
+      double phi = clus->phi();
+      double eta = clus->eta();
+
+      if (recoTracksBarrel->empty())
+        HighEnergy_0tracks_occu3D->Fill(phi, eta, energy);
+      if (recoTracksBarrel->size() == 1)
+        HighEnergy_1tracks_occu3D->Fill(phi, eta, energy);
+      if (recoTracksBarrel->size() == 2)
+        HighEnergy_2tracks_occu3D->Fill(phi, eta, energy);
+
+      std::vector<std::pair<DetId, float> > clusterDetIds = clus->hitsAndFractions();  //get these from the cluster
+      for (std::vector<std::pair<DetId, float> >::const_iterator detitr = clusterDetIds.begin();
+           detitr != clusterDetIds.end();
+           ++detitr) {
+        if ((*detitr).first.det() != DetId::Ecal) {
+          continue;
+        }
+        if ((*detitr).first.subdetId() != EcalBarrel) {
+          continue;
+        }
+        EcalRecHitCollection::const_iterator thishit = hits->find((*detitr).first);
+        if (thishit == hits->end()) {
+          continue;
+        }
+
+        double rechitenergy = thishit->energy();
+        int ieta = ((EBDetId)(*detitr).first).ieta();
+        int iphi = ((EBDetId)(*detitr).first).iphi();
+        if (rechitenergy > minRecHitAmpEB_) {
+          if (recoTracksBarrel->empty())
+            HighEnergy_0tracks_occu3DXtal->Fill(iphi, ieta, rechitenergy);
+          if (recoTracksBarrel->size() == 1)
+            HighEnergy_1tracks_occu3DXtal->Fill(iphi, ieta, rechitenergy);
+          if (recoTracksBarrel->size() == 2)
+            HighEnergy_2tracks_occu3DXtal->Fill(iphi, ieta, rechitenergy);
+
+          if (rechitenergy > 10)
+            edm::LogWarning("EcalCosmicsHists") << "!!!!! Crystal with energy " << rechitenergy << " at (ieta,iphi) ("
+                                                << ieta << " ," << iphi << "); Id: " << (*detitr).first.det();
+        }
+      }
     }
-    
+
     // look at angle between 2 recoTracks
-    if ( recoTracksBarrel->size() == 2 ) {
+    if (recoTracksBarrel->size() == 2) {
       reco::TrackCollection::const_iterator Track1 = recoTracksBarrel->begin();
-      reco::TrackCollection::const_iterator Track2 = (recoTracksBarrel->begin())+1;
-      float angle = (acos(sin(Track1->theta()) * cos(Track1->phi()) * sin(Track2->theta()) * cos(Track2->phi()) + sin(Track1->theta()) * sin(Track1->phi()) * sin(Track2->theta()) * sin(Track2->phi()) + cos(Track1->theta()) * cos(Track2->theta())))/0.017453292519943;
+      reco::TrackCollection::const_iterator Track2 = (recoTracksBarrel->begin()) + 1;
+      float angle = (acos(sin(Track1->theta()) * cos(Track1->phi()) * sin(Track2->theta()) * cos(Track2->phi()) +
+                          sin(Track1->theta()) * sin(Track1->phi()) * sin(Track2->theta()) * sin(Track2->phi()) +
+                          cos(Track1->theta()) * cos(Track2->theta()))) /
+                    0.017453292519943;
       //edm::LogWarning("EcalCosmicsHists") << "Tracks angle: " << angle;
       HighEnergy_TracksAngle->Fill(angle);
-      if ( (Track1->innerPosition().phi()) > 0  && (Track2->innerPosition().phi()) < 0 ) {
-	//edm::LogWarning("EcalCosmicsHists") << "Top-bottom tracks";
-	HighEnergy_TracksAngleTopBottom->Fill(angle);
+      if ((Track1->innerPosition().phi()) > 0 && (Track2->innerPosition().phi()) < 0) {
+        //edm::LogWarning("EcalCosmicsHists") << "Top-bottom tracks";
+        HighEnergy_TracksAngleTopBottom->Fill(angle);
       }
-      
-      
     }
   }
-  
+
   // *** end of TrackAssociator code *** //
-  
-  
+
   // *** HCAL RecHits code *** //
-  
+
   //hcal rechits
   edm::Handle<HBHERecHitCollection> hbhe;
   iEvent.getByLabel("hbhereco", hbhe);
-  
+
   edm::Handle<HFRecHitCollection> hfrh;
-  iEvent.getByLabel("hfreco",hfrh);
-  
-  edm::Handle<HORecHitCollection> horh; 
+  iEvent.getByLabel("hfreco", hfrh);
+
+  edm::Handle<HORecHitCollection> horh;
   iEvent.getByLabel("horeco", horh);
-  
-  if ( hbhe.isValid() ) {
-    //    LogInfo("EcalCosmicHists") << "event " << ievt << " HBHE RecHits collection size " << hbhe->size();    
+
+  if (hbhe.isValid()) {
+    //    LogInfo("EcalCosmicHists") << "event " << ievt << " HBHE RecHits collection size " << hbhe->size();
     const HBHERecHitCollection hbheHit = *(hbhe.product());
-    for (HBHERecHitCollection::const_iterator hhit=hbheHit.begin(); hhit!=hbheHit.end(); hhit++) {
+    for (HBHERecHitCollection::const_iterator hhit = hbheHit.begin(); hhit != hbheHit.end(); hhit++) {
       //      if (hhit->energy() > 0.6){
       hcalEnergy_HBHE_->Fill(hhit->energy());
       //      }
@@ -1261,21 +1278,21 @@ EcalCosmicsHists::analyze(edm::Event const & iEvent, edm::EventSetup const & iSe
   } else {
     //    LogWarning("EcalCosmicHists") << " HBHE RecHits **NOT** VALID!! " << endl;
   }
-  
-  if ( hfrh.isValid() ) {
+
+  if (hfrh.isValid()) {
     //    LogInfo("EcalCosmicHists") << "event " << ievt << " HF RecHits collection size " << hfrh->size();
     const HFRecHitCollection hfHit = *(hfrh.product());
-    for (HFRecHitCollection::const_iterator hhit=hfHit.begin(); hhit!=hfHit.end(); hhit++) {
+    for (HFRecHitCollection::const_iterator hhit = hfHit.begin(); hhit != hfHit.end(); hhit++) {
       hcalEnergy_HF_->Fill(hhit->energy());
     }
   } else {
     //    LogWarning("EcalCosmicHists") << " HF RecHits **NOT** VALID!! " << endl;
-  } 
-  
-  if ( horh.isValid() ) {
+  }
+
+  if (horh.isValid()) {
     //    LogInfo("EcalCosmicHists") << "event " << ievt << " HO RecHits collection size " << horh->size();
     const HORecHitCollection hoHit = *(horh.product());
-    for (HORecHitCollection::const_iterator hhit=hoHit.begin(); hhit!=hoHit.end(); hhit++) {
+    for (HORecHitCollection::const_iterator hhit = hoHit.begin(); hhit != hoHit.end(); hhit++) {
       //     if (hhit->energy() > 0.6){
       hcalEnergy_HO_->Fill(hhit->energy());
       //     }
@@ -1283,41 +1300,38 @@ EcalCosmicsHists::analyze(edm::Event const & iEvent, edm::EventSetup const & iSe
   } else {
     //    LogWarning("EcalCosmicHists") << " HO RecHits **NOT** VALID!! " << endl;
   }
-  
+
   // *** end of HCAL code *** //
 }
 
-
-
-std::vector<bool> EcalCosmicsHists::determineTriggers(const edm::Event& iEvent, const edm::EventSetup& eventSetup)
-{
-  std::vector<bool> l1Triggers; //DT,CSC,RPC,HCAL,ECAL
-                                //0 , 1 , 2 , 3  , 4
-  for(int i=0;i<5;i++)
+std::vector<bool> EcalCosmicsHists::determineTriggers(const edm::Event& iEvent, const edm::EventSetup& eventSetup) {
+  std::vector<bool> l1Triggers;  //DT,CSC,RPC,HCAL,ECAL
+                                 //0 , 1 , 2 , 3  , 4
+  for (int i = 0; i < 5; i++)
     l1Triggers.push_back(false);
-  
+
   // get the GMTReadoutCollection
-  Handle<L1MuGMTReadoutCollection> gmtrc_handle; 
-  iEvent.getByLabel(l1GMTReadoutRecTag_,gmtrc_handle);
+  Handle<L1MuGMTReadoutCollection> gmtrc_handle;
+  iEvent.getByLabel(l1GMTReadoutRecTag_, gmtrc_handle);
   L1MuGMTReadoutCollection const* gmtrc = gmtrc_handle.product();
-  if (!(gmtrc_handle.isValid())) 
-    {
-      LogWarning("EcalCosmicsHists") << "l1MuGMTReadoutCollection" << " not available";
-      return l1Triggers;
-    }
+  if (!(gmtrc_handle.isValid())) {
+    LogWarning("EcalCosmicsHists") << "l1MuGMTReadoutCollection"
+                                   << " not available";
+    return l1Triggers;
+  }
   // get hold of L1GlobalReadoutRecord
   Handle<L1GlobalTriggerReadoutRecord> L1GTRR;
-  iEvent.getByLabel(l1GTReadoutRecTag_,L1GTRR);
-  
+  iEvent.getByLabel(l1GTReadoutRecTag_, L1GTRR);
+
   //Ecal
   edm::ESHandle<L1GtTriggerMenu> menuRcd;
-  eventSetup.get<L1GtTriggerMenuRcd>().get(menuRcd) ;
+  eventSetup.get<L1GtTriggerMenuRcd>().get(menuRcd);
   const L1GtTriggerMenu* menu = menuRcd.product();
-  edm::Handle< L1GlobalTriggerReadoutRecord > gtRecord;
-  iEvent.getByLabel( edm::InputTag("gtDigis"), gtRecord);
+  edm::Handle<L1GlobalTriggerReadoutRecord> gtRecord;
+  iEvent.getByLabel(edm::InputTag("gtDigis"), gtRecord);
   // Get dWord after masking disabled bits
   const DecisionWord dWord = gtRecord->decisionWord();
-  
+
   bool l1SingleEG1 = menu->gtAlgorithmResult("L1_SingleEG1", dWord);
   bool l1SingleEG5 = menu->gtAlgorithmResult("L1_SingleEG5", dWord);
   bool l1SingleEG8 = menu->gtAlgorithmResult("L1_SingleEG8", dWord);
@@ -1329,668 +1343,1518 @@ std::vector<bool> EcalCosmicsHists::determineTriggers(const edm::Event& iEvent, 
   bool l1DoubleNoIsoEGBTBtight = menu->gtAlgorithmResult("L1_DoubleNoIsoEG_BTB_tight", dWord);
   bool l1DoubleNoIsoEGBTBloose = menu->gtAlgorithmResult("L1_DoubleNoIsoEG_BTB_loose ", dWord);
   bool l1DoubleNoIsoEGTopBottom = menu->gtAlgorithmResult("L1_DoubleNoIsoEGTopBottom", dWord);
-  bool l1DoubleNoIsoEGTopBottomCen  = menu->gtAlgorithmResult("L1_DoubleNoIsoEGTopBottomCen", dWord);
-  bool l1DoubleNoIsoEGTopBottomCen2  = menu->gtAlgorithmResult("L1_DoubleNoIsoEGTopBottomCen2", dWord);
-  bool l1DoubleNoIsoEGTopBottomCenVert  = menu->gtAlgorithmResult("L1_DoubleNoIsoEGTopBottomCenVert", dWord);
-  
-  l1Triggers[4] = l1SingleEG1 || l1SingleEG5 || l1SingleEG8 || l1SingleEG10 || l1SingleEG12 || l1SingleEG15
-    || l1SingleEG20 || l1SingleEG25 || l1DoubleNoIsoEGBTBtight || l1DoubleNoIsoEGBTBloose
-    || l1DoubleNoIsoEGTopBottom || l1DoubleNoIsoEGTopBottomCen || l1DoubleNoIsoEGTopBottomCen2
-    || l1DoubleNoIsoEGTopBottomCenVert;
-  
+  bool l1DoubleNoIsoEGTopBottomCen = menu->gtAlgorithmResult("L1_DoubleNoIsoEGTopBottomCen", dWord);
+  bool l1DoubleNoIsoEGTopBottomCen2 = menu->gtAlgorithmResult("L1_DoubleNoIsoEGTopBottomCen2", dWord);
+  bool l1DoubleNoIsoEGTopBottomCenVert = menu->gtAlgorithmResult("L1_DoubleNoIsoEGTopBottomCenVert", dWord);
+
+  l1Triggers[4] = l1SingleEG1 || l1SingleEG5 || l1SingleEG8 || l1SingleEG10 || l1SingleEG12 || l1SingleEG15 ||
+                  l1SingleEG20 || l1SingleEG25 || l1DoubleNoIsoEGBTBtight || l1DoubleNoIsoEGBTBloose ||
+                  l1DoubleNoIsoEGTopBottom || l1DoubleNoIsoEGTopBottomCen || l1DoubleNoIsoEGTopBottomCen2 ||
+                  l1DoubleNoIsoEGTopBottomCenVert;
+
   std::vector<L1MuGMTReadoutRecord> gmt_records = gmtrc->getRecords();
   std::vector<L1MuGMTReadoutRecord>::const_iterator igmtrr;
-  for(igmtrr=gmt_records.begin(); igmtrr!=gmt_records.end(); igmtrr++) {
+  for (igmtrr = gmt_records.begin(); igmtrr != gmt_records.end(); igmtrr++) {
     std::vector<L1MuRegionalCand>::const_iterator iter1;
     std::vector<L1MuRegionalCand> rmc;
-    
+
     //DT triggers
     int idt = 0;
     rmc = igmtrr->getDTBXCands();
-    for(iter1=rmc.begin(); iter1!=rmc.end(); iter1++) {
-      if ( !(*iter1).empty() ) {
+    for (iter1 = rmc.begin(); iter1 != rmc.end(); iter1++) {
+      if (!(*iter1).empty()) {
         idt++;
       }
     }
-    //if(idt>0) std::cout << "Found " << idt << " valid DT candidates in bx wrt. L1A = " 
+    //if(idt>0) std::cout << "Found " << idt << " valid DT candidates in bx wrt. L1A = "
     //  << igmtrr->getBxInEvent() << std::endl;
-    if(igmtrr->getBxInEvent()==0 && idt>0) l1Triggers[0] = true;
-    
+    if (igmtrr->getBxInEvent() == 0 && idt > 0)
+      l1Triggers[0] = true;
+
     //RPC triggers
     int irpcb = 0;
     rmc = igmtrr->getBrlRPCCands();
-    for(iter1=rmc.begin(); iter1!=rmc.end(); iter1++) {
-      if ( !(*iter1).empty() ) {
+    for (iter1 = rmc.begin(); iter1 != rmc.end(); iter1++) {
+      if (!(*iter1).empty()) {
         irpcb++;
       }
     }
-    //if(irpcb>0) std::cout << "Found " << irpcb << " valid RPC candidates in bx wrt. L1A = " 
+    //if(irpcb>0) std::cout << "Found " << irpcb << " valid RPC candidates in bx wrt. L1A = "
     //  << igmtrr->getBxInEvent() << std::endl;
-    if(igmtrr->getBxInEvent()==0 && irpcb>0) l1Triggers[2] = true;
-    
+    if (igmtrr->getBxInEvent() == 0 && irpcb > 0)
+      l1Triggers[2] = true;
+
     //CSC Triggers
     int icsc = 0;
     rmc = igmtrr->getCSCCands();
-    for(iter1=rmc.begin(); iter1!=rmc.end(); iter1++) {
-      if ( !(*iter1).empty() ) {
+    for (iter1 = rmc.begin(); iter1 != rmc.end(); iter1++) {
+      if (!(*iter1).empty()) {
         icsc++;
       }
     }
-    //if(icsc>0) std::cout << "Found " << icsc << " valid CSC candidates in bx wrt. L1A = " 
+    //if(icsc>0) std::cout << "Found " << icsc << " valid CSC candidates in bx wrt. L1A = "
     //  << igmtrr->getBxInEvent() << std::endl;
-    if(igmtrr->getBxInEvent()==0 && icsc>0) l1Triggers[1] = true;
+    if (igmtrr->getBxInEvent() == 0 && icsc > 0)
+      l1Triggers[1] = true;
   }
-  
+
   L1GlobalTriggerReadoutRecord const* gtrr = L1GTRR.product();
-  
-  for(int ibx=-1; ibx<=1; ibx++) {
+
+  for (int ibx = -1; ibx <= 1; ibx++) {
     bool hcal_top = false;
     bool hcal_bot = false;
-    const L1GtPsbWord psb = gtrr->gtPsbWord(0xbb0d,ibx);
+    const L1GtPsbWord psb = gtrr->gtPsbWord(0xbb0d, ibx);
     std::vector<int> valid_phi;
-    if((psb.aData(4)&0x3f) >= 1) {valid_phi.push_back( (psb.aData(4)>>10)&0x1f ); }
-    if((psb.bData(4)&0x3f) >= 1) {valid_phi.push_back( (psb.bData(4)>>10)&0x1f ); }
-    if((psb.aData(5)&0x3f) >= 1) {valid_phi.push_back( (psb.aData(5)>>10)&0x1f ); }
-    if((psb.bData(5)&0x3f) >= 1) {valid_phi.push_back( (psb.bData(5)>>10)&0x1f ); }
-    std::vector<int>::const_iterator iphi;
-    for(iphi=valid_phi.begin(); iphi!=valid_phi.end(); iphi++) {
-      //std::cout << "Found HCAL mip with phi=" << *iphi << " in bx wrt. L1A = " << ibx << std::endl;
-      if(*iphi<9) hcal_top=true;
-      if(*iphi>8) hcal_bot=true;
+    if ((psb.aData(4) & 0x3f) >= 1) {
+      valid_phi.push_back((psb.aData(4) >> 10) & 0x1f);
     }
-    if(ibx==0 && hcal_top && hcal_bot) l1Triggers[3]=true;
+    if ((psb.bData(4) & 0x3f) >= 1) {
+      valid_phi.push_back((psb.bData(4) >> 10) & 0x1f);
+    }
+    if ((psb.aData(5) & 0x3f) >= 1) {
+      valid_phi.push_back((psb.aData(5) >> 10) & 0x1f);
+    }
+    if ((psb.bData(5) & 0x3f) >= 1) {
+      valid_phi.push_back((psb.bData(5) >> 10) & 0x1f);
+    }
+    std::vector<int>::const_iterator iphi;
+    for (iphi = valid_phi.begin(); iphi != valid_phi.end(); iphi++) {
+      //std::cout << "Found HCAL mip with phi=" << *iphi << " in bx wrt. L1A = " << ibx << std::endl;
+      if (*iphi < 9)
+        hcal_top = true;
+      if (*iphi > 8)
+        hcal_bot = true;
+    }
+    if (ibx == 0 && hcal_top && hcal_bot)
+      l1Triggers[3] = true;
   }
-  
+
   edm::LogInfo("EcalCosmicsHists") << "**** Trigger SourceSource ****";
-  if(l1Triggers[0]) edm::LogInfo("EcalCosmicsHists") << "DT";
-  if(l1Triggers[2]) edm::LogInfo("EcalCosmicsHists") << "RPC";
-  if(l1Triggers[1]) edm::LogInfo("EcalCosmicsHists") << "CSC";
-  if(l1Triggers[3]) edm::LogInfo("EcalCosmicsHists") << "HCAL";
-  if(l1Triggers[4]) edm::LogInfo("EcalCosmicsHists") << "ECAL";
+  if (l1Triggers[0])
+    edm::LogInfo("EcalCosmicsHists") << "DT";
+  if (l1Triggers[2])
+    edm::LogInfo("EcalCosmicsHists") << "RPC";
+  if (l1Triggers[1])
+    edm::LogInfo("EcalCosmicsHists") << "CSC";
+  if (l1Triggers[3])
+    edm::LogInfo("EcalCosmicsHists") << "HCAL";
+  if (l1Triggers[4])
+    edm::LogInfo("EcalCosmicsHists") << "ECAL";
   edm::LogInfo("EcalCosmicsHists") << "************************";
-  
+
   return l1Triggers;
 }
 
 // insert the hist map into the map keyed by FED number
-void EcalCosmicsHists::initHists(int FED)
-{
+void EcalCosmicsHists::initHists(int FED) {
   using namespace std;
-  
+
   string FEDid = intToString(FED);
   string title1 = "Energy of Seed Crystal ";
   title1.append(fedMap_->getSliceFromFed(FED));
   title1.append(";Seed Energy (GeV);Number of Cosmics");
   string name1 = "SeedEnergyFED";
   name1.append(intToString(FED));
-  int numBins = 200;//(int)round(histRangeMax_-histRangeMin_)+1;
-  TH1F* hist = new TH1F(name1.c_str(),title1.c_str(), numBins, histRangeMin_, histRangeMax_);
+  int numBins = 200;  //(int)round(histRangeMax_-histRangeMin_)+1;
+  TH1F* hist = new TH1F(name1.c_str(), title1.c_str(), numBins, histRangeMin_, histRangeMax_);
   FEDsAndHists_[FED] = hist;
   FEDsAndHists_[FED]->SetDirectory(nullptr);
-  
-  TH1F* E2hist = new TH1F(Form("E2_FED_%d",FED),Form("E2_FED_%d",FED), numBins, histRangeMin_, histRangeMax_);
+
+  TH1F* E2hist = new TH1F(Form("E2_FED_%d", FED), Form("E2_FED_%d", FED), numBins, histRangeMin_, histRangeMax_);
   FEDsAndE2Hists_[FED] = E2hist;
   FEDsAndE2Hists_[FED]->SetDirectory(nullptr);
-  
-  TH1F* energyhist = new TH1F(Form("Energy_FED_%d",FED),Form("Energy_FED_%d",FED), numBins, histRangeMin_, histRangeMax_);
+
+  TH1F* energyhist =
+      new TH1F(Form("Energy_FED_%d", FED), Form("Energy_FED_%d", FED), numBins, histRangeMin_, histRangeMax_);
   FEDsAndenergyHists_[FED] = energyhist;
   FEDsAndenergyHists_[FED]->SetDirectory(nullptr);
-  
-  TH2F* E2vsE1hist = new TH2F(Form("E2vsE1_FED_%d",FED),Form("E2vsE1_FED_%d",FED), numBins, histRangeMin_, histRangeMax_, numBins, histRangeMin_, histRangeMax_);
+
+  TH2F* E2vsE1hist = new TH2F(Form("E2vsE1_FED_%d", FED),
+                              Form("E2vsE1_FED_%d", FED),
+                              numBins,
+                              histRangeMin_,
+                              histRangeMax_,
+                              numBins,
+                              histRangeMin_,
+                              histRangeMax_);
   FEDsAndE2vsE1Hists_[FED] = E2vsE1hist;
   FEDsAndE2vsE1Hists_[FED]->SetDirectory(nullptr);
-  
-  TH2F* energyvsE1hist = new TH2F(Form("EnergyvsE1_FED_%d",FED),Form("EnergyvsE1_FED_%d",FED), numBins, histRangeMin_, histRangeMax_, numBins, histRangeMin_, histRangeMax_);
+
+  TH2F* energyvsE1hist = new TH2F(Form("EnergyvsE1_FED_%d", FED),
+                                  Form("EnergyvsE1_FED_%d", FED),
+                                  numBins,
+                                  histRangeMin_,
+                                  histRangeMax_,
+                                  numBins,
+                                  histRangeMin_,
+                                  histRangeMax_);
   FEDsAndenergyvsE1Hists_[FED] = energyvsE1hist;
   FEDsAndenergyvsE1Hists_[FED]->SetDirectory(nullptr);
-  
+
   title1 = "Time for ";
   title1.append(fedMap_->getSliceFromFed(FED));
   title1.append(";Relative Time (1 clock = 25ns);Events");
   name1 = "TimeFED";
   name1.append(intToString(FED));
-  TH1F* timingHist = new TH1F(name1.c_str(),title1.c_str(),78,-7,7);
+  TH1F* timingHist = new TH1F(name1.c_str(), title1.c_str(), 78, -7, 7);
   FEDsAndTimingHists_[FED] = timingHist;
   FEDsAndTimingHists_[FED]->SetDirectory(nullptr);
-  
-  TH1F* freqHist = new TH1F(Form("Frequency_FED_%d",FED),Form("Frequency for FED %d;Event Number",FED),100,0.,100000);
+
+  TH1F* freqHist =
+      new TH1F(Form("Frequency_FED_%d", FED), Form("Frequency for FED %d;Event Number", FED), 100, 0., 100000);
   FEDsAndFrequencyHists_[FED] = freqHist;
   FEDsAndFrequencyHists_[FED]->SetDirectory(nullptr);
-  
-  TH1F* iphiProfileHist = new TH1F(Form("iPhi_Profile_FED_%d",FED),Form("iPhi Profile for FED %d",FED),360,1.,361);
+
+  TH1F* iphiProfileHist =
+      new TH1F(Form("iPhi_Profile_FED_%d", FED), Form("iPhi Profile for FED %d", FED), 360, 1., 361);
   FEDsAndiPhiProfileHists_[FED] = iphiProfileHist;
   FEDsAndiPhiProfileHists_[FED]->SetDirectory(nullptr);
-  
-  TH1F* ietaProfileHist = new TH1F(Form("iEta_Profile_FED_%d",FED),Form("iEta Profile for FED %d",FED),172,-86,86);
+
+  TH1F* ietaProfileHist =
+      new TH1F(Form("iEta_Profile_FED_%d", FED), Form("iEta Profile for FED %d", FED), 172, -86, 86);
   FEDsAndiEtaProfileHists_[FED] = ietaProfileHist;
   FEDsAndiEtaProfileHists_[FED]->SetDirectory(nullptr);
-  
-  TH2F* timingHistVsFreq = new TH2F(Form("timeVsFreqFED_%d",FED),Form("time Vs Freq FED %d",FED),78,-7,7,100,0.,100000);
+
+  TH2F* timingHistVsFreq =
+      new TH2F(Form("timeVsFreqFED_%d", FED), Form("time Vs Freq FED %d", FED), 78, -7, 7, 100, 0., 100000);
   FEDsAndTimingVsFreqHists_[FED] = timingHistVsFreq;
   FEDsAndTimingVsFreqHists_[FED]->SetDirectory(nullptr);
-  
-  TH2F* timingHistVsAmp = new TH2F(Form("timeVsAmpFED_%d",FED),Form("time Vs Amp FED %d",FED),78,-7,7,numBins,histRangeMin_,histRangeMax_);
+
+  TH2F* timingHistVsAmp = new TH2F(
+      Form("timeVsAmpFED_%d", FED), Form("time Vs Amp FED %d", FED), 78, -7, 7, numBins, histRangeMin_, histRangeMax_);
   FEDsAndTimingVsAmpHists_[FED] = timingHistVsAmp;
   FEDsAndTimingVsAmpHists_[FED]->SetDirectory(nullptr);
-  
-  TH1F* numXtalInClusterHist = new TH1F(Form("NumXtalsInCluster_FED_%d",FED),Form("Num active Xtals In Cluster for FED %d;Num Active Xtals",FED),25,0,25);
+
+  TH1F* numXtalInClusterHist = new TH1F(Form("NumXtalsInCluster_FED_%d", FED),
+                                        Form("Num active Xtals In Cluster for FED %d;Num Active Xtals", FED),
+                                        25,
+                                        0,
+                                        25);
   FEDsAndNumXtalsInClusterHists_[FED] = numXtalInClusterHist;
   FEDsAndNumXtalsInClusterHists_[FED]->SetDirectory(nullptr);
-  
-  TH2F* OccupHist = new TH2F(Form("occupFED_%d",FED),Form("Occupancy FED %d;i#eta;i#phi",FED),85,1,86,20,1,21);
+
+  TH2F* OccupHist = new TH2F(Form("occupFED_%d", FED), Form("Occupancy FED %d;i#eta;i#phi", FED), 85, 1, 86, 20, 1, 21);
   FEDsAndOccupancyHists_[FED] = OccupHist;
   FEDsAndOccupancyHists_[FED]->SetDirectory(nullptr);
-  
-  TH2F* timingHistVsPhi = new TH2F(Form("timeVsPhiFED_%d",FED),Form("time Vs Phi FED %d;Relative Time (1 clock = 25ns);i#phi",FED),78,-7,7,20,1,21);
+
+  TH2F* timingHistVsPhi = new TH2F(Form("timeVsPhiFED_%d", FED),
+                                   Form("time Vs Phi FED %d;Relative Time (1 clock = 25ns);i#phi", FED),
+                                   78,
+                                   -7,
+                                   7,
+                                   20,
+                                   1,
+                                   21);
   FEDsAndTimingVsPhiHists_[FED] = timingHistVsPhi;
   FEDsAndTimingVsPhiHists_[FED]->SetDirectory(nullptr);
-  
-  TH2F* timingHistVsModule = new TH2F(Form("timeVsModuleFED_%d",FED),Form("time Vs Module FED %d;Relative Time (1 clock = 25ns);i#eta",FED),78,-7,7,4,1,86);
+
+  TH2F* timingHistVsModule = new TH2F(Form("timeVsModuleFED_%d", FED),
+                                      Form("time Vs Module FED %d;Relative Time (1 clock = 25ns);i#eta", FED),
+                                      78,
+                                      -7,
+                                      7,
+                                      4,
+                                      1,
+                                      86);
   FEDsAndTimingVsModuleHists_[FED] = timingHistVsModule;
   FEDsAndTimingVsModuleHists_[FED]->SetDirectory(nullptr);
 
-  TH2F* dccRuntypeVsBxFED = new TH2F(Form("DCCRuntypeVsBxFED_%d",FED),Form("DCC Runtype vs. BX FED %d",FED),3600,0,3600,24,0,24);
+  TH2F* dccRuntypeVsBxFED =
+      new TH2F(Form("DCCRuntypeVsBxFED_%d", FED), Form("DCC Runtype vs. BX FED %d", FED), 3600, 0, 3600, 24, 0, 24);
   FEDsAndDCCRuntypeVsBxHists_[FED] = dccRuntypeVsBxFED;
-  FEDsAndDCCRuntypeVsBxHists_[FED]->SetDirectory(nullptr); 
-  
+  FEDsAndDCCRuntypeVsBxHists_[FED]->SetDirectory(nullptr);
 }
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-EcalCosmicsHists::beginRun(edm::Run const &, edm::EventSetup const & eventSetup)
-{
-  edm::ESHandle< EcalElectronicsMapping > handle;
-  eventSetup.get< EcalMappingRcd >().get(handle);
+void EcalCosmicsHists::beginRun(edm::Run const&, edm::EventSetup const& eventSetup) {
+  edm::ESHandle<EcalElectronicsMapping> handle;
+  eventSetup.get<EcalMappingRcd>().get(handle);
   ecalElectronicsMap_ = handle.product();
-  
+
   //Here I will init some of the specific histograms
-  int numBins = 200;//(int)round(histRangeMax_-histRangeMin_)+1;
-  
+  int numBins = 200;  //(int)round(histRangeMax_-histRangeMin_)+1;
+
   //=============Special Bins for TT and Modules borders=============================
-  double ttEtaBins[36] = {-85, -80, -75, -70, -65, -60, -55, -50, -45, -40, -35, -30, -25, -20, -15, -10, -5, 0, 1, 6, 11, 16, 21, 26, 31, 36, 41, 46, 51, 56, 61, 66, 71, 76, 81, 86 };
-  double modEtaBins[10]={-85, -65, -45, -25, 0, 1, 26, 46, 66, 86};
+  double ttEtaBins[36] = {-85, -80, -75, -70, -65, -60, -55, -50, -45, -40, -35, -30, -25, -20, -15, -10, -5, 0,
+                          1,   6,   11,  16,  21,  26,  31,  36,  41,  46,  51,  56,  61,  66,  71,  76,  81, 86};
+  double modEtaBins[10] = {-85, -65, -45, -25, 0, 1, 26, 46, 66, 86};
   double ttPhiBins[73];
   double modPhiBins[19];
   double timingBins[79];
   double highEBins[11];
-  for (int i = 0; i < 79; ++i)
-    {
-      timingBins[i]=-7.+double(i)*14./78.;
-      if (i<73) 
-	{
-          ttPhiBins[i]=1+5*i;
-          if ( i < 19) 
-	    {
-              modPhiBins[i]=1+20*i;
-              if (i < 11)
-		{
-		  highEBins[i]=10.+double(i)*20.;
-		}
-	    }
-	}
-      
+  for (int i = 0; i < 79; ++i) {
+    timingBins[i] = -7. + double(i) * 14. / 78.;
+    if (i < 73) {
+      ttPhiBins[i] = 1 + 5 * i;
+      if (i < 19) {
+        modPhiBins[i] = 1 + 20 * i;
+        if (i < 11) {
+          highEBins[i] = 10. + double(i) * 20.;
+        }
+      }
     }
+  }
   //=============END Special Bins for TT and Modules borders===========================
-  
+
   //====================Frequency for Event timing information=========================
-  double timingEndInSeconds = runTimeLength_*3600.;  
-  double timingBinWidth     = timingEndInSeconds/double(numTimingBins_);
+  double timingEndInSeconds = runTimeLength_ * 3600.;
+  double timingBinWidth = timingEndInSeconds / double(numTimingBins_);
   //====================END Frequency for Event timing information=====================
-  
 
-  allFedsenergyHist_           = new TH1F("energy_AllClusters","energy_AllClusters;Cluster Energy (GeV)",numBins,histRangeMin_,histRangeMax_);
-  allFedsenergyHighHist_       = new TH1F("energyHigh_AllClusters","energyHigh_AllClusters;Cluster Energy (GeV)",numBins,histRangeMin_,200.0);
-  allFedsenergyOnlyHighHist_       = new TH1F("energyHigh_HighEnergyClusters","energy of High Energy Clusters;Cluster Energy (GeV)",numBins,histRangeMin_,200.0);
-  allFedsE2Hist_           = new TH1F("E2_AllClusters","E2_AllClusters;Seed+highest neighbor energy (GeV)",numBins,histRangeMin_,histRangeMax_);
-  allFedsE2vsE1Hist_       = new TH2F("E2vsE1_AllClusters","E2vsE1_AllClusters;Seed Energy (GeV);Seed+highest neighbor energy (GeV)",numBins,histRangeMin_,histRangeMax_,numBins,histRangeMin_,histRangeMax_);
-  allFedsenergyvsE1Hist_       = new TH2F("energyvsE1_AllClusters","energyvsE1_AllClusters;Seed Energy (GeV);Energy(GeV)",numBins,histRangeMin_,histRangeMax_,numBins,histRangeMin_,histRangeMax_);
-  allFedsTimingHist_       = new TH1F("timeForAllFeds","timeForAllFeds;Relative Time (1 clock = 25ns)",78,-7,7);
-  allFedsTimingVsFreqHist_ = new TH2F("timeVsFreqAllEvent","time Vs Freq All events;Relative Time (1 clock = 25ns);Event Number",78,-7,7,2000,0.,200000);
-  allFedsTimingVsAmpHist_  = new TH2F("timeVsAmpAllEvents","time Vs Amp All Events;Relative Time (1 clock = 25ns);Amplitude (GeV)",78,-7,7,numBins,histRangeMin_,histRangeMax_);
-  allFedsFrequencyHist_    = new TH1F("FrequencyAllEvent","Frequency for All events;Event Number",2000,0.,200000);
-  
+  allFedsenergyHist_ =
+      new TH1F("energy_AllClusters", "energy_AllClusters;Cluster Energy (GeV)", numBins, histRangeMin_, histRangeMax_);
+  allFedsenergyHighHist_ =
+      new TH1F("energyHigh_AllClusters", "energyHigh_AllClusters;Cluster Energy (GeV)", numBins, histRangeMin_, 200.0);
+  allFedsenergyOnlyHighHist_ = new TH1F("energyHigh_HighEnergyClusters",
+                                        "energy of High Energy Clusters;Cluster Energy (GeV)",
+                                        numBins,
+                                        histRangeMin_,
+                                        200.0);
+  allFedsE2Hist_ = new TH1F(
+      "E2_AllClusters", "E2_AllClusters;Seed+highest neighbor energy (GeV)", numBins, histRangeMin_, histRangeMax_);
+  allFedsE2vsE1Hist_ = new TH2F("E2vsE1_AllClusters",
+                                "E2vsE1_AllClusters;Seed Energy (GeV);Seed+highest neighbor energy (GeV)",
+                                numBins,
+                                histRangeMin_,
+                                histRangeMax_,
+                                numBins,
+                                histRangeMin_,
+                                histRangeMax_);
+  allFedsenergyvsE1Hist_ = new TH2F("energyvsE1_AllClusters",
+                                    "energyvsE1_AllClusters;Seed Energy (GeV);Energy(GeV)",
+                                    numBins,
+                                    histRangeMin_,
+                                    histRangeMax_,
+                                    numBins,
+                                    histRangeMin_,
+                                    histRangeMax_);
+  allFedsTimingHist_ = new TH1F("timeForAllFeds", "timeForAllFeds;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  allFedsTimingVsFreqHist_ = new TH2F("timeVsFreqAllEvent",
+                                      "time Vs Freq All events;Relative Time (1 clock = 25ns);Event Number",
+                                      78,
+                                      -7,
+                                      7,
+                                      2000,
+                                      0.,
+                                      200000);
+  allFedsTimingVsAmpHist_ = new TH2F("timeVsAmpAllEvents",
+                                     "time Vs Amp All Events;Relative Time (1 clock = 25ns);Amplitude (GeV)",
+                                     78,
+                                     -7,
+                                     7,
+                                     numBins,
+                                     histRangeMin_,
+                                     histRangeMax_);
+  allFedsFrequencyHist_ = new TH1F("FrequencyAllEvent", "Frequency for All events;Event Number", 2000, 0., 200000);
+
   //--------Special Hists for times stamp info----------------------------------------------
-  allFedsFreqTimeHist_     = new TH1F("FrequencyAllEventsInTime",Form("Time of Cosmic Events; Time (s);Passing Event rate/%5g s",timingBinWidth),numTimingBins_,0.,timingEndInSeconds);
-  allFedsFreqTimeVsPhiHist_= new TH2F("FrequencyAllEventsInTimeVsPhi",Form("Time of Cosmic Events vs iPhi; iPhi;Time (s)/%5g s",timingBinWidth*360.),360,1.,361.,numTimingBins_/360,0.,timingEndInSeconds);
-  allFedsFreqTimeVsPhiTTHist_= new TH2F("FrequencyAllEventsInTimeVsTTPhi",Form("Time of Cosmic Events vs iPhi (TT bins); iPhi;Time (s)/%5g s",timingBinWidth*72.),72,1.,361.,numTimingBins_/72,0.,timingEndInSeconds);
-  allFedsFreqTimeVsEtaHist_= new TH2F("FrequencyAllEventsInTimeVsEta",Form("Time of Cosmic Events vs iEta; Time (s)/%5g s; iEta" ,timingBinWidth*172.),numTimingBins_/172,0.,timingEndInSeconds,172,-86.,86.);
-  allFedsFreqTimeVsEtaTTHist_= new TH2F("FrequencyAllEventsInTimeVsTTEta",Form("Time of Cosmic Events vs Eta (TT bins);Time (s)/%5g s; iEta" ,timingBinWidth*35.),numTimingBins_/35,0.,timingEndInSeconds,35,ttEtaBins);
+  allFedsFreqTimeHist_ = new TH1F("FrequencyAllEventsInTime",
+                                  Form("Time of Cosmic Events; Time (s);Passing Event rate/%5g s", timingBinWidth),
+                                  numTimingBins_,
+                                  0.,
+                                  timingEndInSeconds);
+  allFedsFreqTimeVsPhiHist_ =
+      new TH2F("FrequencyAllEventsInTimeVsPhi",
+               Form("Time of Cosmic Events vs iPhi; iPhi;Time (s)/%5g s", timingBinWidth * 360.),
+               360,
+               1.,
+               361.,
+               numTimingBins_ / 360,
+               0.,
+               timingEndInSeconds);
+  allFedsFreqTimeVsPhiTTHist_ =
+      new TH2F("FrequencyAllEventsInTimeVsTTPhi",
+               Form("Time of Cosmic Events vs iPhi (TT bins); iPhi;Time (s)/%5g s", timingBinWidth * 72.),
+               72,
+               1.,
+               361.,
+               numTimingBins_ / 72,
+               0.,
+               timingEndInSeconds);
+  allFedsFreqTimeVsEtaHist_ =
+      new TH2F("FrequencyAllEventsInTimeVsEta",
+               Form("Time of Cosmic Events vs iEta; Time (s)/%5g s; iEta", timingBinWidth * 172.),
+               numTimingBins_ / 172,
+               0.,
+               timingEndInSeconds,
+               172,
+               -86.,
+               86.);
+  allFedsFreqTimeVsEtaTTHist_ =
+      new TH2F("FrequencyAllEventsInTimeVsTTEta",
+               Form("Time of Cosmic Events vs Eta (TT bins);Time (s)/%5g s; iEta", timingBinWidth * 35.),
+               numTimingBins_ / 35,
+               0.,
+               timingEndInSeconds,
+               35,
+               ttEtaBins);
   //--------END Special Hists for times stamp info------------------------------------------
-  
-  allFedsiPhiProfileHist_  = new TH1F("iPhiProfileAllEvents","iPhi Profile all events;i#phi",360,1.,361.);
-  allFedsiEtaProfileHist_  = new TH1F("iEtaProfileAllEvents","iEta Profile all events;i#eta",172,-86,86);
-  
-  allOccupancy_            = new TH2F("OccupancyAllEvents","Occupancy all events;i#phi;i#eta",360,1.,361.,172,-86,86);  
-  TrueOccupancy_            = new TH2F("TrueOccupancyAllEvents","True Occupancy all events;#phi;#eta",360,-3.14159,3.14159,172,-1.5,1.5);
-  allOccupancyCoarse_      = new TH2F("OccupancyAllEventsCoarse","Occupancy all events Coarse;i#phi;i#eta",360/5,1,361.,35,ttEtaBins);  
-  TrueOccupancyCoarse_      = new TH2F("TrueOccupancyAllEventsCoarse","True Occupancy all events Coarse;#phi;#eta",360/5,-3.14159,3.14159,34,-1.5,1.5);
-  
-  
+
+  allFedsiPhiProfileHist_ = new TH1F("iPhiProfileAllEvents", "iPhi Profile all events;i#phi", 360, 1., 361.);
+  allFedsiEtaProfileHist_ = new TH1F("iEtaProfileAllEvents", "iEta Profile all events;i#eta", 172, -86, 86);
+
+  allOccupancy_ = new TH2F("OccupancyAllEvents", "Occupancy all events;i#phi;i#eta", 360, 1., 361., 172, -86, 86);
+  TrueOccupancy_ =
+      new TH2F("TrueOccupancyAllEvents", "True Occupancy all events;#phi;#eta", 360, -3.14159, 3.14159, 172, -1.5, 1.5);
+  allOccupancyCoarse_ =
+      new TH2F("OccupancyAllEventsCoarse", "Occupancy all events Coarse;i#phi;i#eta", 360 / 5, 1, 361., 35, ttEtaBins);
+  TrueOccupancyCoarse_ = new TH2F("TrueOccupancyAllEventsCoarse",
+                                  "True Occupancy all events Coarse;#phi;#eta",
+                                  360 / 5,
+                                  -3.14159,
+                                  3.14159,
+                                  34,
+                                  -1.5,
+                                  1.5);
+
   // single xtal cluster occupancy
-  allOccupancySingleXtal_  = new TH2F("OccupancySingleXtal","Occupancy single xtal clusters;i#phi;i#eta",360,1.,361.,172,-86,86);
-  energySingleXtalHist_    = new TH1F("energy_SingleXtalClusters","Energy single xtal clusters;Cluster Energy (GeV)",numBins,histRangeMin_,200.0);
-  
-  allFedsTimingPhiHist_          = new TH2F("timePhiAllFEDs","time vs Phi for all FEDs (TT binning);i#phi;Relative Time (1 clock = 25ns)",72,1,361,78,-7,7);
-  allFedsTimingPhiEbpHist_       = new TH2F("timePhiEBP","time vs Phi for FEDs in EB+ (TT binning) ;i#phi;Relative Time (1 clock = 25ns)",72,1,361,78,-7,7);
-  allFedsTimingPhiEbmHist_       = new TH2F("timePhiEBM","time vs Phi for FEDs in EB- (TT binning);i#phi;Relative Time (1 clock = 25ns)",72,1,361,78,-7,7);
-  allFedsTimingPhiEtaHist_       = new TH3F("timePhiEtaAllFEDs","(Phi,Eta,time) for all FEDs (SM,M binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",18,modPhiBins,9,modEtaBins,78,timingBins);  
-  allFedsTimingTTHist_           = new TH3F("timeTTAllFEDs","(Phi,Eta,time) for all FEDs (SM,TT binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",72,ttPhiBins,35,ttEtaBins,78,timingBins); 
-  allFedsTimingLMHist_           = new TH2F("timeLMAllFEDs","(LM,time) for all FEDs (SM,LM binning);LM;Relative Time (1 clock = 25ns)",92, 1, 92,78,-7,7);
-  
-  allFedsTimingEbpHist_       = new TH1F("timeEBP","time for FEDs in EB+;Relative Time (1 clock = 25ns)",78,-7,7);
-  allFedsTimingEbmHist_       = new TH1F("timeEBM","time for FEDs in EB-;Relative Time (1 clock = 25ns)",78,-7,7);
-  allFedsTimingEbpTopHist_    = new TH1F("timeEBPTop","time for FEDs in EB+ Top;Relative Time (1 clock = 25ns)",78,-7,7);
-  allFedsTimingEbmTopHist_    = new TH1F("timeEBMTop","time for FEDs in EB- Top;Relative Time (1 clock = 25ns)",78,-7,7);
-  allFedsTimingEbpBottomHist_ = new TH1F("timeEBPBottom","time for FEDs in EB+ Bottom;Relative Time (1 clock = 25ns)",78,-7,7);
-  allFedsTimingEbmBottomHist_ = new TH1F("timeEBMBottom","time for FEDs in EB- Bottom;Relative Time (1 clock = 25ns)",78,-7,7);
-  
-  numberofCosmicsHist_ = new TH1F("numberofCosmicsPerEvent","Number of cosmics per event;Number of Cosmics",30,0,30);
-  numberofCosmicsHistEB_ = new TH1F("numberofCosmicsPerEvent_EB","Number of cosmics per event EB;Number of Cosmics",30,0,30);
+  allOccupancySingleXtal_ =
+      new TH2F("OccupancySingleXtal", "Occupancy single xtal clusters;i#phi;i#eta", 360, 1., 361., 172, -86, 86);
+  energySingleXtalHist_ = new TH1F(
+      "energy_SingleXtalClusters", "Energy single xtal clusters;Cluster Energy (GeV)", numBins, histRangeMin_, 200.0);
 
-  numberofCosmicsWTrackHist_ = new TH1F("numberofCosmicsWTrackPerEvent","Number of cosmics with track per event",30,0,30);
-  numberofCosmicsTopBottomHist_ = new TH1F("numberofCosmicsTopBottomPerEvent","Number of top bottom cosmics per event;Number of Cosmics",30,0,30);
-  numberofGoodEvtFreq_  = new TH1F("frequencyOfGoodEvents","Number of events with cosmic vs Event;Event Number;Number of Good Events/100 Events",2000,0,200000);
-  
-  numberofCrossedEcalIdsHist_ = new TH1F("numberofCrossedEcalCosmicsPerEvent","Number of crossed ECAL cosmics per event;Number of Crossed Cosmics",10,0,10);
-  
-  allOccupancyExclusiveECAL_            = new TH2F("OccupancyAllEvents_ExclusiveECAL","Occupancy all events Exclusive ECAL ;i#phi;i#eta",360,1.,361.,172,-86,86);
-  allOccupancyCoarseExclusiveECAL_      = new TH2F("OccupancyAllEventsCoarse_ExclusiveECAL","Occupancy all events Coarse Exclusive ECAL;i#phi;i#eta",360/5,ttPhiBins,35, ttEtaBins);
-  allOccupancyECAL_            = new TH2F("OccupancyAllEvents_ECAL","Occupancy all events ECAL;i#phi;i#eta",360,1.,361.,172,-86,86);
-  allOccupancyCoarseECAL_      = new TH2F("OccupancyAllEventsCoarse_ECAL","Occupancy all events Coarse ECAL;i#phi;i#eta",360/5,ttPhiBins,35, ttEtaBins);
-  allFedsTimingHistECAL_       = new TH1F("timeForAllFeds_ECAL","timeForAllFeds ECAL;Relative Time (1 clock = 25ns)",78,-7,7);
-  allFedsTimingPhiEtaHistECAL_ = new TH3F("timePhiEtaAllFEDs_ECAL","ECAL (Phi,Eta,time) for all FEDs (SM,M binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",18,modPhiBins,9, modEtaBins,78,timingBins); 
-  allFedsTimingTTHistECAL_     = new TH3F("timeTTAllFEDs_ECAL","ECAL (Phi,Eta,time) for all FEDs (SM,TT binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",72,ttPhiBins,35,ttEtaBins,78,timingBins); 
-  allFedsTimingLMHistECAL_     = new TH2F("timeLMAllFEDs_ECAL","ECAL (LM,time) for all FEDs (SM,LM binning);LM;Relative Time (1 clock = 25ns)",92, 1, 92,78,-7,7); 
-  
-  allOccupancyExclusiveDT_            = new TH2F("OccupancyAllEvents_ExclusiveDT","Occupancy all events Exclusive DT;i#phi;i#eta",360,1.,361.,172,-86,86);
-  allOccupancyCoarseExclusiveDT_      = new TH2F("OccupancyAllEventsCoarse_ExclusiveDT","Occupancy all events Coarse Exclusive DT;i#phi;i#eta",360/5,1,361.,35,ttEtaBins);
-  allOccupancyDT_            = new TH2F("OccupancyAllEvents_DT","Occupancy all events DT;i#phi;i#eta",360,1.,361.,172,-86,86);
-  allOccupancyCoarseDT_      = new TH2F("OccupancyAllEventsCoarse_DT","Occupancy all events Coarse DT;i#phi;i#eta",360/5,1,361.,35,ttEtaBins);
-  allFedsTimingHistDT_       = new TH1F("timeForAllFeds_DT","timeForAllFeds DT;Relative Time (1 clock = 25ns)",78,-7,7);
-  allFedsTimingPhiEtaHistDT_ = new TH3F("timePhiEtaAllFEDs_DT","DT (Phi,Eta,time) for all FEDs (SM,M binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",18,modPhiBins,9, modEtaBins,78,timingBins);  
-  allFedsTimingTTHistDT_   = new TH3F("timeTTAllFEDs_DT","DT (Phi,Eta,time) for all FEDs (SM,TT binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",72,ttPhiBins,35,ttEtaBins,78,timingBins); 
-  allFedsTimingLMHistDT_   = new TH2F("timeLMAllFEDs_DT","DT (LM,time) for all FEDs (SM,LM binning);LM;Relative Time (1 clock = 25ns)",92, 1, 92,78,-7,7); 
-  
-  allOccupancyExclusiveRPC_            = new TH2F("OccupancyAllEvents_ExclusiveRPC","Occupancy all events Exclusive RPC;i#phi;i#eta",360,1.,361.,172,-86,86);
-  allOccupancyCoarseExclusiveRPC_      = new TH2F("OccupancyAllEventsCoarse_ExclusiveRPC","Occupancy all events Coarse Exclusive RPC;i#phi;i#eta",360/5,1,361.,35, ttEtaBins);
-  allOccupancyRPC_            = new TH2F("OccupancyAllEvents_RPC","Occupancy all events RPC;i#phi;i#eta",360,1.,361.,172,-86,86);
-  allOccupancyCoarseRPC_      = new TH2F("OccupancyAllEventsCoarse_RPC","Occupancy all events Coarse RPC;i#phi;i#eta",360/5,1,361.,35, ttEtaBins);
-  allFedsTimingHistRPC_       = new TH1F("timeForAllFeds_RPC","timeForAllFeds RPC;Relative Time (1 clock = 25ns)",78,-7,7);
-  allFedsTimingPhiEtaHistRPC_ = new TH3F("timePhiEtaAllFEDs_RPC","RPC (Phi,Eta,time) for all FEDs (SM,M binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",18,modPhiBins,9, modEtaBins,78,timingBins);  
-  allFedsTimingTTHistRPC_     = new TH3F("timeTTAllFEDs_RPC","RPC (Phi,Eta,time) for all FEDs (SM,TT binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",72,ttPhiBins,35,ttEtaBins,78,timingBins); 
-  allFedsTimingLMHistRPC_     = new TH2F("timeLMAllFEDs_RPC","RPC (LM,time) for all FEDs (SM,LM binning);LM;Relative Time (1 clock = 25ns)",92, 1, 92,78,-7,7); 
-  
-  allOccupancyExclusiveCSC_            = new TH2F("OccupancyAllEvents_ExclusiveCSC","Occupancy all events Exclusive CSC;i#phi;i#eta",360,1.,361.,172,-86,86);
-  allOccupancyCoarseExclusiveCSC_      = new TH2F("OccupancyAllEventsCoarse_ExclusiveCSC","Occupancy all events Coarse Exclusive CSC;i#phi;i#eta",360/5,1,361.,35, ttEtaBins);
-  allOccupancyCSC_            = new TH2F("OccupancyAllEvents_CSC","Occupancy all events CSC;i#phi;i#eta",360,1.,361.,172,-86,86);
-  allOccupancyCoarseCSC_      = new TH2F("OccupancyAllEventsCoarse_CSC","Occupancy all events Coarse CSC;i#phi;i#eta",360/5,1,361.,35, ttEtaBins);
-  allFedsTimingHistCSC_       = new TH1F("timeForAllFeds_CSC","timeForAllFeds CSC;Relative Time (1 clock = 25ns)",78,-7,7);
-  allFedsTimingPhiEtaHistCSC_ = new TH3F("timePhiEtaAllFEDs_CSC","CSC (Phi,Eta,time) for all FEDs (SM,M binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",18,modPhiBins,9, modEtaBins,78,timingBins);  
-  allFedsTimingTTHistCSC_    = new TH3F("timeTTAllFEDs_CSC","CSC (Phi,Eta,time) for all FEDs (SM,TT binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",72,ttPhiBins,35,ttEtaBins,78,timingBins); 
-  allFedsTimingLMHistCSC_    = new TH2F("timeLMAllFEDs_CSC","CSC (LM,time) for all FEDs (SM,LM binning);LM;Relative Time (1 clock = 25ns)",92, 1, 62,78,-7,7); 
-  
-  allOccupancyExclusiveHCAL_            = new TH2F("OccupancyAllEvents_ExclusiveHCAL","Occupancy all events Exclusive HCAL;i#phi;i#eta",360,1.,361.,172,-86,86);
-  allOccupancyCoarseExclusiveHCAL_      = new TH2F("OccupancyAllEventsCoarse_ExclusiveHCAL","Occupancy all events Coarse Exclusive HCAL;i#phi;i#eta",360/5,1,361.,35, ttEtaBins);
-  allOccupancyHCAL_            = new TH2F("OccupancyAllEvents_HCAL","Occupancy all events HCAL;i#phi;i#eta",360,1.,361.,172,-86,86);
-  allOccupancyCoarseHCAL_      = new TH2F("OccupancyAllEventsCoarse_HCAL","Occupancy all events Coarse HCAL;i#phi;i#eta",360/5,1,361.,35, ttEtaBins);
-  allFedsTimingHistHCAL_       = new TH1F("timeForAllFeds_HCAL","timeForAllFeds HCAL;Relative Time (1 clock = 25ns)",78,-7,7);
-  allFedsTimingPhiEtaHistHCAL_ = new TH3F("timePhiEtaAllFEDs_HCAL","HCAL (Phi,Eta,time) for all FEDs (SM,M binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",18,modPhiBins,9, modEtaBins,78,timingBins);  
-  allFedsTimingTTHistHCAL_     = new TH3F("timeTTAllFEDs_HCAL","HCAL (Phi,Eta,time) for all FEDs (SM,TT binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",72,ttPhiBins,35,ttEtaBins,78,timingBins); 
-  allFedsTimingLMHistHCAL_     = new TH2F("timeLMAllFEDs_HCAL","HCAL (LM,time) for all FEDs (SM,LM binning);LM;Relative Time (1 clock = 25ns)",92, 1, 92,78,-7,7); 
-  
-  TrueBCOccupancy_            = new TH2F("BCTrueOccupancyAllEvents","True SB Occupancy all events;#phi;#eta",360,-3.14159,3.14159,172,-1.5,1.5);
-  TrueBCOccupancyCoarse_      = new TH2F("BCTrueOccupancyAllEventsCoarse","True BC Occupancy all events Coarse;#phi;#eta",360/5,-3.14159,3.14159,34,-1.5 ,1.5);
-  
-  numberofBCinSC_ = new TH1F("numberofBCinSC","Number of Basic Clusters in Super Cluster;Num Basic Clusters",20,0,20);//SC
-  numberofBCinSCphi_ = new TH2F("numberofBCinSCphi","Number of Basic Clusters in Super Cluster;phi;Num Basic Clusters",360/5,-3.14159,3.14159,20,0,20);//SC
-  
-  allFedsTimingHistEcalMuon_   = new TH1F("timeForAllFeds_EcalMuon","timeForAllFeds Ecal+Muon;Relative Time (1 clock = 25ns)",78,-7,7);
-  
-  triggerHist_ = new TH1F("triggerHist","Trigger Number",5,0,5);
-  triggerHist_->GetXaxis()->SetBinLabel(1,"ECAL");
-  triggerHist_->GetXaxis()->SetBinLabel(2,"HCAL");
-  triggerHist_->GetXaxis()->SetBinLabel(3,"DT");
-  triggerHist_->GetXaxis()->SetBinLabel(4,"RPC");
-  triggerHist_->GetXaxis()->SetBinLabel(5,"CSC");
-  
-  triggerExclusiveHist_ = new TH1F("triggerExclusiveHist","Trigger Number (Mutually Exclusive)",5,0,5);  triggerExclusiveHist_->GetXaxis()->SetBinLabel(1,"ECAL");
-  triggerExclusiveHist_->GetXaxis()->SetBinLabel(2,"HCAL");
-  triggerExclusiveHist_->GetXaxis()->SetBinLabel(3,"DT");
-  triggerExclusiveHist_->GetXaxis()->SetBinLabel(4,"RPC");
-  triggerExclusiveHist_->GetXaxis()->SetBinLabel(5,"CSC");
-  
-  runNumberHist_ = new TH1F("runNumberHist","Run Number",1,0,1);
-  
-  deltaRHist_ = new TH1F("deltaRHist","deltaR",500,-0.5,499.5); 
-  deltaEtaHist_ = new TH1F("deltaIEtaHist","deltaIEta",170,-85.5,84.5);
-  deltaPhiHist_ = new TH1F("deltaIPhiHist","deltaIPhi",720,-360.5,359.5);
-  ratioAssocTracksHist_ = new TH1F("ratioAssocTracks","num assoc. tracks/tracks through Ecal",11,0,1.1);
-  ratioAssocClustersHist_ = new TH1F("ratioAssocClusters","num assoc. clusters/total clusters",11,0,1.1);
-  trackAssoc_muonsEcal_= new TH2F("trackAssoc_muonsEcal","Map of muon hits in Ecal", 360,1.,361.,172,-86,86);//360, 0 , 360, 170,-85 ,85);
-  deltaEtaDeltaPhiHist_ = new TH2F("deltaEtaDeltaPhi","Delta ieta vs. delta iphi",170,-85.5,84.5,720,-360.5,359.5); 
-  seedTrackEtaHist_ = new TH2F("seedTrackEta","track ieta vs. seed ieta",170,-85.5,84.5,170,-85.5,84.5); 
-  seedTrackPhiHist_ = new TH2F("seedTrackPhi","track iphi vs. seed iphi",720,-360.5,359.5,720,-360.5,359.5); 
+  allFedsTimingPhiHist_ = new TH2F("timePhiAllFEDs",
+                                   "time vs Phi for all FEDs (TT binning);i#phi;Relative Time (1 clock = 25ns)",
+                                   72,
+                                   1,
+                                   361,
+                                   78,
+                                   -7,
+                                   7);
+  allFedsTimingPhiEbpHist_ = new TH2F("timePhiEBP",
+                                      "time vs Phi for FEDs in EB+ (TT binning) ;i#phi;Relative Time (1 clock = 25ns)",
+                                      72,
+                                      1,
+                                      361,
+                                      78,
+                                      -7,
+                                      7);
+  allFedsTimingPhiEbmHist_ = new TH2F("timePhiEBM",
+                                      "time vs Phi for FEDs in EB- (TT binning);i#phi;Relative Time (1 clock = 25ns)",
+                                      72,
+                                      1,
+                                      361,
+                                      78,
+                                      -7,
+                                      7);
+  allFedsTimingPhiEtaHist_ =
+      new TH3F("timePhiEtaAllFEDs",
+               "(Phi,Eta,time) for all FEDs (SM,M binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",
+               18,
+               modPhiBins,
+               9,
+               modEtaBins,
+               78,
+               timingBins);
+  allFedsTimingTTHist_ =
+      new TH3F("timeTTAllFEDs",
+               "(Phi,Eta,time) for all FEDs (SM,TT binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",
+               72,
+               ttPhiBins,
+               35,
+               ttEtaBins,
+               78,
+               timingBins);
+  allFedsTimingLMHist_ = new TH2F(
+      "timeLMAllFEDs", "(LM,time) for all FEDs (SM,LM binning);LM;Relative Time (1 clock = 25ns)", 92, 1, 92, 78, -7, 7);
 
-  dccEventVsBxHist_ = new TH2F("dccEventVsBx","DCC Runtype vs. bunch crossing",3600,0,3600,24,0,24);
-  dccBXErrorByFEDHist_ = new TH1F("dccBXErrorByFED","Incorrect BX number by FED",54,601,655);
-  dccOrbitErrorByFEDHist_ = new TH1F("dccOrbitErrorByFED","Incorrect orbit number by FED",54,601,655);
-  dccRuntypeErrorByFEDHist_ = new TH1F("dccRuntypeErrorByFED","Incorrect DCC Runtype by FED",54,601,655);
-  dccRuntypeHist_ = new TH1F("dccRuntype","DCC Runtype frequency",24,0,24);
-  dccErrorVsBxHist_ = new TH2F("dccErrorVsBX","DCC Errors vs. BX",3600,0,3600,3,0,3);
-  
-  hcalEnergy_HBHE_ = new TH1F("hcalEnergy_HBHE","RecHit Energy HBHE",440,-10,100);
-  hcalEnergy_HF_   = new TH1F("hcalEnergy_HF","RecHit Energy HF",440,-10,100);
-  hcalEnergy_HO_   = new TH1F("hcalEnergy_HO","RecHit Energy HO",440,-10,100);
-  hcalHEHBecalEB_  = new TH2F("hcalHEHBecalEB","HCAL HBHE RecHit energy vs ECAL EB energy",numBins,histRangeMin_,300.0,40,-5,5);
-  
-  NumXtalsInClusterHist_              = new TH1F("NumXtalsInClusterAllHist","Number of Xtals in Cluster;NumXtals",150,0,150);
-  numxtalsVsEnergy_                   = new TH2F("NumXtalsVsEnergy","Number of Xtals in Cluster vs Energy;Energy (GeV);Number of Xtals in Cluster",numBins,histRangeMin_,histRangeMax_, 150,0,150);
-  numxtalsVsHighEnergy_               = new TH2F("NumXtalsVsHighEnergy","Number of Xtals in Cluster vs Energy;Energy (GeV);Number of Xtals in Cluster",numBins,histRangeMin_,200., 150,0,150);
-  
+  allFedsTimingEbpHist_ = new TH1F("timeEBP", "time for FEDs in EB+;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  allFedsTimingEbmHist_ = new TH1F("timeEBM", "time for FEDs in EB-;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  allFedsTimingEbpTopHist_ =
+      new TH1F("timeEBPTop", "time for FEDs in EB+ Top;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  allFedsTimingEbmTopHist_ =
+      new TH1F("timeEBMTop", "time for FEDs in EB- Top;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  allFedsTimingEbpBottomHist_ =
+      new TH1F("timeEBPBottom", "time for FEDs in EB+ Bottom;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  allFedsTimingEbmBottomHist_ =
+      new TH1F("timeEBMBottom", "time for FEDs in EB- Bottom;Relative Time (1 clock = 25ns)", 78, -7, 7);
+
+  numberofCosmicsHist_ =
+      new TH1F("numberofCosmicsPerEvent", "Number of cosmics per event;Number of Cosmics", 30, 0, 30);
+  numberofCosmicsHistEB_ =
+      new TH1F("numberofCosmicsPerEvent_EB", "Number of cosmics per event EB;Number of Cosmics", 30, 0, 30);
+
+  numberofCosmicsWTrackHist_ =
+      new TH1F("numberofCosmicsWTrackPerEvent", "Number of cosmics with track per event", 30, 0, 30);
+  numberofCosmicsTopBottomHist_ = new TH1F(
+      "numberofCosmicsTopBottomPerEvent", "Number of top bottom cosmics per event;Number of Cosmics", 30, 0, 30);
+  numberofGoodEvtFreq_ = new TH1F("frequencyOfGoodEvents",
+                                  "Number of events with cosmic vs Event;Event Number;Number of Good Events/100 Events",
+                                  2000,
+                                  0,
+                                  200000);
+
+  numberofCrossedEcalIdsHist_ = new TH1F("numberofCrossedEcalCosmicsPerEvent",
+                                         "Number of crossed ECAL cosmics per event;Number of Crossed Cosmics",
+                                         10,
+                                         0,
+                                         10);
+
+  allOccupancyExclusiveECAL_ = new TH2F("OccupancyAllEvents_ExclusiveECAL",
+                                        "Occupancy all events Exclusive ECAL ;i#phi;i#eta",
+                                        360,
+                                        1.,
+                                        361.,
+                                        172,
+                                        -86,
+                                        86);
+  allOccupancyCoarseExclusiveECAL_ = new TH2F("OccupancyAllEventsCoarse_ExclusiveECAL",
+                                              "Occupancy all events Coarse Exclusive ECAL;i#phi;i#eta",
+                                              360 / 5,
+                                              ttPhiBins,
+                                              35,
+                                              ttEtaBins);
+  allOccupancyECAL_ =
+      new TH2F("OccupancyAllEvents_ECAL", "Occupancy all events ECAL;i#phi;i#eta", 360, 1., 361., 172, -86, 86);
+  allOccupancyCoarseECAL_ = new TH2F("OccupancyAllEventsCoarse_ECAL",
+                                     "Occupancy all events Coarse ECAL;i#phi;i#eta",
+                                     360 / 5,
+                                     ttPhiBins,
+                                     35,
+                                     ttEtaBins);
+  allFedsTimingHistECAL_ =
+      new TH1F("timeForAllFeds_ECAL", "timeForAllFeds ECAL;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  allFedsTimingPhiEtaHistECAL_ =
+      new TH3F("timePhiEtaAllFEDs_ECAL",
+               "ECAL (Phi,Eta,time) for all FEDs (SM,M binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",
+               18,
+               modPhiBins,
+               9,
+               modEtaBins,
+               78,
+               timingBins);
+  allFedsTimingTTHistECAL_ =
+      new TH3F("timeTTAllFEDs_ECAL",
+               "ECAL (Phi,Eta,time) for all FEDs (SM,TT binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",
+               72,
+               ttPhiBins,
+               35,
+               ttEtaBins,
+               78,
+               timingBins);
+  allFedsTimingLMHistECAL_ = new TH2F("timeLMAllFEDs_ECAL",
+                                      "ECAL (LM,time) for all FEDs (SM,LM binning);LM;Relative Time (1 clock = 25ns)",
+                                      92,
+                                      1,
+                                      92,
+                                      78,
+                                      -7,
+                                      7);
+
+  allOccupancyExclusiveDT_ = new TH2F(
+      "OccupancyAllEvents_ExclusiveDT", "Occupancy all events Exclusive DT;i#phi;i#eta", 360, 1., 361., 172, -86, 86);
+  allOccupancyCoarseExclusiveDT_ = new TH2F("OccupancyAllEventsCoarse_ExclusiveDT",
+                                            "Occupancy all events Coarse Exclusive DT;i#phi;i#eta",
+                                            360 / 5,
+                                            1,
+                                            361.,
+                                            35,
+                                            ttEtaBins);
+  allOccupancyDT_ =
+      new TH2F("OccupancyAllEvents_DT", "Occupancy all events DT;i#phi;i#eta", 360, 1., 361., 172, -86, 86);
+  allOccupancyCoarseDT_ = new TH2F(
+      "OccupancyAllEventsCoarse_DT", "Occupancy all events Coarse DT;i#phi;i#eta", 360 / 5, 1, 361., 35, ttEtaBins);
+  allFedsTimingHistDT_ = new TH1F("timeForAllFeds_DT", "timeForAllFeds DT;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  allFedsTimingPhiEtaHistDT_ =
+      new TH3F("timePhiEtaAllFEDs_DT",
+               "DT (Phi,Eta,time) for all FEDs (SM,M binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",
+               18,
+               modPhiBins,
+               9,
+               modEtaBins,
+               78,
+               timingBins);
+  allFedsTimingTTHistDT_ =
+      new TH3F("timeTTAllFEDs_DT",
+               "DT (Phi,Eta,time) for all FEDs (SM,TT binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",
+               72,
+               ttPhiBins,
+               35,
+               ttEtaBins,
+               78,
+               timingBins);
+  allFedsTimingLMHistDT_ = new TH2F("timeLMAllFEDs_DT",
+                                    "DT (LM,time) for all FEDs (SM,LM binning);LM;Relative Time (1 clock = 25ns)",
+                                    92,
+                                    1,
+                                    92,
+                                    78,
+                                    -7,
+                                    7);
+
+  allOccupancyExclusiveRPC_ = new TH2F(
+      "OccupancyAllEvents_ExclusiveRPC", "Occupancy all events Exclusive RPC;i#phi;i#eta", 360, 1., 361., 172, -86, 86);
+  allOccupancyCoarseExclusiveRPC_ = new TH2F("OccupancyAllEventsCoarse_ExclusiveRPC",
+                                             "Occupancy all events Coarse Exclusive RPC;i#phi;i#eta",
+                                             360 / 5,
+                                             1,
+                                             361.,
+                                             35,
+                                             ttEtaBins);
+  allOccupancyRPC_ =
+      new TH2F("OccupancyAllEvents_RPC", "Occupancy all events RPC;i#phi;i#eta", 360, 1., 361., 172, -86, 86);
+  allOccupancyCoarseRPC_ = new TH2F(
+      "OccupancyAllEventsCoarse_RPC", "Occupancy all events Coarse RPC;i#phi;i#eta", 360 / 5, 1, 361., 35, ttEtaBins);
+  allFedsTimingHistRPC_ =
+      new TH1F("timeForAllFeds_RPC", "timeForAllFeds RPC;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  allFedsTimingPhiEtaHistRPC_ =
+      new TH3F("timePhiEtaAllFEDs_RPC",
+               "RPC (Phi,Eta,time) for all FEDs (SM,M binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",
+               18,
+               modPhiBins,
+               9,
+               modEtaBins,
+               78,
+               timingBins);
+  allFedsTimingTTHistRPC_ =
+      new TH3F("timeTTAllFEDs_RPC",
+               "RPC (Phi,Eta,time) for all FEDs (SM,TT binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",
+               72,
+               ttPhiBins,
+               35,
+               ttEtaBins,
+               78,
+               timingBins);
+  allFedsTimingLMHistRPC_ = new TH2F("timeLMAllFEDs_RPC",
+                                     "RPC (LM,time) for all FEDs (SM,LM binning);LM;Relative Time (1 clock = 25ns)",
+                                     92,
+                                     1,
+                                     92,
+                                     78,
+                                     -7,
+                                     7);
+
+  allOccupancyExclusiveCSC_ = new TH2F(
+      "OccupancyAllEvents_ExclusiveCSC", "Occupancy all events Exclusive CSC;i#phi;i#eta", 360, 1., 361., 172, -86, 86);
+  allOccupancyCoarseExclusiveCSC_ = new TH2F("OccupancyAllEventsCoarse_ExclusiveCSC",
+                                             "Occupancy all events Coarse Exclusive CSC;i#phi;i#eta",
+                                             360 / 5,
+                                             1,
+                                             361.,
+                                             35,
+                                             ttEtaBins);
+  allOccupancyCSC_ =
+      new TH2F("OccupancyAllEvents_CSC", "Occupancy all events CSC;i#phi;i#eta", 360, 1., 361., 172, -86, 86);
+  allOccupancyCoarseCSC_ = new TH2F(
+      "OccupancyAllEventsCoarse_CSC", "Occupancy all events Coarse CSC;i#phi;i#eta", 360 / 5, 1, 361., 35, ttEtaBins);
+  allFedsTimingHistCSC_ =
+      new TH1F("timeForAllFeds_CSC", "timeForAllFeds CSC;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  allFedsTimingPhiEtaHistCSC_ =
+      new TH3F("timePhiEtaAllFEDs_CSC",
+               "CSC (Phi,Eta,time) for all FEDs (SM,M binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",
+               18,
+               modPhiBins,
+               9,
+               modEtaBins,
+               78,
+               timingBins);
+  allFedsTimingTTHistCSC_ =
+      new TH3F("timeTTAllFEDs_CSC",
+               "CSC (Phi,Eta,time) for all FEDs (SM,TT binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",
+               72,
+               ttPhiBins,
+               35,
+               ttEtaBins,
+               78,
+               timingBins);
+  allFedsTimingLMHistCSC_ = new TH2F("timeLMAllFEDs_CSC",
+                                     "CSC (LM,time) for all FEDs (SM,LM binning);LM;Relative Time (1 clock = 25ns)",
+                                     92,
+                                     1,
+                                     62,
+                                     78,
+                                     -7,
+                                     7);
+
+  allOccupancyExclusiveHCAL_ = new TH2F("OccupancyAllEvents_ExclusiveHCAL",
+                                        "Occupancy all events Exclusive HCAL;i#phi;i#eta",
+                                        360,
+                                        1.,
+                                        361.,
+                                        172,
+                                        -86,
+                                        86);
+  allOccupancyCoarseExclusiveHCAL_ = new TH2F("OccupancyAllEventsCoarse_ExclusiveHCAL",
+                                              "Occupancy all events Coarse Exclusive HCAL;i#phi;i#eta",
+                                              360 / 5,
+                                              1,
+                                              361.,
+                                              35,
+                                              ttEtaBins);
+  allOccupancyHCAL_ =
+      new TH2F("OccupancyAllEvents_HCAL", "Occupancy all events HCAL;i#phi;i#eta", 360, 1., 361., 172, -86, 86);
+  allOccupancyCoarseHCAL_ = new TH2F(
+      "OccupancyAllEventsCoarse_HCAL", "Occupancy all events Coarse HCAL;i#phi;i#eta", 360 / 5, 1, 361., 35, ttEtaBins);
+  allFedsTimingHistHCAL_ =
+      new TH1F("timeForAllFeds_HCAL", "timeForAllFeds HCAL;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  allFedsTimingPhiEtaHistHCAL_ =
+      new TH3F("timePhiEtaAllFEDs_HCAL",
+               "HCAL (Phi,Eta,time) for all FEDs (SM,M binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",
+               18,
+               modPhiBins,
+               9,
+               modEtaBins,
+               78,
+               timingBins);
+  allFedsTimingTTHistHCAL_ =
+      new TH3F("timeTTAllFEDs_HCAL",
+               "HCAL (Phi,Eta,time) for all FEDs (SM,TT binning);i#phi;i#eta;Relative Time (1 clock = 25ns)",
+               72,
+               ttPhiBins,
+               35,
+               ttEtaBins,
+               78,
+               timingBins);
+  allFedsTimingLMHistHCAL_ = new TH2F("timeLMAllFEDs_HCAL",
+                                      "HCAL (LM,time) for all FEDs (SM,LM binning);LM;Relative Time (1 clock = 25ns)",
+                                      92,
+                                      1,
+                                      92,
+                                      78,
+                                      -7,
+                                      7);
+
+  TrueBCOccupancy_ = new TH2F(
+      "BCTrueOccupancyAllEvents", "True SB Occupancy all events;#phi;#eta", 360, -3.14159, 3.14159, 172, -1.5, 1.5);
+  TrueBCOccupancyCoarse_ = new TH2F("BCTrueOccupancyAllEventsCoarse",
+                                    "True BC Occupancy all events Coarse;#phi;#eta",
+                                    360 / 5,
+                                    -3.14159,
+                                    3.14159,
+                                    34,
+                                    -1.5,
+                                    1.5);
+
+  numberofBCinSC_ =
+      new TH1F("numberofBCinSC", "Number of Basic Clusters in Super Cluster;Num Basic Clusters", 20, 0, 20);  //SC
+  numberofBCinSCphi_ = new TH2F("numberofBCinSCphi",
+                                "Number of Basic Clusters in Super Cluster;phi;Num Basic Clusters",
+                                360 / 5,
+                                -3.14159,
+                                3.14159,
+                                20,
+                                0,
+                                20);  //SC
+
+  allFedsTimingHistEcalMuon_ =
+      new TH1F("timeForAllFeds_EcalMuon", "timeForAllFeds Ecal+Muon;Relative Time (1 clock = 25ns)", 78, -7, 7);
+
+  triggerHist_ = new TH1F("triggerHist", "Trigger Number", 5, 0, 5);
+  triggerHist_->GetXaxis()->SetBinLabel(1, "ECAL");
+  triggerHist_->GetXaxis()->SetBinLabel(2, "HCAL");
+  triggerHist_->GetXaxis()->SetBinLabel(3, "DT");
+  triggerHist_->GetXaxis()->SetBinLabel(4, "RPC");
+  triggerHist_->GetXaxis()->SetBinLabel(5, "CSC");
+
+  triggerExclusiveHist_ = new TH1F("triggerExclusiveHist", "Trigger Number (Mutually Exclusive)", 5, 0, 5);
+  triggerExclusiveHist_->GetXaxis()->SetBinLabel(1, "ECAL");
+  triggerExclusiveHist_->GetXaxis()->SetBinLabel(2, "HCAL");
+  triggerExclusiveHist_->GetXaxis()->SetBinLabel(3, "DT");
+  triggerExclusiveHist_->GetXaxis()->SetBinLabel(4, "RPC");
+  triggerExclusiveHist_->GetXaxis()->SetBinLabel(5, "CSC");
+
+  runNumberHist_ = new TH1F("runNumberHist", "Run Number", 1, 0, 1);
+
+  deltaRHist_ = new TH1F("deltaRHist", "deltaR", 500, -0.5, 499.5);
+  deltaEtaHist_ = new TH1F("deltaIEtaHist", "deltaIEta", 170, -85.5, 84.5);
+  deltaPhiHist_ = new TH1F("deltaIPhiHist", "deltaIPhi", 720, -360.5, 359.5);
+  ratioAssocTracksHist_ = new TH1F("ratioAssocTracks", "num assoc. tracks/tracks through Ecal", 11, 0, 1.1);
+  ratioAssocClustersHist_ = new TH1F("ratioAssocClusters", "num assoc. clusters/total clusters", 11, 0, 1.1);
+  trackAssoc_muonsEcal_ = new TH2F(
+      "trackAssoc_muonsEcal", "Map of muon hits in Ecal", 360, 1., 361., 172, -86, 86);  //360, 0 , 360, 170,-85 ,85);
+  deltaEtaDeltaPhiHist_ =
+      new TH2F("deltaEtaDeltaPhi", "Delta ieta vs. delta iphi", 170, -85.5, 84.5, 720, -360.5, 359.5);
+  seedTrackEtaHist_ = new TH2F("seedTrackEta", "track ieta vs. seed ieta", 170, -85.5, 84.5, 170, -85.5, 84.5);
+  seedTrackPhiHist_ = new TH2F("seedTrackPhi", "track iphi vs. seed iphi", 720, -360.5, 359.5, 720, -360.5, 359.5);
+
+  dccEventVsBxHist_ = new TH2F("dccEventVsBx", "DCC Runtype vs. bunch crossing", 3600, 0, 3600, 24, 0, 24);
+  dccBXErrorByFEDHist_ = new TH1F("dccBXErrorByFED", "Incorrect BX number by FED", 54, 601, 655);
+  dccOrbitErrorByFEDHist_ = new TH1F("dccOrbitErrorByFED", "Incorrect orbit number by FED", 54, 601, 655);
+  dccRuntypeErrorByFEDHist_ = new TH1F("dccRuntypeErrorByFED", "Incorrect DCC Runtype by FED", 54, 601, 655);
+  dccRuntypeHist_ = new TH1F("dccRuntype", "DCC Runtype frequency", 24, 0, 24);
+  dccErrorVsBxHist_ = new TH2F("dccErrorVsBX", "DCC Errors vs. BX", 3600, 0, 3600, 3, 0, 3);
+
+  hcalEnergy_HBHE_ = new TH1F("hcalEnergy_HBHE", "RecHit Energy HBHE", 440, -10, 100);
+  hcalEnergy_HF_ = new TH1F("hcalEnergy_HF", "RecHit Energy HF", 440, -10, 100);
+  hcalEnergy_HO_ = new TH1F("hcalEnergy_HO", "RecHit Energy HO", 440, -10, 100);
+  hcalHEHBecalEB_ =
+      new TH2F("hcalHEHBecalEB", "HCAL HBHE RecHit energy vs ECAL EB energy", numBins, histRangeMin_, 300.0, 40, -5, 5);
+
+  NumXtalsInClusterHist_ = new TH1F("NumXtalsInClusterAllHist", "Number of Xtals in Cluster;NumXtals", 150, 0, 150);
+  numxtalsVsEnergy_ = new TH2F("NumXtalsVsEnergy",
+                               "Number of Xtals in Cluster vs Energy;Energy (GeV);Number of Xtals in Cluster",
+                               numBins,
+                               histRangeMin_,
+                               histRangeMax_,
+                               150,
+                               0,
+                               150);
+  numxtalsVsHighEnergy_ = new TH2F("NumXtalsVsHighEnergy",
+                                   "Number of Xtals in Cluster vs Energy;Energy (GeV);Number of Xtals in Cluster",
+                                   numBins,
+                                   histRangeMin_,
+                                   200.,
+                                   150,
+                                   0,
+                                   150);
+
   // high energy analysis
-  allOccupancyHighEnergy_             = new TH2F("OccupancyHighEnergyEvents","Occupancy high energy events;i#phi;i#eta",360,1.,361.,172,-86,86);
-  allOccupancyHighEnergyCoarse_       = new TH2F("OccupancyHighEnergyEventsCoarse","Occupancy high energy events Coarse;i#phi;i#eta",72,ttPhiBins,35,ttEtaBins); 
-  allFedsOccupancyHighEnergyHist_     = new TH3F("OccupancyHighEnergyEvents3D","(Phi,Eta,energy) for all high energy events;i#phi;i#eta;energy (GeV)",18,modPhiBins,9,modEtaBins,10,highEBins);
-  allFedsNumXtalsInClusterHist_       = new TH1F("NumActiveXtalsInClusterAllHist","Number of active Xtals in Cluster;NumXtals",100,0,100);
-  
-  HighEnergy_NumXtal                  = new TH1F("HighEnergy_NumXtal","Num crystals in high E clusters;num crystals",150,0,150);
-  HighEnergy_NumXtalFedId             = new TH2F("HighEnergy_NumXtalFedId","Num crystals in cluster vs FedId;FedId;num crystals",36,610.,645.,150,0,150);
-  HighEnergy_NumXtaliphi              = new TH2F("HighEnergy_NumXtaliphi","Num crystals in cluster vs iphi;i#phi;num crystals",360,1.,361.,150,0,150);
-  HighEnergy_energy3D                 = new TH3F("HighEnergy_energy3D","(Phi,Eta,energy) for all high energy events;i#phi;i#eta;energy (GeV)",72,ttPhiBins,35,ttEtaBins,10,highEBins);
-  
-  HighEnergy_energyNumXtal            = new TH2F("HighEnergy_energyNumXtal","Energy in cluster vs Num crystals in cluster;num crystals;energy",150,0,150,200,0.,200.);
-  
-  HighEnergy_bestSeed                 = new TH1F("HighEnergy_bestSeedEnergy","BestSeed Energy from TrackAss",200,0.,200.);
-  HighEnergy_bestSeedOccupancy        = new TH2F("HighEnergy_bestSeedOccupancy","Occupancy HighEn events from TrackAss;i#phi;i#eta",360,1.,361.,172,-86,86);
-  
-  HighEnergy_numClusHighEn            = new TH1F("HighEnergy_numClusHighEn","Num High Energy Clusters",7,0,7);
-  HighEnergy_ratioClusters            = new TH1F("HighEnergy_ratioClusters","Num High Energy Clusters/Num tot Clusters",100,0.,1.1);
-  
-  HighEnergy_numRecoTrackBarrel       = new TH1F("HighEnergy_numRecoTracksBarrel","Num BarrelRecoTracks",10,0,10);
-  HighEnergy_TracksAngle              = new TH1F("HighEnergy_TracksAngle","Angle between tracks",720,0.,180.);
-  HighEnergy_TracksAngleTopBottom     = new TH1F("HighEnergy_TopBottomTracksAngle","Angle between top-bottom tracks",720,0.,180.);
-  
-  HighEnergy_2GeV_occuCoarse          = new TH2F("HighEnergy_occu2GeV_Coarse","Occupancy high energy events with more than 2 GeV;i#phi;i#eta",72,ttPhiBins,35,ttEtaBins); 
-  HighEnergy_2GeV_occu3D              = new TH3F("HighEnergy_2GeV_energy3D","(iphi,ieta,energy) for all high energy events w > 10 GeV;i#phi;i#eta;energy (GeV)",72,ttPhiBins,35,ttEtaBins,10,highEBins);
-  HighEnergy_100GeV_occuCoarse        = new TH2F("HighEnergy_occu100GeV_Coarse","Occupancy high energy events with more than 100 GeV;i#phi;i#eta",72,ttPhiBins,35,ttEtaBins); 
-  HighEnergy_100GeV_occu3D            = new TH3F("HighEnergy_100GeV_energy3D","(iphi,ieta,energy) for all high energy events more than 100 GeV;i#phi;i#eta;energy (GeV)",72,ttPhiBins,35,ttEtaBins,10,highEBins);
-  HighEnergy_0tracks_occu3D           = new TH3F("HighEnergy_0Tracks_energy3D","(iphi,ieta,energy) for all events with 0 tracks;i#phi;i#eta;energy (GeV)",72,ttPhiBins,35,ttEtaBins,10,highEBins);
-  HighEnergy_1tracks_occu3D           = new TH3F("HighEnergy_1Tracks_energy3D","(iphi,ieta,energy) for all events with 1 tracks;i#phi;i#eta;energy (GeV)",72,ttPhiBins,35,ttEtaBins,10,highEBins);
-  HighEnergy_2tracks_occu3D           = new TH3F("HighEnergy_2Tracks_energy3D","(iphi,ieta,energy) for all events with 2 tracks;i#phi;i#eta;energy (GeV)",72,ttPhiBins,35,ttEtaBins,10,highEBins);
-  HighEnergy_0tracks_occu3DXtal       = new TH3F("HighEnergy_0Tracks_energy3DXtal","(iphi,ieta,energy) for all events with 0 tracks;i#phi;i#eta;energy (GeV)",360,1.,361.,172,-86,86,200,0.,200.);
-  HighEnergy_1tracks_occu3DXtal       = new TH3F("HighEnergy_1Tracks_energy3DXtal","(iphi,ieta,energy) for all events with 1 tracks;i#phi;i#eta;energy (GeV)",360,1.,361.,172,-86,86,200,0.,200.);
-  HighEnergy_2tracks_occu3DXtal       = new TH3F("HighEnergy_2Tracks_energy3DXtal","(iphi,ieta,energy) for all events with 2 tracks;i#phi;i#eta;energy (GeV)",360,1.,361.,172,-86,86,200,0.,200.);
+  allOccupancyHighEnergy_ =
+      new TH2F("OccupancyHighEnergyEvents", "Occupancy high energy events;i#phi;i#eta", 360, 1., 361., 172, -86, 86);
+  allOccupancyHighEnergyCoarse_ = new TH2F("OccupancyHighEnergyEventsCoarse",
+                                           "Occupancy high energy events Coarse;i#phi;i#eta",
+                                           72,
+                                           ttPhiBins,
+                                           35,
+                                           ttEtaBins);
+  allFedsOccupancyHighEnergyHist_ = new TH3F("OccupancyHighEnergyEvents3D",
+                                             "(Phi,Eta,energy) for all high energy events;i#phi;i#eta;energy (GeV)",
+                                             18,
+                                             modPhiBins,
+                                             9,
+                                             modEtaBins,
+                                             10,
+                                             highEBins);
+  allFedsNumXtalsInClusterHist_ =
+      new TH1F("NumActiveXtalsInClusterAllHist", "Number of active Xtals in Cluster;NumXtals", 100, 0, 100);
+
+  HighEnergy_NumXtal = new TH1F("HighEnergy_NumXtal", "Num crystals in high E clusters;num crystals", 150, 0, 150);
+  HighEnergy_NumXtalFedId = new TH2F(
+      "HighEnergy_NumXtalFedId", "Num crystals in cluster vs FedId;FedId;num crystals", 36, 610., 645., 150, 0, 150);
+  HighEnergy_NumXtaliphi = new TH2F(
+      "HighEnergy_NumXtaliphi", "Num crystals in cluster vs iphi;i#phi;num crystals", 360, 1., 361., 150, 0, 150);
+  HighEnergy_energy3D = new TH3F("HighEnergy_energy3D",
+                                 "(Phi,Eta,energy) for all high energy events;i#phi;i#eta;energy (GeV)",
+                                 72,
+                                 ttPhiBins,
+                                 35,
+                                 ttEtaBins,
+                                 10,
+                                 highEBins);
+
+  HighEnergy_energyNumXtal = new TH2F("HighEnergy_energyNumXtal",
+                                      "Energy in cluster vs Num crystals in cluster;num crystals;energy",
+                                      150,
+                                      0,
+                                      150,
+                                      200,
+                                      0.,
+                                      200.);
+
+  HighEnergy_bestSeed = new TH1F("HighEnergy_bestSeedEnergy", "BestSeed Energy from TrackAss", 200, 0., 200.);
+  HighEnergy_bestSeedOccupancy = new TH2F(
+      "HighEnergy_bestSeedOccupancy", "Occupancy HighEn events from TrackAss;i#phi;i#eta", 360, 1., 361., 172, -86, 86);
+
+  HighEnergy_numClusHighEn = new TH1F("HighEnergy_numClusHighEn", "Num High Energy Clusters", 7, 0, 7);
+  HighEnergy_ratioClusters =
+      new TH1F("HighEnergy_ratioClusters", "Num High Energy Clusters/Num tot Clusters", 100, 0., 1.1);
+
+  HighEnergy_numRecoTrackBarrel = new TH1F("HighEnergy_numRecoTracksBarrel", "Num BarrelRecoTracks", 10, 0, 10);
+  HighEnergy_TracksAngle = new TH1F("HighEnergy_TracksAngle", "Angle between tracks", 720, 0., 180.);
+  HighEnergy_TracksAngleTopBottom =
+      new TH1F("HighEnergy_TopBottomTracksAngle", "Angle between top-bottom tracks", 720, 0., 180.);
+
+  HighEnergy_2GeV_occuCoarse = new TH2F("HighEnergy_occu2GeV_Coarse",
+                                        "Occupancy high energy events with more than 2 GeV;i#phi;i#eta",
+                                        72,
+                                        ttPhiBins,
+                                        35,
+                                        ttEtaBins);
+  HighEnergy_2GeV_occu3D = new TH3F("HighEnergy_2GeV_energy3D",
+                                    "(iphi,ieta,energy) for all high energy events w > 10 GeV;i#phi;i#eta;energy (GeV)",
+                                    72,
+                                    ttPhiBins,
+                                    35,
+                                    ttEtaBins,
+                                    10,
+                                    highEBins);
+  HighEnergy_100GeV_occuCoarse = new TH2F("HighEnergy_occu100GeV_Coarse",
+                                          "Occupancy high energy events with more than 100 GeV;i#phi;i#eta",
+                                          72,
+                                          ttPhiBins,
+                                          35,
+                                          ttEtaBins);
+  HighEnergy_100GeV_occu3D =
+      new TH3F("HighEnergy_100GeV_energy3D",
+               "(iphi,ieta,energy) for all high energy events more than 100 GeV;i#phi;i#eta;energy (GeV)",
+               72,
+               ttPhiBins,
+               35,
+               ttEtaBins,
+               10,
+               highEBins);
+  HighEnergy_0tracks_occu3D = new TH3F("HighEnergy_0Tracks_energy3D",
+                                       "(iphi,ieta,energy) for all events with 0 tracks;i#phi;i#eta;energy (GeV)",
+                                       72,
+                                       ttPhiBins,
+                                       35,
+                                       ttEtaBins,
+                                       10,
+                                       highEBins);
+  HighEnergy_1tracks_occu3D = new TH3F("HighEnergy_1Tracks_energy3D",
+                                       "(iphi,ieta,energy) for all events with 1 tracks;i#phi;i#eta;energy (GeV)",
+                                       72,
+                                       ttPhiBins,
+                                       35,
+                                       ttEtaBins,
+                                       10,
+                                       highEBins);
+  HighEnergy_2tracks_occu3D = new TH3F("HighEnergy_2Tracks_energy3D",
+                                       "(iphi,ieta,energy) for all events with 2 tracks;i#phi;i#eta;energy (GeV)",
+                                       72,
+                                       ttPhiBins,
+                                       35,
+                                       ttEtaBins,
+                                       10,
+                                       highEBins);
+  HighEnergy_0tracks_occu3DXtal = new TH3F("HighEnergy_0Tracks_energy3DXtal",
+                                           "(iphi,ieta,energy) for all events with 0 tracks;i#phi;i#eta;energy (GeV)",
+                                           360,
+                                           1.,
+                                           361.,
+                                           172,
+                                           -86,
+                                           86,
+                                           200,
+                                           0.,
+                                           200.);
+  HighEnergy_1tracks_occu3DXtal = new TH3F("HighEnergy_1Tracks_energy3DXtal",
+                                           "(iphi,ieta,energy) for all events with 1 tracks;i#phi;i#eta;energy (GeV)",
+                                           360,
+                                           1.,
+                                           361.,
+                                           172,
+                                           -86,
+                                           86,
+                                           200,
+                                           0.,
+                                           200.);
+  HighEnergy_2tracks_occu3DXtal = new TH3F("HighEnergy_2Tracks_energy3DXtal",
+                                           "(iphi,ieta,energy) for all events with 2 tracks;i#phi;i#eta;energy (GeV)",
+                                           360,
+                                           1.,
+                                           361.,
+                                           172,
+                                           -86,
+                                           86,
+                                           200,
+                                           0.,
+                                           200.);
 
   //EE histograms
 
   // EE-
-  EEM_FedsSeedEnergyHist_           = new TH1F("SeedEnergyAllFEDs","Seed Energy for EEM Feds; Seed Energy (GeV)",200,histRangeMin_,10.0);
+  EEM_FedsSeedEnergyHist_ =
+      new TH1F("SeedEnergyAllFEDs", "Seed Energy for EEM Feds; Seed Energy (GeV)", 200, histRangeMin_, 10.0);
 
-  EEM_AllOccupancyCoarse_           = new TH2F("OccupancyAllEventsCoarse","Occupancy all events Coarse EEM;ix;iy",20,0,100,20,0,100);
-  EEM_AllOccupancy_                 = new TH2F("OccupancyAllEvents","Occupancy all events EEM;ix;iy",100,0,100,100,0,100);
-  EEM_FedsenergyHist_               = new TH1F("energy_AllClusters","energy_AllClusters_EEM;Cluster Energy (GeV)",numBins,histRangeMin_,10.0);
-  EEM_FedsenergyHighHist_           = new TH1F("energyHigh_AllClusters","energyHigh_AllClusters in EEM;Cluster Energy (GeV)",numBins,histRangeMin_,200.0);
-  EEM_FedsenergyOnlyHighHist_       = new TH1F("energyHigh_HighEnergyClusters","energy of High Energy Clusters in EEM;Cluster Energy (GeV)",numBins,histRangeMin_,200.0);
-  EEM_FedsE2Hist_                   = new TH1F("E2_AllClusters","E2_AllClusters_EEM;Seed+highest neighbor energy (GeV)",numBins,histRangeMin_,10.0);
-  EEM_FedsE2vsE1Hist_               = new TH2F("E2vsE1_AllClusters","E2vsE1_AllClusters_EEM;Seed Energy (GeV);Seed+highest neighbor energy (GeV)",numBins,histRangeMin_,10.0,numBins,histRangeMin_,10.0);
-  EEM_FedsenergyvsE1Hist_           = new TH2F("energyvsE1_AllClusters","energyvsE1_AllClusters_EEM;Seed Energy (GeV);Energy(GeV)",numBins,histRangeMin_,10.0,numBins,histRangeMin_,10.0);
-  EEM_FedsTimingHist_               = new TH1F("timeForAllFeds","timeForAllFeds_EEM;Relative Time (1 clock = 25ns)",78,-7,7);
-  EEM_numberofCosmicsHist_ = new TH1F("numberofCosmicsPerEvent","Number of cosmics per event EEM;Number of Cosmics",30,0,30);
-  
-  EEM_FedsTimingVsAmpHist_          = new TH2F("timeVsAmpAllEvents","time Vs Amp All Events EEM;Relative Time (1 clock = 25ns);Amplitude (GeV)",78,-7,7,numBins,histRangeMin_,10.0);
-  EEM_FedsTimingTTHist_             = new TH3F("timeTTAllFEDs","(ix,iy,time) for all FEDs (SM,TT binning) EEM;ix;iy;Relative Time (1 clock = 25ns)",20,0,100,20,0,100,78,-7,7); 
-  
-  EEM_OccupancySingleXtal_          = new TH2F("OccupancySingleXtal","Occupancy single xtal clusters EEM;ix;iy",100,0,100,100,0,100);
-  EEM_energySingleXtalHist_         = new TH1F("energy_SingleXtalClusters","Energy single xtal clusters EEM;Cluster Energy (GeV)",numBins,histRangeMin_,200.0);
-  
-  EEM_OccupancyExclusiveECAL_       = new TH2F("OccupancyAllEvents_ExclusiveECAL","Occupancy all events Exclusive ECAL  EEM;ix;iy",100,0,100,100,0,100);
-  EEM_OccupancyCoarseExclusiveECAL_ = new TH2F("OccupancyAllEventsCoarse_ExclusiveECAL","Occupancy all events Coarse Exclusive ECAL EEM;ix;iy",20,0,100,20,0,100);
-  EEM_OccupancyECAL_                = new TH2F("OccupancyAllEvents_ECAL","Occupancy all events ECAL EEM;ix;iy",100,0,100,100,0,100);
-  EEM_OccupancyCoarseECAL_          = new TH2F("OccupancyAllEventsCoarse_ECAL","Occupancy all events Coarse ECAL EEM;ix;iy",20,0,100,20,0,100);
-  EEM_FedsTimingHistECAL_           = new TH1F("timeForAllFeds_ECAL","timeForAllFeds ECAL EEM;Relative Time (1 clock = 25ns)",78,-7,7);
-  EEM_FedsTimingTTHistECAL_         = new TH3F("timeTTAllFEDs_ECAL","(ix,iy,time) for all FEDs (SM,TT binning) ECAL EEM;ix;iy;Relative Time (1 clock = 25ns)",20,0,100,20,0,100,78,-7,7); 
-  
-  EEM_OccupancyExclusiveDT_         = new TH2F("OccupancyAllEvents_ExclusiveDT","Occupancy all events Exclusive DT EEM;ix;iy",100,0,100,100,0,100);
-  EEM_OccupancyCoarseExclusiveDT_   = new TH2F("OccupancyAllEventsCoarse_ExclusiveDT","Occupancy all events Coarse Exclusive DT EEM;ix;iy",20,0,100,20,0,100);
-  EEM_OccupancyDT_                  = new TH2F("OccupancyAllEvents_DT","Occupancy all events DT EEM;ix;iy",100,0,100,100,0,100);
-  EEM_OccupancyCoarseDT_            = new TH2F("OccupancyAllEventsCoarse_DT","Occupancy all events Coarse DT EEM;ix;iy",20,0,100,20,0,100);
-  EEM_FedsTimingHistDT_             = new TH1F("timeForAllFeds_DT","timeForAllFeds DT EEM;Relative Time (1 clock = 25ns)",78,-7,7);
-  EEM_FedsTimingTTHistDT_         = new TH3F("timeTTAllFEDs_DT","(ix,iy,time) for all FEDs (SM,TT binning) DT EEM;ix;iy;Relative Time (1 clock = 25ns)",20,0,100,20,0,100,78,-7,7); 
-  
-  EEM_OccupancyExclusiveRPC_        = new TH2F("OccupancyAllEvents_ExclusiveRPC","Occupancy all events Exclusive RPC EEM;ix;iy",100,0,100,100,0,100);
-  EEM_OccupancyCoarseExclusiveRPC_  = new TH2F("OccupancyAllEventsCoarse_ExclusiveRPC","Occupancy all events Coarse Exclusive RPC EEM;ix;iy",20,0,100,20,0,100);
-  EEM_OccupancyRPC_                 = new TH2F("OccupancyAllEvents_RPC","Occupancy all events RPC EEM;ix;iy",100,0,100,100,0,100);
-  EEM_OccupancyCoarseRPC_           = new TH2F("OccupancyAllEventsCoarse_RPC","Occupancy all events Coarse RPC EEM;ix;iy",20,0,100,20,0,100);
-  EEM_FedsTimingHistRPC_            = new TH1F("timeForAllFeds_RPC","timeForAllFeds RPC EEM;Relative Time (1 clock = 25ns)",78,-7,7);
-  EEM_FedsTimingTTHistRPC_          = new TH3F("timeTTAllFEDs_RPC","(ix,iy,time) for all FEDs (SM,TT binning) RPC EEM;ix;iy;Relative Time (1 clock = 25ns)",20,0,100,20,0,100,78,-7,7); 
-  
-  EEM_OccupancyExclusiveCSC_        = new TH2F("OccupancyAllEvents_ExclusiveCSC","Occupancy all events Exclusive CSC EEM;ix;iy",100,0,100,100,0,100);
-  EEM_OccupancyCoarseExclusiveCSC_  = new TH2F("OccupancyAllEventsCoarse_ExclusiveCSC","Occupancy all events Coarse Exclusive CSC EEM;ix;iy",20,0,100,20,0,100);
-  EEM_OccupancyCSC_                 = new TH2F("OccupancyAllEvents_CSC","Occupancy all events CSC EEM;ix;iy",100,0,100,100,0,100);
-  EEM_OccupancyCoarseCSC_           = new TH2F("OccupancyAllEventsCoarse_CSC","Occupancy all events Coarse CSC EEM;ix;iy",20,0,100,20,0,100);
-  EEM_FedsTimingHistCSC_            = new TH1F("timeForAllFeds_CSC","timeForAllFeds CSC EEM;Relative Time (1 clock = 25ns)",78,-7,7);
-  EEM_FedsTimingTTHistCSC_          = new TH3F("timeTTAllFEDs_CSC","(ix,iy,time) for all FEDs (SM,TT binning) CSC EEM;ix;iy;Relative Time (1 clock = 25ns)",20,0,100,20,0,100,78,-7,7); 
-  
-  EEM_OccupancyExclusiveHCAL_       = new TH2F("OccupancyAllEvents_ExclusiveHCAL","Occupancy all events Exclusive HCAL EEM;ix;iy",100,0,100,100,0,100);
-  EEM_OccupancyCoarseExclusiveHCAL_ = new TH2F("OccupancyAllEventsCoarse_ExclusiveHCAL","Occupancy all events Coarse Exclusive HCAL EEM;ix;iy",20,0,100,20,0,100);
-  EEM_OccupancyHCAL_                = new TH2F("OccupancyAllEvents_HCAL","Occupancy all events HCAL EEM;ix;iy",100,0,100,100,0,100);
-  EEM_OccupancyCoarseHCAL_          = new TH2F("OccupancyAllEventsCoarse_HCAL","Occupancy all events Coarse HCAL EEM;ix;iy",20,0,100,20,0,100);
-  EEM_FedsTimingHistHCAL_           = new TH1F("timeForAllFeds_HCAL","timeForAllFeds HCAL EEM;Relative Time (1 clock = 25ns)",78,-7,7);
-  EEM_FedsTimingTTHistHCAL_         = new TH3F("timeTTAllFEDs_HCAL","(ix,iy,time) for all FEDs (SM,TT binning) HCAL EEM;ix;iy;Relative Time (1 clock = 25ns)",20,0,100,20,0,100,78,-7,7); 
-  
-  EEM_numberofBCinSC_               = new TH1F("numberofBCinSC","Number of Basic Clusters in Super Cluster EEM;Num Basic Clusters",20,0,20);
-  
-  EEM_triggerHist_                  = new TH1F("triggerHist","Trigger Number EEM",5,0,5);
-  EEM_triggerHist_->GetXaxis()->SetBinLabel(1,"ECAL");
-  EEM_triggerHist_->GetXaxis()->SetBinLabel(2,"HCAL");
-  EEM_triggerHist_->GetXaxis()->SetBinLabel(3,"DT");
-  EEM_triggerHist_->GetXaxis()->SetBinLabel(4,"RPC");
-  EEM_triggerHist_->GetXaxis()->SetBinLabel(5,"CSC");
-  
-  EEM_triggerExclusiveHist_         = new TH1F("triggerExclusiveHist","Trigger Number (Mutually Exclusive) EEM",5,0,5);  triggerExclusiveHist_->GetXaxis()->SetBinLabel(1,"ECAL");
-  EEM_triggerExclusiveHist_->GetXaxis()->SetBinLabel(2,"HCAL");
-  EEM_triggerExclusiveHist_->GetXaxis()->SetBinLabel(3,"DT");
-  EEM_triggerExclusiveHist_->GetXaxis()->SetBinLabel(4,"RPC");
-  EEM_triggerExclusiveHist_->GetXaxis()->SetBinLabel(5,"CSC");
-  
-  EEM_NumXtalsInClusterHist_        = new TH1F("NumXtalsInClusterAllHist","Number of Xtals in Cluster EEM;NumXtals",150,0,150);
-  EEM_numxtalsVsEnergy_             = new TH2F("NumXtalsVsEnergy","Number of Xtals in Cluster vs Energy EEM;Energy (GeV);Number of Xtals in Cluster",numBins,histRangeMin_,10.0, 150,0,150);
-  EEM_numxtalsVsHighEnergy_         = new TH2F("NumXtalsVsHighEnergy","Number of Xtals in Cluster vs Energy EEM;Energy (GeV);Number of Xtals in Cluster",numBins,histRangeMin_,200., 150,0,150);
-  
-  EEM_OccupancyHighEnergy_          = new TH2F("OccupancyHighEnergyEvents","Occupancy high energy events EEM;ix;iy",100,0,100,100,0,100);
-  EEM_OccupancyHighEnergyCoarse_    = new TH2F("OccupancyHighEnergyEventsCoarse","Occupancy high energy events Coarse EEM;ix;iy",20,0,100,20,0,100);
-  
-  EEM_FedsNumXtalsInClusterHist_    = new TH1F("NumActiveXtalsInClusterAllHist","Number of active Xtals in Cluster EEM;NumXtals",100,0,100);
+  EEM_AllOccupancyCoarse_ =
+      new TH2F("OccupancyAllEventsCoarse", "Occupancy all events Coarse EEM;ix;iy", 20, 0, 100, 20, 0, 100);
+  EEM_AllOccupancy_ = new TH2F("OccupancyAllEvents", "Occupancy all events EEM;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEM_FedsenergyHist_ =
+      new TH1F("energy_AllClusters", "energy_AllClusters_EEM;Cluster Energy (GeV)", numBins, histRangeMin_, 10.0);
+  EEM_FedsenergyHighHist_ = new TH1F(
+      "energyHigh_AllClusters", "energyHigh_AllClusters in EEM;Cluster Energy (GeV)", numBins, histRangeMin_, 200.0);
+  EEM_FedsenergyOnlyHighHist_ = new TH1F("energyHigh_HighEnergyClusters",
+                                         "energy of High Energy Clusters in EEM;Cluster Energy (GeV)",
+                                         numBins,
+                                         histRangeMin_,
+                                         200.0);
+  EEM_FedsE2Hist_ =
+      new TH1F("E2_AllClusters", "E2_AllClusters_EEM;Seed+highest neighbor energy (GeV)", numBins, histRangeMin_, 10.0);
+  EEM_FedsE2vsE1Hist_ = new TH2F("E2vsE1_AllClusters",
+                                 "E2vsE1_AllClusters_EEM;Seed Energy (GeV);Seed+highest neighbor energy (GeV)",
+                                 numBins,
+                                 histRangeMin_,
+                                 10.0,
+                                 numBins,
+                                 histRangeMin_,
+                                 10.0);
+  EEM_FedsenergyvsE1Hist_ = new TH2F("energyvsE1_AllClusters",
+                                     "energyvsE1_AllClusters_EEM;Seed Energy (GeV);Energy(GeV)",
+                                     numBins,
+                                     histRangeMin_,
+                                     10.0,
+                                     numBins,
+                                     histRangeMin_,
+                                     10.0);
+  EEM_FedsTimingHist_ = new TH1F("timeForAllFeds", "timeForAllFeds_EEM;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  EEM_numberofCosmicsHist_ =
+      new TH1F("numberofCosmicsPerEvent", "Number of cosmics per event EEM;Number of Cosmics", 30, 0, 30);
 
-  
+  EEM_FedsTimingVsAmpHist_ = new TH2F("timeVsAmpAllEvents",
+                                      "time Vs Amp All Events EEM;Relative Time (1 clock = 25ns);Amplitude (GeV)",
+                                      78,
+                                      -7,
+                                      7,
+                                      numBins,
+                                      histRangeMin_,
+                                      10.0);
+  EEM_FedsTimingTTHist_ = new TH3F("timeTTAllFEDs",
+                                   "(ix,iy,time) for all FEDs (SM,TT binning) EEM;ix;iy;Relative Time (1 clock = 25ns)",
+                                   20,
+                                   0,
+                                   100,
+                                   20,
+                                   0,
+                                   100,
+                                   78,
+                                   -7,
+                                   7);
+
+  EEM_OccupancySingleXtal_ =
+      new TH2F("OccupancySingleXtal", "Occupancy single xtal clusters EEM;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEM_energySingleXtalHist_ = new TH1F("energy_SingleXtalClusters",
+                                       "Energy single xtal clusters EEM;Cluster Energy (GeV)",
+                                       numBins,
+                                       histRangeMin_,
+                                       200.0);
+
+  EEM_OccupancyExclusiveECAL_ = new TH2F(
+      "OccupancyAllEvents_ExclusiveECAL", "Occupancy all events Exclusive ECAL  EEM;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEM_OccupancyCoarseExclusiveECAL_ = new TH2F("OccupancyAllEventsCoarse_ExclusiveECAL",
+                                               "Occupancy all events Coarse Exclusive ECAL EEM;ix;iy",
+                                               20,
+                                               0,
+                                               100,
+                                               20,
+                                               0,
+                                               100);
+  EEM_OccupancyECAL_ =
+      new TH2F("OccupancyAllEvents_ECAL", "Occupancy all events ECAL EEM;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEM_OccupancyCoarseECAL_ =
+      new TH2F("OccupancyAllEventsCoarse_ECAL", "Occupancy all events Coarse ECAL EEM;ix;iy", 20, 0, 100, 20, 0, 100);
+  EEM_FedsTimingHistECAL_ =
+      new TH1F("timeForAllFeds_ECAL", "timeForAllFeds ECAL EEM;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  EEM_FedsTimingTTHistECAL_ =
+      new TH3F("timeTTAllFEDs_ECAL",
+               "(ix,iy,time) for all FEDs (SM,TT binning) ECAL EEM;ix;iy;Relative Time (1 clock = 25ns)",
+               20,
+               0,
+               100,
+               20,
+               0,
+               100,
+               78,
+               -7,
+               7);
+
+  EEM_OccupancyExclusiveDT_ = new TH2F(
+      "OccupancyAllEvents_ExclusiveDT", "Occupancy all events Exclusive DT EEM;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEM_OccupancyCoarseExclusiveDT_ = new TH2F("OccupancyAllEventsCoarse_ExclusiveDT",
+                                             "Occupancy all events Coarse Exclusive DT EEM;ix;iy",
+                                             20,
+                                             0,
+                                             100,
+                                             20,
+                                             0,
+                                             100);
+  EEM_OccupancyDT_ = new TH2F("OccupancyAllEvents_DT", "Occupancy all events DT EEM;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEM_OccupancyCoarseDT_ =
+      new TH2F("OccupancyAllEventsCoarse_DT", "Occupancy all events Coarse DT EEM;ix;iy", 20, 0, 100, 20, 0, 100);
+  EEM_FedsTimingHistDT_ =
+      new TH1F("timeForAllFeds_DT", "timeForAllFeds DT EEM;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  EEM_FedsTimingTTHistDT_ =
+      new TH3F("timeTTAllFEDs_DT",
+               "(ix,iy,time) for all FEDs (SM,TT binning) DT EEM;ix;iy;Relative Time (1 clock = 25ns)",
+               20,
+               0,
+               100,
+               20,
+               0,
+               100,
+               78,
+               -7,
+               7);
+
+  EEM_OccupancyExclusiveRPC_ = new TH2F(
+      "OccupancyAllEvents_ExclusiveRPC", "Occupancy all events Exclusive RPC EEM;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEM_OccupancyCoarseExclusiveRPC_ = new TH2F("OccupancyAllEventsCoarse_ExclusiveRPC",
+                                              "Occupancy all events Coarse Exclusive RPC EEM;ix;iy",
+                                              20,
+                                              0,
+                                              100,
+                                              20,
+                                              0,
+                                              100);
+  EEM_OccupancyRPC_ =
+      new TH2F("OccupancyAllEvents_RPC", "Occupancy all events RPC EEM;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEM_OccupancyCoarseRPC_ =
+      new TH2F("OccupancyAllEventsCoarse_RPC", "Occupancy all events Coarse RPC EEM;ix;iy", 20, 0, 100, 20, 0, 100);
+  EEM_FedsTimingHistRPC_ =
+      new TH1F("timeForAllFeds_RPC", "timeForAllFeds RPC EEM;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  EEM_FedsTimingTTHistRPC_ =
+      new TH3F("timeTTAllFEDs_RPC",
+               "(ix,iy,time) for all FEDs (SM,TT binning) RPC EEM;ix;iy;Relative Time (1 clock = 25ns)",
+               20,
+               0,
+               100,
+               20,
+               0,
+               100,
+               78,
+               -7,
+               7);
+
+  EEM_OccupancyExclusiveCSC_ = new TH2F(
+      "OccupancyAllEvents_ExclusiveCSC", "Occupancy all events Exclusive CSC EEM;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEM_OccupancyCoarseExclusiveCSC_ = new TH2F("OccupancyAllEventsCoarse_ExclusiveCSC",
+                                              "Occupancy all events Coarse Exclusive CSC EEM;ix;iy",
+                                              20,
+                                              0,
+                                              100,
+                                              20,
+                                              0,
+                                              100);
+  EEM_OccupancyCSC_ =
+      new TH2F("OccupancyAllEvents_CSC", "Occupancy all events CSC EEM;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEM_OccupancyCoarseCSC_ =
+      new TH2F("OccupancyAllEventsCoarse_CSC", "Occupancy all events Coarse CSC EEM;ix;iy", 20, 0, 100, 20, 0, 100);
+  EEM_FedsTimingHistCSC_ =
+      new TH1F("timeForAllFeds_CSC", "timeForAllFeds CSC EEM;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  EEM_FedsTimingTTHistCSC_ =
+      new TH3F("timeTTAllFEDs_CSC",
+               "(ix,iy,time) for all FEDs (SM,TT binning) CSC EEM;ix;iy;Relative Time (1 clock = 25ns)",
+               20,
+               0,
+               100,
+               20,
+               0,
+               100,
+               78,
+               -7,
+               7);
+
+  EEM_OccupancyExclusiveHCAL_ = new TH2F(
+      "OccupancyAllEvents_ExclusiveHCAL", "Occupancy all events Exclusive HCAL EEM;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEM_OccupancyCoarseExclusiveHCAL_ = new TH2F("OccupancyAllEventsCoarse_ExclusiveHCAL",
+                                               "Occupancy all events Coarse Exclusive HCAL EEM;ix;iy",
+                                               20,
+                                               0,
+                                               100,
+                                               20,
+                                               0,
+                                               100);
+  EEM_OccupancyHCAL_ =
+      new TH2F("OccupancyAllEvents_HCAL", "Occupancy all events HCAL EEM;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEM_OccupancyCoarseHCAL_ =
+      new TH2F("OccupancyAllEventsCoarse_HCAL", "Occupancy all events Coarse HCAL EEM;ix;iy", 20, 0, 100, 20, 0, 100);
+  EEM_FedsTimingHistHCAL_ =
+      new TH1F("timeForAllFeds_HCAL", "timeForAllFeds HCAL EEM;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  EEM_FedsTimingTTHistHCAL_ =
+      new TH3F("timeTTAllFEDs_HCAL",
+               "(ix,iy,time) for all FEDs (SM,TT binning) HCAL EEM;ix;iy;Relative Time (1 clock = 25ns)",
+               20,
+               0,
+               100,
+               20,
+               0,
+               100,
+               78,
+               -7,
+               7);
+
+  EEM_numberofBCinSC_ =
+      new TH1F("numberofBCinSC", "Number of Basic Clusters in Super Cluster EEM;Num Basic Clusters", 20, 0, 20);
+
+  EEM_triggerHist_ = new TH1F("triggerHist", "Trigger Number EEM", 5, 0, 5);
+  EEM_triggerHist_->GetXaxis()->SetBinLabel(1, "ECAL");
+  EEM_triggerHist_->GetXaxis()->SetBinLabel(2, "HCAL");
+  EEM_triggerHist_->GetXaxis()->SetBinLabel(3, "DT");
+  EEM_triggerHist_->GetXaxis()->SetBinLabel(4, "RPC");
+  EEM_triggerHist_->GetXaxis()->SetBinLabel(5, "CSC");
+
+  EEM_triggerExclusiveHist_ = new TH1F("triggerExclusiveHist", "Trigger Number (Mutually Exclusive) EEM", 5, 0, 5);
+  triggerExclusiveHist_->GetXaxis()->SetBinLabel(1, "ECAL");
+  EEM_triggerExclusiveHist_->GetXaxis()->SetBinLabel(2, "HCAL");
+  EEM_triggerExclusiveHist_->GetXaxis()->SetBinLabel(3, "DT");
+  EEM_triggerExclusiveHist_->GetXaxis()->SetBinLabel(4, "RPC");
+  EEM_triggerExclusiveHist_->GetXaxis()->SetBinLabel(5, "CSC");
+
+  EEM_NumXtalsInClusterHist_ =
+      new TH1F("NumXtalsInClusterAllHist", "Number of Xtals in Cluster EEM;NumXtals", 150, 0, 150);
+  EEM_numxtalsVsEnergy_ = new TH2F("NumXtalsVsEnergy",
+                                   "Number of Xtals in Cluster vs Energy EEM;Energy (GeV);Number of Xtals in Cluster",
+                                   numBins,
+                                   histRangeMin_,
+                                   10.0,
+                                   150,
+                                   0,
+                                   150);
+  EEM_numxtalsVsHighEnergy_ =
+      new TH2F("NumXtalsVsHighEnergy",
+               "Number of Xtals in Cluster vs Energy EEM;Energy (GeV);Number of Xtals in Cluster",
+               numBins,
+               histRangeMin_,
+               200.,
+               150,
+               0,
+               150);
+
+  EEM_OccupancyHighEnergy_ =
+      new TH2F("OccupancyHighEnergyEvents", "Occupancy high energy events EEM;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEM_OccupancyHighEnergyCoarse_ = new TH2F(
+      "OccupancyHighEnergyEventsCoarse", "Occupancy high energy events Coarse EEM;ix;iy", 20, 0, 100, 20, 0, 100);
+
+  EEM_FedsNumXtalsInClusterHist_ =
+      new TH1F("NumActiveXtalsInClusterAllHist", "Number of active Xtals in Cluster EEM;NumXtals", 100, 0, 100);
+
   // EE+
-  EEP_FedsSeedEnergyHist_           = new TH1F("SeedEnergyAllFEDs","Seed Energy for EEP Feds; Seed Energy (GeV)",200,histRangeMin_,10.0);
+  EEP_FedsSeedEnergyHist_ =
+      new TH1F("SeedEnergyAllFEDs", "Seed Energy for EEP Feds; Seed Energy (GeV)", 200, histRangeMin_, 10.0);
 
-  EEP_AllOccupancyCoarse_           = new TH2F("OccupancyAllEventsCoarse","Occupancy all events Coarse EEP;ix;iy",20,0,100,20,0,100);
-  EEP_AllOccupancy_                 = new TH2F("OccupancyAllEvents","Occupancy all events EEP;ix;iy",100,0,100,100,0,100);
-  EEP_FedsenergyHist_               = new TH1F("energy_AllClusters","energy_AllClusters_EEP;Cluster Energy (GeV)",numBins,histRangeMin_,10.0);
-  EEP_FedsenergyHighHist_           = new TH1F("energyHigh_AllClusters","energyHigh_AllClusters in EEP;Cluster Energy (GeV)",numBins,histRangeMin_,200.0);
-  EEP_FedsenergyOnlyHighHist_       = new TH1F("energyHigh_HighEnergyClusters","energy of High Energy Clusters in EEP;Cluster Energy (GeV)",numBins,histRangeMin_,200.0);
-  EEP_FedsE2Hist_                   = new TH1F("E2_AllClusters","E2_AllClusters_EEP;Seed+highest neighbor energy (GeV)",numBins,histRangeMin_,10.0);
-  EEP_FedsE2vsE1Hist_               = new TH2F("E2vsE1_AllClusters","E2vsE1_AllClusters_EEP;Seed Energy (GeV);Seed+highest neighbor energy (GeV)",numBins,histRangeMin_,10.0,numBins,histRangeMin_,10.0);
-  EEP_FedsenergyvsE1Hist_           = new TH2F("energyvsE1_AllClusters","energyvsE1_AllClusters_EEP;Seed Energy (GeV);Energy(GeV)",numBins,histRangeMin_,10.0,numBins,histRangeMin_,10.0);
-  EEP_FedsTimingHist_               = new TH1F("timeForAllFeds","timeForAllFeds_EEP;Relative Time (1 clock = 25ns)",78,-7,7);
-  EEP_numberofCosmicsHist_ = new TH1F("numberofCosmicsPerEvent","Number of cosmics per event EEP;Number of Cosmics",30,0,30);
+  EEP_AllOccupancyCoarse_ =
+      new TH2F("OccupancyAllEventsCoarse", "Occupancy all events Coarse EEP;ix;iy", 20, 0, 100, 20, 0, 100);
+  EEP_AllOccupancy_ = new TH2F("OccupancyAllEvents", "Occupancy all events EEP;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEP_FedsenergyHist_ =
+      new TH1F("energy_AllClusters", "energy_AllClusters_EEP;Cluster Energy (GeV)", numBins, histRangeMin_, 10.0);
+  EEP_FedsenergyHighHist_ = new TH1F(
+      "energyHigh_AllClusters", "energyHigh_AllClusters in EEP;Cluster Energy (GeV)", numBins, histRangeMin_, 200.0);
+  EEP_FedsenergyOnlyHighHist_ = new TH1F("energyHigh_HighEnergyClusters",
+                                         "energy of High Energy Clusters in EEP;Cluster Energy (GeV)",
+                                         numBins,
+                                         histRangeMin_,
+                                         200.0);
+  EEP_FedsE2Hist_ =
+      new TH1F("E2_AllClusters", "E2_AllClusters_EEP;Seed+highest neighbor energy (GeV)", numBins, histRangeMin_, 10.0);
+  EEP_FedsE2vsE1Hist_ = new TH2F("E2vsE1_AllClusters",
+                                 "E2vsE1_AllClusters_EEP;Seed Energy (GeV);Seed+highest neighbor energy (GeV)",
+                                 numBins,
+                                 histRangeMin_,
+                                 10.0,
+                                 numBins,
+                                 histRangeMin_,
+                                 10.0);
+  EEP_FedsenergyvsE1Hist_ = new TH2F("energyvsE1_AllClusters",
+                                     "energyvsE1_AllClusters_EEP;Seed Energy (GeV);Energy(GeV)",
+                                     numBins,
+                                     histRangeMin_,
+                                     10.0,
+                                     numBins,
+                                     histRangeMin_,
+                                     10.0);
+  EEP_FedsTimingHist_ = new TH1F("timeForAllFeds", "timeForAllFeds_EEP;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  EEP_numberofCosmicsHist_ =
+      new TH1F("numberofCosmicsPerEvent", "Number of cosmics per event EEP;Number of Cosmics", 30, 0, 30);
 
-  EEP_FedsTimingVsAmpHist_          = new TH2F("timeVsAmpAllEvents","time Vs Amp All Events EEP;Relative Time (1 clock = 25ns);Amplitude (GeV)",78,-7,7,numBins,histRangeMin_,10.0);
-  EEP_FedsTimingTTHist_             = new TH3F("timeTTAllFEDs","(ix,iy,time) for all FEDs (SM,TT binning) EEP;ix;iy;Relative Time (1 clock = 25ns)",20,0,100,20,0,100,78,-7,7); 
-  
-  EEP_OccupancySingleXtal_          = new TH2F("OccupancySingleXtal","Occupancy single xtal clusters EEP;ix;iy",100,0,100,100,0,100);
-  EEP_energySingleXtalHist_         = new TH1F("energy_SingleXtalClusters","Energy single xtal clusters EEP;Cluster Energy (GeV)",numBins,histRangeMin_,200.0);
-  
-  EEP_OccupancyExclusiveECAL_       = new TH2F("OccupancyAllEvents_ExclusiveECAL","Occupancy all events Exclusive ECAL  EEP;ix;iy",100,0,100,100,0,100);
-  EEP_OccupancyCoarseExclusiveECAL_ = new TH2F("OccupancyAllEventsCoarse_ExclusiveECAL","Occupancy all events Coarse Exclusive ECAL EEP;ix;iy",20,0,100,20,0,100);
-  EEP_OccupancyECAL_                = new TH2F("OccupancyAllEvents_ECAL","Occupancy all events ECAL EEP;ix;iy",100,0,100,100,0,100);
-  EEP_OccupancyCoarseECAL_          = new TH2F("OccupancyAllEventsCoarse_ECAL","Occupancy all events Coarse ECAL EEP;ix;iy",20,0,100,20,0,100);
-  EEP_FedsTimingHistECAL_           = new TH1F("timeForAllFeds_ECAL","timeForAllFeds ECAL EEP;Relative Time (1 clock = 25ns)",78,-7,7);
-  EEP_FedsTimingTTHistECAL_         = new TH3F("timeTTAllFEDs_ECAL","(ix,iy,time) for all FEDs (SM,TT binning) ECAL EEP;ix;iy;Relative Time (1 clock = 25ns)",20,0,100,20,0,100,78,-7,7); 
-  
-  EEP_OccupancyExclusiveDT_         = new TH2F("OccupancyAllEvents_ExclusiveDT","Occupancy all events Exclusive DT EEP;ix;iy",100,0,100,100,0,100);
-  EEP_OccupancyCoarseExclusiveDT_   = new TH2F("OccupancyAllEventsCoarse_ExclusiveDT","Occupancy all events Coarse Exclusive DT EEP;ix;iy",20,0,100,20,0,100);
-  EEP_OccupancyDT_                  = new TH2F("OccupancyAllEvents_DT","Occupancy all events DT EEP;ix;iy",100,0,100,100,0,100);
-  EEP_OccupancyCoarseDT_            = new TH2F("OccupancyAllEventsCoarse_DT","Occupancy all events Coarse DT EEP;ix;iy",20,0,100,20,0,100);
-  EEP_FedsTimingHistDT_             = new TH1F("timeForAllFeds_DT","timeForAllFeds DT EEP;Relative Time (1 clock = 25ns)",78,-7,7);
-  EEP_FedsTimingTTHistDT_         = new TH3F("timeTTAllFEDs_DT","(ix,iy,time) for all FEDs (SM,TT binning) DT EEP;ix;iy;Relative Time (1 clock = 25ns)",20,0,100,20,0,100,78,-7,7); 
-  
-  EEP_OccupancyExclusiveRPC_        = new TH2F("OccupancyAllEvents_ExclusiveRPC","Occupancy all events Exclusive RPC EEP;ix;iy",100,0,100,100,0,100);
-  EEP_OccupancyCoarseExclusiveRPC_  = new TH2F("OccupancyAllEventsCoarse_ExclusiveRPC","Occupancy all events Coarse Exclusive RPC EEP;ix;iy",20,0,100,20,0,100);
-  EEP_OccupancyRPC_                 = new TH2F("OccupancyAllEvents_RPC","Occupancy all events RPC EEP;ix;iy",100,0,100,100,0,100);
-  EEP_OccupancyCoarseRPC_           = new TH2F("OccupancyAllEventsCoarse_RPC","Occupancy all events Coarse RPC EEP;ix;iy",20,0,100,20,0,100);
-  EEP_FedsTimingHistRPC_            = new TH1F("timeForAllFeds_RPC","timeForAllFeds RPC EEP;Relative Time (1 clock = 25ns)",78,-7,7);
-  EEP_FedsTimingTTHistRPC_          = new TH3F("timeTTAllFEDs_RPC","(ix,iy,time) for all FEDs (SM,TT binning) RPC EEP;ix;iy;Relative Time (1 clock = 25ns)",20,0,100,20,0,100,78,-7,7); 
-  
-  EEP_OccupancyExclusiveCSC_        = new TH2F("OccupancyAllEvents_ExclusiveCSC","Occupancy all events Exclusive CSC EEP;ix;iy",100,0,100,100,0,100);
-  EEP_OccupancyCoarseExclusiveCSC_  = new TH2F("OccupancyAllEventsCoarse_ExclusiveCSC","Occupancy all events Coarse Exclusive CSC EEP;ix;iy",20,0,100,20,0,100);
-  EEP_OccupancyCSC_                 = new TH2F("OccupancyAllEvents_CSC","Occupancy all events CSC EEP;ix;iy",100,0,100,100,0,100);
-  EEP_OccupancyCoarseCSC_           = new TH2F("OccupancyAllEventsCoarse_CSC","Occupancy all events Coarse CSC EEP;ix;iy",20,0,100,20,0,100);
-  EEP_FedsTimingHistCSC_            = new TH1F("timeForAllFeds_CSC","timeForAllFeds CSC EEP;Relative Time (1 clock = 25ns)",78,-7,7);
-  EEP_FedsTimingTTHistCSC_          = new TH3F("timeTTAllFEDs_CSC","(ix,iy,time) for all FEDs (SM,TT binning) CSC EEP;ix;iy;Relative Time (1 clock = 25ns)",20,0,100,20,0,100,78,-7,7); 
-  
-  EEP_OccupancyExclusiveHCAL_       = new TH2F("OccupancyAllEvents_ExclusiveHCAL","Occupancy all events Exclusive HCAL EEP;ix;iy",100,0,100,100,0,100);
-  EEP_OccupancyCoarseExclusiveHCAL_ = new TH2F("OccupancyAllEventsCoarse_ExclusiveHCAL","Occupancy all events Coarse Exclusive HCAL EEP;ix;iy",20,0,100,20,0,100);
-  EEP_OccupancyHCAL_                = new TH2F("OccupancyAllEvents_HCAL","Occupancy all events HCAL EEP;ix;iy",100,0,100,100,0,100);
-  EEP_OccupancyCoarseHCAL_          = new TH2F("OccupancyAllEventsCoarse_HCAL","Occupancy all events Coarse HCAL EEP;ix;iy",20,0,100,20,0,100);
-  EEP_FedsTimingHistHCAL_           = new TH1F("timeForAllFeds_HCAL","timeForAllFeds HCAL EEP;Relative Time (1 clock = 25ns)",78,-7,7);
-  EEP_FedsTimingTTHistHCAL_         = new TH3F("timeTTAllFEDs_HCAL","(ix,iy,time) for all FEDs (SM,TT binning) HCAL EEP;ix;iy;Relative Time (1 clock = 25ns)",20,0,100,20,0,100,78,-7,7); 
-  
-  EEP_numberofBCinSC_               = new TH1F("numberofBCinSC","Number of Basic Clusters in Super Cluster EEP;Num Basic Clusters",20,0,20);
-  
-  EEP_triggerHist_                  = new TH1F("triggerHist","Trigger Number EEP",5,0,5);
-  EEP_triggerHist_->GetXaxis()->SetBinLabel(1,"ECAL");
-  EEP_triggerHist_->GetXaxis()->SetBinLabel(2,"HCAL");
-  EEP_triggerHist_->GetXaxis()->SetBinLabel(3,"DT");
-  EEP_triggerHist_->GetXaxis()->SetBinLabel(4,"RPC");
-  EEP_triggerHist_->GetXaxis()->SetBinLabel(5,"CSC");
-  
-  EEP_triggerExclusiveHist_         = new TH1F("triggerExclusiveHist","Trigger Number (Mutually Exclusive) EEP",5,0,5);  
-  EEP_triggerExclusiveHist_->GetXaxis()->SetBinLabel(1,"ECAL");
-  EEP_triggerExclusiveHist_->GetXaxis()->SetBinLabel(2,"HCAL");
-  EEP_triggerExclusiveHist_->GetXaxis()->SetBinLabel(3,"DT");
-  EEP_triggerExclusiveHist_->GetXaxis()->SetBinLabel(4,"RPC");
-  EEP_triggerExclusiveHist_->GetXaxis()->SetBinLabel(5,"CSC");
-  
-  EEP_NumXtalsInClusterHist_        = new TH1F("NumXtalsInClusterAllHist","Number of Xtals in Cluster EEP;NumXtals",150,0,150);
-  EEP_numxtalsVsEnergy_             = new TH2F("NumXtalsVsEnergy","Number of Xtals in Cluster vs Energy EEP;Energy (GeV);Number of Xtals in Cluster",numBins,histRangeMin_,10.0, 150,0,150);
-  EEP_numxtalsVsHighEnergy_         = new TH2F("NumXtalsVsHighEnergy","Number of Xtals in Cluster vs Energy EEP;Energy (GeV);Number of Xtals in Cluster",numBins,histRangeMin_,200., 150,0,150);
-  
-  EEP_OccupancyHighEnergy_          = new TH2F("OccupancyHighEnergyEvents","Occupancy high energy events EEP;ix;iy",100,0,100,100,0,100);
-  EEP_OccupancyHighEnergyCoarse_    = new TH2F("OccupancyHighEnergyEventsCoarse","Occupancy high energy events Coarse EEP;ix;iy",20,0,100,20,0,100);
-  
-  EEP_FedsNumXtalsInClusterHist_    = new TH1F("NumActiveXtalsInClusterAllHist","Number of active Xtals in Cluster EEP;NumXtals",100,0,100);
-  
+  EEP_FedsTimingVsAmpHist_ = new TH2F("timeVsAmpAllEvents",
+                                      "time Vs Amp All Events EEP;Relative Time (1 clock = 25ns);Amplitude (GeV)",
+                                      78,
+                                      -7,
+                                      7,
+                                      numBins,
+                                      histRangeMin_,
+                                      10.0);
+  EEP_FedsTimingTTHist_ = new TH3F("timeTTAllFEDs",
+                                   "(ix,iy,time) for all FEDs (SM,TT binning) EEP;ix;iy;Relative Time (1 clock = 25ns)",
+                                   20,
+                                   0,
+                                   100,
+                                   20,
+                                   0,
+                                   100,
+                                   78,
+                                   -7,
+                                   7);
 
+  EEP_OccupancySingleXtal_ =
+      new TH2F("OccupancySingleXtal", "Occupancy single xtal clusters EEP;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEP_energySingleXtalHist_ = new TH1F("energy_SingleXtalClusters",
+                                       "Energy single xtal clusters EEP;Cluster Energy (GeV)",
+                                       numBins,
+                                       histRangeMin_,
+                                       200.0);
+
+  EEP_OccupancyExclusiveECAL_ = new TH2F(
+      "OccupancyAllEvents_ExclusiveECAL", "Occupancy all events Exclusive ECAL  EEP;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEP_OccupancyCoarseExclusiveECAL_ = new TH2F("OccupancyAllEventsCoarse_ExclusiveECAL",
+                                               "Occupancy all events Coarse Exclusive ECAL EEP;ix;iy",
+                                               20,
+                                               0,
+                                               100,
+                                               20,
+                                               0,
+                                               100);
+  EEP_OccupancyECAL_ =
+      new TH2F("OccupancyAllEvents_ECAL", "Occupancy all events ECAL EEP;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEP_OccupancyCoarseECAL_ =
+      new TH2F("OccupancyAllEventsCoarse_ECAL", "Occupancy all events Coarse ECAL EEP;ix;iy", 20, 0, 100, 20, 0, 100);
+  EEP_FedsTimingHistECAL_ =
+      new TH1F("timeForAllFeds_ECAL", "timeForAllFeds ECAL EEP;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  EEP_FedsTimingTTHistECAL_ =
+      new TH3F("timeTTAllFEDs_ECAL",
+               "(ix,iy,time) for all FEDs (SM,TT binning) ECAL EEP;ix;iy;Relative Time (1 clock = 25ns)",
+               20,
+               0,
+               100,
+               20,
+               0,
+               100,
+               78,
+               -7,
+               7);
+
+  EEP_OccupancyExclusiveDT_ = new TH2F(
+      "OccupancyAllEvents_ExclusiveDT", "Occupancy all events Exclusive DT EEP;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEP_OccupancyCoarseExclusiveDT_ = new TH2F("OccupancyAllEventsCoarse_ExclusiveDT",
+                                             "Occupancy all events Coarse Exclusive DT EEP;ix;iy",
+                                             20,
+                                             0,
+                                             100,
+                                             20,
+                                             0,
+                                             100);
+  EEP_OccupancyDT_ = new TH2F("OccupancyAllEvents_DT", "Occupancy all events DT EEP;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEP_OccupancyCoarseDT_ =
+      new TH2F("OccupancyAllEventsCoarse_DT", "Occupancy all events Coarse DT EEP;ix;iy", 20, 0, 100, 20, 0, 100);
+  EEP_FedsTimingHistDT_ =
+      new TH1F("timeForAllFeds_DT", "timeForAllFeds DT EEP;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  EEP_FedsTimingTTHistDT_ =
+      new TH3F("timeTTAllFEDs_DT",
+               "(ix,iy,time) for all FEDs (SM,TT binning) DT EEP;ix;iy;Relative Time (1 clock = 25ns)",
+               20,
+               0,
+               100,
+               20,
+               0,
+               100,
+               78,
+               -7,
+               7);
+
+  EEP_OccupancyExclusiveRPC_ = new TH2F(
+      "OccupancyAllEvents_ExclusiveRPC", "Occupancy all events Exclusive RPC EEP;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEP_OccupancyCoarseExclusiveRPC_ = new TH2F("OccupancyAllEventsCoarse_ExclusiveRPC",
+                                              "Occupancy all events Coarse Exclusive RPC EEP;ix;iy",
+                                              20,
+                                              0,
+                                              100,
+                                              20,
+                                              0,
+                                              100);
+  EEP_OccupancyRPC_ =
+      new TH2F("OccupancyAllEvents_RPC", "Occupancy all events RPC EEP;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEP_OccupancyCoarseRPC_ =
+      new TH2F("OccupancyAllEventsCoarse_RPC", "Occupancy all events Coarse RPC EEP;ix;iy", 20, 0, 100, 20, 0, 100);
+  EEP_FedsTimingHistRPC_ =
+      new TH1F("timeForAllFeds_RPC", "timeForAllFeds RPC EEP;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  EEP_FedsTimingTTHistRPC_ =
+      new TH3F("timeTTAllFEDs_RPC",
+               "(ix,iy,time) for all FEDs (SM,TT binning) RPC EEP;ix;iy;Relative Time (1 clock = 25ns)",
+               20,
+               0,
+               100,
+               20,
+               0,
+               100,
+               78,
+               -7,
+               7);
+
+  EEP_OccupancyExclusiveCSC_ = new TH2F(
+      "OccupancyAllEvents_ExclusiveCSC", "Occupancy all events Exclusive CSC EEP;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEP_OccupancyCoarseExclusiveCSC_ = new TH2F("OccupancyAllEventsCoarse_ExclusiveCSC",
+                                              "Occupancy all events Coarse Exclusive CSC EEP;ix;iy",
+                                              20,
+                                              0,
+                                              100,
+                                              20,
+                                              0,
+                                              100);
+  EEP_OccupancyCSC_ =
+      new TH2F("OccupancyAllEvents_CSC", "Occupancy all events CSC EEP;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEP_OccupancyCoarseCSC_ =
+      new TH2F("OccupancyAllEventsCoarse_CSC", "Occupancy all events Coarse CSC EEP;ix;iy", 20, 0, 100, 20, 0, 100);
+  EEP_FedsTimingHistCSC_ =
+      new TH1F("timeForAllFeds_CSC", "timeForAllFeds CSC EEP;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  EEP_FedsTimingTTHistCSC_ =
+      new TH3F("timeTTAllFEDs_CSC",
+               "(ix,iy,time) for all FEDs (SM,TT binning) CSC EEP;ix;iy;Relative Time (1 clock = 25ns)",
+               20,
+               0,
+               100,
+               20,
+               0,
+               100,
+               78,
+               -7,
+               7);
+
+  EEP_OccupancyExclusiveHCAL_ = new TH2F(
+      "OccupancyAllEvents_ExclusiveHCAL", "Occupancy all events Exclusive HCAL EEP;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEP_OccupancyCoarseExclusiveHCAL_ = new TH2F("OccupancyAllEventsCoarse_ExclusiveHCAL",
+                                               "Occupancy all events Coarse Exclusive HCAL EEP;ix;iy",
+                                               20,
+                                               0,
+                                               100,
+                                               20,
+                                               0,
+                                               100);
+  EEP_OccupancyHCAL_ =
+      new TH2F("OccupancyAllEvents_HCAL", "Occupancy all events HCAL EEP;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEP_OccupancyCoarseHCAL_ =
+      new TH2F("OccupancyAllEventsCoarse_HCAL", "Occupancy all events Coarse HCAL EEP;ix;iy", 20, 0, 100, 20, 0, 100);
+  EEP_FedsTimingHistHCAL_ =
+      new TH1F("timeForAllFeds_HCAL", "timeForAllFeds HCAL EEP;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  EEP_FedsTimingTTHistHCAL_ =
+      new TH3F("timeTTAllFEDs_HCAL",
+               "(ix,iy,time) for all FEDs (SM,TT binning) HCAL EEP;ix;iy;Relative Time (1 clock = 25ns)",
+               20,
+               0,
+               100,
+               20,
+               0,
+               100,
+               78,
+               -7,
+               7);
+
+  EEP_numberofBCinSC_ =
+      new TH1F("numberofBCinSC", "Number of Basic Clusters in Super Cluster EEP;Num Basic Clusters", 20, 0, 20);
+
+  EEP_triggerHist_ = new TH1F("triggerHist", "Trigger Number EEP", 5, 0, 5);
+  EEP_triggerHist_->GetXaxis()->SetBinLabel(1, "ECAL");
+  EEP_triggerHist_->GetXaxis()->SetBinLabel(2, "HCAL");
+  EEP_triggerHist_->GetXaxis()->SetBinLabel(3, "DT");
+  EEP_triggerHist_->GetXaxis()->SetBinLabel(4, "RPC");
+  EEP_triggerHist_->GetXaxis()->SetBinLabel(5, "CSC");
+
+  EEP_triggerExclusiveHist_ = new TH1F("triggerExclusiveHist", "Trigger Number (Mutually Exclusive) EEP", 5, 0, 5);
+  EEP_triggerExclusiveHist_->GetXaxis()->SetBinLabel(1, "ECAL");
+  EEP_triggerExclusiveHist_->GetXaxis()->SetBinLabel(2, "HCAL");
+  EEP_triggerExclusiveHist_->GetXaxis()->SetBinLabel(3, "DT");
+  EEP_triggerExclusiveHist_->GetXaxis()->SetBinLabel(4, "RPC");
+  EEP_triggerExclusiveHist_->GetXaxis()->SetBinLabel(5, "CSC");
+
+  EEP_NumXtalsInClusterHist_ =
+      new TH1F("NumXtalsInClusterAllHist", "Number of Xtals in Cluster EEP;NumXtals", 150, 0, 150);
+  EEP_numxtalsVsEnergy_ = new TH2F("NumXtalsVsEnergy",
+                                   "Number of Xtals in Cluster vs Energy EEP;Energy (GeV);Number of Xtals in Cluster",
+                                   numBins,
+                                   histRangeMin_,
+                                   10.0,
+                                   150,
+                                   0,
+                                   150);
+  EEP_numxtalsVsHighEnergy_ =
+      new TH2F("NumXtalsVsHighEnergy",
+               "Number of Xtals in Cluster vs Energy EEP;Energy (GeV);Number of Xtals in Cluster",
+               numBins,
+               histRangeMin_,
+               200.,
+               150,
+               0,
+               150);
+
+  EEP_OccupancyHighEnergy_ =
+      new TH2F("OccupancyHighEnergyEvents", "Occupancy high energy events EEP;ix;iy", 100, 0, 100, 100, 0, 100);
+  EEP_OccupancyHighEnergyCoarse_ = new TH2F(
+      "OccupancyHighEnergyEventsCoarse", "Occupancy high energy events Coarse EEP;ix;iy", 20, 0, 100, 20, 0, 100);
+
+  EEP_FedsNumXtalsInClusterHist_ =
+      new TH1F("NumActiveXtalsInClusterAllHist", "Number of active Xtals in Cluster EEP;NumXtals", 100, 0, 100);
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-EcalCosmicsHists::endJob()
-{
+void EcalCosmicsHists::endJob() {
   using namespace std;
   if (runInFileName_) {
-    fileName_ += "-"+intToString(runNum_)+".graph.root";
+    fileName_ += "-" + intToString(runNum_) + ".graph.root";
   } else {
     fileName_ += ".root";
   }
-  
-  TFile root_file_(fileName_.c_str() , "RECREATE");
-  
-  for(map<int,TH1F*>::const_iterator itr = FEDsAndHists_.begin();
-      itr != FEDsAndHists_.end(); ++itr) {
+
+  TFile root_file_(fileName_.c_str(), "RECREATE");
+
+  for (map<int, TH1F*>::const_iterator itr = FEDsAndHists_.begin(); itr != FEDsAndHists_.end(); ++itr) {
     string dir = fedMap_->getSliceFromFed(itr->first);
     TDirectory* FEDdir = gDirectory->mkdir(dir.c_str());
     FEDdir->cd();
-    
+
     TH1F* hist = itr->second;
-    if(hist!=nullptr)
+    if (hist != nullptr)
       hist->Write();
     else {
       cerr << "EcalCosmicsHists: Error: This shouldn't happen!" << endl;
     }
     // Write out timing hist
     hist = FEDsAndTimingHists_[itr->first];
-    if(hist!=nullptr)
+    if (hist != nullptr)
       hist->Write();
     else {
       cerr << "EcalCosmicsHists: Error: This shouldn't happen!" << endl;
     }
-    
+
     hist = FEDsAndFrequencyHists_[itr->first];
     hist->Write();
-    
+
     hist = FEDsAndiPhiProfileHists_[itr->first];
     hist->Write();
-    
+
     hist = FEDsAndiEtaProfileHists_[itr->first];
     hist->Write();
-    
+
     hist = FEDsAndE2Hists_[itr->first];
     hist->Write();
-    
+
     hist = FEDsAndenergyHists_[itr->first];
     hist->Write();
-    
+
     hist = FEDsAndNumXtalsInClusterHists_[itr->first];
     hist->Write();
-    
+
     TH2F* hist2 = FEDsAndTimingVsAmpHists_[itr->first];
     hist2->Write();
-    
+
     hist2 = FEDsAndTimingVsFreqHists_[itr->first];
     hist2->Write();
-    
+
     hist2 = FEDsAndE2vsE1Hists_[itr->first];
     hist2->Write();
-    
+
     hist2 = FEDsAndenergyvsE1Hists_[itr->first];
     hist2->Write();
-    
+
     hist2 = FEDsAndOccupancyHists_[itr->first];
     hist2->Write();
-    
+
     hist2 = FEDsAndTimingVsPhiHists_[itr->first];
     hist2->Write();
-    
+
     hist2 = FEDsAndTimingVsModuleHists_[itr->first];
     hist2->Write();
 
     //2d hist
-    map<int,TH2F*>::const_iterator itr2d;
+    map<int, TH2F*>::const_iterator itr2d;
     itr2d = FEDsAndDCCRuntypeVsBxHists_.find(itr->first);
-    if(itr2d != FEDsAndDCCRuntypeVsBxHists_.end())
-    {
+    if (itr2d != FEDsAndDCCRuntypeVsBxHists_.end()) {
       TH2F* hist2 = itr2d->second;
-      hist2->GetYaxis()->SetBinLabel(1,"COSMIC");
-      hist2->GetYaxis()->SetBinLabel(2,"BEAMH4");
-      hist2->GetYaxis()->SetBinLabel(3,"BEAMH2");
-      hist2->GetYaxis()->SetBinLabel(4,"MTCC");
-      hist2->GetYaxis()->SetBinLabel(5,"LASER_STD");
-      hist2->GetYaxis()->SetBinLabel(6,"LASER_POWER_SCAN");
-      hist2->GetYaxis()->SetBinLabel(7,"LASER_DELAY_SCAN");
-      hist2->GetYaxis()->SetBinLabel(8,"TESTPULSE_SCAN_MEM");
-      hist2->GetYaxis()->SetBinLabel(9,"TESTPULSE_MGPA");
-      hist2->GetYaxis()->SetBinLabel(10,"PEDESTAL_STD");
-      hist2->GetYaxis()->SetBinLabel(11,"PEDESTAL_OFFSET_SCAN");
-      hist2->GetYaxis()->SetBinLabel(12,"PEDESTAL_25NS_SCAN");
-      hist2->GetYaxis()->SetBinLabel(13,"LED_STD");
-      hist2->GetYaxis()->SetBinLabel(14,"PHYSICS_GLOBAL");
-      hist2->GetYaxis()->SetBinLabel(15,"COSMICS_GLOBAL");
-      hist2->GetYaxis()->SetBinLabel(16,"HALO_GLOBAL");
-      hist2->GetYaxis()->SetBinLabel(17,"LASER_GAP");
-      hist2->GetYaxis()->SetBinLabel(18,"TESTPULSE_GAP");
-      hist2->GetYaxis()->SetBinLabel(19,"PEDESTAL_GAP");
-      hist2->GetYaxis()->SetBinLabel(20,"LED_GAP");
-      hist2->GetYaxis()->SetBinLabel(21,"PHYSICS_LOCAL");
-      hist2->GetYaxis()->SetBinLabel(22,"COSMICS_LOCAL");
-      hist2->GetYaxis()->SetBinLabel(23,"HALO_LOCAL");
-      hist2->GetYaxis()->SetBinLabel(24,"CALIB_LOCAL");
+      hist2->GetYaxis()->SetBinLabel(1, "COSMIC");
+      hist2->GetYaxis()->SetBinLabel(2, "BEAMH4");
+      hist2->GetYaxis()->SetBinLabel(3, "BEAMH2");
+      hist2->GetYaxis()->SetBinLabel(4, "MTCC");
+      hist2->GetYaxis()->SetBinLabel(5, "LASER_STD");
+      hist2->GetYaxis()->SetBinLabel(6, "LASER_POWER_SCAN");
+      hist2->GetYaxis()->SetBinLabel(7, "LASER_DELAY_SCAN");
+      hist2->GetYaxis()->SetBinLabel(8, "TESTPULSE_SCAN_MEM");
+      hist2->GetYaxis()->SetBinLabel(9, "TESTPULSE_MGPA");
+      hist2->GetYaxis()->SetBinLabel(10, "PEDESTAL_STD");
+      hist2->GetYaxis()->SetBinLabel(11, "PEDESTAL_OFFSET_SCAN");
+      hist2->GetYaxis()->SetBinLabel(12, "PEDESTAL_25NS_SCAN");
+      hist2->GetYaxis()->SetBinLabel(13, "LED_STD");
+      hist2->GetYaxis()->SetBinLabel(14, "PHYSICS_GLOBAL");
+      hist2->GetYaxis()->SetBinLabel(15, "COSMICS_GLOBAL");
+      hist2->GetYaxis()->SetBinLabel(16, "HALO_GLOBAL");
+      hist2->GetYaxis()->SetBinLabel(17, "LASER_GAP");
+      hist2->GetYaxis()->SetBinLabel(18, "TESTPULSE_GAP");
+      hist2->GetYaxis()->SetBinLabel(19, "PEDESTAL_GAP");
+      hist2->GetYaxis()->SetBinLabel(20, "LED_GAP");
+      hist2->GetYaxis()->SetBinLabel(21, "PHYSICS_LOCAL");
+      hist2->GetYaxis()->SetBinLabel(22, "COSMICS_LOCAL");
+      hist2->GetYaxis()->SetBinLabel(23, "HALO_LOCAL");
+      hist2->GetYaxis()->SetBinLabel(24, "CALIB_LOCAL");
       hist2->Write();
     }
-    
+
     root_file_.cd();
   }
   allFedsHist_->Write();
@@ -2029,14 +2893,14 @@ EcalCosmicsHists::endJob()
   allFedsTimingLMHist_->Write();
   allFedsOccupancyHighEnergyHist_->Write();
 
-  numberofBCinSC_->Write();//SC
-  numberofBCinSCphi_->Write();//SC
-  TrueBCOccupancyCoarse_->Write();//BC
-  TrueBCOccupancy_->Write(); //BC
+  numberofBCinSC_->Write();         //SC
+  numberofBCinSCphi_->Write();      //SC
+  TrueBCOccupancyCoarse_->Write();  //BC
+  TrueBCOccupancy_->Write();        //BC
 
   numxtalsVsEnergy_->Write();
   numxtalsVsHighEnergy_->Write();
-  
+
   allOccupancyExclusiveECAL_->Write();
   allOccupancyCoarseExclusiveECAL_->Write();
   allOccupancyECAL_->Write();
@@ -2088,15 +2952,15 @@ EcalCosmicsHists::endJob()
   TDirectory* EEMinusDir = gDirectory->mkdir("EEMinus");
   EEMinusDir->cd();
   EEM_FedsSeedEnergyHist_->Write();
-  EEM_AllOccupancyCoarse_->Write(); 
-  EEM_AllOccupancy_->Write(); 
+  EEM_AllOccupancyCoarse_->Write();
+  EEM_AllOccupancy_->Write();
   EEM_FedsenergyHist_->Write();
   EEM_FedsenergyHighHist_->Write();
   EEM_FedsenergyOnlyHighHist_->Write();
   EEM_FedsE2Hist_->Write();
   EEM_FedsE2vsE1Hist_->Write();
   EEM_FedsenergyvsE1Hist_->Write();
-  EEM_FedsTimingHist_->Write();        
+  EEM_FedsTimingHist_->Write();
   EEM_numberofCosmicsHist_->Write();
   EEM_FedsTimingVsAmpHist_->Write();
   EEM_FedsTimingTTHist_->Write();
@@ -2146,15 +3010,15 @@ EcalCosmicsHists::endJob()
   TDirectory* EEPlusDir = gDirectory->mkdir("EEPlus");
   EEPlusDir->cd();
   EEP_FedsSeedEnergyHist_->Write();
-  EEP_AllOccupancyCoarse_->Write(); 
-  EEP_AllOccupancy_->Write(); 
+  EEP_AllOccupancyCoarse_->Write();
+  EEP_AllOccupancy_->Write();
   EEP_FedsenergyHist_->Write();
   EEP_FedsenergyHighHist_->Write();
   EEP_FedsenergyOnlyHighHist_->Write();
   EEP_FedsE2Hist_->Write();
   EEP_FedsE2vsE1Hist_->Write();
   EEP_FedsenergyvsE1Hist_->Write();
-  EEP_FedsTimingHist_->Write();        
+  EEP_FedsTimingHist_->Write();
   EEP_numberofCosmicsHist_->Write();
   EEP_FedsTimingVsAmpHist_->Write();
   EEP_FedsTimingTTHist_->Write();
@@ -2205,7 +3069,7 @@ EcalCosmicsHists::endJob()
   triggerExclusiveHist_->Write();
 
   NumXtalsInClusterHist_->Write();
-  
+
   numberofCosmicsHist_->Write();
   numberofCosmicsHistEB_->Write();
 
@@ -2214,7 +3078,7 @@ EcalCosmicsHists::endJob()
   numberofGoodEvtFreq_->Write();
   numberofCrossedEcalIdsHist_->Write();
 
-  runNumberHist_->SetBinContent(1,runNum_);
+  runNumberHist_->SetBinContent(1, runNum_);
   runNumberHist_->Write();
 
   deltaRHist_->Write();
@@ -2231,7 +3095,7 @@ EcalCosmicsHists::endJob()
   dccRuntypeErrorByFEDHist_->Write();
   dccErrorVsBxHist_->Write();
   dccRuntypeHist_->Write();
-  
+
   trackAssoc_muonsEcal_->Write();
 
   hcalEnergy_HBHE_->Write();
@@ -2243,7 +3107,7 @@ EcalCosmicsHists::endJob()
   highEnergyDir->cd();
   HighEnergy_NumXtal->Write();
   HighEnergy_NumXtalFedId->Write();
-  HighEnergy_NumXtaliphi->Write();  
+  HighEnergy_NumXtaliphi->Write();
   HighEnergy_energy3D->Write();
   HighEnergy_energyNumXtal->Write();
   HighEnergy_bestSeed->Write();
@@ -2272,27 +3136,27 @@ EcalCosmicsHists::endJob()
   allFedsFreqTimeVsPhiHist_->Write();
   allFedsFreqTimeVsPhiTTHist_->Write();
   allFedsFreqTimeVsEtaHist_->Write();
-  allFedsFreqTimeVsEtaTTHist_->Write(); 
+  allFedsFreqTimeVsEtaTTHist_->Write();
 
   root_file_.cd();
 
   root_file_.Close();
 
-  LogWarning("EcalCosmicsHists") << "---> Number of cosmic events: " << cosmicCounter_ << " in " << naiveEvtNum_ << " events.";
-  LogWarning("EcalCosmicsHists") << "---> Number of EB cosmic events: " << cosmicCounterEB_ << " in " << naiveEvtNum_ << " events.";
-  LogWarning("EcalCosmicsHists") << "---> Number of EE- cosmic events: " << cosmicCounterEEM_ << " in " << naiveEvtNum_ << " events.";
-  LogWarning("EcalCosmicsHists") << "---> Number of EE+ cosmic events: " << cosmicCounterEEP_ << " in " << naiveEvtNum_ << " events.";
+  LogWarning("EcalCosmicsHists") << "---> Number of cosmic events: " << cosmicCounter_ << " in " << naiveEvtNum_
+                                 << " events.";
+  LogWarning("EcalCosmicsHists") << "---> Number of EB cosmic events: " << cosmicCounterEB_ << " in " << naiveEvtNum_
+                                 << " events.";
+  LogWarning("EcalCosmicsHists") << "---> Number of EE- cosmic events: " << cosmicCounterEEM_ << " in " << naiveEvtNum_
+                                 << " events.";
+  LogWarning("EcalCosmicsHists") << "---> Number of EE+ cosmic events: " << cosmicCounterEEP_ << " in " << naiveEvtNum_
+                                 << " events.";
 
   //  LogWarning("EcalCosmicsHists") << "---> Number of top+bottom cosmic events: " << cosmicCounterTopBottom_ << " in " << cosmicCounter_ << " cosmics in " << naiveEvtNum_ << " events.";
-
 }
 
-
-std::string EcalCosmicsHists::intToString(int num)
-{
-    using namespace std;
-    ostringstream myStream;
-    myStream << num << flush;
-    return(myStream.str()); //returns the string form of the stringstream object
+std::string EcalCosmicsHists::intToString(int num) {
+  using namespace std;
+  ostringstream myStream;
+  myStream << num << flush;
+  return (myStream.str());  //returns the string form of the stringstream object
 }
-

--- a/CaloOnlineTools/EcalTools/plugins/EcalCosmicsHists.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalCosmicsHists.h
@@ -1,8 +1,8 @@
 // -*- C++ -*-
 //
-// Package:   EcalCosmicsHists 
-// Class:     EcalCosmicsHists 
-// 
+// Package:   EcalCosmicsHists
+// Class:     EcalCosmicsHists
+//
 /**\class EcalCosmicsHists EcalCosmicsHists.cc
 
  Description: <one line class summary>
@@ -15,7 +15,6 @@
 //         Created:  Th Nov 22 5:46:22 CEST 2007
 //
 //
-
 
 // system include files
 #include <memory>
@@ -52,7 +51,6 @@
 #include "TGraph.h"
 #include "TNtuple.h"
 
-
 // *** for TrackAssociation
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -68,21 +66,20 @@
 //
 
 class EcalCosmicsHists : public edm::EDAnalyzer {
-   public:
-      explicit EcalCosmicsHists(const edm::ParameterSet&);
-      ~EcalCosmicsHists() override;
+public:
+  explicit EcalCosmicsHists(const edm::ParameterSet&);
+  ~EcalCosmicsHists() override;
 
-
-   private:
-      void beginRun(edm::Run const &, edm::EventSetup const &) override ;
-      void analyze(edm::Event const &, edm::EventSetup const &) override;
-      void endJob() override ;
-      std::string intToString(int num);
-      void initHists(int);
-      std::vector<bool> determineTriggers(const edm::Event&, const edm::EventSetup& eventSetup);
+private:
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
+  void endJob() override;
+  std::string intToString(int num);
+  void initHists(int);
+  std::vector<bool> determineTriggers(const edm::Event&, const edm::EventSetup& eventSetup);
 
   // ----------member data ---------------------------
-  
+
   edm::InputTag ecalRawDataColl_;
   edm::InputTag ecalRecHitCollectionEB_;
   edm::InputTag ecalRecHitCollectionEE_;
@@ -90,7 +87,7 @@ class EcalCosmicsHists : public edm::EDAnalyzer {
   edm::InputTag endcapClusterCollection_;
   edm::InputTag l1GTReadoutRecTag_;
   edm::InputTag l1GMTReadoutRecTag_;
-  
+
   int runNum_;
   double histRangeMax_, histRangeMin_;
   double minTimingAmpEB_;
@@ -98,32 +95,32 @@ class EcalCosmicsHists : public edm::EDAnalyzer {
   double minRecHitAmpEB_;
   double minRecHitAmpEE_;
   double minHighEnergy_;
-  
-  double *ttEtaBins;
-  double *modEtaBins;
+
+  double* ttEtaBins;
+  double* modEtaBins;
   std::string fileName_;
   bool runInFileName_;
 
   double startTime_, runTimeLength_;
-  int numTimingBins_; 
-  
-  std::map<int,TH1F*> FEDsAndHists_;
-  std::map<int,TH1F*> FEDsAndE2Hists_;
-  std::map<int,TH1F*> FEDsAndenergyHists_;
-  std::map<int,TH1F*> FEDsAndTimingHists_;
-  std::map<int,TH1F*> FEDsAndFrequencyHists_;
-  std::map<int,TH1F*> FEDsAndiPhiProfileHists_;
-  std::map<int,TH1F*> FEDsAndNumXtalsInClusterHists_;
-  std::map<int,TH1F*> FEDsAndiEtaProfileHists_;
-  std::map<int,TH2F*> FEDsAndTimingVsFreqHists_;
-  std::map<int,TH2F*> FEDsAndTimingVsAmpHists_;
-  std::map<int,TH2F*> FEDsAndE2vsE1Hists_;
-  std::map<int,TH2F*> FEDsAndenergyvsE1Hists_;
-  std::map<int,TH2F*> FEDsAndOccupancyHists_;  
-  std::map<int,TH2F*> FEDsAndTimingVsPhiHists_;  
-  std::map<int,TH2F*> FEDsAndTimingVsEtaHists_;  
-  std::map<int,TH2F*> FEDsAndTimingVsModuleHists_;  
-  std::map<int,TH2F*> FEDsAndDCCRuntypeVsBxHists_;
+  int numTimingBins_;
+
+  std::map<int, TH1F*> FEDsAndHists_;
+  std::map<int, TH1F*> FEDsAndE2Hists_;
+  std::map<int, TH1F*> FEDsAndenergyHists_;
+  std::map<int, TH1F*> FEDsAndTimingHists_;
+  std::map<int, TH1F*> FEDsAndFrequencyHists_;
+  std::map<int, TH1F*> FEDsAndiPhiProfileHists_;
+  std::map<int, TH1F*> FEDsAndNumXtalsInClusterHists_;
+  std::map<int, TH1F*> FEDsAndiEtaProfileHists_;
+  std::map<int, TH2F*> FEDsAndTimingVsFreqHists_;
+  std::map<int, TH2F*> FEDsAndTimingVsAmpHists_;
+  std::map<int, TH2F*> FEDsAndE2vsE1Hists_;
+  std::map<int, TH2F*> FEDsAndenergyvsE1Hists_;
+  std::map<int, TH2F*> FEDsAndOccupancyHists_;
+  std::map<int, TH2F*> FEDsAndTimingVsPhiHists_;
+  std::map<int, TH2F*> FEDsAndTimingVsEtaHists_;
+  std::map<int, TH2F*> FEDsAndTimingVsModuleHists_;
+  std::map<int, TH2F*> FEDsAndDCCRuntypeVsBxHists_;
 
   TH1F* allFedsHist_;
   TH1F* allFedsE2Hist_;
@@ -143,8 +140,8 @@ class EcalCosmicsHists : public edm::EDAnalyzer {
   TH1F* numberofCosmicsHistEB_;
 
   //TH1F* numberofSCCosmicsHist_;//SC Num cosmics
-  TH1F* numberofBCinSC_;//SC Num cosmics
-  TH2F* numberofBCinSCphi_;//SC
+  TH1F* numberofBCinSC_;     //SC Num cosmics
+  TH2F* numberofBCinSCphi_;  //SC
 
   TH2F* TrueBCOccupancy_;
   TH2F* TrueBCOccupancyCoarse_;
@@ -154,10 +151,10 @@ class EcalCosmicsHists : public edm::EDAnalyzer {
 
   TH2F* allFedsE2vsE1Hist_;
   TH2F* allFedsenergyvsE1Hist_;
-  TH2F* allOccupancy_; //New file to do eta-phi occupancy
-  TH2F* TrueOccupancy_; //New file to do eta-phi occupancy
-  TH2F* allOccupancyCoarse_; //New file to do eta-phi occupancy
-  TH2F* TrueOccupancyCoarse_; //New file to do eta-phi occupancy
+  TH2F* allOccupancy_;         //New file to do eta-phi occupancy
+  TH2F* TrueOccupancy_;        //New file to do eta-phi occupancy
+  TH2F* allOccupancyCoarse_;   //New file to do eta-phi occupancy
+  TH2F* TrueOccupancyCoarse_;  //New file to do eta-phi occupancy
 
   // single xtal clusters
   TH2F* allOccupancySingleXtal_;
@@ -180,58 +177,58 @@ class EcalCosmicsHists : public edm::EDAnalyzer {
   TH1F* allFedsTimingEbpBottomHist_;
   TH1F* allFedsTimingEbmBottomHist_;
 
-  TH2F* allOccupancyECAL_; 
-  TH2F* allOccupancyCoarseECAL_; 
-  TH2F* allOccupancyExclusiveECAL_; 
-  TH2F* allOccupancyCoarseExclusiveECAL_; 
+  TH2F* allOccupancyECAL_;
+  TH2F* allOccupancyCoarseECAL_;
+  TH2F* allOccupancyExclusiveECAL_;
+  TH2F* allOccupancyCoarseExclusiveECAL_;
   TH1F* allFedsTimingHistECAL_;
   TH3F* allFedsTimingPhiEtaHistECAL_;
   TH3F* allFedsTimingTTHistECAL_;
   TH2F* allFedsTimingLMHistECAL_;
 
-  TH2F* allOccupancyDT_; 
-  TH2F* allOccupancyCoarseDT_; 
-  TH2F* allOccupancyExclusiveDT_; 
-  TH2F* allOccupancyCoarseExclusiveDT_; 
+  TH2F* allOccupancyDT_;
+  TH2F* allOccupancyCoarseDT_;
+  TH2F* allOccupancyExclusiveDT_;
+  TH2F* allOccupancyCoarseExclusiveDT_;
   TH1F* allFedsTimingHistDT_;
   TH3F* allFedsTimingPhiEtaHistDT_;
   TH3F* allFedsTimingTTHistDT_;
   TH2F* allFedsTimingLMHistDT_;
 
-  TH2F* allOccupancyRPC_; 
-  TH2F* allOccupancyCoarseRPC_; 
-  TH2F* allOccupancyExclusiveRPC_; 
-  TH2F* allOccupancyCoarseExclusiveRPC_; 
+  TH2F* allOccupancyRPC_;
+  TH2F* allOccupancyCoarseRPC_;
+  TH2F* allOccupancyExclusiveRPC_;
+  TH2F* allOccupancyCoarseExclusiveRPC_;
   TH1F* allFedsTimingHistRPC_;
   TH3F* allFedsTimingPhiEtaHistRPC_;
   TH3F* allFedsTimingTTHistRPC_;
   TH2F* allFedsTimingLMHistRPC_;
 
-  TH2F* allOccupancyCSC_; 
-  TH2F* allOccupancyCoarseCSC_; 
-  TH2F* allOccupancyExclusiveCSC_; 
-  TH2F* allOccupancyCoarseExclusiveCSC_; 
+  TH2F* allOccupancyCSC_;
+  TH2F* allOccupancyCoarseCSC_;
+  TH2F* allOccupancyExclusiveCSC_;
+  TH2F* allOccupancyCoarseExclusiveCSC_;
   TH1F* allFedsTimingHistCSC_;
   TH3F* allFedsTimingPhiEtaHistCSC_;
   TH3F* allFedsTimingTTHistCSC_;
   TH2F* allFedsTimingLMHistCSC_;
 
-  TH2F* allOccupancyHCAL_; 
-  TH2F* allOccupancyCoarseHCAL_; 
-  TH2F* allOccupancyExclusiveHCAL_; 
-  TH2F* allOccupancyCoarseExclusiveHCAL_; 
+  TH2F* allOccupancyHCAL_;
+  TH2F* allOccupancyCoarseHCAL_;
+  TH2F* allOccupancyExclusiveHCAL_;
+  TH2F* allOccupancyCoarseExclusiveHCAL_;
   TH1F* allFedsTimingHistHCAL_;
   TH3F* allFedsTimingPhiEtaHistHCAL_;
   TH3F* allFedsTimingTTHistHCAL_;
   TH2F* allFedsTimingLMHistHCAL_;
 
   TH1F* allFedsTimingHistEcalMuon_;
-  
+
   TH1F* triggerHist_;
   TH1F* triggerExclusiveHist_;
 
-  TH2F* allOccupancyHighEnergy_; 
-  TH2F* allOccupancyHighEnergyCoarse_; 
+  TH2F* allOccupancyHighEnergy_;
+  TH2F* allOccupancyHighEnergyCoarse_;
   TH3F* allFedsOccupancyHighEnergyHist_;
 
   TH1F* runNumberHist_;
@@ -251,7 +248,7 @@ class EcalCosmicsHists : public edm::EDAnalyzer {
   TH1F* dccRuntypeErrorByFEDHist_;
   TH1F* dccRuntypeHist_;
   TH2F* dccErrorVsBxHist_;
-  
+
   // track association
   TH2F* trackAssoc_muonsEcal_;
   TrackDetectorAssociator trackAssociator_;
@@ -263,10 +260,10 @@ class EcalCosmicsHists : public edm::EDAnalyzer {
   int cosmicCounterTopBottom_;
 
   // hcal energy
-  TH1F * hcalEnergy_HBHE_;
-  TH1F * hcalEnergy_HF_;
-  TH1F * hcalEnergy_HO_;
-  TH2F * hcalHEHBecalEB_;
+  TH1F* hcalEnergy_HBHE_;
+  TH1F* hcalEnergy_HF_;
+  TH1F* hcalEnergy_HO_;
+  TH2F* hcalHEHBecalEB_;
 
   // high energy analysis (inherited from serena)
   TH1F* HighEnergy_NumXtal;
@@ -296,14 +293,14 @@ class EcalCosmicsHists : public edm::EDAnalyzer {
   TH3F* HighEnergy_0tracks_occu3DXtal;
   TH3F* HighEnergy_1tracks_occu3DXtal;
   TH3F* HighEnergy_2tracks_occu3DXtal;
-  
+
   //for timestamp information
   TH1F* allFedsFreqTimeHist_;
   TH2F* allFedsFreqTimeVsPhiHist_;
   TH2F* allFedsFreqTimeVsPhiTTHist_;
   TH2F* allFedsFreqTimeVsEtaHist_;
   TH2F* allFedsFreqTimeVsEtaTTHist_;
-  
+
   // Plots for EE
   TH2F* EEP_AllOccupancyCoarse_;
   TH2F* EEP_AllOccupancy_;
@@ -326,50 +323,50 @@ class EcalCosmicsHists : public edm::EDAnalyzer {
   TH2F* EEP_OccupancySingleXtal_;
   TH1F* EEP_energySingleXtalHist_;
 
-  TH1F* EEP_FedsTimingHist_;        
+  TH1F* EEP_FedsTimingHist_;
   TH2F* EEP_FedsTimingVsAmpHist_;
   TH3F* EEP_FedsTimingTTHist_;
 
-  TH2F* EEP_OccupancyECAL_; 
-  TH2F* EEP_OccupancyCoarseECAL_; 
-  TH2F* EEP_OccupancyExclusiveECAL_; 
-  TH2F* EEP_OccupancyCoarseExclusiveECAL_; 
+  TH2F* EEP_OccupancyECAL_;
+  TH2F* EEP_OccupancyCoarseECAL_;
+  TH2F* EEP_OccupancyExclusiveECAL_;
+  TH2F* EEP_OccupancyCoarseExclusiveECAL_;
   TH1F* EEP_FedsTimingHistECAL_;
   TH3F* EEP_FedsTimingTTHistECAL_;
 
-  TH2F* EEP_OccupancyDT_; 
-  TH2F* EEP_OccupancyCoarseDT_; 
-  TH2F* EEP_OccupancyExclusiveDT_; 
-  TH2F* EEP_OccupancyCoarseExclusiveDT_; 
+  TH2F* EEP_OccupancyDT_;
+  TH2F* EEP_OccupancyCoarseDT_;
+  TH2F* EEP_OccupancyExclusiveDT_;
+  TH2F* EEP_OccupancyCoarseExclusiveDT_;
   TH1F* EEP_FedsTimingHistDT_;
   TH3F* EEP_FedsTimingTTHistDT_;
 
-  TH2F* EEP_OccupancyRPC_; 
-  TH2F* EEP_OccupancyCoarseRPC_; 
-  TH2F* EEP_OccupancyExclusiveRPC_; 
-  TH2F* EEP_OccupancyCoarseExclusiveRPC_; 
+  TH2F* EEP_OccupancyRPC_;
+  TH2F* EEP_OccupancyCoarseRPC_;
+  TH2F* EEP_OccupancyExclusiveRPC_;
+  TH2F* EEP_OccupancyCoarseExclusiveRPC_;
   TH1F* EEP_FedsTimingHistRPC_;
   TH3F* EEP_FedsTimingTTHistRPC_;
 
-  TH2F* EEP_OccupancyCSC_; 
-  TH2F* EEP_OccupancyCoarseCSC_; 
-  TH2F* EEP_OccupancyExclusiveCSC_; 
-  TH2F* EEP_OccupancyCoarseExclusiveCSC_; 
+  TH2F* EEP_OccupancyCSC_;
+  TH2F* EEP_OccupancyCoarseCSC_;
+  TH2F* EEP_OccupancyExclusiveCSC_;
+  TH2F* EEP_OccupancyCoarseExclusiveCSC_;
   TH1F* EEP_FedsTimingHistCSC_;
   TH3F* EEP_FedsTimingTTHistCSC_;
 
-  TH2F* EEP_OccupancyHCAL_; 
-  TH2F* EEP_OccupancyCoarseHCAL_; 
-  TH2F* EEP_OccupancyExclusiveHCAL_; 
-  TH2F* EEP_OccupancyCoarseExclusiveHCAL_; 
+  TH2F* EEP_OccupancyHCAL_;
+  TH2F* EEP_OccupancyCoarseHCAL_;
+  TH2F* EEP_OccupancyExclusiveHCAL_;
+  TH2F* EEP_OccupancyCoarseExclusiveHCAL_;
   TH1F* EEP_FedsTimingHistHCAL_;
   TH3F* EEP_FedsTimingTTHistHCAL_;
 
   TH1F* EEP_triggerHist_;
   TH1F* EEP_triggerExclusiveHist_;
 
-  TH2F* EEP_OccupancyHighEnergy_; 
-  TH2F* EEP_OccupancyHighEnergyCoarse_; 
+  TH2F* EEP_OccupancyHighEnergy_;
+  TH2F* EEP_OccupancyHighEnergyCoarse_;
 
   // EE-
   TH2F* EEM_AllOccupancyCoarse_;
@@ -393,56 +390,56 @@ class EcalCosmicsHists : public edm::EDAnalyzer {
   TH2F* EEM_OccupancySingleXtal_;
   TH1F* EEM_energySingleXtalHist_;
 
-  TH1F* EEM_FedsTimingHist_;        
+  TH1F* EEM_FedsTimingHist_;
   TH2F* EEM_FedsTimingVsAmpHist_;
   TH3F* EEM_FedsTimingTTHist_;
 
-  TH2F* EEM_OccupancyECAL_; 
-  TH2F* EEM_OccupancyCoarseECAL_; 
-  TH2F* EEM_OccupancyExclusiveECAL_; 
-  TH2F* EEM_OccupancyCoarseExclusiveECAL_; 
+  TH2F* EEM_OccupancyECAL_;
+  TH2F* EEM_OccupancyCoarseECAL_;
+  TH2F* EEM_OccupancyExclusiveECAL_;
+  TH2F* EEM_OccupancyCoarseExclusiveECAL_;
   TH1F* EEM_FedsTimingHistECAL_;
   TH3F* EEM_FedsTimingTTHistECAL_;
 
-  TH2F* EEM_OccupancyDT_; 
-  TH2F* EEM_OccupancyCoarseDT_; 
-  TH2F* EEM_OccupancyExclusiveDT_; 
-  TH2F* EEM_OccupancyCoarseExclusiveDT_; 
+  TH2F* EEM_OccupancyDT_;
+  TH2F* EEM_OccupancyCoarseDT_;
+  TH2F* EEM_OccupancyExclusiveDT_;
+  TH2F* EEM_OccupancyCoarseExclusiveDT_;
   TH1F* EEM_FedsTimingHistDT_;
   TH3F* EEM_FedsTimingTTHistDT_;
 
-  TH2F* EEM_OccupancyRPC_; 
-  TH2F* EEM_OccupancyCoarseRPC_; 
-  TH2F* EEM_OccupancyExclusiveRPC_; 
-  TH2F* EEM_OccupancyCoarseExclusiveRPC_; 
+  TH2F* EEM_OccupancyRPC_;
+  TH2F* EEM_OccupancyCoarseRPC_;
+  TH2F* EEM_OccupancyExclusiveRPC_;
+  TH2F* EEM_OccupancyCoarseExclusiveRPC_;
   TH1F* EEM_FedsTimingHistRPC_;
   TH3F* EEM_FedsTimingTTHistRPC_;
 
-  TH2F* EEM_OccupancyCSC_; 
-  TH2F* EEM_OccupancyCoarseCSC_; 
-  TH2F* EEM_OccupancyExclusiveCSC_; 
-  TH2F* EEM_OccupancyCoarseExclusiveCSC_; 
+  TH2F* EEM_OccupancyCSC_;
+  TH2F* EEM_OccupancyCoarseCSC_;
+  TH2F* EEM_OccupancyExclusiveCSC_;
+  TH2F* EEM_OccupancyCoarseExclusiveCSC_;
   TH1F* EEM_FedsTimingHistCSC_;
   TH3F* EEM_FedsTimingTTHistCSC_;
 
-  TH2F* EEM_OccupancyHCAL_; 
-  TH2F* EEM_OccupancyCoarseHCAL_; 
-  TH2F* EEM_OccupancyExclusiveHCAL_; 
-  TH2F* EEM_OccupancyCoarseExclusiveHCAL_; 
+  TH2F* EEM_OccupancyHCAL_;
+  TH2F* EEM_OccupancyCoarseHCAL_;
+  TH2F* EEM_OccupancyExclusiveHCAL_;
+  TH2F* EEM_OccupancyCoarseExclusiveHCAL_;
   TH1F* EEM_FedsTimingHistHCAL_;
   TH3F* EEM_FedsTimingTTHistHCAL_;
-  
+
   TH1F* EEM_triggerHist_;
   TH1F* EEM_triggerExclusiveHist_;
 
-  TH2F* EEM_OccupancyHighEnergy_; 
-  TH2F* EEM_OccupancyHighEnergyCoarse_; 
+  TH2F* EEM_OccupancyHighEnergy_;
+  TH2F* EEM_OccupancyHighEnergyCoarse_;
 
   EcalFedMap* fedMap_;
 
   TFile* file;
-  
-  int naiveEvtNum_; 
+
+  int naiveEvtNum_;
   int cosmicCounter_;
   int cosmicCounterEB_;
   int cosmicCounterEEP_;
@@ -452,5 +449,4 @@ class EcalCosmicsHists : public edm::EDAnalyzer {
   std::vector<std::string> l1Names_;
 
   const EcalElectronicsMapping* ecalElectronicsMap_;
-
 };

--- a/CaloOnlineTools/EcalTools/plugins/EcalDCCHeaderDisplay.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalDCCHeaderDisplay.cc
@@ -9,77 +9,74 @@
 
 #include "CaloOnlineTools/EcalTools/plugins/EcalDCCHeaderDisplay.h"
 
-EcalDCCHeaderDisplay::EcalDCCHeaderDisplay(const edm::ParameterSet& iConfig){
+EcalDCCHeaderDisplay::EcalDCCHeaderDisplay(const edm::ParameterSet& iConfig) {
   EcalDCCHeaderCollection_ = iConfig.getParameter<edm::InputTag>("EcalDCCHeaderCollection");
 }
 
-
-void EcalDCCHeaderDisplay::analyze( const edm::Event & e, const  edm::EventSetup& c){
-    
+void EcalDCCHeaderDisplay::analyze(const edm::Event& e, const edm::EventSetup& c) {
   edm::Handle<EcalRawDataCollection> DCCHeaders;
   e.getByLabel(EcalDCCHeaderCollection_, DCCHeaders);
-    
 
-  std::cout << "\n\n ^^^^^^^^^^^^^^^^^^ [EcalDCCHeaderDisplay]  DCCHeaders collection size " << DCCHeaders->size() << std::endl;
-  std::cout << "          [EcalDCCHeaderDisplay]  the Header(s)\n"  << std::endl;
-  //short dumpConter =0;      
+  std::cout << "\n\n ^^^^^^^^^^^^^^^^^^ [EcalDCCHeaderDisplay]  DCCHeaders collection size " << DCCHeaders->size()
+            << std::endl;
+  std::cout << "          [EcalDCCHeaderDisplay]  the Header(s)\n" << std::endl;
+  //short dumpConter =0;
 
-  for ( EcalRawDataCollection::const_iterator headerItr= DCCHeaders->begin();headerItr != DCCHeaders->end(); 
-	++headerItr ) {
-    //      int nevt =headerItr->getLV1(); 
+  for (EcalRawDataCollection::const_iterator headerItr = DCCHeaders->begin(); headerItr != DCCHeaders->end();
+       ++headerItr) {
+    //      int nevt =headerItr->getLV1();
     bool skip = false;
 
-    if(skip){continue;}
-    std::cout<<"###################################################################### \n";
-    std::cout << "FedId: "<< headerItr->fedId() <<"\n";
-      
-    std::cout << "DCCErrors: "<<headerItr->getDCCErrors()<<"\n";
-    std::cout<<"Run Number: "<<headerItr->getRunNumber()<<"\n";
-    std::cout<<"Event number (LV1): "<<headerItr->getLV1()<<"\n";
-    std::cout<<"Orbit: "<<headerItr->getOrbit()<<"\n";
-    std::cout<<"BX: "<<headerItr->getBX()<<"\n";
-    std::cout<<"TRIGGER TYPE: "<< headerItr->getBasicTriggerType()<<"\n";
-      
-    std::cout<<"RUNTYPE: "<< headerItr->getRunType()<<"\n";
-    std::cout<<"Half: "<<headerItr->getRtHalf()<<"\n";
-    std::cout<<"DCCIdInTCCCommand: "<<headerItr->getDccInTCCCommand()<<"\n";
-    std::cout<<"MGPA gain: "<<headerItr->getMgpaGain()<<"\n";
-    std::cout<<"MEM gain: "<<headerItr->getMemGain()<<"\n";
-    EcalDCCHeaderBlock::EcalDCCEventSettings settings = headerItr->getEventSettings();
-    std::cout<<"LaserPower: "<<  settings.LaserPower<<"\n";
-    std::cout <<"LAserFilter: "<<settings.LaserFilter<<"\n";
-    std::cout<<"Wavelenght: "<<settings.wavelength<<"\n";
-    std::cout<<"delay: "<<settings.delay<<"\n";
-    std::cout<<"MEM Vinj: "<< settings.MEMVinj<<"\n";
-    std::cout<<"MGPA content: "<<settings.mgpa_content<<"\n";
-    std::cout<<"Ped offset dac: "<<settings.ped_offset<<"\n";
+    if (skip) {
+      continue;
+    }
+    std::cout << "###################################################################### \n";
+    std::cout << "FedId: " << headerItr->fedId() << "\n";
 
-    std::cout<<"Selective Readout: "<<headerItr->getSelectiveReadout()<<"\n";
-    std::cout<<"ZS: "<<headerItr->getZeroSuppression()<<"\n";
-    std::cout <<"TZS: "<<headerItr->getTestZeroSuppression()<<"\n";
-    std::cout<<"SRStatus: "<<headerItr->getSrpStatus()<<"\n";
+    std::cout << "DCCErrors: " << headerItr->getDCCErrors() << "\n";
+    std::cout << "Run Number: " << headerItr->getRunNumber() << "\n";
+    std::cout << "Event number (LV1): " << headerItr->getLV1() << "\n";
+    std::cout << "Orbit: " << headerItr->getOrbit() << "\n";
+    std::cout << "BX: " << headerItr->getBX() << "\n";
+    std::cout << "TRIGGER TYPE: " << headerItr->getBasicTriggerType() << "\n";
+
+    std::cout << "RUNTYPE: " << headerItr->getRunType() << "\n";
+    std::cout << "Half: " << headerItr->getRtHalf() << "\n";
+    std::cout << "DCCIdInTCCCommand: " << headerItr->getDccInTCCCommand() << "\n";
+    std::cout << "MGPA gain: " << headerItr->getMgpaGain() << "\n";
+    std::cout << "MEM gain: " << headerItr->getMemGain() << "\n";
+    EcalDCCHeaderBlock::EcalDCCEventSettings settings = headerItr->getEventSettings();
+    std::cout << "LaserPower: " << settings.LaserPower << "\n";
+    std::cout << "LAserFilter: " << settings.LaserFilter << "\n";
+    std::cout << "Wavelenght: " << settings.wavelength << "\n";
+    std::cout << "delay: " << settings.delay << "\n";
+    std::cout << "MEM Vinj: " << settings.MEMVinj << "\n";
+    std::cout << "MGPA content: " << settings.mgpa_content << "\n";
+    std::cout << "Ped offset dac: " << settings.ped_offset << "\n";
+
+    std::cout << "Selective Readout: " << headerItr->getSelectiveReadout() << "\n";
+    std::cout << "ZS: " << headerItr->getZeroSuppression() << "\n";
+    std::cout << "TZS: " << headerItr->getTestZeroSuppression() << "\n";
+    std::cout << "SRStatus: " << headerItr->getSrpStatus() << "\n";
 
     std::vector<short> TCCStatus = headerItr->getTccStatus();
-    std::cout<<"TCC Status size: "<<TCCStatus.size()<<std::endl;
-    std::cout<<"TCC Status: ";
-    for(unsigned u =0;u<TCCStatus.size();u++){
-      std::cout<<TCCStatus[u]<<" ";
+    std::cout << "TCC Status size: " << TCCStatus.size() << std::endl;
+    std::cout << "TCC Status: ";
+    for (unsigned u = 0; u < TCCStatus.size(); u++) {
+      std::cout << TCCStatus[u] << " ";
     }
-    std::cout<<std::endl;
-      
+    std::cout << std::endl;
+
     std::vector<short> TTStatus = headerItr->getFEStatus();
-    std::cout<<"TT Status size: "<<TTStatus.size()<<std::endl;
-    std::cout<<"TT Statuses: ";
-    for(unsigned u =0;u<TTStatus.size();u++){
-      if ( !(u%14) ) std::cout<<std::endl; // TODO: add space after first six in a row
-      std::cout<<TTStatus[u]<<" ";
+    std::cout << "TT Status size: " << TTStatus.size() << std::endl;
+    std::cout << "TT Statuses: ";
+    for (unsigned u = 0; u < TTStatus.size(); u++) {
+      if (!(u % 14))
+        std::cout << std::endl;  // TODO: add space after first six in a row
+      std::cout << TTStatus[u] << " ";
     }
-    std::cout<<std::endl;
-    std::cout<<"######################################################################"<<std::endl;;
-
-  }	
-     
-} 
-
-
-
+    std::cout << std::endl;
+    std::cout << "######################################################################" << std::endl;
+    ;
+  }
+}

--- a/CaloOnlineTools/EcalTools/plugins/EcalDCCHeaderDisplay.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalDCCHeaderDisplay.h
@@ -15,19 +15,13 @@
 #include <iostream>
 #include <vector>
 
-
-
-class EcalDCCHeaderDisplay: public edm::EDAnalyzer{
-  
+class EcalDCCHeaderDisplay : public edm::EDAnalyzer {
 public:
   EcalDCCHeaderDisplay(const edm::ParameterSet& ps);
-  
-protected:
 
-  void analyze( const edm::Event & e, const  edm::EventSetup& c) override;
+protected:
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 private:
   edm::InputTag EcalDCCHeaderCollection_;
-
 };
-

--- a/CaloOnlineTools/EcalTools/plugins/EcalDigiDisplay.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalDigiDisplay.cc
@@ -31,120 +31,119 @@
 
 //==========================================================================
 EcalDigiDisplay::EcalDigiDisplay(const edm::ParameterSet& ps) {
-//=========================================================================
-  
+  //=========================================================================
+
   ebDigiCollection_ = ps.getParameter<std::string>("ebDigiCollection");
   eeDigiCollection_ = ps.getParameter<std::string>("eeDigiCollection");
-  digiProducer_     = ps.getParameter<std::string>("digiProducer");
+  digiProducer_ = ps.getParameter<std::string>("digiProducer");
 
   requestedFeds_ = ps.getUntrackedParameter<std::vector<int> >("requestedFeds");
-  requestedEbs_  = ps.getUntrackedParameter<std::vector<std::string> >("requestedEbs");
+  requestedEbs_ = ps.getUntrackedParameter<std::vector<std::string> >("requestedEbs");
 
-  cryDigi       = ps.getUntrackedParameter<bool>("cryDigi");
-  ttDigi        = ps.getUntrackedParameter<bool>("ttDigi");
-  pnDigi      = ps.getUntrackedParameter<bool>("pnDigi");
-   
-  mode           = ps.getUntrackedParameter<int>("mode");
-  listChannels   = ps.getUntrackedParameter<std::vector<int> >("listChannels");
-  listTowers     = ps.getUntrackedParameter<std::vector<int> >("listTowers");
-  listPns        = ps.getUntrackedParameter<std::vector<int> >("listPns");
+  cryDigi = ps.getUntrackedParameter<bool>("cryDigi");
+  ttDigi = ps.getUntrackedParameter<bool>("ttDigi");
+  pnDigi = ps.getUntrackedParameter<bool>("pnDigi");
+
+  mode = ps.getUntrackedParameter<int>("mode");
+  listChannels = ps.getUntrackedParameter<std::vector<int> >("listChannels");
+  listTowers = ps.getUntrackedParameter<std::vector<int> >("listTowers");
+  listPns = ps.getUntrackedParameter<std::vector<int> >("listPns");
 
   std::vector<int> listDefaults;
   listDefaults.push_back(-1);
-  requestedFeds_ = ps.getUntrackedParameter<std::vector<int> >("requestedFeds",listDefaults);
+  requestedFeds_ = ps.getUntrackedParameter<std::vector<int> >("requestedFeds", listDefaults);
   bool fedIsGiven = false;
-  
+
   std::vector<std::string> ebDefaults;
   ebDefaults.push_back("none");
-  requestedEbs_  = ps.getUntrackedParameter<std::vector<std::string> >("requestedEbs",ebDefaults);
+  requestedEbs_ = ps.getUntrackedParameter<std::vector<std::string> >("requestedEbs", ebDefaults);
   // FEDs and EBs
-  if ( requestedFeds_[0] != -1 ) {
+  if (requestedFeds_[0] != -1) {
     edm::LogInfo("EcalDigiDisplay") << "FED id is given! Goining to beginRun! ";
     fedIsGiven = true;
-  }else {
-    if ( requestedEbs_[0] !="none" ) {
+  } else {
+    if (requestedEbs_[0] != "none") {
       //EB id is given and convert to FED id
       requestedFeds_.clear();
       fedMap = new EcalFedMap();
-      for (std::vector<std::string>::const_iterator ebItr = requestedEbs_.begin(); 
-	   ebItr!= requestedEbs_.end();  ++ebItr) {
-	requestedFeds_.push_back(fedMap->getFedFromSlice(*ebItr));
+      for (std::vector<std::string>::const_iterator ebItr = requestedEbs_.begin(); ebItr != requestedEbs_.end();
+           ++ebItr) {
+        requestedFeds_.push_back(fedMap->getFedFromSlice(*ebItr));
       }
       delete fedMap;
     } else {
       //Select all FEDs in the Event
-      for ( int i=601; i<655; ++i){
-	requestedFeds_.push_back(i);
+      for (int i = 601; i < 655; ++i) {
+        requestedFeds_.push_back(i);
       }
     }
   }
 
   //Channel list
-  listChannels = ps.getUntrackedParameter<std::vector<int> >("listChannels",listDefaults);
+  listChannels = ps.getUntrackedParameter<std::vector<int> >("listChannels", listDefaults);
   //Tower list
-  listTowers     = ps.getUntrackedParameter<std::vector<int> >("listTowers", listDefaults);
-  
+  listTowers = ps.getUntrackedParameter<std::vector<int> >("listTowers", listDefaults);
+
   //Consistancy checks:
   std::vector<int>::iterator fedIter;
   std::vector<int>::iterator intIter;
   inputIsOk = true;
 
-  if ( fedIsGiven ) {
-    for ( fedIter = requestedFeds_.begin(); fedIter!=requestedFeds_.end(); ++fedIter) {  
-      if ( (*fedIter) < 601 || (*fedIter) > 655 ) {
-	edm::LogError("EcalDigiDisplay") << " FED value: " << (*fedIter) << " found in requetsedFeds. "
-					 << " Valid range is 601-654. Returning.";
-	inputIsOk = false;
-	return;
-      }//Loop over requetsed FEDS
-    } 
+  if (fedIsGiven) {
+    for (fedIter = requestedFeds_.begin(); fedIter != requestedFeds_.end(); ++fedIter) {
+      if ((*fedIter) < 601 || (*fedIter) > 655) {
+        edm::LogError("EcalDigiDisplay") << " FED value: " << (*fedIter) << " found in requetsedFeds. "
+                                         << " Valid range is 601-654. Returning.";
+        inputIsOk = false;
+        return;
+      }  //Loop over requetsed FEDS
+    }
   }
-  bool barrelSM  = false;  
+  bool barrelSM = false;
   //Loop over and Check if Barrel SM is picked up
-  for (fedIter = requestedFeds_.begin(); fedIter!=requestedFeds_.end(); ++fedIter) {
-    if ( (*fedIter) > 609 && (*fedIter) < 646 && inputIsOk )      // if EB SM is being picked up
+  for (fedIter = requestedFeds_.begin(); fedIter != requestedFeds_.end(); ++fedIter) {
+    if ((*fedIter) > 609 && (*fedIter) < 646 && inputIsOk)  // if EB SM is being picked up
       barrelSM = true;
   }
-  
-  if ( barrelSM ) {
-    if ( cryDigi ) {
-    // Check with channels in Barrel
-      for (intIter = listChannels.begin(); intIter != listChannels.end(); intIter++)  {  
-	if ( ((*intIter) < 1) ||  (1700 < (*intIter)) )       {  
-	  edm::LogError("EcalDigiDisplay") << " ic value: " << (*intIter) << " found in listChannels. "
-					   << " Valid range is 1-1700. Returning.";
-	  inputIsOk = false;
-	  return;
-	}
+
+  if (barrelSM) {
+    if (cryDigi) {
+      // Check with channels in Barrel
+      for (intIter = listChannels.begin(); intIter != listChannels.end(); intIter++) {
+        if (((*intIter) < 1) || (1700 < (*intIter))) {
+          edm::LogError("EcalDigiDisplay") << " ic value: " << (*intIter) << " found in listChannels. "
+                                           << " Valid range is 1-1700. Returning.";
+          inputIsOk = false;
+          return;
+        }
       }
     }
     //Check with Towers in Barrel
-    if ( ttDigi ) {
-      for (intIter = listTowers.begin(); intIter != listTowers.end(); intIter++) {
-	
-	if ( ((*intIter) < 1) ||  (70 < (*intIter)) )       {  
-	  edm::LogError("EcalDigiDisplay") << " TT value: " << (*intIter) << " found in listTowers. "
-					   << " Valid range for EB SM is 1-70. Returning.";
-	  inputIsOk = false;
-	  return;
-	}
-      }
-    }
-  }else  //if EE DCC is being picked up  
     if (ttDigi) {
-      //Check with Towers in Endcap
-      for (intIter = listTowers.begin(); intIter != listTowers.end(); intIter++) { 
-	if ( (*intIter) > 34 )       { 
-	  edm::LogError("EcalDigiDisplay") << " TT value: " << (*intIter) << " found in listTowers. "
-					   << " Valid range for EE DCC is 1-34. Returning.";
-	  inputIsOk = false;
-	  return;
-	}
+      for (intIter = listTowers.begin(); intIter != listTowers.end(); intIter++) {
+        if (((*intIter) < 1) || (70 < (*intIter))) {
+          edm::LogError("EcalDigiDisplay") << " TT value: " << (*intIter) << " found in listTowers. "
+                                           << " Valid range for EB SM is 1-70. Returning.";
+          inputIsOk = false;
+          return;
+        }
       }
     }
+  } else  //if EE DCC is being picked up
+      if (ttDigi) {
+    //Check with Towers in Endcap
+    for (intIter = listTowers.begin(); intIter != listTowers.end(); intIter++) {
+      if ((*intIter) > 34) {
+        edm::LogError("EcalDigiDisplay") << " TT value: " << (*intIter) << " found in listTowers. "
+                                         << " Valid range for EE DCC is 1-34. Returning.";
+        inputIsOk = false;
+        return;
+      }
+    }
+  }
 
   //PNs
-  listPns     = ps.getUntrackedParameter<std::vector<int> >("listPns",listDefaults);
+  listPns = ps.getUntrackedParameter<std::vector<int> >("listPns", listDefaults);
   /*
   if ( listPns[0] != -1 ) pnDigi = true;
   else {
@@ -154,76 +153,77 @@ EcalDigiDisplay::EcalDigiDisplay(const edm::ParameterSet& ps) {
     }
   }
   */
-  if ( pnDigi ) {
+  if (pnDigi) {
     for (intIter = listPns.begin(); intIter != listPns.end(); intIter++) {
-      if ( ((*intIter) < 1) ||  (10 < (*intIter)) )       {  
-	edm::LogError("EcalDigiDisplay") << " Pn number : " << (*intIter) << " found in listPns. "
-					 << " Valid range is 1-10. Returning.";
-	inputIsOk = false;
-	return;
+      if (((*intIter) < 1) || (10 < (*intIter))) {
+        edm::LogError("EcalDigiDisplay") << " Pn number : " << (*intIter) << " found in listPns. "
+                                         << " Valid range is 1-10. Returning.";
+        inputIsOk = false;
+        return;
       }
     }
   }
 }
 //=========================================================================
 EcalDigiDisplay::~EcalDigiDisplay() {
-//=========================================================================
+  //=========================================================================
   //delete *;
 }
-    
+
 //========================================================================
-void EcalDigiDisplay::beginRun(edm::Run const &, edm::EventSetup const& c) {
-//========================================================================
+void EcalDigiDisplay::beginRun(edm::Run const&, edm::EventSetup const& c) {
+  //========================================================================
   edm::LogInfo("EcalDigiDisplay") << "entering beginRun! ";
 
   edm::ESHandle<EcalElectronicsMapping> elecHandle;
-    c.get<EcalMappingRcd>().get(elecHandle);
+  c.get<EcalMappingRcd>().get(elecHandle);
   ecalElectronicsMap_ = elecHandle.product();
 }
 
 //========================================================================
-void EcalDigiDisplay::analyze( edm::Event const & e, edm::EventSetup const & c) {
-//========================================================================
+void EcalDigiDisplay::analyze(edm::Event const& e, edm::EventSetup const& c) {
+  //========================================================================
 
-  if (!inputIsOk) return;
-  
+  if (!inputIsOk)
+    return;
+
   //Get DCC headers
   edm::Handle<EcalRawDataCollection> dccHeader;
   try {
-    e.getByLabel(digiProducer_,dccHeader);
+    e.getByLabel(digiProducer_, dccHeader);
   } catch (cms::Exception& ex) {
     edm::LogError("EcalDigiUnpackerModule") << "Can't get DCC Headers!";
   }
-    
+
   //
   bool ebDigisFound = false;
   bool eeDigisFound = false;
   bool pnDigisFound = false;
   // retrieving crystal data from Event
-  edm::Handle<EBDigiCollection>  eb_digis;    
+  edm::Handle<EBDigiCollection> eb_digis;
   try {
-    e.getByLabel(digiProducer_,ebDigiCollection_, eb_digis);
-    if ( !eb_digis->empty() )
+    e.getByLabel(digiProducer_, ebDigiCollection_, eb_digis);
+    if (!eb_digis->empty())
       ebDigisFound = true;
   } catch (cms::Exception& ex) {
     edm::LogError("EcalDigiUnpackerModule") << "EB Digis were not found!";
   }
-  
+
   //
-  edm::Handle<EEDigiCollection>  ee_digis;    
+  edm::Handle<EEDigiCollection> ee_digis;
   try {
-    e.getByLabel(digiProducer_,eeDigiCollection_, ee_digis);
-    if ( !ee_digis->empty() )
+    e.getByLabel(digiProducer_, eeDigiCollection_, ee_digis);
+    if (!ee_digis->empty())
       eeDigisFound = true;
   } catch (cms::Exception& ex) {
     edm::LogError("EcalDigiUnpackerModule") << "EE Digis were not found!";
   }
-  
+
   // retrieving crystal PN diodes from Event
-  edm::Handle<EcalPnDiodeDigiCollection>  pn_digis;
+  edm::Handle<EcalPnDiodeDigiCollection> pn_digis;
   try {
     e.getByLabel(digiProducer_, pn_digis);
-    if ( !pn_digis->empty())
+    if (!pn_digis->empty())
       pnDigisFound = true;
   } catch (cms::Exception& ex) {
     edm::LogError("EcalDigiUnpackerModule") << "PNs were not found!";
@@ -232,18 +232,18 @@ void EcalDigiDisplay::analyze( edm::Event const & e, edm::EventSetup const & c) 
   //=============================
   //Call for funcitons
   //=============================
-  if ( cryDigi || ttDigi ) {
-    if ( ebDigisFound )
+  if (cryDigi || ttDigi) {
+    if (ebDigisFound)
       readEBDigis(eb_digis, mode);
-    if ( eeDigisFound )
+    if (eeDigisFound)
       readEEDigis(ee_digis, mode);
-    if ( !(ebDigisFound || eeDigisFound) ) {
+    if (!(ebDigisFound || eeDigisFound)) {
       edm::LogWarning("EcalDigiUnpackerModule") << "No Digis were found! Returning..";
       return;
     }
   }
-  if ( pnDigi ) {
-    if (pnDigisFound )
+  if (pnDigi) {
+    if (pnDigisFound)
       readPNDigis(pn_digis, mode);
   }
 }
@@ -252,152 +252,153 @@ void EcalDigiDisplay::analyze( edm::Event const & e, edm::EventSetup const & c) 
 // FUNCTIONS
 //////////////////////////////////
 
-void EcalDigiDisplay::readEBDigis (edm::Handle<EBDigiCollection> digis, int Mode) {
-
-  for ( EBDigiCollection::const_iterator digiItr= digis->begin();digiItr != digis->end(); 
-	++digiItr ) {		
-
+void EcalDigiDisplay::readEBDigis(edm::Handle<EBDigiCollection> digis, int Mode) {
+  for (EBDigiCollection::const_iterator digiItr = digis->begin(); digiItr != digis->end(); ++digiItr) {
     EBDetId detId = EBDetId((*digiItr).id());
     EcalElectronicsId elecId = ecalElectronicsMap_->getElectronicsId(detId);
 
     int FEDid = elecId.dccId() + 600;
-    std::vector<int>::iterator fedIter = find(requestedFeds_.begin(), requestedFeds_.end(), FEDid); 
-    if (fedIter ==  requestedFeds_.end()) continue;
+    std::vector<int>::iterator fedIter = find(requestedFeds_.begin(), requestedFeds_.end(), FEDid);
+    if (fedIter == requestedFeds_.end())
+      continue;
 
     int ic = EBDetId((*digiItr).id()).ic();
     int tt = EBDetId((*digiItr).id()).tower().iTT();
 
-    //Check if Mode is set 1 or 2 
-    if ( Mode ==1 ) {
-      edm::LogInfo("EcalDigiDisplay") << "\n\n^^^^^^^^^^^^^^^^^^ [EcalDigiDisplay]  digi cry collection size " << digis->size();
-      edm::LogInfo("EcalDigiDisplay") << "                       [EcalDigiDisplay]  dumping first " << listChannels[0] << " crystals\n";
+    //Check if Mode is set 1 or 2
+    if (Mode == 1) {
+      edm::LogInfo("EcalDigiDisplay") << "\n\n^^^^^^^^^^^^^^^^^^ [EcalDigiDisplay]  digi cry collection size "
+                                      << digis->size();
+      edm::LogInfo("EcalDigiDisplay") << "                       [EcalDigiDisplay]  dumping first " << listChannels[0]
+                                      << " crystals\n";
       //It will break if all required digis are dumpped
-      if( ic  > listChannels[0]) continue;  
-    } else if  ( Mode==2 ) {
-
+      if (ic > listChannels[0])
+        continue;
+    } else if (Mode == 2) {
       std::vector<int>::iterator icIterCh;
       std::vector<int>::iterator icIterTt;
       icIterCh = find(listChannels.begin(), listChannels.end(), ic);
       icIterTt = find(listTowers.begin(), listTowers.end(), tt);
-      if (icIterCh == listChannels.end() && icIterTt == listTowers.end() ) continue;   
-      edm::LogInfo("EcalDigiDisplay") << "\n\n^^^^^^^^^^^^^^^^^^ [EcalDigiDisplay]  digi cry collection size " << digis->size();
+      if (icIterCh == listChannels.end() && icIterTt == listTowers.end())
+        continue;
+      edm::LogInfo("EcalDigiDisplay") << "\n\n^^^^^^^^^^^^^^^^^^ [EcalDigiDisplay]  digi cry collection size "
+                                      << digis->size();
     } else {
       edm::LogInfo("EcalDigiDisplay") << "[EcalDigiDisplay] parameter mode set to: " << Mode
-				      << ". Only mode 1 and 2 are allowed. Returning...";
+                                      << ". Only mode 1 and 2 are allowed. Returning...";
       inputIsOk = false;
       return;
     }
     std::cout << "FEDID: " << FEDid << std::endl;
-    std::cout << "Tower: " << EBDetId((*digiItr).id()).tower().iTT()
-	      <<" ic-cry: " 
-	      << EBDetId((*digiItr).id()).ic() << " i-phi: " 
-	      << EBDetId((*digiItr).id()).iphi() << " j-eta: " 
-	      << EBDetId((*digiItr).id()).ieta() << std::endl;
+    std::cout << "Tower: " << EBDetId((*digiItr).id()).tower().iTT() << " ic-cry: " << EBDetId((*digiItr).id()).ic()
+              << " i-phi: " << EBDetId((*digiItr).id()).iphi() << " j-eta: " << EBDetId((*digiItr).id()).ieta()
+              << std::endl;
     //Get Samples
-    for ( unsigned int i=0; i< (*digiItr).size() ; ++i ) {
-      EBDataFrame df( *digiItr );
-      if (!(i%3)  )  std::cout << "\n\t";
-      std::cout << "sId: " << (i+1) << " " <<  df.sample(i) << "\t";
-    } 
+    for (unsigned int i = 0; i < (*digiItr).size(); ++i) {
+      EBDataFrame df(*digiItr);
+      if (!(i % 3))
+        std::cout << "\n\t";
+      std::cout << "sId: " << (i + 1) << " " << df.sample(i) << "\t";
+    }
     std::cout << " " << std::endl;
   }
 }
 
 //Function for EE Digis
-void EcalDigiDisplay::readEEDigis (edm::Handle<EEDigiCollection> digis, int Mode) {
-
+void EcalDigiDisplay::readEEDigis(edm::Handle<EEDigiCollection> digis, int Mode) {
   //For Endcap so far works only  Mode 2
-  if ( Mode!=2 ) {
+  if (Mode != 2) {
     std::cout << "For Endcap mode needs to be set to 2" << std::endl;
     return;
   }
-  
-  for ( EEDigiCollection::const_iterator digiItr= digis->begin();digiItr != digis->end(); 
-	++digiItr ) {		
-    
+
+  for (EEDigiCollection::const_iterator digiItr = digis->begin(); digiItr != digis->end(); ++digiItr) {
     //Make sure that digis are form requested place
     EEDetId detId = EEDetId((*digiItr).id());
     EcalElectronicsId elecId = ecalElectronicsMap_->getElectronicsId(detId);
 
     int FEDid = elecId.dccId() + 600;
     std::vector<int>::iterator fedIter = find(requestedFeds_.begin(), requestedFeds_.end(), FEDid);
-    if (fedIter ==  requestedFeds_.end()) continue;
+    if (fedIter == requestedFeds_.end())
+      continue;
 
-    edm::LogInfo("EcalDigiDisplay") << "\n\n^^^^^^^^^^^^^^^^^^ [EcalDigiDisplay]  digi cry collection size " << digis->size();
-    
-    int crystalId = 10000 * FEDid + 100 * elecId.towerId() + 5 * (elecId.stripId()-1)+elecId.xtalId();
-    int chId = elecId.towerId();    // this is a channel in Endcap DCC, sometimes also called as Super Crystal
+    edm::LogInfo("EcalDigiDisplay") << "\n\n^^^^^^^^^^^^^^^^^^ [EcalDigiDisplay]  digi cry collection size "
+                                    << digis->size();
+
+    int crystalId = 10000 * FEDid + 100 * elecId.towerId() + 5 * (elecId.stripId() - 1) + elecId.xtalId();
+    int chId = elecId.towerId();  // this is a channel in Endcap DCC, sometimes also called as Super Crystal
 
     std::vector<int>::iterator icIterCh;
     std::vector<int>::iterator icIterTt;
     icIterCh = find(listChannels.begin(), listChannels.end(), crystalId);
     icIterTt = find(listTowers.begin(), listTowers.end(), chId);
-    if ( icIterCh == listChannels.end() &&  icIterTt == listTowers.end() ) continue; 
-    
+    if (icIterCh == listChannels.end() && icIterTt == listTowers.end())
+      continue;
+
     std::cout << "FEDID: " << FEDid << std::endl;
-    std::cout << "Tower: " << elecId.towerId()    
-	      << "crystalId: " 
-	      << crystalId << " i-x: " 
-	      << EEDetId((*digiItr).id()).ix() << " j-y: " 
-	      << EEDetId((*digiItr).id()).iy() << std::endl;
-    
-    //Get samples 
-    for ( unsigned int i=0; i< (*digiItr).size() ; ++i ) {
-      EEDataFrame df( *digiItr );
-      if (!(i%3)  )  std::cout << "\n\t";
-      std::cout << "sId: " << (i+1) << " " <<  df.sample(i) << "\t";
-    }       
+    std::cout << "Tower: " << elecId.towerId() << "crystalId: " << crystalId
+              << " i-x: " << EEDetId((*digiItr).id()).ix() << " j-y: " << EEDetId((*digiItr).id()).iy() << std::endl;
+
+    //Get samples
+    for (unsigned int i = 0; i < (*digiItr).size(); ++i) {
+      EEDataFrame df(*digiItr);
+      if (!(i % 3))
+        std::cout << "\n\t";
+      std::cout << "sId: " << (i + 1) << " " << df.sample(i) << "\t";
+    }
     std::cout << " " << std::endl;
   }
 }
 
 void EcalDigiDisplay::readPNDigis(edm::Handle<EcalPnDiodeDigiCollection> PNs, int Mode) {
-
   int pnDigiCounter = 0;
 
   //Loop over PN digis
-  for ( EcalPnDiodeDigiCollection::const_iterator pnItr = PNs->begin(); pnItr != PNs->end(); ++pnItr ) {
+  for (EcalPnDiodeDigiCollection::const_iterator pnItr = PNs->begin(); pnItr != PNs->end(); ++pnItr) {
     EcalPnDiodeDetId pnDetId = EcalPnDiodeDetId((*pnItr).id());
     //Make sure that we look at the requested place
     int FEDid = pnDetId.iDCCId() + 600;
     std::vector<int>::iterator fedIter = find(requestedFeds_.begin(), requestedFeds_.end(), FEDid);
-    if (fedIter ==  requestedFeds_.end()) continue;
+    if (fedIter == requestedFeds_.end())
+      continue;
     int pnNum = (*pnItr).id().iPnId();
-    
-    if ( Mode == 1) {
-      edm::LogInfo("EcalDigiDisplay") << "\n\n^^^^^^^^^^^^^^^^^^ EcalDigiDisplay  digi PN collection.  Size: " << PNs->size();
-      edm::LogInfo("EcalDigiDisplay") << "                       [EcalDigiDisplay]  dumping first " << listPns[0] << " PNs ";
-      
-      if ( (pnDigiCounter++) >= listPns[0] ) break;
-    } else if ( Mode == 2) {
-      edm::LogInfo("EcalDigiDisplay") << "\n\n^^^^^^^^^^^^^^^^^^ EcalDigiDisplay  digi PN collection.  Size: " << PNs->size();
-      
+
+    if (Mode == 1) {
+      edm::LogInfo("EcalDigiDisplay") << "\n\n^^^^^^^^^^^^^^^^^^ EcalDigiDisplay  digi PN collection.  Size: "
+                                      << PNs->size();
+      edm::LogInfo("EcalDigiDisplay") << "                       [EcalDigiDisplay]  dumping first " << listPns[0]
+                                      << " PNs ";
+
+      if ((pnDigiCounter++) >= listPns[0])
+        break;
+    } else if (Mode == 2) {
+      edm::LogInfo("EcalDigiDisplay") << "\n\n^^^^^^^^^^^^^^^^^^ EcalDigiDisplay  digi PN collection.  Size: "
+                                      << PNs->size();
+
       // Check that we look at PN from the given list
       std::vector<int>::iterator pnIter;
       pnIter = find(listPns.begin(), listPns.end(), pnNum);
-      if (pnIter == listPns.end())  continue; 
+      if (pnIter == listPns.end())
+        continue;
     } else {
-      edm::LogError("EcalDigiDisplay")<< "[EcalDigiDisplay] parameter mode set to: " << Mode
-				      << ". Only mode 1 and 2 are allowed. Returning...";
+      edm::LogError("EcalDigiDisplay") << "[EcalDigiDisplay] parameter mode set to: " << Mode
+                                       << ". Only mode 1 and 2 are allowed. Returning...";
       inputIsOk = false;
       return;
     }
-    
+
     std::cout << "DCCID: " << pnDetId.iDCCId() << std::endl;
     std::cout << "\nPN num: " << (*pnItr).id().iPnId();
-    for ( int samId=0; samId < (*pnItr).size() ; samId++ ) {
-      if (!(samId%3)  )  std::cout << "\n\t";
-      std::cout <<  "sId: " << (samId+1) << " "
-		<< (*pnItr).sample(samId) 
-		<< "\t";
+    for (int samId = 0; samId < (*pnItr).size(); samId++) {
+      if (!(samId % 3))
+        std::cout << "\n\t";
+      std::cout << "sId: " << (samId + 1) << " " << (*pnItr).sample(samId) << "\t";
     }
   }
 }
 
 //===================================================
 void EcalDigiDisplay::endJob() {
-//==================================================
-  edm::LogInfo("EcalDigiDisplay") << "DONE!.... " ;
+  //==================================================
+  edm::LogInfo("EcalDigiDisplay") << "DONE!.... ";
 }
-
-

--- a/CaloOnlineTools/EcalTools/plugins/EcalDigiDisplay.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalDigiDisplay.h
@@ -18,22 +18,22 @@
 // class declaration
 
 class EcalDigiDisplay : public edm::EDAnalyzer {
- public:
+public:
   //Constractor
   EcalDigiDisplay(const edm::ParameterSet& ps);
   //Distractor
   ~EcalDigiDisplay() override;
-  
- private:
-  void analyze( edm::Event const & e, edm::EventSetup const & c) override;
-  void beginRun(edm::Run const &, edm::EventSetup const & c) override;
+
+private:
+  void analyze(edm::Event const& e, edm::EventSetup const& c) override;
+  void beginRun(edm::Run const&, edm::EventSetup const& c) override;
   void endJob() override;
-  
- protected:
-  void readEBDigis (edm::Handle<EBDigiCollection> digis, int Mode);
-  void readEEDigis (edm::Handle<EEDigiCollection> digis, int Mode);
-  void readPNDigis (edm::Handle<EcalPnDiodeDigiCollection> PNs, int Mode);
-  
+
+protected:
+  void readEBDigis(edm::Handle<EBDigiCollection> digis, int Mode);
+  void readEEDigis(edm::Handle<EEDigiCollection> digis, int Mode);
+  void readPNDigis(edm::Handle<EcalPnDiodeDigiCollection> PNs, int Mode);
+
   EcalFedMap* fedMap;
 
   std::string ebDigiCollection_;
@@ -47,13 +47,13 @@ class EcalDigiDisplay : public edm::EDAnalyzer {
   bool cryDigi;
   bool ttDigi;
   bool pnDigi;
-  
+
   int mode;
- 
+
   std::vector<int> listChannels;
   std::vector<int> listTowers;
   std::vector<int> listPns;
-  
+
   const EcalElectronicsMapping* ecalElectronicsMap_;
 };
 #endif

--- a/CaloOnlineTools/EcalTools/plugins/EcalDisplaysByEvent.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalDisplaysByEvent.cc
@@ -1,8 +1,8 @@
 // -*- C++ -*-
 //
-// Package:   EcalDisplaysByEvent 
-// Class:     EcalDisplaysByEvent 
-// 
+// Package:   EcalDisplaysByEvent
+// Class:     EcalDisplaysByEvent
+//
 /**\class EcalDisplaysByEvent EcalDisplaysByEvent.cc
 
  Description: <one line class summary>
@@ -21,9 +21,9 @@
 #include "TLatex.h"
 #include "TLine.h"
 #include "TProfile2D.h"
-#include <utility> 
-#include <string> 
-#include <vector> 
+#include <utility>
+#include <string>
+#include <vector>
 using namespace edm;
 using namespace std;
 
@@ -34,119 +34,103 @@ using namespace std;
 //
 // static data member definitions
 //
-float EcalDisplaysByEvent::gainRatio[3] = { 1., 2. , 12. }; 
+float EcalDisplaysByEvent::gainRatio[3] = {1., 2., 12.};
 edm::Service<TFileService> EcalDisplaysByEvent::fileService;
 
 //
 // constructors and destructor
 //
-EcalDisplaysByEvent::EcalDisplaysByEvent(const edm::ParameterSet& iConfig) :
-  EBRecHitCollection_ (iConfig.getParameter<edm::InputTag>("EcalRecHitCollectionEB")),
-  EERecHitCollection_ (iConfig.getParameter<edm::InputTag>("EcalRecHitCollectionEE")),
-  EBDigis_ (iConfig.getParameter<edm::InputTag>("EBDigiCollection")),
-  EEDigis_ (iConfig.getParameter<edm::InputTag>("EEDigiCollection")),
-  headerProducer_ (iConfig.getParameter<edm::InputTag> ("headerProducer")),
-  runNum_(-1),
-  side_ (iConfig.getUntrackedParameter<int>("side", 3)),
-  threshold_ (iConfig.getUntrackedParameter<double>("amplitudeThreshold", 0.5)),
-  minTimingAmp_ (iConfig.getUntrackedParameter<double>("minimumTimingAmplitude", 0.100)),
-  makeDigiGraphs_ (iConfig.getUntrackedParameter<bool>("makeDigiGraphs", false)),
-  makeTimingHistos_ (iConfig.getUntrackedParameter<bool>("makeTimingHistos", true)),
-  makeEnergyHistos_ (iConfig.getUntrackedParameter<bool>("makeEnergyHistos", true)),
-  makeOccupancyHistos_ (iConfig.getUntrackedParameter<bool>("makeOccupancyHistos", true)),
-  histRangeMin_ (iConfig.getUntrackedParameter<double>("histogramMinRange",0.0)),
-  histRangeMax_ (iConfig.getUntrackedParameter<double>("histogramMaxRange",1.8)),
-  minTimingEnergyEB_ (iConfig.getUntrackedParameter<double>("minTimingEnergyEB",0.0)),
-  minTimingEnergyEE_ (iConfig.getUntrackedParameter<double>("minTimingEnergyEE",0.0))
-{
+EcalDisplaysByEvent::EcalDisplaysByEvent(const edm::ParameterSet& iConfig)
+    : EBRecHitCollection_(iConfig.getParameter<edm::InputTag>("EcalRecHitCollectionEB")),
+      EERecHitCollection_(iConfig.getParameter<edm::InputTag>("EcalRecHitCollectionEE")),
+      EBDigis_(iConfig.getParameter<edm::InputTag>("EBDigiCollection")),
+      EEDigis_(iConfig.getParameter<edm::InputTag>("EEDigiCollection")),
+      headerProducer_(iConfig.getParameter<edm::InputTag>("headerProducer")),
+      runNum_(-1),
+      side_(iConfig.getUntrackedParameter<int>("side", 3)),
+      threshold_(iConfig.getUntrackedParameter<double>("amplitudeThreshold", 0.5)),
+      minTimingAmp_(iConfig.getUntrackedParameter<double>("minimumTimingAmplitude", 0.100)),
+      makeDigiGraphs_(iConfig.getUntrackedParameter<bool>("makeDigiGraphs", false)),
+      makeTimingHistos_(iConfig.getUntrackedParameter<bool>("makeTimingHistos", true)),
+      makeEnergyHistos_(iConfig.getUntrackedParameter<bool>("makeEnergyHistos", true)),
+      makeOccupancyHistos_(iConfig.getUntrackedParameter<bool>("makeOccupancyHistos", true)),
+      histRangeMin_(iConfig.getUntrackedParameter<double>("histogramMinRange", 0.0)),
+      histRangeMax_(iConfig.getUntrackedParameter<double>("histogramMaxRange", 1.8)),
+      minTimingEnergyEB_(iConfig.getUntrackedParameter<double>("minTimingEnergyEB", 0.0)),
+      minTimingEnergyEE_(iConfig.getUntrackedParameter<double>("minTimingEnergyEE", 0.0)) {
   vector<int> listDefaults;
   listDefaults.push_back(-1);
-  
+
   maskedChannels_ = iConfig.getUntrackedParameter<vector<int> >("maskedChannels", listDefaults);
   maskedFEDs_ = iConfig.getUntrackedParameter<vector<int> >("maskedFEDs", listDefaults);
-  seedCrys_ = iConfig.getUntrackedParameter<vector<int> >("seedCrys",listDefaults);
+  seedCrys_ = iConfig.getUntrackedParameter<vector<int> >("seedCrys", listDefaults);
 
   vector<string> defaultMaskedEBs;
   defaultMaskedEBs.push_back("none");
-  maskedEBs_ =  iConfig.getUntrackedParameter<vector<string> >("maskedEBs",defaultMaskedEBs);
-  
+  maskedEBs_ = iConfig.getUntrackedParameter<vector<string> >("maskedEBs", defaultMaskedEBs);
+
   fedMap_ = new EcalFedMap();
 
   string title1 = "Jitter for all FEDs all events";
   string name1 = "JitterAllFEDsAllEvents";
-  allFedsTimingHist_ = fileService->make<TH1F>(name1.c_str(),title1.c_str(),150,-7,7);
+  allFedsTimingHist_ = fileService->make<TH1F>(name1.c_str(), title1.c_str(), 150, -7, 7);
 
   // load up the maskedFED list with the proper FEDids
-  if(maskedFEDs_[0]==-1)
-  {
+  if (maskedFEDs_[0] == -1) {
     //if "actual" EB id given, then convert to FEDid and put in listFEDs_
-    if(maskedEBs_[0] != "none")
-    {
+    if (maskedEBs_[0] != "none") {
       maskedFEDs_.clear();
-      for(vector<string>::const_iterator ebItr = maskedEBs_.begin(); ebItr != maskedEBs_.end(); ++ebItr)
-      {
+      for (vector<string>::const_iterator ebItr = maskedEBs_.begin(); ebItr != maskedEBs_.end(); ++ebItr) {
         maskedFEDs_.push_back(fedMap_->getFedFromSlice(*ebItr));
       }
     }
   }
-  
-  for (int i=0; i<10; i++)        
+
+  for (int i = 0; i < 10; i++)
     abscissa[i] = i;
-  
+
   naiveEvtNum_ = 0;
 
   initAllEventHistos();
 }
 
-
-EcalDisplaysByEvent::~EcalDisplaysByEvent()
-{
-}
-
+EcalDisplaysByEvent::~EcalDisplaysByEvent() {}
 
 //
 // member functions
 //
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-EcalDisplaysByEvent::beginRun(edm::Run const &, edm::EventSetup const & c)
-{
-  edm::ESHandle< EcalElectronicsMapping > handle;
-  c.get< EcalMappingRcd >().get(handle);
+void EcalDisplaysByEvent::beginRun(edm::Run const&, edm::EventSetup const& c) {
+  edm::ESHandle<EcalElectronicsMapping> handle;
+  c.get<EcalMappingRcd>().get(handle);
   ecalElectronicsMap_ = handle.product();
 }
 
 // ------------ method called to for each event  ------------
-void
-EcalDisplaysByEvent::analyze(edm::Event const & iEvent, edm::EventSetup const & iSetup)
-{
-
+void EcalDisplaysByEvent::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
   // get the headers
   // (one header for each supermodule)
   edm::Handle<EcalRawDataCollection> DCCHeaders;
   iEvent.getByLabel(headerProducer_, DCCHeaders);
 
-  for (EcalRawDataCollection::const_iterator headerItr= DCCHeaders->begin();
-		  headerItr != DCCHeaders->end (); 
-		  ++headerItr) 
-  {
-    FEDsAndDCCHeaders_[headerItr->id()+600] = *headerItr;
+  for (EcalRawDataCollection::const_iterator headerItr = DCCHeaders->begin(); headerItr != DCCHeaders->end();
+       ++headerItr) {
+    FEDsAndDCCHeaders_[headerItr->id() + 600] = *headerItr;
   }
 
   int ievt = iEvent.id().event();
   naiveEvtNum_++;
 
-  if(runNum_==-1)
-  {
+  if (runNum_ == -1) {
     runNum_ = iEvent.id().run();
-    canvasNames_ = fileService->make<TTree>("canvasNames","Names of written canvases");
+    canvasNames_ = fileService->make<TTree>("canvasNames", "Names of written canvases");
     names = new std::vector<string>();
-    canvasNames_->Branch("names","vector<string>",&names);
-    
-    histoCanvasNames_ = fileService->make<TTree>("histoCanvasNames","Names of written canvases with histos");
+    canvasNames_->Branch("names", "vector<string>", &names);
+
+    histoCanvasNames_ = fileService->make<TTree>("histoCanvasNames", "Names of written canvases with histos");
     histoCanvasNamesVector = new std::vector<string>();
-    histoCanvasNames_->Branch("histoCanvasNamesVector","vector<string>",&histoCanvasNamesVector);
+    histoCanvasNames_->Branch("histoCanvasNamesVector", "vector<string>", &histoCanvasNamesVector);
   }
 
   //We only want the 3x3's for this event...
@@ -165,109 +149,95 @@ EcalDisplaysByEvent::analyze(edm::Event const & iEvent, edm::EventSetup const & 
 
   // Initialize histos for this event
   initEvtByEvtHists(naiveEvtNum_, ievt);
-  
+
   bool hasEBdigis = false;
   bool hasEEdigis = false;
-  if(!EBdigisHandle->empty())
+  if (!EBdigisHandle->empty())
     hasEBdigis = true;
-  if(!EEdigisHandle->empty())
+  if (!EEdigisHandle->empty())
     hasEEdigis = true;
 
   // Produce the digi graphs
-  if(makeDigiGraphs_)
-  {
-    if(hasEBdigis) //if event has digis, it should have hits
+  if (makeDigiGraphs_) {
+    if (hasEBdigis)  //if event has digis, it should have hits
       selectHits(EBhits, ievt, caloTopo);
-    if(hasEEdigis)
+    if (hasEEdigis)
       selectHits(EEhits, ievt, caloTopo);
   }
 
   // Produce the histos
-  if(hasEBdigis)
-  {
+  if (hasEBdigis) {
     makeHistos(EBdigisHandle);
     makeHistos(EBhits);
   }
-  if(hasEEdigis)
-  {
+  if (hasEEdigis) {
     makeHistos(EEdigisHandle);
     makeHistos(EEhits);
   }
 
-  if(hasEBdigis || hasEEdigis)
+  if (hasEBdigis || hasEEdigis)
     drawHistos();
 
   deleteEvtByEvtHists();
 }
 
-
-void EcalDisplaysByEvent::selectHits(Handle<EcalRecHitCollection> hits,
-    int ievt, ESHandle<CaloTopology> caloTopo)
-{
-  for (EcalRecHitCollection::const_iterator hitItr = hits->begin(); hitItr != hits->end(); ++hitItr)
-  {
+void EcalDisplaysByEvent::selectHits(Handle<EcalRecHitCollection> hits, int ievt, ESHandle<CaloTopology> caloTopo) {
+  for (EcalRecHitCollection::const_iterator hitItr = hits->begin(); hitItr != hits->end(); ++hitItr) {
     EcalRecHit hit = (*hitItr);
     DetId det = hit.id();
     EcalElectronicsId elecId = ecalElectronicsMap_->getElectronicsId(det);
-    int FEDid = 600+elecId.dccId();
+    int FEDid = 600 + elecId.dccId();
     bool isBarrel = true;
-    if(FEDid < 610 || FEDid > 645)
+    if (FEDid < 610 || FEDid > 645)
       isBarrel = false;
     int cryIndex = isBarrel ? ((EBDetId)det).hashedIndex() : getEEIndex(elecId);
     int ic = isBarrel ? ((EBDetId)det).ic() : getEEIndex(elecId);
-    
+
     float ampli = hit.energy();
 
     vector<int>::iterator result;
     result = find(maskedFEDs_.begin(), maskedFEDs_.end(), FEDid);
-    if(result != maskedFEDs_.end())
-    {
+    if (result != maskedFEDs_.end()) {
       //LogWarning("EcalDisplaysByEvent") << "skipping uncalRecHit for FED " << FEDid << " ; amplitude " << ampli;
       continue;
-    }      
+    }
     result = find(maskedChannels_.begin(), maskedChannels_.end(), cryIndex);
-    if  (result != maskedChannels_.end())
-    {
+    if (result != maskedChannels_.end()) {
       //LogWarning("EcalDisplaysByEvent") << "skipping uncalRecHit for channel: " << cryIndex << " in fed: " << FEDid << " with amplitude " << ampli ;
       continue;
-    } 
+    }
     bool cryIsInList = false;
     result = find(seedCrys_.begin(), seedCrys_.end(), cryIndex);
-    if  (result != seedCrys_.end())
+    if (result != seedCrys_.end())
       cryIsInList = true;
 
     // Either we must have a user-requested cry (in which case there is no amplitude selection)
     // Or we pick all crys that pass the amplitude cut (in which case there is no fixed crystal selection)
-    if(cryIsInList || (seedCrys_.empty() && ampli > threshold_))
-    {
+    if (cryIsInList || (seedCrys_.empty() && ampli > threshold_)) {
       // We have a winner!
       crysAndAmplitudesMap_[cryIndex] = ampli;
-      string name = "Digis_Event" + intToString(naiveEvtNum_) + "_ic" + intToString(ic)
-        + "_FED" + intToString(FEDid);
+      string name = "Digis_Event" + intToString(naiveEvtNum_) + "_ic" + intToString(ic) + "_FED" + intToString(FEDid);
       string title = "Digis";
       string seed = "ic" + intToString(ic) + "_FED" + intToString(FEDid);
-      int freq=1;
-      pair<map<string,int>::iterator,bool> pair = seedFrequencyMap_.insert(make_pair(seed,freq));
-      if(!pair.second)
-      {
+      int freq = 1;
+      pair<map<string, int>::iterator, bool> pair = seedFrequencyMap_.insert(make_pair(seed, freq));
+      if (!pair.second) {
         ++(pair.first->second);
       }
-      
+
       //TODO: move this also to TFileService
-      TCanvas can(name.c_str(),title.c_str(),200,50,900,900);
-      can.Divide(side_,side_);
+      TCanvas can(name.c_str(), title.c_str(), 200, 50, 900, 900);
+      can.Divide(side_, side_);
       TGraph* myGraph;
 
-      CaloNavigator<DetId> cursor = CaloNavigator<DetId>(det,caloTopo->getSubdetectorTopology(det));
+      CaloNavigator<DetId> cursor = CaloNavigator<DetId>(det, caloTopo->getSubdetectorTopology(det));
       //Now put each graph in one by one
-      for(int j=side_/2; j>=-side_/2; --j)
-      {
-        for(int i=-side_/2; i<=side_/2; ++i)
-        {
+      for (int j = side_ / 2; j >= -side_ / 2; --j) {
+        for (int i = -side_ / 2; i <= side_ / 2; ++i) {
           cursor.home();
-          cursor.offsetBy(i,j);
-          can.cd(i+1+side_/2+side_*(1-j));
-          myGraph = selectDigi(*cursor,ievt);
+          cursor.offsetBy(i, j);
+          can.cd(i + 1 + side_ / 2 + side_ * (1 - j));
+          myGraph = selectDigi(*cursor, ievt);
           myGraph->Draw("A*");
         }
       }
@@ -277,106 +247,99 @@ void EcalDisplaysByEvent::selectHits(Handle<EcalRecHitCollection> hits,
   }
 }
 
-TGraph* EcalDisplaysByEvent::selectDigi(DetId thisDet, int ievt)
-{
+TGraph* EcalDisplaysByEvent::selectDigi(DetId thisDet, int ievt) {
   int emptyY[10];
-  for (int i=0; i<10; i++)
+  for (int i = 0; i < 10; i++)
     emptyY[i] = 0;
   TGraph* emptyGraph = fileService->make<TGraph>(10, abscissa, emptyY);
   emptyGraph->SetTitle("NOT ECAL");
-  
+
   //If the DetId is not from Ecal, return
-  if(thisDet.det() != DetId::Ecal)
+  if (thisDet.det() != DetId::Ecal)
     return emptyGraph;
-  
+
   emptyGraph->SetTitle("NO DIGIS");
-  //find digi we need  -- can't get find() to work; need DataFrame(DetId det) to work? 
+  //find digi we need  -- can't get find() to work; need DataFrame(DetId det) to work?
   EcalElectronicsId elecId = ecalElectronicsMap_->getElectronicsId(thisDet);
-  int FEDid = 600+elecId.dccId();
+  int FEDid = 600 + elecId.dccId();
   bool isBarrel = true;
-  if(FEDid < 610 || FEDid > 645)
+  if (FEDid < 610 || FEDid > 645)
     isBarrel = false;
   int cryIndex = isBarrel ? ((EBDetId)thisDet).hashedIndex() : getEEIndex(elecId);
   int ic = isBarrel ? ((EBDetId)thisDet).ic() : cryIndex;
 
   string sliceName = fedMap_->getSliceFromFed(FEDid);
   EcalDataFrame df;
-  if(isBarrel)
-  {
+  if (isBarrel) {
     EBDigiCollection::const_iterator digiItr = EBdigisHandle->begin();
-    while(digiItr != EBdigisHandle->end() && ((*digiItr).id() != (EBDetId)thisDet))
-    {
+    while (digiItr != EBdigisHandle->end() && ((*digiItr).id() != (EBDetId)thisDet)) {
       ++digiItr;
     }
-    if(digiItr==EBdigisHandle->end())
-    {
+    if (digiItr == EBdigisHandle->end()) {
       //LogWarning("EcalDisplaysByEvent") << "Cannot find digi for ic:" << ic
       //  << " FED:" << FEDid << " evt:" << naiveEvtNum_;
       return emptyGraph;
-    }
-    else
+    } else
       df = *digiItr;
-  }
-  else
-  {
+  } else {
     EEDigiCollection::const_iterator digiItr = EEdigisHandle->begin();
-    while(digiItr != EEdigisHandle->end() && ((*digiItr).id() != (EEDetId)thisDet))
-    {
+    while (digiItr != EEdigisHandle->end() && ((*digiItr).id() != (EEDetId)thisDet)) {
       ++digiItr;
     }
-    if(digiItr==EEdigisHandle->end())
-    {
+    if (digiItr == EEdigisHandle->end()) {
       //LogWarning("EcalDisplaysByEvent") << "Cannot find digi for ic:" << ic
       //  << " FED:" << FEDid << " evt:" << naiveEvtNum_;
       return emptyGraph;
-    }
-    else df = *digiItr;
+    } else
+      df = *digiItr;
   }
 
   int gainId = FEDsAndDCCHeaders_[FEDid].getMgpaGain();
   int gainHuman;
-  if      (gainId ==1) gainHuman =12;
-  else if (gainId ==2) gainHuman =6;
-  else if (gainId ==3) gainHuman =1;
-  else                 gainHuman =-1; 
+  if (gainId == 1)
+    gainHuman = 12;
+  else if (gainId == 2)
+    gainHuman = 6;
+  else if (gainId == 3)
+    gainHuman = 1;
+  else
+    gainHuman = -1;
 
   double pedestal = 200;
 
   emptyGraph->SetTitle("FIRST TWO SAMPLES NOT GAIN12");
-  if(df.sample(0).gainId()!=1 || df.sample(1).gainId()!=1) return emptyGraph; //goes to the next digi
+  if (df.sample(0).gainId() != 1 || df.sample(1).gainId() != 1)
+    return emptyGraph;  //goes to the next digi
   else {
     ordinate[0] = df.sample(0).adc();
     ordinate[1] = df.sample(1).adc();
-    pedestal = (double)(ordinate[0]+ordinate[1])/(double)2;
-  } 
+    pedestal = (double)(ordinate[0] + ordinate[1]) / (double)2;
+  }
 
-
-  for (int i=0; i < df.size(); ++i ) {
+  for (int i = 0; i < df.size(); ++i) {
     if (df.sample(i).gainId() != 0)
-      ordinate[i] = (int)(pedestal+(df.sample(i).adc()-pedestal)*gainRatio[df.sample(i).gainId()-1]);
+      ordinate[i] = (int)(pedestal + (df.sample(i).adc() - pedestal) * gainRatio[df.sample(i).gainId() - 1]);
     else
-      ordinate[i] = 49152; //Saturation of gain1 
+      ordinate[i] = 49152;  //Saturation of gain1
   }
 
   TGraph* oneGraph = fileService->make<TGraph>(10, abscissa, ordinate);
-  string name = "Graph_ev" + intToString(naiveEvtNum_) + "_ic" + intToString(ic)
-    + "_FED" + intToString(FEDid);
-  string gainString = (gainId==1) ? "Free" : intToString(gainHuman);
-  string title = "Event" + intToString(naiveEvtNum_) + "_lv1a" + intToString(ievt) +
-    "_ic" + intToString(ic) + "_" + sliceName + "_gain" + gainString;
-    
+  string name = "Graph_ev" + intToString(naiveEvtNum_) + "_ic" + intToString(ic) + "_FED" + intToString(FEDid);
+  string gainString = (gainId == 1) ? "Free" : intToString(gainHuman);
+  string title = "Event" + intToString(naiveEvtNum_) + "_lv1a" + intToString(ievt) + "_ic" + intToString(ic) + "_" +
+                 sliceName + "_gain" + gainString;
+
   float energy = 0;
-  map<int,float>::const_iterator itr;
+  map<int, float>::const_iterator itr;
   itr = crysAndAmplitudesMap_.find(cryIndex);
-  if(itr!=crysAndAmplitudesMap_.end())
-  {
+  if (itr != crysAndAmplitudesMap_.end()) {
     //edm::LogWarning("EcalDisplaysByEvent")<< "itr->second(ampli)="<< itr->second;
-    energy = (float) itr->second;
+    energy = (float)itr->second;
   }
   //else
   //edm::LogWarning("EcalDisplaysByEvent") << "cry " << ic << "not found in ampMap";
 
-  title+="_Energy"+floatToString(round(energy*1000));
+  title += "_Energy" + floatToString(round(energy * 1000));
 
   oneGraph->SetTitle(title.c_str());
   oneGraph->SetName(name.c_str());
@@ -385,206 +348,169 @@ TGraph* EcalDisplaysByEvent::selectDigi(DetId thisDet, int ievt)
   return oneGraph;
 }
 
-int EcalDisplaysByEvent::getEEIndex(EcalElectronicsId elecId)
-{
-  int FEDid = 600+elecId.dccId();
-  return 10000*FEDid+100*elecId.towerId()+5*(elecId.stripId()-1)+elecId.xtalId();
+int EcalDisplaysByEvent::getEEIndex(EcalElectronicsId elecId) {
+  int FEDid = 600 + elecId.dccId();
+  return 10000 * FEDid + 100 * elecId.towerId() + 5 * (elecId.stripId() - 1) + elecId.xtalId();
 }
 
 void EcalDisplaysByEvent::makeHistos(Handle<EBDigiCollection> ebDigiHandle) {
-   const EBDigiCollection* ebDigis = ebDigiHandle.product();
-   for(EBDigiCollection::const_iterator digiItr = ebDigis->begin(); digiItr != ebDigis->end(); ++digiItr) {
-      EBDetId digiId = digiItr->id();
-      int ieta = digiId.ieta();
-      int iphi = digiId.iphi();
-      digiOccupancyEBAll_->Fill(iphi,ieta);
-      digiOccupancyEBcoarseAll_->Fill(iphi,ieta);
-      if(makeOccupancyHistos_)
-      {
-        digiOccupancyEB_->Fill(iphi,ieta);
-        digiOccupancyEBcoarse_->Fill(iphi,ieta);
-      }
-   }
+  const EBDigiCollection* ebDigis = ebDigiHandle.product();
+  for (EBDigiCollection::const_iterator digiItr = ebDigis->begin(); digiItr != ebDigis->end(); ++digiItr) {
+    EBDetId digiId = digiItr->id();
+    int ieta = digiId.ieta();
+    int iphi = digiId.iphi();
+    digiOccupancyEBAll_->Fill(iphi, ieta);
+    digiOccupancyEBcoarseAll_->Fill(iphi, ieta);
+    if (makeOccupancyHistos_) {
+      digiOccupancyEB_->Fill(iphi, ieta);
+      digiOccupancyEBcoarse_->Fill(iphi, ieta);
+    }
+  }
 }
 
 void EcalDisplaysByEvent::makeHistos(Handle<EEDigiCollection> eeDigiHandle) {
-   const EEDigiCollection* eeDigis = eeDigiHandle.product();
-   for(EEDigiCollection::const_iterator digiItr = eeDigis->begin(); digiItr != eeDigis->end(); ++digiItr) {
-      DetId det = digiItr->id();
-      EcalElectronicsId elecId = ecalElectronicsMap_->getElectronicsId(det);
-      size_t FEDid = 600+elecId.dccId();
-      bool isEEM = false;
-      if(FEDid < 610)
-	isEEM = true;
-      EEDetId digiId = digiItr->id();
-      int ieta = digiId.iy();
-      int iphi = digiId.ix();
-      if(isEEM)
-      {
-	 digiOccupancyEEMAll_->Fill(iphi,ieta);
-	 digiOccupancyEEMcoarseAll_->Fill(iphi,ieta);
-         if(makeOccupancyHistos_)
-         {
-           digiOccupancyEEMcoarse_->Fill(iphi,ieta);
-           digiOccupancyEEM_->Fill(iphi,ieta);
-         }
+  const EEDigiCollection* eeDigis = eeDigiHandle.product();
+  for (EEDigiCollection::const_iterator digiItr = eeDigis->begin(); digiItr != eeDigis->end(); ++digiItr) {
+    DetId det = digiItr->id();
+    EcalElectronicsId elecId = ecalElectronicsMap_->getElectronicsId(det);
+    size_t FEDid = 600 + elecId.dccId();
+    bool isEEM = false;
+    if (FEDid < 610)
+      isEEM = true;
+    EEDetId digiId = digiItr->id();
+    int ieta = digiId.iy();
+    int iphi = digiId.ix();
+    if (isEEM) {
+      digiOccupancyEEMAll_->Fill(iphi, ieta);
+      digiOccupancyEEMcoarseAll_->Fill(iphi, ieta);
+      if (makeOccupancyHistos_) {
+        digiOccupancyEEMcoarse_->Fill(iphi, ieta);
+        digiOccupancyEEM_->Fill(iphi, ieta);
       }
-      else
-      {
-	 digiOccupancyEEPAll_->Fill(iphi,ieta);
-	 digiOccupancyEEPcoarseAll_->Fill(iphi,ieta);
-         if(makeOccupancyHistos_)
-         {
-           digiOccupancyEEP_->Fill(iphi,ieta);
-           digiOccupancyEEPcoarse_->Fill(iphi,ieta);
-         }
-      }  
-   }
+    } else {
+      digiOccupancyEEPAll_->Fill(iphi, ieta);
+      digiOccupancyEEPcoarseAll_->Fill(iphi, ieta);
+      if (makeOccupancyHistos_) {
+        digiOccupancyEEP_->Fill(iphi, ieta);
+        digiOccupancyEEPcoarse_->Fill(iphi, ieta);
+      }
+    }
+  }
 }
 
-void EcalDisplaysByEvent::makeHistos(Handle<EcalRecHitCollection> hits)
-{
-  for (EcalRecHitCollection::const_iterator hitItr = hits->begin(); hitItr != hits->end(); ++hitItr)
-  {
+void EcalDisplaysByEvent::makeHistos(Handle<EcalRecHitCollection> hits) {
+  for (EcalRecHitCollection::const_iterator hitItr = hits->begin(); hitItr != hits->end(); ++hitItr) {
     EcalRecHit hit = (*hitItr);
     DetId det = hit.id();
     EcalElectronicsId elecId = ecalElectronicsMap_->getElectronicsId(det);
-    int FEDid = 600+elecId.dccId();
+    int FEDid = 600 + elecId.dccId();
     bool isBarrel = true;
     bool isEEM = false;
-    if(FEDid < 610 || FEDid > 645)
-    {
+    if (FEDid < 610 || FEDid > 645) {
       isBarrel = false;
-      if(FEDid < 610)
+      if (FEDid < 610)
         isEEM = true;
     }
     int iphi = isBarrel ? ((EBDetId)det).iphi() : ((EEDetId)det).ix();
     int ieta = isBarrel ? ((EBDetId)det).ieta() : ((EEDetId)det).iy();
     float energy = hit.energy();
     float time = hit.time();
-    
+
     // Fill energy histos
-    if(makeEnergyHistos_)
-    {
-      if(isBarrel)
-      {
+    if (makeEnergyHistos_) {
+      if (isBarrel) {
         energyEB_->Fill(energy);
-        energyMapEB_->Fill(iphi,ieta,energy);
-        energyMapEBcoarse_->Fill(iphi,ieta,energy);
-      }
-      else if(isEEM)
-      {
+        energyMapEB_->Fill(iphi, ieta, energy);
+        energyMapEBcoarse_->Fill(iphi, ieta, energy);
+      } else if (isEEM) {
         energyEEM_->Fill(energy);
-        energyMapEEM_->Fill(iphi,ieta,energy);
-        energyMapEEMcoarse_->Fill(iphi,ieta,energy);
-      }
-      else
-      {
+        energyMapEEM_->Fill(iphi, ieta, energy);
+        energyMapEEMcoarse_->Fill(iphi, ieta, energy);
+      } else {
         energyEEP_->Fill(energy);
-        energyMapEEP_->Fill(iphi,ieta,energy);
-        energyMapEEPcoarse_->Fill(iphi,ieta,energy);
+        energyMapEEP_->Fill(iphi, ieta, energy);
+        energyMapEEPcoarse_->Fill(iphi, ieta, energy);
       }
     }
     // Fill occupancy histos
-    if(makeOccupancyHistos_)
-    {
-      if(isBarrel)
-      {
-        recHitOccupancyEB_->Fill(iphi,ieta);
-        recHitOccupancyEBcoarse_->Fill(iphi,ieta);
-      }
-      else if(isEEM)
-      {
-	 recHitOccupancyEEM_->Fill(iphi,ieta);
-	 recHitOccupancyEEMcoarse_->Fill(iphi,ieta);
-      }
-      else
-      {
-	 recHitOccupancyEEP_->Fill(iphi,ieta);
-	 recHitOccupancyEEPcoarse_->Fill(iphi,ieta);
+    if (makeOccupancyHistos_) {
+      if (isBarrel) {
+        recHitOccupancyEB_->Fill(iphi, ieta);
+        recHitOccupancyEBcoarse_->Fill(iphi, ieta);
+      } else if (isEEM) {
+        recHitOccupancyEEM_->Fill(iphi, ieta);
+        recHitOccupancyEEMcoarse_->Fill(iphi, ieta);
+      } else {
+        recHitOccupancyEEP_->Fill(iphi, ieta);
+        recHitOccupancyEEPcoarse_->Fill(iphi, ieta);
       }
     }
 
     // Fill timing histos
-    if(makeTimingHistos_)
-    {
-      if(isBarrel) {
+    if (makeTimingHistos_) {
+      if (isBarrel) {
         timingEB_->Fill(time);
-	if(energy > minTimingEnergyEB_) {
-	   timingMapEB_->Fill(iphi,ieta,time);
-	   //timingMapEBCoarse_->Fill(iphi,ieta,time);
-	}
-      }
-      else if(isEEM) {
-	 timingEEM_->Fill(time);
-	 if(energy > minTimingEnergyEE_)
-         {
-	    timingMapEEM_->Fill(iphi,ieta,time);
-	    //timingMapEEMCoarse_->Fill(iphi,ieta,time);
-         }
-      }
-      else {
-	 timingEEP_->Fill(time);
-	 if(energy > minTimingEnergyEE_)
-         {
-	    timingMapEEP_->Fill(iphi,ieta,time);
-	    //timingMapEEPCoarse_->Fill(iphi,ieta,time);
-         }
+        if (energy > minTimingEnergyEB_) {
+          timingMapEB_->Fill(iphi, ieta, time);
+          //timingMapEBCoarse_->Fill(iphi,ieta,time);
+        }
+      } else if (isEEM) {
+        timingEEM_->Fill(time);
+        if (energy > minTimingEnergyEE_) {
+          timingMapEEM_->Fill(iphi, ieta, time);
+          //timingMapEEMCoarse_->Fill(iphi,ieta,time);
+        }
+      } else {
+        timingEEP_->Fill(time);
+        if (energy > minTimingEnergyEE_) {
+          timingMapEEP_->Fill(iphi, ieta, time);
+          //timingMapEEPCoarse_->Fill(iphi,ieta,time);
+        }
       }
     }
 
     //All events
-    if(isBarrel)
-    {
+    if (isBarrel) {
       energyEBAll_->Fill(energy);
-      energyMapEBAll_->Fill(iphi,ieta,energy);
-      energyMapEBcoarseAll_->Fill(iphi,ieta,energy);
-      recHitOccupancyEBAll_->Fill(iphi,ieta);
-      recHitOccupancyEBcoarseAll_->Fill(iphi,ieta);
+      energyMapEBAll_->Fill(iphi, ieta, energy);
+      energyMapEBcoarseAll_->Fill(iphi, ieta, energy);
+      recHitOccupancyEBAll_->Fill(iphi, ieta);
+      recHitOccupancyEBcoarseAll_->Fill(iphi, ieta);
       timingEBAll_->Fill(time);
-      if(energy > minTimingEnergyEB_)
-      {
-        timingMapEBAll_->Fill(iphi,ieta,time);
-        timingMapEBCoarseAll_->Fill(iphi,ieta,time);
+      if (energy > minTimingEnergyEB_) {
+        timingMapEBAll_->Fill(iphi, ieta, time);
+        timingMapEBCoarseAll_->Fill(iphi, ieta, time);
       }
-    }
-    else if(isEEM)
-    {
+    } else if (isEEM) {
       energyEEMAll_->Fill(energy);
-      energyMapEEMAll_->Fill(iphi,ieta,energy);
-      energyMapEEMcoarseAll_->Fill(iphi,ieta,energy);
-      recHitOccupancyEEMAll_->Fill(iphi,ieta);
-      recHitOccupancyEEMcoarseAll_->Fill(iphi,ieta);
+      energyMapEEMAll_->Fill(iphi, ieta, energy);
+      energyMapEEMcoarseAll_->Fill(iphi, ieta, energy);
+      recHitOccupancyEEMAll_->Fill(iphi, ieta);
+      recHitOccupancyEEMcoarseAll_->Fill(iphi, ieta);
       timingEEMAll_->Fill(time);
-      if(energy > minTimingEnergyEE_)
-      {
-        timingMapEEMAll_->Fill(iphi,ieta,time);
-        timingMapEEMCoarseAll_->Fill(iphi,ieta,time);
+      if (energy > minTimingEnergyEE_) {
+        timingMapEEMAll_->Fill(iphi, ieta, time);
+        timingMapEEMCoarseAll_->Fill(iphi, ieta, time);
       }
-    }
-    else
-    {
+    } else {
       energyEEPAll_->Fill(energy);
-      energyMapEEPAll_->Fill(iphi,ieta,energy);
-      energyMapEEPcoarseAll_->Fill(iphi,ieta,energy);
-      recHitOccupancyEEPAll_->Fill(iphi,ieta);
-      recHitOccupancyEEPcoarseAll_->Fill(iphi,ieta);
+      energyMapEEPAll_->Fill(iphi, ieta, energy);
+      energyMapEEPcoarseAll_->Fill(iphi, ieta, energy);
+      recHitOccupancyEEPAll_->Fill(iphi, ieta);
+      recHitOccupancyEEPcoarseAll_->Fill(iphi, ieta);
       timingEEPAll_->Fill(time);
-      if(energy > minTimingEnergyEE_)
-      {
-        timingMapEEPAll_->Fill(iphi,ieta,time);
-        timingMapEEPCoarseAll_->Fill(iphi,ieta,time);
+      if (energy > minTimingEnergyEE_) {
+        timingMapEEPAll_->Fill(iphi, ieta, time);
+        timingMapEEPCoarseAll_->Fill(iphi, ieta, time);
       }
     }
     // Fill FED-by-FED timing histos (all events)
     TH1F* timingHist = FEDsAndTimingHists_[FEDid];
-    if(timingHist==nullptr)
-    {
+    if (timingHist == nullptr) {
       initHists(FEDid);
       timingHist = FEDsAndTimingHists_[FEDid];
     }
-    if(energy > minTimingAmp_)
-    {
+    if (energy > minTimingAmp_) {
       timingHist->Fill(hit.time());
       allFedsTimingHist_->Fill(hit.time());
     }
@@ -592,196 +518,185 @@ void EcalDisplaysByEvent::makeHistos(Handle<EcalRecHitCollection> hits)
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-EcalDisplaysByEvent::endJob()
-{
+void EcalDisplaysByEvent::endJob() {
   //All-event canvases
-  drawCanvas(timingCanvasAll_,timingEEMAll_,timingEBAll_,timingEEPAll_);
-  drawCanvas(timingMapCanvasAll_,timingMapEEMAll_,timingMapEBAll_,timingMapEEPAll_);
-  drawCanvas(energyCanvasAll_,energyEEMAll_,energyEBAll_,energyEEPAll_);
-  drawCanvas(energyMapCanvasAll_,energyMapEEMAll_,energyMapEBAll_,energyMapEEPAll_);
-  drawCanvas(energyMapCoarseCanvasAll_,energyMapEEMcoarseAll_,energyMapEBcoarseAll_,energyMapEEPcoarseAll_);
-  drawCanvas(recHitOccupancyCanvasAll_,recHitOccupancyEEMAll_,recHitOccupancyEBAll_,recHitOccupancyEEPAll_);
-  drawCanvas(recHitOccupancyCoarseCanvasAll_,recHitOccupancyEEMcoarseAll_,recHitOccupancyEBcoarseAll_,recHitOccupancyEEPcoarseAll_);
-  drawCanvas(digiOccupancyCanvasAll_,digiOccupancyEEMAll_,digiOccupancyEBAll_,digiOccupancyEEPAll_);
-  drawCanvas(digiOccupancyCoarseCanvasAll_,digiOccupancyEEMcoarseAll_,digiOccupancyEBcoarseAll_,digiOccupancyEEPcoarseAll_);
+  drawCanvas(timingCanvasAll_, timingEEMAll_, timingEBAll_, timingEEPAll_);
+  drawCanvas(timingMapCanvasAll_, timingMapEEMAll_, timingMapEBAll_, timingMapEEPAll_);
+  drawCanvas(energyCanvasAll_, energyEEMAll_, energyEBAll_, energyEEPAll_);
+  drawCanvas(energyMapCanvasAll_, energyMapEEMAll_, energyMapEBAll_, energyMapEEPAll_);
+  drawCanvas(energyMapCoarseCanvasAll_, energyMapEEMcoarseAll_, energyMapEBcoarseAll_, energyMapEEPcoarseAll_);
+  drawCanvas(recHitOccupancyCanvasAll_, recHitOccupancyEEMAll_, recHitOccupancyEBAll_, recHitOccupancyEEPAll_);
+  drawCanvas(recHitOccupancyCoarseCanvasAll_,
+             recHitOccupancyEEMcoarseAll_,
+             recHitOccupancyEBcoarseAll_,
+             recHitOccupancyEEPcoarseAll_);
+  drawCanvas(digiOccupancyCanvasAll_, digiOccupancyEEMAll_, digiOccupancyEBAll_, digiOccupancyEEPAll_);
+  drawCanvas(
+      digiOccupancyCoarseCanvasAll_, digiOccupancyEEMcoarseAll_, digiOccupancyEBcoarseAll_, digiOccupancyEEPcoarseAll_);
 
-  if(runNum_ != -1) {
+  if (runNum_ != -1) {
     canvasNames_->Fill();
     histoCanvasNames_->Fill();
   }
 
   string frequencies = "";
-  for(std::map<std::string,int>::const_iterator itr = seedFrequencyMap_.begin();
-      itr != seedFrequencyMap_.end(); ++itr)
-  {
-    if(itr->second > 1)
-    {
-      frequencies+=itr->first;
-      frequencies+=" Frequency: ";
-      frequencies+=intToString(itr->second);
-      frequencies+="\n";
+  for (std::map<std::string, int>::const_iterator itr = seedFrequencyMap_.begin(); itr != seedFrequencyMap_.end();
+       ++itr) {
+    if (itr->second > 1) {
+      frequencies += itr->first;
+      frequencies += " Frequency: ";
+      frequencies += intToString(itr->second);
+      frequencies += "\n";
     }
   }
-  LogWarning("EcalDisplaysByEvent") << "Found seeds with frequency > 1: " << "\n\n" << frequencies;
-  
+  LogWarning("EcalDisplaysByEvent") << "Found seeds with frequency > 1: "
+                                    << "\n\n"
+                                    << frequencies;
+
   std::string channels;
-  for(std::vector<int>::const_iterator itr = maskedChannels_.begin();
-      itr != maskedChannels_.end(); ++itr)
-  {
-    channels+=intToString(*itr);
-    channels+=",";
+  for (std::vector<int>::const_iterator itr = maskedChannels_.begin(); itr != maskedChannels_.end(); ++itr) {
+    channels += intToString(*itr);
+    channels += ",";
   }
-  
+
   std::string feds;
-  for(std::vector<int>::const_iterator itr = maskedFEDs_.begin();
-      itr != maskedFEDs_.end(); ++itr)
-  {
-    feds+=intToString(*itr);
-    feds+=",";
+  for (std::vector<int>::const_iterator itr = maskedFEDs_.begin(); itr != maskedFEDs_.end(); ++itr) {
+    feds += intToString(*itr);
+    feds += ",";
   }
 
   LogWarning("EcalDisplaysByEvent") << "Masked channels are: " << channels;
   LogWarning("EcalDisplaysByEvent") << "Masked FEDs are: " << feds << " and that is all!";
 }
 
-std::string EcalDisplaysByEvent::intToString(int num)
-{
-    using namespace std;
-    ostringstream myStream;
-    myStream << num << flush;
-    return(myStream.str()); //returns the string form of the stringstream object
+std::string EcalDisplaysByEvent::intToString(int num) {
+  using namespace std;
+  ostringstream myStream;
+  myStream << num << flush;
+  return (myStream.str());  //returns the string form of the stringstream object
 }
 
-std::string EcalDisplaysByEvent::floatToString(float num)
-{
-    using namespace std;
-    ostringstream myStream;
-    myStream << num << flush;
-    return(myStream.str()); //returns the string form of the stringstream object
+std::string EcalDisplaysByEvent::floatToString(float num) {
+  using namespace std;
+  ostringstream myStream;
+  myStream << num << flush;
+  return (myStream.str());  //returns the string form of the stringstream object
 }
 
 // insert the hist map into the map keyed by FED number
-void EcalDisplaysByEvent::initHists(int FED)
-{
+void EcalDisplaysByEvent::initHists(int FED) {
   using namespace std;
-  
+
   string title1 = "Jitter for ";
   title1.append(fedMap_->getSliceFromFed(FED));
   string name1 = "JitterFED";
   name1.append(intToString(FED));
-  TH1F* timingHist = fileService->make<TH1F>(name1.c_str(),title1.c_str(),150,-7,7);
+  TH1F* timingHist = fileService->make<TH1F>(name1.c_str(), title1.c_str(), 150, -7, 7);
   FEDsAndTimingHists_[FED] = timingHist;
 }
 
-void EcalDisplaysByEvent::initEvtByEvtHists(int naiveEvtNum_, int ievt)
-{
-  string lastPart = intToString(naiveEvtNum_)+"_LV1a"+intToString(ievt);
-  if(makeTimingHistos_)
-  {
-    string canvasTitle = "Timing_Event"+lastPart;
-    timingEB_ = new TH1F("timeForAllFedsEB","timeForAllFeds;Relative Time (1 clock = 25ns)",78,-7,7);
-    timingEEM_ = new TH1F("timeForAllFedsEEM","timeForAllFeds_EEM;Relative Time (1 clock = 25ns)",78,-7,7);
-    timingEEP_ = new TH1F("timeForAllFedsEEP","timeForAllFeds_EEP;Relative Time (1 clock = 25ns)",78,-7,7);
-    timingCanvas_ = new TCanvas(canvasTitle.c_str(), canvasTitle.c_str(),300,60,500,200);
+void EcalDisplaysByEvent::initEvtByEvtHists(int naiveEvtNum_, int ievt) {
+  string lastPart = intToString(naiveEvtNum_) + "_LV1a" + intToString(ievt);
+  if (makeTimingHistos_) {
+    string canvasTitle = "Timing_Event" + lastPart;
+    timingEB_ = new TH1F("timeForAllFedsEB", "timeForAllFeds;Relative Time (1 clock = 25ns)", 78, -7, 7);
+    timingEEM_ = new TH1F("timeForAllFedsEEM", "timeForAllFeds_EEM;Relative Time (1 clock = 25ns)", 78, -7, 7);
+    timingEEP_ = new TH1F("timeForAllFedsEEP", "timeForAllFeds_EEP;Relative Time (1 clock = 25ns)", 78, -7, 7);
+    timingCanvas_ = new TCanvas(canvasTitle.c_str(), canvasTitle.c_str(), 300, 60, 500, 200);
     timingMapEB_ = init3DEcalHist("TimingMap", EB_FINE);
     timingMapEEM_ = init3DEcalHist("TimingMap", EEM_FINE);
     timingMapEEP_ = init3DEcalHist("TimingMap", EEP_FINE);
-    timingMapCanvas_ = init2DEcalCanvas("TimingMap_Event"+lastPart);
+    timingMapCanvas_ = init2DEcalCanvas("TimingMap_Event" + lastPart);
     //timingMapEBCoarse_ = init3DEcalHist("TimingMap", EB_COARSE);
     timingMapEEMCoarse_ = init3DEcalHist("TimingMap", EEM_COARSE);
     timingMapEEPCoarse_ = init3DEcalHist("TimingMap", EEP_COARSE);
-    //timingMapCoarseCanvas_ = init2DEcalCanvas("TimingMapCoarse_Event"+lastPart);  
+    //timingMapCoarseCanvas_ = init2DEcalCanvas("TimingMapCoarse_Event"+lastPart);
   }
-  if(makeEnergyHistos_)
-  {
-    energyEB_ = new TH1F("energyEB","Energy for EB Feds (GeV)",200,histRangeMin_,histRangeMax_);
-    energyEEM_ = new TH1F("energyEEM","Energy for EEM Feds (GeV)",200,histRangeMin_,10.0);
-    energyEEP_ = new TH1F("energyEEP","Energy for EEP Feds (GeV)",200,histRangeMin_,10.0);
-    string canvasTitle = "Energy_Event"+lastPart;
-    energyCanvas_ = new TCanvas(canvasTitle.c_str(), canvasTitle.c_str(),300,60,500,200);
+  if (makeEnergyHistos_) {
+    energyEB_ = new TH1F("energyEB", "Energy for EB Feds (GeV)", 200, histRangeMin_, histRangeMax_);
+    energyEEM_ = new TH1F("energyEEM", "Energy for EEM Feds (GeV)", 200, histRangeMin_, 10.0);
+    energyEEP_ = new TH1F("energyEEP", "Energy for EEP Feds (GeV)", 200, histRangeMin_, 10.0);
+    string canvasTitle = "Energy_Event" + lastPart;
+    energyCanvas_ = new TCanvas(canvasTitle.c_str(), canvasTitle.c_str(), 300, 60, 500, 200);
 
     // Energy map hists
-    energyMapEB_            = init2DEcalHist("EnergyMap",EB_FINE);
-    energyMapEBcoarse_      = init2DEcalHist("EnergyMap",EB_COARSE);
-    energyMapEEMcoarse_           = init2DEcalHist("EnergyMap",EEM_COARSE);
-    energyMapEEM_                 = init2DEcalHist("EnergyMap",EEM_FINE);
-    energyMapEEPcoarse_           = init2DEcalHist("EnergyMap",EEP_COARSE);
-    energyMapEEP_                 = init2DEcalHist("EnergyMap",EEP_FINE);
-    energyMapCanvas_ = init2DEcalCanvas("EnergyMap_Event"+lastPart);
-    energyMapCoarseCanvas_ = init2DEcalCanvas("EnergyMapCoarse_Event"+lastPart);
+    energyMapEB_ = init2DEcalHist("EnergyMap", EB_FINE);
+    energyMapEBcoarse_ = init2DEcalHist("EnergyMap", EB_COARSE);
+    energyMapEEMcoarse_ = init2DEcalHist("EnergyMap", EEM_COARSE);
+    energyMapEEM_ = init2DEcalHist("EnergyMap", EEM_FINE);
+    energyMapEEPcoarse_ = init2DEcalHist("EnergyMap", EEP_COARSE);
+    energyMapEEP_ = init2DEcalHist("EnergyMap", EEP_FINE);
+    energyMapCanvas_ = init2DEcalCanvas("EnergyMap_Event" + lastPart);
+    energyMapCoarseCanvas_ = init2DEcalCanvas("EnergyMapCoarse_Event" + lastPart);
   }
-  if(makeOccupancyHistos_) 
-  {
-     // RecHit Occupancy
-    recHitOccupancyEB_ = init2DEcalHist("RecHitOccupancy",EB_FINE);
-    recHitOccupancyEBcoarse_ = init2DEcalHist("RecHitOccupancy",EB_COARSE);
-    recHitOccupancyEEMcoarse_ = init2DEcalHist("RecHitOccupancy",EEM_COARSE);
-    recHitOccupancyEEM_ = init2DEcalHist("RecHitOccupancy",EEM_FINE);
-    recHitOccupancyEEPcoarse_ = init2DEcalHist("RecHitOccupancy",EEP_COARSE);
-    recHitOccupancyEEP_ = init2DEcalHist("RecHitOccupancy",EEP_FINE);
-    recHitOccupancyCanvas_ = init2DEcalCanvas("RecHitOccupancy_Event"+lastPart);
-    recHitOccupancyCoarseCanvas_ =init2DEcalCanvas("RecHitOccupancyCoarse_Event"+lastPart);
+  if (makeOccupancyHistos_) {
+    // RecHit Occupancy
+    recHitOccupancyEB_ = init2DEcalHist("RecHitOccupancy", EB_FINE);
+    recHitOccupancyEBcoarse_ = init2DEcalHist("RecHitOccupancy", EB_COARSE);
+    recHitOccupancyEEMcoarse_ = init2DEcalHist("RecHitOccupancy", EEM_COARSE);
+    recHitOccupancyEEM_ = init2DEcalHist("RecHitOccupancy", EEM_FINE);
+    recHitOccupancyEEPcoarse_ = init2DEcalHist("RecHitOccupancy", EEP_COARSE);
+    recHitOccupancyEEP_ = init2DEcalHist("RecHitOccupancy", EEP_FINE);
+    recHitOccupancyCanvas_ = init2DEcalCanvas("RecHitOccupancy_Event" + lastPart);
+    recHitOccupancyCoarseCanvas_ = init2DEcalCanvas("RecHitOccupancyCoarse_Event" + lastPart);
 
     //DigiOccupancy
-    digiOccupancyEB_ = init2DEcalHist("DigiOccupancy",EB_FINE);
+    digiOccupancyEB_ = init2DEcalHist("DigiOccupancy", EB_FINE);
     digiOccupancyEBcoarse_ = init2DEcalHist("DigiOccupancy", EB_COARSE);
-    digiOccupancyEEMcoarse_ = init2DEcalHist("DigiOccupancy",EEM_COARSE);
-    digiOccupancyEEM_ = init2DEcalHist("DigiOccupancy",EEM_FINE);
-    digiOccupancyEEPcoarse_ = init2DEcalHist("DigiOccupancy",EEP_COARSE);
-    digiOccupancyEEP_ = init2DEcalHist("DigiOccupancy",EEP_FINE);
-    digiOccupancyCanvas_ = init2DEcalCanvas("DigiOccupancy_Event"+lastPart);
-    digiOccupancyCoarseCanvas_ = init2DEcalCanvas("DigiOccupancyCoarse_Event"+lastPart);
+    digiOccupancyEEMcoarse_ = init2DEcalHist("DigiOccupancy", EEM_COARSE);
+    digiOccupancyEEM_ = init2DEcalHist("DigiOccupancy", EEM_FINE);
+    digiOccupancyEEPcoarse_ = init2DEcalHist("DigiOccupancy", EEP_COARSE);
+    digiOccupancyEEP_ = init2DEcalHist("DigiOccupancy", EEP_FINE);
+    digiOccupancyCanvas_ = init2DEcalCanvas("DigiOccupancy_Event" + lastPart);
+    digiOccupancyCoarseCanvas_ = init2DEcalCanvas("DigiOccupancyCoarse_Event" + lastPart);
   }
 }
 
-void EcalDisplaysByEvent::deleteEvtByEvtHists()
-{
-    delete timingEB_;
-    delete timingEEM_;
-    delete timingEEP_;
-    delete timingMapEB_;
-    delete timingMapEEM_;
-    delete timingMapEEP_;
-    delete timingCanvas_;
-    delete timingMapCanvas_;
-    delete energyEB_;
-    delete energyEEM_;
-    delete energyEEP_;
-    delete energyMapEB_;
-    delete energyMapEEM_;
-    delete energyMapEEP_;
-    delete energyMapEBcoarse_;
-    delete energyMapEEMcoarse_;
-    delete energyMapEEPcoarse_;
-    delete energyCanvas_;
-    delete energyMapCanvas_;
-    delete energyMapCoarseCanvas_;
-    delete recHitOccupancyEB_;
-    delete recHitOccupancyEEP_;
-    delete recHitOccupancyEEM_;
-    delete recHitOccupancyEBcoarse_;
-    delete recHitOccupancyEEMcoarse_;
-    delete recHitOccupancyEEPcoarse_;
-    delete digiOccupancyEB_;
-    delete digiOccupancyEEM_;
-    delete digiOccupancyEEP_;
-    delete digiOccupancyEBcoarse_;
-    delete digiOccupancyEEMcoarse_;
-    delete digiOccupancyEEPcoarse_;
-    delete recHitOccupancyCanvas_;
-    delete recHitOccupancyCoarseCanvas_;
-    delete digiOccupancyCanvas_;
-    delete digiOccupancyCoarseCanvas_;
+void EcalDisplaysByEvent::deleteEvtByEvtHists() {
+  delete timingEB_;
+  delete timingEEM_;
+  delete timingEEP_;
+  delete timingMapEB_;
+  delete timingMapEEM_;
+  delete timingMapEEP_;
+  delete timingCanvas_;
+  delete timingMapCanvas_;
+  delete energyEB_;
+  delete energyEEM_;
+  delete energyEEP_;
+  delete energyMapEB_;
+  delete energyMapEEM_;
+  delete energyMapEEP_;
+  delete energyMapEBcoarse_;
+  delete energyMapEEMcoarse_;
+  delete energyMapEEPcoarse_;
+  delete energyCanvas_;
+  delete energyMapCanvas_;
+  delete energyMapCoarseCanvas_;
+  delete recHitOccupancyEB_;
+  delete recHitOccupancyEEP_;
+  delete recHitOccupancyEEM_;
+  delete recHitOccupancyEBcoarse_;
+  delete recHitOccupancyEEMcoarse_;
+  delete recHitOccupancyEEPcoarse_;
+  delete digiOccupancyEB_;
+  delete digiOccupancyEEM_;
+  delete digiOccupancyEEP_;
+  delete digiOccupancyEBcoarse_;
+  delete digiOccupancyEEMcoarse_;
+  delete digiOccupancyEEPcoarse_;
+  delete recHitOccupancyCanvas_;
+  delete recHitOccupancyCoarseCanvas_;
+  delete digiOccupancyCanvas_;
+  delete digiOccupancyCoarseCanvas_;
 }
 
-void EcalDisplaysByEvent::initAllEventHistos()
-{
+void EcalDisplaysByEvent::initAllEventHistos() {
   string canvasTitle = "Timing_AllEvents";
-  timingEBAll_ = new TH1F("timeForAllFedsEBAll","timeForAllFeds;Relative Time (1 clock = 25ns)",78,-7,7);
-  timingEEMAll_ = new TH1F("timeForAllFedsEEMAll","timeForAllFeds_EEM;Relative Time (1 clock = 25ns)",78,-7,7);
-  timingEEPAll_ = new TH1F("timeForAllFedsEEPAll","timeForAllFeds_EEP;Relative Time (1 clock = 25ns)",78,-7,7);
-  timingCanvasAll_ = new TCanvas(canvasTitle.c_str(), canvasTitle.c_str(),300,60,500,200);
+  timingEBAll_ = new TH1F("timeForAllFedsEBAll", "timeForAllFeds;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  timingEEMAll_ = new TH1F("timeForAllFedsEEMAll", "timeForAllFeds_EEM;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  timingEEPAll_ = new TH1F("timeForAllFedsEEPAll", "timeForAllFeds_EEP;Relative Time (1 clock = 25ns)", 78, -7, 7);
+  timingCanvasAll_ = new TCanvas(canvasTitle.c_str(), canvasTitle.c_str(), 300, 60, 500, 200);
   timingMapEBAll_ = init3DEcalHist("TimingMapA", EB_FINE);
   timingMapEEMAll_ = init3DEcalHist("TimingMapA", EEM_FINE);
   timingMapEEPAll_ = init3DEcalHist("TimingMapA", EEP_FINE);
@@ -789,212 +704,195 @@ void EcalDisplaysByEvent::initAllEventHistos()
   timingMapEBCoarseAll_ = init3DEcalHist("TimingMapA", EB_COARSE);
   timingMapEEMCoarseAll_ = init3DEcalHist("TimingMapA", EEM_COARSE);
   timingMapEEPCoarseAll_ = init3DEcalHist("TimingMapA", EEP_COARSE);
-  //timingMapCoarseCanvasAll_ = init2DEcalCanvas("TimingMapCoarse_AllEvents"); 
-  energyEBAll_ = new TH1F("energyEBAllEvents","Energy for EB Feds (GeV)",200,histRangeMin_,histRangeMax_);
-  energyEEMAll_ = new TH1F("energyEEMAllEvents","Energy for EEM Feds (GeV)",200,histRangeMin_,10.0);
-  energyEEPAll_ = new TH1F("energyEEPAllEvents","Energy for EEP Feds (GeV)",200,histRangeMin_,10.0);
+  //timingMapCoarseCanvasAll_ = init2DEcalCanvas("TimingMapCoarse_AllEvents");
+  energyEBAll_ = new TH1F("energyEBAllEvents", "Energy for EB Feds (GeV)", 200, histRangeMin_, histRangeMax_);
+  energyEEMAll_ = new TH1F("energyEEMAllEvents", "Energy for EEM Feds (GeV)", 200, histRangeMin_, 10.0);
+  energyEEPAll_ = new TH1F("energyEEPAllEvents", "Energy for EEP Feds (GeV)", 200, histRangeMin_, 10.0);
   canvasTitle = "Energy_AllEvents";
-  energyCanvasAll_ = new TCanvas(canvasTitle.c_str(), canvasTitle.c_str(),300,60,500,200);
+  energyCanvasAll_ = new TCanvas(canvasTitle.c_str(), canvasTitle.c_str(), 300, 60, 500, 200);
 
   // Energy map hists
-  energyMapEBAll_            = init2DEcalHist("EnergyMapA",EB_FINE);
-  energyMapEBcoarseAll_      = init2DEcalHist("EnergyMapA",EB_COARSE);
-  energyMapEEMcoarseAll_           = init2DEcalHist("EnergyMapA",EEM_COARSE);
-  energyMapEEMAll_                 = init2DEcalHist("EnergyMapA",EEM_FINE);
-  energyMapEEPcoarseAll_           = init2DEcalHist("EnergyMapA",EEP_COARSE);
-  energyMapEEPAll_                 = init2DEcalHist("EnergyMapA",EEP_FINE);
+  energyMapEBAll_ = init2DEcalHist("EnergyMapA", EB_FINE);
+  energyMapEBcoarseAll_ = init2DEcalHist("EnergyMapA", EB_COARSE);
+  energyMapEEMcoarseAll_ = init2DEcalHist("EnergyMapA", EEM_COARSE);
+  energyMapEEMAll_ = init2DEcalHist("EnergyMapA", EEM_FINE);
+  energyMapEEPcoarseAll_ = init2DEcalHist("EnergyMapA", EEP_COARSE);
+  energyMapEEPAll_ = init2DEcalHist("EnergyMapA", EEP_FINE);
   energyMapCanvasAll_ = init2DEcalCanvas("EnergyMap_AllEvents");
   energyMapCoarseCanvasAll_ = init2DEcalCanvas("EnergyMapCoarse_AllEvents");
   // RecHit Occupancy
-  recHitOccupancyEBAll_ = init2DEcalHist("RecHitOccupancyA",EB_FINE);
-  recHitOccupancyEBcoarseAll_ = init2DEcalHist("RecHitOccupancyA",EB_COARSE);
-  recHitOccupancyEEMcoarseAll_ = init2DEcalHist("RecHitOccupancyA",EEM_COARSE);
-  recHitOccupancyEEMAll_ = init2DEcalHist("RecHitOccupancyA",EEM_FINE);
-  recHitOccupancyEEPcoarseAll_ = init2DEcalHist("RecHitOccupancyA",EEP_COARSE);
-  recHitOccupancyEEPAll_ = init2DEcalHist("RecHitOccupancyA",EEP_FINE);
+  recHitOccupancyEBAll_ = init2DEcalHist("RecHitOccupancyA", EB_FINE);
+  recHitOccupancyEBcoarseAll_ = init2DEcalHist("RecHitOccupancyA", EB_COARSE);
+  recHitOccupancyEEMcoarseAll_ = init2DEcalHist("RecHitOccupancyA", EEM_COARSE);
+  recHitOccupancyEEMAll_ = init2DEcalHist("RecHitOccupancyA", EEM_FINE);
+  recHitOccupancyEEPcoarseAll_ = init2DEcalHist("RecHitOccupancyA", EEP_COARSE);
+  recHitOccupancyEEPAll_ = init2DEcalHist("RecHitOccupancyA", EEP_FINE);
   recHitOccupancyCanvasAll_ = init2DEcalCanvas("RecHitOccupancy_AllEvents");
-  recHitOccupancyCoarseCanvasAll_ =init2DEcalCanvas("RecHitOccupancyCoarse_AllEvents");
+  recHitOccupancyCoarseCanvasAll_ = init2DEcalCanvas("RecHitOccupancyCoarse_AllEvents");
 
   //DigiOccupancy
-  digiOccupancyEBAll_ = init2DEcalHist("DigiOccupancyA",EB_FINE);
+  digiOccupancyEBAll_ = init2DEcalHist("DigiOccupancyA", EB_FINE);
   digiOccupancyEBcoarseAll_ = init2DEcalHist("DigiOccupancyA", EB_COARSE);
-  digiOccupancyEEMcoarseAll_ = init2DEcalHist("DigiOccupancyA",EEM_COARSE);
-  digiOccupancyEEMAll_ = init2DEcalHist("DigiOccupancyA",EEM_FINE);
-  digiOccupancyEEPcoarseAll_ = init2DEcalHist("DigiOccupancyA",EEP_COARSE);
-  digiOccupancyEEPAll_ = init2DEcalHist("DigiOccupancyA",EEP_FINE);
+  digiOccupancyEEMcoarseAll_ = init2DEcalHist("DigiOccupancyA", EEM_COARSE);
+  digiOccupancyEEMAll_ = init2DEcalHist("DigiOccupancyA", EEM_FINE);
+  digiOccupancyEEPcoarseAll_ = init2DEcalHist("DigiOccupancyA", EEP_COARSE);
+  digiOccupancyEEPAll_ = init2DEcalHist("DigiOccupancyA", EEP_FINE);
   digiOccupancyCanvasAll_ = init2DEcalCanvas("DigiOccupancy_AllEvents");
   digiOccupancyCoarseCanvasAll_ = init2DEcalCanvas("DigiOccupancyCoarse_AllEvents");
-
 }
 
-
 TH3F* EcalDisplaysByEvent::init3DEcalHist(std::string histTypeName, int subDet) {
-   TH3F* hist;
-   bool isBarrel = (subDet == EB_FINE || subDet == EB_COARSE) ? true : false;
-   bool isCoarse = (subDet == EB_COARSE || subDet == EEM_COARSE || subDet == EEP_COARSE) ? true : false; 
-   bool isEEM = (subDet == EEM_FINE || subDet == EEM_COARSE) ? true : false;
-   std::string histName = histTypeName;
-   std::string histTitle = histTypeName;
-   double ttEtaBins[36] = {-85, -80, -75, -70, -65, -60, -55, -50, -45, -40, -35, -30, -25, -20, -15, -10, -5, 0, 1, 6, 11, 16, 21, 26, 31, 36, 41, 46, 51, 56, 61, 66, 71, 76, 81, 86 };
-   double modEtaBins[10]={-85, -65, -45, -25, 0, 1, 26, 46, 66, 86};
-   double ttPhiBins[73];
-   double modPhiBins[19];
-   double timingBins[79];
-   for (int i = 0; i < 79; ++i)
-   {
-      timingBins[i]= 6 - 7. + double(i) * 14. / 78.;
-      if (i<73)  
-      {       
-	 ttPhiBins[i]=1+5*i;
-	 if ( i < 19) 
-	 {       
-	    modPhiBins[i]=1+20*i;
-	 }       
-      }       
+  TH3F* hist;
+  bool isBarrel = (subDet == EB_FINE || subDet == EB_COARSE) ? true : false;
+  bool isCoarse = (subDet == EB_COARSE || subDet == EEM_COARSE || subDet == EEP_COARSE) ? true : false;
+  bool isEEM = (subDet == EEM_FINE || subDet == EEM_COARSE) ? true : false;
+  std::string histName = histTypeName;
+  std::string histTitle = histTypeName;
+  double ttEtaBins[36] = {-85, -80, -75, -70, -65, -60, -55, -50, -45, -40, -35, -30, -25, -20, -15, -10, -5, 0,
+                          1,   6,   11,  16,  21,  26,  31,  36,  41,  46,  51,  56,  61,  66,  71,  76,  81, 86};
+  double modEtaBins[10] = {-85, -65, -45, -25, 0, 1, 26, 46, 66, 86};
+  double ttPhiBins[73];
+  double modPhiBins[19];
+  double timingBins[79];
+  for (int i = 0; i < 79; ++i) {
+    timingBins[i] = 6 - 7. + double(i) * 14. / 78.;
+    if (i < 73) {
+      ttPhiBins[i] = 1 + 5 * i;
+      if (i < 19) {
+        modPhiBins[i] = 1 + 20 * i;
+      }
+    }
+  }
 
-   }
-
-   if(isBarrel) {
-      histName = histName + "EB";
-      histTitle = histTitle + " EB";
-      if(isCoarse) {
-	 histName = histName + "Coarse";
-	 histTitle = histTitle + " by Module Nominal value = 6;iphi;ieta ";
-	 hist = new TH3F(histName.c_str(),histTitle.c_str(),18,modPhiBins,9,modEtaBins,78,timingBins);
-      }
-      else {
-	 histTitle = histTitle + " by TT Nominal value = 6;iphi;ieta";
-	 hist = new TH3F(histName.c_str(),histTitle.c_str(),360/5,ttPhiBins,35,ttEtaBins,78,timingBins);
-      }
-   }
-   else {
-      double ttXBins[21];
-      double ttYBins[21];
-      for(int i=0;i!=21;++i) {
-	 ttXBins[i] = 1 + 5*i;
-	 ttYBins[i] = 1 + 5*i;
-      }
-      if(isEEM) {
-	 histName = histName + "EEM";
-	 histTitle = histTitle + " EEM";
-      }
-      else {
-	 histName = histName + "EEP";
-	 histTitle = histTitle + " EEP";
-      }
-      if(isCoarse) {
-	 histName = histName + "Coarse";
-	 histTitle = histTitle + " by Module Nominal value = 6;ix;iy";
-	 hist = new TH3F(histName.c_str(),histTitle.c_str(),20,ttXBins,20,ttYBins,78,timingBins);
-      }
-      else {
-	 histTitle = histTitle + " by TT Nominal value = 6;ix;iy";
-	 hist = new TH3F(histName.c_str(),histTitle.c_str(),20,ttXBins,20,ttYBins,78,timingBins);
-      }
-   }
-   return hist;
+  if (isBarrel) {
+    histName = histName + "EB";
+    histTitle = histTitle + " EB";
+    if (isCoarse) {
+      histName = histName + "Coarse";
+      histTitle = histTitle + " by Module Nominal value = 6;iphi;ieta ";
+      hist = new TH3F(histName.c_str(), histTitle.c_str(), 18, modPhiBins, 9, modEtaBins, 78, timingBins);
+    } else {
+      histTitle = histTitle + " by TT Nominal value = 6;iphi;ieta";
+      hist = new TH3F(histName.c_str(), histTitle.c_str(), 360 / 5, ttPhiBins, 35, ttEtaBins, 78, timingBins);
+    }
+  } else {
+    double ttXBins[21];
+    double ttYBins[21];
+    for (int i = 0; i != 21; ++i) {
+      ttXBins[i] = 1 + 5 * i;
+      ttYBins[i] = 1 + 5 * i;
+    }
+    if (isEEM) {
+      histName = histName + "EEM";
+      histTitle = histTitle + " EEM";
+    } else {
+      histName = histName + "EEP";
+      histTitle = histTitle + " EEP";
+    }
+    if (isCoarse) {
+      histName = histName + "Coarse";
+      histTitle = histTitle + " by Module Nominal value = 6;ix;iy";
+      hist = new TH3F(histName.c_str(), histTitle.c_str(), 20, ttXBins, 20, ttYBins, 78, timingBins);
+    } else {
+      histTitle = histTitle + " by TT Nominal value = 6;ix;iy";
+      hist = new TH3F(histName.c_str(), histTitle.c_str(), 20, ttXBins, 20, ttYBins, 78, timingBins);
+    }
+  }
+  return hist;
 }
 
 TH2F* EcalDisplaysByEvent::init2DEcalHist(std::string histTypeName, int subDet) {
-   TH2F* hist;
-   bool isBarrel = (subDet == EB_FINE || subDet == EB_COARSE) ? true : false;
-   bool isCoarse = (subDet == EB_COARSE || subDet == EEM_COARSE || subDet == EEP_COARSE) ? true : false; 
-   bool isEEM = (subDet == EEM_FINE || subDet == EEM_COARSE) ? true : false;
-   std::string histName = histTypeName;
-   std::string histTitle = histTypeName;
-   if(isBarrel) {
-      histName = histName + "EB";
-      histTitle = histTitle + " EB";
-      if(isCoarse) {
-	 histName = histName + "Coarse";
-	 histTitle = histTitle + " Coarse;iphi;ieta";
-	 double ttEtaBins[36] = {-85, -80, -75, -70, -65, -60, -55, -50, -45, -40, 
-	    -35, -30, -25, -20, -15, -10, -5, 0, 1, 6, 11, 16, 
-	    21, 26, 31, 36, 41, 46, 51, 56, 61, 66, 71, 76, 81, 86 };
-	 hist = new TH2F(histName.c_str(),histTitle.c_str(),360/5,1,361.,35,ttEtaBins);
-      }
-      else {
-	 histTitle = histTitle + ";iphi;ieta";
-	 hist = new TH2F(histName.c_str(),histTitle.c_str(),360,1,361.,172,-86,86);
-      }
-   }
-   else {
-      if(isEEM) {
-	 histName = histName + "EEM";
-	 histTitle = histTitle + " EEM";
-      }
-      else {
-	 histName = histName + "EEP";
-	 histTitle = histTitle + " EEP";
-      }
-      if(isCoarse) {
-	 histName = histName + "Coarse";
-	 histTitle = histTitle + " Coarse;ix;iy";
-	 hist = new TH2F(histName.c_str(),histTitle.c_str(),20,1,101,20,1,101);
-      }
-      else {
-	 histTitle = histTitle + ";ix;iy";
-	 hist = new TH2F(histName.c_str(),histTitle.c_str(),100,1,101,100,1,101);
-      }
-   }
-   return hist;
+  TH2F* hist;
+  bool isBarrel = (subDet == EB_FINE || subDet == EB_COARSE) ? true : false;
+  bool isCoarse = (subDet == EB_COARSE || subDet == EEM_COARSE || subDet == EEP_COARSE) ? true : false;
+  bool isEEM = (subDet == EEM_FINE || subDet == EEM_COARSE) ? true : false;
+  std::string histName = histTypeName;
+  std::string histTitle = histTypeName;
+  if (isBarrel) {
+    histName = histName + "EB";
+    histTitle = histTitle + " EB";
+    if (isCoarse) {
+      histName = histName + "Coarse";
+      histTitle = histTitle + " Coarse;iphi;ieta";
+      double ttEtaBins[36] = {-85, -80, -75, -70, -65, -60, -55, -50, -45, -40, -35, -30, -25, -20, -15, -10, -5, 0,
+                              1,   6,   11,  16,  21,  26,  31,  36,  41,  46,  51,  56,  61,  66,  71,  76,  81, 86};
+      hist = new TH2F(histName.c_str(), histTitle.c_str(), 360 / 5, 1, 361., 35, ttEtaBins);
+    } else {
+      histTitle = histTitle + ";iphi;ieta";
+      hist = new TH2F(histName.c_str(), histTitle.c_str(), 360, 1, 361., 172, -86, 86);
+    }
+  } else {
+    if (isEEM) {
+      histName = histName + "EEM";
+      histTitle = histTitle + " EEM";
+    } else {
+      histName = histName + "EEP";
+      histTitle = histTitle + " EEP";
+    }
+    if (isCoarse) {
+      histName = histName + "Coarse";
+      histTitle = histTitle + " Coarse;ix;iy";
+      hist = new TH2F(histName.c_str(), histTitle.c_str(), 20, 1, 101, 20, 1, 101);
+    } else {
+      histTitle = histTitle + ";ix;iy";
+      hist = new TH2F(histName.c_str(), histTitle.c_str(), 100, 1, 101, 100, 1, 101);
+    }
+  }
+  return hist;
 }
 
 TCanvas* EcalDisplaysByEvent::init2DEcalCanvas(std::string canvasTitle) {
-    TCanvas* canvas = new TCanvas(canvasTitle.c_str(), canvasTitle.c_str(),300,60,500,200);
-    return canvas;
+  TCanvas* canvas = new TCanvas(canvasTitle.c_str(), canvasTitle.c_str(), 300, 60, 500, 200);
+  return canvas;
 }
 
-void EcalDisplaysByEvent::drawHistos()
-{
-  if(makeTimingHistos_)
-  {
+void EcalDisplaysByEvent::drawHistos() {
+  if (makeTimingHistos_) {
     // Put the timing canvas together
-    drawCanvas(timingCanvas_,timingEEM_,timingEB_,timingEEP_);
+    drawCanvas(timingCanvas_, timingEEM_, timingEB_, timingEEP_);
     //   drawCanvas(timingMapCoarseCanvas_,timingMapEEMCoarse_,timingMapEBCoarse_,timingMapEEPCoarse_);
-    drawCanvas(timingMapCanvas_,timingMapEEM_,timingMapEB_,timingMapEEP_);
+    drawCanvas(timingMapCanvas_, timingMapEEM_, timingMapEB_, timingMapEEP_);
   }
-  if(makeEnergyHistos_)
-  {
+  if (makeEnergyHistos_) {
     // Put the energy canvas together
-    drawCanvas(energyCanvas_,energyEEM_,energyEB_,energyEEP_);
+    drawCanvas(energyCanvas_, energyEEM_, energyEB_, energyEEP_);
     // Put the energy map canvas together
-    drawCanvas(energyMapCanvas_,energyMapEEM_,energyMapEB_,energyMapEEP_);
-    drawCanvas(energyMapCoarseCanvas_,energyMapEEMcoarse_,energyMapEBcoarse_,energyMapEEPcoarse_);
+    drawCanvas(energyMapCanvas_, energyMapEEM_, energyMapEB_, energyMapEEP_);
+    drawCanvas(energyMapCoarseCanvas_, energyMapEEMcoarse_, energyMapEBcoarse_, energyMapEEPcoarse_);
   }
-  if(makeOccupancyHistos_)
-  {
+  if (makeOccupancyHistos_) {
     // Put the occupancy canvas together
-    drawCanvas(recHitOccupancyCanvas_,recHitOccupancyEEM_,recHitOccupancyEB_,recHitOccupancyEEP_);
-    drawCanvas(recHitOccupancyCoarseCanvas_,recHitOccupancyEEMcoarse_,recHitOccupancyEBcoarse_,recHitOccupancyEEPcoarse_);
+    drawCanvas(recHitOccupancyCanvas_, recHitOccupancyEEM_, recHitOccupancyEB_, recHitOccupancyEEP_);
+    drawCanvas(
+        recHitOccupancyCoarseCanvas_, recHitOccupancyEEMcoarse_, recHitOccupancyEBcoarse_, recHitOccupancyEEPcoarse_);
     // And the same for the digis
-    drawCanvas(digiOccupancyCanvas_,digiOccupancyEEM_,digiOccupancyEB_,digiOccupancyEEP_);
-    drawCanvas(digiOccupancyCoarseCanvas_,digiOccupancyEEMcoarse_,digiOccupancyEBcoarse_,digiOccupancyEEPcoarse_);
+    drawCanvas(digiOccupancyCanvas_, digiOccupancyEEM_, digiOccupancyEB_, digiOccupancyEEP_);
+    drawCanvas(digiOccupancyCoarseCanvas_, digiOccupancyEEMcoarse_, digiOccupancyEBcoarse_, digiOccupancyEEPcoarse_);
   }
 }
 
 void EcalDisplaysByEvent::drawCanvas(TCanvas* canvas, TH1F* hist1, TH1F* hist2, TH1F* hist3) {
-  canvas->Divide(1,2); 
-  canvas->cd(1)->Divide(2,1); 
+  canvas->Divide(1, 2);
+  canvas->cd(1)->Divide(2, 1);
   canvas->cd(1)->cd(1);
   hist1->Draw();
-  canvas->cd(2); 
+  canvas->cd(2);
   hist2->Draw();
   canvas->cd(1)->cd(2);
-  hist3->Draw(); 
+  hist3->Draw();
   histoCanvasNamesVector->push_back(canvas->GetName());
-  canvas->SetCanvasSize(500,500);
+  canvas->SetCanvasSize(500, 500);
   canvas->SetFixedAspectRatio(true);
   canvas->Write();
 }
 
 void EcalDisplaysByEvent::drawCanvas(TCanvas* canvas, TH2F* hist1, TH2F* hist2, TH2F* hist3) {
-  canvas->Divide(1,2);
-  canvas->cd(1)->Divide(2,1);
+  canvas->Divide(1, 2);
+  canvas->cd(1)->Divide(2, 1);
   // EEM
   canvas->cd(1)->cd(1);
   hist1->Draw("colz");
-  drawEELines();  
+  drawEELines();
   // EB
   canvas->cd(2);
   hist2->Draw("colz");
@@ -1005,107 +903,116 @@ void EcalDisplaysByEvent::drawCanvas(TCanvas* canvas, TH2F* hist1, TH2F* hist2, 
   // EEP
   canvas->cd(1)->cd(2);
   hist3->Draw("colz");
-  drawEELines();  
+  drawEELines();
   histoCanvasNamesVector->push_back(canvas->GetName());
-  canvas->SetCanvasSize(500,500);
+  canvas->SetCanvasSize(500, 500);
   canvas->SetFixedAspectRatio(true);
   canvas->Write();
 }
 
 void EcalDisplaysByEvent::drawCanvas(TCanvas* canvas, TH3F* hist1, TH3F* hist2, TH3F* hist3) {
-   if(canvas == timingMapCoarseCanvas_) {
-      canvas->cd();
-      TProfile2D* profile2 = (TProfile2D*) hist2->Project3DProfile("yx");
-      profile2->Draw("colz");
-      drawTimingErrors(profile2);
-   }
-   else {
-      canvas->Divide(1,2);
-      canvas->cd(1)->Divide(2,1);
-      // EEM
-      canvas->cd(1)->cd(1);
-      TProfile2D* profile1 = (TProfile2D*) hist1->Project3DProfile("yx");
-      profile1->Draw("colz");
-      drawEELines();  
-      // EB
-      canvas->cd(2);
-      TProfile2D* profile2 = (TProfile2D*) hist2->Project3DProfile("yx");
-      profile2->Draw("colz");
-      profile2->GetXaxis()->SetNdivisions(-18);
-      profile2->GetYaxis()->SetNdivisions(2);
-      canvas->GetPad(2)->SetGridx(1);
-      canvas->GetPad(2)->SetGridy(1);
-      // EEP
-      canvas->cd(1)->cd(2);
-      TProfile2D* profile3 = (TProfile2D*) hist3->Project3DProfile("yx");
-      profile3->Draw("colz");
-      drawEELines();  
-   }
-   histoCanvasNamesVector->push_back(canvas->GetName());
-   canvas->SetCanvasSize(500,500);
-   canvas->SetFixedAspectRatio(true);
-   canvas->Write();
+  if (canvas == timingMapCoarseCanvas_) {
+    canvas->cd();
+    TProfile2D* profile2 = (TProfile2D*)hist2->Project3DProfile("yx");
+    profile2->Draw("colz");
+    drawTimingErrors(profile2);
+  } else {
+    canvas->Divide(1, 2);
+    canvas->cd(1)->Divide(2, 1);
+    // EEM
+    canvas->cd(1)->cd(1);
+    TProfile2D* profile1 = (TProfile2D*)hist1->Project3DProfile("yx");
+    profile1->Draw("colz");
+    drawEELines();
+    // EB
+    canvas->cd(2);
+    TProfile2D* profile2 = (TProfile2D*)hist2->Project3DProfile("yx");
+    profile2->Draw("colz");
+    profile2->GetXaxis()->SetNdivisions(-18);
+    profile2->GetYaxis()->SetNdivisions(2);
+    canvas->GetPad(2)->SetGridx(1);
+    canvas->GetPad(2)->SetGridy(1);
+    // EEP
+    canvas->cd(1)->cd(2);
+    TProfile2D* profile3 = (TProfile2D*)hist3->Project3DProfile("yx");
+    profile3->Draw("colz");
+    drawEELines();
+  }
+  histoCanvasNamesVector->push_back(canvas->GetName());
+  canvas->SetCanvasSize(500, 500);
+  canvas->SetFixedAspectRatio(true);
+  canvas->Write();
 }
 
 void EcalDisplaysByEvent::drawTimingErrors(TProfile2D* profile) {
-   int nxb = profile->GetNbinsX();
-   int nyb = profile->GetNbinsY();
-   char tempErr[200];
-   for(int i=0;i!=nxb;++i) {
-      for(int j=0;j!=nyb;++j) {
-	 int xb = i+1;
-	 int yb = j+1;
-//   std::cout << "xb: " << xb << "\tyb: " << yb << std::endl;
-	 double xcorr = profile->GetBinCenter(xb);
-	 double ycorr = profile->GetBinCenter(yb);
-	 sprintf(tempErr,"%0.2f",profile->GetBinError(xb,yb));
-	 int nBin = profile->GetBin(xb,yb,0);
-	 int nBinEntries = (int) profile->GetBinEntries(nBin);
-	 if(nBinEntries != 0) {
-	    TLatex* tex = new TLatex(xcorr,ycorr,tempErr);
-	    tex->SetTextAlign(23);
-	    tex->SetTextSize(42);
-	    tex->SetTextSize(0.025);
-	    tex->SetLineWidth(2);
-	    tex->Draw();
-            delete tex;
-	 }
-	 sprintf(tempErr,"%i",nBinEntries);
-	 if(nBinEntries!=0) {
-	    TLatex* tex = new TLatex(xcorr,ycorr,tempErr);
-	    tex->SetTextAlign(21);
-	    tex->SetTextFont(42);
-	    tex->SetTextSize(0.025);
-	    tex->SetLineWidth(2);
-	    tex->Draw();
-            delete tex;
-	 }
+  int nxb = profile->GetNbinsX();
+  int nyb = profile->GetNbinsY();
+  char tempErr[200];
+  for (int i = 0; i != nxb; ++i) {
+    for (int j = 0; j != nyb; ++j) {
+      int xb = i + 1;
+      int yb = j + 1;
+      //   std::cout << "xb: " << xb << "\tyb: " << yb << std::endl;
+      double xcorr = profile->GetBinCenter(xb);
+      double ycorr = profile->GetBinCenter(yb);
+      sprintf(tempErr, "%0.2f", profile->GetBinError(xb, yb));
+      int nBin = profile->GetBin(xb, yb, 0);
+      int nBinEntries = (int)profile->GetBinEntries(nBin);
+      if (nBinEntries != 0) {
+        TLatex* tex = new TLatex(xcorr, ycorr, tempErr);
+        tex->SetTextAlign(23);
+        tex->SetTextSize(42);
+        tex->SetTextSize(0.025);
+        tex->SetLineWidth(2);
+        tex->Draw();
+        delete tex;
       }
-   }
+      sprintf(tempErr, "%i", nBinEntries);
+      if (nBinEntries != 0) {
+        TLatex* tex = new TLatex(xcorr, ycorr, tempErr);
+        tex->SetTextAlign(21);
+        tex->SetTextFont(42);
+        tex->SetTextSize(0.025);
+        tex->SetLineWidth(2);
+        tex->Draw();
+        delete tex;
+      }
+    }
+  }
 }
 
 void EcalDisplaysByEvent::drawEELines() {
+  int ixSectorsEE[202] = {
+      61, 61, 60, 60, 59, 59, 58, 58, 57, 57, 55, 55, 45, 45, 43, 43, 42, 42, 41, 41,  40,  40,  39,  39, 40, 40,
+      41, 41, 42, 42, 43, 43, 45, 45, 55, 55, 57, 57, 58, 58, 59, 59, 60, 60, 61, 61,  0,   100, 100, 97, 97, 95,
+      95, 92, 92, 87, 87, 85, 85, 80, 80, 75, 75, 65, 65, 60, 60, 40, 40, 35, 35, 25,  25,  20,  20,  15, 15, 13,
+      13, 8,  8,  5,  5,  3,  3,  0,  0,  3,  3,  5,  5,  8,  8,  13, 13, 15, 15, 20,  20,  25,  25,  35, 35, 40,
+      40, 60, 60, 65, 65, 75, 75, 80, 80, 85, 85, 87, 87, 92, 92, 95, 95, 97, 97, 100, 100, 0,   61,  65, 65, 70,
+      70, 80, 80, 90, 90, 92, 0,  61, 65, 65, 90, 90, 97, 0,  57, 60, 60, 65, 65, 70,  70,  75,  75,  80, 80, 0,
+      50, 50, 0,  43, 40, 40, 35, 35, 30, 30, 25, 25, 20, 20, 0,  39, 35, 35, 10, 10,  3,   0,   39,  35, 35, 30,
+      30, 20, 20, 10, 10, 8,  0,  45, 45, 40, 40, 35, 35, 0,  55, 55, 60, 60, 65, 65};
 
-  int ixSectorsEE[202] = {61, 61, 60, 60, 59, 59, 58, 58, 57, 57, 55, 55, 45, 45, 43, 43, 42, 42, 41, 41, 40, 40, 39, 39, 40, 40, 41, 41, 42, 42, 43, 43, 45, 45, 55, 55, 57, 57, 58, 58, 59, 59, 60, 60, 61, 61, 0,100,100, 97, 97, 95, 95, 92, 92, 87, 87, 85, 85, 80, 80, 75, 75, 65, 65, 60, 60, 40, 40, 35, 35, 25, 25, 20, 20, 15, 15, 13, 13,  8,  8,  5,  5,  3,  3,  0,  0,  3,  3,  5,  5,  8,  8, 13, 13, 15, 15, 20, 20, 25, 25, 35, 35, 40, 40, 60, 60, 65, 65, 75, 75, 80, 80, 85, 85, 87, 87, 92, 92, 95, 95, 97, 97,100,100,  0, 61, 65, 65, 70, 70, 80, 80, 90, 90, 92,  0, 61, 65, 65, 90, 90, 97,  0, 57, 60, 60, 65, 65, 70, 70, 75, 75, 80, 80,  0, 50, 50,  0, 43, 40, 40, 35, 35, 30, 30, 25, 25, 20, 20,  0, 39, 35, 35, 10, 10,  3,  0, 39, 35, 35, 30, 30, 20, 20, 10, 10,  8,  0, 45, 45, 40, 40, 35, 35,  0, 55, 55, 60, 60, 65, 65};
- 
-  int iySectorsEE[202] = {50, 55, 55, 57, 57, 58, 58, 59, 59, 60, 60, 61, 61, 60, 60, 59, 59, 58, 58, 57, 57, 55, 55, 45, 45, 43, 43, 42, 42, 41, 41, 40, 40, 39, 39, 40, 40, 41, 41, 42, 42, 43, 43, 45, 45, 50,  0, 50, 60, 60, 65, 65, 75, 75, 80, 80, 85, 85, 87, 87, 92, 92, 95, 95, 97, 97,100,100, 97, 97, 95, 95, 92, 92, 87, 87, 85, 85, 80, 80, 75, 75, 65, 65, 60, 60, 40, 40, 35, 35, 25, 25, 20, 20, 15, 15, 13, 13,  8,  8,  5,  5,  3,  3,  0,  0,  3,  3,  5,  5,  8,  8, 13, 13, 15, 15, 20, 20, 25, 25, 35, 35, 40, 40, 50,  0, 45, 45, 40, 40, 35, 35, 30, 30, 25, 25,  0, 50, 50, 55, 55, 60, 60,  0, 60, 60, 65, 65, 70, 70, 75, 75, 85, 85, 87,  0, 61,100,  0, 60, 60, 65, 65, 70, 70, 75, 75, 85, 85, 87,  0, 50, 50, 55, 55, 60, 60,  0, 45, 45, 40, 40, 35, 35, 30, 30, 25, 25,  0, 39, 30, 30, 15, 15,  5,  0, 39, 30, 30, 15, 15,  5};
+  int iySectorsEE[202] = {50, 55, 55, 57, 57, 58, 58, 59, 59, 60, 60, 61, 61, 60, 60, 59, 59, 58, 58, 57,  57,  55,  55,
+                          45, 45, 43, 43, 42, 42, 41, 41, 40, 40, 39, 39, 40, 40, 41, 41, 42, 42, 43, 43,  45,  45,  50,
+                          0,  50, 60, 60, 65, 65, 75, 75, 80, 80, 85, 85, 87, 87, 92, 92, 95, 95, 97, 97,  100, 100, 97,
+                          97, 95, 95, 92, 92, 87, 87, 85, 85, 80, 80, 75, 75, 65, 65, 60, 60, 40, 40, 35,  35,  25,  25,
+                          20, 20, 15, 15, 13, 13, 8,  8,  5,  5,  3,  3,  0,  0,  3,  3,  5,  5,  8,  8,   13,  13,  15,
+                          15, 20, 20, 25, 25, 35, 35, 40, 40, 50, 0,  45, 45, 40, 40, 35, 35, 30, 30, 25,  25,  0,   50,
+                          50, 55, 55, 60, 60, 0,  60, 60, 65, 65, 70, 70, 75, 75, 85, 85, 87, 0,  61, 100, 0,   60,  60,
+                          65, 65, 70, 70, 75, 75, 85, 85, 87, 0,  50, 50, 55, 55, 60, 60, 0,  45, 45, 40,  40,  35,  35,
+                          30, 30, 25, 25, 0,  39, 30, 30, 15, 15, 5,  0,  39, 30, 30, 15, 15, 5};
 
+  for (int i = 0; i < 202; i++) {
+    ixSectorsEE[i] += 1;
+    iySectorsEE[i] += 1;
+    //   std::cout << i << " " << ixSectorsEE[i] << " " << iySectorsEE[i] << std::endl;
+  }
 
- for ( int i=0; i<202; i++) {
-   ixSectorsEE[i] += 1;
-   iySectorsEE[i] += 1;
-//   std::cout << i << " " << ixSectorsEE[i] << " " << iySectorsEE[i] << std::endl;
- }
-
- TLine l;
- l.SetLineWidth(1);
- for ( int i=0; i<201; i=i+1) {
-   if ( (ixSectorsEE[i]!=1 || iySectorsEE[i]!=1) && 
-	(ixSectorsEE[i+1]!=1 || iySectorsEE[i+1]!=1) ) {
-     l.DrawLine(ixSectorsEE[i], iySectorsEE[i], 
-		ixSectorsEE[i+1], iySectorsEE[i+1]);
-   }
- }
-
-
+  TLine l;
+  l.SetLineWidth(1);
+  for (int i = 0; i < 201; i = i + 1) {
+    if ((ixSectorsEE[i] != 1 || iySectorsEE[i] != 1) && (ixSectorsEE[i + 1] != 1 || iySectorsEE[i + 1] != 1)) {
+      l.DrawLine(ixSectorsEE[i], iySectorsEE[i], ixSectorsEE[i + 1], iySectorsEE[i + 1]);
+    }
+  }
 }

--- a/CaloOnlineTools/EcalTools/plugins/EcalDisplaysByEvent.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalDisplaysByEvent.h
@@ -1,8 +1,8 @@
 // -*- C++ -*-
 //
-// Package:   EcalDisplaysByEvent 
-// Class:     EcalDisplaysByEvent 
-// 
+// Package:   EcalDisplaysByEvent
+// Class:     EcalDisplaysByEvent
+//
 /**\class EcalDisplaysByEvent EcalDisplaysByEvent.cc
 
  Description: <one line class summary>
@@ -15,7 +15,6 @@
 //         Created:  Th Aug 28 5:46:22 CEST 2007
 //
 //
-
 
 // system include files
 #include <memory>
@@ -56,53 +55,43 @@
 #include "TTree.h"
 #include "TCanvas.h"
 
-
 //
 // class declaration
 //
 
 class EcalDisplaysByEvent : public edm::EDAnalyzer {
-   public:
-      explicit EcalDisplaysByEvent(const edm::ParameterSet&);
-      ~EcalDisplaysByEvent() override;
+public:
+  explicit EcalDisplaysByEvent(const edm::ParameterSet&);
+  ~EcalDisplaysByEvent() override;
 
+private:
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
+  void endJob() override;
+  std::string intToString(int num);
+  std::string floatToString(float num);
+  void initHists(int);
+  void initEvtByEvtHists(int naiveEvtNum_, int ievt);
+  void deleteEvtByEvtHists();
+  void initAllEventHistos();
+  enum Ecal2DHistSubDetType { EB_FINE = 0, EB_COARSE = 1, EEM_FINE = 2, EEM_COARSE = 3, EEP_FINE = 4, EEP_COARSE = 5 };
+  TH2F* init2DEcalHist(std::string histTypeName, int subDet);
+  TH3F* init3DEcalHist(std::string histTypeName, int dubDet);
+  TCanvas* init2DEcalCanvas(std::string canvasName);
+  void selectHits(edm::Handle<EcalRecHitCollection> hits, int ievt, edm::ESHandle<CaloTopology> caloTopo);
+  TGraph* selectDigi(DetId det, int ievt);
+  int getEEIndex(EcalElectronicsId elecId);
+  void makeHistos(edm::Handle<EBDigiCollection> ebDigis);
+  void makeHistos(edm::Handle<EEDigiCollection> eeDigis);
+  void makeHistos(edm::Handle<EcalRecHitCollection> hits);
+  void drawHistos();
+  void drawCanvas(TCanvas* canvas, TH1F* hist1, TH1F* hist2, TH1F* hist3);
+  void drawCanvas(TCanvas* canvas, TH2F* hist1, TH2F* hist2, TH2F* hist3);
+  void drawCanvas(TCanvas* canvas, TH3F* hist1, TH3F* hist2, TH3F* hist3);
+  void drawTimingErrors(TProfile2D* profile);
+  void drawEELines();
 
-   private:
-      void beginRun(edm::Run const &, edm::EventSetup const &) override ;
-      void analyze(edm::Event const &, edm::EventSetup const &) override;
-      void endJob() override ;
-      std::string intToString(int num);
-      std::string floatToString(float num);
-      void initHists(int);
-      void initEvtByEvtHists(int naiveEvtNum_, int ievt);
-      void deleteEvtByEvtHists();
-      void initAllEventHistos();
-      enum Ecal2DHistSubDetType {
-	 EB_FINE 	= 0,
-	 EB_COARSE 	= 1,
-	 EEM_FINE	= 2,
-	 EEM_COARSE	= 3,
-	 EEP_FINE	= 4,
-	 EEP_COARSE	= 5
-      };
-      TH2F* init2DEcalHist(std::string histTypeName, int subDet);
-      TH3F* init3DEcalHist(std::string histTypeName, int dubDet);
-      TCanvas* init2DEcalCanvas(std::string canvasName);
-      void selectHits(edm::Handle<EcalRecHitCollection> hits,
-          int ievt, edm::ESHandle<CaloTopology> caloTopo);
-      TGraph* selectDigi(DetId det, int ievt);
-      int getEEIndex(EcalElectronicsId elecId);
-      void makeHistos(edm::Handle<EBDigiCollection> ebDigis);
-      void makeHistos(edm::Handle<EEDigiCollection> eeDigis);
-      void makeHistos(edm::Handle<EcalRecHitCollection> hits);
-      void drawHistos();
-      void drawCanvas(TCanvas* canvas, TH1F* hist1, TH1F* hist2, TH1F* hist3);
-      void drawCanvas(TCanvas* canvas, TH2F* hist1, TH2F* hist2, TH2F* hist3);
-      void drawCanvas(TCanvas* canvas, TH3F* hist1, TH3F* hist2, TH3F* hist3);
-      void drawTimingErrors(TProfile2D* profile);
-      void drawEELines();
-
-    // ----------member data ---------------------------
+  // ----------member data ---------------------------
 
   edm::InputTag EBRecHitCollection_;
   edm::InputTag EERecHitCollection_;
@@ -128,7 +117,7 @@ class EcalDisplaysByEvent : public edm::EDAnalyzer {
 
   std::set<EBDetId> listEBChannels;
   std::set<EEDetId> listEEChannels;
-    
+
   int abscissa[10];
   int ordinate[10];
 
@@ -141,11 +130,11 @@ class EcalDisplaysByEvent : public edm::EDAnalyzer {
   std::vector<int> maskedFEDs_;
   std::vector<int> seedCrys_;
   std::vector<std::string> maskedEBs_;
-  std::map<int,TH1F*> FEDsAndTimingHists_;
-  std::map<int,float> crysAndAmplitudesMap_;
-  std::map<int,EcalDCCHeaderBlock> FEDsAndDCCHeaders_;
-  std::map<std::string,int> seedFrequencyMap_;
-  
+  std::map<int, TH1F*> FEDsAndTimingHists_;
+  std::map<int, float> crysAndAmplitudesMap_;
+  std::map<int, EcalDCCHeaderBlock> FEDsAndDCCHeaders_;
+  std::map<std::string, int> seedFrequencyMap_;
+
   TH1F* allFedsTimingHist_;
   // For event-by-evet histos
   TH1F* timingEB_;
@@ -230,11 +219,11 @@ class EcalDisplaysByEvent : public edm::EDAnalyzer {
   TCanvas* digiOccupancyCoarseCanvasAll_;
   TCanvas* timingMapCoarseCanvasAll_;
   TCanvas* timingMapCanvasAll_;
-  
+
   TTree* canvasNames_;
   TTree* histoCanvasNames_;
   EcalFedMap* fedMap_;
   const EcalElectronicsMapping* ecalElectronicsMap_;
- 
-  int naiveEvtNum_; 
+
+  int naiveEvtNum_;
 };

--- a/CaloOnlineTools/EcalTools/plugins/EcalExclusiveTrigFilter.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalExclusiveTrigFilter.cc
@@ -2,7 +2,7 @@
 //
 // Package:    EcalExclusiveTrigFilter
 // Class:      EcalExclusiveTrigFilter
-// 
+//
 /**\class EcalExclusiveTrigFilter EcalExclusiveTrigFilter.cc CaloOnlineTools/EcalExclusiveTrigFilter/src/EcalExclusiveTrigFilter.cc
 
  Description: <one line class summary>
@@ -33,77 +33,61 @@ using namespace std;
 //
 // constructors and destructor
 //
-EcalExclusiveTrigFilter::EcalExclusiveTrigFilter(const edm::ParameterSet& iConfig) :
-  l1GTReadoutRecTag_ (iConfig.getUntrackedParameter<std::string>("L1GlobalReadoutRecord","gtDigis"))
-{
-   //now do what ever initialization is needed
-
+EcalExclusiveTrigFilter::EcalExclusiveTrigFilter(const edm::ParameterSet& iConfig)
+    : l1GTReadoutRecTag_(iConfig.getUntrackedParameter<std::string>("L1GlobalReadoutRecord", "gtDigis")) {
+  //now do what ever initialization is needed
 }
 
-
-EcalExclusiveTrigFilter::~EcalExclusiveTrigFilter()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+EcalExclusiveTrigFilter::~EcalExclusiveTrigFilter() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called on each new Event  ------------
-bool
-EcalExclusiveTrigFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+bool EcalExclusiveTrigFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // get the GMTReadoutCollection
-  Handle<L1MuGMTReadoutCollection> gmtrc_handle; 
-  iEvent.getByLabel(l1GTReadoutRecTag_,gmtrc_handle);
+  Handle<L1MuGMTReadoutCollection> gmtrc_handle;
+  iEvent.getByLabel(l1GTReadoutRecTag_, gmtrc_handle);
   L1MuGMTReadoutCollection const* gmtrc = gmtrc_handle.product();
-  if (!(gmtrc_handle.isValid())) 
-  {
-    LogWarning("EcalExclusiveTrigFilter") << "l1MuGMTReadoutCollection" << " not available";
+  if (!(gmtrc_handle.isValid())) {
+    LogWarning("EcalExclusiveTrigFilter") << "l1MuGMTReadoutCollection"
+                                          << " not available";
     //return;
   }
 
   // get hold of L1GlobalReadoutRecord
   Handle<L1GlobalTriggerReadoutRecord> L1GTRR;
-  iEvent.getByLabel(l1GTReadoutRecTag_,L1GTRR);
+  iEvent.getByLabel(l1GTReadoutRecTag_, L1GTRR);
   bool isEcalL1 = false;
   const unsigned int sizeOfDecisionWord(L1GTRR->decisionWord().size());
-  if (!(L1GTRR.isValid()))
-  {
+  if (!(L1GTRR.isValid())) {
     LogWarning("EcalExclusiveTrigFilter") << l1GTReadoutRecTag_ << " not available";
     //return;
-  }
-  else if(sizeOfDecisionWord<128)
-  {
-    LogWarning("EcalExclusiveTrigFilter") << "size of L1 decisionword is " << sizeOfDecisionWord
-      << "; L1 Ecal triggering bits not available";
-  }
-  else
-  {
+  } else if (sizeOfDecisionWord < 128) {
+    LogWarning("EcalExclusiveTrigFilter")
+        << "size of L1 decisionword is " << sizeOfDecisionWord << "; L1 Ecal triggering bits not available";
+  } else {
     l1Names_.resize(sizeOfDecisionWord);
     l1Accepts_.resize(sizeOfDecisionWord);
-    for (unsigned int i=0; i!=sizeOfDecisionWord; ++i) {
-      l1Accepts_[i]=0;
-      l1Names_[i]="NameNotAvailable";
+    for (unsigned int i = 0; i != sizeOfDecisionWord; ++i) {
+      l1Accepts_[i] = 0;
+      l1Names_[i] = "NameNotAvailable";
     }
-    for (unsigned int i=0; i!=sizeOfDecisionWord; ++i) {
-      if (L1GTRR->decisionWord()[i])
-      {
+    for (unsigned int i = 0; i != sizeOfDecisionWord; ++i) {
+      if (L1GTRR->decisionWord()[i]) {
         l1Accepts_[i]++;
         //cout << "L1A bit: " << i << endl;
       }
     }
 
-    if(l1Accepts_[14] || l1Accepts_[15] || l1Accepts_[16] || l1Accepts_[17]
-        || l1Accepts_[18] || l1Accepts_[19] || l1Accepts_[20])
+    if (l1Accepts_[14] || l1Accepts_[15] || l1Accepts_[16] || l1Accepts_[17] || l1Accepts_[18] || l1Accepts_[19] ||
+        l1Accepts_[20])
       isEcalL1 = true;
-    if(l1Accepts_[73] || l1Accepts_[74] || l1Accepts_[75] || l1Accepts_[76]
-        || l1Accepts_[77] || l1Accepts_[78])
+    if (l1Accepts_[73] || l1Accepts_[74] || l1Accepts_[75] || l1Accepts_[76] || l1Accepts_[77] || l1Accepts_[78])
       isEcalL1 = true;
   }
 
@@ -115,78 +99,95 @@ EcalExclusiveTrigFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
   std::vector<L1MuGMTReadoutRecord> gmt_records = gmtrc->getRecords();
   std::vector<L1MuGMTReadoutRecord>::const_iterator igmtrr;
 
-    for(igmtrr=gmt_records.begin(); igmtrr!=gmt_records.end(); igmtrr++) {
+  for (igmtrr = gmt_records.begin(); igmtrr != gmt_records.end(); igmtrr++) {
+    std::vector<L1MuRegionalCand>::const_iterator iter1;
+    std::vector<L1MuRegionalCand> rmc;
 
-      std::vector<L1MuRegionalCand>::const_iterator iter1;
-      std::vector<L1MuRegionalCand> rmc;
-
-      //DT triggers
-      int idt = 0;
-      rmc = igmtrr->getDTBXCands();
-      for(iter1=rmc.begin(); iter1!=rmc.end(); iter1++) {
-        if ( !(*iter1).empty() ) {
-          idt++;
-        }
+    //DT triggers
+    int idt = 0;
+    rmc = igmtrr->getDTBXCands();
+    for (iter1 = rmc.begin(); iter1 != rmc.end(); iter1++) {
+      if (!(*iter1).empty()) {
+        idt++;
       }
-
-      //if(idt>0) std::cout << "Found " << idt << " valid DT candidates in bx wrt. L1A = " 
-      //  << igmtrr->getBxInEvent() << std::endl;
-      if(igmtrr->getBxInEvent()==0 && idt>0) isDTL1 = true;
-
-      //RPC triggers
-      int irpcb = 0;
-      rmc = igmtrr->getBrlRPCCands();
-      for(iter1=rmc.begin(); iter1!=rmc.end(); iter1++) {
-        if ( !(*iter1).empty() ) {
-          irpcb++;
-        }
-      }
-
-      //if(irpcb>0) std::cout << "Found " << irpcb << " valid RPC candidates in bx wrt. L1A = " 
-      //  << igmtrr->getBxInEvent() << std::endl;
-      if(igmtrr->getBxInEvent()==0 && irpcb>0) isRPCL1 = true;
-
-      //CSC Triggers
-      int icsc = 0;
-      rmc = igmtrr->getCSCCands();
-      for(iter1=rmc.begin(); iter1!=rmc.end(); iter1++) {
-        if ( !(*iter1).empty() ) {
-          icsc++;
-        }
-      }
-      //if(icsc>0) std::cout << "Found " << icsc << " valid CSC candidates in bx wrt. L1A = " 
-      //    //  << igmtrr->getBxInEvent() << std::endl;
-      if(igmtrr->getBxInEvent()==0 && icsc>0) isCSCL1 = true;
     }
 
-    L1GlobalTriggerReadoutRecord const* gtrr = L1GTRR.product();
+    //if(idt>0) std::cout << "Found " << idt << " valid DT candidates in bx wrt. L1A = "
+    //  << igmtrr->getBxInEvent() << std::endl;
+    if (igmtrr->getBxInEvent() == 0 && idt > 0)
+      isDTL1 = true;
 
-    for(int ibx=-1; ibx<=1; ibx++) {
-      bool hcal_top = false;
-      bool hcal_bot = false;
-      const L1GtPsbWord psb = gtrr->gtPsbWord(0xbb0d,ibx);
-      std::vector<int> valid_phi;
-      if((psb.aData(4)&0x3f) >= 1) {valid_phi.push_back( (psb.aData(4)>>10)&0x1f ); }
-      if((psb.bData(4)&0x3f) >= 1) {valid_phi.push_back( (psb.bData(4)>>10)&0x1f ); }
-      if((psb.aData(5)&0x3f) >= 1) {valid_phi.push_back( (psb.aData(5)>>10)&0x1f ); }
-      if((psb.bData(5)&0x3f) >= 1) {valid_phi.push_back( (psb.bData(5)>>10)&0x1f ); }
-      std::vector<int>::const_iterator iphi;
-      for(iphi=valid_phi.begin(); iphi!=valid_phi.end(); iphi++) {
-        //std::cout << "Found HCAL mip with phi=" << *iphi << " in bx wrt. L1A = " << ibx << std::endl;
-        if(*iphi<9) hcal_top=true;
-        if(*iphi>8) hcal_bot=true;
+    //RPC triggers
+    int irpcb = 0;
+    rmc = igmtrr->getBrlRPCCands();
+    for (iter1 = rmc.begin(); iter1 != rmc.end(); iter1++) {
+      if (!(*iter1).empty()) {
+        irpcb++;
       }
-      if(ibx==0 && hcal_top && hcal_bot) isHCALL1=true;
     }
 
-    std::cout << "**** Trigger Source ****" << std::endl;
-    if(isDTL1) std::cout << "DT" << std::endl;
-    if(isRPCL1) std::cout << "RPC" << std::endl;
-    if(isCSCL1) cout << "CSC" << endl;
-    if(isHCALL1) std::cout << "HCAL" << std::endl;
-    if(isEcalL1) std::cout << "ECAL" << std::endl;
-    std::cout << "************************" << std::endl;
+    //if(irpcb>0) std::cout << "Found " << irpcb << " valid RPC candidates in bx wrt. L1A = "
+    //  << igmtrr->getBxInEvent() << std::endl;
+    if (igmtrr->getBxInEvent() == 0 && irpcb > 0)
+      isRPCL1 = true;
 
-    return(isEcalL1 && !isDTL1 && !isRPCL1 && !isCSCL1 && !isHCALL1);
+    //CSC Triggers
+    int icsc = 0;
+    rmc = igmtrr->getCSCCands();
+    for (iter1 = rmc.begin(); iter1 != rmc.end(); iter1++) {
+      if (!(*iter1).empty()) {
+        icsc++;
+      }
+    }
+    //if(icsc>0) std::cout << "Found " << icsc << " valid CSC candidates in bx wrt. L1A = "
+    //    //  << igmtrr->getBxInEvent() << std::endl;
+    if (igmtrr->getBxInEvent() == 0 && icsc > 0)
+      isCSCL1 = true;
+  }
 
+  L1GlobalTriggerReadoutRecord const* gtrr = L1GTRR.product();
+
+  for (int ibx = -1; ibx <= 1; ibx++) {
+    bool hcal_top = false;
+    bool hcal_bot = false;
+    const L1GtPsbWord psb = gtrr->gtPsbWord(0xbb0d, ibx);
+    std::vector<int> valid_phi;
+    if ((psb.aData(4) & 0x3f) >= 1) {
+      valid_phi.push_back((psb.aData(4) >> 10) & 0x1f);
+    }
+    if ((psb.bData(4) & 0x3f) >= 1) {
+      valid_phi.push_back((psb.bData(4) >> 10) & 0x1f);
+    }
+    if ((psb.aData(5) & 0x3f) >= 1) {
+      valid_phi.push_back((psb.aData(5) >> 10) & 0x1f);
+    }
+    if ((psb.bData(5) & 0x3f) >= 1) {
+      valid_phi.push_back((psb.bData(5) >> 10) & 0x1f);
+    }
+    std::vector<int>::const_iterator iphi;
+    for (iphi = valid_phi.begin(); iphi != valid_phi.end(); iphi++) {
+      //std::cout << "Found HCAL mip with phi=" << *iphi << " in bx wrt. L1A = " << ibx << std::endl;
+      if (*iphi < 9)
+        hcal_top = true;
+      if (*iphi > 8)
+        hcal_bot = true;
+    }
+    if (ibx == 0 && hcal_top && hcal_bot)
+      isHCALL1 = true;
+  }
+
+  std::cout << "**** Trigger Source ****" << std::endl;
+  if (isDTL1)
+    std::cout << "DT" << std::endl;
+  if (isRPCL1)
+    std::cout << "RPC" << std::endl;
+  if (isCSCL1)
+    cout << "CSC" << endl;
+  if (isHCALL1)
+    std::cout << "HCAL" << std::endl;
+  if (isEcalL1)
+    std::cout << "ECAL" << std::endl;
+  std::cout << "************************" << std::endl;
+
+  return (isEcalL1 && !isDTL1 && !isRPCL1 && !isCSCL1 && !isHCALL1);
 }

--- a/CaloOnlineTools/EcalTools/plugins/EcalExclusiveTrigFilter.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalExclusiveTrigFilter.h
@@ -2,7 +2,7 @@
 //
 // Package:    EcalExclusiveTrigFilter
 // Class:      EcalExclusiveTrigFilter
-// 
+//
 /**\class EcalExclusiveTrigFilter EcalExclusiveTrigFilter.cc CaloOnlineTools/EcalExclusiveTrigFilter/src/EcalExclusiveTrigFilter.cc
 
  Description: <one line class summary>
@@ -15,7 +15,6 @@
 //         Created:  Thu May 22 11:40:12 CEST 2008
 //
 //
-
 
 // system include files
 #include <memory>
@@ -36,15 +35,15 @@
 //
 
 class EcalExclusiveTrigFilter : public edm::EDFilter {
-   public:
-      explicit EcalExclusiveTrigFilter(const edm::ParameterSet&);
-      ~EcalExclusiveTrigFilter() override;
+public:
+  explicit EcalExclusiveTrigFilter(const edm::ParameterSet&);
+  ~EcalExclusiveTrigFilter() override;
 
-   private:
-      bool filter(edm::Event&, const edm::EventSetup&) override;
-      
-      // ----------member data ---------------------------
-        edm::InputTag l1GTReadoutRecTag_;        
-        std::vector<int> l1Accepts_;
-        std::vector<std::string> l1Names_;
+private:
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+
+  // ----------member data ---------------------------
+  edm::InputTag l1GTReadoutRecTag_;
+  std::vector<int> l1Accepts_;
+  std::vector<std::string> l1Names_;
 };

--- a/CaloOnlineTools/EcalTools/plugins/EcalFEDErrorFilter.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalFEDErrorFilter.cc
@@ -18,70 +18,59 @@ Implementation:
 
 #include "CaloOnlineTools/EcalTools/plugins/EcalFEDErrorFilter.h"
 
-
 //
 // constructors and destructor
 //
-EcalFEDErrorFilter::EcalFEDErrorFilter(const edm::ParameterSet& iConfig) :
-  HLTFilter(iConfig)
-{
+EcalFEDErrorFilter::EcalFEDErrorFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) {
   //now do what ever initialization is needed
 
-  DataLabel_     = iConfig.getParameter<edm::InputTag>("InputLabel");
-  fedUnpackList_ = iConfig.getUntrackedParameter< std::vector<int> >("FEDs", std::vector<int>());
+  DataLabel_ = iConfig.getParameter<edm::InputTag>("InputLabel");
+  fedUnpackList_ = iConfig.getUntrackedParameter<std::vector<int> >("FEDs", std::vector<int>());
   if (fedUnpackList_.empty())
-    for (int i=FEDNumbering::MINECALFEDID; i<=FEDNumbering::MAXECALFEDID; i++)
+    for (int i = FEDNumbering::MINECALFEDID; i <= FEDNumbering::MAXECALFEDID; i++)
       fedUnpackList_.push_back(i);
 }
 
-
-EcalFEDErrorFilter::~EcalFEDErrorFilter()
-{
-
+EcalFEDErrorFilter::~EcalFEDErrorFilter() {
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
-
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called on each new Event  ------------
-bool
-EcalFEDErrorFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
-{
+bool EcalFEDErrorFilter::hltFilter(edm::Event& iEvent,
+                                   const edm::EventSetup& iSetup,
+                                   trigger::TriggerFilterObjectWithRefs& filterproduct) const {
   using namespace edm;
 
   edm::Handle<FEDRawDataCollection> rawdata;
-  iEvent.getByLabel(DataLabel_,rawdata);
+  iEvent.getByLabel(DataLabel_, rawdata);
 
   // get fed raw data and SM id
 
   // loop over FEDS
-  for (std::vector<int>::const_iterator i=fedUnpackList_.begin(); i!=fedUnpackList_.end(); i++)
-    {
+  for (std::vector<int>::const_iterator i = fedUnpackList_.begin(); i != fedUnpackList_.end(); i++) {
+    // get fed raw data and SM id
+    const FEDRawData& fedData = rawdata->FEDData(*i);
+    int length = fedData.size() / sizeof(uint64_t);
 
-      // get fed raw data and SM id
-      const FEDRawData & fedData = rawdata->FEDData(*i);
-      int length = fedData.size()/sizeof(uint64_t);
-
-      //    LogDebug("EcalRawToDigi") << "raw data length: " << length ;
-      //if data size is not null interpret data
-      if ( length >= 1 )
-	{
-      	    uint64_t * pData = (uint64_t *)(fedData.data());
-	    //When crc error is found return true
-	    uint64_t * fedTrailer = pData + (length - 1);
-	    bool crcError = (*fedTrailer >> 2 ) & 0x1;
-	    if (crcError)
-	      {
-		std::cout << "CRCERROR in FED " << *i << " trailer is " << std::setw(8)   << std::hex << (*fedTrailer) << std::endl;
-		return true;
-	      }
-	}
+    //    LogDebug("EcalRawToDigi") << "raw data length: " << length ;
+    //if data size is not null interpret data
+    if (length >= 1) {
+      uint64_t* pData = (uint64_t*)(fedData.data());
+      //When crc error is found return true
+      uint64_t* fedTrailer = pData + (length - 1);
+      bool crcError = (*fedTrailer >> 2) & 0x1;
+      if (crcError) {
+        std::cout << "CRCERROR in FED " << *i << " trailer is " << std::setw(8) << std::hex << (*fedTrailer)
+                  << std::endl;
+        return true;
+      }
     }
+  }
 
   return false;
 }

--- a/CaloOnlineTools/EcalTools/plugins/EcalFEDErrorFilter.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalFEDErrorFilter.h
@@ -16,7 +16,6 @@ Implementation:
 //
 //
 
-
 // system include files
 #include <memory>
 
@@ -48,11 +47,12 @@ public:
   ~EcalFEDErrorFilter() override;
 
 private:
-  bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+  bool hltFilter(edm::Event&,
+                 const edm::EventSetup&,
+                 trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
 
   // ----------member data ---------------------------
 
-  edm::InputTag     DataLabel_;
+  edm::InputTag DataLabel_;
   std::vector<int> fedUnpackList_;
-
 };

--- a/CaloOnlineTools/EcalTools/plugins/EcalFEDWithCRCErrorProducer.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalFEDWithCRCErrorProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    EcalFEDWithCRCErrorProducer
 // Class:      EcalFEDWithCRCErrorProducer
-// 
+//
 /**\class EcalFEDWithCRCErrorProducer EcalFEDWithCRCErrorProducer.cc filter/EcalFEDWithCRCErrorProducer/src/EcalFEDWithCRCErrorProducer.cc
 
 Description: <one line class summary>
@@ -15,7 +15,6 @@ Implementation:
 //         Created:  Tue Jan 22 13:55:00 CET 2008
 //
 //
-
 
 // system include files
 #include <memory>
@@ -42,104 +41,87 @@ Implementation:
 // class declaration
 //
 
-class EcalFEDWithCRCErrorProducer : public edm::EDProducer 
-{
+class EcalFEDWithCRCErrorProducer : public edm::EDProducer {
 public:
   explicit EcalFEDWithCRCErrorProducer(const edm::ParameterSet&);
   ~EcalFEDWithCRCErrorProducer() override;
-  
+
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-  
+
   // ----------member data ---------------------------
-  
-  edm::InputTag     DataLabel_;
+
+  edm::InputTag DataLabel_;
   std::vector<int> fedUnpackList_;
   bool writeAllEcalFEDs_;
 };
 
-
-
 //
 // constructors and destructor
 //
-EcalFEDWithCRCErrorProducer::EcalFEDWithCRCErrorProducer(const edm::ParameterSet& iConfig)
-{
+EcalFEDWithCRCErrorProducer::EcalFEDWithCRCErrorProducer(const edm::ParameterSet& iConfig) {
   //now do what ever initialization is needed
 
-  DataLabel_     = iConfig.getParameter<edm::InputTag>("InputLabel");
-  fedUnpackList_ = iConfig.getUntrackedParameter< std::vector<int> >("FEDs", std::vector<int>());
-  writeAllEcalFEDs_ = iConfig.getUntrackedParameter<bool >("writeAllEcalFED", false);
-  if (fedUnpackList_.empty()) 
-    for (int i=FEDNumbering::MINECALFEDID; i<=FEDNumbering::MAXECALFEDID; i++)
+  DataLabel_ = iConfig.getParameter<edm::InputTag>("InputLabel");
+  fedUnpackList_ = iConfig.getUntrackedParameter<std::vector<int> >("FEDs", std::vector<int>());
+  writeAllEcalFEDs_ = iConfig.getUntrackedParameter<bool>("writeAllEcalFED", false);
+  if (fedUnpackList_.empty())
+    for (int i = FEDNumbering::MINECALFEDID; i <= FEDNumbering::MAXECALFEDID; i++)
       fedUnpackList_.push_back(i);
 
-  produces< FEDRawDataCollection >();
+  produces<FEDRawDataCollection>();
 }
 
-
-EcalFEDWithCRCErrorProducer::~EcalFEDWithCRCErrorProducer()
-{
- 
+EcalFEDWithCRCErrorProducer::~EcalFEDWithCRCErrorProducer() {
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
-
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called on each new Event  ------------
-void
-EcalFEDWithCRCErrorProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void EcalFEDWithCRCErrorProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
-  edm::Handle<FEDRawDataCollection> rawdata;  
-  iEvent.getByLabel(DataLabel_,rawdata);
+  edm::Handle<FEDRawDataCollection> rawdata;
+  iEvent.getByLabel(DataLabel_, rawdata);
 
   auto producedData = std::make_unique<FEDRawDataCollection>();
   // get fed raw data and SM id
 
   // loop over FEDS
-  for (std::vector<int>::const_iterator i=fedUnpackList_.begin(); i!=fedUnpackList_.end(); i++) 
-    {
+  for (std::vector<int>::const_iterator i = fedUnpackList_.begin(); i != fedUnpackList_.end(); i++) {
+    // get fed raw data and SM id
+    const FEDRawData& fedData = rawdata->FEDData(*i);
+    int length = fedData.size() / sizeof(uint64_t);
 
-      // get fed raw data and SM id
-      const FEDRawData & fedData = rawdata->FEDData(*i);
-      int length = fedData.size()/sizeof(uint64_t);
-
-      //    LogDebug("EcalRawToDigi") << "raw data length: " << length ;
-      //if data size is not null interpret data
-      if ( length >= 1 )
-	{
-      	    uint64_t * pData = (uint64_t *)(fedData.data());
-	    //When crc error is found return true
-	    uint64_t * fedTrailer = pData + (length - 1);
-	    bool crcError = (*fedTrailer >> 2 ) & 0x1; 
-	    // this fed has data -- lets copy it
-	    if (writeAllEcalFEDs_ || crcError)
-	      {
-		FEDRawData & fedDataProd = producedData->FEDData(*i);
-		if ( fedDataProd.size() != 0 ) 
-		  {
-		    //                std::cout << " More than one FEDRawDataCollection with data in FED ";
-		    //                std::cout << j << " Skipping the 2nd\n";
-		    continue;
-		  }
-		fedDataProd.resize(fedData.size());
-		unsigned char *dataProd=fedDataProd.data();
-		const unsigned char *data=fedData.data();
-		for ( unsigned int k=0; k<fedData.size(); ++k ) 
-		  {
-		    dataProd[k]=data[k];
-		  }
-	      }
-	}
+    //    LogDebug("EcalRawToDigi") << "raw data length: " << length ;
+    //if data size is not null interpret data
+    if (length >= 1) {
+      uint64_t* pData = (uint64_t*)(fedData.data());
+      //When crc error is found return true
+      uint64_t* fedTrailer = pData + (length - 1);
+      bool crcError = (*fedTrailer >> 2) & 0x1;
+      // this fed has data -- lets copy it
+      if (writeAllEcalFEDs_ || crcError) {
+        FEDRawData& fedDataProd = producedData->FEDData(*i);
+        if (fedDataProd.size() != 0) {
+          //                std::cout << " More than one FEDRawDataCollection with data in FED ";
+          //                std::cout << j << " Skipping the 2nd\n";
+          continue;
+        }
+        fedDataProd.resize(fedData.size());
+        unsigned char* dataProd = fedDataProd.data();
+        const unsigned char* data = fedData.data();
+        for (unsigned int k = 0; k < fedData.size(); ++k) {
+          dataProd[k] = data[k];
+        }
+      }
     }
-  
+  }
+
   iEvent.put(std::move(producedData));
 }
 

--- a/CaloOnlineTools/EcalTools/plugins/EcalHexDisplay.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalHexDisplay.cc
@@ -6,71 +6,60 @@
 
 #include "CaloOnlineTools/EcalTools/plugins/EcalHexDisplay.h"
 
-EcalHexDisplay::EcalHexDisplay(const edm::ParameterSet& ps) :
-    verbosity_ (ps.getUntrackedParameter<int>("verbosity",1)),
-    beg_fed_id_ (ps.getUntrackedParameter<int>("beg_fed_id",0)),
-    end_fed_id_ (ps.getUntrackedParameter<int>("end_fed_id",654)),
-    first_event_ (ps.getUntrackedParameter<int>("first_event",1)),
-    last_event_  (ps.getUntrackedParameter<int>("last_event",9999999)),
-    event_ (0),
-    writeDcc_ (ps.getUntrackedParameter<bool>("writeDCC",false)),
-    filename_ (ps.getUntrackedParameter<std::string>("filename","dump.bin")),
-    fedRawDataCollectionTag_(ps.getParameter<edm::InputTag>("fedRawDataCollectionTag"))
-{  
-}
+EcalHexDisplay::EcalHexDisplay(const edm::ParameterSet& ps)
+    : verbosity_(ps.getUntrackedParameter<int>("verbosity", 1)),
+      beg_fed_id_(ps.getUntrackedParameter<int>("beg_fed_id", 0)),
+      end_fed_id_(ps.getUntrackedParameter<int>("end_fed_id", 654)),
+      first_event_(ps.getUntrackedParameter<int>("first_event", 1)),
+      last_event_(ps.getUntrackedParameter<int>("last_event", 9999999)),
+      event_(0),
+      writeDcc_(ps.getUntrackedParameter<bool>("writeDCC", false)),
+      filename_(ps.getUntrackedParameter<std::string>("filename", "dump.bin")),
+      fedRawDataCollectionTag_(ps.getParameter<edm::InputTag>("fedRawDataCollectionTag")) {}
 
-void EcalHexDisplay::analyze( const edm::Event & e, const  edm::EventSetup& c){
-  
+void EcalHexDisplay::analyze(const edm::Event& e, const edm::EventSetup& c) {
   event_++;
-  if (event_ < first_event_ || last_event_ < event_) return;
-  
+  if (event_ < first_event_ || last_event_ < event_)
+    return;
 
   edm::Handle<FEDRawDataCollection> rawdata;
-  e.getByLabel(fedRawDataCollectionTag_, rawdata);  
+  e.getByLabel(fedRawDataCollectionTag_, rawdata);
 
-  std::ofstream dumpFile (filename_.c_str(),std::ios::app );
-  
-  for (int id= 0; id<=FEDNumbering::MAXFEDID; ++id){ 
-    
-    if (id < beg_fed_id_ || end_fed_id_ < id) continue;
+  std::ofstream dumpFile(filename_.c_str(), std::ios::app);
+
+  for (int id = 0; id <= FEDNumbering::MAXFEDID; ++id) {
+    if (id < beg_fed_id_ || end_fed_id_ < id)
+      continue;
 
     const FEDRawData& data = rawdata->FEDData(id);
-    
-    if (data.size()>4){      
-      
-      std::cout << "\n\n\n[EcalHexDumperModule] Event: " 
-		<< std::dec << event_ 
-		<< " fed_id: " << id 
-		<< " size_fed: " << data.size() << "\n"<< std::endl;
-      
-      if ( ( data.size() %16 ) !=0)
-	{
-	  std::cout << "***********************************************" << std::endl;
-	  std::cout<< "Fed size in bits not multiple of 64, strange." << std::endl;
-	  std::cout << "***********************************************" << std::endl;
-	}
-      
-      
+
+    if (data.size() > 4) {
+      std::cout << "\n\n\n[EcalHexDumperModule] Event: " << std::dec << event_ << " fed_id: " << id
+                << " size_fed: " << data.size() << "\n"
+                << std::endl;
+
+      if ((data.size() % 16) != 0) {
+        std::cout << "***********************************************" << std::endl;
+        std::cout << "Fed size in bits not multiple of 64, strange." << std::endl;
+        std::cout << "***********************************************" << std::endl;
+      }
+
       int length = data.size();
-      const unsigned long               * pData     = ( reinterpret_cast<unsigned long*>(const_cast<unsigned char*> ( data.data())));
+      const unsigned long* pData = (reinterpret_cast<unsigned long*>(const_cast<unsigned char*>(data.data())));
       std::cout << std::setfill('0');
-      for (int words=0; words < length/4; (words+=2)  )
-	{
-	  std::cout << std::setw(8)   << std::hex << pData[words+1] << " ";
-	  std::cout << std::setw(8)   << std::hex << pData[words] << std::endl;
-	}
+      for (int words = 0; words < length / 4; (words += 2)) {
+        std::cout << std::setw(8) << std::hex << pData[words + 1] << " ";
+        std::cout << std::setw(8) << std::hex << pData[words] << std::endl;
+      }
 
       std::cout << "\n";
 
-
-      if (beg_fed_id_ <= id && id <= end_fed_id_ && writeDcc_)
-	{
-	  dumpFile.write( reinterpret_cast <const char *> (pData), length);
-	}
+      if (beg_fed_id_ <= id && id <= end_fed_id_ && writeDcc_) {
+        dumpFile.write(reinterpret_cast<const char*>(pData), length);
+      }
     }
-    
   }
-  dumpFile.close();    
-  if (! writeDcc_) remove(filename_.c_str()); 
+  dumpFile.close();
+  if (!writeDcc_)
+    remove(filename_.c_str());
 }
-

--- a/CaloOnlineTools/EcalTools/plugins/EcalHexDisplay.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalHexDisplay.h
@@ -4,7 +4,6 @@
  *
  */
 
-
 #include <FWCore/Framework/interface/EDAnalyzer.h>
 #include <FWCore/Framework/interface/Event.h>
 #include <FWCore/Framework/interface/MakerMacros.h>
@@ -21,26 +20,24 @@
 #include <cstdio>
 #include <fstream>
 
-#include <iomanip> 
+#include <iomanip>
 
+class EcalHexDisplay : public edm::EDAnalyzer {
+public:
+  EcalHexDisplay(const edm::ParameterSet& ps);
 
-class EcalHexDisplay: public edm::EDAnalyzer {
+protected:
+  int verbosity_;
+  int beg_fed_id_;
+  int end_fed_id_;
+  int first_event_;
+  int last_event_;
+  int event_;
+  bool writeDcc_;
+  std::string filename_;
 
-  public:
-    EcalHexDisplay(const edm::ParameterSet& ps);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
-  protected:
-    int      verbosity_;
-    int      beg_fed_id_;
-    int      end_fed_id_;
-    int      first_event_;
-    int      last_event_;
-    int      event_;
-    bool     writeDcc_;
-    std::string   filename_;
-
-    void analyze(const edm::Event & e, const  edm::EventSetup& c) override;
-
-  private:
-    edm::InputTag fedRawDataCollectionTag_;
+private:
+  edm::InputTag fedRawDataCollectionTag_;
 };

--- a/CaloOnlineTools/EcalTools/plugins/EcalMipGraphs.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalMipGraphs.cc
@@ -1,8 +1,8 @@
 // -*- C++ -*-
 //
-// Package:   EcalMipGraphs 
-// Class:     EcalMipGraphs 
-// 
+// Package:   EcalMipGraphs
+// Class:     EcalMipGraphs
+//
 /**\class EcalMipGraphs EcalMipGraphs.cc
 
  Description: <one line class summary>
@@ -33,97 +33,82 @@ using namespace std;
 //
 // static data member definitions
 //
-float EcalMipGraphs::gainRatio[3] = { 1., 2. , 12. }; 
+float EcalMipGraphs::gainRatio[3] = {1., 2., 12.};
 edm::Service<TFileService> EcalMipGraphs::fileService;
 
 //
 // constructors and destructor
 //
-EcalMipGraphs::EcalMipGraphs(const edm::ParameterSet& iConfig) :
-  EBRecHitCollection_ (iConfig.getParameter<edm::InputTag>("EcalRecHitCollectionEB")),
-  EERecHitCollection_ (iConfig.getParameter<edm::InputTag>("EcalRecHitCollectionEE")),
-  EBDigis_ (iConfig.getParameter<edm::InputTag>("EBDigiCollection")),
-  EEDigis_ (iConfig.getParameter<edm::InputTag>("EEDigiCollection")),
-  headerProducer_ (iConfig.getParameter<edm::InputTag> ("headerProducer")),
-  runNum_(-1),
-  side_ (iConfig.getUntrackedParameter<int>("side", 3)),
-  threshold_ (iConfig.getUntrackedParameter<double>("amplitudeThreshold", 12.0)),
-  minTimingAmp_ (iConfig.getUntrackedParameter<double>("minimumTimingAmplitude", 0.100))
-{
+EcalMipGraphs::EcalMipGraphs(const edm::ParameterSet& iConfig)
+    : EBRecHitCollection_(iConfig.getParameter<edm::InputTag>("EcalRecHitCollectionEB")),
+      EERecHitCollection_(iConfig.getParameter<edm::InputTag>("EcalRecHitCollectionEE")),
+      EBDigis_(iConfig.getParameter<edm::InputTag>("EBDigiCollection")),
+      EEDigis_(iConfig.getParameter<edm::InputTag>("EEDigiCollection")),
+      headerProducer_(iConfig.getParameter<edm::InputTag>("headerProducer")),
+      runNum_(-1),
+      side_(iConfig.getUntrackedParameter<int>("side", 3)),
+      threshold_(iConfig.getUntrackedParameter<double>("amplitudeThreshold", 12.0)),
+      minTimingAmp_(iConfig.getUntrackedParameter<double>("minimumTimingAmplitude", 0.100)) {
   vector<int> listDefaults;
   listDefaults.push_back(-1);
-  
+
   maskedChannels_ = iConfig.getUntrackedParameter<vector<int> >("maskedChannels", listDefaults);
   maskedFEDs_ = iConfig.getUntrackedParameter<vector<int> >("maskedFEDs", listDefaults);
-  seedCrys_ = iConfig.getUntrackedParameter<vector<int> >("seedCrys",vector<int>());
+  seedCrys_ = iConfig.getUntrackedParameter<vector<int> >("seedCrys", vector<int>());
 
   vector<string> defaultMaskedEBs;
   defaultMaskedEBs.push_back("none");
-  maskedEBs_ =  iConfig.getUntrackedParameter<vector<string> >("maskedEBs",defaultMaskedEBs);
-  
+  maskedEBs_ = iConfig.getUntrackedParameter<vector<string> >("maskedEBs", defaultMaskedEBs);
+
   fedMap_ = new EcalFedMap();
 
   string title1 = "Jitter for all FEDs";
   string name1 = "JitterAllFEDs";
-  allFedsTimingHist_ = fileService->make<TH1F>(name1.c_str(),title1.c_str(),150,-7,7);
-  
+  allFedsTimingHist_ = fileService->make<TH1F>(name1.c_str(), title1.c_str(), 150, -7, 7);
+
   // load up the maskedFED list with the proper FEDids
-  if(maskedFEDs_[0]==-1)
-  {
+  if (maskedFEDs_[0] == -1) {
     //if "actual" EB id given, then convert to FEDid and put in listFEDs_
-    if(maskedEBs_[0] != "none")
-    {
+    if (maskedEBs_[0] != "none") {
       maskedFEDs_.clear();
-      for(vector<string>::const_iterator ebItr = maskedEBs_.begin(); ebItr != maskedEBs_.end(); ++ebItr)
-      {
+      for (vector<string>::const_iterator ebItr = maskedEBs_.begin(); ebItr != maskedEBs_.end(); ++ebItr) {
         maskedFEDs_.push_back(fedMap_->getFedFromSlice(*ebItr));
       }
     }
   }
-  
-  for (int i=0; i<10; i++)        
+
+  for (int i = 0; i < 10; i++)
     abscissa[i] = i;
-  
+
   naiveEvtNum_ = 0;
-
 }
 
-
-EcalMipGraphs::~EcalMipGraphs()
-{
-}
-
+EcalMipGraphs::~EcalMipGraphs() {}
 
 //
 // member functions
 //
 
 // ------------ method called to for each event  ------------
-void
-EcalMipGraphs::analyze(edm::Event const & iEvent, edm::EventSetup const & iSetup)
-{
-
+void EcalMipGraphs::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
   // get the headers
   // (one header for each supermodule)
   edm::Handle<EcalRawDataCollection> DCCHeaders;
   iEvent.getByLabel(headerProducer_, DCCHeaders);
 
-  for (EcalRawDataCollection::const_iterator headerItr= DCCHeaders->begin();
-		  headerItr != DCCHeaders->end (); 
-		  ++headerItr) 
-  {
-    FEDsAndDCCHeaders_[headerItr->id()+600] = *headerItr;
+  for (EcalRawDataCollection::const_iterator headerItr = DCCHeaders->begin(); headerItr != DCCHeaders->end();
+       ++headerItr) {
+    FEDsAndDCCHeaders_[headerItr->id() + 600] = *headerItr;
   }
 
   int ievt = iEvent.id().event();
   naiveEvtNum_++;
 
-  if(runNum_==-1)
-  {
+  if (runNum_ == -1) {
     runNum_ = iEvent.id().run();
-    canvasNames_ = fileService->make<TTree>("canvasNames","Names of written canvases");
+    canvasNames_ = fileService->make<TTree>("canvasNames", "Names of written canvases");
     names = new std::vector<string>();
-    canvasNames_->Branch("names","vector<string>",&names);
+    canvasNames_->Branch("names", "vector<string>", &names);
   }
 
   //We only want the 3x3's for this event...
@@ -144,110 +129,101 @@ EcalMipGraphs::analyze(edm::Event const & iEvent, edm::EventSetup const & iSetup
 
   selectHits(EBhits, ievt, caloTopo);
   selectHits(EEhits, ievt, caloTopo);
-  
 }
 
-
-TGraph* EcalMipGraphs::selectDigi(DetId thisDet, int ievt)
-{
+TGraph* EcalMipGraphs::selectDigi(DetId thisDet, int ievt) {
   int emptyY[10];
-  for (int i=0; i<10; i++)
+  for (int i = 0; i < 10; i++)
     emptyY[i] = 0;
   TGraph* emptyGraph = fileService->make<TGraph>(10, abscissa, emptyY);
   emptyGraph->SetTitle("NOT ECAL");
-  
+
   //If the DetId is not from Ecal, return
-  if(thisDet.det() != DetId::Ecal)
+  if (thisDet.det() != DetId::Ecal)
     return emptyGraph;
-  
+
   emptyGraph->SetTitle("NO DIGIS");
-  //find digi we need  -- can't get find() to work; need DataFrame(DetId det) to work? 
+  //find digi we need  -- can't get find() to work; need DataFrame(DetId det) to work?
   EcalElectronicsId elecId = ecalElectronicsMap_->getElectronicsId(thisDet);
-  int FEDid = 600+elecId.dccId();
+  int FEDid = 600 + elecId.dccId();
   bool isBarrel = true;
-  if(FEDid < 610 || FEDid > 645)
+  if (FEDid < 610 || FEDid > 645)
     isBarrel = false;
   int cryIndex = isBarrel ? ((EBDetId)thisDet).hashedIndex() : getEEIndex(elecId);
   int ic = isBarrel ? ((EBDetId)thisDet).ic() : cryIndex;
 
   string sliceName = fedMap_->getSliceFromFed(FEDid);
   EcalDataFrame df;
-  if(isBarrel)
-  {
+  if (isBarrel) {
     EBDigiCollection::const_iterator digiItr = EBdigisHandle->begin();
-    while(digiItr != EBdigisHandle->end() && ((*digiItr).id() != (EBDetId)thisDet))
-    {
+    while (digiItr != EBdigisHandle->end() && ((*digiItr).id() != (EBDetId)thisDet)) {
       ++digiItr;
     }
-    if(digiItr==EBdigisHandle->end())
-    {
+    if (digiItr == EBdigisHandle->end()) {
       //LogWarning("EcalMipGraphs") << "Cannot find digi for ic:" << ic
       //  << " FED:" << FEDid << " evt:" << naiveEvtNum_;
       return emptyGraph;
-    }
-    else
+    } else
       df = *digiItr;
-  }
-  else
-  {
+  } else {
     EEDigiCollection::const_iterator digiItr = EEdigisHandle->begin();
-    while(digiItr != EEdigisHandle->end() && ((*digiItr).id() != (EEDetId)thisDet))
-    {
+    while (digiItr != EEdigisHandle->end() && ((*digiItr).id() != (EEDetId)thisDet)) {
       ++digiItr;
     }
-    if(digiItr==EEdigisHandle->end())
-    {
+    if (digiItr == EEdigisHandle->end()) {
       //LogWarning("EcalMipGraphs") << "Cannot find digi for ic:" << ic
       //  << " FED:" << FEDid << " evt:" << naiveEvtNum_;
       return emptyGraph;
-    }
-    else df = *digiItr;
+    } else
+      df = *digiItr;
   }
 
   int gainId = FEDsAndDCCHeaders_[FEDid].getMgpaGain();
   int gainHuman;
-  if      (gainId ==1) gainHuman =12;
-  else if (gainId ==2) gainHuman =6;
-  else if (gainId ==3) gainHuman =1;
-  else                 gainHuman =-1; 
+  if (gainId == 1)
+    gainHuman = 12;
+  else if (gainId == 2)
+    gainHuman = 6;
+  else if (gainId == 3)
+    gainHuman = 1;
+  else
+    gainHuman = -1;
 
   double pedestal = 200;
 
   emptyGraph->SetTitle("FIRST TWO SAMPLES NOT GAIN12");
-  if(df.sample(0).gainId()!=1 || df.sample(1).gainId()!=1) return emptyGraph; //goes to the next digi
+  if (df.sample(0).gainId() != 1 || df.sample(1).gainId() != 1)
+    return emptyGraph;  //goes to the next digi
   else {
     ordinate[0] = df.sample(0).adc();
     ordinate[1] = df.sample(1).adc();
-    pedestal = (double)(ordinate[0]+ordinate[1])/(double)2;
-  } 
+    pedestal = (double)(ordinate[0] + ordinate[1]) / (double)2;
+  }
 
-
-  for (int i=0; i < df.size(); ++i ) {
+  for (int i = 0; i < df.size(); ++i) {
     if (df.sample(i).gainId() != 0)
-      ordinate[i] = (int)(pedestal+(df.sample(i).adc()-pedestal)*gainRatio[df.sample(i).gainId()-1]);
+      ordinate[i] = (int)(pedestal + (df.sample(i).adc() - pedestal) * gainRatio[df.sample(i).gainId() - 1]);
     else
-      ordinate[i] = 49152; //Saturation of gain1 
+      ordinate[i] = 49152;  //Saturation of gain1
   }
 
   TGraph* oneGraph = fileService->make<TGraph>(10, abscissa, ordinate);
-  string name = "Graph_ev" + intToString(naiveEvtNum_) + "_ic" + intToString(ic)
-    + "_FED" + intToString(FEDid);
-  string gainString = (gainId==1) ? "Free" : intToString(gainHuman);
-  string title = "Event" + intToString(naiveEvtNum_) + "_lv1a" + intToString(ievt) +
-    "_ic" + intToString(ic) + "_" + sliceName + "_gain" + gainString;
-    
+  string name = "Graph_ev" + intToString(naiveEvtNum_) + "_ic" + intToString(ic) + "_FED" + intToString(FEDid);
+  string gainString = (gainId == 1) ? "Free" : intToString(gainHuman);
+  string title = "Event" + intToString(naiveEvtNum_) + "_lv1a" + intToString(ievt) + "_ic" + intToString(ic) + "_" +
+                 sliceName + "_gain" + gainString;
+
   float energy = 0;
-  map<int,float>::const_iterator itr;
+  map<int, float>::const_iterator itr;
   itr = crysAndAmplitudesMap_.find(cryIndex);
-  if(itr!=crysAndAmplitudesMap_.end())
-  {
+  if (itr != crysAndAmplitudesMap_.end()) {
     //edm::LogWarning("EcalMipGraphs")<< "itr->second(ampli)="<< itr->second;
-    energy = (float) itr->second;
+    energy = (float)itr->second;
   }
   //else
   //edm::LogWarning("EcalMipGraphs") << "cry " << ic << "not found in ampMap";
 
-  title+="_Energy"+floatToString(round(energy*1000));
+  title += "_Energy" + floatToString(round(energy * 1000));
 
   oneGraph->SetTitle(title.c_str());
   oneGraph->SetName(name.c_str());
@@ -256,73 +232,63 @@ TGraph* EcalMipGraphs::selectDigi(DetId thisDet, int ievt)
   return oneGraph;
 }
 
-void EcalMipGraphs::selectHits(Handle<EcalRecHitCollection> hits,
-    int ievt, ESHandle<CaloTopology> caloTopo)
-{
-  for (EcalRecHitCollection::const_iterator hitItr = hits->begin(); hitItr != hits->end(); ++hitItr)
-  {
+void EcalMipGraphs::selectHits(Handle<EcalRecHitCollection> hits, int ievt, ESHandle<CaloTopology> caloTopo) {
+  for (EcalRecHitCollection::const_iterator hitItr = hits->begin(); hitItr != hits->end(); ++hitItr) {
     EcalRecHit hit = (*hitItr);
     DetId det = hit.id();
     EcalElectronicsId elecId = ecalElectronicsMap_->getElectronicsId(det);
-    int FEDid = 600+elecId.dccId();
+    int FEDid = 600 + elecId.dccId();
     bool isBarrel = true;
-    if(FEDid < 610 || FEDid > 645)
+    if (FEDid < 610 || FEDid > 645)
       isBarrel = false;
     int cryIndex = isBarrel ? ((EBDetId)det).hashedIndex() : ((EEDetId)det).hashedIndex();
     int ic = isBarrel ? ((EBDetId)det).ic() : getEEIndex(elecId);
-    
+
     float ampli = hit.energy();
 
     vector<int>::iterator result;
     result = find(maskedFEDs_.begin(), maskedFEDs_.end(), FEDid);
-    if(result != maskedFEDs_.end())
-    {
+    if (result != maskedFEDs_.end()) {
       //LogWarning("EcalMipGraphs") << "skipping uncalRecHit for FED " << FEDid << " ; amplitude " << ampli;
       continue;
-    }      
+    }
     result = find(maskedChannels_.begin(), maskedChannels_.end(), cryIndex);
-    if  (result != maskedChannels_.end())
-    {
+    if (result != maskedChannels_.end()) {
       //LogWarning("EcalMipGraphs") << "skipping uncalRecHit for channel: " << cryIndex << " in fed: " << FEDid << " with amplitude " << ampli ;
       continue;
-    } 
+    }
     bool cryIsInList = false;
     result = find(seedCrys_.begin(), seedCrys_.end(), cryIndex);
-    if  (result != seedCrys_.end())
+    if (result != seedCrys_.end())
       cryIsInList = true;
 
     // Either we must have a user-requested cry (in which case there is no amplitude selection)
     // Or we pick all crys that pass the amplitude cut (in which case there is no fixed crystal selection)
-    if(cryIsInList || (seedCrys_.empty() && ampli > threshold_))
-    {
+    if (cryIsInList || (seedCrys_.empty() && ampli > threshold_)) {
       // We have a winner!
       crysAndAmplitudesMap_[cryIndex] = ampli;
-      string name = "Event" + intToString(naiveEvtNum_) + "_ic" + intToString(ic)
-        + "_FED" + intToString(FEDid);
+      string name = "Event" + intToString(naiveEvtNum_) + "_ic" + intToString(ic) + "_FED" + intToString(FEDid);
       string title = "Digis";
       string seed = "ic" + intToString(ic) + "_FED" + intToString(FEDid);
-      int freq=1;
-      pair<map<string,int>::iterator,bool> pair = seedFrequencyMap_.insert(make_pair(seed,freq));
-      if(!pair.second)
-      {
+      int freq = 1;
+      pair<map<string, int>::iterator, bool> pair = seedFrequencyMap_.insert(make_pair(seed, freq));
+      if (!pair.second) {
         ++(pair.first->second);
       }
-      
-      TCanvas can(name.c_str(),title.c_str(),200,50,900,900);
-      can.Divide(side_,side_);
+
+      TCanvas can(name.c_str(), title.c_str(), 200, 50, 900, 900);
+      can.Divide(side_, side_);
       TGraph* myGraph;
       int canvasNum = 1;
 
-      CaloNavigator<DetId> cursor = CaloNavigator<DetId>(det,caloTopo->getSubdetectorTopology(det));
+      CaloNavigator<DetId> cursor = CaloNavigator<DetId>(det, caloTopo->getSubdetectorTopology(det));
       //Now put each graph in one by one
-      for(int j=side_/2; j>=-side_/2; --j)
-      {
-        for(int i=-side_/2; i<=side_/2; ++i)
-        {
+      for (int j = side_ / 2; j >= -side_ / 2; --j) {
+        for (int i = -side_ / 2; i <= side_ / 2; ++i) {
           cursor.home();
-          cursor.offsetBy(i,j);
+          cursor.offsetBy(i, j);
           can.cd(canvasNum);
-          myGraph = selectDigi(*cursor,ievt);
+          myGraph = selectDigi(*cursor, ievt);
           myGraph->Draw("A*");
           canvasNum++;
         }
@@ -330,102 +296,87 @@ void EcalMipGraphs::selectHits(Handle<EcalRecHitCollection> hits,
       can.Write();
       names->push_back(name);
     }
-    
+
     TH1F* timingHist = FEDsAndTimingHists_[FEDid];
-    if(timingHist==nullptr)
-    {
+    if (timingHist == nullptr) {
       initHists(FEDid);
       timingHist = FEDsAndTimingHists_[FEDid];
     }
-    if(ampli > minTimingAmp_)
-    {
+    if (ampli > minTimingAmp_) {
       timingHist->Fill(hit.time());
       allFedsTimingHist_->Fill(hit.time());
     }
   }
 }
 
-int EcalMipGraphs::getEEIndex(EcalElectronicsId elecId)
-{
-  int FEDid = 600+elecId.dccId();
-  return 10000*FEDid+100*elecId.towerId()+5*(elecId.stripId()-1)+elecId.xtalId();
+int EcalMipGraphs::getEEIndex(EcalElectronicsId elecId) {
+  int FEDid = 600 + elecId.dccId();
+  return 10000 * FEDid + 100 * elecId.towerId() + 5 * (elecId.stripId() - 1) + elecId.xtalId();
 }
 
 // insert the hist map into the map keyed by FED number
-void EcalMipGraphs::initHists(int FED)
-{
+void EcalMipGraphs::initHists(int FED) {
   using namespace std;
-  
+
   string title1 = "Jitter for ";
   title1.append(fedMap_->getSliceFromFed(FED));
   string name1 = "JitterFED";
   name1.append(intToString(FED));
-  TH1F* timingHist = fileService->make<TH1F>(name1.c_str(),title1.c_str(),150,-7,7);
+  TH1F* timingHist = fileService->make<TH1F>(name1.c_str(), title1.c_str(), 150, -7, 7);
   FEDsAndTimingHists_[FED] = timingHist;
 }
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-EcalMipGraphs::beginRun(edm::Run const &, edm::EventSetup const & c)
-{
-  edm::ESHandle< EcalElectronicsMapping > handle;
-  c.get< EcalMappingRcd >().get(handle);
+void EcalMipGraphs::beginRun(edm::Run const&, edm::EventSetup const& c) {
+  edm::ESHandle<EcalElectronicsMapping> handle;
+  c.get<EcalMappingRcd>().get(handle);
   ecalElectronicsMap_ = handle.product();
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-EcalMipGraphs::endJob()
-{
+void EcalMipGraphs::endJob() {
   canvasNames_->Fill();
 
   string frequencies = "";
-  for(std::map<std::string,int>::const_iterator itr = seedFrequencyMap_.begin();
-      itr != seedFrequencyMap_.end(); ++itr)
-  {
-    if(itr->second > 1)
-    {
-      frequencies+=itr->first;
-      frequencies+=" Frequency: ";
-      frequencies+=intToString(itr->second);
-      frequencies+="\n";
+  for (std::map<std::string, int>::const_iterator itr = seedFrequencyMap_.begin(); itr != seedFrequencyMap_.end();
+       ++itr) {
+    if (itr->second > 1) {
+      frequencies += itr->first;
+      frequencies += " Frequency: ";
+      frequencies += intToString(itr->second);
+      frequencies += "\n";
     }
   }
-  LogWarning("EcalMipGraphs") << "Found seeds with frequency > 1: " << "\n\n" << frequencies;
-  
+  LogWarning("EcalMipGraphs") << "Found seeds with frequency > 1: "
+                              << "\n\n"
+                              << frequencies;
+
   std::string channels;
-  for(std::vector<int>::const_iterator itr = maskedChannels_.begin();
-      itr != maskedChannels_.end(); ++itr)
-  {
-    channels+=intToString(*itr);
-    channels+=",";
+  for (std::vector<int>::const_iterator itr = maskedChannels_.begin(); itr != maskedChannels_.end(); ++itr) {
+    channels += intToString(*itr);
+    channels += ",";
   }
-  
+
   std::string feds;
-  for(std::vector<int>::const_iterator itr = maskedFEDs_.begin();
-      itr != maskedFEDs_.end(); ++itr)
-  {
-    feds+=intToString(*itr);
-    feds+=",";
+  for (std::vector<int>::const_iterator itr = maskedFEDs_.begin(); itr != maskedFEDs_.end(); ++itr) {
+    feds += intToString(*itr);
+    feds += ",";
   }
 
   LogWarning("EcalMipGraphs") << "Masked channels are: " << channels;
   LogWarning("EcalMipGraphs") << "Masked FEDs are: " << feds << " and that is all!";
 }
 
-
-std::string EcalMipGraphs::intToString(int num)
-{
-    using namespace std;
-    ostringstream myStream;
-    myStream << num << flush;
-    return(myStream.str()); //returns the string form of the stringstream object
+std::string EcalMipGraphs::intToString(int num) {
+  using namespace std;
+  ostringstream myStream;
+  myStream << num << flush;
+  return (myStream.str());  //returns the string form of the stringstream object
 }
 
-std::string EcalMipGraphs::floatToString(float num)
-{
-    using namespace std;
-    ostringstream myStream;
-    myStream << num << flush;
-    return(myStream.str()); //returns the string form of the stringstream object
+std::string EcalMipGraphs::floatToString(float num) {
+  using namespace std;
+  ostringstream myStream;
+  myStream << num << flush;
+  return (myStream.str());  //returns the string form of the stringstream object
 }

--- a/CaloOnlineTools/EcalTools/plugins/EcalMipGraphs.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalMipGraphs.h
@@ -1,8 +1,8 @@
 // -*- C++ -*-
 //
-// Package:   EcalMipGraphs 
-// Class:     EcalMipGraphs 
-// 
+// Package:   EcalMipGraphs
+// Class:     EcalMipGraphs
+//
 /**\class EcalMipGraphs EcalMipGraphs.cc
 
  Description: <one line class summary>
@@ -15,7 +15,6 @@
 //         Created:  Th Nov 22 5:46:22 CEST 2007
 //
 //
-
 
 // system include files
 #include <memory>
@@ -53,31 +52,28 @@
 #include "TGraph.h"
 #include "TTree.h"
 
-
 //
 // class declaration
 //
 
 class EcalMipGraphs : public edm::EDAnalyzer {
-   public:
-      explicit EcalMipGraphs(const edm::ParameterSet&);
-      ~EcalMipGraphs() override;
+public:
+  explicit EcalMipGraphs(const edm::ParameterSet&);
+  ~EcalMipGraphs() override;
 
+private:
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
+  void endJob() override;
+  std::string intToString(int num);
+  std::string floatToString(float num);
+  void writeGraphs();
+  void initHists(int);
+  void selectHits(edm::Handle<EcalRecHitCollection> hits, int ievt, edm::ESHandle<CaloTopology> caloTopo);
+  TGraph* selectDigi(DetId det, int ievt);
+  int getEEIndex(EcalElectronicsId elecId);
 
-   private:
-      void beginRun(edm::Run const &, edm::EventSetup const &) override ;
-      void analyze(edm::Event const &, edm::EventSetup const &) override;
-      void endJob() override ;
-      std::string intToString(int num);
-      std::string floatToString(float num);
-      void writeGraphs();
-      void initHists(int);
-      void selectHits(edm::Handle<EcalRecHitCollection> hits,
-          int ievt, edm::ESHandle<CaloTopology> caloTopo);
-      TGraph* selectDigi(DetId det, int ievt);
-      int getEEIndex(EcalElectronicsId elecId);
-
-    // ----------member data ---------------------------
+  // ----------member data ---------------------------
 
   edm::InputTag EBRecHitCollection_;
   edm::InputTag EERecHitCollection_;
@@ -95,7 +91,7 @@ class EcalMipGraphs : public edm::EDAnalyzer {
 
   std::set<EBDetId> listEBChannels;
   std::set<EEDetId> listEEChannels;
-    
+
   int abscissa[10];
   int ordinate[10];
 
@@ -107,17 +103,17 @@ class EcalMipGraphs : public edm::EDAnalyzer {
   std::vector<int> maskedFEDs_;
   std::vector<int> seedCrys_;
   std::vector<std::string> maskedEBs_;
-  std::map<int,TH1F*> FEDsAndTimingHists_;
-  std::map<int,float> crysAndAmplitudesMap_;
-  std::map<int,EcalDCCHeaderBlock> FEDsAndDCCHeaders_;
-  std::map<std::string,int> seedFrequencyMap_;
-  
+  std::map<int, TH1F*> FEDsAndTimingHists_;
+  std::map<int, float> crysAndAmplitudesMap_;
+  std::map<int, EcalDCCHeaderBlock> FEDsAndDCCHeaders_;
+  std::map<std::string, int> seedFrequencyMap_;
+
   TH1F* allFedsTimingHist_;
-  
+
   TFile* file_;
   TTree* canvasNames_;
   EcalFedMap* fedMap_;
   const EcalElectronicsMapping* ecalElectronicsMap_;
- 
-  int naiveEvtNum_; 
+
+  int naiveEvtNum_;
 };

--- a/CaloOnlineTools/EcalTools/plugins/EcalPedHists.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalPedHists.cc
@@ -10,13 +10,12 @@
 
 #include "CaloOnlineTools/EcalTools/plugins/EcalPedHists.h"
 
-EcalPedHists::EcalPedHists(const edm::ParameterSet& ps) :
-  runNum_(-1),
-  fileName_ (ps.getUntrackedParameter<std::string>("fileName", std::string("ecalPedDigiDump"))),
-  barrelDigiCollection_ (ps.getParameter<edm::InputTag> ("EBdigiCollection")),
-  endcapDigiCollection_ (ps.getParameter<edm::InputTag> ("EEdigiCollection")),
-  headerProducer_ (ps.getParameter<edm::InputTag> ("headerProducer"))
-{
+EcalPedHists::EcalPedHists(const edm::ParameterSet& ps)
+    : runNum_(-1),
+      fileName_(ps.getUntrackedParameter<std::string>("fileName", std::string("ecalPedDigiDump"))),
+      barrelDigiCollection_(ps.getParameter<edm::InputTag>("EBdigiCollection")),
+      endcapDigiCollection_(ps.getParameter<edm::InputTag>("EEdigiCollection")),
+      headerProducer_(ps.getParameter<edm::InputTag>("headerProducer")) {
   using namespace std;
 
   fedMap_ = new EcalFedMap();
@@ -24,60 +23,48 @@ EcalPedHists::EcalPedHists(const edm::ParameterSet& ps) :
   //for(int i=601; i<655; ++i)
   //{
   //  listDefaults.push_back(i);
-  //} 
+  //}
   listFEDs_ = ps.getUntrackedParameter<vector<int> >("listFEDs");
   listEBs_ = ps.getUntrackedParameter<vector<string> >("listEBs");
- 
-  if(listFEDs_.empty())
-  {
+
+  if (listFEDs_.empty()) {
     allFEDsSelected_ = false;
     //if "actual" EB id given, then convert to FEDid and put in listFEDs_
-    if(!listEBs_.empty())
-    {
+    if (!listEBs_.empty()) {
       listFEDs_.clear();
-      for(vector<string>::const_iterator itr = listEBs_.begin(); itr != listEBs_.end(); ++itr)
-      {
+      for (vector<string>::const_iterator itr = listEBs_.begin(); itr != listEBs_.end(); ++itr) {
         listFEDs_.push_back(fedMap_->getFedFromSlice(*itr));
       }
     }
-  }
-  else if(listFEDs_[0]==-1)
-  {
-  // Apply no selection if -1 is passed in FED list
+  } else if (listFEDs_[0] == -1) {
+    // Apply no selection if -1 is passed in FED list
     allFEDsSelected_ = true;
     //debug
     //cout << "no selection on FEDs!" << endl;
     //inputIsOk_=false;
     //return;
     //listFEDs_ = listDefaults;
-  }
-  else
-  {
+  } else {
     //in this case, listFEDs should be populated
     allFEDsSelected_ = false;
   }
 
-  if(!allFEDsSelected_)
-  {
+  if (!allFEDsSelected_) {
     // Verify FED numbers are valid
-    for (vector<int>::const_iterator intIter = listFEDs_.begin(); intIter != listFEDs_.end(); intIter++)
-    {  
-      if ( ((*intIter) < 601)||(654 < (*intIter)) )
-      {  
+    for (vector<int>::const_iterator intIter = listFEDs_.begin(); intIter != listFEDs_.end(); intIter++) {
+      if (((*intIter) < 601) || (654 < (*intIter))) {
         cout << "[EcalPedHists] FED value: " << (*intIter) << " found in listFEDs. "
-          << " Valid range is 601-654. Returning." << endl;
+             << " Valid range is 601-654. Returning." << endl;
         inputIsOk_ = false;
         return;
-      }
-      else
+      } else
         theRealFedSet_.insert(*intIter);
     }
   }
 
   vector<int> listDefaults = vector<int>();
   listDefaults.clear();
-  for(int i=1; i<1701; ++i)
-  {
+  for (int i = 1; i < 1701; ++i) {
     listDefaults.push_back(i);
   }
   listChannels_ = ps.getUntrackedParameter<vector<int> >("listChannels", listDefaults);
@@ -87,89 +74,77 @@ EcalPedHists::EcalPedHists(const edm::ParameterSet& ps) :
   listDefaults.push_back(1);
   listDefaults.push_back(2);
   listSamples_ = ps.getUntrackedParameter<vector<int> >("listSamples", listDefaults);
-  
+
   inputIsOk_ = true;
   vector<int>::iterator intIter;
-  
+
   // Verify crystal numbers are valid
-  for (intIter = listChannels_.begin(); intIter != listChannels_.end(); ++intIter)
-  { 
-      //TODO: Fix crystal index checking?
-      //if ( ((*intIter) < 1)||(1700 < (*intIter)) )       
-      //{  
-      //  cout << "[EcalPedHists] ic value: " << (*intIter) << " found in listChannels. "
-      //  	  << " Valid range is 1-1700. Returning." << endl;
-      //  inputIsOk_ = false;
-      //  return;
-      //}
+  for (intIter = listChannels_.begin(); intIter != listChannels_.end(); ++intIter) {
+    //TODO: Fix crystal index checking?
+    //if ( ((*intIter) < 1)||(1700 < (*intIter)) )
+    //{
+    //  cout << "[EcalPedHists] ic value: " << (*intIter) << " found in listChannels. "
+    //  	  << " Valid range is 1-1700. Returning." << endl;
+    //  inputIsOk_ = false;
+    //  return;
+    //}
   }
   // Verify sample numbers are valid
-  for (intIter = listSamples_.begin(); intIter != listSamples_.end(); intIter++)
-  {  
-      if ( ((*intIter) < 1)||(10 < (*intIter)) )
-      {  
-	cout << "[EcalPedHists] sample number: " << (*intIter) << " found in listSamples. "
-		  << " Valid range is 1-10. Returning." << endl;
-	inputIsOk_ = false;
-	return;
-      }
+  for (intIter = listSamples_.begin(); intIter != listSamples_.end(); intIter++) {
+    if (((*intIter) < 1) || (10 < (*intIter))) {
+      cout << "[EcalPedHists] sample number: " << (*intIter) << " found in listSamples. "
+           << " Valid range is 1-10. Returning." << endl;
+      inputIsOk_ = false;
+      return;
+    }
   }
-
 }
 
-EcalPedHists::~EcalPedHists() 
-{
-}
+EcalPedHists::~EcalPedHists() {}
 
-void EcalPedHists::beginRun(edm::Run const &, edm::EventSetup const & c)
-{
+void EcalPedHists::beginRun(edm::Run const&, edm::EventSetup const& c) {
   edm::ESHandle<EcalElectronicsMapping> elecHandle;
   c.get<EcalMappingRcd>().get(elecHandle);
   ecalElectronicsMap_ = elecHandle.product();
 }
 
-void EcalPedHists::endJob(void)
-{
+void EcalPedHists::endJob(void) {
   using namespace std;
-  if(inputIsOk_)
-  { 
+  if (inputIsOk_) {
     //debug
     //cout << "endJob:creating root file!" << endl;
-    
-    fileName_ += "-"+intToString(runNum_)+".graph.root";
 
-    TFile root_file_(fileName_.c_str() , "RECREATE");
+    fileName_ += "-" + intToString(runNum_) + ".graph.root";
+
+    TFile root_file_(fileName_.c_str(), "RECREATE");
     //Loop over FEDs first
-    for(set<int>::const_iterator FEDitr = theRealFedSet_.begin(); FEDitr != theRealFedSet_.end(); ++FEDitr)
-    {
-      if(!histsFilled_)
+    for (set<int>::const_iterator FEDitr = theRealFedSet_.begin(); FEDitr != theRealFedSet_.end(); ++FEDitr) {
+      if (!histsFilled_)
         break;
       string dir = fedMap_->getSliceFromFed(*FEDitr);
       TDirectory* FEDdir = gDirectory->mkdir(dir.c_str());
       FEDdir->cd();
       //root_file_.mkdir(dir.c_str());
       //root_file_.cd(dir.c_str());
-      map<string,TH1F*> mapHistos = FEDsAndHistMaps_[*FEDitr];
-      
+      map<string, TH1F*> mapHistos = FEDsAndHistMaps_[*FEDitr];
+
       //Loop over channels; write histos and directory structure
-      for (vector<int>::const_iterator itr = listChannels_.begin(); itr!=listChannels_.end(); itr++)
-      {
+      for (vector<int>::const_iterator itr = listChannels_.begin(); itr != listChannels_.end(); itr++) {
         //debug
         //cout << "loop over channels" << endl;
-        
+
         TH1F* hist = nullptr;
         string chnl = intToString(*itr);
         string name1 = "Cry";
-        name1.append(chnl+"Gain1");
+        name1.append(chnl + "Gain1");
         string name2 = "Cry";
-        name2.append(chnl+"Gain6");
+        name2.append(chnl + "Gain6");
         string name3 = "Cry";
-        name3.append(chnl+"Gain12");
+        name3.append(chnl + "Gain12");
         hist = mapHistos[name1];
         // This is a sanity check only
-        if(hist!=nullptr)
-        {
-          string cryDirName = "Cry_"+chnl;
+        if (hist != nullptr) {
+          string cryDirName = "Cry_" + chnl;
           TDirectory* cryDir = FEDdir->mkdir(cryDirName.c_str());
           cryDir->cd();
           hist->SetDirectory(cryDir);
@@ -182,9 +157,7 @@ void EcalPedHists::endJob(void)
           hist->Write();
           //root_file_.cd(dir.c_str());
           root_file_.cd();
-        }
-        else
-        {
+        } else {
           cerr << "EcalPedHists: Error: This shouldn't happen!" << endl;
         }
       }
@@ -194,45 +167,39 @@ void EcalPedHists::endJob(void)
   }
 }
 
-void EcalPedHists::analyze(const edm::Event& e, const edm::EventSetup& c)
-{
+void EcalPedHists::analyze(const edm::Event& e, const edm::EventSetup& c) {
   using namespace std;
   using namespace edm;
 
   if (!inputIsOk_)
     return;
-  
+
   // loop over the headers, this is to detect missing FEDs if all are selected
-  if(allFEDsSelected_)
-  {
+  if (allFEDsSelected_) {
     edm::Handle<EcalRawDataCollection> DCCHeaders;
     try {
-      e.getByLabel (headerProducer_, DCCHeaders);
-    } catch ( std::exception& ex ) {
-      edm::LogError ("EcalPedHists") << "Error! can't get the product " 
-        << headerProducer_;
+      e.getByLabel(headerProducer_, DCCHeaders);
+    } catch (std::exception& ex) {
+      edm::LogError("EcalPedHists") << "Error! can't get the product " << headerProducer_;
       return;
     }
 
-    for (EcalRawDataCollection::const_iterator headerItr= DCCHeaders->begin();
-        headerItr != DCCHeaders->end (); 
-        ++headerItr) 
-    {
-      int FEDid = 600+headerItr->id();
+    for (EcalRawDataCollection::const_iterator headerItr = DCCHeaders->begin(); headerItr != DCCHeaders->end();
+         ++headerItr) {
+      int FEDid = 600 + headerItr->id();
       theRealFedSet_.insert(FEDid);
     }
   }
 
   // loop over fed list and make sure that there are histo maps
-  for(set<int>::const_iterator fedItr = theRealFedSet_.begin(); fedItr != theRealFedSet_.end(); ++fedItr)
-  {
-    if(FEDsAndHistMaps_.find(*fedItr)==FEDsAndHistMaps_.end())
+  for (set<int>::const_iterator fedItr = theRealFedSet_.begin(); fedItr != theRealFedSet_.end(); ++fedItr) {
+    if (FEDsAndHistMaps_.find(*fedItr) == FEDsAndHistMaps_.end())
       initHists(*fedItr);
   }
-  
+
   //debug
   //cout << "analyze...input is ok? " << inputIsOk_ << endl;
-  
+
   bool barrelDigisFound = true;
   bool endcapDigisFound = true;
   // get the barrel digis
@@ -240,11 +207,9 @@ void EcalPedHists::analyze(const edm::Event& e, const edm::EventSetup& c)
   // TODO; SIC: fix this behavior
   Handle<EBDigiCollection> barrelDigis;
   try {
-    e.getByLabel (barrelDigiCollection_, barrelDigis);
-  } catch ( std::exception& ex ) 
-  {
-    edm::LogError ("EcalPedOffset") << "Error! can't get the product " 
-      << barrelDigiCollection_;
+    e.getByLabel(barrelDigiCollection_, barrelDigis);
+  } catch (std::exception& ex) {
+    edm::LogError("EcalPedOffset") << "Error! can't get the product " << barrelDigiCollection_;
     barrelDigisFound = false;
   }
   // get the endcap digis
@@ -252,75 +217,68 @@ void EcalPedHists::analyze(const edm::Event& e, const edm::EventSetup& c)
   // TODO; SIC: fix this behavior
   Handle<EEDigiCollection> endcapDigis;
   try {
-    e.getByLabel (endcapDigiCollection_, endcapDigis);
-  } catch ( std::exception& ex ) 
-  {
-    edm::LogError ("EcalPedOffset") << "Error! can't get the product " 
-      << endcapDigiCollection_;
+    e.getByLabel(endcapDigiCollection_, endcapDigis);
+  } catch (std::exception& ex) {
+    edm::LogError("EcalPedOffset") << "Error! can't get the product " << endcapDigiCollection_;
     endcapDigisFound = false;
   }
-  
-  if(barrelDigisFound)
+
+  if (barrelDigisFound)
     readEBdigis(barrelDigis);
-  if(endcapDigisFound)
+  if (endcapDigisFound)
     readEEdigis(endcapDigis);
-  if(!barrelDigisFound && !endcapDigisFound)
-    edm::LogError ("EcalPedOffset") << "No digis found in the event!";
-  
-  if(runNum_==-1)
+  if (!barrelDigisFound && !endcapDigisFound)
+    edm::LogError("EcalPedOffset") << "No digis found in the event!";
+
+  if (runNum_ == -1)
     runNum_ = e.id().run();
 }
 
 // insert the 3-entry hist map into the map keyed by FED number
-void EcalPedHists::initHists(int FED)
-{
+void EcalPedHists::initHists(int FED) {
   using namespace std;
   //using namespace edm;
 
-  std::map<string,TH1F*> histMap;
+  std::map<string, TH1F*> histMap;
   //debug
   //cout << "Initializing map for FED:" << *FEDitr << endl;
-  for (vector<int>::const_iterator intIter = listChannels_.begin(); intIter != listChannels_.end(); ++intIter)
-  { 
+  for (vector<int>::const_iterator intIter = listChannels_.begin(); intIter != listChannels_.end(); ++intIter) {
     //Put 3 histos (1 per gain) for the channel into the map
     string FEDid = intToString(FED);
     string chnl = intToString(*intIter);
     string title1 = "Gain1 ADC Counts for channel ";
     title1.append(chnl);
     string name1 = "Cry";
-    name1.append(chnl+"Gain1");
+    name1.append(chnl + "Gain1");
     string title2 = "Gain6 ADC Counts for channel ";
     title2.append(chnl);
     string name2 = "Cry";
-    name2.append(chnl+"Gain6");
+    name2.append(chnl + "Gain6");
     string title3 = "Gain12 ADC Counts for channel ";
     title3.append(chnl);
     string name3 = "Cry";
-    name3.append(chnl+"Gain12");
-    histMap.insert(make_pair(name1,new TH1F(name1.c_str(),title1.c_str(),75,175.0,250.0)));
+    name3.append(chnl + "Gain12");
+    histMap.insert(make_pair(name1, new TH1F(name1.c_str(), title1.c_str(), 75, 175.0, 250.0)));
     histMap[name1]->SetDirectory(nullptr);
-    histMap.insert(make_pair(name2,new TH1F(name2.c_str(),title2.c_str(),75,175.0,250.0)));
+    histMap.insert(make_pair(name2, new TH1F(name2.c_str(), title2.c_str(), 75, 175.0, 250.0)));
     histMap[name2]->SetDirectory(nullptr);
-    histMap.insert(make_pair(name3,new TH1F(name3.c_str(),title3.c_str(),75,175.0,250.0)));
+    histMap.insert(make_pair(name3, new TH1F(name3.c_str(), title3.c_str(), 75, 175.0, 250.0)));
     histMap[name3]->SetDirectory(nullptr);
   }
-  FEDsAndHistMaps_.insert(make_pair(FED,histMap));
+  FEDsAndHistMaps_.insert(make_pair(FED, histMap));
 }
 
-
-void EcalPedHists::readEBdigis(edm::Handle<EBDigiCollection> digis)
-{
+void EcalPedHists::readEBdigis(edm::Handle<EBDigiCollection> digis) {
   using namespace std;
   using namespace edm;
   //debug
   //cout << "readEBdigis" << endl;
-  
+
   // Loop over digis
-  for (EBDigiCollection::const_iterator digiItr= digis->begin();digiItr != digis->end(); ++digiItr )
-  {
+  for (EBDigiCollection::const_iterator digiItr = digis->begin(); digiItr != digis->end(); ++digiItr) {
     EBDetId detId = EBDetId(digiItr->id());
     EcalElectronicsId elecId = ecalElectronicsMap_->getElectronicsId(detId);
-    int FEDid = 600+elecId.dccId();
+    int FEDid = 600 + elecId.dccId();
     int crystalId = detId.ic();
 
     //debug
@@ -339,47 +297,43 @@ void EcalPedHists::readEBdigis(edm::Handle<EBDigiCollection> digis)
 
     // Get the adc counts from the selected samples and fill the corresponding histogram
     // Must subtract 1 from user-given sample list (e.g., user's sample 1 -> sample 0)
-    for (vector<int>::iterator itr = listSamples_.begin(); itr!=listSamples_.end(); itr++)
-    {
+    for (vector<int>::iterator itr = listSamples_.begin(); itr != listSamples_.end(); itr++) {
       histsFilled_ = true;
-      map<string,TH1F*> mapHistos = FEDsAndHistMaps_[FEDid];
+      map<string, TH1F*> mapHistos = FEDsAndHistMaps_[FEDid];
       string chnl = intToString(crystalId);
       string name1 = "Cry";
-      name1.append(chnl+"Gain1");
+      name1.append(chnl + "Gain1");
       string name2 = "Cry";
-      name2.append(chnl+"Gain6");
+      name2.append(chnl + "Gain6");
       string name3 = "Cry";
-      name3.append(chnl+"Gain12");
+      name3.append(chnl + "Gain12");
       TH1F* hist = nullptr;
-      if(((EBDataFrame)(*digiItr)).sample(*itr-1).gainId()==3)
+      if (((EBDataFrame)(*digiItr)).sample(*itr - 1).gainId() == 3)
         hist = mapHistos[name1];
-      if(((EBDataFrame)(*digiItr)).sample(*itr-1).gainId()==2)
+      if (((EBDataFrame)(*digiItr)).sample(*itr - 1).gainId() == 2)
         hist = mapHistos[name2];
-      if(((EBDataFrame)(*digiItr)).sample(*itr-1).gainId()==1)
+      if (((EBDataFrame)(*digiItr)).sample(*itr - 1).gainId() == 1)
         hist = mapHistos[name3];
-      if(hist!=nullptr)
-        hist->Fill(((EBDataFrame)(*digiItr)).sample(*itr-1).adc());
+      if (hist != nullptr)
+        hist->Fill(((EBDataFrame)(*digiItr)).sample(*itr - 1).adc());
       else
         cerr << "EcalPedHistDumper: Error: This shouldn't happen!" << endl;
     }
   }
 }
 
-
-void EcalPedHists::readEEdigis(edm::Handle<EEDigiCollection> digis)
-{
+void EcalPedHists::readEEdigis(edm::Handle<EEDigiCollection> digis) {
   using namespace std;
   using namespace edm;
   //debug
   //cout << "readEEdigis" << endl;
-  
+
   // Loop over digis
-  for (EEDigiCollection::const_iterator digiItr= digis->begin();digiItr != digis->end(); ++digiItr )
-  {
+  for (EEDigiCollection::const_iterator digiItr = digis->begin(); digiItr != digis->end(); ++digiItr) {
     EEDetId detId = EEDetId(digiItr->id());
     EcalElectronicsId elecId = ecalElectronicsMap_->getElectronicsId(detId);
-    int FEDid = 600+elecId.dccId();
-    int crystalId = 10000*FEDid+100*elecId.towerId()+5*(elecId.stripId()-1)+elecId.xtalId();
+    int FEDid = 600 + elecId.dccId();
+    int crystalId = 10000 * FEDid + 100 * elecId.towerId() + 5 * (elecId.stripId() - 1) + elecId.xtalId();
 
     //Select desired FEDs only
     set<int>::const_iterator fedIter = find(theRealFedSet_.begin(), theRealFedSet_.end(), FEDid);
@@ -394,43 +348,38 @@ void EcalPedHists::readEEdigis(edm::Handle<EEDigiCollection> digis)
 
     // Get the adc counts from the selected samples and fill the corresponding histogram
     // Must subtract 1 from user-given sample list (e.g., user's sample 1 -> sample 0)
-    for (vector<int>::iterator itr = listSamples_.begin(); itr!=listSamples_.end(); itr++)
-    {
+    for (vector<int>::iterator itr = listSamples_.begin(); itr != listSamples_.end(); itr++) {
       histsFilled_ = true;
-      map<string,TH1F*> mapHistos = FEDsAndHistMaps_[FEDid];
+      map<string, TH1F*> mapHistos = FEDsAndHistMaps_[FEDid];
       string chnl = intToString(crystalId);
       string name1 = "Cry";
-      name1.append(chnl+"Gain1");
+      name1.append(chnl + "Gain1");
       string name2 = "Cry";
-      name2.append(chnl+"Gain6");
+      name2.append(chnl + "Gain6");
       string name3 = "Cry";
-      name3.append(chnl+"Gain12");
+      name3.append(chnl + "Gain12");
       TH1F* hist = nullptr;
-      if(((EBDataFrame)(*digiItr)).sample(*itr-1).gainId()==3)
+      if (((EBDataFrame)(*digiItr)).sample(*itr - 1).gainId() == 3)
         hist = mapHistos[name1];
-      if(((EBDataFrame)(*digiItr)).sample(*itr-1).gainId()==2)
+      if (((EBDataFrame)(*digiItr)).sample(*itr - 1).gainId() == 2)
         hist = mapHistos[name2];
-      if(((EBDataFrame)(*digiItr)).sample(*itr-1).gainId()==1)
+      if (((EBDataFrame)(*digiItr)).sample(*itr - 1).gainId() == 1)
         hist = mapHistos[name3];
-      if(hist!=nullptr)
-        hist->Fill(((EBDataFrame)(*digiItr)).sample(*itr-1).adc());
+      if (hist != nullptr)
+        hist->Fill(((EBDataFrame)(*digiItr)).sample(*itr - 1).adc());
       else
         cerr << "EcalPedHistDumper: Error: This shouldn't happen!" << endl;
     }
   }
 }
 
-
-std::string EcalPedHists::intToString(int num)
-{
+std::string EcalPedHists::intToString(int num) {
   using namespace std;
   //
   // outputs the number into the string stream and then flushes
   // the buffer (makes sure the output is put into the stream)
   //
-  ostringstream myStream; //creates an ostringstream object
+  ostringstream myStream;  //creates an ostringstream object
   myStream << num << flush;
-  return(myStream.str()); //returns the string form of the stringstream object
+  return (myStream.str());  //returns the string form of the stringstream object
 }
-
-

--- a/CaloOnlineTools/EcalTools/plugins/EcalPedHists.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalPedHists.h
@@ -29,40 +29,39 @@
 #include "TH1.h"
 #include "TDirectory.h"
 
-typedef std::map<std::string,TH1F*> stringHistMap;
+typedef std::map<std::string, TH1F*> stringHistMap;
 
-class EcalPedHists: public edm::EDAnalyzer
-{ 
-  public:
-    EcalPedHists(const edm::ParameterSet& ps);   
-    ~EcalPedHists() override;
+class EcalPedHists : public edm::EDAnalyzer {
+public:
+  EcalPedHists(const edm::ParameterSet& ps);
+  ~EcalPedHists() override;
 
-  protected:
-    void analyze(const edm::Event & e, const  edm::EventSetup& c) override;
-    void beginRun(edm::Run const &, edm::EventSetup const & c) override;
-    void endJob(void) override;
+protected:
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+  void beginRun(edm::Run const&, edm::EventSetup const& c) override;
+  void endJob(void) override;
 
-  private:
-    std::string intToString(int num);
-    void readEBdigis(edm::Handle<EBDigiCollection> digis);
-    void readEEdigis(edm::Handle<EEDigiCollection> digis);
-    void initHists(int FED);
+private:
+  std::string intToString(int num);
+  void readEBdigis(edm::Handle<EBDigiCollection> digis);
+  void readEEdigis(edm::Handle<EEDigiCollection> digis);
+  void initHists(int FED);
 
-    int runNum_;
-    bool inputIsOk_;
-    bool allFEDsSelected_;
-    bool histsFilled_;
-    std::string fileName_;
-    edm::InputTag barrelDigiCollection_;
-    edm::InputTag endcapDigiCollection_;
-    edm::InputTag headerProducer_;
-    std::vector<int> listChannels_;
-    std::vector<int> listSamples_;
-    std::vector<int> listFEDs_;
-    std::vector<std::string> listEBs_;
-    std::map<int,stringHistMap> FEDsAndHistMaps_;
-    std::set<int> theRealFedSet_;
-    EcalFedMap* fedMap_;
-    TFile * root_file_;
-    const EcalElectronicsMapping* ecalElectronicsMap_;
+  int runNum_;
+  bool inputIsOk_;
+  bool allFEDsSelected_;
+  bool histsFilled_;
+  std::string fileName_;
+  edm::InputTag barrelDigiCollection_;
+  edm::InputTag endcapDigiCollection_;
+  edm::InputTag headerProducer_;
+  std::vector<int> listChannels_;
+  std::vector<int> listSamples_;
+  std::vector<int> listFEDs_;
+  std::vector<std::string> listEBs_;
+  std::map<int, stringHistMap> FEDsAndHistMaps_;
+  std::set<int> theRealFedSet_;
+  EcalFedMap* fedMap_;
+  TFile* root_file_;
+  const EcalElectronicsMapping* ecalElectronicsMap_;
 };

--- a/CaloOnlineTools/EcalTools/plugins/EcalPnGraphs.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalPnGraphs.cc
@@ -26,112 +26,112 @@
 #include "TFile.h"
 #include "TGraph.h"
 
-
 //=============================================================================
-EcalPnGraphs::EcalPnGraphs(const edm::ParameterSet& ps){  
-//=============================================================================
+EcalPnGraphs::EcalPnGraphs(const edm::ParameterSet& ps) {
+  //=============================================================================
 
-  digiProducer_     = ps.getParameter<std::string>("digiProducer");
-  fileName = ps.getUntrackedParameter<std::string >("fileName", std::string("toto") );
+  digiProducer_ = ps.getParameter<std::string>("digiProducer");
+  fileName = ps.getUntrackedParameter<std::string>("fileName", std::string("toto"));
 
   first_Pn = 0;
 
   listPns = ps.getUntrackedParameter<std::vector<int> >("listPns", std::vector<int>());
-  numPn   = ps.getUntrackedParameter< int >("numPn");
+  numPn = ps.getUntrackedParameter<int>("numPn");
 
   std::vector<int> listDefaults;
   listDefaults.push_back(-1);
-  feds_ = ps.getUntrackedParameter<std::vector<int> > ("requestedFeds",listDefaults);
+  feds_ = ps.getUntrackedParameter<std::vector<int> >("requestedFeds", listDefaults);
   bool fedIsGiven = false;
 
   std::vector<std::string> ebDefaults;
   ebDefaults.push_back("none");
-  ebs_  = ps.getUntrackedParameter<std::vector<std::string> >("requestedEbs",ebDefaults);
+  ebs_ = ps.getUntrackedParameter<std::vector<std::string> >("requestedEbs", ebDefaults);
 
   //FEDs and EBs
-  if ( feds_[0] != -1 ) {
+  if (feds_[0] != -1) {
     edm::LogInfo("EcalPnGraphs") << "FED id is given! Goining to beginJob! ";
     fedIsGiven = true;
-  }else {
+  } else {
     feds_.clear();
-    if ( ebs_[0] !="none" ) {
+    if (ebs_[0] != "none") {
       //EB id is given and convert to FED id
-      fedMap = new EcalFedMap(); 
-      for (std::vector<std::string>::const_iterator ebItr = ebs_.begin(); 
-	   ebItr!= ebs_.end();  ++ebItr) {
-	feds_.push_back(fedMap->getFedFromSlice(*ebItr));
+      fedMap = new EcalFedMap();
+      for (std::vector<std::string>::const_iterator ebItr = ebs_.begin(); ebItr != ebs_.end(); ++ebItr) {
+        feds_.push_back(fedMap->getFedFromSlice(*ebItr));
       }
       delete fedMap;
     } else {
       //Select all FEDs in the Event
-      for ( int i=601; i<655; ++i){
-	feds_.push_back(i);
+      for (int i = 601; i < 655; ++i) {
+        feds_.push_back(i);
       }
     }
   }
-  
+
   // consistency checks checks
-  inputIsOk       = true;
+  inputIsOk = true;
   //check with FEDs
-  if ( fedIsGiven ) {
+  if (fedIsGiven) {
     std::vector<int>::iterator fedIter;
-    for (fedIter = feds_.begin(); fedIter!=feds_.end(); ++fedIter) {
-      if ( (*fedIter) < 601 || (*fedIter) > 654) {                      
-	std::cout << "[EcalPnGraphs] pn number : " << (*fedIter) << " found in listFeds. "
-		  << " Valid range is [601-654]. Returning." << std::endl;
-	inputIsOk = false;
-	return;
+    for (fedIter = feds_.begin(); fedIter != feds_.end(); ++fedIter) {
+      if ((*fedIter) < 601 || (*fedIter) > 654) {
+        std::cout << "[EcalPnGraphs] pn number : " << (*fedIter) << " found in listFeds. "
+                  << " Valid range is [601-654]. Returning." << std::endl;
+        inputIsOk = false;
+        return;
       }
     }
   }
 
   //Check with Pns
-  if ( listPns[0] != -1 ) { 
+  if (listPns[0] != -1) {
     std::vector<int>::iterator intIter;
-    for (intIter = listPns.begin(); intIter != listPns.end(); intIter++)  {  
-      if ( ((*intIter) < 1) ||  (10 < (*intIter)) )       {  
-	std::cout << "[EcalPnGraphs] pn number : " << (*intIter) << " found in listPns. "
-		  << " Valid range is 1-10. Returning." << std::endl;
-	inputIsOk = false;
-	return;
+    for (intIter = listPns.begin(); intIter != listPns.end(); intIter++) {
+      if (((*intIter) < 1) || (10 < (*intIter))) {
+        std::cout << "[EcalPnGraphs] pn number : " << (*intIter) << " found in listPns. "
+                  << " Valid range is 1-10. Returning." << std::endl;
+        inputIsOk = false;
+        return;
       }
-      if (!first_Pn )   first_Pn = (*intIter);	
+      if (!first_Pn)
+        first_Pn = (*intIter);
     }
   } else {
     listPns.clear();
-    listPns.push_back(5); 
-    listPns.push_back(6); 
+    listPns.push_back(5);
+    listPns.push_back(6);
   }
-  
+
   // setting the abcissa array once for all
-  for (int i=0; i<50; i++)        abscissa[i] = i;
-  
+  for (int i = 0; i < 50; i++)
+    abscissa[i] = i;
+
   // local event counter (in general different from LV1)
-  eventCounter =0;
+  eventCounter = 0;
 }
 
-
 //=============================================================================
-EcalPnGraphs::~EcalPnGraphs(){  
-//=============================================================================
+EcalPnGraphs::~EcalPnGraphs() {
+  //=============================================================================
   //delete *;
 }
 
 //=============================================================================
 void EcalPnGraphs::beginJob() {
-//=============================================================================
-  edm::LogInfo("EcalPhGraphs") << "entering beginJob! " ;
+  //=============================================================================
+  edm::LogInfo("EcalPhGraphs") << "entering beginJob! ";
 }
 
 //=============================================================================
-void EcalPnGraphs::analyze( const edm::Event & e, const  edm::EventSetup& c){
-//=============================================================================
+void EcalPnGraphs::analyze(const edm::Event& e, const edm::EventSetup& c) {
+  //=============================================================================
 
   eventCounter++;
-  if (!inputIsOk) return;
+  if (!inputIsOk)
+    return;
 
   // retrieving crystal PN diodes from Event
-  edm::Handle<EcalPnDiodeDigiCollection>  pn_digis;
+  edm::Handle<EcalPnDiodeDigiCollection> pn_digis;
   try {
     e.getByLabel(digiProducer_, pn_digis);
   } catch (cms::Exception& ex) {
@@ -142,81 +142,80 @@ void EcalPnGraphs::analyze( const edm::Event & e, const  edm::EventSetup& c){
   // - listPns is the list as given by the user
   // -numPn is the number of Pns (centered at Pn from listPns) for which graphs are required
   std::vector<int>::iterator pn_it;
-  for ( pn_it = listPns.begin();  pn_it != listPns.end() ; pn_it++  )
-    {
-      int ipn    = (*pn_it);
-      int hpn = numPn;
-      
-      for (int u = (-hpn) ; u<=hpn; u++){	  
-	  int ipn_c = ipn + u;
-	  if (ipn_c < 1 || ipn_c > 10) continue;
-	  std::vector<int>::iterator notInList = find(listAllPns.begin(), listAllPns.end(), ipn_c);
-	  if ( notInList == listAllPns.end() ) {
-	    listAllPns.push_back ( ipn_c );
-	  }
+  for (pn_it = listPns.begin(); pn_it != listPns.end(); pn_it++) {
+    int ipn = (*pn_it);
+    int hpn = numPn;
+
+    for (int u = (-hpn); u <= hpn; u++) {
+      int ipn_c = ipn + u;
+      if (ipn_c < 1 || ipn_c > 10)
+        continue;
+      std::vector<int>::iterator notInList = find(listAllPns.begin(), listAllPns.end(), ipn_c);
+      if (notInList == listAllPns.end()) {
+        listAllPns.push_back(ipn_c);
       }
     }
-  
+  }
+
   //Loop over PN digis
-  for ( EcalPnDiodeDigiCollection::const_iterator pnItr = pn_digis->begin(); pnItr != pn_digis->end(); ++pnItr )  {
+  for (EcalPnDiodeDigiCollection::const_iterator pnItr = pn_digis->begin(); pnItr != pn_digis->end(); ++pnItr) {
     //Get PNid of a digi
     int ipn = (*pnItr).id().iPnId();
     //Get DCC id where the digi is from
-    int ieb    = EcalPnDiodeDetId((*pnItr).id()).iDCCId();
-    
+    int ieb = EcalPnDiodeDetId((*pnItr).id()).iDCCId();
+
     //Make sure that these are PnDigis from the requested FEDid
     int FEDid = ieb + 600;
 
     std::vector<int>::iterator fedIter = find(feds_.begin(), feds_.end(), FEDid);
 
-    if ( fedIter == feds_.end() ) {
-      edm::LogWarning("EcalPnGraphs")<< "For Event " << eventCounter << " PnDigis are not found from requested SM!. returning...";
+    if (fedIter == feds_.end()) {
+      edm::LogWarning("EcalPnGraphs") << "For Event " << eventCounter
+                                      << " PnDigis are not found from requested SM!. returning...";
       return;
     }
     // selecting desired Pns only
     std::vector<int>::iterator iPnIter;
-    iPnIter     = find( listAllPns.begin() , listAllPns.end() , ipn);
-    if (iPnIter == listAllPns.end()) continue; 
-    
-    for ( int i=0; i< (*pnItr).size() && i<50; ++i ) {
+    iPnIter = find(listAllPns.begin(), listAllPns.end(), ipn);
+    if (iPnIter == listAllPns.end())
+      continue;
+
+    for (int i = 0; i < (*pnItr).size() && i < 50; ++i) {
       ordinate[i] = (*pnItr).sample(i).adc();
     }
     //make grapn of ph digis
-    TGraph oneGraph(50, abscissa,ordinate);
+    TGraph oneGraph(50, abscissa, ordinate);
     std::string title;
-    title = "Graph_ev" + intToString( eventCounter )
-          + "_FED" + intToString( FEDid )
-          + "_ipn" + intToString( ipn );
+    title = "Graph_ev" + intToString(eventCounter) + "_FED" + intToString(FEDid) + "_ipn" + intToString(ipn);
     oneGraph.SetTitle(title.c_str());
     oneGraph.SetName(title.c_str());
     graphs.push_back(oneGraph);
-    
-  }// loop over Pn digis
+
+  }  // loop over Pn digis
 }
 
-std::string EcalPnGraphs::intToString(int num)
-{
+std::string EcalPnGraphs::intToString(int num) {
   //
   // outputs the number into the string stream and then flushes
   // the buffer (makes sure the output is put into the stream)
   //
-  std::ostringstream myStream; //creates an ostringstream object
+  std::ostringstream myStream;  //creates an ostringstream object
   myStream << num << std::flush;
-  
-  return(myStream.str()); //returns the string form of the stringstream object
-} 
+
+  return (myStream.str());  //returns the string form of the stringstream object
+}
 
 //=============================================================================
 void EcalPnGraphs::endJob() {
-//=============================================================================
-  fileName +=  ( std::string("_Pn")    + intToString(first_Pn) ); 
+  //=============================================================================
+  fileName += (std::string("_Pn") + intToString(first_Pn));
   fileName += ".graph.root";
 
-  root_file = new TFile( fileName.c_str() , "RECREATE" );
+  root_file = new TFile(fileName.c_str(), "RECREATE");
   std::vector<TGraph>::iterator gr_it;
-  for ( gr_it = graphs.begin(); gr_it !=  graphs.end(); gr_it++ )      (*gr_it).Write();
+  for (gr_it = graphs.begin(); gr_it != graphs.end(); gr_it++)
+    (*gr_it).Write();
   root_file->Close();
 
-  edm::LogInfo("EcalPnGraphs") << "DONE!.... " ;
+  edm::LogInfo("EcalPnGraphs") << "DONE!.... ";
 }
-

--- a/CaloOnlineTools/EcalTools/plugins/EcalPnGraphs.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalPnGraphs.h
@@ -17,28 +17,23 @@
 #include "TFile.h"
 #include "TGraph.h"
 
-
-
-class EcalPnGraphs: public edm::EDAnalyzer{
-  
+class EcalPnGraphs : public edm::EDAnalyzer {
 public:
-
-  EcalPnGraphs(const edm::ParameterSet& ps);   
+  EcalPnGraphs(const edm::ParameterSet& ps);
   ~EcalPnGraphs() override;
-    
+
 private:
-  void analyze(const edm::Event & e, const  edm::EventSetup& c) override;
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   void beginJob() override;
   void endJob() override;
- 
+
   //  void pnGraphs (edm::Handle<EcalPnDiodeDigiCollection> PNs );
 
   std::string intToString(int num);
 
   EcalFedMap* fedMap;
-  
-protected:
 
+protected:
   //  std::string ebDigiCollection_;
   //std::string eeDigiCollection_;
   std::string digiProducer_;
@@ -48,10 +43,9 @@ protected:
 
   int verbosity;
   int eventCounter;
-   
+
   //  std::vector<int ieb_id;
   int first_Pn;
-  
 
   bool inputIsOk;
 
@@ -66,12 +60,10 @@ protected:
 
   int abscissa[50];
   int ordinate[50];
-  
+
   std::vector<TGraph> graphs;
-  
-  TFile * root_file;
-  
+
+  TFile* root_file;
 };
 
 #endif
-

--- a/CaloOnlineTools/EcalTools/plugins/EcalPulseShapeGrapher.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalPulseShapeGrapher.cc
@@ -2,7 +2,7 @@
 //
 // Package:    EcalPulseShapeGrapher
 // Class:      EcalPulseShapeGrapher
-// 
+//
 /**\class EcalPulseShapeGrapher EcalPulseShapeGrapher.cc Analyzers/EcalPulseShapeGrapher/src/EcalPulseShapeGrapher.cc
 
  Description: <one line class summary>
@@ -29,267 +29,246 @@
 //
 // constructors and destructor
 //
-EcalPulseShapeGrapher::EcalPulseShapeGrapher(const edm::ParameterSet& iConfig) :
-EBUncalibratedRecHitCollection_ (iConfig.getParameter<edm::InputTag>("EBUncalibratedRecHitCollection")),
-EBDigis_ (iConfig.getParameter<edm::InputTag>("EBDigiCollection")),
-EEUncalibratedRecHitCollection_ (iConfig.getParameter<edm::InputTag>("EEUncalibratedRecHitCollection")),
-EEDigis_ (iConfig.getParameter<edm::InputTag>("EEDigiCollection")),
-ampCut_ (iConfig.getUntrackedParameter<int>("AmplitudeCutADC", 13)),
-rootFilename_ (iConfig.getUntrackedParameter<std::string>("rootFilename","pulseShapeGrapher"))
-{
-   //now do what ever initialization is needed
+EcalPulseShapeGrapher::EcalPulseShapeGrapher(const edm::ParameterSet& iConfig)
+    : EBUncalibratedRecHitCollection_(iConfig.getParameter<edm::InputTag>("EBUncalibratedRecHitCollection")),
+      EBDigis_(iConfig.getParameter<edm::InputTag>("EBDigiCollection")),
+      EEUncalibratedRecHitCollection_(iConfig.getParameter<edm::InputTag>("EEUncalibratedRecHitCollection")),
+      EEDigis_(iConfig.getParameter<edm::InputTag>("EEDigiCollection")),
+      ampCut_(iConfig.getUntrackedParameter<int>("AmplitudeCutADC", 13)),
+      rootFilename_(iConfig.getUntrackedParameter<std::string>("rootFilename", "pulseShapeGrapher")) {
+  //now do what ever initialization is needed
 
-   std::vector<int> listDefaults;
-   listDefaults.push_back(-1);
-   listChannels_ = iConfig.getUntrackedParameter<std::vector<int> >("listChannels", listDefaults);
+  std::vector<int> listDefaults;
+  listDefaults.push_back(-1);
+  listChannels_ = iConfig.getUntrackedParameter<std::vector<int> >("listChannels", listDefaults);
 
-   for(std::vector<int>::const_iterator itr = listChannels_.begin(); itr != listChannels_.end(); ++itr)
-   {
-     std::string title = "Amplitude of cry "+intToString(*itr);
-     std::string name = "ampOfCry"+intToString(*itr);
-     ampHistMap_[*itr] = new TH1F(name.c_str(),title.c_str(),100,0,100);
-     ampHistMap_[*itr]->GetXaxis()->SetTitle("ADC");
+  for (std::vector<int>::const_iterator itr = listChannels_.begin(); itr != listChannels_.end(); ++itr) {
+    std::string title = "Amplitude of cry " + intToString(*itr);
+    std::string name = "ampOfCry" + intToString(*itr);
+    ampHistMap_[*itr] = new TH1F(name.c_str(), title.c_str(), 100, 0, 100);
+    ampHistMap_[*itr]->GetXaxis()->SetTitle("ADC");
 
-     title = "Amplitude (over 13 ADC) of cry "+intToString(*itr);
-     name = "cutAmpOfCry"+intToString(*itr);
-     cutAmpHistMap_[*itr] = new TH1F(name.c_str(),title.c_str(),100,0,100);
-     cutAmpHistMap_[*itr]->GetXaxis()->SetTitle("ADC");
+    title = "Amplitude (over 13 ADC) of cry " + intToString(*itr);
+    name = "cutAmpOfCry" + intToString(*itr);
+    cutAmpHistMap_[*itr] = new TH1F(name.c_str(), title.c_str(), 100, 0, 100);
+    cutAmpHistMap_[*itr]->GetXaxis()->SetTitle("ADC");
 
-     title = "Pulse shape of cry "+intToString(*itr);
-     name = "PulseShapeCry"+intToString(*itr);
-     pulseShapeHistMap_[*itr] = new TH2F(name.c_str(),title.c_str(),10,0,10,220,-20,2);
-     pulseShapeHistMap_[*itr]->GetXaxis()->SetTitle("sample");
+    title = "Pulse shape of cry " + intToString(*itr);
+    name = "PulseShapeCry" + intToString(*itr);
+    pulseShapeHistMap_[*itr] = new TH2F(name.c_str(), title.c_str(), 10, 0, 10, 220, -20, 2);
+    pulseShapeHistMap_[*itr]->GetXaxis()->SetTitle("sample");
 
-     title = "Raw Pulse shape of cry "+intToString(*itr);
-     name = "RawPulseShapeCry"+intToString(*itr);
-     rawPulseShapeHistMap_[*itr] = new TH2F(name.c_str(),title.c_str(),10,0,10,500,0,500);
-     rawPulseShapeHistMap_[*itr]->GetXaxis()->SetTitle("sample");
-     
-     title = "Amplitude of first sample, cry "+intToString(*itr);
-     name = "AmpOfFirstSampleCry"+intToString(*itr);
-     firstSampleHistMap_[*itr] = new TH1F(name.c_str(),title.c_str(),300,100,400);
-     firstSampleHistMap_[*itr]->GetXaxis()->SetTitle("ADC");
-   }
-   
-   fedMap_ = new EcalFedMap();
-   
-   for (int i=0; i<10; i++)
-     abscissa[i] = i;
+    title = "Raw Pulse shape of cry " + intToString(*itr);
+    name = "RawPulseShapeCry" + intToString(*itr);
+    rawPulseShapeHistMap_[*itr] = new TH2F(name.c_str(), title.c_str(), 10, 0, 10, 500, 0, 500);
+    rawPulseShapeHistMap_[*itr]->GetXaxis()->SetTitle("sample");
+
+    title = "Amplitude of first sample, cry " + intToString(*itr);
+    name = "AmpOfFirstSampleCry" + intToString(*itr);
+    firstSampleHistMap_[*itr] = new TH1F(name.c_str(), title.c_str(), 300, 100, 400);
+    firstSampleHistMap_[*itr]->GetXaxis()->SetTitle("ADC");
+  }
+
+  fedMap_ = new EcalFedMap();
+
+  for (int i = 0; i < 10; i++)
+    abscissa[i] = i;
 }
 
-
-EcalPulseShapeGrapher::~EcalPulseShapeGrapher()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+EcalPulseShapeGrapher::~EcalPulseShapeGrapher() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to for each event  ------------
-void
-EcalPulseShapeGrapher::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-   using namespace std;
+void EcalPulseShapeGrapher::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace std;
 
-   int numHitsWithActivity = 0;
-   
-   //int eventNum = iEvent.id().event();
-   //vector<EcalUncalibratedRecHit> sampleHitsPastCut;
-   
-   Handle<EcalUncalibratedRecHitCollection> EBHits;
-   iEvent.getByLabel(EBUncalibratedRecHitCollection_, EBHits);
-   Handle<EcalUncalibratedRecHitCollection> EEHits;
-   iEvent.getByLabel(EEUncalibratedRecHitCollection_, EEHits);
-   //cout << "event: " << eventNum << " sample hits collection size: " << sampleHits->size() << endl;
-   //Handle<EcalUncalibratedRecHitCollection> fittedHits;
-   //iEvent.getByLabel(FittedUncalibratedRecHitCollection_, fittedHits);
-   Handle<EBDigiCollection>  EBdigis;
-   iEvent.getByLabel(EBDigis_, EBdigis);
-   Handle<EEDigiCollection>  EEdigis;
-   iEvent.getByLabel(EEDigis_, EEdigis);
-   //cout << "event: " << eventNum << " digi collection size: " << digis->size() << endl;
+  int numHitsWithActivity = 0;
 
-   unique_ptr<EcalElectronicsMapping> ecalElectronicsMap(new EcalElectronicsMapping);
+  //int eventNum = iEvent.id().event();
+  //vector<EcalUncalibratedRecHit> sampleHitsPastCut;
 
-   // Loop over the hits
-   for(EcalUncalibratedRecHitCollection::const_iterator hitItr = EBHits->begin(); hitItr != EBHits->end(); ++hitItr)
-   {
-     EcalUncalibratedRecHit hit = (*hitItr);
-     float amplitude = hit.amplitude();
-     EBDetId hitDetId = hit.id();
+  Handle<EcalUncalibratedRecHitCollection> EBHits;
+  iEvent.getByLabel(EBUncalibratedRecHitCollection_, EBHits);
+  Handle<EcalUncalibratedRecHitCollection> EEHits;
+  iEvent.getByLabel(EEUncalibratedRecHitCollection_, EEHits);
+  //cout << "event: " << eventNum << " sample hits collection size: " << sampleHits->size() << endl;
+  //Handle<EcalUncalibratedRecHitCollection> fittedHits;
+  //iEvent.getByLabel(FittedUncalibratedRecHitCollection_, fittedHits);
+  Handle<EBDigiCollection> EBdigis;
+  iEvent.getByLabel(EBDigis_, EBdigis);
+  Handle<EEDigiCollection> EEdigis;
+  iEvent.getByLabel(EEDigis_, EEdigis);
+  //cout << "event: " << eventNum << " digi collection size: " << digis->size() << endl;
 
-     // Get the Fedid
-     EcalElectronicsId elecId = ecalElectronicsMap->getElectronicsId(hitDetId);
-     int FEDid = 600+elecId.dccId();
-     string SMname = fedMap_->getSliceFromFed(FEDid);
-     
-     vector<int>::const_iterator itr = listChannels_.begin();
-     while(itr != listChannels_.end() && (*itr) != hitDetId.hashedIndex())
-     {
-       itr++;
-     }
-     if(itr==listChannels_.end())
-       continue;
+  unique_ptr<EcalElectronicsMapping> ecalElectronicsMap(new EcalElectronicsMapping);
 
-     ampHistMap_[hitDetId.hashedIndex()]->Fill(amplitude);
-     //cout << "Cry hash:" << hitDetId.hashedIndex() << " amplitude: " << amplitude << endl;
-     if(amplitude < ampCut_)
-       continue;
+  // Loop over the hits
+  for (EcalUncalibratedRecHitCollection::const_iterator hitItr = EBHits->begin(); hitItr != EBHits->end(); ++hitItr) {
+    EcalUncalibratedRecHit hit = (*hitItr);
+    float amplitude = hit.amplitude();
+    EBDetId hitDetId = hit.id();
 
-     cutAmpHistMap_[hitDetId.hashedIndex()]->Fill(amplitude);
-     numHitsWithActivity++;
-     EBDigiCollection::const_iterator digiItr= EBdigis->begin();
-     while(digiItr != EBdigis->end() && digiItr->id() != hitItr->id())
-     {
-       digiItr++;
-     }
-     if(digiItr == EBdigis->end())
-       continue;
+    // Get the Fedid
+    EcalElectronicsId elecId = ecalElectronicsMap->getElectronicsId(hitDetId);
+    int FEDid = 600 + elecId.dccId();
+    string SMname = fedMap_->getSliceFromFed(FEDid);
 
-     double sampleADC[10];
-     EBDataFrame df(*digiItr);
-     double pedestal = 200;
+    vector<int>::const_iterator itr = listChannels_.begin();
+    while (itr != listChannels_.end() && (*itr) != hitDetId.hashedIndex()) {
+      itr++;
+    }
+    if (itr == listChannels_.end())
+      continue;
 
-     if(df.sample(0).gainId()!=1 || df.sample(1).gainId()!=1) continue; //goes to the next digi
-     else {
-       sampleADC[0] = df.sample(0).adc();
-       sampleADC[1] = df.sample(1).adc();
-       pedestal = (double)(sampleADC[0]+sampleADC[1])/(double)2;
-     } 
+    ampHistMap_[hitDetId.hashedIndex()]->Fill(amplitude);
+    //cout << "Cry hash:" << hitDetId.hashedIndex() << " amplitude: " << amplitude << endl;
+    if (amplitude < ampCut_)
+      continue;
 
-     for (int i=0; (unsigned int)i< digiItr->size(); ++i ) {
-       EBDataFrame df(*digiItr);
-       double gain = 12.;
-       if(df.sample(i).gainId()==1)
-         gain = 1.;
-       else if(df.sample(i).gainId()==2)
-         gain = 2.;
-       sampleADC[i] = pedestal+(df.sample(i).adc()-pedestal)*gain;
-     }
+    cutAmpHistMap_[hitDetId.hashedIndex()]->Fill(amplitude);
+    numHitsWithActivity++;
+    EBDigiCollection::const_iterator digiItr = EBdigis->begin();
+    while (digiItr != EBdigis->end() && digiItr->id() != hitItr->id()) {
+      digiItr++;
+    }
+    if (digiItr == EBdigis->end())
+      continue;
 
-     //cout << "1) maxsample amp:" << maxSampleAmp << " maxSampleIndex:" << maxSampleIndex << endl;
-     for(int i=0; i<10;++i)
-     {
-       //cout << "Filling hist for:" << hitDetId.hashedIndex() << " with sample:" << i 
-         //<< " amp:" <<(float)(df.sample(i).adc()-baseline)/(maxSampleAmp-baseline) << endl;
-       //cout << "ADC of sample:" << df.sample(i).adc() << " baseline:" << baseline << " maxSampleAmp:" 
-         //<< maxSampleAmp << endl << endl;
-       pulseShapeHistMap_[hitDetId.hashedIndex()]->Fill(i, (float)(sampleADC[i]-pedestal)/amplitude);
-       rawPulseShapeHistMap_[hitDetId.hashedIndex()]->Fill(i, (float)(sampleADC[i]));
-     }
-     firstSampleHistMap_[hitDetId.hashedIndex()]->Fill(sampleADC[0]);
-   }
+    double sampleADC[10];
+    EBDataFrame df(*digiItr);
+    double pedestal = 200;
 
-   // Now do the same for the EE hits
-   for(EcalUncalibratedRecHitCollection::const_iterator hitItr = EEHits->begin(); hitItr != EEHits->end(); ++hitItr)
-   {
-     EcalUncalibratedRecHit hit = (*hitItr);
-     float amplitude = hit.amplitude();
-     EEDetId hitDetId = hit.id();
+    if (df.sample(0).gainId() != 1 || df.sample(1).gainId() != 1)
+      continue;  //goes to the next digi
+    else {
+      sampleADC[0] = df.sample(0).adc();
+      sampleADC[1] = df.sample(1).adc();
+      pedestal = (double)(sampleADC[0] + sampleADC[1]) / (double)2;
+    }
 
-     // Get the Fedid
-     EcalElectronicsId elecId = ecalElectronicsMap->getElectronicsId(hitDetId);
-     int FEDid = 600+elecId.dccId();
-     string SMname = fedMap_->getSliceFromFed(FEDid);
-     
-     vector<int>::const_iterator itr = listChannels_.begin();
-     while(itr != listChannels_.end() && (*itr) != hitDetId.hashedIndex())
-     {
-       itr++;
-     }
-     if(itr==listChannels_.end())
-       continue;
+    for (int i = 0; (unsigned int)i < digiItr->size(); ++i) {
+      EBDataFrame df(*digiItr);
+      double gain = 12.;
+      if (df.sample(i).gainId() == 1)
+        gain = 1.;
+      else if (df.sample(i).gainId() == 2)
+        gain = 2.;
+      sampleADC[i] = pedestal + (df.sample(i).adc() - pedestal) * gain;
+    }
 
-     ampHistMap_[hitDetId.hashedIndex()]->Fill(amplitude);
-     //cout << "Cry hash:" << hitDetId.hashedIndex() << " amplitude: " << amplitude << endl;
-     if(amplitude < ampCut_)
-       continue;
+    //cout << "1) maxsample amp:" << maxSampleAmp << " maxSampleIndex:" << maxSampleIndex << endl;
+    for (int i = 0; i < 10; ++i) {
+      //cout << "Filling hist for:" << hitDetId.hashedIndex() << " with sample:" << i
+      //<< " amp:" <<(float)(df.sample(i).adc()-baseline)/(maxSampleAmp-baseline) << endl;
+      //cout << "ADC of sample:" << df.sample(i).adc() << " baseline:" << baseline << " maxSampleAmp:"
+      //<< maxSampleAmp << endl << endl;
+      pulseShapeHistMap_[hitDetId.hashedIndex()]->Fill(i, (float)(sampleADC[i] - pedestal) / amplitude);
+      rawPulseShapeHistMap_[hitDetId.hashedIndex()]->Fill(i, (float)(sampleADC[i]));
+    }
+    firstSampleHistMap_[hitDetId.hashedIndex()]->Fill(sampleADC[0]);
+  }
 
-     cutAmpHistMap_[hitDetId.hashedIndex()]->Fill(amplitude);
-     numHitsWithActivity++;
-     EEDigiCollection::const_iterator digiItr= EEdigis->begin();
-     while(digiItr != EEdigis->end() && digiItr->id() != hitItr->id())
-     {
-       digiItr++;
-     }
-     if(digiItr == EEdigis->end())
-       continue;
+  // Now do the same for the EE hits
+  for (EcalUncalibratedRecHitCollection::const_iterator hitItr = EEHits->begin(); hitItr != EEHits->end(); ++hitItr) {
+    EcalUncalibratedRecHit hit = (*hitItr);
+    float amplitude = hit.amplitude();
+    EEDetId hitDetId = hit.id();
 
-     double sampleADC[10];
-     EEDataFrame df(*digiItr);
-     double pedestal = 200;
+    // Get the Fedid
+    EcalElectronicsId elecId = ecalElectronicsMap->getElectronicsId(hitDetId);
+    int FEDid = 600 + elecId.dccId();
+    string SMname = fedMap_->getSliceFromFed(FEDid);
 
-     if(df.sample(0).gainId()!=1 || df.sample(1).gainId()!=1) continue; //goes to the next digi
-     else {
-       sampleADC[0] = df.sample(0).adc();
-       sampleADC[1] = df.sample(1).adc();
-       pedestal = (double)(sampleADC[0]+sampleADC[1])/(double)2;
-     } 
+    vector<int>::const_iterator itr = listChannels_.begin();
+    while (itr != listChannels_.end() && (*itr) != hitDetId.hashedIndex()) {
+      itr++;
+    }
+    if (itr == listChannels_.end())
+      continue;
 
-     for (int i=0; (unsigned int)i< digiItr->size(); ++i ) {
-       EEDataFrame df(*digiItr);
-       double gain = 12.;
-       if(df.sample(i).gainId()==1)
-         gain = 1.;
-       else if(df.sample(i).gainId()==2)
-         gain = 2.;
-       sampleADC[i] = pedestal+(df.sample(i).adc()-pedestal)*gain;
-     }
+    ampHistMap_[hitDetId.hashedIndex()]->Fill(amplitude);
+    //cout << "Cry hash:" << hitDetId.hashedIndex() << " amplitude: " << amplitude << endl;
+    if (amplitude < ampCut_)
+      continue;
 
-     //cout << "1) maxsample amp:" << maxSampleAmp << " maxSampleIndex:" << maxSampleIndex << endl;
-     for(int i=0; i<10;++i)
-     {
-       //cout << "Filling hist for:" << hitDetId.hashedIndex() << " with sample:" << i 
-         //<< " amp:" <<(float)(df.sample(i).adc()-baseline)/(maxSampleAmp-baseline) << endl;
-       //cout << "ADC of sample:" << df.sample(i).adc() << " baseline:" << baseline << " maxSampleAmp:" 
-         //<< maxSampleAmp << endl << endl;
-       pulseShapeHistMap_[hitDetId.hashedIndex()]->Fill(i, (float)(sampleADC[i]-pedestal)/amplitude);
-       rawPulseShapeHistMap_[hitDetId.hashedIndex()]->Fill(i, (float)(sampleADC[i]));
-     }
-     firstSampleHistMap_[hitDetId.hashedIndex()]->Fill(sampleADC[0]);
-   }
+    cutAmpHistMap_[hitDetId.hashedIndex()]->Fill(amplitude);
+    numHitsWithActivity++;
+    EEDigiCollection::const_iterator digiItr = EEdigis->begin();
+    while (digiItr != EEdigis->end() && digiItr->id() != hitItr->id()) {
+      digiItr++;
+    }
+    if (digiItr == EEdigis->end())
+      continue;
+
+    double sampleADC[10];
+    EEDataFrame df(*digiItr);
+    double pedestal = 200;
+
+    if (df.sample(0).gainId() != 1 || df.sample(1).gainId() != 1)
+      continue;  //goes to the next digi
+    else {
+      sampleADC[0] = df.sample(0).adc();
+      sampleADC[1] = df.sample(1).adc();
+      pedestal = (double)(sampleADC[0] + sampleADC[1]) / (double)2;
+    }
+
+    for (int i = 0; (unsigned int)i < digiItr->size(); ++i) {
+      EEDataFrame df(*digiItr);
+      double gain = 12.;
+      if (df.sample(i).gainId() == 1)
+        gain = 1.;
+      else if (df.sample(i).gainId() == 2)
+        gain = 2.;
+      sampleADC[i] = pedestal + (df.sample(i).adc() - pedestal) * gain;
+    }
+
+    //cout << "1) maxsample amp:" << maxSampleAmp << " maxSampleIndex:" << maxSampleIndex << endl;
+    for (int i = 0; i < 10; ++i) {
+      //cout << "Filling hist for:" << hitDetId.hashedIndex() << " with sample:" << i
+      //<< " amp:" <<(float)(df.sample(i).adc()-baseline)/(maxSampleAmp-baseline) << endl;
+      //cout << "ADC of sample:" << df.sample(i).adc() << " baseline:" << baseline << " maxSampleAmp:"
+      //<< maxSampleAmp << endl << endl;
+      pulseShapeHistMap_[hitDetId.hashedIndex()]->Fill(i, (float)(sampleADC[i] - pedestal) / amplitude);
+      rawPulseShapeHistMap_[hitDetId.hashedIndex()]->Fill(i, (float)(sampleADC[i]));
+    }
+    firstSampleHistMap_[hitDetId.hashedIndex()]->Fill(sampleADC[0]);
+  }
 }
 
-
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-EcalPulseShapeGrapher::endJob() {
-  
-   rootFilename_+=".root";
-   file_ = new TFile(rootFilename_.c_str(),"RECREATE");
-   TH1::AddDirectory(false);
-  
-   for(std::vector<int>::const_iterator itr = listChannels_.begin(); itr != listChannels_.end(); ++itr)
-   {
-     ampHistMap_[*itr]->Write();
-     cutAmpHistMap_[*itr]->Write();
-     firstSampleHistMap_[*itr]->Write();
+void EcalPulseShapeGrapher::endJob() {
+  rootFilename_ += ".root";
+  file_ = new TFile(rootFilename_.c_str(), "RECREATE");
+  TH1::AddDirectory(false);
 
-     rawPulseShapeHistMap_[*itr]->Write();
-     TProfile* t2 = (TProfile*) (rawPulseShapeHistMap_[*itr]->ProfileX());
-     t2->Write();
-     //TODO: fix the normalization so these are correct
-     //pulseShapeHistMap_[*itr]->Write();
-     //TProfile* t1 = (TProfile*) (pulseShapeHistMap_[*itr]->ProfileX());
-     //t1->Write();
-   }
+  for (std::vector<int>::const_iterator itr = listChannels_.begin(); itr != listChannels_.end(); ++itr) {
+    ampHistMap_[*itr]->Write();
+    cutAmpHistMap_[*itr]->Write();
+    firstSampleHistMap_[*itr]->Write();
 
-   
+    rawPulseShapeHistMap_[*itr]->Write();
+    TProfile* t2 = (TProfile*)(rawPulseShapeHistMap_[*itr]->ProfileX());
+    t2->Write();
+    //TODO: fix the normalization so these are correct
+    //pulseShapeHistMap_[*itr]->Write();
+    //TProfile* t1 = (TProfile*) (pulseShapeHistMap_[*itr]->ProfileX());
+    //t1->Write();
+  }
+
   file_->Write();
   file_->Close();
 }
 
-std::string EcalPulseShapeGrapher::intToString(int num)
-{
+std::string EcalPulseShapeGrapher::intToString(int num) {
   using namespace std;
   ostringstream myStream;
   myStream << num << flush;
-  return(myStream.str()); //returns the string form of the stringstream object
+  return (myStream.str());  //returns the string form of the stringstream object
 }

--- a/CaloOnlineTools/EcalTools/plugins/EcalPulseShapeGrapher.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalPulseShapeGrapher.h
@@ -2,7 +2,7 @@
 //
 // Package:    EcalPulseShapeGrapher
 // Class:      EcalPulseShapeGrapher
-// 
+//
 /**\class EcalPulseShapeGrapher EcalPulseShapeGrapher.cc EcalPulseShapeGrapher.h
 
  Description: <one line class summary>
@@ -44,36 +44,35 @@
 //
 
 class EcalPulseShapeGrapher : public edm::EDAnalyzer {
-   public:
-      explicit EcalPulseShapeGrapher(const edm::ParameterSet&);
-      ~EcalPulseShapeGrapher() override;
+public:
+  explicit EcalPulseShapeGrapher(const edm::ParameterSet&);
+  ~EcalPulseShapeGrapher() override;
 
+private:
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
-   private:
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob() override ;
+  std::string intToString(int);
 
-      std::string intToString(int);
+  edm::InputTag EBUncalibratedRecHitCollection_;
+  edm::InputTag EBDigis_;
+  edm::InputTag EEUncalibratedRecHitCollection_;
+  edm::InputTag EEDigis_;
 
-      edm::InputTag EBUncalibratedRecHitCollection_;
-      edm::InputTag EBDigis_;
-      edm::InputTag EEUncalibratedRecHitCollection_;
-      edm::InputTag EEDigis_;
+  int abscissa[10];
+  int ordinate[10];
+  std::vector<int> listChannels_;
+  std::map<int, TH1F*> ampHistMap_;
+  std::map<int, TH2F*> pulseShapeHistMap_;
+  std::map<int, TH1F*> firstSampleHistMap_;
+  std::map<int, TH2F*> rawPulseShapeHistMap_;
+  std::map<int, TH1F*> cutAmpHistMap_;
 
-      int abscissa[10];
-      int ordinate[10];
-      std::vector<int> listChannels_;
-      std::map<int,TH1F*> ampHistMap_;
-      std::map<int,TH2F*> pulseShapeHistMap_;
-      std::map<int,TH1F*> firstSampleHistMap_;
-      std::map<int,TH2F*> rawPulseShapeHistMap_;
-      std::map<int,TH1F*> cutAmpHistMap_;
-      
-      int ampCut_;
-      std::string rootFilename_;
+  int ampCut_;
+  std::string rootFilename_;
 
-      TFile* file_;
-         
-      EcalFedMap* fedMap_;
-      // ----------member data ---------------------------
+  TFile* file_;
+
+  EcalFedMap* fedMap_;
+  // ----------member data ---------------------------
 };

--- a/CaloOnlineTools/EcalTools/plugins/EcalRecHitsFilter.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalRecHitsFilter.cc
@@ -5,8 +5,7 @@
 //
 //class EcalHighEnCosmicFilter EcalHighEnCosmicFilter.cc
 //
-// Original Author:  
-
+// Original Author:
 
 #include <memory>
 #include <vector>
@@ -36,58 +35,50 @@ using namespace std;
 using namespace reco;
 
 //
-EcalRecHitsFilter::EcalRecHitsFilter(const edm::ParameterSet& iConfig) :
-  NumBadXtalsThreshold_ (iConfig.getUntrackedParameter<int>("NumberXtalsThreshold")),
-  EBRecHitCollection_ (iConfig.getParameter<edm::InputTag>("EcalRecHitCollectionEB"))
+EcalRecHitsFilter::EcalRecHitsFilter(const edm::ParameterSet& iConfig)
+    : NumBadXtalsThreshold_(iConfig.getUntrackedParameter<int>("NumberXtalsThreshold")),
+      EBRecHitCollection_(iConfig.getParameter<edm::InputTag>("EcalRecHitCollectionEB"))
 
 {
   EnergyCut = (iConfig.getUntrackedParameter<double>("energycut"));
 }
 
-EcalRecHitsFilter::~EcalRecHitsFilter()
-{
-}
+EcalRecHitsFilter::~EcalRecHitsFilter() {}
 
-bool EcalRecHitsFilter::filter( edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+bool EcalRecHitsFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //int ievt = iEvent.id().event();
   Handle<EcalRecHitCollection> EBhits;
-  iEvent.getByLabel(EBRecHitCollection_,EBhits);
+  iEvent.getByLabel(EBRecHitCollection_, EBhits);
 
   bool accepted = true;
   int nRecHitsGreater1GevPerEvent = 0;
 
-  for (EcalRecHitCollection::const_iterator hitItr = EBhits->begin(); hitItr != EBhits->end(); ++hitItr)
-    {
+  for (EcalRecHitCollection::const_iterator hitItr = EBhits->begin(); hitItr != EBhits->end(); ++hitItr) {
+    EcalRecHit hit = (*hitItr);
+    EBDetId det = hit.id();
 
-      EcalRecHit hit = (*hitItr);
-      EBDetId det = hit.id();
-  
-      float ampli = hit.energy();
-      if(ampli > EnergyCut /*1GeV*/)
- 	{
-	  nRecHitsGreater1GevPerEvent++;
- 	  nRecHitsGreater1GevPerEvent_hist_MAP->Fill(det.iphi(),det.ieta());
- 	}
+    float ampli = hit.energy();
+    if (ampli > EnergyCut /*1GeV*/) {
+      nRecHitsGreater1GevPerEvent++;
+      nRecHitsGreater1GevPerEvent_hist_MAP->Fill(det.iphi(), det.ieta());
     }
+  }
   nRecHitsGreater1GevPerEvent_hist->Fill(nRecHitsGreater1GevPerEvent);
-  if(nRecHitsGreater1GevPerEvent > NumBadXtalsThreshold_ ) accepted = false;
+  if (nRecHitsGreater1GevPerEvent > NumBadXtalsThreshold_)
+    accepted = false;
   return accepted;
 }
 
-void 
-EcalRecHitsFilter::beginJob()
-{
-  nRecHitsGreater1GevPerEvent_hist = new TH1F("nRecHitsGreater1GevPerEvent_hist","nRecHitsGreater1GevPerEvent_hist",65000,0.,65000.);
-  nRecHitsGreater1GevPerEvent_hist_MAP = new TH2F("nRecHitsGreater1GevPerEvent_hist_MAP","nRecHitsGreater1GevPerEvent_hist_MAP",360,1.,361.,171,-85.,86.);
+void EcalRecHitsFilter::beginJob() {
+  nRecHitsGreater1GevPerEvent_hist =
+      new TH1F("nRecHitsGreater1GevPerEvent_hist", "nRecHitsGreater1GevPerEvent_hist", 65000, 0., 65000.);
+  nRecHitsGreater1GevPerEvent_hist_MAP = new TH2F(
+      "nRecHitsGreater1GevPerEvent_hist_MAP", "nRecHitsGreater1GevPerEvent_hist_MAP", 360, 1., 361., 171, -85., 86.);
 }
 
-
-void 
-EcalRecHitsFilter::endJob()
-{
+void EcalRecHitsFilter::endJob() {
   cout << "------EcalRecHitsFilter EndJob------>>>>>>>>>>" << endl;
-  file = new TFile("RecHitFilter.root" , "RECREATE");
+  file = new TFile("RecHitFilter.root", "RECREATE");
   file->cd();
   nRecHitsGreater1GevPerEvent_hist_MAP->Write();
   nRecHitsGreater1GevPerEvent_hist->Write();

--- a/CaloOnlineTools/EcalTools/plugins/EcalRecHitsFilter.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalRecHitsFilter.h
@@ -5,13 +5,12 @@
 //
 //class EcalRecHitsFilter EcalRecHitsFilter.cc
 //
-// Original Author:  
+// Original Author:
 //         Created:  We May 14 10:10:52 CEST 2008
 //
 
 #ifndef EcalRecHitsFilter_H
 #define EcalRecHitsFilter_H
-
 
 // system include files
 #include <memory>
@@ -45,23 +44,22 @@
 //
 
 class EcalRecHitsFilter : public edm::EDFilter {
-   public:
-      explicit EcalRecHitsFilter(const edm::ParameterSet &);
-      ~EcalRecHitsFilter() override;
+public:
+  explicit EcalRecHitsFilter(const edm::ParameterSet&);
+  ~EcalRecHitsFilter() override;
 
-   private:
-      void beginJob() override ;
-      bool filter ( edm::Event &, const edm::EventSetup &) override;
-      void endJob() override ;
+private:
+  void beginJob() override;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
-      double EnergyCut;  
-      int NumBadXtalsThreshold_; 
-      edm::InputTag EBRecHitCollection_;
-    
+  double EnergyCut;
+  int NumBadXtalsThreshold_;
+  edm::InputTag EBRecHitCollection_;
 
-      TH1F* nRecHitsGreater1GevPerEvent_hist;
-      TH2F* nRecHitsGreater1GevPerEvent_hist_MAP;
-      TFile* file;
+  TH1F* nRecHitsGreater1GevPerEvent_hist;
+  TH2F* nRecHitsGreater1GevPerEvent_hist_MAP;
+  TFile* file;
 };
 
 #endif

--- a/CaloOnlineTools/EcalTools/plugins/EcalTPGAnalyzer.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalTPGAnalyzer.cc
@@ -7,7 +7,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 #include <utility>
@@ -48,161 +47,146 @@
 using namespace edm;
 class CaloSubdetectorGeometry;
 
-EcalTPGAnalyzer::EcalTPGAnalyzer(const edm::ParameterSet&  iConfig)
-{
-  tpCollection_ = iConfig.getParameter<edm::InputTag>("TPCollection") ;
-  tpEmulatorCollection_ = iConfig.getParameter<edm::InputTag>("TPEmulatorCollection") ;
-  digiCollectionEB_ = iConfig.getParameter<edm::InputTag>("DigiCollectionEB") ;
-  digiCollectionEE_ = iConfig.getParameter<edm::InputTag>("DigiCollectionEE") ;
-  gtRecordCollectionTag_ = iConfig.getParameter<std::string>("GTRecordCollection") ;
+EcalTPGAnalyzer::EcalTPGAnalyzer(const edm::ParameterSet& iConfig) {
+  tpCollection_ = iConfig.getParameter<edm::InputTag>("TPCollection");
+  tpEmulatorCollection_ = iConfig.getParameter<edm::InputTag>("TPEmulatorCollection");
+  digiCollectionEB_ = iConfig.getParameter<edm::InputTag>("DigiCollectionEB");
+  digiCollectionEE_ = iConfig.getParameter<edm::InputTag>("DigiCollectionEE");
+  gtRecordCollectionTag_ = iConfig.getParameter<std::string>("GTRecordCollection");
 
   allowTP_ = iConfig.getParameter<bool>("ReadTriggerPrimitives");
   useEE_ = iConfig.getParameter<bool>("UseEndCap");
   print_ = iConfig.getParameter<bool>("Print");
 
   // file
-  file_ = new TFile("ECALTPGtree.root","RECREATE");
-  file_->cd() ;
+  file_ = new TFile("ECALTPGtree.root", "RECREATE");
+  file_->cd();
 
   // tree
-  tree_ = new TTree( "EcalTPGAnalysis","EcalTPGAnalysis" );
+  tree_ = new TTree("EcalTPGAnalysis", "EcalTPGAnalysis");
 
-  tree_->Branch("runNb",&treeVariables_.runNb,"runNb/i"); //
-  tree_->Branch("evtNb",&treeVariables_.evtNb,"evtNb/i"); //
-  tree_->Branch("bxNb",&treeVariables_.bxNb,"bxNb/i"); //
-  tree_->Branch("orbitNb",&treeVariables_.orbitNb,"orbitNb/i"); //
-  tree_->Branch("nbOfActiveTriggers",&treeVariables_.nbOfActiveTriggers,"nbOfActiveTriggers/i"); //
-  tree_->Branch("activeTriggers",treeVariables_.activeTriggers,"activeTriggers[nbOfActiveTriggers]/I"); //
+  tree_->Branch("runNb", &treeVariables_.runNb, "runNb/i");                                                //
+  tree_->Branch("evtNb", &treeVariables_.evtNb, "evtNb/i");                                                //
+  tree_->Branch("bxNb", &treeVariables_.bxNb, "bxNb/i");                                                   //
+  tree_->Branch("orbitNb", &treeVariables_.orbitNb, "orbitNb/i");                                          //
+  tree_->Branch("nbOfActiveTriggers", &treeVariables_.nbOfActiveTriggers, "nbOfActiveTriggers/i");         //
+  tree_->Branch("activeTriggers", treeVariables_.activeTriggers, "activeTriggers[nbOfActiveTriggers]/I");  //
 
-  tree_->Branch("nbOfTowers",&treeVariables_.nbOfTowers,"nbOfTowers/i"); //
-  tree_->Branch("ieta", treeVariables_.ieta,"ieta[nbOfTowers]/I");//
-  tree_->Branch("iphi", treeVariables_.iphi,"iphi[nbOfTowers]/I");//
-  tree_->Branch("nbOfXtals", treeVariables_.nbOfXtals,"nbOfXtals[nbOfTowers]/I");//
-  tree_->Branch("rawTPData", treeVariables_.rawTPData,"rawTPData[nbOfTowers]/I");//
-  tree_->Branch("rawTPEmul1", treeVariables_.rawTPEmul1,"rawTPEmul1[nbOfTowers]/I");//
-  tree_->Branch("rawTPEmul2", treeVariables_.rawTPEmul2,"rawTPEmul2[nbOfTowers]/I");//
-  tree_->Branch("rawTPEmul3", treeVariables_.rawTPEmul3,"rawTPEmul3[nbOfTowers]/I");//
-  tree_->Branch("rawTPEmul4", treeVariables_.rawTPEmul4,"rawTPEmul4[nbOfTowers]/I");//
-  tree_->Branch("rawTPEmul5", treeVariables_.rawTPEmul5,"rawTPEmul5[nbOfTowers]/I");//
-  tree_->Branch("eRec", treeVariables_.eRec,"eRec[nbOfTowers]/F");//
+  tree_->Branch("nbOfTowers", &treeVariables_.nbOfTowers, "nbOfTowers/i");             //
+  tree_->Branch("ieta", treeVariables_.ieta, "ieta[nbOfTowers]/I");                    //
+  tree_->Branch("iphi", treeVariables_.iphi, "iphi[nbOfTowers]/I");                    //
+  tree_->Branch("nbOfXtals", treeVariables_.nbOfXtals, "nbOfXtals[nbOfTowers]/I");     //
+  tree_->Branch("rawTPData", treeVariables_.rawTPData, "rawTPData[nbOfTowers]/I");     //
+  tree_->Branch("rawTPEmul1", treeVariables_.rawTPEmul1, "rawTPEmul1[nbOfTowers]/I");  //
+  tree_->Branch("rawTPEmul2", treeVariables_.rawTPEmul2, "rawTPEmul2[nbOfTowers]/I");  //
+  tree_->Branch("rawTPEmul3", treeVariables_.rawTPEmul3, "rawTPEmul3[nbOfTowers]/I");  //
+  tree_->Branch("rawTPEmul4", treeVariables_.rawTPEmul4, "rawTPEmul4[nbOfTowers]/I");  //
+  tree_->Branch("rawTPEmul5", treeVariables_.rawTPEmul5, "rawTPEmul5[nbOfTowers]/I");  //
+  tree_->Branch("eRec", treeVariables_.eRec, "eRec[nbOfTowers]/F");                    //
 }
 
-
-EcalTPGAnalyzer::~EcalTPGAnalyzer()
-{
+EcalTPGAnalyzer::~EcalTPGAnalyzer() {
   file_->cd();
   tree_->Write();
   file_->Close();
 }
 
-void EcalTPGAnalyzer::beginRun(edm::Run const &, edm::EventSetup const & evtSetup)
-{
+void EcalTPGAnalyzer::beginRun(edm::Run const&, edm::EventSetup const& evtSetup) {
   // geometry
   ESHandle<CaloGeometry> theGeometry;
   ESHandle<CaloSubdetectorGeometry> theEndcapGeometry_handle, theBarrelGeometry_handle;
 
-  evtSetup.get<CaloGeometryRecord>().get( theGeometry );
-  evtSetup.get<EcalEndcapGeometryRecord>().get("EcalEndcap",theEndcapGeometry_handle);
-  evtSetup.get<EcalBarrelGeometryRecord>().get("EcalBarrel",theBarrelGeometry_handle);
+  evtSetup.get<CaloGeometryRecord>().get(theGeometry);
+  evtSetup.get<EcalEndcapGeometryRecord>().get("EcalEndcap", theEndcapGeometry_handle);
+  evtSetup.get<EcalBarrelGeometryRecord>().get("EcalBarrel", theBarrelGeometry_handle);
 
   evtSetup.get<IdealGeometryRecord>().get(eTTmap_);
   theEndcapGeometry_ = &(*theEndcapGeometry_handle);
   theBarrelGeometry_ = &(*theBarrelGeometry_handle);
 }
 
-
-void EcalTPGAnalyzer::analyze(edm::Event const & iEvent, edm::EventSetup const & iSetup)
-{
-
-
+void EcalTPGAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
   using namespace edm;
   using namespace std;
 
-  if (print_) std::cout<<"==========="<<iEvent.id()<<std::endl ;
+  if (print_)
+    std::cout << "===========" << iEvent.id() << std::endl;
 
-
-  map<EcalTrigTowerDetId, towerEner> mapTower ;
-  map<EcalTrigTowerDetId, towerEner>::iterator itTT ;
-
-
+  map<EcalTrigTowerDetId, towerEner> mapTower;
+  map<EcalTrigTowerDetId, towerEner>::iterator itTT;
 
   ///////////////////////////
   // get Evts info
   ///////////////////////////
 
-  treeVariables_.runNb = iEvent.id().run() ;
-  treeVariables_.evtNb = iEvent.id().event() ;
-  treeVariables_.bxNb = iEvent.bunchCrossing() ;
-  treeVariables_.orbitNb = iEvent.orbitNumber() ;
-  
+  treeVariables_.runNb = iEvent.id().run();
+  treeVariables_.evtNb = iEvent.id().event();
+  treeVariables_.bxNb = iEvent.bunchCrossing();
+  treeVariables_.orbitNb = iEvent.orbitNumber();
 
   ///////////////////////////
   // get L1 info
   ///////////////////////////
-  
-  edm::Handle< L1GlobalTriggerReadoutRecord > gtRecord;
-  iEvent.getByLabel( edm::InputTag(gtRecordCollectionTag_), gtRecord);
-  DecisionWord dWord = gtRecord->decisionWord();   // this will get the decision word *before* masking disabled bits
 
-  edm::ESHandle< L1GtTriggerMask > l1GtTmAlgo;
-  iSetup.get< L1GtTriggerMaskAlgoTrigRcd >().get( l1GtTmAlgo );        
+  edm::Handle<L1GlobalTriggerReadoutRecord> gtRecord;
+  iEvent.getByLabel(edm::InputTag(gtRecordCollectionTag_), gtRecord);
+  DecisionWord dWord = gtRecord->decisionWord();  // this will get the decision word *before* masking disabled bits
+
+  edm::ESHandle<L1GtTriggerMask> l1GtTmAlgo;
+  iSetup.get<L1GtTriggerMaskAlgoTrigRcd>().get(l1GtTmAlgo);
   std::vector<unsigned int> triggerMaskAlgoTrig = l1GtTmAlgo.product()->gtTriggerMask();
 
-  // apply masks on algo    
+  // apply masks on algo
   int iDaq = 0;
   int iBit = -1;
-  treeVariables_.nbOfActiveTriggers = 0 ;
-  for (std::vector<bool>::iterator itBit = dWord.begin(); itBit != dWord.end(); ++itBit) {        
+  treeVariables_.nbOfActiveTriggers = 0;
+  for (std::vector<bool>::iterator itBit = dWord.begin(); itBit != dWord.end(); ++itBit) {
     iBit++;
     int maskBit = triggerMaskAlgoTrig[iBit] & (1 << iDaq);
-    if (maskBit) *itBit = false;
+    if (maskBit)
+      *itBit = false;
     if (*itBit) {
-      treeVariables_.activeTriggers[treeVariables_.nbOfActiveTriggers] = iBit ;
-      treeVariables_.nbOfActiveTriggers++ ;      
+      treeVariables_.activeTriggers[treeVariables_.nbOfActiveTriggers] = iBit;
+      treeVariables_.nbOfActiveTriggers++;
     }
   }
 
-
-
-
-
-  /////////////////////////// 
-  // Get TP data  
+  ///////////////////////////
+  // Get TP data
   ///////////////////////////
 
   edm::Handle<EcalTrigPrimDigiCollection> tp;
-  iEvent.getByLabel(tpCollection_,tp);
-  if (print_) std::cout<<"TP collection size="<<tp.product()->size()<<std::endl ;
+  iEvent.getByLabel(tpCollection_, tp);
+  if (print_)
+    std::cout << "TP collection size=" << tp.product()->size() << std::endl;
 
-  for (unsigned int i=0;i<tp.product()->size();i++) {
+  for (unsigned int i = 0; i < tp.product()->size(); i++) {
     EcalTriggerPrimitiveDigi d = (*(tp.product()))[i];
-    const EcalTrigTowerDetId TPtowid= d.id();
-    towerEner tE ;
-    tE.iphi_ = TPtowid.iphi() ;
-    tE.ieta_ = TPtowid.ieta() ;
-    tE.tpgADC_ = d[0].raw() ;
-    mapTower[TPtowid] = tE ;
+    const EcalTrigTowerDetId TPtowid = d.id();
+    towerEner tE;
+    tE.iphi_ = TPtowid.iphi();
+    tE.ieta_ = TPtowid.ieta();
+    tE.tpgADC_ = d[0].raw();
+    mapTower[TPtowid] = tE;
   }
-
-
 
   ///////////////////////////
   // Get Emulators TP
   ///////////////////////////
 
-  edm::Handle<EcalTrigPrimDigiCollection> tpEmul ;
+  edm::Handle<EcalTrigPrimDigiCollection> tpEmul;
   iEvent.getByLabel(tpEmulatorCollection_, tpEmul);
-  if (print_) std::cout<<"TPEmulator collection size="<<tpEmul.product()->size()<<std::endl ;
+  if (print_)
+    std::cout << "TPEmulator collection size=" << tpEmul.product()->size() << std::endl;
 
-  for (unsigned int i=0;i<tpEmul.product()->size();i++) {
+  for (unsigned int i = 0; i < tpEmul.product()->size(); i++) {
     EcalTriggerPrimitiveDigi d = (*(tpEmul.product()))[i];
-    const EcalTrigTowerDetId TPtowid= d.id();
-    itTT = mapTower.find(TPtowid) ;
+    const EcalTrigTowerDetId TPtowid = d.id();
+    itTT = mapTower.find(TPtowid);
     if (itTT != mapTower.end())
-      for (int j=0 ; j<5 ; j++) (itTT->second).tpgEmul_[j] = d[j].raw() ;
+      for (int j = 0; j < 5; j++)
+        (itTT->second).tpgEmul_[j] = d[j].raw();
   }
-
-
 
   ///////////////////////////
   // Get nb of crystals read out
@@ -212,59 +196,54 @@ void EcalTPGAnalyzer::analyze(edm::Event const & iEvent, edm::EventSetup const &
   edm::Handle<EBDigiCollection> digiEB;
   iEvent.getByLabel(digiCollectionEB_, digiEB);
 
-  for (unsigned int i=0;i<digiEB.product()->size();i++) {
-    const EBDataFrame & df = (*(digiEB.product()))[i];    
-    const EBDetId & id = df.id();
+  for (unsigned int i = 0; i < digiEB.product()->size(); i++) {
+    const EBDataFrame& df = (*(digiEB.product()))[i];
+    const EBDetId& id = df.id();
     const EcalTrigTowerDetId towid = id.tower();
-    itTT = mapTower.find(towid) ;
-    if (itTT != mapTower.end()) (itTT->second).nbXtal_++ ;
+    itTT = mapTower.find(towid);
+    if (itTT != mapTower.end())
+      (itTT->second).nbXtal_++;
   }
 
   if (useEE_) {
     // Get EE xtal digi inputs
     edm::Handle<EEDigiCollection> digiEE;
     iEvent.getByLabel(digiCollectionEE_, digiEE);
-    for (unsigned int i=0;i<digiEE.product()->size();i++) {
-      const EEDataFrame & df = (*(digiEE.product()))[i];
-      const EEDetId & id = df.id();
+    for (unsigned int i = 0; i < digiEE.product()->size(); i++) {
+      const EEDataFrame& df = (*(digiEE.product()))[i];
+      const EEDetId& id = df.id();
       const EcalTrigTowerDetId towid = (*eTTmap_).towerOf(id);
-      itTT = mapTower.find(towid) ;
-      if (itTT != mapTower.end()) (itTT->second).nbXtal_++ ;
+      itTT = mapTower.find(towid);
+      if (itTT != mapTower.end())
+        (itTT->second).nbXtal_++;
     }
   }
 
-  ///////////////////////////  
+  ///////////////////////////
   // Get rechits
   ///////////////////////////
 
   //... to be completed
 
-
-
-
-
-  ///////////////////////////  
+  ///////////////////////////
   // fill tree
-  ///////////////////////////  
+  ///////////////////////////
 
-  treeVariables_.nbOfTowers = mapTower.size() ;
-  int towerNb = 0 ;
-  for (itTT = mapTower.begin() ; itTT != mapTower.end() ; ++itTT) {
-    treeVariables_.ieta[towerNb] = (itTT->second).ieta_ ;
-    treeVariables_.iphi[towerNb] = (itTT->second).iphi_ ;
-    treeVariables_.nbOfXtals[towerNb] = (itTT->second).nbXtal_ ;
-    treeVariables_.rawTPData[towerNb] = (itTT->second).tpgADC_ ;
-    treeVariables_.rawTPEmul1[towerNb] = (itTT->second).tpgEmul_[0] ;
-    treeVariables_.rawTPEmul2[towerNb] = (itTT->second).tpgEmul_[1] ;
-    treeVariables_.rawTPEmul3[towerNb] = (itTT->second).tpgEmul_[2] ;
-    treeVariables_.rawTPEmul4[towerNb] = (itTT->second).tpgEmul_[3] ;
-    treeVariables_.rawTPEmul5[towerNb] = (itTT->second).tpgEmul_[4] ;
-    treeVariables_.eRec[towerNb] = (itTT->second).eRec_ ;
-    towerNb++ ;
+  treeVariables_.nbOfTowers = mapTower.size();
+  int towerNb = 0;
+  for (itTT = mapTower.begin(); itTT != mapTower.end(); ++itTT) {
+    treeVariables_.ieta[towerNb] = (itTT->second).ieta_;
+    treeVariables_.iphi[towerNb] = (itTT->second).iphi_;
+    treeVariables_.nbOfXtals[towerNb] = (itTT->second).nbXtal_;
+    treeVariables_.rawTPData[towerNb] = (itTT->second).tpgADC_;
+    treeVariables_.rawTPEmul1[towerNb] = (itTT->second).tpgEmul_[0];
+    treeVariables_.rawTPEmul2[towerNb] = (itTT->second).tpgEmul_[1];
+    treeVariables_.rawTPEmul3[towerNb] = (itTT->second).tpgEmul_[2];
+    treeVariables_.rawTPEmul4[towerNb] = (itTT->second).tpgEmul_[3];
+    treeVariables_.rawTPEmul5[towerNb] = (itTT->second).tpgEmul_[4];
+    treeVariables_.eRec[towerNb] = (itTT->second).eRec_;
+    towerNb++;
   }
 
-  tree_->Fill() ;
-
+  tree_->Fill();
 }
-
-

--- a/CaloOnlineTools/EcalTools/plugins/EcalTPGAnalyzer.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalTPGAnalyzer.h
@@ -1,7 +1,7 @@
 // -*- C++ -*-
 //
 // Class:      EcalTPGAnalyzer
-// 
+//
 //
 // Original Author:  Pascal Paganini
 //
@@ -17,76 +17,68 @@
 #include <TFile.h>
 #include <TTree.h>
 
-class CaloSubdetectorGeometry ;
-
+class CaloSubdetectorGeometry;
 
 // Auxiliary class
-class towerEner {   
- public:
-  float eRec_ ;
-  int tpgEmul_[5] ;
-  int tpgADC_; 
-  int iphi_, ieta_, nbXtal_ ;
-  towerEner()
-    : eRec_(0), tpgADC_(0),  
-      iphi_(-999), ieta_(-999), nbXtal_(0)
-  { 
-    for (int i=0 ; i<5 ; i ++) tpgEmul_[i] = 0 ; 
+class towerEner {
+public:
+  float eRec_;
+  int tpgEmul_[5];
+  int tpgADC_;
+  int iphi_, ieta_, nbXtal_;
+  towerEner() : eRec_(0), tpgADC_(0), iphi_(-999), ieta_(-999), nbXtal_(0) {
+    for (int i = 0; i < 5; i++)
+      tpgEmul_[i] = 0;
   }
 };
 
-
 class EcalTPGAnalyzer : public edm::EDAnalyzer {
 public:
-  explicit EcalTPGAnalyzer(const edm::ParameterSet&);
-  ~EcalTPGAnalyzer() override;  
+  explicit EcalTPGAnalyzer(const edm::ParameterSet &);
+  ~EcalTPGAnalyzer() override;
   void analyze(edm::Event const &, edm::EventSetup const &) override;
-  void beginRun(edm::Run const &, edm::EventSetup const &) override ;
-  
+  void beginRun(edm::Run const &, edm::EventSetup const &) override;
+
 private:
-  struct EcalTPGVariables
-  {
+  struct EcalTPGVariables {
     // event variables
-    unsigned int runNb ;
-    unsigned int evtNb ;
-    unsigned int bxNb ;
-    unsigned int orbitNb ;
-    unsigned int nbOfActiveTriggers ;
-    int activeTriggers[128] ;
+    unsigned int runNb;
+    unsigned int evtNb;
+    unsigned int bxNb;
+    unsigned int orbitNb;
+    unsigned int nbOfActiveTriggers;
+    int activeTriggers[128];
 
     // tower variables
-    unsigned int nbOfTowers ; //max 4032 EB+EE
-    int ieta[4032] ;
-    int iphi[4032] ;
-    int nbOfXtals[4032] ;
-    int rawTPData[4032] ;
-    int rawTPEmul1[4032] ;
-    int rawTPEmul2[4032] ;
-    int rawTPEmul3[4032] ;
-    int rawTPEmul4[4032] ;
-    int rawTPEmul5[4032] ;
-    float eRec[4032] ;
-  } ;
+    unsigned int nbOfTowers;  //max 4032 EB+EE
+    int ieta[4032];
+    int iphi[4032];
+    int nbOfXtals[4032];
+    int rawTPData[4032];
+    int rawTPEmul1[4032];
+    int rawTPEmul2[4032];
+    int rawTPEmul3[4032];
+    int rawTPEmul4[4032];
+    int rawTPEmul5[4032];
+    float eRec[4032];
+  };
 
 private:
-  TFile * file_;
-  TTree * tree_ ;
-  EcalTPGVariables treeVariables_ ;
+  TFile *file_;
+  TTree *tree_;
+  EcalTPGVariables treeVariables_;
 
-  edm::InputTag tpCollection_ ;
-  edm::InputTag tpEmulatorCollection_ ;
-  edm::InputTag digiCollectionEB_ ;
-  edm::InputTag digiCollectionEE_ ;
-  std::string gtRecordCollectionTag_ ;
+  edm::InputTag tpCollection_;
+  edm::InputTag tpEmulatorCollection_;
+  edm::InputTag digiCollectionEB_;
+  edm::InputTag digiCollectionEE_;
+  std::string gtRecordCollectionTag_;
 
-  bool allowTP_ ;
-  bool useEE_ ;
-  bool print_ ;
+  bool allowTP_;
+  bool useEE_;
+  bool print_;
 
-  const CaloSubdetectorGeometry * theEndcapGeometry_ ;
-  const CaloSubdetectorGeometry * theBarrelGeometry_ ;
+  const CaloSubdetectorGeometry *theEndcapGeometry_;
+  const CaloSubdetectorGeometry *theBarrelGeometry_;
   edm::ESHandle<EcalTrigTowerConstituentsMap> eTTmap_;
-
-
 };
-

--- a/CaloOnlineTools/EcalTools/plugins/EcalURecHitHists.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalURecHitHists.cc
@@ -1,8 +1,8 @@
 // -*- C++ -*-
 //
-// Package:   EcalURecHitHists 
-// Class:     EcalURecHitHists 
-// 
+// Package:   EcalURecHitHists
+// Class:     EcalURecHitHists
+//
 /**\class EcalURecHitHists EcalURecHitHists.cc
 
  Description: <one line class summary>
@@ -33,62 +33,52 @@ using namespace std;
 //
 // constructors and destructor
 //
-EcalURecHitHists::EcalURecHitHists(const edm::ParameterSet& iConfig) :
-  EBUncalibratedRecHitCollection_ (iConfig.getParameter<edm::InputTag>("EBUncalibratedRecHitCollection")),
-  EEUncalibratedRecHitCollection_ (iConfig.getParameter<edm::InputTag>("EEUncalibratedRecHitCollection")),
-  runNum_(-1),
-  histRangeMax_ (iConfig.getUntrackedParameter<double>("histogramMaxRange",200.0)),
-  histRangeMin_ (iConfig.getUntrackedParameter<double>("histogramMinRange",-10.0)),
-  fileName_ (iConfig.getUntrackedParameter<std::string>("fileName", std::string("ecalURechHitHists")))
-{
+EcalURecHitHists::EcalURecHitHists(const edm::ParameterSet& iConfig)
+    : EBUncalibratedRecHitCollection_(iConfig.getParameter<edm::InputTag>("EBUncalibratedRecHitCollection")),
+      EEUncalibratedRecHitCollection_(iConfig.getParameter<edm::InputTag>("EEUncalibratedRecHitCollection")),
+      runNum_(-1),
+      histRangeMax_(iConfig.getUntrackedParameter<double>("histogramMaxRange", 200.0)),
+      histRangeMin_(iConfig.getUntrackedParameter<double>("histogramMinRange", -10.0)),
+      fileName_(iConfig.getUntrackedParameter<std::string>("fileName", std::string("ecalURechHitHists"))) {
   vector<int> listDefaults;
   listDefaults.push_back(-1);
-  
+
   maskedChannels_ = iConfig.getUntrackedParameter<vector<int> >("maskedChannels", listDefaults);
   maskedFEDs_ = iConfig.getUntrackedParameter<vector<int> >("maskedFEDs", listDefaults);
 
   vector<string> defaultMaskedEBs;
   defaultMaskedEBs.push_back("none");
-  maskedEBs_ =  iConfig.getUntrackedParameter<vector<string> >("maskedEBs",defaultMaskedEBs);
-  
+  maskedEBs_ = iConfig.getUntrackedParameter<vector<string> >("maskedEBs", defaultMaskedEBs);
+
   fedMap_ = new EcalFedMap();
   string title1 = "Uncalib Rec Hits (ADC counts)";
   string name1 = "URecHitsAllFEDs";
-  int numBins = (int)round(histRangeMax_-histRangeMin_)+1;
-  allFedsHist_ = new TH1F(name1.c_str(),title1.c_str(),numBins,histRangeMin_,histRangeMax_);
+  int numBins = (int)round(histRangeMax_ - histRangeMin_) + 1;
+  allFedsHist_ = new TH1F(name1.c_str(), title1.c_str(), numBins, histRangeMin_, histRangeMax_);
   title1 = "Jitter for all FEDs";
   name1 = "JitterAllFEDs";
-  allFedsTimingHist_ = new TH1F(name1.c_str(),title1.c_str(),14,-7,7);
+  allFedsTimingHist_ = new TH1F(name1.c_str(), title1.c_str(), 14, -7, 7);
 
   // load up the maskedFED list with the proper FEDids
-  if(maskedFEDs_[0]==-1)
-  {
+  if (maskedFEDs_[0] == -1) {
     //if "actual" EB id given, then convert to FEDid and put in listFEDs_
-    if(maskedEBs_[0] != "none")
-    {
+    if (maskedEBs_[0] != "none") {
       maskedFEDs_.clear();
-      for(vector<string>::const_iterator ebItr = maskedEBs_.begin(); ebItr != maskedEBs_.end(); ++ebItr)
-      {
+      for (vector<string>::const_iterator ebItr = maskedEBs_.begin(); ebItr != maskedEBs_.end(); ++ebItr) {
         maskedFEDs_.push_back(fedMap_->getFedFromSlice(*ebItr));
       }
     }
   }
 }
 
-
-EcalURecHitHists::~EcalURecHitHists()
-{
-}
-
+EcalURecHitHists::~EcalURecHitHists() {}
 
 //
 // member functions
 //
 
 // ------------ method called to for each event  ------------
-void
-EcalURecHitHists::analyze(edm::Event const & iEvent, edm::EventSetup const & iSetup)
-{
+void EcalURecHitHists::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
   int ievt = iEvent.id().event();
   Handle<EcalUncalibratedRecHitCollection> EBhits;
   Handle<EcalUncalibratedRecHitCollection> EEhits;
@@ -99,158 +89,139 @@ EcalURecHitHists::analyze(edm::Event const & iEvent, edm::EventSetup const & iSe
   iEvent.getByLabel(EEUncalibratedRecHitCollection_, EEhits);
   LogDebug("EcalURecHitHists") << "event " << ievt << " hits collection size " << EEhits->size();
 
-  for (EcalUncalibratedRecHitCollection::const_iterator hitItr = EBhits->begin(); hitItr != EBhits->end(); ++hitItr)
-  {
+  for (EcalUncalibratedRecHitCollection::const_iterator hitItr = EBhits->begin(); hitItr != EBhits->end(); ++hitItr) {
     EcalUncalibratedRecHit hit = (*hitItr);
     EBDetId ebDet = hit.id();
     int ic = ebDet.ic();
     int hashedIndex = ebDet.hashedIndex();
     EcalElectronicsId elecId = ecalElectronicsMap_->getElectronicsId(ebDet);
-    int FEDid = 600+elecId.dccId();
+    int FEDid = 600 + elecId.dccId();
     float ampli = hit.amplitude();
 
     vector<int>::iterator result;
     result = find(maskedFEDs_.begin(), maskedFEDs_.end(), FEDid);
-    if(result != maskedFEDs_.end())
-    {
+    if (result != maskedFEDs_.end()) {
       LogWarning("EcalURecHitHists") << "skipping uncalRecHit for FED " << FEDid << " ; amplitude " << ampli;
       continue;
-    }      
+    }
 
     result = find(maskedChannels_.begin(), maskedChannels_.end(), hashedIndex);
-    if  (result != maskedChannels_.end())
-    {
-      LogWarning("EcalURecHitHists") << "skipping uncalRecHit for channel: " << ic << " with amplitude " << ampli ;
+    if (result != maskedChannels_.end()) {
+      LogWarning("EcalURecHitHists") << "skipping uncalRecHit for channel: " << ic << " with amplitude " << ampli;
       continue;
-    }      
+    }
 
     // fill the proper hist
     TH1F* uRecHist = FEDsAndHists_[FEDid];
     TH1F* timingHist = FEDsAndTimingHists_[FEDid];
-    if(uRecHist==nullptr)
-    {
+    if (uRecHist == nullptr) {
       initHists(FEDid);
       uRecHist = FEDsAndHists_[FEDid];
       timingHist = FEDsAndTimingHists_[FEDid];
     }
-    
+
     uRecHist->Fill(ampli);
     allFedsHist_->Fill(ampli);
     timingHist->Fill(hit.jitter());
     allFedsTimingHist_->Fill(hit.jitter());
   }
-  
+
   // Again for the endcap
-  for (EcalUncalibratedRecHitCollection::const_iterator hitItr = EEhits->begin(); hitItr != EEhits->end(); ++hitItr)
-  {
+  for (EcalUncalibratedRecHitCollection::const_iterator hitItr = EEhits->begin(); hitItr != EEhits->end(); ++hitItr) {
     EcalUncalibratedRecHit hit = (*hitItr);
     EEDetId eeDet = hit.id();
     int ic = eeDet.ic();
     int hashedIndex = eeDet.hashedIndex();
     EcalElectronicsId elecId = ecalElectronicsMap_->getElectronicsId(eeDet);
-    int FEDid = 600+elecId.dccId();
+    int FEDid = 600 + elecId.dccId();
     float ampli = hit.amplitude();
 
     vector<int>::iterator result;
     result = find(maskedFEDs_.begin(), maskedFEDs_.end(), FEDid);
-    if(result != maskedFEDs_.end())
-    {
+    if (result != maskedFEDs_.end()) {
       LogWarning("EcalURecHitHists") << "skipping uncalRecHit for FED " << FEDid << " ; amplitude " << ampli;
       continue;
-    }      
+    }
 
     result = find(maskedChannels_.begin(), maskedChannels_.end(), hashedIndex);
-    if  (result != maskedChannels_.end())
-    {
-      LogWarning("EcalURecHitHists") << "skipping uncalRecHit for channel: " << ic << " with amplitude " << ampli ;
+    if (result != maskedChannels_.end()) {
+      LogWarning("EcalURecHitHists") << "skipping uncalRecHit for channel: " << ic << " with amplitude " << ampli;
       continue;
-    }      
+    }
 
     // fill the proper hist
     TH1F* uRecHist = FEDsAndHists_[FEDid];
     TH1F* timingHist = FEDsAndTimingHists_[FEDid];
-    if(uRecHist==nullptr)
-    {
+    if (uRecHist == nullptr) {
       initHists(FEDid);
       uRecHist = FEDsAndHists_[FEDid];
       timingHist = FEDsAndTimingHists_[FEDid];
     }
-    
+
     uRecHist->Fill(ampli);
     allFedsHist_->Fill(ampli);
     timingHist->Fill(hit.jitter());
     allFedsTimingHist_->Fill(hit.jitter());
   }
 
-  if(runNum_==-1)
-  {
+  if (runNum_ == -1) {
     runNum_ = iEvent.id().run();
   }
 }
 
-
 // insert the hist map into the map keyed by FED number
-void EcalURecHitHists::initHists(int FED)
-{
+void EcalURecHitHists::initHists(int FED) {
   using namespace std;
-  
+
   string FEDid = intToString(FED);
   string title1 = "Uncalib Rec Hits (ADC counts) for ";
   title1.append(fedMap_->getSliceFromFed(FED));
   string name1 = "URecHitsFED";
   name1.append(intToString(FED));
-  int numBins = (int)round(histRangeMax_-histRangeMin_)+1;
-  TH1F* hist = new TH1F(name1.c_str(),title1.c_str(), numBins, histRangeMin_, histRangeMax_);
+  int numBins = (int)round(histRangeMax_ - histRangeMin_) + 1;
+  TH1F* hist = new TH1F(name1.c_str(), title1.c_str(), numBins, histRangeMin_, histRangeMax_);
   FEDsAndHists_[FED] = hist;
   FEDsAndHists_[FED]->SetDirectory(nullptr);
-  
+
   title1 = "Jitter for ";
   title1.append(fedMap_->getSliceFromFed(FED));
   name1 = "JitterFED";
   name1.append(intToString(FED));
-  TH1F* timingHist = new TH1F(name1.c_str(),title1.c_str(),14,-7,7);
+  TH1F* timingHist = new TH1F(name1.c_str(), title1.c_str(), 14, -7, 7);
   FEDsAndTimingHists_[FED] = timingHist;
   FEDsAndTimingHists_[FED]->SetDirectory(nullptr);
 }
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-EcalURecHitHists::beginRun(edm::Run const &, edm::EventSetup const & c)
-{
+void EcalURecHitHists::beginRun(edm::Run const&, edm::EventSetup const& c) {
   edm::ESHandle<EcalElectronicsMapping> elecHandle;
   c.get<EcalMappingRcd>().get(elecHandle);
   ecalElectronicsMap_ = elecHandle.product();
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-EcalURecHitHists::endJob()
-{
+void EcalURecHitHists::endJob() {
   using namespace std;
-  fileName_ += "-"+intToString(runNum_)+".graph.root";
+  fileName_ += "-" + intToString(runNum_) + ".graph.root";
 
-  TFile root_file_(fileName_.c_str() , "RECREATE");
+  TFile root_file_(fileName_.c_str(), "RECREATE");
 
-  for(map<int,TH1F*>::const_iterator itr = FEDsAndHists_.begin();
-      itr != FEDsAndHists_.end(); ++itr)
-  {
+  for (map<int, TH1F*>::const_iterator itr = FEDsAndHists_.begin(); itr != FEDsAndHists_.end(); ++itr) {
     string dir = fedMap_->getSliceFromFed(itr->first);
     TDirectory* FEDdir = gDirectory->mkdir(dir.c_str());
     FEDdir->cd();
 
     TH1F* hist = itr->second;
-    if(hist!=nullptr)
+    if (hist != nullptr)
       hist->Write();
-    else
-    {
+    else {
       cerr << "EcalPedHists: Error: This shouldn't happen!" << endl;
     }
     // Write out timing hist
     hist = FEDsAndTimingHists_[itr->first];
-    if(hist!=nullptr)
+    if (hist != nullptr)
       hist->Write();
-    else
-    {
+    else {
       cerr << "EcalPedHists: Error: This shouldn't happen!" << endl;
     }
     root_file_.cd();
@@ -260,22 +231,17 @@ EcalURecHitHists::endJob()
   root_file_.Close();
 
   std::string channels;
-  for(std::vector<int>::const_iterator itr = maskedChannels_.begin();
-      itr != maskedChannels_.end(); ++itr)
-  {
-    channels+=intToString(*itr);
-    channels+=",";
+  for (std::vector<int>::const_iterator itr = maskedChannels_.begin(); itr != maskedChannels_.end(); ++itr) {
+    channels += intToString(*itr);
+    channels += ",";
   }
-  
+
   LogWarning("EcalMipGraphs") << "Masked channels are: " << channels << " and that is all!";
 }
 
-
-std::string EcalURecHitHists::intToString(int num)
-{
-    using namespace std;
-    ostringstream myStream;
-    myStream << num << flush;
-    return(myStream.str()); //returns the string form of the stringstream object
+std::string EcalURecHitHists::intToString(int num) {
+  using namespace std;
+  ostringstream myStream;
+  myStream << num << flush;
+  return (myStream.str());  //returns the string form of the stringstream object
 }
-

--- a/CaloOnlineTools/EcalTools/plugins/EcalURecHitHists.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalURecHitHists.h
@@ -1,8 +1,8 @@
 // -*- C++ -*-
 //
-// Package:   EcalURecHitHists 
-// Class:     EcalURecHitHists 
-// 
+// Package:   EcalURecHitHists
+// Class:     EcalURecHitHists
+//
 /**\class EcalURecHitHists EcalURecHitHists.cc
 
  Description: <one line class summary>
@@ -15,7 +15,6 @@
 //         Created:  Th Nov 22 5:46:22 CEST 2007
 //
 //
-
 
 // system include files
 #include <memory>
@@ -53,19 +52,18 @@
 //
 
 class EcalURecHitHists : public edm::EDAnalyzer {
-   public:
-      explicit EcalURecHitHists(const edm::ParameterSet&);
-      ~EcalURecHitHists() override;
+public:
+  explicit EcalURecHitHists(const edm::ParameterSet&);
+  ~EcalURecHitHists() override;
 
+private:
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
+  void endJob() override;
+  std::string intToString(int num);
+  void initHists(int);
 
-   private:
-      void beginRun(edm::Run const &, edm::EventSetup const &) override ;
-      void analyze(edm::Event const &, edm::EventSetup const &) override;
-      void endJob() override ;
-      std::string intToString(int num);
-      void initHists(int);
-
-    // ----------member data ---------------------------
+  // ----------member data ---------------------------
 
   edm::InputTag EBUncalibratedRecHitCollection_;
   edm::InputTag EEUncalibratedRecHitCollection_;
@@ -76,8 +74,8 @@ class EcalURecHitHists : public edm::EDAnalyzer {
   std::vector<int> maskedChannels_;
   std::vector<int> maskedFEDs_;
   std::vector<std::string> maskedEBs_;
-  std::map<int,TH1F*> FEDsAndHists_;
-  std::map<int,TH1F*> FEDsAndTimingHists_;
+  std::map<int, TH1F*> FEDsAndHists_;
+  std::map<int, TH1F*> FEDsAndTimingHists_;
 
   TH1F* allFedsHist_;
   TH1F* allFedsTimingHist_;

--- a/CaloOnlineTools/EcalTools/plugins/plugins.cc
+++ b/CaloOnlineTools/EcalTools/plugins/plugins.cc
@@ -15,7 +15,6 @@
 #include "CaloOnlineTools/EcalTools/plugins/EcalDisplaysByEvent.h"
 #include "CaloOnlineTools/EcalTools/plugins/EcalFEDErrorFilter.h"
 
-
 DEFINE_FWK_MODULE(EcalDigiDisplay);
 DEFINE_FWK_MODULE(EcalPnGraphs);
 DEFINE_FWK_MODULE(EcalDCCHeaderDisplay);

--- a/CaloOnlineTools/EcalTools/src/EcalFedMap.cc
+++ b/CaloOnlineTools/EcalTools/src/EcalFedMap.cc
@@ -1,83 +1,78 @@
 #include "CaloOnlineTools/EcalTools/interface/EcalFedMap.h"
 #include <iostream>
-#include <cctype> // for toupper
+#include <cctype>  // for toupper
 #include <algorithm>
 
-EcalFedMap::~EcalFedMap(){}
+EcalFedMap::~EcalFedMap() {}
 
-EcalFedMap::EcalFedMap(){
-
+EcalFedMap::EcalFedMap() {
   // EE-
-  fedToSliceMap_.insert( std::make_pair(601, "EE-07") );
-  fedToSliceMap_.insert( std::make_pair(602, "EE-08") );
-  fedToSliceMap_.insert( std::make_pair(603, "EE-09") );
-  fedToSliceMap_.insert( std::make_pair(604, "EE-01") );
-  fedToSliceMap_.insert( std::make_pair(605, "EE-02") );
-  fedToSliceMap_.insert( std::make_pair(606, "EE-03") );
-  fedToSliceMap_.insert( std::make_pair(607, "EE-04") );
-  fedToSliceMap_.insert( std::make_pair(608, "EE-05") );
-  fedToSliceMap_.insert( std::make_pair(609, "EE-06") );
+  fedToSliceMap_.insert(std::make_pair(601, "EE-07"));
+  fedToSliceMap_.insert(std::make_pair(602, "EE-08"));
+  fedToSliceMap_.insert(std::make_pair(603, "EE-09"));
+  fedToSliceMap_.insert(std::make_pair(604, "EE-01"));
+  fedToSliceMap_.insert(std::make_pair(605, "EE-02"));
+  fedToSliceMap_.insert(std::make_pair(606, "EE-03"));
+  fedToSliceMap_.insert(std::make_pair(607, "EE-04"));
+  fedToSliceMap_.insert(std::make_pair(608, "EE-05"));
+  fedToSliceMap_.insert(std::make_pair(609, "EE-06"));
 
   // EB-
-  fedToSliceMap_.insert( std::make_pair(610, "EB-01") );
-  fedToSliceMap_.insert( std::make_pair(611, "EB-02") );
-  fedToSliceMap_.insert( std::make_pair(612, "EB-03") );
-  fedToSliceMap_.insert( std::make_pair(613, "EB-04") );
-  fedToSliceMap_.insert( std::make_pair(614, "EB-05") );
-  fedToSliceMap_.insert( std::make_pair(615, "EB-06") );
-  fedToSliceMap_.insert( std::make_pair(616, "EB-07") );
-  fedToSliceMap_.insert( std::make_pair(617, "EB-08") );
-  fedToSliceMap_.insert( std::make_pair(618, "EB-09") );
-  fedToSliceMap_.insert( std::make_pair(619, "EB-10") );
-  fedToSliceMap_.insert( std::make_pair(620, "EB-11") );
-  fedToSliceMap_.insert( std::make_pair(621, "EB-12") );
-  fedToSliceMap_.insert( std::make_pair(622, "EB-13") );
-  fedToSliceMap_.insert( std::make_pair(623, "EB-14") );
-  fedToSliceMap_.insert( std::make_pair(624, "EB-15") );
-  fedToSliceMap_.insert( std::make_pair(625, "EB-16") );
-  fedToSliceMap_.insert( std::make_pair(626, "EB-17") );
-  fedToSliceMap_.insert( std::make_pair(627, "EB-18") );
+  fedToSliceMap_.insert(std::make_pair(610, "EB-01"));
+  fedToSliceMap_.insert(std::make_pair(611, "EB-02"));
+  fedToSliceMap_.insert(std::make_pair(612, "EB-03"));
+  fedToSliceMap_.insert(std::make_pair(613, "EB-04"));
+  fedToSliceMap_.insert(std::make_pair(614, "EB-05"));
+  fedToSliceMap_.insert(std::make_pair(615, "EB-06"));
+  fedToSliceMap_.insert(std::make_pair(616, "EB-07"));
+  fedToSliceMap_.insert(std::make_pair(617, "EB-08"));
+  fedToSliceMap_.insert(std::make_pair(618, "EB-09"));
+  fedToSliceMap_.insert(std::make_pair(619, "EB-10"));
+  fedToSliceMap_.insert(std::make_pair(620, "EB-11"));
+  fedToSliceMap_.insert(std::make_pair(621, "EB-12"));
+  fedToSliceMap_.insert(std::make_pair(622, "EB-13"));
+  fedToSliceMap_.insert(std::make_pair(623, "EB-14"));
+  fedToSliceMap_.insert(std::make_pair(624, "EB-15"));
+  fedToSliceMap_.insert(std::make_pair(625, "EB-16"));
+  fedToSliceMap_.insert(std::make_pair(626, "EB-17"));
+  fedToSliceMap_.insert(std::make_pair(627, "EB-18"));
 
   // EB+
-  fedToSliceMap_.insert( std::make_pair(628, "EB+01") );
-  fedToSliceMap_.insert( std::make_pair(629, "EB+02") );
-  fedToSliceMap_.insert( std::make_pair(630, "EB+03") );
-  fedToSliceMap_.insert( std::make_pair(631, "EB+04") );
-  fedToSliceMap_.insert( std::make_pair(632, "EB+05") );
-  fedToSliceMap_.insert( std::make_pair(633, "EB+06") );
-  fedToSliceMap_.insert( std::make_pair(634, "EB+07") );
-  fedToSliceMap_.insert( std::make_pair(635, "EB+08") );
-  fedToSliceMap_.insert( std::make_pair(636, "EB+09") );
-  fedToSliceMap_.insert( std::make_pair(637, "EB+10") );
-  fedToSliceMap_.insert( std::make_pair(638, "EB+11") );
-  fedToSliceMap_.insert( std::make_pair(639, "EB+12") );
-  fedToSliceMap_.insert( std::make_pair(640, "EB+13") );
-  fedToSliceMap_.insert( std::make_pair(641, "EB+14") );
-  fedToSliceMap_.insert( std::make_pair(642, "EB+15") );
-  fedToSliceMap_.insert( std::make_pair(643, "EB+16") );
-  fedToSliceMap_.insert( std::make_pair(644, "EB+17") );
-  fedToSliceMap_.insert( std::make_pair(645, "EB+18") );
+  fedToSliceMap_.insert(std::make_pair(628, "EB+01"));
+  fedToSliceMap_.insert(std::make_pair(629, "EB+02"));
+  fedToSliceMap_.insert(std::make_pair(630, "EB+03"));
+  fedToSliceMap_.insert(std::make_pair(631, "EB+04"));
+  fedToSliceMap_.insert(std::make_pair(632, "EB+05"));
+  fedToSliceMap_.insert(std::make_pair(633, "EB+06"));
+  fedToSliceMap_.insert(std::make_pair(634, "EB+07"));
+  fedToSliceMap_.insert(std::make_pair(635, "EB+08"));
+  fedToSliceMap_.insert(std::make_pair(636, "EB+09"));
+  fedToSliceMap_.insert(std::make_pair(637, "EB+10"));
+  fedToSliceMap_.insert(std::make_pair(638, "EB+11"));
+  fedToSliceMap_.insert(std::make_pair(639, "EB+12"));
+  fedToSliceMap_.insert(std::make_pair(640, "EB+13"));
+  fedToSliceMap_.insert(std::make_pair(641, "EB+14"));
+  fedToSliceMap_.insert(std::make_pair(642, "EB+15"));
+  fedToSliceMap_.insert(std::make_pair(643, "EB+16"));
+  fedToSliceMap_.insert(std::make_pair(644, "EB+17"));
+  fedToSliceMap_.insert(std::make_pair(645, "EB+18"));
 
   // EE+
-  fedToSliceMap_.insert( std::make_pair(646, "EE+07") );
-  fedToSliceMap_.insert( std::make_pair(647, "EE+08") );
-  fedToSliceMap_.insert( std::make_pair(648, "EE+09") );
-  fedToSliceMap_.insert( std::make_pair(649, "EE+01") );
-  fedToSliceMap_.insert( std::make_pair(650, "EE+02") );
-  fedToSliceMap_.insert( std::make_pair(651, "EE+03") );
-  fedToSliceMap_.insert( std::make_pair(652, "EE+04") );
-  fedToSliceMap_.insert( std::make_pair(653, "EE+05") );
-  fedToSliceMap_.insert( std::make_pair(654, "EE+06") );
-
+  fedToSliceMap_.insert(std::make_pair(646, "EE+07"));
+  fedToSliceMap_.insert(std::make_pair(647, "EE+08"));
+  fedToSliceMap_.insert(std::make_pair(648, "EE+09"));
+  fedToSliceMap_.insert(std::make_pair(649, "EE+01"));
+  fedToSliceMap_.insert(std::make_pair(650, "EE+02"));
+  fedToSliceMap_.insert(std::make_pair(651, "EE+03"));
+  fedToSliceMap_.insert(std::make_pair(652, "EE+04"));
+  fedToSliceMap_.insert(std::make_pair(653, "EE+05"));
+  fedToSliceMap_.insert(std::make_pair(654, "EE+06"));
 
   std::map<int, std::string>::iterator it;
-  for (it = fedToSliceMap_.begin();
-       it != fedToSliceMap_.end();
-       it++)
-    {
-      //  std::cout<<  "fed: "<< (*it).first << " slice: " << (*it).second << std::endl;
-      sliceToFedMap_.insert( std::make_pair( (*it).second, (*it).first) );
-    }
+  for (it = fedToSliceMap_.begin(); it != fedToSliceMap_.end(); it++) {
+    //  std::cout<<  "fed: "<< (*it).first << " slice: " << (*it).second << std::endl;
+    sliceToFedMap_.insert(std::make_pair((*it).second, (*it).first));
+  }
 
   //  std::map<std::string, int>::iterator ti;
   //  for (ti = sliceToFedMap_.begin();
@@ -86,30 +81,25 @@ EcalFedMap::EcalFedMap(){
   //    {
   //      //      std::cout<<  "slice: "<< (*ti).first << " fed: " << (*ti).second << std::endl;
   //    }
-
 }
 
-
-std::string EcalFedMap::getSliceFromFed(int fedNumber)
-{
+std::string EcalFedMap::getSliceFromFed(int fedNumber) {
   //std::cout << "received: " << fedNumber << std::endl;
-  std::map< int, std::string >::iterator found  = fedToSliceMap_.find(fedNumber);
-  
-  if ( found != fedToSliceMap_.end() ) 
-    return (* found).second;
+  std::map<int, std::string>::iterator found = fedToSliceMap_.find(fedNumber);
+
+  if (found != fedToSliceMap_.end())
+    return (*found).second;
   else
     return std::string("invalid Fed");
 }
 
-int EcalFedMap::getFedFromSlice(std::string slice)
-{
-
+int EcalFedMap::getFedFromSlice(std::string slice) {
   transform(slice.begin(), slice.end(), slice.begin(), toupper);
 
-  std::map< std::string , int>::iterator found  = sliceToFedMap_.find(slice);
-  
-  if ( found != sliceToFedMap_.end() ) 
-    return (* found).second;
+  std::map<std::string, int>::iterator found = sliceToFedMap_.find(slice);
+
+  if (found != sliceToFedMap_.end())
+    return (*found).second;
   else
     return -999;
 }

--- a/CondFormats/MFObjects/interface/MagFieldConfig.h
+++ b/CondFormats/MFObjects/interface/MagFieldConfig.h
@@ -15,21 +15,21 @@
 #include <vector>
 #include <map>
 
-namespace edm {class ParameterSet;}
+namespace edm {
+  class ParameterSet;
+}
 
 namespace magneticfield {
   typedef std::map<int, std::pair<std::string, int> > TableFileMap;
 }
 
-
 class MagFieldConfig {
 public:
-
-  MagFieldConfig(){}
+  MagFieldConfig() {}
 
   /// Constructor
-  MagFieldConfig(const edm::ParameterSet& pset, bool debug=false);
-  
+  MagFieldConfig(const edm::ParameterSet& pset, bool debug = false);
+
   // Operations
 public:
   std::vector<unsigned> expandList(const std::string& list);
@@ -38,7 +38,7 @@ public:
   int geometryVersion;
 
   /// Version of the data tables to be used
-  std::string version;  
+  std::string version;
 
   /// Specification of which data table is to be used for each volume
   magneticfield::TableFileMap gridFiles;
@@ -46,17 +46,15 @@ public:
   /// Scaling factors for the field in specific volumes
   std::vector<int> keys;
   std::vector<double> values;
-  
+
   /// Label or type of the tracker parametrization
   std::string slaveFieldVersion;
 
   /// Parameters for the tracker parametrization
-  /// (not used in legacy producers where slaveFieldVersion is the label of the 
+  /// (not used in legacy producers where slaveFieldVersion is the label of the
   /// parametrization in the EventSetup)
   std::vector<double> slaveFieldParameters;
 
   COND_SERIALIZABLE;
 };
 #endif
-
-

--- a/CondFormats/MFObjects/src/MagFieldConfig.cc
+++ b/CondFormats/MFObjects/src/MagFieldConfig.cc
@@ -17,47 +17,45 @@
 using namespace std;
 using namespace magneticfield;
 
-
 MagFieldConfig::MagFieldConfig(const edm::ParameterSet& pset, bool debug) {
-  
   version = pset.getParameter<std::string>("version");
   geometryVersion = pset.getParameter<int>("geometryVersion");
 
-
   // Get specification for the grid tables to be used.
   typedef vector<edm::ParameterSet> VPSet;
-  
+
   VPSet fileSpec = pset.getParameter<VPSet>("gridFiles");
   if (!fileSpec.empty()) {
-    for(VPSet::const_iterator rule = fileSpec.begin(); rule != fileSpec.end(); ++rule){
+    for (VPSet::const_iterator rule = fileSpec.begin(); rule != fileSpec.end(); ++rule) {
       string s_volumes = rule->getParameter<string>("volumes");
-      string s_sectors = rule->getParameter<string>("sectors"); // 0 means all volumes
-      int master       = rule->getParameter<int>("master");
-      string path      = rule->getParameter<string>("path");
+      string s_sectors = rule->getParameter<string>("sectors");  // 0 means all volumes
+      int master = rule->getParameter<int>("master");
+      string path = rule->getParameter<string>("path");
 
       vector<unsigned> volumes = expandList(s_volumes);
       vector<unsigned> sectors = expandList(s_sectors);
 
       if (debug) {
-	cout << "Volumes: " << s_volumes <<" Sectors: " << s_sectors 
-	     << " Master: " << master << " Path:   " << path << endl;
-	cout << " Expanded volumes: ";
-	copy(volumes.begin(), volumes.end(), ostream_iterator<unsigned>(cout, " "));
-	cout << endl;
-	cout << " Expanded sectors: ";
-	copy(sectors.begin(), sectors.end(), ostream_iterator<unsigned>(cout, " "));
-	cout << endl;
+        cout << "Volumes: " << s_volumes << " Sectors: " << s_sectors << " Master: " << master << " Path:   " << path
+             << endl;
+        cout << " Expanded volumes: ";
+        copy(volumes.begin(), volumes.end(), ostream_iterator<unsigned>(cout, " "));
+        cout << endl;
+        cout << " Expanded sectors: ";
+        copy(sectors.begin(), sectors.end(), ostream_iterator<unsigned>(cout, " "));
+        cout << endl;
       }
-	
-      for (vector<unsigned>::iterator i = volumes.begin(); i!=volumes.end(); ++i){
-	for (vector<unsigned>::iterator j = sectors.begin(); j!=sectors.end(); ++j){
-	  unsigned vpacked = (*i)*100+(*j);
-	  if (gridFiles.find(vpacked)==gridFiles.end()) {
-	    gridFiles[vpacked] = make_pair(path, master);
-	  } else {
-	    throw cms::Exception("ConfigurationError") << "VolumeBasedMagneticFieldESProducer: malformed gridFiles config parameter" << endl;
-	  }
-	}
+
+      for (vector<unsigned>::iterator i = volumes.begin(); i != volumes.end(); ++i) {
+        for (vector<unsigned>::iterator j = sectors.begin(); j != sectors.end(); ++j) {
+          unsigned vpacked = (*i) * 100 + (*j);
+          if (gridFiles.find(vpacked) == gridFiles.end()) {
+            gridFiles[vpacked] = make_pair(path, master);
+          } else {
+            throw cms::Exception("ConfigurationError")
+                << "VolumeBasedMagneticFieldESProducer: malformed gridFiles config parameter" << endl;
+          }
+        }
       }
     }
   }
@@ -66,15 +64,13 @@ MagFieldConfig::MagFieldConfig(const edm::ParameterSet& pset, bool debug) {
   keys = pset.getParameter<vector<int> >("scalingVolumes");
   values = pset.getParameter<vector<double> >("scalingFactors");
 
-
-  // Slave field label. Either a label of an existing map (legacy support), or the 
+  // Slave field label. Either a label of an existing map (legacy support), or the
   // type of parametrization to be constructed with the "paramData" parameters.
   slaveFieldVersion = pset.getParameter<string>("paramLabel");
   // Check for compatibility with older configurations
   if (pset.existsAs<vector<double> >("paramData")) {
     slaveFieldParameters = pset.getParameter<vector<double> >("paramData");
   }
-
 }
 
 vector<unsigned> MagFieldConfig::expandList(const string& list) {
@@ -82,15 +78,16 @@ vector<unsigned> MagFieldConfig::expandList(const string& list) {
   vector<unsigned> values;
   vstring v1;
   boost::split(v1, list, boost::is_any_of(","));
-  for (vstring::const_iterator i= v1.begin(); i!=v1.end(); ++i){
+  for (vstring::const_iterator i = v1.begin(); i != v1.end(); ++i) {
     vstring v2;
-    boost::split(v2, *i, boost::is_any_of("-"));	
+    boost::split(v2, *i, boost::is_any_of("-"));
     unsigned start = boost::lexical_cast<unsigned>(v2.front());
-    unsigned end   = boost::lexical_cast<unsigned>(v2.back());
-    if ((v2.size()>2) || (start>end)) {
-      throw cms::Exception("ConfigurationError") << "VolumeBasedMagneticFieldESProducerFromDB: malformed configuration" << list << endl;
+    unsigned end = boost::lexical_cast<unsigned>(v2.back());
+    if ((v2.size() > 2) || (start > end)) {
+      throw cms::Exception("ConfigurationError")
+          << "VolumeBasedMagneticFieldESProducerFromDB: malformed configuration" << list << endl;
     }
-    for (unsigned k = start; k<=end; ++k){
+    for (unsigned k = start; k <= end; ++k) {
       values.push_back(k);
     }
   }

--- a/CondFormats/MFObjects/src/classes.h
+++ b/CondFormats/MFObjects/src/classes.h
@@ -4,4 +4,4 @@ namespace CondFormats_MFObjects {
   struct dictionary {
     MagFieldConfig conf;
   };
-}
+}  // namespace CondFormats_MFObjects

--- a/CondFormats/MFObjects/test/MagFieldConfigDBWriter.cc
+++ b/CondFormats/MFObjects/test/MagFieldConfigDBWriter.cc
@@ -13,59 +13,54 @@
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "CondFormats/MFObjects/interface/MagFieldConfig.h"
 
-
 class MagFieldConfigDBWriter : public edm::EDAnalyzer {
- public:
+public:
   /// Constructor
   MagFieldConfigDBWriter(const edm::ParameterSet& pset);
 
   /// Destructor
   ~MagFieldConfigDBWriter();
-  
+
   virtual void beginRun(const edm::Run& run, const edm::EventSetup& setup){};
 
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup){}
- 
-  virtual void endJob();
-  
- private:
-  MagFieldConfig* conf;
+  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) {}
 
+  virtual void endJob();
+
+private:
+  MagFieldConfig* conf;
 };
 
-MagFieldConfigDBWriter::MagFieldConfigDBWriter(const edm::ParameterSet& pset){
-  conf = new MagFieldConfig(pset, false);  
+MagFieldConfigDBWriter::MagFieldConfigDBWriter(const edm::ParameterSet& pset) {
+  conf = new MagFieldConfig(pset, false);
 }
 
-MagFieldConfigDBWriter::~MagFieldConfigDBWriter(){
-  delete conf;
-}
-
+MagFieldConfigDBWriter::~MagFieldConfigDBWriter() { delete conf; }
 
 void MagFieldConfigDBWriter::endJob() {
-  std::string record = "MagFieldConfigRcd";  
-    // Write the ttrig object to DB
+  std::string record = "MagFieldConfigRcd";
+  // Write the ttrig object to DB
   edm::Service<cond::service::PoolDBOutputService> dbOutputSvc;
-  if(dbOutputSvc.isAvailable()){
-    try{
-      if(dbOutputSvc->isNewTagRequest(record)){
-	//create mode
-	dbOutputSvc->writeOne<MagFieldConfig>(conf, dbOutputSvc->beginOfTime(),record);
-      }else{
-	//append mode. Note: correct PoolDBESSource must be loaded
-	dbOutputSvc->writeOne<MagFieldConfig>(conf, dbOutputSvc->currentTime(),record);
+  if (dbOutputSvc.isAvailable()) {
+    try {
+      if (dbOutputSvc->isNewTagRequest(record)) {
+        //create mode
+        dbOutputSvc->writeOne<MagFieldConfig>(conf, dbOutputSvc->beginOfTime(), record);
+      } else {
+        //append mode. Note: correct PoolDBESSource must be loaded
+        dbOutputSvc->writeOne<MagFieldConfig>(conf, dbOutputSvc->currentTime(), record);
       }
-    }catch(const cond::Exception& er){
+    } catch (const cond::Exception& er) {
       std::cout << er.what() << std::endl;
-    }catch(const std::exception& er){
+    } catch (const std::exception& er) {
       std::cout << "[MagFieldConfigDBWriter] caught std::exception " << er.what() << std::endl;
-    }catch(...){
+    } catch (...) {
       std::cout << "[MagFieldConfigDBWriter] Unexpected exception" << std::endl;
     }
-  }else{
+  } else {
     std::cout << "Service PoolDBOutputService is unavailable" << std::endl;
   }
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_FWK_MODULE(MagFieldConfigDBWriter);                                                                                       
+DEFINE_FWK_MODULE(MagFieldConfigDBWriter);

--- a/CondFormats/MFObjects/test/testSerializationMFObjects.cpp
+++ b/CondFormats/MFObjects/test/testSerializationMFObjects.cpp
@@ -2,9 +2,7 @@
 
 #include "CondFormats/MFObjects/src/headers.h"
 
-
-int main()
-{
+int main() {
   testSerialization<MagFieldConfig>();
   return 0;
 }


### PR DESCRIPTION

Applying code-format for CMSSW category alca.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/199//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Same as #26675 but with correct CMS clang-format customization (see #26686)
